### PR TITLE
feat(dashboard): add task/agent/gate/cascade filter to harness-health-sections

### DIFF
--- a/dashboard/src/components/harness-health-sections.test.ts
+++ b/dashboard/src/components/harness-health-sections.test.ts
@@ -11,8 +11,22 @@ import {
   emptyReasonText,
   verdictTone,
   verdictSummary,
+  filterVerdicts,
 } from './harness-health-sections'
-import type { HarnessHealthData } from './harness-health-state'
+import type { HarnessHealthData, HarnessVerdictItem } from './harness-health-state'
+
+function makeVerdict(overrides: Partial<HarnessVerdictItem> = {}): HarnessVerdictItem {
+  return {
+    timestamp: 1_700_000_000_000,
+    task_id: 'task-1',
+    task_title: 'Task One',
+    agent_name: 'agent-alpha',
+    gate: 'code_quality',
+    verdict: 'approve',
+    evaluator_cascade: 'evaluator-cascade',
+    ...overrides,
+  }
+}
 
 function makeData(overrides: Partial<HarnessHealthData['overview']> = {}): HarnessHealthData {
   return {
@@ -340,5 +354,77 @@ describe('verdictSummary', () => {
 
   it('returns reject for whitespace-only reason', () => {
     expect(verdictSummary('reject:   ')).toBe('reject')
+  })
+})
+
+// ================================================================
+// filterVerdicts
+// ================================================================
+
+describe('filterVerdicts', () => {
+  const items: HarnessVerdictItem[] = [
+    makeVerdict({ task_id: 't-1', task_title: 'Refactor keeper loop', agent_name: 'alpha', gate: 'code_quality', evaluator_cascade: 'cas-a', verdict: 'approve' }),
+    makeVerdict({ task_id: 't-2', task_title: 'Add dashboard filter', agent_name: 'beta', gate: 'documentation', evaluator_cascade: 'cas-b', verdict: 'reject:vague notes' }),
+    makeVerdict({ task_id: 't-3', task_title: 'Token counter fix', agent_name: 'gamma', gate: 'code_quality', evaluator_cascade: 'cas-c', verdict: 'approve:conditional' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterVerdicts(items, '')).toBe(items)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterVerdicts(items, '   ')).toBe(items)
+  })
+
+  it('matches by task_title substring (case-insensitive)', () => {
+    const result = filterVerdicts(items, 'DASHBOARD')
+    expect(result.map(r => r.task_id)).toEqual(['t-2'])
+  })
+
+  it('matches by agent_name substring', () => {
+    const result = filterVerdicts(items, 'gamma')
+    expect(result.map(r => r.task_id)).toEqual(['t-3'])
+  })
+
+  it('matches by gate substring returning multiple rows', () => {
+    const result = filterVerdicts(items, 'code_quality')
+    expect(result.map(r => r.task_id)).toEqual(['t-1', 't-3'])
+  })
+
+  it('matches by evaluator_cascade substring', () => {
+    const result = filterVerdicts(items, 'cas-b')
+    expect(result.map(r => r.task_id)).toEqual(['t-2'])
+  })
+
+  it('matches by verdict substring', () => {
+    const result = filterVerdicts(items, 'reject')
+    expect(result.map(r => r.task_id)).toEqual(['t-2'])
+  })
+
+  it('matches by task_id substring', () => {
+    const result = filterVerdicts(items, 't-1')
+    expect(result.map(r => r.task_id)).toEqual(['t-1'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterVerdicts(items, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterVerdicts(items, '  alpha  ')).toHaveLength(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = items.slice()
+    filterVerdicts(items, 'alpha')
+    expect(items).toEqual(copy)
+  })
+
+  it('handles items with empty string fields safely', () => {
+    const sparse: HarnessVerdictItem[] = [
+      makeVerdict({ task_id: '', task_title: '', agent_name: '', gate: '', evaluator_cascade: '', verdict: 'approve' }),
+    ]
+    expect(filterVerdicts(sparse, 'approve')).toHaveLength(1)
+    expect(filterVerdicts(sparse, 'anything-else')).toHaveLength(0)
   })
 })

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -1,6 +1,8 @@
 // Harness health reusable section sub-components.
 
 import { html } from 'htm/preact'
+import { useMemo } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
 import { navigate } from '../router'
 import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
@@ -13,6 +15,35 @@ import type {
   PreCompactEvent,
   HandoffEvent,
 } from './harness-health-state'
+
+/**
+ * Pure filter for recent verdict rows.
+ *
+ * Case-insensitive substring match on `task_title`, `task_id`, `agent_name`,
+ * `gate`, `evaluator_cascade`, and `verdict` so operators can locate a
+ * verdict by any visible identifier.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * `useMemo` keeps referential equality for the non-filtering path.
+ *
+ * Input is never mutated.
+ */
+export function filterVerdicts(
+  items: readonly HarnessVerdictItem[],
+  query: string,
+): readonly HarnessVerdictItem[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return items
+  return items.filter(item => {
+    if (item.task_title && item.task_title.toLowerCase().includes(needle)) return true
+    if (item.task_id && item.task_id.toLowerCase().includes(needle)) return true
+    if (item.agent_name && item.agent_name.toLowerCase().includes(needle)) return true
+    if (item.gate && item.gate.toLowerCase().includes(needle)) return true
+    if (item.evaluator_cascade && item.evaluator_cascade.toLowerCase().includes(needle)) return true
+    if (item.verdict && item.verdict.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 // ── Helper functions ──
 
@@ -272,29 +303,48 @@ export function RailHeader({
 // ── Section components ──
 
 export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
+  const query = useSignal('')
+  const visibleItems = useMemo(
+    () => filterVerdicts(items, query.value),
+    [items, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
+
   if (items.length === 0) {
     return html`<${EmptySignal} text="최근 평가 판정이 없습니다." />`
   }
 
   return html`
     <div class="space-y-2">
-      ${items.map(item => html`
-        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <div class="text-sm font-medium text-[var(--text-strong)]">${item.task_title || item.task_id}</div>
-              <div class="mt-1 text-xs text-[var(--text-muted)]">
-                ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
+      <div class="flex justify-end">
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="task / agent / gate / cascade 필터"
+          aria-label="판정 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && visibleItems.length === 0
+        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${items.length} items)</div>`
+        : visibleItems.map(item => html`
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <div class="text-sm font-medium text-[var(--text-strong)]">${item.task_title || item.task_id}</div>
+                <div class="mt-1 text-xs text-[var(--text-muted)]">
+                  ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
+                </div>
               </div>
+              <span class=${`inline-block h-2.5 w-2.5 rounded-full ${verdictTone(item.verdict)}`} />
             </div>
-            <span class=${`inline-block h-2.5 w-2.5 rounded-full ${verdictTone(item.verdict)}`} />
+            <div class="mt-2 text-sm text-[var(--text-body)]">${verdictSummary(item.verdict)}</div>
+            ${item.fallback_reason ? html`
+              <div class="mt-2 break-all text-xs text-[var(--warn)]">${item.fallback_reason}</div>
+            ` : null}
           </div>
-          <div class="mt-2 text-sm text-[var(--text-body)]">${verdictSummary(item.verdict)}</div>
-          ${item.fallback_reason ? html`
-            <div class="mt-2 break-all text-xs text-[var(--warn)]">${item.fallback_reason}</div>
-          ` : null}
-        </div>
-      `)}
+        `)}
     </div>
   `
 }


### PR DESCRIPTION
## 요약

`harness-health-sections.ts` 의 **최근 판정** 리스트 (`RecentVerdictsList`) 에 자유 텍스트 필터를 추가합니다. Safety Harness 패널에서 누적된 verdict들 사이에서 특정 task, 특정 agent, 또는 특정 evaluator_cascade에서 reject된 판정을 찾으려면 스크롤이 필요했습니다.

## 왜 이 리스트인가

`harness-health-sections.ts` 의 5개 `.map` 사이트:

- `entries.map` (L173, GateChart) — gate 분포 바 차트. gate 카디널리티 낮음 (4~6).
- **`items.map` (L281, RecentVerdictsList)** — **verdict 누적, `task_title`/`task_id`/`agent_name`/`gate`/`evaluator_cascade`/`verdict` 6-field 자유 텍스트** ← 선택
- `section.recent_events.map` (L309, PreCompactList) — 키퍼별 압축 이벤트, 필터 가능하나 필드 수가 적음.
- `item.strategies.map` (L324, 중첩) — 한 압축 이벤트 내부의 전략 태그.
- `section.recent_events.map` (L342, HandoffList) — handoff 이벤트, 필터 가능하나 keeper_name 외에는 trace_id hex만.

Recent Verdicts는 가장 많은 field 다양성과 가장 긴 축적 수를 가진 리스트이며, 운영자가 "알파 agent 최근 reject만 보고 싶다" 같은 조회 요구가 가장 빈번한 표면입니다.

## 변경

- `filterVerdicts(items, query)` 순수 함수를 `harness-health-sections.ts` 에서 export. case-insensitive substring.
  - `task_title` → `task_id` → `agent_name` → `gate` → `evaluator_cascade` → `verdict` 순으로 OR 매칭.
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지 → `useMemo` 재계산 없음.
- 입력 비변이 (`readonly HarnessVerdictItem[]`).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 실제 비어있음(`최근 평가 판정이 없습니다.`) 과 구분.
- 검색 input은 리스트가 비어있지 않을 때만 표시 (verdict 한 건이라도 있을 때만).
- 한국어 placeholder: `task / agent / gate / cascade 필터`.
- 컴포넌트 내부에서 `useSignal('')` 로 query 상태를 소유 — 부모 `harness-health.ts` 는 수정 불필요.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/harness-health-sections.test.ts`: 65/65 pass (기존 53 + 신규 12).
- `pnpm exec eslint .`: 0 errors.

신규 12건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. `task_title` substring 매칭 (case-insensitive)
4. `agent_name` substring 매칭
5. `gate` substring → 여러 행 매칭
6. `evaluator_cascade` substring 매칭
7. `verdict` substring 매칭 (reject 키워드)
8. `task_id` substring 매칭
9. no-match → 빈 배열
10. trim 적용
11. 입력 비변이
12. 빈 문자열 필드 안전 처리

## CI 관련

Main CI는 현재 GREEN. Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트 (`GateChart`, `PreCompactList`, `HandoffList`, 그리고 중첩 `strategies`) 는 건드리지 않음. 상위 `harness-health.ts` 도 건드리지 않음 (query state를 컴포넌트 내부로 encapsulation). iter-7/8/9/11/12 seed-hint 패턴 유지.