### PR TITLE
feat(dashboard): add field/label/state/meaning filter to fsm-hub-pipeline-panels

### DIFF
--- a/dashboard/src/components/fsm-hub-pipeline-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ObservedLaneSummary } from './fsm-hub-types'
+import { filterObservedLanes } from './fsm-hub-pipeline-panels'
+
+function makeLane(overrides: Partial<ObservedLaneSummary> = {}): ObservedLaneSummary {
+  return {
+    field: 'KTC',
+    label: '턴 주기',
+    value: 'idle',
+    tone: 'info',
+    stalled: false,
+    meaning: 'Waiting for the next heartbeat cycle',
+    observedForSec: 12,
+    transitionCount: 1,
+    ...overrides,
+  }
+}
+
+describe('filterObservedLanes', () => {
+  const lanes: ObservedLaneSummary[] = [
+    makeLane({ field: 'KTC', label: '턴 주기', value: 'idle', meaning: 'Waiting for the next heartbeat cycle' }),
+    makeLane({ field: 'KDP', label: '의사결정', value: 'guard_ok', meaning: 'All safety guards passed' }),
+    makeLane({ field: 'KCL', label: '캐스케이드', value: 'trying', meaning: 'Attempting inference with the selected provider' }),
+    makeLane({ field: 'KMC', label: '컨텍스트 압축', value: 'accumulating', meaning: 'Collecting messages' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterObservedLanes(lanes, '')).toBe(lanes)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterObservedLanes(lanes, '   ')).toBe(lanes)
+  })
+
+  it('matches by field substring (case-insensitive)', () => {
+    const result = filterObservedLanes(lanes, 'kcl')
+    expect(result.map(l => l.field)).toEqual(['KCL'])
+  })
+
+  it('matches by label substring (Korean)', () => {
+    const result = filterObservedLanes(lanes, '캐스케이드')
+    expect(result.map(l => l.field)).toEqual(['KCL'])
+  })
+
+  it('matches by value substring', () => {
+    const result = filterObservedLanes(lanes, 'trying')
+    expect(result.map(l => l.field)).toEqual(['KCL'])
+  })
+
+  it('matches by meaning substring', () => {
+    const result = filterObservedLanes(lanes, 'heartbeat')
+    expect(result.map(l => l.field)).toEqual(['KTC'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterObservedLanes(lanes, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterObservedLanes(lanes, '  KCL  ').map(l => l.field)).toEqual(['KCL'])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = lanes.slice()
+    filterObservedLanes(lanes, 'trying')
+    expect(lanes).toEqual(copy)
+  })
+
+  it('handles lanes with empty meaning safely', () => {
+    const input: ObservedLaneSummary[] = [makeLane({ field: 'KSM', label: 'phase', value: 'Stable', meaning: '' })]
+    expect(filterObservedLanes(input, 'KSM')).toHaveLength(1)
+    expect(filterObservedLanes(input, 'anything-else')).toHaveLength(0)
+  })
+})

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -6,6 +6,7 @@ import type { KeeperCompositeSnapshot } from '../api/keeper'
 import {
   type CompositeObservation,
   type InsightTone,
+  type ObservedLaneSummary,
   type StateEntries,
   fmtDuration,
   displayState,
@@ -15,6 +16,36 @@ import { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
 import { deriveSwimlaneSegments } from './fsm-hub-derivations'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
+
+/**
+ * Pure filter for observed lane summaries shown in the Operator Meaning
+ * grid (KTC/KDP/KCL/KMC + phase lanes).
+ *
+ * Case-insensitive substring match on `lane.field`, `lane.label`,
+ * `lane.value`, and `lane.meaning` in that order so operators can isolate
+ * one sub-FSM by its short code (`KCL`), by its Korean label
+ * (`캐스케이드`), by the current state value (`trying`, `idle`), or by a
+ * keyword in the explanatory meaning.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * `useMemo` keeps referential equality for the non-filtering path.
+ *
+ * Input is never mutated.
+ */
+export function filterObservedLanes(
+  lanes: readonly ObservedLaneSummary[],
+  query: string,
+): readonly ObservedLaneSummary[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return lanes
+  return lanes.filter(lane => {
+    if (lane.field.toLowerCase().includes(needle)) return true
+    if (lane.label.toLowerCase().includes(needle)) return true
+    if (lane.value.toLowerCase().includes(needle)) return true
+    if (lane.meaning.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 const INSIGHT_BADGE_CLS: Record<InsightTone, string> = {
   ok: 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]',
@@ -47,6 +78,13 @@ export function OperationalMeaningPanel({
   const panelCls = INSIGHT_PANEL_CLS[insight.tone]
   const isAlarm = insight.tone === 'warn' || insight.tone === 'error'
 
+  const [query, setQuery] = useState('')
+  const visibleLanes = useMemo(
+    () => filterObservedLanes(lanes, query),
+    [lanes, query],
+  )
+  const isFiltering = query.trim() !== ''
+
   return html`
     <div
       class=${`rounded-xl border p-4 transition-colors duration-300 ${panelCls}`}
@@ -76,24 +114,42 @@ export function OperationalMeaningPanel({
         `)}
       </div>
 
-      <div class="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-5">
-        ${lanes.map(lane => html`
-          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-            <div class="flex items-center justify-between gap-2">
-              <span class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
-              <span class=${`rounded-full border px-1.5 py-0.5 text-[8px] font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
-                ${fmtDuration(lane.observedForSec)}
-              </span>
-            </div>
-            <div class="mt-1 font-mono text-[13px] font-semibold text-[var(--text-strong)]">${lane.value}</div>
-            <div class="mt-0.5 text-[9px] text-[var(--text-dim)]">${lane.label}</div>
-            <div class="mt-1.5 text-[9px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
-            <div class="mt-1 text-[8px] font-mono text-[var(--text-dim)]">
-              ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
-            </div>
-          </div>
-        `)}
+      <div class="mt-4 flex items-center justify-between gap-2">
+        <div class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          관찰 레인
+        </div>
+        <input
+          type="search"
+          value=${query}
+          placeholder="field / label / state / meaning 필터"
+          aria-label="관찰 레인 필터"
+          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+          class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
       </div>
+
+      ${isFiltering && visibleLanes.length === 0 && lanes.length > 0
+        ? html`<div class="mt-2 py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${lanes.length} lanes)</div>`
+        : html`
+          <div class="mt-2 grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+            ${visibleLanes.map(lane => html`
+              <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+                <div class="flex items-center justify-between gap-2">
+                  <span class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
+                  <span class=${`rounded-full border px-1.5 py-0.5 text-[8px] font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
+                    ${fmtDuration(lane.observedForSec)}
+                  </span>
+                </div>
+                <div class="mt-1 font-mono text-[13px] font-semibold text-[var(--text-strong)]">${lane.value}</div>
+                <div class="mt-0.5 text-[9px] text-[var(--text-dim)]">${lane.label}</div>
+                <div class="mt-1.5 text-[9px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
+                <div class="mt-1 text-[8px] font-mono text-[var(--text-dim)]">
+                  ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
+                </div>
+              </div>
+            `)}
+          </div>
+        `}
     </div>
   `
 }


### PR DESCRIPTION
## 요약

`fsm-hub-pipeline-panels.ts` 의 **OperationalMeaningPanel** 관찰 레인 그리드 (`lanes.map`, KTC/KDP/KCL/KMC + phase, 총 5 카드) 에 자유 텍스트 필터를 추가합니다. 모든 lane이 active인 keeper에서는 그리드가 밀집해, 특정 sub-FSM 한 장만 보거나 `trying`/`Overflowed` 같은 특정 state에 걸친 lane만 추리는 데 전체 카드를 스캔해야 했습니다.

## 왜 이 리스트인가

`fsm-hub-pipeline-panels.ts` 의 4개 `.map` 사이트:

- `insight.evidence.map` (line 72) — 작은 badge string 모음, 카디널리티가 적고 필터 가치가 낮음
- **`lanes.map` (line 80, OperationalMeaningPanel 그리드)** — **5 카드, `field`/`label`/`value`/`meaning` 4 필드, 가장 구조가 풍부** ← 선택
- `bars.map` (line 151, PhaseSparkline SVG) — 시각 primitive, 필터 대상 아님
- TurnPipelineStrip의 4 고정 step — `.map`이 아니라 컴포넌트 호출 4번 고정

`lanes.map` 만이 자유 텍스트 substring 매칭이 의미 있는 구조(field/label/value/meaning)를 갖고 있습니다.

## 변경

- `filterObservedLanes(lanes, query)` 순수 함수를 `fsm-hub-pipeline-panels.ts` 에서 export. case-insensitive substring.
  - `lane.field` (e.g. `KCL`), `lane.label` (e.g. `캐스케이드`), `lane.value` (e.g. `trying`, `idle`), `lane.meaning` (설명 텍스트) 순서로 매칭. first match wins.
- 빈/공백 query 는 입력 참조 그대로 반환 → `useMemo` identity 유지.
- 입력 비변이 (`readonly ObservedLaneSummary[]`).
- 필터가 모든 카드를 숨기면 별도 empty-state: `필터 결과 없음 (N lanes)`.
- 한국어 placeholder: `field / label / state / meaning 필터`.
- Panel 내 다른 요소 (headline, detail, Next step, evidence badges) 는 필터 대상 아님 — 이 영역은 lane 집계의 상위 요약이므로 함께 숨기면 맥락이 사라짐.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/fsm-hub-pipeline-panels.test.ts`: 10/10 pass.
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. `field` substring case-insensitive 매칭
4. `label` 한국어 매칭 (`캐스케이드`)
5. `value` substring 매칭 (`trying`)
6. `meaning` substring 매칭 (`heartbeat`)
7. no-match → 빈 배열
8. trim 적용
9. 입력 비변이
10. 빈 `meaning` 안전 처리

## CI 관련

Main CI는 현재 GREEN. Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정 (`fsm-hub-pipeline-panels.ts`, `fsm-hub-pipeline-panels.test.ts`). `fsm-hub.ts` (iter23 #7878) 와 `fsm-hub-timeline-panels.ts` (iter26 #7886) 는 건드리지 않음. iter-7/8/9/11/12/23/26 seed-hint 패턴 유지.