### PR TITLE
feat(autoresearch): Implement CSV export for Autoresearch audit logs

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -510,6 +510,11 @@ export function Autoresearch() {
           <${StartFormButton}
             class="px-2.5 py-1 rounded text-[11px] text-accent border border-accent/40 hover:bg-[var(--accent-10)] transition-colors"
           />
+          <a href="/api/v1/autoresearch/loops/csv" download="autoresearch_loops.csv"
+            class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
+          >
+            CSV 다운로드
+          </a>
           <button type="button"
             class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
             onClick=${() => { void refreshAutoresearchSurface() }}

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -219,6 +219,92 @@ let autoresearch_loops_json ~(base_path : string) : Yojson.Safe.t =
       ("total", `Int (List.length sorted));
     ]
 
+let escape_csv s =
+  let s = String.concat "\"\"" (String.split_on_char '"' s) in
+  "\"" ^ s ^ "\""
+
+let json_string_safe json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> escape_csv s
+  | `Null -> ""
+  | _ -> ""
+
+let json_number_safe json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> string_of_int i
+  | `Float f -> Printf.sprintf "%.4f" f
+  | `Null -> ""
+  | _ -> ""
+
+let json_bool_safe json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> string_of_bool b
+  | `Null -> ""
+  | _ -> ""
+
+let autoresearch_loops_csv ~(base_path : string) : string =
+  let active_entries =
+    Autoresearch.with_loops_ro (fun () ->
+      Hashtbl.fold
+        (fun _id (state : Autoresearch_types.loop_state) acc ->
+          match safe_active_entry_json ~base_path state with
+          | Some entry -> entry :: acc
+          | None -> acc)
+        Autoresearch.active_loops [])
+  in
+  let active_ids =
+    List.map (fun (id, _, _) -> id) active_entries
+  in
+  let persisted_ids =
+    Autoresearch.scan_persisted_loop_ids ~base_path
+    |> List.filter (fun id -> not (List.mem id active_ids))
+  in
+  let persisted_entries =
+    List.filter_map
+      (fun loop_id ->
+        match Autoresearch.load_state ~base_path loop_id with
+        | Some summary -> safe_persisted_entry_json ~base_path summary
+        | None -> None)
+      persisted_ids
+  in
+  let all = active_entries @ persisted_entries in
+  let sorted =
+    List.sort
+      (fun (_, a, _) (_, b, _) ->
+        let by_live = Int.compare a.live_rank b.live_rank in
+        if by_live <> 0 then by_live
+        else
+        let by_status = Int.compare a.status_rank b.status_rank in
+        if by_status <> 0 then by_status
+        else Float.compare a.neg_updated_at b.neg_updated_at)
+      all
+  in
+  let headers = "loop_id,author,goal,metric_fn,model_model,target_file,status,current_cycle,max_cycles,baseline,best_score,best_cycle,total_keeps,total_discards,elapsed_s,updated_at,live\n" in
+  let rows =
+    List.map (fun (_, _, json) ->
+      String.concat "," [
+        json_string_safe json "loop_id";
+        json_string_safe json "author";
+        json_string_safe json "goal";
+        json_string_safe json "metric_fn";
+        json_string_safe json "model_model";
+        json_string_safe json "target_file";
+        json_string_safe json "status";
+        json_number_safe json "current_cycle";
+        json_number_safe json "max_cycles";
+        json_number_safe json "baseline";
+        json_number_safe json "best_score";
+        json_number_safe json "best_cycle";
+        json_number_safe json "total_keeps";
+        json_number_safe json "total_discards";
+        json_number_safe json "elapsed_s";
+        json_number_safe json "updated_at";
+        json_bool_safe json "live";
+      ] ^ "\n"
+    ) sorted
+  in
+  headers ^ String.concat "" rows
+
 (** Build the loop detail JSON for GET /api/v1/autoresearch/loops/:loopId.
     Includes full cycle history. *)
 let autoresearch_loop_detail_json ~(base_path : string)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -627,6 +627,22 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/autoresearch/loops/csv" ->
+          let state = get_server_state () in
+          let base_path = state.Mcp_server.room_config.base_path in
+          let csv = Dashboard_http_autoresearch.autoresearch_loops_csv ~base_path in
+          let headers =
+            H2.Headers.of_list
+              [
+                ("content-type", "text/csv; charset=utf-8");
+                ("content-disposition", "attachment; filename=\"autoresearch_loops.csv\"");
+              ]
+          in
+          let response = H2.Response.create ~headers `OK in
+          let body = H2.Reqd.respond_with_streaming h2_reqd response in
+          H2.Body.Writer.write_string body csv;
+          H2.Body.Writer.close body
+
       | `GET, p when String.length p > 27
                    && String.sub p 0 27 = "/api/v1/autoresearch/loops/" ->
           let state = get_server_state () in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -660,6 +660,22 @@ and add_autoresearch_routes router =
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  (* Autoresearch loops CSV export *)
+  |> Http.Router.get "/api/v1/autoresearch/loops/csv" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let csv = Dashboard_http_autoresearch.autoresearch_loops_csv ~base_path in
+         let headers =
+           Httpun.Headers.of_list
+             [
+               ("content-type", "text/csv; charset=utf-8");
+               ("content-disposition", "attachment; filename=\"autoresearch_loops.csv\"");
+             ]
+         in
+         let response = Httpun.Response.create ~headers `OK in
+         Httpun.Reqd.respond_with_string reqd response csv
+       ) request reqd)
+
   (* Autoresearch loop detail -- single loop with full cycle history *)
   |> Http.Router.prefix_get "/api/v1/autoresearch/loops/" (fun request reqd ->
        with_public_read (fun state req reqd ->


### PR DESCRIPTION
## Description
Enterprise Improvement: Add a CSV export feature for Autoresearch audit logs. Provide an endpoint and a UI button in the dashboard to download a CSV containing the history, cost, performance metrics, and decisions of all or filtered loops for reporting purposes.

## Changes
- Built `autoresearch_loops_csv` in `Dashboard_http_autoresearch.ml` which streams active and persisted loop summaries into a CSV string.
- Registered `/api/v1/autoresearch/loops/csv` handler returning `text/csv` and `attachment` Content-Disposition.
- Included an `<a>` element with `download` attribute in the Dashboard frontend for one-click access.

Fixes MASC Issue task-207