### PR TITLE
fix(board): start flusher actor when jsonl backend activates

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -35,6 +35,28 @@ type board_sse_event =
   | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
 
 let backend_state : backend_state Atomic.t = Atomic.make Uninitialized
+let flusher_started : bool Atomic.t = Atomic.make false
+
+let start_flusher_actor ~sw store =
+  Eio.Fiber.fork ~sw (fun () ->
+    Log.BoardLog.info "Board flusher actor started";
+    while true do
+      match Eio.Stream.take store.Board.flusher_inbox with
+      | Board_types.Flush ->
+          (try Board.flush_dirty store
+           with exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
+      | Board_types.Sweep ->
+          (try ignore (Board.sweep store)
+           with exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
+    done
+  )
+
+let ensure_flusher_actor store =
+  match Eio_context.get_switch_opt () with
+  | None -> ()
+  | Some sw ->
+      if Atomic.compare_and_set flusher_started false true then
+        start_flusher_actor ~sw store
 
 
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option Atomic.t = Atomic.make None
@@ -66,15 +88,18 @@ let init_jsonl () =
   if match Atomic.get backend_state with Active _ -> true | Uninitialized -> false then
     Log.BoardLog.warn "already initialized, ignoring init_jsonl"
   else begin
-    let backend = Active (Jsonl (Board.global ())) in
-    if Atomic.compare_and_set backend_state Uninitialized backend then
+    let store = Board.global () in
+    let backend = Active (Jsonl store) in
+    if Atomic.compare_and_set backend_state Uninitialized backend then begin
+      ensure_flusher_actor store;
       Log.BoardLog.info "JSONL backend initialized"
-    else
+    end else
       Log.BoardLog.warn "already initialized concurrently, ignoring init_jsonl"
   end
 
 let reset_for_test () =
-  Atomic.set backend_state Uninitialized
+  Atomic.set backend_state Uninitialized;
+  Atomic.set flusher_started false
 
 let jsonl_forced () =
   match Env_config.Board.backend_opt () with
@@ -83,15 +108,22 @@ let jsonl_forced () =
 
 let backend () =
   match Atomic.get backend_state with
-  | Active backend -> backend
+  | Active (Jsonl store as backend) ->
+      ensure_flusher_actor store;
+      backend
   | Uninitialized ->
       Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
-      let b = Jsonl (Board.global ()) in
+      let store = Board.global () in
+      let b = Jsonl store in
       let backend_val = Active b in
       let _ = Atomic.compare_and_set backend_state Uninitialized backend_val in
       match Atomic.get backend_state with
-      | Active active_b -> active_b
-      | Uninitialized -> b
+      | Active (Jsonl active_store as active_b) ->
+          ensure_flusher_actor active_store;
+          active_b
+      | Uninitialized ->
+          ensure_flusher_actor store;
+          b
 
 let sort_posts_in_memory ~sort_by (posts : Board.post list) =
   match sort_by with
@@ -369,19 +401,3 @@ let backend_name () =
   match Atomic.get backend_state with
   | Active (Jsonl _) -> "jsonl"
   | Uninitialized -> "uninitialized"
-
-let start_flusher_actor ~sw =
-  match backend () with
-  | Jsonl store ->
-      Eio.Fiber.fork ~sw (fun () ->
-        Log.BoardLog.info "Board flusher actor started";
-        while true do
-          match Eio.Stream.take store.flusher_inbox with
-          | Board_types.Flush ->
-              (try Board.flush_dirty store
-               with exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
-          | Board_types.Sweep ->
-              (try ignore (Board.sweep store)
-               with exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
-        done
-      )

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -356,6 +356,52 @@ let test_vote_flip () =
       | Ok score ->
           Alcotest.(check int) "score after flip" (-1) score
 
+let test_vote_persisted_by_flusher_actor () =
+  try
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    let clock = Eio.Stdenv.clock env in
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    Eio_context.with_test_env
+      ~net:(Eio.Stdenv.net env)
+      ~clock
+      ~mono_clock:(Eio.Stdenv.mono_clock env)
+      ~sw
+      (fun () ->
+        ignore (fresh_test_base_path ());
+        Board.reset_global_for_test ();
+        Board_dispatch.reset_for_test ();
+        Board_dispatch.init_jsonl ();
+        let post_id =
+          match
+            Board_dispatch.create_post ~author:"persist-test" ~content:"persist my vote"
+              ~post_kind:Board.Human_post ()
+          with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok post -> Board.Post_id.to_string post.id
+        in
+        (match Board_dispatch.vote ~voter:"judge" ~post_id ~direction:Board.Up with
+         | Error e -> Alcotest.fail (Board.show_board_error e)
+         | Ok _ -> ());
+        let store =
+          match Board_dispatch.backend () with
+          | Board_dispatch.Jsonl store -> store
+        in
+        store.last_flush <- 0.0;
+        (match Board_dispatch.get_post ~post_id with
+         | Ok _ -> ()
+         | Error e -> Alcotest.fail (Board.show_board_error e));
+        Eio.Time.sleep clock 0.1;
+        Board.reset_global_for_test ();
+        Board_dispatch.reset_for_test ();
+        Board_dispatch.init_jsonl ();
+        (match Board_dispatch.get_post ~post_id with
+         | Error e -> Alcotest.fail (Board.show_board_error e)
+         | Ok post ->
+             Alcotest.(check int) "vote persisted after restart" 1 post.votes_up);
+        Eio.Switch.fail sw Exit)
+  with Exit -> ()
+
 (** {1 Stats / Search / Hearth} *)
 
 let test_stats () =
@@ -472,6 +518,8 @@ let () =
       Alcotest.test_case "upvote" `Quick (with_eio test_vote_post);
       Alcotest.test_case "dedup" `Quick (with_eio test_vote_dedup);
       Alcotest.test_case "flip" `Quick (with_eio test_vote_flip);
+      Alcotest.test_case "vote persisted by flusher actor" `Quick
+        test_vote_persisted_by_flusher_actor;
     ];
     "misc", [
       Alcotest.test_case "stats" `Quick (with_eio test_stats);


### PR DESCRIPTION
## Summary

Start the board flusher actor as part of JSONL backend activation instead of only defining the actor loop. Also add a regression test that proves vote state survives a restart once deferred flush is armed.

## Product impact

Without this fix, merged PR #7809 leaves `main` in a state where deferred board flush and TTL sweep never start. That can strand dirty vote/comment state in memory and keep expired rows from being swept.

## Evidence

- `main` commit `7559ca44ef266cf7a0241aab59f7d8ad64c29b0f` adds `start_flusher_actor` but never calls it from `init_jsonl` or `backend()`.
- This patch wires actor startup to backend activation and resets the startup guard in test resets.
- Added regression test: `vote persisted by flusher actor` in `test/test_board_dispatch.ml`.

## Review evidence

- `opam exec -- dune build --build-dir _build_pr7809 --root . test/test_board_dispatch.exe`
- `_build_pr7809/default/test/test_board_dispatch.exe test --compact`

## Linked issue

Closes #7910
