### PR TITLE
feat(dashboard): add name/model/runtime filter to keeper groups in connector-status

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -577,3 +577,127 @@ describe('ConnectorStatusPanel', () => {
     expect(novaText).toContain('runtime keeper-nova-agent')
   })
 })
+
+describe('filterKeeperGroups', () => {
+  // Shape-compatible sample. `filterKeeperGroups` only reads `name` and
+  // `keeper.{active_model, model, primary_model, agent_name}` so bindings
+  // are allowed to be empty and `unknown` never matters.
+  type GroupLike = {
+    name: string
+    keeper: {
+      name: string
+      active_model?: string
+      model?: string
+      primary_model?: string
+      agent_name?: string
+    } | null
+    bindings: Array<{ channel_id: string; keeper_name: string }>
+    unknown: boolean
+  }
+
+  function group(
+    name: string,
+    keeper: GroupLike['keeper'] = { name },
+  ): GroupLike {
+    return { name, keeper, bindings: [], unknown: false }
+  }
+
+  async function loadFilter() {
+    // Fresh module — other tests may have mocked api/gate etc. We don't
+    // need any mocks here; a raw re-import is fine.
+    vi.resetModules()
+    const module = await import('./connector-status')
+    return module.filterKeeperGroups as (
+      groups: readonly GroupLike[],
+      query: string,
+    ) => readonly GroupLike[]
+  }
+
+  it('returns the input reference unchanged for empty query', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('nova'), group('luna')]
+    expect(filterKeeperGroups(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference unchanged for whitespace-only query', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('nova')]
+    expect(filterKeeperGroups(rows, '   ')).toBe(rows)
+  })
+
+  it('matches on name case-insensitively', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('Nova'), group('luna'), group('atlas')]
+    const filtered = filterKeeperGroups(rows, 'NOVA')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.name).toBe('Nova')
+  })
+
+  it('matches on active_model via substring', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [
+      group('nova', { name: 'nova', active_model: 'gemini-2.5-flash' }),
+      group('luna', { name: 'luna', active_model: 'claude-opus-4' }),
+    ]
+    const filtered = filterKeeperGroups(rows, 'gemini')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.name).toBe('nova')
+  })
+
+  it('falls back from active_model to model when active_model is empty', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [
+      group('nova', { name: 'nova', active_model: '   ', model: 'gemini-flash' }),
+    ]
+    const filtered = filterKeeperGroups(rows, 'gemini')
+    expect(filtered).toHaveLength(1)
+  })
+
+  it('matches on agent_name runtime label when distinct from keeper name', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [
+      group('nova', { name: 'nova', agent_name: 'keeper-nova-agent' }),
+    ]
+    expect(filterKeeperGroups(rows, 'keeper-nova-agent')).toHaveLength(1)
+  })
+
+  it('does not match agent_name when it equals the keeper name', async () => {
+    // Runtime label helper returns '' when agent_name === name, so the
+    // query should not match via the runtime field. It still matches on
+    // the name field itself.
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('nova', { name: 'nova', agent_name: 'nova' })]
+    expect(filterKeeperGroups(rows, 'nova')).toHaveLength(1)
+    // But a query targeting only the runtime label must miss when no
+    // fields contain it.
+    const onlyRuntime = [
+      group('nova', { name: 'nova', agent_name: 'nova' }),
+    ]
+    expect(filterKeeperGroups(onlyRuntime, 'keeper-nova-agent')).toEqual([])
+  })
+
+  it('returns an empty array when no rows match', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('nova'), group('luna')]
+    expect(filterKeeperGroups(rows, 'nonexistent-zzz')).toEqual([])
+  })
+
+  it('handles null keeper (unknown groups) without throwing', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows: GroupLike[] = [
+      { name: 'ghost', keeper: null, bindings: [], unknown: true },
+    ]
+    expect(filterKeeperGroups(rows, 'ghost')).toHaveLength(1)
+    // Model and runtime are empty for null keeper — only name matches.
+    expect(filterKeeperGroups(rows, 'gemini')).toEqual([])
+  })
+
+  it('does not mutate the input array', async () => {
+    const filterKeeperGroups = await loadFilter()
+    const rows = [group('nova'), group('luna'), group('atlas')]
+    const originalOrder = rows.map(r => r.name)
+    filterKeeperGroups(rows, 'luna')
+    expect(rows.map(r => r.name)).toEqual(originalOrder)
+    expect(rows).toHaveLength(3)
+  })
+})

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -113,6 +113,39 @@ const actionLoading = signal(false)
 const channelDraft = signal('')
 const expandedKeeperFor = signal<string | null>(null)
 const headerExpanded = signal(false)
+const keeperGroupQuery = signal('')
+
+/**
+ * Pure filter for keeper groups rendered in the "Keeper-first" panel.
+ *
+ * Case-insensitive substring match on `group.name`, the keeper's
+ * resolved model label (active_model / model / primary_model), and
+ * the keeper's resolved runtime label (agent_name when distinct from
+ * name). Operators on a crowded connector can locate a keeper by
+ * partial name, by the model it is running, or by its runtime agent.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no
+ * new array allocation, preserves referential equality).
+ *
+ * Input is never mutated. `unknown` keeper groups are surfaced
+ * separately below this panel, so the filter only applies to the
+ * `knownGroups` array — matching what the operator can see.
+ */
+export function filterKeeperGroups(
+  groups: readonly KeeperGroup[],
+  query: string,
+): readonly KeeperGroup[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return groups
+  return groups.filter(group => {
+    if (group.name.toLowerCase().includes(needle)) return true
+    const model = modelLabelForKeeper(group.keeper).toLowerCase()
+    if (model !== '' && model.includes(needle)) return true
+    const runtime = runtimeLabelForKeeper(group.keeper).toLowerCase()
+    if (runtime !== '' && runtime.includes(needle)) return true
+    return false
+  })
+}
 
 type ConnectorStatusSnapshot = {
   gate: GateStatusData | null
@@ -482,6 +515,10 @@ function ConnectorLivePanel({
     unknownGroups.push({ name, keeper: null, bindings, unknown: true })
   }
 
+  const keeperQuery = keeperGroupQuery.value
+  const visibleKnownGroups = filterKeeperGroups(knownGroups, keeperQuery)
+  const isFilteringKeepers = keeperQuery.trim() !== ''
+
   const browserDot: LivenessDot = {
     label: 'Browser → Server',
     state: connectorError ? 'down' : 'ok',
@@ -718,7 +755,21 @@ function ConnectorLivePanel({
       ${knownGroups.length > 0
         ? html`
             <div class="mt-3 space-y-2" id=${`keepers-${connectorId}`}>
-              ${knownGroups.map(group => {
+              <div class="flex items-center justify-end">
+                <input
+                  type="search"
+                  value=${keeperQuery}
+                  placeholder="keeper / model / runtime 필터"
+                  aria-label="Keeper 필터"
+                  data-testid=${`keeper-filter-${connectorId}`}
+                  onInput=${(e: Event) => { keeperGroupQuery.value = (e.target as HTMLInputElement).value }}
+                  class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                />
+              </div>
+              ${isFilteringKeepers && visibleKnownGroups.length === 0
+                ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${knownGroups.length} keepers)</div>`
+                : null}
+              ${visibleKnownGroups.map(group => {
                 const keeper = group.keeper
                 const expanded = expandedKeeperFor.value === group.name
                 const toggleExpand = () => {
@@ -1243,4 +1294,5 @@ export function resetConnectorStatusState() {
   channelDraft.value = ''
   expandedKeeperFor.value = null
   headerExpanded.value = false
+  keeperGroupQuery.value = ''
 }


### PR DESCRIPTION
## 요약

`connector-status.ts` 의 **Keeper-first 그룹 리스트** (`knownGroups`) 에 자유 텍스트 필터를 추가합니다. 커넥터 페이지에 keeper가 많을수록 Keeper-first 섹션이 길어지는데, 특정 keeper 이름, 실행 중인 model 변형, 또는 runtime agent 이름으로 한 줄을 찾을 방법이 없었습니다.

Supersedes #7853 (closed due to stale base; 1018-LOC fork of `connector-status.ts` couldn't rebase onto 1246-LOC current main).

## 왜 이 리스트인가

`connector-status.ts` 의 15개 `.map` 사이트:

- `gate.bindings.map` (line 456) — 필터 소스, connector channel로 축소. 리스트 아님.
- `gate.recent_events.map` (line 459) — 동일.
- `configuredBindings.map` (line 460) — 소수.
- `keepers.map` (line 472/473) — **`knownGroups` 구축 베이스**.
- `livenessDots.map` (line 639) — 고정 2-3개, 필터 의미 없음.
- **`knownGroups.map` (line 721)** — **커넥터당 표시되는 keeper 그룹, 카디널리티 가장 큼, `name`/`model`/`runtime` 3 필드 검색 가능** ← 선택
- `group.bindings.map` (line 751, 853) — 그룹 내 채널, 소수.
- `observedRooms.slice(0, 8).map` (line 804) — 상위 8개만, 이미 제한됨.
- `unknownGroups.map` (line 843) — 이미 별도 "예상치 못한 keeper" 표면.
- `visibleConnectors.map` (line 1154) — 이미 `activeConnectorFilter()` + URL sub-section으로 필터 됨.
- `d.bindings.slice(0, 6).map` / `d.recent_events.slice(0, 8).map` (line 1208, 1221) — 이미 상위 N개 제한.
- `d.channels.map` (line 1231) — 커넥터당 수 적음(4개 전후), 필터 이득 적음.

Keeper 그룹은 파일 헤더 주석(`Keeper-first layout`)이 명시하는 주요 조직 단위이자 유일하게 flotilla 규모로 확장되는 리스트입니다. `visibleConnectors` 는 URL 기반으로 이미 필터링되고, `d.channels` 는 per-connector로 스케일하지 않습니다.

Runners-up: `d.channels` (이전 #7853 이 선택). 현재 main 기준으론 커넥터당 카디널리티가 낮아 keeper 그룹이 우위.

## 변경

- `filterKeeperGroups(groups, query)` 순수 함수를 `connector-status.ts` 에서 export.
  - Case-insensitive substring match on `group.name`, resolved model label (`active_model` → `model` → `primary_model`), resolved runtime label (`agent_name` when distinct from `name`).
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지.
- 입력 비변이 (`readonly KeeperGroup[]`).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N keepers)`.
- `knownGroups` 만 필터링 — `unknownGroups` 는 이미 별도 "예상치 못한 keeper" 섹션이라 원본 유지.
- `resetConnectorStatusState` 에 `keeperGroupQuery` 초기화 추가 (테스트 격리 + 커넥터 전환 초기화).
- 검색 input은 `knownGroups.length > 0` 일 때만 표시(이미 감싸고 있는 `knownGroups.length > 0` 가드 내부).
- 한국어 placeholder: `keeper / model / runtime 필터`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/connector-status.test.ts`: 21/21 pass (기존 11 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. case-insensitive (`name`)
4. `active_model` substring 매칭
5. `active_model` 빈 문자열일 때 `model` 로 fallback
6. `agent_name` runtime 매칭
7. `agent_name === name` 이면 runtime 매칭 제외(여전히 name으로 매칭)
8. no-match → 빈 배열
9. null keeper (unknown 그룹) — name 매칭만, model/runtime 공백
10. 입력 비변이

## CI 관련

Main CI는 현재 GREEN. Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트(`visibleConnectors`, `d.channels`, `d.bindings`, `d.recent_events`, `group.bindings`, `unknownGroups`) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.