### PR TITLE
fix(keeper-supervisor): swallow finally cleanup exceptions to prevent Fun.Finally_raised server crash

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -147,34 +147,46 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                publish_lifecycle ~phase:Keeper_state_machine.Crashed
                  "crashed" meta.name reason ()))
       ~finally:(fun () ->
-        Keeper_registry.cleanup_tracking ~base_path meta.name;
-        if not !resolved then begin
-          if Shutdown.is_shutting_down_global () then begin
-            Log.Keeper.warn "%s: fiber unresolved during shutdown (not a crash)" meta.name;
-            Keeper_registry.mark_dead ~base_path meta.name
-              ~at:(Time_compat.now ());
-            ignore (resolve_done (`Crashed "shutdown"))
-          end else begin
-            let reason =
-              Keeper_registry.failure_reason_to_string
-                Keeper_registry.Fiber_unresolved in
-            Keeper_registry.set_failure_reason ~base_path meta.name
-              (Some Keeper_registry.Fiber_unresolved);
-            let ts = Time_compat.now () in
-            Keeper_registry.record_crash ~base_path
-              meta.name ts reason;
-            let rc = match Keeper_registry.get ~base_path meta.name with
-              | Some e -> e.restart_count | None -> 0 in
-            Keeper_crash_persistence.enqueue_record ~keepers_dir
-              ~name:meta.name ~ts ~reason ~restart_count:rc;
-            Keeper_registry.record_error ~base_path meta.name reason;
-            ignore (Keeper_registry.dispatch_event ~base_path meta.name
-              (Keeper_state_machine.Fiber_terminated { outcome = reason }));
-            if resolve_done (`Crashed reason) then
-              publish_lifecycle ~phase:Keeper_state_machine.Crashed
-                "crashed" meta.name reason ()
+        (* Finally runs best-effort. Any exception raised here (including
+           Eio.Cancel.Cancelled, which propagates during concurrent fiber
+           teardown) would be re-wrapped by [Fun.protect] as
+           [Fun.Finally_raised], masking the original body exception and
+           crashing the server (see masc-mcp crash 2026-04-17). Swallow
+           everything and log — cleanup is advisory, state-machine events
+           already fired on the body's happy/error paths. *)
+        try
+          Keeper_registry.cleanup_tracking ~base_path meta.name;
+          if not !resolved then begin
+            if Shutdown.is_shutting_down_global () then begin
+              Log.Keeper.warn "%s: fiber unresolved during shutdown (not a crash)" meta.name;
+              Keeper_registry.mark_dead ~base_path meta.name
+                ~at:(Time_compat.now ());
+              ignore (resolve_done (`Crashed "shutdown"))
+            end else begin
+              let reason =
+                Keeper_registry.failure_reason_to_string
+                  Keeper_registry.Fiber_unresolved in
+              Keeper_registry.set_failure_reason ~base_path meta.name
+                (Some Keeper_registry.Fiber_unresolved);
+              let ts = Time_compat.now () in
+              Keeper_registry.record_crash ~base_path
+                meta.name ts reason;
+              let rc = match Keeper_registry.get ~base_path meta.name with
+                | Some e -> e.restart_count | None -> 0 in
+              Keeper_crash_persistence.enqueue_record ~keepers_dir
+                ~name:meta.name ~ts ~reason ~restart_count:rc;
+              Keeper_registry.record_error ~base_path meta.name reason;
+              ignore (Keeper_registry.dispatch_event ~base_path meta.name
+                (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+              if resolve_done (`Crashed reason) then
+                publish_lifecycle ~phase:Keeper_state_machine.Crashed
+                  "crashed" meta.name reason ()
+            end
           end
-        end))
+        with exn ->
+          Log.Keeper.warn
+            "%s: supervisor finally cleanup failed (suppressed to avoid Fun.Finally_raised): %s"
+            meta.name (Printexc.to_string exn)))
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (meta : keeper_meta) =


### PR DESCRIPTION
## Problem

Server FATAL crash observed 2026-04-17 15:38:47:

```
[Keeper] registry: phase transition name=sangsu old=running new=crashed event=fiber_terminated(fiber_unresolved)
[Server] [FATAL] Unhandled exception: Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first
```

Stacktrace terminates at `bin/main_eio.ml:536` `Eio.Fiber.first(run_server, await_shutdown_signal)` with `Fun.protect.finally_no_exn` wrapping `Cancelled`.

## Root Cause

`lib/keeper/keeper_supervisor.ml:103` uses stdlib `Fun.protect` with a `~finally` block that performs Eio operations (`Keeper_registry.*`, `Keeper_crash_persistence.enqueue_record`, `publish_lifecycle`). When one sibling fiber wins `Fiber.first`, the supervisor fiber enters cancellation, and those Eio calls inside `~finally` re-raise `Cancelled`. `Fun.protect.finally_no_exn` re-wraps the cancellation as `Fun.Finally_raised`, masking the original body exception and crashing the server.

This is the exact pattern CLAUDE.md's `software-development.md` warns about:

> Fun.protect는 finally 예외가 원래 예외를 덮을 수 있음 (Fun.Finally_raised). Out_of_memory/Stack_overflow/비동기 예외는 보호 불가.

## Fix

Wrap the `~finally` body in `try ... with exn -> Log.Keeper.warn ...`. Cleanup is advisory (state-machine events already fire on the body's happy/error paths); best-effort semantics match the existing shutdown flow.

## Alternatives Considered

- `Switch.on_release` requires plumbing the switch through the supervisor API — higher blast radius for a hotfix.
- Explicit `try/with/cleanup` restructure without `Fun.protect` — clearer semantically but 4× code churn; keep for follow-up refactor.

## Test Plan

- `dune build` passes
- Server should log cleanup failures instead of crashing when a keeper fiber is cancelled during shutdown or sibling fiber failure
