### PR TITLE
feat(dashboard): 📍 where-to-find hints for connector credential fields

### DIFF
--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -9,6 +9,7 @@ import {
   _testParseSchema,
   _testBuildEnvBlock,
   _testIsSensitive,
+  _testGetFieldHint,
 } from './connector-config-form'
 
 const flushUi = async () => {
@@ -59,6 +60,22 @@ describe('connector-config-form pure helpers', () => {
 
     expect(block).toContain('DISCORD_BOT_TOKEN=')
     expect(block).not.toContain('GATE_TIMEOUT_SEC')
+  })
+
+  it('getFieldHint returns where-to-find guidance for known credentials, null otherwise', () => {
+    const discord = _testGetFieldHint('DISCORD_BOT_TOKEN')
+    expect(discord?.where).toContain('Discord Developer Portal')
+    expect(discord?.url).toBe('https://discord.com/developers/applications')
+
+    const slack = _testGetFieldHint('SLACK_BOT_TOKEN')
+    expect(slack?.where).toContain('xoxb')
+
+    const telegram = _testGetFieldHint('TELEGRAM_BOT_TOKEN')
+    expect(telegram?.url).toBe('https://t.me/BotFather')
+
+    // Unknown fields must not fabricate hints.
+    expect(_testGetFieldHint('GATE_BASE_URL')).toBeNull()
+    expect(_testGetFieldHint('STATUS_HEARTBEAT_SEC')).toBeNull()
   })
 
   it('isSensitive flags token/secret/password/api_key variants', () => {
@@ -264,6 +281,40 @@ describe('ConnectorConfigForm', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(5)
     expect(fetchSpy.mock.calls[3]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
     expect(fetchSpy.mock.calls[4]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
+  })
+
+  it('renders where-to-find hint block for DISCORD_BOT_TOKEN when schema contains it', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          id: 'discord',
+          schema: {
+            properties: {
+              DISCORD_BOT_TOKEN: { type: 'string' },
+              GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
+            },
+            required: ['DISCORD_BOT_TOKEN'],
+          },
+        }),
+        { status: 200 },
+      ),
+    )
+    render(html`
+      <div>
+        <${ConnectorConfigToggle} connectorId="discord" />
+        <${ConnectorConfigForm} connectorId="discord" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    const hint = container.querySelector('[data-field-hint="DISCORD_BOT_TOKEN"]')
+    expect(hint).toBeTruthy()
+    expect(hint?.textContent).toContain('Discord Developer Portal')
+    // Unknown fields stay clean — hint must not leak to GATE_BASE_URL.
+    expect(container.querySelector('[data-field-hint="GATE_BASE_URL"]')).toBeNull()
   })
 
   it('after toggle + fetch, renders required field marker and password input for token', async () => {

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -103,6 +103,42 @@ function isSensitive(name: string): boolean {
   return /token|secret|password|api[_-]?key/i.test(name)
 }
 
+// Where-to-find hints for credentials. Pydantic `description` fields cover
+// "what this is"; FIELD_HINTS covers "where do I click to obtain it" — the
+// question operators actually ask. Keys match the BotConfig field name
+// verbatim. Absent keys render nothing (no fabrication for unknown fields).
+interface FieldHint {
+  where: string
+  url?: string
+}
+
+const FIELD_HINTS: Record<string, FieldHint> = {
+  DISCORD_BOT_TOKEN: {
+    where: 'Discord Developer Portal → Applications → <your app> → Bot → Reset Token',
+    url: 'https://discord.com/developers/applications',
+  },
+  SLACK_BOT_TOKEN: {
+    where: 'Slack App → OAuth & Permissions → Bot User OAuth Token (xoxb-…)',
+    url: 'https://api.slack.com/apps',
+  },
+  SLACK_APP_TOKEN: {
+    where: 'Slack App → Basic Information → App-Level Tokens → Generate (xapp-…)',
+    url: 'https://api.slack.com/apps',
+  },
+  SLACK_SIGNING_SECRET: {
+    where: 'Slack App → Basic Information → App Credentials → Signing Secret',
+    url: 'https://api.slack.com/apps',
+  },
+  TELEGRAM_BOT_TOKEN: {
+    where: '@BotFather → /newbot (또는 기존 봇이면 /token)',
+    url: 'https://t.me/BotFather',
+  },
+}
+
+function getFieldHint(name: string): FieldHint | null {
+  return FIELD_HINTS[name] ?? null
+}
+
 function defaultToString(value: unknown): string {
   if (value === undefined || value === null) return ''
   if (typeof value === 'boolean') return value ? 'true' : 'false'
@@ -446,6 +482,26 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
             ${field.description
               ? html`<div class="text-[10px] text-[var(--text-dim)]">${field.description}</div>`
               : null}
+            ${(() => {
+              const hint = getFieldHint(field.name)
+              if (hint === null) return null
+              return html`
+                <div class="rounded border border-sky-400/20 bg-sky-500/5 px-2 py-1 text-[10px] text-sky-200" data-field-hint=${field.name}>
+                  <span class="mr-1" aria-hidden="true">📍</span>
+                  <span>${hint.where}</span>
+                  ${hint.url
+                    ? html`
+                        <a
+                          href=${hint.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="ml-1 underline hover:text-sky-100"
+                        >열기 ↗</a>
+                      `
+                    : null}
+                </div>
+              `
+            })()}
           </div>
         `)}
       </div>
@@ -488,4 +544,8 @@ export function _testBuildEnvBlock(fields: FieldShape[], values: Record<string, 
 
 export function _testIsSensitive(name: string): boolean {
   return isSensitive(name)
+}
+
+export function _testGetFieldHint(name: string): FieldHint | null {
+  return getFieldHint(name)
 }


### PR DESCRIPTION
## Problem

Operators open the connector config form and see `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, etc. — but no answer to the actual question: *"where do I click to get this?"*

Pydantic `description` is mounted in the form already; that covers **what** each field is. It does **not** tell the operator the 3-click path in the provider's UI to obtain the value.

## Change

Add a frontend-only `FIELD_HINTS` map keyed on BotConfig field names:

| Field | Where |
|-------|-------|
| `DISCORD_BOT_TOKEN` | Discord Developer Portal → Applications → <app> → Bot → Reset Token |
| `SLACK_BOT_TOKEN` | Slack App → OAuth & Permissions → Bot User OAuth Token (`xoxb-…`) |
| `SLACK_APP_TOKEN` | Slack App → Basic Information → App-Level Tokens → Generate (`xapp-…`) |
| `SLACK_SIGNING_SECRET` | Slack App → Basic Information → App Credentials → Signing Secret |
| `TELEGRAM_BOT_TOKEN` | @BotFather → /newbot (또는 /token) |

Rendered as a blue `📍` info strip directly under the input, with an optional "열기 ↗" external link.

Fields without a known hint (`GATE_BASE_URL`, `STATUS_HEARTBEAT_SEC`, …) render nothing. No fabricated guidance for unknown keys.

## Why frontend, not Pydantic

Two reasons keep these in the dashboard rather than `BotConfig` descriptions:

1. Pydantic descriptions are surfaced via `model_json_schema()` — they live with the code. URLs/UI click paths drift on the *provider* side, not ours, so they belong closer to the UI iteration loop.
2. Frontend can also render clickable links; plaintext `description` cannot.

## Tests

- `_testGetFieldHint` — pure: known field returns `{ where, url }`, unknown returns `null`.
- DOM: `[data-field-hint="DISCORD_BOT_TOKEN"]` present when schema contains the field; `[data-field-hint="GATE_BASE_URL"]` absent.

12/12 tests pass.

## Follow-ups

- iMessage uses macOS-local DB + framework permissions, not credentials — no hint needed for its fields.
- Telegram user-mode (`TELEGRAM_API_ID`/`TELEGRAM_API_HASH` via my.telegram.org) only applies if we ship a user-mode sidecar; not adding yet to avoid drift.