### PR TITLE
docs: retire team_session references in 4 last_verified: 2026-04-17 docs

### DIFF
--- a/docs/architecture-boundary.md
+++ b/docs/architecture-boundary.md
@@ -44,7 +44,6 @@ Modules where Agent_sdk usage is the core purpose. These are not MASC violations
 | Runtime | `worker_oas`, `oas_worker`, `oas_worker_exec`, `worker_run_once` |
 | Evaluation | `eval_calibration`, `eval_oas_probe` |
 | Memory | `memory_oas_bridge` |
-| Session | `team_session_oas_bridge`, `team_session_plan` |
 
 ### Bridge Files (connection points)
 
@@ -53,7 +52,6 @@ Files that explicitly bridge MASC and OAS. Named with `_oas` or `_oas_adapter` s
 | File | Purpose |
 |---|---|
 | `verifier_oas.ml` | Verification verdict to OAS Hooks/Guardrails |
-| `team_session_oas_bridge.ml` | MASC session / planned_worker projection into OAS Swarm config and agent entries (`collaboration_context` omitted by design) |
 | `context_compact_oas.ml` | Context compaction via OAS Context_reducer |
 | `keeper_hooks_oas.ml` | Keeper lifecycle hooks to OAS hooks |
 

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -481,16 +481,14 @@ Detailed implementation checklist lives in
 | `oas_worker` / `worker_oas` / `verifier_oas` | Correct | MASC consumes OAS runtime/build/hook contracts without teaching OAS about room/task semantics |
 | `context_compact_oas` | Acceptable but lossy | OAS reducer is authoritative, but MASC marker heuristics still influence scoring |
 | `memory_oas_bridge` | Acceptable but lossy | consumer adapter is correct; lifecycle is still seed/flush driven rather than hook-first |
-| `team_session_oas_bridge` | Acceptable but lossy | OAS Swarm runs the session, but metadata/projection gaps remain |
 | keeper context/checkpoint continuity path | Boundary violation | duplicate runtime ownership + raw text continuity markers remain |
 
 ### 12.3 Priority Order
 
 1. keeper runtime state ownership
 2. marker/text leakage
-3. team-session bridge fidelity
-4. memory bridge hardening
-5. doc truth alignment
+3. memory bridge hardening
+4. doc truth alignment
 
 ---
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -127,7 +127,6 @@ Correctness gate가 아닌 orchestration/benchmark/behavior 실험. Runbook과 �
 | MDAL (`test_mdal_*`) | 3 | `test_mdal.ml`, `test_mdal_store.ml` |
 | Worker (`test_worker_*`) | 3 | `test_worker_runtime.ml`, `test_worker_dev_tools.ml` |
 | Verification (`test_verif*`) | 3 | `test_verifier_oas_bridge.ml` |
-| Team (`test_team_*`) | 2 | `test_team_session_oas_bridge.ml` |
 | Memory (`test_memory_*`) | 1 | `test_memory_oas_5tier.ml` |
 | 기타 | ~50+ | auth, encryption, spawn, bounded, etc. |
 

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -117,17 +117,9 @@ code_refs:
 | Event Trace | Append-only events.jsonl | IMPL | 58KB, 1000+ entries |
 | Intent Tools | create/status/update/forecast | IMPL | MCP tool registry 등록 + dispatch 연결 완료 |
 
-### 07-Team Session (94% IMPL)
+### 07-Team Session (RETIRED)
 
-| Section | Feature | Status | Evidence |
-|---------|---------|--------|----------|
-| 47-field Session Record | Identity+Config+Runtime+Timestamps+Proof | IMPL | team_session_types.ml 697 LOC |
-| 3 Orchestration Modes | Manual/Assist/Auto | IMPL | Engine handles all 3 |
-| OAS Bridge | session→swarm_config, worker→agent_entry | IMPL | team_session_oas_bridge.ml 414 LOC |
-| Swarm Runner | Load→convert→callbacks→run→apply | IMPL | team_session_swarm_runner.ml |
-| Report/Proof | Markdown/JSON, Standard/Strong | IMPL | team_session_report_proof.ml 419 LOC |
-| Tool Surface | 9 handler modules, 4.5K LOC | IMPL | God file 분할 완료 |
-| Session Bridge Fidelity | `worker_specs` projection + prompt context, no `collaboration_context` | Architectural | fidelity gap remains by design |
+전체 `team_session_*` 모듈과 OAS Swarm bridge는 retired surface이며 runtime에서 제거됐다. 역사적 맥락은 `docs/spec/00-glossary.md`의 "Team Session (retired)" 항목과 `docs/OAS-MASC-BOUNDARY.md`의 "Team-session swarm | Removed" 항목을 참고한다.
 
 ### 08-Governance (100% IMPL)
 


### PR DESCRIPTION
## Summary

Gen33 드리프트 캡처: `lib/team_session/` 디렉토리는 #6217 (Phase 1, -10K LOC)에서 제거됐지만, `last_verified: 2026-04-17` 스탬프가 달린 4개 문서가 여전히 `team_session_oas_bridge` / `team_session_plan` / `team_session_*.ml` 을 live 표면으로 기재하고 있음. 특히 `C-implementation-status.md`는 "07-Team Session (94% IMPL)"로 선언하며 삭제된 `team_session_types.ml 697 LOC`, `team_session_oas_bridge.ml 414 LOC`, `team_session_report_proof.ml 419 LOC` 등을 IMPL evidence로 제시.

## Changes

- `docs/architecture-boundary.md`: Session OAS-Native row + `team_session_oas_bridge.ml` Bridge Files row 제거
- `docs/spec/C-implementation-status.md`: 07-Team Session 섹션 전체 (7 rows) → RETIRED 단락으로 교체, glossary / OAS-MASC-BOUNDARY 참조
- `docs/spec/13-oas-integration.md`: 12.2 boundary audit의 `team_session_oas_bridge` row 제거, 12.3 priority #3 (team-session bridge fidelity) 제거 및 재정렬
- `docs/spec/15-testing.md`: Team test 그룹 행 제거 (`test_team_session_oas_bridge.ml` 미존재 확인)

## Verification

- `bash scripts/check-doc-truth.sh` pass (retired claim은 이미 glossary + OAS-MASC-BOUNDARY에서 regression-lock 중)
- `ls lib/team_session*`, `ls test/ | grep team_session` 공백 확인

## Test plan

- [x] Doc truth gate local pass
- [x] File existence empirical check
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)