### PR TITLE
feat(dashboard): add name/category filter to resolved allowlist in tool-allowlist-editor

### DIFF
--- a/dashboard/src/components/tools/tool-allowlist-editor.test.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.test.ts
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 
 import {
   buildResolvedAllowlistGroups,
+  filterResolvedTools,
   ResolvedPreview,
 } from './tool-allowlist-editor'
 
@@ -27,6 +28,64 @@ describe('buildResolvedAllowlistGroups', () => {
       { category: 'board', names: ['board-a', 'board-b'] },
       { category: 'misc', names: ['misc-a'] },
     ])
+  })
+})
+
+describe('filterResolvedTools', () => {
+  const catMap = new Map<string, string>([
+    ['board-post', 'board'],
+    ['board-read', 'board'],
+    ['shell-exec', 'shell'],
+    ['memory-store', 'memory'],
+    ['Graph-Query', 'graph'],
+  ])
+
+  it('returns input reference when query is empty', () => {
+    const tools = ['board-post', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, '')).toBe(tools)
+  })
+
+  it('returns input reference when query is whitespace', () => {
+    const tools = ['board-post', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, '   ')).toBe(tools)
+  })
+
+  it('matches tool name substring case-insensitively', () => {
+    const tools = ['board-post', 'board-read', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, 'BOARD')).toEqual(['board-post', 'board-read'])
+  })
+
+  it('matches category substring case-insensitively', () => {
+    const tools = ['board-post', 'shell-exec', 'memory-store']
+    expect(filterResolvedTools(tools, catMap, 'MEM')).toEqual(['memory-store'])
+  })
+
+  it('matches mixed-case tool names', () => {
+    const tools = ['Graph-Query', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, 'graph')).toEqual(['Graph-Query'])
+  })
+
+  it('returns empty array when nothing matches', () => {
+    const tools = ['board-post', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, 'zzznope')).toEqual([])
+  })
+
+  it('handles tools without a category entry (no crash, no category match)', () => {
+    const tools = ['orphan-tool', 'board-post']
+    expect(filterResolvedTools(tools, catMap, 'board')).toEqual(['board-post'])
+    expect(filterResolvedTools(tools, catMap, 'orphan')).toEqual(['orphan-tool'])
+  })
+
+  it('does not mutate the input array', () => {
+    const tools = ['board-post', 'shell-exec', 'memory-store']
+    const snapshot = [...tools]
+    filterResolvedTools(tools, catMap, 'board')
+    expect(tools).toEqual(snapshot)
+  })
+
+  it('trims query before matching', () => {
+    const tools = ['board-post', 'shell-exec']
+    expect(filterResolvedTools(tools, catMap, '  board  ')).toEqual(['board-post'])
   })
 })
 

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -149,14 +149,47 @@ export function buildResolvedAllowlistGroups(
     .sort((left, right) => right.names.length - left.names.length || left.category.localeCompare(right.category))
 }
 
+/**
+ * Pure filter for resolved allowlist tool names.
+ *
+ * Case-insensitive substring match on the tool name itself and on its
+ * category (via `catMap`) so operators can locate a tool by partial
+ * name or by category (e.g. "board", "shell").
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * useMemo keeps referential identity for the non-filtering path.
+ *
+ * Input is never mutated.
+ */
+export function filterResolvedTools(
+  tools: readonly string[],
+  catMap: Map<string, string>,
+  query: string,
+): readonly string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return tools
+  return tools.filter(name => {
+    if (name.toLowerCase().includes(needle)) return true
+    const cat = catMap.get(name)
+    if (cat && cat.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Map<string, string> }) {
   const [expanded, setExpanded] = useState(false)
+  const [query, setQuery] = useState('')
   const firstTool = tools[0] ?? null
   const lastTool = tools.length > 0 ? tools[tools.length - 1] : null
 
   useEffect(() => {
     setExpanded(false)
   }, [tools.length, firstTool, lastTool])
+
+  const visibleTools = useMemo(
+    () => filterResolvedTools(tools, catMap, query),
+    [tools, catMap, query],
+  )
 
   if (tools.length === 0) {
     return html`
@@ -167,49 +200,64 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
     `
   }
 
-  const groups = buildResolvedAllowlistGroups(tools, catMap)
+  const isFiltering = query.trim() !== ''
+  const groups = buildResolvedAllowlistGroups([...visibleTools], catMap)
   const visibleGroups = expanded ? groups : groups.slice(0, RESOLVED_CATEGORY_PREVIEW_LIMIT)
   const hasHiddenContent = groups.length > RESOLVED_CATEGORY_PREVIEW_LIMIT
     || groups.some(group => group.names.length > RESOLVED_TOOLS_PER_CATEGORY_LIMIT)
 
   return html`
     <div class="flex flex-col gap-1">
-      <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-        resolved allowlist (${tools.length}개, ${groups.length} 카테고리)
-      </span>
-      <div class="flex flex-col gap-2">
-        ${visibleGroups.map(group => {
-          const visibleNames = expanded ? group.names : group.names.slice(0, RESOLVED_TOOLS_PER_CATEGORY_LIMIT)
-          const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
-          return html`
-          <div class="flex flex-col gap-1">
-            <span class="text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
-            <div class="flex flex-wrap gap-1">
-              ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
-              ${!expanded && hiddenToolCount > 0
-                ? html`
-                    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
-                      +${hiddenToolCount}
-                    </span>
-                  `
-                : null}
-            </div>
-          </div>
-        `
-        })}
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          resolved allowlist (${tools.length}개, ${groups.length} 카테고리)
+        </span>
+        <input
+          type="search"
+          value=${query}
+          placeholder="도구/카테고리 필터"
+          aria-label="resolved allowlist 필터"
+          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+          class="min-w-[140px] max-w-[220px] flex-1 rounded-md border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+        />
       </div>
-      ${hasHiddenContent
-        ? html`
-            <button type="button"
-              class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
-              aria-expanded=${expanded}
-              aria-label=${expanded ? 'resolved allowlist 접기' : `resolved allowlist 전체 ${tools.length}개 보기`}
-              onClick=${() => setExpanded(value => !value)}
-            >
-              ${expanded ? '접기' : `전체 ${tools.length}개 보기`}
-            </button>
-          `
-        : null}
+      ${isFiltering && visibleTools.length === 0
+        ? html`<div class="py-3 text-center text-[11px] text-[var(--text-muted)]">필터 결과 없음 (${tools.length}개 도구)</div>`
+        : html`
+          <div class="flex flex-col gap-2">
+            ${visibleGroups.map(group => {
+              const visibleNames = expanded ? group.names : group.names.slice(0, RESOLVED_TOOLS_PER_CATEGORY_LIMIT)
+              const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
+              return html`
+              <div class="flex flex-col gap-1">
+                <span class="text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
+                <div class="flex flex-wrap gap-1">
+                  ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
+                  ${!expanded && hiddenToolCount > 0
+                    ? html`
+                        <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+                          +${hiddenToolCount}
+                        </span>
+                      `
+                    : null}
+                </div>
+              </div>
+            `
+            })}
+          </div>
+          ${hasHiddenContent
+            ? html`
+                <button type="button"
+                  class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+                  aria-expanded=${expanded}
+                  aria-label=${expanded ? 'resolved allowlist 접기' : `resolved allowlist 전체 ${tools.length}개 보기`}
+                  onClick=${() => setExpanded(value => !value)}
+                >
+                  ${expanded ? '접기' : `전체 ${tools.length}개 보기`}
+                </button>
+              `
+            : null}
+        `}
     </div>
   `
 }


### PR DESCRIPTION
## 요약

`tool-allowlist-editor.ts` 의 **`ResolvedPreview`** (keeper 의 resolved allowlist 를 카테고리별로 그룹화하여 렌더링) 에 자유 텍스트 필터를 추가합니다. 브로드한 preset (`full`, `coding`) 을 사용하는 keeper 는 tool 수가 많아 expand/collapse 경계를 넘어 스크롤됩니다. 특정 tool 이 resolved set 에 포함됐는지, 어떤 카테고리에 속하는지 빠르게 확인할 방법이 없었습니다.

## 왜 이 리스트인가

`tool-allowlist-editor.ts` 의 10개 `.map` 사이트:

- L37 `inv.map(t => t.name).sort()` — 데이터 변환 (UI 리스트 아님)
- L67 `parseToolList` 의 `.map(s => s.trim())` — 입력 파싱
- L145 `buildResolvedAllowlistGroups` 의 `.map([cat, names])` — 데이터 변환
- **L181 `visibleGroups.map(group)` / L188 `visibleNames.map(name)`** — **`ResolvedPreview` 가 resolved allowlist 전체를 렌더. 전체 preset(`full`) 기준 50+개 tool, 이 파일에서 가장 큰 사용자-대면 리스트** ← 선택
- L293 `items.map(name)` (`ToolSearchPicker.items`) — 이미 downshift combobox 의 검색창 존재, 중복 필터 불필요
- L314/L318 `Array.from(groupedFiltered.entries()).map` / `names.map` — 이미 combobox 의 필터된 출력
- L498 `(['preset', 'custom'] as const).map` — 2개 항목, 카디널리티 너무 낮음
- L520 `Object.entries(PRESET_DESCRIPTIONS).map` — 5개 preset, 카디널리티 너무 낮음

`ResolvedPreview` 는 keeper 한 명의 resolved allowlist 전체 (보통 20~80개 tool) 를 보여주는 유일한 리스트라 필터 이득이 가장 큽니다.

## 변경

- `filterResolvedTools(tools, catMap, query)` 순수 함수를 `tool-allowlist-editor.ts` 에서 export. case-insensitive substring.
  - tool 이름 자체에 substring match, 또는 해당 tool 의 카테고리 이름 (`catMap.get(name)`) 에 substring match.
- 빈/공백 query 는 입력 참조 그대로 반환 → `useMemo` 가 비필터 경로에서 identity 유지.
- 입력 비변이 (`readonly string[]`).
- 필터가 모든 tool 을 숨기면 별도 empty-state: `필터 결과 없음 (N개 도구)` — 실제 비어있음(`resolved allowlist 없음`) 과 구분.
- `ResolvedPreview` 헤더에 `<input type="search">` 추가. 한국어 placeholder: `도구/카테고리 필터`.
- `aria-label="resolved allowlist 필터"`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/tools/tool-allowlist-editor.test.ts`: 11/11 pass (기존 2 + 신규 9).
- `pnpm exec eslint .`: 0 errors.

신규 9건:
1. 빈 query → 입력 참조 동일 (`.toBe(tools)`)
2. 공백만 있는 query → 입력 참조 동일
3. case-insensitive tool 이름 매칭 (`BOARD` → `board-*`)
4. case-insensitive 카테고리 매칭 (`MEM` → `memory-*`)
5. mixed-case tool 이름 (`Graph-Query`) 매칭
6. no-match → 빈 배열
7. `catMap` 에 없는 orphan tool 도 crash 없이 처리 (이름만 매칭)
8. 입력 비변이 (snapshot 비교)
9. trim 적용 (`  board  ` → `board-*`)

## CI 관련

Main CI 는 현재 GREEN. Dashboard-only 변경, 2 파일.

## 범위 제한

Dashboard 파일 2개 (`tool-allowlist-editor.ts` + `tool-allowlist-editor.test.ts`) 만 수정. ONE list 원칙 유지 — 다른 `.map` 사이트 (`ToolSearchPicker.items`, mode toggle, preset dropdown) 는 건드리지 않음. iter-7/8/9/11/12 (`d1d411264` `filterFleetRows` 참조) seed-hint 패턴 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)