### PR TITLE
feat(dashboard): add kind/signal/message filter to config-resolution-panel

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -2,7 +2,17 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigResolutionPanel } from './config-resolution-panel'
+import type { DashboardRuntimeDiagnostic } from '../../api/dashboard'
+import { ConfigResolutionPanel, filterDiagnostics } from './config-resolution-panel'
+
+function diag(
+  kind: string,
+  message: string,
+  signal?: string,
+  ts = '2026-04-17T00:00:00Z',
+): DashboardRuntimeDiagnostic {
+  return signal === undefined ? { ts, kind, message } : { ts, kind, message, signal }
+}
 
 async function flush(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
@@ -248,5 +258,67 @@ describe('ConfigResolutionPanel', () => {
 
     expect(container.textContent).toContain('local .masc')
     expect(container.textContent).toContain('/tmp/project/.masc/config')
+  })
+})
+
+describe('filterDiagnostics', () => {
+  const sample: readonly DashboardRuntimeDiagnostic[] = [
+    diag('external_signal', 'Received SIGTERM, shutting down server.', 'SIGTERM'),
+    diag('external_signal', 'Received SIGINT from operator.', 'SIGINT'),
+    diag('config_drift', 'Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).'),
+    diag('keeper_heartbeat', 'keeper stale for 42s', 'heartbeat_stale'),
+  ]
+
+  it('returns the input reference when the query is empty', () => {
+    expect(filterDiagnostics(sample, '')).toBe(sample)
+  })
+
+  it('returns the input reference when the query is whitespace-only', () => {
+    expect(filterDiagnostics(sample, '   ')).toBe(sample)
+  })
+
+  it('trims the query before matching', () => {
+    const result = filterDiagnostics(sample, '  SIGTERM  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.signal).toBe('SIGTERM')
+  })
+
+  it('matches kind case-insensitively', () => {
+    const result = filterDiagnostics(sample, 'EXTERNAL_signal')
+    expect(result).toHaveLength(2)
+  })
+
+  it('matches signal case-insensitively', () => {
+    const result = filterDiagnostics(sample, 'sigint')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.signal).toBe('SIGINT')
+  })
+
+  it('matches substring in the message body', () => {
+    const result = filterDiagnostics(sample, 'deadbee')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe('config_drift')
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterDiagnostics(sample, 'no-such-term-xyz')).toEqual([])
+  })
+
+  it('skips undefined signal fields without crashing', () => {
+    const result = filterDiagnostics(sample, 'heartbeat')
+    // kind match ("keeper_heartbeat") + signal match ("heartbeat_stale") on the same row
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe('keeper_heartbeat')
+  })
+
+  it('returns an empty array when the input is empty', () => {
+    expect(filterDiagnostics([], 'anything')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const before = sample.map(item => ({ ...item }))
+    filterDiagnostics(sample, 'sigterm')
+    expect(sample).toEqual(before)
+    expect(sample).toHaveLength(4)
   })
 })

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import type {
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
@@ -10,6 +10,32 @@ import type {
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
 import { Card } from '../common/card'
+
+/**
+ * Pure filter for runtime diagnostics entries.
+ *
+ * Case-insensitive substring match on `kind`, `signal`, and `message` in
+ * that order (first match wins). Operators can isolate a single class of
+ * runtime warning (e.g. `external_signal`), a specific POSIX signal
+ * (`SIGTERM`), or search free text in the message body.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * useMemo keeps referential identity for the non-filtering path.
+ * Input is never mutated; `readonly` is preserved.
+ */
+export function filterDiagnostics(
+  diagnostics: readonly DashboardRuntimeDiagnostic[],
+  query: string,
+): readonly DashboardRuntimeDiagnostic[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return diagnostics
+  return diagnostics.filter(item => {
+    if (item.kind.toLowerCase().includes(needle)) return true
+    if (item.signal && item.signal.toLowerCase().includes(needle)) return true
+    if (item.message.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 function toneClass(status: string): string {
   switch (status) {
@@ -392,6 +418,14 @@ export function ConfigResolutionPanel({
   resolution: DashboardConfigResolution | undefined
   runtimeResolution?: DashboardRuntimeResolution
 }) {
+  const diagnosticsQuery = useSignal('')
+  const allDiagnostics = runtimeResolution?.diagnostics ?? []
+  const visibleDiagnostics = useMemo(
+    () => filterDiagnostics(allDiagnostics, diagnosticsQuery.value),
+    [allDiagnostics, diagnosticsQuery.value],
+  )
+  const isFilteringDiagnostics = diagnosticsQuery.value.trim() !== ''
+
   if (!resolution && !runtimeResolution) return null
 
   const rootPath = resolution?.config_root.path ?? ''
@@ -494,17 +528,37 @@ export function ConfigResolutionPanel({
               </div>
 
               <div class="mt-4">
-                <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                  recent diagnostics
+                <div class="mb-2 flex items-center justify-between gap-2">
+                  <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    recent diagnostics
+                  </div>
+                  ${runtimeResolution.diagnostics.length > 0
+                    ? html`
+                        <input
+                          type="search"
+                          value=${diagnosticsQuery.value}
+                          placeholder="kind / signal / message 필터"
+                          aria-label="Diagnostics 필터"
+                          onInput=${(e: Event) => { diagnosticsQuery.value = (e.target as HTMLInputElement).value }}
+                          class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                        />
+                      `
+                    : null}
                 </div>
                 <div class="flex flex-col gap-3">
-                  ${runtimeResolution.diagnostics.length > 0
-                    ? runtimeResolution.diagnostics.map(item => html`<${DiagnosticRow} item=${item} />`)
-                    : html`
+                  ${runtimeResolution.diagnostics.length === 0
+                    ? html`
                         <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
                           최근 runtime warning이 없습니다.
                         </div>
-                      `}
+                      `
+                    : isFilteringDiagnostics && visibleDiagnostics.length === 0
+                      ? html`
+                          <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-center text-[12px] text-[var(--text-muted)]">
+                            필터 결과 없음 (${runtimeResolution.diagnostics.length} diagnostics)
+                          </div>
+                        `
+                      : visibleDiagnostics.map(item => html`<${DiagnosticRow} item=${item} />`)}
                 </div>
               </div>
 


### PR DESCRIPTION
## 요약

`config-resolution-panel.ts` 의 **recent diagnostics** 리스트 (`runtimeResolution.diagnostics`, `DiagnosticRow`) 에 자유 텍스트 필터를 추가합니다. 장시간 실행되는 서버에서는 `external_signal`, `config_drift`, `keeper_heartbeat` 엔트리가 누적되어, 특정 SIGTERM 하나나 하나의 commit-drift 항목을 찾기 위해 전체 리스트를 훑어봐야 했습니다.

## 왜 이 리스트인가

`config-resolution-panel.ts` 의 4개 `.map` 사이트:

- `warnings.map` (line 162, WarningBlock) — config warnings 문자열 리스트. 카디널리티 낮고 단일 필드 문자열이라 필터 이득이 적음.
- `probe.observations?.map` (line 362, RuntimeProbePanel) — kv probe observations, 보통 1-3개.
- `probe.errors?.map` (line 374, RuntimeProbePanel) — probe errors, 보통 0-2개.
- **`runtimeResolution.diagnostics.map` (line 502, recent diagnostics)** — **runtime lifecycle 전체에서 누적된 diagnostic 엔트리, 카디널리티 가장 큼, `kind`/`signal`/`message` 3-field 자유 텍스트** ← 선택

위쪽 config entries (`config_root`/`cascade`/`prompts`/`keepers`/`personas`, `base_path`/`workspace_path`/...) 는 고정 5~6행 grid 라서 필터 대상이 아닙니다.

## 변경

- `filterDiagnostics(diagnostics, query)` 순수 함수를 `config-resolution-panel.ts` 에서 export. case-insensitive substring.
  - `kind` → `signal` → `message` 순서로 first-match-wins.
- 빈/공백 query 는 입력 참조 그대로 반환 → useMemo identity 유지.
- 입력 비변이 (`readonly DashboardRuntimeDiagnostic[]`).
- 검색 input 은 `diagnostics.length > 0` 일 때만 표시 (빈 상태 `최근 runtime warning이 없습니다.` 와 간섭 없음).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N diagnostics)` — 실제 비어있음 메시지와 구분.
- 한국어 placeholder: `kind / signal / message 필터`.
- 기존 `ConfigResolutionPanel` 시그니처/props 변경 없음. 내부 `useSignal` + `useMemo` 로 필터 상태 관리.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/tools/config-resolution-panel.test.ts`: 17/17 pass (기존 7 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (kind)
5. case-insensitive (signal)
6. message substring
7. no-match → 빈 배열
8. `signal` undefined 필드 skip
9. 빈 입력 배열 → 빈 결과
10. 입력 비변이

## CI 관련

Main CI 는 현재 GREEN. Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정 (`config-resolution-panel.ts`, `config-resolution-panel.test.ts`). 다른 `.map` 사이트 (warnings, probe observations, probe errors) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.