### PR TITLE
feat(dashboard): add name/state/focus filter to overview agent pulse

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -512,3 +512,167 @@ describe('ToolCallHealthPanel', () => {
     expect(container.textContent).toContain('0.0%')
   }, 15000)
 })
+
+describe('filterAgentPulseRows', () => {
+  interface AgentLike {
+    name: string
+    koreanName: string | null
+    emoji: string | null
+    model: string | null
+    status: string
+    state: 'working' | 'watching' | 'quiet' | 'offline'
+    focus: string | null
+    currentTask: string | null
+    recentTools: string[]
+    recentOutputPreview: string | null
+    contextRatio: number | null
+    lastSignalAt: string | null
+    lastSignalAgeSec: number | null
+    signalTruth: string | null
+    relatedSessionId: string | null
+  }
+
+  function makeAgent(overrides: Partial<AgentLike>): AgentLike {
+    return {
+      name: 'dreamer',
+      koreanName: '몽상가',
+      emoji: null,
+      model: null,
+      status: 'ok',
+      state: 'working',
+      focus: null,
+      currentTask: null,
+      recentTools: [],
+      recentOutputPreview: null,
+      contextRatio: null,
+      lastSignalAt: null,
+      lastSignalAgeSec: null,
+      signalTruth: null,
+      relatedSessionId: null,
+      ...overrides,
+    }
+  }
+
+  async function loadFilter() {
+    vi.resetModules()
+    vi.doMock('../../mission-store', () => ({
+      missionSnapshot: { value: null },
+      missionLoading: { value: false },
+      refreshMissionSnapshot: vi.fn(),
+    }))
+    vi.doMock('../../namespace-truth-store', () => ({
+      namespaceTruth: { value: null },
+      namespaceTruthLoading: { value: false },
+      refreshNamespaceTruth: vi.fn(),
+    }))
+    vi.doMock('../../observatory-store', () => ({
+      topActiveAgents: { value: [] },
+    }))
+    vi.doMock('../../sse', () => ({
+      journal: [],
+      connected: { value: true },
+      eventCount: { value: 0 },
+      lastEvent: { value: null },
+    }))
+    vi.doMock('../../router', () => ({
+      navigate: vi.fn(),
+      hashForRoute: vi.fn().mockReturnValue('#'),
+    }))
+    vi.doMock('./situation-banner', () => ({ SituationBanner: () => null }))
+    vi.doMock('./attention-spotlight', () => ({ AttentionSpotlight: () => null }))
+    vi.doMock('./narrative-timeline', () => ({ NarrativeTimeline: () => null }))
+    vi.doMock('./agent-avatar', () => ({ AgentAvatar: () => null }))
+    vi.doMock('../transport-health', () => ({ TransportHealthPanel: () => null }))
+    vi.doMock('../perf-snapshot', () => ({ PerfSnapshotPanel: () => null }))
+    return import('./overview')
+  }
+
+  it('returns the input reference unchanged for an empty query', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'dreamer' }), makeAgent({ name: 'weaver' })]
+    expect(filterAgentPulseRows(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference unchanged for a whitespace-only query', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'dreamer' })]
+    expect(filterAgentPulseRows(rows, '   \t  ')).toBe(rows)
+  })
+
+  it('trims the query before matching', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'dreamer' }), makeAgent({ name: 'weaver' })]
+    const filtered = filterAgentPulseRows(rows, '  dream  ')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('dreamer')
+  })
+
+  it('matches on name case-insensitively', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'Dreamer' }), makeAgent({ name: 'Weaver' })]
+    const filtered = filterAgentPulseRows(rows, 'DREAM')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('Dreamer')
+  })
+
+  it('matches on koreanName substring', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [
+      makeAgent({ name: 'dreamer', koreanName: '몽상가' }),
+      makeAgent({ name: 'weaver', koreanName: '직조자' }),
+    ]
+    const filtered = filterAgentPulseRows(rows, '직조')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('weaver')
+  })
+
+  it('matches on state', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [
+      makeAgent({ name: 'dreamer', state: 'working' }),
+      makeAgent({ name: 'weaver', state: 'quiet' }),
+      makeAgent({ name: 'scribe', state: 'working' }),
+    ]
+    const filtered = filterAgentPulseRows(rows, 'working')
+    expect(filtered).toHaveLength(2)
+    expect(filtered.map(a => a.name)).toEqual(['dreamer', 'scribe'])
+  })
+
+  it('matches on focus substring', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [
+      makeAgent({ name: 'dreamer', focus: 'reviewing PR #7892' }),
+      makeAgent({ name: 'weaver', focus: 'drafting ADR' }),
+    ]
+    const filtered = filterAgentPulseRows(rows, 'pr #7892')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('dreamer')
+  })
+
+  it('returns an empty array when no row matches', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'dreamer' }), makeAgent({ name: 'weaver' })]
+    const filtered = filterAgentPulseRows(rows, 'nonexistent')
+    expect(filtered).toEqual([])
+  })
+
+  it('handles null/missing optional fields without throwing', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [
+      makeAgent({ name: 'dreamer', koreanName: null, focus: null }),
+      makeAgent({ name: 'weaver', koreanName: null, focus: null }),
+    ]
+    const filtered = filterAgentPulseRows(rows, 'dream')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('dreamer')
+  })
+
+  it('does not mutate the input array', async () => {
+    const { filterAgentPulseRows } = await loadFilter()
+    const rows = [makeAgent({ name: 'dreamer' }), makeAgent({ name: 'weaver' })]
+    const snapshot = rows.map(a => a.name)
+    filterAgentPulseRows(rows, 'weaver')
+    expect(rows.map(a => a.name)).toEqual(snapshot)
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,6 +2,8 @@
 // "What's happening right now?" — answer in 1 second, no scroll.
 
 import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
+import { useMemo } from 'preact/hooks'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
 import { TimeAgo } from '../common/time-ago'
@@ -395,8 +397,43 @@ function agentStateDot(state: string): string {
   return 'bg-[#555]'
 }
 
+/**
+ * Pure filter for the Agent Pulse roster.
+ *
+ * Case-insensitive substring match on `name`, `koreanName`, `state`, and
+ * `focus` (in that order; first match wins) so operators can locate one
+ * agent by partial name, switch to everyone in a given state
+ * (e.g. `working`), or find agents whose current focus mentions a
+ * particular topic.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * useMemo preserves referential equality for the non-filtering path.
+ *
+ * Input is never mutated; ObservatoryAgent is treated as readonly.
+ */
+export function filterAgentPulseRows(
+  agents: readonly ObservatoryAgent[],
+  query: string,
+): readonly ObservatoryAgent[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return agents
+  return agents.filter(a => {
+    if (a.name && a.name.toLowerCase().includes(needle)) return true
+    if (a.koreanName && a.koreanName.toLowerCase().includes(needle)) return true
+    if (a.state && a.state.toLowerCase().includes(needle)) return true
+    if (a.focus && a.focus.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 function AgentPulse() {
   const agents = topActiveAgents.value
+  const query = useSignal('')
+  const visibleAgents = useMemo(
+    () => filterAgentPulseRows(agents, query.value),
+    [agents, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
   if (agents.length === 0) return null
 
   return html`
@@ -408,8 +445,24 @@ function AgentPulse() {
         linkTab="monitoring"
         linkParams=${{ section: 'agents' }}
       />
+      <div class="mb-3 flex items-center justify-between gap-2">
+        <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">
+          ${isFiltering ? `${visibleAgents.length}/${agents.length}명` : `${agents.length}명`}
+        </div>
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="이름 / 상태 / focus 필터"
+          aria-label="에이전트 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && visibleAgents.length === 0
+        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${agents.length}명)</div>`
+        : null}
       <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
-        ${agents.map((a: ObservatoryAgent) => html`
+        ${visibleAgents.map((a: ObservatoryAgent) => html`
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'agents', agent: a.name }}


### PR DESCRIPTION
## 요약

`overview.ts` 의 **Agent Pulse** 그리드 (`topActiveAgents`, line 465 `agents.map`) 에 자유 텍스트 필터를 추가합니다. Home 화면의 `에이전트` 카드는 auto-fill 그리드로 top active agent를 무한 확장 렌더링하기 때문에, 바쁜 플릿에서는 이름으로 한 에이전트를 찾거나 `working` 상태만 골라보려 할 때 스크롤이 필요했습니다.

## 왜 이 리스트인가

`overview.ts` 의 5개 `.map` 사이트:

- `userSessions.map` (line 383, HotSessions) — `slice(0, 5)` 로 이미 top 5 로 컷, 카디널리티 낮음.
- **`agents.map` (line 465, AgentPulse)** — **`topActiveAgents` 는 auto-fill 그리드로 렌더되고 cap이 없어 플릿 규모에 비례. `name` / `koreanName` / `state` / `focus` 네 필드 모두 자유 텍스트가 풍부** ← 선택.
- `agents.map` 내부의 `koreanName !== name` 렌더는 같은 루프 안이라 별도 리스트 아님.
- `configResolution?.warnings.slice(0, 2).map` (line 696) — 경고 최대 2개.
- `runtimeResolution?.warnings.slice(0, 2).map` (line 699) — 경고 최대 2개.

HotSessions 와 warnings 는 의도적으로 slice cap 이 걸려 있어 스크롤 압력이 없고, AgentPulse 만 operator가 `dreamer` / `working` / `PR 리뷰` 같은 질의로 드릴다운하고 싶어지는 유일한 후보입니다.

## 변경

- `filterAgentPulseRows(agents, query)` 순수 함수를 `overview.ts` 에서 export. case-insensitive substring.
  - `name`, `koreanName`, `state`, `focus` 순서로 first-match-wins.
- 빈/공백 query 는 입력 참조 그대로 반환 → useMemo identity 유지.
- 입력 비변이 (`readonly ObservatoryAgent[]`).
- Agent Pulse 헤더 아래 `<input type="search">` (한국어 placeholder: `이름 / 상태 / focus 필터`).
- 필터 결과가 빈 경우 별도 empty-state: `필터 결과 없음 (N명)` — 원래 데이터가 있다는 신호.
- 필터 중이면 카운터가 `N/M명` 으로, 비필터 시 `N명` 으로 표시.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/overview/overview.test.ts`: 21/21 pass (기존 11 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (name)
5. koreanName substring 매칭
6. state 매칭 (`working`)
7. focus substring 매칭
8. no-match → 빈 배열
9. null optional 필드에서도 안 throw
10. 입력 비변이

## CI 관련

Main CI 는 현재 GREEN. Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트 (HotSessions, warnings) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.