### PR TITLE
feat(dashboard): add keeper-name search to fleet-fsm-matrix snapshots

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import {
   chipClassFor,
+  filterSnapshotsByName,
   FLEET_HISTORY_LEN,
   inferKeeperNameFrom,
   pushObservation,
@@ -173,5 +174,62 @@ describe('pushObservation', () => {
     const t1 = pushObservation({}, [warn])
     const t2 = pushObservation(t1, [cool])
     expect(t2.beta!.breaker).toEqual(['warning', 'cooling'])
+  })
+})
+
+describe('filterSnapshotsByName', () => {
+  const alpha = snapshot({ name: 'alpha-keeper' })
+  const beta = snapshot({ name: 'BetaRunner' })
+  const gamma = snapshot({ name: 'gen12-payroll' })
+  const all = [alpha, beta, gamma]
+
+  it('returns the input reference unchanged for an empty query', () => {
+    const out = filterSnapshotsByName(all, '')
+    expect(out).toBe(all)
+  })
+
+  it('returns the input reference unchanged for whitespace-only queries', () => {
+    const out = filterSnapshotsByName(all, '   \t\n')
+    expect(out).toBe(all)
+  })
+
+  it('matches by case-insensitive substring on the inferred keeper name', () => {
+    const out = filterSnapshotsByName(all, 'BETA')
+    expect(out).toEqual([beta])
+  })
+
+  it('trims leading/trailing whitespace before matching', () => {
+    const out = filterSnapshotsByName(all, '  alpha  ')
+    expect(out).toEqual([alpha])
+  })
+
+  it('matches on a partial-middle substring', () => {
+    // "payroll" is suffixy; "12-pay" is a true middle substring.
+    const out = filterSnapshotsByName(all, '12-pay')
+    expect(out).toEqual([gamma])
+  })
+
+  it('returns an empty array (not the input ref) when no name matches', () => {
+    const out = filterSnapshotsByName(all, 'zzz-nothing-matches')
+    expect(out).toEqual([])
+    expect(out).not.toBe(all)
+  })
+
+  it('matches multiple keepers when the substring is shared', () => {
+    const keepers = [
+      snapshot({ name: 'gen12-alpha' }),
+      snapshot({ name: 'gen12-beta' }),
+      snapshot({ name: 'other-keeper' }),
+    ]
+    const out = filterSnapshotsByName(keepers, 'gen12')
+    expect(out).toHaveLength(2)
+    expect(out.map(s => inferKeeperNameFrom(s))).toEqual(['gen12-alpha', 'gen12-beta'])
+  })
+
+  it('does not mutate the input array', () => {
+    const snapshots = [...all]
+    const before = [...snapshots]
+    filterSnapshotsByName(snapshots, 'alpha')
+    expect(snapshots).toEqual(before)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -18,6 +18,7 @@
  */
 
 import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import { fetchKeepersComposite } from '../api/keeper'
@@ -25,6 +26,7 @@ import type {
   FleetCompositeSnapshot,
   KeeperCompositeSnapshot,
 } from '../api/keeper'
+import { TextInput } from './common/input'
 import {
   displayState,
   extractLaneValue,
@@ -210,6 +212,9 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   // returns a fresh record per tick and we pair it with a setData call
   // which triggers the re-render — avoids a redundant state subscription.
   const historyRef = useRef<KeeperFleetHistory>({})
+  // Component-scoped search query. useSignal auto-resets on unmount;
+  // no manual cleanup needed. Matches fleet-telemetry-panel pattern.
+  const query = useSignal('')
 
   useEffect(() => {
     let cancelled = false
@@ -283,6 +288,9 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     `
   }
 
+  const filtered = filterSnapshotsByName(data.snapshots, query.value)
+  const emptyColspan = 1 + AXES.length
+
   return html`
     <section
       data-testid="fleet-fsm-matrix"
@@ -315,6 +323,21 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
             `
           : null}
       </header>
+      <div class="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-3 py-2">
+        <${TextInput}
+          value=${query.value}
+          type="search"
+          ariaLabel="키퍼 이름 검색"
+          placeholder="keeper 이름"
+          class="min-w-[200px] flex-1 !py-1 !text-[11px]"
+          onInput=${(e: Event) => {
+            query.value = (e.target as HTMLInputElement).value
+          }}
+        />
+        <span data-testid="fleet-fsm-matrix-count" class="text-xs text-zinc-500">
+          ${filtered.length}/${data.snapshots.length}
+        </span>
+      </div>
       <div class="overflow-x-auto">
         <table class="min-w-full text-xs">
           <thead class="bg-zinc-900 text-zinc-300">
@@ -328,51 +351,63 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
             </tr>
           </thead>
           <tbody>
-            ${data.snapshots.map(snap => {
-              const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
-              const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
-              const name = inferKeeperNameFrom(snap)
-              return html`
-                <tr
-                  data-keeper=${name}
-                  class="border-t border-zinc-800 hover:bg-zinc-900 ${rowTone}"
-                  onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
-                >
-                  <td class="px-3 py-2 font-mono text-zinc-200">${name}</td>
-                  ${AXES.map(a => {
-                    const raw = extractLaneValue(snap, a.key)
-                    const cls = chipClassFor(raw)
-                    const series = historyRef.current[name]?.[a.key] ?? [raw]
-                    return html`
-                      <td class="px-3 py-2 align-top">
-                        <div class="flex flex-col gap-1">
-                          <span
-                            data-cell
-                            data-axis=${a.key}
-                            class="inline-block self-start rounded border px-2 py-0.5 ${cls}"
-                          >${displayState(raw)}</span>
-                          <div
-                            data-spark
-                            data-axis=${a.key}
-                            class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
-                            title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
-                          >
-                            ${series.map((v, i) => html`
+            ${filtered.length === 0
+              ? html`
+                  <tr data-testid="fleet-fsm-matrix-empty">
+                    <td
+                      colspan=${emptyColspan}
+                      class="px-3 py-4 text-center text-xs text-zinc-500"
+                    >
+                      검색 결과 없음
+                    </td>
+                  </tr>
+                `
+              : filtered.map(snap => {
+                  const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
+                  const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
+                  const name = inferKeeperNameFrom(snap)
+                  return html`
+                    <tr
+                      key=${name}
+                      data-keeper=${name}
+                      class="border-t border-zinc-800 hover:bg-zinc-900 ${rowTone}"
+                      onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
+                    >
+                      <td class="px-3 py-2 font-mono text-zinc-200">${name}</td>
+                      ${AXES.map(a => {
+                        const raw = extractLaneValue(snap, a.key)
+                        const cls = chipClassFor(raw)
+                        const series = historyRef.current[name]?.[a.key] ?? [raw]
+                        return html`
+                          <td class="px-3 py-2 align-top">
+                            <div class="flex flex-col gap-1">
                               <span
-                                key=${i}
-                                data-spark-bar
-                                class="h-full w-0.5 ${sparkClassFor(v)}"
-                                title=${displayState(v)}
-                              ></span>
-                            `)}
-                          </div>
-                        </div>
-                      </td>
-                    `
-                  })}
-                </tr>
-              `
-            })}
+                                data-cell
+                                data-axis=${a.key}
+                                class="inline-block self-start rounded border px-2 py-0.5 ${cls}"
+                              >${displayState(raw)}</span>
+                              <div
+                                data-spark
+                                data-axis=${a.key}
+                                class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
+                                title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
+                              >
+                                ${series.map((v, i) => html`
+                                  <span
+                                    key=${i}
+                                    data-spark-bar
+                                    class="h-full w-0.5 ${sparkClassFor(v)}"
+                                    title=${displayState(v)}
+                                  ></span>
+                                `)}
+                              </div>
+                            </div>
+                          </td>
+                        `
+                      })}
+                    </tr>
+                  `
+                })}
           </tbody>
         </table>
       </div>
@@ -389,6 +424,25 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
 export function inferKeeperNameFrom(snap: KeeperCompositeSnapshot): string {
   const m = /^keeper:([^:]+):/.exec(snap.correlation_id)
   return m?.[1] ?? snap.correlation_id
+}
+
+/**
+ * Pure filter for fleet snapshots by inferred keeper name.
+ *
+ * Case-insensitive substring match on `inferKeeperNameFrom(snap)`. Empty
+ * or whitespace-only queries return the input reference unchanged (no
+ * new array allocation, preserves referential equality for memoisation
+ * and for cheap re-render skips). Input is never mutated.
+ */
+export function filterSnapshotsByName(
+  snapshots: readonly KeeperCompositeSnapshot[],
+  query: string,
+): readonly KeeperCompositeSnapshot[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return snapshots
+  return snapshots.filter(snap =>
+    inferKeeperNameFrom(snap).toLowerCase().includes(needle),
+  )
 }
 
 // Re-exported helpers let tests target the pure slices without spinning


### PR DESCRIPTION
## Summary
- Adds a case-insensitive substring search to the `data.snapshots` table in `fleet-fsm-matrix.ts`, matching on the keeper name inferred via `inferKeeperNameFrom(snap)` (parsed from `correlation_id`).
- Exports a pure helper `filterSnapshotsByName(snapshots, query)` alongside `inferKeeperNameFrom`. Empty/whitespace query returns the input reference unchanged; no mutation.
- Uses `useSignal('')` (component-scoped, auto-resets on unmount), mirroring the `fleet-telemetry-panel.ts` pattern. `TextInput` from `common/input.ts` is placed above the `<table>` outside the sticky thead, with `type="search"`, `ariaLabel="키퍼 이름 검색"`, `placeholder="keeper 이름"`. A small `filtered/total` counter sits next to the input.
- Stable `key=${name}` added to filtered `<tr>` so Preact diffs rows correctly.
- Empty-match path renders `<tr data-testid="fleet-fsm-matrix-empty"><td colspan=${1 + AXES.length}>검색 결과 없음</td></tr>`.

## Tests
- 8 new cases in `fleet-fsm-matrix.test.ts`:
  - empty query → ref-equal
  - whitespace-only query → ref-equal
  - case-insensitive substring match
  - trimmed match
  - partial-middle substring match
  - no-match returns a fresh empty array (not the input ref)
  - multi-match preserves order
  - input array is not mutated
- Focused run: `pnpm test fleet-fsm-matrix.test.ts` → 24 passed.
- Full suite: `pnpm test` → 2946 passed / 192 files. Baseline flakes (`governance-risk.test.ts`, `telemetry-unified.test.ts`) were green this run; no new failures.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test fleet-fsm-matrix.test.ts` passes
- [x] `pnpm test` full suite passes (2946 tests)
- [x] `grep -q filterSnapshotsByName src/components/fleet-fsm-matrix.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)