### PR TITLE
[codex] Harden keeper tool and cascade fallbacks

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -114,10 +114,31 @@ let try_acquire url =
 
 (* ── Env parsing ────────────────────────────────────────────────── *)
 
-let int_of_env ?(default = 0) name =
+type env_int_value =
+  | Missing
+  | Blank
+  | Parsed of int
+  | Invalid of string
+
+let read_env_int name =
   match Sys.getenv_opt name with
-  | None | Some "" -> default
-  | Some s -> (try int_of_string (String.trim s) with _ -> default)
+  | None -> Missing
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then Blank
+    else
+      match Safe_ops.int_of_string_safe trimmed with
+      | Some value -> Parsed value
+      | None -> Invalid raw
+
+let int_of_env ?(default = 0) name =
+  match read_env_int name with
+  | Missing
+  | Blank -> default
+  | Parsed value -> value
+  | Invalid raw ->
+    Log.Misc.warn "Invalid int for %s=%S, using default %d" name raw default;
+    default
 
 let ollama_default_max () =
   max 1 (int_of_env ~default:1 "MASC_OLLAMA_MAX_CONCURRENT")
@@ -126,23 +147,51 @@ let cli_default_max () =
   max 1 (int_of_env ~default:1 "MASC_CLI_MAX_CONCURRENT")
 
 (* Parse "url=max,url=max,..." from MASC_CLIENT_CAPACITY. *)
+type capacity_entry_error =
+  | Missing_separator of string
+  | Empty_url of string
+  | Invalid_capacity of string
+  | Non_positive_capacity of int
+
+let capacity_entry_error_message = function
+  | Missing_separator raw ->
+    Printf.sprintf "missing '=' in %S" raw
+  | Empty_url raw ->
+    Printf.sprintf "empty url in %S" raw
+  | Invalid_capacity raw ->
+    Printf.sprintf "invalid capacity %S" raw
+  | Non_positive_capacity value ->
+    Printf.sprintf "capacity must be >= 1 (got %d)" value
+
+let parse_capacity_entry raw_item =
+  let item = String.trim raw_item in
+  if item = "" then Ok None
+  else
+    match String.index_opt item '=' with
+    | None -> Error (Missing_separator item)
+    | Some idx ->
+      let url = String.trim (String.sub item 0 idx) in
+      let raw_capacity =
+        String.trim
+          (String.sub item (idx + 1) (String.length item - idx - 1))
+      in
+      if url = "" then Error (Empty_url item)
+      else
+        match Safe_ops.int_of_string_safe raw_capacity with
+        | Some n when n >= 1 -> Ok (Some (url, n))
+        | Some n -> Error (Non_positive_capacity n)
+        | None -> Error (Invalid_capacity raw_capacity)
+
 let parse_capacity_env s =
   String.split_on_char ',' s
   |> List.filter_map (fun item ->
-         let item = String.trim item in
-         if item = "" then None
-         else
-           match String.index_opt item '=' with
-           | None -> None
-           | Some idx ->
-             let url = String.trim (String.sub item 0 idx) in
-             let rest =
-               String.trim
-                 (String.sub item (idx + 1) (String.length item - idx - 1))
-             in
-             match int_of_string_opt rest with
-             | Some n when n >= 1 && url <> "" -> Some (url, n)
-             | _ -> None)
+         match parse_capacity_entry item with
+         | Ok (Some entry) -> Some entry
+         | Ok None -> None
+         | Error err ->
+           Log.Misc.warn "Ignoring invalid MASC_CLIENT_CAPACITY entry: %s"
+             (capacity_entry_error_message err);
+           None)
 
 let () =
   match Sys.getenv_opt "MASC_CLIENT_CAPACITY" with

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -374,7 +374,7 @@ let weighted_shuffle
     : Cascade_config_loader.weighted_entry list =
   match entries with
   | [] | [_] -> entries
-  | _ ->
+  | first :: rest ->
     let total_weight =
       List.fold_left (fun acc (e : Cascade_config_loader.weighted_entry) ->
           acc + e.weight) 0 entries
@@ -382,11 +382,7 @@ let weighted_shuffle
     if total_weight <= 0 then entries
     else
       let r = rand_int total_weight in
-      let default_selected, default_remaining =
-        match entries with
-        | first :: rest -> (first, rest)
-        | [] -> assert false
-      in
+      let default_selected, default_remaining = (first, rest) in
       (* Find the selected entry via cumulative weight *)
       let rec find_selected cumulative = function
         | [] -> (* fallback: first entry *)

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -39,24 +39,50 @@ let getenv_with_alias ~primary ~deprecated =
        some
      | None -> None)
 
+let read_float_setting ~primary ~deprecated ~default =
+  match getenv_with_alias ~primary ~deprecated with
+  | None -> default
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then default
+    else
+      match Safe_ops.float_of_string_safe trimmed with
+      | Some value -> value
+      | None ->
+        Log.Misc.warn "Invalid float for %s=%S, using default %.1f"
+          primary raw default;
+        default
+
+let read_int_setting ~primary ~deprecated ~default =
+  match getenv_with_alias ~primary ~deprecated with
+  | None -> default
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then default
+    else
+      match Safe_ops.int_of_string_safe trimmed with
+      | Some value -> value
+      | None ->
+        Log.Misc.warn "Invalid int for %s=%S, using default %d"
+          primary raw default;
+        default
+
 (** Rolling window duration in seconds.  Events older than this are
     discarded on read.  Default: 300s (5 minutes), matching OpenRouter's
     rolling percentile window. *)
 let window_sec =
-  match getenv_with_alias
-          ~primary:"MASC_CASCADE_HEALTH_WINDOW_SEC"
-          ~deprecated:"OAS_CASCADE_HEALTH_WINDOW_SEC" with
-  | Some s -> (try Float.of_string s with _ -> 300.0)
-  | None -> 300.0
+  read_float_setting
+    ~primary:"MASC_CASCADE_HEALTH_WINDOW_SEC"
+    ~deprecated:"OAS_CASCADE_HEALTH_WINDOW_SEC"
+    ~default:300.0
 
 (** Number of consecutive failures before cooldown activates.
     Default: 3, matching LiteLLM's [allowed_fails] concept. *)
 let cooldown_threshold =
-  match getenv_with_alias
-          ~primary:"MASC_CASCADE_COOLDOWN_THRESHOLD"
-          ~deprecated:"OAS_CASCADE_COOLDOWN_THRESHOLD" with
-  | Some s -> (try int_of_string s with _ -> 3)
-  | None -> 3
+  read_int_setting
+    ~primary:"MASC_CASCADE_COOLDOWN_THRESHOLD"
+    ~deprecated:"OAS_CASCADE_COOLDOWN_THRESHOLD"
+    ~default:3
 
 (** Cooldown duration in seconds.  During cooldown, the provider is
     skipped (not attempted).  Default: 60s.
@@ -69,11 +95,10 @@ let cooldown_threshold =
     Override via [MASC_CASCADE_COOLDOWN_SEC] if recovery latency matters
     more than thrashing avoidance in your deployment. *)
 let cooldown_sec =
-  match getenv_with_alias
-          ~primary:"MASC_CASCADE_COOLDOWN_SEC"
-          ~deprecated:"OAS_CASCADE_COOLDOWN_SEC" with
-  | Some s -> (try Float.of_string s with _ -> 60.0)
-  | None -> 60.0
+  read_float_setting
+    ~primary:"MASC_CASCADE_COOLDOWN_SEC"
+    ~deprecated:"OAS_CASCADE_COOLDOWN_SEC"
+    ~default:60.0
 
 (* ── Types ────────────────────────────────────── *)
 

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -46,6 +46,39 @@ let tool_search_fn
   ref (fun ~query:_ ~max_results:_ ->
     `Assoc [ ("results", `List []) ])
 
+type tool_result_payload =
+  | Structured_success
+  | Structured_error
+  | Plain_text
+  | Malformed_structured of string
+
+let looks_like_structured_payload payload =
+  let len = String.length payload in
+  let rec find_first_nonspace i =
+    if i >= len then None
+    else
+      match payload.[i] with
+      | ' ' | '\t' | '\n' | '\r' -> find_first_nonspace (i + 1)
+      | c -> Some c
+  in
+  match find_first_nonspace 0 with
+  | Some ('{' | '[') -> true
+  | Some _ | None -> false
+
+let classify_tool_result_payload payload =
+  if not (looks_like_structured_payload payload) then Plain_text
+  else
+    match Safe_ops.parse_json_safe ~context:"Keeper_exec_tools.classify_tool_result_payload" payload with
+    | Error msg -> Malformed_structured msg
+    | Ok (`Assoc fields) ->
+      let is_error =
+        match List.assoc_opt "ok" fields with
+        | Some (`Bool false) -> true
+        | _ -> List.mem_assoc "error" fields
+      in
+      if is_error then Structured_error else Structured_success
+    | Ok _ -> Structured_success
+
 
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)
@@ -63,25 +96,26 @@ let execute_keeper_tool_call
   let args = input in
   let now_ts = Time_compat.now () in
   let apply_circuit_breaker result =
-    (* Detect error in JSON result and enrich with corrective hint
-       if the same error class has repeated [threshold] times. *)
-    let is_error =
-      try
-        match Yojson.Safe.from_string result with
-        | `Assoc fields ->
-          (match List.assoc_opt "ok" fields with
-           | Some (`Bool false) -> true
-           | _ -> List.mem_assoc "error" fields)
-        | _ -> false
-      with _ -> false
-    in
-    if is_error then
+    match classify_tool_result_payload result with
+    | Structured_error ->
       Keeper_failure_circuit_breaker.maybe_enrich_error
         ~keeper_name:meta.name ~error_msg:result
-    else begin
+    | Structured_success
+    | Plain_text ->
       Keeper_failure_circuit_breaker.record_success ~keeper_name:meta.name;
       result
-    end
+    | Malformed_structured parse_error ->
+      Log.Keeper.error
+        "keeper:%s tool:%s produced malformed structured payload: %s"
+        meta.name name parse_error;
+      let breaker_msg =
+        Printf.sprintf "malformed_tool_result: %s" parse_error
+      in
+      let _ =
+        Keeper_failure_circuit_breaker.maybe_enrich_error
+          ~keeper_name:meta.name ~error_msg:breaker_msg
+      in
+      result
   in
   let lookup = tool_access_lookup_of_meta meta in
   apply_circuit_breaker (

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -129,6 +129,22 @@ val notify_tool_call_observers :
 val tool_search_fn :
   (query:string -> max_results:int -> Yojson.Safe.t) ref
 
+(** Classification of a keeper tool result payload for circuit-breaker
+    bookkeeping.
+
+    Plain text is treated as a valid success path because some keeper tools
+    intentionally return markdown/text on success. JSON-looking payloads
+    (leading [{] or [[] after whitespace) are parsed so malformed structured
+    output does not silently reset the breaker. *)
+type tool_result_payload =
+  | Structured_success
+  | Structured_error
+  | Plain_text
+  | Malformed_structured of string
+
+(** Inspect a keeper tool result payload without applying side effects. *)
+val classify_tool_result_payload : string -> tool_result_payload
+
 (** Tag-based dispatch callback for masc_* tools without handler registry entries.
     Set at server init to [Keeper_tag_dispatch.dispatch]. Default: returns None.
     See #4579. *)

--- a/test/dune
+++ b/test/dune
@@ -584,6 +584,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_exec_tools)
+ (modules test_keeper_exec_tools)
+ (libraries masc_test_deps))
+
+(test
  (name test_cascade_health_tracker)
  (modules test_cascade_health_tracker)
  (libraries masc_test_deps))

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -1,0 +1,70 @@
+open Alcotest
+
+module KET = Masc_mcp.Keeper_exec_tools
+
+let payload_kind = function
+  | KET.Structured_success -> "structured_success"
+  | KET.Structured_error -> "structured_error"
+  | KET.Plain_text -> "plain_text"
+  | KET.Malformed_structured _ -> "malformed_structured"
+
+let check_kind ~msg expected payload =
+  check string msg expected
+    (payload_kind (KET.classify_tool_result_payload payload))
+
+let test_plain_text_is_success_shape () =
+  check_kind
+    ~msg:"plain text stays plain_text"
+    "plain_text"
+    "## Search Results\n\n- keeper_fs_read"
+
+let test_plain_text_with_leading_whitespace_stays_plain () =
+  check_kind
+    ~msg:"leading whitespace plain text stays plain_text"
+    "plain_text"
+    "  completed successfully"
+
+let test_structured_success_json () =
+  check_kind
+    ~msg:"ok=true object is structured_success"
+    "structured_success"
+    {|{"ok":true,"result":"done"}|}
+
+let test_structured_error_json () =
+  check_kind
+    ~msg:"error object is structured_error"
+    "structured_error"
+    {|{"ok":false,"error":"boom"}|}
+
+let test_structured_array_counts_as_success_shape () =
+  check_kind
+    ~msg:"json array remains structured_success"
+    "structured_success"
+    {|[{"task_id":"T-1"}]|}
+
+let test_malformed_json_like_payload_detected () =
+  match KET.classify_tool_result_payload {|{"ok":true|} with
+  | KET.Malformed_structured detail ->
+    check bool "detail mentions JSON parse error"
+      true (String.length detail > 0)
+  | other ->
+    fail
+      (Printf.sprintf "expected malformed_structured, got %s"
+         (payload_kind other))
+
+let () =
+  run "Keeper_exec_tools" [
+    ("classify_tool_result_payload", [
+      test_case "plain text" `Quick test_plain_text_is_success_shape;
+      test_case "plain text with leading whitespace" `Quick
+        test_plain_text_with_leading_whitespace_stays_plain;
+      test_case "structured success object" `Quick
+        test_structured_success_json;
+      test_case "structured error object" `Quick
+        test_structured_error_json;
+      test_case "structured array" `Quick
+        test_structured_array_counts_as_success_shape;
+      test_case "malformed json-like payload" `Quick
+        test_malformed_json_like_payload_detected;
+    ]);
+  ]


### PR DESCRIPTION
## What changed
- add a typed keeper tool result classifier so malformed JSON-like payloads no longer silently reset the keeper circuit breaker while plain text success payloads still work
- replace silent numeric/env fallbacks in cascade client capacity and health tracker with explicit parsing plus warning logs
- remove an impossible `assert false` branch from cascade weighted shuffle
- add regression coverage for keeper tool result classification

## Why
Several core-path flows were still treating malformed structured output or invalid env/config input as benign defaults. That made failures harder to observe and weakened the value of OCaml's type system in the runtime path.

## Impact
- malformed structured keeper tool payloads are now visible as errors in logs instead of being treated like successful JSON
- invalid cascade env settings continue to fall back compatibly, but now emit warnings instead of failing silently
- weighted shuffle no longer relies on an unreachable assertion

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-core-critical-path`
- `./_build/default/test/test_keeper_exec_tools.exe`
- `./_build/default/test/test_keeper_task_dispatch.exe`
- `./_build/default/test/test_cascade_health_tracker.exe`
- `./_build/default/test/test_cascade_strategy.exe`
