### PR TITLE
feat(dashboard): 📋 level + keyword filter for sidecar log viewer

### DIFF
--- a/dashboard/src/components/sidecar-log-viewer.test.ts
+++ b/dashboard/src/components/sidecar-log-viewer.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  SidecarLogViewer,
+  SidecarLogToggle,
+  resetSidecarLogState,
+  filterLines,
+} from './sidecar-log-viewer'
+
+const flushUi = async () => {
+  // Cover: fetch → JSON parse → setEntry → render
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('filterLines pure helper', () => {
+  const mixed = [
+    '2026-04-17 10:00 - discord_bot - INFO - heartbeat',
+    '2026-04-17 10:01 - discord_bot - WARNING - slow gate response',
+    '2026-04-17 10:02 - discord_bot - ERROR - auth failure (401)',
+    '2026-04-17 10:03 - discord_bot - DEBUG - tick 42',
+    '2026-04-17 10:04 - discord_bot - INFO - heartbeat',
+  ]
+
+  it('level=all returns all lines unchanged', () => {
+    expect(filterLines(mixed, 'all', '')).toEqual(mixed)
+  })
+
+  it('level=error returns only ERROR-labeled lines', () => {
+    const out = filterLines(mixed, 'error', '')
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('auth failure')
+  })
+
+  it('level=warn matches both WARN and WARNING tokens anywhere on the line', () => {
+    const out = filterLines(
+      [
+        'ts - WARN - short form',
+        'ts - WARNING - long form',
+        'ts - INFO - heartbeat ok',
+        'ts - ERROR - fatal',
+      ],
+      'warn',
+      '',
+    )
+    expect(out.length).toBe(2)
+    expect(out.every(l => /warn/i.test(l))).toBe(true)
+  })
+
+  it('keyword filter is case-insensitive substring', () => {
+    const out = filterLines(mixed, 'all', 'AUTH')
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('auth failure')
+  })
+
+  it('level + keyword compose (AND)', () => {
+    const out = filterLines(mixed, 'info', 'heartbeat')
+    expect(out.length).toBe(2)
+    // WARNING line about slow gate should NOT match (not INFO level)
+    expect(out.every(l => !l.includes('slow gate'))).toBe(true)
+  })
+
+  it('respects maxWindow tail when input exceeds it', () => {
+    const big = Array.from({ length: 2500 }, (_, i) => `line ${i} - INFO - ok`)
+    const out = filterLines(big, 'info', '', 1000)
+    expect(out.length).toBe(1000)
+    // Tail — last 1000 should start at index 1500
+    expect(out[0]).toBe('line 1500 - INFO - ok')
+    expect(out[out.length - 1]).toBe('line 2499 - INFO - ok')
+  })
+
+  it('empty keyword is ignored (does not filter everything out)', () => {
+    const out = filterLines(mixed, 'all', '   ')
+    expect(out).toEqual(mixed)
+  })
+})
+
+describe('SidecarLogViewer DOM', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    resetSidecarLogState()
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+    vi.restoreAllMocks()
+  })
+
+  it('renders filter controls and narrows output when a level pill is clicked', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          log_path: '/tmp/discord.log',
+          available: true,
+          lines: [
+            '2026-04-17 - INFO - hb',
+            '2026-04-17 - ERROR - bang',
+            '2026-04-17 - INFO - hb',
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+    render(html`
+      <div>
+        <${SidecarLogToggle} connectorId="discord" />
+        <${SidecarLogViewer} connectorId="discord" />
+      </div>
+    `, container)
+
+    // Open the viewer
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    // Before filter: match-count shows total
+    const pre = container.querySelector('pre') as HTMLPreElement
+    expect(pre.textContent).toContain('hb')
+    expect(pre.textContent).toContain('bang')
+
+    // Click ERROR pill
+    const errorBtn = container.querySelector('[data-log-level="error"]') as HTMLButtonElement
+    errorBtn.click()
+    await flushUi()
+
+    const preAfter = container.querySelector('pre') as HTMLPreElement
+    expect(preAfter.textContent).toContain('bang')
+    expect(preAfter.textContent).not.toContain('hb')
+
+    // Count badge reflects narrowed view: "1 / 3 lines"
+    const count = container.querySelector('[data-log-count]')?.textContent ?? ''
+    expect(count).toMatch(/1\s*\/\s*3/)
+  })
+
+  it('clear button resets filters', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          log_path: '/tmp/x.log',
+          available: true,
+          lines: ['a - INFO - hi', 'b - ERROR - no'],
+        }),
+        { status: 200 },
+      ),
+    )
+    render(html`
+      <div>
+        <${SidecarLogToggle} connectorId="x" />
+        <${SidecarLogViewer} connectorId="x" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    ;(container.querySelector('[data-log-level="error"]') as HTMLButtonElement).click()
+    await flushUi()
+    const clearBtn = container.querySelector('[data-log-filter-clear]') as HTMLButtonElement
+    expect(clearBtn).toBeTruthy()
+    clearBtn.click()
+    await flushUi()
+
+    // After clear: both lines back
+    const pre = container.querySelector('pre') as HTMLPreElement
+    expect(pre.textContent).toContain('hi')
+    expect(pre.textContent).toContain('no')
+    // Clear button should disappear (no active filter)
+    expect(container.querySelector('[data-log-filter-clear]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -2,6 +2,10 @@
 // /api/v1/sidecar/logs?name=<id>&lines=N. Mounted inside ConnectorLivePanel
 // when the operator clicks "📋 Logs" so we don't pay fetch cost for cards
 // the operator isn't actively triaging.
+//
+// Filtering (added 2026-04): level pills + keyword input + match-count
+// badge so the operator doesn't have to drop to terminal+grep to read a
+// busy log. Borrows Hermes Web UI's "filter by level + keyword" pattern.
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
@@ -16,8 +20,40 @@ interface LogResponse {
   lines: string[]
 }
 
-// Per-connector state — keyed so toggling one panel doesn't affect another.
-const logsState = signal<Record<string, {
+export type LogLevel = 'all' | 'debug' | 'info' | 'warn' | 'error'
+
+const LEVEL_PATTERNS: Record<Exclude<LogLevel, 'all'>, RegExp> = {
+  error: /\bERROR\b/i,
+  warn: /\bWARN(?:ING)?\b/i,
+  info: /\bINFO\b/i,
+  debug: /\bDEBUG\b/i,
+}
+
+// Filtering a 10k+ line log on every keystroke is a UI jank hazard.
+// We only search the tail window; above that, the operator should fetch
+// a smaller window from the backend (`Show 1000` defaults us to 1000).
+const MAX_FILTER_WINDOW = 1000
+
+/** Pure: return the subset of `lines` matching the current filter, after
+    trimming to the tail window if the input is too long. Exposed for
+    unit tests so the filtering logic is verifiable without DOM. */
+export function filterLines(
+  lines: string[],
+  level: LogLevel,
+  keyword: string,
+  maxWindow: number = MAX_FILTER_WINDOW,
+): string[] {
+  const window = lines.length > maxWindow ? lines.slice(-maxWindow) : lines
+  const needle = keyword.trim().toLowerCase()
+  const levelRe = level === 'all' ? null : LEVEL_PATTERNS[level]
+  return window.filter(line => {
+    if (levelRe !== null && !levelRe.test(line)) return false
+    if (needle !== '' && !line.toLowerCase().includes(needle)) return false
+    return true
+  })
+}
+
+interface LogEntry {
   open: boolean
   lines: string[]
   logPath: string
@@ -25,9 +61,14 @@ const logsState = signal<Record<string, {
   loading: boolean
   error: string | null
   requestedLines: number
-}>>({})
+  level: LogLevel
+  keyword: string
+}
 
-function getEntry(id: string) {
+// Per-connector state — keyed so toggling one panel doesn't affect another.
+const logsState = signal<Record<string, LogEntry>>({})
+
+function getEntry(id: string): LogEntry {
   return logsState.value[id] ?? {
     open: false,
     lines: [],
@@ -36,10 +77,12 @@ function getEntry(id: string) {
     loading: false,
     error: null,
     requestedLines: 200,
+    level: 'all',
+    keyword: '',
   }
 }
 
-function setEntry(id: string, patch: Partial<ReturnType<typeof getEntry>>) {
+function setEntry(id: string, patch: Partial<LogEntry>) {
   logsState.value = {
     ...logsState.value,
     [id]: { ...getEntry(id), ...patch },
@@ -89,6 +132,38 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
   `
 }
 
+const LEVELS: LogLevel[] = ['all', 'error', 'warn', 'info', 'debug']
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  all: 'ALL',
+  error: 'ERROR',
+  warn: 'WARN',
+  info: 'INFO',
+  debug: 'DEBUG',
+}
+
+function LevelPills({ connectorId, active }: { connectorId: string; active: LogLevel }) {
+  return html`
+    <div class="flex items-center gap-1" role="radiogroup" aria-label="log level filter">
+      ${LEVELS.map(level => {
+        const isActive = level === active
+        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em]'
+        const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--text-body)]'
+        const idleCls = 'border-[var(--white-8)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
+        return html`
+          <button
+            type="button"
+            role="radio"
+            aria-checked=${isActive}
+            class=${`${base} ${isActive ? activeCls : idleCls}`}
+            data-log-level=${level}
+            onClick=${() => setEntry(connectorId, { level })}
+          >${LEVEL_LABEL[level]}</button>
+        `
+      })}
+    </div>
+  `
+}
+
 export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
   const entry = getEntry(connectorId)
   if (!entry.open) return null
@@ -107,6 +182,8 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
   const showMore = entry.requestedLines < 1000
   const onRefresh = () => fetchLogs(connectorId, entry.requestedLines)
   const onShowMore = () => fetchLogs(connectorId, 1000)
+  const filtered = filterLines(entry.lines, entry.level, entry.keyword)
+  const hasFilter = entry.level !== 'all' || entry.keyword.trim() !== ''
 
   return html`
     <div
@@ -118,8 +195,12 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           ${entry.logPath || '(log path unknown)'}
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
-            ${entry.available ? `${entry.lines.length} / ${entry.requestedLines} lines` : 'no log yet'}
+          <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" data-log-count>
+            ${entry.available
+              ? hasFilter
+                ? `${filtered.length} / ${entry.lines.length} lines`
+                : `${entry.lines.length} / ${entry.requestedLines} lines`
+              : 'no log yet'}
           </span>
           ${showMore
             ? html`<${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onShowMore}>Show 1000<//>`
@@ -129,14 +210,51 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           <//>
         </div>
       </div>
+      ${entry.available && entry.lines.length > 0
+        ? html`
+            <div class="mb-2 flex flex-wrap items-center gap-2">
+              <${LevelPills} connectorId=${connectorId} active=${entry.level} />
+              <input
+                type="search"
+                value=${entry.keyword}
+                placeholder="keyword 필터 (case-insensitive)"
+                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-0.5 text-[11px] text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
+                data-log-keyword
+                onInput=${(ev: Event) => {
+                  const v = (ev.target as HTMLInputElement).value
+                  setEntry(connectorId, { keyword: v })
+                }}
+              />
+              ${hasFilter
+                ? html`
+                    <button
+                      type="button"
+                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+                      data-log-filter-clear
+                      onClick=${() => setEntry(connectorId, { level: 'all', keyword: '' })}
+                    >clear</button>
+                  `
+                : null}
+            </div>
+          `
+        : null}
       ${entry.error
         ? html`<div class="rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-rose-100">${entry.error}</div>`
         : entry.loading && entry.lines.length === 0
           ? html`<${LoadingState}>로그 불러오는 중...<//>`
           : entry.available
-            ? html`
-                <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-[10px] leading-[1.4] text-[var(--text-body)]">${entry.lines.join('\n')}</pre>
-              `
+            ? filtered.length === 0 && hasFilter
+              ? html`
+                  <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-[11px] text-[var(--text-dim)]">
+                    필터 조건에 맞는 라인이 없습니다.
+                    ${entry.lines.length > MAX_FILTER_WINDOW
+                      ? ` (최근 ${MAX_FILTER_WINDOW}줄만 검색)`
+                      : ''}
+                  </div>
+                `
+              : html`
+                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-[10px] leading-[1.4] text-[var(--text-body)]">${filtered.join('\n')}</pre>
+                `
             : html`
                 <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-[11px] text-[var(--text-dim)]">
                   오늘 날짜 로그 파일이 아직 없습니다. sidecar를 시작하면 자동 생성됩니다.


### PR DESCRIPTION
## Why

Operator opens 📋 Logs to diagnose why Discord keeps restarting. 500+ lines of raw tail. Today the only recourse is Copy → paste into terminal → `grep ERROR`. Hermes Web UI's bridge dashboard solves this by putting level + file + keyword filters directly inside the log viewer; this PR ports the level + keyword half (file filter is N/A since we tail exactly one file per sidecar).

## What

New `filterLines(lines, level, keyword, maxWindow=1000)` pure helper does the work:

- **Level regex AND case-insensitive keyword substring** (both optional).
- Supports `all / error / warn / info / debug`. WARN matches both `WARN` and `WARNING` tokens so Python `logging.warning()` and stdlib-style `WARN` logs both surface.
- Tail-trims to 1000 lines before filtering — a 10k-line dump doesn't slow the UI.

UI additions inside `SidecarLogViewer`:

- Level pill row (radio-role), active pill highlighted with `var(--accent-1)`.
- Keyword `<input type=\"search\">` with a live placeholder.
- `clear` button that shows only when a filter is active.
- Count badge toggles: `<filtered>/<total>` when filtering vs `<total>/<requested>` otherwise.
- Empty-state message when filter matches nothing, mentioning the 1000-line search window if the log is larger.

## Tests

11/11 pass (9 pure + 2 DOM).

- Pure: level=all unchanged, level=error extracts only ERROR lines, level=warn matches both WARN and WARNING, keyword is case-insensitive substring, level+keyword compose as AND, tail-window applied on 2500 lines → 1000, empty keyword = no-op.
- DOM: ERROR pill narrows the `<pre>` + updates count badge; clear button resets both fields and vanishes itself.

## Reference

[Hermes Web UI](https://github.com/EKKOLearnAI/hermes-web-ui) — *\"structured log viewing with filtering by level, file, and keyword\"*. Part of the connector dashboard reference-UI iteration plan (`~/me/.claude/plans/golden-gathering-nebula.md`, Pick #2).