### PR TITLE
[dash-iter47] sidecar-log-viewer grep filter

### DIFF
--- a/dashboard/src/components/sidecar-log-viewer.test.ts
+++ b/dashboard/src/components/sidecar-log-viewer.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { filterLogLines } from './sidecar-log-viewer'
+
+describe('filterLogLines', () => {
+  const lines: readonly string[] = [
+    '2026-04-17T10:00:00 INFO starting sidecar',
+    '2026-04-17T10:00:01 DEBUG config loaded',
+    '2026-04-17T10:00:02 ERROR connection refused',
+    '2026-04-17T10:00:03 INFO retry scheduled',
+    '2026-04-17T10:00:04 ERROR timeout',
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterLogLines(lines, '')).toBe(lines)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterLogLines(lines, '   ')).toBe(lines)
+  })
+
+  it('matches case-insensitively', () => {
+    const result = filterLogLines(lines, 'ERROR')
+    expect(result).toHaveLength(2)
+    const lower = filterLogLines(lines, 'error')
+    expect(lower).toEqual(result)
+  })
+
+  it('trims the query before matching', () => {
+    expect(filterLogLines(lines, '  DEBUG  ')).toEqual([
+      '2026-04-17T10:00:01 DEBUG config loaded',
+    ])
+  })
+
+  it('returns multiple matches', () => {
+    const result = filterLogLines(lines, 'info')
+    expect(result).toHaveLength(2)
+    expect(result.map(line => line.includes('INFO'))).toEqual([true, true])
+  })
+
+  it('returns empty array when no line matches', () => {
+    expect(filterLogLines(lines, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = lines.slice()
+    filterLogLines(lines, 'ERROR')
+    expect(lines).toEqual(copy)
+  })
+
+  it('handles empty input array', () => {
+    const empty: readonly string[] = []
+    expect(filterLogLines(empty, 'anything')).toHaveLength(0)
+    expect(filterLogLines(empty, '')).toBe(empty)
+  })
+})

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -4,10 +4,26 @@
 // the operator isn't actively triaging.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
-import { signal } from '@preact/signals'
+import { useEffect, useMemo } from 'preact/hooks'
+import { signal, useSignal } from '@preact/signals'
 import { ActionButton } from './common/button'
 import { LoadingState } from './common/feedback-state'
+
+/**
+ * Pure grep-like filter for log lines.
+ *
+ * Case-insensitive substring match on each line. Empty/whitespace query
+ * returns the input reference unchanged (no new array allocation,
+ * preserves referential equality for useMemo). Input is never mutated.
+ */
+export function filterLogLines(
+  lines: readonly string[],
+  query: string,
+): readonly string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return lines
+  return lines.filter(line => line.toLowerCase().includes(needle))
+}
 
 interface LogResponse {
   ok: boolean
@@ -91,10 +107,14 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
 
 export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
   const entry = getEntry(connectorId)
-  if (!entry.open) return null
+  // Per-viewer filter state — kept local (not in module-level logsState) so
+  // each connector's grep box lives as long as the viewer is mounted and
+  // doesn't pollute the shared fetch cache.
+  const logQuery = useSignal('')
 
   // Poll every 30s while open so the panel stays roughly fresh without
-  // the dashboard fetching for closed cards.
+  // the dashboard fetching for closed cards. Hook must run unconditionally
+  // (Rules of Hooks); the early-return below just skips rendering.
   useEffect(() => {
     const id = setInterval(() => {
       if (getEntry(connectorId).open) {
@@ -104,6 +124,14 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
     return () => clearInterval(id)
   }, [connectorId])
 
+  const visibleLines = useMemo(
+    () => filterLogLines(entry.lines, logQuery.value),
+    [entry.lines, logQuery.value],
+  )
+
+  if (!entry.open) return null
+
+  const isFiltering = logQuery.value.trim() !== ''
   const showMore = entry.requestedLines < 1000
   const onRefresh = () => fetchLogs(connectorId, entry.requestedLines)
   const onShowMore = () => fetchLogs(connectorId, 1000)
@@ -119,7 +147,11 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
         </div>
         <div class="flex items-center gap-2">
           <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
-            ${entry.available ? `${entry.lines.length} / ${entry.requestedLines} lines` : 'no log yet'}
+            ${entry.available
+              ? isFiltering
+                ? `${visibleLines.length}/${entry.lines.length} lines`
+                : `${entry.lines.length} / ${entry.requestedLines} lines`
+              : 'no log yet'}
           </span>
           ${showMore
             ? html`<${ActionButton} variant="ghost" size="sm" disabled=${entry.loading} onClick=${onShowMore}>Show 1000<//>`
@@ -129,14 +161,34 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           <//>
         </div>
       </div>
+      ${entry.available && entry.lines.length > 0
+        ? html`
+            <div class="mb-2">
+              <input
+                type="search"
+                value=${logQuery.value}
+                placeholder="grep…"
+                aria-label=${`Log filter for ${connectorId}`}
+                onInput=${(e: Event) => { logQuery.value = (e.target as HTMLInputElement).value }}
+                class="w-full rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 font-mono text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              />
+            </div>
+          `
+        : null}
       ${entry.error
         ? html`<div class="rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-rose-100">${entry.error}</div>`
         : entry.loading && entry.lines.length === 0
           ? html`<${LoadingState}>로그 불러오는 중...<//>`
           : entry.available
-            ? html`
-                <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-[10px] leading-[1.4] text-[var(--text-body)]">${entry.lines.join('\n')}</pre>
-              `
+            ? isFiltering && visibleLines.length === 0
+              ? html`
+                  <div class="rounded bg-[var(--bg-0)] px-3 py-3 text-center font-mono text-[10px] text-[var(--text-dim)]">
+                    0 lines match filter
+                  </div>
+                `
+              : html`
+                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-[10px] leading-[1.4] text-[var(--text-body)]">${visibleLines.join('\n')}</pre>
+                `
             : html`
                 <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-[11px] text-[var(--text-dim)]">
                   오늘 날짜 로그 파일이 아직 없습니다. sidecar를 시작하면 자동 생성됩니다.


### PR DESCRIPTION
## Summary
- Pure `filterLogLines(lines, query)` helper with ref-equal empty-query shortcut.
- Per-viewer signal + useMemo wiring (state local, not shared via logsState).
- Matched/total counter when filter active.

## Test plan
- [x] Unit tests (empty / case-insensitive / trimmed / no-match / multi-match)
- [x] pnpm typecheck + lint green locally
- [ ] CI green