### PR TITLE
docs(spec): mark 06-Command Plane section RETIRED in C-implementation-status

### DIFF
--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -103,19 +103,9 @@ code_refs:
 | TOML Config | config/keepers/*.toml | IMPL | keeper_toml_loader.ml |
 | OAS Memory.t Bridge | 5-tier JSONL-only mapping | IMPL | memory_oas_bridge.ml (v2.140.0 filesystem-first 완료) |
 
-### 06-Command Plane (95% IMPL)
+### 06-Command Plane (RETIRED)
 
-| Section | Feature | Status | Evidence |
-|---------|---------|--------|----------|
-| Unit Hierarchy | Company→Platoon→Squad→Agent_unit | IMPL | cp_types.ml + units.json |
-| Operation Lifecycle | Planned→Active→Paused→Completed | IMPL | cp_lifecycle.ml + 100+ operations |
-| Search Fabric V1 | 10-dimension Bayesian scoring | IMPL | cp_search_fabric.ml 622 LOC |
-| Snapshot System | 6-section mtime cache | IMPL | cp_snapshot_core.ml 758 LOC |
-| Cleanup Pipeline | 5-stage cascading GC | IMPL | cp_cleanup.ml 266 LOC |
-| Orchestra | Node/edge/signal graph synthesis | IMPL | command_plane_orchestra.ml 798 LOC |
-| Policy Decisions | Pending→Approved/Denied/Expired | IMPL | cp_lifecycle_policy.ml 838 LOC |
-| Event Trace | Append-only events.jsonl | IMPL | 58KB, 1000+ entries |
-| Intent Tools | create/status/update/forecast | IMPL | MCP tool registry 등록 + dispatch 연결 완료 |
+전체 Command Plane 서브시스템(`lib/command_plane/`, `cp_lifecycle.ml`, `cp_search_fabric.ml`, `cp_snapshot_core.ml`, `cp_cleanup.ml`, `command_plane_orchestra.ml`, `cp_lifecycle_policy.ml`, `cp_types.ml`, `command_plane_v2.ml`)와 HTTP compatibility lane은 retired surface다. 역사적 맥락은 `docs/spec/06-command-plane.md`의 "Historical Reference" status와 `docs/spec/00-glossary.md`의 Command Plane 항목을 참고한다. 현재 coordination truth는 `board_posts` + keeper FSM으로 대체됐다.
 
 ### 07-Team Session (94% IMPL)
 


### PR DESCRIPTION
## Summary

Gen34 드리프트 캡처: Command Plane 서브시스템은 완전 제거됐지만 (`project_masc-cp-removed`: -20,150 LOC, #7337+#7349 merged), `C-implementation-status.md` §06은 여전히 "95% IMPL"로 선언하며 삭제된 파일들을 evidence로 제시:

- `cp_types.ml`, `cp_lifecycle.ml`, `cp_search_fabric.ml` (622 LOC)
- `cp_snapshot_core.ml` (758 LOC), `cp_cleanup.ml` (266 LOC)
- `command_plane_orchestra.ml` (798 LOC), `cp_lifecycle_policy.ml` (838 LOC)

`find lib/ -name 'cp_*' -o -name 'command_plane*'` 결과 공백 — 어느 파일도 존재하지 않음. frontmatter `last_verified: 2026-04-17`이지만 body는 거짓.

## Change

§06 IMPL 표 → RETIRED 단락으로 교체. `docs/spec/06-command-plane.md` (이미 Historical Reference status)와 glossary 참조. 현재 coordination truth는 `board_posts` + keeper FSM임을 명시.

## Pattern

Gen33 #7920 (07-Team Session section)과 동일한 구조 — `C-implementation-status.md`가 사라진 모듈들을 IMPL로 주장하는 over-claim 드리프트. 같은 판정 기준, 다른 타겟.

## Test plan

- [x] `bash scripts/check-doc-truth.sh` pass
- [x] `find lib/ -name 'cp_*'` empty (drift 실측)
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)