### PR TITLE
feat(dashboard): 🔁 auto-restart toggle — Save chains into stop+start

### DIFF
--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -317,6 +317,132 @@ describe('ConnectorConfigForm', () => {
     expect(container.querySelector('[data-field-hint="GATE_BASE_URL"]')).toBeNull()
   })
 
+
+  it('auto-restart OFF by default; Save button label stays "Save"; single POST on click', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            id: 'discord',
+            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config POST
+
+    render(html`
+      <div>
+        <${ConnectorConfigToggle} connectorId="discord" />
+        <${ConnectorConfigForm} connectorId="discord" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    const toggle = container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement
+    expect(toggle).toBeTruthy()
+    expect(toggle.checked).toBe(false)
+
+    const saveBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === 'Save') as HTMLButtonElement
+    expect(saveBtn).toBeTruthy()
+    saveBtn.click()
+    await flushUi()
+    await flushUi()
+    // schema + values + config POST, no stop/start
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('auto-restart ON: Save button becomes "Save & Apply" and chains config→stop→start', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            id: 'discord',
+            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, signaled: true }), { status: 200 })) // stop
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 })) // start
+
+    render(html`
+      <div>
+        <${ConnectorConfigToggle} connectorId="discord" />
+        <${ConnectorConfigForm} connectorId="discord" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    const toggle = container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement
+    toggle.click()
+    await flushUi()
+
+    const btn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === 'Save & Apply') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    btn.click()
+    await new Promise(r => setTimeout(r, 1000))
+    await flushUi()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5)
+    const urls = fetchSpy.mock.calls.slice(2).map(c => String(c[0]))
+    expect(urls[0]).toContain('/api/v1/sidecar/config?name=discord')
+    expect(urls[1]).toContain('/api/v1/sidecar/stop?name=discord')
+    expect(urls[2]).toContain('/api/v1/sidecar/start?name=discord')
+  })
+
+  it('auto-restart soft-stop: if stop rejects, start still fires', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            id: 'discord',
+            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config
+      .mockRejectedValueOnce(new Error('stop refused')) // stop rejects
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 })) // start still fires
+
+    render(html`
+      <div>
+        <${ConnectorConfigToggle} connectorId="discord" />
+        <${ConnectorConfigForm} connectorId="discord" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    await flushUi()
+
+    ;(container.querySelector('[data-auto-restart-toggle]') as HTMLInputElement).click()
+    await flushUi()
+    const btn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === 'Save & Apply') as HTMLButtonElement
+    btn.click()
+    await new Promise(r => setTimeout(r, 1000))
+    await flushUi()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5)
+    const last = fetchSpy.mock.calls.slice(-2).map(c => String(c[0]))
+    expect(last[0]).toContain('/sidecar/stop')
+    expect(last[1]).toContain('/sidecar/start')
+  })
+
   it('after toggle + fetch, renders required field marker and password input for token', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -61,6 +61,7 @@ interface FormEntry {
   saving: boolean
   lastSavedAt: number | null
   restarting: boolean
+  autoRestart: boolean
 }
 
 const formState = signal<Record<string, FormEntry>>({})
@@ -76,6 +77,7 @@ function emptyEntry(): FormEntry {
     saving: false,
     lastSavedAt: null,
     restarting: false,
+    autoRestart: false,
   }
 }
 
@@ -240,24 +242,35 @@ async function saveConfig(id: string) {
       throw new Error(`HTTP ${res.status}${text ? `: ${text.slice(0, 200)}` : ''}`)
     }
     setEntry(id, { saving: false, lastSavedAt: Date.now() })
-    showToast(`${id} config 저장됨 — sidecar 재시작 시 반영`, 'success', 2400)
+    if (getEntry(id).autoRestart) {
+      // Auto-restart path: apply-config chains save → apply so the
+      // operator doesn't have to click 🔄. "apply" is a soft restart —
+      // stop is best-effort (sidecar may be down), start is strict.
+      showToast(`${id} config 저장됨 — 자동 적용 중...`, 'success', 1500)
+      await applyConfigChange(id)
+    } else {
+      showToast(`${id} config 저장됨 — sidecar 재시작 시 반영`, 'success', 2400)
+    }
   } catch (err) {
     setEntry(id, { saving: false })
     showToast(err instanceof Error ? err.message : 'config save failed', 'error')
   }
 }
 
-async function restartSidecar(id: string) {
+/** Soft restart: stop (best-effort — sidecar may already be down),
+    800ms grace, then start (strict). Used both as the backing for the
+    manual 🔄 button and as the auto-restart step after save. */
+async function applyConfigChange(id: string) {
   setEntry(id, { restarting: true })
   try {
-    const stopRes = await fetch(`/api/v1/sidecar/stop?name=${encodeURIComponent(id)}`, {
-      method: 'POST',
-      headers: { Accept: 'application/json' },
-    })
-    if (!stopRes.ok) throw new Error(`stop HTTP ${stopRes.status}`)
-    // Brief grace so the SIGTERM has a moment to land before we re-spawn —
-    // run.sh stop returns once it has signalled, not once the process has
-    // exited. 800ms is enough for a clean shutdown of the bridges we ship.
+    try {
+      await fetch(`/api/v1/sidecar/stop?name=${encodeURIComponent(id)}`, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+      })
+    } catch {
+      // Stop failures are non-fatal here — target might not be running.
+    }
     await new Promise(r => setTimeout(r, 800))
     const startRes = await fetch(`/api/v1/sidecar/start?name=${encodeURIComponent(id)}`, {
       method: 'POST',
@@ -266,10 +279,16 @@ async function restartSidecar(id: string) {
     if (!startRes.ok) throw new Error(`start HTTP ${startRes.status}`)
     showToast(`${id} 재시작 완료 — 새 config 적용됨`, 'success', 2400)
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'restart failed', 'error')
+    showToast(err instanceof Error ? err.message : 'apply failed', 'error')
   } finally {
     setEntry(id, { restarting: false })
   }
+}
+
+async function restartSidecar(id: string) {
+  // Manual 🔄 button and auto-restart both route through the same soft
+  // restart — the only difference is who triggered it.
+  await applyConfigChange(id)
 }
 
 function buildEnvBlock(entry: FormEntry): string {
@@ -452,17 +471,42 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
               `
             : null}
         </div>
-        <${ActionButton}
-          variant="ghost"
-          size="sm"
-          disabled=${entry.saving || missingRequired(entry).length > 0}
-          title=${missingRequired(entry).length > 0
-            ? `필수 필드: ${missingRequired(entry).join(', ')}`
-            : 'POST /api/v1/sidecar/config — sidecar 재시작 시 반영'}
-          onClick=${() => { void saveConfig(connectorId) }}
-        >
-          ${entry.saving ? '저장 중...' : 'Save'}
-        <//>
+        <div class="flex items-center gap-2">
+          <label
+            class="flex cursor-pointer items-center gap-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            title="저장 직후 자동으로 sidecar 재시작 (stop → 800ms → start)"
+          >
+            <input
+              type="checkbox"
+              class="cursor-pointer"
+              checked=${entry.autoRestart}
+              data-auto-restart-toggle
+              onChange=${(ev: Event) => {
+                setEntry(connectorId, { autoRestart: (ev.target as HTMLInputElement).checked })
+              }}
+            />
+            <span>Auto restart</span>
+          </label>
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            disabled=${entry.saving || entry.restarting || missingRequired(entry).length > 0}
+            title=${missingRequired(entry).length > 0
+              ? `필수 필드: ${missingRequired(entry).join(', ')}`
+              : entry.autoRestart
+                ? 'POST /sidecar/config → stop → 800ms → start'
+                : 'POST /api/v1/sidecar/config — sidecar 재시작 시 반영'}
+            onClick=${() => { void saveConfig(connectorId) }}
+          >
+            ${entry.saving
+              ? '저장 중...'
+              : entry.restarting
+                ? '적용 중...'
+                : entry.autoRestart
+                  ? 'Save & Apply'
+                  : 'Save'}
+          <//>
+        </div>
       </div>
 
       <div class="space-y-2.5">


### PR DESCRIPTION
## Why

Config form had two steps: **Save** (writes \`config.toml\`), then 🔄 **재시작** (stop → 800ms → start). Every operator who changed a token had to click both buttons. [Coolify](https://coolify.io/)'s pattern: form + implicit re-deploy so editing config *feels* like editing live state.

## What

A tiny \"Auto restart\" checkbox next to Save. Off by default — opt-in, never surprise.

| Toggle | Button label | Behavior |
|--------|-------------|----------|
| OFF (default) | **Save** | POST /config only |
| ON            | **Save & Apply** | POST /config → (best-effort) stop → 800ms → start |

Refactor bonus: new `applyConfigChange(id)` is a **soft restart**. The previous `restartSidecar` threw loudly when stop failed — which is wrong for a freshly-configured (not yet running) sidecar. Now stop is best-effort (`catch { /* ignore */ }`), start is strict. Manual 🔄 button and auto-restart share this code path.

## Tests

13/13 pass. 3 new cases:
- Default OFF → Save is a single POST to /config (no stop/start).
- ON → button re-labels to \"Save & Apply\", chain fires /config → /stop → /start in order.
- ON + stop rejection → start still fires (soft-stop contract).

## Reference

[Coolify](https://coolify.io/docs/get-started/screenshots) — config form + auto re-deploy. Part of the connector dashboard reference-UI iteration plan (\`~/me/.claude/plans/golden-gathering-nebula.md\`, backlog item B2).