### PR TITLE
[dash-iter49] handoff-timeline text filter

### DIFF
--- a/dashboard/src/components/handoff-timeline.test.ts
+++ b/dashboard/src/components/handoff-timeline.test.ts
@@ -5,6 +5,7 @@ import {
   CHIP_CLASS_BY_KIND,
   deriveHandoffArcs,
   deriveTimelineRows,
+  filterTimelineRows,
   kindOfEventType,
   type TimelineRow,
 } from './handoff-timeline'
@@ -221,5 +222,69 @@ describe('deriveHandoffArcs', () => {
     ]
     const arcs = deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)
     expect(arcs).toHaveLength(1)
+  })
+})
+
+describe('filterTimelineRows', () => {
+  const sample: readonly TimelineRow[] = [
+    {
+      keeper: 'alpha',
+      chips: [
+        { ts: 1, eventType: 'agent_started', kind: 'lifecycle' },
+        { ts: 2, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'beta', taskId: 'T-100' },
+      ],
+    },
+    {
+      keeper: 'Beta',
+      chips: [
+        { ts: 3, eventType: 'tool_called', kind: 'tool', taskId: 'T-200' },
+      ],
+    },
+    {
+      keeper: 'gamma',
+      chips: [
+        { ts: 4, eventType: 'turn_completed', kind: 'lifecycle' },
+      ],
+    },
+  ]
+
+  it('returns the input reference unchanged on empty query', () => {
+    expect(filterTimelineRows(sample, '')).toBe(sample)
+  })
+
+  it('returns the input reference unchanged on whitespace-only query', () => {
+    expect(filterTimelineRows(sample, '   \t  ')).toBe(sample)
+  })
+
+  it('is case-insensitive on keeper match', () => {
+    // 'GAMMA' only matches the `gamma` keeper — no chip field contains it,
+    // so this isolates keeper-name case-insensitivity.
+    const out = filterTimelineRows(sample, 'GAMMA')
+    expect(out.map(r => r.keeper)).toEqual(['gamma'])
+  })
+
+  it('trims the query before matching', () => {
+    const out = filterTimelineRows(sample, '  alpha  ')
+    expect(out.map(r => r.keeper)).toEqual(['alpha'])
+  })
+
+  it('matches across keeper + chip.eventType + chip.taskId + chip.peerAgent', () => {
+    // event type across any chip on a row
+    expect(filterTimelineRows(sample, 'handoff_requested').map(r => r.keeper)).toEqual(['alpha'])
+    // taskId partial match
+    expect(filterTimelineRows(sample, 't-200').map(r => r.keeper)).toEqual(['Beta'])
+    // peerAgent match (on alpha's chip pointing at beta)
+    expect(filterTimelineRows(sample, 'beta').map(r => r.keeper).sort()).toEqual(['Beta', 'alpha'])
+  })
+
+  it('returns empty array when no row matches', () => {
+    expect(filterTimelineRows(sample, 'zzz-nope')).toEqual([])
+  })
+
+  it('does not mutate the input rows or their chips', () => {
+    const snapshot = JSON.stringify(sample)
+    void filterTimelineRows(sample, 'alpha')
+    void filterTimelineRows(sample, 'T-100')
+    expect(JSON.stringify(sample)).toBe(snapshot)
   })
 })

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -26,7 +26,8 @@
 // `pointer-events: none` on the overlay so chips remain clickable.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
 
 export type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
@@ -183,6 +184,36 @@ export function deriveHandoffArcs(
   return arcs
 }
 
+/**
+ * Pure filter for timeline rows.
+ *
+ * Case-insensitive substring match on `row.keeper` and on each chip's
+ * `eventType`, `taskId`, and `peerAgent`. Operators can locate a row by
+ * partial keeper name, by an event type (e.g. "handoff_requested"), by
+ * a task identifier, or by the peer agent involved in a handoff.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no new
+ * array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated.
+ */
+export function filterTimelineRows(
+  rows: readonly TimelineRow[],
+  query: string,
+): readonly TimelineRow[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(row => {
+    if (row.keeper.toLowerCase().includes(needle)) return true
+    for (const chip of row.chips) {
+      if (chip.eventType.toLowerCase().includes(needle)) return true
+      if (chip.taskId && chip.taskId.toLowerCase().includes(needle)) return true
+      if (chip.peerAgent && chip.peerAgent.toLowerCase().includes(needle)) return true
+    }
+    return false
+  })
+}
+
 const ROW_HEIGHT_PX = 24
 const ROW_GAP_PX = 4
 const ROW_STRIDE_PX = ROW_HEIGHT_PX + ROW_GAP_PX
@@ -210,6 +241,7 @@ export function HandoffTimeline({
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState<number>(() => Date.now())
   const latestRequestId = useRef(0)
+  const query = useSignal('')
 
   useEffect(() => {
     let cancelled = false
@@ -245,6 +277,11 @@ export function HandoffTimeline({
   const windowStart = now - windowMs
   const rows = deriveTimelineRows(entries, windowStart, windowEnd)
   const span = windowEnd - windowStart
+  const visibleRows = useMemo(
+    () => filterTimelineRows(rows, query.value),
+    [rows, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
 
   return html`
     <section class="rounded-xl border border-card-border bg-card-bg p-4 flex flex-col gap-3">
@@ -273,16 +310,28 @@ export function HandoffTimeline({
           </span>
         </div>
       </header>
+      <div class="flex items-center justify-end">
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="keeper / event / task / peer 필터"
+          aria-label="Handoff timeline 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-card-border bg-bg-1/40 px-2 py-1 text-[11px] text-text placeholder:text-text-dim focus:outline-none focus:border-accent"
+        />
+      </div>
       ${error !== null
         ? html`<p class="text-[11px] text-red-400">오류: ${error}</p>`
         : rows.length === 0
           ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
-          : html`
+          : isFiltering && visibleRows.length === 0
+            ? html`<p class="text-[11px] text-text-dim">필터 결과 없음 (${rows.length} handoffs)</p>`
+            : html`
               <div class="flex flex-col gap-1 relative">
                 ${(() => {
-                  const arcs = deriveHandoffArcs(rows, windowStart, windowEnd)
+                  const arcs = deriveHandoffArcs(visibleRows, windowStart, windowEnd)
                   if (arcs.length === 0) return null
-                  const totalH = rows.length * ROW_STRIDE_PX - ROW_GAP_PX
+                  const totalH = visibleRows.length * ROW_STRIDE_PX - ROW_GAP_PX
                   return html`
                     <svg
                       class="absolute pointer-events-none"
@@ -301,7 +350,7 @@ export function HandoffTimeline({
                     </svg>
                   `
                 })()}
-                ${rows.map(row => {
+                ${visibleRows.map(row => {
                   const isSelected = selectedKeeper === row.keeper
                   const labelCls = isSelected
                     ? 'text-text ring-1 ring-accent bg-accent/10'


### PR DESCRIPTION
## Summary
- Pure `filterTimelineRows(rows, query)` helper with ref-equal empty-query shortcut.
- Matches `row.keeper` plus each chip's `eventType`, `taskId`, `peerAgent` (case-insensitive, trimmed).
- `useSignal('')` + `useMemo` wiring in `HandoffTimeline`, input rendered above the rows with existing Tailwind utility classes; distinct filter-empty (`필터 결과 없음 (N handoffs)`) vs data-empty states.

## Test plan
- [x] 7 new unit tests for `filterTimelineRows` (empty-ref, whitespace-ref, case-insensitive on keeper, trimmed, multi-field match across keeper/eventType/taskId/peerAgent, no-match, no-mutation)
- [x] Existing 20 handoff-timeline tests still pass (27 total)
- [x] `pnpm typecheck` + `pnpm lint` green locally
- [ ] CI green