### PR TITLE
[dash-iter50] memory-post comment tree filter

### DIFF
--- a/dashboard/src/components/memory-post-detail.test.ts
+++ b/dashboard/src/components/memory-post-detail.test.ts
@@ -55,7 +55,8 @@ vi.mock('./memory-state', () => ({
   refreshBoard: vi.fn(),
 }))
 
-import { CommentThread, PostDetail } from './memory-post-detail'
+import { CommentThread, PostDetail, filterCommentTree } from './memory-post-detail'
+import type { BoardComment } from '../types/core'
 
 afterEach(() => {
   cleanup()
@@ -86,6 +87,100 @@ describe('CommentThread', () => {
 
     expect(screen.getByText('orphan reply still visible')).toBeInTheDocument()
     expect(screen.getByText(/댓글 1개/)).toBeInTheDocument()
+  })
+})
+
+describe('filterCommentTree', () => {
+  const comment = (
+    id: string,
+    parent_id: string | null,
+    content: string,
+  ): BoardComment => ({
+    id,
+    post_id: 'post-1',
+    parent_id,
+    author: 'agent',
+    content,
+    created_at: '2026-04-17T00:00:00Z',
+  })
+
+  // Tree:
+  //   r1 "alpha"
+  //     c11 "beta"
+  //       c111 "gamma"
+  //   r2 "delta"
+  //     c21 "epsilon"
+  const r1 = comment('r1', null, 'alpha')
+  const c11 = comment('c11', 'r1', 'beta')
+  const c111 = comment('c111', 'c11', 'gamma')
+  const r2 = comment('r2', null, 'delta')
+  const c21 = comment('c21', 'r2', 'epsilon')
+
+  const roots: readonly BoardComment[] = [r1, r2]
+  const childrenMap = new Map<string, readonly BoardComment[]>([
+    ['r1', [c11]],
+    ['c11', [c111]],
+    ['r2', [c21]],
+  ])
+
+  it('returns original references on empty query (ref-equal)', () => {
+    const out = filterCommentTree(roots, childrenMap, '')
+    expect(out.roots).toBe(roots)
+    expect(out.childrenMap).toBe(childrenMap)
+  })
+
+  it('returns original references on whitespace-only query', () => {
+    const out = filterCommentTree(roots, childrenMap, '   ')
+    expect(out.roots).toBe(roots)
+    expect(out.childrenMap).toBe(childrenMap)
+  })
+
+  it('matches direct root substring case-insensitively', () => {
+    const out = filterCommentTree(roots, childrenMap, 'ALPHA')
+    expect(out.roots.map(c => c.id)).toEqual(['r1'])
+    // r1 alone matches; its descendants are not kept (only ancestor chain is preserved up, not descendants down).
+    expect(out.childrenMap.get('r1')).toBeUndefined()
+  })
+
+  it('preserves ancestor chain when a deep descendant matches', () => {
+    const out = filterCommentTree(roots, childrenMap, 'gamma')
+    expect(out.roots.map(c => c.id)).toEqual(['r1'])
+    expect(out.childrenMap.get('r1')?.map(c => c.id)).toEqual(['c11'])
+    expect(out.childrenMap.get('c11')?.map(c => c.id)).toEqual(['c111'])
+    expect(out.childrenMap.get('r2')).toBeUndefined()
+    expect(out.childrenMap.get('c21')).toBeUndefined()
+  })
+
+  it('preserves ancestor when intermediate child matches', () => {
+    const out = filterCommentTree(roots, childrenMap, 'beta')
+    expect(out.roots.map(c => c.id)).toEqual(['r1'])
+    expect(out.childrenMap.get('r1')?.map(c => c.id)).toEqual(['c11'])
+    // c11 itself matches but has no matched descendants -> no entry for c11.
+    expect(out.childrenMap.get('c11')).toBeUndefined()
+  })
+
+  it('returns empty roots on no match', () => {
+    const out = filterCommentTree(roots, childrenMap, 'zzzzz')
+    expect(out.roots).toEqual([])
+    expect(out.childrenMap.size).toBe(0)
+  })
+
+  it('trims the query before matching', () => {
+    const out = filterCommentTree(roots, childrenMap, '   alpha   ')
+    expect(out.roots.map(c => c.id)).toEqual(['r1'])
+  })
+
+  it('does not mutate the original collections', () => {
+    const rootsSnapshot = [...roots]
+    const childrenSnapshot = new Map(
+      [...childrenMap.entries()].map(([k, v]) => [k, [...v]] as const),
+    )
+    filterCommentTree(roots, childrenMap, 'gamma')
+    expect(roots).toEqual(rootsSnapshot)
+    expect(childrenMap.size).toBe(childrenSnapshot.size)
+    for (const [k, v] of childrenSnapshot) {
+      expect([...(childrenMap.get(k) ?? [])]).toEqual([...v])
+    }
   })
 })
 

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -56,6 +57,57 @@ function buildCommentTree(comments: BoardComment[]): { roots: BoardComment[]; ch
   return { roots, childrenMap }
 }
 
+/**
+ * Pure tree-aware text filter on a comment forest.
+ *
+ * Case-insensitive substring match on `comment.content`.
+ *
+ * A comment is kept if it matches OR any descendant matches. The ancestor
+ * chain is preserved so matches retain their reply context. The returned
+ * `childrenMap` contains only entries whose child list survived filtering.
+ *
+ * Empty/whitespace query returns the original `{ roots, childrenMap }` by
+ * reference (no new allocations, preserves referential equality for memo).
+ *
+ * Input collections are never mutated.
+ */
+export function filterCommentTree(
+  roots: readonly BoardComment[],
+  childrenMap: ReadonlyMap<string, readonly BoardComment[]>,
+  query: string,
+): { roots: readonly BoardComment[]; childrenMap: ReadonlyMap<string, readonly BoardComment[]> } {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return { roots, childrenMap }
+
+  const matches = (c: BoardComment): boolean =>
+    (c.content ?? '').toLowerCase().includes(needle)
+
+  const nextChildren = new Map<string, readonly BoardComment[]>()
+
+  // Recursively returns a filtered child list if any descendant (or self) matches.
+  // Side effect: populates `nextChildren` for any parent whose filtered child list
+  // is non-empty.
+  const walk = (c: BoardComment): boolean => {
+    const children = childrenMap.get(c.id) ?? []
+    const keptChildren: BoardComment[] = []
+    for (const child of children) {
+      if (walk(child)) keptChildren.push(child)
+    }
+    const selfMatches = matches(c)
+    if (keptChildren.length > 0) {
+      nextChildren.set(c.id, keptChildren)
+      return true
+    }
+    return selfMatches
+  }
+
+  const nextRoots: BoardComment[] = []
+  for (const r of roots) {
+    if (walk(r)) nextRoots.push(r)
+  }
+  return { roots: nextRoots, childrenMap: nextChildren }
+}
+
 // ── Comment item ───────────────────────────────────────────────────
 function CommentItem({
   comment,
@@ -66,7 +118,7 @@ function CommentItem({
   comment: BoardComment
   postId: string
   depth?: number
-  childrenMap: Map<string, BoardComment[]>
+  childrenMap: ReadonlyMap<string, readonly BoardComment[]>
 }) {
   const contentChars = Array.from(comment.content ?? '')
   const needsTruncation = contentChars.length > 300
@@ -135,24 +187,47 @@ function CommentItem({
 
 // ── Comment thread ─────────────────────────────────────────────────
 export function CommentThread({ comments, postId }: { comments: BoardComment[]; postId: string }) {
+  const query = useSignal('')
+  const [expanded, setExpanded] = useState(false)
+  const INITIAL_SHOW = 5
+
+  const { roots, childrenMap } = useMemo(() => buildCommentTree(comments), [comments])
+  const { roots: filteredRoots, childrenMap: filteredChildrenMap } = useMemo(
+    () => filterCommentTree(roots, childrenMap, query.value),
+    [roots, childrenMap, query.value],
+  )
+
   if (comments.length === 0) return html`<${EmptyState} message="아직 댓글이 없습니다" compact />`
 
-  const { roots, childrenMap } = buildCommentTree(comments)
-  const INITIAL_SHOW = 5
-  const [expanded, setExpanded] = useState(false)
-  const hiddenCount = roots.length - INITIAL_SHOW
-  const visible = expanded || roots.length <= INITIAL_SHOW ? roots : roots.slice(-INITIAL_SHOW)
+  const isFiltering = query.value.trim() !== ''
+  const hiddenCount = filteredRoots.length - INITIAL_SHOW
+  const visible = expanded || filteredRoots.length <= INITIAL_SHOW
+    ? filteredRoots
+    : filteredRoots.slice(-INITIAL_SHOW)
 
   return html`
     <div class="flex flex-col gap-2">
-      <div class="text-[11px] text-[var(--text-muted)] mb-1">댓글 ${comments.length}개</div>
+      <div class="flex items-center gap-2 mb-1">
+        <div class="text-[11px] text-[var(--text-muted)]">댓글 ${comments.length}개${isFiltering ? ` · 일치 ${filteredRoots.length}` : ''}</div>
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="댓글 내용 검색"
+          aria-label="댓글 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="ml-auto min-w-[140px] max-w-[220px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && filteredRoots.length === 0 ? html`
+        <${EmptyState} message=${`"${query.value.trim()}" 일치하는 댓글 없음`} compact />
+      ` : null}
       ${!expanded && hiddenCount > 0 ? html`
         <button type="button"
           class="text-[12px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기</button>
       ` : null}
-      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${childrenMap} />`)}
+      ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <button type="button"
           class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"


### PR DESCRIPTION
## Summary
- Tree-aware `filterCommentTree(roots, childrenMap, query)` preserves ancestor chain on descendant match.
- Empty query returns original references (ref-equal fast path).
- Runs BEFORE existing expand/slice pagination — composes cleanly.

## Test plan
- [x] Tree fixture tests (descendant match preserves ancestors)
- [x] Ref-equal on empty query
- [x] pnpm typecheck + lint green locally
- [ ] CI green