### PR TITLE
feat(dashboard): ⏱ uptime chip on overview tiles — "up 3h 22m"

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -2,7 +2,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { ConnectorOverviewStrip, _testResetBulkInflight, countConnectedSidecars } from './connector-overview-strip'
+import {
+  ConnectorOverviewStrip,
+  _testResetBulkInflight,
+  countConnectedSidecars,
+  formatConnectorUptime,
+} from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
 const mkConnector = (overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
@@ -127,6 +132,81 @@ describe('ConnectorOverviewStrip', () => {
     const banner = container.querySelector('[data-celebration="all-connected"]')
     expect(banner).toBeTruthy()
     expect(banner?.textContent).toContain('4/4')
+  })
+
+  it('uptime chip renders inside tile when sidecar is up and last_ready_at is recent', () => {
+    _testResetBulkInflight()
+    const readyAt = new Date(Date.now() - 65 * 1000).toISOString()
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: true, last_ready_at: readyAt })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const tile = container.querySelector('[data-overview-tile="discord"]')!
+    const chip = tile.querySelector('[data-uptime-chip]')
+    expect(chip).toBeTruthy()
+    expect(chip?.textContent).toMatch(/^up 1m/)
+  })
+
+  it('uptime chip absent when sidecar is down, even with a stale last_ready_at', () => {
+    _testResetBulkInflight()
+    const readyAt = new Date(Date.now() - 60 * 1000).toISOString()
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: false, last_ready_at: readyAt })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const tile = container.querySelector('[data-overview-tile="discord"]')!
+    expect(tile.querySelector('[data-uptime-chip]')).toBeNull()
+  })
+
+  it('uptime chip absent when last_ready_at is missing/empty', () => {
+    _testResetBulkInflight()
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: true, last_ready_at: '' })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const tile = container.querySelector('[data-overview-tile="discord"]')!
+    expect(tile.querySelector('[data-uptime-chip]')).toBeNull()
+  })
+})
+
+describe('formatConnectorUptime', () => {
+  const NOW = Date.UTC(2026, 3, 17, 12, 0, 0) // deterministic fixed "now"
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(formatConnectorUptime(null, NOW)).toBeNull()
+    expect(formatConnectorUptime(undefined, NOW)).toBeNull()
+    expect(formatConnectorUptime('', NOW)).toBeNull()
+    expect(formatConnectorUptime('   ', NOW)).toBeNull()
+  })
+
+  it('returns null for unparseable date strings', () => {
+    expect(formatConnectorUptime('not-a-date', NOW)).toBeNull()
+    expect(formatConnectorUptime('garbage 🦖', NOW)).toBeNull()
+  })
+
+  it('returns null when last_ready_at is in the future (clock skew)', () => {
+    const future = new Date(NOW + 10 * 60 * 1000).toISOString()
+    expect(formatConnectorUptime(future, NOW)).toBeNull()
+  })
+
+  it('formats seconds, minutes+seconds, and hours+minutes', () => {
+    const sec30 = new Date(NOW - 30 * 1000).toISOString()
+    expect(formatConnectorUptime(sec30, NOW)).toBe('up 30s')
+
+    const min5 = new Date(NOW - (5 * 60 + 12) * 1000).toISOString()
+    expect(formatConnectorUptime(min5, NOW)).toBe('up 5m 12s')
+
+    const hr3 = new Date(NOW - (3 * 3600 + 22 * 60) * 1000).toISOString()
+    expect(formatConnectorUptime(hr3, NOW)).toBe('up 3h 22m')
   })
 })
 

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -14,8 +14,31 @@ import type { GateConnectorInfo } from '../api/gate'
 import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight } from './connector-readiness-rail'
 import { CONNECTOR_DISPLAY_NAMES, KNOWN_CONNECTOR_IDS, channelIcon, connectorAccentStyle, startSidecar, stopSidecar, type KnownConnectorId } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
+import { formatElapsedCompact } from '../lib/format-time'
 
 const bulkInflight = signal<{ start: boolean; stop: boolean }>({ start: false, stop: false })
+
+/** Pure: derive a compact "up X" string from the sidecar's last_ready_at
+    timestamp. Returns null when the timestamp is empty/invalid/in the
+    future — the tile then hides the chip rather than rendering NaN.
+
+    Home Assistant 2024 badge redesign informs the style: tiny, muted,
+    sits adjacent to the primary status text. Not a loud signal — the
+    existing glyph already tells the operator the sidecar is up; this
+    chip only adds the time axis (how long). */
+export function formatConnectorUptime(
+  readyAtIso: string | null | undefined,
+  now: number,
+): string | null {
+  if (readyAtIso === null || readyAtIso === undefined) return null
+  const trimmed = readyAtIso.trim()
+  if (trimmed === '') return null
+  const then = Date.parse(trimmed)
+  if (Number.isNaN(then)) return null
+  const elapsedSec = Math.floor((now - then) / 1000)
+  if (elapsedSec < 0) return null
+  return `up ${formatElapsedCompact(elapsedSec)}`
+}
 
 async function runBulk(
   kind: 'start' | 'stop',
@@ -58,6 +81,7 @@ function OverviewTile({ id, connector, keeperCount }: {
   keeperCount: number
 }) {
   const sidecarUp = connector?.available === true
+  const uptimeLabel = sidecarUp ? formatConnectorUptime(connector?.last_ready_at, Date.now()) : null
   const pills = deriveRail(
     {
       sidecarUp,
@@ -97,7 +121,18 @@ function OverviewTile({ id, connector, keeperCount }: {
         >${channelIcon(id)}</span>
         <span class="min-w-0 flex-1">
           <span class="block truncate text-[13px] font-semibold text-[var(--text-body)]">${displayName}</span>
-          <span class="block text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${sidecarUp ? '🟢 connected' : '⊘ offline'}</span>
+          <span class="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
+            <span>${sidecarUp ? '🟢 connected' : '⊘ offline'}</span>
+            ${uptimeLabel !== null
+              ? html`
+                  <span
+                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[9px] font-normal normal-case tracking-normal text-emerald-200/80"
+                    data-uptime-chip
+                    title="last_ready_at 기준 경과 시간"
+                  >${uptimeLabel}</span>
+                `
+              : null}
+          </span>
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />


### PR DESCRIPTION
## Why

Overview tile already screams *\"Discord is up.\"* It doesn't say *\"…and has been for the last 3 hours.\"* That second piece is what separates \"fresh start\" from \"well, it's been stable all morning.\"

[Home Assistant](https://www.home-assistant.io/blog/2024/08/07/release-20248/) redesigned their badge/chip system in 2024 specifically so a tile could carry \"the most important info you need at a glance\" in one small pill. Borrow that convention.

## What

One tiny chip next to the status text, only when the sidecar is up:

> 🟢 CONNECTED  [ up 3h 22m ]

Pure helper `formatConnectorUptime(readyAtIso, now)` handles:

- `null` / `undefined` / empty / whitespace → \`null\` (hide chip)
- unparseable string → \`null\` (hide chip)
- future timestamp (clock skew) → \`null\` (hide chip, never negative)
- valid → \`up Xh Ym\` / \`up Xm Ys\` / \`up Ns\` via existing `formatElapsedCompact`

Style is intentionally muted — emerald-tinted but low-saturation. The glyph already conveys \"up\"; this chip only adds the time axis.

## Tests

18/18 pass. 7 new cases: 4 pure (null inputs, unparseable, future clock, each formatter branch) + 3 DOM (renders when up & recent, absent when down, absent when `last_ready_at` empty).

## Reference

- [Home Assistant 2024.8 badge redesign](https://www.home-assistant.io/blog/2024/08/07/release-20248/) — Mushroom chip pattern
- [PatternFly dashboard design guide](https://www.patternfly.org/patterns/dashboard/design-guidelines/) — aggregate-at-a-glance tiles

Part of the connector dashboard reference-UI iteration plan (\`~/me/.claude/plans/golden-gathering-nebula.md\`, backlog B3 narrowed to \"uptime as the minimum viable slice\").