### PR TITLE
docs(spec): sync module_tag (43→21 variants) + drop command-plane from primary domains

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -24,8 +24,8 @@ Scope:
 
 - Canonical behavior in this document is derived from code.
 - "Current host audit" is a dated snapshot of the machine inspected on 2026-04-09.
-- Primary runtime domains are `tasks`, `board`, `goals`, `governance`, `autoresearch`, `keepers`, and `command-plane`.
-- `team-sessions`, `local-workers`, and `oas-runtime` are documented only as compatibility or execution-artifact lanes, not as the primary product concept.
+- Primary runtime domains are `tasks`, `board`, `goals`, `governance`, `autoresearch`, and `keepers`.
+- `team-sessions`, `local-workers`, `oas-runtime`, and `command-plane` are documented only as compatibility, historical, or execution-artifact lanes, not as the primary product concept.
 
 ## 1. Boot Inputs and Precedence
 

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -479,22 +479,22 @@ type post_hook = Tool_result.t -> Tool_result.t
 
 ```ocaml
 type module_tag =
-  | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
-  | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
-  | Mod_tempo | Mod_portal | Mod_worktree
-  | Mod_code_swarm | Mod_code | Mod_code_write | Mod_vote | Mod_social
-  | Mod_council | Mod_a2a | Mod_handover
-  | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
-  | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit
-  | Mod_cost | Mod_agent | Mod_task | Mod_room
+  | Mod_plan | Mod_operator
+  | Mod_local_runtime
+  | Mod_worktree
+  | Mod_code | Mod_code_write
+  | Mod_a2a
+  | Mod_run
+  | Mod_compact
+  | Mod_agent | Mod_task | Mod_room
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
-  | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
-  | Mod_notifications | Mod_inline
-  | Mod_autoresearch | Mod_research | Mod_model_catalog
-  | Mod_shard | Mod_fire_task
+  | Mod_library | Mod_keeper
+  | Mod_inline
+  | Mod_autoresearch
+  | Mod_shard
 ```
 
-43개 variant. 도구 이름으로 O(1) tag lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다.
+21개 variant (SSOT: `lib/tool_dispatch.mli`). 도구 이름으로 O(1) tag lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다. Retired 모듈들(command_plane, team_session, voice, mdal, goals, heartbeat, encryption, auth, hat, audit, rate_limit, cost, social, vote, council, handover, relay, cache, tempo, portal, code_swarm, notifications, research, model_catalog, fire_task)은 tag 목록에서 제거됐다.
 
 ### 4.4 Tool_result.t (structured)
 


### PR DESCRIPTION
## Summary

Gen35 드리프트 2건 수정 — 모두 `last_verified: 2026-04-17` 스탬프가 달린 파일에서 실제 code/runtime과 어긋난 claim 정리.

### 1. \`02-types-and-invariants.md\` §4.3 Module Tag

Doc이 \`module_tag\`를 43개 variant로 선언. 실제 \`lib/tool_dispatch.mli:108\` + \`.ml:193\` 정의는 **21개**.

Doc에만 있는 22개 retired variants: \`Mod_command_plane\`, \`Mod_team_session\`, \`Mod_voice\`, \`Mod_mdal\`, \`Mod_goals\`, \`Mod_heartbeat\`, \`Mod_encryption\`, \`Mod_auth\`, \`Mod_hat\`, \`Mod_audit\`, \`Mod_rate_limit\`, \`Mod_cost\`, \`Mod_social\`, \`Mod_vote\`, \`Mod_council\`, \`Mod_handover\`, \`Mod_relay\`, \`Mod_cache\`, \`Mod_tempo\`, \`Mod_portal\`, \`Mod_code_swarm\`, \`Mod_notifications\`, \`Mod_research\`, \`Mod_model_catalog\`, \`Mod_fire_task\`.

→ code block을 실제 \`.mli\` 원문으로 재작성. SSOT pointer 추가. Retired tag family 열거.

### 2. \`BOOT-ENV-STATE-INVENTORY.md\` Scope

"Primary runtime domains are \`tasks\`, \`board\`, \`goals\`, \`governance\`, \`autoresearch\`, \`keepers\`, and \`command-plane\`" → \`command-plane\`은 purge 완료(#7337+#7349, -20,150 LOC)된 retired 서브시스템. primary domain 목록에서 제거, compatibility/historical lane 문장으로 이동.

## Pattern (Gen33~35 공통 구조)

같은 드리프트 감사 FSM, 다른 타겟:
- Gen33 #7920: \`team_session_*\` references in 4 stamped docs
- Gen34 #7932: §06 Command Plane "95% IMPL" section with 9 dead file refs
- Gen35 (이 PR): \`module_tag\` type claim + primary runtime domain scope

판정 기준: \`last_verified\` today + doc이 주장하는 identifier가 실제 repo에 없음 → retire.

## Test plan

- [x] \`bash scripts/check-doc-truth.sh\` pass
- [x] \`sed -n '193,210p' lib/tool_dispatch.ml\`와 doc code block 일치 확인
- [x] \`find lib/ -name 'cp_*'\` empty 재확인
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)