### PR TITLE
refactor(dashboard): connector view 3-layer redesign (summary + dense table + K×M matrix)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ConnectorKeeperMatrix,
+  deriveMatrix,
+  type MatrixData,
+} from './connector-keeper-matrix'
+import type { GateConnectorInfo } from '../api/gate'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+
+const mkConnector = (id: string, overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
+  connector_id: id,
+  display_name: id,
+  channel: id,
+  available: overrides.available ?? false,
+  gate_healthy: overrides.gate_healthy ?? null,
+  configured_bindings: overrides.configured_bindings ?? [],
+  capabilities: overrides.capabilities ?? ['bindings'],
+  ...(overrides as object),
+}) as GateConnectorInfo
+
+const mkKeeper = (name: string): GateKeeperInfo =>
+  ({ name }) as GateKeeperInfo
+
+describe('deriveMatrix', () => {
+  it('returns 4 columns in known order', () => {
+    const m = deriveMatrix([], [])
+    expect(m.columns).toEqual(['discord', 'imessage', 'slack', 'telegram'])
+  })
+
+  it('cell is na when keeper exists but connector is offline', () => {
+    const connectors = [mkConnector('discord', { available: false })]
+    const keepers = [mkKeeper('alpha')]
+    const m = deriveMatrix(connectors, keepers)
+    const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
+    const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
+    expect(discordCell.state).toBe('na')
+  })
+
+  it('cell is unbound when connector is up but no binding exists', () => {
+    const connectors = [mkConnector('discord', { available: true })]
+    const keepers = [mkKeeper('alpha')]
+    const m = deriveMatrix(connectors, keepers)
+    const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
+    const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
+    expect(discordCell.state).toBe('unbound')
+  })
+
+  it('cell is bound with count when binding exists', () => {
+    const connectors = [mkConnector('discord', {
+      available: true,
+      configured_bindings: [
+        { channel_id: 'c1', keeper_name: 'alpha' },
+        { channel_id: 'c2', keeper_name: 'alpha' },
+      ] as never,
+    })]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    const firstRow = m.rows[0]!
+    const cell = firstRow.cells.find(c => c.connectorId === 'discord')!
+    expect(cell.state).toBe('bound')
+    expect(cell.bindingCount).toBe(2)
+  })
+
+  it('surfaces unknown keepers referenced by bindings', () => {
+    const connectors = [mkConnector('slack', {
+      available: true,
+      configured_bindings: [{ channel_id: 'c1', keeper_name: 'ghost' }] as never,
+    })]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    expect(m.rows.some(r => r.keeperName === 'ghost' && !r.known)).toBe(true)
+    const ghostRow = m.rows.find(r => r.keeperName === 'ghost')!
+    const slackCell = ghostRow.cells.find(c => c.connectorId === 'slack')!
+    expect(slackCell.state).toBe('unknown')
+  })
+
+  it('totals reflect live connectors and total bindings', () => {
+    const connectors = [
+      mkConnector('discord', {
+        available: true,
+        configured_bindings: [{ channel_id: 'c1', keeper_name: 'alpha' }] as never,
+      }),
+      mkConnector('slack', { available: false }),
+    ]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha'), mkKeeper('beta')])
+    expect(m.totals.knownKeepers).toBe(2)
+    expect(m.totals.liveConnectors).toBe(1)
+    expect(m.totals.totalBindings).toBe(1)
+    expect(m.totals.unknownKeepers).toBe(0)
+  })
+})
+
+describe('ConnectorKeeperMatrix', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('renders empty-state copy when no keepers exist', () => {
+    const matrix: MatrixData = deriveMatrix([], [])
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    expect(container.textContent).toContain('No keepers yet')
+  })
+
+  it('renders a cell button for each (keeper × connector) pair', () => {
+    const connectors = [
+      mkConnector('discord', { available: true, configured_bindings: [{ channel_id: 'c1', keeper_name: 'alpha' }] as never }),
+    ]
+    const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
+    const matrix = deriveMatrix(connectors, keepers)
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    const cells = container.querySelectorAll('[data-matrix-cell]')
+    // 2 keepers × 4 connectors = 8 cells
+    expect(cells.length).toBe(8)
+    // alpha × discord is bound
+    const bound = container.querySelector('[data-matrix-cell="alpha:discord"]')!
+    expect(bound.getAttribute('data-matrix-state')).toBe('bound')
+  })
+})

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -1,0 +1,264 @@
+// ConnectorKeeperMatrix — K×M binding grid.
+//
+// Rows   = keepers (from `fetchGateKeepers` + any referenced-but-unknown
+//          keepers surfaced by connector configured_bindings).
+// Cols   = the 4 known connectors (discord, imessage, slack, telegram).
+// Cell   = binding state for (keeper, connector):
+//            bound   — at least one channel bound, shows count
+//            unbound — connector is up and operator can bind (clickable)
+//            na      — connector is offline (cannot evaluate)
+//            unknown — connector directory missing this keeper
+//
+// Replaces the "per-card bindings list" fan-out in the old layout by
+// showing the full matrix in one place. Scales horizontally as more
+// connectors ship and vertically as more keepers come online.
+//
+// Data shape is kept pure in `deriveMatrix` so it can be tested without
+// DOM/signals. The component below is a thin renderer.
+
+import { html } from 'htm/preact'
+import type { GateConnectorInfo } from '../api/gate'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+import {
+  CONNECTOR_DISPLAY_NAMES,
+  KNOWN_CONNECTOR_IDS,
+  channelIcon,
+  type KnownConnectorId,
+} from './connector-status'
+import { openConnectorConfig } from './connector-config-form'
+
+export type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
+
+export interface MatrixCell {
+  connectorId: KnownConnectorId
+  keeperName: string
+  state: MatrixCellState
+  bindingCount: number
+}
+
+export interface MatrixRow {
+  keeperName: string
+  known: boolean
+  cells: MatrixCell[]
+}
+
+export interface MatrixData {
+  columns: KnownConnectorId[]
+  rows: MatrixRow[]
+  totals: {
+    knownKeepers: number
+    unknownKeepers: number
+    totalBindings: number
+    liveConnectors: number
+  }
+}
+
+function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
+  return connectors.find(c => c.connector_id === id) ?? null
+}
+
+/** Derive the matrix from connectors + keepers. Pure, unit-testable. */
+export function deriveMatrix(
+  connectors: GateConnectorInfo[],
+  keepers: GateKeeperInfo[],
+): MatrixData {
+  const columns: KnownConnectorId[] = [...KNOWN_CONNECTOR_IDS]
+  const knownKeeperNames = new Set(keepers.map(k => k.name))
+
+  const unknownKeeperNames = new Set<string>()
+  for (const c of connectors) {
+    for (const b of c.configured_bindings ?? []) {
+      if (!knownKeeperNames.has(b.keeper_name)) {
+        unknownKeeperNames.add(b.keeper_name)
+      }
+    }
+  }
+
+  const allKeeperRows: Array<{ name: string; known: boolean }> = [
+    ...keepers.map(k => ({ name: k.name, known: true })),
+    ...[...unknownKeeperNames].sort().map(name => ({ name, known: false })),
+  ]
+
+  let totalBindings = 0
+  const rows: MatrixRow[] = allKeeperRows.map(({ name, known }) => {
+    const cells: MatrixCell[] = columns.map(connectorId => {
+      const connector = findConnector(connectors, connectorId)
+      const connectorUp = connector?.available === true
+      const bindings = (connector?.configured_bindings ?? []).filter(
+        b => b.keeper_name === name,
+      )
+      const count = bindings.length
+      totalBindings += count
+      let state: MatrixCellState
+      if (!known) {
+        state = count > 0 ? 'unknown' : 'na'
+      } else if (count > 0) {
+        state = 'bound'
+      } else if (connectorUp) {
+        state = 'unbound'
+      } else {
+        state = 'na'
+      }
+      return { connectorId, keeperName: name, state, bindingCount: count }
+    })
+    return { keeperName: name, known, cells }
+  })
+
+  const liveConnectors = connectors.filter(c => c.available === true).length
+
+  return {
+    columns,
+    rows,
+    totals: {
+      knownKeepers: keepers.length,
+      unknownKeepers: unknownKeeperNames.size,
+      totalBindings,
+      liveConnectors,
+    },
+  }
+}
+
+const CELL_TONE: Record<MatrixCellState, { dot: string; text: string; bg: string }> = {
+  bound:   { dot: 'bg-emerald-400',     text: 'text-emerald-100',        bg: 'bg-emerald-500/10' },
+  unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
+  na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
+  unknown: { dot: 'bg-amber-400',       text: 'text-amber-100',          bg: 'bg-amber-500/10'   },
+}
+
+const CELL_GLYPH: Record<MatrixCellState, string> = {
+  bound:   '●',
+  unbound: '+',
+  na:      '—',
+  unknown: '⚠',
+}
+
+function scrollToConnectorRow(connectorId: string) {
+  const el = document.getElementById(`connector-row-${connectorId}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function scrollToKeeper(keeperName: string) {
+  const el = document.getElementById(`keepers-${keeperName}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function MatrixCellButton({ cell }: { cell: MatrixCell }) {
+  const tone = CELL_TONE[cell.state]
+  const label = (() => {
+    switch (cell.state) {
+      case 'bound':   return `${cell.bindingCount} ch`
+      case 'unbound': return 'bind'
+      case 'na':      return ''
+      case 'unknown': return `${cell.bindingCount}?`
+    }
+  })()
+  const title = (() => {
+    const conn = CONNECTOR_DISPLAY_NAMES[cell.connectorId] ?? cell.connectorId
+    switch (cell.state) {
+      case 'bound':   return `${cell.keeperName} · ${conn} · ${cell.bindingCount} channel(s) — 클릭하면 상세로 이동`
+      case 'unbound': return `${cell.keeperName} · ${conn} — 클릭하면 바인딩 추가`
+      case 'na':      return `${cell.keeperName} · ${conn} — 커넥터 오프라인`
+      case 'unknown': return `${cell.keeperName} · ${conn} — 디렉토리 밖 keeper 참조됨`
+    }
+  })()
+  const disabled = cell.state === 'na'
+  const onClick = () => {
+    if (cell.state === 'unbound') {
+      openConnectorConfig(cell.connectorId)
+      return
+    }
+    scrollToConnectorRow(cell.connectorId)
+  }
+  return html`
+    <button
+      type="button"
+      class=${`flex h-full w-full cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[11px] transition-colors ${tone.bg} ${tone.text} hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-40`}
+      onClick=${onClick}
+      disabled=${disabled}
+      title=${title}
+      data-matrix-cell=${`${cell.keeperName}:${cell.connectorId}`}
+      data-matrix-state=${cell.state}
+    >
+      <span class=${`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`}></span>
+      <span>${CELL_GLYPH[cell.state]}</span>
+      ${label ? html`<span class="hidden md:inline">${label}</span>` : null}
+    </button>
+  `
+}
+
+export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
+  const hasKeepers = matrix.rows.length > 0
+  // Grid template: one wide keeper-name column, N fixed-width connector cols.
+  // Fixed column widths make the grid *align*, which is the whole point.
+  const gridCols = `grid-template-columns: minmax(160px, 1fr) repeat(${matrix.columns.length}, minmax(80px, 1fr));`
+
+  return html`
+    <section class="mb-4 rounded-lg border border-[var(--card-border)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
+      <header class="mb-2 flex items-baseline justify-between gap-3">
+        <div>
+          <h4 class="text-[12px] font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">
+            Keeper × Connector Matrix
+          </h4>
+          <p class="mt-0.5 text-[10px] text-[var(--text-dim)]">
+            ${matrix.totals.knownKeepers} keeper${matrix.totals.knownKeepers === 1 ? '' : 's'}
+            · ${matrix.totals.liveConnectors}/${matrix.columns.length} connector
+            · ${matrix.totals.totalBindings} binding${matrix.totals.totalBindings === 1 ? '' : 's'}
+            ${matrix.totals.unknownKeepers > 0
+              ? html`· <span class="text-amber-200">${matrix.totals.unknownKeepers} unknown</span>`
+              : null}
+          </p>
+        </div>
+        <div class="text-[10px] text-[var(--text-dim)]">
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>bound</span>
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-8)]"></span>unbound</span>
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-4)]"></span>n/a</span>
+          <span><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-amber-400"></span>unknown</span>
+        </div>
+      </header>
+
+      ${!hasKeepers
+        ? html`
+            <div class="rounded-md border border-dashed border-[var(--card-border)] px-3 py-4 text-center text-[11px] text-[var(--text-dim)]">
+              No keepers yet — add one under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart.
+            </div>
+          `
+        : html`
+            <div class="overflow-x-auto">
+              <div class="grid gap-1 text-[11px]" style=${gridCols} data-matrix-grid>
+                <div class="px-1 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
+                ${matrix.columns.map(colId => html`
+                  <button
+                    type="button"
+                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[10px] uppercase tracking-[0.12em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                    onClick=${() => scrollToConnectorRow(colId)}
+                    title=${`${CONNECTOR_DISPLAY_NAMES[colId] ?? colId} — 행으로 이동`}
+                  >
+                    <span aria-hidden="true">${channelIcon(colId)}</span>
+                    <span>${CONNECTOR_DISPLAY_NAMES[colId] ?? colId}</span>
+                  </button>
+                `)}
+
+                ${matrix.rows.map(row => html`
+                  <${MatrixRowRender} row=${row} />
+                `)}
+              </div>
+            </div>
+          `}
+    </section>
+  `
+}
+
+function MatrixRowRender({ row }: { row: MatrixRow }) {
+  return html`
+    <button
+      type="button"
+      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-[12px] hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-amber-100'}`}
+      onClick=${() => scrollToKeeper(row.keeperName)}
+      title=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
+    >
+      ${row.known ? null : html`<span class="text-amber-300" aria-hidden="true">⚠</span>`}
+      <span class="truncate">${row.keeperName}</span>
+    </button>
+    ${row.cells.map(cell => html`<${MatrixCellButton} cell=${cell} />`)}
+  `
+}

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -2,8 +2,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { ConnectorOverviewStrip, _testResetBulkInflight } from './connector-overview-strip'
+import {
+  ConnectorOverviewStrip,
+  ConnectorBulkActions,
+  _testResetBulkInflight,
+} from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
 
 const mkConnector = (overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
   connector_id: overrides.connector_id ?? 'discord',
@@ -16,92 +21,130 @@ const mkConnector = (overrides: Partial<GateConnectorInfo> = {}): GateConnectorI
   ...(overrides as object),
 }) as GateConnectorInfo
 
+const noopDetail = () => null
+
 describe('ConnectorOverviewStrip', () => {
   let container: HTMLElement
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    _testResetBulkInflight()
   })
   afterEach(() => {
     document.body.removeChild(container)
   })
 
-  it('always renders one tile per known sidecar (4 tiles)', () => {
-    render(
-      html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`,
-      container,
-    )
-    const tiles = container.querySelectorAll('[data-overview-tile]')
-    expect(tiles.length).toBe(4)
-    const ids = Array.from(tiles).map(t => t.getAttribute('data-overview-tile'))
-    expect(ids).toEqual(['discord', 'imessage', 'slack', 'telegram'])
-  })
-
-  it('marks running connector as 🟢 connected and offline ones as ⊘ offline', () => {
+  it('renders one row per known sidecar (4 rows)', () => {
     render(
       html`<${ConnectorOverviewStrip}
-        connectors=${[mkConnector({ connector_id: 'discord', available: true })]}
-        keeperCount=${0}
+        connectors=${[]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
       />`,
       container,
     )
-    const discordTile = container.querySelector('[data-overview-tile="discord"]')!
-    const imessageTile = container.querySelector('[data-overview-tile="imessage"]')!
-    expect(discordTile.textContent).toContain('connected')
-    expect(imessageTile.textContent).toContain('offline')
+    const rows = container.querySelectorAll('[data-connector-row]')
+    expect(rows.length).toBe(4)
+    const ids = Array.from(rows).map(r => r.getAttribute('data-connector-row'))
+    expect(ids).toEqual(['discord', 'imessage', 'slack', 'telegram'])
   })
 
-  it('Start All button counts only sidecars currently down', () => {
-    _testResetBulkInflight()
+  it('marks running connector as CONNECTED and offline ones as OFFLINE', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: true })]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
+      />`,
+      container,
+    )
+    const discordRow = container.querySelector('[data-connector-row="discord"]')!
+    const imessageRow = container.querySelector('[data-connector-row="imessage"]')!
+    expect(discordRow.textContent).toContain('connected')
+    expect(imessageRow.textContent).toContain('offline')
+  })
+
+  it('summary bar reflects up/warn/down counts', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[
+          mkConnector({ connector_id: 'discord', available: true, gate_healthy: true, configured_bindings: [{ channel_id: 'c1', keeper_name: 'k1' }] as never }),
+          mkConnector({ connector_id: 'slack', available: true, gate_healthy: true, configured_bindings: [] }),
+        ]}
+        keepers=${[{ name: 'k1' }] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
+      />`,
+      container,
+    )
+    const summary = container.querySelector('[data-panel="connector-summary-bar"]')!
+    // discord: all pills ok → up. slack: bindings warn (keeper exists, none bound) → warn.
+    // imessage, telegram: sidecar down → down.
+    expect(summary.textContent).toContain('1 up')
+    expect(summary.textContent).toContain('1 warn')
+    expect(summary.textContent).toContain('2 down')
+  })
+
+  it('Start All / Stop All counts disabled states correctly', () => {
     render(
       html`<${ConnectorOverviewStrip}
         connectors=${[
           mkConnector({ connector_id: 'discord', available: true }),
           mkConnector({ connector_id: 'slack', available: true }),
         ]}
-        keeperCount=${0}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
       />`,
       container,
     )
     const startBtn = container.querySelector('[data-bulk-action="start"]') as HTMLButtonElement
     const stopBtn = container.querySelector('[data-bulk-action="stop"]') as HTMLButtonElement
-    // 2 of 4 are up → 2 down → Start All shows (2). 2 up → Stop All (2).
     expect(startBtn.textContent).toContain('(2)')
     expect(stopBtn.textContent).toContain('(2)')
   })
 
-  it('Start All disabled when all sidecars are already up', () => {
-    _testResetBulkInflight()
-    const allUp = ['discord', 'imessage', 'slack', 'telegram'].map(id =>
-      mkConnector({ connector_id: id, available: true }),
-    )
+  it('renders 4 readiness cells inside each row', () => {
     render(
-      html`<${ConnectorOverviewStrip} connectors=${allUp} keeperCount=${0} />`,
+      html`<${ConnectorOverviewStrip}
+        connectors=${[]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
+      />`,
       container,
     )
-    const startBtn = container.querySelector('[data-bulk-action="start"]') as HTMLButtonElement
-    expect(startBtn.disabled).toBe(true)
-    expect(startBtn.title).toContain('이미 실행')
+    const row = container.querySelector('[data-connector-row="discord"]')!
+    const cells = row.querySelectorAll('[data-rail-pill]')
+    expect(cells.length).toBe(4)
   })
 
-  it('Stop All disabled when nothing is up', () => {
-    _testResetBulkInflight()
+  it('clicking a row reveals expanded detail slot', async () => {
     render(
-      html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`,
+      html`<${ConnectorOverviewStrip}
+        connectors=${[]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${(c: GateConnectorInfo | null) => html`<div data-test-expanded=${c?.connector_id ?? 'null'}>EXPAND</div>`}
+      />`,
       container,
     )
-    const stopBtn = container.querySelector('[data-bulk-action="stop"]') as HTMLButtonElement
-    expect(stopBtn.disabled).toBe(true)
-    expect(stopBtn.title).toContain('실행 중인 sidecar 없음')
+    // No expansion initially.
+    expect(container.querySelector('[data-test-expanded]')).toBeNull()
+    const row = container.querySelector('[data-connector-row="slack"]')!
+    const toggle = row.querySelector<HTMLButtonElement>('button[aria-label*="detail toggle"]')!
+    toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    // Let the signal update flush through preact's render queue.
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+    expect(container.querySelector('[data-test-expanded]')).not.toBeNull()
+    expect(container.querySelector('[data-connector-row-detail="slack"]')).not.toBeNull()
   })
 
-  it('renders 4 readiness pills inside each tile', () => {
+  it('ConnectorBulkActions stays exported for onboarding grid', () => {
     render(
-      html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`,
+      html`<${ConnectorBulkActions} connectors=${[] as GateConnectorInfo[]} />`,
       container,
     )
-    const discordTile = container.querySelector('[data-overview-tile="discord"]')!
-    const pills = discordTile.querySelectorAll('[data-rail-pill]')
-    expect(pills.length).toBe(4)
+    expect(container.querySelector('[data-bulk-action="start"]')).not.toBeNull()
+    expect(container.querySelector('[data-bulk-action="stop"]')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import {
   ConnectorOverviewStrip,
   ConnectorBulkActions,
+  deriveMascPaths,
   _testResetBulkInflight,
 } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
@@ -146,5 +147,56 @@ describe('ConnectorOverviewStrip', () => {
     )
     expect(container.querySelector('[data-bulk-action="start"]')).not.toBeNull()
     expect(container.querySelector('[data-bulk-action="stop"]')).not.toBeNull()
+  })
+
+  it('renders row-level config and guide icon buttons', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[] as GateConnectorInfo[]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
+      />`,
+      container,
+    )
+    const row = container.querySelector('[data-connector-row="imessage"]')!
+    expect(row.querySelector('[data-row-action="config"]')).not.toBeNull()
+    expect(row.querySelector('[data-row-action="guide"]')).not.toBeNull()
+  })
+
+  it('mounts the Paths strip panel', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[] as GateConnectorInfo[]}
+        keepers=${[] as GateKeeperInfo[]}
+        renderExpandedDetail=${noopDetail}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-panel="connector-paths-strip"]')).not.toBeNull()
+  })
+})
+
+describe('deriveMascPaths', () => {
+  it('falls back to repo-relative paths when no connector has names_path', () => {
+    const paths = deriveMascPaths([])
+    expect(paths.connectorsDir).toBeNull()
+    expect(paths.logsDir).toBeNull()
+    expect(paths.keepersDir).toBe('config/keepers/')
+    expect(paths.sidecarsDir).toBe('sidecars/')
+  })
+
+  it('derives connectors + logs dir from names_path pattern', () => {
+    const c = mkConnector({
+      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+    } as never)
+    const paths = deriveMascPaths([c])
+    expect(paths.connectorsDir).toBe('/Users/alice/.masc/connectors/')
+    expect(paths.logsDir).toBe('/Users/alice/.masc/logs/')
+  })
+
+  it('falls back when names_path is non-standard', () => {
+    const c = mkConnector({ names_path: '/somewhere/else/names.json' } as never)
+    const paths = deriveMascPaths([c])
+    expect(paths.connectorsDir).toBeNull()
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -36,13 +36,94 @@ import {
   type KnownConnectorId,
 } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
+import { CopyableCode } from './common/copyable-code'
 
 const bulkInflight = signal<{ start: boolean; stop: boolean }>({ start: false, stop: false })
 const expandedRow = signal<KnownConnectorId | null>(null)
+const pathsExpanded = signal<boolean>(false)
 
 export function _testResetBulkInflight() {
   bulkInflight.value = { start: false, stop: false }
   expandedRow.value = null
+  pathsExpanded.value = false
+}
+
+export interface MascPaths {
+  connectorsDir: string | null
+  logsDir: string | null
+  keepersDir: string
+  sidecarsDir: string
+}
+
+/** Derive MASC-managed paths from the first connector that has a names_path.
+    Returns `null` fields when no runtime has been observed yet. Keeper and
+    sidecar paths are repo-relative conventions and never null. Pure helper. */
+export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
+  const fallback: MascPaths = {
+    connectorsDir: null,
+    logsDir: null,
+    keepersDir: 'config/keepers/',
+    sidecarsDir: 'sidecars/',
+  }
+  const withPath = connectors.find(c => typeof c.names_path === 'string' && c.names_path.length > 0)
+  if (!withPath) return fallback
+  const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
+  if (!match) return fallback
+  const mascRoot = match[1] ?? ''
+  return {
+    connectorsDir: `${mascRoot}/connectors/`,
+    logsDir: `${mascRoot}/logs/`,
+    keepersDir: 'config/keepers/',
+    sidecarsDir: 'sidecars/',
+  }
+}
+
+function PathRow({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return html`
+    <div class="flex items-center gap-2" data-paths-row=${label}>
+      <span class="w-[100px] shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" title=${hint}>${label}</span>
+      <div class="min-w-0 flex-1">
+        <${CopyableCode} command=${value} ariaLabel=${`Copy ${label} path`} />
+      </div>
+    </div>
+  `
+}
+
+function PathsStrip({ connectors }: { connectors: GateConnectorInfo[] }) {
+  const paths = deriveMascPaths(connectors)
+  const open = pathsExpanded.value
+  return html`
+    <div class="mb-3 rounded-lg border border-[var(--card-border)] bg-[var(--bg-1)]" data-panel="connector-paths-strip">
+      <button
+        type="button"
+        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+        onClick=${() => { pathsExpanded.value = !open }}
+        aria-expanded=${open}
+        aria-controls="connector-paths-body"
+      >
+        <span>
+          <span class="mr-2 text-[10px] uppercase tracking-[0.14em]">Paths</span>
+          <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
+          <span class="ml-2 text-[var(--text-dim)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
+        </span>
+        <span>${open ? '▴' : '▾'}</span>
+      </button>
+      ${open
+        ? html`
+            <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--card-border)] px-3 py-2">
+              ${paths.connectorsDir
+                ? html`<${PathRow} label="Connectors" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
+                : null}
+              ${paths.logsDir
+                ? html`<${PathRow} label="Logs" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
+                : null}
+              <${PathRow} label="Keepers" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
+              <${PathRow} label="Sidecars" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />
+            </div>
+          `
+        : null}
+    </div>
+  `
 }
 
 function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
@@ -286,6 +367,22 @@ function ConnectorRow({ id, connector, keepers, renderExpandedDetail }: RowProps
           <button
             type="button"
             class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 py-0.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            onClick=${() => openConnectorConfig(id)}
+            title=${`${displayName} 설정 폼 열기`}
+            aria-label=${`${displayName} config`}
+            data-row-action="config"
+          >⚙</button>
+          <button
+            type="button"
+            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 py-0.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            onClick=${() => { expandedRow.value = id }}
+            title=${`${displayName} 설치 가이드 (3 STEPS)`}
+            aria-label=${`${displayName} guide`}
+            data-row-action="guide"
+          >?</button>
+          <button
+            type="button"
+            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 py-0.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
             onClick=${toggleExpand}
             aria-label=${`${displayName} detail toggle`}
           >${isExpanded ? '▴' : '▾'}</button>
@@ -308,6 +405,7 @@ export function ConnectorOverviewStrip({ connectors, keepers, renderExpandedDeta
   return html`
     <div class="mb-4" data-panel="connector-overview">
       <${SummaryBar} connectors=${connectors} keepers=${keepers} />
+      <${PathsStrip} connectors=${connectors} />
       <div class="grid gap-1.5 px-1 pb-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
            style=${ROW_GRID_COLS}>
         <span></span>

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -1,21 +1,53 @@
-// ConnectorOverviewStrip — top-of-page compact strip showing all 4 known
-// sidecars at once. Each tile is a brand-colored mini card with the
-// readiness rail underneath and one primary action (Start when down,
-// Stop when up). Clicking the tile body smooth-scrolls to that
-// connector's full panel below in the page.
+// ConnectorOverviewStrip — top-level operator console for the all-bridges view.
 //
-// Rendered only on the all-connectors view (`section=connector-status`).
-// Per-bridge sub-sections already filter to one panel and don't need an
-// at-a-glance strip on top.
+// Layer 1: Summary Bar (one row)
+//   total / up / warn / down + bulk Start All / Stop All.
+//
+// Layer 2: Dense Connector Table (one row per connector)
+//   Fixed-width columns give natural alignment that a flex-grid of pills
+//   cannot. Row states collapse the four readiness axes (token, process,
+//   gate, bindings) into compact cells so N×M scales horizontally without
+//   re-wrapping mid-label.
+//
+// Rendered only on the all-connectors view. A single-connector filter
+// continues to render the full ConnectorLivePanel directly.
+//
+// Expanded detail for a row is supplied by the caller via
+// `renderExpandedDetail`, avoiding a circular import with connector-status.ts.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import type { ComponentChildren } from 'preact'
 import type { GateConnectorInfo } from '../api/gate'
-import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight } from './connector-readiness-rail'
-import { CONNECTOR_DISPLAY_NAMES, KNOWN_CONNECTOR_IDS, channelIcon, connectorAccentStyle, startSidecar, stopSidecar, type KnownConnectorId } from './connector-status'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+import {
+  deriveRail,
+  getRailInflight,
+  withRailInflight,
+  type RailPill,
+  type RailState,
+} from './connector-readiness-rail'
+import {
+  CONNECTOR_DISPLAY_NAMES,
+  KNOWN_CONNECTOR_IDS,
+  channelIcon,
+  startSidecar,
+  stopSidecar,
+  type KnownConnectorId,
+} from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
 
 const bulkInflight = signal<{ start: boolean; stop: boolean }>({ start: false, stop: false })
+const expandedRow = signal<KnownConnectorId | null>(null)
+
+export function _testResetBulkInflight() {
+  bulkInflight.value = { start: false, stop: false }
+  expandedRow.value = null
+}
+
+function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
+  return connectors.find(c => c.connector_id === id) ?? null
+}
 
 async function runBulk(
   kind: 'start' | 'stop',
@@ -26,8 +58,6 @@ async function runBulk(
   bulkInflight.value = { ...bulkInflight.value, [kind]: true }
   try {
     const targets = KNOWN_CONNECTOR_IDS.filter(id => predicate(findConnector(connectors, id)))
-    // Per-connector pulse (the same withRailInflight that single-pill uses) so
-    // each tile's Process pill shows progress; runs in parallel.
     await Promise.allSettled(
       targets.map(id =>
         withRailInflight(id, 'process', () => kind === 'start' ? startSidecar(id) : stopSidecar(id)),
@@ -38,76 +68,7 @@ async function runBulk(
   }
 }
 
-interface OverviewProps {
-  connectors: GateConnectorInfo[]
-  keeperCount: number
-}
-
-function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
-  return connectors.find(c => c.connector_id === id) ?? null
-}
-
-function scrollToCard(id: string) {
-  const el = document.getElementById(`connector-card-${id}`)
-  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-}
-
-function OverviewTile({ id, connector, keeperCount }: {
-  id: KnownConnectorId
-  connector: GateConnectorInfo | null
-  keeperCount: number
-}) {
-  const sidecarUp = connector?.available === true
-  const pills = deriveRail(
-    {
-      sidecarUp,
-      gateHealthy: connector?.gate_healthy ?? null,
-      bindingCount: connector?.configured_bindings?.length ?? 0,
-      keeperCount,
-    },
-    {
-      openConfig: () => openConnectorConfig(id),
-      toggleProcess: () => {
-        void withRailInflight(id, 'process', () =>
-          sidecarUp ? stopSidecar(id) : startSidecar(id),
-        )
-      },
-      expandHeader: () => scrollToCard(id),
-      scrollToBindings: () => scrollToCard(id),
-    },
-    getRailInflight(id),
-  )
-  const accent = connectorAccentStyle(id)
-  const displayName = CONNECTOR_DISPLAY_NAMES[id] ?? id
-
-  return html`
-    <div
-      class="flex min-w-0 flex-col gap-2 rounded-lg border border-[var(--white-8)] bg-[var(--bg-1)] p-3 transition-colors hover:border-[var(--white-10)]"
-      data-overview-tile=${id}
-    >
-      <button
-        type="button"
-        class="flex min-w-0 cursor-pointer items-center gap-2 text-left"
-        onClick=${() => scrollToCard(id)}
-        aria-label=${`${displayName} 카드로 이동`}
-      >
-        <span
-          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[14px]"
-          style=${accent}
-        >${channelIcon(id)}</span>
-        <span class="min-w-0 flex-1">
-          <span class="block truncate text-[13px] font-semibold text-[var(--text-body)]">${displayName}</span>
-          <span class="block text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${sidecarUp ? '🟢 connected' : '⊘ offline'}</span>
-        </span>
-      </button>
-      <${ConnectorReadinessRail} pills=${pills} />
-    </div>
-  `
-}
-
-/** Standalone export of the bulk Start All / Stop All buttons so the
-    cold-start onboarding view can mount the same controls without
-    having to render the full overview strip. */
+/** Standalone export used by onboarding (cold-start) view. */
 export function ConnectorBulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   return BulkActions({ connectors })
 }
@@ -118,7 +79,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   const startBusy = bulkInflight.value.start
   const stopBusy = bulkInflight.value.stop
   return html`
-    <div class="mb-2 flex items-center justify-end gap-2 text-[11px] text-[var(--text-dim)]">
+    <div class="flex items-center justify-end gap-2 text-[11px] text-[var(--text-dim)]">
       <span>일괄:</span>
       <button
         type="button"
@@ -144,23 +105,232 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   `
 }
 
-export function ConnectorOverviewStrip({ connectors, keeperCount }: OverviewProps) {
+interface SummaryCounts {
+  up: number
+  warn: number
+  down: number
+  total: number
+}
+
+function computeSummary(connectors: GateConnectorInfo[], keepers: GateKeeperInfo[]): SummaryCounts {
+  let up = 0
+  let warn = 0
+  let down = 0
+  const noop = () => {}
+  for (const id of KNOWN_CONNECTOR_IDS) {
+    const c = findConnector(connectors, id)
+    if (!c || c.available !== true) { down++; continue }
+    const pills = deriveRail({
+      sidecarUp: true,
+      gateHealthy: c.gate_healthy ?? null,
+      bindingCount: c.configured_bindings?.length ?? 0,
+      keeperCount: keepers.length,
+    }, { openConfig: noop, toggleProcess: noop, expandHeader: noop, scrollToBindings: noop })
+    if (pills.some(p => p.state === 'bad')) down++
+    else if (pills.some(p => p.state === 'warn')) warn++
+    else up++
+  }
+  return { up, warn, down, total: KNOWN_CONNECTOR_IDS.length }
+}
+
+function SummaryBar({ connectors, keepers }: { connectors: GateConnectorInfo[]; keepers: GateKeeperInfo[] }) {
+  const s = computeSummary(connectors, keepers)
   return html`
-    <div class="mb-4">
+    <div class="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--card-border)] bg-[var(--bg-1)] px-3 py-2 text-[12px]" data-panel="connector-summary-bar">
+      <div class="flex flex-wrap items-center gap-3">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">커넥터</span>
+        <span class="font-semibold text-[var(--text-body)]" data-summary-total>${s.total}</span>
+        <span class="flex items-center gap-1 text-emerald-200" title="모든 축 정상" data-summary-up>
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
+          <span>${s.up} up</span>
+        </span>
+        <span class="flex items-center gap-1 text-amber-200" title="일부 축 주의" data-summary-warn>
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-amber-400"></span>
+          <span>${s.warn} warn</span>
+        </span>
+        <span class="flex items-center gap-1 text-rose-200" title="sidecar 오프라인 또는 실패" data-summary-down>
+          <span class="inline-block h-1.5 w-1.5 rounded-full bg-rose-400"></span>
+          <span>${s.down} down</span>
+        </span>
+      </div>
       <${BulkActions} connectors=${connectors} />
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    </div>
+  `
+}
+
+const CELL_TONE: Record<RailState, { text: string; dot: string; bg: string }> = {
+  ok:   { text: 'text-emerald-200',       dot: 'bg-emerald-400',      bg: 'bg-emerald-500/8' },
+  warn: { text: 'text-amber-200',         dot: 'bg-amber-400',        bg: 'bg-amber-500/8' },
+  bad:  { text: 'text-rose-200',          dot: 'bg-rose-400',         bg: 'bg-rose-500/8' },
+  idle: { text: 'text-[var(--text-dim)]', dot: 'bg-[var(--white-8)]', bg: 'bg-transparent' },
+}
+
+const CELL_GLYPH: Record<RailState, string> = { ok: '✓', warn: '!', bad: '⊘', idle: '·' }
+
+function RailCell({ pill }: { pill: RailPill }) {
+  const tone = CELL_TONE[pill.state]
+  const inflight = pill.inflight === true
+  return html`
+    <button
+      type="button"
+      class=${`flex h-full w-full cursor-pointer items-center justify-center rounded text-[12px] transition-colors ${tone.bg} ${tone.text} hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-40 ${inflight ? 'animate-pulse' : ''}`}
+      onClick=${pill.onClick}
+      disabled=${inflight}
+      title=${`${pill.label}: ${pill.detail}${pill.hint ? ' — ' + pill.hint : ''}`}
+      data-rail-pill=${pill.key}
+      data-rail-state=${pill.state}
+    >
+      <span class=${`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold ${inflight ? 'bg-[var(--white-10)]' : tone.dot} text-[var(--bg-0)]`}>
+        ${inflight ? '…' : CELL_GLYPH[pill.state]}
+      </span>
+    </button>
+  `
+}
+
+// Brand accent per connector for the 4px left bar (no card-wide gradient).
+const LEFT_BAR_COLOR: Record<KnownConnectorId, string> = {
+  discord:  'bg-[rgb(88,101,242)]',
+  imessage: 'bg-[rgb(48,209,88)]',
+  slack:    'bg-[rgb(236,178,46)]',
+  telegram: 'bg-[rgb(34,158,217)]',
+}
+
+const ROW_GRID_COLS =
+  'grid-template-columns: 4px 24px minmax(120px, 1.4fr) minmax(100px, 1fr) repeat(4, 40px) minmax(140px, 1.4fr) auto;'
+
+interface RowProps {
+  id: KnownConnectorId
+  connector: GateConnectorInfo | null
+  keepers: GateKeeperInfo[]
+  renderExpandedDetail: (c: GateConnectorInfo | null) => ComponentChildren
+}
+
+function connectorKeeperNames(connector: GateConnectorInfo | null): string[] {
+  if (!connector) return []
+  const names = new Set<string>()
+  for (const b of connector.configured_bindings ?? []) names.add(b.keeper_name)
+  return [...names].sort()
+}
+
+function ConnectorRow({ id, connector, keepers, renderExpandedDetail }: RowProps) {
+  const sidecarUp = connector?.available === true
+  const toggleExpand = () => {
+    expandedRow.value = expandedRow.value === id ? null : id
+  }
+  const pills = deriveRail(
+    {
+      sidecarUp,
+      gateHealthy: connector?.gate_healthy ?? null,
+      bindingCount: connector?.configured_bindings?.length ?? 0,
+      keeperCount: keepers.length,
+    },
+    {
+      openConfig: () => openConnectorConfig(id),
+      toggleProcess: () => {
+        void withRailInflight(id, 'process', () =>
+          sidecarUp ? stopSidecar(id) : startSidecar(id),
+        )
+      },
+      expandHeader: toggleExpand,
+      scrollToBindings: toggleExpand,
+    },
+    getRailInflight(id),
+  )
+  const displayName = CONNECTOR_DISPLAY_NAMES[id] ?? id
+  // Lowercase in DOM so textContent-based assertions (connected/offline) keep
+  // matching; `uppercase` class provides the visual rendering.
+  const stateText = sidecarUp ? 'connected' : 'offline'
+  const stateTone = sidecarUp ? 'text-emerald-200' : 'text-[var(--text-dim)]'
+  const stateGlyph = sidecarUp ? '🟢' : '⊘'
+  const keeperNames = connectorKeeperNames(connector)
+  const bindingCount = connector?.configured_bindings?.length ?? 0
+  const isExpanded = expandedRow.value === id
+  const summary = keeperNames.length === 0
+    ? '—'
+    : `${bindingCount} ch · ${keeperNames.slice(0, 2).join(', ')}${keeperNames.length > 2 ? ` +${keeperNames.length - 2}` : ''}`
+
+  return html`
+    <div id=${`connector-row-${id}`} class="overflow-hidden rounded-md border border-[var(--card-border)] bg-[var(--bg-1)]" data-connector-row=${id}>
+      <div class="grid items-stretch" style=${ROW_GRID_COLS}>
+        <div class=${`min-h-[40px] ${LEFT_BAR_COLOR[id]}`} aria-hidden="true"></div>
+        <button
+          type="button"
+          class="flex items-center justify-center text-base leading-none hover:text-[var(--text-body)]"
+          onClick=${toggleExpand}
+          aria-label=${`${displayName} 상세 ${isExpanded ? '접기' : '펼치기'}`}
+          aria-expanded=${isExpanded}
+        >${channelIcon(id)}</button>
+        <button
+          type="button"
+          class="flex items-center truncate py-2 text-left text-[13px] font-semibold text-[var(--text-body)] hover:text-emerald-100"
+          onClick=${toggleExpand}
+        >${displayName}</button>
+        <span class=${`flex items-center gap-1.5 py-2 text-[11px] uppercase tracking-[0.12em] ${stateTone}`}>
+          <span aria-hidden="true">${stateGlyph}</span>
+          <span>${stateText}</span>
+        </span>
+        ${pills.map(pill => html`<${RailCell} pill=${pill} />`)}
+        <span class="flex items-center truncate py-2 text-[11px] text-[var(--text-dim)]" title=${keeperNames.join(', ') || 'no keepers bound'}>
+          ${summary}
+        </span>
+        <div class="flex items-center gap-1 px-2">
+          <button
+            type="button"
+            class=${`cursor-pointer rounded border px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] hover:brightness-125 ${sidecarUp
+              ? 'border-rose-400/30 bg-rose-500/12 text-rose-100'
+              : 'border-emerald-400/30 bg-emerald-500/12 text-emerald-100'}`}
+            onClick=${() => { void withRailInflight(id, 'process', () => sidecarUp ? stopSidecar(id) : startSidecar(id)) }}
+            title=${sidecarUp ? 'sidecar 정지' : 'sidecar 시작'}
+            data-row-action=${sidecarUp ? 'stop' : 'start'}
+          >${sidecarUp ? 'Stop' : 'Start'}</button>
+          <button
+            type="button"
+            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 py-0.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            onClick=${toggleExpand}
+            aria-label=${`${displayName} detail toggle`}
+          >${isExpanded ? '▴' : '▾'}</button>
+        </div>
+      </div>
+      ${isExpanded
+        ? html`<div class="border-t border-[var(--card-border)] bg-[var(--white-3)] p-3" data-connector-row-detail=${id}>${renderExpandedDetail(connector)}</div>`
+        : null}
+    </div>
+  `
+}
+
+interface OverviewProps {
+  connectors: GateConnectorInfo[]
+  keepers: GateKeeperInfo[]
+  renderExpandedDetail: (connector: GateConnectorInfo | null) => ComponentChildren
+}
+
+export function ConnectorOverviewStrip({ connectors, keepers, renderExpandedDetail }: OverviewProps) {
+  return html`
+    <div class="mb-4" data-panel="connector-overview">
+      <${SummaryBar} connectors=${connectors} keepers=${keepers} />
+      <div class="grid gap-1.5 px-1 pb-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+           style=${ROW_GRID_COLS}>
+        <span></span>
+        <span></span>
+        <span>Name</span>
+        <span>State</span>
+        <span class="text-center" title="Token">TKN</span>
+        <span class="text-center" title="Process">PRC</span>
+        <span class="text-center" title="Gate">GTE</span>
+        <span class="text-center" title="Bindings">BND</span>
+        <span>Keepers</span>
+        <span class="pr-2 text-right">Actions</span>
+      </div>
+      <div class="flex flex-col gap-1.5">
         ${KNOWN_CONNECTOR_IDS.map(id => html`
-          <${OverviewTile}
+          <${ConnectorRow}
             id=${id}
             connector=${findConnector(connectors, id)}
-            keeperCount=${keeperCount}
+            keepers=${keepers}
+            renderExpandedDetail=${renderExpandedDetail}
           />
         `)}
       </div>
     </div>
   `
-}
-
-export function _testResetBulkInflight() {
-  bulkInflight.value = { start: false, stop: false }
 }

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -176,6 +176,19 @@ async function flushUi(): Promise<void> {
   }
 }
 
+/** Click the expand toggle for a connector row so the detail panel
+    (previously always-visible) renders its contents. Used by tests that
+    target fields now nested under the row-expand slot of the dense table. */
+async function expandRow(container: HTMLElement, connectorId: string): Promise<void> {
+  const row = container.querySelector(`[data-connector-row="${connectorId}"]`)
+  if (!row) return
+  const toggle = row.querySelector<HTMLButtonElement>(
+    `button[aria-label*="detail toggle"]`,
+  )
+  toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  await flushUi()
+}
+
 async function loadComponentWithApi(api: {
   fetchGateStatus: () => Promise<unknown>
   fetchGateConnectors: () => Promise<unknown>
@@ -239,6 +252,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(fetchGateStatus).toHaveBeenCalled()
@@ -280,6 +294,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(text).toContain('Discord')
@@ -340,6 +355,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'imessage')
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(text).toContain('reply self-chat')
@@ -377,6 +393,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const addChannelButton = container.querySelector<HTMLButtonElement>('button[aria-label="add channel to nova"]')
     expect(addChannelButton).not.toBeNull()
@@ -426,6 +443,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const lunaGroup = container.querySelector('[data-keeper="luna"]')
     const novaGroup = container.querySelector('[data-keeper="nova"]')
@@ -458,6 +476,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('⚠')
@@ -491,6 +510,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('Sidecar not started')
@@ -519,12 +539,13 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('No keepers configured')
   })
 
-  it('expands [▾] header toggle to show per-dot liveness and metadata', async () => {
+  it('row expand reveals per-dot liveness and metadata block', async () => {
     const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
     const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
     const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
@@ -543,10 +564,7 @@ describe('ConnectorStatusPanel', () => {
     expect(beforeText).not.toContain('Browser → Server')
     expect(beforeText).not.toContain('keeper dir 2')
 
-    const toggleButton = container.querySelector<HTMLButtonElement>('button[aria-label="toggle header details"]')
-    expect(toggleButton).not.toBeNull()
-    toggleButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await flushUi()
+    await expandRow(container, 'discord')
 
     const afterText = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(afterText).toContain('Browser → Server')
@@ -568,6 +586,7 @@ describe('ConnectorStatusPanel', () => {
 
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
+    await expandRow(container, 'discord')
 
     const novaGroup = container.querySelector('[data-keeper="nova"]')
     expect(novaGroup).not.toBeNull()

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -34,6 +34,7 @@ import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight }
 import { StartupCheckBanner, markStartAttempt, clearStartAttempt } from './sidecar-startup-watch'
 import { QuickBindForm } from './connector-quick-bind'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
+import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
 
@@ -106,7 +107,9 @@ const CONNECTOR_ACCENT_RGB: Record<string, string> = {
 
 export function connectorAccentStyle(connectorId: string): string {
   const rgb = CONNECTOR_ACCENT_RGB[connectorId] ?? '120,130,150'
-  return `background:linear-gradient(135deg,rgba(${rgb},0.16),rgba(${rgb},0.04))`
+  // Dimmed from 0.16→0.08 so the dashboard overview doesn't flood the card
+  // area with brand colour when multiple connector cards stack vertically.
+  return `background:linear-gradient(135deg,rgba(${rgb},0.08),rgba(${rgb},0.02))`
 }
 
 const actionLoading = signal(false)
@@ -420,6 +423,7 @@ function ConnectorLivePanel({
   connectorError,
   keeperDirectoryError,
   loading,
+  chromeless = false,
 }: {
   connector: GateConnectorInfo | null
   gate: GateStatusData | null
@@ -427,6 +431,10 @@ function ConnectorLivePanel({
   connectorError: string | null
   keeperDirectoryError: string | null
   loading: boolean
+  /** When true, skip the outer card chrome (border/gradient/id/rounded).
+      Used inside the dense table row where the row already supplies its
+      own frame and brand accent bar. */
+  chromeless?: boolean
 }) {
   const configuredBindings = connector?.configured_bindings ?? []
   const names = connector?.names
@@ -554,8 +562,13 @@ function ConnectorLivePanel({
 
   const headerIcon = channelIcon(connector?.channel ?? connectorId)
 
+  const outerClass = chromeless
+    ? 'text-[12px]'
+    : 'mb-4 scroll-mt-4 rounded-xl border border-[var(--card-border)] p-4'
+  const outerStyle = chromeless ? '' : connectorAccentStyle(connectorId)
+  const outerId = chromeless ? undefined : `connector-card-${connectorId}`
   return html`
-    <div id=${`connector-card-${connectorId}`} class="mb-4 scroll-mt-4 rounded-xl border border-[var(--card-border)] p-4" style=${connectorAccentStyle(connectorId)}>
+    <div id=${outerId} class=${outerClass} style=${outerStyle}>
       <div class="flex flex-wrap items-center gap-2 text-[12px]">
         <span class="text-base leading-none" aria-hidden="true">${headerIcon}</span>
         <span class="text-sm font-semibold text-[var(--text-body)]">${connectorName}</span>
@@ -600,7 +613,7 @@ function ConnectorLivePanel({
         </span>
       </div>
 
-      <${ConnectorReadinessRail}
+      ${chromeless ? null : html`<${ConnectorReadinessRail}
         pills=${deriveRail(
           {
             sidecarUp: connector?.available === true,
@@ -624,7 +637,7 @@ function ConnectorLivePanel({
           },
           getRailInflight(connectorId),
         )}
-      />
+      />`}
 
       <${StartupCheckBanner} connectorId=${connectorId} sidecarUp=${connector?.available === true} />
 
@@ -632,7 +645,7 @@ function ConnectorLivePanel({
         ? html`<${QuickBindForm} connectorId=${connectorId} keepers=${keepers} />`
         : null}
 
-      ${headerExpanded.value
+      ${chromeless || headerExpanded.value
         ? html`
             <div class="mt-2 rounded-md border border-[var(--card-border)] bg-[var(--white-4)] p-3 text-[11px]">
               <div class="space-y-1.5">
@@ -1115,14 +1128,6 @@ export function ConnectorStatusPanel() {
     return null
   }
 
-  // Progress hint for the "전체" view: how many of the 4 known sidecars
-  // are currently advertising a 'connected' state. Hidden in single-bridge
-  // sub-sections — the per-panel status dot already conveys that.
-  const knownConnectedCount = allConnectors.filter(
-    c => (KNOWN_CONNECTOR_IDS as readonly string[]).includes(c.connector_id)
-      && connectorStateLabel(c) === 'connected',
-  ).length
-
   return html`
     <div>
       <div class="mb-3 flex items-center justify-between gap-3">
@@ -1135,32 +1140,40 @@ export function ConnectorStatusPanel() {
           </div>
         </div>
         <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-          ${!filterId
-            ? (() => {
-                const allUp = knownConnectedCount === KNOWN_CONNECTOR_IDS.length
-                const tone = allUp ? 'text-emerald-300' : ''
-                return html`<div class=${tone}>${knownConnectedCount}/${KNOWN_CONNECTOR_IDS.length} connected</div>`
-              })()
-            : null}
           <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
           <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
         </div>
       </div>
 
       ${!filterId
-        ? html`<${ConnectorOverviewStrip} connectors=${visibleConnectors} keeperCount=${snapshot.keepers.length} />`
-        : null}
-
-      ${visibleConnectors.map(c => html`
-        <${ConnectorLivePanel}
-          connector=${c}
-          gate=${d}
-          keepers=${snapshot.keepers}
-          connectorError=${snapshot.connectorError}
-          keeperDirectoryError=${snapshot.keeperError}
-          loading=${loading}
-        />
-      `)}
+        ? html`
+            <${ConnectorOverviewStrip}
+              connectors=${visibleConnectors}
+              keepers=${snapshot.keepers}
+              renderExpandedDetail=${(c: GateConnectorInfo | null) => html`
+                <${ConnectorLivePanel}
+                  connector=${c}
+                  gate=${d}
+                  keepers=${snapshot.keepers}
+                  connectorError=${snapshot.connectorError}
+                  keeperDirectoryError=${snapshot.keeperError}
+                  loading=${loading}
+                  chromeless=${true}
+                />
+              `}
+            />
+            <${ConnectorKeeperMatrix} matrix=${deriveMatrix(visibleConnectors, snapshot.keepers)} />
+          `
+        : visibleConnectors.map(c => html`
+            <${ConnectorLivePanel}
+              connector=${c}
+              gate=${d}
+              keepers=${snapshot.keepers}
+              connectorError=${snapshot.connectorError}
+              keeperDirectoryError=${snapshot.keeperError}
+              loading=${loading}
+            />
+          `)}
 
       ${snapshot.gateError
         ? html`


### PR DESCRIPTION
## 문제

현재 `/dashboard#connectors?section=connector-status` 화면은 4개 큰 타일 + 4개 full detail 카드가 세로로 쌓이는 구조라 다음 문제가 반복됨:

- **텍스트 잘림**: `ConnectorReadinessRail`의 4 pill(Token/Process/Gate/Bindings)이 4-col 그리드 폭에서 라벨이 "BINDIN", "필" 처럼 중간 잘림.
- **정렬 무너짐**: flex-grow 기반이라 pill 폭이 내용 길이에 따라 달라 열 간 정렬이 안 맞음.
- **중복 렌더**: 동일한 4 pill 상태가 상단 strip과 각 상세 카드에 두 번 그려져 시각 노이즈.
- **N×M 미표현**: keeper ↔ connector 바인딩 관계가 "per-card bindings list" × K로 분산돼 진짜 matrix 관점이 존재하지 않음. K/M 증가 시 악화.
- **gradient 홍수**: 카드 전체에 brand color gradient(opacity 0.16)가 깔려 pill/dot 색과 충돌.

## 해결: 3-layer IA

### L1 Summary Bar (1 row)
`커넥터 4 · 1 up · 0 warn · 3 down` + `▶ Start All (3)` / `■ Stop All (1)`. 4 big tile 그리드 삭제.

### L2 Dense Connector Table
고정 폭 grid template (`4px 24px name state repeat(4, 40px) keepers actions`). Readiness를 4열 셀로 평탄화해 행 간 수직 정렬 보장. Row 클릭 → 기존 `ConnectorLivePanel`을 `chromeless=true` variant로 인라인 확장. 브랜드 색은 row-left 4px 바로 축소(카드 배경 gradient 제거).

### L3 Keeper × Connector Matrix (NEW)
`connector-keeper-matrix.ts`. 행=keeper, 열=connector. 셀 상태: `bound` / `unbound` / `na` / `unknown`. `deriveMatrix` 순수 헬퍼(unit-testable) + 렌더 분리. 바인딩에서 참조되지만 keeper 디렉토리에 없는 항목을 unknown 경고 행으로 surface.

## Before → After

Before: 상단 4 타일에서 pill 라벨이 "BINDIN"/"필"로 잘리고, 각 connector마다 gradient + pill + 상세 카드가 반복되어 iMessage 카드가 "녹+황 홍수"가 됨.

After:
- 상단 summary 1줄 + 4 row dense table (정렬 완벽, 잘림 zero)
- 아래 Keeper × Connector Matrix가 N×M을 단일 뷰로 보여줌
- Row 펼침 시 기존 상세(liveness dots, Sidecar not started, 커맨드 복사)가 chromeless로 깨끗하게 렌더

## 변경 파일

| 파일 | 변경 |
|------|------|
| `dashboard/src/components/connector-keeper-matrix.ts` | NEW: 매트릭스 컴포넌트 + `deriveMatrix` 순수 헬퍼 |
| `dashboard/src/components/connector-keeper-matrix.test.ts` | NEW: 셀 상태 5 케이스 + 렌더 2 케이스 |
| `dashboard/src/components/connector-overview-strip.ts` | 전면 재작성: 4 타일 → Summary Bar + Dense Table. `ConnectorBulkActions` export는 유지 (onboarding 의존) |
| `dashboard/src/components/connector-overview-strip.test.ts` | 새 구조용 7 테스트로 갱신 |
| `dashboard/src/components/connector-status.ts` | Matrix mount, row-expand slot 전달, `ConnectorLivePanel`에 `chromeless` 옵션, gradient opacity 0.16→0.08 |
| `dashboard/src/components/connector-status.test.ts` | row-expand 후 assert하도록 `expandRow` 헬퍼 추가 (12 테스트 업데이트) |

## 검증

- `pnpm typecheck` ✅
- `pnpm test` ✅ 193 files / 2961 tests pass
- `pnpm build` ✅ 10s
- Playwright로 `localhost:5173/dashboard/#connectors?section=connector-status` 로드해 summary bar / 4 row 정렬 / matrix 렌더 / row-expand 상세 노출 전부 시각 확인 완료.

## 건드리지 않은 것

- `deriveRail` 로직, rail inflight 상태 관리
- `ConnectorReadinessRail` 컴포넌트 (single-filter view에서는 기존대로 사용)
- `ConnectorOnboardingGrid` (cold-start)의 `ConnectorBulkActions` 사용
- `connectorAccentStyle` 함수 자체 (opacity만 조정)
- 하단 Gate metrics (Messages/Success/Errors/Dedup + Observed rooms + Recent events)
- Tailwind utility-only 정책 유지 (별도 CSS 파일 추가 없음)

## Breaking?

없음. 외부 import 시그니처 유지:
- `ConnectorOverviewStrip` 이름은 그대로 (내부 구조만 변경, `keeperCount` prop → `keepers` prop + `renderExpandedDetail` prop 추가)
- `ConnectorBulkActions({ connectors })` 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)