### PR TITLE
feat(dashboard): add outcomes rollup to keeper JSON response

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -203,6 +203,31 @@ let read_recent_verdicts ?since ?until ?(limit = max_recent_verdicts) ()
   in
   trim_recent limit verdicts
 
+let read_recent_verdicts_for_agents
+    ?since ?until ?(limit = max_recent_verdicts) ~agent_names ()
+    : harness_verdict_item list =
+  let wanted =
+    agent_names
+    |> List.map String.trim
+    |> List.filter (fun name -> name <> "")
+  in
+  if wanted = [] then []
+  else
+    let is_wanted name = List.exists (String.equal name) wanted in
+    let records = read_store_records (Eval_calibration.get_store ()) ?since ?until () in
+    let verdicts : harness_verdict_item list =
+      records
+      |> List.filter_map verdict_item_of_json
+      |> List.filter (fun verdict -> is_wanted verdict.agent_name)
+    in
+    let verdicts =
+      List.sort
+        (fun (left : harness_verdict_item) (right : harness_verdict_item) ->
+          Float.compare right.timestamp left.timestamp)
+        verdicts
+    in
+    trim_recent limit verdicts
+
 let read_pre_compact_events ?since ?until () =
   let records = read_store_records (get_pre_compact_store ()) ?since ?until () in
   let events : pre_compact_event list =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -46,6 +46,117 @@ let compute_health_score
     let raw = 100.0 -. budget_penalty -. crash_penalty -. context_penalty in
     Int.max 0 (Int.min 100 (Float.to_int raw))
 
+(** Outcomes rollup: aggregate successes / failures / validation for a keeper.
+
+    Data sources (all already in-process, zero new schema):
+    - [Keeper_transition_audit.recent_transitions] (50-entry ring) → turn,
+      compaction, handoff outcomes classified by [selected_event].
+    - [registry_entry] crash_log / restart_count / turn_consecutive_failures
+      → resilience counters.
+    - [Dashboard_harness_health.read_recent_verdicts] → OAS verdict pass/fail
+      scoped to this keeper by [agent_name].
+
+    Conservation law (spec {!KeeperOutcomesConservation.tla}):
+      successes.substantive_turns + failures.turn_failed + failures.gate_rejected
+        = observed_turns
+    holds by construction: observed_turns is computed from the same ring pass.
+    [gate_rejected] is 0 until CDAL verdict gate (#7531) lands; this does not
+    break conservation because no event bucket routes to it yet. *)
+let compute_outcomes_rollup
+    ~keeper_name
+    ~agent_name
+    ~(registry_entry : Keeper_registry.registry_entry option) : Yojson.Safe.t =
+  let succ_turns = ref 0 in
+  let succ_compactions = ref 0 in
+  let succ_handoffs = ref 0 in
+  let fail_turn = ref 0 in
+  let fail_compaction = ref 0 in
+  let fail_handoff = ref 0 in
+  let transitions =
+    Keeper_transition_audit.recent_transitions ~keeper_name ~limit:50
+  in
+  List.iter (fun (tr : Keeper_transition_audit.transition_record) ->
+    match tr.selected_event with
+    | Keeper_state_machine.Turn_succeeded -> incr succ_turns
+    | Turn_failed _ -> incr fail_turn
+    | Compaction_completed _ -> incr succ_compactions
+    | Compaction_failed _ -> incr fail_compaction
+    | Handoff_completed _ -> incr succ_handoffs
+    | Handoff_failed _ -> incr fail_handoff
+    | _ -> ()
+  ) transitions;
+  let observed_turns = !succ_turns + !fail_turn in
+  let crashes, restarts, consecutive_fail =
+    match registry_entry with
+    | Some (e : Keeper_registry.registry_entry) ->
+        List.length e.crash_log, e.restart_count, e.turn_consecutive_failures
+    | None -> 0, 0, 0
+  in
+  let keeper_verdicts =
+    try
+      Dashboard_harness_health.read_recent_verdicts ~limit:50 ()
+      |> List.filter (fun (v : Dashboard_harness_health.harness_verdict_item) ->
+           v.agent_name = keeper_name || v.agent_name = agent_name)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> []
+  in
+  let pass_v = ref 0 in
+  let fail_v = ref 0 in
+  let unknown_v = ref 0 in
+  let fail_reasons = Hashtbl.create 8 in
+  List.iter (fun (v : Dashboard_harness_health.harness_verdict_item) ->
+    match String.lowercase_ascii v.verdict with
+    | "pass" -> incr pass_v
+    | "fail" | "reject" ->
+        incr fail_v;
+        let r = Option.value v.fallback_reason ~default:"unspecified" in
+        let cur = try Hashtbl.find fail_reasons r with Not_found -> 0 in
+        Hashtbl.replace fail_reasons r (cur + 1)
+    | _ -> incr unknown_v
+  ) keeper_verdicts;
+  let top_failure_reasons =
+    Hashtbl.fold (fun k v acc -> (k, v) :: acc) fail_reasons []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+    |> List.filteri (fun i _ -> i < 3)
+    |> List.map (fun (r, _) -> `String r)
+  in
+  let last_verdict_at =
+    match keeper_verdicts with
+    | [] -> `Null
+    | v :: _ -> `Float v.timestamp
+  in
+  `Assoc [
+    ("window", `String "transition_ring_last_50");
+    ("observed_turns", `Int observed_turns);
+    ("successes", `Assoc [
+      ("substantive_turns", `Int !succ_turns);
+      ("compactions_ok", `Int !succ_compactions);
+      ("handoffs_ok", `Int !succ_handoffs);
+    ]);
+    ("failures", `Assoc [
+      ("turn_failed", `Int !fail_turn);
+      (* gate_rejected reserved for CDAL verdict gate (#7531); 0 until merged. *)
+      ("gate_rejected", `Int 0);
+      ("compaction_failed", `Int !fail_compaction);
+      ("handoff_failed", `Int !fail_handoff);
+      ("crashes", `Int crashes);
+      ("restarts", `Int restarts);
+      ("consecutive_fail_current", `Int consecutive_fail);
+    ]);
+    ("validation", `Assoc [
+      ("oas_verdicts", `Assoc [
+        ("pass", `Int !pass_v);
+        ("fail", `Int !fail_v);
+        ("unknown", `Int !unknown_v);
+        ("top_failure_reasons", `List top_failure_reasons);
+      ]);
+      (* cdal_gate: null until CDAL verdict gate (#7531) merges. *)
+      ("cdal_gate", `Null);
+      ("last_verdict_at", last_verdict_at);
+    ]);
+  ]
+
 (** Estimate seconds until Dead based on current restart_count and
     exponential backoff schedule. Returns None if already dead or
     restart_count >= max_restarts. *)
@@ -330,6 +441,12 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 Keeper_state_machine.conditions_to_json entry.conditions
             | None -> `Null
           in
+          let outcomes_json =
+            compute_outcomes_rollup
+              ~keeper_name:m.name
+              ~agent_name:m.agent_name
+              ~registry_entry
+          in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m
@@ -557,6 +674,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 | Some p -> `String p
                 | None -> `Null);
               ("conditions", conditions_json);
+              ("outcomes", outcomes_json);
             ] @ runtime_blocker_fields @ [
               ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -59,12 +59,13 @@ let compute_health_score
     Conservation law (spec {!KeeperOutcomesConservation.tla}):
       successes.substantive_turns + failures.turn_failed + failures.gate_rejected
         = observed_turns
-    holds by construction: observed_turns is computed from the same ring pass.
-    [gate_rejected] is 0 until CDAL verdict gate (#7531) lands; this does not
-    break conservation because no event bucket routes to it yet. *)
+    holds by construction only for buckets backed by the transition ring pass.
+    Historical [gate_rejected] counts are not yet persisted in the same read
+    model, so the field remains 0 until a keeper-turn source is added. *)
 let compute_outcomes_rollup
     ~keeper_name
     ~agent_name
+    ~recent_crash_count
     ~(registry_entry : Keeper_registry.registry_entry option) : Yojson.Safe.t =
   let succ_turns = ref 0 in
   let succ_compactions = ref 0 in
@@ -86,17 +87,18 @@ let compute_outcomes_rollup
     | _ -> ()
   ) transitions;
   let observed_turns = !succ_turns + !fail_turn in
-  let crashes, restarts, consecutive_fail =
+  let restarts, consecutive_fail =
     match registry_entry with
     | Some (e : Keeper_registry.registry_entry) ->
-        List.length e.crash_log, e.restart_count, e.turn_consecutive_failures
-    | None -> 0, 0, 0
+        e.restart_count, e.turn_consecutive_failures
+    | None -> 0, 0
   in
   let keeper_verdicts =
     try
-      Dashboard_harness_health.read_recent_verdicts ~limit:50 ()
-      |> List.filter (fun (v : Dashboard_harness_health.harness_verdict_item) ->
-           v.agent_name = keeper_name || v.agent_name = agent_name)
+      Dashboard_harness_health.read_recent_verdicts_for_agents
+        ~limit:50
+        ~agent_names:[ keeper_name; agent_name ]
+        ()
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | _ -> []
@@ -106,18 +108,26 @@ let compute_outcomes_rollup
   let unknown_v = ref 0 in
   let fail_reasons = Hashtbl.create 8 in
   List.iter (fun (v : Dashboard_harness_health.harness_verdict_item) ->
-    match String.lowercase_ascii v.verdict with
-    | "pass" -> incr pass_v
-    | "fail" | "reject" ->
+    match Eval_calibration.verdict_of_string (String.lowercase_ascii v.verdict) with
+    | Some Anti_rationalization.Approve -> incr pass_v
+    | Some (Anti_rationalization.Reject reason) ->
         incr fail_v;
-        let r = Option.value v.fallback_reason ~default:"unspecified" in
+        let r =
+          match v.fallback_reason, String.trim reason with
+          | Some fallback_reason, _ -> fallback_reason
+          | None, "" -> "unspecified"
+          | None, parsed_reason -> parsed_reason
+        in
         let cur = try Hashtbl.find fail_reasons r with Not_found -> 0 in
         Hashtbl.replace fail_reasons r (cur + 1)
-    | _ -> incr unknown_v
+    | None -> incr unknown_v
   ) keeper_verdicts;
   let top_failure_reasons =
     Hashtbl.fold (fun k v acc -> (k, v) :: acc) fail_reasons []
-    |> List.sort (fun (_, a) (_, b) -> compare b a)
+    |> List.sort (fun (left_reason, left_count) (right_reason, right_count) ->
+         let count_cmp = compare right_count left_count in
+         if count_cmp <> 0 then count_cmp
+         else String.compare left_reason right_reason)
     |> List.filteri (fun i _ -> i < 3)
     |> List.map (fun (r, _) -> `String r)
   in
@@ -136,11 +146,11 @@ let compute_outcomes_rollup
     ]);
     ("failures", `Assoc [
       ("turn_failed", `Int !fail_turn);
-      (* gate_rejected reserved for CDAL verdict gate (#7531); 0 until merged. *)
+      (* Historical gate_rejected counts are not persisted yet. *)
       ("gate_rejected", `Int 0);
       ("compaction_failed", `Int !fail_compaction);
       ("handoff_failed", `Int !fail_handoff);
-      ("crashes", `Int crashes);
+      ("crashes", `Int recent_crash_count);
       ("restarts", `Int restarts);
       ("consecutive_fail_current", `Int consecutive_fail);
     ]);
@@ -441,17 +451,11 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 Keeper_state_machine.conditions_to_json entry.conditions
             | None -> `Null
           in
-          let outcomes_json =
-            compute_outcomes_rollup
-              ~keeper_name:m.name
-              ~agent_name:m.agent_name
-              ~registry_entry
-          in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m
           in
-          let supervisor_diagnostics =
+          let supervisor_diagnostics, recent_crash_count =
             match registry_entry with
             | Some entry ->
                 let crash_log =
@@ -482,7 +486,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   ~recent_crash_count:(List.length combined_log)
                   ~is_dead:(Option.is_some entry.dead_since_ts)
                   ~context_ratio:ctx_ratio in
-                `Assoc [
+                (`Assoc [
                   ("restart_count", `Int entry.restart_count);
                   ("max_restarts", `Int max_restarts);
                   ("crash_log", `List combined_log);
@@ -501,9 +505,9 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                       ~restart_count:entry.restart_count ~max_restarts with
                     | Some eta -> `Float eta
                     | None -> `Null);
-                ]
+                ], List.length combined_log)
             | None ->
-                `Assoc [
+                (`Assoc [
                   ("restart_count", `Int 0);
                   ("max_restarts", `Int max_restarts);
                   ("crash_log", `List []);
@@ -512,7 +516,14 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   ("sp_events", `List []);
                   ("health_score", `Int 100);
                   ("dead_eta_sec", `Null);
-                ]
+                ], 0)
+          in
+          let outcomes_json =
+            compute_outcomes_rollup
+              ~keeper_name:m.name
+              ~agent_name:m.agent_name
+              ~recent_crash_count
+              ~registry_entry
           in
 
           let context =

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -118,6 +118,24 @@ let make_result ?(verdict = AR.Approve) ?(gate = AR.Structured_tool)
     fallback_reason;
   }
 
+let append_verdict_record ~timestamp ~agent_name ~task_id ~verdict ?fallback_reason () =
+  Dated_jsonl.append (Cal.get_store ())
+    (`Assoc
+      [
+        ("record_type", `String "verdict");
+        ("notes_hash", `String ("hash-" ^ task_id));
+        ("task_id", `String task_id);
+        ("task_title", `String ("Task " ^ task_id));
+        ("agent_name", `String agent_name);
+        ("verdict", `String verdict);
+        ("gate", `String "structured_tool");
+        ("evaluator_cascade", `String "cross_verifier");
+        ("timestamp", `Float timestamp);
+      ]
+      @ match fallback_reason with
+        | Some reason -> [ ("fallback_reason", `String reason) ]
+        | None -> [])
+
 let test_runtime_signals_are_persisted () =
   with_test_stores @@ fun config ->
   ignore
@@ -254,6 +272,67 @@ let test_overview_warns_when_evaluator_falls_back () =
   check (float 0.0001) "fallback ratio" 1.0
     Yojson.Safe.Util.(overview |> member "fallback_ratio" |> to_float)
 
+let test_agent_scoped_verdicts_filter_before_limit () =
+  with_test_stores @@ fun _config ->
+  append_verdict_record
+    ~timestamp:100.0
+    ~agent_name:"keeper-a"
+    ~task_id:"keeper-1"
+    ~verdict:"approve"
+    ();
+  append_verdict_record
+    ~timestamp:101.0
+    ~agent_name:"keeper-agent"
+    ~task_id:"keeper-2"
+    ~verdict:"reject:schema_violation"
+    ();
+  for i = 0 to 9 do
+    append_verdict_record
+      ~timestamp:(200.0 +. float_of_int i)
+      ~agent_name:"other-agent"
+      ~task_id:(Printf.sprintf "other-%d" i)
+      ~verdict:"reject"
+      ~fallback_reason:"timeout"
+      ()
+  done;
+  let global_latest =
+    Harness.read_recent_verdicts ~limit:1 ()
+  in
+  check string "global latest is other agent" "other-agent"
+    (match global_latest with
+     | verdict :: _ -> verdict.agent_name
+     | [] -> failwith "expected global verdict");
+  let scoped =
+    Harness.read_recent_verdicts_for_agents
+      ~limit:5
+      ~agent_names:[ "keeper-a"; "keeper-agent" ]
+      ()
+  in
+  check int "scoped verdict count survives global crowding" 2 (List.length scoped);
+  check string "scoped latest verdict agent alias" "keeper-agent"
+    (match scoped with
+     | verdict :: _ -> verdict.agent_name
+     | [] -> failwith "expected scoped verdict");
+  let outcomes =
+    Masc_mcp.Dashboard_http_keeper.compute_outcomes_rollup
+      ~keeper_name:"keeper-a"
+      ~agent_name:"keeper-agent"
+      ~recent_crash_count:0
+      ~registry_entry:None
+  in
+  check int "outcomes pass count uses scoped helper" 1
+    Yojson.Safe.Util.(outcomes |> member "validation" |> member "oas_verdicts" |> member "pass" |> to_int);
+  check int "outcomes fail count parses reject variants" 1
+    Yojson.Safe.Util.(outcomes |> member "validation" |> member "oas_verdicts" |> member "fail" |> to_int);
+  check int "outcomes unknown count stays zero" 0
+    Yojson.Safe.Util.(outcomes |> member "validation" |> member "oas_verdicts" |> member "unknown" |> to_int);
+  check (list string) "failure reasons parse reject suffix"
+    [ "schema_violation" ]
+    Yojson.Safe.Util.(outcomes |> member "validation" |> member "oas_verdicts"
+      |> member "top_failure_reasons" |> to_list |> filter_string);
+  check (option float) "last verdict timestamp preserved" (Some 101.0)
+    Yojson.Safe.Util.(outcomes |> member "validation" |> member "last_verdict_at" |> to_float_option)
+
 let () =
   run "Dashboard_harness_health"
     [
@@ -271,5 +350,7 @@ let () =
             test_runtime_stale_status;
           test_case "fallback-heavy evaluator shows warning overview" `Quick
             test_overview_warns_when_evaluator_falls_back;
+          test_case "agent-scoped verdicts filter before limit" `Quick
+            test_agent_scoped_verdicts_filter_before_limit;
         ] );
     ]


### PR DESCRIPTION
## Summary

Keeper agent modal redesign **PR 3** (plan: `curried-moseying-whisper`). Aggregates per-keeper successes / failures / validation into an `outcomes` block on `/api/v1/keepers` — pure read-model over three existing in-process sources, **zero new schema**.

## Data sources

| Source | API | Contribution |
|---|---|---|
| Transition ring (50 entries) | `Keeper_transition_audit.recent_transitions` | turn / compaction / handoff success-or-failure buckets |
| Registry entry | `crash_log`, `restart_count`, `turn_consecutive_failures` | resilience counters |
| Harness verdicts | `Dashboard_harness_health.read_recent_verdicts` filtered by `agent_name` | OAS validator pass/fail + top-3 fallback reasons |

## JSON shape

\`\`\`json
"outcomes": {
  "window": "transition_ring_last_50",
  "observed_turns": 48,
  "successes": {
    "substantive_turns": 42,
    "compactions_ok": 7,
    "handoffs_ok": 1
  },
  "failures": {
    "turn_failed": 6,
    "gate_rejected": 0,
    "compaction_failed": 0,
    "handoff_failed": 0,
    "crashes": 0,
    "restarts": 2,
    "consecutive_fail_current": 0
  },
  "validation": {
    "oas_verdicts": {
      "pass": 18, "fail": 2, "unknown": 0,
      "top_failure_reasons": ["schema_violation", "timeout"]
    },
    "cdal_gate": null,
    "last_verdict_at": 1744862302.4
  }
}
\`\`\`

## Conservation law

Spec: [`KeeperOutcomesConservation.tla`](../blob/main/specs/keeper-state-machine/KeeperOutcomesConservation.tla) (merged #7757).

\`\`\`
successes.substantive_turns + failures.turn_failed + failures.gate_rejected
  = observed_turns
\`\`\`

Holds **by construction** — \`observed_turns\` is computed from the same ring pass that bumps the success/fail counters. \`gate_rejected\` is 0 until CDAL verdict gate (#7531) merges; no event bucket routes there yet so conservation is not broken.

## Out of scope

- PR 4 (frontend 4-section SignalGroup) consumes this payload — follow-up.
- PR 5 (Success/Failure Ledger + Validator Pass Rate + Resilience Profile renderers).
- PR 9 (CDAL \`cdal_gate\` wiring + \`pending_verification\`) — depends on #7531.

## Test plan

- [ ] Local \`curl /api/v1/keepers\` shows \`outcomes\` on each keeper entry.
- [ ] Fire a deliberate turn failure (timeout) → \`failures.turn_failed\` increments, \`successes + failures = observed_turns\` remains.
- [ ] Keeper with no transitions yet → all counters 0, \`observed_turns=0\`.
- [ ] CI passes.

## Stack context

- Spec stack (merged): #7748 (KeeperDwellMonotone) · #7757 (KeeperOutcomesConservation) · #7758 (KeeperCounterCausality)
- Impl stack (merged): #7762 (conditions serialization) · #7771 (Phase dwell)
- **This PR**: outcomes rollup backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)