### PR TITLE
refactor(autoresearch): Remove exception-throwing serde helpers to enforce Result types

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -59,19 +59,14 @@ let option_first_some left right =
 (* ================================================================ *)
 
 let decision_to_string = Autoresearch_serde.decision_to_string
-let decision_of_string = Autoresearch_serde.decision_of_string
 let decision_of_string_result = Autoresearch_serde.decision_of_string_result
 let status_to_string = Autoresearch_serde.status_to_string
-let status_of_string = Autoresearch_serde.status_of_string
 let status_of_string_result = Autoresearch_serde.status_of_string_result
 let cycle_to_yojson = Autoresearch_serde.cycle_to_yojson
-let cycle_of_yojson = Autoresearch_serde.cycle_of_yojson
 let cycle_of_yojson_result = Autoresearch_serde.cycle_of_yojson_result
 let state_to_yojson = Autoresearch_serde.state_to_yojson
-let state_of_yojson = Autoresearch_serde.state_of_yojson
 let state_of_yojson_result = Autoresearch_serde.state_of_yojson_result
 let swarm_link_to_yojson = Autoresearch_serde.swarm_link_to_yojson
-let swarm_link_of_yojson = Autoresearch_serde.swarm_link_of_yojson
 let swarm_link_of_yojson_result = Autoresearch_serde.swarm_link_of_yojson_result
 
 (* ================================================================ *)

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -9,11 +9,6 @@ include Autoresearch_types
 
 let decision_to_string = function Keep -> "keep" | Discard -> "discard"
 
-let decision_of_string = function
-  | "keep" -> Keep
-  | "discard" -> Discard
-  | s -> invalid_arg (Printf.sprintf "Unknown decision: %s" s)
-
 let decision_of_string_result = function
   | "keep" -> Ok Keep
   | "discard" -> Ok Discard
@@ -24,13 +19,6 @@ let status_to_string = function
   | Completed -> "completed"
   | Stopped -> "stopped"
   | Error -> "error"
-
-let status_of_string = function
-  | "running" -> Some Running
-  | "completed" -> Some Completed
-  | "stopped" -> Some Stopped
-  | "error" -> Some Error
-  | _ -> None
 
 let status_of_string_result = function
   | "running" -> Ok Running
@@ -186,11 +174,6 @@ let cycle_of_yojson_result (json : Yojson.Safe.t) : (cycle_record, string) resul
       timestamp;
     }
 
-let cycle_of_yojson (json : Yojson.Safe.t) : cycle_record =
-  match cycle_of_yojson_result json with
-  | Ok value -> value
-  | Stdlib.Error msg -> invalid_arg msg
-
 let state_to_yojson (s : loop_state) : Yojson.Safe.t =
   `Assoc [
     ("loop_id", `String s.loop_id);
@@ -336,11 +319,6 @@ let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) 
       lower_is_better;
     }
 
-let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
-  match state_of_yojson_result json with
-  | Ok value -> value
-  | Stdlib.Error msg -> invalid_arg msg
-
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
   `Assoc
     [
@@ -376,7 +354,3 @@ let swarm_link_of_yojson_result (json : Yojson.Safe.t) : (swarm_link, string) re
       linked_at;
     }
 
-let swarm_link_of_yojson (json : Yojson.Safe.t) : swarm_link =
-  match swarm_link_of_yojson_result json with
-  | Ok value -> value
-  | Stdlib.Error msg -> invalid_arg msg


### PR DESCRIPTION
## Description
Enterprise Improvement: Refactor codebase to use idiomatic OCaml Result/Option types. Removes exception-throwing unsafe decoding functions from `autoresearch_serde` forcing all call-sites to handle validation errors via `Result.t`.

## Changes
- Removed `decision_of_string`
- Removed `status_of_string`
- Removed `cycle_of_yojson`
- Removed `state_of_yojson`
- Removed `swarm_link_of_yojson`

All modules are now safely constrained to use `_result` suffixed functions.

Fixes task-208