### PR TITLE
docs: drop retired CP/MDAL from DASHBOARD-INTEGRATION + fix self-contradicting BENCHMARK-RUNBOOK

### DIFF
--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -157,7 +157,7 @@ scripts/harness_agent_swarm_live.sh
 
 ## session runtime local64 compat lane
 
-Removed. Team-session compat harnesses are retired; use managed-operation live proof and command-plane read models instead.
+Removed. Team-session compat harnesses and the command-plane HTTP lane are both retired; use board_posts + keeper FSM read models for coordination truth and the canonical dashboard projections (`/api/v1/dashboard/mission`, `/api/v1/dashboard/execution`, `/api/v1/dashboard/board`) for live proof.
 
 ## 최소 unit 예시
 

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -18,9 +18,8 @@ code_refs:
 - `execution`: workers, tasks, keepers, continuity pressure
 - `memory`: durable posts/comments only
 - `governance`: debates and voting only
-- `planning`: goals, MDAL loops, backlog posture
+- `planning`: goals, backlog posture
 - `intervene`: mutating operator actions
-- `command`: command-plane truth
 
 Experimental features such as TRPG live under `lab`.
 
@@ -48,7 +47,7 @@ Experimental features such as TRPG live under `lab`.
 - `GET /api/v1/dashboard/shell`
   - shell-only room status and top-level counts
 - `GET /api/v1/dashboard/mission`
-  - mission summary derived from operator + command truth
+  - mission summary derived from operator truth
 - `GET /api/v1/dashboard/execution`
   - `summary`, `execution_queue`, `operation_briefs`, `worker_support_briefs`, `continuity_briefs`, `offline_worker_briefs`
   - compatibility payloads remain: `agents`, `tasks`, `messages`, `keepers`
@@ -58,10 +57,10 @@ Experimental features such as TRPG live under `lab`.
 - `GET /api/v1/dashboard/governance`
   - `debates`, `sessions`, governance summary
 - `GET /api/v1/dashboard/planning`
-  - `goals`, `rollup`, `mdal`, `task_backlog`
+  - `goals`, `rollup`, `task_backlog`
 
 ## Raw Domain Endpoints
-- `/api/v1/board*`, `/api/v1/governance*`, `/api/v1/operator*`, `/api/v1/command-plane*`
+- `/api/v1/board*`, `/api/v1/governance*`, `/api/v1/operator*`
 - These may still exist for domain consumers or drill-down flows.
 - The dashboard client should prefer the canonical projection endpoints above.
 
@@ -78,8 +77,6 @@ Experimental features such as TRPG live under `lab`.
   - `board_post`
   - `board_comment`
   - `decision_*`
-  - `mdal_*`
-  - `command_plane_*`
   - `operator_*`
 
 ## Error Contract


### PR DESCRIPTION
## Summary

Gen36 드리프트 — 운영 가이드가 retired 서브시스템을 fallback으로 추천하는 자기모순 + 대시보드 통합 문서의 CP/MDAL 잔존 언급 정리.

### DASHBOARD-INTEGRATION.md (5 inline drifts)

1. Canonical Main Surfaces: \`command\`: command-plane truth 행 제거, planning의 "MDAL loops" 삭제
2. \`/api/v1/dashboard/mission\`: "operator + command truth" → "operator truth" (CP 소멸)
3. \`/api/v1/dashboard/planning\`: 필드 목록에서 \`mdal\` 제거
4. Raw Domain Endpoints: \`/api/v1/command-plane*\` 제거 (lib/server/에 핸들러 0개)
5. SSE event classes: \`mdal_*\`, \`command_plane_*\` 제거 (emitter 없음)

### BENCHMARK-RUNBOOK.md 자기모순 정정

Line 160: \"Team-session compat harnesses are retired; use managed-operation live proof and command-plane read models instead.\" — 그런데 command-plane도 retired. 자기모순.

→ board_posts + keeper FSM + canonical dashboard projection으로 fallback 경로 수정.

(\`masc_unit_define\`, \`masc_dispatch_tick\` 등 CP-era tool 예제는 downstream에 남아있지만 별도 generation에서 큰 PR로 처리.)

## Pattern

Gen33~35 공통 drift FSM의 연장, 새 판정 기준 추가:
- Gen33-35: \"code-ref identifier가 repo에 없으면 retire\"
- Gen36 추가: \"retired X를 Y로 대체하라 말하지만 Y도 retired\" — 자기모순 fallback instruction

## Test plan

- [x] \`bash scripts/check-doc-truth.sh\` pass
- [x] \`rg -l 'command_plane_' lib/\` → env_config_governance.ml만 (stub only)
- [x] \`find lib/ -name 'mdal*'\` empty
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)