### PR TITLE
docs(spec): drop dead code_refs + retire Agent Ecosystem Types section

### DIFF
--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -5,7 +5,6 @@ code_refs:
   - lib/types/
   - lib/tool_dispatch.ml
   - lib/agent_identity.ml
-  - lib/agent_ecosystem.ml
 ---
 
 # Types and Invariants
@@ -14,7 +13,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Foundation |
-| Maps to | `lib/types/`, `lib/message_schema.ml`, `lib/tool_dispatch.ml`, `lib/agent_identity.ml`, `lib/agent_ecosystem.ml` |
+| Maps to | `lib/types/`, `lib/tool_dispatch.ml`, `lib/agent_identity.ml` |
 | Dependencies | 00-glossary.md |
 
 ---
@@ -578,56 +577,9 @@ MAGI 3인 체제(Melchior/Balthasar/Casper)에 Athena와 Generalist를 추가한
 
 ---
 
-## 6. Agent Ecosystem Types
+## 6. Agent Ecosystem Types (RETIRED)
 
-**소스**: `lib/agent_ecosystem.mli`
-
-### 6.1 Agent Type (생명주기)
-
-```ocaml
-type agent_lifecycle =
-  | Keeper_long_lived  (* Keepalive 기반 장기 실행 *)
-  | Visitor            (* Session 기반 *)
-  | Ephemeral          (* Task 기반, 작업 완료 후 소멸 *)
-```
-
-### 6.2 Agent Profile
-
-```ocaml
-type agent_profile = {
-  name : string;
-  role : string;
-  traits : string list;
-  avatar : string option;
-}
-```
-
-### 6.3 Lineage (세대 추적)
-
-```ocaml
-type lineage = {
-  generation : int;
-  parent_hash : string option;
-  ancestors : string list;
-  mutations : string list;
-}
-```
-
-에이전트 간 계보를 추적한다. `spawn_child`로 새 세대를 생성하면 `generation`이 증가하고 부모 해시가 기록된다.
-
-### 6.4 Extended Identity
-
-```ocaml
-type extended = {
-  base : Agent_identity.t;
-  hash : string;
-  agent_type : agent_type;
-  profile : agent_profile;
-  lineage : lineage;
-}
-```
-
-`Agent_identity.t`를 확장하여 프로필, 생명주기 타입, 계보를 추가한다. `to_base_with_metadata`/`from_base_with_metadata`로 base identity와 상호 변환한다.
+`lib/agent_ecosystem.mli`와 `agent_lifecycle`, `agent_profile`, `lineage`, `extended` 타입은 dead code sweep (#2848)에서 `lib/anti_fake`, `lib/agent_neo4j`와 함께 제거됐다 (-1368 LOC). 현재 agent identity는 `lib/agent_identity.ml` 하나로 정리됐고, 생명주기 추적은 `lib/coord/coord_lifecycle.ml` + `observe_agent_lifecycle` hook이 담당한다.
 
 ---
 

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -4,7 +4,6 @@ last_verified: 2026-04-17
 code_refs:
   - lib/
   - dune-project
-  - lib/sdk_version.ml
 ---
 
 # Appendix C: Implementation Status Report

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -4,7 +4,6 @@ last_verified: 2026-04-17
 code_refs:
   - docs/spec/
   - dune-project
-  - lib/sdk_version.ml
 ---
 
 # MASC Specification Index


### PR DESCRIPTION
## Summary

Gen37 — 새 판정 렌즈로 동일 FSM을 plug: **frontmatter \`code_refs:\` 블록의 paths가 실제로 존재하는가**.

84개 \`last_verified: 2026-04-17\` 스탬프 파일을 AWK로 훑어 code_refs 추출 + existence check. 3개 spec 문서에서 5개 dead path 발견.

## Drifts fixed

### Frontmatter
- \`SPEC-INDEX.md\` → \`lib/sdk_version.ml\` (never existed in MASC; OAS copy-paste residue)
- \`C-implementation-status.md\` → \`lib/sdk_version.ml\` (same)
- \`02-types-and-invariants.md\` → \`lib/agent_ecosystem.ml\` (removed in #2848)

### Body
- \`02-types-and-invariants.md\` line 17 "Maps to" row: dropped \`lib/agent_ecosystem.ml\` + \`lib/message_schema.ml\` (both missing)
- \`02-types-and-invariants.md\` §6 "Agent Ecosystem Types": 40+ lines claiming \`agent_lifecycle\`/\`agent_profile\`/\`lineage\`/\`extended\` types from \`lib/agent_ecosystem.mli\` — replaced with RETIRED paragraph pointing to surviving surfaces (\`agent_identity.ml\`, \`coord/coord_lifecycle.ml\`)

## Verification

\`\`\`
# Before fix
$ find lib/ -name 'sdk_version*' -o -name 'agent_ecosystem*' -o -name 'message_schema*'
(empty)
$ git log --oneline --all -- 'lib/agent_ecosystem*'
a1bab8402 refactor: remove dead anti_fake, agent_ecosystem, agent_neo4j modules (-1368 LOC) (#2848)
\`\`\`

## FSM plug progression

- Gen33: body text referencing deleted .ml files (team_session)
- Gen34: section-level IMPL claim for deleted subsystem (Command Plane)
- Gen35: type variant count drift (module_tag 43→21) + primary domain scope
- Gen36: self-contradicting fallback instructions (retired X suggests retired Y)
- **Gen37: frontmatter \`code_refs:\` pointing at nonexistent paths** — structural metadata layer

같은 감사 FSM, 새 렌즈.

## Test plan

- [x] \`bash scripts/check-doc-truth.sh\` pass
- [x] Full \`code_refs:\` path existence scan on 84 stamped files
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)