### PR TITLE
feat(dashboard): add Zod parse boundary for SSE events

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,7 +33,8 @@
     "valibot": "^1.3.1",
     "vis-data": "^8.0.3",
     "vis-network": "^10.0.2",
-    "vis-timeline": "^8.5.0"
+    "vis-timeline": "^8.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       vis-timeline:
         specifier: ^8.5.0
         version: 8.5.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@3.0.0(@egjs/hammerjs@2.0.17))(uuid@11.1.0)(vis-data@8.0.3(uuid@11.1.0)(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@6.0.0(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AttributionSchema,
+  parseSSEMessage,
+  SSEMessageSchema,
+  SSEEventTypeSchema,
+} from './sse'
+
+describe('SSEEventTypeSchema', () => {
+  it('accepts a known event type', () => {
+    expect(SSEEventTypeSchema.parse('keeper_heartbeat')).toBe('keeper_heartbeat')
+  })
+
+  it('rejects an unknown event type', () => {
+    const r = SSEEventTypeSchema.safeParse('this_is_not_a_real_event')
+    expect(r.success).toBe(false)
+  })
+})
+
+describe('AttributionSchema', () => {
+  it('parses a passed outcome', () => {
+    const r = AttributionSchema.safeParse({
+      origin: 'det',
+      gate: 'keeper_fsm',
+      evidence: { note: 'ok' },
+      outcome: { kind: 'passed' },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('parses a partial_pass outcome with score/rationale', () => {
+    const r = AttributionSchema.safeParse({
+      origin: 'nondet',
+      gate: 'verification',
+      evidence: {},
+      outcome: { kind: 'partial_pass', score: 0.75, rationale: 'mostly ok' },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects an unknown outcome kind', () => {
+    const r = AttributionSchema.safeParse({
+      origin: 'det',
+      gate: 'verification',
+      evidence: {},
+      outcome: { kind: 'weird_kind' },
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects partial_pass without score', () => {
+    const r = AttributionSchema.safeParse({
+      origin: 'det',
+      gate: 'verification',
+      evidence: {},
+      outcome: { kind: 'partial_pass', rationale: 'x' },
+    })
+    expect(r.success).toBe(false)
+  })
+})
+
+describe('SSEMessageSchema', () => {
+  it('accepts a minimal known event', () => {
+    const r = SSEMessageSchema.safeParse({ type: 'heartbeat' })
+    expect(r.success).toBe(true)
+    if (r.success) expect(r.data.type).toBe('heartbeat')
+  })
+
+  it('accepts a keeper_tool_call with typed fields', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_tool_call',
+      keeper_name: 'k1',
+      tool_name: 'bash',
+      duration_ms: 1234,
+      success: true,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects wrong type on a known field', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_tool_call',
+      duration_ms: 'not_a_number',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects missing type discriminator', () => {
+    const r = SSEMessageSchema.safeParse({ agent: 'nobody' })
+    expect(r.success).toBe(false)
+  })
+
+  it('passes through unknown fields (forward-compat)', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'heartbeat',
+      some_new_backend_field: 42,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('parses an OAS event with attribution envelope', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'oas:turn_completed',
+      correlation_id: 'abc',
+      run_id: 'r1',
+      attribution: {
+        origin: 'det',
+        gate: 'oas_completion',
+        evidence: { reason: 'ok' },
+        outcome: { kind: 'passed' },
+      },
+    })
+    expect(r.success).toBe(true)
+  })
+})
+
+describe('parseSSEMessage', () => {
+  it('returns the parsed message for a valid input', () => {
+    const msg = parseSSEMessage({ type: 'broadcast', message: 'hi' })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('broadcast')
+  })
+
+  it('returns null and warns on invalid input', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({ type: 'not_a_real_type' })
+    expect(msg).toBeNull()
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
+  it('returns null for a non-object payload', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseSSEMessage('just a string')).toBeNull()
+    expect(parseSSEMessage(42)).toBeNull()
+    expect(parseSSEMessage(null)).toBeNull()
+    warnSpy.mockRestore()
+  })
+})

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -1,0 +1,224 @@
+// Zod schema-at-boundary for SSE events from the MCP server.
+//
+// Parse gate: the top-level `type` discriminator is validated against a
+// closed enum so unknown event names surface as drift instead of becoming
+// silent no-ops. All other fields are declared as optional (mirrors the
+// existing `SSEEvent` interface) so new backend payload shapes don't hard-
+// fail the dashboard — but the field types are still checked when present.
+//
+// TypeScript SSOT: src/types/sse.ts (SSEEvent interface).
+// Phase 1 goal: eliminate the `as SSEEvent` cast in src/sse.ts by giving
+// onmessage a checked parse boundary. Phase 2 will split this into a
+// per-variant z.discriminatedUnion so handlers can switch exhaustively.
+
+import { z } from 'zod'
+
+// --- Type discriminator (closed enum) -------------------------------------
+// Mirror of `SSEEventType` in ../types/sse.ts. Keep in sync on add/remove.
+// Strict: an unknown `type` value causes safeParse to fail and the event
+// is dropped with a console.warn.
+export const SSEEventTypeSchema = z.enum([
+  'agent_joined',
+  'agent_left',
+  'broadcast',
+  'task_update',
+  'board_post',
+  'masc/board_post',
+  'board_comment',
+  'masc/board_comment',
+  'board_delete',
+  'masc/board_delete',
+  'post_created',
+  'comment_added',
+  'post_voted',
+  'comment_voted',
+  'heartbeat',
+  'keeper_heartbeat',
+  'keeper_handoff',
+  'masc/keeper_handoff',
+  'keeper_compaction',
+  'masc/keeper_compaction',
+  'keeper_guardrail',
+  'masc/keeper_guardrail',
+  'keeper_phase_changed',
+  'keeper_composite_changed',
+  'keeper_tool_call',
+  'masc/keeper_tool_call',
+  'keeper_tool_skipped',
+  'keeper_turn_complete',
+  'masc/keeper_turn_complete',
+  'client_input_approved',
+  'client_input_rejected',
+  'client_input_updated',
+  'governance_param_changed',
+  'approval:pending',
+  'approval:resolved',
+  'oas:masc:autonomy:agent_selected',
+  'oas:masc:autonomy:agent_decision',
+  'oas:masc:autonomy:agent_action_executed',
+  'oas:masc:keeper:snapshot',
+  'oas:masc:keeper:lifecycle',
+  'oas:masc:trust_updated',
+  'oas:masc:reputation_changed',
+  'oas:agent_started',
+  'oas:agent_completed',
+  'oas:tool_called',
+  'oas:tool_completed',
+  'oas:turn_started',
+  'oas:turn_completed',
+  'oas:context_compacted',
+  'oas:task_state_changed',
+  'oas:masc:harness:verdict_recorded',
+  'oas:masc:harness:pre_compact',
+  'oas:masc:harness:handoff',
+  'room_truth_snapshot',
+  'namespace_truth_snapshot',
+  'execution_snapshot',
+  'operator_snapshot',
+  'operator_digest',
+  'transport_health_snapshot',
+])
+
+export type SSEEventType = z.infer<typeof SSEEventTypeSchema>
+
+// --- Attribution envelope (nested discriminated union) --------------------
+// OCaml SSOT: lib/attribution.mli. Structurally mirrors AttributionOutcome
+// which is a discriminated union on `kind`. Zod's discriminatedUnion
+// matches exactly — unknown `kind` fails parse.
+
+const AttributionOutcomeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('passed') }),
+  z.object({
+    kind: z.literal('policy_failed'),
+    reason: z.string(),
+  }),
+  z.object({
+    kind: z.literal('transition_blocked'),
+    from_state: z.string(),
+    to_state: z.string(),
+    reason: z.string(),
+  }),
+  z.object({
+    kind: z.literal('partial_pass'),
+    score: z.number(),
+    rationale: z.string(),
+  }),
+])
+
+export const AttributionSchema = z.object({
+  origin: z.enum(['det', 'nondet']),
+  // `gate` is intentionally open: known canonical names are documented in
+  // the TS SSEEvent AttributionGate union but new gates must not break
+  // existing clients.
+  gate: z.string(),
+  evidence: z.record(z.string(), z.unknown()),
+  outcome: AttributionOutcomeSchema,
+})
+
+export type Attribution = z.infer<typeof AttributionSchema>
+
+// --- SSE envelope --------------------------------------------------------
+// Strict on discriminator (`type`), permissive on payload (every other
+// field optional). Unknown fields pass through to preserve forward-
+// compat: a newer server emitting a new payload field must not crash
+// a slightly older dashboard. Typed fields still reject wrong-type values.
+export const SSEMessageSchema = z
+  .object({
+    type: SSEEventTypeSchema,
+    severity: z.string().optional(),
+    source: z.string().optional(),
+    agent: z.string().optional(),
+    from: z.string().optional(),
+    from_agent: z.string().optional(),
+    message: z.string().optional(),
+    content: z.string().optional(),
+    task_id: z.string().optional(),
+    status: z.string().optional(),
+    post_id: z.string().optional(),
+    comment_id: z.string().optional(),
+    title: z.string().optional(),
+    author: z.string().optional(),
+    voter: z.string().optional(),
+    direction: z.string().optional(),
+    hearth: z.string().optional(),
+    agent_name: z.string().optional(),
+    keeper_name: z.string().optional(),
+    event_type: z.string().optional(),
+    // Keeper event fields
+    name: z.string().optional(),
+    generation: z.number().optional(),
+    context_ratio: z.number().optional(),
+    ts_unix: z.number().optional(),
+    from_generation: z.number().optional(),
+    to_generation: z.number().optional(),
+    from_model: z.string().optional(),
+    to_model: z.string().optional(),
+    before_tokens: z.number().optional(),
+    after_tokens: z.number().optional(),
+    saved_tokens: z.number().optional(),
+    trigger: z.string().optional(),
+    reason: z.string().optional(),
+    // Phase transitions
+    prev_phase: z.string().optional(),
+    new_phase: z.string().optional(),
+    event: z.string().optional(),
+    // Tool call / skip fields
+    tool_name: z.string().optional(),
+    duration_ms: z.number().optional(),
+    success: z.boolean().optional(),
+    error_text: z.string().optional(),
+    reason_code: z.string().optional(),
+    turn: z.number().optional(),
+    phase: z.string().optional(),
+    from_state: z.string().optional(),
+    to_state: z.string().optional(),
+    session_id: z.string().optional(),
+    operation_id: z.string().optional(),
+    worker_run_id: z.string().optional(),
+    // Turn complete enrichment
+    model_used: z.string().optional(),
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    cost_usd: z.number().optional(),
+    tool_calls_made: z.number().optional(),
+    total_turns: z.number().optional(),
+    // Generic OAS payload container
+    payload: z.record(z.string(), z.unknown()).optional(),
+    // OAS envelope
+    correlation_id: z.string().optional(),
+    run_id: z.string().optional(),
+    // Gate attribution envelope
+    attribution: AttributionSchema.optional(),
+  })
+  .passthrough()
+
+export type SSEMessage = z.infer<typeof SSEMessageSchema>
+
+/** Schema drift error for SSE boundary.
+ *  Matches the GateStatusSchemaDriftError pattern used by Valibot schemas. */
+export class SSESchemaDriftError extends Error {
+  constructor(
+    public readonly issues: readonly { path?: string; message: string }[],
+    public readonly raw: unknown,
+  ) {
+    super(`SSE schema drift: ${issues.map((i) => i.message).join('; ')}`)
+    this.name = 'SSESchemaDriftError'
+  }
+}
+
+/** Parse-or-drop boundary. Returns the typed message on success.
+ *  On failure logs a console.warn with the drift issue and returns null;
+ *  the caller drops the event. */
+export function parseSSEMessage(raw: unknown): SSEMessage | null {
+  const result = SSEMessageSchema.safeParse(raw)
+  if (result.success) return result.data
+  // Surface drift in dev tools without crashing the stream. Aggregate issues
+  // into one warn; keep payload visible so operators can diff server output.
+  const issues = result.error.issues.map((i) => ({
+    path: i.path.join('.'),
+    message: i.message,
+  }))
+  // eslint-disable-next-line no-console
+  console.warn('[SSE] schema drift, event dropped', { issues, raw })
+  return null
+}

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -13,6 +13,7 @@ import {
 } from './journal-entry'
 import { appendLiveToolCall } from './components/session-trace/session-trace-state'
 import { applyOasRuntimeEvent } from './oas-runtime-store'
+import { parseSSEMessage } from './schemas/sse'
 
 import {
   RECONNECT_BASE_MS,
@@ -250,17 +251,29 @@ export function connectSSE(): void {
   }
 
   es.onmessage = (e: MessageEvent) => {
+    let raw: unknown
     try {
-      const raw = JSON.parse(e.data as string)
-      // Unwrap JSON-RPC notifications: extract params as the actual event.
-      // Server wraps events as {"jsonrpc":"2.0","method":"masc/event","params":{type,agent,...}}
-      const event: SSEEvent = (raw.jsonrpc && raw.params?.type) ? raw.params : raw
-      eventCount.value++
-      lastEvent.value = event
-      handleEvent(event)
+      raw = JSON.parse(e.data as string)
     } catch {
       // Non-JSON SSE data (e.g., heartbeat text)
+      return
     }
+    // Unwrap JSON-RPC notifications: extract params as the actual event.
+    // Server wraps events as {"jsonrpc":"2.0","method":"masc/event","params":{type,agent,...}}
+    const rawRecord = raw as { jsonrpc?: unknown; params?: { type?: unknown } }
+    const candidate: unknown =
+      rawRecord && rawRecord.jsonrpc && rawRecord.params?.type
+        ? rawRecord.params
+        : raw
+    const parsed = parseSSEMessage(candidate)
+    if (!parsed) return
+    // SSEMessage's field set is a superset of SSEEvent at runtime — the
+    // schema mirrors the interface. Cast here keeps downstream callers
+    // unchanged while Phase 2 migrates them to the schema-derived type.
+    const event = parsed as unknown as SSEEvent
+    eventCount.value++
+    lastEvent.value = event
+    handleEvent(event)
   }
 }
 


### PR DESCRIPTION
## Summary

SSE 이벤트 수신 경로에 Zod 기반 parse 게이트를 추가합니다. 이전엔 `JSON.parse` 직후 `as SSEEvent` 캐스트만 하고 runtime 검증 없이 핸들러로 흐르던 구조였습니다.

- `src/schemas/sse.ts` (신규)
  - `SSEEventTypeSchema` — 알려진 60여개 event 이름을 closed \`z.enum\` 으로. 미지의 `type`은 parse 실패 → drop + console.warn.
  - `AttributionSchema` — OCaml SSOT(`lib/attribution.mli`)의 discriminated union을 `z.discriminatedUnion('kind', [...])` 로 mirror. 알 수 없는 outcome kind는 parse 실패.
  - `SSEMessageSchema` — envelope. type field는 strict, 나머지는 타입 명시+optional, `.passthrough()`로 새 필드 forward-compat.
  - `SSESchemaDriftError` — 기존 `GateStatusSchemaDriftError` 컨벤션에 맞춘 에러 클래스.
  - `parseSSEMessage(raw)` — success → 타입화 메시지 반환, fail → null + 단일 aggregated warn.
- `src/sse.ts` `onmessage` 블록
  - `as SSEEvent` 캐스트 제거. `parseSSEMessage` 게이트 통과한 이벤트만 `handleEvent` 로.
  - Non-JSON data는 이전처럼 조용히 drop.
- `dashboard/package.json` — `zod ^4.3.6` 추가. 기존 Valibot은 `api/schemas/`에 그대로 유지 (공존).
- `src/schemas/sse.test.ts` — 15 케이스 (알려진/미지 type, 필드 타입, discriminator 누락, unknown 필드 passthrough, Attribution variants, parse-or-drop).

## Why

\"빡센 타입\" 원칙과 기존 수동 캐스트 패턴의 충돌. 서버가 `type`을 빠뜨리거나 오타 난 이벤트를 보내면 이전 구조는 `{type: undefined, ...}` 를 `SSEEvent`로 취급해 UI에 silent defect가 섞입니다.

Zod 게이트의 첫 기능은 **type 디스크리미네이터 검증** — 이것만으로도 대부분의 drift가 로그로 surface됩니다. 필드 타입 검사는 명시된 필드 범위 내에서 자동으로 따라붙습니다.

## Scope discipline

- **Phase 1만 포함**: envelope 단일 object schema + passthrough. 60여개 이벤트 각각에 대한 per-variant `z.discriminatedUnion` 정의는 **Phase 2**로 분리. 대표 5–6개(keeper_tool_call, oas:turn_completed 등)부터 필드 필수값/타입을 조이는 후속 PR 계획.
- **Valibot 유지**: `src/api/schemas/` HTTP response schema는 건드리지 않음. Zod는 SSE 경계 전용으로 도입. 생태계 통일은 별도 결정.
- **`SSEEvent` 인터페이스 보존**: 핸들러 호환성을 위해 현재 cast는 한 번 남아있음 (`parsed as unknown as SSEEvent`). Phase 2에서 schema-inferred type으로 완전 교체 예정.

## Verification

```bash
cd dashboard
pnpm test src/schemas/sse.test.ts
# Test Files  1 passed (1)
#       Tests 15 passed (15)

pnpm typecheck   # no errors
pnpm build        # clean build, pre-existing chunk size warning unchanged
```

## Follow-ups (out of scope)

- [ ] Phase 2: `z.discriminatedUnion('type', [...])` per-variant schema.
- [ ] Handler migration: `as SSEEvent` 제거, schema-derived union 사용.
- [ ] JSON.parse 나머지 33곳 (`rg \"JSON.parse\" dashboard/src/`) 중 검증 없는 지점 순차 도입.
- [ ] OCaml ↔ TS shared contract RFC (atd/OpenAPI/handcrafted+golden test 비교).

## Test plan

- [x] `pnpm test src/schemas/sse.test.ts` — 15/15 pass
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean
- [ ] CI: Dashboard, Build and Test
- [ ] Local dashboard에서 실제 MCP 서버 이벤트 수신 정상 — 별도 수동 검증