### PR TITLE
feat(dashboard): add model-id + tool-name search to runtime-monitor models

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { providerTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber } from './runtime-monitor'
+import { providerTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics } from './runtime-monitor'
 import type { DashboardRuntimeProviderSnapshot, DashboardRuntimeModelMetric } from '../api/dashboard'
 
 function makeProvider(overrides: Partial<DashboardRuntimeProviderSnapshot> = {}): DashboardRuntimeProviderSnapshot {
@@ -160,5 +160,65 @@ describe('fmtNumber', () => {
   it('formats with custom digits', () => {
     const result = fmtNumber(1234.567, 2)
     expect(result).toContain('1,234.57')
+  })
+})
+
+// ── filterModelMetrics ──
+
+describe('filterModelMetrics', () => {
+  const sample: readonly DashboardRuntimeModelMetric[] = [
+    makeMetric({ model_id: 'groq:openai/gpt-oss-120b', top_tools: [{ tool: 'read_file', count: 3 }] }),
+    makeMetric({ model_id: 'anthropic:claude-opus-4', top_tools: [{ tool: 'Bash', count: 5 }] }),
+    makeMetric({ model_id: 'ollama:qwen3-coder-30b', top_tools: [] }),
+  ]
+
+  it('returns input reference unchanged for empty query', () => {
+    const result = filterModelMetrics(sample, '')
+    expect(result).toBe(sample)
+  })
+
+  it('returns input reference unchanged for whitespace-only query', () => {
+    const result = filterModelMetrics(sample, '   ')
+    expect(result).toBe(sample)
+  })
+
+  it('matches on model_id substring', () => {
+    const result = filterModelMetrics(sample, 'gpt-oss')
+    expect(result.map(m => m.model_id)).toEqual(['groq:openai/gpt-oss-120b'])
+  })
+
+  it('matches on top_tools[].tool name substring', () => {
+    const result = filterModelMetrics(sample, 'read_file')
+    expect(result.map(m => m.model_id)).toEqual(['groq:openai/gpt-oss-120b'])
+  })
+
+  it('is case-insensitive', () => {
+    const result = filterModelMetrics(sample, 'BASH')
+    expect(result.map(m => m.model_id)).toEqual(['anthropic:claude-opus-4'])
+  })
+
+  it('trims leading/trailing whitespace from query', () => {
+    const result = filterModelMetrics(sample, '  qwen3  ')
+    expect(result.map(m => m.model_id)).toEqual(['ollama:qwen3-coder-30b'])
+  })
+
+  it('returns empty array when no match', () => {
+    const result = filterModelMetrics(sample, 'nonexistent-xyz')
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not mutate input array', () => {
+    const before = sample.map(m => m.model_id)
+    filterModelMetrics(sample, 'groq')
+    const after = sample.map(m => m.model_id)
+    expect(after).toEqual(before)
+  })
+
+  it('handles null top_tools safely', () => {
+    const data: readonly DashboardRuntimeModelMetric[] = [
+      makeMetric({ model_id: 'x:y', top_tools: null }),
+    ]
+    const result = filterModelMetrics(data, 'x:y')
+    expect(result).toHaveLength(1)
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -15,7 +15,29 @@ import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
+import { TextInput } from './common/input'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+
+/**
+ * Filters model metrics by case-insensitive substring match against
+ * `model_id` and any `top_tools[].tool` name. Empty/whitespace query
+ * returns the input reference unchanged (ref-equal). No mutation.
+ */
+export function filterModelMetrics(
+  models: readonly DashboardRuntimeModelMetric[],
+  query: string,
+): readonly DashboardRuntimeModelMetric[] {
+  const trimmed = query.trim().toLowerCase()
+  if (trimmed.length === 0) return models
+  return models.filter(m => {
+    if (m.model_id.toLowerCase().includes(trimmed)) return true
+    const tools = m.top_tools ?? []
+    for (const t of tools) {
+      if (t.tool.toLowerCase().includes(trimmed)) return true
+    }
+    return false
+  })
+}
 
 interface RuntimeData {
   providers: DashboardRuntimeProvidersResponse | null
@@ -109,6 +131,7 @@ export function RuntimeMonitor() {
   const resource = resourceRef.current
   const windowMinutes = useSignal(30)
   const expandedModel = useSignal<string | null>(null)
+  const modelSearch = useSignal('')
 
   const load = () => loadRuntimeData(resource, windowMinutes.value)
 
@@ -219,10 +242,23 @@ export function RuntimeMonitor() {
             detail=${`${fmtNumber(metrics?.models.reduce((sum, m) => sum + (m.total_tool_calls ?? 0), 0))} tool calls`}
           />
         </div>
+        <div class="flex items-center justify-end mb-2">
+          <${TextInput}
+            type="search"
+            ariaLabel="모델 ID 검색"
+            placeholder="model_id 또는 도구 이름"
+            class="min-w-[220px] flex-1 !py-1 !text-[11px]"
+            value=${modelSearch.value}
+            onInput=${(e: Event) => { modelSearch.value = (e.target as HTMLInputElement).value }}
+          />
+        </div>
+        ${(metrics?.models ?? []).length > 0 && filterModelMetrics(metrics?.models ?? [], modelSearch.value).length === 0
+          ? html`<div class="text-[11px] text-[var(--text-muted)] mb-2">검색 결과 없음 (${metrics?.models.length ?? 0}개 중)</div>`
+          : null}
         <div class="flex flex-col gap-3">
           ${(metrics?.models ?? []).length > 0
-            ? metrics?.models.map(metric => html`
-                <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
+            ? filterModelMetrics(metrics?.models ?? [], modelSearch.value).map(metric => html`
+                <article key=${metric.model_id} class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-[13px] text-text-strong">${metric.model_id}</strong>


### PR DESCRIPTION
## Summary
- Adds case-insensitive substring search across `metric.model_id` + `metric.top_tools[].tool` name in `RuntimeMonitor` models list.
- New pure exported helper `filterModelMetrics(models, query)` — empty/whitespace query returns input reference unchanged (ref-equal), no mutation.
- `useSignal('')` for `modelSearch` (component-scoped → auto-reset on unmount).
- `TextInput` from `common/input.ts` placed in a right-aligned header row above the model cards; `ariaLabel="모델 ID 검색"`, `placeholder="model_id 또는 도구 이름"`.
- Stable `key=${metric.model_id}` on filtered article cards (prevents Preact re-diff issues after filter).
- Empty-state "검색 결과 없음 (N개 중)" row when query yields 0 matches.

## Tests
- +9 cases in `runtime-monitor.test.ts` — empty/whitespace ref-equal, model_id match, tool-name match, case-insensitive, trimmed, no-match, no-mutation, null top_tools safety.
- Target suite: **40/40 pass**.
- `tsc --noEmit`: clean.
- Full suite: 2 timing timeouts this run (`observatory.test.ts`, `namespace-truth-store.test.ts`) — environmental flakes under 5-worktree parallel vitest contention, unrelated to this diff.

## Collision zone respected
Scope limited to `runtime-monitor.{ts,test.ts}` only. Does not touch any file in recent merged/open dashboard filter PRs (fleet-fsm-matrix, agent-roster, fsm-hub, governance*, overview, config-resolution-panel, activity-graph, mission-briefing-card, sidecar-log-viewer, agent-detail*, handoff-timeline, memory-post, attribution-events, autoresearch, harness-health-sections, agent-profile, connector-status, transport-health).

## Test plan
- [ ] RuntimeMonitor models section renders search input
- [ ] Typing filters models by `model_id` (case-insensitive)
- [ ] Typing filters models by `top_tools[].tool` name
- [ ] Empty result shows "검색 결과 없음 (N개 중)"
- [ ] Filtered rows preserve stable `key=${model_id}` (no flicker on narrow)