### PR TITLE
feat(dashboard): ⌨ keyboard shortcuts for connector navigation (1-4, ?)

### DIFF
--- a/dashboard/src/components/connector-keyboard-shortcuts.test.ts
+++ b/dashboard/src/components/connector-keyboard-shortcuts.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ConnectorKeyboardShortcuts,
+  mapKeyToConnectorId,
+  shouldSkipShortcut,
+  _testResetShortcutState,
+  _testIsCheatsheetOpen,
+} from './connector-keyboard-shortcuts'
+
+describe('mapKeyToConnectorId', () => {
+  it('maps 1..4 to discord/imessage/slack/telegram', () => {
+    expect(mapKeyToConnectorId('1')).toBe('discord')
+    expect(mapKeyToConnectorId('2')).toBe('imessage')
+    expect(mapKeyToConnectorId('3')).toBe('slack')
+    expect(mapKeyToConnectorId('4')).toBe('telegram')
+  })
+
+  it('returns null for out-of-range digits', () => {
+    expect(mapKeyToConnectorId('0')).toBeNull()
+    expect(mapKeyToConnectorId('5')).toBeNull()
+    expect(mapKeyToConnectorId('9')).toBeNull()
+  })
+
+  it('returns null for non-digit keys', () => {
+    expect(mapKeyToConnectorId('a')).toBeNull()
+    expect(mapKeyToConnectorId('?')).toBeNull()
+    expect(mapKeyToConnectorId(' ')).toBeNull()
+    expect(mapKeyToConnectorId('Enter')).toBeNull()
+    expect(mapKeyToConnectorId('')).toBeNull()
+  })
+
+  it('returns null for multi-char keys like "11"', () => {
+    expect(mapKeyToConnectorId('11')).toBeNull()
+    expect(mapKeyToConnectorId('1a')).toBeNull()
+  })
+})
+
+describe('shouldSkipShortcut', () => {
+  it('skips when target is INPUT', () => {
+    const inp = document.createElement('input')
+    expect(shouldSkipShortcut(inp)).toBe(true)
+  })
+
+  it('skips when target is TEXTAREA', () => {
+    const ta = document.createElement('textarea')
+    expect(shouldSkipShortcut(ta)).toBe(true)
+  })
+
+  it('skips when target is SELECT', () => {
+    const sel = document.createElement('select')
+    expect(shouldSkipShortcut(sel)).toBe(true)
+  })
+
+  it('skips when target is contentEditable', () => {
+    const div = document.createElement('div')
+    div.setAttribute('contenteditable', 'true')
+    // happy-dom reflects the attribute into the property
+    Object.defineProperty(div, 'isContentEditable', { value: true })
+    expect(shouldSkipShortcut(div)).toBe(true)
+  })
+
+  it('does not skip for a plain div', () => {
+    const div = document.createElement('div')
+    expect(shouldSkipShortcut(div)).toBe(false)
+  })
+
+  it('does not skip when target is null', () => {
+    expect(shouldSkipShortcut(null)).toBe(false)
+  })
+})
+
+describe('ConnectorKeyboardShortcuts DOM', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetShortcutState()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    _testResetShortcutState()
+  })
+
+  // useEffect runs on a microtask after mount, so we always flush twice
+  // before firing events that rely on the window listener being attached.
+  const flushMount = async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  it('renders nothing by default (cheatsheet closed)', () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    expect(container.querySelector('[data-connector-shortcut-cheatsheet]')).toBeNull()
+  })
+
+  it('opens cheatsheet on "?" keydown, closes on second "?"', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    expect(_testIsCheatsheetOpen()).toBe(true)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    expect(_testIsCheatsheetOpen()).toBe(false)
+  })
+
+  it('closes cheatsheet on Escape', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    expect(_testIsCheatsheetOpen()).toBe(true)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(_testIsCheatsheetOpen()).toBe(false)
+  })
+
+  it('ignores "1" when focus is inside an input (typing, not navigating)', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    try {
+      // Scroll target card exists but the keystroke should NOT scroll because the
+      // input is the event target — simulate by dispatching on the input.
+      const card = document.createElement('div')
+      card.id = 'connector-card-discord'
+      document.body.appendChild(card)
+      let scrolled = false
+      card.scrollIntoView = () => { scrolled = true }
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: '1', bubbles: true }))
+      expect(scrolled).toBe(false)
+      document.body.removeChild(card)
+    } finally {
+      document.body.removeChild(input)
+    }
+  })
+
+  it('ignores modified keys (cmd/ctrl/alt + 1)', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    const card = document.createElement('div')
+    card.id = 'connector-card-discord'
+    document.body.appendChild(card)
+    let scrolled = false
+    card.scrollIntoView = () => { scrolled = true }
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1', metaKey: true }))
+      expect(scrolled).toBe(false)
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1', ctrlKey: true }))
+      expect(scrolled).toBe(false)
+    } finally {
+      document.body.removeChild(card)
+    }
+  })
+
+  it('scrolls to connector card when digit key is pressed', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    const card = document.createElement('div')
+    card.id = 'connector-card-slack'
+    document.body.appendChild(card)
+    let scrolledTo: ScrollIntoViewOptions | boolean | undefined
+    card.scrollIntoView = ((opts: ScrollIntoViewOptions | boolean | undefined) => {
+      scrolledTo = opts
+    }) as HTMLElement['scrollIntoView']
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }))
+      expect(scrolledTo).toBeDefined()
+    } finally {
+      document.body.removeChild(card)
+    }
+  })
+
+  it('cheatsheet lists all known connectors and the "?" toggle key', async () => {
+    render(html`<${ConnectorKeyboardShortcuts} />`, container)
+    await flushMount()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    // Signal update → re-render is scheduled on the microtask queue.
+    await Promise.resolve()
+    await Promise.resolve()
+    const sheet = container.querySelector('[data-connector-shortcut-cheatsheet]')
+    expect(sheet).toBeTruthy()
+    const text = sheet!.textContent ?? ''
+    expect(text).toContain('discord')
+    expect(text).toContain('imessage')
+    expect(text).toContain('slack')
+    expect(text).toContain('telegram')
+    expect(text).toContain('?')
+  })
+})

--- a/dashboard/src/components/connector-keyboard-shortcuts.ts
+++ b/dashboard/src/components/connector-keyboard-shortcuts.ts
@@ -1,0 +1,115 @@
+// ConnectorKeyboardShortcuts — lightweight keyboard navigation for the
+// all-connectors view. Pressing `1`–`4` smooth-scrolls to the matching
+// connector card (in the same KNOWN_CONNECTOR_IDS order as the tiles:
+// 1=discord, 2=imessage, 3=slack, 4=telegram). Pressing `?` toggles a
+// small floating cheatsheet.
+//
+// Reference pattern — Linear `cmd+K` / Gmail `?` / GitHub's single-key
+// shortcuts (`g` + `p` etc.): low-friction keyboard navigation that
+// operator power-users can reach for without learning a whole palette.
+// We keep it deliberately tiny — 4 tiles only, so no fuzzy search is
+// needed; the numeric row is immediate and teachable.
+//
+// Safety: all handlers bail when the focused element is an editable
+// surface (input / textarea / contenteditable / open select) so typing
+// a "1" into the log viewer's keyword field never scrolls the page.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useLayoutEffect } from 'preact/hooks'
+import { KNOWN_CONNECTOR_IDS, type KnownConnectorId } from './connector-status'
+
+const cheatsheetOpen = signal(false)
+
+/** Pure: map a keyboard key to a known connector id using the tile
+    ordering. Returns null for anything that isn't "1".."N" where N is
+    the number of known connectors. Exported for unit tests so we can
+    pin the digit-to-id mapping without a real keydown event. */
+export function mapKeyToConnectorId(key: string): KnownConnectorId | null {
+  if (key.length !== 1) return null
+  const digit = Number.parseInt(key, 10)
+  if (Number.isNaN(digit)) return null
+  if (digit < 1 || digit > KNOWN_CONNECTOR_IDS.length) return null
+  return KNOWN_CONNECTOR_IDS[digit - 1] ?? null
+}
+
+/** Pure: should this keydown be ignored because the operator is typing
+    into a form field? Split out so tests can pin the branches without
+    creating real DOM. */
+export function shouldSkipShortcut(target: EventTarget | null): boolean {
+  if (target === null) return false
+  if (!(target instanceof Element)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  const editable = (target as HTMLElement).isContentEditable
+  return editable === true
+}
+
+function scrollToCard(id: string) {
+  const el = document.getElementById(`connector-card-${id}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+export function ConnectorKeyboardShortcuts() {
+  // Register on window so shortcuts work regardless of focus target
+  // (except editable surfaces — see shouldSkipShortcut). Syncing to an
+  // external system (window's keydown stream) is a legitimate useEffect
+  // use-case; useLayoutEffect here makes the listener available the
+  // moment the section paints, which keeps our test assertions sync.
+  useLayoutEffect(() => {
+    const handler = (ev: KeyboardEvent) => {
+      if (shouldSkipShortcut(ev.target)) return
+      if (ev.metaKey || ev.ctrlKey || ev.altKey) return
+      if (ev.key === '?') {
+        cheatsheetOpen.value = !cheatsheetOpen.value
+        ev.preventDefault()
+        return
+      }
+      if (ev.key === 'Escape' && cheatsheetOpen.value) {
+        cheatsheetOpen.value = false
+        ev.preventDefault()
+        return
+      }
+      const id = mapKeyToConnectorId(ev.key)
+      if (id !== null) {
+        scrollToCard(id)
+        ev.preventDefault()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  // Reading the signal here binds re-renders of this component to the
+  // toggle — keeps cheatsheet open/close purely reactive, no manual
+  // state plumbing needed.
+  if (!cheatsheetOpen.value) return null
+  return html`
+    <div
+      class="fixed bottom-4 right-4 z-50 rounded-lg border border-[var(--white-10)] bg-[var(--bg-1)] p-3 text-[11px] text-[var(--text-body)] shadow-lg"
+      data-connector-shortcut-cheatsheet
+      role="dialog"
+      aria-label="커넥터 단축키"
+    >
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">Shortcuts</div>
+      ${KNOWN_CONNECTOR_IDS.map((id, i) => html`
+        <div class="flex items-center justify-between gap-4">
+          <kbd class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] px-1.5 py-[1px] text-[10px] font-mono">${i + 1}</kbd>
+          <span class="text-[var(--text-dim)]">→ ${id}</span>
+        </div>
+      `)}
+      <div class="mt-1.5 flex items-center justify-between gap-4 border-t border-[var(--white-8)] pt-1.5">
+        <kbd class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] px-1.5 py-[1px] text-[10px] font-mono">?</kbd>
+        <span class="text-[var(--text-dim)]">toggle</span>
+      </div>
+    </div>
+  `
+}
+
+export function _testResetShortcutState() {
+  cheatsheetOpen.value = false
+}
+
+export function _testIsCheatsheetOpen(): boolean {
+  return cheatsheetOpen.value
+}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -34,6 +34,7 @@ import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight }
 import { StartupCheckBanner, markStartAttempt, clearStartAttempt } from './sidecar-startup-watch'
 import { QuickBindForm } from './connector-quick-bind'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
+import { ConnectorKeyboardShortcuts } from './connector-keyboard-shortcuts'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
 
@@ -1201,6 +1202,7 @@ export function ConnectorStatusPanel() {
       ${!filterId
         ? html`<${ConnectorOverviewStrip} connectors=${visibleConnectors} keeperCount=${snapshot.keepers.length} />`
         : null}
+      ${!filterId ? html`<${ConnectorKeyboardShortcuts} />` : null}
 
       ${visibleConnectors.map(c => html`
         <${ConnectorLivePanel}


### PR DESCRIPTION
## Summary

Adds a lightweight keyboard navigation layer to the all-connectors view:

| Key | Action |
|---|---|
| `1`..`4` | Smooth-scroll to discord / imessage / slack / telegram tile |
| `?` | Toggle small cheatsheet (bottom-right) |
| `Esc` | Close cheatsheet |

Reference: **Linear cmd+K** + **Gmail `?`** + **GitHub single-key shortcuts**. Operator power-users reach for the numeric row without learning a palette. Only 4 tiles, so no fuzzy search needed.

### Design notes

- **Self-contained new file** (`connector-keyboard-shortcuts.ts`) — zero surface area shared with in-flight PRs #7925/#7933/#7937/#7944 on the same stack.
- **Mount site**: `connector-status.ts` next to the overview strip, only when no sub-filter is active (same guard as the strip itself).
- **Focus safety**: skips when target is `INPUT`/`TEXTAREA`/`SELECT`/`contentEditable` — typing `1` into the log-filter keyword field doesn't scroll the page.
- **Modifier skip**: `cmd/ctrl/alt + 1` ignored so browser shortcuts aren't shadowed.
- **`useLayoutEffect`** for the listener registration — fires synchronously after commit so DOM tests don't need rAF tricks.

### Scope

- `dashboard/src/components/connector-keyboard-shortcuts.ts` (new, ~110 LOC)
- `dashboard/src/components/connector-keyboard-shortcuts.test.ts` (new, ~170 LOC)
- `dashboard/src/components/connector-status.ts` (+2 LOC, import + mount)

## Test plan

- [x] 17/17 vitest green (4 pure + 6 pure + 7 DOM)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: `cd dashboard && npm run dev` → `/#section=connector-status` → press `1` scrolls to Discord, `?` shows cheatsheet, typing `1` in log keyword field does NOT scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)