### PR TITLE
feat(dashboard): surface conditions that diverge from current phase

### DIFF
--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -1,0 +1,138 @@
+// Divergent conditions — active observables that are inconsistent with
+// the current FSM phase, surfaced as amber chips in the Agent Modal.
+//
+// Why this matters: [Keeper_state_machine.conditions] holds 16 booleans
+// (RFC-0002 §4) that together drive the phase transition function. When
+// the keeper is healthy, conditions are consistent with the phase —
+// e.g. [phase=Running ∧ heartbeat_healthy=true]. A *divergence* is a
+// condition observed in a state the phase hasn't yet acknowledged,
+// e.g. [phase=Running ∧ context_handoff_needed=true]: the observer can
+// see the signal, but the FSM hasn't transitioned to HandingOff yet.
+//
+// Showing all 16 booleans is noise; showing none hides the "why aren't
+// we transitioning?" signal. The middle ground is to surface only the
+// divergent ones, annotated with a ko-language reason.
+//
+// The liveness invariant that justifies each divergence rule (phase
+// MUST eventually transition under fairness) is proved in
+// [specs/keeper-state-machine/KeeperConditionsGovernPhase.tla] — planned
+// to land as PR 6a alongside this UI.
+
+import { html } from 'htm/preact'
+import type { Keeper, KeeperConditions, KeeperPhase } from '../types'
+
+type DivergenceFn = (value: boolean, phase: KeeperPhase | null | undefined) => string | null
+
+const isOperating = (p: KeeperPhase | null | undefined): boolean =>
+  p === 'Running' || p === 'Failing' || p === 'Overflowed'
+
+const isTerminated = (p: KeeperPhase | null | undefined): boolean =>
+  p === 'Stopped' || p === 'Dead' || p === 'Crashed'
+
+/** Rule table — each entry returns a ko-language reason when divergent,
+ *  null when the condition is consistent with (or expected by) the phase. */
+const DIVERGENCE_RULES: Partial<Record<keyof KeeperConditions, DivergenceFn>> = {
+  context_handoff_needed: (v, p) =>
+    v && (p === 'Running' || p === 'Failing')
+      ? '핸드오프 필요 신호가 있지만 아직 HandingOff/Compacting으로 전환 전'
+      : null,
+
+  context_overflow: (v, p) =>
+    v && p !== 'Overflowed' && !isTerminated(p)
+      ? '컨텍스트 overflow 감지됨 (phase 미반영)'
+      : null,
+
+  compact_retry_exhausted: (v, p) =>
+    v && p !== 'Failing' && !isTerminated(p)
+      ? '압축 재시도 소진 — Failing phase로 전환 필요'
+      : null,
+
+  stop_requested: (v, p) =>
+    v && p !== 'Draining' && !isTerminated(p)
+      ? '정지 요청됐으나 Draining 미진입'
+      : null,
+
+  operator_paused: (v, p) =>
+    v && p !== 'Paused'
+      ? '오퍼레이터가 pause했으나 Paused phase 미반영'
+      : null,
+
+  guardrail_triggered: (v, p) =>
+    v && p !== 'Paused' && p !== 'Failing' && !isTerminated(p)
+      ? '가드레일 발동 (격리 phase 미전환)'
+      : null,
+
+  turn_healthy: (v, p) =>
+    !v && p !== 'Failing' && !isTerminated(p)
+      ? '턴 실패 누적 — Failing phase 기대'
+      : null,
+
+  heartbeat_healthy: (v, p) =>
+    !v && isOperating(p)
+      ? '하트비트 불건전 (운영 phase 중)'
+      : null,
+
+  fiber_alive: (v, p) =>
+    !v && p !== 'Offline' && !isTerminated(p)
+      ? '파이버 죽음 (Offline도 종료도 아님)'
+      : null,
+
+  restart_budget_remaining: (v, p) =>
+    !v && !isTerminated(p)
+      ? '재시작 예산 소진 (Dead phase 기대)'
+      : null,
+}
+
+interface Divergence {
+  field: keyof KeeperConditions
+  value: boolean
+  reason: string
+}
+
+export function computeDivergences(
+  conditions: KeeperConditions,
+  phase: KeeperPhase | null | undefined,
+): Divergence[] {
+  const out: Divergence[] = []
+  for (const [field, fn] of Object.entries(DIVERGENCE_RULES) as Array<[
+    keyof KeeperConditions,
+    DivergenceFn,
+  ]>) {
+    const v = conditions[field]
+    const reason = fn(v, phase)
+    if (reason != null) out.push({ field, value: v, reason })
+  }
+  return out
+}
+
+/** Section wrapper for the Agent Modal. Renders nothing when [keeper.conditions]
+ *  is unset or every condition is consistent with the phase. */
+export function KeeperConditionsDivergent({ keeper }: { keeper: Keeper }) {
+  if (!keeper.conditions) return null
+  const divs = computeDivergences(keeper.conditions, keeper.phase)
+  if (divs.length === 0) return null
+
+  return html`
+    <section class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
+      <header class="mb-2 flex items-baseline justify-between gap-2">
+        <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--warn)]">
+          ⚠️ 조건-Phase 불일치
+        </h3>
+        <span class="text-[10px] text-[var(--text-dim)]">phase가 아직 반응하지 않은 관측 신호</span>
+      </header>
+      <div class="flex flex-wrap gap-1.5">
+        ${divs.map(d => html`
+          <span
+            class="px-2 py-0.5 rounded-full border border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)] text-[var(--warn)] text-[11px] font-mono tabular-nums"
+            title=${d.reason}
+          >
+            ${d.field}=${String(d.value)}
+          </span>
+        `)}
+      </div>
+      <div class="mt-2 text-[10px] text-[var(--text-dim)] leading-snug">
+        ${divs[0].reason}${divs.length > 1 ? ` (외 ${divs.length - 1}건, 칩 hover로 확인)` : ''}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -61,6 +61,7 @@ import {
 } from './keeper-config-panel'
 import { PipelineStageBar } from './keeper-pipeline-stage'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
+import { KeeperConditionsDivergent } from './keeper-conditions-divergent'
 import { KeeperStateDiagramPanel } from './keeper-state-diagram'
 import { KeeperMemoryTierPanel } from './keeper-memory-tier-panel'
 import { AgentJournalStream } from './agent-detail-journal'
@@ -1010,6 +1011,9 @@ export function KeeperDetailOverlay() {
             <${KeeperMemoryTierPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
           </div>
         </details>
+
+        ${'' /* ── Divergent conditions (amber banner; renders only when phase lags observed signals) ── */}
+        <${KeeperConditionsDivergent} keeper=${keeper} />
 
         ${'' /* ── KPIs ── */}
         <${KpiGrid} keeper=${keeper} />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -661,6 +661,7 @@ export interface Keeper {
   relationships?: Record<string, string>
   supervisor_diagnostics?: KeeperSupervisorDiagnostics
   outcomes?: KeeperOutcomes
+  conditions?: KeeperConditions
 }
 
 /** Outcomes rollup — aggregated successes / failures / validation
@@ -703,6 +704,27 @@ export interface KeeperOutcomes {
     }
     last_verdict_at: number | null
   }
+}
+
+/** 16 observable conditions that drive the keeper FSM (RFC-0002 §4).
+ *  Serialized by [Keeper_state_machine.conditions_to_json]. */
+export interface KeeperConditions {
+  launch_pending: boolean
+  fiber_alive: boolean
+  heartbeat_healthy: boolean
+  turn_healthy: boolean
+  context_within_budget: boolean
+  context_handoff_needed: boolean
+  compaction_active: boolean
+  handoff_active: boolean
+  operator_paused: boolean
+  stop_requested: boolean
+  restart_budget_remaining: boolean
+  backoff_elapsed: boolean
+  guardrail_triggered: boolean
+  drain_complete: boolean
+  context_overflow: boolean
+  compact_retry_exhausted: boolean
 }
 
 export interface KeeperSupervisorCrashLogEntry {


### PR DESCRIPTION
Base=#7951. Amber banner for divergent conditions (phase가 반응하지 않은 관측 신호). 10-rule table in keeper-conditions-divergent.ts. Types: KeeperConditions. Build+lint green. Liveness spec (PR 6a) 병렬 준비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)