### PR TITLE
feat(dashboard): ♿ AA accessibility pass on connector readiness rail

### DIFF
--- a/dashboard/src/components/connector-readiness-rail.test.ts
+++ b/dashboard/src/components/connector-readiness-rail.test.ts
@@ -10,7 +10,9 @@ import {
   getRailInflight,
   withRailInflight,
   resetRailInflightState,
+  railPillAriaLabel,
   type RailHandlers,
+  type RailPill,
 } from './connector-readiness-rail'
 
 const noop: RailHandlers = {
@@ -151,5 +153,69 @@ describe('ConnectorReadinessRail rendering', () => {
     const tokenPill = container.querySelector('[data-rail-pill="token"]') as HTMLButtonElement
     tokenPill.click()
     expect(opened).toBe(1)
+  })
+
+  it('each pill carries a screen-reader aria-label and a keyboard focus ring', () => {
+    const pills = deriveRail(
+      { sidecarUp: false, gateHealthy: null, bindingCount: 0, keeperCount: 0 },
+      noop,
+    )
+    render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    const tokenPill = container.querySelector('[data-rail-pill="token"]') as HTMLButtonElement
+    // AA: button has an aria-label that includes both the label AND the
+    // action-outcome detail, so screen readers announce more than "Token".
+    const aria = tokenPill.getAttribute('aria-label') ?? ''
+    expect(aria).toContain('Token')
+    expect(aria).toContain('Config')
+    // Focus ring is applied via focus-visible so mouse clicks don't light up.
+    expect(tokenPill.className).toContain('focus-visible:outline')
+  })
+
+  it('inflight pill sets aria-busy="true"', () => {
+    const pills = deriveRail(
+      { sidecarUp: false, gateHealthy: null, bindingCount: 0, keeperCount: 0 },
+      noop,
+      { process: true },
+    )
+    render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    const processPill = container.querySelector('[data-rail-pill="process"]') as HTMLButtonElement
+    expect(processPill.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('decorative glyph spans are aria-hidden so AT does not read "dot dot dot"', () => {
+    const pills = deriveRail(
+      { sidecarUp: true, gateHealthy: true, bindingCount: 1, keeperCount: 1 },
+      noop,
+    )
+    render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    const tokenPill = container.querySelector('[data-rail-pill="token"]')!
+    const hidden = tokenPill.querySelectorAll('[aria-hidden="true"]')
+    // One for the glyph circle + one for uppercase label + one for detail line.
+    expect(hidden.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('railPillAriaLabel', () => {
+  const basePill: RailPill = {
+    key: 'token',
+    state: 'ok',
+    label: 'Token',
+    detail: '설정됨',
+    hint: null,
+    onClick: () => {},
+  }
+
+  it('includes label and detail with an em-dash separator', () => {
+    expect(railPillAriaLabel(basePill)).toBe('Token — 설정됨')
+  })
+
+  it('appends hint when provided', () => {
+    const pill = { ...basePill, hint: '클릭하면 Config' }
+    expect(railPillAriaLabel(pill)).toBe('Token — 설정됨 — 클릭하면 Config')
+  })
+
+  it('replaces detail with "진행 중" when inflight so AT announces the busy state', () => {
+    const pill = { ...basePill, inflight: true }
+    expect(railPillAriaLabel(pill)).toBe('Token — 진행 중')
   })
 })

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -98,26 +98,48 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   },
 }
 
+/** Pure: compose a screen-reader label for the pill so assistive
+    technology reads "Token — 설정됨 (sidecar 부팅 통과). 클릭하면 Config" instead
+    of just "Token" (which is what a button with only visible <span>
+    children would otherwise expose). Kept pure so tests can pin the
+    concatenation rules without mounting a DOM. */
+export function railPillAriaLabel(pill: RailPill): string {
+  const detail = pill.inflight === true ? '진행 중' : pill.detail
+  const parts = [pill.label, detail]
+  if (pill.hint !== null) parts.push(pill.hint)
+  return parts.join(' — ')
+}
+
 function Pill({ pill }: { pill: RailPill }) {
   const tone = TONE[pill.state]
   const inflight = pill.inflight === true
+  // Focus ring uses the same accent token as the rest of the dashboard's
+  // interactive focus states (PatternFly AA target: visible 2px ring on
+  // keyboard-only focus, :focus-visible so mouse clicks don't light up).
+  // aria-busy announces the pulsing "진행 중…" state to AT without needing
+  // a separate visually-hidden <span>.
   return html`
     <button
       type="button"
-      class=${`group flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-left transition-colors ${tone.bg} ${tone.border} hover:brightness-125 ${inflight ? 'animate-pulse' : ''}`}
+      class=${`group flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent-1)] ${tone.bg} ${tone.border} hover:brightness-125 ${inflight ? 'animate-pulse' : ''}`}
       title=${pill.hint ?? pill.detail}
+      aria-label=${railPillAriaLabel(pill)}
+      aria-busy=${inflight ? 'true' : 'false'}
       onClick=${pill.onClick}
       data-rail-pill=${pill.key}
       data-rail-state=${pill.state}
       data-rail-inflight=${inflight ? 'true' : 'false'}
       disabled=${inflight}
     >
-      <span class=${`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-bold ${inflight ? 'bg-[var(--white-10)]' : tone.dot} text-[var(--bg-0)]`}>
+      <span
+        aria-hidden="true"
+        class=${`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-bold ${inflight ? 'bg-[var(--white-10)]' : tone.dot} text-[var(--bg-0)]`}
+      >
         ${inflight ? '…' : tone.icon}
       </span>
       <span class="min-w-0 flex-1">
-        <span class=${`block text-[10px] uppercase tracking-[0.14em] ${tone.text}`}>${pill.label}</span>
-        <span class="block truncate text-[11px] text-[var(--text-body)]">${inflight ? '진행 중...' : pill.detail}</span>
+        <span aria-hidden="true" class=${`block text-[10px] uppercase tracking-[0.14em] ${tone.text}`}>${pill.label}</span>
+        <span aria-hidden="true" class="block truncate text-[11px] text-[var(--text-body)]">${inflight ? '진행 중...' : pill.detail}</span>
       </span>
     </button>
   `


### PR DESCRIPTION
## Summary

Adds proper screen-reader + keyboard affordances to the 4-pill readiness rail. Steals from PatternFly/GitHub Primer \"accessible data\" guidelines.

| Before | After |
|---|---|
| Button exposes only \"Token\" to AT | \`aria-label\` = \`Token — 설정됨 — 클릭하면 Config\` |
| Pulsing pill invisible to AT | \`aria-busy=\"true\"\` during inflight |
| Browser-default focus ring (inconsistent across browsers) | \`focus-visible\` accent outline 2px |
| Decorative glyph/label/detail read twice | Inner spans \`aria-hidden=\"true\"\` |

### Design notes

- **\`focus-visible\`, not \`focus\`**: Chromium mouse clicks also focus buttons. A permanent ring on click makes the rail flicker during normal ops. WCAG 2.1 AA sweet spot.
- **Pure helper \`railPillAriaLabel\`**: keeps the label composition unit-testable without DOM — same pattern as other connector components in this stack.
- **No parallel-PR conflict**: \`connector-readiness-rail.ts\` is untouched by the 5 open Draft PRs on the overview strip / config form / log viewer.

### Scope

- \`dashboard/src/components/connector-readiness-rail.ts\` (~15 LOC edit)
- \`dashboard/src/components/connector-readiness-rail.test.ts\` (+3 DOM + 3 pure tests)

## Test plan

- [x] 16/16 vitest green
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: tab through pills → 2px accent ring only on keyboard focus
- [ ] Manual: VoiceOver — \"Token, dash, 설정됨\" announced instead of just \"Token button\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)