### PR TITLE
refactor(sse): consolidate on shared Lockfree_atomic

### DIFF
--- a/lib/lockfree_atomic.ml
+++ b/lib/lockfree_atomic.ml
@@ -9,3 +9,14 @@ let rec update_with_result atomic f =
   let new_val, result = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then result
   else update_with_result atomic f
+
+type ('state, 'result) commit = {
+  next_state : 'state;
+  result : 'result;
+}
+
+let rec update_with_commit atomic f =
+  let old_val = Atomic.get atomic in
+  let { next_state; result } = f old_val in
+  if Atomic.compare_and_set atomic old_val next_state then result
+  else update_with_commit atomic f

--- a/lib/lockfree_atomic.mli
+++ b/lib/lockfree_atomic.mli
@@ -20,3 +20,15 @@ val update : 'a Atomic.t -> ('a -> 'a) -> unit
     Important: [f] may be invoked multiple times under contention. It must
     be pure with respect to observable effects, or tolerate repeated calls. *)
 val update_with_result : 'a Atomic.t -> ('a -> 'a * 'b) -> 'b
+
+(** Record-labelled commit describing the next state and a derived value.
+    Equivalent to the tuple form used by [update_with_result]; provided for
+    call sites where positional tuples hurt readability. *)
+type ('state, 'result) commit = {
+  next_state : 'state;
+  result : 'result;
+}
+
+(** [update_with_commit atomic f] is [update_with_result] but [f] returns
+    a labelled [commit] record instead of a tuple. *)
+val update_with_commit : 'a Atomic.t -> ('a -> ('a, 'b) commit) -> 'b

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -25,17 +25,6 @@
 (** Classification of an SSE session's traffic role. *)
 module SMap = Map.Make(String)
 
-type ('state, 'result) atomic_commit = {
-  next_state : 'state;
-  result : 'result;
-}
-
-let rec atomic_update_result atomic f =
-  let old_state = Atomic.get atomic in
-  let { next_state; result } = f old_state in
-  if Atomic.compare_and_set atomic old_state next_state then result
-  else atomic_update_result atomic f
-
 (* Test-only hooks for forcing a CAS retry in white-box unit tests. *)
 let register_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None
 let buffer_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None
@@ -193,7 +182,7 @@ let event_buffer : (int * string * float) list Atomic.t = Atomic.make []
 
 (** Add event to buffer, maintaining max size *)
 let buffer_event event_id event_str =
-  atomic_update_result event_buffer (fun lst ->
+  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
     run_test_hook buffer_commit_test_hook;
     let timestamp = Time_compat.now () in
     let next = (event_id, event_str, timestamp) :: lst in
@@ -215,7 +204,7 @@ let get_events_after last_id =
     Returns count of evicted events. *)
 let cleanup_expired_events () =
   let now = Time_compat.now () in
-  atomic_update_result event_buffer (fun lst ->
+  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
     let remaining_oldest_first, evicted =
       List.fold_left
         (fun (kept, evicted) (((_id, _ev, ts) as item) : int * string * float) ->
@@ -292,7 +281,7 @@ let register ?(kind = Coordinator) session_id ~push ~last_event_id =
     last_seen_at = Atomic.make 0.0;
   } in
   let evicted =
-    atomic_update_result clients (fun state ->
+    Lockfree_atomic.update_with_commit clients (fun state ->
       run_test_hook register_commit_test_hook;
       let evicted =
         if state.count >= max_clients && not (SMap.mem session_id state.entries) then
@@ -342,7 +331,7 @@ let register ?(kind = Coordinator) session_id ~push ~last_event_id =
 (** Unregister an SSE client *)
 let unregister session_id =
   let removed =
-    atomic_update_result clients (fun state ->
+    Lockfree_atomic.update_with_commit clients (fun state ->
       if SMap.mem session_id state.entries then
         let next_entries = SMap.remove session_id state.entries in
         {
@@ -366,7 +355,7 @@ let unregister session_id =
     that re-used the same session_id. *)
 let unregister_if_current session_id client_id =
   let removed =
-    atomic_update_result clients (fun state ->
+    Lockfree_atomic.update_with_commit clients (fun state ->
       match SMap.find_opt session_id state.entries with
       | Some client when client.id = client_id ->
           let next_entries = SMap.remove session_id state.entries in
@@ -468,7 +457,7 @@ let current_external_subscriber_count_with_prefix prefix =
 let subscribe_external ~id ~callback ?(is_alive = fun () -> true) () =
   let subscriber = { sub_id = id; callback; is_alive } in
   let replaced, count =
-    atomic_update_result external_subscribers (fun state ->
+    Lockfree_atomic.update_with_commit external_subscribers (fun state ->
       let replaced = SMap.mem id state.subscribers in
       let next_subscribers = SMap.add id subscriber state.subscribers in
       let next_count = if replaced then state.count else state.count + 1 in
@@ -487,7 +476,7 @@ let subscribe_external ~id ~callback ?(is_alive = fun () -> true) () =
 (** Remove a previously registered external subscriber. *)
 let unsubscribe_external id =
   let removed, count =
-    atomic_update_result external_subscribers (fun state ->
+    Lockfree_atomic.update_with_commit external_subscribers (fun state ->
       if SMap.mem id state.subscribers then
         let next_subscribers = SMap.remove id state.subscribers in
         let next_count = state.count - 1 in
@@ -515,7 +504,7 @@ let external_subscriber_count_with_prefix prefix =
   current_external_subscriber_count_with_prefix prefix
 
 let remove_external_subscribers ids =
-  atomic_update_result external_subscribers (fun state ->
+  Lockfree_atomic.update_with_commit external_subscribers (fun state ->
     let removed_ids, next_subscribers =
       List.fold_left
         (fun (removed, acc) id ->
@@ -739,7 +728,7 @@ let all_session_ids () =
     Returns the number of clients that were closed. *)
 let close_all_clients () =
   let sessions =
-    atomic_update_result clients (fun state ->
+    Lockfree_atomic.update_with_commit clients (fun state ->
       let sessions = SMap.fold (fun sid _ acc -> sid :: acc) state.entries [] in
       {
         next_state = empty_client_registry_state;

--- a/test/test_lockfree_atomic.ml
+++ b/test/test_lockfree_atomic.ml
@@ -55,6 +55,25 @@ let test_update_never_loses_work () =
   done;
   Alcotest.(check int) "no updates lost" 1000 (Atomic.get a)
 
+let test_update_with_commit_returns_derived_value () =
+  let a = Atomic.make 10 in
+  let prev =
+    L.update_with_commit a (fun n -> { L.next_state = n * 2; result = n })
+  in
+  Alcotest.(check int) "commit returns pre-update snapshot" 10 prev;
+  Alcotest.(check int) "state transformed" 20 (Atomic.get a)
+
+let test_update_with_commit_on_map () =
+  let module SMap = Map.Make (String) in
+  let a = Atomic.make SMap.empty in
+  let inserted =
+    L.update_with_commit a (fun m ->
+        let m' = SMap.add "k" 42 m in
+        { L.next_state = m'; result = SMap.cardinal m' })
+  in
+  Alcotest.(check int) "cardinal after insert" 1 inserted;
+  Alcotest.(check bool) "key present" true (SMap.mem "k" (Atomic.get a))
+
 let () =
   Alcotest.run "Lockfree_atomic" [
     "update", [
@@ -67,5 +86,10 @@ let () =
       Alcotest.test_case "map insert" `Quick test_update_with_result_on_map;
       Alcotest.test_case "contention replay" `Quick
         test_update_with_result_replays_on_contention;
+    ];
+    "update_with_commit", [
+      Alcotest.test_case "derived value" `Quick
+        test_update_with_commit_returns_derived_value;
+      Alcotest.test_case "map insert" `Quick test_update_with_commit_on_map;
     ];
   ]

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -134,7 +134,7 @@ let test_register_uses_successful_commit_time_after_retry () =
         (Some (fun () ->
            if Atomic.compare_and_set forced_retry false true then begin
              ignore
-               (Sse.atomic_update_result Sse.clients (fun state ->
+               (Masc_mcp.Lockfree_atomic.update_with_commit Sse.clients (fun state ->
                     {
                       next_state = { state with count = state.count };
                       result = ();
@@ -194,7 +194,7 @@ let test_buffer_event_timestamps_successful_commit_after_retry () =
         (Some (fun () ->
            if Atomic.compare_and_set forced_retry false true then begin
              ignore
-               (Sse.atomic_update_result Sse.event_buffer (fun buffer ->
+               (Masc_mcp.Lockfree_atomic.update_with_commit Sse.event_buffer (fun buffer ->
                     {
                       next_state = List.map (fun item -> item) buffer;
                       result = ();


### PR DESCRIPTION
## Summary

**Stacked on #7952** — base is `refactor/lockfree-atomic-helper`, not `main`. Do not merge until #7952 lands.

`lib/sse.ml`의 로컬 `atomic_update_result` + `atomic_commit` record를 제거하고 `Lockfree_atomic` 공용 심볼로 재지목. #7862가 도입한 lock-free 변환 자체는 그대로 두고, **helper만 통일**합니다.

- `Lockfree_atomic.commit` type으로 로컬 `atomic_commit` 대체. 필드 동일(`next_state`, `result`) 이므로 9개 call site의 record literal은 OCaml field disambiguation으로 그대로 type check.
- 9곳의 `atomic_update_result` 호출 → `Lockfree_atomic.update_with_commit`.
- `test/test_sse_coverage.ml` 외부 레퍼런스 추종.
- `Lockfree_atomic` 에 `update_with_commit` 2 케이스 추가 (derived value, map insert).

## Why

`Lockfree_atomic.update_with_result` (tuple) 은 terse 쓰임에 좋지만, `sse.ml` 처럼 state/result가 둘 다 복잡한 곳엔 positional tuple이 가독성을 떨어뜨립니다. `update_with_commit` (record 라벨) 이 같은 의미론을 이름으로 나타냅니다.

두 변종을 같은 모듈에서 제공하면 중복 기능 없이 "짧은 건 tuple, 긴 건 record" 관습이 정착됩니다.

## Scope discipline

- `sse.ml`의 lock-free 구조 자체는 이전 #7862에서 이미 착지했으므로 **건드리지 않습니다**. 이 PR은 helper 통일만.
- behavior 동일 — Hashtbl → SMap 같은 자료구조 변경 없음.

## Verification

```bash
dune build --root . @check
dune build --root . test/test_sse.exe test/test_sse_qw.exe \
                     test/test_sse_stream.exe test/test_sse_coverage.exe \
                     test/test_lockfree_atomic.exe
_build/default/test/test_sse.exe             # 4 / 4 pass
_build/default/test/test_sse_coverage.exe    # 32 / 32 pass
_build/default/test/test_lockfree_atomic.exe # 7 / 7 pass
```

## Follow-ups (out of scope)

- [ ] `tool_registry` 동일 consolidation (사용 패턴 있다면)
- [ ] 남은 직접 `Atomic.compare_and_set` CAS 루프 감사 (`rg "Atomic\.compare_and_set" lib/`)
- [ ] Test 추가: `update_with_commit` 의 contention 케이스 (이미 `update_with_result` 가 커버 — 구현이 동일한 CAS 루프이므로 중복 회피)

## Test plan

- [x] dune build --root . @check
- [x] test_sse 4/4
- [x] test_sse_coverage 32/32
- [x] test_lockfree_atomic 7/7
- [ ] CI: 전체 Build and Test, Health, TLA+