### PR TITLE
feat(scripts): runtime gate for frontmatter code_refs existence

### DIFF
--- a/scripts/check-doc-code-refs.sh
+++ b/scripts/check-doc-code-refs.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-doc-code-refs.sh [--apply-stamp-day YYYY-MM-DD]
+
+Walks every docs/ markdown with YAML frontmatter containing a `code_refs:`
+block and verifies each listed path exists in the repo. Fails with exit 1
+if any listed code_refs path is missing.
+
+Rationale: `last_verified` + `code_refs` is a machine-readable claim that
+"this doc has been checked against these repo paths on this date". If the
+path does not exist, the claim is false and the doc must either update
+the ref or drop it. See the Gen33-39 drift sweep history for precedent.
+
+Options:
+  --apply-stamp-day YYYY-MM-DD
+      Restrict the audit to docs whose `last_verified:` equals this date.
+      Useful when a batch frontmatter PR lands and you want to verify only
+      that batch without auditing the whole docs tree.
+
+  -h, --help
+      Show this help.
+EOF
+}
+
+stamp_filter=""
+while (($# > 0)); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --apply-stamp-day)
+      shift
+      [[ $# -gt 0 ]] || { usage >&2; exit 1; }
+      stamp_filter="$1"
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+missing=()
+
+extract_code_refs() {
+  local file="$1"
+  awk -v stamp="$stamp_filter" '
+    BEGIN { fm = 0; in_refs = 0; stamp_ok = (stamp == "") ? 1 : 0 }
+    /^---[[:space:]]*$/ {
+      fm++
+      if (fm > 2) exit
+      next
+    }
+    fm == 1 && /^last_verified:[[:space:]]*/ {
+      if (stamp != "") {
+        split($0, parts, /[[:space:]]+/)
+        if (parts[2] == stamp) stamp_ok = 1
+      }
+      next
+    }
+    fm == 1 && /^code_refs:[[:space:]]*$/ { in_refs = 1; next }
+    fm == 1 && /^[a-zA-Z_][a-zA-Z0-9_]*:/ { in_refs = 0; next }
+    fm == 1 && in_refs && /^[[:space:]]+-[[:space:]]+/ {
+      sub(/^[[:space:]]+-[[:space:]]+/, "")
+      sub(/[[:space:]]*#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      if ($0 != "" && stamp_ok) print $0
+    }
+  ' "$file"
+}
+
+while IFS= read -r doc; do
+  [[ -z "$doc" ]] && continue
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    # Skip placeholders and glob patterns — they are not meant to be real paths.
+    [[ "$ref" == *"<"* ]] && continue
+    [[ "$ref" == *"*"* ]] && continue
+    if [[ ! -e "$ref" ]]; then
+      missing+=("$doc → $ref")
+    fi
+  done < <(extract_code_refs "$doc")
+done < <(find docs -type f -name '*.md' | sort)
+
+if ((${#missing[@]} > 0)); then
+  printf 'doc code_refs check failed: %d missing path(s)\n' "${#missing[@]}" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+printf 'Doc code_refs OK: every frontmatter code_refs path exists in the repo\n'

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -178,3 +178,5 @@ if ((${#missing_refs[@]} > 0)); then
 fi
 
 printf 'Doc truth OK: front-door docs and key specs are aligned with current repo truth\n'
+
+scripts/check-doc-code-refs.sh


### PR DESCRIPTION
## Summary

Gen40 — **FSM을 manual loop에서 CI gate로 승격**. Gen33-39 /loop sweep에서 7 PR 머지하며 찾아낸 \"last_verified stamp + dead code_refs\" 드리프트 패턴을 자동화.

## What

신규 \`scripts/check-doc-code-refs.sh\`:
- 모든 \`docs/*.md\` 프론트매터 스캔
- 정확한 YAML 파싱 (첫 \`---\` ↔ 둘째 \`---\` 사이만, 본문 구분선 \`---\` 무시)
- \`code_refs:\` 리스트의 각 경로 존재 여부 확인, 누락 시 exit 1
- glob 패턴(\`*\`)과 template placeholder(\`<file>\`)는 skip
- Optional \`--apply-stamp-day YYYY-MM-DD\` 필터 (batch frontmatter 감사용)

\`scripts/check-doc-truth.sh\` 말미에 호출 추가 → 기존 CI/local 워크플로 자동 pickup.

## Why

**Policy ↔ Runtime Drift Gate** (memory/feedback_policy-runtime-drift-gate.md) 실천. \"이 문서는 오늘 이 코드 경로들과 일치함\"이라는 기계 판독 가능한 claim은, 런타임 검증 없으면 언제든 거짓말로 drift 가능.

## FSM plug 해석

- **FSM (불변)**: \`frontmatter.code_refs[i] must exist in repo\`
- **Plug (과거)**: 인간이 /loop generation마다 awk 돌림
- **Plug (현재)**: shell script가 매 push마다 돌림

\"FSM 단단하면 판정 기준만 Plug\" 원칙대로, 기준은 그대로 두고 실행 매체를 교체. 7세대 수동 반복이 낳은 통찰을 항구화.

## Verification

\`\`\`bash
# Positive state (Gen33-39 cleanup 후)
$ scripts/check-doc-code-refs.sh
Doc code_refs OK: every frontmatter code_refs path exists in the repo

# Negative test: lib/nonexistent_module.ml을 SPEC-INDEX frontmatter에 주입
$ scripts/check-doc-code-refs.sh
doc code_refs check failed: 1 missing path(s)
  docs/spec/SPEC-INDEX.md → lib/nonexistent_module.ml
$ echo \$?
1
\`\`\`

## Scope

- 신규 파일 1개 (+96 lines)
- \`check-doc-truth.sh\`에 2 lines 추가 (호출 wiring)
- 기존 contract test 5개 모두 통과 (content lock 보존)
- 문서 수정 0

## Test plan

- [x] Positive test (현재 repo state)
- [x] Negative test (주입 후 복구)
- [x] \`check-doc-truth.sh\` integration 동작
- [ ] CI Lint + Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)