### PR TITLE
feat(dashboard): ⏱ live-ticking counter on sidecar-startup warning banner

### DIFF
--- a/dashboard/src/components/sidecar-startup-watch.test.ts
+++ b/dashboard/src/components/sidecar-startup-watch.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import {
@@ -77,6 +77,55 @@ describe('StartupCheckBanner rendering', () => {
   it('renders nothing when no attempt has been marked', () => {
     render(html`<${StartupCheckBanner} connectorId="discord" sidecarUp=${false} />`, container)
     expect(container.querySelector('[data-startup-warning]')).toBeNull()
+  })
+
+  it('elapsed counter renders once past grace, pinned to startAt-based seconds', () => {
+    const t0 = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(t0)
+    try {
+      markStartAttempt('discord')
+      vi.setSystemTime(t0 + 6_000) // 6s past grace (GRACE=5s)
+      render(html`<${StartupCheckBanner} connectorId="discord" sidecarUp=${false} />`, container)
+      const elapsed = container.querySelector('[data-startup-warning-elapsed]')
+      expect(elapsed).toBeTruthy()
+      expect(elapsed!.getAttribute('data-startup-warning-elapsed')).toBe('6')
+      expect(elapsed!.textContent).toContain('6s')
+    } finally {
+      vi.useRealTimers()
+      resetStartupWatchState()
+    }
+  })
+
+  it('live counter ticks every second while the banner is mounted', async () => {
+    const t0 = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(t0)
+    try {
+      markStartAttempt('discord')
+      vi.setSystemTime(t0 + 6_000)
+      render(html`<${StartupCheckBanner} connectorId="discord" sidecarUp=${false} />`, container)
+      // Wait one microtask so layout-effect's setInterval is armed.
+      await Promise.resolve()
+      expect(
+        container.querySelector('[data-startup-warning-elapsed]')!.getAttribute('data-startup-warning-elapsed'),
+      ).toBe('6')
+
+      // advanceTimersByTimeAsync moves the fake system clock AND fires
+      // scheduled timers, so we don't need a separate setSystemTime.
+      await vi.advanceTimersByTimeAsync(2000) // now t0 + 8s
+      expect(
+        container.querySelector('[data-startup-warning-elapsed]')!.getAttribute('data-startup-warning-elapsed'),
+      ).toBe('8')
+
+      await vi.advanceTimersByTimeAsync(4000) // now t0 + 12s
+      expect(
+        container.querySelector('[data-startup-warning-elapsed]')!.getAttribute('data-startup-warning-elapsed'),
+      ).toBe('12')
+    } finally {
+      vi.useRealTimers()
+      resetStartupWatchState()
+    }
   })
 
   it('dismiss (×) button clears the attempt', () => {

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -15,7 +15,18 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { useLayoutEffect, useState } from 'preact/hooks'
 import { openSidecarLogs } from './sidecar-log-viewer'
+
+/** How often the live counter in the banner re-renders. 1000ms matches
+    the unit the banner displays ("N초 경과"), so the counter ticks
+    precisely when the displayed seconds change.
+
+    Reference — Grafana live counter + Stripe Dashboard "processing for
+    N seconds" chrome: watching the number tick is how the operator
+    knows the system hasn't silently stalled on them. Cheap: setInterval
+    inside a component that only mounts during the 55s warning window. */
+const LIVE_TICK_MS = 1000
 
 const lastStartAt = signal<Record<string, number>>({})
 
@@ -64,7 +75,21 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
   sidecarUp: boolean
 }) {
   const startAt = lastStartAt.value[connectorId] ?? null
-  if (!shouldShowStartupWarning(startAt, sidecarUp)) return null
+  const visible = shouldShowStartupWarning(startAt, sidecarUp)
+
+  // Local tick — causes the counter line to re-render once a second
+  // while the banner is visible, independent of the parent's poll
+  // cadence. Layout-effect variant so the interval is already armed by
+  // the time a test dispatches a clock advance (keeps happy-dom tests
+  // deterministic without rAF juggling).
+  const [, setTick] = useState(0)
+  useLayoutEffect(() => {
+    if (!visible) return
+    const id = setInterval(() => setTick(t => t + 1), LIVE_TICK_MS)
+    return () => clearInterval(id)
+  }, [visible])
+
+  if (!visible) return null
 
   const elapsedSec = startAt !== null ? Math.floor((Date.now() - startAt) / 1000) : 0
 
@@ -75,7 +100,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
     >
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
       <div class="min-w-0 flex-1">
-        <div class="font-semibold">기동 응답 없음 (${elapsedSec}s 경과)</div>
+        <div class="font-semibold" data-startup-warning-elapsed=${String(elapsedSec)}>기동 응답 없음 (${elapsedSec}s 경과)</div>
         <div class="text-[10px] opacity-90">
           Start 요청은 보냈지만 sidecar가 online으로 올라오지 않았습니다.
           토큰 검증 실패 / 의존성 누락이 가장 흔한 원인 — 로그를 확인하세요.


### PR DESCRIPTION
## Summary

The startup-warning banner already showed \`N초 경과\`, but the number only refreshed when the parent poller ticked (every 2 seconds). Between ticks the counter looked stalled — the very thing the banner exists to rule out.

Add a local 1-second interval inside the banner so the seconds climb in real time, independent of the parent's render cadence.

Reference — **Grafana's live counter** + **Stripe Dashboard's \"processing for N seconds\"** chrome: the climbing digit is itself the \"system is alive\" signal. When a sidecar is slow to come online, watching the counter advance is how the operator knows nothing silently froze.

### Design notes

- **\`LIVE_TICK_MS = 1000\`** matches the displayed unit — re-renders are aligned with the digit that's about to change.
- **\`useLayoutEffect\` gates on \`visible\`** — interval only arms while the banner is on screen; grace-window / 60s-upper-bound expiry both unmount for free.
- **\`data-startup-warning-elapsed=\"N\"\`** — lets tests pin the tick against \`vi.advanceTimersByTimeAsync\` without parsing Korean text.

### Scope

- \`dashboard/src/components/sidecar-startup-watch.ts\` (+15 LOC)
- \`dashboard/src/components/sidecar-startup-watch.test.ts\` (+2 DOM tests with fake timers)

## Test plan

- [x] 12/12 vitest green (fake-timer based)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: manually kill Discord sidecar's port → click Start → banner appears after 5s grace → counter ticks 6, 7, 8, 9, 10… without waiting for the 2s parent poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)