### PR TITLE
feat(keeper): behavioral regime deriver MVP (7th FSM axis, Crashing/Thrashing/Healthy)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -458,6 +458,7 @@
    keeper_decision_pipeline_contract
    keeper_turn_cycle_contract
    keeper_composite_observer
+   keeper_behavioral_regime
    keeper_campaign_fsm
    keeper_unified_prompt
    keeper_unified_turn

--- a/lib/keeper/keeper_behavioral_regime.ml
+++ b/lib/keeper/keeper_behavioral_regime.ml
@@ -1,0 +1,141 @@
+(** Behavioral regime deriver — pure. See [.mli] for contract. *)
+
+(* Use [Keeper_registry.StringMap] so [registry_entry.tool_usage]
+   typechecks directly without coercion. A fresh [Map.Make(String)]
+   here would be a distinct nominal type even though structurally
+   identical. *)
+module StringMap = Keeper_registry.StringMap
+
+type regime =
+  | Crashing
+  | Thrashing
+  | Healthy
+
+let all_regimes = [ Crashing; Thrashing; Healthy ]
+
+let string_of_regime = function
+  | Crashing -> "crashing"
+  | Thrashing -> "thrashing"
+  | Healthy -> "healthy"
+
+let regime_of_string = function
+  | "crashing" -> Some Crashing
+  | "thrashing" -> Some Thrashing
+  | "healthy" -> Some Healthy
+  | _ -> None
+
+type reason = {
+  rule_id : string;
+  evidence : string list;
+}
+
+type snapshot = {
+  regime : regime;
+  reason : reason;
+  updated_at : float;
+}
+
+(* ── Thresholds (exposed for tests) ─────────────────────── *)
+
+let turn_fail_streak_threshold = 3
+let recent_restart_window_sec = 300.0
+let recent_restart_count_threshold = 2
+let tool_failure_count_threshold = 3
+let tool_failure_ratio_threshold = 0.7
+
+(* ── Rule predicates ────────────────────────────────────── *)
+
+(* Crashing: keeper has restarted repeatedly in a recent window. We
+   look at [restart_count] together with [last_restart_ts] so a
+   long-lived keeper that restarted once at t=0 does not linger in
+   Crashing forever. *)
+let crashing_rule ~now (e : Keeper_registry.registry_entry) : reason option =
+  if e.restart_count >= recent_restart_count_threshold
+     && now -. e.last_restart_ts <= recent_restart_window_sec
+  then
+    Some {
+      rule_id = "recent_restart_streak";
+      evidence = [
+        Printf.sprintf "restart_count=%d" e.restart_count;
+        Printf.sprintf "last_restart_age_sec=%.1f" (now -. e.last_restart_ts);
+      ];
+    }
+  else None
+
+(* Thrashing rule A: the runtime's own turn failure counter is at or
+   above threshold. Coarser than per-tool-args hashing (the plan's
+   original signal) but uses a field [registry_entry] actually carries. *)
+let thrashing_turn_streak_rule (e : Keeper_registry.registry_entry) : reason option =
+  if e.turn_consecutive_failures >= turn_fail_streak_threshold
+  then
+    Some {
+      rule_id = "turn_fail_streak";
+      evidence = [
+        Printf.sprintf "turn_consecutive_failures=%d" e.turn_consecutive_failures;
+      ];
+    }
+  else None
+
+(* Thrashing rule B: any single tool has accumulated a failure-dominant
+   usage profile. [tool_call_entry] is per-tool aggregate (not per-args),
+   so this catches "a keeper keeps calling a tool that keeps failing" —
+   the same structural pathology as the plan's "same args ≥3 fails" but
+   at lower resolution. *)
+let tool_failure_ratio (entry : Keeper_types.tool_call_entry) : float =
+  if entry.count <= 0 then 0.0
+  else float_of_int entry.failures /. float_of_int entry.count
+
+let thrashing_tool_saturation_rule
+    (tool_usage : Keeper_types.tool_call_entry StringMap.t) : reason option =
+  let offenders =
+    StringMap.fold
+      (fun name entry acc ->
+         if entry.Keeper_types.failures >= tool_failure_count_threshold
+            && tool_failure_ratio entry >= tool_failure_ratio_threshold
+         then (name, entry) :: acc
+         else acc)
+      tool_usage
+      []
+  in
+  match offenders with
+  | [] -> None
+  | (name, entry) :: _ ->
+      Some {
+        rule_id = "tool_failure_saturation";
+        evidence = [
+          Printf.sprintf "tool=%s" name;
+          Printf.sprintf "failures=%d/%d" entry.failures entry.count;
+          Printf.sprintf "ratio=%.2f" (tool_failure_ratio entry);
+        ];
+      }
+
+(* ── Deriver ────────────────────────────────────────────── *)
+
+let healthy_reason = {
+  rule_id = "default_healthy";
+  evidence = [];
+}
+
+let derive ~now (entry : Keeper_registry.registry_entry) : snapshot =
+  let regime, reason =
+    match crashing_rule ~now entry with
+    | Some r -> Crashing, r
+    | None ->
+        match thrashing_turn_streak_rule entry with
+        | Some r -> Thrashing, r
+        | None ->
+            match thrashing_tool_saturation_rule entry.tool_usage with
+            | Some r -> Thrashing, r
+            | None -> Healthy, healthy_reason
+  in
+  { regime; reason; updated_at = now }
+
+(* ── JSON projection ────────────────────────────────────── *)
+
+let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
+  `Assoc [
+    "regime", `String (string_of_regime s.regime);
+    "rule_id", `String s.reason.rule_id;
+    "evidence", `List (List.map (fun e -> `String e) s.reason.evidence);
+    "updated_at", `Float s.updated_at;
+  ]

--- a/lib/keeper/keeper_behavioral_regime.ml
+++ b/lib/keeper/keeper_behavioral_regime.ml
@@ -1,11 +1,5 @@
 (** Behavioral regime deriver — pure. See [.mli] for contract. *)
 
-(* Use [Keeper_registry.StringMap] so [registry_entry.tool_usage]
-   typechecks directly without coercion. A fresh [Map.Make(String)]
-   here would be a distinct nominal type even though structurally
-   identical. *)
-module StringMap = Keeper_registry.StringMap
-
 type regime =
   | Crashing
   | Thrashing
@@ -23,6 +17,18 @@ let regime_of_string = function
   | "thrashing" -> Some Thrashing
   | "healthy" -> Some Healthy
   | _ -> None
+
+type tool_aggregate = {
+  count : int;
+  failures : int;
+}
+
+type input = {
+  turn_consecutive_failures : int;
+  restart_count : int;
+  last_restart_ts : float;
+  tool_aggregates : (string * tool_aggregate) list;
+}
 
 type reason = {
   rule_id : string;
@@ -45,67 +51,51 @@ let tool_failure_ratio_threshold = 0.7
 
 (* ── Rule predicates ────────────────────────────────────── *)
 
-(* Crashing: keeper has restarted repeatedly in a recent window. We
-   look at [restart_count] together with [last_restart_ts] so a
-   long-lived keeper that restarted once at t=0 does not linger in
-   Crashing forever. *)
-let crashing_rule ~now (e : Keeper_registry.registry_entry) : reason option =
-  if e.restart_count >= recent_restart_count_threshold
-     && now -. e.last_restart_ts <= recent_restart_window_sec
+let crashing_rule ~now (i : input) : reason option =
+  if i.restart_count >= recent_restart_count_threshold
+     && now -. i.last_restart_ts <= recent_restart_window_sec
   then
     Some {
       rule_id = "recent_restart_streak";
       evidence = [
-        Printf.sprintf "restart_count=%d" e.restart_count;
-        Printf.sprintf "last_restart_age_sec=%.1f" (now -. e.last_restart_ts);
+        Printf.sprintf "restart_count=%d" i.restart_count;
+        Printf.sprintf "last_restart_age_sec=%.1f" (now -. i.last_restart_ts);
       ];
     }
   else None
 
-(* Thrashing rule A: the runtime's own turn failure counter is at or
-   above threshold. Coarser than per-tool-args hashing (the plan's
-   original signal) but uses a field [registry_entry] actually carries. *)
-let thrashing_turn_streak_rule (e : Keeper_registry.registry_entry) : reason option =
-  if e.turn_consecutive_failures >= turn_fail_streak_threshold
+let thrashing_turn_streak_rule (i : input) : reason option =
+  if i.turn_consecutive_failures >= turn_fail_streak_threshold
   then
     Some {
       rule_id = "turn_fail_streak";
       evidence = [
-        Printf.sprintf "turn_consecutive_failures=%d" e.turn_consecutive_failures;
+        Printf.sprintf "turn_consecutive_failures=%d" i.turn_consecutive_failures;
       ];
     }
   else None
 
-(* Thrashing rule B: any single tool has accumulated a failure-dominant
-   usage profile. [tool_call_entry] is per-tool aggregate (not per-args),
-   so this catches "a keeper keeps calling a tool that keeps failing" —
-   the same structural pathology as the plan's "same args ≥3 fails" but
-   at lower resolution. *)
-let tool_failure_ratio (entry : Keeper_types.tool_call_entry) : float =
-  if entry.count <= 0 then 0.0
-  else float_of_int entry.failures /. float_of_int entry.count
+let tool_failure_ratio (agg : tool_aggregate) : float =
+  if agg.count <= 0 then 0.0
+  else float_of_int agg.failures /. float_of_int agg.count
 
-let thrashing_tool_saturation_rule
-    (tool_usage : Keeper_types.tool_call_entry StringMap.t) : reason option =
-  let offenders =
-    StringMap.fold
-      (fun name entry acc ->
-         if entry.Keeper_types.failures >= tool_failure_count_threshold
-            && tool_failure_ratio entry >= tool_failure_ratio_threshold
-         then (name, entry) :: acc
-         else acc)
-      tool_usage
-      []
+let thrashing_tool_saturation_rule (aggs : (string * tool_aggregate) list) : reason option =
+  let saturated =
+    List.filter
+      (fun (_name, a) ->
+         a.failures >= tool_failure_count_threshold
+         && tool_failure_ratio a >= tool_failure_ratio_threshold)
+      aggs
   in
-  match offenders with
+  match saturated with
   | [] -> None
-  | (name, entry) :: _ ->
+  | (name, agg) :: _ ->
       Some {
         rule_id = "tool_failure_saturation";
         evidence = [
           Printf.sprintf "tool=%s" name;
-          Printf.sprintf "failures=%d/%d" entry.failures entry.count;
-          Printf.sprintf "ratio=%.2f" (tool_failure_ratio entry);
+          Printf.sprintf "failures=%d/%d" agg.failures agg.count;
+          Printf.sprintf "ratio=%.2f" (tool_failure_ratio agg);
         ];
       }
 
@@ -116,15 +106,15 @@ let healthy_reason = {
   evidence = [];
 }
 
-let derive ~now (entry : Keeper_registry.registry_entry) : snapshot =
+let derive ~now (i : input) : snapshot =
   let regime, reason =
-    match crashing_rule ~now entry with
+    match crashing_rule ~now i with
     | Some r -> Crashing, r
     | None ->
-        match thrashing_turn_streak_rule entry with
+        match thrashing_turn_streak_rule i with
         | Some r -> Thrashing, r
         | None ->
-            match thrashing_tool_saturation_rule entry.tool_usage with
+            match thrashing_tool_saturation_rule i.tool_aggregates with
             | Some r -> Thrashing, r
             | None -> Healthy, healthy_reason
   in

--- a/lib/keeper/keeper_behavioral_regime.mli
+++ b/lib/keeper/keeper_behavioral_regime.mli
@@ -1,0 +1,128 @@
+(** Keeper Behavioral Regime — pure projection (7th FSM axis MVP).
+
+    Projects a [Keeper_registry.registry_entry] into a {b derived}
+    behavioral regime — distinct from the 6 mechanical FSM axes
+    (KSM/KTC/KDP/KCL/KMC/KCB) which capture "where in the code".
+
+    This axis answers the orthogonal question: "what mode is the
+    keeper actually in?" Example regimes (research basis: Anthropic
+    persona vectors, Jason Wei CS25 V4 emergent-capability cliffs,
+    Fowler circuit breaker, Reflexion rumination spiral).
+
+    Contract (mirrors [Keeper_composite_observer]):
+    - Pure read. No mutation, no I/O, no event emission.
+    - Does not read provider names, token counts, or context bytes —
+      those belong to OAS (see [feedback_masc-oas-layer-boundary]).
+    - Only consumes fields already materialised on [registry_entry].
+
+    MVP scope: 3 regimes derived from turn-failure counter + restart
+    history + tool-usage aggregates. Phase 2 adds Ruminating /
+    Avoiding / Saturated / Echoing once richer telemetry hooks exist.
+
+    @since RFC-0003 Phase 3 — 7th axis. *)
+
+(** Regime values are ordered by precedence (highest first). When
+    multiple rules fire simultaneously, the highest-precedence one
+    wins. Rationale: Jason Wei's "emergent capability cliff" framing
+    — regime transition is discrete, not gradient-interpolated, so a
+    single-value enum is closer to the phenomenon than a boolean
+    vector of independent flags. *)
+type regime =
+  | Crashing
+      (** Lifecycle instability — restart count elevated in a recent
+          window. Highest precedence because it subsumes downstream
+          regimes (a crashing keeper cannot meaningfully thrash). *)
+  | Thrashing
+      (** Repeated failure without recovery — turn failures or per-tool
+          failure saturation. Analog of Fowler circuit-breaker pre-trip
+          but at the turn level rather than per-call. *)
+  | Healthy
+      (** None of the above. Default. *)
+
+val all_regimes : regime list
+(** Enumeration of all regime values in precedence order. Used by
+    the dashboard to build a stable column header. *)
+
+val regime_of_string : string -> regime option
+(** [regime_of_string s] parses a canonical lowercase name. Returns
+    [None] when [s] does not match any declared regime. *)
+
+val string_of_regime : regime -> string
+(** [string_of_regime r] returns the canonical lowercase name. Stable
+    wire format — the dashboard and TLA+ spec both depend on it. *)
+
+(** Reason carries {b why} the deriver picked this regime. The dashboard
+    hub panel surfaces it verbatim so an operator can see which rule
+    fired and on what values — no guesswork. *)
+type reason = {
+  rule_id : string;
+      (** Short stable identifier (e.g. ["turn_fail_streak"]). *)
+  evidence : string list;
+      (** Concrete values that made the rule fire — already
+          human-readable (e.g. ["turn_consecutive_failures=5"]). *)
+}
+
+(** Snapshot returned per keeper per poll. *)
+type snapshot = {
+  regime : regime;
+  reason : reason;
+      (** Empty evidence + [rule_id = "default_healthy"] when
+          [regime = Healthy]. *)
+  updated_at : float;
+      (** Wall-clock when the snapshot was computed. *)
+}
+
+val derive :
+  now:float ->
+  Keeper_registry.registry_entry ->
+  snapshot
+(** [derive ~now entry] applies the regime rules in precedence order
+    and returns the first match (or [Healthy] when none match).
+
+    [now] is injected for determinism and testing — the deriver does
+    not call [Unix.time] itself, matching the pure-projection contract
+    of [Keeper_composite_observer]. Typical caller: the composite
+    observer wrapper, which already has a wall-clock source. *)
+
+val snapshot_to_json : snapshot -> Yojson.Safe.t
+(** JSON projection for the dashboard telemetry response. Shape:
+
+    {[
+      {
+        "regime": "thrashing",
+        "rule_id": "turn_fail_streak",
+        "evidence": [ "turn_consecutive_failures=5" ],
+        "updated_at": 1234567890.12
+      }
+    ]}
+
+    Stable — the dashboard API schema treats this as a forward-compat
+    sub-object, and the TLA+ regime invariant reads [regime] as the
+    enum value directly. *)
+
+(** {1 Thresholds}
+
+    Tunable constants exposed for tests. Defaults are conservative;
+    revisit after 2-week empirical observation (per plan
+    {e Track C}: empirical-before-design). *)
+
+val turn_fail_streak_threshold : int
+(** [turn_consecutive_failures >= N] triggers Thrashing.
+    Default: 3. *)
+
+val recent_restart_window_sec : float
+(** Restarts within this window count as {e recent} for Crashing.
+    Default: 300.0 (5 minutes). *)
+
+val recent_restart_count_threshold : int
+(** [restart_count] at or above this AND within the recent window
+    triggers Crashing. Default: 2. *)
+
+val tool_failure_count_threshold : int
+(** A tool with [failures >= this] AND failure ratio exceeding
+    {!tool_failure_ratio_threshold} contributes to Thrashing.
+    Default: 3. *)
+
+val tool_failure_ratio_threshold : float
+(** Minimum [failures / count] ratio for a tool to count as saturated.
+    Default: 0.7. *)

--- a/lib/keeper/keeper_behavioral_regime.mli
+++ b/lib/keeper/keeper_behavioral_regime.mli
@@ -1,22 +1,26 @@
 (** Keeper Behavioral Regime — pure projection (7th FSM axis MVP).
 
-    Projects a [Keeper_registry.registry_entry] into a {b derived}
+    Projects a keeper's {b observable signals} into a derived
     behavioral regime — distinct from the 6 mechanical FSM axes
     (KSM/KTC/KDP/KCL/KMC/KCB) which capture "where in the code".
 
     This axis answers the orthogonal question: "what mode is the
-    keeper actually in?" Example regimes (research basis: Anthropic
-    persona vectors, Jason Wei CS25 V4 emergent-capability cliffs,
-    Fowler circuit breaker, Reflexion rumination spiral).
+    keeper actually in?" (research basis: Anthropic persona vectors,
+    Jason Wei CS25 V4 emergent-capability cliffs, Fowler circuit
+    breaker.)
 
     Contract (mirrors [Keeper_composite_observer]):
     - Pure read. No mutation, no I/O, no event emission.
     - Does not read provider names, token counts, or context bytes —
       those belong to OAS (see [feedback_masc-oas-layer-boundary]).
-    - Only consumes fields already materialised on [registry_entry].
+    - Takes a {b minimal} input record {!input} rather than the full
+      [Keeper_registry.registry_entry]. The wrapper in
+      [Dashboard_behavioral_regime] handles projection from the
+      registry entry; this keeps the deriver trivially testable and
+      framework-free (Alexis King, "Parse don't validate").
 
     MVP scope: 3 regimes derived from turn-failure counter + restart
-    history + tool-usage aggregates. Phase 2 adds Ruminating /
+    history + per-tool failure aggregates. Phase 2 adds Ruminating /
     Avoiding / Saturated / Echoing once richer telemetry hooks exist.
 
     @since RFC-0003 Phase 3 — 7th axis. *)
@@ -30,26 +34,39 @@
 type regime =
   | Crashing
       (** Lifecycle instability — restart count elevated in a recent
-          window. Highest precedence because it subsumes downstream
-          regimes (a crashing keeper cannot meaningfully thrash). *)
+          window. Highest precedence because a crashing keeper cannot
+          meaningfully thrash. *)
   | Thrashing
       (** Repeated failure without recovery — turn failures or per-tool
           failure saturation. Analog of Fowler circuit-breaker pre-trip
-          but at the turn level rather than per-call. *)
+          at the turn level rather than per-call. *)
   | Healthy
       (** None of the above. Default. *)
 
 val all_regimes : regime list
-(** Enumeration of all regime values in precedence order. Used by
-    the dashboard to build a stable column header. *)
-
 val regime_of_string : string -> regime option
-(** [regime_of_string s] parses a canonical lowercase name. Returns
-    [None] when [s] does not match any declared regime. *)
-
 val string_of_regime : regime -> string
-(** [string_of_regime r] returns the canonical lowercase name. Stable
-    wire format — the dashboard and TLA+ spec both depend on it. *)
+
+(** A single tool's aggregate usage. Mirrors the shape of
+    [Keeper_types.tool_call_entry] but is declared here so the
+    deriver does not depend on that module directly. *)
+type tool_aggregate = {
+  count : int;
+  failures : int;
+}
+
+(** Minimal input the deriver needs. All fields are the caller's
+    responsibility to project from whatever stateful source
+    (registry entry, replay log, test fixture). *)
+type input = {
+  turn_consecutive_failures : int;
+  restart_count : int;
+  last_restart_ts : float;
+      (** Unix seconds; 0.0 when the keeper has never restarted. *)
+  tool_aggregates : (string * tool_aggregate) list;
+      (** One entry per tool the keeper has invoked. Empty list when
+          no tool has been used yet. *)
+}
 
 (** Reason carries {b why} the deriver picked this regime. The dashboard
     hub panel surfaces it verbatim so an operator can see which rule
@@ -59,33 +76,24 @@ type reason = {
       (** Short stable identifier (e.g. ["turn_fail_streak"]). *)
   evidence : string list;
       (** Concrete values that made the rule fire — already
-          human-readable (e.g. ["turn_consecutive_failures=5"]). *)
+          human-readable. *)
 }
 
-(** Snapshot returned per keeper per poll. *)
 type snapshot = {
   regime : regime;
   reason : reason;
       (** Empty evidence + [rule_id = "default_healthy"] when
           [regime = Healthy]. *)
   updated_at : float;
-      (** Wall-clock when the snapshot was computed. *)
 }
 
-val derive :
-  now:float ->
-  Keeper_registry.registry_entry ->
-  snapshot
-(** [derive ~now entry] applies the regime rules in precedence order
-    and returns the first match (or [Healthy] when none match).
-
-    [now] is injected for determinism and testing — the deriver does
-    not call [Unix.time] itself, matching the pure-projection contract
-    of [Keeper_composite_observer]. Typical caller: the composite
-    observer wrapper, which already has a wall-clock source. *)
+val derive : now:float -> input -> snapshot
+(** Apply the regime rules in precedence order and return the first
+    match (or [Healthy] when none match). [now] is injected so the
+    deriver stays pure and deterministic. *)
 
 val snapshot_to_json : snapshot -> Yojson.Safe.t
-(** JSON projection for the dashboard telemetry response. Shape:
+(** Stable wire format. Shape:
 
     {[
       {
@@ -95,34 +103,16 @@ val snapshot_to_json : snapshot -> Yojson.Safe.t
         "updated_at": 1234567890.12
       }
     ]}
-
-    Stable — the dashboard API schema treats this as a forward-compat
-    sub-object, and the TLA+ regime invariant reads [regime] as the
-    enum value directly. *)
+*)
 
 (** {1 Thresholds}
 
-    Tunable constants exposed for tests. Defaults are conservative;
-    revisit after 2-week empirical observation (per plan
-    {e Track C}: empirical-before-design). *)
+    Tunable constants. Defaults are conservative; revisit after
+    2-week empirical observation (plan {e Track C}:
+    empirical-before-design). *)
 
 val turn_fail_streak_threshold : int
-(** [turn_consecutive_failures >= N] triggers Thrashing.
-    Default: 3. *)
-
 val recent_restart_window_sec : float
-(** Restarts within this window count as {e recent} for Crashing.
-    Default: 300.0 (5 minutes). *)
-
 val recent_restart_count_threshold : int
-(** [restart_count] at or above this AND within the recent window
-    triggers Crashing. Default: 2. *)
-
 val tool_failure_count_threshold : int
-(** A tool with [failures >= this] AND failure ratio exceeding
-    {!tool_failure_ratio_threshold} contributes to Thrashing.
-    Default: 3. *)
-
 val tool_failure_ratio_threshold : float
-(** Minimum [failures / count] ratio for a tool to count as saturated.
-    Default: 0.7. *)

--- a/test/dune
+++ b/test/dune
@@ -73,6 +73,7 @@
         test_decision_pipeline
         test_decision_pipeline_observer
         test_keeper_composite_observer
+        test_keeper_behavioral_regime
         test_keeper_telemetry_feedback
         test_keeper_toml
         test_keeper_runtime_toml
@@ -165,6 +166,7 @@
           test_decision_pipeline
           test_decision_pipeline_observer
           test_keeper_composite_observer
+          test_keeper_behavioral_regime
           test_keeper_telemetry_feedback
           test_keeper_toml
           test_keeper_runtime_toml

--- a/test/test_keeper_behavioral_regime.ml
+++ b/test/test_keeper_behavioral_regime.ml
@@ -1,0 +1,201 @@
+(** Tests for Keeper_behavioral_regime — 7th FSM axis MVP deriver.
+
+    The deriver is a pure function over a small input record so each
+    boundary case can be tested in isolation, without constructing a
+    full [Keeper_registry.registry_entry]. *)
+
+open Alcotest
+
+module R = Masc_mcp.Keeper_behavioral_regime
+
+let now = 1_000_000.0
+
+let healthy_input : R.input = {
+  turn_consecutive_failures = 0;
+  restart_count = 0;
+  last_restart_ts = 0.0;
+  tool_aggregates = [];
+}
+
+let regime_testable = testable
+  (fun fmt r -> Format.pp_print_string fmt (R.string_of_regime r))
+  (fun a b -> R.string_of_regime a = R.string_of_regime b)
+
+(* ── Healthy: baseline ──────────────────────────────────── *)
+
+let test_healthy_default () =
+  let s = R.derive ~now healthy_input in
+  check regime_testable "default is Healthy" R.Healthy s.regime;
+  check string "default rule_id" "default_healthy" s.reason.rule_id;
+  check (list string) "no evidence" [] s.reason.evidence
+
+(* ── Thrashing: turn failure streak ─────────────────────── *)
+
+let test_turn_streak_below_threshold_is_healthy () =
+  let input = {
+    healthy_input with
+    turn_consecutive_failures = R.turn_fail_streak_threshold - 1;
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "N-1 failures stays Healthy" R.Healthy s.regime
+
+let test_turn_streak_at_threshold_is_thrashing () =
+  let input = {
+    healthy_input with
+    turn_consecutive_failures = R.turn_fail_streak_threshold;
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "N failures flips to Thrashing" R.Thrashing s.regime;
+  check string "turn_fail_streak rule fired"
+    "turn_fail_streak" s.reason.rule_id
+
+(* ── Thrashing: tool failure saturation ─────────────────── *)
+
+let test_tool_saturated_is_thrashing () =
+  let input = {
+    healthy_input with
+    tool_aggregates = [
+      ("read_file", { R.count = 10; failures = 8 });  (* 0.8 ratio, 8 fails *)
+    ];
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "saturated tool → Thrashing" R.Thrashing s.regime;
+  check string "tool_failure_saturation rule fired"
+    "tool_failure_saturation" s.reason.rule_id
+
+let test_tool_below_count_threshold_is_healthy () =
+  let input = {
+    healthy_input with
+    (* failures below count threshold even though ratio is 1.0 *)
+    tool_aggregates = [ ("x", { R.count = 2; failures = 2 }) ];
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "2 failures stays Healthy" R.Healthy s.regime
+
+let test_tool_below_ratio_threshold_is_healthy () =
+  let input = {
+    healthy_input with
+    (* 5 failures but ratio 0.5 < 0.7 threshold *)
+    tool_aggregates = [ ("x", { R.count = 10; failures = 5 }) ];
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "low-ratio tool stays Healthy" R.Healthy s.regime
+
+(* ── Crashing: recent restart streak ────────────────────── *)
+
+let test_restart_within_window_is_crashing () =
+  let input = {
+    healthy_input with
+    restart_count = R.recent_restart_count_threshold;
+    last_restart_ts = now -. 60.0;  (* within 5 min window *)
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "recent restart → Crashing" R.Crashing s.regime;
+  check string "recent_restart_streak rule fired"
+    "recent_restart_streak" s.reason.rule_id
+
+let test_restart_outside_window_is_healthy () =
+  let input = {
+    healthy_input with
+    restart_count = 5;
+    last_restart_ts = now -. (R.recent_restart_window_sec +. 10.0);
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "old restart does not linger" R.Healthy s.regime
+
+let test_single_restart_is_healthy () =
+  let input = {
+    healthy_input with
+    restart_count = 1;
+    last_restart_ts = now -. 1.0;
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "one restart below threshold" R.Healthy s.regime
+
+(* ── Precedence: Crashing beats Thrashing ───────────────── *)
+
+let test_crashing_takes_precedence_over_thrashing () =
+  let input : R.input = {
+    (* both restart streak AND turn fail streak firing *)
+    turn_consecutive_failures = R.turn_fail_streak_threshold + 5;
+    restart_count = R.recent_restart_count_threshold + 1;
+    last_restart_ts = now -. 10.0;
+    tool_aggregates = [];
+  } in
+  let s = R.derive ~now input in
+  check regime_testable "Crashing wins" R.Crashing s.regime;
+  check string "Crashing rule reported, not Thrashing"
+    "recent_restart_streak" s.reason.rule_id
+
+(* ── Evidence includes concrete values ──────────────────── *)
+
+let test_turn_streak_evidence_includes_value () =
+  let input = {
+    healthy_input with turn_consecutive_failures = 7;
+  } in
+  let s = R.derive ~now input in
+  check (list string)
+    "evidence carries the exact count"
+    [ "turn_consecutive_failures=7" ]
+    s.reason.evidence
+
+(* ── Enum round-trip ────────────────────────────────────── *)
+
+let test_regime_string_roundtrip () =
+  List.iter (fun r ->
+    let s = R.string_of_regime r in
+    match R.regime_of_string s with
+    | Some r' ->
+        check regime_testable
+          (Printf.sprintf "roundtrip %s" s) r r'
+    | None ->
+        failf "regime_of_string did not parse %S" s
+  ) R.all_regimes
+
+(* ── JSON shape is stable ───────────────────────────────── *)
+
+let test_snapshot_json_shape () =
+  let s : R.snapshot = {
+    regime = R.Thrashing;
+    reason = { rule_id = "turn_fail_streak"; evidence = [ "turn_consecutive_failures=5" ] };
+    updated_at = 1234567890.0;
+  } in
+  let json = R.snapshot_to_json s in
+  let expected =
+    `Assoc [
+      "regime", `String "thrashing";
+      "rule_id", `String "turn_fail_streak";
+      "evidence", `List [ `String "turn_consecutive_failures=5" ];
+      "updated_at", `Float 1234567890.0;
+    ]
+  in
+  check string "JSON matches stable shape"
+    (Yojson.Safe.to_string expected)
+    (Yojson.Safe.to_string json)
+
+let () =
+  run "keeper_behavioral_regime" [
+    "default",
+    [ test_case "healthy is default" `Quick test_healthy_default ];
+    "thrashing_turn_streak",
+    [ test_case "below threshold is healthy" `Quick test_turn_streak_below_threshold_is_healthy
+    ; test_case "at threshold flips to thrashing" `Quick test_turn_streak_at_threshold_is_thrashing
+    ; test_case "evidence includes value" `Quick test_turn_streak_evidence_includes_value
+    ];
+    "thrashing_tool_saturation",
+    [ test_case "saturated tool is thrashing" `Quick test_tool_saturated_is_thrashing
+    ; test_case "low count stays healthy" `Quick test_tool_below_count_threshold_is_healthy
+    ; test_case "low ratio stays healthy" `Quick test_tool_below_ratio_threshold_is_healthy
+    ];
+    "crashing",
+    [ test_case "recent restart streak" `Quick test_restart_within_window_is_crashing
+    ; test_case "old restart expires" `Quick test_restart_outside_window_is_healthy
+    ; test_case "single restart stays healthy" `Quick test_single_restart_is_healthy
+    ];
+    "precedence",
+    [ test_case "crashing beats thrashing" `Quick test_crashing_takes_precedence_over_thrashing ];
+    "serialisation",
+    [ test_case "regime string roundtrip" `Quick test_regime_string_roundtrip
+    ; test_case "snapshot json shape" `Quick test_snapshot_json_shape
+    ];
+  ]


### PR DESCRIPTION
## Summary

Adds a **pure-projection deriver** for a 7th FSM axis — the orthogonal *behavioral regime* of a keeper — on top of the existing 6 mechanical axes (KSM/KTC/KDP/KCL/KMC/KCB).

- New module: \`lib/keeper/keeper_behavioral_regime.{ml,mli}\`
- 13 Alcotest unit tests covering boundaries, precedence, JSON shape round-trip
- **Not wired to dashboard yet** — deriver stands alone. Wrapper + TS column in follow-ups

### 3 MVP regimes (precedence order)

| Regime | Rule | Evidence |
|---|---|---|
| \`Crashing\` | \`restart_count ≥ 2\` within last 300s | \`restart_count=N, last_restart_age_sec=X\` |
| \`Thrashing\` | \`turn_consecutive_failures ≥ 3\` OR any tool with ≥3 failures at ratio ≥0.7 | \`turn_consecutive_failures=N\` or \`tool=X failures=N/M ratio=Z\` |
| \`Healthy\` | Default | — |

### Research basis (plan: \`planning/claude-plans/squishy-wibbling-corbato.md\`)

- **Anthropic Persona Vectors** (arXiv:2507.21509): behavioral states as measurable trait projections (Tier 1 infeasible via consumer API → Tier 3 heuristic MVP)
- **Jason Wei & Hyung Won Chung, CS25 V4** (YouTube \`3gb-ZkVRemQ\`): \"emergent capability cliffs\" justify **discrete single-value enum** over boolean-vector Harel regions
- **Ashish Vaswani, CS25 V3** (\`1GbDTTK3aR4\`): \"retrieval as a tool\" = regime interface → \`Thrashing\` as tool-failure saturation is directly motivated
- **Fowler Circuit Breaker**: per-turn analog (not per-call like KCB axis #6)

## Contract preserved

- Pure read. No mutation, no I/O, no event emission.
- Takes minimal \`input\` record (4 fields) — caller projects from \`registry_entry\`. Keeps deriver trivially testable; aligns with Alexis King \"Parse don't validate\"
- Does not read provider names, token counts, context bytes (MASC-OAS layer boundary preserved)

## Follow-ups (separate PRs)

1. \`Dashboard_behavioral_regime\` wrapper: project \`registry_entry → input\`, expose via dashboard telemetry JSON
2. TS: 7th column in \`FleetFsmMatrix\` + regime-diagnostic panel in \`FsmHub\`
3. TLA+ \`KeeperBehavioralRegime.tla\` + Bug Model pair, register in \`scripts/tla-check.sh\`
4. Phase 2 regimes: \`Ruminating\`/\`Avoiding\`/\`Saturated\`/\`Echoing\` (requires richer telemetry hooks — output length ratio, handoff-avoidance detector, context budget ratio, board embedding similarity)

## Test plan
- [x] 13 unit tests pass locally (\`dune exec test/test_keeper_behavioral_regime.exe\`)
- [ ] CI green
- [ ] Review (ready-for-review after CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)