### PR TITLE
refactor(dashboard): promote Live Judge to page title, purge empty toolbar card

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -52,14 +52,25 @@ function GovernanceSummaryStrip() {
         </div>
       </div>
     ` : null}
-    <div class="mb-2.5 flex items-center justify-between px-0.5">
-      <div class="flex items-center gap-3">
-        <h2 class="text-lg font-bold text-text-strong tracking-wide">거버넌스</h2>
+    <div class="mb-2.5 flex items-center justify-between gap-3 px-0.5">
+      <div class="flex items-center gap-3 min-w-0">
+        <h2 class="text-lg font-bold text-text-strong tracking-wide">Live Judge</h2>
         <span class="rounded-md border border-white/5 bg-[var(--white-3)] px-2 py-0.5 text-[11px] font-medium text-text-muted">
           ${judgeOnlyLabel}
         </span>
       </div>
-      ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}
+      <div class="flex items-center gap-3 shrink-0">
+        ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          class="rounded-lg border-transparent bg-[var(--white-3)] px-2.5 py-1 text-[12px] font-semibold text-text-muted hover:bg-white/10 hover:text-text-strong"
+          onClick=${refreshGovernance}
+          disabled=${governanceLoading.value}
+        >
+          ${governanceLoading.value ? '새로고침 중...' : '새로고침'}
+        <//>
+      </div>
     </div>
     <div class="mb-5 grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
       <${KpiCard} label="Judge 상태" value=${liveJudgeState} hint=${judge?.keeper_name?.trim() || 'live judge'} />
@@ -68,6 +79,7 @@ function GovernanceSummaryStrip() {
       <${KpiCard} label="관리자 승인 대기" value=${approvalCount} hint="live" />
     </div>
     <${JudgeStatusBar} />
+    ${governanceError.value ? html`<div class="mb-5 rounded-lg border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
   `
 }
 
@@ -98,29 +110,6 @@ function JudgeStatusBar() {
             </span>
           `
         : null}
-    </div>
-  `
-}
-
-function LiveGovernanceToolbar() {
-  return html`
-    <div class="mb-5">
-      <${Card} title="Live Judge" variant="compact">
-        <div class="flex flex-col gap-3">
-          <div class="flex flex-wrap items-center justify-end gap-3">
-            <${ActionButton}
-              variant="ghost"
-              size="lg"
-              class="rounded-xl border-transparent bg-[var(--white-3)] px-3.5 py-2 text-[13px] font-semibold text-text-muted hover:bg-white/10 hover:text-text-strong"
-              onClick=${refreshGovernance}
-              disabled=${governanceLoading.value}
-            >
-              ${governanceLoading.value ? '새로고침 중...' : '새로고침'}
-            <//>
-          </div>
-          ${governanceError.value ? html`<div class="rounded-lg border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
-        </div>
-      <//>
     </div>
   `
 }
@@ -490,7 +479,6 @@ export function Governance() {
     <div class="flex flex-col gap-0.5">
       <${KeeperApprovalAlertBanner} />
       <${GovernanceSummaryStrip} />
-      <${LiveGovernanceToolbar} />
       <${KeeperApprovalQueueSection} />
       <${JudgmentsSection} />
     </div>


### PR DESCRIPTION
## 사용자 리포트

> "Live Judge … 새로고침 Keeper HITL 승인 대기 … 0건 대기 … 현재 대시보드에서 처리할 keeper 승인 요청이 없습니다. **이거 더 잘 보이게 하시고**"

## 진단

`governance.ts`에 두 개의 카드가 중복된 역할을 하고 있었습니다.

| 요소 | 이전 | 관찰 |
|---|---|---|
| `GovernanceSummaryStrip` | h2 "거버넌스" + KPI 4개 + JudgeStatusBar | 실제 데이터 밀도 높음 |
| `LiveGovernanceToolbar` | Card title "Live Judge" + 새로고침 버튼 1개 + 에러 배너 (조건부) | **99%가 빈 공간** — 새로고침 버튼 하나 띄우려고 Card + padding + title bar까지 다 소비 |

"Live Judge"라는 **이름만** `LiveGovernanceToolbar`에 있고 **정보**는 전부 아래 섹션에 있어, 페이지 상단이 heading-without-content 구조가 됐습니다. 사용자가 봤던 인상의 출처.

## 변경

`LiveGovernanceToolbar`를 삭제하고 두 가지 책임을 `GovernanceSummaryStrip`에 통합:

- h2 title: \`거버넌스\` → \`Live Judge\` (테스트가 \`Live Judge\` + \`새로고침\` 텍스트를 확인하므로 라벨은 승격 이동)
- 새로고침 버튼: 제목 오른쪽 (generated_at 옆). lg → sm ghost 버튼. 페이지 chrome이 아닌 tool로 보이도록
- 에러 배너: KPI grid + JudgeStatusBar 아래에 그대로 노출

## 효과

- **-12 LOC** (44→32), 함수 1개 제거
- **~70px** vertical dead space 회수 → KPI grid + JudgeStatusBar + KeeperApprovalQueueSection가 더 촘촘히
- 0건 empty state 카드가 **Live Judge 헤더 밑에 바로** 오므로 시선이 empty → pending transition을 즉시 감지 가능
- 1건+일 때는 `KeeperApprovalAlertBanner`(기존)가 `ring-2` 테두리 + `AlertTriangle` + "지금 검토 →"로 이미 최상단 강조 중

## 테스트

```
Test Files  4 passed (4)
Tests       124 passed (124)
```

- `governance.test.ts` \"Live Judge\" + \"새로고침\" assert 유지 (텍스트 위치만 이동)
- typecheck 통과

## 리스크

- **없음**. 같은 기능을 더 적은 DOM으로 구현. `governanceError` 배너 위치가 Summary Strip 아래로 올라오지만 여전히 시각적 threshold 위. 리렌더 경로 동일 (store 기반).

## Non-goals

- `KeeperApprovalAlertBanner` 자체는 이미 충분히 강조돼 있어 건드리지 않음
- \`KeeperApprovalEmptyState\` primary/secondary 텍스트 간결화는 별도 cycle 후보 (이번 PR scope에 없음)

## 관련

- Gen32 iteration. Gen29 #7938 / Gen30 #7948 merged. Gen31 #7962 Draft.
- 사용자의 5개 리포트 중 나머지는 이전 PR에서 이미 해결됨:
  - `/api/v1/operator` 404 → #7633
  - placeholder pollution → ops/index.ts 재작성
  - 즉시 검토/최근 처리 count mismatch → ops/index.ts 단일 섹션화
  - 룸 전략 → Room module retirement (#7355)

🤖 Generated with [Claude Code](https://claude.com/claude-code)