### PR TITLE
feat(dashboard): ⌨🔗 quick-bind form — Enter-to-submit + per-connector channel ID hint

### DIFF
--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -2,7 +2,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { QuickBindForm, resetQuickBindState } from './connector-quick-bind'
+import {
+  QuickBindForm,
+  resetQuickBindState,
+  channelIdPlaceholder,
+} from './connector-quick-bind'
 import type { GateKeeperInfo } from '../api/gate'
 
 const mkKeeper = (name: string): GateKeeperInfo => ({ name } as GateKeeperInfo)
@@ -70,5 +74,63 @@ describe('QuickBindForm', () => {
     const body = bindCall?.[1]?.body as string
     expect(body).toContain('"channel_id":"1234567890"')
     expect(body).toContain('"keeper_name":"kpr-a"')
+  })
+
+  it('pressing Enter in the channel input submits the bind (no button click needed)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    const form = container.querySelector('[data-quick-bind="slack"]')!
+    const input = form.querySelector('input') as HTMLInputElement
+    input.value = 'C09TK9L4DV4'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+
+    const bindCall = fetchSpy.mock.calls.find(c => String(c[0]).includes('/api/v1/gate/connector/bind'))
+    expect(bindCall).toBeTruthy()
+    const body = bindCall?.[1]?.body as string
+    expect(body).toContain('"channel_id":"C09TK9L4DV4"')
+  })
+
+  it('renders the connector-specific placeholder (Slack shows C-prefix example, not Discord snowflake)', () => {
+    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    const input = container.querySelector('[data-quick-bind="slack"] input') as HTMLInputElement
+    const placeholder = input.getAttribute('placeholder') ?? ''
+    expect(placeholder).toContain('C0123ABCD')
+    expect(placeholder).not.toContain('18-19 digit')
+  })
+})
+
+describe('channelIdPlaceholder', () => {
+  it('discord placeholder is an 18-19 digit snowflake hint', () => {
+    const p = channelIdPlaceholder('discord')
+    expect(p).toMatch(/18-19 digit/)
+    expect(p).toMatch(/\d{18,19}/)
+  })
+
+  it('slack placeholder includes C-prefix and #-name variants', () => {
+    const p = channelIdPlaceholder('slack')
+    expect(p).toContain('C0123ABCD')
+    expect(p).toContain('#general')
+  })
+
+  it('telegram placeholder includes -100 format and @username variant', () => {
+    const p = channelIdPlaceholder('telegram')
+    expect(p).toContain('-100')
+    expect(p).toContain('@channel_name')
+  })
+
+  it('imessage placeholder shows phone + group id examples', () => {
+    const p = channelIdPlaceholder('imessage')
+    expect(p).toContain('+1')
+    expect(p).toContain('group id')
+  })
+
+  it('unknown connector falls through to a neutral example', () => {
+    expect(channelIdPlaceholder('xyz-unknown')).toContain('1234567890')
   })
 })

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -38,6 +38,34 @@ export function resetQuickBindState() {
   formState.value = {}
 }
 
+/** Pure: map a connector_id to the channel-id placeholder example that
+    matches that platform's native format. Keeps the hint close to what
+    the operator will copy-paste from the target app.
+
+    - discord  → 18-19 digit snowflake (right-click channel → Copy ID)
+    - imessage → +1XXXXXXXXXX or group id
+    - slack    → C-prefix or #name (right-click channel in Slack →
+                 Copy link → last path segment)
+    - telegram → -100… or @channel_name
+
+    Reference — Linear / Stripe onboarding: show an example that LOOKS
+    like what the operator will paste, not a generic "ID". Unknown
+    connectors fall through to a neutral example. */
+export function channelIdPlaceholder(connectorId: string): string {
+  switch (connectorId) {
+    case 'discord':
+      return '1234567890123456789 (18-19 digit snowflake)'
+    case 'slack':
+      return 'C0123ABCD 또는 #general'
+    case 'telegram':
+      return '-1001234567890 또는 @channel_name'
+    case 'imessage':
+      return '+1XXXXXXXXXX 또는 group id'
+    default:
+      return '1234567890 또는 #general'
+  }
+}
+
 async function submit(connectorId: string, entry: FormEntry) {
   const channel = entry.channelId.trim()
   if (!channel || !entry.keeperName) return
@@ -81,10 +109,18 @@ export function QuickBindForm({ connectorId, keepers }: {
         <${TextInput}
           id=${`qb-channel-${connectorId}`}
           value=${entry.channelId}
-          placeholder="1234567890 또는 #general"
+          placeholder=${channelIdPlaceholder(connectorId)}
           onInput=${(ev: InputEvent) => {
             const target = ev.currentTarget as HTMLInputElement
             setEntry(connectorId, { channelId: target.value })
+          }}
+          onKeyDown=${(ev: KeyboardEvent) => {
+            // Enter submits from either input; Shift+Enter falls through
+            // in case we ever swap this field for a multi-line input.
+            if (ev.key === 'Enter' && !ev.shiftKey) {
+              ev.preventDefault()
+              void submit(connectorId, getEntry(connectorId, keepers))
+            }
           }}
         />
       </div>


### PR DESCRIPTION
## Summary

Two tiny UX steals for the QuickBindForm (the single-row keeper↔channel binding at the top of each connector card).

### 1. Enter submits

**Reference — Linear / Stripe form pattern.** Paste → Enter → bound. No mouse reach for \`🔗 Bind\`.

\`\`\`ts
onKeyDown = ev => { if (ev.key === 'Enter' && !ev.shiftKey) submit() }
\`\`\`

### 2. Connector-specific placeholder

**Reference — Linear / Stripe onboarding.** Show an example that LOOKS like what the operator will paste, not a generic \"ID\".

| Connector | Placeholder example |
|---|---|
| discord | \`1234567890123456789 (18-19 digit snowflake)\` |
| slack | \`C0123ABCD 또는 #general\` |
| telegram | \`-1001234567890 또는 @channel_name\` |
| imessage | \`+1XXXXXXXXXX 또는 group id\` |

The placeholder stays as a visible hint, so the operator never has to remember which connector wants which format.

### Scope

- \`dashboard/src/components/connector-quick-bind.ts\` (+pure helper, +onKeyDown, placeholder wiring)
- \`dashboard/src/components/connector-quick-bind.test.ts\` (+2 DOM + 5 pure tests)

## Test plan

- [x] 11/11 vitest green (first try)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: Discord card → type channel ID → Enter submits without button click
- [ ] Manual: Slack card → placeholder shows \`C0123ABCD\`, not Discord's snowflake

🤖 Generated with [Claude Code](https://claude.com/claude-code)