### PR TITLE
feat(dashboard): CopyIdButton + copy on transport-health hot session ids

### DIFF
--- a/dashboard/src/components/common/copy-id-button.test.ts
+++ b/dashboard/src/components/common/copy-id-button.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { copyToClipboard } from './copyable-code'
+
+// happy-dom does not expose `document.execCommand` by default. Assign/delete
+// directly rather than spying on an undefined property.
+
+type ExecCommandFn = (cmd: string) => boolean
+// Loose-type escape hatch — `Document.execCommand` is declared non-optional
+// in lib.dom.d.ts, but happy-dom omits it, so we need to both assign and
+// delete the property through a typed-any reference.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const doc = document as any
+
+describe('copyToClipboard', () => {
+  const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+  const realExec: ExecCommandFn | undefined = doc.execCommand
+
+  function setClipboard(value: { writeText: (t: string) => Promise<void> } | undefined): void {
+    Object.defineProperty(navigator, 'clipboard', {
+      value,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  function setExec(fn: ExecCommandFn | undefined): void {
+    if (fn === undefined) {
+      delete doc.execCommand
+    } else {
+      doc.execCommand = fn
+    }
+  }
+
+  afterEach(() => {
+    setClipboard(realClipboard as unknown as { writeText: (t: string) => Promise<void> } | undefined)
+    setExec(realExec)
+    vi.restoreAllMocks()
+  })
+
+  it('uses navigator.clipboard.writeText when available and returns true on success', async () => {
+    const writeText = vi.fn(async () => {})
+    setClipboard({ writeText })
+
+    const ok = await copyToClipboard('abc-123')
+    expect(ok).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('abc-123')
+  })
+
+  it('falls back to execCommand when clipboard API throws and reports execCommand result', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('permission denied')
+    })
+    setClipboard({ writeText })
+    const execFn = vi.fn<ExecCommandFn>(() => true)
+    setExec(execFn)
+
+    const ok = await copyToClipboard('fallback-value')
+    expect(ok).toBe(true)
+    expect(execFn).toHaveBeenCalledWith('copy')
+  })
+
+  it('returns false when execCommand fails in the fallback path', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('permission denied')
+    })
+    setClipboard({ writeText })
+    setExec(() => false)
+
+    const ok = await copyToClipboard('x')
+    expect(ok).toBe(false)
+  })
+
+  it('returns false when execCommand itself throws', async () => {
+    setClipboard(undefined)
+    setExec(() => {
+      throw new Error('not allowed')
+    })
+
+    const ok = await copyToClipboard('x')
+    expect(ok).toBe(false)
+  })
+
+  it('removes the temporary textarea after use', async () => {
+    setClipboard(undefined)
+    setExec(() => true)
+    const before = document.querySelectorAll('textarea').length
+
+    await copyToClipboard('cleanup-test')
+    const after = document.querySelectorAll('textarea').length
+    expect(after).toBe(before)
+  })
+})

--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -1,0 +1,44 @@
+// CopyIdButton — compact icon-only copy button for UUIDs / session_ids
+// next to an existing <code>/mono text display. No container styling —
+// the caller controls layout. Reuses copyToClipboard from copyable-code.
+
+import { html } from 'htm/preact'
+import { Copy, Check } from 'lucide-preact'
+import { useState } from 'preact/hooks'
+import { showToast } from './toast'
+import { copyToClipboard } from './copyable-code'
+
+export interface CopyIdButtonProps {
+  value: string
+  label?: string
+  ariaLabel?: string
+  size?: number
+}
+
+export function CopyIdButton({ value, label, ariaLabel, size = 12 }: CopyIdButtonProps) {
+  const [justCopied, setJustCopied] = useState(false)
+
+  const onCopy = async (e: MouseEvent) => {
+    e.stopPropagation()
+    const ok = await copyToClipboard(value)
+    if (ok) {
+      setJustCopied(true)
+      showToast(label ? `Copied: ${label}` : 'Copied', 'success', 1400)
+      setTimeout(() => setJustCopied(false), 1200)
+    } else {
+      showToast('Copy failed', 'error')
+    }
+  }
+
+  return html`
+    <button
+      type="button"
+      class="inline-flex shrink-0 cursor-pointer items-center justify-center rounded p-0.5 text-[var(--text-dim)] opacity-60 transition-all hover:bg-[var(--white-8)] hover:text-[var(--text-body)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--accent-30)]"
+      aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
+      title=${ariaLabel || (label ? `Copy ${label}` : 'Copy')}
+      onClick=${onCopy}
+    >
+      ${justCopied ? html`<${Check} size=${size} />` : html`<${Copy} size=${size} />`}
+    </button>
+  `
+}

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -13,7 +13,7 @@ export interface CopyableCodeProps {
   ariaLabel?: string
 }
 
-async function copyToClipboard(text: string): Promise<boolean> {
+export async function copyToClipboard(text: string): Promise<boolean> {
   if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text)

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -13,6 +13,7 @@ import {
 } from '../api/transport-health'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { TextInput } from './common/input'
+import { CopyIdButton } from './common/copy-id-button'
 
 type StatusTone = 'ok' | 'warn' | 'bad'
 
@@ -485,7 +486,10 @@ export function TransportHealthPanel() {
                     ${filtered.map((session) => html`
                       <div key=${session.session_id} class="rounded-lg border border-card-border/60 bg-bg-1/60 p-3">
                         <div class="flex items-center justify-between gap-2 mb-1">
-                          <span class="text-[11px] font-mono text-text-strong">${compactId(session.session_id)}</span>
+                          <div class="flex min-w-0 items-center gap-1">
+                            <span class="truncate text-[11px] font-mono text-text-strong">${compactId(session.session_id)}</span>
+                            <${CopyIdButton} value=${session.session_id} label="session_id" />
+                          </div>
                           <span class="text-[10px] uppercase tracking-wider text-text-muted">${session.kind}</span>
                         </div>
                         <div class="text-[11px] text-text-body">queue ${session.queue_depth}</div>


### PR DESCRIPTION
## Summary
Pivot iteration — filter-axis seed space is saturated across this session + the parallel autocoder (18+ PRs on text-search). This ships a **non-search** axis so the loop keeps producing orthogonal value instead of colliding on the same panels.

- **New `common/copy-id-button.ts`** — icon-only copy button for UUID/session_id-style inline displays. Props `{ value, label, ariaLabel, size }`. Icon toggles `Copy → Check` on success, toast via `showToast`, `stopPropagation` to avoid wrapping-card click hijack.
- **`common/copyable-code.ts`** — promote `copyToClipboard` to an exported helper so the two buttons share the one clipboard-API-with-execCommand-fallback impl.
- **`transport-health.ts`** — wire `<${CopyIdButton} value=${session.session_id} label="session_id" />` next to the `compactId(...)` display on hot-queue session cards. Operators can one-click copy full UUIDs instead of squinting at the 8-char truncation.

## Tests
+5 cases in `common/copy-id-button.test.ts` covering: clipboard.writeText success, fallback when writeText throws, fallback `execCommand` returning false, fallback `execCommand` throwing, temporary textarea cleanup.

**Target suite: 5/5 pass. `tsc --noEmit`: clean.**

## Collision zone respected
Scope is 4 files, all additive or new:
- `common/copy-id-button.ts` (new)
- `common/copy-id-button.test.ts` (new)
- `common/copyable-code.ts` (export 1 line; no behaviour change)
- `transport-health.ts` (wraps 2 lines around existing `compactId` span; iter-15 filter untouched)

Does not overlap with any active or merged iter's filter patches.

## Test plan
- [ ] Hot session card shows copy button next to compactId
- [ ] Clicking button copies full `session_id`, shows toast + check icon for ~1.2s
- [ ] Button doesn't trigger card click/navigation
- [ ] Fallback works when `navigator.clipboard` is unavailable