### PR TITLE
feat(dashboard): ☑ per-step completion checklist on SetupGuideCard

### DIFF
--- a/dashboard/src/components/setup-guide-card.test.ts
+++ b/dashboard/src/components/setup-guide-card.test.ts
@@ -2,7 +2,12 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { SetupGuideCard, resetSetupGuideExpansionState } from './setup-guide-card'
+import {
+  SetupGuideCard,
+  resetSetupGuideExpansionState,
+  stepCompletionSummary,
+  countCompletedSteps,
+} from './setup-guide-card'
 
 async function flushUi(): Promise<void> {
   await Promise.resolve()
@@ -73,6 +78,51 @@ describe('SetupGuideCard', () => {
     expect(container.querySelector('ol')).toBeNull()
   })
 
+  it('checking a step updates the header from "N steps" to "1 of N done"', async () => {
+    render(html`<${SetupGuideCard} connectorId="discord" />`, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // Header starts as "N steps"
+    const progress = container.querySelector('[data-setup-progress="discord"]')!
+    expect(progress.textContent).toMatch(/\d+ steps/)
+
+    const firstCheckbox = container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement
+    expect(firstCheckbox).toBeTruthy()
+    firstCheckbox.click()
+    await flushUi()
+
+    const progressAfter = container.querySelector('[data-setup-progress="discord"]')!
+    expect(progressAfter.textContent).toMatch(/1 of \d+ done/)
+  })
+
+  it('unchecking a step reverts the header copy', async () => {
+    render(html`<${SetupGuideCard} connectorId="slack" />`, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    const box = container.querySelector('[data-setup-step="slack:0"]') as HTMLInputElement
+    box.click()
+    await flushUi()
+    expect(container.querySelector('[data-setup-progress="slack"]')!.textContent).toMatch(/1 of \d+ done/)
+    box.click()
+    await flushUi()
+    expect(container.querySelector('[data-setup-progress="slack"]')!.textContent).toMatch(/\d+ steps/)
+  })
+
+  it('step completion is keyed per connectorId — Discord progress does not leak into Telegram', async () => {
+    // Complete a step on Discord
+    render(html`<${SetupGuideCard} connectorId="discord" />`, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-setup-step="discord:0"]') as HTMLInputElement).click()
+    await flushUi()
+
+    // Switch to Telegram — header should still say "N steps" (not "X of N done")
+    render(html`<${SetupGuideCard} connectorId="telegram" />`, container)
+    await flushUi()
+    expect(container.querySelector('[data-setup-progress="telegram"]')!.textContent).toMatch(/\d+ steps/)
+  })
+
   it('keeps expand state independent per connectorId', async () => {
     // Open Discord card
     render(html`<${SetupGuideCard} connectorId="discord" />`, container)
@@ -84,5 +134,32 @@ describe('SetupGuideCard', () => {
     render(html`<${SetupGuideCard} connectorId="telegram" />`, container)
     await flushUi()
     expect(container.querySelector('button[aria-expanded]')?.getAttribute('aria-expanded')).toBe('false')
+  })
+})
+
+describe('stepCompletionSummary / countCompletedSteps', () => {
+  it('"5 steps" when zero completed, "3 of 5 done" otherwise', () => {
+    expect(stepCompletionSummary(0, 5)).toBe('5 steps')
+    expect(stepCompletionSummary(1, 5)).toBe('1 of 5 done')
+    expect(stepCompletionSummary(3, 5)).toBe('3 of 5 done')
+    expect(stepCompletionSummary(5, 5)).toBe('5 of 5 done')
+  })
+
+  it('negative completed treated as zero', () => {
+    expect(stepCompletionSummary(-1, 5)).toBe('5 steps')
+  })
+
+  it('countCompletedSteps returns 0 for undefined map', () => {
+    expect(countCompletedSteps(undefined, 5)).toBe(0)
+  })
+
+  it('countCompletedSteps counts only indices below total (stale index safety)', () => {
+    const m = { 0: true, 2: true, 99: true }
+    expect(countCompletedSteps(m, 5)).toBe(2) // 99 is out of bounds
+  })
+
+  it('countCompletedSteps ignores false/undefined entries', () => {
+    const m = { 0: true, 1: false, 2: true }
+    expect(countCompletedSteps(m, 5)).toBe(2)
   })
 })

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -11,6 +11,47 @@ import { CONNECTOR_SETUP_GUIDES } from './connector-setup-guides'
 // doesn't carry over an open card.
 const expandedFor = signal<Record<string, boolean>>({})
 
+// Per-connector per-step completion (indexed by step position in
+// CONNECTOR_SETUP_GUIDES). In-memory only; the guide changes rarely
+// enough that session-scoped tracking is fine, and a fresh reload
+// resetting to 0% matches "picking up the setup again" semantics.
+//
+// Reference — Stripe Dashboard onboarding + GitHub "set up your
+// account" checklist: each platform step is a checkbox the operator
+// ticks as they go, with a progress count in the header so the
+// operator can tell at a glance how far they are.
+const completedSteps = signal<Record<string, Record<number, boolean>>>({})
+
+/** Pure: render "5 steps" when nothing done, "3 of 5 done" once any
+    step is checked. Exposed so tests can pin the copy without mounting
+    a DOM. Rich Hickey: make the presentation layer not have to re-
+    derive what the data layer already knows. */
+export function stepCompletionSummary(completed: number, total: number): string {
+  if (completed <= 0) return `${total} steps`
+  return `${completed} of ${total} done`
+}
+
+/** Pure: count the `true` entries in a per-step completion map. Guards
+    against stale indices (step removed from the guide but still tracked
+    as complete) by capping at `total`. */
+export function countCompletedSteps(
+  completedMap: Record<number, boolean> | undefined,
+  total: number,
+): number {
+  if (completedMap === undefined) return 0
+  let n = 0
+  for (let i = 0; i < total; i++) {
+    if (completedMap[i] === true) n++
+  }
+  return n
+}
+
+function toggleStepCompletion(connectorId: string, stepIndex: number) {
+  const cur = completedSteps.value[connectorId] ?? {}
+  const next = { ...cur, [stepIndex]: !cur[stepIndex] }
+  completedSteps.value = { ...completedSteps.value, [connectorId]: next }
+}
+
 function ExternalLinkChip({ href, label }: { href: string; label: string }) {
   return html`
     <a
@@ -33,6 +74,8 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
   const toggle = () => {
     expandedFor.value = { ...expandedFor.value, [connectorId]: !isOpen }
   }
+  const completedMap = completedSteps.value[connectorId]
+  const doneCount = countCompletedSteps(completedMap, guide.steps.length)
 
   return html`
     <div class="mt-2 rounded-md border border-[var(--white-8)] bg-[var(--white-2)]">
@@ -49,22 +92,45 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           </span>
           <span class="font-medium">처음 설치하나요? · ${guide.title}</span>
         </div>
-        <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${guide.steps.length} steps</span>
+        <span
+          class=${`text-[10px] uppercase tracking-[0.14em] ${doneCount > 0 ? 'text-emerald-300/80' : 'text-[var(--text-dim)]'}`}
+          data-setup-progress=${connectorId}
+        >${stepCompletionSummary(doneCount, guide.steps.length)}</span>
       </button>
 
       ${isOpen
         ? html`
             <div id=${`setup-guide-${connectorId}`} class="border-t border-[var(--white-8)] px-3 py-2.5 text-[11px] text-[var(--text-body)]">
               <p class="mb-2 text-[var(--text-dim)]">${guide.intro}</p>
-              <ol class="ml-4 list-decimal space-y-1.5 marker:text-[var(--text-dim)]">
-                ${guide.steps.map(step => html`
-                  <li>
-                    <span>${step.text}</span>
-                    ${step.link
-                      ? html`<span class="ml-1.5"><${ExternalLinkChip} href=${step.link.href} label=${step.link.label} /></span>`
-                      : null}
-                  </li>
-                `)}
+              <ol class="ml-4 list-none space-y-1.5">
+                ${guide.steps.map((step, idx) => {
+                  const done = completedMap?.[idx] === true
+                  return html`
+                    <li class="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        class="mt-[3px] shrink-0 cursor-pointer accent-emerald-400"
+                        id=${`setup-step-${connectorId}-${idx}`}
+                        data-setup-step=${`${connectorId}:${idx}`}
+                        checked=${done}
+                        onClick=${(ev: Event) => {
+                          ev.stopPropagation()
+                          toggleStepCompletion(connectorId, idx)
+                        }}
+                        aria-label=${`step ${idx + 1} done`}
+                      />
+                      <label
+                        for=${`setup-step-${connectorId}-${idx}`}
+                        class=${`min-w-0 flex-1 cursor-pointer ${done ? 'text-[var(--text-dim)] line-through decoration-[var(--white-10)]' : ''}`}
+                      >
+                        <span>${step.text}</span>
+                        ${step.link
+                          ? html`<span class="ml-1.5"><${ExternalLinkChip} href=${step.link.href} label=${step.link.label} /></span>`
+                          : null}
+                      </label>
+                    </li>
+                  `
+                })}
               </ol>
               ${guide.references.length > 0
                 ? html`
@@ -83,4 +149,5 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
 
 export function resetSetupGuideExpansionState() {
   expandedFor.value = {}
+  completedSteps.value = {}
 }


### PR DESCRIPTION
## Summary

Steal from **Stripe Dashboard's \"Activate your account\"** + **GitHub's \"Complete your account setup\"**: each step of the \"처음 설치하나요?\" guide becomes a checkbox the operator ticks as they go, and the card header turns into a live progress counter.

| Before | After |
|---|---|
| \"5 steps\" (static count) | \"5 steps\" → \"3 of 5 done\" as operator ticks |
| Plain \`<ol>\` bullets | Checkbox + label, strike-through + muted on done |

### Design notes

- **In-memory tracking** (same pattern as existing \`expandedFor\` signal). Fresh reload → 0% — matches \"picking up from a clean desk\" semantics.
- **Pure helpers** \`stepCompletionSummary\` + \`countCompletedSteps\` so the copy decisions + stale-index safety are unit-testable without DOM.
- **\`stopPropagation\` on checkbox clicks** so ticking a step doesn't collapse the card.
- **Emerald header once any step done** — tiny visual reward, consistent with the rest of the dashboard's \"progress = emerald\" convention.

### Scope

- \`dashboard/src/components/setup-guide-card.ts\` (+pure helpers, checkbox render, progress copy)
- \`dashboard/src/components/setup-guide-card.test.ts\` (+3 DOM + 5 pure tests)

## Test plan

- [x] 13/13 vitest green (first try)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: Discord setup card → expand → tick step 1 → header flips to \"1 of 5 done\" in green → tick 2 → \"2 of 5 done\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)