### PR TITLE
fix(keeper): preserve raw cascade_name; canonicalize at point-of-use

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -46,12 +46,32 @@ let profile_json ~config_path name =
     ("candidates", `List (List.map candidate_to_json trace.candidates));
   ]
 
-let keeper_profile_json (entry : Keeper_registry.registry_entry) : Yojson.Safe.t =
-  `Assoc [
-    ("keeper", `String entry.name);
-    ("cascade_name", `String entry.meta.cascade_name);
-    ("canonical", `String (Keeper_cascade_profile.canonicalize entry.meta.cascade_name));
+(* Two-column contract consumed by the dashboard's "Keeper → Cascade
+   Mapping" table:
+
+   - [cascade_name]: raw value from the keeper meta (TOML / state JSON
+     round-trip).  NOT canonicalized here — downstream call sites
+     canonicalize at point-of-use.
+   - [canonical]: the cascade actually used by [Cascade_runtime] for
+     model resolution.
+
+   When the two differ, the UI surfaces that the keeper's declared
+   cascade is not a recognized variant (classic parse-don't-validate
+   drift).  When they match, the UI renders "—" in the canonical column.
+
+   Exposed as a pure helper so the contract can be exercised without
+   synthesizing a full [Keeper_registry.registry_entry]. *)
+let keeper_profile_fields ~keeper ~cascade_name : (string * Yojson.Safe.t) list =
+  [ ("keeper", `String keeper);
+    ("cascade_name", `String cascade_name);
+    ("canonical", `String (Keeper_cascade_profile.canonicalize cascade_name));
   ]
+
+let keeper_profile_json (entry : Keeper_registry.registry_entry) : Yojson.Safe.t =
+  `Assoc
+    (keeper_profile_fields
+       ~keeper:entry.name
+       ~cascade_name:entry.meta.cascade_name)
 
 let config_json () =
   let config_path = Cascade_runtime.cascade_config_path () in

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -39,6 +39,19 @@
     @since 0.6.0 *)
 val config_json : unit -> Yojson.Safe.t
 
+(** Build the per-keeper row of [keeper_profiles] without a full
+    {!Keeper_registry.registry_entry}. Exposed so the raw-vs-canonical
+    contract can be exercised in tests directly.
+
+    The [cascade_name] argument is forwarded as-is (not canonicalized);
+    the [canonical] field is [Keeper_cascade_profile.canonicalize
+    cascade_name]. When the two match, the UI renders "—" in the
+    canonical column.
+
+    @since 0.9.9 *)
+val keeper_profile_fields :
+  keeper:string -> cascade_name:string -> (string * Yojson.Safe.t) list
+
 (** JSON snapshot of the cascade health tracker.
 
     Shape:

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -126,7 +126,15 @@ let ensure_keeper_meta config name =
     let signal_changed =
       meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled in
     let denylist_changed = meta.tool_denylist <> target_denylist in
-    let cascade_changed = meta.cascade_name <> target_cascade_name in
+    (* [meta.cascade_name] may be a raw TOML/JSON value while
+       [target_cascade_name] is already canonicalized; canonicalize both
+       sides so a reload that only normalizes the spelling (e.g.
+       whitespace, historical aliases like "oas-keeper_unified") does not
+       register as a change. *)
+    let cascade_changed =
+      Keeper_cascade_profile.canonicalize meta.cascade_name
+      <> target_cascade_name
+    in
     let personality_changed =
       meta.goal <> target_goal
       || meta.short_goal <> target_short_goal
@@ -178,7 +186,14 @@ let ensure_keeper_meta config name =
         };
         room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
-        cascade_name = target_cascade_name;
+        (* Preserve raw [meta.cascade_name] when the cascade itself did
+           not change, even if another field (personality, policy, ...)
+           triggered a re-sync.  Otherwise a reconcile caused by an
+           unrelated field would silently canonicalize cascade_name and
+           hide drift from the dashboard [canonical] column. *)
+        cascade_name =
+          if cascade_changed then target_cascade_name
+          else meta.cascade_name;
         goal = target_goal;
         short_goal = target_short_goal;
         mid_goal = target_mid_goal;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -119,12 +119,19 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     cascade_name =
       (* TOML cascade_name takes precedence over runtime JSON when present.
          Without this, changing cascade_name in keepers/*.toml has no effect
-         until the runtime JSON is deleted.  See #6747. *)
+         until the runtime JSON is deleted.  See #6747.
+
+         Store the raw string as declared in TOML / state JSON.  Downstream
+         consumers ([Cascade_runtime], [Keeper_status_bridge],
+         [Admission_queue], ...) already canonicalize at point-of-use, so
+         preserving the raw value here lets the dashboard surface config
+         drift (keeper TOML referencing an unknown cascade name) via the
+         [canonical] column of [Dashboard_cascade.keeper_profile_json]. *)
       (match p.profile_defaults.cascade_name with
-       | Some name -> Keeper_cascade_profile.canonicalize name
+       | Some name -> name
        | None ->
          if String.trim old.cascade_name <> "" then
-           Keeper_cascade_profile.canonicalize old.cascade_name
+           old.cascade_name
          else Keeper_config.default_cascade_name);
     will =
       Option.value

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -863,8 +863,10 @@ let parse_keeper_identity (json : Yojson.Safe.t)
   in
   let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
   let pk_cascade_name =
+    (* Preserve the raw cascade_name as persisted in runtime JSON so the
+       dashboard can distinguish "declared in TOML" from "canonicalized
+       fallback".  Downstream code canonicalizes at point-of-use. *)
     Safe_ops.json_string ~default:Keeper_config.default_cascade_name "cascade_name" json
-    |> Keeper_cascade_profile.canonicalize
   in
   let pk_models =
     match json |> Yojson.Safe.Util.member "models" with

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -200,6 +200,67 @@ let test_slo_top_level_shape () =
   check bool "has status" true (List.mem_assoc "status" fs);
   check bool "has violations" true (List.mem_assoc "violations" fs)
 
+(* ── keeper_profile_json: raw vs canonical contract ──────────────── *)
+
+(* These tests exercise the pure [keeper_profile_json] projection directly
+   on a synthesized [Keeper_registry.registry_entry] shape.  They verify
+   the two-column contract the dashboard UI depends on:
+
+   - [cascade_name] = raw string from TOML / state JSON
+   - [canonical]   = [Keeper_cascade_profile.canonicalize] of the raw
+
+   When the two match (declared cascade is in the canonicalize variant),
+   the UI collapses the canonical cell to "—"; when they diverge (e.g.
+   TOML references an unknown cascade, or a legacy alias), the UI surfaces
+   the mismatch as config drift. *)
+
+let lookup fields key =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> s
+  | Some _ -> fail (Printf.sprintf "%s should be string" key)
+  | None -> fail (Printf.sprintf "%s missing" key)
+
+let test_keeper_profile_preserves_raw_unknown_cascade () =
+  (* Genuinely unknown cascade — not in [Keeper_cascade_profile.t] and
+     not a registered legacy alias. Typical sources: typos, personal
+     playground profiles, vendor drift. The raw string must survive so
+     the dashboard [canonical] column renders the mismatch. *)
+  let fs =
+    Masc_mcp.Dashboard_cascade.keeper_profile_fields
+      ~keeper:"cheolsu" ~cascade_name:"playground_experiment_xyz"
+  in
+  check string "keeper name forwarded" "cheolsu" (lookup fs "keeper");
+  check string "cascade_name preserves raw TOML value"
+    "playground_experiment_xyz" (lookup fs "cascade_name");
+  check string "canonical collapses unknown → keeper_unified"
+    "keeper_unified" (lookup fs "canonical");
+  check bool "raw and canonical differ → UI shows drift"
+    true (lookup fs "cascade_name" <> lookup fs "canonical")
+
+let test_keeper_profile_preserves_raw_legacy_alias () =
+  let fs =
+    Masc_mcp.Dashboard_cascade.keeper_profile_fields
+      ~keeper:"alice" ~cascade_name:"oas-keeper_unified"
+  in
+  check string "legacy alias preserved as raw"
+    "oas-keeper_unified" (lookup fs "cascade_name");
+  check string "legacy alias canonicalizes to keeper_unified"
+    "keeper_unified" (lookup fs "canonical");
+  check bool "raw and canonical differ → UI shows drift"
+    true (lookup fs "cascade_name" <> lookup fs "canonical")
+
+let test_keeper_profile_canonical_matches_when_raw_is_canonical () =
+  let fs =
+    Masc_mcp.Dashboard_cascade.keeper_profile_fields
+      ~keeper:"verdict" ~cascade_name:"keeper_unified"
+  in
+  check string "cascade_name stays canonical"
+    "keeper_unified" (lookup fs "cascade_name");
+  check string "canonical matches"
+    "keeper_unified" (lookup fs "canonical");
+  check bool "raw == canonical → UI renders —"
+    true (lookup fs "cascade_name" = lookup fs "canonical")
+
 (* ── Suite ─────────────────────────────────────────── *)
 
 let () =
@@ -220,5 +281,13 @@ let () =
       test_case "partial filtered drops ratio" `Quick test_slo_partial_filtered;
       test_case "exhaustion > 10 → violated" `Quick test_slo_exhaustion_breach;
       test_case "burn_rate math" `Quick test_slo_burn_rate_math;
+    ];
+    "keeper_profile_json", [
+      test_case "unknown cascade preserves raw, canonical shows drift"
+        `Quick test_keeper_profile_preserves_raw_unknown_cascade;
+      test_case "legacy alias preserves raw, canonicalizes at point-of-use"
+        `Quick test_keeper_profile_preserves_raw_legacy_alias;
+      test_case "canonical cascade: raw == canonical (UI renders —)"
+        `Quick test_keeper_profile_canonical_matches_when_raw_is_canonical;
     ];
   ]

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -21,7 +21,12 @@ let test_valid_trace_id () =
       check string "agent_name" "keeper-alice-agent" meta.agent_name
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
-let test_legacy_keeper_cascade_alias_normalized () =
+let test_legacy_keeper_cascade_alias_preserved_raw () =
+  (* Parse should preserve the raw cascade_name as declared in JSON so the
+     dashboard can surface config drift between the declared value and its
+     canonicalized resolution.  Legacy aliases (e.g. "oas-keeper_unified")
+     still resolve to the canonical at point-of-use via
+     [Keeper_cascade_profile.canonicalize]. *)
   let json =
     `Assoc
       [
@@ -34,8 +39,37 @@ let test_legacy_keeper_cascade_alias_normalized () =
   in
   match Keeper_types.meta_of_json json with
   | Ok meta ->
-      check string "legacy alias normalized"
-        Keeper_config.default_cascade_name meta.cascade_name
+      check string "legacy alias preserved raw"
+        "oas-keeper_unified" meta.cascade_name;
+      check string "legacy alias canonicalizes to default"
+        Keeper_config.default_cascade_name
+        (Keeper_cascade_profile.canonicalize meta.cascade_name)
+  | Error e -> fail ("expected Ok, got Error: " ^ e)
+
+let test_unknown_cascade_name_preserved_raw () =
+  (* Genuinely unknown user-declared cascade names (typos, personal
+     playground profiles, vendor drift) must survive parse so the
+     dashboard [canonical] column can show the mismatch.  Prior
+     behaviour silently collapsed them to "keeper_unified", masking
+     config drift. *)
+  let json =
+    `Assoc
+      [
+        ("name", `String "cheolsu");
+        ("agent_name", `String "keeper-cheolsu-agent");
+        ("trace_id", `String "cheolsu-001");
+        ("goal", `String "test");
+        ("cascade_name", `String "playground_experiment_xyz");
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta ->
+      check string "raw user-declared cascade preserved"
+        "playground_experiment_xyz" meta.cascade_name;
+      (* Point-of-use canonicalize still maps unknown → default. *)
+      check string "unknown canonicalizes to default"
+        Keeper_config.default_cascade_name
+        (Keeper_cascade_profile.canonicalize meta.cascade_name)
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
 let test_missing_trace_id () =
@@ -79,8 +113,10 @@ let () =
   run "keeper_identity_parse"
     [ ( "parse_keeper_identity"
       , [ test_case "valid trace_id" `Quick test_valid_trace_id
-        ; test_case "legacy keeper cascade alias normalized" `Quick
-            test_legacy_keeper_cascade_alias_normalized
+        ; test_case "legacy keeper cascade alias preserved raw" `Quick
+            test_legacy_keeper_cascade_alias_preserved_raw
+        ; test_case "unknown cascade name preserved raw" `Quick
+            test_unknown_cascade_name_preserved_raw
         ; test_case "missing trace_id field" `Quick test_missing_trace_id
         ; test_case "empty trace_id" `Quick test_empty_trace_id
         ; test_case "invalid trace_id (..)" `Quick test_invalid_trace_id


### PR DESCRIPTION
## 맥락

Dashboard Runtime 페이지의 **Keeper → Cascade Mapping** 패널이 11 keeper 전원에 대해 `CANONICAL = —` 를 표시한다. 즉 "declared == canonical" 로 보이는 상태인데, 실제 operator 의도와 runtime 동작을 구분할 수 없는 구조라 config drift 를 놓친다.

Upstream 에서 `Keeper_cascade_profile.t` variant 가 14개로 확장되면서 과거 "drift 8종" (`resilient_breaker` 등) 은 canonical 로 승격됐다. 하지만 legacy alias (`oas-keeper_unified`, `coding_first`) 와 typo/playground 값은 여전히 존재하고, 이들을 파서/TOML reload 가 즉시 canonicalize 해버리면 dashboard 에서 관찰이 불가능하다.

## 변경

Parse-Don't-Validate. 시스템 경계(parse, TOML reload) 에서 raw 값을 보존하고, 실제 resolve 가 필요한 지점에서만 canonicalize 한다.

| 지점 | before | after |
|---|---|---|
| `keeper_types.parse_keeper_identity` | JSON → canonicalize → store | JSON → store raw |
| `keeper_turn_up_update.update_keeper` | TOML → canonicalize → store | TOML → store raw |
| `keeper_runtime.ensure_keeper_meta` (비교) | `meta <> target` | `canonicalize(meta) <> target` |
| `keeper_runtime.ensure_keeper_meta` (assign) | 항상 `target_cascade_name` 로 덮어씀 | `cascade_changed` 일 때만 덮어씀 |
| `dashboard_cascade` | — | `keeper_profile_fields` pure helper 추출 (testability) |

Downstream (`Cascade_runtime`, `Keeper_status_bridge`, `Admission_queue`, `Oas_worker_named`) 는 이미 point-of-use 에서 canonicalize 하므로 model resolution 동작은 불변.

## Dashboard 결과

`Dashboard_cascade.keeper_profile_json` 이 반환하는 per-keeper row:

\`\`\`json
{ \"keeper\": \"alice\",
  \"cascade_name\": \"oas-keeper_unified\",
  \"canonical\": \"keeper_unified\" }
\`\`\`

- raw ≠ canonical → UI 에 drift 표시
- raw == canonical → UI 가 \"—\" 렌더링

## 테스트

- `test_dashboard_cascade` 14개 통과
  - 신규 3: unknown preserves raw, legacy alias preserves raw, canonical round-trip
- `test_keeper_identity_parse` 6개 통과
  - 신규 1: unknown cascade preserved raw (rename: legacy alias 테스트도 raw 보존 계약으로 갱신)
- 관련 keeper suite 5개 / 46 tests 모두 통과 (no regression)
  - test_keeper_cascade_profile, test_keeper_cascade_routing, test_keeper_runtime_config_ssot, test_keeper_runtime_denylist, test_keeper_runtime_toml

## 후속

이 PR 는 관찰성 파운데이션만 제공한다. Dashboard UI (Cascade Profiles + Keeper Mapping 위젯 병합, 한국어-only label sweep) 는 별도 PR 로 분리.

Part of: PR-1 of PR-1 → PR-2 → PR-3 → PR-4 series (dashboard 신뢰성 트랙).