### PR TITLE
feat(dashboard): 📋 inline "Copied" badge + 10 tests on CopyableCode

### DIFF
--- a/dashboard/src/components/common/copyable-code.test.ts
+++ b/dashboard/src/components/common/copyable-code.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { CopyableCode } from './copyable-code'
+
+const flushUi = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+describe('CopyableCode', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    vi.restoreAllMocks()
+  })
+
+  it('renders the command text inside a <code> element', () => {
+    render(html`<${CopyableCode} command="ls -la" />`, container)
+    const code = container.querySelector('code')
+    expect(code).toBeTruthy()
+    expect(code!.textContent).toBe('ls -la')
+  })
+
+  it('renders the optional label uppercase tag when provided', () => {
+    render(html`<${CopyableCode} command="npm test" label="test cmd" />`, container)
+    expect(container.textContent).toContain('test cmd')
+  })
+
+  it('default aria-label is "Copy command"; customized when label or ariaLabel provided', () => {
+    render(html`<${CopyableCode} command="x" />`, container)
+    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('Copy command')
+  })
+
+  it('aria-label uses "Copy <label>" when label set but ariaLabel missing', () => {
+    render(html`<${CopyableCode} command="x" label="start" />`, container)
+    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('Copy start')
+  })
+
+  it('explicit ariaLabel overrides the default computation', () => {
+    render(html`<${CopyableCode} command="x" label="start" ariaLabel="override-me" />`, container)
+    expect(container.querySelector('[data-copy-button]')!.getAttribute('aria-label')).toBe('override-me')
+  })
+
+  it('root carries data-copied="false" before any click', () => {
+    render(html`<${CopyableCode} command="x" />`, container)
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copied')).toBe('false')
+    expect(container.querySelector('[data-copied-badge]')).toBeNull()
+  })
+
+  it('clicking the copy button calls navigator.clipboard.writeText with the command', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    render(html`<${CopyableCode} command="echo hello" />`, container)
+    const btn = container.querySelector('[data-copy-button]') as HTMLButtonElement
+    btn.click()
+    await flushUi()
+
+    expect(writeText).toHaveBeenCalledWith('echo hello')
+  })
+
+  it('after successful copy: data-copied=true, badge rendered, icon swapped', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    render(html`<${CopyableCode} command="echo hi" label="greet" />`, container)
+    const btn = container.querySelector('[data-copy-button]') as HTMLButtonElement
+    btn.click()
+    await flushUi()
+
+    const root = container.querySelector('[data-copyable-code]')!
+    expect(root.getAttribute('data-copied')).toBe('true')
+    const badge = container.querySelector('[data-copied-badge]')
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toContain('Copied')
+    // aria-live=polite so screen readers get the state change
+    expect(badge!.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('falls back to execCommand when navigator.clipboard.writeText rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'))
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    // happy-dom doesn't define execCommand as an own property; install
+    // a stub first so vi.spyOn can see it.
+    ;(document as any).execCommand = () => true
+    const execSpy = vi.spyOn(document, 'execCommand').mockReturnValue(true)
+
+    render(html`<${CopyableCode} command="fallback" />`, container)
+    ;(container.querySelector('[data-copy-button]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(writeText).toHaveBeenCalledWith('fallback')
+    expect(execSpy).toHaveBeenCalledWith('copy')
+    // Fallback still counts as success → data-copied flips to true
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copied')).toBe('true')
+  })
+
+  it('leaves data-copied="false" when both clipboard paths fail', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    ;(document as any).execCommand = () => false
+    vi.spyOn(document, 'execCommand').mockReturnValue(false)
+
+    render(html`<${CopyableCode} command="x" />`, container)
+    ;(container.querySelector('[data-copy-button]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.querySelector('[data-copyable-code]')!.getAttribute('data-copied')).toBe('false')
+    expect(container.querySelector('[data-copied-badge]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -53,16 +53,29 @@ export function CopyableCode({ command, label, ariaLabel }: CopyableCodeProps) {
     }
   }
 
+  // Inline "Copied" confirmation — GitHub / VSCode gist pattern: the
+  // icon swap alone is too subtle when the operator's eyes are on the
+  // target terminal, so we flash a tiny text pill next to it for ~1.4s.
+  // aria-live="polite" makes screen readers announce the success even
+  // when they weren't focused on the button.
   return html`
-    <div class="group flex items-center gap-2 rounded-md border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-1.5 transition-colors hover:border-[var(--white-10)] hover:bg-[var(--white-4)]">
+    <div
+      class="group flex items-center gap-2 rounded-md border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-1.5 transition-colors hover:border-[var(--white-10)] hover:bg-[var(--white-4)]"
+      data-copyable-code
+      data-copied=${justCopied ? 'true' : 'false'}
+    >
       ${label
         ? html`<span class="shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${label}</span>`
         : null}
       <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-[11px] text-[var(--text-body)]">${command}</code>
+      ${justCopied
+        ? html`<span class="shrink-0 text-[10px] font-semibold text-emerald-300" data-copied-badge aria-live="polite">✓ Copied</span>`
+        : null}
       <button
         type="button"
         class="shrink-0 cursor-pointer rounded border border-transparent p-1 text-[var(--text-dim)] opacity-60 transition-opacity hover:bg-[var(--white-8)] hover:text-[var(--text-body)] focus-visible:opacity-100 group-hover:opacity-100"
         aria-label=${ariaLabel || (label ? `Copy ${label}` : 'Copy command')}
+        data-copy-button
         onClick=${onCopy}
       >
         ${justCopied ? html`<${Check} size=${14} />` : html`<${Copy} size=${14} />`}


### PR DESCRIPTION
## Summary

Two pickups for CopyableCode — the most-reused snippet chrome in the dashboard (~12 mount sites across onboarding, config, run.sh hints).

### 1. Inline \"✓ Copied\" badge

**Reference — GitHub gist / VSCode code snippet.** The existing Copy → Check icon swap is too subtle when the operator's eyes are on the target terminal. A tiny emerald text pill next to the icon flashes for the same ~1.4s window. \`aria-live=\"polite\"\` lets screen readers announce the success.

### 2. Test file from scratch (0 → 10 tests)

This component had **zero coverage** despite being the most-reused snippet chrome. Tests now pin:

- command + label rendering
- aria-label computation (default / label-based / explicit override)
- navigator.clipboard happy path
- execCommand fallback when writeText rejects
- \`data-copied=\"true\"\` ↔ badge render invariant
- \`data-copied=\"false\"\` stays when both clipboard paths fail

### Observability hooks

Added 4 \`data-*\` attributes so assertions don't depend on class names or visible text:
\`data-copyable-code\`, \`data-copied\`, \`data-copy-button\`, \`data-copied-badge\`.

### happy-dom gotcha

\`vi.spyOn(document, 'execCommand')\` fails because happy-dom doesn't define it as an own property. Install the stub first, then spy. Inline comment explains the trap.

## Test plan

- [x] 10/10 vitest green
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: click any onboarding card's \"start\" code row → \"✓ Copied\" badge flashes for ~1.4s next to the ✓ icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)