### PR TITLE
[dash-iter56] harness-health compaction + handoff lists filter

### DIFF
--- a/dashboard/src/components/harness-health-sections.test.ts
+++ b/dashboard/src/components/harness-health-sections.test.ts
@@ -12,8 +12,15 @@ import {
   verdictTone,
   verdictSummary,
   filterVerdicts,
+  filterPreCompactEvents,
+  filterHandoffEvents,
 } from './harness-health-sections'
-import type { HarnessHealthData, HarnessVerdictItem } from './harness-health-state'
+import type {
+  HarnessHealthData,
+  HarnessVerdictItem,
+  PreCompactEvent,
+  HandoffEvent,
+} from './harness-health-state'
 
 function makeVerdict(overrides: Partial<HarnessVerdictItem> = {}): HarnessVerdictItem {
   return {
@@ -426,5 +433,155 @@ describe('filterVerdicts', () => {
     ]
     expect(filterVerdicts(sparse, 'approve')).toHaveLength(1)
     expect(filterVerdicts(sparse, 'anything-else')).toHaveLength(0)
+  })
+})
+
+// ================================================================
+// filterPreCompactEvents
+// ================================================================
+
+function makePreCompact(overrides: Partial<PreCompactEvent> = {}): PreCompactEvent {
+  return {
+    timestamp: 1_700_000_000_000,
+    keeper_name: 'keeper-alpha',
+    context_ratio: 0.5,
+    message_count: 10,
+    token_count: 1000,
+    strategies: ['summarize'],
+    model_family: 'claude-sonnet',
+    trigger: 'ratio_threshold',
+    ...overrides,
+  }
+}
+
+describe('filterPreCompactEvents', () => {
+  const items: PreCompactEvent[] = [
+    makePreCompact({ keeper_name: 'keeper-alpha', trigger: 'ratio_threshold', model_family: 'claude-sonnet', strategies: ['summarize', 'drop_old'] }),
+    makePreCompact({ keeper_name: 'keeper-beta', trigger: 'manual', model_family: 'glm-4.6', strategies: ['handoff'] }),
+    makePreCompact({ keeper_name: 'keeper-gamma', trigger: 'token_cap', model_family: 'qwen-3', strategies: [] }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterPreCompactEvents(items, '')).toBe(items)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterPreCompactEvents(items, '   ')).toBe(items)
+  })
+
+  it('matches by keeper_name (case-insensitive)', () => {
+    const result = filterPreCompactEvents(items, 'ALPHA')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-alpha'])
+  })
+
+  it('matches by trigger substring', () => {
+    const result = filterPreCompactEvents(items, 'manual')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by model_family substring', () => {
+    const result = filterPreCompactEvents(items, 'glm')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by strategies entry substring', () => {
+    const result = filterPreCompactEvents(items, 'drop_old')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-alpha'])
+  })
+
+  it('matches strategies case-insensitively', () => {
+    const result = filterPreCompactEvents(items, 'HANDOFF')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterPreCompactEvents(items, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterPreCompactEvents(items, '  gamma  ')).toHaveLength(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = items.slice()
+    filterPreCompactEvents(items, 'alpha')
+    expect(items).toEqual(copy)
+  })
+})
+
+// ================================================================
+// filterHandoffEvents
+// ================================================================
+
+function makeHandoff(overrides: Partial<HandoffEvent> = {}): HandoffEvent {
+  return {
+    timestamp: 1_700_000_000_000,
+    keeper_name: 'keeper-alpha',
+    trace_id: 'abc12345deadbeef',
+    generation: 3,
+    next_generation: 4,
+    prev_trace_id: 'oldtrace0000',
+    new_trace_id: 'newtrace9999',
+    to_model: 'claude-sonnet',
+    ...overrides,
+  }
+}
+
+describe('filterHandoffEvents', () => {
+  const items: HandoffEvent[] = [
+    makeHandoff({ keeper_name: 'keeper-alpha', to_model: 'claude-sonnet', trace_id: 'alpha-trace-aaaa', prev_trace_id: 'prev-alpha', new_trace_id: 'new-alpha' }),
+    makeHandoff({ keeper_name: 'keeper-beta', to_model: 'glm-4.6', trace_id: 'beta-trace-bbbb', prev_trace_id: 'prev-beta', new_trace_id: 'new-beta' }),
+    makeHandoff({ keeper_name: 'keeper-gamma', to_model: null, trace_id: 'gamma-trace-cccc', prev_trace_id: null, new_trace_id: null }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterHandoffEvents(items, '')).toBe(items)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterHandoffEvents(items, '   ')).toBe(items)
+  })
+
+  it('matches by keeper_name (case-insensitive)', () => {
+    const result = filterHandoffEvents(items, 'BETA')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by to_model substring', () => {
+    const result = filterHandoffEvents(items, 'glm')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by trace_id substring', () => {
+    const result = filterHandoffEvents(items, 'gamma-trace')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-gamma'])
+  })
+
+  it('matches by prev_trace_id substring', () => {
+    const result = filterHandoffEvents(items, 'prev-alpha')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-alpha'])
+  })
+
+  it('matches by new_trace_id substring', () => {
+    const result = filterHandoffEvents(items, 'new-beta')
+    expect(result.map(r => r.keeper_name)).toEqual(['keeper-beta'])
+  })
+
+  it('handles null to_model safely', () => {
+    expect(filterHandoffEvents(items, 'keeper-gamma')).toHaveLength(1)
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterHandoffEvents(items, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterHandoffEvents(items, '  alpha  ')).toHaveLength(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = items.slice()
+    filterHandoffEvents(items, 'alpha')
+    expect(items).toEqual(copy)
   })
 })

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -45,6 +45,52 @@ export function filterVerdicts(
   })
 }
 
+/**
+ * Pure filter for pre-compact events.
+ *
+ * Case-insensitive substring match on `keeper_name`, `trigger`, `model_family`,
+ * and any entry of `strategies`. Empty/whitespace query returns the input
+ * reference unchanged so `useMemo` keeps referential equality. Input is
+ * never mutated.
+ */
+export function filterPreCompactEvents(
+  items: readonly PreCompactEvent[],
+  query: string,
+): readonly PreCompactEvent[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return items
+  return items.filter(item => {
+    if (item.keeper_name && item.keeper_name.toLowerCase().includes(needle)) return true
+    if (item.trigger && item.trigger.toLowerCase().includes(needle)) return true
+    if (item.model_family && item.model_family.toLowerCase().includes(needle)) return true
+    if (item.strategies.some(s => s.toLowerCase().includes(needle))) return true
+    return false
+  })
+}
+
+/**
+ * Pure filter for handoff events.
+ *
+ * Case-insensitive substring match on `keeper_name`, `to_model`, `trace_id`,
+ * `prev_trace_id`, and `new_trace_id`. Empty/whitespace query returns the
+ * input reference unchanged. Input is never mutated.
+ */
+export function filterHandoffEvents(
+  items: readonly HandoffEvent[],
+  query: string,
+): readonly HandoffEvent[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return items
+  return items.filter(item => {
+    if (item.keeper_name && item.keeper_name.toLowerCase().includes(needle)) return true
+    if (item.to_model && item.to_model.toLowerCase().includes(needle)) return true
+    if (item.trace_id && item.trace_id.toLowerCase().includes(needle)) return true
+    if (item.prev_trace_id && item.prev_trace_id.toLowerCase().includes(needle)) return true
+    if (item.new_trace_id && item.new_trace_id.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 // ── Helper functions ──
 
 export function railStatusLabel(status: RailStatus): string {
@@ -350,62 +396,100 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
 }
 
 export function PreCompactList({ section }: { section: HarnessSignalSection<PreCompactEvent> }) {
+  const query = useSignal('')
+  const visibleItems = useMemo(
+    () => filterPreCompactEvents(section.recent_events, query.value),
+    [section.recent_events, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
+
   if (section.recent_events.length === 0) {
     return html`<${EmptySignal} text=${emptyReasonText(section.empty_reason)} />`
   }
 
   return html`
     <div class="space-y-2">
-      ${section.recent_events.map(item => html`
-        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="flex items-start justify-between gap-3">
-            <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
-            <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
-          </div>
-          <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
-            <span>컨텍스트 ${Math.round(item.context_ratio * 100)}%</span>
-            <span>메시지 ${item.message_count}건</span>
-            <span>토큰 ${item.token_count.toLocaleString()}</span>
-            <span>${item.model_family || '모델 미확인'}</span>
-          </div>
-          <div class="mt-2 text-xs text-[var(--text-muted)]">${item.trigger}</div>
-          ${item.strategies.length > 0 ? html`
-            <div class="mt-2 flex flex-wrap gap-1">
-              ${item.strategies.map(strategy => html`
-                <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${strategy}</span>
-              `)}
+      <div class="flex justify-end">
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="keeper / trigger / model / strategy 필터"
+          aria-label="압축 이벤트 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && visibleItems.length === 0
+        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        : visibleItems.map(item => html`
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="flex items-start justify-between gap-3">
+              <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
+              <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
             </div>
-          ` : null}
-        </div>
-      `)}
+            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
+              <span>컨텍스트 ${Math.round(item.context_ratio * 100)}%</span>
+              <span>메시지 ${item.message_count}건</span>
+              <span>토큰 ${item.token_count.toLocaleString()}</span>
+              <span>${item.model_family || '모델 미확인'}</span>
+            </div>
+            <div class="mt-2 text-xs text-[var(--text-muted)]">${item.trigger}</div>
+            ${item.strategies.length > 0 ? html`
+              <div class="mt-2 flex flex-wrap gap-1">
+                ${item.strategies.map(strategy => html`
+                  <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${strategy}</span>
+                `)}
+              </div>
+            ` : null}
+          </div>
+        `)}
     </div>
   `
 }
 
 export function HandoffList({ section }: { section: HarnessSignalSection<HandoffEvent> }) {
+  const query = useSignal('')
+  const visibleItems = useMemo(
+    () => filterHandoffEvents(section.recent_events, query.value),
+    [section.recent_events, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
+
   if (section.recent_events.length === 0) {
     return html`<${EmptySignal} text=${emptyReasonText(section.empty_reason)} />`
   }
 
   return html`
     <div class="space-y-2">
-      ${section.recent_events.map(item => html`
-        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="flex items-start justify-between gap-3">
-            <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
-            <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+      <div class="flex justify-end">
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="keeper / model / trace_id 필터"
+          aria-label="세대 교체 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && visibleItems.length === 0
+        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        : visibleItems.map(item => html`
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="flex items-start justify-between gap-3">
+              <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
+              <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+            </div>
+            <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
+              <span>${item.generation}세대</span>
+              <span>다음 ${item.next_generation ?? '-'}세대</span>
+              <span class="font-mono">${item.trace_id.slice(0, 8)}</span>
+              <span>${item.to_model ?? '모델 미확인'}</span>
+            </div>
+            ${item.prev_trace_id ? html`
+              <div class="mt-2 text-xs text-[var(--text-muted)]">이전 ${item.prev_trace_id.slice(0, 8)} → 새 ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
+            ` : null}
           </div>
-          <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
-            <span>${item.generation}세대</span>
-            <span>다음 ${item.next_generation ?? '-'}세대</span>
-            <span class="font-mono">${item.trace_id.slice(0, 8)}</span>
-            <span>${item.to_model ?? '모델 미확인'}</span>
-          </div>
-          ${item.prev_trace_id ? html`
-            <div class="mt-2 text-xs text-[var(--text-muted)]">이전 ${item.prev_trace_id.slice(0, 8)} → 새 ${item.new_trace_id?.slice(0, 8) ?? '-'}</div>
-          ` : null}
-        </div>
-      `)}
+        `)}
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- Pure \`filterPreCompactEvents\` + \`filterHandoffEvents\` helpers (case-insensitive, trimmed, ref-equal on empty).
- Independent useSignal + useMemo per list.
- Leaves existing \`visibleItems\` filter (separate section) untouched.

## Test plan
- [x] Unit tests per helper (ref-equal / case-insensitive / trimmed / no-match / multi-field)
- [x] pnpm typecheck + lint green locally
- [ ] CI green