### PR TITLE
docs(design): retire capsule-execution-plan Slices A-C (team_session purge follow-up)

### DIFF
--- a/docs/design/masc-capsule-execution-plan.md
+++ b/docs/design/masc-capsule-execution-plan.md
@@ -9,8 +9,16 @@ code_refs:
 
 # MASC Capsule Execution Plan
 
-Updated: 2026-04-02
+Updated: 2026-04-17
 Scope: `masc-mcp` only
+
+> **Note (2026-04-17)**: The Immediate Slices catalog below (Slices A–C) targeted the
+> `team_session` subsystem, which has since been retired — see
+> `docs/spec/00-glossary.md` "Team Session (retired)" and
+> `docs/OAS-MASC-BOUNDARY.md` "Team-session swarm | Removed". The Product Thesis,
+> Boundary Rules, Execution Order, Social Runtime Invariants, and Review Gate
+> sections remain the current design stance. Slices A–C are preserved as
+> migration context only and no longer reflect active implementation targets.
 
 This document is the execution companion for work that stays inside the
 `masc-mcp` capsule.
@@ -121,9 +129,18 @@ Treat these as tested product contracts, not conventions:
 - no delegate-to-broken-worker path
 - no proof/report state that contradicts runtime history
 
-## Immediate Slices
+## Immediate Slices (Historical — team_session retired)
 
-### Slice A. Delegate-Readiness Contract
+The three slices below describe the delegate-readiness / worker-proof /
+runtime-visibility workstreams that were planned against the now-retired
+`team_session` subsystem. The named `lib/team_session/*` and
+`lib/tool_team_session_*` modules no longer exist in the repository. The
+slices are kept so follow-on work on the current coordination surface
+(`board_posts` + keeper FSM + canonical dashboard projections) can reuse
+the framing: "delegate readiness → proof read model → runtime/model
+visibility".
+
+### Slice A. Delegate-Readiness Contract (historical)
 
 Goal:
 
@@ -131,7 +148,7 @@ Goal:
 - delegate failures explain the blocked reason and guidance
 - denial leaves an event trail
 
-Primary modules:
+Primary modules (historical — all removed with the `team_session` purge):
 
 - `lib/team_session/team_session_engine_status.ml`
 - `lib/tool_team_session_step.ml`
@@ -139,36 +156,36 @@ Primary modules:
 - `test/test_tool_team_session_step_routing.ml`
 - `test/test_tool_team_session_misc.ml`
 
-Done when:
+Done when (historical target, not currently pursued):
 
 - checkpoint-only workers are not misreported as delegate-ready
 - in-flight workers are visibly blocked
 - delegate denial says why, not just “not ready”
 
-### Slice B. Worker-Proof Read Model
+### Slice B. Worker-Proof Read Model (historical)
 
 Goal:
 
 - status, proof, and dashboard all surface the same worker-run evidence summary
 
-Primary modules:
+Primary modules (historical — all removed with the `team_session` purge):
 
 - `lib/team_session/team_session_report_proof.ml`
 - `lib/dashboard/dashboard_proof.ml`
 - `lib/team_session/team_session_store.ml`
 
-Done when:
+Done when (historical target, not currently pursued):
 
 - worker proof metadata can be traced from session status to proof views
 - missing evidence is distinguishable from unavailable evidence
 
-### Slice C. Runtime / Model Visibility
+### Slice C. Runtime / Model Visibility (historical)
 
 Goal:
 
 - operator can answer “which worker ran where, with what model, under what tool surface?”
 
-Primary modules:
+Primary modules (historical — all removed with the `team_session` purge):
 
 - `lib/team_session/team_session_oas_bridge.ml`
 - `lib/team_session/team_session_engine_status.ml`


### PR DESCRIPTION
## Summary

`docs/design/masc-capsule-execution-plan.md` claimed `status: live` + `last_verified: 2026-04-17`, but its entire Immediate Slices catalog (A/B/C) referenced the `team_session` subsystem that was retired earlier (see `docs/spec/00-glossary.md` Team Session entry and `docs/OAS-MASC-BOUNDARY.md` `Team-session swarm | Removed` row).

9 dead refs across slices:
- `lib/team_session/team_session_engine_status.ml`
- `lib/team_session/team_session_oas_bridge.ml`
- `lib/team_session/team_session_report_proof.ml`
- `lib/team_session/team_session_store.ml`
- `lib/tool_team_session_step.ml`
- `lib/tool_team_session_step_exec.ml`
- `lib/dashboard/dashboard_proof.ml`
- `test/test_tool_team_session_step_routing.ml`
- `test/test_tool_team_session_misc.ml`

Surgical retire instead of wholesale deletion, consistent with Gen39 glossary and Gen41 keeper-spec approach:
- Added top-of-doc note explaining the retirement
- Renamed section to `Immediate Slices (Historical — team_session retired)` with framing kept as migration context for future coordination work on `board_posts` + keeper FSM
- Each slice now labeled `(historical)` with explicit `Primary modules (historical — all removed with the team_session purge)` qualifier
- Bumped `Updated:` from 2026-04-02 to 2026-04-17 to match `last_verified`

Product Thesis, Boundary Rules, Execution Order, Social Runtime Invariants, and Review Gate kept verbatim — those principles still hold.

Gate status: `scripts/check-doc-truth.sh` and `scripts/check-doc-code-refs.sh` both pass.

## Drift generation context

This is Gen42 of the iterative doc-drift loop. Previous generations:
- Gen33–39: retired-subsystem body sweeps (agent_ecosystem, message_schema, Chain Engine, Team Session glossary, CPv2)
- Gen40: elevated manual FSM to runtime CI gate (`scripts/check-doc-code-refs.sh`, #7966)
- Gen41: active-subsystem internal refactor lag (keeper module rename, #7972)
- Gen42: doc `status: live` vs subject-matter retired lifecycle mismatch

## Test plan
- [x] `bash scripts/check-doc-truth.sh` passes
- [x] `bash scripts/check-doc-code-refs.sh` passes
- [x] No frontmatter `code_refs` changes (already accurate — only kept live refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)