### PR TITLE
feat(dashboard): 🍞 cap visible toasts at 5 + test coverage (0→9)

### DIFF
--- a/dashboard/src/components/common/toast.test.ts
+++ b/dashboard/src/components/common/toast.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  showToast,
+  showActionToast,
+  ToastContainer,
+  MAX_VISIBLE_TOASTS,
+  _testResetToasts,
+  _testGetToasts,
+} from './toast'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('toast queue semantics', () => {
+  beforeEach(() => { _testResetToasts() })
+  afterEach(() => { _testResetToasts(); vi.useRealTimers() })
+
+  it('showToast enqueues a single toast with the provided type', () => {
+    showToast('first message', 'success')
+    const q = _testGetToasts()
+    expect(q.length).toBe(1)
+    expect(q[0]!.message).toBe('first message')
+    expect(q[0]!.type).toBe('success')
+  })
+
+  it('toasts are auto-dismissed after the duration', () => {
+    vi.useFakeTimers()
+    showToast('gone soon', 'success', 2000)
+    expect(_testGetToasts().length).toBe(1)
+    vi.advanceTimersByTime(2000)
+    expect(_testGetToasts().length).toBe(0)
+  })
+
+  it('queue caps at MAX_VISIBLE_TOASTS — oldest is evicted when the Nth+1 arrives', () => {
+    for (let i = 0; i < MAX_VISIBLE_TOASTS + 2; i++) {
+      showToast(`msg ${i}`, 'success', 60_000) // long duration so nothing auto-expires
+    }
+    const q = _testGetToasts()
+    expect(q.length).toBe(MAX_VISIBLE_TOASTS)
+    // The two oldest (msg 0 and msg 1) should be gone; the tail should win.
+    expect(q[0]!.message).toBe(`msg 2`)
+    expect(q[q.length - 1]!.message).toBe(`msg ${MAX_VISIBLE_TOASTS + 1}`)
+  })
+
+  it('error toasts land in the queue with type="error"', () => {
+    showToast('boom', 'error')
+    expect(_testGetToasts()[0]!.type).toBe('error')
+  })
+
+  it('showActionToast stores the action on the toast', () => {
+    const cb = vi.fn()
+    showActionToast('retry this', { label: 'Retry', onClick: cb }, 'error', 60_000)
+    const q = _testGetToasts()
+    expect(q.length).toBe(1)
+    // Public snapshot doesn't expose the action; assert via render instead.
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    try {
+      render(html`<${ToastContainer} />`, container)
+      const actionBtn = Array.from(container.querySelectorAll('button'))
+        .find(b => b.textContent === 'Retry') as HTMLButtonElement | undefined
+      expect(actionBtn).toBeTruthy()
+      actionBtn!.click()
+      expect(cb).toHaveBeenCalledOnce()
+    } finally {
+      render(null, container)
+      document.body.removeChild(container)
+    }
+  })
+})
+
+describe('ToastContainer rendering', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetToasts()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+    _testResetToasts()
+  })
+
+  it('renders nothing when the queue is empty', () => {
+    render(html`<${ToastContainer} />`, container)
+    // Empty queue returns null → no outlet markup.
+    expect(container.querySelector('[role="status"]')).toBeNull()
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('success toast renders with role="status" (non-alerting)', async () => {
+    showToast('ok', 'success', 60_000)
+    render(html`<${ToastContainer} />`, container)
+    await flushUi()
+    expect(container.querySelector('[role="status"]')).toBeTruthy()
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('error toast renders with role="alert" (loud, screen-reader interrupting)', async () => {
+    showToast('boom', 'error', 60_000)
+    render(html`<${ToastContainer} />`, container)
+    await flushUi()
+    expect(container.querySelector('[role="alert"]')).toBeTruthy()
+  })
+
+  it('close (×) button removes only its own toast, not neighbors', async () => {
+    showToast('keep', 'success', 60_000)
+    showToast('kill', 'error', 60_000)
+    render(html`<${ToastContainer} />`, container)
+    await flushUi()
+
+    // Find the toast element whose text is "kill" and click its close button
+    const errorToast = container.querySelector('[role="alert"]')!
+    const closeBtn = errorToast.querySelector('button[aria-label="닫기"]') as HTMLButtonElement
+    closeBtn.click()
+    await flushUi()
+
+    const remaining = _testGetToasts()
+    expect(remaining.length).toBe(1)
+    expect(remaining[0]!.message).toBe('keep')
+  })
+})

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -20,6 +20,25 @@ interface Toast {
 let _nextId = 0
 const toasts = signal<Toast[]>([])
 
+/** Sonner / react-hot-toast cap: more than ~5 visible at once degrades
+    into screen spam. When a sixth arrives we evict the oldest so the
+    new one lands without the stack growing unbounded.
+
+    Reference — Sonner's `visibleToasts` default is 3; react-hot-toast
+    doesn't cap out of the box but most teams wrap it with a cap. We
+    pick 5 here because masc-mcp often bursts 3-4 "sidecar started"
+    toasts on bulk Start All, and 5 leaves headroom for one incidental
+    toast on top. */
+export const MAX_VISIBLE_TOASTS = 5
+
+function enqueueToast(toast: Toast) {
+  const current = toasts.value
+  const next = current.length >= MAX_VISIBLE_TOASTS
+    ? [...current.slice(current.length - MAX_VISIBLE_TOASTS + 1), toast]
+    : [...current, toast]
+  toasts.value = next
+}
+
 const BORDER_COLOR: Record<ToastType, string> = {
   success: 'border-l-[var(--ok)]',
   warning: 'border-l-[var(--warn)]',
@@ -40,8 +59,7 @@ const ICON: Record<ToastType, () => ComponentChildren> = {
 
 export function showToast(message: string, type: ToastType = 'success', durationMs = 4000) {
   const id = ++_nextId
-  toasts.value = [...toasts.value, { id, message, type }]
-
+  enqueueToast({ id, message, type })
   setTimeout(() => {
     toasts.value = toasts.value.filter(t => t.id !== id)
   }, durationMs)
@@ -49,8 +67,7 @@ export function showToast(message: string, type: ToastType = 'success', duration
 
 export function showActionToast(message: string, action: ToastAction, type: ToastType = 'error', durationMs = 12000) {
   const id = ++_nextId
-  toasts.value = [...toasts.value, { id, message, type, action }]
-
+  enqueueToast({ id, message, type, action })
   setTimeout(() => {
     toasts.value = toasts.value.filter(t => t.id !== id)
   }, durationMs)
@@ -58,6 +75,19 @@ export function showActionToast(message: string, action: ToastAction, type: Toas
 
 function dismissToast(id: number) {
   toasts.value = toasts.value.filter(t => t.id !== id)
+}
+
+/** Test-only: wipe the toast queue so assertions don't see leftovers
+    from earlier tests. Not a public reset — the sequence id counter
+    is deliberately left intact so ids remain unique across tests. */
+export function _testResetToasts() {
+  toasts.value = []
+}
+
+/** Test-only: snapshot of the current toast queue. Keeps the signal
+    private while still letting tests assert on the stored shape. */
+export function _testGetToasts(): ReadonlyArray<{ id: number; message: string; type: ToastType }> {
+  return toasts.value.map(t => ({ id: t.id, message: t.message, type: t.type }))
 }
 
 export function ToastContainer() {


### PR DESCRIPTION
## Summary

Two pickups for the shared toast module:

### 1. Visible-toast cap (Sonner / react-hot-toast pattern)

\`MAX_VISIBLE_TOASTS = 5\` — more than that degrades into screen spam. masc-mcp's bulk **Start All** already bursts 3-4 \"sidecar 시작 요청\" toasts in quick succession, so one incidental toast on top can leave the operator looking at a 7-row stack fanning past the fold.

When a 6th toast arrives, the oldest is evicted. O(n) slice on a 5-element array, no ring buffer needed.

### 2. Test file from scratch (0 → 9 tests)

Toast module had **zero coverage**. Tests now pin:

- Enqueue + auto-dismiss after duration (fake timers)
- Queue cap eviction when 7 arrive in a row (keeps last 5)
- \`showActionToast\` stores + invokes the callback via its rendered button
- \`ToastContainer\` roles: \`role=\"status\"\` for success, \`role=\"alert\"\` for error
- Close button removes only its own toast, not neighbors
- Empty queue renders no outlet

### Design notes

- **Sequence id counter NOT reset** by \`_testResetToasts\` — ids stay monotonic across tests so \"same toast\" assertions hold.
- **Only additive surface area**: \`MAX_VISIBLE_TOASTS\`, \`enqueueToast\`, \`_testResetToasts\`, \`_testGetToasts\` are new. Existing \`showToast\` / \`showActionToast\` signatures unchanged.
- **Leaf module** — no conflict risk with stack PRs.

## Test plan

- [x] 9/9 vitest green (7s runtime)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: trigger Start All with 4 sidecars down + one manual toast → stack stays at 5, oldest rolls off

🤖 Generated with [Claude Code](https://claude.com/claude-code)