### PR TITLE
fix(dashboard): 🏷 TextInput/TextArea forward `id` — orphan <label for> a11y regression fix

### DIFF
--- a/dashboard/src/components/common/input.test.ts
+++ b/dashboard/src/components/common/input.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { TextInput, TextArea } from './input'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('TextInput', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders an <input> with the given value + placeholder', () => {
+    render(html`<${TextInput} value="hello" placeholder="type here" />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('hello')
+    expect(input.placeholder).toBe('type here')
+  })
+
+  it('defaults type to "text" when not provided', () => {
+    render(html`<${TextInput} />`, container)
+    expect(container.querySelector('input')!.getAttribute('type')).toBe('text')
+  })
+
+  it('type="password" is forwarded', () => {
+    render(html`<${TextInput} type="password" />`, container)
+    expect(container.querySelector('input')!.getAttribute('type')).toBe('password')
+  })
+
+  it('forwards id to the <input> so <label for> resolves (accessibility contract)', () => {
+    // This is the regression guard: TextInput previously dropped `id`
+    // silently, making <label for="..."> labels orphan. See the
+    // whitelist warning in input.ts.
+    render(html`<${TextInput} id="my-input" />`, container)
+    const input = container.querySelector('input')!
+    expect(input.id).toBe('my-input')
+
+    // And the end-to-end label lookup works:
+    const label = document.createElement('label')
+    label.setAttribute('for', 'my-input')
+    label.textContent = 'Click me'
+    container.appendChild(label)
+    const target = container.querySelector(`#${label.getAttribute('for')}`)
+    expect(target).toBe(input)
+  })
+
+  it('disabled=true sets the attribute so clicks/focus are no-ops', () => {
+    render(html`<${TextInput} disabled=${true} />`, container)
+    expect((container.querySelector('input') as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('aria-label is forwarded', () => {
+    render(html`<${TextInput} ariaLabel="search keeper" />`, container)
+    expect(container.querySelector('input')!.getAttribute('aria-label')).toBe('search keeper')
+  })
+
+  it('onInput fires with the current input value', async () => {
+    const spy = vi.fn()
+    render(html`<${TextInput} onInput=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.value = 'typed'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    const ev = spy.mock.calls[0]![0] as Event
+    expect((ev.target as HTMLInputElement).value).toBe('typed')
+  })
+
+  it('onKeyDown fires on key events', async () => {
+    const spy = vi.fn()
+    render(html`<${TextInput} onKeyDown=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('forwards name + autoComplete attributes', () => {
+    render(
+      html`<${TextInput} name="channel" autoComplete="off" />`,
+      container,
+    )
+    const input = container.querySelector('input')!
+    expect(input.getAttribute('name')).toBe('channel')
+    expect(input.getAttribute('autocomplete')).toBe('off')
+  })
+
+  it('extra `class` prop is appended to the base class string', () => {
+    render(html`<${TextInput} class="extra-hook" />`, container)
+    expect(container.querySelector('input')!.className).toContain('extra-hook')
+  })
+})
+
+describe('TextArea', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a <textarea> with the given value + rows', () => {
+    render(html`<${TextArea} value="body" rows=${5} />`, container)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(ta).toBeTruthy()
+    expect(ta.value).toBe('body')
+    expect(ta.getAttribute('rows')).toBe('5')
+  })
+
+  it('forwards id for <label for> accessibility', () => {
+    render(html`<${TextArea} id="notes" />`, container)
+    expect(container.querySelector('textarea')!.id).toBe('notes')
+  })
+
+  it('disabled=true renders disabled textarea', () => {
+    render(html`<${TextArea} disabled=${true} />`, container)
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).disabled).toBe(true)
+  })
+
+  it('onInput fires with the current textarea value', async () => {
+    const spy = vi.fn()
+    render(html`<${TextArea} onInput=${spy} />`, container)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.value = 'multi\nline'
+    ta.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+})

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -1,11 +1,19 @@
 // TextInput / TextArea — consistent form inputs
-// Replaces 6+ inline input patterns with consistent styling
+// Replaces 6+ inline input patterns with consistent styling.
+//
+// Props are whitelisted (no implicit spread), so EVERY prop a caller
+// expects to reach the DOM must be listed here explicitly. A missing
+// entry silently drops the attribute — most painfully for `id`, which
+// `<label for="...">` callers rely on for focus routing and screen
+// readers. If you add a new prop to the interface, add it to the JSX
+// below too.
 
 import { html } from 'htm/preact'
 
 const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface TextInputProps {
+  id?: string
   value?: string
   placeholder?: string
   disabled?: boolean
@@ -19,6 +27,7 @@ interface TextInputProps {
 }
 
 export function TextInput({
+  id,
   value,
   placeholder,
   disabled,
@@ -32,6 +41,7 @@ export function TextInput({
 }: TextInputProps) {
   return html`
     <input
+      id=${id}
       type=${type}
       class="${INPUT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
       value=${value}
@@ -47,6 +57,7 @@ export function TextInput({
 }
 
 interface TextAreaProps {
+  id?: string
   value?: string
   placeholder?: string
   rows?: number
@@ -58,6 +69,7 @@ interface TextAreaProps {
 }
 
 export function TextArea({
+  id,
   value,
   placeholder,
   rows,
@@ -69,6 +81,7 @@ export function TextArea({
 }: TextAreaProps) {
   return html`
     <textarea
+      id=${id}
       class="${INPUT_BASE} px-3 py-2 text-[13px] min-h-[80px] resize-y ${cx ?? ''}"
       placeholder=${placeholder}
       rows=${rows}


### PR DESCRIPTION
## Summary

Small but real accessibility bug: \`TextInput\`'s destructuring whitelist didn't include \`id\`, so callers like \`QuickBindForm\` that pass \`<TextInput id=\"qb-channel-discord\" />\` with a sibling \`<label for=\"qb-channel-discord\">\` were silently producing **orphan labels**. Screen-reader / mouse clicks on the label didn't route focus to the input. Same hole on \`TextArea\`.

### Why it slipped through

htm/preact function components do **NOT** implicitly spread unlisted props to children (unlike React's \`...rest\` idiom). A missing prop in the destructure silently drops the attribute without a type or runtime error.

### Fix

- \`id?: string\` added to both prop interfaces, forwarded to the element.
- New doc comment warning future editors: props are a strict whitelist — **add every prop you expect to reach the DOM**.

### Test file from scratch (0 → 14)

- **Regression guard**: TextInput / TextArea both verify \`id\` forwarding with an end-to-end \`<label for=...>\` lookup in happy-dom.
- Attribute forwarding (type / placeholder / value / disabled / aria-label / name / autoComplete / class / rows).
- Event forwarding (onInput, onKeyDown).

### Downstream

- \`connector-quick-bind.test.ts\` — 11/11 still pass.
- No behavior change for existing callers; \`id\` just works now.

## Test plan

- [x] 14/14 vitest green (2.7s runtime)
- [x] \`npx tsc --noEmit\` clean
- [x] Downstream connector-quick-bind tests still green
- [ ] Manual: open Discord quick-bind form → click the \"채널 ID\" label → focus lands on the input (not just the general form area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)