### PR TITLE
fix(cascade): split Accept_rejected from success; add evict_idle + rejected_in_window

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1778,6 +1778,12 @@ export interface CascadeHealthProvider {
   in_cooldown: boolean
   cooldown_expires_at: number | null
   events_in_window: number
+  /** Subset of [events_in_window] with outcome "rejected" — response
+   *  arrived but was rejected by the cascade's accept predicate. Split
+   *  so the dashboard can tell "provider down" from "provider returns
+   *  unusable output".
+   *  @since 0.160.0 — optional for backward compat with older servers. */
+  rejected_in_window?: number
 }
 
 export interface CascadeHealthResponse {

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -318,12 +318,17 @@ function HealthTable({
               <th class="text-right py-1">Success</th>
               <th class="text-right py-1">Consec. fail</th>
               <th class="text-right py-1">Events</th>
+              <th
+                class="text-right py-1"
+                title="응답은 왔지만 accept 게이트에서 거부된 이벤트 수"
+              >Rejected</th>
               <th class="text-right py-1">Cooldown</th>
             </tr>
           </thead>
           <tbody>
             ${filtered.map((p: CascadeHealthProvider) => {
               const tone = providerTone(p)
+              const rejected = p.rejected_in_window ?? 0
               return html`
               <tr class="border-b border-[var(--card-border)] last:border-b-0">
                 <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
@@ -331,6 +336,11 @@ function HealthTable({
                 <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
                 <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
                 <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
+                <td class="py-1 text-right tabular-nums">
+                  ${rejected > 0
+                    ? html`<span class="text-[var(--warn)]">${rejected}</span>`
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                </td>
                 <td class="py-1 text-right">
                   ${p.in_cooldown
                     ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -102,7 +102,13 @@ let cooldown_sec =
 
 (* ── Types ────────────────────────────────────── *)
 
-type outcome = Success | Failure
+(* [Rejected] is the third outcome kind introduced in 0.160.0.  It
+   represents "response arrived but the cascade's accept predicate
+   rejected it" — behaviorally equivalent to [Failure] (same cooldown
+   trigger, same success-rate impact) but visible to the dashboard so
+   operators can tell a down provider apart from one whose outputs are
+   consistently unusable. *)
+type outcome = Success | Failure | Rejected
 
 type event = {
   time: float;  (* Unix timestamp *)
@@ -159,7 +165,13 @@ let record t ~provider_key ~outcome ~now =
       state.consecutive_failures <- 0;
       (* Clear cooldown on success — provider recovered *)
       state.cooldown_until <- 0.0
-    | Failure ->
+    | Failure | Rejected ->
+      (* Rejected responses indicate unusable output (gate reject, empty
+         body, schema miss).  Treat identically to Failure for cooldown
+         and consecutive-failure tracking — a provider whose responses
+         are consistently rejected is as useless as one that never
+         responds.  The outcome tag is preserved in [events] so
+         [provider_info] can count Rejected separately for dashboards. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
       if state.consecutive_failures >= cooldown_threshold then
         state.cooldown_until <- now +. cooldown_sec)
@@ -169,6 +181,9 @@ let record_success t ~provider_key =
 
 let record_failure t ~provider_key =
   record t ~provider_key ~outcome:Failure ~now:(Unix.gettimeofday ())
+
+let record_rejected t ~provider_key =
+  record t ~provider_key ~outcome:Rejected ~now:(Unix.gettimeofday ())
 
 (* ── Queries ──────────────────────────────────── *)
 
@@ -244,6 +259,7 @@ type provider_info = {
   in_cooldown : bool;
   cooldown_expires_at : float option;
   events_in_window : int;
+  rejected_in_window : int;
 }
 
 let build_info_locked ~now ~key state =
@@ -251,6 +267,8 @@ let build_info_locked ~now ~key state =
   let total = List.length recent in
   let successes = List.length
       (List.filter (fun e -> e.outcome = Success) recent) in
+  let rejected = List.length
+      (List.filter (fun e -> e.outcome = Rejected) recent) in
   let rate =
     if total = 0 then 1.0
     else float_of_int successes /. float_of_int total
@@ -263,6 +281,7 @@ let build_info_locked ~now ~key state =
     in_cooldown = in_cd;
     cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
     events_in_window = total;
+    rejected_in_window = rejected;
   }
 
 let provider_info t ~provider_key =
@@ -272,7 +291,32 @@ let provider_info t ~provider_key =
     | Some state ->
       Some (build_info_locked ~now:(Unix.gettimeofday ()) ~key:provider_key state))
 
+(** Evict tracker entries whose rolling window has fully aged out and
+    whose cooldown has expired — they carry no information but would
+    still appear on the dashboard as stale rows.  [consecutive_failures]
+    is intentionally ignored: without an active cooldown or recent
+    events, the counter is just a leftover that will be reset on the
+    next call anyway. *)
+let evict_idle t =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    let to_remove =
+      Hashtbl.fold
+        (fun key state acc ->
+          let recent = prune_old_events now state.events in
+          if recent = [] && state.cooldown_until <= now then key :: acc
+          else acc)
+        t.providers
+        []
+    in
+    List.iter (Hashtbl.remove t.providers) to_remove;
+    List.length to_remove)
+
 let all_providers t =
+  (* Opportunistic maintenance: reaping aged-out entries here keeps the
+     dashboard's provider list stable without a separate maintenance
+     fiber.  Dashboard polls every 30s, so this is bounded. *)
+  let _ : int = evict_idle t in
   with_lock t (fun () ->
     let now = Unix.gettimeofday () in
     Hashtbl.fold

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -37,6 +37,32 @@ val record_success : t -> provider_key:string -> unit
     counter; triggers cooldown when threshold is reached. *)
 val record_failure : t -> provider_key:string -> unit
 
+(** Record a provider call where the response arrived but was rejected
+    by the cascade's [accept] predicate (e.g. empty body, schema gate).
+
+    Behaves like {!record_failure} for cooldown / weight purposes — a
+    provider whose outputs are consistently unusable should be skipped —
+    but is counted separately in [provider_info.rejected_in_window] so
+    the dashboard can distinguish "provider down" from "provider returns
+    garbage".
+
+    Prior to 0.160.0 this path called {!record_success} (the response
+    technically arrived), which silently masked gate drift: a provider
+    could rank 100% healthy while every call fell through to the next
+    cascade tier.
+
+    @since 0.160.0 *)
+val record_rejected : t -> provider_key:string -> unit
+
+(** Drop tracker entries whose rolling window is empty AND whose cooldown
+    has expired.  Intended as opportunistic maintenance — idle providers
+    carry no information but keep growing the hashtable (and pollute the
+    dashboard).
+
+    @return number of entries evicted.
+    @since 0.160.0 *)
+val evict_idle : t -> int
+
 (** Success rate in the rolling window (0.0 to 1.0).
     Returns 1.0 for unknown providers (optimistic default). *)
 val success_rate : t -> provider_key:string -> float
@@ -65,6 +91,7 @@ type provider_info = {
   in_cooldown : bool;
   cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
   events_in_window : int;             (** Events retained in rolling window *)
+  rejected_in_window : int;           (** Subset of [events_in_window] whose outcome was [Rejected]. @since 0.160.0 *)
 }
 
 (** Structured info for a single provider. Returns [None] if untracked.

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -125,6 +125,11 @@ let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
      | Some t -> `Float t
      | None -> `Null);
     ("events_in_window", `Int info.events_in_window);
+    (* rejected_in_window ⊆ events_in_window: responses that arrived
+       but were rejected by the cascade's accept predicate.  Split out
+       so dashboards can distinguish "provider down" from "provider
+       returns unusable output". *)
+    ("rejected_in_window", `Int info.rejected_in_window);
   ]
 
 let health_json () =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -449,7 +449,15 @@ let run_named
         on_success ~provider_key:provider_cfg.model_id;
         Ok result
       | Ok result ->
-        Cascade_health_tracker.(record_success global ~provider_key:provider_cfg.model_id);
+        (* Response arrived but failed the cascade's [accept] predicate
+           (empty body, schema gate, etc.).  Prior to 0.160.0 this
+           called [record_success] on the rationale that "the provider
+           answered"; that masked gate drift because provider health
+           stayed 100% while every call fell through to the next tier.
+           [record_rejected] behaves like a failure for cooldown /
+           weight but keeps the [Rejected] tag so the dashboard can
+           distinguish it from hard errors. *)
+        Cascade_health_tracker.(record_rejected global ~provider_key:provider_cfg.model_id);
         (* FSM: Accept_rejected → decide *)
         let reason = Printf.sprintf "response rejected by accept (model=%s)" result.response.model in
         let outcome = Cascade_fsm.Accept_rejected

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -59,7 +59,87 @@ let test_provider_info_reflects_events () =
   | None -> fail "provider_info returned None after record calls"
   | Some info ->
     check int "events_in_window = 2" 2 info.events_in_window;
-    check int "consecutive_failures = 1" 1 info.consecutive_failures
+    check int "consecutive_failures = 1" 1 info.consecutive_failures;
+    check int "no rejected events yet" 0 info.rejected_in_window
+
+(* ── Rejected outcome (0.160.0) ────────────────────── *)
+
+let test_rejected_counts_as_failure_for_cooldown () =
+  (* Cooldown_threshold defaults to 3.  Rejected must count toward the
+     same consecutive-failure streak as hard errors so a provider whose
+     outputs are unusable eventually stops being retried. *)
+  let t = H.create () in
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  check bool "3 consecutive rejections trip cooldown"
+    true (H.is_in_cooldown t ~provider_key:"p")
+
+let test_rejected_counts_against_success_rate () =
+  (* A provider whose responses are all rejected should rank 0.0 — not
+     100% as it did before 0.160.0 when [Accept_rejected] called
+     [record_success]. *)
+  let t = H.create () in
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  check (float 0.001) "success_rate = 0.0 after only rejections"
+    0.0 (H.success_rate t ~provider_key:"p")
+
+let test_rejected_separately_counted_in_provider_info () =
+  let t = H.create () in
+  H.record_success t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p";
+  match H.provider_info t ~provider_key:"p" with
+  | None -> fail "provider_info returned None"
+  | Some info ->
+    check int "events_in_window = 4" 4 info.events_in_window;
+    check int "rejected_in_window = 2 (failures excluded)" 2
+      info.rejected_in_window
+
+let test_success_after_rejected_clears_streak () =
+  let t = H.create () in
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  H.record_success t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p";
+  check bool "success resets rejected streak"
+    false (H.is_in_cooldown t ~provider_key:"p")
+
+(* ── evict_idle (0.160.0) ──────────────────────────── *)
+
+let test_evict_idle_drops_no_event_providers () =
+  (* Unknown providers were never recorded — they do not appear in
+     the tracker at all, so evict_idle is a no-op for them.  We model
+     an idle provider by recording an event, then simulating time
+     passage via direct state manipulation is not exposed, so instead
+     we create one active and one that was recorded long ago by
+     forcing event cleanup through the internal record path.
+
+     This test exercises the behavioral guarantee:
+     all_providers transparently removes entries whose rolling
+     window is empty (no events) and whose cooldown is not active. *)
+  let t = H.create () in
+  H.record_success t ~provider_key:"live";
+  (* A provider with zero recorded events is simply not in the
+     tracker.  But we can exercise the post-cooldown empty-window
+     path by recording then relying on window_sec elapse — not
+     practical in unit test.  Use the contract instead: evict_idle
+     is idempotent on a tracker where every provider has events. *)
+  check int "evict_idle returns 0 when everyone has fresh events"
+    0 (H.evict_idle t);
+  match H.provider_info t ~provider_key:"live" with
+  | Some _ -> ()
+  | None -> fail "evict_idle dropped a provider with fresh events"
+
+let test_evict_idle_returns_zero_when_all_active () =
+  let t = H.create () in
+  H.record_success t ~provider_key:"a";
+  H.record_failure t ~provider_key:"b";
+  check int "no eviction when all providers have recent events"
+    0 (H.evict_idle t)
 
 let () =
   run "cascade_health_tracker" [
@@ -78,5 +158,21 @@ let () =
         test_effective_weight_unknown_full;
       test_case "provider_info reflects events" `Quick
         test_provider_info_reflects_events;
+    ];
+    "rejected", [
+      test_case "rejected counts toward cooldown" `Quick
+        test_rejected_counts_as_failure_for_cooldown;
+      test_case "rejected lowers success_rate" `Quick
+        test_rejected_counts_against_success_rate;
+      test_case "rejected_in_window split from failures" `Quick
+        test_rejected_separately_counted_in_provider_info;
+      test_case "success clears rejected streak" `Quick
+        test_success_after_rejected_clears_streak;
+    ];
+    "evict_idle", [
+      test_case "zero eviction on active tracker" `Quick
+        test_evict_idle_drops_no_event_providers;
+      test_case "all-active → no eviction" `Quick
+        test_evict_idle_returns_zero_when_all_active;
     ];
   ]


### PR DESCRIPTION
## 맥락

Runtime 대시보드의 Health Tracker 에서 \`qwen3.5:35b-a3b-nvfp4 100%\` 이 보이는데, 사용자 관찰에 따르면 실제 keeper output 은 cascade fallback 이 자주 일어남. 원인: \`oas_worker_named\` 의 Accept_rejected 분기가 \`record_success\` 를 호출해서 **응답이 도착만 하면 "성공"으로 기록**됨.

응답은 왔지만 \`accept\` 게이트 (empty body / schema miss / 기타) 에서 거부되면, 소비자 입장에선 실패와 구분 안 된다. 대시보드 success_rate 가 100% 인데 실제로는 매 호출마다 다음 cascade tier 로 떨어지는 silent drift.

## 변경

### Backend — \`Cascade_health_tracker\`

- \`outcome\` variant 에 \`Rejected\` 추가. Cooldown / success_rate 계산에서는 \`Failure\` 와 동일하게 취급 (consec_failure 증가, cooldown 트리거) — provider 의 출력이 계속 거부되면 skip 해야 하는 건 down 과 똑같다.
- 이벤트 ring 에는 \`Rejected\` tag 보존 → \`provider_info.rejected_in_window\` 로 집계 (events_in_window 의 subset).
- \`record_rejected\` 신규 entry point.
- \`evict_idle\`: rolling window 빈 + cooldown 만료 provider 엔트리 제거. \`all_providers\` 초입에서 opportunistic 호출해서 stale row 가 쌓이지 않게.

### Call-site — \`Oas_worker_named\` (~L449)

\`\`\`ocaml
| Ok result ->
  Cascade_health_tracker.(record_rejected global ~provider_key:...);  (* was record_success *)
\`\`\`

### Dashboard

- \`health_json\` 에 \`rejected_in_window\` 필드 추가.
- TS \`CascadeHealthProvider.rejected_in_window?\` (optional, old server 호환).
- HealthTable 에 Rejected 칼럼 추가. \`> 0\` 일 때 \`--warn\` 색으로 강조.

## 테스트

- \`test_cascade_health_tracker\`: 7 → 13 케이스
  - 신규 4 (rejected 계열): 3회 연속 rejected → cooldown, rejected → success_rate 0.0, rejected_in_window 분리 집계, success 가 rejected streak 리셋
  - 신규 2 (evict_idle): 활성 tracker 에서 0 eviction, 상태 보존
- \`test_cascade_strategy\` (49) + \`test_dashboard_cascade\` (14) 회귀 없음
- TS typecheck clean, 47 vitest 통과

## 의도적으로 뺀 것

원래 PR 제목에 있던 "scope health tracker by cascade/keeper" 는 deliberate 하게 제외:
- (cascade × provider_key) 로 쪼개면 tracker 크기 N배, warmup 시간 N배
- 가장 흔한 실패 모드는 model-wide outage — cascade-specific 세분화는 신호 대비 노이즈 증가
- 필요하면 대시보드 쪽에 "이 provider 는 cascade X, Y, Z 에 참조됨" annotation 으로 해결 가능 (별도 PR)

## Dependency

#7978 (PR-1) merged 상태에서 동작. dashboard_cascade 는 backward-compatible.

Part of PR-1 → PR-2 → PR-3 → PR-4 dashboard reliability series.