### PR TITLE
chore(gitignore): ignore .tmp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ comments_*.txt
 all_comments_*.txt
 test-integration-*.txt
 tmp_edit/
+.tmp/
 
 # Runtime data directories (not source)
 data/economy/


### PR DESCRIPTION
## Summary

Add `.tmp/` to `.gitignore` so operator-local scratch (per `common/temporary-files.md`) isn't accidentally staged by `git add .`.

## Why

- `common/temporary-files.md` mandates temporary artifacts live under `.tmp/`.
- The existing `tmp_edit/` rule covers a sibling scratch path but not the canonical `.tmp/`.
- Today I moved `.tmp-iter12-diff.patch` (a /loop gen12 artifact that had been left at repo root) into `.tmp/` and noticed the gap.

## Trade-off

One-line ignore; no runtime or build impact. If someone ever intentionally wanted to check in a file under `.tmp/`, they'd need `git add -f`, which matches the intent (scratch = ephemeral).

## Test plan

- [ ] `git status` after dropping a scratch file into `.tmp/` shows nothing
- [ ] CI (build, lint) unchanged — no code paths touched