### PR TITLE
feat(dashboard): ☑ expand Checkbox prop whitelist (id/name/aria/value/testId) + tests (0→13)

### DIFF
--- a/dashboard/src/components/common/checkbox.test.ts
+++ b/dashboard/src/components/common/checkbox.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Checkbox } from './checkbox'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('Checkbox', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders an <input type="checkbox">', () => {
+    render(html`<${Checkbox} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    expect(cb).toBeTruthy()
+    expect(cb.type).toBe('checkbox')
+  })
+
+  it('checked=true renders a checked input', () => {
+    render(html`<${Checkbox} checked=${true} />`, container)
+    expect((container.querySelector('input') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('disabled=true disables the input', () => {
+    render(html`<${Checkbox} disabled=${true} />`, container)
+    expect((container.querySelector('input') as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('forwards id so <label for> can resolve (accessibility contract)', () => {
+    // Regression guard: Checkbox previously dropped `id`, making
+    // <label for="..."> orphan. A sighted-but-screen-reader user would
+    // hear "checkbox" with no name.
+    render(html`<${Checkbox} id="opt-in" />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    expect(cb.id).toBe('opt-in')
+
+    // End-to-end label association works:
+    const label = document.createElement('label')
+    label.setAttribute('for', 'opt-in')
+    label.textContent = 'Send me emails'
+    container.appendChild(label)
+    expect(container.querySelector(`#${label.getAttribute('for')}`)).toBe(cb)
+  })
+
+  it('forwards name for FormData serialization', () => {
+    render(html`<${Checkbox} name="newsletter" checked=${true} />`, container)
+    expect(container.querySelector('input')!.getAttribute('name')).toBe('newsletter')
+  })
+
+  it('forwards value — the string submitted when checked', () => {
+    render(html`<${Checkbox} name="tier" value="pro" checked=${true} />`, container)
+    expect(container.querySelector('input')!.getAttribute('value')).toBe('pro')
+  })
+
+  it('aria-label is forwarded (accessible name without external <label>)', () => {
+    render(html`<${Checkbox} ariaLabel="Accept terms" />`, container)
+    expect(container.querySelector('input')!.getAttribute('aria-label')).toBe('Accept terms')
+  })
+
+  it('aria-labelledby is forwarded (external-id label reference)', () => {
+    render(html`<${Checkbox} ariaLabelledby="tos-heading" />`, container)
+    expect(container.querySelector('input')!.getAttribute('aria-labelledby')).toBe('tos-heading')
+  })
+
+  it('testId renders as data-testid (E2E stable hook)', () => {
+    render(html`<${Checkbox} testId="optin-newsletter" />`, container)
+    expect(container.querySelector('input')!.getAttribute('data-testid')).toBe('optin-newsletter')
+  })
+
+  it('onChange fires with the new checked boolean when user toggles on', async () => {
+    const spy = vi.fn()
+    render(html`<${Checkbox} onChange=${spy} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    cb.checked = true
+    cb.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]![0]).toBe(true)
+  })
+
+  it('onChange fires with false when user toggles off', async () => {
+    const spy = vi.fn()
+    render(html`<${Checkbox} checked=${true} onChange=${spy} />`, container)
+    const cb = container.querySelector('input') as HTMLInputElement
+    cb.checked = false
+    cb.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]![0]).toBe(false)
+  })
+
+  it('extra `class` prop is appended to the base class string', () => {
+    render(html`<${Checkbox} class="extra-hook" />`, container)
+    expect(container.querySelector('input')!.className).toContain('extra-hook')
+  })
+
+  it('base classes are still present even when `class` extension is given', () => {
+    render(html`<${Checkbox} class="extra-hook" />`, container)
+    const cn = container.querySelector('input')!.className
+    // Accent + rounded are part of CHECKBOX_BASE; regression would strip them.
+    expect(cn).toContain('rounded')
+    expect(cn).toContain('accent-[var(--accent)]')
+  })
+})

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -1,3 +1,15 @@
+// Checkbox — consistent checkbox primitive for forms and toggles.
+//
+// Props are a strict whitelist — htm/preact function components do NOT
+// implicitly spread unlisted props to children. This matters more for
+// <input type="checkbox"> than for most primitives: without `id` a
+// `<label for="...">` can't resolve, and without `ariaLabel` /
+// `ariaLabelledby` a screen reader reading the checkbox alone has no
+// accessible name at all. If you add a new prop to the interface below,
+// also add it to the JSX — missing entries silently drop, which is how
+// two earlier callers (ActionButton pre-refactor, TextInput pre-refactor)
+// ended up shipping orphan labels.
+
 import { html } from 'htm/preact'
 
 const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
@@ -6,10 +18,52 @@ interface CheckboxProps {
   checked?: boolean
   disabled?: boolean
   class?: string
+  /** Forwarded to the DOM id so `<label for="...">` can resolve. Without
+      this, external labels are orphan and screen readers read "checkbox"
+      with no name. */
+  id?: string
+  /** Form field name for native submit + FormData serialization. */
+  name?: string
+  /** Accessible name when no visible label is associated via `for`. */
+  ariaLabel?: string
+  /** Reference another element's id as the accessible name. Useful when
+      the label sits near the checkbox but isn't wrapped around it. */
+  ariaLabelledby?: string
+  /** The submitted form value when the checkbox is checked. Distinct
+      from `checked`: `value` is the string that ends up in FormData. */
+  value?: string
+  /** Rendered as `data-testid` so E2E / unit tests can target this
+      checkbox without coupling to DOM position. */
+  testId?: string
   onChange?: (checked: boolean) => void
 }
 
-export function Checkbox({ checked, disabled, class: cx, onChange }: CheckboxProps) {
+export function Checkbox({
+  checked,
+  disabled,
+  class: cx,
+  id,
+  name,
+  ariaLabel,
+  ariaLabelledby,
+  value,
+  testId,
+  onChange,
+}: CheckboxProps) {
   const handleChange = (e: Event) => { onChange?.((e.target as HTMLInputElement).checked) }
-  return html`<input type="checkbox" class="${CHECKBOX_BASE} ${cx ?? ''}" checked=${checked} disabled=${disabled} onChange=${handleChange} />`
+  return html`
+    <input
+      type="checkbox"
+      id=${id}
+      name=${name}
+      value=${value}
+      class="${CHECKBOX_BASE} ${cx ?? ''}"
+      checked=${checked}
+      disabled=${disabled}
+      aria-label=${ariaLabel}
+      aria-labelledby=${ariaLabelledby}
+      data-testid=${testId}
+      onChange=${handleChange}
+    />
+  `
 }


### PR DESCRIPTION
## Summary

Third chip in the whitelist-drop cleanup after #7987 (`TextInput`) and #7995 (`ActionButton`). `Checkbox` had the worst a11y gap of the three: without `id`, `<label for=\"...\">` can't resolve, so a screen-reader user hears "checkbox" with no accessible name.

## Added props (all optional, backward-compat)

| Prop | Purpose |
|------|---------|
| `id` | `<label for=\"...\">` / programmatic focus |
| `name` | FormData serialization on native submit |
| `ariaLabel` | Accessible name without an external `<label>` |
| `ariaLabelledby` | Reference an external label by id |
| `value` | Submitted form value when checked |
| `testId` | `data-testid` for E2E/unit stable hooks |

Module doc now warns about htm/preact whitelist discipline (mirrors `input.ts`/`button.ts`).

## Tests (13, 0→13)

- `type=\"checkbox\"` default render
- `checked` / `disabled` forwarding
- **`id` → end-to-end `<label for>` lookup regression guard**
- `name` + `value` FormData attrs
- `aria-label` + `aria-labelledby` + `data-testid`
- `onChange` with `true` (toggle on) and `false` (toggle off)
- `class` append + base class preservation

## Callers

Only real caller today is `tool-executor/schema-field.ts` (pass-through with `checked` + `onChange`), which continues to work unchanged.

## Reference

Continuation of the form-primitive whitelist sweep. Pattern source: Material UI / Chakra / HeadlessUI rich-prop form primitives.

## Test plan

- [x] `npx vitest run src/components/common/checkbox.test.ts` → 13/13 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)