### PR TITLE
feat(dashboard): CopyIdButton next to truncated trace_id displays

### DIFF
--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -6,6 +6,7 @@ import { useSignal } from '@preact/signals'
 import { navigate } from '../router'
 import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
+import { CopyIdButton } from './common/copy-id-button'
 import type {
   RailStatus,
   GateDistribution,
@@ -482,7 +483,10 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
             <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
               <span>${item.generation}세대</span>
               <span>다음 ${item.next_generation ?? '-'}세대</span>
-              <span class="font-mono">${item.trace_id.slice(0, 8)}</span>
+              <span class="inline-flex items-center gap-1">
+                <span class="font-mono" title=${item.trace_id}>${item.trace_id.slice(0, 8)}</span>
+                <${CopyIdButton} value=${item.trace_id} label="trace_id" size=${10} />
+              </span>
               <span>${item.to_model ?? '모델 미확인'}</span>
             </div>
             ${item.prev_trace_id ? html`

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -12,6 +12,7 @@ import { TimeAgo } from './common/time-ago'
 import { toolCategory, durationColor, formatArgs, prettyArgs, formatDuration, summarizeEntries } from './tool-call-shared'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
+import { CopyIdButton } from './common/copy-id-button'
 import { keeperHeartbeats } from '../store'
 import { isConnected } from '../sse'
 import { TRAJECTORY_HEARTBEAT_STALE_MS, LIVENESS_TICK_MS, CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from '../config/constants'
@@ -429,7 +430,10 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
             : isOnline
               ? html`<span class="text-[10px] text-[var(--text-dim)]">online</span>`
               : null}
-          <span class="text-[10px] font-mono text-[var(--text-dim)]">trace: ${data.trace_id.slice(0, 8)}</span>
+          <span class="inline-flex items-center gap-1">
+            <span class="text-[10px] font-mono text-[var(--text-dim)]" title=${data.trace_id}>trace: ${data.trace_id.slice(0, 8)}</span>
+            <${CopyIdButton} value=${data.trace_id} label="trace_id" size=${10} />
+          </span>
           <span class="text-[10px] text-[var(--text-dim)]">gen ${data.generation}</span>
           ${contextRatio != null
             ? html`<span class="text-[10px] font-mono ${contextRatio > CONTEXT_RATIO_CRITICAL ? 'text-[var(--bad)]' : contextRatio > CONTEXT_RATIO_WARN ? 'text-[var(--warn)]' : 'text-[var(--text-dim)]'}">ctx ${(contextRatio * 100).toFixed(0)}%</span>`


### PR DESCRIPTION
## Summary
- Two panels truncate `trace_id` to `slice(0, 8)` with no way to see or copy full value.
- Add `CopyIdButton` (size=10) next to each truncated span + `title=` tooltip.

## Wire-up points
1. **harness-health-sections** (~line 485): per verdict row in \`recent_events\` list.
2. **keeper-trajectory-timeline** (~line 432): per-session header ("trace: ${short}").

## Test plan
- [x] \`pnpm typecheck\` clean
- [ ] CI: Build and Test / Dashboard / Lint
- [ ] Visual spot-check (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)