### PR TITLE
feat(dashboard): add K×M ConnectorKeeperMatrix under all-connectors view

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ConnectorKeeperMatrix,
+  deriveMatrix,
+  type MatrixData,
+} from './connector-keeper-matrix'
+import type { GateConnectorInfo } from '../api/gate'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+
+const mkConnector = (id: string, overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
+  connector_id: id,
+  display_name: id,
+  channel: id,
+  available: overrides.available ?? false,
+  gate_healthy: overrides.gate_healthy ?? null,
+  configured_bindings: overrides.configured_bindings ?? [],
+  capabilities: overrides.capabilities ?? ['bindings'],
+  ...(overrides as object),
+}) as GateConnectorInfo
+
+const mkKeeper = (name: string): GateKeeperInfo =>
+  ({ name }) as GateKeeperInfo
+
+describe('deriveMatrix', () => {
+  it('returns 4 columns in known order', () => {
+    const m = deriveMatrix([], [])
+    expect(m.columns).toEqual(['discord', 'imessage', 'slack', 'telegram'])
+  })
+
+  it('cell is na when keeper exists but connector is offline', () => {
+    const connectors = [mkConnector('discord', { available: false })]
+    const keepers = [mkKeeper('alpha')]
+    const m = deriveMatrix(connectors, keepers)
+    const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
+    const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
+    expect(discordCell.state).toBe('na')
+  })
+
+  it('cell is unbound when connector is up but no binding exists', () => {
+    const connectors = [mkConnector('discord', { available: true })]
+    const keepers = [mkKeeper('alpha')]
+    const m = deriveMatrix(connectors, keepers)
+    const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
+    const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
+    expect(discordCell.state).toBe('unbound')
+  })
+
+  it('cell is bound with count when binding exists', () => {
+    const connectors = [mkConnector('discord', {
+      available: true,
+      configured_bindings: [
+        { channel_id: 'c1', keeper_name: 'alpha' },
+        { channel_id: 'c2', keeper_name: 'alpha' },
+      ] as never,
+    })]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    const firstRow = m.rows[0]!
+    const cell = firstRow.cells.find(c => c.connectorId === 'discord')!
+    expect(cell.state).toBe('bound')
+    expect(cell.bindingCount).toBe(2)
+  })
+
+  it('surfaces unknown keepers referenced by bindings', () => {
+    const connectors = [mkConnector('slack', {
+      available: true,
+      configured_bindings: [{ channel_id: 'c1', keeper_name: 'ghost' }] as never,
+    })]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    expect(m.rows.some(r => r.keeperName === 'ghost' && !r.known)).toBe(true)
+    const ghostRow = m.rows.find(r => r.keeperName === 'ghost')!
+    const slackCell = ghostRow.cells.find(c => c.connectorId === 'slack')!
+    expect(slackCell.state).toBe('unknown')
+  })
+
+  it('totals reflect live connectors and total bindings', () => {
+    const connectors = [
+      mkConnector('discord', {
+        available: true,
+        configured_bindings: [{ channel_id: 'c1', keeper_name: 'alpha' }] as never,
+      }),
+      mkConnector('slack', { available: false }),
+    ]
+    const m = deriveMatrix(connectors, [mkKeeper('alpha'), mkKeeper('beta')])
+    expect(m.totals.knownKeepers).toBe(2)
+    expect(m.totals.liveConnectors).toBe(1)
+    expect(m.totals.totalBindings).toBe(1)
+    expect(m.totals.unknownKeepers).toBe(0)
+  })
+})
+
+describe('ConnectorKeeperMatrix', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('renders empty-state copy when no keepers exist', () => {
+    const matrix: MatrixData = deriveMatrix([], [])
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    expect(container.textContent).toContain('No keepers yet')
+  })
+
+  it('renders a cell button for each (keeper × connector) pair', () => {
+    const connectors = [
+      mkConnector('discord', { available: true, configured_bindings: [{ channel_id: 'c1', keeper_name: 'alpha' }] as never }),
+    ]
+    const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
+    const matrix = deriveMatrix(connectors, keepers)
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    const cells = container.querySelectorAll('[data-matrix-cell]')
+    // 2 keepers × 4 connectors = 8 cells
+    expect(cells.length).toBe(8)
+    // alpha × discord is bound
+    const bound = container.querySelector('[data-matrix-cell="alpha:discord"]')!
+    expect(bound.getAttribute('data-matrix-state')).toBe('bound')
+  })
+})

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -1,0 +1,264 @@
+// ConnectorKeeperMatrix — K×M binding grid.
+//
+// Rows   = keepers (from `fetchGateKeepers` + any referenced-but-unknown
+//          keepers surfaced by connector configured_bindings).
+// Cols   = the 4 known connectors (discord, imessage, slack, telegram).
+// Cell   = binding state for (keeper, connector):
+//            bound   — at least one channel bound, shows count
+//            unbound — connector is up and operator can bind (clickable)
+//            na      — connector is offline (cannot evaluate)
+//            unknown — connector directory missing this keeper
+//
+// Replaces the "per-card bindings list" fan-out in the old layout by
+// showing the full matrix in one place. Scales horizontally as more
+// connectors ship and vertically as more keepers come online.
+//
+// Data shape is kept pure in `deriveMatrix` so it can be tested without
+// DOM/signals. The component below is a thin renderer.
+
+import { html } from 'htm/preact'
+import type { GateConnectorInfo } from '../api/gate'
+import type { GateKeeperInfo } from '../api/schemas/gate-keepers'
+import {
+  CONNECTOR_DISPLAY_NAMES,
+  KNOWN_CONNECTOR_IDS,
+  channelIcon,
+  type KnownConnectorId,
+} from './connector-status'
+import { openConnectorConfig } from './connector-config-form'
+
+export type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
+
+export interface MatrixCell {
+  connectorId: KnownConnectorId
+  keeperName: string
+  state: MatrixCellState
+  bindingCount: number
+}
+
+export interface MatrixRow {
+  keeperName: string
+  known: boolean
+  cells: MatrixCell[]
+}
+
+export interface MatrixData {
+  columns: KnownConnectorId[]
+  rows: MatrixRow[]
+  totals: {
+    knownKeepers: number
+    unknownKeepers: number
+    totalBindings: number
+    liveConnectors: number
+  }
+}
+
+function findConnector(connectors: GateConnectorInfo[], id: string): GateConnectorInfo | null {
+  return connectors.find(c => c.connector_id === id) ?? null
+}
+
+/** Derive the matrix from connectors + keepers. Pure, unit-testable. */
+export function deriveMatrix(
+  connectors: GateConnectorInfo[],
+  keepers: GateKeeperInfo[],
+): MatrixData {
+  const columns: KnownConnectorId[] = [...KNOWN_CONNECTOR_IDS]
+  const knownKeeperNames = new Set(keepers.map(k => k.name))
+
+  const unknownKeeperNames = new Set<string>()
+  for (const c of connectors) {
+    for (const b of c.configured_bindings ?? []) {
+      if (!knownKeeperNames.has(b.keeper_name)) {
+        unknownKeeperNames.add(b.keeper_name)
+      }
+    }
+  }
+
+  const allKeeperRows: Array<{ name: string; known: boolean }> = [
+    ...keepers.map(k => ({ name: k.name, known: true })),
+    ...[...unknownKeeperNames].sort().map(name => ({ name, known: false })),
+  ]
+
+  let totalBindings = 0
+  const rows: MatrixRow[] = allKeeperRows.map(({ name, known }) => {
+    const cells: MatrixCell[] = columns.map(connectorId => {
+      const connector = findConnector(connectors, connectorId)
+      const connectorUp = connector?.available === true
+      const bindings = (connector?.configured_bindings ?? []).filter(
+        b => b.keeper_name === name,
+      )
+      const count = bindings.length
+      totalBindings += count
+      let state: MatrixCellState
+      if (!known) {
+        state = count > 0 ? 'unknown' : 'na'
+      } else if (count > 0) {
+        state = 'bound'
+      } else if (connectorUp) {
+        state = 'unbound'
+      } else {
+        state = 'na'
+      }
+      return { connectorId, keeperName: name, state, bindingCount: count }
+    })
+    return { keeperName: name, known, cells }
+  })
+
+  const liveConnectors = connectors.filter(c => c.available === true).length
+
+  return {
+    columns,
+    rows,
+    totals: {
+      knownKeepers: keepers.length,
+      unknownKeepers: unknownKeeperNames.size,
+      totalBindings,
+      liveConnectors,
+    },
+  }
+}
+
+const CELL_TONE: Record<MatrixCellState, { dot: string; text: string; bg: string }> = {
+  bound:   { dot: 'bg-emerald-400',     text: 'text-emerald-100',        bg: 'bg-emerald-500/10' },
+  unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
+  na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
+  unknown: { dot: 'bg-amber-400',       text: 'text-amber-100',          bg: 'bg-amber-500/10'   },
+}
+
+const CELL_GLYPH: Record<MatrixCellState, string> = {
+  bound:   '●',
+  unbound: '+',
+  na:      '—',
+  unknown: '⚠',
+}
+
+function scrollToConnectorRow(connectorId: string) {
+  const el = document.getElementById(`connector-row-${connectorId}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function scrollToKeeper(keeperName: string) {
+  const el = document.getElementById(`keepers-${keeperName}`)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function MatrixCellButton({ cell }: { cell: MatrixCell }) {
+  const tone = CELL_TONE[cell.state]
+  const label = (() => {
+    switch (cell.state) {
+      case 'bound':   return `${cell.bindingCount} ch`
+      case 'unbound': return 'bind'
+      case 'na':      return ''
+      case 'unknown': return `${cell.bindingCount}?`
+    }
+  })()
+  const title = (() => {
+    const conn = CONNECTOR_DISPLAY_NAMES[cell.connectorId] ?? cell.connectorId
+    switch (cell.state) {
+      case 'bound':   return `${cell.keeperName} · ${conn} · ${cell.bindingCount} channel(s) — 클릭하면 상세로 이동`
+      case 'unbound': return `${cell.keeperName} · ${conn} — 클릭하면 바인딩 추가`
+      case 'na':      return `${cell.keeperName} · ${conn} — 커넥터 오프라인`
+      case 'unknown': return `${cell.keeperName} · ${conn} — 디렉토리 밖 keeper 참조됨`
+    }
+  })()
+  const disabled = cell.state === 'na'
+  const onClick = () => {
+    if (cell.state === 'unbound') {
+      openConnectorConfig(cell.connectorId)
+      return
+    }
+    scrollToConnectorRow(cell.connectorId)
+  }
+  return html`
+    <button
+      type="button"
+      class=${`flex h-full w-full cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[11px] transition-colors ${tone.bg} ${tone.text} hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-40`}
+      onClick=${onClick}
+      disabled=${disabled}
+      title=${title}
+      data-matrix-cell=${`${cell.keeperName}:${cell.connectorId}`}
+      data-matrix-state=${cell.state}
+    >
+      <span class=${`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`}></span>
+      <span>${CELL_GLYPH[cell.state]}</span>
+      ${label ? html`<span class="hidden md:inline">${label}</span>` : null}
+    </button>
+  `
+}
+
+export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
+  const hasKeepers = matrix.rows.length > 0
+  // Grid template: one wide keeper-name column, N fixed-width connector cols.
+  // Fixed column widths make the grid *align*, which is the whole point.
+  const gridCols = `grid-template-columns: minmax(160px, 1fr) repeat(${matrix.columns.length}, minmax(80px, 1fr));`
+
+  return html`
+    <section class="mb-4 rounded-lg border border-[var(--card-border)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
+      <header class="mb-2 flex items-baseline justify-between gap-3">
+        <div>
+          <h4 class="text-[12px] font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">
+            Keeper × Connector Matrix
+          </h4>
+          <p class="mt-0.5 text-[10px] text-[var(--text-dim)]">
+            ${matrix.totals.knownKeepers} keeper${matrix.totals.knownKeepers === 1 ? '' : 's'}
+            · ${matrix.totals.liveConnectors}/${matrix.columns.length} connector
+            · ${matrix.totals.totalBindings} binding${matrix.totals.totalBindings === 1 ? '' : 's'}
+            ${matrix.totals.unknownKeepers > 0
+              ? html`· <span class="text-amber-200">${matrix.totals.unknownKeepers} unknown</span>`
+              : null}
+          </p>
+        </div>
+        <div class="text-[10px] text-[var(--text-dim)]">
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>bound</span>
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-8)]"></span>unbound</span>
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-4)]"></span>n/a</span>
+          <span><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-amber-400"></span>unknown</span>
+        </div>
+      </header>
+
+      ${!hasKeepers
+        ? html`
+            <div class="rounded-md border border-dashed border-[var(--card-border)] px-3 py-4 text-center text-[11px] text-[var(--text-dim)]">
+              No keepers yet — add one under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart.
+            </div>
+          `
+        : html`
+            <div class="overflow-x-auto">
+              <div class="grid gap-1 text-[11px]" style=${gridCols} data-matrix-grid>
+                <div class="px-1 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
+                ${matrix.columns.map(colId => html`
+                  <button
+                    type="button"
+                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[10px] uppercase tracking-[0.12em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                    onClick=${() => scrollToConnectorRow(colId)}
+                    title=${`${CONNECTOR_DISPLAY_NAMES[colId] ?? colId} — 행으로 이동`}
+                  >
+                    <span aria-hidden="true">${channelIcon(colId)}</span>
+                    <span>${CONNECTOR_DISPLAY_NAMES[colId] ?? colId}</span>
+                  </button>
+                `)}
+
+                ${matrix.rows.map(row => html`
+                  <${MatrixRowRender} row=${row} />
+                `)}
+              </div>
+            </div>
+          `}
+    </section>
+  `
+}
+
+function MatrixRowRender({ row }: { row: MatrixRow }) {
+  return html`
+    <button
+      type="button"
+      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-[12px] hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-amber-100'}`}
+      onClick=${() => scrollToKeeper(row.keeperName)}
+      title=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
+    >
+      ${row.known ? null : html`<span class="text-amber-300" aria-hidden="true">⚠</span>`}
+      <span class="truncate">${row.keeperName}</span>
+    </button>
+    ${row.cells.map(cell => html`<${MatrixCellButton} cell=${cell} />`)}
+  `
+}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -35,6 +35,7 @@ import { StartupCheckBanner, markStartAttempt, clearStartAttempt } from './sidec
 import { QuickBindForm } from './connector-quick-bind'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
 import { ConnectorKeyboardShortcuts } from './connector-keyboard-shortcuts'
+import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
 
@@ -1201,6 +1202,9 @@ export function ConnectorStatusPanel() {
 
       ${!filterId
         ? html`<${ConnectorOverviewStrip} connectors=${visibleConnectors} keeperCount=${snapshot.keepers.length} />`
+        : null}
+      ${!filterId
+        ? html`<${ConnectorKeeperMatrix} matrix=${deriveMatrix(visibleConnectors, snapshot.keepers)} />`
         : null}
       ${!filterId ? html`<${ConnectorKeyboardShortcuts} />` : null}
 


### PR DESCRIPTION
## Summary
- 새로운 `ConnectorKeeperMatrix` 컴포넌트: all-connectors 뷰 하단에 K×M 매트릭스 한 개.
- Pure `deriveMatrix(connectors, keepers)` helper — DOM 없이 단위 테스트.
- 4가지 셀 상태: `bound`(●) / `unbound`(+) / `na`(—) / `unknown`(⚠).
- `unknown` 키퍼(바인딩에는 있으나 snapshot.keepers에 없음)를 표면화 — 이전에는 로그 tailing으로만 발견 가능.

## Motivation
기존 overview tile strip은 "커넥터별 준비도"는 보여주지만 **"어느 키퍼가 어느 커넥터에 묶였나?"** 질문에는 답하지 못함. 각 타일 열어서 per-card binding 리스트를 4번 읽고 머릿속에서 K×M 매트릭스를 합성해야 함. 직접 답하는 단일 표가 없음.

#7944 aggregate summary / #7925 incident banner / #7937 uptime chip / #7906 sticky+celebration / #7958 keyboard shortcuts는 모두 **tile feature 추가**이며, K×M visualization 공백은 그대로. 이 PR은 그 구조적 공백을 최소 surface로 메움.

## Scope (deliberately minimal)
- New file: `connector-keeper-matrix.ts` (264 LOC) + `connector-keeper-matrix.test.ts` (124 LOC)
- `connector-status.ts`: +3 LOC (1 import + 1 mount block, `!filterId` guard와 동일 gating)
- 기존 레이아웃 / tile strip / keyboard shortcuts 건드리지 않음. drift 재발 위험 최소.

## Evidence
- ✅ Targeted tests: 8/8 matrix + 21/21 connector-status
- ✅ TypeScript strict: no errors in touched files
- ✅ Build: `pnpm build` green

## Linked issue
Refs concerns originally raised in closed #7940 ("nxm 구성일텐데 이렇게해서 충분할까?") — restores only the net-new visualization from that larger redesign.

## Test plan
- [ ] 로컬에서 all-connectors 뷰 렌더링 후 매트릭스가 tile strip 아래 표시
- [ ] 바인딩 있는 셀 ●, 빈 셀 +, sidecar down 커넥터 행 —, stale keeper 이름 ⚠
- [ ] sub-section (단일 커넥터 필터) 진입 시 매트릭스 숨김