### PR TITLE
chore(dashboard): purge retired runtime-params / param-audit state cluster

### DIFF
--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -3,8 +3,6 @@ import {
   decideGovernanceExecutionOrder,
   fetchDashboardGovernance,
   fetchGovernanceCaseStatus,
-  fetchParamAudit,
-  fetchRuntimeParams,
   resolveGovernanceApproval,
   submitGovernanceCaseBrief,
   submitGovernancePetition,
@@ -27,8 +25,6 @@ import {
   selectedDecisionKey,
   selectedCaseDetail,
   detailLoading,
-  runtimeParamsResource,
-  paramAuditResource,
 } from './governance-signals'
 
 async function loadDecisionDetail(item: GovernanceDecisionItem | null) {
@@ -142,20 +138,3 @@ export async function respondToKeeperApproval(id: string, decision: 'approve' | 
   }
 }
 
-export async function loadRuntimeParams() {
-  await runtimeParamsResource.load(async () => {
-    const data = await fetchRuntimeParams()
-    return { parameters: data.parameters ?? [], surfaces: data.surfaces ?? [] }
-  }).catch(err => {
-    console.debug('[governance] runtime params load failed (optional)', err instanceof Error ? err.message : err)
-  })
-}
-
-export async function loadParamAudit(limit = 50) {
-  await paramAuditResource.load(async () => {
-    const data = await fetchParamAudit(limit)
-    return data.entries ?? []
-  }).catch(err => {
-    console.debug('[governance] param audit load failed (optional)', err instanceof Error ? err.message : err)
-  })
-}

--- a/dashboard/src/components/governance-signals.ts
+++ b/dashboard/src/components/governance-signals.ts
@@ -3,7 +3,6 @@ import type {
   DashboardGovernanceResponse,
   GovernanceCaseBundle,
 } from '../types'
-import type { RuntimeParam, RuntimeParamsSurface, ParamAuditEntry } from '../api'
 import type { GovernanceFilter } from './governance-utils'
 import { createAsyncResource, getData } from '../lib/async-state'
 
@@ -31,18 +30,3 @@ export const governanceFilter = signal<GovernanceFilter>('open')
 export const selectedDecisionKey = signal<string | null>(null)
 export const selectedCaseDetail = signal<GovernanceCaseBundle | null>(null)
 export const detailLoading = signal(false)
-
-// ── Runtime params resource ──
-const runtimeParamsResource = createAsyncResource<{ parameters: RuntimeParam[]; surfaces: RuntimeParamsSurface[] }>()
-export { runtimeParamsResource }
-
-export const runtimeParams = computed(() => getData(runtimeParamsResource.state.value)?.parameters ?? [])
-export const runtimeSurfaces = computed(() => getData(runtimeParamsResource.state.value)?.surfaces ?? [])
-export const runtimeLoading = computed(() => runtimeParamsResource.state.value.status === 'loading')
-
-// ── Param audit resource ──
-const paramAuditResource = createAsyncResource<ParamAuditEntry[]>()
-export { paramAuditResource }
-
-export const paramAuditEntries = computed(() => getData(paramAuditResource.state.value) ?? [])
-export const paramAuditLoading = computed(() => paramAuditResource.state.value.status === 'loading')

--- a/dashboard/src/components/governance-store.ts
+++ b/dashboard/src/components/governance-store.ts
@@ -15,11 +15,6 @@ export {
   selectedDecisionKey,
   selectedCaseDetail,
   detailLoading,
-  runtimeParams,
-  runtimeSurfaces,
-  runtimeLoading,
-  paramAuditEntries,
-  paramAuditLoading,
 } from './governance-signals'
 export {
   selectDecision,
@@ -28,6 +23,4 @@ export {
   submitBrief,
   respondToExecutionOrder,
   respondToKeeperApproval,
-  loadRuntimeParams,
-  loadParamAudit,
 } from './governance-actions'

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -20,7 +20,7 @@ import {
 import { formatAgeSummary } from './governance-utils'
 
 // Re-export for consumers that import from './governance'
-export { refreshGovernance, loadRuntimeParams, loadParamAudit } from './governance-store'
+export { refreshGovernance } from './governance-store'
 
 function GovernanceSummaryStrip() {
   const data = governanceData.value

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -232,10 +232,8 @@ function handleKeeperLifecycle(event: { type: string; name?: string }): void {
   }
 }
 
-async function handleGovernance(): Promise<void> {
+function handleGovernance(): void {
   _refreshGovernanceFn?.()
-  const { loadRuntimeParams } = await import('./components/governance')
-  loadRuntimeParams()
 }
 
 async function refreshActiveRoute(): Promise<void> {


### PR DESCRIPTION
## What

Gen31 #7927이 governance-panels cluster를 retire했을 때 소비자가 사라졌으나, backing **signal cluster + fetch-driver + SSE handler 재호출**이 뒤에 남아 매 governance SSE event마다 결과를 **구독자 0인 computed에** 채우고 있었음. Silent CPU + network burn 제거.

## Dead signal scan 배경

368개 `signal()`/`computed()` 선언을 전수 스캔 → 39개 후보 중 이 cluster가 가장 명백한 **완전 dead** 그룹:

| 파일 | 제거 대상 |
|---|---|
| `governance-signals.ts` | `runtimeParamsResource`, `runtimeParams`, `runtimeSurfaces`, `runtimeLoading`, `paramAuditResource`, `paramAuditEntries`, `paramAuditLoading` |
| `governance-actions.ts` | `loadRuntimeParams()`, `loadParamAudit()` + 관련 imports |
| `governance-store.ts` | 5 signal + 2 action re-exports |
| `governance.ts` | 2 action re-exports |
| `sse-store.ts` | `handleGovernance()`에서 `loadRuntimeParams()` 동적 import + 호출 |

## 효과

- **-46 LOC**
- Governance SSE tick 경로에서 `await import(...)` + `runtimeParamsResource.load(...)` 왕복 제거 → 매 이벤트당 async work 감소
- `sse-store.handleGovernance`가 async → sync 단순화 (`_refreshGovernanceFn?.()` 한 줄)
- 368개 signal 중 5개 dead computed + 1 orphan resource 정리 → dead-signal scanner의 실제 신호 대비 noise 감소

## 검증

- typecheck pass
- 124/124 governance tests pass (test mocks 그대로 두었음 — `fetchParamAudit`, `fetchRuntimeParams` 등은 mock이라 실제 호출 없음)

## Non-goal

- \`api/dashboard.ts\`의 \`fetchRuntimeParams\`, \`fetchParamAudit\`, \`setRuntimeParam\`, \`clearRuntimeParam\` 함수 + 관련 타입은 이번 PR에서 건드리지 않음. 이들은 이제 runtime caller 0이지만 제거하면 api 배럴/타입 export 표면이 변경되어 blast radius가 커짐. 별도 Gen36 cleanup.

## 관련 PR

| # | 내용 |
|---|---|
| #7927 (earlier) | governance-panels cluster retirement (UI 제거) |
| #7962 Gen31 | governance-panels/detail/strips 삭제 |
| **이 PR Gen35** | 남아있던 signal + fetch-driver 정리 |
| Gen36 후보 | fetchRuntimeParams 등 4 함수 + 5 타입 제거 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)