### PR TITLE
refactor(dashboard): disambiguate 'runtime' label overload + KO-only card titles

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -692,7 +692,7 @@ export function CascadeConfigPanel() {
           : null}
       <//>
 
-      <${Card} title="Client Capacity — 최근 이벤트">
+      <${Card} title="Client Capacity · 최근 이벤트">
         ${history
           ? html`<${ClientCapacityHistoryTable} history=${history} />`
           : null}
@@ -704,7 +704,7 @@ export function CascadeConfigPanel() {
           : html`<${EmptyState}>SLO 데이터를 불러오는 중입니다.<//>`}
       <//>
 
-      <${Card} title="Strategy Decisions — cycle 추적">
+      <${Card} title="Strategy Decisions · 사이클 추적">
         ${trace
           ? html`
             <div class="flex items-center gap-3 mb-3">

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -77,8 +77,12 @@ describe('monitoring navigation labels', () => {
 
     expect(labelFor('observatory')).toBe('관찰소 (beta)')
     expect(labelFor('fleet-health')).toBe('플릿 텔레메트리')
-    expect(labelFor('runtime')).toBe('런타임')
-    expect(labelFor('agents')).toBe('런타임 디렉터리')
+    // "캐스케이드" and "에이전트 디렉터리" replaced the duplicated
+    // "런타임" labels (one section renamed to cascade, the other to
+    // agent directory) so monitoring no longer has two sidebar items
+    // whose labels collide on the same word.
+    expect(labelFor('runtime')).toBe('캐스케이드')
+    expect(labelFor('agents')).toBe('에이전트 디렉터리')
   })
 
   it('does not expose sessions section (removed in Phase 0 of RFC-MASC-006)', () => {
@@ -102,6 +106,19 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('telemetry')
     expect(ids).not.toContain('metrics')
     expect(ids).not.toContain('governance')
+  })
+
+  it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {
+    const sections = visibleSectionItemsForTab('monitoring')
+    const labels = sections.map(item => item.label)
+    const uniq = new Set(labels)
+    expect(uniq.size).toBe(labels.length)
+    // Regression guard: the word "런타임" used to label both
+    // section[id=runtime] and section[id=agents], making it impossible
+    // to tell process-instance liveness apart from cascade routing by
+    // reading the sidebar alone.
+    const runtimeOccurrences = labels.filter(l => l === '런타임').length
+    expect(runtimeOccurrences).toBe(0)
   })
 })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -68,7 +68,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: '모니터링',
     icon: '📡',
-    description: '런타임 디렉터리와 플릿 신호 관찰',
+    description: '에이전트 디렉터리와 플릿 신호 관찰',
     defaultTab: 'monitoring',
     defaultParams: { section: 'agents' },
     tabs: ['monitoring'],
@@ -137,14 +137,14 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'agents',
-      label: '런타임 디렉터리',
-      description: '누가 살아 있고 어떤 런타임인지 빠르게 훑어봅니다. 이벤트, 도구, 거버넌스는 플릿 텔레메트리에서 봅니다.',
+      label: '에이전트 디렉터리',
+      description: '누가 살아 있고 어떤 프로세스 위에 떠 있는지 빠르게 훑어봅니다. 이벤트, 도구, 거버넌스는 플릿 텔레메트리에서 봅니다.',
       params: { section: 'agents' },
     },
     {
       id: 'runtime',
-      label: '런타임',
-      description: 'provider health, 슬롯 용량, model inference snapshot.',
+      label: '캐스케이드',
+      description: 'Provider 건강도, 슬롯 용량, 모델 선택 스냅샷을 한 화면에서 봅니다.',
       params: { section: 'runtime' },
     },
     {
@@ -242,7 +242,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'harness',
       label: '세이프티 하네스',
-      description: '평가 모델, 압축 전 상태, 세대 교체 rail 감시 상태.',
+      description: '평가 모델, 압축 전 상태, 세대 교체 모니터링 상태.',
       params: { section: 'harness' },
     },
   ],


### PR DESCRIPTION
## 맥락

Monitoring 사이드바에 \"런타임\" 이라는 label 이 **두 개의 다른 섹션** 에 달려 있었다.

| id | 기존 label | 실제 의미 |
|---|---|---|
| \`agents\` | \"런타임 디렉터리\" | 프로세스 인스턴스 생존 현황 (who's alive) |
| \`runtime\` | \"런타임\" | cascade routing / provider 건강도 (cascade infra) |

같은 단어 두 번 쓰니 사이드바만 봐서는 \"누가 살아 있나\" 와 \"cascade 가 어떻게 돌고 있나\" 를 구분할 수 없었다.

## 변경

### Section rename (label + description 만, id 는 유지 → URL 안정)

\`\`\`diff
 agents:
-  label: '런타임 디렉터리'
-  desc:  '누가 살아 있고 어떤 런타임인지 ...'
+  label: '에이전트 디렉터리'
+  desc:  '누가 살아 있고 어떤 프로세스 위에 떠 있는지 ...'

 runtime:
-  label: '런타임'
-  desc:  'provider health, 슬롯 용량, model inference snapshot.'
+  label: '캐스케이드'
+  desc:  'Provider 건강도, 슬롯 용량, 모델 선택 스냅샷을 한 화면에서 봅니다.'
\`\`\`

Monitoring surface description 도 같은 단어 의존을 제거:

\`\`\`diff
- description: '런타임 디렉터리와 플릿 신호 관찰'
+ description: '에이전트 디렉터리와 플릿 신호 관찰'
\`\`\`

### KO-only 정리 (동일 PR 에서 이미 건드린 파일만)

PR-2 에서 병합한 \`cascade-config-panel.ts\` Card title 영한 dash 혼용 정리:

\`\`\`diff
- title="Client Capacity — 최근 이벤트"
+ title="Client Capacity · 최근 이벤트"

- title="Strategy Decisions — cycle 추적"
+ title="Strategy Decisions · 사이클 추적"
\`\`\`

\`lab > harness\` 설명에서 \"rail\" 제거 (KO-only).

## 회귀 가드

사이드바 label 충돌이 다시 들어오지 못하게 테스트 추가:

\`\`\`ts
it('monitoring sidebar labels are unique (no overloaded term like \"런타임\")', () => {
  const labels = visibleSectionItemsForTab('monitoring').map(i => i.label)
  expect(new Set(labels).size).toBe(labels.length)
  expect(labels.filter(l => l === '런타임').length).toBe(0)
})
\`\`\`

## 테스트

- \`navigation.test.ts\`: 기존 label 단언 2건 업데이트 + 중복 레이블 회귀 가드 1건 추가
- 82 vitest 전부 통과 (navigation 6 + cascade-config-panel 47 + ...)
- \`tsc --noEmit\` 통과, \`eslint\` 통과

## Scope 제한

\`keeper-detail\`, \`oas-health-chip\`, \`prompt-registry\`, \`activity-graph\` 등에 \"런타임\" 이 여전히 남아있지만 각각 **로컬 컨텍스트에서 명확** 하다 (\"런타임 설정\", \"OAS 런타임\", \"런타임 오버라이드\" 등). 이 PR 은 monitoring sidebar 의 collision 만 타겟.

Part of PR-1 → PR-2 → PR-3 → PR-4 dashboard reliability series (최종).