### PR TITLE
feat(dashboard): 🔢 expand NumberInput prop whitelist (id/name/aria/keyboard/blur/testId) + tests (0→15)

### DIFF
--- a/dashboard/src/components/common/number-input.test.ts
+++ b/dashboard/src/components/common/number-input.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { NumberInput } from './number-input'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('NumberInput', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders an <input type="number">', () => {
+    render(html`<${NumberInput} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.type).toBe('number')
+  })
+
+  it('forwards value + placeholder', () => {
+    render(html`<${NumberInput} value=${42} placeholder="rows" />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input.value).toBe('42')
+    expect(input.placeholder).toBe('rows')
+  })
+
+  it('forwards min / max / step constraints', () => {
+    render(html`<${NumberInput} min=${0} max=${100} step=${5} />`, container)
+    const input = container.querySelector('input')!
+    expect(input.getAttribute('min')).toBe('0')
+    expect(input.getAttribute('max')).toBe('100')
+    expect(input.getAttribute('step')).toBe('5')
+  })
+
+  it('forwards id so <label for> can resolve (a11y contract)', () => {
+    // Regression guard: NumberInput previously dropped `id`, making
+    // `<label for="...">` orphan. Mirrors the TextInput fix in #7987.
+    render(html`<${NumberInput} id="port" />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input.id).toBe('port')
+
+    const label = document.createElement('label')
+    label.setAttribute('for', 'port')
+    label.textContent = 'Port'
+    container.appendChild(label)
+    expect(container.querySelector(`#${label.getAttribute('for')}`)).toBe(input)
+  })
+
+  it('forwards name for FormData serialization', () => {
+    render(html`<${NumberInput} name="port" />`, container)
+    expect(container.querySelector('input')!.getAttribute('name')).toBe('port')
+  })
+
+  it('aria-label and aria-labelledby are forwarded', () => {
+    render(html`<${NumberInput} ariaLabel="server port" ariaLabelledby="hdr-port" />`, container)
+    const input = container.querySelector('input')!
+    expect(input.getAttribute('aria-label')).toBe('server port')
+    expect(input.getAttribute('aria-labelledby')).toBe('hdr-port')
+  })
+
+  it('autoComplete is forwarded as autocomplete attr', () => {
+    render(html`<${NumberInput} autoComplete="off" />`, container)
+    expect(container.querySelector('input')!.getAttribute('autocomplete')).toBe('off')
+  })
+
+  it('testId renders as data-testid (E2E stable hook)', () => {
+    render(html`<${NumberInput} testId="cfg-port" />`, container)
+    expect(container.querySelector('input')!.getAttribute('data-testid')).toBe('cfg-port')
+  })
+
+  it('disabled=true disables the input', () => {
+    render(html`<${NumberInput} disabled=${true} />`, container)
+    expect((container.querySelector('input') as HTMLInputElement).disabled).toBe(true)
+  })
+
+  it('onInput fires with the numeric value on input change', async () => {
+    const spy = vi.fn()
+    render(html`<${NumberInput} onInput=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.value = '42'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]![0]).toBe(42)
+  })
+
+  it('onInput fires with undefined when the field is cleared', async () => {
+    const spy = vi.fn()
+    render(html`<${NumberInput} value=${7} onInput=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.value = ''
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]![0]).toBeUndefined()
+  })
+
+  it('onInput does NOT fire when the raw string fails Number() coercion', async () => {
+    // Regression guard for the NaN branch — Number("12e") is NaN but
+    // <input type="number"> lets the raw string through during typing.
+    // Without the guard, we'd leak NaN into caller state.
+    const spy = vi.fn()
+    render(html`<${NumberInput} onInput=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    // happy-dom preserves whatever we assign to .value, so we can force
+    // a non-numeric string even though the browser would filter it.
+    input.value = 'not-a-number'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    // Either Number('') was coerced via the empty branch (value cleared)
+    // OR nothing fired (NaN branch). Both acceptable — never NaN.
+    for (const call of spy.mock.calls) {
+      const v = call[0]
+      if (v !== undefined) expect(Number.isNaN(v)).toBe(false)
+    }
+  })
+
+  it('onKeyDown fires on key events (Enter-to-submit contract)', async () => {
+    const spy = vi.fn()
+    render(html`<${NumberInput} onKeyDown=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('onBlur fires when focus leaves the input (validate-on-blur contract)', async () => {
+    const spy = vi.fn()
+    render(html`<${NumberInput} onBlur=${spy} />`, container)
+    const input = container.querySelector('input') as HTMLInputElement
+    input.focus()
+    input.blur()
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('extra `class` prop is appended to the base class string', () => {
+    render(html`<${NumberInput} class="extra-hook" />`, container)
+    expect(container.querySelector('input')!.className).toContain('extra-hook')
+  })
+})

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -1,3 +1,13 @@
+// NumberInput — numeric-only input primitive with Number() coercion in onInput.
+//
+// Props are a strict whitelist — htm/preact function components do NOT
+// implicitly spread unlisted props. Without `id`, `<label for="...">`
+// can't resolve; without `ariaLabel`/`ariaLabelledby`, screen readers
+// read "number input" with no accessible name. Missing keyboard hooks
+// (`onKeyDown`/`onBlur`) block Enter-to-submit and validation-on-blur
+// flows. If you add a prop to the interface, add it to the JSX too.
+// (Pattern mirrors input.ts / button.ts / checkbox.ts.)
+
 import { html } from 'htm/preact'
 
 const INPUT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
@@ -10,10 +20,47 @@ interface NumberInputProps {
   step?: number | 'any'
   min?: number
   max?: number
+  /** Forwarded to DOM id so `<label for="...">` resolves. */
+  id?: string
+  /** Form field name for native submit + FormData. */
+  name?: string
+  /** Accessible name when no visible <label> is associated via `for`. */
+  ariaLabel?: string
+  /** Reference an external label by id (e.g. a shared heading). */
+  ariaLabelledby?: string
+  /** Browser autofill hint — "off" for sensitive fields, or a token
+      like "one-time-code". */
+  autoComplete?: string
+  /** Rendered as `data-testid` so E2E / unit tests can target this
+      input without coupling to DOM position. */
+  testId?: string
   onInput?: (value: number | undefined) => void
+  /** Raw keyboard handler — lets callers implement Enter-to-submit,
+      arrow-key steppers, Escape-to-cancel without re-deriving them. */
+  onKeyDown?: (e: KeyboardEvent) => void
+  /** Fires when the input loses focus — the natural hook for
+      validation-on-blur ("must be ≥ 0"), snap-to-step, etc. */
+  onBlur?: (e: FocusEvent) => void
 }
 
-export function NumberInput({ value, placeholder, disabled, class: cx, step, min, max, onInput }: NumberInputProps) {
+export function NumberInput({
+  value,
+  placeholder,
+  disabled,
+  class: cx,
+  step,
+  min,
+  max,
+  id,
+  name,
+  ariaLabel,
+  ariaLabelledby,
+  autoComplete,
+  testId,
+  onInput,
+  onKeyDown,
+  onBlur,
+}: NumberInputProps) {
   const handleInput = (e: Event) => {
     const raw = (e.target as HTMLInputElement).value
     if (raw === '') { onInput?.(undefined); return }
@@ -21,7 +68,24 @@ export function NumberInput({ value, placeholder, disabled, class: cx, step, min
     if (!Number.isNaN(num)) onInput?.(num)
   }
   return html`
-    <input type="number" class="${INPUT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}" value=${value}
-      placeholder=${placeholder} disabled=${disabled} step=${step} min=${min} max=${max} onInput=${handleInput} />
+    <input
+      type="number"
+      id=${id}
+      name=${name}
+      class="${INPUT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
+      value=${value}
+      placeholder=${placeholder}
+      disabled=${disabled}
+      step=${step}
+      min=${min}
+      max=${max}
+      aria-label=${ariaLabel}
+      aria-labelledby=${ariaLabelledby}
+      autocomplete=${autoComplete}
+      data-testid=${testId}
+      onInput=${handleInput}
+      onKeyDown=${onKeyDown}
+      onBlur=${onBlur}
+    />
   `
 }


### PR DESCRIPTION
## Summary

**Fourth chip** in the whitelist-drop cleanup after #7987 (`TextInput`), #7995 (`ActionButton`), #8000 (`Checkbox`). Same silent-prop-drop class of bug: htm/preact function components don't spread unlisted props, so missing destructure entries silently drop from the DOM.

## Added props (all optional, backward-compat)

| Prop | Purpose |
|------|---------|
| `id` | `<label for=\"...\">` resolves |
| `name` | FormData serialization on native submit |
| `ariaLabel` | Accessible name without an external `<label>` |
| `ariaLabelledby` | Reference an external label by id |
| `autoComplete` | Browser autofill hint (e.g. `\"off\"`, `\"one-time-code\"`) |
| `testId` | `data-testid` for E2E/unit stable hooks |
| `onKeyDown` | Enter-to-submit / arrow-stepper / Escape-to-cancel |
| `onBlur` | Validation-on-blur, snap-to-step |

Module doc now documents the whitelist discipline with a back-ref to `input.ts` / `button.ts` / `checkbox.ts` (4 primitives, one pattern).

## Tests (15, 0→15)

- `type=\"number\"` default render
- `value` / `placeholder` / `min` / `max` / `step` forwarding
- **`id` → end-to-end `<label for>` lookup regression guard**
- `name` FormData attr
- `aria-label` / `aria-labelledby` / `autocomplete` / `data-testid`
- `disabled` forwarding
- `onInput` → numeric value
- `onInput` → `undefined` on clear
- **NaN guard: non-numeric string never leaks `NaN`**
- `onKeyDown` fires (Enter-to-submit contract)
- `onBlur` fires (validate-on-blur contract)
- `class` append preserving base classes

## Callers

Only real caller today is `tool-executor/schema-field.ts` (pass-through with `value` + `onInput`), which continues to work unchanged.

## Test plan

- [x] `npx vitest run src/components/common/number-input.test.ts` → 15/15 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)