### PR TITLE
feat(dashboard): ⬇ expand Select prop whitelist (id/name/aria/required/blur/testId) + tests (0→14)

### DIFF
--- a/dashboard/src/components/common/select.test.ts
+++ b/dashboard/src/components/common/select.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { Select } from './select'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('Select', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a <select> with string options', () => {
+    render(html`<${Select} options=${['a', 'b', 'c']} />`, container)
+    const sel = container.querySelector('select') as HTMLSelectElement
+    expect(sel).toBeTruthy()
+    const opts = Array.from(sel.querySelectorAll('option')).map(o => o.value)
+    expect(opts).toEqual(['a', 'b', 'c'])
+  })
+
+  it('renders {value, label} options with distinct display text', () => {
+    render(
+      html`<${Select} options=${[{ value: 'x', label: 'Extra' }, { value: 'y', label: 'Yankee' }]} />`,
+      container,
+    )
+    const opts = Array.from(container.querySelectorAll('option'))
+    expect(opts.map(o => o.value)).toEqual(['x', 'y'])
+    expect(opts.map(o => o.textContent)).toEqual(['Extra', 'Yankee'])
+  })
+
+  it('placeholder renders as a disabled+hidden option when provided', () => {
+    render(html`<${Select} options=${['a']} placeholder="-- pick --" />`, container)
+    const first = container.querySelector('option')!
+    expect(first.textContent).toBe('-- pick --')
+    expect(first.hasAttribute('disabled')).toBe(true)
+    expect(first.hasAttribute('hidden')).toBe(true)
+  })
+
+  it('no placeholder option is rendered when placeholder is absent', () => {
+    render(html`<${Select} options=${['a', 'b']} />`, container)
+    expect(container.querySelectorAll('option').length).toBe(2)
+  })
+
+  it('forwards id so <label for> can resolve (a11y contract)', () => {
+    // Regression guard — Select previously dropped `id` silently,
+    // making `<label for="...">` orphan.
+    render(html`<${Select} options=${['a']} id="role" />`, container)
+    const sel = container.querySelector('select') as HTMLSelectElement
+    expect(sel.id).toBe('role')
+
+    const label = document.createElement('label')
+    label.setAttribute('for', 'role')
+    label.textContent = 'Role'
+    container.appendChild(label)
+    expect(container.querySelector(`#${label.getAttribute('for')}`)).toBe(sel)
+  })
+
+  it('forwards name for FormData serialization', () => {
+    render(html`<${Select} options=${['a']} name="role" />`, container)
+    expect(container.querySelector('select')!.getAttribute('name')).toBe('role')
+  })
+
+  it('aria-label and aria-labelledby are forwarded', () => {
+    render(html`<${Select} options=${['a']} ariaLabel="role" ariaLabelledby="hdr-role" />`, container)
+    const sel = container.querySelector('select')!
+    expect(sel.getAttribute('aria-label')).toBe('role')
+    expect(sel.getAttribute('aria-labelledby')).toBe('hdr-role')
+  })
+
+  it('testId renders as data-testid (E2E stable hook, avoids i18n coupling)', () => {
+    render(html`<${Select} options=${['a']} testId="role-picker" />`, container)
+    expect(container.querySelector('select')!.getAttribute('data-testid')).toBe('role-picker')
+  })
+
+  it('required is forwarded (native form validation hook)', () => {
+    render(html`<${Select} options=${['a']} required=${true} />`, container)
+    expect((container.querySelector('select') as HTMLSelectElement).required).toBe(true)
+  })
+
+  it('disabled disables the <select>', () => {
+    render(html`<${Select} options=${['a']} disabled=${true} />`, container)
+    expect((container.querySelector('select') as HTMLSelectElement).disabled).toBe(true)
+  })
+
+  it('onInput fires with the new value on change', async () => {
+    const spy = vi.fn()
+    render(html`<${Select} options=${['a', 'b', 'c']} onInput=${spy} />`, container)
+    const sel = container.querySelector('select') as HTMLSelectElement
+    sel.value = 'b'
+    sel.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]![0]).toBe('b')
+  })
+
+  it('onBlur fires when focus leaves the select (validate-on-blur contract)', async () => {
+    const spy = vi.fn()
+    render(html`<${Select} options=${['a']} onBlur=${spy} />`, container)
+    const sel = container.querySelector('select') as HTMLSelectElement
+    sel.focus()
+    sel.blur()
+    await flushUi()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('extra `class` prop is appended to the base class string', () => {
+    render(html`<${Select} options=${['a']} class="extra-hook" />`, container)
+    expect(container.querySelector('select')!.className).toContain('extra-hook')
+  })
+
+  it('base classes preserved even when `class` extension is given', () => {
+    render(html`<${Select} options=${['a']} class="extra-hook" />`, container)
+    const cn = container.querySelector('select')!.className
+    expect(cn).toContain('rounded-lg')
+    expect(cn).toContain('appearance-none')
+  })
+})

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -1,3 +1,14 @@
+// Select — native <select> primitive with string-or-{value,label} options.
+//
+// Props are a strict whitelist — htm/preact function components do NOT
+// implicitly spread unlisted props. Without `id`, `<label for="...">`
+// can't resolve; without `ariaLabel`/`ariaLabelledby`, screen readers
+// read "combobox" / "select" with no accessible name. Missing `onBlur`
+// blocks validate-on-blur flows. Missing `testId` forces E2E tests to
+// couple to visible option text (which may be i18n'd).
+// If you add a prop to the interface, add it to the JSX too.
+// (Pattern mirrors input.ts / button.ts / checkbox.ts / number-input.ts.)
+
 import { html } from 'htm/preact'
 
 const SELECT_BASE = 'w-full rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
@@ -10,14 +21,56 @@ interface SelectProps {
   placeholder?: string
   disabled?: boolean
   class?: string
+  /** Forwarded to DOM id so `<label for="...">` resolves. */
+  id?: string
+  /** Form field name for native submit + FormData. */
+  name?: string
+  /** Accessible name when no visible <label> is associated via `for`. */
+  ariaLabel?: string
+  /** Reference an external label by id. */
+  ariaLabelledby?: string
+  /** Rendered as `data-testid` so E2E / unit tests can target this
+      <select> without coupling to option text (which may be i18n'd). */
+  testId?: string
+  /** Native required flag — participates in form validation. */
+  required?: boolean
   onInput?: (value: string) => void
+  /** Fires when the select loses focus — the natural hook for
+      validate-on-blur ("you must pick one"). */
+  onBlur?: (e: FocusEvent) => void
 }
 
-export function Select({ value, options, placeholder, disabled, class: cx, onInput }: SelectProps) {
+export function Select({
+  value,
+  options,
+  placeholder,
+  disabled,
+  class: cx,
+  id,
+  name,
+  ariaLabel,
+  ariaLabelledby,
+  testId,
+  required,
+  onInput,
+  onBlur,
+}: SelectProps) {
   const handleChange = (e: Event) => { onInput?.((e.target as HTMLSelectElement).value) }
   const currentValue = value ?? ''
   return html`
-    <select class="${SELECT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}" value=${currentValue} disabled=${disabled} onChange=${handleChange}>
+    <select
+      id=${id}
+      name=${name}
+      class="${SELECT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
+      value=${currentValue}
+      disabled=${disabled}
+      aria-label=${ariaLabel}
+      aria-labelledby=${ariaLabelledby}
+      data-testid=${testId}
+      required=${required}
+      onChange=${handleChange}
+      onBlur=${onBlur}
+    >
       ${placeholder ? html`<option value="" disabled hidden>${placeholder}</option>` : null}
       ${options.map(opt => {
         const v = typeof opt === 'string' ? opt : opt.value


### PR DESCRIPTION
## Summary

**Fifth chip** — completes the form-primitive whitelist sweep in `dashboard/src/components/common/`. Follows #7987 (TextInput), #7995 (ActionButton), #8000 (Checkbox), #8005 (NumberInput). Same silent-prop-drop class of bug.

## Added props (all optional, backward-compat)

| Prop | Purpose |
|------|---------|
| `id` | `<label for=\"...\">` resolves |
| `name` | FormData serialization on native submit |
| `ariaLabel` | Accessible name without an external `<label>` |
| `ariaLabelledby` | Reference an external label by id |
| `testId` | `data-testid` — decouples E2E from i18n'd option text |
| `required` | Native form validation flag |
| `onBlur` | Validate-on-blur (\"you must pick one\") hook |

Module doc back-refs input.ts / button.ts / checkbox.ts / number-input.ts — **5 primitives, one discipline**.

## Tests (14, 0→14)

- String options + `{value, label}` options with distinct display text
- Placeholder renders as `disabled+hidden` option; absent when unset
- **`id` → end-to-end `<label for>` lookup regression guard**
- `name` FormData attr
- `aria-label` / `aria-labelledby` / `data-testid`
- `required` / `disabled` forwarding
- `onInput` fires with the selected value
- `onBlur` fires (validate-on-blur contract)
- `class` append + base class preservation

## Callers

`tool-executor/schema-field.ts` and `task-manage/task-create-form.ts` — both pass-through with `value`/`options`/`onInput`, continue to work unchanged.

## Test plan

- [x] `npx vitest run src/components/common/select.test.ts` → 14/14 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)