### PR TITLE
docs(spec): sync 11-board Maps-to + retire 15-testing §5.3/§5.5/§5.6 (anti_fake/keeper_verifier/keeper_contract)

### DIFF
--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -13,7 +13,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Room |
-| Maps to | `lib/board/` (sub-library), `lib/board.ml`, `lib/tool_board.ml`, `lib/tool_vote.ml`, `lib/tool_social.ml` |
+| Maps to | `lib/board_types/` (sub-library), `lib/board.ml`, `lib/tool_board.ml` (successor to former `lib/tool_vote.ml` + `lib/tool_social.ml`, both folded into `tool_board.ml` — see that file's header "Replaces tool_social.ml for new installations") |
 | Dependencies | 09-server-transport |
 | LOC | ~4.1K |
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -13,7 +13,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Foundation |
-| Maps to | `test/`, `lib/eval_gate.ml`, `lib/eval_harness.ml`, `lib/anti_fake.ml`, `lib/trajectory.ml`, `lib/keeper/keeper_verifier.ml`, `lib/keeper/keeper_contract.ml` |
+| Maps to | `test/`, `lib/eval_gate.ml`, `lib/eval_harness.ml`, `lib/trajectory.ml`, `lib/verifier_core.ml`, `lib/verifier_oas.ml`, `lib/keeper/keeper_guards.ml` |
 | Dependencies | (all subsystem specs) |
 | Test Files | 319 (.ml), 6 (bench), 3 (fixtures/other) |
 
@@ -201,36 +201,11 @@ type scenario = {
 - `Deterministic`: 필드(result/tool_name/error)에 대한 Exact/Contains/Regex/NotContains 매칭. 0 지연.
 - `ModelBased`: LLM에 rubric과 결과를 제출하여 0.0-1.0 점수 산출. 비용 발생.
 
-### 5.3 Anti-Fake (lib/anti_fake.ml)
+### 5.3 Anti-Fake (RETIRED)
 
-테스트 코드 품질 자동 점수화. 허위 테스트 패턴을 감지한다.
+`lib/anti_fake.ml`는 허위 테스트 패턴 감지(`assert true`, `let _ =`, `(* TODO *)` 등에 대한 자동 감점 + `score_result`/`audit_summary` 집계)를 제공하던 모듈이었고, #2848 dead-code sweep에서 `lib/agent_ecosystem`/`lib/agent_neo4j`와 함께 제거됐다 (`grep -rn anti_fake lib/ test/` → 0 hits).
 
-**감점 패턴 (penalties)**:
-
-| 패턴 | 감점 | 심각도 |
-|------|------|--------|
-| `assert true` | -0.3 | Critical |
-| `assert_bool "" true` | -0.3 | Critical |
-| `let _ =` | -0.2 | Warning |
-| `(* TODO` / `(* FIXME` | -0.15 | Warning |
-| `skip` / `ignore` | -0.1 | Info |
-| `fun _ ->` | -0.05 | Info |
-
-**가점 지표** (rewards): `Alcotest.check`, `assert_equal`, `roundtrip`, `property`, `QCheck`.
-
-**결과 타입**:
-
-```ocaml
-type score_result = {
-  file_path : string;
-  raw_score : float;
-  final_score : float;
-  findings : finding list;
-  quality_tier : string;      (* 점수 구간에 따른 등급 *)
-}
-```
-
-`audit_summary`는 전체 파일에 대한 avg/min/max 점수와 fake_count/suspect_count를 집계한다.
+현재는 `scripts/check-test-quality.sh`와 `eval_harness`의 trajectory-level assertion 검증이 그 역할을 부분 승계하며, 전용 테스트 품질 게이트는 노출되지 않는다.
 
 ### 5.4 Trajectory (lib/trajectory.ml)
 
@@ -253,29 +228,25 @@ Keeper tool call의 JSONL 기반 궤적 로깅. 결정적 재생, 비용 누적,
 
 **trajectory_outcome**: `Completed | Failed | Timeout | CostExceeded | Gated`.
 
-### 5.5 Keeper Verifier (lib/keeper/keeper_verifier.ml)
+### 5.5 Verifier (lib/verifier_core.ml, lib/verifier_oas.ml)
 
-Generator-Verifier 루프. Keeper 자율 행동의 사전 검증.
+`lib/keeper/keeper_verifier.ml`가 단일 모듈로 제공하던 Generator–Verifier 루프는 `lib/verifier_core.ml`(코어 판정 로직)과 `lib/verifier_oas.ml`(OAS-bound execution path)로 2분할됐고, keeper 레벨의 사전 검증(guard gating)은 `lib/keeper/keeper_guards.ml`로 이동했다 (구 `keeper_verifier.ml`는 제거, #2589 및 05-keeper-agent 스펙 참조).
+
+현 루프:
 
 ```
-proposed_action -> risk_level 분류 (Safe/Moderate/Dangerous)
-               -> cost 추정
-               -> Verifier 판정: PASS / WARN / FAIL
+proposed_action -> verifier_core: risk_level 분류 (Safe/Moderate/Dangerous)
+                                  + cost 추정
+                                  + PASS / WARN / FAIL
+              -> keeper_guards: execution-time guard (permission, rate, safety)
+              -> verifier_oas: OAS execution path에서 재확인
 ```
 
-- **PASS**: 실행 진행
-- **WARN**: 실행하되 trajectory에 concern 기록
-- **FAIL**: 실행 차단, broadcast로 통보
+### 5.6 Keeper Contract (RETIRED)
 
-Budget: 검증당 max 200 output tokens (~$0.01).
+`lib/keeper/keeper_contract.ml`는 keeper 정책/런타임 enum의 typed 표현(예: `room_scope = Current | All (legacy)`)을 제공했고, single-room 통합 과정에서 `room_scope` 타입과 함께 제거됐다 (`grep -rn 'type room_scope' lib/` → 0 hits; 남은 `room_scope_*` 식별자는 캐시 helper 함수 이름일 뿐 타입 정의가 아님).
 
-### 5.6 Keeper Contract (lib/keeper/keeper_contract.ml)
-
-Keeper 정책/런타임 열거형의 typed 정의. JSON 및 MCP 문자열 표현과의 경계를 타입으로 관리한다.
-
-| 타입 | 값 | 설명 |
-|------|-----|------|
-| `room_scope` | Current (`All` legacy alias) | single-room compatibility field |
+Keeper 관련 enum의 현재 typed boundary는 05-keeper-agent 스펙의 §2 module table을 따른다.
 
 ---
 


### PR DESCRIPTION
## Summary

Two sibling spec drifts, 5 total dead refs.

### 11-board.md (2 dead refs)
- Maps-to row referenced `lib/tool_vote.ml` and `lib/tool_social.ml`
- Both folded into `lib/tool_board.ml` — its header literally reads `Replaces tool_social.ml for new installations`
- Also corrected `lib/board/` → `lib/board_types/` to match the actual sub-library path

### 15-testing.md (3 dead refs)

| Section | Dead ref | Status / successor |
|---------|----------|-------------------|
| §5.3 Anti-Fake | `lib/anti_fake.ml` | Removed in #2848 dead-code sweep; 0 grep hits |
| §5.5 Keeper Verifier | `lib/keeper/keeper_verifier.ml` | Removed #2589; split into `verifier_core.ml` + `verifier_oas.ml` + `keeper/keeper_guards.ml` |
| §5.6 Keeper Contract | `lib/keeper/keeper_contract.ml` | Purged with single-room unification; `type room_scope` 0 hits (remaining `room_scope_*` are cache-helper function names only) |

§5.3 and §5.6 collapsed into RETIRED paragraphs with grep evidence. §5.5 rewritten to describe the 3-way successor split:

```
proposed_action -> verifier_core: risk_level 분류 + cost + PASS/WARN/FAIL
              -> keeper_guards: execution-time guard (permission, rate, safety)
              -> verifier_oas: OAS execution path에서 재확인
```

Maps-to row adjusted: dropped 3 dead refs, added `verifier_core`/`verifier_oas`/`keeper_guards`.

## Numbers
- 11-board.md: +2 / −1
- 15-testing.md: +15 / −46
- Net: 17 insert / 47 delete

## Gen context
Gen44 of the iterative doc-drift loop. Combined two small-drift files in one PR since both are `docs/spec/` surgical retires with the same pattern (RETIRED paragraph + grep evidence + successor pointer) established in Gen37/39/41/43.

## Test plan
- [x] `bash scripts/check-doc-truth.sh` → Version truth OK + Doc truth OK + Doc code_refs OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)