### PR TITLE
feat(dashboard): 🕒 TimeAgo renders as semantic <time> + aria-label + mode prop + tests (0→19)

### DIFF
--- a/dashboard/src/components/common/time-ago.test.ts
+++ b/dashboard/src/components/common/time-ago.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  TimeAgo,
+  toMs,
+  toIsoDatetime,
+  toAccessibleLabel,
+  pickDisplayText,
+} from './time-ago'
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('toMs (pure normalization)', () => {
+  it('passes unix ms through unchanged', () => {
+    expect(toMs(1_700_000_000_000)).toBe(1_700_000_000_000)
+  })
+
+  it('multiplies unix seconds (< 1e12) by 1000', () => {
+    // 1_700_000_000 seconds → 1_700_000_000_000 ms
+    expect(toMs(1_700_000_000)).toBe(1_700_000_000_000)
+  })
+
+  it('parses ISO strings via Date constructor', () => {
+    const iso = '2026-04-17T18:30:00.000Z'
+    expect(toMs(iso)).toBe(new Date(iso).getTime())
+  })
+})
+
+describe('toIsoDatetime', () => {
+  it('produces a valid ISO 8601 string from unix ms', () => {
+    const out = toIsoDatetime(1_700_000_000_000)
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+
+  it('round-trips through Date parsing', () => {
+    const ms = 1_700_000_000_000
+    const iso = toIsoDatetime(ms)
+    expect(new Date(iso).getTime()).toBe(ms)
+  })
+})
+
+describe('toAccessibleLabel', () => {
+  it('contains both a relative and absolute portion', () => {
+    const recent = Date.now() - 60_000 // 1 minute ago
+    const label = toAccessibleLabel(recent)
+    // Relative part should mention "분 전" (minutes ago in ko)
+    expect(label).toMatch(/분 전|초 전/)
+    // Absolute part is in parens
+    expect(label).toMatch(/\(.+\)/)
+  })
+})
+
+describe('pickDisplayText', () => {
+  const recent = Date.now() - 60_000
+
+  it('mode=relative returns only the relative fragment (no parens)', () => {
+    const out = pickDisplayText(recent, 'relative')
+    expect(out).not.toContain('(')
+    expect(out).not.toContain('·')
+  })
+
+  it('mode=absolute returns only the absolute fragment (no "전")', () => {
+    const out = pickDisplayText(recent, 'absolute')
+    expect(out).not.toMatch(/전/)
+  })
+
+  it('mode=both joins relative and absolute with "·"', () => {
+    const out = pickDisplayText(recent, 'both')
+    expect(out).toContain('·')
+  })
+})
+
+describe('TimeAgo component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a <time> element (HTML5 semantic, not <span>)', () => {
+    // Regression guard — Reference pattern: Slack/GitHub/Linear all use
+    // <time datetime="...">. <span> is not machine-readable.
+    render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} />`, container)
+    const el = container.querySelector('time')
+    expect(el).toBeTruthy()
+    expect(container.querySelector('span.time-ago')).toBeNull()
+  })
+
+  it('datetime attr is a valid ISO 8601 string', () => {
+    render(html`<${TimeAgo} timestamp=${1_700_000_000_000} />`, container)
+    const el = container.querySelector('time')!
+    expect(el.getAttribute('datetime')).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+  })
+
+  it('aria-label includes both relative and absolute portions (AT context)', () => {
+    render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} />`, container)
+    const el = container.querySelector('time')!
+    const label = el.getAttribute('aria-label') ?? ''
+    expect(label).toMatch(/분 전|초 전/) // relative part
+    expect(label).toMatch(/\(.+\)/) // absolute part in parens
+  })
+
+  it('title attr contains the ISO timestamp (hover tooltip)', () => {
+    render(html`<${TimeAgo} timestamp=${1_700_000_000_000} />`, container)
+    const el = container.querySelector('time')!
+    expect(el.getAttribute('title')).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('mode="absolute" renders only the absolute fragment', () => {
+    render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} mode="absolute" />`, container)
+    const el = container.querySelector('time')!
+    expect(el.textContent).not.toMatch(/전/)
+  })
+
+  it('mode="both" renders both fragments joined by "·"', () => {
+    render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} mode="both" />`, container)
+    const el = container.querySelector('time')!
+    expect(el.textContent).toContain('·')
+  })
+
+  it('default mode is "relative"', () => {
+    render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} />`, container)
+    const el = container.querySelector('time')!
+    // No absolute-part separator in relative-only mode.
+    expect(el.textContent).not.toContain('·')
+  })
+
+  it('class prop is appended to the base "time-ago" class', () => {
+    render(html`<${TimeAgo} timestamp=${Date.now()} class="text-dim" />`, container)
+    const el = container.querySelector('time')!
+    expect(el.className).toContain('time-ago')
+    expect(el.className).toContain('text-dim')
+  })
+
+  it('accepts unix seconds timestamps (legacy backend contract)', () => {
+    // Backends returning `generated_at: 1_700_000_000` (seconds) shouldn't
+    // get read as year 1970 — the < 1e12 branch re-scales to ms.
+    const seconds = 1_700_000_000
+    render(html`<${TimeAgo} timestamp=${seconds} />`, container)
+    const el = container.querySelector('time')!
+    const dt = el.getAttribute('datetime')!
+    // Should land in 2023-11 (the actual date of that epoch), not 1970.
+    expect(dt.startsWith('2023-11')).toBe(true)
+  })
+
+  it('live clock tick updates relative text without parent re-render', async () => {
+    // The singleton interval should re-run the component's read of
+    // `relativeClock.value`. We don't care about exact string, only
+    // that the DOM text CAN refresh — assert by vi advancing fake timers.
+    vi.useFakeTimers()
+    try {
+      const start = Date.now()
+      // Render a "just now" time.
+      render(html`<${TimeAgo} timestamp=${start} />`, container)
+      const before = container.querySelector('time')!.textContent
+      // Advance clock by 5 minutes.
+      vi.advanceTimersByTime(5 * 60_000)
+      // Let preact flush.
+      await flushUi()
+      const after = container.querySelector('time')!.textContent
+      // We don't assert equality on the exact label, just that something
+      // was re-derivable (before/after still come from formatTimeAgo).
+      expect(before).toBeTruthy()
+      expect(after).toBeTruthy()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -1,12 +1,24 @@
 // Relative time display — "2분 전", "3시간 전" 등.
+//
+// Reference UI pattern (Slack / GitHub / Linear): render as HTML5
+// `<time datetime="...">` semantic element (machine-readable, valid
+// landmark), title attr for hover tooltip with absolute time, aria-label
+// with both relative and absolute so screen readers don't just hear
+// "2분 전" without date context. Three render modes let callers pick
+// the density they need.
 
 import { signal } from '@preact/signals'
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
-import { formatTimeAgo } from '../../lib/format-time'
+import { formatTimeAgo, formatTimestampKo } from '../../lib/format-time'
+
+type TimeAgoMode = 'relative' | 'absolute' | 'both'
 
 interface TimeAgoProps {
   timestamp: string | number
+  /** relative="2분 전" (default) · absolute="04. 17. 18:30" · both="2분 전 · 04. 17. 18:30" */
+  mode?: TimeAgoMode
+  class?: string
 }
 
 const CLOCK_TICK_MS = 30_000
@@ -27,7 +39,42 @@ function stopRelativeClock(): void {
   relativeClockTimer = null
 }
 
-export function TimeAgo({ timestamp }: TimeAgoProps) {
+/** Normalize a timestamp (ISO string, unix seconds, or unix ms) to ms.
+    Exposed for unit tests so the normalization rule is verifiable. */
+export function toMs(ts: string | number): number {
+  if (typeof ts === 'string') return new Date(ts).getTime()
+  return ts < 1_000_000_000_000 ? ts * 1000 : ts
+}
+
+/** ISO 8601 string for the `<time datetime="...">` attribute. Machine-readable
+    timestamp that dev tools and crawlers can parse without re-running our
+    format logic. */
+export function toIsoDatetime(ts: string | number): string {
+  return new Date(toMs(ts)).toISOString()
+}
+
+/** Unix-seconds form for `formatTimestampKo`, which expects seconds. */
+function toUnixSeconds(ts: string | number): number {
+  return Math.floor(toMs(ts) / 1000)
+}
+
+/** Accessible label for screen readers: combines relative "2분 전" with
+    the absolute ko-KR formatted date. Without this, an AT user hears only
+    "2분 전" and loses the anchor point. */
+export function toAccessibleLabel(ts: string | number): string {
+  return `${formatTimeAgo(ts)} (${formatTimestampKo(toUnixSeconds(ts))})`
+}
+
+/** Pick the displayed text based on mode. */
+export function pickDisplayText(ts: string | number, mode: TimeAgoMode): string {
+  const rel = formatTimeAgo(ts)
+  if (mode === 'relative') return rel
+  const abs = formatTimestampKo(toUnixSeconds(ts))
+  if (mode === 'absolute') return abs
+  return `${rel} · ${abs}`
+}
+
+export function TimeAgo({ timestamp, mode = 'relative', class: cx }: TimeAgoProps) {
   useEffect(() => {
     relativeClockSubscribers += 1
     startRelativeClock()
@@ -37,13 +84,13 @@ export function TimeAgo({ timestamp }: TimeAgoProps) {
     }
   }, [])
 
+  // Subscribe to the tick so relative text refreshes without parent re-render.
   void relativeClock.value
-  const text = formatTimeAgo(timestamp)
-  const title =
-    typeof timestamp === 'string'
-      ? timestamp
-      : new Date(timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp).toISOString()
-  return html`<span class="time-ago" title=${title}>${text}</span>`
+  const text = pickDisplayText(timestamp, mode)
+  const iso = toIsoDatetime(timestamp)
+  const label = toAccessibleLabel(timestamp)
+  const cls = cx ? `time-ago ${cx}` : 'time-ago'
+  return html`<time class=${cls} datetime=${iso} title=${iso} aria-label=${label}>${text}</time>`
 }
 
 export { formatTimeAgo }


### PR DESCRIPTION
## Summary

First **non-form-primitive chip** after the 5-PR whitelist sweep (#7987/#7995/#8000/#8005/#8007). Borrows the Slack / GitHub / Linear relative-time pattern: semantic `<time datetime=\"...\">` element, aria-label that keeps AT users anchored, and a `mode` prop so callers pick display density.

## Upgrades

| Change | Why |
|--------|-----|
| `<span>` → `<time datetime=\"...\">` | HTML5 semantic, machine-readable. Dev tools / crawlers / AT can parse without re-running our format logic. |
| `aria-label` = \"2분 전 (04. 17. 18:30)\" | AT previously heard only \"2분 전\" — useless without a date anchor. |
| `mode` prop: `'relative'` (default) · `'absolute'` · `'both'` | Headers want absolute, inline annotations want relative, detail views want both. |
| `class` prop appended to base | Caller theming without forking the component. |
| ISO datetime reused as `title` | Hover tooltip with full timestamp. |

## Pure helpers (testable without DOM)

| Helper | Role |
|--------|------|
| `toMs(ts)` | Normalize ISO string / unix s / unix ms → ms |
| `toIsoDatetime(ts)` | ISO 8601 for `<time datetime=\"...\">` |
| `toAccessibleLabel(ts)` | `\"{relative} ({absolute})\"` |
| `pickDisplayText(ts, mode)` | Mode-aware text selection |

## Tests (19, 0→19)

- `toMs`: ms passthrough + seconds→ms rescale + ISO parsing
- `toIsoDatetime`: valid ISO + round-trip
- `toAccessibleLabel`: relative + absolute combined
- `pickDisplayText`: all three modes
- Component: `<time>` not `<span>` (regression guard)
- Component: `datetime` attr is ISO
- Component: `aria-label` has both parts
- Component: `title` contains ISO
- Component: modes render correct text
- Component: `class` prop append
- **Component: unix seconds contract** (1_700_000_000 → 2023-11, not 1970)
- Component: live-clock tick doesn't crash with fake timers

## Backward compat

Existing callers pass only `timestamp` and continue to work — all additions optional. `formatTimeAgo` re-export preserved for `harness-health-sections.ts` / `feature-health.ts`.

Callers: `governance.ts` (×5), `agent-detail-worker.ts` (×1) — all pass-through.

## Test plan

- [x] `npx vitest run src/components/common/time-ago.test.ts` → 19/19 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)