### PR TITLE
[dash-iter58] highlight-on-match helper + wire into 2 panels

### DIFF
--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -11,6 +11,7 @@ import {
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
+import { highlightMatch } from '../lib/highlight-match'
 
 interface Props {
   agentName: string
@@ -237,12 +238,12 @@ export function AgentDetailMemory({ agentName }: Props) {
                             <div class="flex items-center justify-between gap-2">
                               <div class="flex items-center gap-2 min-w-0">
                                 <span class="${outcomeColor}">${outcomeIcon}</span>
-                                <span class="truncate text-zinc-300">${ep.summary}</span>
+                                <span class="truncate text-zinc-300">${highlightMatch(ep.summary, episodeQuery.value)}</span>
                               </div>
                               <span class="text-[10px] text-zinc-500 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
                             </div>
                             ${ep.learnings.length > 0
-                              ? html`<div class="mt-1 text-[11px] text-zinc-400 pl-3 border-l border-zinc-700">${ep.learnings[0]}</div>`
+                              ? html`<div class="mt-1 text-[11px] text-zinc-400 pl-3 border-l border-zinc-700">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
                               : null}
                           </div>
                         `

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -18,6 +18,7 @@ import {
 import { SurfaceCard } from './common/card'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { EmptyState } from './common/empty-state'
+import { highlightMatch } from '../lib/highlight-match'
 
 const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
@@ -154,16 +155,18 @@ function GateCard({
 }
 
 function EventRow({
-  event, onSelect, active,
+  event, onSelect, active, query,
 }: {
   event: AttributionEvent
   onSelect: () => void
   active: boolean
+  query: string
 }) {
   const a = event.attribution
   const rowBg = active
     ? 'bg-white/5'
     : 'hover:bg-white/5'
+  const reasonText = reasonOf(a)
   return html`
     <button
       type="button"
@@ -174,14 +177,14 @@ function EventRow({
         ${formatTs(event.recorded_at)}
       </span>
       <span class="text-[10px] px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)} shrink-0">
-        ${a.origin}
+        ${highlightMatch(a.origin, query)}
       </span>
-      <span class="font-mono text-[11px] w-36 shrink-0">${a.gate}</span>
+      <span class="font-mono text-[11px] w-36 shrink-0">${highlightMatch(a.gate, query)}</span>
       <span class="${outcomeToneClass(a.outcome.kind)} shrink-0 w-20">
         ${outcomeLabel(a)}
       </span>
       <span class="text-[var(--text-muted)] truncate grow min-w-0">
-        ${reasonOf(a) || '—'}
+        ${reasonText ? highlightMatch(reasonText, query) : '—'}
       </span>
     </button>
   `
@@ -356,6 +359,7 @@ export function AttributionPanel() {
                   <${EventRow}
                     event=${ev}
                     active=${selectedEventIdx.value === idx}
+                    query=${query.value}
                     onSelect=${() => { selectedEventIdx.value = idx }}
                   />
                 `)}

--- a/dashboard/src/lib/highlight-match.test.ts
+++ b/dashboard/src/lib/highlight-match.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { highlightMatch, highlightSafe } from './highlight-match'
+
+// The <mark> branches are emitted as htm/preact VNode objects. We don't
+// assert on their internal shape here (that couples us to htm internals);
+// we just check string chunks via typeof + that non-string entries are
+// objects in the expected positions.
+function isMark(part: unknown): boolean {
+  return typeof part === 'object' && part !== null
+}
+
+describe('highlightMatch', () => {
+  it('returns [text] for empty needle', () => {
+    const parts = highlightMatch('hello world', '')
+    expect(parts).toEqual(['hello world'])
+  })
+
+  it('returns [text] for whitespace-only needle', () => {
+    const parts = highlightMatch('hello world', '   ')
+    expect(parts).toEqual(['hello world'])
+  })
+
+  it('returns [text] when no match is found', () => {
+    const parts = highlightMatch('hello world', 'xyz')
+    expect(parts).toEqual(['hello world'])
+  })
+
+  it('wraps a single mid-string match into 3 parts', () => {
+    const parts = highlightMatch('hello world', 'lo w')
+    expect(parts).toHaveLength(3)
+    expect(parts[0]).toBe('hel')
+    expect(isMark(parts[1])).toBe(true)
+    expect(parts[2]).toBe('orld')
+  })
+
+  it('alternates parts for multiple non-adjacent matches', () => {
+    const parts = highlightMatch('foo bar foo baz foo', 'foo')
+    // raw prefix/suffix around 3 matches (suffix for last is empty when
+    // match is at end; here last match is followed by nothing so no
+    // trailing chunk). Expect: mark, " bar ", mark, " baz ", mark.
+    expect(parts).toHaveLength(5)
+    expect(isMark(parts[0])).toBe(true)
+    expect(parts[1]).toBe(' bar ')
+    expect(isMark(parts[2])).toBe(true)
+    expect(parts[3]).toBe(' baz ')
+    expect(isMark(parts[4])).toBe(true)
+  })
+
+  it('collapses adjacent matches into a single highlight', () => {
+    // "abab" with needle "ab" → two adjacent matches [0,2) and [2,4).
+    const parts = highlightMatch('abab', 'ab')
+    expect(parts).toHaveLength(1)
+    expect(isMark(parts[0])).toBe(true)
+  })
+
+  it('collapses overlapping matches into a single highlight', () => {
+    // "aaaa" with needle "aa" → indexOf from 0,1,2 → ranges
+    // [0,2),[1,3),[2,4), all overlap → merge to [0,4).
+    const parts = highlightMatch('aaaa', 'aa')
+    expect(parts).toHaveLength(1)
+    expect(isMark(parts[0])).toBe(true)
+  })
+
+  it('preserves original casing when match is case-insensitive', () => {
+    // We can't reach into the htm VNode to inspect the inner string
+    // directly without coupling to internals, so we use a shape check:
+    // original text "Test" should appear as a single <mark> chunk only.
+    const parts = highlightMatch('Test', 'test')
+    expect(parts).toHaveLength(1)
+    expect(isMark(parts[0])).toBe(true)
+    // Sanity: lowercased needle should also match the capitalised text.
+    const parts2 = highlightMatch('abc TEST xyz', 'test')
+    expect(parts2).toHaveLength(3)
+    expect(parts2[0]).toBe('abc ')
+    expect(isMark(parts2[1])).toBe(true)
+    expect(parts2[2]).toBe(' xyz')
+  })
+
+  it('emits no empty prefix when match is at the start', () => {
+    const parts = highlightMatch('foobar', 'foo')
+    expect(parts).toHaveLength(2)
+    expect(isMark(parts[0])).toBe(true)
+    expect(parts[1]).toBe('bar')
+  })
+
+  it('emits no empty suffix when match is at the end', () => {
+    const parts = highlightMatch('foobar', 'bar')
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toBe('foo')
+    expect(isMark(parts[1])).toBe(true)
+  })
+
+  it('returns [""] for empty text', () => {
+    expect(highlightMatch('', 'anything')).toEqual([''])
+  })
+})
+
+describe('highlightSafe', () => {
+  it('returns [""] for null', () => {
+    expect(highlightSafe(null, 'x')).toEqual([''])
+  })
+
+  it('returns [""] for undefined', () => {
+    expect(highlightSafe(undefined, 'x')).toEqual([''])
+  })
+
+  it('delegates to highlightMatch for non-empty text', () => {
+    const parts = highlightSafe('hello', 'ell')
+    expect(parts).toHaveLength(3)
+    expect(parts[0]).toBe('h')
+    expect(isMark(parts[1])).toBe(true)
+    expect(parts[2]).toBe('o')
+  })
+})

--- a/dashboard/src/lib/highlight-match.ts
+++ b/dashboard/src/lib/highlight-match.ts
@@ -1,0 +1,83 @@
+// Highlight-on-match utility.
+//
+// Splits `text` into alternating raw string / <mark>-wrapped Preact
+// fragments on case-insensitive substring match of `needle`. Designed to
+// be dropped into an htm template without changing surrounding DOM:
+//
+//     ${highlightMatch(row.summary, query.value)}
+//
+// When `needle` is empty / whitespace-only the function returns `[text]`
+// unchanged so callers can render unconditionally. Original casing of the
+// matched substring is preserved (the lowercased needle is only used to
+// locate indices).
+
+import { html } from 'htm/preact'
+
+/**
+ * Split `text` into a sequence of Preact-renderable parts, wrapping each
+ * case-insensitive occurrence of `needle` in a `<mark>` tag. Adjacent /
+ * overlapping matches are merged into a single `<mark>` span.
+ *
+ * - Empty or whitespace-only `needle` → `[text]` (single raw string).
+ * - Empty `text` → `['']` (single empty raw string, preserves stable shape).
+ * - No match → `[text]` unchanged.
+ * - Leading / trailing match produces no empty prefix or suffix parts.
+ */
+export function highlightMatch(text: string, needle: string): readonly unknown[] {
+  const trimmed = needle.trim()
+  if (trimmed === '') return [text]
+  if (text === '') return ['']
+
+  const lowerText = text.toLowerCase()
+  const lowerNeedle = trimmed.toLowerCase()
+  const needleLen = lowerNeedle.length
+
+  // 1st pass: collect raw match positions (possibly overlapping if the
+  // needle itself overlaps its own shifts, e.g. needle "aa" in "aaaa").
+  const raw: Array<{ start: number; end: number }> = []
+  let from = 0
+  while (from <= lowerText.length - needleLen) {
+    const idx = lowerText.indexOf(lowerNeedle, from)
+    if (idx === -1) break
+    raw.push({ start: idx, end: idx + needleLen })
+    from = idx + 1 // advance by 1 so overlapping matches are captured
+  }
+
+  if (raw.length === 0) return [text]
+
+  // 2nd pass: merge overlapping / adjacent ranges into single spans.
+  const merged: Array<{ start: number; end: number }> = []
+  for (const r of raw) {
+    const last = merged[merged.length - 1]
+    if (last && r.start <= last.end) {
+      if (r.end > last.end) last.end = r.end
+    } else {
+      merged.push({ start: r.start, end: r.end })
+    }
+  }
+
+  // 3rd pass: emit alternating raw / <mark> parts, slicing the ORIGINAL
+  // text to preserve casing. Skip zero-length prefix/suffix chunks.
+  const parts: unknown[] = []
+  let cursor = 0
+  for (const { start, end } of merged) {
+    if (start > cursor) parts.push(text.slice(cursor, start))
+    const matched = text.slice(start, end)
+    parts.push(
+      html`<mark class="bg-yellow-500/20 text-inherit rounded-sm px-0.5">${matched}</mark>`,
+    )
+    cursor = end
+  }
+  if (cursor < text.length) parts.push(text.slice(cursor))
+  return parts
+}
+
+/**
+ * Nullable-safe wrapper. `null` / `undefined` text renders as empty string.
+ */
+export function highlightSafe(
+  text: string | null | undefined,
+  needle: string,
+): readonly unknown[] {
+  return text ? highlightMatch(text, needle) : ['']
+}


### PR DESCRIPTION
## Summary
- New \`highlightMatch(text, needle)\` pure helper — case-insensitive, preserves original casing, returns Preact-renderable parts (raw strings + \`<mark>\`-wrapped VNodes).
- Wired into \`agent-detail-memory\` (episode summary + first learning) and \`attribution-panel\` (gate / origin badge / reason) — exactly the fields that the existing \`filterEpisodes\` / \`filterAttributionEvents\` pure helpers match on.
- Empty / whitespace needle returns \`[text]\` unchanged — no-op when not filtering (callers can drop it in unconditionally).

## Design notes
- Indexing loop (\`toLowerCase().indexOf\`) rather than regex — user input never reaches the regex engine, no escaping footgun.
- Adjacent / overlapping matches merged into a single \`<mark>\` span (second pass collapses ranges).
- Tailwind class: \`bg-yellow-500/20 text-inherit rounded-sm px-0.5\` — soft translucent yellow, inherits foreground color so it survives the dark theme without a contrast fight. (No prior \`<mark>\` styling existed in the codebase; chose a muted tint consistent with the focus-ring palette.)
- \`event_type\` is matched by \`filterEpisodes\` but is not rendered anywhere in the episode card, so nothing to highlight there. \`learnings\` is an array — only the first element is rendered today, so only that one is highlighted (same field the user sees).

## Test plan
- [x] 14 unit tests on \`highlightMatch\` / \`highlightSafe\` (empty / no-match / single / multi / adjacent / overlapping / case / boundary / nullable)
- [x] Existing component tests green (45 tests across 3 files, no HTML-string assertions needed changes)
- [x] \`pnpm typecheck\` + \`pnpm lint\` green locally
- [ ] CI green