### PR TITLE
feat(dashboard): add ConnectorPathsStrip disclosure panel

### DIFF
--- a/dashboard/src/components/connector-paths-strip.test.ts
+++ b/dashboard/src/components/connector-paths-strip.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ConnectorPathsStrip,
+  deriveMascPaths,
+  _testResetPathsStrip,
+} from './connector-paths-strip'
+import type { GateConnectorInfo } from '../api/gate'
+
+const mkConnector = (overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
+  connector_id: overrides.connector_id ?? 'discord',
+  display_name: overrides.display_name ?? 'Discord',
+  channel: overrides.channel ?? 'discord',
+  available: overrides.available ?? true,
+  gate_healthy: overrides.gate_healthy ?? true,
+  configured_bindings: overrides.configured_bindings ?? [],
+  capabilities: overrides.capabilities ?? ['bindings'],
+  ...(overrides as object),
+}) as GateConnectorInfo
+
+describe('deriveMascPaths', () => {
+  it('falls back to repo-relative paths when no connector has names_path', () => {
+    const paths = deriveMascPaths([])
+    expect(paths.connectorsDir).toBeNull()
+    expect(paths.logsDir).toBeNull()
+    expect(paths.keepersDir).toBe('config/keepers/')
+    expect(paths.sidecarsDir).toBe('sidecars/')
+  })
+
+  it('derives connectors + logs dir from standard names_path pattern', () => {
+    const c = mkConnector({
+      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+    } as never)
+    const paths = deriveMascPaths([c])
+    expect(paths.connectorsDir).toBe('/Users/alice/.masc/connectors/')
+    expect(paths.logsDir).toBe('/Users/alice/.masc/logs/')
+  })
+
+  it('falls back when names_path is non-standard', () => {
+    const c = mkConnector({ names_path: '/somewhere/else/names.json' } as never)
+    const paths = deriveMascPaths([c])
+    expect(paths.connectorsDir).toBeNull()
+    expect(paths.logsDir).toBeNull()
+  })
+
+  it('ignores empty / whitespace names_path and falls through to next connector', () => {
+    const c1 = mkConnector({ connector_id: 'discord', names_path: '' } as never)
+    const c2 = mkConnector({
+      connector_id: 'slack',
+      names_path: '/home/bob/.masc/connectors/slack/names.json',
+    } as never)
+    const paths = deriveMascPaths([c1, c2])
+    expect(paths.connectorsDir).toBe('/home/bob/.masc/connectors/')
+  })
+})
+
+describe('ConnectorPathsStrip', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetPathsStrip()
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('mounts the paths strip panel', () => {
+    render(html`<${ConnectorPathsStrip} connectors=${[]} />`, container)
+    expect(container.querySelector('[data-panel="connector-paths-strip"]')).not.toBeNull()
+  })
+
+  it('is collapsed by default — body rows are absent until expanded', () => {
+    render(html`<${ConnectorPathsStrip} connectors=${[]} />`, container)
+    expect(container.querySelector('[data-paths-row]')).toBeNull()
+  })
+
+  it('expands on header click and reveals keeper + sidecar rows even with no runtime', async () => {
+    render(html`<${ConnectorPathsStrip} connectors=${[]} />`, container)
+    const toggle = container.querySelector<HTMLButtonElement>('[data-panel="connector-paths-strip"] button')!
+    toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+    const rows = container.querySelectorAll('[data-paths-row]')
+    const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
+    expect(labels).toEqual(['Keepers', 'Sidecars'])
+  })
+
+  it('surfaces Connectors + Logs rows once a connector reports a names_path', async () => {
+    const c = mkConnector({
+      names_path: '/Users/alice/.masc/connectors/discord/names.json',
+    } as never)
+    render(html`<${ConnectorPathsStrip} connectors=${[c]} />`, container)
+    const toggle = container.querySelector<HTMLButtonElement>('[data-panel="connector-paths-strip"] button')!
+    toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+    const rows = container.querySelectorAll('[data-paths-row]')
+    const labels = Array.from(rows).map(r => r.getAttribute('data-paths-row'))
+    expect(labels).toEqual(['Connectors', 'Logs', 'Keepers', 'Sidecars'])
+  })
+
+  it('header shows runtime hint when no connector has names_path', () => {
+    render(html`<${ConnectorPathsStrip} connectors=${[]} />`, container)
+    const header = container.querySelector('[data-panel="connector-paths-strip"] button')!
+    expect(header.textContent).toContain('런타임 미관찰')
+  })
+})

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -1,0 +1,118 @@
+// ConnectorPathsStrip — collapsible disclosure panel that answers the
+// "where is my config?" question in one glance.
+//
+// Operators repeatedly ask "where does this keeper's TOML live?" or
+// "where is the sidecar log?" and today the only answer is a code tour
+// or Slack. This strip surfaces four MASC-managed paths directly:
+//
+//   - Connectors dir : {mascRoot}/connectors/ — sidecar names.json /
+//                      status.json; derived from an observed connector's
+//                      `names_path` if available
+//   - Logs dir       : {mascRoot}/logs/       — sidecar log directory
+//   - Keepers dir    : config/keepers/         — keeper TOML (repo-relative)
+//   - Sidecars dir   : sidecars/               — sidecar run.sh scripts
+//                                                (repo-relative)
+//
+// The top two are derived from runtime; the bottom two are repo-relative
+// conventions and always shown. Collapsed by default so the main overview
+// strip stays dense.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import type { GateConnectorInfo } from '../api/gate'
+import { CopyableCode } from './common/copyable-code'
+
+const pathsExpanded = signal<boolean>(false)
+
+export function _testResetPathsStrip() {
+  pathsExpanded.value = false
+}
+
+export interface MascPaths {
+  connectorsDir: string | null
+  logsDir: string | null
+  keepersDir: string
+  sidecarsDir: string
+}
+
+/** Pure: derive MASC-managed paths from the first connector whose
+    runtime has been observed (has a `names_path`). Returns `null` for
+    dynamic fields when no runtime data yet. Repo-relative conventions
+    (keepers/, sidecars/) are never null — they're stable regardless of
+    runtime state. Cold-start / pre-runtime view still gets useful
+    paths for the static half. */
+export function deriveMascPaths(connectors: GateConnectorInfo[]): MascPaths {
+  const fallback: MascPaths = {
+    connectorsDir: null,
+    logsDir: null,
+    keepersDir: 'config/keepers/',
+    sidecarsDir: 'sidecars/',
+  }
+  const withPath = connectors.find(
+    c => typeof c.names_path === 'string' && c.names_path.length > 0,
+  )
+  if (!withPath) return fallback
+  const match = withPath.names_path.match(/^(.*)\/connectors\/[^/]+\/names\.json$/)
+  if (!match) return fallback
+  const mascRoot = match[1] ?? ''
+  return {
+    connectorsDir: `${mascRoot}/connectors/`,
+    logsDir: `${mascRoot}/logs/`,
+    keepersDir: 'config/keepers/',
+    sidecarsDir: 'sidecars/',
+  }
+}
+
+function PathRow({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return html`
+    <div class="flex items-center gap-2" data-paths-row=${label}>
+      <span
+        class="w-[100px] shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+        title=${hint}
+      >${label}</span>
+      <div class="min-w-0 flex-1">
+        <${CopyableCode} command=${value} ariaLabel=${`Copy ${label} path`} />
+      </div>
+    </div>
+  `
+}
+
+export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorInfo[] }) {
+  const paths = deriveMascPaths(connectors)
+  const open = pathsExpanded.value
+  return html`
+    <div
+      class="mb-3 rounded-lg border border-[var(--card-border)] bg-[var(--bg-1)]"
+      data-panel="connector-paths-strip"
+    >
+      <button
+        type="button"
+        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+        onClick=${() => { pathsExpanded.value = !open }}
+        aria-expanded=${open}
+        aria-controls="connector-paths-body"
+      >
+        <span>
+          <span class="mr-2 text-[10px] uppercase tracking-[0.14em]">Paths</span>
+          <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
+          <span class="ml-2 text-[var(--text-dim)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
+        </span>
+        <span>${open ? '▴' : '▾'}</span>
+      </button>
+      ${open
+        ? html`
+            <div id="connector-paths-body" class="space-y-1.5 border-t border-[var(--card-border)] px-3 py-2">
+              ${paths.connectorsDir
+                ? html`<${PathRow} label="Connectors" value=${paths.connectorsDir} hint="sidecar names.json / status.json 위치" />`
+                : null}
+              ${paths.logsDir
+                ? html`<${PathRow} label="Logs" value=${paths.logsDir} hint="sidecar 로그 디렉토리" />`
+                : null}
+              <${PathRow} label="Keepers" value=${paths.keepersDir} hint="keeper TOML 설정 파일" />
+              <${PathRow} label="Sidecars" value=${paths.sidecarsDir} hint="sidecar 스크립트 (run.sh) 위치" />
+            </div>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -36,6 +36,7 @@ import { QuickBindForm } from './connector-quick-bind'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
 import { ConnectorKeyboardShortcuts } from './connector-keyboard-shortcuts'
 import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
+import { ConnectorPathsStrip } from './connector-paths-strip'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { route } from '../router'
 
@@ -1205,6 +1206,9 @@ export function ConnectorStatusPanel() {
         : null}
       ${!filterId
         ? html`<${ConnectorKeeperMatrix} matrix=${deriveMatrix(visibleConnectors, snapshot.keepers)} />`
+        : null}
+      ${!filterId
+        ? html`<${ConnectorPathsStrip} connectors=${visibleConnectors} />`
         : null}
       ${!filterId ? html`<${ConnectorKeyboardShortcuts} />` : null}
 


### PR DESCRIPTION
## Summary
- 새 `ConnectorPathsStrip` — all-connectors 뷰 아래 접혀있는 경로 패널.
- 4개 MASC 경로 one-click 표시: `connectors/`, `logs/`, `config/keepers/`, `sidecars/`.
- Pure `deriveMascPaths(connectors)` — `names_path` 정규식 파싱, runtime 없을 때 fallback.
- 각 경로는 `CopyableCode` — 클릭 시 절대 경로 클립보드 복사.

## Motivation
"keeper TOML 어디 있어요?" / "sidecar 로그 어디서 봐요?" 질문을 operator가 반복. 답은 코드 투어 또는 Slack ping. 이 디스클로저 패널이 0클릭(접혔을 때는 primary path 표시) → 1클릭(확장하여 모든 경로) → 1클릭(복사)로 흐름 축약.

원래 #7940 redesign에 포함됐던 조각 중 가장 독립적인 부분만 추출. 기존 tile strip / matrix / keyboard shortcuts 손대지 않음.

## Scope
- New: `connector-paths-strip.ts` (118 LOC) + `connector-paths-strip.test.ts` (118 LOC)
- `connector-status.ts`: +4 LOC (1 import + 1 mount block)
- 기존 컴포넌트 손대지 않음 → drift 재발 위험 최소.

## Evidence
- ✅ Tests: 9/9 new + 21/21 connector-status
- ✅ TypeScript strict: no errors in touched files
- ✅ Build: clean
- 4 pure `deriveMascPaths` branches: empty / standard / non-standard / fallthrough
- 5 DOM behaviors: mount / collapsed-default / click-expand / runtime surfacing / no-runtime hint

## Linked issue
Refs #7940 — restores the "where is my config?" disclosure that was closed with the larger redesign, without re-introducing any tile-layout conflicts.

## Test plan
- [ ] all-connectors 뷰에서 matrix 아래 paths 패널 접혀있음
- [ ] 클릭 시 확장 → Keepers / Sidecars 항상 표시
- [ ] connector runtime이 감지되면 Connectors / Logs 추가로 표시
- [ ] 각 행의 경로 클릭 시 클립보드 복사