### PR TITLE
[dash-iter57] persist filter state via useSavedSignal hook

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -13,6 +13,7 @@ import {
 import { resetKeeper } from '../api/keeper'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { useSavedSignal } from '../lib/saved-signal'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
@@ -353,7 +354,7 @@ export function FleetTelemetryPanel() {
   const latestRequestId = useRef(0)
   const activeController = useRef<AbortController | null>(null)
   const state = useSignal<FleetTelemetryState>(emptyState())
-  const query = useSignal('')
+  const [query] = useSavedSignal('dash:filter:fleet-telemetry:query', '')
 
   const loadFleetTelemetry = async () => {
     activeController.current?.abort()

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -7,6 +7,7 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import { useSavedSignal } from '../lib/saved-signal'
 import { get, type GetOptions } from '../api/core'
 
 export interface ToolRejection {
@@ -107,7 +108,7 @@ export function GovernanceMonitor() {
   }
   const resource = resourceRef.current
   const windowMinutes = useSignal(60)
-  const query = useSignal('')
+  const [query] = useSavedSignal('dash:filter:governance-monitor:query', '')
 
   const load = () =>
     resource.load(async (signal) => fetchGovernanceToolEvents(windowMinutes.value, { signal }))

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -26,9 +26,9 @@
 // `pointer-events: none` on the overlay so chips remain clickable.
 
 import { html } from 'htm/preact'
-import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
+import { useSavedSignal } from '../lib/saved-signal'
 
 export type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
 
@@ -241,7 +241,7 @@ export function HandoffTimeline({
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState<number>(() => Date.now())
   const latestRequestId = useRef(0)
-  const query = useSignal('')
+  const [query] = useSavedSignal('dash:filter:handoff-timeline:query', '')
 
   useEffect(() => {
     let cancelled = false

--- a/dashboard/src/lib/saved-signal.test.ts
+++ b/dashboard/src/lib/saved-signal.test.ts
@@ -1,0 +1,140 @@
+import { html } from 'htm/preact'
+import { cleanup, render, act } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSavedSignal } from './saved-signal'
+
+// Small test harness: a component that calls the hook and exposes the
+// current signal + reset via refs so the test can drive it.
+interface HookRef<T> {
+  getValue: () => T
+  setValue: (v: T) => void
+  reset: () => void
+}
+
+function makeHarness<T>(key: string, initial: T, ref: HookRef<T> | { current: HookRef<T> | null }) {
+  const Host = () => {
+    const [signal, reset] = useSavedSignal<T>(key, initial)
+    const slot: HookRef<T> = {
+      getValue: () => signal.value,
+      setValue: (v) => { signal.value = v },
+      reset,
+    }
+    if ('current' in ref) ref.current = slot
+    else Object.assign(ref, slot)
+    return html`<div data-testid="host">${String(signal.value)}</div>`
+  }
+  return Host
+}
+
+describe('useSavedSignal', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('starts with initial when localStorage has no entry', () => {
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:none', 'init', ref)
+    render(html`<${Host} />`)
+    expect(ref.current?.getValue()).toBe('init')
+  })
+
+  it('hydrates from localStorage on mount when entry exists', () => {
+    window.localStorage.setItem('dash:test:hydrate', JSON.stringify('stored-value'))
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:hydrate', 'init', ref)
+    render(html`<${Host} />`)
+    expect(ref.current?.getValue()).toBe('stored-value')
+  })
+
+  it('writes JSON on change', async () => {
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:write', '', ref)
+    render(html`<${Host} />`)
+    await act(async () => { ref.current?.setValue('hello') })
+    expect(window.localStorage.getItem('dash:test:write')).toBe(JSON.stringify('hello'))
+  })
+
+  it('removes key when value is empty string (tidy)', async () => {
+    window.localStorage.setItem('dash:test:tidy', JSON.stringify('prior'))
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:tidy', '', ref)
+    render(html`<${Host} />`)
+    // Initial value hydrated from storage = 'prior'; set back to ''
+    await act(async () => { ref.current?.setValue('') })
+    expect(window.localStorage.getItem('dash:test:tidy')).toBeNull()
+  })
+
+  it('removes key when value equals initial (tidy)', async () => {
+    window.localStorage.setItem('dash:test:tidy-init', JSON.stringify('other'))
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:tidy-init', 'default', ref)
+    render(html`<${Host} />`)
+    await act(async () => { ref.current?.setValue('default') })
+    expect(window.localStorage.getItem('dash:test:tidy-init')).toBeNull()
+  })
+
+  it('reset() clears localStorage and resets the signal', async () => {
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:reset', 'init', ref)
+    render(html`<${Host} />`)
+    await act(async () => { ref.current?.setValue('changed') })
+    expect(window.localStorage.getItem('dash:test:reset')).toBe(JSON.stringify('changed'))
+    await act(async () => { ref.current?.reset() })
+    expect(ref.current?.getValue()).toBe('init')
+    expect(window.localStorage.getItem('dash:test:reset')).toBeNull()
+  })
+
+  it('falls back to initial on malformed stored JSON and does not throw', () => {
+    window.localStorage.setItem('dash:test:malformed', '{not valid json')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const ref: { current: HookRef<string> | null } = { current: null }
+    const Host = makeHarness('dash:test:malformed', 'init', ref)
+    expect(() => render(html`<${Host} />`)).not.toThrow()
+    expect(ref.current?.getValue()).toBe('init')
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('round-trips numbers, booleans, and plain objects', async () => {
+    const numRef: { current: HookRef<number> | null } = { current: null }
+    render(html`<${makeHarness<number>('dash:test:num', 0, numRef)} />`)
+    await act(async () => { numRef.current?.setValue(42) })
+    expect(window.localStorage.getItem('dash:test:num')).toBe('42')
+
+    const boolRef: { current: HookRef<boolean> | null } = { current: null }
+    render(html`<${makeHarness<boolean>('dash:test:bool', false, boolRef)} />`)
+    await act(async () => { boolRef.current?.setValue(true) })
+    expect(window.localStorage.getItem('dash:test:bool')).toBe('true')
+
+    type Obj = { a: number; b: string }
+    const objRef: { current: HookRef<Obj> | null } = { current: null }
+    render(html`<${makeHarness<Obj>('dash:test:obj', { a: 0, b: '' }, objRef)} />`)
+    await act(async () => { objRef.current?.setValue({ a: 1, b: 'x' }) })
+    expect(window.localStorage.getItem('dash:test:obj')).toBe(JSON.stringify({ a: 1, b: 'x' }))
+
+    // Re-mount the object harness and confirm hydration.
+    cleanup()
+    const objRef2: { current: HookRef<Obj> | null } = { current: null }
+    render(html`<${makeHarness<Obj>('dash:test:obj', { a: 0, b: '' }, objRef2)} />`)
+    expect(objRef2.current?.getValue()).toEqual({ a: 1, b: 'x' })
+  })
+
+  it('survives absence of window.localStorage (SSR-ish)', () => {
+    // Simulate localStorage being unavailable. We can't undefine `window` under
+    // happy-dom cleanly, but we can replace localStorage with undefined.
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage')
+    try {
+      Object.defineProperty(window, 'localStorage', { configurable: true, value: undefined })
+      const ref: { current: HookRef<string> | null } = { current: null }
+      const Host = makeHarness('dash:test:ssr', 'init', ref)
+      expect(() => render(html`<${Host} />`)).not.toThrow()
+      expect(ref.current?.getValue()).toBe('init')
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original)
+    }
+  })
+})

--- a/dashboard/src/lib/saved-signal.ts
+++ b/dashboard/src/lib/saved-signal.ts
@@ -1,0 +1,82 @@
+import { useSignal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import type { Signal } from '@preact/signals'
+
+/**
+ * `useSignal` variant that persists its value to `localStorage`.
+ *
+ * Semantics:
+ *   - First mount reads the stored JSON value under `key` (if present and parseable)
+ *     and assigns it to `signal.value`. If parsing fails or the key is absent, the
+ *     signal keeps `initial`.
+ *   - Every subsequent change writes the new value as JSON to `localStorage[key]`.
+ *   - If the new value equals the empty string `''` or equals `initial` (via
+ *     `Object.is` for primitives), the key is removed instead of written, keeping
+ *     storage tidy.
+ *   - Write/read failures (quota, malformed JSON, missing `window`) are caught
+ *     and logged via `console.warn`; the in-memory signal continues to work.
+ *
+ * Returns the `Signal<T>` plus a `reset()` helper that clears the stored entry
+ * and assigns `initial` back to the signal.
+ *
+ * Recommended key shape: `dash:filter:<component-tag>:<field>`.
+ * Only intended for JSON-serializable values (string, number, boolean, plain
+ * objects/arrays of the same).
+ */
+export function useSavedSignal<T>(key: string, initial: T): [Signal<T>, () => void] {
+  const signal = useSignal<T>(initial)
+  const hydrated = useRef(false)
+
+  // Mount: read persisted value once (if any).
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+      hydrated.current = true
+      return
+    }
+    try {
+      const raw = window.localStorage.getItem(key)
+      if (raw !== null) {
+        const parsed = JSON.parse(raw) as T
+        signal.value = parsed
+      }
+    } catch (err) {
+      console.warn(`[useSavedSignal] failed to read "${key}":`, err)
+    }
+    hydrated.current = true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  // Persist on change (after hydration to avoid writing the initial default).
+  useEffect(() => {
+    if (!hydrated.current) return
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return
+    try {
+      const value = signal.value
+      const isEmpty = value === '' || Object.is(value, initial)
+      if (isEmpty) {
+        window.localStorage.removeItem(key)
+        return
+      }
+      const encoded = JSON.stringify(value)
+      const current = window.localStorage.getItem(key)
+      if (current !== encoded) {
+        window.localStorage.setItem(key, encoded)
+      }
+    } catch (err) {
+      console.warn(`[useSavedSignal] failed to write "${key}":`, err)
+    }
+  }, [signal.value, key, initial, signal])
+
+  const reset = () => {
+    if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
+      try {
+        window.localStorage.removeItem(key)
+      } catch (err) {
+        console.warn(`[useSavedSignal] failed to clear "${key}":`, err)
+      }
+    }
+    signal.value = initial
+  }
+
+  return [signal, reset]
+}


### PR DESCRIPTION
## Summary
- New `useSavedSignal(key, initial)` hook — localStorage-backed signal, SSR-safe, empty-value tidies storage.
- Applied to 3 representative panels (fleet-telemetry, handoff-timeline, governance-monitor). Same UX, just persistent across reloads.
- Rollout strategy: once this lands, follow-up PRs can wire the other ~30 filter components.

## Test plan
- [x] 9 unit tests on the hook (SSR-safe / round-trip / reset / malformed value / tidy-on-empty / tidy-on-initial)
- [x] Existing component tests still green (62 passing across the 3 panels + fleet-health host)
- [x] pnpm typecheck + lint green locally
- [ ] CI green