### PR TITLE
feat(dashboard): 📉 Sparkline a11y + stats helpers + decorative mode + tests (0→18)

### DIFF
--- a/dashboard/src/components/common/sparkline.test.ts
+++ b/dashboard/src/components/common/sparkline.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  Sparkline,
+  sparklineStats,
+  sparklineAriaLabel,
+} from './sparkline'
+
+describe('sparklineStats (pure)', () => {
+  it('returns null for < 2 values (too short to form a trend)', () => {
+    expect(sparklineStats([])).toBeNull()
+    expect(sparklineStats([42])).toBeNull()
+  })
+
+  it('computes first / latest / min / max / range / delta correctly', () => {
+    const s = sparklineStats([10, 15, 8, 20, 12])
+    expect(s).toEqual({
+      first: 10,
+      latest: 12,
+      min: 8,
+      max: 20,
+      range: 12,
+      delta: 2,
+    })
+  })
+
+  it('handles a flat series (range=0, delta=0)', () => {
+    const s = sparklineStats([5, 5, 5, 5])
+    expect(s).toEqual({
+      first: 5,
+      latest: 5,
+      min: 5,
+      max: 5,
+      range: 0,
+      delta: 0,
+    })
+  })
+
+  it('handles negative values and a downward trend', () => {
+    const s = sparklineStats([-2, 0, -5, -8])
+    expect(s?.first).toBe(-2)
+    expect(s?.latest).toBe(-8)
+    expect(s?.min).toBe(-8)
+    expect(s?.max).toBe(0)
+    expect(s?.delta).toBe(-6)
+  })
+})
+
+describe('sparklineAriaLabel (pure)', () => {
+  it('returns the insufficient-data label for < 2 values', () => {
+    expect(sparklineAriaLabel([42])).toBe('Sparkline (insufficient data)')
+    expect(sparklineAriaLabel([])).toBe('Sparkline (insufficient data)')
+  })
+
+  it('formats integers without decimal places', () => {
+    const label = sparklineAriaLabel([10, 15, 20])
+    expect(label).toBe('Sparkline: 10 → 20 (min 10, max 20)')
+  })
+
+  it('formats non-integer values with 2 decimal places', () => {
+    const label = sparklineAriaLabel([1.2345, 2.5, 3.7])
+    expect(label).toContain('1.23')
+    expect(label).toContain('3.70')
+  })
+
+  it('mentions first → latest and min/max bounds (Grafana convention)', () => {
+    // Regression guard: the Grafana stat-panel narrative is
+    // "first → latest (min X, max Y)". Any reorder breaks AT contract.
+    const label = sparklineAriaLabel([5, 10, 2, 8])
+    expect(label).toMatch(/^Sparkline: 5 → 8/)
+    expect(label).toContain('min 2')
+    expect(label).toContain('max 10')
+  })
+})
+
+describe('Sparkline component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('returns null (renders nothing) for < 2 values', () => {
+    render(html`<${Sparkline} values=${[42]} />`, container)
+    expect(container.querySelector('canvas')).toBeNull()
+  })
+
+  it('renders a <canvas> for 2+ values', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} />`, container)
+    expect(container.querySelector('canvas')).toBeTruthy()
+  })
+
+  it('canvas has role="img" (AT treats it as an image, not a generic element)', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} />`, container)
+    const c = container.querySelector('canvas')!
+    expect(c.getAttribute('role')).toBe('img')
+  })
+
+  it('default aria-label narrates first → latest + bounds (no caller work)', () => {
+    render(html`<${Sparkline} values=${[10, 20, 15]} />`, container)
+    const label = container.querySelector('canvas')!.getAttribute('aria-label')
+    expect(label).toBe('Sparkline: 10 → 15 (min 10, max 20)')
+  })
+
+  it('caller can override aria-label with a custom narrative', () => {
+    render(
+      html`<${Sparkline} values=${[1, 2, 3]} ariaLabel="Request rate over the last hour" />`,
+      container,
+    )
+    expect(container.querySelector('canvas')!.getAttribute('aria-label')).toBe(
+      'Request rate over the last hour',
+    )
+  })
+
+  it('ariaHidden=true removes aria-label AND sets aria-hidden="true" (decorative-only)', () => {
+    // Regression guard: callers with a numeric label next to the
+    // sparkline don't want AT to double-read. aria-hidden must win
+    // over auto-generated aria-label.
+    render(html`<${Sparkline} values=${[1, 2, 3]} ariaHidden=${true} />`, container)
+    const c = container.querySelector('canvas')!
+    expect(c.getAttribute('aria-hidden')).toBe('true')
+    expect(c.hasAttribute('aria-label')).toBe(false)
+  })
+
+  it('ariaHidden=false / undefined keeps aria-label and omits aria-hidden', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} />`, container)
+    const c = container.querySelector('canvas')!
+    expect(c.hasAttribute('aria-label')).toBe(true)
+    expect(c.hasAttribute('aria-hidden')).toBe(false)
+  })
+
+  it('testId renders as data-testid (E2E stable hook)', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} testId="tok-per-sec" />`, container)
+    expect(container.querySelector('canvas')!.getAttribute('data-testid')).toBe('tok-per-sec')
+  })
+
+  it('class prop is appended to the base "block" class', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} class="my-2" />`, container)
+    const cn = container.querySelector('canvas')!.className
+    expect(cn).toContain('block')
+    expect(cn).toContain('my-2')
+  })
+
+  it('base class preserved when no `class` prop is passed', () => {
+    render(html`<${Sparkline} values=${[1, 2, 3]} />`, container)
+    expect(container.querySelector('canvas')!.className).toBe('block')
+  })
+})

--- a/dashboard/src/components/common/sparkline.ts
+++ b/dashboard/src/components/common/sparkline.ts
@@ -1,5 +1,12 @@
-// Sparkline — inline Canvas 2D sparkline chart
+// Sparkline — inline Canvas 2D sparkline chart.
 // Draws a filled area, polyline stroke, and a dot at the latest data point.
+//
+// Reference UI pattern (Grafana / Datadog stat panels): a canvas-only
+// sparkline is INVISIBLE to assistive tech — AT users get nothing. We
+// expose a default aria-label with "first → latest (min / max)" stats
+// so screen readers still get the narrative. Callers that use the
+// sparkline purely as decoration next to a numeric stat can pass
+// `ariaHidden=true` to avoid redundant read-outs.
 
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
@@ -9,6 +16,54 @@ interface SparklineProps {
   width?: number
   height?: number
   color?: string
+  class?: string
+  /** Override the auto-generated accessible label. Useful when the
+      surrounding context already tells the story and you want a
+      shorter narrative. */
+  ariaLabel?: string
+  /** Mark as purely decorative — AT will skip it. Use when a numeric
+      label sits right next to the sparkline and they'd otherwise be
+      read twice ("42 — Sparkline: 42 → 58 …"). */
+  ariaHidden?: boolean
+  /** `data-testid` for E2E hooks. */
+  testId?: string
+}
+
+/** Stats derived from the series — exposed for callers that want to
+    render their own trend badges AND for unit tests (no canvas needed). */
+export interface SparklineStats {
+  first: number
+  latest: number
+  min: number
+  max: number
+  range: number
+  /** latest - first; 0 when series is flat. */
+  delta: number
+}
+
+/** Pure: compute summary stats from a values array. Returns null if
+    the series is too short to form a sparkline (< 2 points). */
+export function sparklineStats(values: number[]): SparklineStats | null {
+  if (values.length < 2) return null
+  const first = values[0]!
+  const latest = values[values.length - 1]!
+  let min = first
+  let max = first
+  for (const v of values) {
+    if (v < min) min = v
+    if (v > max) max = v
+  }
+  return { first, latest, min, max, range: max - min, delta: latest - first }
+}
+
+/** Pure: build a default screen-reader label from the stats. Matches
+    the Grafana "first → latest (min / max)" convention so AT users get
+    the trend AND the bounds. */
+export function sparklineAriaLabel(values: number[]): string {
+  const s = sparklineStats(values)
+  if (s === null) return 'Sparkline (insufficient data)'
+  const fmt = (n: number) => Number.isInteger(n) ? String(n) : n.toFixed(2)
+  return `Sparkline: ${fmt(s.first)} → ${fmt(s.latest)} (min ${fmt(s.min)}, max ${fmt(s.max)})`
 }
 
 export function Sparkline({
@@ -16,6 +71,10 @@ export function Sparkline({
   width = 120,
   height = 28,
   color = '#22d3ee',
+  class: cx,
+  ariaLabel,
+  ariaHidden,
+  testId,
 }: SparklineProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -23,7 +82,7 @@ export function Sparkline({
     const canvas = canvasRef.current
     if (!canvas || values.length < 2) return
 
-    const dpr = window.devicePixelRatio || 1
+    const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1
     canvas.width = width * dpr
     canvas.height = height * dpr
     canvas.style.width = `${width}px`
@@ -84,5 +143,14 @@ export function Sparkline({
 
   if (values.length < 2) return null
 
-  return html`<canvas ref=${canvasRef} class="block" />`
+  const cls = cx ? `block ${cx}` : 'block'
+  const label = ariaHidden === true ? undefined : (ariaLabel ?? sparklineAriaLabel(values))
+  return html`<canvas
+    ref=${canvasRef}
+    class=${cls}
+    role="img"
+    aria-label=${label}
+    aria-hidden=${ariaHidden === true ? 'true' : undefined}
+    data-testid=${testId}
+  />`
 }


### PR DESCRIPTION
## Summary

Canvas-only sparklines are **INVISIBLE to assistive tech** — AT users get nothing. Reference UI (Grafana / Datadog stat panels) attaches a narrative aria-label: \"first → latest (min X, max Y)\". This chip ports that pattern.

## Upgrades

| Change | Why |
|--------|-----|
| `role=\"img\"` + auto aria-label | Grafana convention: \"Sparkline: 10 → 15 (min 10, max 20)\" |
| `ariaLabel` prop override | Caller can write richer narrative (\"Request rate over the last hour\") |
| `ariaHidden` prop | Decorative-only mode — prevents AT double-read when numeric label sits next to the sparkline |
| `class` prop | Caller theming |
| `testId` prop | E2E stable hook |
| SSR-safe `window` guard | `devicePixelRatio` no longer crashes in SSR / node test runs |

## Pure helpers (testable without canvas)

```ts
sparklineStats(values)  // { first, latest, min, max, range, delta } | null
sparklineAriaLabel(values)  // narrative string
```

Exposed so callers can render their own trend badges without re-deriving the math.

## Tests (18, 0→18)

**Pure helpers:**
- `sparklineStats`: null for <2, integer series, flat, negative downward trend
- `sparklineAriaLabel`: insufficient-data label, integer format, 2-decimal for non-integer, **Grafana convention regression guard** (first→latest, then min, then max)

**Component:**
- Returns null for <2 values
- Renders `<canvas>` for 2+
- `role=\"img\"` (not generic element)
- Default aria-label narrates from stats
- Custom aria-label override
- **ariaHidden=true removes aria-label AND adds aria-hidden=\"true\"** (regression guard against double-read)
- ariaHidden=false keeps aria-label
- `testId` → `data-testid`
- `class` append + base class preservation

## Backward compat

Sole caller `fleet-telemetry-panel.ts` passes only `values/width/height/color` — unchanged. Inline Sparklines in `keeper-tool-telemetry.ts` and `keeper-detail-panels.ts:miniSparkline` are separate files, not affected.

## Test plan

- [x] `npx vitest run src/components/common/sparkline.test.ts` → 18/18 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)