### PR TITLE
feat(dashboard): CopyIdButton for worker/session/operation ID pills

### DIFF
--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
+import { CopyIdButton } from './common/copy-id-button'
 import { workerBriefForAgent } from './agent-detail-state'
 import { trimText } from '../lib/truncate'
 
@@ -33,7 +34,8 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
         ${worker.related_session_id ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
             <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">세션</span>
-            <span class="font-mono" style="font-size: 11px">${worker.related_session_id}</span>
+            <span class="font-mono truncate" style="font-size: 11px" title=${worker.related_session_id}>${worker.related_session_id}</span>
+            <${CopyIdButton} value=${worker.related_session_id} label="session_id" size=${10} />
           </div>
         ` : null}
         ${worker.last_signal_at ? html`

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { RouteLink } from './common/route-link'
+import { CopyIdButton } from './common/copy-id-button'
 import { toolCategory } from './tool-call-shared'
 import type { DashboardProofWorkerRunEvidence } from '../types'
 import { relativeTime } from '../lib/format-time'
@@ -27,9 +28,18 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
         <div class="flex flex-col gap-1.5 min-w-0">
           <strong class="text-[13px] text-text-strong font-bold tracking-wide">${item.worker_name ?? item.worker_run_id}</strong>
           <div class="flex flex-wrap gap-2 text-[11px] text-text-muted font-medium items-center">
-            <span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5">${item.worker_run_id}</span>
-            ${item.session_id ? html`<span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5">S ${item.session_id}</span>` : null}
-            ${item.operation_id ? html`<span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5">OP ${item.operation_id}</span>` : null}
+            <span class="inline-flex items-center gap-1">
+              <span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5" title=${item.worker_run_id}>${item.worker_run_id}</span>
+              <${CopyIdButton} value=${item.worker_run_id} label="worker_run_id" size=${10} />
+            </span>
+            ${item.session_id ? html`<span class="inline-flex items-center gap-1">
+              <span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5" title=${item.session_id}>S ${item.session_id}</span>
+              <${CopyIdButton} value=${item.session_id} label="session_id" size=${10} />
+            </span>` : null}
+            ${item.operation_id ? html`<span class="inline-flex items-center gap-1">
+              <span class="font-mono bg-white/5 px-1.5 py-0.5 rounded border border-white/5" title=${item.operation_id}>OP ${item.operation_id}</span>
+              <${CopyIdButton} value=${item.operation_id} label="operation_id" size=${10} />
+            </span>` : null}
             <span class="text-text-dim/60">•</span>
             <span>${item.ts_iso ? relativeTime(item.ts_iso) : '기록 없음'}</span>
           </div>


### PR DESCRIPTION
## Summary
Third wave of `CopyIdButton` wire-up (after #7973 component + #7989 fingerprints + #8001 trace_id).

## Wire-up points
1. **agent-detail-worker** AgentWorkerBrief: `worker.related_session_id` row now has copy + title.
2. **proof-sections** WorkerRunEvidenceRow: three ID pills (`worker_run_id`, `session_id`, `operation_id`) each paired with copy + title.

No visual footprint when ID is null (pills already conditional).

## Test plan
- [x] `pnpm typecheck` clean
- [ ] CI: Build and Test / Dashboard / Lint
- [ ] Visual spot-check (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)