### PR TITLE
chore(dashboard): purge retired runtime-params / param-audit API surface

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -406,63 +406,6 @@ export async function decideGovernanceExecutionOrder(
   throw governanceCasesRetiredError()
 }
 
-export interface RuntimeParamMeta {
-  description: string
-  value_type: string
-  min_value?: number
-  max_value?: number
-}
-
-export interface RuntimeParam {
-  key: string
-  current: unknown
-  default: unknown
-  has_override: boolean
-  meta?: RuntimeParamMeta | null
-}
-
-export interface RuntimeParamsSurface {
-  id: string
-  description: string
-  risk: string
-  param_keys: string[]
-}
-
-export interface RuntimeParamsResponse {
-  parameters: RuntimeParam[]
-  surfaces: RuntimeParamsSurface[]
-}
-
-export function fetchRuntimeParams(): Promise<RuntimeParamsResponse> {
-  return get('/api/v1/governance/params')
-}
-
-export function setRuntimeParam(paramKey: string, value: unknown, reason = ''): Promise<{ ok: boolean; message: string }> {
-  return post('/api/v1/governance/params/set', { param_key: paramKey, value, reason })
-}
-
-export function clearRuntimeParam(paramKey: string): Promise<{ ok: boolean; message: string }> {
-  return post('/api/v1/governance/params/clear', { param_key: paramKey })
-}
-
-export interface ParamAuditEntry {
-  timestamp: number
-  key: string
-  old_value: unknown
-  new_value: unknown
-  actor: string
-  case_id?: string
-}
-
-export interface ParamAuditResponse {
-  entries: ParamAuditEntry[]
-  count: number
-}
-
-export function fetchParamAudit(limit = 50): Promise<ParamAuditResponse> {
-  return get(`/api/v1/governance/params/audit?limit=${limit}`)
-}
-
 export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
   return get('/api/v1/dashboard/mission')
 }

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -39,9 +39,7 @@ function governanceBundle(): GovernanceCaseBundle {
 async function loadComponentWithApi(api: {
   decideGovernanceExecutionOrder: () => Promise<void>
   fetchDashboardGovernance: () => Promise<DashboardGovernanceResponse>
-  fetchParamAudit: (limit?: number) => Promise<{ entries: [] }>
   fetchGovernanceCaseStatus: (caseId: string) => Promise<GovernanceCaseBundle>
-  fetchRuntimeParams: () => Promise<{ parameters: []; surfaces: [] }>
   resolveGovernanceApproval: (id: string, decision: 'approve' | 'reject', reason?: string) => Promise<{ ok: boolean; id: string; decision: 'approve' | 'reject' }>
   submitGovernanceCaseBrief: () => Promise<GovernanceCaseBundle>
   submitGovernancePetition: () => Promise<{ case: { id: string } }>
@@ -86,9 +84,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(response),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -136,9 +132,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(withJudgments),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -176,9 +170,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(offlineJudge),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -230,9 +222,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance,
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval,
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -289,9 +279,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(retiredOffline),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -325,9 +313,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(retiredIdle),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -358,9 +344,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(hitlEmptyOffline),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
@@ -396,9 +380,7 @@ describe('Governance surface', () => {
     const { Governance } = await loadComponentWithApi({
       decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
       fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(hitlEmptyHealthy),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
       fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
       resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
       submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
       submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),


### PR DESCRIPTION
## Summary

`/loop 20m` Gen36. `#8003` (Gen35)에서 UI + signals 레이어를 제거한 뒤에도 API surface가 남아있던 것을 정리했습니다. production import 0, test mock만 12회.

## 변경

| 파일 | LOC | 내용 |
|---|---|---|
| `dashboard/src/api/dashboard.ts` | -57 | 4 함수 + 5 타입 한 덩어리 삭제 (line 409-464) |
| `dashboard/src/components/governance.test.ts` | -18 | `loadComponentWithApi` interface 2줄 + mock 16줄 삭제 |
| **합계** | **-75** | |

### 제거된 symbol
- **Functions (4)**: `fetchRuntimeParams`, `setRuntimeParam`, `clearRuntimeParam`, `fetchParamAudit`
- **Types (5)**: `RuntimeParamMeta`, `RuntimeParam`, `RuntimeParamsSurface`, `RuntimeParamsResponse`, `ParamAuditEntry`, `ParamAuditResponse`
- **API endpoints** (백엔드는 건드리지 않음): `/api/v1/governance/params`, `/api/v1/governance/params/set`, `/api/v1/governance/params/clear`, `/api/v1/governance/params/audit`

### 근거
```
$ grep -rn 'fetchRuntimeParams|fetchParamAudit|setRuntimeParam|clearRuntimeParam' dashboard/src/ | grep -v '.test.' | grep -v 'api/dashboard.ts'
(empty)
```

## 검증

- `bun run build`: ✅ 17.82s
- `bun run test`: ✅ 207 files passed

## /loop 스택 (Gen29~36)

| PR | Gen | 상태 | 범위 |
|---|---|---|---|
| #7938 | 29 | MERGED | dashboard orphan 3종 |
| #7948 | 30 | MERGED | keeper_handoff_delta OCaml |
| #7962 | 31 | MERGED | governance-panels cluster |
| #7969 | 32 | MERGED | LiveGovernanceToolbar |
| #7977 | 33 | MERGED | 33 dead exports |
| #7991 | 34 | MERGED | mission-cards barrel |
| #8003 | 35 | MERGED | runtime-params signals |
| **#TBD** | **36** | **Draft** | **runtime-params API surface** |

누적 dead code: **-1,576 LOC** (Gen29-35 합계 -1,501 + 본 PR -75)

## 다음 cycle 후보
- 34개 stale worktree 정리 (repo 운영 hygiene)
- 남은 28 write-only signal 중 store.ts 묶음 (UI 보강 또는 삭제)

## Test plan
- [ ] 기존 CI 통과 확인
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)