### PR TITLE
docs(design): rename CDAL-PHASE1A cdal_eval refs to cdal_eval_v1 + clarify successors

### DIFF
--- a/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
+++ b/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
@@ -60,7 +60,7 @@ Before writing code, confirm the producer side:
 - `oas/lib/mode_enforcer.ml` — runtime enforcement logic (producer side)
 - `oas/lib/proof_capture.ml` — proof artifact writer (producer side)
 - `oas/lib/proof_store.mli` — proof store read interface
-- `masc-mcp/lib/cdal_eval.ml` — current evaluator (anti-pattern reference, not implementation guide)
+- `masc-mcp/lib/cdal_eval_v1.ml` — current evaluator (anti-pattern reference, not implementation guide). The previous `cdal_eval.ml` was renamed to `cdal_eval_v1.ml` to mark it as the legacy path; `cdal_loader.ml`, `cdal_judge.ml`, `cdal_friction_projection.ml` (the Phase-1A deliverables listed in §1) now exist under `lib/` and are the canonical successors.
 
 These files tell you what exists today.
 The docs tell you what you are allowed to claim from those fields.
@@ -148,7 +148,7 @@ Unavailable means `None`, not inference.
 
 Legacy cleanup (after Phase-1A validation):
 
-- delete substring/ref-count logic from `cdal_eval.ml` only after the new evaluator passes replay tests on real bundles
+- delete substring/ref-count logic from `cdal_eval_v1.ml` only after the new evaluator passes replay tests on real bundles
 
 ## 10. Minimum Review Checklist
 


### PR DESCRIPTION
## Summary

Two body-level references to `cdal_eval.ml` in `docs/design/CDAL-PHASE1A-TEAM-START-HERE.md` pointed to a module that was renamed to `cdal_eval_v1.ml` (to mark it as the legacy evaluator). Both occurrences fixed:

| Line | Before | After |
|------|--------|-------|
| §3 producer-side file list | `masc-mcp/lib/cdal_eval.ml` | `masc-mcp/lib/cdal_eval_v1.ml` + successor note |
| §9 legacy cleanup checklist | `cdal_eval.ml` | `cdal_eval_v1.ml` |

§3 also gained a clarifying sentence that the Phase-1A deliverables (`Cdal_loader`, `Cdal_judge`, `Cdal_friction_projection`) are now landed as `lib/cdal_loader.ml`, `lib/cdal_judge.ml`, `lib/cdal_friction_projection.ml`, which recasts the doc's framing from "what you will build" to "what the successor modules already are; this doc is now an anti-pattern/replay-test reference".

## Why this is the only fix

A repo-wide body-level scan surfaced 38 candidate "dead" refs across `docs/spec/` + `docs/design/`, but per-ref inspection shows the non-CDAL hits fall into three categories, none of which are real drift:

1. **Cross-repo references** — paths like `oas/lib/risk_contract.mli`. My body scanner matches on the `lib/X.ml` substring and misses the `oas/` prefix, flagging them as dead when they point to a different repo.
2. **Intentional gap documentation** — `docs/design/inventory-gap-analysis-rfc.md` explicitly lists `lib/tool_tempo.ml`, `lib/tool_encryption.ml`, `lib/tool_notifications.ml` as "dead handler (PR #4750에서 제거)". The doc is documenting the removal, not claiming the modules are live.
3. **Retirement paragraphs from earlier generations** — Gen37/39/41/43/44 collapsed retired subsystems into RETIRED prose that still names the removed modules for migration context. That pattern is already accepted on prior PRs.

Scanner refinement (prefix check + retirement-section skip) is deferred to a later generation. Surgical fix-per-generation remains cheaper.

## Gen context

Gen45 of the iterative doc-drift loop. Previous generations (33–44) cleared retired subsystems and elevated the frontmatter gate. Gen45's judgment plug shifts to **silent rename detection** — a live active subsystem whose module file changed name without the design doc catching up. Different class from Gen38 (room → coord silent rename) because there the module moved directory; here it gained a `_v1` suffix to mark legacy.

## Test plan
- [x] `bash scripts/check-doc-truth.sh` → Version truth OK + Doc truth OK + Doc code_refs OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)