### PR TITLE
feat(keeper): behavioral-regime observer wrapper + HTTP endpoints

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -461,6 +461,7 @@
    keeper_turn_cycle_contract
    keeper_composite_observer
    keeper_behavioral_regime
+   keeper_behavioral_regime_observer
    keeper_campaign_fsm
    keeper_unified_prompt
    keeper_unified_turn

--- a/lib/keeper/keeper_behavioral_regime_observer.ml
+++ b/lib/keeper/keeper_behavioral_regime_observer.ml
@@ -1,0 +1,37 @@
+(** Behavioral regime observer — pure projection from registry entry.
+    See [.mli] for contract. *)
+
+module R = Keeper_behavioral_regime
+module KR = Keeper_registry
+
+type snapshot = R.snapshot
+
+let tool_aggregates_of_entry (entry : KR.registry_entry)
+  : (string * R.tool_aggregate) list =
+  KR.StringMap.fold
+    (fun name (e : Keeper_types.tool_call_entry) acc ->
+       (name, { R.count = e.count; failures = e.failures }) :: acc)
+    entry.tool_usage
+    []
+
+let input_of_entry (entry : KR.registry_entry) : R.input =
+  {
+    turn_consecutive_failures = entry.turn_consecutive_failures;
+    restart_count = entry.restart_count;
+    last_restart_ts = entry.last_restart_ts;
+    tool_aggregates = tool_aggregates_of_entry entry;
+  }
+
+let observe ?now (entry : KR.registry_entry) : snapshot =
+  let now =
+    match now with
+    | Some t -> t
+    | None -> Unix.gettimeofday ()
+  in
+  R.derive ~now (input_of_entry entry)
+
+let all_snapshots ~(base_path : string) () : snapshot list =
+  KR.all ~base_path ()
+  |> List.map (fun entry -> observe entry)
+
+let snapshot_to_json = R.snapshot_to_json

--- a/lib/keeper/keeper_behavioral_regime_observer.mli
+++ b/lib/keeper/keeper_behavioral_regime_observer.mli
@@ -1,0 +1,28 @@
+(** Behavioral Regime Observer — pure projection wrapper.
+
+    Wraps the minimal-input deriver in [Keeper_behavioral_regime] with a
+    projection from [Keeper_registry.registry_entry], so the dashboard
+    HTTP layer and fleet-matrix endpoint can call a single function
+    instead of manually extracting per-entry fields.
+
+    Contract mirrors [Keeper_composite_observer]:
+    - Pure read. No mutation, no I/O, no event emission.
+    - Does not read provider names, token counts, or context bytes —
+      those belong to OAS (see [feedback_masc-oas-layer-boundary]).
+
+    @since RFC-0003 Phase 3 — 7th FSM axis (behavioral regime). *)
+
+type snapshot = Keeper_behavioral_regime.snapshot
+
+(** Derive a behavioral-regime snapshot from a live registry entry.
+    [now] is injected so the observer stays deterministic; defaults
+    to [Unix.gettimeofday ()] when omitted. *)
+val observe :
+  ?now:float -> Keeper_registry.registry_entry -> snapshot
+
+(** Observe every registered keeper under [base_path] once. Used by
+    the fleet-wide regime endpoint. Preserves registry iteration order. *)
+val all_snapshots : base_path:string -> unit -> snapshot list
+
+(** Stable JSON wire format — delegates to [Keeper_behavioral_regime]. *)
+val snapshot_to_json : snapshot -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1252,6 +1252,48 @@ let handle_keeper_get_subroutes state req request reqd =
          let json = Keeper_composite_observer.snapshot_to_json snapshot in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd)
+  else if req_path = prefix ^ "regime" then
+    (* 7th FSM axis MVP: fleet-wide behavioral-regime snapshot. Same
+       purity contract as the composite route above, uses the
+       [Keeper_behavioral_regime_observer] pure projection. *)
+    let base_path = state.Mcp_server.room_config.base_path in
+    let snapshots =
+      Keeper_behavioral_regime_observer.all_snapshots ~base_path ()
+    in
+    let json =
+      `Assoc [
+        "generated_at", `Float (Unix.gettimeofday ());
+        "count", `Int (List.length snapshots);
+        "snapshots",
+          `List
+            (List.map
+               Keeper_behavioral_regime_observer.snapshot_to_json
+               snapshots);
+      ]
+    in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
+  else if ends_with "/regime" then
+    (* Per-keeper behavioral-regime snapshot. *)
+    let name = extract_name "/regime" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let base_path = state.Mcp_server.room_config.base_path in
+      (match Keeper_registry.get ~base_path name with
+       | None ->
+         Http.Response.json ~status:`Not_found
+           (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
+       | Some entry ->
+         let snapshot =
+           Keeper_behavioral_regime_observer.observe entry
+         in
+         let json =
+           Keeper_behavioral_regime_observer.snapshot_to_json snapshot
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd)
   else
     Http.Response.json ~status:`Not_found
       {|{"error":"not found"}|} reqd


### PR DESCRIPTION
## Summary
7th FSM axis (behavioral regime) MVP wiring — projection layer from `Keeper_registry.registry_entry` to `Keeper_behavioral_regime.input` + two HTTP endpoints mirroring the composite observer shape.

## Motivation
#7968 landed the minimal-input deriver (`Crashing / Thrashing / Healthy`) with 13 unit tests. That deriver operates on a tiny record so it can be tested in isolation. This PR supplies the missing projection wrapper so the dashboard can actually consume the regime signal without re-implementing registry field extraction at every call site.

## Changes
- `lib/keeper/keeper_behavioral_regime_observer.{ml,mli}` — pure projection: registry entry → snapshot, plus `all_snapshots ~base_path` for fleet rollups. Contract mirrors `Keeper_composite_observer`.
- `lib/server/server_dashboard_http_keeper_api.ml` — add `GET /api/v1/keepers/regime` (fleet) and `/api/v1/keepers/:name/regime` (per-keeper), same shape as the existing `/composite` routes.
- `lib/dune` — register new module.

## Contract
- Pure read. No mutation, no I/O, no event emission.
- Does not read provider names, token counts, or context bytes (MASC↔OAS boundary preserved).
- `now` is injected so the observer stays deterministic under test.

## Not in this PR (follow-ups)
- Unit tests for the observer projection (deriver is already covered in #7968; wrapper tests go in a follow-up).
- TS dashboard 7th column on `FleetFsmMatrix` + regime panel on `FsmHub`.
- `KeeperBehavioralRegime.tla` spec + Bug Model pair.

## Test plan
- [x] `dune build lib/` — clean.
- [ ] Unit test (follow-up PR).
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)