### PR TITLE
feat(scripts): OAS API surface drift gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -95,6 +95,13 @@ release-evidence:
 # Fast local-only doctor for OAS/agent_sdk pin drift in the current switch.
 doctor-oas-pin:
 	bash scripts/check-oas-pin.sh --local-only
+
+# Check OAS API surface (Event_bus variants, HttpError variants, Metrics fields)
+# against scripts/oas-api-surface.json fingerprint. Catches upstream variant/field
+# additions before they surface as scattered non-exhaustive warnings in consumer
+# modules. Regenerate with: bash scripts/oas-drift-check.sh --regenerate
+doctor-oas-drift:
+	bash scripts/oas-drift-check.sh
 
 # Development setup
 dev-setup: pin-external-deps install-deps

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,0 +1,39 @@
+{
+  "pinned_sha": "92c3077afe5be2f1f8f47bbb479be1e159b802f8",
+  "pinned_version": "v0.155.1",
+  "surfaces": {
+    "event_bus_payload_variants": [
+      "AgentCompleted",
+      "AgentFailed",
+      "AgentStarted",
+      "ContentReplacementKept",
+      "ContentReplacementReplaced",
+      "ContextCompacted",
+      "ContextCompactStarted",
+      "ContextOverflowImminent",
+      "Custom",
+      "ElicitationCompleted",
+      "HandoffCompleted",
+      "HandoffRequested",
+      "SlotSchedulerObserved",
+      "ToolCalled",
+      "ToolCompleted",
+      "TurnCompleted",
+      "TurnStarted"
+    ],
+    "http_error_variants": [
+      "AcceptRejected",
+      "CliTransportRequired",
+      "HttpError",
+      "NetworkError"
+    ],
+    "metrics_fields": [
+      "on_cache_hit",
+      "on_cache_miss",
+      "on_error",
+      "on_http_status",
+      "on_request_end",
+      "on_request_start"
+    ]
+  }
+}

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Fingerprints OAS's public type surfaces (Event_bus payload variants,
+# Http_client error variants, Metrics.t record fields) and diffs against
+# the committed scripts/oas-api-surface.json.
+#
+# Purpose: when OAS adds/removes/renames a variant or field, MASC's
+# consumer-side pattern matches break. CI catches the compile error
+# eventually, but the information arrives late and scattered across N
+# files. This script reports the surface delta at pin-bump time, before
+# the build fails, so authors can plan consumer adjustments deliberately
+# rather than reactively.
+#
+# Usage:
+#   scripts/oas-drift-check.sh               # check; exit 0 match / 2 drift / 1 error
+#   scripts/oas-drift-check.sh --regenerate  # rewrite fingerprint from pinned SHA source
+#   scripts/oas-drift-check.sh --print       # print current surfaces, no diff
+#
+# Source resolution (first hit wins):
+#   1. $AGENT_SDK_LOCAL_REPO if a git checkout at the pinned SHA
+#   2. git fetch into temp bare clone (reuses check-oas-pin.sh pattern)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FINGERPRINT_FILE="${REPO_ROOT}/scripts/oas-api-surface.json"
+
+# shellcheck source=oas-agent-sdk-pin.sh
+source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
+
+MODE="check"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --regenerate) MODE="regenerate"; shift ;;
+    --print)      MODE="print"; shift ;;
+    -h|--help)
+      sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "jq required" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Source resolution
+# ---------------------------------------------------------------------------
+
+resolve_source_dir() {
+  local out_var="$1"
+
+  if [[ -n "${AGENT_SDK_LOCAL_REPO:-}" ]] \
+     && git -C "${AGENT_SDK_LOCAL_REPO}" rev-parse --is-inside-work-tree \
+        >/dev/null 2>&1; then
+    local head
+    head="$(git -C "${AGENT_SDK_LOCAL_REPO}" rev-parse HEAD 2>/dev/null || true)"
+    if [[ "${head}" == "${OAS_AGENT_SDK_SHA}" ]]; then
+      printf -v "${out_var}" '%s' "${AGENT_SDK_LOCAL_REPO}"
+      return 0
+    fi
+    echo "AGENT_SDK_LOCAL_REPO=${AGENT_SDK_LOCAL_REPO} is at ${head:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
+    return 1
+  fi
+
+  # Fallback: temp clone from upstream URL
+  local scratch
+  scratch="$(mktemp -d -t oas-drift-src.XXXXXX)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${scratch}'" EXIT
+
+  if ! GIT_DIR="${scratch}/bare" git init -q --bare; then
+    echo "git init bare failed" >&2; return 1
+  fi
+  if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags --depth=1 \
+         "${OAS_AGENT_SDK_URL}" "${OAS_AGENT_SDK_SHA}" 2>/dev/null; then
+    echo "git fetch of ${OAS_AGENT_SDK_SHA} from ${OAS_AGENT_SDK_URL} failed" >&2
+    return 1
+  fi
+  mkdir -p "${scratch}/tree"
+  if ! GIT_DIR="${scratch}/bare" git archive --format=tar FETCH_HEAD \
+        | tar -x -C "${scratch}/tree"; then
+    echo "git archive extract failed" >&2
+    return 1
+  fi
+  printf -v "${out_var}" '%s' "${scratch}/tree"
+}
+
+# ---------------------------------------------------------------------------
+# Surface extraction
+# ---------------------------------------------------------------------------
+
+# Event_bus payload variants live as `  | VariantName of { ... }` inside the
+# `type payload = ` block in lib/event_bus.ml.
+extract_event_bus_variants() {
+  local src="$1"
+  local file="${src}/lib/event_bus.ml"
+  [[ -f "${file}" ]] || { echo "missing ${file}" >&2; return 1; }
+  awk '
+    /^type payload/ { inblock=1; next }
+    inblock && /^(and|type|let|module) / { inblock=0 }
+    inblock && /^  \| [A-Z]/ {
+      sub(/^  \| /, ""); sub(/[[:space:]].*/, "");
+      print
+    }
+  ' "${file}" | sort -u
+}
+
+# Http_client error variants from the .mli type http_error.
+extract_http_error_variants() {
+  local src="$1"
+  local file="${src}/lib/llm_provider/http_client.mli"
+  [[ -f "${file}" ]] || { echo "missing ${file}" >&2; return 1; }
+  awk '
+    /^type http_error/ { inblock=1; next }
+    inblock && /^(and|type|val|let|module) / { inblock=0 }
+    inblock && /^  \| [A-Z]/ {
+      sub(/^  \| /, ""); sub(/[[:space:]].*/, "");
+      print
+    }
+  ' "${file}" | sort -u
+}
+
+# Metrics.t record fields from the .mli type t.
+extract_metrics_fields() {
+  local src="$1"
+  local file="${src}/lib/llm_provider/metrics.mli"
+  [[ -f "${file}" ]] || { echo "missing ${file}" >&2; return 1; }
+  awk '
+    /^type t = \{/ { inblock=1; next }
+    inblock && /^\}/ { inblock=0 }
+    inblock && /^  [a-z_]+:/ {
+      sub(/:.*/, ""); sub(/^[[:space:]]+/, "");
+      print
+    }
+  ' "${file}" | sort -u
+}
+
+lines_to_json_array() {
+  # stdin: one entry per line; stdout: JSON array
+  jq -R . | jq -s .
+}
+
+build_fingerprint() {
+  local src="$1"
+  local ebv hev mf
+  ebv="$(extract_event_bus_variants   "${src}" | lines_to_json_array)"
+  hev="$(extract_http_error_variants  "${src}" | lines_to_json_array)"
+  mf="$( extract_metrics_fields       "${src}" | lines_to_json_array)"
+
+  jq -n \
+    --arg sha "${OAS_AGENT_SDK_SHA}" \
+    --arg ver "${OAS_AGENT_SDK_BASE_VERSION}" \
+    --argjson ebv "${ebv}" \
+    --argjson hev "${hev}" \
+    --argjson mf  "${mf}" \
+    '{
+       pinned_sha:        $sha,
+       pinned_version:    $ver,
+       surfaces: {
+         event_bus_payload_variants: $ebv,
+         http_error_variants:        $hev,
+         metrics_fields:             $mf
+       }
+     }'
+}
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+diff_arrays_added() {
+  jq -cn --argjson a "$2" --argjson b "$1" '($a - $b) | sort'
+}
+diff_arrays_removed() {
+  jq -cn --argjson a "$2" --argjson b "$1" '($b - $a) | sort'
+}
+
+report_diff() {
+  local section_name="$1" prev_arr="$2" curr_arr="$3"
+  local added removed
+  added="$(diff_arrays_added   "${prev_arr}" "${curr_arr}")"
+  removed="$(diff_arrays_removed "${prev_arr}" "${curr_arr}")"
+  local added_count removed_count
+  added_count="$(jq 'length' <<<"${added}")"
+  removed_count="$(jq 'length' <<<"${removed}")"
+
+  if (( added_count == 0 && removed_count == 0 )); then
+    return 0
+  fi
+
+  echo
+  echo "  [${section_name}]"
+  if (( added_count > 0 )); then
+    echo "    added:"
+    jq -r '.[] | "      + " + .' <<<"${added}"
+  fi
+  if (( removed_count > 0 )); then
+    echo "    removed:"
+    jq -r '.[] | "      - " + .' <<<"${removed}"
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+src_dir=""
+resolve_source_dir src_dir || { echo "cannot locate OAS source at ${OAS_AGENT_SDK_SHA}" >&2; exit 1; }
+
+current="$(build_fingerprint "${src_dir}")"
+
+case "${MODE}" in
+  print)
+    jq . <<<"${current}"
+    exit 0
+    ;;
+  regenerate)
+    printf '%s\n' "${current}" | jq . > "${FINGERPRINT_FILE}"
+    echo "wrote fingerprint: ${FINGERPRINT_FILE}"
+    exit 0
+    ;;
+  check)
+    if [[ ! -f "${FINGERPRINT_FILE}" ]]; then
+      echo "fingerprint file missing: ${FINGERPRINT_FILE}" >&2
+      echo "  repair: bash scripts/oas-drift-check.sh --regenerate" >&2
+      exit 1
+    fi
+    prev="$(cat "${FINGERPRINT_FILE}")"
+
+    drift=0
+    for section in event_bus_payload_variants http_error_variants metrics_fields; do
+      prev_arr="$(jq ".surfaces.${section}" <<<"${prev}")"
+      curr_arr="$(jq ".surfaces.${section}" <<<"${current}")"
+      if ! report_diff "${section}" "${prev_arr}" "${curr_arr}"; then
+        drift=1
+      fi
+    done
+
+    if (( drift == 0 )); then
+      echo "OAS API surface matches fingerprint (pinned_sha=${OAS_AGENT_SDK_SHA})"
+      exit 0
+    fi
+
+    echo
+    echo "OAS API surface drift detected against ${FINGERPRINT_FILE}." >&2
+    echo "  Review the delta above against MASC consumer sites:" >&2
+    echo "    lib/oas_sse_bridge.ml             (Event_bus payload matches)" >&2
+    echo "    lib/cascade/cascade_health_filter.ml  (http_error matches)" >&2
+    echo "    lib/oas_worker_cascade.ml         (Metrics.t literals)" >&2
+    echo "  After consumer changes land:" >&2
+    echo "    bash scripts/oas-drift-check.sh --regenerate" >&2
+    echo "    and commit the updated fingerprint." >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- `scripts/oas-drift-check.sh` fingerprints OAS public types at the pinned SHA (Event_bus payload variants, Http_client error variants, Metrics.t fields) and diffs against `scripts/oas-api-surface.json`
- `scripts/oas-api-surface.json` committed as SSOT: 17 payload variants / 4 HttpError variants / 6 Metrics fields for pinned SHA `92c3077a`
- `make doctor-oas-drift` target for local checks

## Product impact

- Shifts OAS pin-bump regressions from "scattered `-Werror` non-exhaustive warnings across 3+ consumer files" to "one consolidated delta at pin-bump time"
- No runtime behavior change; purely dev/CI tooling
- Lower mean-time-to-detect for OAS boundary drift; future CI integration (follow-up PR) will lower mean-time-to-repair

## Why

OAS bumps frequently add/rename variants and fields. MASC's consumers (`oas_sse_bridge.ml`, `cascade/cascade_health_filter.ml`, `oas_worker_cascade.ml`) do exhaustive pattern matching; non-exhaustive warnings become `-Werror` failures scattered across files. The information arrives late and diffuse instead of at pin-bump time as one consolidated view.

## How it reports

```
  [event_bus_payload_variants]
    added:
      + ContentReplacementKept
      + SlotSchedulerObserved
    removed:
      - TaskStateChanged
```

Exit 0 on match, exit 2 on drift — enforces "update consumers + regenerate fingerprint" as one atomic PR.

## Scope boundaries

- Does **not** modify `check-oas-pin.sh` or `.github/workflows/ci.yml` — CI integration deliberately deferred so the fingerprint workflow can be tried without blocking builds
- Does **not** fix any current drift; masc-mcp main builds green today
- No OCaml code touched

## Evidence

Local verification in worktree at pinned SHA `92c3077a`:

```
$ AGENT_SDK_LOCAL_REPO=/Users/dancer/me/workspace/yousleepwhen/oas bash scripts/oas-drift-check.sh
OAS API surface matches fingerprint (pinned_sha=92c3077afe5be2f1f8f47bbb479be1e159b802f8)
EXIT=0

$ bash scripts/oas-drift-check.sh   # git fetch fallback path
OAS API surface matches fingerprint (pinned_sha=92c3077afe5be2f1f8f47bbb479be1e159b802f8)
EXIT=0

$ jq '.surfaces.event_bus_payload_variants -= ["Custom"]' scripts/oas-api-surface.json > /tmp/x && mv /tmp/x scripts/oas-api-surface.json
$ bash scripts/oas-drift-check.sh
  [event_bus_payload_variants]
    added:
      + Custom
OAS API surface drift detected ...
EXIT=2
```

Both source resolution paths (`AGENT_SDK_LOCAL_REPO` local checkout and `git fetch` bare-clone fallback) and the drift-reporting path verified.

## Review evidence

- Self-review only for this tooling PR (shell script + JSON SSOT + Makefile target)
- No cross-model review requested; surface is dev-only, no runtime blast radius
- Reviewer focus request: validate extraction regex robustness against OAS source style changes (e.g., `type payload = ...` renamed to `type event_payload`)

## Linked issue

Refs — no prior issue; this PR preempts the pattern observed across masc-mcp PRs #7459, #7464, #7466 (tool error message iterations) and `check-existing-prs-before-fix` / `policy-runtime-drift-gate` feedback memories, where OAS boundary drift surfaced as scattered pattern-match failures.

## Test plan

- [x] `make doctor-oas-drift` exit 0 on clean state (both resolution paths)
- [x] Simulated drift exits 2 with correct `added`/`removed` reporting
- [ ] CI lint/shellcheck on new script (will run on this PR)
- [ ] Follow-up PR wires CI integration once the regenerate flow is adopted

🤖 Generated with [Claude Code](https://claude.com/claude-code)