### PR TITLE
[dash-iter59] extend ErrorBoundary with onError + fallback props

### DIFF
--- a/dashboard/src/components/common/error-boundary.test.ts
+++ b/dashboard/src/components/common/error-boundary.test.ts
@@ -41,4 +41,120 @@ describe('ErrorBoundary', () => {
     expect(button?.className).toContain('border-[var(--card-border)]')
     expect(button?.className).not.toContain('card rounded-xl-border')
   })
+
+  it('renders children untouched when no error is thrown', async () => {
+    render(
+      html`<${ErrorBoundary} label="ok"><span data-testid="child">hi</span><//>`,
+      container,
+    )
+    await flushUi()
+    const child = container.querySelector('[data-testid="child"]')
+    expect(child?.textContent).toBe('hi')
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('calls onError with the thrown error and an info object', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onError = vi.fn()
+
+    render(
+      html`<${ErrorBoundary} label="telemetry" onError=${onError}>
+        <${Boom} />
+      <//>`,
+      container,
+    )
+    await flushUi()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    const firstCall = onError.mock.calls[0]
+    if (!firstCall) throw new Error('onError not called')
+    const [err, info] = firstCall
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('boom')
+    // info is an object (Preact passes { componentStack } when available,
+    // but shape is best-effort across runtimes).
+    expect(typeof info).toBe('object')
+  })
+
+  it('still calls the default console.error before onError (backwards-compatible log)', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onError = vi.fn()
+
+    render(
+      html`<${ErrorBoundary} label="ordered" onError=${onError}>
+        <${Boom} />
+      <//>`,
+      container,
+    )
+    await flushUi()
+
+    // Default log must always fire (backwards-compatibility guarantee).
+    const loggedPrefix = consoleSpy.mock.calls.some(
+      (args) =>
+        typeof args[0] === 'string' && args[0].includes('[ErrorBoundary:ordered]'),
+    )
+    expect(loggedPrefix).toBe(true)
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('renders a custom fallback instead of the default card when provided', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fallback = (err: Error) =>
+      html`<div data-testid="custom-fallback">custom: ${err.message}</div>`
+
+    render(
+      html`<${ErrorBoundary} label="custom" fallback=${fallback}>
+        <${Boom} />
+      <//>`,
+      container,
+    )
+    await flushUi()
+
+    const custom = container.querySelector('[data-testid="custom-fallback"]')
+    expect(custom?.textContent).toBe('custom: boom')
+    // Default card must NOT render when a fallback is supplied.
+    expect(container.querySelector('.error-card')).toBeNull()
+  })
+
+  it('fallback receives a reset callback that clears the error', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const captured: { reset: (() => void) | null } = { reset: null }
+
+    const fallback = (err: Error, reset: () => void): unknown => {
+      captured.reset = reset
+      return html`<div data-testid="fb">err:${err.message}</div>`
+    }
+
+    function Child({ shouldThrow }: { shouldThrow: boolean }) {
+      if (shouldThrow) throw new Error('boom')
+      return html`<span data-testid="ok">ok</span>`
+    }
+
+    // First render: throws -> fallback shown.
+    render(
+      html`<${ErrorBoundary} label="reset" fallback=${fallback}>
+        <${Child} shouldThrow=${true} />
+      <//>`,
+      container,
+    )
+    await flushUi()
+    expect(container.querySelector('[data-testid="fb"]')).not.toBeNull()
+    expect(typeof captured.reset).toBe('function')
+
+    // Re-render with non-throwing child, then call reset.
+    render(
+      html`<${ErrorBoundary} label="reset" fallback=${fallback}>
+        <${Child} shouldThrow=${false} />
+      <//>`,
+      container,
+    )
+    await flushUi()
+
+    captured.reset?.()
+    await flushUi()
+
+    // After reset, child renders normally.
+    expect(container.querySelector('[data-testid="ok"]')?.textContent).toBe('ok')
+    expect(container.querySelector('[data-testid="fb"]')).toBeNull()
+  })
 })

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -2,8 +2,14 @@ import { html } from 'htm/preact'
 import { Component, type ComponentChildren } from 'preact'
 import { AlertOctagon, RefreshCcw } from 'lucide-preact'
 
+export interface ErrorBoundaryInfo {
+  componentStack?: string
+}
+
 interface Props {
   label?: string
+  fallback?: (error: Error, reset: () => void) => ComponentChildren
+  onError?: (error: Error, info: ErrorBoundaryInfo) => void
   children: ComponentChildren
 }
 
@@ -18,12 +24,20 @@ export class ErrorBoundary extends Component<Props, State> {
     return { error }
   }
 
-  componentDidCatch(error: Error) {
+  private reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  componentDidCatch(error: Error, info: ErrorBoundaryInfo) {
     console.error(`[ErrorBoundary:${this.props.label ?? 'unknown'}]`, error)
+    this.props.onError?.(error, info)
   }
 
   render() {
     if (this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback(this.state.error, this.reset)
+      }
       return html`
         <div class="error-card rounded-xl my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-md">
           <div class="shrink-0 text-[var(--bad)] mt-0.5">
@@ -34,7 +48,7 @@ export class ErrorBoundary extends Component<Props, State> {
             <pre class="text-[13px] whitespace-pre-wrap opacity-80 text-[var(--text-body)] overflow-x-auto bg-[rgba(0,0,0,0.2)] p-2 rounded">${this.state.error.message}</pre>
             <button type="button"
               class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded-md border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--text-strong)] text-[13px] hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bad)]"
-              onClick=${() => this.setState({ error: null })}
+              onClick=${this.reset}
             >
               <${RefreshCcw} size=${14} />
               다시 시도

--- a/dashboard/src/lib/error-reporter.test.ts
+++ b/dashboard/src/lib/error-reporter.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildErrorPayload, reportDashboardError } from './error-reporter'
+
+describe('reportDashboardError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('always calls console.error with a tagged prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const err = new Error('kaboom')
+    reportDashboardError(err, { componentStack: 'at <Foo>' })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    const call = spy.mock.calls[0]
+    if (!call) throw new Error('console.error not called')
+    expect(call[0]).toBe('[dashboard-error]')
+    expect(call[1]).toBe(err)
+    expect(call[2]).toEqual({ componentStack: 'at <Foo>' })
+  })
+
+  it('does not throw when console.error throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      throw new Error('console exploded')
+    })
+    expect(() =>
+      reportDashboardError(new Error('x'), { componentStack: 's' }),
+    ).not.toThrow()
+  })
+
+  it('accepts a missing info argument', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => reportDashboardError(new Error('noinfo'))).not.toThrow()
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('buildErrorPayload', () => {
+  it('includes stack when present', () => {
+    const err = new Error('with-stack')
+    // Node auto-populates err.stack.
+    expect(err.stack).toBeTruthy()
+    const payload = buildErrorPayload(err, { componentStack: 'cs' })
+    expect(payload.message).toBe('with-stack')
+    expect(payload.component_stack).toBe('cs')
+    expect(payload.stack).toBe(err.stack)
+    expect(typeof payload.ts).toBe('string')
+  })
+
+  it('omits stack when error has no stack', () => {
+    const err = new Error('no-stack')
+    // Force-remove the stack to simulate engines that omit it.
+    Object.defineProperty(err, 'stack', { value: undefined, configurable: true })
+    const payload = buildErrorPayload(err)
+    expect('stack' in payload).toBe(false)
+    expect(payload.message).toBe('no-stack')
+  })
+
+  it('sets url and user_agent in a browser-like env (happy-dom)', () => {
+    const payload = buildErrorPayload(new Error('env'))
+    // happy-dom provides window.location and navigator.
+    expect(typeof payload.url).toBe('string')
+    expect(typeof payload.user_agent).toBe('string')
+  })
+})

--- a/dashboard/src/lib/error-reporter.ts
+++ b/dashboard/src/lib/error-reporter.ts
@@ -1,0 +1,63 @@
+/**
+ * Best-effort dashboard error reporter.
+ *
+ * - Always calls console.error with a clear tag.
+ * - Never throws; all failures are swallowed.
+ * - No-op in SSR contexts (no window / no fetch).
+ *
+ * NOTE: POST is reserved for a future backend endpoint
+ * (e.g. `/api/v1/dashboard/errors`). That endpoint does not exist
+ * yet, so this reporter is currently console-only. The payload shape
+ * the reporter would send is exposed via `buildErrorPayload` so that
+ * wiring it in later is a single-site change.
+ */
+export interface ReporterInfo {
+  componentStack?: string
+}
+
+const TAG = '[dashboard-error]'
+
+export function reportDashboardError(
+  error: Error,
+  info: ReporterInfo = {},
+): void {
+  try {
+    console.error(TAG, error, info)
+  } catch {
+    // console.error itself threw (extremely unusual). Swallow.
+  }
+
+  // SSR / non-browser guard. If the caller ever enables a POST branch,
+  // it must bail early when fetch or window is unavailable.
+  if (typeof window === 'undefined' || typeof fetch === 'undefined') {
+    return
+  }
+}
+
+/**
+ * Payload shape the reporter will POST once the backend endpoint ships.
+ * Exported for testability and so the contract is visible at import sites.
+ *
+ * - `stack` is only included when `error.stack` exists.
+ * - `url` / `user_agent` are only set in browser contexts.
+ */
+export function buildErrorPayload(
+  error: Error,
+  info: ReporterInfo = {},
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    message: error.message,
+    component_stack: info.componentStack,
+    url:
+      typeof window !== 'undefined' && window.location
+        ? window.location.href
+        : undefined,
+    user_agent:
+      typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+    ts: new Date().toISOString(),
+  }
+  if (error.stack) {
+    payload.stack = error.stack
+  }
+  return payload
+}


### PR DESCRIPTION
## Summary
- Two optional props on `ErrorBoundary`: `onError(error, info)` and `fallback(error, reset)`. 100% backwards-compatible — existing callers (`dashboard-shell.ts`, `work.ts`) are untouched, default card + `다시 시도` reset path unchanged, `console.error('[ErrorBoundary:<label>]', ...)` still fires first.
- New `dashboard/src/lib/error-reporter.ts` — best-effort reporter. Always tags + `console.error`s, never throws, no-ops in SSR. POST is intentionally omitted: no `/api/v1/dashboard/errors` endpoint exists on the backend yet (grepped `lib/` — zero hits). `buildErrorPayload` is exported so enabling POST later is a single-site change.
- `main.ts`: **unchanged**. `ErrorBoundary` is not mounted at the dashboard root — only per-route in `dashboard-shell.ts` and `work.ts`. Root-mount + `onError=${reportDashboardError}` wiring is deliberately left for follow-up per the iter59 scope gate.

## Design decisions
- `reset` is a stable bound class method (`private reset = () => this.setState({ error: null })`) so custom fallbacks don't need referential memoization to avoid thrashing.
- Ordering in `componentDidCatch`: backwards-compatible `console.error` first, then `onError?.(error, info)`. This preserves every existing debug flow.
- `error-reporter` does not reach for `fetch` at all right now. The SSR guard (`typeof window/fetch === 'undefined'`) is still in place so enabling the POST branch is a 1-line change without re-auditing the guards.

## Test plan
- [x] 6 ErrorBoundary tests: existing card-token test + children-untouched + onError called with (error, info) + default `console.error` still fires + custom fallback replaces default card + fallback `reset` callback clears the error and re-renders children
- [x] 6 error-reporter tests: always `console.error`s with tag + no throw when console.error throws + optional info arg + `buildErrorPayload` includes stack when present / omits when absent / populates url+user_agent in happy-dom
- [x] `pnpm test` (error-boundary + error-reporter): 12/12 pass
- [x] `pnpm typecheck`: clean
- [x] `pnpm lint`: clean
- [x] `pnpm build`: green
- [ ] CI green