### PR TITLE
fix(dashboard): use 4-column grid on readiness rail (no more pill truncation)

### DIFF
--- a/dashboard/src/components/connector-readiness-rail.test.ts
+++ b/dashboard/src/components/connector-readiness-rail.test.ts
@@ -219,3 +219,44 @@ describe('railPillAriaLabel', () => {
     expect(railPillAriaLabel(pill)).toBe('Token — 진행 중')
   })
 })
+
+describe('ConnectorReadinessRail layout', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    resetRailInflightState()
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  // Regression guard for the truncation bug ("BINDIN…", "필…"): under
+  // flex-wrap, per-pill width depended on intrinsic label width, so short
+  // labels (Token) snapped tiny and long labels (Bindings) blew out and
+  // truncated mid-word. A 4-column grid forces equal widths across all 4
+  // pills, so when truncation does happen at narrow tile widths, it happens
+  // symmetrically.
+  it('uses a 4-column grid (not flex-wrap) so pill widths are equal', () => {
+    const pills = deriveRail(
+      { sidecarUp: true, gateHealthy: true, bindingCount: 1, keeperCount: 1 },
+      noop,
+    )
+    render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    const rail = container.querySelector('[data-rail-layout="grid-4"]')
+    expect(rail).toBeTruthy()
+    expect(rail?.className).toContain('grid')
+    expect(rail?.className).toContain('grid-cols-4')
+    expect(rail?.className).not.toContain('flex-wrap')
+  })
+
+  it('renders exactly 4 pill buttons regardless of state mix', () => {
+    const pills = deriveRail(
+      { sidecarUp: false, gateHealthy: null, bindingCount: 0, keeperCount: 0 },
+      noop,
+    )
+    render(html`<${ConnectorReadinessRail} pills=${pills} />`, container)
+    const buttons = container.querySelectorAll('[data-rail-pill]')
+    expect(buttons.length).toBe(4)
+  })
+})

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -146,8 +146,15 @@ function Pill({ pill }: { pill: RailPill }) {
 }
 
 export function ConnectorReadinessRail({ pills }: { pills: RailPill[] }) {
+  // Grid (not flex-wrap) so all four pills share equal column widths. Under
+  // flex-wrap, per-pill width depended on intrinsic content, which meant
+  // short-label pills (Token) snapped tiny while long-label pills (Bindings)
+  // blew out and wrapped mid-word ("BINDIN…", "필…"). A 4-column grid makes
+  // every card's rail line up at the same cell boundaries across the 4-tile
+  // strip, and labels truncate symmetrically when the tile is narrow instead
+  // of each pill truncating at a different point.
   return html`
-    <div class="mt-2 flex flex-wrap items-stretch gap-2">
+    <div class="mt-2 grid grid-cols-4 items-stretch gap-2" data-rail-layout="grid-4">
       ${pills.map(pill => html`<${Pill} pill=${pill} />`)}
     </div>
   `


### PR DESCRIPTION
## Summary
- readiness rail의 외곽 레이아웃을 `flex flex-wrap` → `grid grid-cols-4`로 1줄 교체.
- 4개 pill이 항상 동일 column 폭 → tile 간 정렬 일관성 확보 + 라벨 truncation 대칭화.
- Pill 내부 / state 유도 / inflight 동작 **변경 없음** — 순수 레이아웃 회귀 수정.

## Motivation
원래 #7940에서 제기된 "정렬 안 맞고, 텍스트 다 깨지고, 넓이 배분이 구리고" 불만의 **구조적 원인**. `flex flex-wrap` 하에서 각 pill 폭이 라벨 길이에 의존 — Token(짧음)은 작아지고 Bindings(김)는 벗어나서 wrap. 카드 간 교차 비교 불가능.

`grid grid-cols-4`는 4개 같은 폭 column. 좁을 때도 4개가 **같은 위치에서** 잘림 → "BINDIN…" / "필…" 같은 중간 절단 비대칭 해소.

## Scope (1 line layout fix)
- `connector-readiness-rail.ts`: +8 / -1 (classname + `data-rail-layout` + 주석)
- `connector-readiness-rail.test.ts`: +38 (regression guards)
- 다른 파일 손대지 않음.

## Evidence
- ✅ Tests: 16/16 (기존 14 + 새 2 regression guard)
- ✅ TypeScript strict: no errors
- ✅ Pill 내부 / accessibility / state derivation / inflight 모두 그대로

## Linked issue
Refs #7940 — 원래 redesign PR에서 제기된 pill truncation 이슈를 tile 레이아웃 대체 없이 해결.

## Test plan
- [ ] Narrow viewport (600-800px)에서 4개 connector card의 pill들이 같은 x-coordinate에서 시작
- [ ] 라벨이 truncate 될 때 4개가 같은 길이에서 절단
- [ ] Token/Process/Gate/Bindings가 각 card에서 동일 column에 있음