### PR TITLE
chore(dashboard): purge 7 write-only execution signals from store.ts

### DIFF
--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -15,10 +15,7 @@ import type {
   BoardSortMode,
   KeeperLifecycleState,
   Goal,
-  DashboardExecutionSummary,
-  DashboardExecutionQueueItem,
   DashboardExecutionSessionBrief,
-  DashboardExecutionOperationBrief,
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
@@ -47,9 +44,7 @@ import { FetchScheduler } from './lib/fetch-scheduler'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
-  normalizeExecutionSummary,
-  normalizeExecutionQueueItem,
-  normalizeExecutionOperationBrief, normalizeExecutionWorkerSupportBrief,
+  normalizeExecutionWorkerSupportBrief,
   normalizeExecutionContinuityBrief,
   mergeMessages,
   normalizeServerStatus, mergeServerStatus,
@@ -81,17 +76,12 @@ export const tasks = signal<Task[]>([])
 export const messages = signal<Message[]>([])
 export const keepers = signal<Keeper[]>([])
 export const serverStatus = signal<ServerStatus | null>(null)
-export const executionSummary = signal<DashboardExecutionSummary | null>(null)
 export const executionLoaded = signal(false)
 export const executionLoading = signal(false)
 export const executionError = signal<string | null>(null)
-export const lastExecutionAttemptAt = signal<string | null>(null)
-export const executionQueue = signal<DashboardExecutionQueueItem[]>([])
 export const executionSessionBriefs = signal<DashboardExecutionSessionBrief[]>([])
-export const executionOperationBriefs = signal<DashboardExecutionOperationBrief[]>([])
 export const executionWorkerSupportBriefs = signal<DashboardExecutionWorkerSupportBrief[]>([])
 export const executionContinuityBriefs = signal<DashboardExecutionContinuityBrief[]>([])
-export const executionOfflineWorkerBriefs = signal<DashboardExecutionWorkerSupportBrief[]>([])
 
 // --- Keeper heartbeat tracking (name -> last heartbeat timestamp ms) ---
 
@@ -277,13 +267,8 @@ export const boardLoading = signal(false)
 
 // --- Refresh timestamps ---
 
-export const lastDashboardRefreshAt = signal<string | null>(null)
 export const lastBoardRefreshAt = signal<string | null>(null)
 export const lastGoalsRefreshAt = signal<string | null>(null)
-
-// --- Execution TTL guard (Phase 1C) ---
-
-export const lastExecutionRefreshAt = signal<number>(0)
 
 export const tasksByStatus = computed(() => {
   const all = tasks.value
@@ -391,7 +376,6 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   inflightDashboardRefresh = (async () => {
     try {
       await Promise.all([refreshShell(opts), refreshExecution(opts)])
-      lastDashboardRefreshAt.value = new Date().toISOString()
     } catch (err) {
       console.warn('[Dashboard] refresh error:', err)
     } finally {
@@ -509,15 +493,6 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .filter((row): row is Message => row !== null)
   messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
   keepers.value = normalizeKeepers(data.keepers)
-  executionSummary.value = normalizeExecutionSummary(data.summary)
-  const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
-    .map(normalizeExecutionQueueItem)
-    .filter((row): row is DashboardExecutionQueueItem => row !== null)
-  setArrayByKeyIfChanged(executionQueue, normalizedQueue, q => q.id)
-  const normalizedOpBriefs = (Array.isArray(data.operation_briefs) ? data.operation_briefs : [])
-    .map(normalizeExecutionOperationBrief)
-    .filter((row): row is DashboardExecutionOperationBrief => row !== null)
-  setArrayByKeyIfChanged(executionOperationBriefs, normalizedOpBriefs, o => o.operation_id)
   const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
     .map(normalizeExecutionWorkerSupportBrief)
     .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
@@ -526,19 +501,12 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .map(normalizeExecutionContinuityBrief)
     .filter((row): row is DashboardExecutionContinuityBrief => row !== null)
   setArrayByKeyIfChanged(executionContinuityBriefs, normalizedContinuityBriefs, c => c.name)
-  const normalizedOfflineBriefs = (Array.isArray(data.offline_worker_briefs) ? data.offline_worker_briefs : [])
-    .map(normalizeExecutionWorkerSupportBrief)
-    .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
-  setArrayByKeyIfChanged(executionOfflineWorkerBriefs, normalizedOfflineBriefs, w => w.name)
   executionLoaded.value = true
-  lastExecutionRefreshAt.value = Date.now()
-  lastDashboardRefreshAt.value = new Date().toISOString()
 }
 
 async function doFetchExecution(): Promise<void> {
   executionLoading.value = true
   executionError.value = null
-  lastExecutionAttemptAt.value = new Date().toISOString()
   try {
     const data = await fetchDashboardExecution()
     hydrateExecutionSnapshot(data)


### PR DESCRIPTION
## Summary

`/loop 20m` Gen37. `store.ts`의 execution 파이프라인에서 매 fetch tick마다 `.value = ...`로 쓰이지만 어디서도 읽히지 않는 **7개 write-only signal**과 그 연산 블록을 제거.

> Dead signal은 단순 unused import가 아니라 **silent runtime cost** — SSE event loop가 매 tick마다 normalizer를 돌려 배열을 만들어 signal에 넣고, 그 signal을 아무도 구독하지 않는 구조.

## 제거된 signals (0 reader 전부 검증)

| Signal | 용도 (원래) | 현 상태 |
|---|---|---|
| `executionSummary` | top-level summary box | 0 reader |
| `lastExecutionAttemptAt` | retry UI | 0 reader |
| `executionQueue` | priority queue panel | 0 reader |
| `executionOperationBriefs` | operation cards | 0 reader |
| `executionOfflineWorkerBriefs` | offline worker list | 0 reader |
| `lastDashboardRefreshAt` | stale badge | 0 reader |
| `lastExecutionRefreshAt` | TTL guard (Phase 1C) | 0 reader |

`computed`로 이 signal들을 파생시키는 곳도 0.

## 부수 변경

- `hydrateExecutionSnapshot`: 3개 `normalizedQueue / normalizedOpBriefs / normalizedOfflineBriefs` 연산 블록 삭제 (dead signal에 투입만 하고 있었음)
- `doFetchExecution`: `lastExecutionAttemptAt.value = ...` 1줄 삭제
- `refreshDashboard`: `lastDashboardRefreshAt.value = ...` 1줄 삭제
- `store.ts` imports:
  - **Types 제거**: `DashboardExecutionSummary`, `DashboardExecutionQueueItem`, `DashboardExecutionOperationBrief`
  - **Normalizers 제거**: `normalizeExecutionSummary`, `normalizeExecutionQueueItem`, `normalizeExecutionOperationBrief`
  - **유지**: `types/dashboard-execution.ts`와 `store-normalizers.ts`의 원래 정의 (namespace-truth-normalizers.ts가 여전히 사용 중)

## 변경량

| 파일 | LOC |
|---|---|
| `dashboard/src/store.ts` | **-33 net** (-34 삭제, +1 추가) |

## 검증

- `bun run build`: ✅ 34.92s
- `bun run test`: ✅ **208/208 files pass (3416 tests)**
  - ⚠️ `saved-signal.test.ts` 9 fails는 **pre-existing** — main 브랜치에서도 동일 `TypeError: window.localStorage.clear is not a function` 발생. PR #8014 도입 이후 보임. 본 PR과 무관. 별도 이슈 제안.

## /loop 스택 (Gen29~37)

| PR | Gen | 상태 | 범위 |
|---|---|---|---|
| #7938 | 29 | MERGED | dashboard orphan 3종 |
| #7948 | 30 | MERGED | keeper_handoff_delta OCaml |
| #7962 | 31 | MERGED | governance-panels cluster |
| #7969 | 32 | MERGED | LiveGovernanceToolbar |
| #7977 | 33 | MERGED | 33 dead exports |
| #7991 | 34 | MERGED | mission-cards barrel |
| #8003 | 35 | MERGED | runtime-params signals |
| #8019 | 36 | Draft | runtime-params API surface |
| **#TBD** | **37** | **Draft** | **write-only execution signals** |

누적 dead-code purge: **~-1,609 LOC / 44 public surface symbol**.

## 다음 cycle 후보

- `saved-signal.test.ts` localStorage mock 버그 수정 (별도 scope — 본 PR 외부)
- Gen38: `normalizeExecutionOperationBrief` + `DashboardExecutionOperationBrief` 타입 — Gen37 머지 후 외부 ref 0이 되면 store-normalizers.ts + types에서도 제거 가능
- Gen38b: 34 stale worktree 정리 hygiene

## Test plan
- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)