### PR TITLE
feat(dashboard): 💓 Uptime Kuma style heartbeat history strip under each connector tile

### DIFF
--- a/dashboard/src/components/common/heartbeat-strip.test.ts
+++ b/dashboard/src/components/common/heartbeat-strip.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  HeartbeatStrip,
+  padHistory,
+  summarizeHistory,
+  formatHeartbeatLabel,
+} from './heartbeat-strip'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+
+describe('padHistory (pure)', () => {
+  it('left-pads with "unknown" when history is shorter than slots', () => {
+    const out = padHistory(['up', 'down'], 5)
+    expect(out).toEqual(['unknown', 'unknown', 'unknown', 'up', 'down'])
+  })
+
+  it('returns tail slice when history is longer than slots', () => {
+    const out = padHistory(['up', 'down', 'up', 'down', 'up'], 3)
+    expect(out).toEqual(['up', 'down', 'up'])
+  })
+
+  it('returns the array unchanged when length === slots', () => {
+    const input: HeartbeatState[] = ['up', 'down']
+    const out = padHistory(input, 2)
+    expect(out).toEqual(['up', 'down'])
+  })
+
+  it('pads with slots worth of unknowns when history is empty', () => {
+    const out = padHistory([], 4)
+    expect(out).toEqual(['unknown', 'unknown', 'unknown', 'unknown'])
+  })
+})
+
+describe('summarizeHistory (pure)', () => {
+  it('counts ups / downs / unknowns', () => {
+    const s = summarizeHistory(['up', 'down', 'up', 'unknown', 'up'])
+    expect(s.total).toBe(5)
+    expect(s.up).toBe(3)
+    expect(s.down).toBe(1)
+    expect(s.unknown).toBe(1)
+  })
+
+  it('uptimePct ignores unknowns (Uptime Kuma convention)', () => {
+    // 3 up, 1 down, 1 unknown — uptime = 3 / (3+1) = 75%
+    const s = summarizeHistory(['up', 'down', 'up', 'unknown', 'up'])
+    expect(s.uptimePct).toBe(75)
+  })
+
+  it('uptimePct is null when there are no observed samples', () => {
+    expect(summarizeHistory([]).uptimePct).toBeNull()
+    expect(summarizeHistory(['unknown', 'unknown']).uptimePct).toBeNull()
+  })
+
+  it('100% uptime when all observed samples are "up"', () => {
+    expect(summarizeHistory(['up', 'up', 'up']).uptimePct).toBe(100)
+  })
+
+  it('0% uptime when all observed samples are "down"', () => {
+    expect(summarizeHistory(['down', 'down']).uptimePct).toBe(0)
+  })
+})
+
+describe('formatHeartbeatLabel (pure)', () => {
+  it('returns "no data yet" when uptimePct is null', () => {
+    const label = formatHeartbeatLabel({
+      total: 0, up: 0, down: 0, unknown: 0, uptimePct: null,
+    })
+    expect(label).toBe('Heartbeat: no data yet')
+  })
+
+  it('uses 2 decimal places at ≥99% uptime (Uptime Kuma precision bump)', () => {
+    // Regression guard: high uptime needs more precision or it renders
+    // as "100.0%" which hides the difference between 99.95% and 100%.
+    const label = formatHeartbeatLabel({
+      total: 100, up: 99, down: 1, unknown: 0, uptimePct: 99,
+    })
+    expect(label).toContain('99.00')
+  })
+
+  it('uses 1 decimal for sub-99% uptime', () => {
+    const label = formatHeartbeatLabel({
+      total: 10, up: 5, down: 5, unknown: 0, uptimePct: 50,
+    })
+    expect(label).toContain('50.0')
+    expect(label).not.toContain('50.00')
+  })
+
+  it('includes up/total observed (Uptime Kuma narrative)', () => {
+    const label = formatHeartbeatLabel({
+      total: 5, up: 3, down: 1, unknown: 1, uptimePct: 75,
+    })
+    expect(label).toContain('3/4 observed')
+  })
+})
+
+describe('HeartbeatStrip component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders `slots` bars (default 45)', () => {
+    render(html`<${HeartbeatStrip} history=${['up', 'down']} />`, container)
+    const bars = container.querySelectorAll('[data-heartbeat-bar]')
+    expect(bars.length).toBe(45)
+  })
+
+  it('respects a smaller `slots` prop', () => {
+    render(html`<${HeartbeatStrip} history=${['up', 'down']} slots=${10} />`, container)
+    expect(container.querySelectorAll('[data-heartbeat-bar]').length).toBe(10)
+  })
+
+  it('the last bar is the most recent sample (right=newest)', () => {
+    render(
+      html`<${HeartbeatStrip} history=${['up', 'down']} slots=${4} />`,
+      container,
+    )
+    const bars = Array.from(container.querySelectorAll('[data-heartbeat-bar]'))
+    const states = bars.map(b => b.getAttribute('data-heartbeat-bar'))
+    // slots=4, history=2 → 2 unknown pads + 'up' + 'down'
+    expect(states).toEqual(['unknown', 'unknown', 'up', 'down'])
+  })
+
+  it('role="img" and auto aria-label summarize uptime', () => {
+    render(
+      html`<${HeartbeatStrip} history=${['up', 'up', 'down']} slots=${3} />`,
+      container,
+    )
+    const el = container.querySelector('[role="img"]')!
+    const label = el.getAttribute('aria-label') ?? ''
+    expect(label).toContain('Heartbeat:')
+    expect(label).toContain('2/3')
+  })
+
+  it('custom ariaLabel overrides the auto-generated narrative', () => {
+    render(
+      html`<${HeartbeatStrip} history=${['up']} ariaLabel="Discord pulse" />`,
+      container,
+    )
+    expect(container.querySelector('[role="img"]')!.getAttribute('aria-label')).toBe(
+      'Discord pulse',
+    )
+  })
+
+  it('title attr mirrors aria-label (hover tooltip = AT narrative)', () => {
+    render(html`<${HeartbeatStrip} history=${['up', 'down']} />`, container)
+    const el = container.querySelector('[role="img"]')!
+    expect(el.getAttribute('title')).toBe(el.getAttribute('aria-label'))
+  })
+
+  it('data-heartbeat-uptime = "n/a" when no observed samples', () => {
+    render(html`<${HeartbeatStrip} history=${[]} />`, container)
+    expect(container.querySelector('[role="img"]')!.getAttribute('data-heartbeat-uptime')).toBe('n/a')
+  })
+
+  it('data-heartbeat-uptime is a numeric string when samples exist', () => {
+    render(html`<${HeartbeatStrip} history=${['up', 'up', 'down']} />`, container)
+    const val = container.querySelector('[role="img"]')!.getAttribute('data-heartbeat-uptime')
+    expect(val).toMatch(/^\d+\.\d{2}$/)
+  })
+
+  it('testId renders as data-testid (E2E stable hook)', () => {
+    render(html`<${HeartbeatStrip} history=${['up']} testId="discord-pulse" />`, container)
+    expect(
+      container.querySelector('[data-testid="discord-pulse"]'),
+    ).toBeTruthy()
+  })
+
+  it('class prop is appended to the base layout class', () => {
+    render(html`<${HeartbeatStrip} history=${['up']} class="ml-2" />`, container)
+    const cn = container.querySelector('[role="img"]')!.className
+    expect(cn).toContain('inline-flex')
+    expect(cn).toContain('ml-2')
+  })
+})

--- a/dashboard/src/components/common/heartbeat-strip.ts
+++ b/dashboard/src/components/common/heartbeat-strip.ts
@@ -1,0 +1,110 @@
+// HeartbeatStrip — Uptime Kuma style pulse row showing the last N samples.
+//
+// Reference UI (Uptime Kuma status page): row of ~45 colored bars, left=oldest
+// right=newest, tones: emerald (up), rose (down), muted gray (unknown / no
+// data yet). A single combined tooltip summarizes uptime % + sample count;
+// per-bar hover is intentionally omitted to keep the strip dense.
+
+import { html } from 'htm/preact'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+
+const COLOR: Record<HeartbeatState, string> = {
+  // Emerald 500 / Rose 500 / Zinc 700 — matches the dashboard token palette.
+  up: 'bg-emerald-500',
+  down: 'bg-rose-500',
+  unknown: 'bg-[var(--white-8)]',
+}
+
+const BAR_W = 'w-[4px]'
+const BAR_H = 'h-3'
+const BAR_RADIUS = 'rounded-[1px]'
+
+/** Pure: left-pad the history with 'unknown' so a new connector still
+    renders a full-width strip (empty slots read as "no data yet" rather
+    than a stubby row). */
+export function padHistory(
+  history: HeartbeatState[],
+  slots: number,
+): HeartbeatState[] {
+  if (history.length >= slots) return history.slice(history.length - slots)
+  const padding: HeartbeatState[] = Array(slots - history.length).fill('unknown')
+  return [...padding, ...history]
+}
+
+export interface HeartbeatSummary {
+  total: number
+  up: number
+  down: number
+  unknown: number
+  /** up / (up + down), ignoring unknowns. null when no real samples. */
+  uptimePct: number | null
+}
+
+/** Pure: compute uptime stats from a history array. Uptime % ignores
+    unknown samples (matching Uptime Kuma's "ignore pending" convention). */
+export function summarizeHistory(history: HeartbeatState[]): HeartbeatSummary {
+  let up = 0
+  let down = 0
+  let unknown = 0
+  for (const s of history) {
+    if (s === 'up') up++
+    else if (s === 'down') down++
+    else unknown++
+  }
+  const observed = up + down
+  return {
+    total: history.length,
+    up,
+    down,
+    unknown,
+    uptimePct: observed === 0 ? null : (up / observed) * 100,
+  }
+}
+
+/** Pure: format the tooltip / aria-label narrative. Matches the Uptime
+    Kuma "{uptime}% uptime · {up}/{total}" convention. */
+export function formatHeartbeatLabel(summary: HeartbeatSummary): string {
+  if (summary.uptimePct === null) {
+    return 'Heartbeat: no data yet'
+  }
+  const pct = summary.uptimePct.toFixed(summary.uptimePct >= 99 ? 2 : 1)
+  return `Heartbeat: ${pct}% uptime · ${summary.up}/${summary.up + summary.down} observed`
+}
+
+export interface HeartbeatStripProps {
+  history: HeartbeatState[]
+  /** Number of bar slots to render. Defaults to 45 (Uptime Kuma parity). */
+  slots?: number
+  class?: string
+  /** Override the auto-generated aria-label. */
+  ariaLabel?: string
+  /** `data-testid` for E2E stable hooks. */
+  testId?: string
+}
+
+export function HeartbeatStrip({
+  history,
+  slots = 45,
+  class: cx,
+  ariaLabel,
+  testId,
+}: HeartbeatStripProps) {
+  const bars = padHistory(history, slots)
+  const summary = summarizeHistory(history)
+  const label = ariaLabel ?? formatHeartbeatLabel(summary)
+  const cls = cx ? `inline-flex items-end gap-[2px] ${cx}` : 'inline-flex items-end gap-[2px]'
+  return html`<span
+    class=${cls}
+    role="img"
+    aria-label=${label}
+    title=${label}
+    data-testid=${testId}
+    data-heartbeat-uptime=${summary.uptimePct === null ? 'n/a' : summary.uptimePct.toFixed(2)}
+    data-heartbeat-samples=${summary.total}
+  >${bars.map(state => html`
+    <span
+      class=${`${BAR_W} ${BAR_H} ${BAR_RADIUS} ${COLOR[state]}`}
+      data-heartbeat-bar=${state}
+    ></span>
+  `)}</span>`
+}

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -16,6 +16,23 @@ import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight }
 import { CONNECTOR_DISPLAY_NAMES, KNOWN_CONNECTOR_IDS, channelIcon, connectorAccentStyle, startSidecar, stopSidecar, type KnownConnectorId } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
 import { formatElapsedCompact } from '../lib/format-time'
+import { HeartbeatStrip } from './common/heartbeat-strip'
+import { recordHeartbeat, useHeartbeatHistory, type HeartbeatState } from '../lib/heartbeat-history'
+
+/** Sampling cadence for the heartbeat ring buffer. Chosen so 45 bars
+    cover ~22 minutes of history — matches Uptime Kuma's default
+    "last 45 checks at 30s interval" visual rhythm. */
+const HEARTBEAT_SAMPLE_MS = 30_000
+
+/** Pure: derive the heartbeat state for a connector from the gate info
+    that the overview strip already polls. No extra network calls. */
+export function deriveHeartbeatState(
+  connector: GateConnectorInfo | null,
+): HeartbeatState {
+  if (connector === null) return 'unknown'
+  if (connector.available === true) return 'up'
+  return 'down'
+}
 
 const bulkInflight = signal<{ start: boolean; stop: boolean }>({ start: false, stop: false })
 
@@ -171,8 +188,23 @@ function OverviewTile({ id, connector, keeperCount }: {
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
+      <${TileHeartbeatStrip} id=${id} />
     </div>
   `
+}
+
+/** Uptime Kuma style pulse row under each overview tile. Samples the
+    connector's up/down state every HEARTBEAT_SAMPLE_MS into a per-id
+    ring buffer; the strip reads from that buffer and refreshes via the
+    signal subscription. */
+function TileHeartbeatStrip({ id }: { id: KnownConnectorId }) {
+  const history = useHeartbeatHistory(id)
+  return html`<${HeartbeatStrip}
+    history=${history}
+    slots=${45}
+    class="-ml-[1px]"
+    testId=${`heartbeat-strip-${id}`}
+  />`
 }
 
 /** Standalone export of the bulk Start All / Stop All buttons so the
@@ -313,6 +345,22 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
 export function ConnectorOverviewStrip({ connectors, keeperCount }: OverviewProps) {
   useEffect(() => {
     stripMemory.value = updateStripMemory(stripMemory.value, connectors, Date.now())
+  }, [connectors])
+
+  // Heartbeat sampler — push the current up/down state for each known
+  // connector into the per-id ring buffer on a fixed cadence. This is
+  // what feeds the Uptime Kuma style pulse strip below each tile; the
+  // 30s interval × 45 bars gives ~22 minutes of rolling history.
+  useEffect(() => {
+    const sample = () => {
+      for (const id of KNOWN_CONNECTOR_IDS) {
+        const c = findConnector(connectors, id)
+        recordHeartbeat(id, deriveHeartbeatState(c))
+      }
+    }
+    sample() // immediate first sample so new tiles show a bar straight away
+    const t = window.setInterval(sample, HEARTBEAT_SAMPLE_MS)
+    return () => window.clearInterval(t)
   }, [connectors])
 
   const droppedIds = detectRecentDrops(stripMemory.value, connectors, Date.now())

--- a/dashboard/src/lib/heartbeat-history.test.ts
+++ b/dashboard/src/lib/heartbeat-history.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  recordHeartbeat,
+  getHeartbeatHistory,
+  resetHeartbeatHistory,
+  HEARTBEAT_MAX_SAMPLES,
+} from './heartbeat-history'
+
+describe('heartbeat-history store', () => {
+  beforeEach(() => { resetHeartbeatHistory() })
+
+  it('returns [] for an unknown connector id', () => {
+    expect(getHeartbeatHistory('never-seen')).toEqual([])
+  })
+
+  it('records a single sample', () => {
+    recordHeartbeat('discord', 'up')
+    expect(getHeartbeatHistory('discord')).toEqual(['up'])
+  })
+
+  it('appends samples in order (oldest first, newest last)', () => {
+    recordHeartbeat('discord', 'up')
+    recordHeartbeat('discord', 'down')
+    recordHeartbeat('discord', 'up')
+    expect(getHeartbeatHistory('discord')).toEqual(['up', 'down', 'up'])
+  })
+
+  it('keeps separate histories per connector id', () => {
+    recordHeartbeat('discord', 'up')
+    recordHeartbeat('slack', 'down')
+    expect(getHeartbeatHistory('discord')).toEqual(['up'])
+    expect(getHeartbeatHistory('slack')).toEqual(['down'])
+  })
+
+  it('ring-buffers at HEARTBEAT_MAX_SAMPLES (oldest evicted)', () => {
+    // Fill beyond the cap.
+    for (let i = 0; i < HEARTBEAT_MAX_SAMPLES + 3; i++) {
+      recordHeartbeat('discord', i % 2 === 0 ? 'up' : 'down')
+    }
+    const h = getHeartbeatHistory('discord')
+    expect(h.length).toBe(HEARTBEAT_MAX_SAMPLES)
+    // The 3 oldest were evicted — the most recent sample (index N+2)
+    // is still the tail.
+    const expectedLastState = (HEARTBEAT_MAX_SAMPLES + 2) % 2 === 0 ? 'up' : 'down'
+    expect(h[h.length - 1]).toBe(expectedLastState)
+  })
+
+  it('resetHeartbeatHistory clears everything', () => {
+    recordHeartbeat('discord', 'up')
+    recordHeartbeat('slack', 'down')
+    resetHeartbeatHistory()
+    expect(getHeartbeatHistory('discord')).toEqual([])
+    expect(getHeartbeatHistory('slack')).toEqual([])
+  })
+})

--- a/dashboard/src/lib/heartbeat-history.ts
+++ b/dashboard/src/lib/heartbeat-history.ts
@@ -1,0 +1,45 @@
+// Heartbeat history — per-connector ring buffer of up/down/unknown samples.
+//
+// Reference pattern (Uptime Kuma status page): each monitor gets a row of
+// ~45 colored bars representing the last N heartbeats. We don't have a
+// backend time-series endpoint yet, so we sample the current connector
+// signals in-memory at a fixed cadence. Samples are reset when the page
+// reloads — honest about "since page opened". A future backend history
+// API can swap the read side of this store without touching the strip.
+
+import { signal } from '@preact/signals'
+
+export type HeartbeatState = 'up' | 'down' | 'unknown'
+
+/** How many samples we retain per connector. Matches Uptime Kuma's
+    default bar count so the visual rhythm is familiar. */
+export const HEARTBEAT_MAX_SAMPLES = 45
+
+const history = signal<Record<string, HeartbeatState[]>>({})
+
+/** Record one sample for a connector. Ring-buffers at HEARTBEAT_MAX_SAMPLES. */
+export function recordHeartbeat(connectorId: string, state: HeartbeatState): void {
+  const current = history.value[connectorId] ?? []
+  const next = current.length >= HEARTBEAT_MAX_SAMPLES
+    ? [...current.slice(current.length - HEARTBEAT_MAX_SAMPLES + 1), state]
+    : [...current, state]
+  history.value = { ...history.value, [connectorId]: next }
+}
+
+/** Read the current history for a connector. Returns [] for unknown ids. */
+export function getHeartbeatHistory(connectorId: string): HeartbeatState[] {
+  return history.value[connectorId] ?? []
+}
+
+/** Subscribe-friendly signal read — call inside a component render to
+    re-render when any connector's history changes. */
+export function useHeartbeatHistory(connectorId: string): HeartbeatState[] {
+  // Touching .value registers a subscription when called inside a
+  // component render (preact/signals semantics).
+  return history.value[connectorId] ?? []
+}
+
+/** Clear all recorded history. For tests + "reset fleet view" flows. */
+export function resetHeartbeatHistory(): void {
+  history.value = {}
+}


### PR DESCRIPTION
## Summary

**Reference UI**: [Uptime Kuma](https://github.com/louislam/uptime-kuma) status page — each monitor gets a row of ~45 colored bars showing recent checks. Emerald=up, rose=down, muted=unknown. Operators get an at-a-glance **trend**, not just \"currently UP / offline\".

This chip ports that pattern into each Connector overview tile, so at any moment the strip answers \"was Discord flaky in the last 20 minutes?\" without leaving the page.

## Visual

Under each of the 4 overview tiles, a compact 45-bar strip renders: right=newest, left=oldest. Tooltip + aria-label narrate \"Heartbeat: 97.8% uptime · 88/90 observed\".

## Architecture

| File | Role |
|------|------|
| `lib/heartbeat-history.ts` | Per-connector signal-backed ring buffer (max 45 samples). `recordHeartbeat(id, state)`, `useHeartbeatHistory(id)`, `resetHeartbeatHistory()`. Honest about session scope — samples reset on page reload. A future backend time-series endpoint can swap the read side without touching the strip. |
| `common/heartbeat-strip.ts` | Visual component + pure helpers `padHistory` / `summarizeHistory` / `formatHeartbeatLabel`. role=\"img\" + aria-label so AT users get the narrative. |
| `connector-overview-strip.ts` | Sampler + per-tile strip mount. `deriveHeartbeatState(c)` pure helper + single 30s interval — no extra network calls, piggybacks on the existing connectors prop. 45 bars × 30s = ~22 min rolling window. |

## Uptime Kuma conventions stolen

- Uptime % **ignores unknowns** (observed-only ratio)
- **2-decimal precision at ≥99%** so 99.95% doesn't collapse to \"100%\"
- Newest bar on the right, oldest on the left
- Single combined tooltip — per-bar hover intentionally omitted to keep the strip dense

## Tests (29, 0→29)

**Store:** ring buffer isolation per id, eviction at cap, reset.
**padHistory:** left-pad short / tail-slice long / pass-through equal / all-pad empty.
**summarizeHistory:** counts, uptime % ignoring unknowns, null for no observed, 100% / 0% edge cases.
**formatHeartbeatLabel:** no-data label, 2-decimal at ≥99%, 1-decimal sub-99, up/total narrative.
**Component:** default 45 bars, slots respected, **newest-on-the-right regression guard**, role=\"img\" + narrative aria-label, custom ariaLabel override, title mirrors aria-label, data-heartbeat-uptime n/a vs numeric, testId, class append + base preserved.

Existing `connector-overview-strip.test.ts` (27 tests) still green — no regressions.

## Follow-ups (not in this PR)

- Backend time-series endpoint so samples survive reload
- Strip under the `ConnectorLivePanel` header (current chip: overview tiles only)
- Click-a-bar → jump to that sample's timestamp in the log viewer

## Test plan

- [x] `npx vitest run src/lib/heartbeat-history.test.ts src/components/common/heartbeat-strip.test.ts` → 29/29 green
- [x] `npx vitest run src/components/connector-overview-strip.test.ts` → 27/27 green (regression)
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Visual check on live dashboard
- [ ] Ready for review

Sources:
- [Uptime Kuma status page wiki](https://github.com/louislam/uptime-kuma/wiki/Status-Page)
- [Configurable Range heartbeat bar #1888](https://github.com/louislam/uptime-kuma/issues/1888)

🤖 Generated with [Claude Code](https://claude.com/claude-code)