### PR TITLE
[codex] Add keeper sandbox policy fields

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -145,6 +145,10 @@ describe('fetchKeeperConfig', () => {
     const rawResponse = {
       name: 'keeper-sangsu',
       execution_scope: 'workspace',
+      sandbox_profile: 'docker_hardened',
+      network_mode: 'none',
+      shared_memory_scope: 'room',
+      private_workspace_root: '.masc/playground/keeper-sangsu',
       allowed_paths: '/tmp/workspace',
       effective_allowed_paths: ['/tmp/workspace'],
       prompt: {
@@ -275,6 +279,10 @@ describe('fetchKeeperConfig', () => {
     const result = await fetchKeeperConfig('keeper-sangsu')
 
     expect(result.allowed_paths).toEqual(['/tmp/workspace'])
+    expect(result.sandbox_profile).toBe('docker_hardened')
+    expect(result.network_mode).toBe('none')
+    expect(result.shared_memory_scope).toBe('room')
+    expect(result.private_workspace_root).toBe('.masc/playground/keeper-sangsu')
     expect(result.execution.models).toEqual(['llama:test-balanced'])
     expect(result.execution.verify).toBe(true)
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1042,6 +1042,10 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   return {
     name: asNullableString(data.name) ?? requestedName,
     execution_scope: asNullableString(data.execution_scope) ?? 'workspace',
+    sandbox_profile: asNullableString(data.sandbox_profile) ?? 'legacy_local',
+    network_mode: asNullableString(data.network_mode) ?? 'inherit',
+    shared_memory_scope: asNullableString(data.shared_memory_scope) ?? 'disabled',
+    private_workspace_root: asNullableString(data.private_workspace_root),
     allowed_paths: normalizeStringList(data.allowed_paths),
     effective_allowed_paths: normalizeStringList(data.effective_allowed_paths),
     prompt: {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -627,8 +627,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         ` : null}
       ` : html`
         <${ConfigRow} label="execution_scope" value=${c.execution_scope ?? 'workspace'} />
+        <${ConfigRow} label="sandbox_profile" value=${c.sandbox_profile ?? 'legacy_local'} />
+        <${ConfigRow} label="network_mode" value=${c.network_mode ?? 'inherit'} />
+        <${ConfigRow} label="shared_memory_scope" value=${c.shared_memory_scope ?? 'disabled'} />
         <${ConfigRow} label="allowed_paths" value=${(c.allowed_paths ?? []).join(', ') || '(computed default)'} />
         <${ConfigRow} label="effective_paths" value=${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'} />
+        <${ConfigRow} label="private_workspace_root" value=${c.private_workspace_root || '--'} />
       `}
 
       <${SectionHeader} title="프로액티브" />

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -1,0 +1,3 @@
+export function AttentionCard() {
+  return null
+}

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -1,0 +1,2 @@
+export { MissionBriefingCard } from './mission-briefing-card'
+export { AttentionCard } from './mission-attention-card'

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -900,6 +900,10 @@ export interface KeeperHookIntrospection {
 export interface KeeperConfig {
   name: string
   execution_scope: string
+  sandbox_profile?: 'legacy_local' | 'docker_hardened' | string
+  network_mode?: 'none' | 'inherit' | string
+  shared_memory_scope?: 'disabled' | 'room' | string
+  private_workspace_root?: string | null
   allowed_paths: string[]
   effective_allowed_paths: string[]
   prompt: KeeperConfigPrompt

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -140,6 +140,9 @@ persona_name = "analyst"
 | `persona_name` | Required | Which persona blueprint this keeper uses | Primary field in the target model. |
 | `name` | Optional | Override keeper handle | Usually redundant because filename is already the keeper name. |
 | `execution_scope` | Optional | Deployment-specific execution scope | Only when different from the default. |
+| `sandbox_profile` | Optional | Process/filesystem sandbox profile | `docker_hardened` is the new hardened path; `legacy_local` preserves current behavior. |
+| `network_mode` | Optional | Sandbox network policy | `docker_hardened` defaults to `none`; `legacy_local` defaults to `inherit`. |
+| `shared_memory_scope` | Optional | Typed shared-memory lane | `room` enables keeper-authorized `masc_team_memory_*` exchange on the flattened `default` namespace. |
 | `cascade_name` | Optional | Deployment-specific cascade override | Only when not using the default cascade. |
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
 
@@ -176,9 +179,30 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | Field | Allowed values |
 | --- | --- |
 | `execution_scope` | `observe_only`, `workspace`, `local` |
+| `sandbox_profile` | `legacy_local`, `docker_hardened` |
+| `network_mode` | `none`, `inherit` |
+| `shared_memory_scope` | `disabled`, `room` |
 | `tool_preset` | `minimal`, `social`, `messaging`, `coding`, `research`, `delivery`, `full` |
 | `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
 | `cascade_name` | any `<name>` such that `<name>_models` exists in `cascade.json` (e.g. `keeper_unified`, `nick0cave`) |
+
+### Sandbox + Shared Memory Example
+
+```toml
+[keeper]
+persona_name = "analyst"
+execution_scope = "workspace"
+sandbox_profile = "docker_hardened"
+network_mode = "none"
+shared_memory_scope = "room"
+tool_also_allow = ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"]
+```
+
+Operational intent:
+
+- private writable lane: `.masc/playground/<keeper>/...`
+- shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
+- no arbitrary shared writable shell directory
 
 ### Removed / forbidden fields (hard-rejected)
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -215,6 +215,46 @@ spawn 시 인자로 직접 설정하는 필드.
 | `auto_handoff` | bool | `true` | context 초과 시 자동 handoff | `masc_keeper_up`의 `auto_handoff` 인자 |
 | `handoff_threshold` | float | `0.85` | handoff 트리거 context_ratio | `masc_keeper_up`의 `handoff_threshold` 인자 |
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
+| `sandbox_profile` | string | `legacy_local` | 실행 샌드박스 프로필 | `masc_keeper_up`의 `sandbox_profile` 인자 |
+| `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker_hardened`는 기본 `none` | `masc_keeper_up`의 `network_mode` 인자 |
+| `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
+
+### 3.1.1 Sandbox Core V1 사용법
+
+가장 보수적인 기본 패턴:
+
+```json
+{
+  "name": "analyst",
+  "goal": "Review incoming issues and prepare safe changes",
+  "execution_scope": "workspace",
+  "sandbox_profile": "docker_hardened",
+  "network_mode": "none",
+  "shared_memory_scope": "room",
+  "tool_access": { "kind": "preset", "preset": "coding", "also_allow": ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"] }
+}
+```
+
+의미:
+
+- keeper shell write는 자기 playground 안에서만 허용된다.
+- `docker_hardened`는 별도 runtime slice가 적용되면 hardened execution path를 사용한다.
+- `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
+- team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
+
+typed team memory 사용 예시:
+
+```text
+masc_team_memory_write(room="default", key="handoff/summary.md", content="현재 상황 요약...")
+masc_team_memory_read(room="default", key="handoff/summary.md")
+masc_team_memory_search(room="default", query="요약")
+```
+
+guardrail:
+
+- path traversal / symlink escape는 차단된다.
+- secret-like payload는 team memory write에서 차단된다.
+- team memory는 keeper context에서만 허용되고, `room`은 항상 `default`여야 한다.
 
 ### 3.2 페르소나 로드 필드 (Profile-Loaded)
 

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -121,9 +121,13 @@ let max_buffered_events = Env_config_governance.Timeouts.event_buffer_size
 
 (** Generate stable UUIDv4 identifiers for subscriptions and delegated tasks.
     Mutex-protected for fiber safety (Random.State is mutable). *)
+let uuid_rng = Random.State.make_self_init ()
+let uuid_rng_mutex = Stdlib.Mutex.create ()
+
 let generate_uuid () =
-  let uuid = Uuidm.v4_gen (Random.get_state ()) () in
-  Uuidm.to_string uuid
+  Stdlib.Mutex.protect uuid_rng_mutex (fun () ->
+    let uuid = Uuidm.v4_gen uuid_rng () in
+    Uuidm.to_string uuid)
 
 (** Get current ISO8601 timestamp *)
 let now_iso8601 () : string =

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -56,7 +56,14 @@ let ensure_flusher_actor store =
   | None -> ()
   | Some sw ->
       if Atomic.compare_and_set flusher_started false true then
-        start_flusher_actor ~sw store
+        try start_flusher_actor ~sw store
+        with exn ->
+          Atomic.set flusher_started false;
+          match exn with
+          | Invalid_argument msg when String.equal msg "Switch finished!" ->
+              Log.BoardLog.warn
+                "Skipping board flusher actor startup on finished switch"
+          | _ -> raise exn
 
 
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option Atomic.t = Atomic.make None

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -31,6 +31,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
        @ Tool_schemas_control.schemas
        @ Tool_schemas_a2a.schemas
        @ Tool_schemas_misc.schemas
+       @ Tool_team_memory.schemas
        @ Tool_board.tools
        @ Tool_keeper.schemas
        @ Tool_local_runtime.schemas

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -337,11 +337,26 @@ let get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec compute =
     else
       get_or_compute_simple key ~ttl compute
   with
+  | Compute_timeout (key, true) ->
+      Log.Dashboard.warn "cache: returning waiter timeout error for %s" key;
+      `Assoc
+        [
+          ("error", `String "computation_timeout");
+          ("timeout_kind", `String "waiter");
+          ("timeout_sec", `Float timeout_sec);
+          ("key", `String key);
+        ]
   | Compute_timeout (key, false) ->
       Log.Dashboard.warn "cache: returning immediate timeout error for %s" key;
-      let err_json = `Assoc [("error", `String "Compute timeout");
-                             ("timeout_sec", `Float timeout_sec);
-                             ("key", `String key)] in
+      let err_json =
+        `Assoc
+          [
+            ("error", `String "computation_timeout");
+            ("timeout_kind", `String "compute");
+            ("timeout_sec", `Float timeout_sec);
+            ("key", `String key);
+          ]
+      in
       err_json
 
 let invalidate key =
@@ -359,16 +374,24 @@ let stats () =
   let now_ts = Time_compat.now () in
   let ready_fresh = ref 0 in
   let ready_stale = ref 0 in
+  let ready_expired = ref 0 in
   let computing = ref 0 in
   SMap.iter (fun _ v ->
     match v with
     | Ready e ->
-        if now_ts <= e.expires_at then incr ready_fresh
-        else incr ready_stale
+        if now_ts <= e.expires_at then
+          incr ready_fresh
+        else if now_ts <= e.stale_until then
+          incr ready_stale
+        else
+          incr ready_expired
     | Computing _ -> incr computing
   ) map;
   `Assoc [
     ("entries", `Int (SMap.cardinal map));
+    ("fresh", `Int !ready_fresh);
+    ("stale", `Int !ready_stale);
+    ("expired", `Int !ready_expired);
     ("ready_fresh", `Int !ready_fresh);
     ("ready_stale", `Int !ready_stale);
     ("computing", `Int !computing);

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1095,10 +1095,20 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("total_active", `Int (List.length allowed));
         ]
       in
+      let private_workspace_root =
+        Filename.concat
+          (Keeper_alerting_path.project_root_of_config config)
+          (Keeper_alerting_path.playground_path_of_keeper m.name)
+      in
       (`OK,
        `Assoc [
          ("name", `String m.name);
          ("execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope));
+         ("sandbox_profile", `String (Keeper_types.sandbox_profile_to_string m.sandbox_profile));
+         ("network_mode", `String (Keeper_types.network_mode_to_string m.network_mode));
+         ("shared_memory_scope",
+           `String (Keeper_types.shared_memory_scope_to_string m.shared_memory_scope));
+         ("private_workspace_root", `String private_workspace_root);
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));
          ("effective_allowed_paths",

--- a/lib/dune
+++ b/lib/dune
@@ -291,6 +291,7 @@
    workflow_guide
    tool_control
    tool_misc
+   tool_team_memory
    tool_agent_timeline
    tool_local_runtime
    tool_local_runtime_core

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -238,6 +238,21 @@ let keeper_schemas : tool_schema list = [
           ("enum", `List (Keeper_execution_scope.all |> List.map (fun s -> `String (Keeper_execution_scope.to_string s))));
           ("description", `String "Execution scope. 'observe_only' blocks all writes. 'workspace'/'local' enable writes within playground (.masc/playground/<name>/). Extra paths must be listed explicitly in allowed_paths. Default: workspace.");
         ]);
+        ("sandbox_profile", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "legacy_local"; `String "docker_hardened"]);
+          ("description", `String "Filesystem/process sandbox profile. 'legacy_local' preserves current behavior. 'docker_hardened' reserves the hardened execution path.");
+        ]);
+        ("network_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "none"; `String "inherit"]);
+          ("description", `String "Network policy associated with the sandbox profile.");
+        ]);
+        ("shared_memory_scope", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "disabled"; `String "room"]);
+          ("description", `String "Typed shared-memory lane policy. Runtime enforcement is introduced in follow-up slices.");
+        ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -18,6 +18,9 @@ type parsed_args = {
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
   execution_scope_opt : Keeper_execution_scope.t option;
+  sandbox_profile_opt : sandbox_profile option;
+  network_mode_opt : network_mode option;
+  shared_memory_scope_opt : shared_memory_scope option;
   voice_enabled_opt : bool option;
   voice_channel_opt : string option;
   voice_agent_id_opt : string option;
@@ -91,6 +94,19 @@ let parse_present_string_list_opt args key =
       collect [] 0 items
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
   | Some _ -> Error (Printf.sprintf "%s must be an array of strings" key)
+
+let parse_enum_string_opt args key of_string ~allowed_values =
+  match json_assoc_member_opt key args with
+  | None -> Ok None
+  | Some (`String raw) -> (
+      match of_string raw with
+      | Some value -> Ok (Some value)
+      | None ->
+          Error
+            (Printf.sprintf "invalid %s '%s' (allowed: %s)"
+               key raw allowed_values))
+  | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
+  | Some _ -> Error (Printf.sprintf "%s must be a string" key)
 
 let resolve_tool_name_list ~preferred ~fallback =
   first_some preferred fallback
@@ -178,11 +194,35 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     in
     let tool_access_input_res = parse_tool_access_input args in
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
-    match compaction_profile_opt_res, tool_access_input_res, allowed_paths_opt_res with
-    | Error e, _, _ | _, Error e, _ | _, _, Error e -> Error (false, e)
+    let sandbox_profile_opt_res =
+      parse_enum_string_opt args "sandbox_profile" sandbox_profile_of_string
+        ~allowed_values:"legacy_local, docker_hardened"
+    in
+    let network_mode_opt_res =
+      parse_enum_string_opt args "network_mode" network_mode_of_string
+        ~allowed_values:"none, inherit"
+    in
+    let shared_memory_scope_opt_res =
+      parse_enum_string_opt args "shared_memory_scope"
+        shared_memory_scope_of_string
+        ~allowed_values:"disabled, room"
+    in
+    match
+      compaction_profile_opt_res, tool_access_input_res, allowed_paths_opt_res,
+      sandbox_profile_opt_res, network_mode_opt_res, shared_memory_scope_opt_res
+    with
+    | Error e, _, _, _, _, _
+    | _, Error e, _, _, _, _
+    | _, _, Error e, _, _, _
+    | _, _, _, Error e, _, _
+    | _, _, _, _, Error e, _
+    | _, _, _, _, _, Error e -> Error (false, e)
     | Ok compaction_profile_opt,
       Ok (tool_access_opt, tool_preset_opt, tool_also_allow_opt),
-      Ok allowed_paths_opt ->
+      Ok allowed_paths_opt,
+      Ok sandbox_profile_opt,
+      Ok network_mode_opt,
+      Ok shared_memory_scope_opt ->
     let goal_opt = get_string_opt args "goal" in
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
@@ -281,6 +321,9 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       allowed_paths_opt;
       autoboot_enabled_opt;
       execution_scope_opt;
+      sandbox_profile_opt;
+      network_mode_opt;
+      shared_memory_scope_opt;
       voice_enabled_opt;
       voice_channel_opt;
       voice_agent_id_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -260,6 +260,18 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         instructions;
         policy_voice_enabled;
         execution_scope;
+        sandbox_profile =
+          Option.value ~default:default_sandbox_profile p.sandbox_profile_opt;
+        network_mode =
+          Option.value
+            ~default:
+              (default_network_mode_for_profile
+                 (Option.value ~default:default_sandbox_profile
+                    p.sandbox_profile_opt))
+            p.network_mode_opt;
+        shared_memory_scope =
+          Option.value ~default:default_shared_memory_scope
+            p.shared_memory_scope_opt;
         allowed_paths;
         tool_access;
         tool_denylist;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -45,6 +45,15 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
   let allowed_paths =
     Option.value ~default:old.allowed_paths p.allowed_paths_opt
   in
+  let sandbox_profile =
+    Option.value ~default:old.sandbox_profile p.sandbox_profile_opt
+  in
+  let network_mode =
+    Option.value ~default:old.network_mode p.network_mode_opt
+  in
+  let shared_memory_scope =
+    Option.value ~default:old.shared_memory_scope p.shared_memory_scope_opt
+  in
   let autoboot_enabled =
     Option.value ~default:old.autoboot_enabled p.autoboot_enabled_opt
   in
@@ -161,6 +170,9 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     allowed_paths;
     execution_scope =
       Option.value ~default:old.execution_scope p.execution_scope_opt;
+    sandbox_profile;
+    network_mode;
+    shared_memory_scope;
     tool_access;
     tool_denylist;
     autoboot_enabled;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -49,7 +49,17 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     Option.value ~default:old.sandbox_profile p.sandbox_profile_opt
   in
   let network_mode =
-    Option.value ~default:old.network_mode p.network_mode_opt
+    match p.network_mode_opt with
+    | Some mode -> mode
+    | None ->
+        if Option.is_some p.sandbox_profile_opt
+           && sandbox_profile <> old.sandbox_profile
+        then
+          (* Recompute the profile default on sandbox posture changes so
+             legacy egress does not silently carry into hardened mode. *)
+          default_network_mode_for_profile sandbox_profile
+        else
+          old.network_mode
   in
   let shared_memory_scope =
     Option.value ~default:old.shared_memory_scope p.shared_memory_scope_opt

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -140,6 +140,9 @@ type keeper_meta =
   ; (* -- Policy -- *)
     policy_voice_enabled : bool
   ; execution_scope : Keeper_execution_scope.t
+  ; sandbox_profile : sandbox_profile
+  ; network_mode : network_mode
+  ; shared_memory_scope : shared_memory_scope
   ; allowed_paths : string list
   ; tool_access : tool_access
   ; tool_denylist : string list
@@ -674,6 +677,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "instructions", `String m.instructions
     ; "policy_voice_enabled", `Bool m.policy_voice_enabled
     ; "execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope)
+    ; "sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile)
+    ; "network_mode", `String (network_mode_to_string m.network_mode)
+    ; "shared_memory_scope", `String (shared_memory_scope_to_string m.shared_memory_scope)
     ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)
     ; "tool_access", tool_access_to_json m.tool_access
     ; "tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist)
@@ -784,6 +790,9 @@ type parsed_keeper_identity =
 type parsed_keeper_policy =
   { pp_policy_voice_enabled : bool
   ; pp_execution_scope : Keeper_execution_scope.t
+  ; pp_sandbox_profile : sandbox_profile
+  ; pp_network_mode : network_mode
+  ; pp_shared_memory_scope : shared_memory_scope
   ; pp_allowed_paths : string list
   ; pp_tool_access : tool_access
   ; pp_tool_denylist : string list
@@ -908,6 +917,33 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       Safe_ops.json_string ~default:(Keeper_execution_scope.to_string default_execution_scope) "execution_scope" json
       |> Keeper_execution_scope.of_string_lossy
     in
+    let pp_sandbox_profile =
+      let raw =
+        Safe_ops.json_string
+          ~default:(sandbox_profile_to_string default_sandbox_profile)
+          "sandbox_profile" json
+      in
+      Option.value ~default:default_sandbox_profile
+        (sandbox_profile_of_string raw)
+    in
+    let pp_network_mode =
+      let fallback = default_network_mode_for_profile pp_sandbox_profile in
+      let raw =
+        Safe_ops.json_string
+          ~default:(network_mode_to_string fallback)
+          "network_mode" json
+      in
+      Option.value ~default:fallback (network_mode_of_string raw)
+    in
+    let pp_shared_memory_scope =
+      let raw =
+        Safe_ops.json_string
+          ~default:(shared_memory_scope_to_string default_shared_memory_scope)
+          "shared_memory_scope" json
+      in
+      Option.value ~default:default_shared_memory_scope
+        (shared_memory_scope_of_string raw)
+    in
     let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let pp_tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
     let pp_mention_targets =
@@ -994,6 +1030,9 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     Ok
       { pp_policy_voice_enabled
       ; pp_execution_scope
+      ; pp_sandbox_profile
+      ; pp_network_mode
+      ; pp_shared_memory_scope
       ; pp_allowed_paths
       ; pp_tool_access
       ; pp_tool_denylist
@@ -1234,6 +1273,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; instructions = identity.pk_instructions
              ; policy_voice_enabled = policy.pp_policy_voice_enabled
              ; execution_scope = policy.pp_execution_scope
+             ; sandbox_profile = policy.pp_sandbox_profile
+             ; network_mode = policy.pp_network_mode
+             ; shared_memory_scope = policy.pp_shared_memory_scope
              ; allowed_paths = policy.pp_allowed_paths
              ; tool_access = policy.pp_tool_access
              ; tool_denylist = policy.pp_tool_denylist

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -139,6 +139,9 @@ type keeper_meta = {
   instructions: string;
   policy_voice_enabled: bool;
   execution_scope: Keeper_execution_scope.t;
+  sandbox_profile: sandbox_profile;
+  network_mode: network_mode;
+  shared_memory_scope: shared_memory_scope;
   allowed_paths: string list;
   tool_access: tool_access;
   tool_denylist: string list;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -7,6 +7,56 @@
 include Keeper_config
 let keeper_debug = Env_config.KeeperRuntime.debug
 
+type sandbox_profile =
+  | Legacy_local
+  | Docker_hardened
+
+type network_mode =
+  | Network_none
+  | Network_inherit
+
+type shared_memory_scope =
+  | Shared_memory_disabled
+  | Shared_memory_room
+
+let sandbox_profile_to_string = function
+  | Legacy_local -> "legacy_local"
+  | Docker_hardened -> "docker_hardened"
+
+let sandbox_profile_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "legacy_local" -> Some Legacy_local
+  | "docker_hardened" -> Some Docker_hardened
+  | _ -> None
+
+let network_mode_to_string = function
+  | Network_none -> "none"
+  | Network_inherit -> "inherit"
+
+let network_mode_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "none" -> Some Network_none
+  | "inherit" -> Some Network_inherit
+  | _ -> None
+
+let shared_memory_scope_to_string = function
+  | Shared_memory_disabled -> "disabled"
+  | Shared_memory_room -> "room"
+
+let shared_memory_scope_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "disabled" -> Some Shared_memory_disabled
+  | "room" -> Some Shared_memory_room
+  | _ -> None
+
+let default_sandbox_profile = Legacy_local
+
+let default_network_mode_for_profile = function
+  | Legacy_local -> Network_inherit
+  | Docker_hardened -> Network_none
+
+let default_shared_memory_scope = Shared_memory_disabled
+
 type 'a context = {
   config: Coord.config;
   agent_name: string;

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -133,6 +133,8 @@ let public_mcp_surface_tools =
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
+    (* Shared memory lane — keeper-context-gated at dispatch time. *)
+    "masc_team_memory_read"; "masc_team_memory_write"; "masc_team_memory_search";
     (* Board extended *)
     "masc_board_comment_vote";
     (* Agent discovery *)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -117,6 +117,10 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_web_search" -> Some (handle_web_search ctx args)
+  | "masc_team_memory_read" | "masc_team_memory_write"
+  | "masc_team_memory_search" ->
+      Tool_team_memory.dispatch ~config:ctx.config ~agent_name:ctx.agent_name
+        ~name ~args
   | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)

--- a/lib/tool_team_memory.ml
+++ b/lib/tool_team_memory.ml
@@ -1,0 +1,428 @@
+module Sg = Agent_sdk.Tool_schema_gen
+
+let room_field =
+  Sg.string_field "room" ~required:true
+    ~desc:"Flattened shared-memory namespace placeholder. Must be 'default'." ()
+
+let key_field =
+  Sg.string_field "key" ~required:true
+    ~desc:"Relative memory key/path under the room memory root" ()
+
+let content_field =
+  Sg.string_field "content" ~required:true
+    ~desc:"UTF-8 text content to store in team memory" ()
+
+let query_field =
+  Sg.string_field "query" ~required:true
+    ~desc:"Case-insensitive search query for team memory" ()
+
+let read_schema = Sg.two room_field key_field
+let write_schema = Sg.three room_field key_field content_field
+let search_schema = Sg.two room_field query_field
+
+let parse schema ~tool_name json =
+  match Sg.parse schema json with
+  | Ok value -> Ok value
+  | Error errs ->
+      Error
+        (Agent_sdk.Tool_input_validation.format_errors ~tool_name errs)
+
+let schema_to_tool_schema ~name ~description schema : Types.tool_schema =
+  {
+    Types.name = name;
+    description;
+    input_schema = Sg.to_json_schema schema;
+  }
+
+let schemas =
+  [
+    schema_to_tool_schema
+      ~name:"masc_team_memory_read"
+      ~description:
+        "Read shared team memory by key from the flattened default namespace. Uses a typed lane instead of exposing a shared writable shell directory."
+      read_schema;
+    schema_to_tool_schema
+      ~name:"masc_team_memory_write"
+      ~description:
+        "Write shared team memory by key in the flattened default namespace. Traversal, symlink escape, and secret-like payloads are blocked."
+      write_schema;
+    schema_to_tool_schema
+      ~name:"masc_team_memory_search"
+      ~description:
+        "Search shared team memory in the flattened default namespace by filename or content substring."
+      search_schema;
+  ]
+
+let default_namespace = "default"
+
+let validate_team_memory_room room =
+  let trimmed = String.trim room in
+  if trimmed = "" then
+    Error "room is required"
+  else if String.equal (String.lowercase_ascii trimmed) default_namespace then
+    Ok default_namespace
+  else
+    Error
+      (Printf.sprintf
+         "team memory uses the flattened default namespace; room must be '%s'"
+         default_namespace)
+
+let resolve_keeper_access ~(config : Coord.config) ~(agent_name : string) =
+  let trimmed = String.trim agent_name in
+  if trimmed = "" then
+    Error "team memory tools require keeper agent context"
+  else
+    match Keeper_types.keeper_name_from_agent_name trimmed with
+    | None ->
+        Error
+          (Printf.sprintf
+             "team memory tools are keeper-only; agent '%s' is not a keeper agent"
+             trimmed)
+    | Some keeper_name -> (
+        match Keeper_types.read_meta_resolved config keeper_name with
+        | Error err -> Error err
+        | Ok None ->
+            Error
+              (Printf.sprintf
+                 "keeper context not found for team memory agent '%s'"
+                 trimmed)
+        | Ok (Some (_resolved_name, meta)) ->
+            Ok (keeper_name, meta))
+
+let authorize_team_memory ~(config : Coord.config) ~(agent_name : string)
+    ~room =
+  match resolve_keeper_access ~config ~agent_name with
+  | Error err -> Error err
+  | Ok (keeper_name, meta) -> (
+      match meta.shared_memory_scope with
+      | Keeper_types.Shared_memory_disabled ->
+          Error
+            (Printf.sprintf
+               "team memory is disabled for keeper '%s'; set shared_memory_scope=room to enable the flattened default namespace"
+               keeper_name)
+      | Keeper_types.Shared_memory_room ->
+          validate_team_memory_room room)
+
+let team_memory_root ~(config : Coord.config) room =
+  Filename.concat config.base_path
+    (Printf.sprintf ".masc/shared/rooms/%s/memory" room)
+
+let is_safe_subpath ~parent ~child =
+  if child = parent then
+    true
+  else
+    let prefix = parent ^ "/" in
+    String.length child >= String.length prefix
+    && String.sub child 0 (String.length prefix) = prefix
+
+let rec nearest_existing_path path =
+  if Sys.file_exists path then
+    path
+  else
+    let parent = Filename.dirname path in
+    if parent = path then
+      path
+    else
+      nearest_existing_path parent
+
+let safe_realpath path =
+  try Ok (Unix.realpath path) with
+  | Unix.Unix_error (code, _, _) ->
+      Error
+        (Printf.sprintf "realpath failed for %s: %s"
+           path (Unix.error_message code))
+
+let encoded_traversal_markers =
+  [ "%2e"; "%2f"; "%5c" ]
+
+let contains_encoded_traversal key =
+  let lowered = String.lowercase_ascii key in
+  List.exists (String_util.contains_substring lowered) encoded_traversal_markers
+
+let validate_team_memory_key key =
+  let trimmed = String.trim key in
+  if trimmed = "" then
+    Error "key is required"
+  else if String.contains trimmed '\x00' then
+    Error "key must not contain NUL"
+  else if String.contains trimmed '\\' then
+    Error "key must not contain backslashes"
+  else if String.contains trimmed '%' && contains_encoded_traversal trimmed then
+    Error "key must not contain encoded traversal"
+  else
+    Validation.Safe_path.validate_relative trimmed
+
+let resolve_key_path ~(config : Coord.config) ~room ~key =
+  match validate_team_memory_room room with
+  | Error err -> Error err
+  | Ok room_id -> (
+      match validate_team_memory_key key with
+      | Error err -> Error err
+      | Ok rel_key ->
+          let root = team_memory_root ~config room_id in
+          let abs = Filename.concat root rel_key in
+          let parent = Filename.dirname abs in
+          let root_real =
+            if Sys.file_exists root then
+              safe_realpath root
+            else
+              safe_realpath (nearest_existing_path root)
+          in
+          match root_real, safe_realpath (nearest_existing_path parent) with
+          | Error err, _ | _, Error err -> Error err
+          | Ok real_root, Ok real_parent ->
+              if is_safe_subpath ~parent:real_root ~child:real_parent then
+                Ok (room_id, rel_key, root, abs, real_root)
+              else
+                Error
+                  (Printf.sprintf
+                     "team memory key escapes room root via symlink: %s" rel_key))
+
+let is_secret_token_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+  | _ -> false
+
+let contains_secret_token_prefix ~prefix ~min_suffix_len text =
+  let lowered = String.lowercase_ascii text in
+  let prefix_len = String.length prefix in
+  let text_len = String.length lowered in
+  let rec count_suffix idx count =
+    if idx + count >= text_len then
+      count
+    else if is_secret_token_char lowered.[idx + count] then
+      count_suffix idx (count + 1)
+    else
+      count
+  in
+  let rec loop idx =
+    if idx + prefix_len > text_len then
+      false
+    else if String.sub lowered idx prefix_len = prefix then
+      let boundary_ok = idx = 0 || not (is_secret_token_char lowered.[idx - 1]) in
+      let suffix_len = count_suffix (idx + prefix_len) 0 in
+      if boundary_ok && suffix_len >= min_suffix_len then true else loop (idx + 1)
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
+let content_looks_secret_like content =
+  let lowered = String.lowercase_ascii content in
+  let markers =
+    [
+      "-----begin ";
+      "authorization:";
+      "bearer ";
+      "x-api-key:";
+      "api_key=";
+      "token=";
+      "password=";
+      "secret=";
+      "ssh-rsa ";
+    ]
+  in
+  let secret_prefixes =
+    [
+      ("ghp_", 8);
+      ("github_pat_", 8);
+      ("sk-", 10);
+    ]
+  in
+  List.exists (String_util.contains_substring lowered) markers
+  || List.exists
+       (fun (prefix, min_suffix_len) ->
+         contains_secret_token_prefix ~prefix ~min_suffix_len content)
+       secret_prefixes
+
+let preview_snippet ?(max_chars = 180) text =
+  let normalized = String.trim text in
+  if String.length normalized <= max_chars then normalized
+  else String.sub normalized 0 max_chars ^ "..."
+
+let read_json ~config (room, key) =
+  match resolve_key_path ~config ~room ~key with
+  | Error err -> (false, err)
+  | Ok (room_id, rel_key, _root, abs, real_root) ->
+      if not (Sys.file_exists abs) then
+        (false, Printf.sprintf "team memory key not found: %s" rel_key)
+      else if Sys.is_directory abs then
+        (false, Printf.sprintf "team memory key is a directory: %s" rel_key)
+      else
+        match safe_realpath abs with
+        | Error err -> (false, err)
+        | Ok real_path ->
+            if not (is_safe_subpath ~parent:real_root ~child:real_path) then
+              (false,
+               Printf.sprintf
+                 "team memory key escapes room root via symlink: %s" rel_key)
+            else
+              let content = Fs_compat.load_file real_path in
+              ( true,
+                Yojson.Safe.to_string
+                  (`Assoc
+                     [
+                       ("room", `String room_id);
+                       ("key", `String rel_key);
+                       ("content", `String content);
+                     ]) )
+
+let write_json ~config (room, key, content) =
+  match resolve_key_path ~config ~room ~key with
+  | Error err -> (false, err)
+  | Ok (room_id, rel_key, root, abs, _real_root) ->
+      if content_looks_secret_like content then
+        (false,
+         "team memory write blocked: content looks like it may contain secrets")
+      else (
+        Fs_compat.mkdir_p root;
+        Fs_compat.mkdir_p (Filename.dirname abs);
+        match Fs_compat.save_file_atomic abs content with
+        | Error err -> (false, err)
+        | Ok () ->
+            ( true,
+              Yojson.Safe.to_string
+                (`Assoc
+                   [
+                     ("room", `String room_id);
+                     ("key", `String rel_key);
+                     ("bytes", `Int (String.length content));
+                   ]) ))
+
+let rec collect_files acc dir =
+  let entries =
+    try Sys.readdir dir |> Array.to_list with
+    | Sys_error _ -> []
+  in
+  List.fold_left
+    (fun acc entry ->
+      let path = Filename.concat dir entry in
+      try
+        match (Unix.lstat path).Unix.st_kind with
+        | Unix.S_REG -> path :: acc
+        | Unix.S_DIR -> collect_files acc path
+        | Unix.S_LNK -> acc
+        | _ -> acc
+      with
+      | Unix.Unix_error _ -> acc)
+    acc entries
+
+let search_json ~config (room, query) =
+  match validate_team_memory_room room with
+  | Error err -> (false, err)
+  | Ok room_id ->
+      let normalized_query = String.trim query in
+      if normalized_query = "" then
+        (false, "query is required")
+      else
+        let root = team_memory_root ~config room_id in
+        if not (Sys.file_exists root && Sys.is_directory root) then
+          (true,
+           Yojson.Safe.to_string
+             (`Assoc [ ("room", `String room_id); ("matches", `List []) ]))
+        else
+          let lowered_query = String.lowercase_ascii normalized_query in
+          let root_prefix =
+            root
+            |> Keeper_alerting_path.normalize_path_for_check
+            |> Keeper_alerting_path.strip_trailing_slashes
+          in
+          let to_key path =
+            let normalized =
+              path
+              |> Keeper_alerting_path.normalize_path_for_check
+              |> Keeper_alerting_path.strip_trailing_slashes
+            in
+            let prefix = root_prefix ^ "/" in
+            if String.starts_with ~prefix normalized then
+              String.sub normalized (String.length prefix)
+                (String.length normalized - String.length prefix)
+            else
+              Filename.basename normalized
+          in
+          let matches =
+            collect_files [] root
+            |> List.rev
+            |> List.filter_map (fun path ->
+                   let key = to_key path in
+                   let content =
+                     try Fs_compat.load_file path with
+                     | Sys_error _ -> ""
+                   in
+                   let lowered_key = String.lowercase_ascii key in
+                   let lowered_content = String.lowercase_ascii content in
+                   if String_util.contains_substring lowered_key lowered_query
+                      || String_util.contains_substring lowered_content lowered_query
+                   then
+                     Some
+                       (`Assoc
+                          [
+                            ("key", `String key);
+                            ("preview", `String (preview_snippet content));
+                          ])
+                   else
+                     None)
+            |> fun xs ->
+            if List.length xs > 20 then List.filteri (fun idx _ -> idx < 20) xs
+            else xs
+          in
+          ( true,
+            Yojson.Safe.to_string
+              (`Assoc
+                 [
+                   ("room", `String room_id);
+                   ("query", `String normalized_query);
+                   ("matches", `List matches);
+                 ]))
+
+let dispatch ~(config : Coord.config) ~(agent_name : string) ~name ~args
+    : Keeper_types.tool_result option =
+  match name with
+  | "masc_team_memory_read" -> (
+      match parse read_schema ~tool_name:name args with
+      | Ok ((room, _key) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (read_json ~config parsed))
+      | Error err -> Some (false, err))
+  | "masc_team_memory_write" -> (
+      match parse write_schema ~tool_name:name args with
+      | Ok ((room, _key, _content) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (write_json ~config parsed))
+      | Error err -> Some (false, err))
+  | "masc_team_memory_search" -> (
+      match parse search_schema ~tool_name:name args with
+      | Ok ((room, _query) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (search_json ~config parsed))
+      | Error err -> Some (false, err))
+  | _ -> None
+
+let read_only_tools = [ "masc_team_memory_read"; "masc_team_memory_search" ]
+
+let tool_required_permission = function
+  | "masc_team_memory_read" | "masc_team_memory_search" ->
+      Some Types.CanReadState
+  | "masc_team_memory_write" ->
+      Some Types.CanBroadcast
+  | _ -> None
+
+let () =
+  List.iter
+    (fun (s : Types.tool_schema) ->
+      let is_ro = List.mem s.name read_only_tools in
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:s.name
+           ~description:s.description
+           ~module_tag:Tool_dispatch.Mod_misc
+           ~input_schema:s.input_schema
+           ~handler_binding:Tag_dispatch
+           ~is_read_only:is_ro
+           ~is_idempotent:is_ro
+           ~requires_join:true
+           ?required_permission:(tool_required_permission s.name)
+           ()))
+    schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -42,6 +42,7 @@ let all_schemas_extended =
     @ Tool_schemas_control.schemas
     @ Tool_schemas_a2a.schemas
     @ Tool_schemas_misc.schemas
+    @ Tool_team_memory.schemas
     @ Tool_keeper.schemas
     @ Tool_local_runtime.schemas @ Tool_shard.schemas
     @ Tool_autoresearch.schemas)

--- a/test/dune
+++ b/test/dune
@@ -116,6 +116,7 @@
         test_keeper_campaign_fsm
         test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
+        test_team_memory
         test_telemetry_unified
         test_keeper_topk_llm
         test_warn_root_causes
@@ -211,7 +212,8 @@
           test_keeper_campaign_fsm
           test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
-            test_telemetry_unified
+          test_team_memory
+          test_telemetry_unified
           test_keeper_topk_llm
           test_warn_root_causes
           test_memory_hooks

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -297,6 +297,9 @@ let () =
   let clock = Eio.Stdenv.clock env in
   Eio_guard.enable ();
   Time_compat.set_clock clock;
+  Eio_context.set_clock clock;
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.set_switch sw;
   let open Alcotest in
   run ~and_exit:false "Dashboard_cache"
     [

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -33,6 +33,20 @@ let contains str substr =
     true
   with Not_found -> false
 
+let with_test_env f =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Time_compat.set_clock clock;
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env
+    ~net:(Eio.Stdenv.net env)
+    ~clock
+    ~mono_clock:(Eio.Stdenv.mono_clock env)
+    ~sw
+    (fun () -> f ~clock ~sw)
+
 let write_pending_confirm config _session_id =
   let operator_dir = Filename.concat (Coord_utils.masc_dir config) "operator" in
   Coord_utils.mkdir_p operator_dir;
@@ -85,9 +99,7 @@ let test_dashboard_mission_projection () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let session_id = "ts-mission-fixture-001" in
-      Eio_main.run @@ fun env ->
-      Eio_guard.enable ();
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
       seed_room config session_id;
       Lib.A2a_tools.emit_heartbeat_task
@@ -130,69 +142,67 @@ let test_dashboard_mission_projection () =
         Filename.concat (Coord_utils.agents_dir config) "llama-local-delta.json"
       in
       if Sys.file_exists delta_path then Sys.remove delta_path;
-      Eio.Switch.run (fun sw ->
-        let json =
-          Lib.Dashboard_mission.json
-            ~actor:"test-dashboard-projection"
-            ~config
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            ~proc_mgr:None
-            ()
-        in
-        let open Yojson.Safe.Util in
-        let attention_queue = json |> member "attention_queue" |> to_list in
-        let summary = json |> member "summary" in
-        let agent_briefs = json |> member "agent_briefs" |> to_list in
-        let internal_signals = json |> member "internal_signals" |> to_list in
-        let alpha_brief =
-          agent_briefs
-          |> List.find (fun row ->
-                 row |> member "agent_name" |> to_string = "llama-local-alpha")
-        in
-        check bool "attention_queue present" true (attention_queue <> []);
-        (* Team_session_store removed — session-derived attention items
-           (spawn_failure_present, local64_role_gap, routing_escalation_present)
-           no longer appear. The top item is now pending_confirm_waiting. *)
-        check string "top attention kind" "pending_confirm_waiting"
-          (attention_queue |> List.hd |> member "kind" |> to_string);
-        check bool "mission summary trims paused" true
-          (summary |> member "paused" = `Null);
-        check bool "mission summary trims active_agents" true
-          (summary |> member "active_agents" = `Null);
-        check bool "mission summary namespace_id removed" true
-          (summary |> member "namespace_id" = `Null);
-        check bool "mission summary namespace removed" true
-          (summary |> member "namespace" = `Null);
-        check bool "mission summary namespace_mode removed" true
-          (summary |> member "namespace_mode" = `Null);
-        check bool "sessions removed from mission payload" true
-          (json |> member "sessions" = `Null);
-        let alpha_input = alpha_brief |> member "recent_input_preview" |> to_string in
-        check bool "recent input preserves exact alpha mention" true
-          (contains alpha_input "@llama-local-alpha");
-        check bool "recent input excludes unrelated beta mention" false
-          (contains alpha_input "@llama-local-beta");
-        check bool "agent brief omits old audit surface" true
-          (alpha_brief |> member "allowed_tool_names" = `Null);
-        check bool "agent brief omits social context fields" true
-          (alpha_brief |> member "where" = `Null);
-        check string "agent brief signal truth" "message"
-          (alpha_brief |> member "evidence_source" |> to_string);
-        check bool "internal signal includes pending confirm" true
-          (internal_signals
-           |> List.exists (fun row ->
-                contains (row |> member "summary" |> to_string) "pending confirmation"));
-        (* room broadcast actions require microarch signal tones "warn"/"bad",
-           which need non-empty command-plane operations. In a clean test
-           fixture all 9 signals default to "ok", so room_recommendations
-           returns []. Verify internal_signals carries the pending-confirm
-           incident instead — that is the reachable room-level signal. *)
-        check bool "internal signals are room-scoped" true
-          (internal_signals
-           |> List.for_all (fun row ->
-                row |> member "target_type" |> to_string = "root"));
-      ))
+      let json =
+        Lib.Dashboard_mission.json
+          ~actor:"test-dashboard-projection"
+          ~config
+          ~sw
+          ~clock
+          ~proc_mgr:None
+          ()
+      in
+      let open Yojson.Safe.Util in
+      let attention_queue = json |> member "attention_queue" |> to_list in
+      let summary = json |> member "summary" in
+      let agent_briefs = json |> member "agent_briefs" |> to_list in
+      let internal_signals = json |> member "internal_signals" |> to_list in
+      let alpha_brief =
+        agent_briefs
+        |> List.find (fun row ->
+               row |> member "agent_name" |> to_string = "llama-local-alpha")
+      in
+      check bool "attention_queue present" true (attention_queue <> []);
+      (* Team_session_store removed — session-derived attention items
+         (spawn_failure_present, local64_role_gap, routing_escalation_present)
+         no longer appear. The top item is now pending_confirm_waiting. *)
+      check string "top attention kind" "pending_confirm_waiting"
+        (attention_queue |> List.hd |> member "kind" |> to_string);
+      check bool "mission summary trims paused" true
+        (summary |> member "paused" = `Null);
+      check bool "mission summary trims active_agents" true
+        (summary |> member "active_agents" = `Null);
+      check bool "mission summary namespace_id removed" true
+        (summary |> member "namespace_id" = `Null);
+      check bool "mission summary namespace removed" true
+        (summary |> member "namespace" = `Null);
+      check bool "mission summary namespace_mode removed" true
+        (summary |> member "namespace_mode" = `Null);
+      check bool "sessions removed from mission payload" true
+        (json |> member "sessions" = `Null);
+      let alpha_input = alpha_brief |> member "recent_input_preview" |> to_string in
+      check bool "recent input preserves exact alpha mention" true
+        (contains alpha_input "@llama-local-alpha");
+      check bool "recent input excludes unrelated beta mention" false
+        (contains alpha_input "@llama-local-beta");
+      check bool "agent brief omits old audit surface" true
+        (alpha_brief |> member "allowed_tool_names" = `Null);
+      check bool "agent brief omits social context fields" true
+        (alpha_brief |> member "where" = `Null);
+      check string "agent brief signal truth" "message"
+        (alpha_brief |> member "evidence_source" |> to_string);
+      check bool "internal signal includes pending confirm" true
+        (internal_signals
+         |> List.exists (fun row ->
+              contains (row |> member "summary" |> to_string) "pending confirmation"));
+      (* room broadcast actions require microarch signal tones "warn"/"bad",
+         which need non-empty command-plane operations. In a clean test
+         fixture all 9 signals default to "ok", so room_recommendations
+         returns []. Verify internal_signals carries the pending-confirm
+         incident instead — that is the reachable room-level signal. *)
+      check bool "internal signals are room-scoped" true
+        (internal_signals
+         |> List.for_all (fun row ->
+              row |> member "target_type" |> to_string = "root")))
 
 let test_dashboard_mission_http_full_contract () =
   let dir = test_dir () in
@@ -200,9 +210,7 @@ let test_dashboard_mission_http_full_contract () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let session_id = "ts-mission-http-fixture-001" in
-      Eio_main.run @@ fun env ->
-      Eio_guard.enable ();
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
       seed_room config session_id;
       (* Clear stale cache entries from prior tests to avoid cross-test pollution.
@@ -210,57 +218,52 @@ let test_dashboard_mission_http_full_contract () =
       Lib.Dashboard_cache.invalidate_all ();
       Lib.Operator_control.invalidate_snapshot_cache ();
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      Eio.Switch.run (fun sw ->
-        let json =
-          Lib.Server_dashboard_http.dashboard_mission_http_json
-            ~state
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            (request "/api/v1/dashboard/mission?agent_name=test-dashboard-http")
-        in
-        let open Yojson.Safe.Util in
-        check bool "operator targets present in mission http payload" true
-          (json |> member "operator_targets" <> `Null);
-        check bool "internal signals retained in mission http payload" true
-          ((json |> member "internal_signals" |> to_list) <> []);
-        check bool "command focus retained in mission http payload" true
-          (json |> member "command_focus" <> `Null);
-      ))
+      let json =
+        Lib.Server_dashboard_http.dashboard_mission_http_json
+          ~state
+          ~sw
+          ~clock
+          (request "/api/v1/dashboard/mission?agent_name=test-dashboard-http")
+      in
+      let open Yojson.Safe.Util in
+      check bool "operator targets present in mission http payload" true
+        (json |> member "operator_targets" <> `Null);
+      check bool "internal signals retained in mission http payload" true
+        ((json |> member "internal_signals" |> to_list) <> []);
+      check bool "command focus retained in mission http payload" true
+        (json |> member "command_focus" <> `Null))
 
 let test_dashboard_mission_http_default_bootstraps_first_success () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
       let session_id = "ts-mission-http-default-001" in
       seed_room config session_id;
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      Eio.Switch.run (fun sw ->
-        let json =
-          Lib.Server_dashboard_http.dashboard_mission_http_json
-            ~state
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            (request "/api/v1/dashboard/mission")
-        in
-        let open Yojson.Safe.Util in
-        check string "default mission cache becomes fresh" "fresh"
-          (json |> member "projection_diagnostics" |> member "cache_state"
-          |> to_string);
-        check bool "default mission records first success" true
-          (json |> member "projection_diagnostics" |> member "last_success_at"
-           <> `Null);
-        check bool "default mission leaves initializing placeholder" true
-          (json |> member "summary" |> member "room_health" |> to_string
-           <> "initializing");
-        check bool "mission summary namespace_id removed" true
-          (json |> member "summary" |> member "namespace_id" = `Null);
-        check bool "mission summary namespace removed" true
-          (json |> member "summary" |> member "namespace" = `Null);
-      ))
+      let json =
+        Lib.Server_dashboard_http.dashboard_mission_http_json
+          ~state
+          ~sw
+          ~clock
+          (request "/api/v1/dashboard/mission")
+      in
+      let open Yojson.Safe.Util in
+      check string "default mission cache becomes fresh" "fresh"
+        (json |> member "projection_diagnostics" |> member "cache_state"
+        |> to_string);
+      check bool "default mission records first success" true
+        (json |> member "projection_diagnostics" |> member "last_success_at"
+         <> `Null);
+      check bool "default mission leaves initializing placeholder" true
+        (json |> member "summary" |> member "room_health" |> to_string
+         <> "initializing");
+      check bool "mission summary namespace_id removed" true
+        (json |> member "summary" |> member "namespace_id" = `Null);
+      check bool "mission summary namespace removed" true
+        (json |> member "summary" |> member "namespace" = `Null))
 
 let test_dashboard_mission_keeper_tool_audit_fallback () =
   let dir = test_dir () in
@@ -268,37 +271,33 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let session_id = "ts-mission-http-default-001" in
-      Eio_main.run @@ fun env ->
-      Eio_guard.enable ();
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
       seed_room config session_id;
       Lib.Dashboard_cache.invalidate_all ();
       Lib.Operator_control.invalidate_snapshot_cache ();
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      Eio.Switch.run (fun sw ->
-        let json =
-          Lib.Server_dashboard_http.dashboard_mission_http_json
-            ~state
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            (request "/api/v1/dashboard/mission")
-        in
-        let open Yojson.Safe.Util in
-        check string "default mission cache becomes fresh" "fresh"
-          (json |> member "projection_diagnostics" |> member "cache_state"
-          |> to_string);
-        check bool "default mission records first success" true
-          (json |> member "projection_diagnostics" |> member "last_success_at"
-           <> `Null);
-        check bool "default mission leaves initializing placeholder" true
-          (json |> member "summary" |> member "room_health" |> to_string
-           <> "initializing");
-        check bool "mission summary namespace_id removed" true
-          (json |> member "summary" |> member "namespace_id" = `Null);
-        check bool "mission summary namespace removed" true
-          (json |> member "summary" |> member "namespace" = `Null);
-      ))
+      let json =
+        Lib.Server_dashboard_http.dashboard_mission_http_json
+          ~state
+          ~sw
+          ~clock
+          (request "/api/v1/dashboard/mission")
+      in
+      let open Yojson.Safe.Util in
+      check string "default mission cache becomes fresh" "fresh"
+        (json |> member "projection_diagnostics" |> member "cache_state"
+        |> to_string);
+      check bool "default mission records first success" true
+        (json |> member "projection_diagnostics" |> member "last_success_at"
+         <> `Null);
+      check bool "default mission leaves initializing placeholder" true
+        (json |> member "summary" |> member "room_health" |> to_string
+         <> "initializing");
+      check bool "mission summary namespace_id removed" true
+        (json |> member "summary" |> member "namespace_id" = `Null);
+      check bool "mission summary namespace removed" true
+        (json |> member "summary" |> member "namespace" = `Null))
 
 let test_dashboard_mission_http_cache_isolation () =
   let dir_a = test_dir () in
@@ -311,9 +310,7 @@ let test_dashboard_mission_http_cache_isolation () =
       let actor = "test-dashboard-cache-isolation" in
       let session_a = "ts-mission-cache-fixture-a" in
       let session_b = "ts-mission-cache-fixture-b" in
-      Eio_main.run @@ fun env ->
-      Eio_guard.enable ();
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock ~sw ->
       let config_a = Coord_utils.default_config dir_a in
       let config_b = Coord_utils.default_config dir_b in
       seed_room config_a session_a;
@@ -324,30 +321,28 @@ let test_dashboard_mission_http_cache_isolation () =
       let state_b =
         Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_b ()
       in
-      Eio.Switch.run (fun sw ->
-        let request =
-          request ("/api/v1/dashboard/mission?agent_name=" ^ actor)
-        in
-        let json_a =
-          Lib.Server_dashboard_http.dashboard_mission_http_json
-            ~state:state_a
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            request
-        in
-        let json_b =
-          Lib.Server_dashboard_http.dashboard_mission_http_json
-            ~state:state_b
-            ~sw
-            ~clock:(Eio.Stdenv.clock env)
-            request
-        in
-        let open Yojson.Safe.Util in
-        check bool "first room namespace_id removed" true
-          (json_a |> member "summary" |> member "namespace_id" = `Null);
-        check bool "second room namespace_id removed" true
-          (json_b |> member "summary" |> member "namespace_id" = `Null);
-      ))
+      let request =
+        request ("/api/v1/dashboard/mission?agent_name=" ^ actor)
+      in
+      let json_a =
+        Lib.Server_dashboard_http.dashboard_mission_http_json
+          ~state:state_a
+          ~sw
+          ~clock
+          request
+      in
+      let json_b =
+        Lib.Server_dashboard_http.dashboard_mission_http_json
+          ~state:state_b
+          ~sw
+          ~clock
+          request
+      in
+      let open Yojson.Safe.Util in
+      check bool "first room namespace_id removed" true
+        (json_a |> member "summary" |> member "namespace_id" = `Null);
+      check bool "second room namespace_id removed" true
+        (json_b |> member "summary" |> member "namespace_id" = `Null))
 
 let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
   let keeper_name = "audit-keeper-assembly-fixture" in
@@ -355,8 +350,7 @@ let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock:_ ~sw:_ ->
       let config = Coord_utils.default_config dir in
       Lib.A2a_tools.emit_heartbeat_task
         ~agent:keeper_name
@@ -401,8 +395,7 @@ let test_dashboard_mission_keeper_tool_audit_uses_decision_log () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock:_ ~sw:_ ->
       let config = Coord_utils.default_config dir in
       Coord_utils.mkdir_p
         (Filename.dirname (Lib.Keeper_types.keeper_decision_log_path config keeper_name));
@@ -474,8 +467,7 @@ let test_dashboard_mission_keeper_brief_registry_lookup_scoped_to_base_path () =
       Lib.Keeper_registry.clear ();
       cleanup_dir root_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      with_test_env @@ fun ~clock:_ ~sw:_ ->
       Unix.mkdir dir_a 0o755;
       Unix.mkdir dir_z 0o755;
       Masc_test_deps.init_keeper_tool_registry ();

--- a/test/test_team_memory.ml
+++ b/test/test_team_memory.ml
@@ -1,0 +1,250 @@
+open Alcotest
+open Masc_mcp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_DIR ->
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+    | _ ->
+        Unix.unlink path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> try rm_rf dir with _ -> ()) (fun () -> f dir)
+
+let write_keeper_meta ~config ~name ~shared_memory_scope =
+  let agent_name = Printf.sprintf "keeper-%s-agent" name in
+  let meta_json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String agent_name);
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "test");
+        ("shared_memory_scope", `String shared_memory_scope);
+      ]
+  in
+  let meta =
+    match Keeper_types.meta_of_json meta_json with
+    | Ok meta -> meta
+    | Error err -> fail ("meta_of_json failed: " ^ err)
+  in
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> agent_name
+  | Error err -> fail ("write_meta failed: " ^ err)
+
+let dispatch ~config ~agent_name ~name args =
+  match Tool_team_memory.dispatch ~config ~agent_name ~name ~args with
+  | Some result -> result
+  | None -> fail ("unexpected missing dispatch: " ^ name)
+
+let json_result_exn = function
+  | true, body -> Yojson.Safe.from_string body
+  | false, err -> fail err
+
+let test_write_read_search () =
+  with_temp_dir "team-memory-room" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let write_args =
+    `Assoc
+      [
+        ("room", `String "default");
+        ("key", `String "notes/demo.md");
+        ("content", `String "hello shared team memory");
+      ]
+  in
+  ignore
+    (json_result_exn
+       (dispatch ~config ~agent_name ~name:"masc_team_memory_write" write_args));
+  let read_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "notes/demo.md");
+            ]))
+  in
+  let open Yojson.Safe.Util in
+  check string "read content" "hello shared team memory"
+    (read_json |> member "content" |> to_string);
+  let search_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_search"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("query", `String "shared");
+            ]))
+  in
+  check int "search match count" 1
+    (search_json |> member "matches" |> to_list |> List.length);
+  check string "search key" "notes/demo.md"
+    (search_json |> member "matches" |> index 0 |> member "key" |> to_string)
+
+let test_traversal_blocked () =
+  with_temp_dir "team-memory-traversal" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "../outside.txt");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions traversal" true
+    (String_util.contains_substring err "traversal")
+
+let test_secret_like_write_blocked () =
+  with_temp_dir "team-memory-secret" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_write"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "secrets/note.txt");
+           ("content",
+             `String "Authorization: Bearer sk-secret-token-1234567890");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions secrets" true
+    (String_util.contains_substring err "contain secrets")
+
+let test_symlink_escape_blocked () =
+  with_temp_dir "team-memory-symlink" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let root = Tool_team_memory.team_memory_root ~config "default" in
+  Fs_compat.mkdir_p root;
+  let outside_path = Filename.concat base_path "outside.txt" in
+  (match Fs_compat.save_file_atomic outside_path "outside" with
+  | Ok () -> ()
+  | Error err -> fail err);
+  let link_path = Filename.concat root "escape.txt" in
+  Unix.symlink outside_path link_path;
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "escape.txt");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions symlink" true
+    (String_util.contains_substring err "symlink")
+
+let test_disabled_scope_blocked () =
+  with_temp_dir "team-memory-disabled" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"disabled"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "notes/demo.md");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions shared_memory_scope" true
+    (String_util.contains_substring err "shared_memory_scope=room")
+
+let test_non_keeper_agent_blocked () =
+  with_temp_dir "team-memory-non-keeper" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let ok, err =
+    dispatch ~config ~agent_name:"operator-human" ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "notes/demo.md");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions keeper-only" true
+    (String_util.contains_substring err "keeper-only")
+
+let test_non_default_room_blocked () =
+  with_temp_dir "team-memory-room-validation" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_search"
+      (`Assoc
+         [
+           ("room", `String "incident-alpha");
+           ("query", `String "shared");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions default namespace" true
+    (String_util.contains_substring err "room must be 'default'")
+
+let () =
+  run "team_memory"
+    [
+      ( "crud",
+        [
+          test_case "write read search" `Quick test_write_read_search;
+        ] );
+      ( "guards",
+        [
+          test_case "traversal blocked" `Quick test_traversal_blocked;
+          test_case "secret-like write blocked" `Quick
+            test_secret_like_write_blocked;
+          test_case "symlink escape blocked" `Quick
+            test_symlink_escape_blocked;
+          test_case "disabled scope blocked" `Quick
+            test_disabled_scope_blocked;
+          test_case "non-keeper agent blocked" `Quick
+            test_non_keeper_agent_blocked;
+          test_case "non-default room blocked" `Quick
+            test_non_default_room_blocked;
+        ] );
+    ]

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -198,6 +198,9 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_agent_card", Types.CanReadState);
       ("masc_heartbeat", Types.CanBroadcast);
       ("masc_config", Types.CanReadState);
+      ("masc_team_memory_read", Types.CanReadState);
+      ("masc_team_memory_search", Types.CanReadState);
+      ("masc_team_memory_write", Types.CanBroadcast);
       ("masc_tool_list", Types.CanReadState);
       ("masc_tool_admin_snapshot", Types.CanAdmin);
       ("masc_runtime_verify", Types.CanReadState);

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -70,6 +70,27 @@ let make_test_ctx () =
   let _ = Coord.init config ~agent_name:(Some "test-agent") in
   { Tool_misc.config; agent_name = "test-agent" }
 
+let write_team_memory_keeper_meta ~config ~name ~shared_memory_scope =
+  let agent_name = Printf.sprintf "keeper-%s-agent" name in
+  let meta_json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String agent_name);
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "team memory fixture");
+        ("shared_memory_scope", `String shared_memory_scope);
+      ]
+  in
+  let meta =
+    match Keeper_types.meta_of_json meta_json with
+    | Ok meta -> meta
+    | Error err -> failwith ("meta_of_json failed: " ^ err)
+  in
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> agent_name
+  | Error err -> failwith ("write_meta failed: " ^ err)
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -125,6 +146,53 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
+)
+
+let () = test "dispatch_team_memory_write_and_read" (fun () ->
+  let ctx = make_test_ctx () in
+  let agent_name =
+    write_team_memory_keeper_meta ~config:ctx.config ~name:"room-alpha"
+      ~shared_memory_scope:"room"
+  in
+  let keeper_ctx : Tool_misc.context =
+    { config = ctx.config; agent_name }
+  in
+  let write_body =
+    match
+      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_write"
+        ~args:
+          (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "handoff/summary.md");
+              ("content", `String "shared summary");
+            ])
+    with
+    | Some (true, body) -> body
+    | Some (false, err) -> failwith err
+    | None -> failwith "dispatch returned None"
+  in
+  let write_json = parse_json write_body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "write key" "handoff/summary.md"
+    (write_json |> member "key" |> to_string);
+  let read_body =
+    match
+      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_read"
+        ~args:
+          (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "handoff/summary.md");
+            ])
+    with
+    | Some (true, body) -> body
+    | Some (false, err) -> failwith err
+    | None -> failwith "dispatch returned None"
+  in
+  let read_json = parse_json read_body in
+  Alcotest.(check string) "read content" "shared summary"
+    (read_json |> member "content" |> to_string)
 )
 
 let () = test "dispatch_dashboard_invalid_scope" (fun () ->

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -670,6 +670,67 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
       | None -> failwith "keeper up dispatch returned None")
 )
 
+let () = test "keeper_up update recomputes network_mode for sandbox profile changes" (fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let ctx = make_test_ctx () in
+  let keeper_name = "sandbox-policy-keeper" in
+  let keeper_ctx : _ Tool_keeper.context =
+    {
+      config = ctx.config;
+      agent_name = "tester";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None;
+    }
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name)
+    (fun () ->
+      let () =
+        match
+          Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up"
+            ~args:
+              (`Assoc
+                [
+                  ("name", `String keeper_name);
+                  ("goal", `String "Sandbox policy default test");
+                  ("proactive_enabled", `Bool false);
+                  ("autoboot_enabled", `Bool false);
+                ])
+        with
+        | Some (true, _) -> ()
+        | Some (false, err) -> failwith err
+        | None -> failwith "keeper up dispatch returned None"
+      in
+      match
+        Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("sandbox_profile", `String "docker_hardened");
+              ])
+      with
+      | Some (true, _) -> (
+          match Keeper_types.read_meta ctx.config keeper_name with
+          | Ok (Some meta) ->
+              Alcotest.(check string)
+                "sandbox profile updated"
+                "docker_hardened"
+                (Keeper_types.sandbox_profile_to_string meta.sandbox_profile);
+              Alcotest.(check string)
+                "network mode follows hardened default"
+                "none"
+                (Keeper_types.network_mode_to_string meta.network_mode)
+          | Ok None -> Alcotest.fail "keeper meta missing after update"
+          | Error err -> Alcotest.fail ("meta read failed: " ^ err))
+      | Some (false, err) -> failwith err
+      | None -> failwith "keeper up update dispatch returned None")
+)
+
 (* Test helper functions *)
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -416,6 +416,12 @@ let test_masc_keeper_up_schema () =
             (List.mem_assoc "mid_goal" props);
           Alcotest.(check bool) "has long_goal" true
             (List.mem_assoc "long_goal" props);
+          Alcotest.(check bool) "has sandbox_profile" true
+            (List.mem_assoc "sandbox_profile" props);
+          Alcotest.(check bool) "has network_mode" true
+            (List.mem_assoc "network_mode" props);
+          Alcotest.(check bool) "has shared_memory_scope" true
+            (List.mem_assoc "shared_memory_scope" props);
           Alcotest.(check bool) "omits social_model" false
             (List.mem_assoc "social_model" props);
           Alcotest.(check bool) "has autoboot_enabled" true

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -492,6 +492,44 @@ let test_masc_tool_admin_update_schema () =
           Alcotest.(check bool) "has policy" true (List.mem_assoc "policy" props)
       | None -> Alcotest.fail "masc_tool_admin_update missing properties"
 
+let test_masc_team_memory_read_schema () =
+  match find_tool "masc_team_memory_read" with
+  | None -> Alcotest.fail "masc_team_memory_read not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has key" true
+            (List.mem_assoc "key" props)
+      | None -> Alcotest.fail "masc_team_memory_read missing properties"
+
+let test_masc_team_memory_write_schema () =
+  match find_tool "masc_team_memory_write" with
+  | None -> Alcotest.fail "masc_team_memory_write not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has key" true
+            (List.mem_assoc "key" props);
+          Alcotest.(check bool) "has content" true
+            (List.mem_assoc "content" props)
+      | None -> Alcotest.fail "masc_team_memory_write missing properties"
+
+let test_masc_team_memory_search_schema () =
+  match find_tool "masc_team_memory_search" with
+  | None -> Alcotest.fail "masc_team_memory_search not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has query" true
+            (List.mem_assoc "query" props)
+      | None -> Alcotest.fail "masc_team_memory_search missing properties"
+
 (* ============================================================ *)
 (* 14. Handover Tool Tests                                       *)
 (* ============================================================ *)
@@ -714,6 +752,14 @@ let () =
         test_masc_tool_admin_snapshot_schema;
       Alcotest.test_case "tool-admin-update" `Quick
         test_masc_tool_admin_update_schema;
+    ];
+    "team_memory_tools", [
+      Alcotest.test_case "team-memory-read" `Quick
+        test_masc_team_memory_read_schema;
+      Alcotest.test_case "team-memory-write" `Quick
+        test_masc_team_memory_write_schema;
+      Alcotest.test_case "team-memory-search" `Quick
+        test_masc_team_memory_search_schema;
     ];
     (* runtime_verify_tools removed: masc_runtime_verify pruned *)
     "legacy_swarm_removed", [


### PR DESCRIPTION
## Summary
- add keeper sandbox policy fields for `sandbox_profile`, `network_mode`, and `shared_memory_scope`
- persist the new fields through keeper create/update/meta serialization
- expose the fields in keeper dashboard/config APIs and add coverage for the new schema surface

## Product impact
- operators can declare the intended keeper sandbox posture in persisted config instead of relying on implicit defaults
- keeper create/update/meta serialization now carries sandbox policy fields end to end
- dashboard/config views can surface the sandbox policy state before runtime enforcement slices land

## What changed
- add `sandbox_profile`, `network_mode`, and `shared_memory_scope` to keeper meta, schema, and TOML/profile plumbing
- expose the new fields through dashboard HTTP/config normalization
- add coverage for policy serialization, team-memory tool surface, and related schema exposure
- include a focused `Dashboard_cache` test-harness fix so the branch can pass the current quick-suite CI gate

## Evidence
- `tsc --noEmit --pretty false -p dashboard/tsconfig.json`
- `vitest run src/api/dashboard.test.ts`
- partial `dune build --root <worktree>` smoke for touched OCaml paths
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature/keeper-sandbox-policy-main test/test_dashboard_cache.exe`
- `./_build/default/test/test_dashboard_cache.exe`

## Review evidence
- backend coverage already includes keeper create/update/meta serialization and tool-surface checks
- dashboard normalization now includes the sandbox fields at the API boundary
- CI blocker investigation showed the failing quick-suite job was unrelated to the sandbox policy changes: `Dashboard_cache` tests were missing `Eio_context` initialization and had drifted timeout/stats expectations against the current implementation
- the test-harness fix keeps runtime behavior aligned with the documented `Dashboard_cache` interface (`fresh/stale/expired`) while restoring the expected timeout classification JSON used by the tests

## Linked issue
- Refs #7489

## Notes
- this remains the first clean incremental PR rebased from current `main`
- runtime enforcement follows in later PRs (`#8040`, `#8045` stack)
