### PR TITLE
refactor(lockfree): eliminate global mutexes in approval queue and memory bridge

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -38,10 +38,17 @@ let risk_level_to_string = function
   | High -> "high"
   | Critical -> "critical"
 
-(* ── Global queue (Eio.Mutex-protected) ───────────────────── *)
+(* ── Global queue (Lock-free Atomic.t) ───────────────────── *)
 
-let mu = Eio.Mutex.create ()
-let pending : (string, pending_approval) Hashtbl.t = Hashtbl.create 8
+module SMap = Map.Make(String)
+
+let rec atomic_update atomic f =
+  let old_val = Atomic.get atomic in
+  let new_val = f old_val in
+  if Atomic.compare_and_set atomic old_val new_val then ()
+  else atomic_update atomic f
+
+let pending : pending_approval SMap.t Atomic.t = Atomic.make SMap.empty
 
 (* ── Persistent audit log ────────────────────────────────── *)
 
@@ -176,8 +183,8 @@ let resolve_entry (entry : pending_approval) (decision : decision) =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> ()
 
-let find_pending_id_locked ~keeper_name ~tool_name =
-  Hashtbl.fold
+let find_pending_id ~keeper_name ~tool_name =
+  SMap.fold
     (fun id entry acc ->
       match acc with
       | Some _ -> acc
@@ -186,7 +193,7 @@ let find_pending_id_locked ~keeper_name ~tool_name =
            && String.equal entry.tool_name tool_name
         then Some id
         else None)
-    pending None
+    (Atomic.get pending) None
 
 let sort_entries_by_requested_at entries =
   List.sort
@@ -210,37 +217,33 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
     create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
       ~resolver:(Some resolver) ~on_resolution:None
   in
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
-    Hashtbl.replace pending id entry);
+  atomic_update pending (fun map -> SMap.add id entry map);
   record_pending entry;
-  (* SUSPEND the agent fiber until operator resolves.
-     Fun.protect ensures the pending entry is cleaned up if the fiber
-     is cancelled (e.g. keeper shutdown via Eio.Switch cancellation).
-     Without this, orphan entries accumulate in the hashtbl. (#5949) *)
   Fun.protect
     (fun () -> Eio.Promise.await promise)
     ~finally:(fun () ->
       (try
-         Eio.Mutex.use_rw ~protect:true mu (fun () ->
-           Hashtbl.remove pending id)
+         atomic_update pending (fun map -> SMap.remove id map)
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()))
 
 let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
   : string =
-  let created_entry =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-      match find_pending_id_locked ~keeper_name ~tool_name with
-      | Some id -> (`Existing id)
-      | None ->
+  let created_entry = ref None in
+  atomic_update pending (fun map ->
+    match find_pending_id ~keeper_name ~tool_name with
+    | Some id -> 
+        created_entry := Some (`Existing id);
+        map
+    | None ->
         let id = generate_id () in
         let entry =
           create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
             ~resolver:None ~on_resolution:(Some on_resolution)
         in
-        Hashtbl.replace pending id entry;
-        `Created entry)
-  in
-  match created_entry with
+        created_entry := Some (`Created entry);
+        SMap.add id entry map
+  );
+  match Option.get !created_entry with
   | `Existing id -> id
   | `Created entry ->
     record_pending entry;
@@ -252,15 +255,15 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
     Called from the dashboard approval HTTP handler
     ([server_dashboard_http.ml]). *)
 let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) result =
-  let result =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-    match Hashtbl.find_opt pending id with
-    | None -> Error (Printf.sprintf "approval %s not found or already resolved" id)
+  let result = ref (Error (Printf.sprintf "approval %s not found or already resolved" id)) in
+  atomic_update pending (fun map ->
+    match SMap.find_opt id map with
+    | None -> map
     | Some entry ->
-      Hashtbl.remove pending id;
-      Ok entry)
-  in
-  match result with
+      result := Ok entry;
+      SMap.remove id map
+  );
+  match !result with
   | Error _ as err -> err
   | Ok entry ->
     resolve_entry entry decision;
@@ -270,45 +273,39 @@ let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) resul
 
 (** List all pending approvals as JSON. *)
 let list_pending_json () : Yojson.Safe.t =
-  Eio.Mutex.use_ro mu (fun () ->
-    let entries = Hashtbl.fold (fun _id entry acc ->
-      `Assoc [
-        ("id", `String entry.id);
-        ("keeper_name", `String entry.keeper_name);
-        ("tool_name", `String entry.tool_name);
-        ("risk_level", `String (risk_level_to_string entry.risk_level));
-        ("requested_at", `Float entry.requested_at);
-        ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
-      ] :: acc
-    ) pending [] in
-    `List (sort_entries_by_requested_at entries))
+  let entries = SMap.fold (fun _id entry acc ->
+    `Assoc [
+      ("id", `String entry.id);
+      ("keeper_name", `String entry.keeper_name);
+      ("tool_name", `String entry.tool_name);
+      ("risk_level", `String (risk_level_to_string entry.risk_level));
+      ("requested_at", `Float entry.requested_at);
+      ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+    ] :: acc
+  ) (Atomic.get pending) [] in
+  `List (sort_entries_by_requested_at entries)
 
 let list_pending_dashboard_json () : Yojson.Safe.t =
-  Eio.Mutex.use_ro mu (fun () ->
-    let entries = Hashtbl.fold (fun _id entry acc ->
-      `Assoc [
-        ("id", `String entry.id);
-        ("keeper_name", `String entry.keeper_name);
-        ("tool_name", `String entry.tool_name);
-        ("risk_level", `String (risk_level_to_string entry.risk_level));
-        ("requested_at", `Float entry.requested_at);
-        ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
-        ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
-        ("input", entry.input);
-        ("input_preview", `String (input_preview_of_json entry.input));
-      ] :: acc
-    ) pending [] in
-    `List (sort_entries_by_requested_at entries))
+  let entries = SMap.fold (fun _id entry acc ->
+    `Assoc [
+      ("id", `String entry.id);
+      ("keeper_name", `String entry.keeper_name);
+      ("tool_name", `String entry.tool_name);
+      ("risk_level", `String (risk_level_to_string entry.risk_level));
+      ("requested_at", `Float entry.requested_at);
+      ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
+      ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+      ("input", entry.input);
+      ("input_preview", `String (input_preview_of_json entry.input));
+    ] :: acc
+  ) (Atomic.get pending) [] in
+  `List (sort_entries_by_requested_at entries)
 
 let pending_count () : int =
-  Eio.Mutex.use_ro mu (fun () -> Hashtbl.length pending)
+  SMap.cardinal (Atomic.get pending)
 
 let has_pending_for_keeper ~keeper_name : bool =
-  Eio.Mutex.use_ro mu (fun () ->
-    Hashtbl.fold
-      (fun _ entry acc ->
-        acc || String.equal entry.keeper_name keeper_name)
-      pending false)
+  SMap.fold (fun _ entry acc -> acc || String.equal entry.keeper_name keeper_name) (Atomic.get pending) false
 
 (* ── Timeout cleanup ──────────────────────────────────────── *)
 
@@ -316,16 +313,17 @@ let has_pending_for_keeper ~keeper_name : bool =
     Call periodically from a health loop. *)
 let expire_stale ~max_wait_s =
   let now = Unix.gettimeofday () in
-  let stale =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
-    let stale = Hashtbl.fold (fun id entry acc ->
+  let stale_ref = ref [] in
+  atomic_update pending (fun map ->
+    let stale = SMap.fold (fun id entry acc ->
       if now -. entry.requested_at > max_wait_s
       then (id, entry) :: acc
       else acc
-    ) pending [] in
-    List.iter (fun (id, _entry) -> Hashtbl.remove pending id) stale;
-    stale)
-  in
+    ) map [] in
+    stale_ref := stale;
+    List.fold_left (fun acc (id, _) -> SMap.remove id acc) map stale
+  );
+  let stale = !stale_ref in
   List.iter (fun (id, entry) ->
     let reason = Printf.sprintf
       "approval timed out after %.0fs" (now -. entry.requested_at) in

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -243,9 +243,12 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
         created_entry := Some (`Created entry);
         SMap.add id entry map
   );
-  match Option.get !created_entry with
-  | `Existing id -> id
-  | `Created entry ->
+  (* The ref is always set inside the CAS body above (both branches assign),
+     so None is unreachable. *)
+  match !created_entry with
+  | None -> assert false
+  | Some (`Existing id) -> id
+  | Some (`Created entry) ->
     record_pending entry;
     entry.id
 

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -24,6 +24,14 @@
     @since 2.140.0 (filesystem-first: JSONL long_term_backend always)
     @since 2.266.0 (RFC-MASC-004 Phase 3: imperative seeding removed) *)
 
+module SMap = Map.Make(String)
+
+let rec atomic_update atomic f =
+  let old_val = Atomic.get atomic in
+  let new_val = f old_val in
+  if Atomic.compare_and_set atomic old_val new_val then ()
+  else atomic_update atomic f
+
 (** Default importance for memories stored via OAS Memory.store.
     Configurable via MASC_MEMORY_OAS_DEFAULT_IMPORTANCE. *)
 let default_importance () = Env_config.Memory_oas.default_importance
@@ -74,22 +82,18 @@ let file_stamp_opt path =
   | Sys_error _ -> None
 
 type episode_file_cache = {
-  mutable stamp : file_stamp option;
-  mutable episodes : Institution_eio.episode list;
-  mutable ids : (string, unit) Hashtbl.t;
+  stamp : file_stamp option;
+  episodes : Institution_eio.episode list;
+  ids : unit SMap.t;
 }
 
-let episode_file_cache_tbl : (string, episode_file_cache) Hashtbl.t =
-  Hashtbl.create 4
-
-let episode_cache_mu = Eio.Mutex.create ()
+let episode_file_cache_tbl : episode_file_cache SMap.t Atomic.t =
+  Atomic.make SMap.empty
 
 let episode_ids_of episodes =
-  let ids = Hashtbl.create (max 16 (List.length episodes)) in
-  List.iter
-    (fun (episode : Institution_eio.episode) -> Hashtbl.replace ids episode.id ())
-    episodes;
-  ids
+  List.fold_left
+    (fun acc (episode : Institution_eio.episode) -> SMap.add episode.id () acc)
+    SMap.empty episodes
 
 (* Keep at most this many episodes in the in-memory cache.
    Callers that need fewer use cached_recent_episodes ~limit. *)
@@ -130,20 +134,18 @@ let build_episode_cache_from_disk path =
    calls. *)
 let load_all_episodes_cached () =
   let path = Institution_eio.episodes_jsonl_path () in
+  let current_stamp = file_stamp_opt path in
   let cached_opt =
-    Eio_guard.with_mutex episode_cache_mu (fun () ->
-      let current_stamp = file_stamp_opt path in
-      match Hashtbl.find_opt episode_file_cache_tbl path with
-      | Some cache when cache.stamp = current_stamp -> Some cache
-      | _ -> None)
+    match SMap.find_opt path (Atomic.get episode_file_cache_tbl) with
+    | Some cache when cache.stamp = current_stamp -> Some cache
+    | _ -> None
   in
   match cached_opt with
   | Some cache -> cache
   | None ->
-      (* JSONL read OUTSIDE the mutex. *)
       let fresh = build_episode_cache_from_disk path in
-      Eio_guard.with_mutex episode_cache_mu (fun () ->
-        Hashtbl.replace episode_file_cache_tbl path fresh);
+      atomic_update episode_file_cache_tbl (fun map ->
+        SMap.add path fresh map);
       fresh
 
 let rec drop_list n = function
@@ -173,14 +175,14 @@ let cached_recent_episodes ~limit =
    because [note_episode_flush] just wrote to the file. *)
 let note_episode_flush (episode : Institution_eio.episode) =
   let path = Institution_eio.episodes_jsonl_path () in
-  Eio_guard.with_mutex episode_cache_mu (fun () ->
-    match Hashtbl.find_opt episode_file_cache_tbl path with
-    | None -> ()  (* No cache to update; next loader will populate fresh *)
+  atomic_update episode_file_cache_tbl (fun map ->
+    match SMap.find_opt path map with
+    | None -> map
     | Some cache ->
-      if not (Hashtbl.mem cache.ids episode.id) then begin
+      if not (SMap.mem episode.id cache.ids) then begin
         let episodes = cache.episodes @ [episode] in
-        (* Trim oldest entries when cache exceeds limit *)
         let total = List.length episodes in
+        let ids_ref = ref (SMap.add episode.id () cache.ids) in
         let episodes =
           if total > episode_cache_limit then
             let drop_n = total - episode_cache_limit in
@@ -188,46 +190,48 @@ let note_episode_flush (episode : Institution_eio.episode) =
               | [] -> []
               | remaining when n <= 0 -> remaining
               | (ep : Institution_eio.episode) :: rest ->
-                  Hashtbl.remove cache.ids ep.id;
+                  ids_ref := SMap.remove ep.id !ids_ref;
                   drop_with_evict (n - 1) rest
             in
             drop_with_evict drop_n episodes
           else
             episodes
         in
-        cache.episodes <- episodes;
-        Hashtbl.replace cache.ids episode.id ();
-      end;
-      cache.stamp <- file_stamp_opt path;
-      Hashtbl.replace episode_file_cache_tbl path cache)
+        let new_cache = {
+          stamp = file_stamp_opt path;
+          episodes;
+          ids = !ids_ref;
+        } in
+        SMap.add path new_cache map
+      end else
+        let new_cache = { cache with stamp = file_stamp_opt path } in
+        SMap.add path new_cache map)
 
 type procedure_file_cache = {
-  mutable stamp : file_stamp option;
-  mutable procedures : Procedural_memory.procedure list;
+  stamp : file_stamp option;
+  procedures : Procedural_memory.procedure list;
 }
 
-let procedure_file_cache_tbl : (string, procedure_file_cache) Hashtbl.t =
-  Hashtbl.create 16
-
-let procedure_cache_mu = Eio.Mutex.create ()
+let procedure_file_cache_tbl : procedure_file_cache SMap.t Atomic.t =
+  Atomic.make SMap.empty
 
 let load_procedures_cached ~(agent_name : string) =
-  Eio_guard.with_mutex procedure_cache_mu (fun () ->
-    let path = Procedural_memory.procedures_path ~agent_name in
-    let stamp = file_stamp_opt path in
-    match Hashtbl.find_opt procedure_file_cache_tbl path with
-    | Some cache when cache.stamp = stamp -> cache.procedures
-    | _ ->
-        let procedures = Procedural_memory.load_procedures ~agent_name in
-        Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures };
-        procedures)
+  let path = Procedural_memory.procedures_path ~agent_name in
+  let stamp = file_stamp_opt path in
+  match SMap.find_opt path (Atomic.get procedure_file_cache_tbl) with
+  | Some cache when cache.stamp = stamp -> cache.procedures
+  | _ ->
+      let procedures = Procedural_memory.load_procedures ~agent_name in
+      atomic_update procedure_file_cache_tbl (fun map ->
+        SMap.add path { stamp; procedures } map);
+      procedures
 
 let store_procedures_cache ~(agent_name : string)
     (procedures : Procedural_memory.procedure list) =
-  Eio_guard.with_mutex procedure_cache_mu (fun () ->
-    let path = Procedural_memory.procedures_path ~agent_name in
-    let stamp = file_stamp_opt path in
-    Hashtbl.replace procedure_file_cache_tbl path { stamp; procedures })
+  let path = Procedural_memory.procedures_path ~agent_name in
+  let stamp = file_stamp_opt path in
+  atomic_update procedure_file_cache_tbl (fun map ->
+    SMap.add path { stamp; procedures } map)
 
 let top_procedures_cached ~(agent_name : string) ~(limit : int) =
   load_procedures_cached ~agent_name
@@ -463,7 +467,7 @@ let store_episode_from_snapshot
   Agent_sdk.Memory.store_episode memory episode
 
 let persisted_episode_ids () =
-  Hashtbl.copy (load_all_episodes_cached ()).ids
+  (load_all_episodes_cached ()).ids
 
 (** Flush new OAS episodes.
 
@@ -473,19 +477,18 @@ let flush_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int =
   let persisted_ids = persisted_episode_ids () in
   let path = Institution_eio.episodes_jsonl_path () in
   Fs_compat.mkdir_p (Filename.dirname path);
-  let flushed =
+  let flushed, _ =
     Agent_sdk.Memory.recall_episodes memory ~limit:max_int ()
     |> List.fold_left
-         (fun flushed (episode : Agent_sdk.Memory.episode) ->
-           if Hashtbl.mem persisted_ids episode.id then flushed
+         (fun (flushed, p_ids) (episode : Agent_sdk.Memory.episode) ->
+           if SMap.mem episode.id p_ids then (flushed, p_ids)
            else (
              let persisted = institution_episode_of_oas ~agent_name episode in
-             Hashtbl.replace persisted_ids episode.id ();
              Fs_compat.append_jsonl path
                (Institution_eio.episode_to_json persisted);
              note_episode_flush persisted;
-             flushed + 1))
-         0
+             (flushed + 1, SMap.add episode.id () p_ids)))
+         (0, persisted_ids)
   in
   (* Cap file growth. Called after append so we only rewrite when needed. *)
   if flushed > 0 then begin


### PR DESCRIPTION
## Description

This PR cleans up the last remaining notable hotspots of `Eio.Mutex` lock contention in the codebase.

- **In `keeper_approval_queue.ml`** (11 mutex acquisitions): Replaced the global queue `Hashtbl` and `mu` with a lock-free `Atomic.t` wrapping `Map.Make(String)`.
- **In `memory_oas_bridge.ml`** (7 mutex acquisitions): Replaced `episode_cache_mu` and `procedure_cache_mu` with lock-free atomic maps to avoid blocking concurrent episodic/procedural memory retrievals.
- Implemented CAS loops (`atomic_update`) to manage state transitions thread-safely without blocking fibers.
- Resolved build failures related to missing pattern matches for `CliTransportRequired` and `Llm_provider.Metrics.t`.

With this PR merged, the core MASC-MCP architecture has effectively eliminated almost all heavy `Eio.Mutex` acquisitions across its concurrent subsystems.