### PR TITLE
fix(dashboard): 🟠 Sidecar not-started panel uses amber informational tone (was reading as green success)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -495,6 +495,23 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('Sidecar not started')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
+
+    // Regression guard for the screenshot bug: when a connector card's
+    // brand accent is green (iMessage), the outer card renders a green
+    // gradient; a neutral `bg-[var(--white-4)]` panel sitting inside it
+    // used to read as a "success" tint ("not started" painted green).
+    // The panel now uses informational amber + a Portainer-style left
+    // stripe so it's unambiguously "needs action" regardless of the
+    // parent connector's brand color.
+    const panel = container.querySelector('[data-sidecar-not-started-panel]') as HTMLElement | null
+    expect(panel).toBeTruthy()
+    expect(panel!.className).toContain('bg-amber-500/5')
+    expect(panel!.className).toContain('border-l-amber-500')
+    // And the explicit "Not running" status chip is the one AT users hear.
+    const chip = panel!.querySelector('[data-sidecar-status-chip]')
+    expect(chip).toBeTruthy()
+    expect(chip!.getAttribute('aria-label')).toContain('not running')
+    expect(chip!.textContent).toContain('Not running')
   })
 
   it('shows no-keepers empty state when keeper directory is empty', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -746,10 +746,31 @@ function ConnectorLivePanel({
       ${showSidecarOffEmpty
         ? (() => {
             const cmds = sidecarCommands(connectorId)
+            // Informational amber tone (Railway / Vercel idle-service
+            // convention): "needs action, not broken". Earlier this
+            // panel inherited the connector accent gradient (iMessage =
+            // green), which visually read as "success" on a card that
+            // wasn't running. Amber overrides the accent bleed-through
+            // with an explicit "please click Start" signal. The left
+            // stripe matches the Portainer status-border pattern used
+            // on the outer card for vertical scannability.
             return html`
-              <div class="mt-3 rounded-md border border-dashed border-[var(--card-border)] bg-[var(--white-4)] px-3 py-3 text-[12px]">
+              <div
+                class="mt-3 rounded-md border border-dashed border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-3 text-[12px]"
+                data-sidecar-not-started-panel
+              >
                 <div class="mb-1 flex items-center justify-between gap-2">
-                  <div class="font-medium text-[var(--text-body)]">Sidecar not started</div>
+                  <div class="flex items-center gap-2">
+                    <span
+                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                      aria-label="Sidecar process status: not running"
+                      data-sidecar-status-chip
+                    >
+                      <span aria-hidden="true">⊘</span>
+                      <span>Not running</span>
+                    </span>
+                    <span class="font-medium text-[var(--text-body)]">Sidecar not started</span>
+                  </div>
                   <div class="flex items-center gap-2">
                     <${ActionButton}
                       variant="primary"
@@ -760,7 +781,7 @@ function ConnectorLivePanel({
                     <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${connectorName}</span>
                   </div>
                 </div>
-                <div class="text-[11px] text-[var(--text-dim)]">
+                <div class="text-[11px] text-amber-100/80">
                   Click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal.
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">


### PR DESCRIPTION
## Summary

Directly addresses the **screenshot bug the user flagged**: the \"Sidecar not started\" panel appeared green on the iMessage card, reading as \"success\" when the sidecar was actually not running. Two UI signals were fighting each other.

## Root cause

Two compounding layers:
1. Outer connector card uses `connectorAccentStyle(connectorId)` which sets a brand-color linear gradient background. iMessage's brand is iOS Messages green (`48,209,88`).
2. Inner empty-state panel used `bg-[var(--white-4)]` — a neutral white overlay that **let the parent green gradient bleed through**, painting the panel green.

Result: operator sees a green card labelled \"Sidecar not started\" with a green-tinted child panel. The brand color won over the semantic \"needs action\" signal.

## Reference UI fix

Railway / Vercel idle-service panels: a service that needs operator action renders in **amber** (informational \"needs action\"), never green (reserved for success). The brand color lives on the logo/avatar, not on the state panel.

## Changes

| Before | After |
|--------|-------|
| `bg-[var(--white-4)]` (bleed-through) | `bg-amber-500/5` (explicit amber override) |
| `border-[var(--card-border)]` | `border-amber-400/30` + **4px left stripe** (Portainer #8032 pattern) |
| `text-[var(--text-dim)]` help copy | `text-amber-100/80` (panel-tone cohesion) |
| Title-only header | Inline **\"⊘ NOT RUNNING\"** amber pill next to the title |

## A11y

New status chip carries `aria-label=\"Sidecar process status: not running\"` — screen readers announce the state *before* the title.

## Test plan

Regression guard added inline to the existing \"sidecar-off empty state\" test (avoids touching the 90s-budget fixture):

- [x] Panel has `bg-amber-500/5` + `border-l-amber-500` (screenshot bug guard)
- [x] `data-sidecar-status-chip` hook exists
- [x] Chip `aria-label` contains \"not running\"
- [x] Chip visible text is \"Not running\"
- [x] `npx vitest run src/components/connector-status.test.ts` → 21/21 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Visual check — iMessage card no longer reads as green success when offline

## Scope discipline

Brand gradient **unchanged** — iMessage still looks green when healthy. The amber panel overrides *only* when the sidecar is off, where brand green would misleadingly signal success. The sibling `showNoKeeperEmpty` panel has the same bleed-through issue but is intentionally **left for a follow-up chip** to keep this PR surgical.

Sources:
- [Railway deployments / idle services](https://docs.railway.com/deployments/reference)
- Portainer status-border pattern — applied in #8032

🤖 Generated with [Claude Code](https://claude.com/claude-code)