### PR TITLE
fix(dashboard): 🟠 unify two sibling empty-state panels on amber informational tone (#8038 follow-up)

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -287,6 +287,18 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('Gate metrics unavailable')
     expect(text).toContain('Gate-advertised connector runtime is visible')
     expect(text).toContain('keeper directory unavailable, manual entry only')
+
+    // Directory-error panel uses informational amber + left stripe so
+    // operators don't read the accent-gradient-tinted neutral
+    // background as success. Mirrors the "Sidecar not started" panel
+    // treatment from #8038 for cross-panel consistency.
+    const dirPanel = container.querySelector('[data-keeper-directory-error-panel]') as HTMLElement | null
+    expect(dirPanel).toBeTruthy()
+    expect(dirPanel!.className).toContain('bg-amber-500/5')
+    expect(dirPanel!.className).toContain('border-l-amber-500')
+    // Named chip: "Directory error" is what AT hears.
+    const dirChip = dirPanel!.querySelector('[aria-label]')
+    expect(dirChip?.getAttribute('aria-label')).toContain('unavailable')
   })
 
   it('prefers backend-advertised connector status over derived booleans', async () => {
@@ -522,6 +534,18 @@ describe('ConnectorStatusPanel', () => {
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('No keepers configured')
+
+    // Sibling of the "Sidecar not started" panel (#8038). Same fix:
+    // explicit amber override so the parent accent gradient (iMessage
+    // green) doesn't paint a "no keepers" panel as success.
+    const emptyPanel = container.querySelector('[data-no-keepers-empty-panel]') as HTMLElement | null
+    expect(emptyPanel).toBeTruthy()
+    expect(emptyPanel!.className).toContain('bg-amber-500/5')
+    expect(emptyPanel!.className).toContain('border-l-amber-500')
+    const chip = emptyPanel!.querySelector('[data-no-keepers-status-chip]')
+    expect(chip).toBeTruthy()
+    expect(chip!.getAttribute('aria-label')).toContain('none configured')
+    expect(chip!.textContent).toContain('Not configured')
   })
 
   it('expands [▾] header toggle to show per-dot liveness and metadata', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -729,15 +729,42 @@ function ConnectorLivePanel({
       <${ConnectorConfigForm} connectorId=${connectorId} />
 
       ${keeperDirectoryError && keepers.length === 0
-        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">keeper directory unavailable, manual entry only</div>`
+        ? html`
+            <div
+              class="mt-3 rounded-md border border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-100"
+              data-keeper-directory-error-panel
+            >
+              <span
+                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                aria-label="Keeper directory status: unavailable"
+              >
+                <span aria-hidden="true">⚠</span>
+                <span>Directory error</span>
+              </span>
+              keeper directory unavailable, manual entry only
+            </div>
+          `
         : null}
 
       ${showNoKeeperEmpty
         ? html`
-            <div class="mt-3 rounded-md border border-dashed border-[var(--card-border)] bg-[var(--white-4)] px-3 py-3 text-[12px]">
-              <div class="font-medium text-[var(--text-body)]">No keepers configured</div>
-              <div class="mt-1 text-[10px] text-[var(--text-dim)]">
-                Add keeper config files under config/keepers/ and restart the server.
+            <div
+              class="mt-3 rounded-md border border-dashed border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-3 text-[12px]"
+              data-no-keepers-empty-panel
+            >
+              <div class="mb-1 flex items-center gap-2">
+                <span
+                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                  aria-label="Keeper configuration status: none configured"
+                  data-no-keepers-status-chip
+                >
+                  <span aria-hidden="true">⊘</span>
+                  <span>Not configured</span>
+                </span>
+                <span class="font-medium text-[var(--text-body)]">No keepers configured</span>
+              </div>
+              <div class="text-[10px] text-amber-100/80">
+                Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
               </div>
             </div>
           `


### PR DESCRIPTION
## Summary

Follow-up to #8038 which fixed the \"Sidecar not started\" panel's accent-gradient bleed-through. Two sibling panels in the same card had the same structural bug but were deferred to keep #8038 surgical. This chip closes the loop so **all three \"needs action\" panels** share one consistent amber tone + Portainer left stripe.

## What was missed in #8038

| Panel | State before this PR |
|-------|----------------------|
| `keeperDirectoryError` | Partial amber (`border-amber-400/20 text-amber-100`) but **no left stripe**, doesn't match the Portainer border pattern from #8032 |
| `showNoKeeperEmpty` | Fully neutral (`bg-[var(--white-4)]`) — **let the parent connector accent gradient bleed through**, same bug as #8038. On iMessage (green brand accent) it read as \"No keepers configured, success!\" which is absurd |

## Fix

Both panels now mirror #8038's treatment:

| Property | Value |
|----------|-------|
| Background | `bg-amber-500/5` (explicit override, ignores parent accent) |
| Border | `border-amber-400/30 border-l-4 border-l-amber-500` (Portainer left stripe for vertical scan) |
| Help copy | `text-amber-100/80` (panel-tone cohesion) |
| Named status chip | `\"Directory error\"` / `\"Not configured\"` with aria-label |

## A11y (screen reader order)

- Directory error → *\"Directory error — keeper directory unavailable, manual entry only\"*
- No keepers → *\"Not configured — No keepers configured — Add keeper config files under...\"*

State-first narrative, matching #8038's `\"Not running\"` → title ordering.

## Scope

All three \"needs action\" panels in `connector-status.ts` now share:
- `bg-amber-500/5`
- `border-l-4 border-l-amber-500`
- `<chip> data-*-status-chip` with aria-label

## Test plan

- [x] Appended 2 assertion blocks to existing tests (no new fixtures, no new 90s-budget cost)
- [x] `npx vitest run src/components/connector-status.test.ts` → 21/21 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Visual check — iMessage-accent card with no-keepers state no longer looks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)