### PR TITLE
[codex] Enforce keeper team memory scope

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -140,6 +140,9 @@ persona_name = "analyst"
 | `persona_name` | Required | Which persona blueprint this keeper uses | Primary field in the target model. |
 | `name` | Optional | Override keeper handle | Usually redundant because filename is already the keeper name. |
 | `execution_scope` | Optional | Deployment-specific execution scope | Only when different from the default. |
+| `sandbox_profile` | Optional | Process/filesystem sandbox profile | `docker_hardened` is the new hardened path; `legacy_local` preserves current behavior. |
+| `network_mode` | Optional | Sandbox network policy | `docker_hardened` defaults to `none`; `legacy_local` defaults to `inherit`. |
+| `shared_memory_scope` | Optional | Typed shared-memory lane | `room` enables keeper-authorized `masc_team_memory_*` exchange on the flattened `default` namespace. |
 | `cascade_name` | Optional | Deployment-specific cascade override | Only when not using the default cascade. |
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
 
@@ -176,9 +179,30 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | Field | Allowed values |
 | --- | --- |
 | `execution_scope` | `observe_only`, `workspace`, `local` |
+| `sandbox_profile` | `legacy_local`, `docker_hardened` |
+| `network_mode` | `none`, `inherit` |
+| `shared_memory_scope` | `disabled`, `room` |
 | `tool_preset` | `minimal`, `social`, `messaging`, `coding`, `research`, `delivery`, `full` |
 | `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
 | `cascade_name` | any `<name>` such that `<name>_models` exists in `cascade.json` (e.g. `keeper_unified`, `nick0cave`) |
+
+### Sandbox + Shared Memory Example
+
+```toml
+[keeper]
+persona_name = "analyst"
+execution_scope = "workspace"
+sandbox_profile = "docker_hardened"
+network_mode = "none"
+shared_memory_scope = "room"
+tool_also_allow = ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"]
+```
+
+Operational intent:
+
+- private writable lane: `.masc/playground/<keeper>/...`
+- shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
+- no arbitrary shared writable shell directory
 
 ### Removed / forbidden fields (hard-rejected)
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -215,6 +215,46 @@ spawn 시 인자로 직접 설정하는 필드.
 | `auto_handoff` | bool | `true` | context 초과 시 자동 handoff | `masc_keeper_up`의 `auto_handoff` 인자 |
 | `handoff_threshold` | float | `0.85` | handoff 트리거 context_ratio | `masc_keeper_up`의 `handoff_threshold` 인자 |
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
+| `sandbox_profile` | string | `legacy_local` | 실행 샌드박스 프로필 | `masc_keeper_up`의 `sandbox_profile` 인자 |
+| `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker_hardened`는 기본 `none` | `masc_keeper_up`의 `network_mode` 인자 |
+| `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
+
+### 3.1.1 Sandbox Core V1 사용법
+
+가장 보수적인 기본 패턴:
+
+```json
+{
+  "name": "analyst",
+  "goal": "Review incoming issues and prepare safe changes",
+  "execution_scope": "workspace",
+  "sandbox_profile": "docker_hardened",
+  "network_mode": "none",
+  "shared_memory_scope": "room",
+  "tool_access": { "kind": "preset", "preset": "coding", "also_allow": ["masc_team_memory_read", "masc_team_memory_write", "masc_team_memory_search"] }
+}
+```
+
+의미:
+
+- keeper shell write는 자기 playground 안에서만 허용된다.
+- `docker_hardened`는 별도 runtime slice가 적용되면 hardened execution path를 사용한다.
+- `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
+- team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
+
+typed team memory 사용 예시:
+
+```text
+masc_team_memory_write(room="default", key="handoff/summary.md", content="현재 상황 요약...")
+masc_team_memory_read(room="default", key="handoff/summary.md")
+masc_team_memory_search(room="default", query="요약")
+```
+
+guardrail:
+
+- path traversal / symlink escape는 차단된다.
+- secret-like payload는 team memory write에서 차단된다.
+- team memory는 keeper context에서만 허용되고, `room`은 항상 `default`여야 한다.
 
 ### 3.2 페르소나 로드 필드 (Profile-Loaded)
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -31,6 +31,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
        @ Tool_schemas_control.schemas
        @ Tool_schemas_a2a.schemas
        @ Tool_schemas_misc.schemas
+       @ Tool_team_memory.schemas
        @ Tool_board.tools
        @ Tool_keeper.schemas
        @ Tool_local_runtime.schemas

--- a/lib/dune
+++ b/lib/dune
@@ -291,6 +291,7 @@
    workflow_guide
    tool_control
    tool_misc
+   tool_team_memory
    tool_agent_timeline
    tool_local_runtime
    tool_local_runtime_core

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -117,6 +117,10 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_web_search" -> Some (handle_web_search ctx args)
+  | "masc_team_memory_read" | "masc_team_memory_write"
+  | "masc_team_memory_search" ->
+      Tool_team_memory.dispatch ~config:ctx.config ~agent_name:ctx.agent_name
+        ~name ~args
   | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)

--- a/lib/tool_team_memory.ml
+++ b/lib/tool_team_memory.ml
@@ -1,0 +1,428 @@
+module Sg = Agent_sdk.Tool_schema_gen
+
+let room_field =
+  Sg.string_field "room" ~required:true
+    ~desc:"Flattened shared-memory namespace placeholder. Must be 'default'." ()
+
+let key_field =
+  Sg.string_field "key" ~required:true
+    ~desc:"Relative memory key/path under the room memory root" ()
+
+let content_field =
+  Sg.string_field "content" ~required:true
+    ~desc:"UTF-8 text content to store in team memory" ()
+
+let query_field =
+  Sg.string_field "query" ~required:true
+    ~desc:"Case-insensitive search query for team memory" ()
+
+let read_schema = Sg.two room_field key_field
+let write_schema = Sg.three room_field key_field content_field
+let search_schema = Sg.two room_field query_field
+
+let parse schema ~tool_name json =
+  match Sg.parse schema json with
+  | Ok value -> Ok value
+  | Error errs ->
+      Error
+        (Agent_sdk.Tool_input_validation.format_errors ~tool_name errs)
+
+let schema_to_tool_schema ~name ~description schema : Types.tool_schema =
+  {
+    Types.name = name;
+    description;
+    input_schema = Sg.to_json_schema schema;
+  }
+
+let schemas =
+  [
+    schema_to_tool_schema
+      ~name:"masc_team_memory_read"
+      ~description:
+        "Read shared team memory by key from the flattened default namespace. Uses a typed lane instead of exposing a shared writable shell directory."
+      read_schema;
+    schema_to_tool_schema
+      ~name:"masc_team_memory_write"
+      ~description:
+        "Write shared team memory by key in the flattened default namespace. Traversal, symlink escape, and secret-like payloads are blocked."
+      write_schema;
+    schema_to_tool_schema
+      ~name:"masc_team_memory_search"
+      ~description:
+        "Search shared team memory in the flattened default namespace by filename or content substring."
+      search_schema;
+  ]
+
+let default_namespace = "default"
+
+let validate_team_memory_room room =
+  let trimmed = String.trim room in
+  if trimmed = "" then
+    Error "room is required"
+  else if String.equal (String.lowercase_ascii trimmed) default_namespace then
+    Ok default_namespace
+  else
+    Error
+      (Printf.sprintf
+         "team memory uses the flattened default namespace; room must be '%s'"
+         default_namespace)
+
+let resolve_keeper_access ~(config : Coord.config) ~(agent_name : string) =
+  let trimmed = String.trim agent_name in
+  if trimmed = "" then
+    Error "team memory tools require keeper agent context"
+  else
+    match Keeper_types.keeper_name_from_agent_name trimmed with
+    | None ->
+        Error
+          (Printf.sprintf
+             "team memory tools are keeper-only; agent '%s' is not a keeper agent"
+             trimmed)
+    | Some keeper_name -> (
+        match Keeper_types.read_meta_resolved config keeper_name with
+        | Error err -> Error err
+        | Ok None ->
+            Error
+              (Printf.sprintf
+                 "keeper context not found for team memory agent '%s'"
+                 trimmed)
+        | Ok (Some (_resolved_name, meta)) ->
+            Ok (keeper_name, meta))
+
+let authorize_team_memory ~(config : Coord.config) ~(agent_name : string)
+    ~room =
+  match resolve_keeper_access ~config ~agent_name with
+  | Error err -> Error err
+  | Ok (keeper_name, meta) -> (
+      match meta.shared_memory_scope with
+      | Keeper_types.Shared_memory_disabled ->
+          Error
+            (Printf.sprintf
+               "team memory is disabled for keeper '%s'; set shared_memory_scope=room to enable the flattened default namespace"
+               keeper_name)
+      | Keeper_types.Shared_memory_room ->
+          validate_team_memory_room room)
+
+let team_memory_root ~(config : Coord.config) room =
+  Filename.concat config.base_path
+    (Printf.sprintf ".masc/shared/rooms/%s/memory" room)
+
+let is_safe_subpath ~parent ~child =
+  if child = parent then
+    true
+  else
+    let prefix = parent ^ "/" in
+    String.length child >= String.length prefix
+    && String.sub child 0 (String.length prefix) = prefix
+
+let rec nearest_existing_path path =
+  if Sys.file_exists path then
+    path
+  else
+    let parent = Filename.dirname path in
+    if parent = path then
+      path
+    else
+      nearest_existing_path parent
+
+let safe_realpath path =
+  try Ok (Unix.realpath path) with
+  | Unix.Unix_error (code, _, _) ->
+      Error
+        (Printf.sprintf "realpath failed for %s: %s"
+           path (Unix.error_message code))
+
+let encoded_traversal_markers =
+  [ "%2e"; "%2f"; "%5c" ]
+
+let contains_encoded_traversal key =
+  let lowered = String.lowercase_ascii key in
+  List.exists (String_util.contains_substring lowered) encoded_traversal_markers
+
+let validate_team_memory_key key =
+  let trimmed = String.trim key in
+  if trimmed = "" then
+    Error "key is required"
+  else if String.contains trimmed '\x00' then
+    Error "key must not contain NUL"
+  else if String.contains trimmed '\\' then
+    Error "key must not contain backslashes"
+  else if String.contains trimmed '%' && contains_encoded_traversal trimmed then
+    Error "key must not contain encoded traversal"
+  else
+    Validation.Safe_path.validate_relative trimmed
+
+let resolve_key_path ~(config : Coord.config) ~room ~key =
+  match validate_team_memory_room room with
+  | Error err -> Error err
+  | Ok room_id -> (
+      match validate_team_memory_key key with
+      | Error err -> Error err
+      | Ok rel_key ->
+          let root = team_memory_root ~config room_id in
+          let abs = Filename.concat root rel_key in
+          let parent = Filename.dirname abs in
+          let root_real =
+            if Sys.file_exists root then
+              safe_realpath root
+            else
+              safe_realpath (nearest_existing_path root)
+          in
+          match root_real, safe_realpath (nearest_existing_path parent) with
+          | Error err, _ | _, Error err -> Error err
+          | Ok real_root, Ok real_parent ->
+              if is_safe_subpath ~parent:real_root ~child:real_parent then
+                Ok (room_id, rel_key, root, abs, real_root)
+              else
+                Error
+                  (Printf.sprintf
+                     "team memory key escapes room root via symlink: %s" rel_key))
+
+let is_secret_token_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+  | _ -> false
+
+let contains_secret_token_prefix ~prefix ~min_suffix_len text =
+  let lowered = String.lowercase_ascii text in
+  let prefix_len = String.length prefix in
+  let text_len = String.length lowered in
+  let rec count_suffix idx count =
+    if idx + count >= text_len then
+      count
+    else if is_secret_token_char lowered.[idx + count] then
+      count_suffix idx (count + 1)
+    else
+      count
+  in
+  let rec loop idx =
+    if idx + prefix_len > text_len then
+      false
+    else if String.sub lowered idx prefix_len = prefix then
+      let boundary_ok = idx = 0 || not (is_secret_token_char lowered.[idx - 1]) in
+      let suffix_len = count_suffix (idx + prefix_len) 0 in
+      if boundary_ok && suffix_len >= min_suffix_len then true else loop (idx + 1)
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
+let content_looks_secret_like content =
+  let lowered = String.lowercase_ascii content in
+  let markers =
+    [
+      "-----begin ";
+      "authorization:";
+      "bearer ";
+      "x-api-key:";
+      "api_key=";
+      "token=";
+      "password=";
+      "secret=";
+      "ssh-rsa ";
+    ]
+  in
+  let secret_prefixes =
+    [
+      ("ghp_", 8);
+      ("github_pat_", 8);
+      ("sk-", 10);
+    ]
+  in
+  List.exists (String_util.contains_substring lowered) markers
+  || List.exists
+       (fun (prefix, min_suffix_len) ->
+         contains_secret_token_prefix ~prefix ~min_suffix_len content)
+       secret_prefixes
+
+let preview_snippet ?(max_chars = 180) text =
+  let normalized = String.trim text in
+  if String.length normalized <= max_chars then normalized
+  else String.sub normalized 0 max_chars ^ "..."
+
+let read_json ~config (room, key) =
+  match resolve_key_path ~config ~room ~key with
+  | Error err -> (false, err)
+  | Ok (room_id, rel_key, _root, abs, real_root) ->
+      if not (Sys.file_exists abs) then
+        (false, Printf.sprintf "team memory key not found: %s" rel_key)
+      else if Sys.is_directory abs then
+        (false, Printf.sprintf "team memory key is a directory: %s" rel_key)
+      else
+        match safe_realpath abs with
+        | Error err -> (false, err)
+        | Ok real_path ->
+            if not (is_safe_subpath ~parent:real_root ~child:real_path) then
+              (false,
+               Printf.sprintf
+                 "team memory key escapes room root via symlink: %s" rel_key)
+            else
+              let content = Fs_compat.load_file real_path in
+              ( true,
+                Yojson.Safe.to_string
+                  (`Assoc
+                     [
+                       ("room", `String room_id);
+                       ("key", `String rel_key);
+                       ("content", `String content);
+                     ]) )
+
+let write_json ~config (room, key, content) =
+  match resolve_key_path ~config ~room ~key with
+  | Error err -> (false, err)
+  | Ok (room_id, rel_key, root, abs, _real_root) ->
+      if content_looks_secret_like content then
+        (false,
+         "team memory write blocked: content looks like it may contain secrets")
+      else (
+        Fs_compat.mkdir_p root;
+        Fs_compat.mkdir_p (Filename.dirname abs);
+        match Fs_compat.save_file_atomic abs content with
+        | Error err -> (false, err)
+        | Ok () ->
+            ( true,
+              Yojson.Safe.to_string
+                (`Assoc
+                   [
+                     ("room", `String room_id);
+                     ("key", `String rel_key);
+                     ("bytes", `Int (String.length content));
+                   ]) ))
+
+let rec collect_files acc dir =
+  let entries =
+    try Sys.readdir dir |> Array.to_list with
+    | Sys_error _ -> []
+  in
+  List.fold_left
+    (fun acc entry ->
+      let path = Filename.concat dir entry in
+      try
+        match (Unix.lstat path).Unix.st_kind with
+        | Unix.S_REG -> path :: acc
+        | Unix.S_DIR -> collect_files acc path
+        | Unix.S_LNK -> acc
+        | _ -> acc
+      with
+      | Unix.Unix_error _ -> acc)
+    acc entries
+
+let search_json ~config (room, query) =
+  match validate_team_memory_room room with
+  | Error err -> (false, err)
+  | Ok room_id ->
+      let normalized_query = String.trim query in
+      if normalized_query = "" then
+        (false, "query is required")
+      else
+        let root = team_memory_root ~config room_id in
+        if not (Sys.file_exists root && Sys.is_directory root) then
+          (true,
+           Yojson.Safe.to_string
+             (`Assoc [ ("room", `String room_id); ("matches", `List []) ]))
+        else
+          let lowered_query = String.lowercase_ascii normalized_query in
+          let root_prefix =
+            root
+            |> Keeper_alerting_path.normalize_path_for_check
+            |> Keeper_alerting_path.strip_trailing_slashes
+          in
+          let to_key path =
+            let normalized =
+              path
+              |> Keeper_alerting_path.normalize_path_for_check
+              |> Keeper_alerting_path.strip_trailing_slashes
+            in
+            let prefix = root_prefix ^ "/" in
+            if String.starts_with ~prefix normalized then
+              String.sub normalized (String.length prefix)
+                (String.length normalized - String.length prefix)
+            else
+              Filename.basename normalized
+          in
+          let matches =
+            collect_files [] root
+            |> List.rev
+            |> List.filter_map (fun path ->
+                   let key = to_key path in
+                   let content =
+                     try Fs_compat.load_file path with
+                     | Sys_error _ -> ""
+                   in
+                   let lowered_key = String.lowercase_ascii key in
+                   let lowered_content = String.lowercase_ascii content in
+                   if String_util.contains_substring lowered_key lowered_query
+                      || String_util.contains_substring lowered_content lowered_query
+                   then
+                     Some
+                       (`Assoc
+                          [
+                            ("key", `String key);
+                            ("preview", `String (preview_snippet content));
+                          ])
+                   else
+                     None)
+            |> fun xs ->
+            if List.length xs > 20 then List.filteri (fun idx _ -> idx < 20) xs
+            else xs
+          in
+          ( true,
+            Yojson.Safe.to_string
+              (`Assoc
+                 [
+                   ("room", `String room_id);
+                   ("query", `String normalized_query);
+                   ("matches", `List matches);
+                 ]))
+
+let dispatch ~(config : Coord.config) ~(agent_name : string) ~name ~args
+    : Keeper_types.tool_result option =
+  match name with
+  | "masc_team_memory_read" -> (
+      match parse read_schema ~tool_name:name args with
+      | Ok ((room, _key) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (read_json ~config parsed))
+      | Error err -> Some (false, err))
+  | "masc_team_memory_write" -> (
+      match parse write_schema ~tool_name:name args with
+      | Ok ((room, _key, _content) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (write_json ~config parsed))
+      | Error err -> Some (false, err))
+  | "masc_team_memory_search" -> (
+      match parse search_schema ~tool_name:name args with
+      | Ok ((room, _query) as parsed) -> (
+          match authorize_team_memory ~config ~agent_name ~room with
+          | Error err -> Some (false, err)
+          | Ok _room_id -> Some (search_json ~config parsed))
+      | Error err -> Some (false, err))
+  | _ -> None
+
+let read_only_tools = [ "masc_team_memory_read"; "masc_team_memory_search" ]
+
+let tool_required_permission = function
+  | "masc_team_memory_read" | "masc_team_memory_search" ->
+      Some Types.CanReadState
+  | "masc_team_memory_write" ->
+      Some Types.CanBroadcast
+  | _ -> None
+
+let () =
+  List.iter
+    (fun (s : Types.tool_schema) ->
+      let is_ro = List.mem s.name read_only_tools in
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:s.name
+           ~description:s.description
+           ~module_tag:Tool_dispatch.Mod_misc
+           ~input_schema:s.input_schema
+           ~handler_binding:Tag_dispatch
+           ~is_read_only:is_ro
+           ~is_idempotent:is_ro
+           ~requires_join:true
+           ?required_permission:(tool_required_permission s.name)
+           ()))
+    schemas

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -42,6 +42,7 @@ let all_schemas_extended =
     @ Tool_schemas_control.schemas
     @ Tool_schemas_a2a.schemas
     @ Tool_schemas_misc.schemas
+    @ Tool_team_memory.schemas
     @ Tool_keeper.schemas
     @ Tool_local_runtime.schemas @ Tool_shard.schemas
     @ Tool_autoresearch.schemas)

--- a/test/dune
+++ b/test/dune
@@ -116,6 +116,7 @@
         test_keeper_campaign_fsm
         test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
+        test_team_memory
         test_telemetry_unified
         test_keeper_topk_llm
         test_warn_root_causes
@@ -211,7 +212,8 @@
           test_keeper_campaign_fsm
           test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
-            test_telemetry_unified
+          test_team_memory
+          test_telemetry_unified
           test_keeper_topk_llm
           test_warn_root_causes
           test_memory_hooks

--- a/test/test_team_memory.ml
+++ b/test/test_team_memory.ml
@@ -1,0 +1,250 @@
+open Alcotest
+open Masc_mcp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_DIR ->
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+    | _ ->
+        Unix.unlink path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> try rm_rf dir with _ -> ()) (fun () -> f dir)
+
+let write_keeper_meta ~config ~name ~shared_memory_scope =
+  let agent_name = Printf.sprintf "keeper-%s-agent" name in
+  let meta_json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String agent_name);
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "test");
+        ("shared_memory_scope", `String shared_memory_scope);
+      ]
+  in
+  let meta =
+    match Keeper_types.meta_of_json meta_json with
+    | Ok meta -> meta
+    | Error err -> fail ("meta_of_json failed: " ^ err)
+  in
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> agent_name
+  | Error err -> fail ("write_meta failed: " ^ err)
+
+let dispatch ~config ~agent_name ~name args =
+  match Tool_team_memory.dispatch ~config ~agent_name ~name ~args with
+  | Some result -> result
+  | None -> fail ("unexpected missing dispatch: " ^ name)
+
+let json_result_exn = function
+  | true, body -> Yojson.Safe.from_string body
+  | false, err -> fail err
+
+let test_write_read_search () =
+  with_temp_dir "team-memory-room" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let write_args =
+    `Assoc
+      [
+        ("room", `String "default");
+        ("key", `String "notes/demo.md");
+        ("content", `String "hello shared team memory");
+      ]
+  in
+  ignore
+    (json_result_exn
+       (dispatch ~config ~agent_name ~name:"masc_team_memory_write" write_args));
+  let read_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "notes/demo.md");
+            ]))
+  in
+  let open Yojson.Safe.Util in
+  check string "read content" "hello shared team memory"
+    (read_json |> member "content" |> to_string);
+  let search_json =
+    json_result_exn
+      (dispatch ~config ~agent_name ~name:"masc_team_memory_search"
+         (`Assoc
+            [
+              ("room", `String "default");
+              ("query", `String "shared");
+            ]))
+  in
+  check int "search match count" 1
+    (search_json |> member "matches" |> to_list |> List.length);
+  check string "search key" "notes/demo.md"
+    (search_json |> member "matches" |> index 0 |> member "key" |> to_string)
+
+let test_traversal_blocked () =
+  with_temp_dir "team-memory-traversal" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "../outside.txt");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions traversal" true
+    (String_util.contains_substring err "traversal")
+
+let test_secret_like_write_blocked () =
+  with_temp_dir "team-memory-secret" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_write"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "secrets/note.txt");
+           ("content",
+             `String "Authorization: Bearer sk-secret-token-1234567890");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions secrets" true
+    (String_util.contains_substring err "contain secrets")
+
+let test_symlink_escape_blocked () =
+  with_temp_dir "team-memory-symlink" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let root = Tool_team_memory.team_memory_root ~config "default" in
+  Fs_compat.mkdir_p root;
+  let outside_path = Filename.concat base_path "outside.txt" in
+  (match Fs_compat.save_file_atomic outside_path "outside" with
+  | Ok () -> ()
+  | Error err -> fail err);
+  let link_path = Filename.concat root "escape.txt" in
+  Unix.symlink outside_path link_path;
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "escape.txt");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions symlink" true
+    (String_util.contains_substring err "symlink")
+
+let test_disabled_scope_blocked () =
+  with_temp_dir "team-memory-disabled" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"disabled"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "notes/demo.md");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions shared_memory_scope" true
+    (String_util.contains_substring err "shared_memory_scope=room")
+
+let test_non_keeper_agent_blocked () =
+  with_temp_dir "team-memory-non-keeper" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let ok, err =
+    dispatch ~config ~agent_name:"operator-human" ~name:"masc_team_memory_read"
+      (`Assoc
+         [
+           ("room", `String "default");
+           ("key", `String "notes/demo.md");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions keeper-only" true
+    (String_util.contains_substring err "keeper-only")
+
+let test_non_default_room_blocked () =
+  with_temp_dir "team-memory-room-validation" @@ fun base_path ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Coord.default_config base_path in
+  let agent_name =
+    write_keeper_meta ~config ~name:"room-alpha" ~shared_memory_scope:"room"
+  in
+  let ok, err =
+    dispatch ~config ~agent_name ~name:"masc_team_memory_search"
+      (`Assoc
+         [
+           ("room", `String "incident-alpha");
+           ("query", `String "shared");
+         ])
+  in
+  check bool "blocked" false ok;
+  check bool "mentions default namespace" true
+    (String_util.contains_substring err "room must be 'default'")
+
+let () =
+  run "team_memory"
+    [
+      ( "crud",
+        [
+          test_case "write read search" `Quick test_write_read_search;
+        ] );
+      ( "guards",
+        [
+          test_case "traversal blocked" `Quick test_traversal_blocked;
+          test_case "secret-like write blocked" `Quick
+            test_secret_like_write_blocked;
+          test_case "symlink escape blocked" `Quick
+            test_symlink_escape_blocked;
+          test_case "disabled scope blocked" `Quick
+            test_disabled_scope_blocked;
+          test_case "non-keeper agent blocked" `Quick
+            test_non_keeper_agent_blocked;
+          test_case "non-default room blocked" `Quick
+            test_non_default_room_blocked;
+        ] );
+    ]

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -198,6 +198,9 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_agent_card", Types.CanReadState);
       ("masc_heartbeat", Types.CanBroadcast);
       ("masc_config", Types.CanReadState);
+      ("masc_team_memory_read", Types.CanReadState);
+      ("masc_team_memory_search", Types.CanReadState);
+      ("masc_team_memory_write", Types.CanBroadcast);
       ("masc_tool_list", Types.CanReadState);
       ("masc_tool_admin_snapshot", Types.CanAdmin);
       ("masc_runtime_verify", Types.CanReadState);

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -70,6 +70,27 @@ let make_test_ctx () =
   let _ = Coord.init config ~agent_name:(Some "test-agent") in
   { Tool_misc.config; agent_name = "test-agent" }
 
+let write_team_memory_keeper_meta ~config ~name ~shared_memory_scope =
+  let agent_name = Printf.sprintf "keeper-%s-agent" name in
+  let meta_json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String agent_name);
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "team memory fixture");
+        ("shared_memory_scope", `String shared_memory_scope);
+      ]
+  in
+  let meta =
+    match Keeper_types.meta_of_json meta_json with
+    | Ok meta -> meta
+    | Error err -> failwith ("meta_of_json failed: " ^ err)
+  in
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> agent_name
+  | Error err -> failwith ("write_meta failed: " ^ err)
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -125,6 +146,53 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
+)
+
+let () = test "dispatch_team_memory_write_and_read" (fun () ->
+  let ctx = make_test_ctx () in
+  let agent_name =
+    write_team_memory_keeper_meta ~config:ctx.config ~name:"room-alpha"
+      ~shared_memory_scope:"room"
+  in
+  let keeper_ctx : Tool_misc.context =
+    { config = ctx.config; agent_name }
+  in
+  let write_body =
+    match
+      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_write"
+        ~args:
+          (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "handoff/summary.md");
+              ("content", `String "shared summary");
+            ])
+    with
+    | Some (true, body) -> body
+    | Some (false, err) -> failwith err
+    | None -> failwith "dispatch returned None"
+  in
+  let write_json = parse_json write_body in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "write key" "handoff/summary.md"
+    (write_json |> member "key" |> to_string);
+  let read_body =
+    match
+      Tool_misc.dispatch keeper_ctx ~name:"masc_team_memory_read"
+        ~args:
+          (`Assoc
+            [
+              ("room", `String "default");
+              ("key", `String "handoff/summary.md");
+            ])
+    with
+    | Some (true, body) -> body
+    | Some (false, err) -> failwith err
+    | None -> failwith "dispatch returned None"
+  in
+  let read_json = parse_json read_body in
+  Alcotest.(check string) "read content" "shared summary"
+    (read_json |> member "content" |> to_string)
 )
 
 let () = test "dispatch_dashboard_invalid_scope" (fun () ->

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -492,6 +492,44 @@ let test_masc_tool_admin_update_schema () =
           Alcotest.(check bool) "has policy" true (List.mem_assoc "policy" props)
       | None -> Alcotest.fail "masc_tool_admin_update missing properties"
 
+let test_masc_team_memory_read_schema () =
+  match find_tool "masc_team_memory_read" with
+  | None -> Alcotest.fail "masc_team_memory_read not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has key" true
+            (List.mem_assoc "key" props)
+      | None -> Alcotest.fail "masc_team_memory_read missing properties"
+
+let test_masc_team_memory_write_schema () =
+  match find_tool "masc_team_memory_write" with
+  | None -> Alcotest.fail "masc_team_memory_write not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has key" true
+            (List.mem_assoc "key" props);
+          Alcotest.(check bool) "has content" true
+            (List.mem_assoc "content" props)
+      | None -> Alcotest.fail "masc_team_memory_write missing properties"
+
+let test_masc_team_memory_search_schema () =
+  match find_tool "masc_team_memory_search" with
+  | None -> Alcotest.fail "masc_team_memory_search not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has room" true
+            (List.mem_assoc "room" props);
+          Alcotest.(check bool) "has query" true
+            (List.mem_assoc "query" props)
+      | None -> Alcotest.fail "masc_team_memory_search missing properties"
+
 (* ============================================================ *)
 (* 14. Handover Tool Tests                                       *)
 (* ============================================================ *)
@@ -714,6 +752,14 @@ let () =
         test_masc_tool_admin_snapshot_schema;
       Alcotest.test_case "tool-admin-update" `Quick
         test_masc_tool_admin_update_schema;
+    ];
+    "team_memory_tools", [
+      Alcotest.test_case "team-memory-read" `Quick
+        test_masc_team_memory_read_schema;
+      Alcotest.test_case "team-memory-write" `Quick
+        test_masc_team_memory_write_schema;
+      Alcotest.test_case "team-memory-search" `Quick
+        test_masc_team_memory_search_schema;
     ];
     (* runtime_verify_tools removed: masc_runtime_verify pruned *)
     "legacy_swarm_removed", [


### PR DESCRIPTION
## Summary
- add `masc_team_memory_read`, `masc_team_memory_write`, and `masc_team_memory_search` as typed shared-memory tools
- enforce keeper-only access with `shared_memory_scope=room` and restrict the namespace to flattened `room="default"`
- block traversal, symlink escape, and secret-like payload writes while documenting the operator-facing setup

## Notes
- stacked on top of `#8029`
- this slice turns `shared_memory_scope` from a stored policy field into a real gate for typed team-memory access
- team memory tools still need to be present on the keeper tool surface via `tool_also_allow` / `tool_access.also_allow` when the chosen preset does not expose them

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature/keeper-team-memory-enforcement-main test/test_team_memory.exe test/test_tools_coverage.exe test/test_tool_access_role.exe test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_team_memory.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `./_build/default/test/test_tool_access_role.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
