### PR TITLE
feat(dashboard): 🧮 per-column Totals footer on Keeper × Connector matrix (#8035 pair)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -149,6 +149,66 @@ describe('ConnectorKeeperMatrix', () => {
     expect(alphaChip.getAttribute('data-matrix-row-total-live')).toBe('2')
     expect(alphaChip.textContent).toContain('1/2')
   })
+
+  it('renders a per-column totals footer row (GitHub Actions matrix pattern)', () => {
+    // Two keepers × 4 known connectors. alpha bound to discord + slack,
+    // beta bound to discord only → discord column has 2 bound, slack
+    // column has 1 bound, imessage + telegram have 0 bound.
+    const connectors = [
+      mkConnector('discord', { available: true, configured_bindings: [
+        { channel_id: 'c1', keeper_name: 'alpha' },
+        { channel_id: 'c2', keeper_name: 'beta' },
+      ] as never }),
+      mkConnector('slack', { available: true, configured_bindings: [
+        { channel_id: 'c3', keeper_name: 'alpha' },
+      ] as never }),
+    ]
+    const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
+    const matrix = deriveMatrix(connectors, keepers)
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    // Footer label ("Totals →") is visible.
+    expect(container.querySelector('[data-matrix-column-totals-label]')).toBeTruthy()
+    // Divider is present (semantic break between rows + totals).
+    expect(container.querySelector('[data-matrix-column-totals-divider]')).toBeTruthy()
+    // Per-column totals cells — one per connector column.
+    const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
+    expect(cells.length).toBe(4)
+    // Discord (col 0) = 2 bound.
+    expect(cells[0]!.getAttribute('data-matrix-column-total-bound')).toBe('2')
+    // Slack (col 2) = 1 bound.
+    expect(cells[2]!.getAttribute('data-matrix-column-total-bound')).toBe('1')
+    // Grand total chip = 3 bound.
+    const grand = container.querySelector('[data-matrix-grand-total]')
+    expect(grand?.getAttribute('data-matrix-grand-total-bound')).toBe('3')
+  })
+
+  it('column totals footer highlights amber when a column has unknowns (directory-mismatch guard)', () => {
+    const connectors = [
+      mkConnector('discord', { available: true, configured_bindings: [
+        { channel_id: 'c1', keeper_name: 'alpha' },
+        // gamma is NOT in the keeper directory → unknown cell in discord col
+        { channel_id: 'c2', keeper_name: 'gamma' },
+      ] as never }),
+    ]
+    const keepers = [mkKeeper('alpha')]
+    const matrix = deriveMatrix(connectors, keepers)
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
+    const discordCell = cells[0] as HTMLElement
+    expect(discordCell.getAttribute('data-matrix-column-total-unknown')).toBe('1')
+    expect(discordCell.className).toContain('text-amber-200')
+  })
+
+  it('column totals footer dashes empty columns (no bound, no unbound, no unknown)', () => {
+    // imessage + telegram have 0 bindings and are offline → na cells only.
+    // The totals cell for those columns shows "—" not "0".
+    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')])
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
+    const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
+    // imessage is col 1 — offline, no bindings → all na → dashed.
+    const imessageCell = cells[1] as HTMLElement
+    expect(imessageCell.textContent).toContain('—')
+  })
 })
 
 describe('summarizeMatrixRow (pure)', () => {

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -279,10 +279,70 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
                 ${matrix.rows.map(row => html`
                   <${MatrixRowRender} row=${row} />
                 `)}
+
+                <${MatrixColumnTotalsRow} matrix=${matrix} />
               </div>
             </div>
           `}
     </section>
+  `
+}
+
+/** Per-column totals footer — GitHub Actions matrix + Airflow DAG-grid
+    convention. The row lives INSIDE the same grid as the data rows so
+    its cells align pixel-for-pixel with the connector columns above.
+    Reads "N keepers" where N = bound (actively using this connector). */
+function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
+  const totalBound = matrix.rows.reduce(
+    (acc, row) => acc + row.cells.filter(c => c.state === 'bound').length,
+    0,
+  )
+  return html`
+    <div
+      class="col-span-full mt-1 border-t border-[var(--card-border)]"
+      aria-hidden="true"
+      data-matrix-column-totals-divider
+    ></div>
+    <div
+      class="flex items-center gap-1 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+      data-matrix-column-totals-label
+    >Totals →</div>
+    ${matrix.columns.map((_, idx) => html`
+      <${ColumnTotalsCell} counts=${summarizeMatrixColumn(matrix, idx)} />
+    `)}
+    <div
+      class=${`flex items-center justify-end gap-1 px-1 py-1 text-[10px] tabular-nums ${totalBound > 0 ? 'text-emerald-200' : 'text-[var(--text-dim)]'}`}
+      title=${`Grand total: ${totalBound} bound cells across all keepers × connectors`}
+      data-matrix-grand-total
+      data-matrix-grand-total-bound=${totalBound}
+    >
+      <span aria-hidden="true">●</span>
+      <span>${totalBound}</span>
+    </div>
+  `
+}
+
+function ColumnTotalsCell({ counts }: { counts: MatrixStateCounts }) {
+  const { bound, unbound, unknown } = counts
+  // Show bound count primarily (the interesting one), plus amber badge
+  // when any unknowns exist. Empty column (0 bound, 0 unbound) → dash.
+  const hasAny = bound + unbound + unknown > 0
+  const tone =
+    unknown > 0 ? 'text-amber-200' :
+    bound > 0 ? 'text-emerald-200' :
+    'text-[var(--text-dim)]'
+  const label = hasAny ? `${bound}` : '—'
+  const title = `${bound} bound · ${unbound} unbound · ${unknown} unknown · ${counts.na} n/a`
+  return html`
+    <div
+      class=${`flex items-center justify-center gap-1 px-1 py-1 text-[10px] tabular-nums ${tone}`}
+      title=${title}
+      data-matrix-column-total-bound=${bound}
+      data-matrix-column-total-unknown=${unknown}
+    >
+      <span aria-hidden="true">●</span>
+      <span>${label}</span>
+    </div>
   `
 }
 


### PR DESCRIPTION
## Summary

**#8035 pair**: per-row Coverage chips landed first, per-column Totals footer now completes the matrix totals pattern. Every direction of the keeper × connector grid has scannable summaries — Airflow / GitHub Actions matrix staple.

## Before / After

Before #8035: plain grid, cells only.
After #8035: trailing Coverage column (per-keeper row totals).
**After this PR**: bottom footer row (per-connector column totals + grand total).

```
Keeper ↓/Connector→  Discord  iMessage  Slack  Telegram  Coverage
alpha                  ● 1      —         ● 1    —         ● 2/2
beta                   ● 1      —         —      —         ● 1/3
─────────────────────────────────────────────────────────────────
Totals →               ● 2      —         ● 1    —         ● 3
```

## Design details

Footer row lives **inside the grid** (col-span divider + 1 label + N column cells + 1 grand-total cell) so pixel alignment with data rows above is free.

Per-column cell rules:
| Condition | Tone | Label |
|-----------|------|-------|
| any `unknown` | amber (directory mismatch) | bound count |
| `bound > 0` | emerald | bound count |
| all `na` (empty column) | muted | **\"—\"** (not \"0\" — avoids misreading offline as \"0 keepers\") |
| `bound = 0`, has `unbound` | muted | \"0\" |

Grand total (under Coverage column): sum of all bound cells. Emerald when > 0.

Hover tooltip on each column cell expands to full breakdown: `\"2 bound · 1 unbound · 0 unknown · 1 n/a\"`.

## Reuses

`summarizeMatrixColumn` was intentionally exposed by #8035 (not used there) to avoid plumbing when this chip landed. Single render-side change, zero new pure helpers.

## Tests (+3 new, 18 total)

- Footer renders: label, divider, N column cells, grand total
- Bound counts correct per column (2 bound discord, 1 bound slack)
- Grand total sums correctly across keepers × connectors
- **Amber guard**: column with an unknown cell tints its total chip amber
- **Empty column dash guard**: all-na column renders `\"—\"` not `\"0\"` — avoids misleading operators

All 15 pre-existing tests still green. `MatrixData` contract unchanged. Existing rows render identically — footer is purely additive at the end of grid children.

## Test plan

- [x] `npx vitest run src/components/connector-keeper-matrix.test.ts` → 18/18 green
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Visual check on live dashboard (5+ keepers × 4 connectors)
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)