### PR TITLE
chore(dashboard): remove 2 dead exports from provenance-strip.ts (-28 LOC)

### DIFF
--- a/dashboard/src/components/common/provenance-strip.ts
+++ b/dashboard/src/components/common/provenance-strip.ts
@@ -1,6 +1,3 @@
-import { html } from 'htm/preact'
-import { StatusChip } from './status-chip'
-
 type ProvenanceItem = {
   kind?: string | null
   label?: string | null
@@ -40,29 +37,4 @@ export function provenanceLabel(item: ProvenanceItem): string {
   if (explicit) return explicit
   const kind = normalizeProvenance(item.kind)
   return PROVENANCE_LABELS[kind] ?? (kind || 'unknown')
-}
-
-export function ProvenanceChip({ item }: { item: ProvenanceItem }) {
-  const label = provenanceLabel(item)
-  const tone = provenanceTone(item.kind)
-  return html`<${StatusChip} label=${label} tone=${tone} />`
-}
-
-export function ProvenanceStrip({
-  items,
-  className = 'mission-briefing-meta',
-  testId,
-}: {
-  items: ProvenanceItem[]
-  className?: string
-  testId?: string
-}) {
-  const normalized = items.filter(item => provenanceLabel(item).trim().length > 0)
-  if (normalized.length === 0) return null
-
-  return html`
-    <div class=${className} data-testid=${testId}>
-      ${normalized.map((item, index) => html`<${ProvenanceChip} key=${`${provenanceLabel(item)}-${index}`} item=${item} />`)}
-    </div>
-  `
 }


### PR DESCRIPTION
## Summary

`/loop 20m` Gen40. `provenance-strip.ts`에서 `ProvenanceChip` + `ProvenanceStrip` 두 React 컴포넌트 제거. 테스트와 다른 파일 어디에서도 import되지 않음.

## 변경

| 제거 | LOC | 위치 |
|---|---|---|
| `ProvenanceChip` 컴포넌트 | -5 | line 45-49 |
| `ProvenanceStrip` 컴포넌트 | -18 | line 51-68 |
| `import { html } from 'htm/preact'` | -1 | line 1 (컴포넌트 제거 후 고아) |
| `import { StatusChip } from './status-chip'` | -1 | line 2 (동일) |
| blank line | -1 | separator |
| **합계** | **-28** | |

파일 크기: 68L → 41L

## 유지

- `provenanceTone` + `provenanceLabel`: test에서 사용, 보존
- `ProvenanceItem` type, `PROVENANCE_LABELS`, `normalizeProvenance`: 위 두 함수가 의존

## 배경

`provenance-strip.test.ts`는 `provenanceTone`, `provenanceLabel`만 import함. 두 React 컴포넌트는 아무도 사용하지 않는 orphan — 상위 mission-briefing-meta 관련 UI가 이전 cycle에서 제거되면서 남은 것으로 추정.

## 검증

- `tsc --noEmit`: ✅ error 0
- `bun run build`: ✅ 10.90s
- `bun run test`: ✅ **215 files pass (3528 tests)**
  - `saved-signal.test.ts` 9 fails는 pre-existing (PR #8014)

## /loop 스택 (Gen29~40)

| PR | Gen | 상태 |
|---|---|---|
| #7938~#8003 | 29~35 | MERGED |
| #8019 | 36 | MERGED |
| #8027 | 37 | Ready (CI pending) |
| #8036 | 38 | **MERGED** |
| #8041 | 39 | Draft |
| **#TBD** | **40** | **Draft** |

누적: **~-2,010 LOC**

## 다음 cycle 후보

- Gen41: `keeper-trajectory-timeline.ts` massive cleanup — 11/12 exports가 test-only, `loadTrajectory`만 live. 파일을 ~30 LOC로 축소 (~480 LOC purge) + test 파일 정리. 전용 PR로 진행 필요 (scope 큼).
- Gen42: `tab-refresh.ts::getTabVisitCounts`, `router.ts::{navigateBack, useRoute}` 등 개별 dead fns 8개 sweep
- Gen43: CSS 중복 블록 통합 (dashboard.css↔mission.css)

## Test plan
- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)