### PR TITLE
[codex] Harden keeper sandbox runtime execution

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -148,6 +148,8 @@ describe('fetchKeeperConfig', () => {
       sandbox_profile: 'docker_hardened',
       network_mode: 'none',
       shared_memory_scope: 'room',
+      sandbox_last_error: 'sandbox docker exec failed',
+      effective_sandbox_image: 'ubuntu:24.04@sha256:test',
       private_workspace_root: '.masc/playground/keeper-sangsu',
       allowed_paths: '/tmp/workspace',
       effective_allowed_paths: ['/tmp/workspace'],
@@ -282,6 +284,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.sandbox_profile).toBe('docker_hardened')
     expect(result.network_mode).toBe('none')
     expect(result.shared_memory_scope).toBe('room')
+    expect(result.sandbox_last_error).toBe('sandbox docker exec failed')
+    expect(result.effective_sandbox_image).toBe('ubuntu:24.04@sha256:test')
     expect(result.private_workspace_root).toBe('.masc/playground/keeper-sangsu')
     expect(result.execution.models).toEqual(['llama:test-balanced'])
     expect(result.execution.verify).toBe(true)

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1045,6 +1045,8 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     sandbox_profile: asNullableString(data.sandbox_profile) ?? 'legacy_local',
     network_mode: asNullableString(data.network_mode) ?? 'inherit',
     shared_memory_scope: asNullableString(data.shared_memory_scope) ?? 'disabled',
+    sandbox_last_error: asNullableString(data.sandbox_last_error),
+    effective_sandbox_image: asNullableString(data.effective_sandbox_image),
     private_workspace_root: asNullableString(data.private_workspace_root),
     allowed_paths: normalizeStringList(data.allowed_paths),
     effective_allowed_paths: normalizeStringList(data.effective_allowed_paths),

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -630,9 +630,17 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="sandbox_profile" value=${c.sandbox_profile ?? 'legacy_local'} />
         <${ConfigRow} label="network_mode" value=${c.network_mode ?? 'inherit'} />
         <${ConfigRow} label="shared_memory_scope" value=${c.shared_memory_scope ?? 'disabled'} />
+        <${ConfigRow} label="effective_sandbox_image" value=${c.effective_sandbox_image || '--'} />
         <${ConfigRow} label="allowed_paths" value=${(c.allowed_paths ?? []).join(', ') || '(computed default)'} />
         <${ConfigRow} label="effective_paths" value=${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'} />
         <${ConfigRow} label="private_workspace_root" value=${c.private_workspace_root || '--'} />
+        ${c.sandbox_last_error ? html`
+          <${Callout}
+            title="Sandbox Error"
+            body=${c.sandbox_last_error}
+            tone="warn"
+          />
+        ` : null}
       `}
 
       <${SectionHeader} title="프로액티브" />

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -1,3 +1,0 @@
-export function AttentionCard() {
-  return null
-}

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -1,2 +1,0 @@
-export { MissionBriefingCard } from './mission-briefing-card'
-export { AttentionCard } from './mission-attention-card'

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -891,6 +891,8 @@ export interface KeeperConfig {
   sandbox_profile?: 'legacy_local' | 'docker_hardened' | string
   network_mode?: 'none' | 'inherit' | string
   shared_memory_scope?: 'disabled' | 'room' | string
+  sandbox_last_error?: string | null
+  effective_sandbox_image?: string | null
   private_workspace_root?: string | null
   allowed_paths: string[]
   effective_allowed_paths: string[]

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -203,6 +203,7 @@ Operational intent:
 - private writable lane: `.masc/playground/<keeper>/...`
 - shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
 - no arbitrary shared writable shell directory
+- `docker_hardened`는 `allowed_paths=["*"]`를 거부하고, private playground root 밖 경로도 허용하지 않는다
 
 ### Removed / forbidden fields (hard-rejected)
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -238,7 +238,7 @@ spawn 시 인자로 직접 설정하는 필드.
 의미:
 
 - keeper shell write는 자기 playground 안에서만 허용된다.
-- `docker_hardened`는 별도 runtime slice가 적용되면 hardened execution path를 사용한다.
+- `docker_hardened`는 keeper_bash를 ephemeral Docker sandbox로 실행한다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private playground mount, network=`none`이다.
 - `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
 - team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
 
@@ -255,6 +255,7 @@ guardrail:
 - path traversal / symlink escape는 차단된다.
 - secret-like payload는 team memory write에서 차단된다.
 - team memory는 keeper context에서만 허용되고, `room`은 항상 `default`여야 한다.
+- `legacy_local`는 `network_mode=none`을 허용하지 않는다. `none`은 `docker_hardened`와 함께 써야 한다.
 
 ### 3.2 페르소나 로드 필드 (Profile-Loaded)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -527,6 +527,40 @@ module DockerPlayground = struct
       "MASC_KEEPER_DOCKER_PLAYGROUND_ROOT"
 end
 
+module KeeperSandbox = struct
+  (** Ephemeral Docker image used by sandbox_profile=docker_hardened.
+      Must contain bash and the CLI tools the keeper needs. *)
+  let docker_image =
+    get_string
+      ~default:
+        "ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff"
+      "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+
+  (** pids limit for hardened keeper containers. *)
+  let pids_limit =
+    max 32 (get_int ~default:128 "MASC_KEEPER_SANDBOX_PIDS_LIMIT")
+
+  (** Docker memory limit string, e.g. 2g / 512m. *)
+  let memory =
+    get_string ~default:"2g" "MASC_KEEPER_SANDBOX_MEMORY"
+
+  (** Writable tmpfs size inside the read-only rootfs. *)
+  let tmpfs_size =
+    get_string ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
+
+  (** Optional seccomp profile path passed to [docker run --security-opt]. *)
+  let seccomp_profile =
+    get_string ~default:"" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+
+  (** Fail closed unless Docker reports rootless mode support. *)
+  let require_rootless =
+    get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
+
+  (** Fail closed unless Docker reports userns support. *)
+  let require_userns =
+    get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
+end
+
 module DashboardHealth = struct
   let ctx_critical = get_float ~default:0.9 "MASC_DASHBOARD_HEALTH_CTX_CRITICAL"
   let ctx_warn = get_float ~default:0.8 "MASC_DASHBOARD_HEALTH_CTX_WARN"

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -530,34 +530,34 @@ end
 module KeeperSandbox = struct
   (** Ephemeral Docker image used by sandbox_profile=docker_hardened.
       Must contain bash and the CLI tools the keeper needs. *)
-  let docker_image =
+  let docker_image () =
     get_string
       ~default:
         "ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff"
       "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
 
   (** pids limit for hardened keeper containers. *)
-  let pids_limit =
+  let pids_limit () =
     max 32 (get_int ~default:128 "MASC_KEEPER_SANDBOX_PIDS_LIMIT")
 
   (** Docker memory limit string, e.g. 2g / 512m. *)
-  let memory =
+  let memory () =
     get_string ~default:"2g" "MASC_KEEPER_SANDBOX_MEMORY"
 
   (** Writable tmpfs size inside the read-only rootfs. *)
-  let tmpfs_size =
+  let tmpfs_size () =
     get_string ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
 
   (** Optional seccomp profile path passed to [docker run --security-opt]. *)
-  let seccomp_profile =
+  let seccomp_profile () =
     get_string ~default:"" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
 
   (** Fail closed unless Docker reports rootless mode support. *)
-  let require_rootless =
+  let require_rootless () =
     get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
 
   (** Fail closed unless Docker reports userns support. *)
-  let require_userns =
+  let require_userns () =
     get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
 end
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -425,6 +425,27 @@ let docker_playground_entries =
       "Route keeper_bash through Docker container (feature flag)";
   ]
 
+let keeper_sandbox_entries =
+  [
+    entry
+      ~default:
+        "ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff"
+      "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+      "Digest-pinned Docker image for sandbox_profile=docker_hardened";
+    entry ~default:"128" "MASC_KEEPER_SANDBOX_PIDS_LIMIT"
+      "PID limit for hardened keeper containers";
+    entry ~default:"2g" "MASC_KEEPER_SANDBOX_MEMORY"
+      "Memory limit for hardened keeper containers";
+    entry ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
+      "Writable /tmp tmpfs size for hardened keeper containers";
+    entry ~default:"(none)" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+      "Optional seccomp profile path for hardened keeper containers";
+    entry ~default:"false" "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
+      "Fail closed unless Docker reports rootless mode";
+    entry ~default:"false" "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
+      "Fail closed unless Docker reports userns support";
+  ]
+
 let economy_entries =
   [
     entry ~default:"false" "MASC_ECONOMY_ENABLED"
@@ -943,7 +964,8 @@ let all_categories () =
     category "keeper"
       (keeper_entries @ keeper_alert_entries @ keeper_bootstrap_entries
        @ keeper_keepalive_entries @ keeper_metrics_entries
-       @ keeper_board_entries);
+       @ keeper_board_entries @ docker_playground_entries
+       @ keeper_sandbox_entries);
     category "keeper_execution"
       (keeper_execution_entries @ compaction_entries @ decision_entries
        @ keeper_tool_entries @ keeper_cascade_entries

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1104,7 +1104,7 @@ let keeper_config_json (config : Coord.config) (name : string)
         if m.sandbox_profile = Keeper_types.Docker_hardened
            || (m.sandbox_profile = Keeper_types.Legacy_local
                && Env_config_keeper.DockerPlayground.enabled)
-        then Some Env_config_keeper.KeeperSandbox.docker_image
+        then Some (Env_config_keeper.KeeperSandbox.docker_image ())
         else None
       in
       let private_workspace_root =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1095,6 +1095,18 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("total_active", `Int (List.length allowed));
         ]
       in
+      let sandbox_last_error =
+        match Keeper_registry.get ~base_path:config.base_path m.name with
+        | Some entry -> entry.last_error
+        | None -> None
+      in
+      let effective_sandbox_image =
+        if m.sandbox_profile = Keeper_types.Docker_hardened
+           || (m.sandbox_profile = Keeper_types.Legacy_local
+               && Env_config_keeper.DockerPlayground.enabled)
+        then Some Env_config_keeper.KeeperSandbox.docker_image
+        else None
+      in
       let private_workspace_root =
         Filename.concat
           (Keeper_alerting_path.project_root_of_config config)
@@ -1108,6 +1120,9 @@ let keeper_config_json (config : Coord.config) (name : string)
          ("network_mode", `String (Keeper_types.network_mode_to_string m.network_mode));
          ("shared_memory_scope",
            `String (Keeper_types.shared_memory_scope_to_string m.shared_memory_scope));
+         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
+         ("effective_sandbox_image",
+           Json_util.string_opt_to_json effective_sandbox_image);
          ("private_workspace_root", `String private_workspace_root);
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -431,9 +431,11 @@ let docker_info_security_options ~timeout_sec =
              err)
 
 let ensure_keeper_sandbox_runtime ~timeout_sec =
-  let seccomp_profile = String.trim Env_config_keeper.KeeperSandbox.seccomp_profile in
-  let require_rootless = Env_config_keeper.KeeperSandbox.require_rootless in
-  let require_userns = Env_config_keeper.KeeperSandbox.require_userns in
+  let seccomp_profile =
+    String.trim (Env_config_keeper.KeeperSandbox.seccomp_profile ())
+  in
+  let require_rootless = Env_config_keeper.KeeperSandbox.require_rootless () in
+  let require_userns = Env_config_keeper.KeeperSandbox.require_userns () in
   let seccomp_args =
     if seccomp_profile = "" then
       Ok []
@@ -475,7 +477,7 @@ let run_docker_hardened_bash
     ~(timeout_sec : float)
     ~(cmd : string)
     ~(network_mode : network_mode) =
-  let image = Env_config_keeper.KeeperSandbox.docker_image in
+  let image = Env_config_keeper.KeeperSandbox.docker_image () in
   let sandbox_error_json message =
     Keeper_registry.record_error ~base_path:config.base_path meta.name message;
     error_json message
@@ -517,7 +519,7 @@ let run_docker_hardened_bash
         "--read-only";
         "--tmpfs";
         (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-           Env_config_keeper.KeeperSandbox.tmpfs_size);
+           (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
         "--cap-drop=ALL";
         "--security-opt";
         "no-new-privileges";
@@ -525,9 +527,9 @@ let run_docker_hardened_bash
       @ seccomp_args
       @ [
         "--pids-limit";
-        string_of_int Env_config_keeper.KeeperSandbox.pids_limit;
+        string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
         "--memory";
-        Env_config_keeper.KeeperSandbox.memory;
+        Env_config_keeper.KeeperSandbox.memory ();
         "-v";
         host_root ^ ":" ^ container_root ^ ":rw";
         "--workdir";

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -198,7 +198,7 @@ let resolve_keeper_shell_write_cwd
    The container-side root comes from
    [Env_config_keeper.DockerPlayground.container_playground_root] so the
    mount point is configurable (default "/home/keeper/playground"). *)
-let docker_playground_cwd ~(config : Coord.config) ~(meta : keeper_meta) host_cwd =
+let _docker_playground_cwd ~(config : Coord.config) ~(meta : keeper_meta) host_cwd =
   let root = Keeper_alerting_path.project_root_of_config config in
   let playground_prefix =
     Filename.concat root Playground_paths.all_playgrounds_prefix
@@ -336,6 +336,229 @@ let resolve_keeper_shell_read_path
     in
     resolve_with_autocorrect resolved_raw_path
 
+let keeper_sandbox_container_name (meta : keeper_meta) =
+  Printf.sprintf "masc-keeper-%s-%d-%d"
+    (Coord_utils.safe_filename meta.name)
+    (Unix.getpid ())
+    (int_of_float (Unix.gettimeofday () *. 1000.0))
+
+let keeper_private_container_root (meta : keeper_meta) =
+  Filename.concat
+    Env_config_keeper.DockerPlayground.container_playground_root
+    (Playground_paths.sanitize_keeper_name meta.name)
+
+let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
+    host_cwd =
+  let normalize_path_for_containment path =
+    Keeper_alerting_path.normalize_path_for_check path
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let host_root =
+    Filename.concat
+      (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+    |> normalize_path_for_containment
+  in
+  let container_root = keeper_private_container_root meta in
+  let host_cwd = normalize_path_for_containment host_cwd in
+  if host_cwd = host_root then
+    container_root
+  else if String.starts_with ~prefix:(host_root ^ "/") host_cwd then
+    let suffix =
+      String.sub host_cwd (String.length host_root + 1)
+        (String.length host_cwd - String.length host_root - 1)
+    in
+    Filename.concat container_root suffix
+  else
+    container_root
+
+let effective_sandbox_profile ~(meta : keeper_meta) ~in_playground =
+  if meta.sandbox_profile = Legacy_local
+     && Env_config_keeper.DockerPlayground.enabled
+     && in_playground
+  then
+    (Docker_hardened, Network_inherit)
+  else
+    (meta.sandbox_profile, meta.network_mode)
+
+let nested_container_runtime_tokens =
+  [ "docker"; "podman"; "nerdctl"; "buildah" ]
+
+let sandbox_socket_markers =
+  [
+    "/var/run/docker.sock";
+    "/run/docker.sock";
+    "/run/podman/podman.sock";
+    "podman.sock";
+    "containerd.sock";
+    "buildkitd.sock";
+  ]
+
+let command_uses_nested_container_runtime cmd =
+  let lowered_words = lowercase_shell_words cmd in
+  let lowered_cmd = String.lowercase_ascii cmd in
+  List.exists (fun token -> List.mem token nested_container_runtime_tokens)
+    lowered_words
+  || List.exists (String_util.contains_substring lowered_cmd) sandbox_socket_markers
+
+let docker_info_security_options ~timeout_sec =
+  let st, out =
+    Process_eio.run_argv_with_status
+      ~cwd:(Sys.getcwd ())
+      ~timeout_sec
+      [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ]
+  in
+  if st <> Unix.WEXITED 0 then
+    Error
+      (Printf.sprintf "docker info failed while validating sandbox runtime: %s"
+         (Worker_dev_tools.truncate_for_log out))
+  else
+    try
+      match Yojson.Safe.from_string (String.trim out) with
+      | `List items ->
+          Ok
+            (List.filter_map Yojson.Safe.Util.to_string_option items
+            |> List.map String.lowercase_ascii)
+      | `Null -> Ok []
+      | _ ->
+          Error
+            "docker info returned unexpected SecurityOptions payload while validating sandbox runtime"
+    with
+    | Yojson.Json_error err ->
+        Error
+          (Printf.sprintf
+             "failed to parse docker info SecurityOptions JSON: %s"
+             err)
+
+let ensure_keeper_sandbox_runtime ~timeout_sec =
+  let seccomp_profile = String.trim Env_config_keeper.KeeperSandbox.seccomp_profile in
+  let require_rootless = Env_config_keeper.KeeperSandbox.require_rootless in
+  let require_userns = Env_config_keeper.KeeperSandbox.require_userns in
+  let seccomp_args =
+    if seccomp_profile = "" then
+      Ok []
+    else if Sys.file_exists seccomp_profile then
+      Ok [ "--security-opt"; "seccomp=" ^ seccomp_profile ]
+    else
+      Error
+        (Printf.sprintf
+           "sandbox seccomp profile not found: %s"
+           seccomp_profile)
+  in
+  match seccomp_args with
+  | Error _ as err -> err
+  | Ok seccomp_args ->
+      if not require_rootless && not require_userns then
+        Ok seccomp_args
+      else
+        match docker_info_security_options ~timeout_sec:(min 20.0 (max 5.0 timeout_sec)) with
+        | Error _ as err -> err
+        | Ok security_options ->
+            let has needle =
+              List.exists
+                (fun option_text -> String_util.contains_substring option_text needle)
+                security_options
+            in
+            if require_rootless && not (has "rootless") then
+              Error
+                "sandbox runtime requires Docker rootless mode (set MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS=false to disable this check)"
+            else if require_userns && not (has "userns") then
+              Error
+                "sandbox runtime requires Docker userns support (set MASC_KEEPER_SANDBOX_REQUIRE_USERNS=false to disable this check)"
+            else
+              Ok seccomp_args
+
+let run_docker_hardened_bash
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(cwd : string)
+    ~(timeout_sec : float)
+    ~(cmd : string)
+    ~(network_mode : network_mode) =
+  let image = Env_config_keeper.KeeperSandbox.docker_image in
+  let sandbox_error_json message =
+    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
+    error_json message
+  in
+  if String.trim image = "" then
+    sandbox_error_json "keeper sandbox docker image is not configured"
+  else if command_uses_nested_container_runtime cmd then
+    sandbox_error_json
+      "docker_hardened blocks nested container runtimes and host socket references"
+  else
+    match ensure_keeper_sandbox_runtime ~timeout_sec with
+    | Error err -> sandbox_error_json err
+    | Ok seccomp_args ->
+    let host_root =
+      keeper_playground_root ~config ~meta
+      |> Keeper_alerting_path.normalize_path_for_check
+      |> Keeper_alerting_path.strip_trailing_slashes
+    in
+    let container_name = keeper_sandbox_container_name meta in
+    let container_root = keeper_private_container_root meta in
+    let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
+    let uid = Unix.getuid () in
+    let gid = Unix.getgid () in
+    let network_args =
+      match network_mode with
+      | Network_none -> [ "--network"; "none" ]
+      | Network_inherit -> []
+    in
+    let argv =
+      [
+        "docker";
+        "run";
+        "--rm";
+        "--name";
+        container_name;
+        "-i";
+        "--user";
+        Printf.sprintf "%d:%d" uid gid;
+        "--read-only";
+        "--tmpfs";
+        (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
+           Env_config_keeper.KeeperSandbox.tmpfs_size);
+        "--cap-drop=ALL";
+        "--security-opt";
+        "no-new-privileges";
+      ]
+      @ seccomp_args
+      @ [
+        "--pids-limit";
+        string_of_int Env_config_keeper.KeeperSandbox.pids_limit;
+        "--memory";
+        Env_config_keeper.KeeperSandbox.memory;
+        "-v";
+        host_root ^ ":" ^ container_root ^ ":rw";
+        "--workdir";
+        container_cwd;
+      ]
+      @ network_args
+      @ [ image; "bash"; "-lc"; cmd ^ " 2>&1" ]
+    in
+    let st, out =
+      Process_eio.run_argv_with_status
+        ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+    in
+    if st <> Unix.WEXITED 0 then
+      Keeper_registry.record_error ~base_path:config.base_path meta.name
+        (Printf.sprintf "sandbox docker exec failed (%s): %s"
+           image
+           (Worker_dev_tools.truncate_for_log out))
+    else
+      Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+    Yojson.Safe.to_string
+      (`Assoc
+         [
+           ("ok", `Bool (st = Unix.WEXITED 0));
+           ("cwd", `String cwd);
+           ("sandbox_profile", `String "docker_hardened");
+           ("network_mode", `String (network_mode_to_string network_mode));
+           ("effective_sandbox_image", `String image);
+           ("status", Keeper_alerting_path.process_status_to_json st);
+           ("output", `String out);
+         ])
+
 let handle_keeper_bash
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -380,8 +603,8 @@ let handle_keeper_bash
       String.starts_with ~prefix:(playground_abs ^ "/") (cwd_canonical ^ "/")
       || String.equal playground_abs cwd_canonical
     in
-    let use_docker =
-      Env_config_keeper.DockerPlayground.enabled && in_playground
+    let sandbox_profile, sandbox_network_mode =
+      effective_sandbox_profile ~meta ~in_playground
     in
     (* Destructive guard: always active regardless of Docker or preset *)
     if Worker_dev_tools.is_destructive_bash_operation cmd
@@ -397,30 +620,13 @@ let handle_keeper_bash
            ~retryability:Exec_core.Operator_required
            ~extra:[ "cmd", `String cmd_for_log ]
            ()))
-    else if use_docker then (
-      (* Docker playground path: skip command whitelist and path validation.
-         The container provides isolation — chaining, pipes, tee are safe.
-         Only the destructive guard above is retained. *)
-      Log.Keeper.info "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s"
-        meta.name cwd cmd_for_log;
-      let container = Env_config_keeper.DockerPlayground.container_name in
-      let container_cwd = docker_playground_cwd ~config ~meta cwd in
-      let st, out =
-        Process_eio.run_argv_with_status
-          ~cwd:(Sys.getcwd ()) ~timeout_sec
-          [ "docker"; "exec"; "-u"; "keeper";
-            "-w"; container_cwd;
-            container; "bash"; "-c"; cmd ^ " 2>&1" ]
-      in
-      Yojson.Safe.to_string
-        (Exec_core.process_result_json
-           ~base_path:root
-           ~keeper_name:meta.name
-           ~cmd
-           ~extra:[ "cwd", `String cwd ]
-           ~status:st
-           ~output:out
-           ()))
+    else if sandbox_profile = Docker_hardened then (
+      Log.Keeper.info
+        "DOCKER_HARDENED_EXEC: keeper=%s cwd=%s cmd=%s network=%s"
+        meta.name cwd cmd_for_log (network_mode_to_string sandbox_network_mode);
+      run_docker_hardened_bash
+        ~config ~meta ~cwd ~timeout_sec ~cmd
+        ~network_mode:sandbox_network_mode)
     else
       (* Local execution path: full validation applies *)
       let validate =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -360,6 +360,9 @@ let record_error ~base_path name err =
   Log.Keeper.error "registry: recording error name=%s error=%s" name err;
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
 
+let clear_error ~base_path name =
+  update_entry ~base_path name (fun e -> { e with last_error = None })
+
 let set_failure_reason ~base_path name reason =
   update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -200,6 +200,9 @@ val record_restart : base_path:string -> string -> unit
 (** Record an error message. *)
 val record_error : base_path:string -> string -> string -> unit
 
+(** Clear the last recorded error for a keeper. *)
+val clear_error : base_path:string -> string -> unit
+
 (** Set the structured failure reason for cohort detection. *)
 val set_failure_reason : base_path:string -> string -> failure_reason option -> unit
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -99,6 +99,12 @@ let ensure_keeper_meta config name =
       match defaults.mention_targets with [] -> meta.mention_targets | xs -> xs in
     let target_execution_scope =
       apply_default defaults.execution_scope meta.execution_scope in
+    let target_sandbox_profile =
+      apply_default defaults.sandbox_profile meta.sandbox_profile in
+    let target_network_mode =
+      apply_default defaults.network_mode meta.network_mode in
+    let target_shared_memory_scope =
+      apply_default defaults.shared_memory_scope meta.shared_memory_scope in
     let target_allowed_paths =
       apply_default defaults.allowed_paths meta.allowed_paths in
 
@@ -149,6 +155,9 @@ let ensure_keeper_meta config name =
       || meta.mention_targets <> target_mention_targets
       || meta.tool_access <> target_tool_access
       || meta.execution_scope <> target_execution_scope
+      || meta.sandbox_profile <> target_sandbox_profile
+      || meta.network_mode <> target_network_mode
+      || meta.shared_memory_scope <> target_shared_memory_scope
       || meta.allowed_paths <> target_allowed_paths in
     let discovery_changed =
       meta.work_discovery_enabled <> target_wd_enabled
@@ -206,6 +215,9 @@ let ensure_keeper_meta config name =
         mention_targets = target_mention_targets;
         tool_access = target_tool_access;
         execution_scope = target_execution_scope;
+        sandbox_profile = target_sandbox_profile;
+        network_mode = target_network_mode;
+        shared_memory_scope = target_shared_memory_scope;
         allowed_paths = target_allowed_paths;
         work_discovery_enabled = target_wd_enabled;
         work_discovery_sources = target_wd_sources;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -241,17 +241,17 @@ let keeper_schemas : tool_schema list = [
         ("sandbox_profile", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "legacy_local"; `String "docker_hardened"]);
-          ("description", `String "Filesystem/process sandbox profile. 'legacy_local' preserves current behavior. 'docker_hardened' reserves the hardened execution path.");
+          ("description", `String "Filesystem/process sandbox profile. 'legacy_local' keeps the current local execution model. 'docker_hardened' runs keeper_bash in an ephemeral hardened Docker container rooted at the keeper playground.");
         ]);
         ("network_mode", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "none"; `String "inherit"]);
-          ("description", `String "Network policy associated with the sandbox profile.");
+          ("description", `String "Network policy associated with the sandbox profile. 'none' is valid only with sandbox_profile='docker_hardened'.");
         ]);
         ("shared_memory_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "disabled"; `String "room"]);
-          ("description", `String "Typed shared-memory lane policy. Runtime enforcement is introduced in follow-up slices.");
+          ("description", `String "Typed shared-memory lane policy. 'room' enables keeper-authorized masc_team_memory_* access on the flattened default namespace.");
         ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -899,6 +899,18 @@ let handle_keeper_status ctx args : tool_result =
           Keeper_types.tool_access_custom_allowlist m.tool_access
           |> Option.value ~default:[]
         in
+         let sandbox_last_error =
+           match Keeper_registry.get ~base_path:ctx.config.base_path m.name with
+           | Some entry -> entry.last_error
+           | None -> None
+         in
+         let effective_sandbox_image =
+           if m.sandbox_profile = Docker_hardened
+              || (m.sandbox_profile = Legacy_local
+                  && Env_config_keeper.DockerPlayground.enabled)
+           then Some Env_config_keeper.KeeperSandbox.docker_image
+           else None
+         in
          let runtime_blocker_fields =
           runtime_blocker_fields_json ctx.config m
          in
@@ -946,6 +958,16 @@ let handle_keeper_status ctx args : tool_result =
            ("handoff_count_total", `Int trace_history_count);
            ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
            ("allowed_tool_count", `Int (List.length allowed_tools));
+           ("sandbox_profile",
+             `String (sandbox_profile_to_string m.sandbox_profile));
+           ("network_mode",
+             `String (network_mode_to_string m.network_mode));
+           ("shared_memory_scope",
+             `String (shared_memory_scope_to_string m.shared_memory_scope));
+           ("sandbox_last_error",
+             Json_util.string_opt_to_json sandbox_last_error);
+           ("effective_sandbox_image",
+             Json_util.string_opt_to_json effective_sandbox_image);
            ("tool_policy_mode",
              `String
                (match Keeper_types.tool_access_custom_allowlist m.tool_access with
@@ -1001,6 +1023,14 @@ let handle_keeper_status ctx args : tool_result =
            ("drift", drift_surface_json ());
            ("policy", `Assoc [
              ("voice_tools_available", `Bool (List.mem "keeper_voice_speak" allowed_tools));
+             ("sandbox_profile",
+               `String (sandbox_profile_to_string m.sandbox_profile));
+             ("network_mode",
+               `String (network_mode_to_string m.network_mode));
+             ("shared_memory_scope",
+               `String (shared_memory_scope_to_string m.shared_memory_scope));
+             ("effective_sandbox_image",
+               Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", string_list_to_json m.allowed_paths);
            ("allowed_tools", string_list_to_json allowed_tools);
             ("available_internal_tools", string_list_to_json all_internal_tools);
@@ -1109,7 +1139,16 @@ let handle_keeper_status ctx args : tool_result =
            "execution_context", `Assoc [
              ("playground_path", `String playground_rel);
              ("default_cwd", `String playground_abs);
+             ("private_workspace_root", `String playground_abs);
              ("execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope));
+             ("sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile));
+             ("network_mode", `String (network_mode_to_string m.network_mode));
+             ("shared_memory_scope",
+               `String (shared_memory_scope_to_string m.shared_memory_scope));
+             ("sandbox_last_error",
+               Json_util.string_opt_to_json sandbox_last_error);
+             ("effective_sandbox_image",
+               Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",
                let cache_path = Filename.concat playground_abs

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -908,7 +908,7 @@ let handle_keeper_status ctx args : tool_result =
            if m.sandbox_profile = Docker_hardened
               || (m.sandbox_profile = Legacy_local
                   && Env_config_keeper.DockerPlayground.enabled)
-           then Some Env_config_keeper.KeeperSandbox.docker_image
+           then Some (Env_config_keeper.KeeperSandbox.docker_image ())
            else None
          in
          let runtime_blocker_fields =

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -383,20 +383,37 @@ let private_workspace_root_abs ~(config : Coord.config) keeper_name =
   |> Keeper_alerting_path.normalize_path_for_check
   |> Keeper_alerting_path.strip_trailing_slashes
 
+let sandbox_allowed_path_has_forbidden_segments path =
+  let has_glob =
+    String.exists (function
+      | '*' | '?' | '[' | ']' -> true
+      | _ -> false)
+      path
+  in
+  has_glob
+  || (path
+      |> String.split_on_char '/'
+      |> List.exists (function
+           | "." | ".." -> true
+           | _ -> false))
+
 let sandbox_allowed_path_within_private_root
     ~(config : Coord.config)
     ~keeper_name
     path =
   let trimmed = String.trim path in
   if trimmed = "" then false
-  else if Filename.is_relative trimmed then
-    let private_root_rel = private_workspace_root_rel keeper_name in
-    trimmed = private_root_rel
-    || String.starts_with ~prefix:(private_root_rel ^ "/") trimmed
+  else if sandbox_allowed_path_has_forbidden_segments trimmed then
+    false
   else
     let private_root = private_workspace_root_abs ~config keeper_name in
     let candidate =
-      trimmed
+      (if Filename.is_relative trimmed then
+         Filename.concat
+           (Keeper_alerting_path.project_root_of_config config)
+           trimmed
+       else
+         trimmed)
       |> Keeper_alerting_path.normalize_path_for_check
       |> Keeper_alerting_path.strip_trailing_slashes
     in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -359,3 +359,80 @@ let resolve_mention_targets ~mention_targets_in ~fallback_targets ~name =
     else [ name ]
   in
   raw |> List.filter (fun s -> String.trim s <> "") |> dedupe_keep_order
+
+let resolve_sandbox_profile ~preferred ~fallback =
+  first_some preferred fallback
+  |> Option.value ~default:default_sandbox_profile
+
+let resolve_network_mode ~sandbox_profile ~preferred ~fallback =
+  first_some preferred fallback
+  |> Option.value ~default:(default_network_mode_for_profile sandbox_profile)
+
+let resolve_shared_memory_scope ~preferred ~fallback =
+  first_some preferred fallback
+  |> Option.value ~default:default_shared_memory_scope
+
+let private_workspace_root_rel keeper_name =
+  Keeper_alerting_path.playground_path_of_keeper keeper_name
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let private_workspace_root_abs ~(config : Coord.config) keeper_name =
+  Filename.concat
+    (Keeper_alerting_path.project_root_of_config config)
+    (private_workspace_root_rel keeper_name)
+  |> Keeper_alerting_path.normalize_path_for_check
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let sandbox_allowed_path_within_private_root
+    ~(config : Coord.config)
+    ~keeper_name
+    path =
+  let trimmed = String.trim path in
+  if trimmed = "" then false
+  else if Filename.is_relative trimmed then
+    let private_root_rel = private_workspace_root_rel keeper_name in
+    trimmed = private_root_rel
+    || String.starts_with ~prefix:(private_root_rel ^ "/") trimmed
+  else
+    let private_root = private_workspace_root_abs ~config keeper_name in
+    let candidate =
+      trimmed
+      |> Keeper_alerting_path.normalize_path_for_check
+      |> Keeper_alerting_path.strip_trailing_slashes
+    in
+    candidate = private_root
+    || String.starts_with ~prefix:(private_root ^ "/") candidate
+
+let validate_sandbox_settings
+    ~(config : Coord.config)
+    ~keeper_name
+    ~sandbox_profile
+    ~network_mode
+    ~allowed_paths =
+  match sandbox_profile with
+  | Legacy_local -> (
+      match network_mode with
+      | Network_inherit -> Ok ()
+      | Network_none ->
+          Error
+            "network_mode=none requires sandbox_profile=docker_hardened")
+  | Docker_hardened ->
+      if allowed_paths = [ "*" ] then
+        Error
+          "docker_hardened rejects allowed_paths=[\"*\"]; keep writes inside the private playground root"
+      else
+        let escaping =
+          List.filter
+            (fun path ->
+              not
+                (sandbox_allowed_path_within_private_root ~config ~keeper_name path))
+            allowed_paths
+        in
+        match escaping with
+        | [] -> Ok ()
+        | _ ->
+            Error
+              (Printf.sprintf
+                 "docker_hardened allowed_paths must stay under %s (rejected: %s)"
+                 (private_workspace_root_rel keeper_name)
+                 (String.concat ", " escaping))

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -42,6 +42,22 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     |> first_some p.profile_defaults.execution_scope
     |> Option.value ~default:default_execution_scope
   in
+  let sandbox_profile =
+    resolve_sandbox_profile
+      ~preferred:p.sandbox_profile_opt
+      ~fallback:None
+  in
+  let network_mode =
+    resolve_network_mode
+      ~sandbox_profile
+      ~preferred:p.network_mode_opt
+      ~fallback:None
+  in
+  let shared_memory_scope =
+    resolve_shared_memory_scope
+      ~preferred:p.shared_memory_scope_opt
+      ~fallback:None
+  in
   let voice_enabled =
     Option.value ~default:(default_voice_enabled_for p.name) p.voice_enabled_opt
   in
@@ -72,6 +88,19 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     (false, "goal is required when creating a keeper")
   end
   else
+    match
+      validate_sandbox_settings
+        ~config:ctx.config
+        ~keeper_name:p.name
+        ~sandbox_profile
+        ~network_mode
+        ~allowed_paths
+    with
+    | Error err ->
+        Log.Keeper.warn "create_keeper failed sandbox validation for %s: %s"
+          p.name err;
+        (false, err)
+    | Ok () ->
     let max_active_keepers = Env_config.KeeperBootstrap.max_active_keepers in
     let active_keepers = Keeper_registry.count_running () in
     if max_active_keepers > 0 && active_keepers >= max_active_keepers then begin
@@ -260,18 +289,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         instructions;
         policy_voice_enabled;
         execution_scope;
-        sandbox_profile =
-          Option.value ~default:default_sandbox_profile p.sandbox_profile_opt;
-        network_mode =
-          Option.value
-            ~default:
-              (default_network_mode_for_profile
-                 (Option.value ~default:default_sandbox_profile
-                    p.sandbox_profile_opt))
-            p.network_mode_opt;
-        shared_memory_scope =
-          Option.value ~default:default_shared_memory_scope
-            p.shared_memory_scope_opt;
+        sandbox_profile;
+        network_mode;
+        shared_memory_scope;
         allowed_paths;
         tool_access;
         tool_denylist;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -226,9 +226,22 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     max_context_override = (match p.max_context_override_opt with Some _ as v -> v | None -> old.max_context_override);
     updated_at = now_iso ();
   } in
-  (match write_meta ctx.config updated with
-   | Error e -> (false, e)
-   | Ok () ->
-     stop_keepalive ~base_path:ctx.config.base_path updated.name;
-     start_keepalive ctx updated;
-     (true, Yojson.Safe.to_string (meta_to_json updated)))
+  match
+    validate_sandbox_settings
+      ~config:ctx.config
+      ~keeper_name:p.name
+      ~sandbox_profile
+      ~network_mode
+      ~allowed_paths
+  with
+  | Error err ->
+      Log.Keeper.warn "update_keeper failed sandbox validation for %s: %s"
+        p.name err;
+      (false, err)
+  | Ok () ->
+      (match write_meta ctx.config updated with
+       | Error e -> (false, e)
+       | Ok () ->
+         stop_keepalive ~base_path:ctx.config.base_path updated.name;
+         start_keepalive ctx updated;
+         (true, Yojson.Safe.to_string (meta_to_json updated)))

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -198,6 +198,9 @@ type keeper_profile_defaults = {
   shards : string list option;
   allowed_paths : string list option;
   execution_scope : Keeper_execution_scope.t option;
+  sandbox_profile : sandbox_profile option;
+  network_mode : network_mode option;
+  shared_memory_scope : shared_memory_scope option;
   tool_preset : string option;
   tool_also_allow : string list option;
   tool_denylist : string list option;
@@ -247,6 +250,9 @@ let empty_keeper_profile_defaults = {
   shards = None;
   allowed_paths = None;
   execution_scope = None;
+  sandbox_profile = None;
+  network_mode = None;
+  shared_memory_scope = None;
   tool_preset = None;
   tool_also_allow = None;
   tool_denylist = None;
@@ -351,6 +357,45 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
+  let result =
+    Result.bind result (fun () ->
+        match str "sandbox_profile" with
+        | Some raw -> (
+            match sandbox_profile_of_string raw with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid sandbox_profile '%s' (allowed: legacy_local, docker_hardened)"
+                     raw))
+        | None -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () ->
+        match str "network_mode" with
+        | Some raw -> (
+            match network_mode_of_string raw with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid network_mode '%s' (allowed: none, inherit)"
+                     raw))
+        | None -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () ->
+        match str "shared_memory_scope" with
+        | Some raw -> (
+            match shared_memory_scope_of_string raw with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid shared_memory_scope '%s' (allowed: disabled, room)"
+                     raw))
+        | None -> Ok ())
+  in
   Result.map
     (fun () ->
       {
@@ -386,6 +431,13 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         execution_scope =
           Option.map Keeper_execution_scope.of_string_lossy
             (str "execution_scope");
+        sandbox_profile =
+          Option.bind (str "sandbox_profile") sandbox_profile_of_string;
+        network_mode =
+          Option.bind (str "network_mode") network_mode_of_string;
+        shared_memory_scope =
+          Option.bind (str "shared_memory_scope")
+            shared_memory_scope_of_string;
         tool_preset =
           (match str "tool_preset" with
            | None -> None
@@ -447,6 +499,9 @@ let canonical_keeper_toml_key_names =
   ; "shards"
   ; "allowed_paths"
   ; "execution_scope"
+  ; "sandbox_profile"
+  ; "network_mode"
+  ; "shared_memory_scope"
   ; "tool_preset"
   ; "tool_also_allow"
   ; "also_allow"
@@ -578,6 +633,9 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 execution_scope =
                   Option.map Keeper_execution_scope.of_string_lossy
                     (Safe_ops.json_string_opt "execution_scope" keeper_json);
+                sandbox_profile = None;
+                network_mode = None;
+                shared_memory_scope = None;
                 tool_preset =
                   (match Safe_ops.json_string_opt "tool_preset" keeper_json with
                   | None -> None
@@ -673,6 +731,10 @@ let merge_keeper_profile_defaults
     shards = prefer overlay.shards base.shards;
     allowed_paths = prefer overlay.allowed_paths base.allowed_paths;
     execution_scope = prefer overlay.execution_scope base.execution_scope;
+    sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;
+    network_mode = prefer overlay.network_mode base.network_mode;
+    shared_memory_scope =
+      prefer overlay.shared_memory_scope base.shared_memory_scope;
     tool_preset = prefer overlay.tool_preset base.tool_preset;
     tool_also_allow = prefer overlay.tool_also_allow base.tool_also_allow;
     tool_denylist = prefer overlay.tool_denylist base.tool_denylist;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -388,20 +388,6 @@ let test_dashboard_component_split_contracts () =
   check bool "proof helpers export worker run evidence tone" true
     (file_contains_pattern "dashboard/src/components/proof-helpers.ts"
        "export function workerRunEvidenceTone");
-  (* proof-sections.ts was removed in #8081; the surviving pure
-     helpers live in proof-helpers.ts (asserted above). *)
-  check bool "mission cards re-export briefing card" true
-    (file_contains_pattern "dashboard/src/components/mission-cards.ts"
-       "export { MissionBriefingCard } from './mission-briefing-card'");
-  check bool "mission cards re-export attention card" true
-    (file_contains_pattern "dashboard/src/components/mission-cards.ts"
-       "export { AttentionCard } from './mission-attention-card'");
-  check bool "mission briefing card exported from split file" true
-    (file_contains_pattern "dashboard/src/components/mission-briefing-card.ts"
-       "export function MissionBriefingCard");
-  check bool "mission attention card exported from split file" true
-    (file_contains_pattern "dashboard/src/components/mission-attention-card.ts"
-       "export function AttentionCard");
   check bool "coord backend setup no longer references transaction companion after PG removal" true
     (file_not_contains_pattern "lib/coord/coord_utils_backend_setup.ml"
        "Transaction Pooler companion")

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -299,6 +299,53 @@ let test_docker_hardened_rejects_paths_outside_private_root () =
         check bool "mentions private playground" true
           (String_util.contains_substring err ".masc/playground/sangsu"))
 
+let test_docker_hardened_rejects_root_allowed_path () =
+  with_temp_config (fun config ->
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:["/"]
+    with
+    | Ok () -> fail "expected docker_hardened root-path rejection"
+    | Error err ->
+        check bool "mentions private playground" true
+          (String_util.contains_substring err ".masc/playground/sangsu"))
+
+let test_docker_hardened_rejects_glob_like_allowed_path () =
+  with_temp_config (fun config ->
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:["/tmp/**"]
+    with
+    | Ok () -> fail "expected docker_hardened glob-like path rejection"
+    | Error err ->
+        check bool "mentions rejected path" true
+          (String_util.contains_substring err "/tmp/**"))
+
+let test_docker_hardened_rejects_traversal_allowed_path () =
+  with_temp_config (fun config ->
+    let private_root = KTU.private_workspace_root_rel "sangsu" in
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:
+          [ private_root ^ "/repos/demo/../../../../../../etc/passwd" ]
+    with
+    | Ok () -> fail "expected docker_hardened traversal rejection"
+    | Error err ->
+        check bool "mentions private playground" true
+          (String_util.contains_substring err ".masc/playground/sangsu"))
+
 let test_docker_hardened_accepts_private_root_paths () =
   with_temp_config (fun config ->
     let private_root = KTU.private_workspace_root_rel "sangsu" in
@@ -398,6 +445,12 @@ let () =
         [
           test_case "docker_hardened rejects wildcard allowed_paths" `Quick
             test_docker_hardened_rejects_wildcard_allowed_paths;
+          test_case "docker_hardened rejects root allowed path" `Quick
+            test_docker_hardened_rejects_root_allowed_path;
+          test_case "docker_hardened rejects glob-like allowed path" `Quick
+            test_docker_hardened_rejects_glob_like_allowed_path;
+          test_case "docker_hardened rejects traversal allowed path" `Quick
+            test_docker_hardened_rejects_traversal_allowed_path;
           test_case "docker_hardened rejects paths outside private root" `Quick
             test_docker_hardened_rejects_paths_outside_private_root;
           test_case "docker_hardened accepts private root paths" `Quick

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -7,6 +7,7 @@ open Alcotest
 module KAP = Masc_mcp.Keeper_alerting_path
 module KES = Masc_mcp.Keeper_exec_shared
 module KT = Masc_mcp.Keeper_types
+module KTU = Masc_mcp.Keeper_turn_up_args
 
 let make_meta ?(execution_scope = "observe_only") ?(allowed_paths = [])
     ~name () =
@@ -268,6 +269,77 @@ let test_bare_filename_still_works () =
     | Error err -> fail ("bare filename should still work: " ^ err)
     | Ok path -> check string "bare filename" target path)
 
+let test_docker_hardened_rejects_wildcard_allowed_paths () =
+  with_temp_config (fun config ->
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:["*"]
+    with
+    | Ok () -> fail "expected docker_hardened wildcard rejection"
+    | Error err ->
+        check bool "mentions wildcard" true
+          (String_util.contains_substring err "allowed_paths=[\"*\"]"))
+
+let test_docker_hardened_rejects_paths_outside_private_root () =
+  with_temp_config (fun config ->
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:["workspace/other-repo"]
+    with
+    | Ok () -> fail "expected docker_hardened path rejection"
+    | Error err ->
+        check bool "mentions private playground" true
+          (String_util.contains_substring err ".masc/playground/sangsu"))
+
+let test_docker_hardened_accepts_private_root_paths () =
+  with_temp_config (fun config ->
+    let private_root = KTU.private_workspace_root_rel "sangsu" in
+    ignore (KAP.ensure_playground_bundle ~config ~name:"sangsu");
+    let target_dir =
+      Filename.concat (KAP.project_root_of_config config)
+        (private_root ^ "/repos/demo")
+    in
+    let rec ensure_dir path =
+      if path <> "" && path <> "." && path <> "/" && not (Sys.file_exists path) then (
+        let parent = Filename.dirname path in
+        if parent <> path then ensure_dir parent;
+        Unix.mkdir path 0o755)
+    in
+    ensure_dir target_dir;
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Docker_hardened
+        ~network_mode:KT.Network_none
+        ~allowed_paths:[private_root ^ "/repos/demo"]
+    with
+    | Error err -> fail ("expected private-root allow path, got: " ^ err)
+    | Ok () -> ())
+
+let test_legacy_local_rejects_network_none () =
+  with_temp_config (fun config ->
+    match
+      KTU.validate_sandbox_settings
+        ~config
+        ~keeper_name:"sangsu"
+        ~sandbox_profile:KT.Legacy_local
+        ~network_mode:KT.Network_none
+        ~allowed_paths:[]
+    with
+    | Ok () -> fail "expected legacy_local network rejection"
+    | Error err ->
+        check bool "mentions docker_hardened" true
+          (String_util.contains_substring err "docker_hardened"))
+
 (* ── Runner ── *)
 
 let () =
@@ -321,5 +393,16 @@ let () =
             test_playground_prefix_stripped_relative;
           test_case "bare filename still works after guard" `Quick
             test_bare_filename_still_works;
+        ] );
+      ( "sandbox_validation",
+        [
+          test_case "docker_hardened rejects wildcard allowed_paths" `Quick
+            test_docker_hardened_rejects_wildcard_allowed_paths;
+          test_case "docker_hardened rejects paths outside private root" `Quick
+            test_docker_hardened_rejects_paths_outside_private_root;
+          test_case "docker_hardened accepts private root paths" `Quick
+            test_docker_hardened_accepts_private_root_paths;
+          test_case "legacy_local rejects network none" `Quick
+            test_legacy_local_rejects_network_none;
         ] );
     ]

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -6,6 +6,13 @@
     3. Shell metacharacters (;, |, &, etc.) are rejected
     4. Empty commands are rejected *)
 
+module Coord = Masc_mcp.Coord
+module Config_boot_overrides = Config_boot_overrides
+module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
+module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_types = Masc_mcp.Keeper_types
+module Json = Yojson.Safe.Util
+
 let validate = Masc_mcp.Worker_dev_tools.validate_command
 
 let is_ok = function Ok () -> true | Error _ -> false
@@ -265,6 +272,105 @@ let test_cleanup_dir_does_not_follow_symlinks () =
   Alcotest.(check bool) "cleanup removed base dir" false (Sys.file_exists base);
   Alcotest.(check bool) "outside target preserved" true (Sys.file_exists marker)
 
+let make_config () =
+  let tmp = temp_dir () in
+  ensure_dir (Filename.concat tmp ".masc");
+  (tmp, Coord.default_config tmp)
+
+let make_docker_hardened_meta name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "sandbox test");
+        ("sandbox_profile", `String "docker_hardened");
+        ("network_mode", `String "none");
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_docker_hardened_meta failed: " ^ err)
+
+let with_eio_fs f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  f ()
+
+let with_boot_override name value f =
+  let previous = Config_boot_overrides.get_opt name in
+  Config_boot_overrides.set name value;
+  Fun.protect ~finally:(fun () ->
+    match previous with
+    | Some v -> Config_boot_overrides.set name v
+    | None -> Config_boot_overrides.clear name) f
+
+let parse_error_field raw =
+  Yojson.Safe.from_string raw
+  |> Json.member "error"
+  |> Json.to_string_option
+
+let test_docker_hardened_blocks_nested_docker_command () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_hardened_meta "docker-nested" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ])
+  in
+  match parse_error_field raw with
+  | Some err ->
+      Alcotest.(check bool) "mentions nested container block" true
+        (String_util.contains_substring err
+           "blocks nested container runtimes and host socket references")
+  | None ->
+      Alcotest.fail ("expected error json, got: " ^ raw)
+
+let test_docker_hardened_blocks_docker_socket_reference () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_hardened_meta "docker-sock" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~config ~meta
+      ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ])
+  in
+  match parse_error_field raw with
+  | Some err ->
+      Alcotest.(check bool) "mentions socket block" true
+        (String_util.contains_substring err
+           "blocks nested container runtimes and host socket references")
+  | None ->
+      Alcotest.fail ("expected error json, got: " ^ raw)
+
+let test_docker_hardened_missing_seccomp_profile_fails_closed () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_hardened_meta "missing-seccomp" in
+  with_boot_override "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+    (Filename.concat base_path "missing-seccomp-profile.json")
+    (fun () ->
+      let raw =
+        Keeper_exec_shell.handle_keeper_bash
+          ~config ~meta
+          ~args:(`Assoc [ ("cmd", `String "pwd") ])
+      in
+      match parse_error_field raw with
+      | Some err ->
+          Alcotest.(check bool) "mentions missing seccomp profile" true
+            (String_util.contains_substring err
+               "sandbox seccomp profile not found")
+      | None ->
+          Alcotest.fail ("expected error json, got: " ^ raw))
+
 (** Path traversal: if cwd is canonicalized via realpath before the check,
     ../traversal resolves to the actual target. This test verifies that
     a canonicalized traversal path is correctly rejected.
@@ -328,6 +434,12 @@ let () =
     ]);
     ("edge", [
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;
+      Alcotest.test_case "docker_hardened blocks nested docker command" `Quick
+        test_docker_hardened_blocks_nested_docker_command;
+      Alcotest.test_case "docker_hardened blocks docker socket reference" `Quick
+        test_docker_hardened_blocks_docker_socket_reference;
+      Alcotest.test_case "docker_hardened missing seccomp fails closed" `Quick
+        test_docker_hardened_missing_seccomp_profile_fails_closed;
     ]);
     ("rg_exit_code", [
       Alcotest.test_case "rg exit semantics (0=ok, 1=ok, 2+=error)" `Quick test_rg_exit_code_semantics;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -347,6 +347,16 @@ let test_record_error () =
   | Some e ->
     check (option string) "error recorded" (Some "something broke") e.last_error
 
+let test_clear_error () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "k6-clear" (make_meta "k6-clear") in
+  R.record_error ~base_path:bp "k6-clear" "stale error";
+  R.clear_error ~base_path:bp "k6-clear";
+  match R.get ~base_path:bp "k6-clear" with
+  | None -> fail "expected k6-clear"
+  | Some e ->
+      check (option string) "error cleared" None e.last_error
+
 let test_get_returns_none_for_missing () =
   R.clear ();
   check (option reject) "nonexistent returns None" None
@@ -358,6 +368,7 @@ let test_noop_on_missing () =
   ignore (R.dispatch_event ~base_path:bp "ghost" KSM.Operator_pause);
   R.record_restart ~base_path:bp "ghost";
   R.record_error ~base_path:bp "ghost" "err";
+  R.clear_error ~base_path:bp "ghost";
   R.record_crash ~base_path:bp "ghost" 0.0 "crash";
   R.set_grpc_close ~base_path:bp "ghost" None;
   R.wakeup ~base_path:bp "ghost";
@@ -703,6 +714,7 @@ let () =
           eio_test "record restart" test_record_restart;
           eio_test "is_registered" test_is_registered;
           eio_test "record error" test_record_error;
+          eio_test "clear error" test_clear_error;
           eio_test "get returns None for missing" test_get_returns_none_for_missing;
           eio_test "noop on missing keys" test_noop_on_missing;
           eio_test "register replaces existing" test_register_replaces;

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -146,6 +146,53 @@ policy_voice_enabled = false
       check execution_scope_testable "execution_scope" Keeper_execution_scope.Observe_only updated.Keeper_types.execution_scope;
       check bool "policy_voice_enabled" false updated.policy_voice_enabled
 
+let test_sandbox_policy_resync () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "sandbox-policy-resync-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+{|[keeper]
+goal = "test"
+sandbox_profile = "docker_hardened"
+network_mode = "none"
+shared_memory_scope = "room"
+|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-sandbox-policy-resync");
+            ("sandbox_profile", `String "legacy_local");
+            ("network_mode", `String "inherit");
+            ("shared_memory_scope", `String "disabled");
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check string "sandbox_profile" "docker_hardened"
+        (Keeper_types.sandbox_profile_to_string updated.sandbox_profile);
+      check string "network_mode" "none"
+        (Keeper_types.network_mode_to_string updated.network_mode);
+      check string "shared_memory_scope" "room"
+        (Keeper_types.shared_memory_scope_to_string updated.shared_memory_scope)
+
 (** Test: TOML tool policy and allowed_paths overwrite stale runtime JSON values. *)
 let test_tool_policy_resync () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -758,6 +805,10 @@ let () =
             "TOML policy fields overwrite stale runtime JSON"
             `Quick
             test_policy_resync;
+          test_case
+            "TOML sandbox policy fields overwrite stale runtime JSON"
+            `Quick
+            test_sandbox_policy_resync;
           test_case
             "TOML tool policy fields overwrite stale runtime JSON"
             `Quick


### PR DESCRIPTION
## Summary
- execute `docker_hardened` keeper shell commands in ephemeral hardened Docker containers
- validate sandbox policy at keeper create/update time and resync sandbox defaults from declarative keeper TOML
- expose sandbox runtime status in the dashboard, including `sandbox_last_error` and `effective_sandbox_image`

## Product impact
- `docker_hardened` is no longer a stored policy flag only; keeper shell execution now runs through an actual hardened Docker path
- invalid `allowed_paths` that try to escape the keeper private playground are rejected earlier and more explicitly
- operators can see current sandbox failures and the effective sandbox image directly in keeper detail/config views

## What changed
- add env-driven sandbox runtime knobs for image, pid/memory/tmpfs limits, seccomp profile, and rootless/userns requirements
- enforce private-playground-only writable mounts for `docker_hardened`, block wildcard/out-of-root `allowed_paths`, and reject nested container/socket usage
- clear stale sandbox errors after successful runs and surface current sandbox posture in keeper status/detail and dashboard config panels
- add coverage for sandbox policy validation, nested runtime blocking, seccomp fail-closed behavior, registry error clearing, declarative runtime resync, and the current `Dashboard_cache` CI fix required by the stacked base

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature/keeper-sandbox-runtime-hygiene-main test/test_keeper_allowed_paths.exe test/test_keeper_bash_safety.exe test/test_keeper_registry.exe test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_keeper_allowed_paths.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `pnpm typecheck`
- `pnpm vitest run src/api/dashboard.test.ts src/components/keeper-config-panel.test.ts`

## Review evidence
- added explicit rejection tests for `allowed_paths=["/"]`, glob-like paths, and traversal-shaped private-root escapes
- added public-entry `keeper_bash` tests that prove `docker_hardened` blocks nested `docker run` and `/var/run/docker.sock` references before execution
- added a fail-closed test for missing seccomp profile via sandbox config override
- added `Keeper_registry.clear_error` coverage to lock the stale-error clearing behavior
- local Docker evidence:
  - `docker version --format '{{.Server.Version}}'` -> `29.3.1`
  - `docker info --format '{{json .SecurityOptions}}'` -> `["name=seccomp,profile=builtin","name=cgroupns"]`
  - representative hardened run using the same image family and flags confirmed:
    - read-only rootfs blocked `/rootfs-write`
    - private bind mount remained writable and produced host-visible `marker.txt`

## Linked issue
- Refs #7489

## Stack
- supersedes the remaining stacked runtime slice after `#8029`
