### PR TITLE
chore(dashboard): sweep 10 dead exported functions (-80 LOC, 8 files)

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -42,10 +42,6 @@ export function filterTasksByQuery<T extends { title?: string; description?: str
 
 export const expandedTasks = signal<Set<string>>(new Set())
 
-export function formatMetric(value: number): string {
-  return value.toFixed(4)
-}
-
 export function toggleTaskExpand(id: string) {
   const next = new Set(expandedTasks.value)
   if (next.has(id)) next.delete(id)

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,12 +1,10 @@
 import { signal } from '@preact/signals'
 import { navigate } from '../router'
-import { missionSnapshot } from '../mission-store'
 import type {
   Agent,
   DashboardMissionAttentionQueueItem,
   DashboardMissionAgentBrief,
   DashboardMissionKeeperBrief,
-  DashboardMissionSessionBrief,
   Keeper,
   OperatorAttentionItem,
   OperatorRecommendedAction,
@@ -149,12 +147,6 @@ export function attentionAsIncident(item: DashboardMissionAttentionQueueItem): O
 }
 
 
-export function sessionLookupById() {
-  const mission = missionSnapshot.value
-  if (!mission) return new Map<string, DashboardMissionSessionBrief>()
-  return new Map(mission.sessions.map(item => [item.session_id, item]))
-}
-
 export function toggleAttention(id: string): void {
   selectedAttentionId.value = selectedAttentionId.value === id ? null : id
   selectedSessionId.value = null
@@ -163,11 +155,6 @@ export function toggleAttention(id: string): void {
 export function toggleSession(id: string): void {
   selectedSessionId.value = selectedSessionId.value === id ? null : id
   selectedAttentionId.value = null
-}
-
-export function clearMissionSelection(): void {
-  selectedAttentionId.value = null
-  selectedSessionId.value = null
 }
 
 export function liveStateClass(status?: string | null, health?: string | null): string {

--- a/dashboard/src/components/observatory/anomaly-utils.ts
+++ b/dashboard/src/components/observatory/anomaly-utils.ts
@@ -15,20 +15,6 @@ export interface AnomalyResult {
 
 const DEFAULT_THRESHOLD = 2.0
 
-export interface AnomalySummary {
-  count: number
-  worstDrop: AnomalyResult | null
-}
-
-export function anomalySummary(results: AnomalyResult[]): AnomalySummary {
-  const anomalies = results.filter(r => r.isAnomaly)
-  const drops = anomalies.filter(r => r.zScore < 0)
-  const worstDrop = drops.length > 0
-    ? drops.reduce((worst, cur) => cur.zScore < worst.zScore ? cur : worst)
-    : null
-  return { count: anomalies.length, worstDrop }
-}
-
 export function detectAnomalies(
   windowed: Array<{ point: ToolQualityHourlyPoint; ts: number }>,
   threshold: number = DEFAULT_THRESHOLD,

--- a/dashboard/src/components/proof-helpers.ts
+++ b/dashboard/src/components/proof-helpers.ts
@@ -2,16 +2,11 @@ import type {
   DashboardProofVerdict,
   DashboardProofWorkerRunEvidence,
 } from '../types'
-import { isRecord } from './common/normalize'
 
 export function verdictTone(verdict?: DashboardProofVerdict | null): string {
   if (verdict === 'proven') return 'ok'
   if (verdict === 'partial') return 'warn'
   return 'bad'
-}
-
-export function asRecord(value: unknown): Record<string, unknown> {
-  return isRecord(value) ? value : {}
 }
 
 export function workerRunEvidenceTone(item: DashboardProofWorkerRunEvidence): string {

--- a/dashboard/src/components/task-manage/task-manage-state.ts
+++ b/dashboard/src/components/task-manage/task-manage-state.ts
@@ -27,12 +27,3 @@ export async function createTask(input: TaskCreateInput): Promise<boolean> {
   }
 }
 
-export async function updateTaskPriority(taskId: string, priority: number): Promise<void> {
-  try {
-    await callMcpTool('masc_update_priority', { task_id: taskId, priority })
-    showToast(`우선순위 변경: ${priority}`, 'success')
-    await refreshExecution({ force: true })
-  } catch (err) {
-    showToast(`우선순위 변경 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
-  }
-}

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -122,14 +122,3 @@ export function prettyArgs(args: Record<string, unknown> | string): string {
   try { return JSON.stringify(args, null, 2) } catch { return String(args) }
 }
 
-const RESULT_PREVIEW_MAX_CHARS = 80
-
-export function formatResult(
-  result: string | null,
-  error: string | null,
-  maxLen: number = RESULT_PREVIEW_MAX_CHARS,
-): string {
-  if (error) return `err: ${error}`
-  if (result == null) return '-'
-  return truncate(result, maxLen)
-}

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -1,7 +1,7 @@
 // MASC Dashboard — Hash-based router
 // Reads location.hash for canonical dashboard routes.
 
-import { signal, type ReadonlySignal } from '@preact/signals'
+import { signal } from '@preact/signals'
 import type { RouteState, TabId } from './types'
 import { VALID_TABS } from './types'
 import { normalizeRouteParams, sectionItemsForTab } from './config/navigation'
@@ -182,21 +182,6 @@ export function navigate(tab: TabId, params?: Record<string, string>): void {
 
 export function navigateToPost(postId: string): void {
   window.location.hash = `#workspace?section=board&post=${encodeURIComponent(postId)}`
-}
-
-export function navigateBack(): void {
-  const current = route.value
-  window.location.hash = toHash({
-    tab: current.tab,
-    params: normalizeRouteParams(current.tab, {}),
-    postId: null,
-  })
-}
-
-// --- Hook for components ---
-
-export function useRoute(): ReadonlySignal<RouteState> {
-  return route
 }
 
 export function initRouter(): void {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -138,15 +138,6 @@ function recordTabVisit(tab: string, section?: string): void {
   }
 }
 
-export function getTabVisitCounts(): Record<string, number> {
-  try {
-    const raw = localStorage.getItem(VISIT_COUNTER_KEY)
-    return raw ? JSON.parse(raw) : {}
-  } catch {
-    return {}
-  }
-}
-
 export function refreshForRoute(
   routeState: Pick<RouteState, 'tab' | 'params'>,
   options?: { recordVisit?: boolean },


### PR DESCRIPTION
## Summary

`/loop 20m` Gen42. Dashboard 전수 검색으로 **total refs = 1** (선언 외 참조 0)인 10개 exported 함수를 8개 파일에서 sweep.

## 제거 목록

| 파일 | 함수 |
|---|---|
| `tab-refresh.ts` | `getTabVisitCounts` |
| `router.ts` | `navigateBack`, `useRoute` |
| `components/mission-utils.ts` | `sessionLookupById`, `clearMissionSelection` |
| `components/tool-call-shared.ts` | `formatResult` |
| `components/goals/goal-helpers.ts` | `formatMetric` |
| `components/observatory/anomaly-utils.ts` | `anomalySummary` (+ `AnomalySummary` interface) |
| `components/task-manage/task-manage-state.ts` | `updateTaskPriority` |
| `components/proof-helpers.ts` | `asRecord` |

## Orphan imports 추가 제거 (tsc 수정)

함수 삭제 후 tsc가 잡은 미사용 import 4건:

- `mission-utils.ts`: `missionSnapshot` 변수 + `DashboardMissionSessionBrief` 타입
- `proof-helpers.ts`: `isRecord`
- `router.ts`: `ReadonlySignal` 타입

## 변경량

| 항목 | LOC |
|---|---|
| 함수 본체 | **-77** |
| Orphan imports | **-4** |
| **합계** | **-80** |

## 검증

- `tsc --noEmit`: ✅ error 0
- `bun run build`: ✅ 11.66s
- `bun run test`: ✅ **215 files pass (3528 tests)**
  - `saved-signal.test.ts` 9 fails: pre-existing (PR #8014)

## /loop 스택 (Gen29~42)

| PR | Gen | 상태 | LOC |
|---|---|---|---|
| Gen29~35 | | MERGED | — |
| #8019 | 36 | MERGED | -75 |
| #8027 | 37 | Ready | -33 |
| #8036 | 38 | MERGED | -329 |
| #8041 | 39 | Draft | -44 |
| #8044 | 40 | Draft | -28 |
| #8047 | 41 | Draft | -788 |
| **#TBD** | **42** | **Draft** | **-80** |

누적 dashboard dead-code: **~-2,890 LOC**

## 다음 cycle 후보

- Gen43: `dashboard.css` ↔ `mission.css` 중복 rule 통합
- Gen44: `activity-graph.ts` (487L) `ActivityGraphSurface` 점검 (3 file-imports 있음 — 경유 분석 필요)
- Gen45: `components/keeper-fsm-specs.ts` 3개 dead build*Spec fns
- Gen46: `api/gate.ts` 3 decode fns 전체 dead

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)