### PR TITLE
feat(dashboard): 📊 Grafana Stat-panel header strip (3 mini tiles replace right-aligned text)

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -226,6 +226,73 @@ export function channelIcon(ch: string): string {
 }
 
 const formatUptime = formatElapsedCompact
+
+// ── Header stat strip helpers (Grafana Stat-panel style big-number + label) ──
+
+export type HeaderStatTone = 'ok' | 'partial' | 'bad' | 'default'
+
+/** Pure: threshold tone for "N of M connected" header stat. Grafana
+    Stat-panel convention — emerald when all up, amber when partial,
+    rose when zero. Exposed so downstream tests can pin the thresholds
+    without mounting the panel. */
+export function headerConnectedTone(connected: number, total: number): HeaderStatTone {
+  if (total <= 0) return 'default'
+  if (connected >= total) return 'ok'
+  if (connected <= 0) return 'bad'
+  return 'partial'
+}
+
+/** Pure: threshold tone for a success-rate % stat. Grafana default
+    thresholds — ≥95 green, 70-95 amber, <70 red. */
+export function headerSuccessTone(successPct: number | null | undefined): HeaderStatTone {
+  if (successPct === null || successPct === undefined || Number.isNaN(successPct)) return 'default'
+  if (successPct >= 95) return 'ok'
+  if (successPct >= 70) return 'partial'
+  return 'bad'
+}
+
+/** Pure: map header tone to a Tailwind text-color utility. */
+export function headerStatToneClass(tone: HeaderStatTone): string {
+  switch (tone) {
+    case 'ok':      return 'text-emerald-200'
+    case 'partial': return 'text-amber-200'
+    case 'bad':     return 'text-rose-200'
+    case 'default':
+    default:        return 'text-[var(--text-body)]'
+  }
+}
+
+interface HeaderMiniStatProps {
+  label: string
+  value: string
+  tone?: HeaderStatTone
+  testId?: string
+}
+
+/** Inline mini Grafana-style stat tile — big tabular value on top,
+    tiny uppercase label below, threshold-colored by `tone`. Used by
+    the connector panel header; kept local because the surrounding
+    layout (right-aligned corner trio) doesn't generalize to a shared
+    primitive yet. Promote to common/ once a second caller emerges. */
+export function HeaderMiniStat({
+  label,
+  value,
+  tone = 'default',
+  testId,
+}: HeaderMiniStatProps) {
+  const valueTone = headerStatToneClass(tone)
+  return html`
+    <div
+      class="flex min-w-[60px] flex-col items-end justify-center rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-1 text-right"
+      data-header-mini-stat=${label}
+      data-header-mini-stat-tone=${tone}
+      data-testid=${testId}
+    >
+      <span class=${`text-sm font-semibold tabular-nums leading-tight ${valueTone}`}>${value}</span>
+      <span class="mt-0.5 text-[9px] uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
+    </div>
+  `
+}
 const timeAgo = formatTimeAgoEn
 
 function healthTone(health: string): { dot: string; badge: string; label: string } {
@@ -1263,17 +1330,39 @@ export function ConnectorStatusPanel() {
               : '4종 채널 sidecar(Discord, iMessage, Slack, Telegram)의 라이브 상태와 keeper 바인딩을 한 곳에서.'}
           </div>
         </div>
-        <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-          ${!filterId
-            ? (() => {
-                const allUp = knownConnectedCount === KNOWN_CONNECTOR_IDS.length
-                const tone = allUp ? 'text-emerald-300' : ''
-                return html`<div class=${tone}>${knownConnectedCount}/${KNOWN_CONNECTOR_IDS.length} connected</div>`
-              })()
-            : null}
-          <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
-          <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
-        </div>
+        ${!filterId
+          ? html`
+              <!-- Grafana Stat-panel style header strip: three mini tiles
+                   (big number + tiny label below) side-by-side. Replaces
+                   the previous 3 right-aligned text lines which read as
+                   dense small-caps metadata rather than scannable stats. -->
+              <div class="flex items-stretch gap-2" data-header-stat-strip>
+                <${HeaderMiniStat}
+                  label="connected"
+                  value=${`${knownConnectedCount}/${KNOWN_CONNECTOR_IDS.length}`}
+                  tone=${headerConnectedTone(knownConnectedCount, KNOWN_CONNECTOR_IDS.length)}
+                  testId="header-stat-connected"
+                />
+                <${HeaderMiniStat}
+                  label="success"
+                  value=${d ? `${d.success_rate_pct}%` : '—'}
+                  tone=${d ? headerSuccessTone(d.success_rate_pct) : 'default'}
+                  testId="header-stat-success"
+                />
+                <${HeaderMiniStat}
+                  label="uptime"
+                  value=${d ? formatUptime(d.uptime_seconds) : '—'}
+                  tone="default"
+                  testId="header-stat-uptime"
+                />
+              </div>
+            `
+          : html`
+              <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
+                <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
+              </div>
+            `}
       </div>
 
       ${!filterId

--- a/dashboard/src/components/header-stat-trio.test.ts
+++ b/dashboard/src/components/header-stat-trio.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  headerConnectedTone,
+  headerSuccessTone,
+  headerStatToneClass,
+  HeaderMiniStat,
+} from './connector-status'
+
+describe('headerConnectedTone (pure)', () => {
+  it('ok when connected === total', () => {
+    expect(headerConnectedTone(4, 4)).toBe('ok')
+    expect(headerConnectedTone(1, 1)).toBe('ok')
+  })
+
+  it('partial when some but not all connected', () => {
+    expect(headerConnectedTone(2, 4)).toBe('partial')
+    expect(headerConnectedTone(3, 4)).toBe('partial')
+  })
+
+  it('bad when zero connected out of non-zero total', () => {
+    expect(headerConnectedTone(0, 4)).toBe('bad')
+  })
+
+  it('default when total is 0 (nothing to measure — avoid false "bad")', () => {
+    // Regression guard: empty dashboard shouldn't render a red "0/0"
+    // stat and alarm operators — that's a bootstrapping state, not a
+    // failure.
+    expect(headerConnectedTone(0, 0)).toBe('default')
+    expect(headerConnectedTone(5, 0)).toBe('default')
+  })
+
+  it('ok when connected > total (safety against drift / stale counts)', () => {
+    // If upstream count drifts and reports more connected than expected,
+    // still treat as OK rather than some impossible "partial".
+    expect(headerConnectedTone(5, 4)).toBe('ok')
+  })
+})
+
+describe('headerSuccessTone (pure)', () => {
+  it('ok when >= 95 (Grafana default "healthy" threshold)', () => {
+    expect(headerSuccessTone(95)).toBe('ok')
+    expect(headerSuccessTone(99.9)).toBe('ok')
+    expect(headerSuccessTone(100)).toBe('ok')
+  })
+
+  it('partial for 70..<95 (degraded but serving)', () => {
+    expect(headerSuccessTone(70)).toBe('partial')
+    expect(headerSuccessTone(94.99)).toBe('partial')
+  })
+
+  it('bad below 70 (Grafana default "unhealthy" threshold)', () => {
+    expect(headerSuccessTone(0)).toBe('bad')
+    expect(headerSuccessTone(69.9)).toBe('bad')
+  })
+
+  it('default when success is null / undefined / NaN (no signal)', () => {
+    expect(headerSuccessTone(null)).toBe('default')
+    expect(headerSuccessTone(undefined)).toBe('default')
+    expect(headerSuccessTone(Number.NaN)).toBe('default')
+  })
+})
+
+describe('headerStatToneClass (pure)', () => {
+  it('maps each tone to a distinct text-color utility', () => {
+    expect(headerStatToneClass('ok')).toContain('emerald')
+    expect(headerStatToneClass('partial')).toContain('amber')
+    expect(headerStatToneClass('bad')).toContain('rose')
+    expect(headerStatToneClass('default')).toContain('text-')
+  })
+
+  it('returns a non-empty string for every tone (no "transparent" bug)', () => {
+    for (const t of ['ok', 'partial', 'bad', 'default'] as const) {
+      expect(headerStatToneClass(t).length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('HeaderMiniStat component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders label and value', () => {
+    render(html`<${HeaderMiniStat} label="connected" value="3/4" />`, container)
+    const el = container.querySelector('[data-header-mini-stat="connected"]') as HTMLElement
+    expect(el).toBeTruthy()
+    expect(el.textContent).toContain('3/4')
+    expect(el.textContent).toContain('connected')
+  })
+
+  it('tone attribute reflects the prop (E2E hook)', () => {
+    render(html`<${HeaderMiniStat} label="success" value="87%" tone="partial" />`, container)
+    const el = container.querySelector('[data-header-mini-stat="success"]')!
+    expect(el.getAttribute('data-header-mini-stat-tone')).toBe('partial')
+  })
+
+  it('default tone when prop is omitted', () => {
+    render(html`<${HeaderMiniStat} label="x" value="1" />`, container)
+    const el = container.querySelector('[data-header-mini-stat="x"]')!
+    expect(el.getAttribute('data-header-mini-stat-tone')).toBe('default')
+  })
+
+  it('value carries the tone text-color class (bad → rose)', () => {
+    render(html`<${HeaderMiniStat} label="x" value="0/4" tone="bad" />`, container)
+    const el = container.querySelector('[data-header-mini-stat="x"]')!
+    // Value is the first <span> child.
+    const valueSpan = el.querySelector('span')!
+    expect(valueSpan.className).toContain('rose')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(html`<${HeaderMiniStat} label="x" value="1" testId="header-stat-x" />`, container)
+    expect(container.querySelector('[data-testid="header-stat-x"]')).toBeTruthy()
+  })
+
+  it('value uses tabular-nums so digits align across stats', () => {
+    // Regression guard: "N/M" alignment across three side-by-side
+    // stats breaks without tabular-nums — the "4" in different stat
+    // widths slides around visually.
+    render(html`<${HeaderMiniStat} label="x" value="42" />`, container)
+    const valueSpan = container.querySelector('[data-header-mini-stat="x"] span')!
+    expect(valueSpan.className).toContain('tabular-nums')
+  })
+})


### PR DESCRIPTION
## Summary

**Reference UI**: Grafana Stat visualization. The connector panel's top-right corner previously rendered three small-caps text lines (\"0/4 CONNECTED · SUCCESS 0% · UPTIME 16M 56S\" in the user's screenshot) that read as **metadata** rather than **stats**. Operators scanning multiple dashboards want the numbers to jump off the page — big tabular value + tiny uppercase label + threshold color.

## Before / After

Before — right-aligned small-caps text lines, all muted color:
```
                                                  0/4 CONNECTED
                                                  SUCCESS 0%
                                                  UPTIME 16M 56S
```

After — three mini stat tiles, threshold-colored:
```
┌──────────┬──────────┬──────────┐
│   0/4    │    0%    │ 16m 56s  │   ← big tabular value
│CONNECTED │ SUCCESS  │  UPTIME  │   ← tiny uppercase label
└──────────┴──────────┴──────────┘
      rose      rose      default
```

## Threshold color rules (Grafana defaults)

| Stat | ok (emerald) | partial (amber) | bad (rose) | default |
|------|--------------|-----------------|------------|---------|
| CONNECTED | all up | some up | zero up | total=0 (bootstrapping) |
| SUCCESS | ≥ 95% | 70-95% | < 70% | null/undefined/NaN |
| UPTIME | — (always default — more uptime isn't better, just longer) | | | |

## New exports (testable + reusable)

```ts
type HeaderStatTone = 'ok' | 'partial' | 'bad' | 'default'
headerConnectedTone(c, t): HeaderStatTone
headerSuccessTone(pct): HeaderStatTone
headerStatToneClass(tone): string       // Tailwind text-color utility
<HeaderMiniStat label value tone? testId?>
```

Kept **local to `connector-status.ts`** (not promoted to `common/`) per the \"promote on second caller\" rule. When another panel needs the same strip, lift then.

## Preserved behavior

Filter-view fallback unchanged — when a single-bridge sub-section is active, the two-line \"success / uptime\" text keeps rendering (the sub-section has its own focused context and doesn't need a trio).

## Tests (17 new, dedicated `header-stat-trio.test.ts`)

Separate file to avoid the heavy 90s-budget `connector-status.test.ts` fixture. Coverage:

**Threshold logic:**
- `headerConnectedTone`: ok/partial/bad matrix
- **`total=0 → default`** regression guard — empty dashboard shouldn't alarm operators with red \"0/0\"; it's bootstrapping, not failure
- `connected > total → ok` (stale-count drift safety)
- `headerSuccessTone`: Grafana 95/70/<70 thresholds + null/undefined/NaN → default (no-signal distinct from bad-signal)
- `headerStatToneClass`: distinct color per tone + non-empty for every tone (no \"transparent\" bug)

**Component:**
- Label + value rendering, tone attribute reflects prop, value carries tone text-color class, testId forward
- **`tabular-nums` regression guard** — \"N/M\" digits must align across three side-by-side stats; without it the \"4\" slides around visually at different stat widths

## Backward compat

21 pre-existing `connector-status.test.ts` tests still green. No breaking changes to snapshot, gate metric shape, or filter-view behavior.

## Test plan

- [x] `npx vitest run src/components/header-stat-trio.test.ts` → 17/17 green
- [x] `npx vitest run src/components/connector-status.test.ts` → 21/21 green (regression)
- [x] `npx tsc --noEmit -p .` → clean
- [ ] CI green
- [ ] Visual check — header corner renders three tinted stat tiles
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)