### PR TITLE
feat(dashboard): 💯 HeartbeatUptimeChip — rolling uptime % with threshold tone

### DIFF
--- a/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  HeartbeatUptimeChip,
+  formatUptimeChip,
+} from './heartbeat-uptime-chip'
+import { summarizeHistory } from './heartbeat-strip'
+
+describe('formatUptimeChip (pure)', () => {
+  it('returns null when no observed samples (all unknown / empty)', () => {
+    expect(formatUptimeChip(summarizeHistory([]))).toBeNull()
+    expect(formatUptimeChip(summarizeHistory(['unknown', 'unknown']))).toBeNull()
+  })
+
+  it('100% → operational, label="100"', () => {
+    const view = formatUptimeChip(summarizeHistory(['up', 'up', 'up']))
+    expect(view).toEqual({ label: '100', tone: 'operational' })
+  })
+
+  it('>= 99% → operational with 2-decimal label (Uptime Kuma convention)', () => {
+    // 199 up out of 200 observed = 99.5%
+    const history = [...Array(199).fill('up'), 'down'] as const
+    const view = formatUptimeChip(summarizeHistory(history as unknown as ReturnType<typeof summarizeHistory>['total'] extends number ? any : never))
+    expect(view?.tone).toBe('operational')
+    expect(view?.label).toBe('99.50')
+  })
+
+  it('95-99% → degraded (amber) with 1-decimal label', () => {
+    // 4 up, 1 down = 80% — too low
+    // 19 up, 1 down = 95% — right at threshold
+    const hist = [...Array(19).fill('up'), 'down']
+    const view = formatUptimeChip(summarizeHistory(hist as any))
+    expect(view?.tone).toBe('degraded')
+    expect(view?.label).toBe('95.0')
+  })
+
+  it('< 95% → unhealthy (rose)', () => {
+    // 3 up, 1 down = 75%
+    const view = formatUptimeChip(summarizeHistory(['up', 'up', 'up', 'down']))
+    expect(view?.tone).toBe('unhealthy')
+    expect(view?.label).toBe('75.0')
+  })
+
+  it('unknown samples do not drag the percentage down', () => {
+    // 2 up, 0 down, 10 unknown = 100% of observed
+    const view = formatUptimeChip(summarizeHistory([
+      'unknown', 'unknown', 'up', 'up',
+      'unknown', 'unknown', 'unknown', 'unknown',
+      'unknown', 'unknown', 'unknown', 'unknown',
+    ]))
+    expect(view).toEqual({ label: '100', tone: 'operational' })
+  })
+
+  it('99.995% rounds up and renders as exact "100"', () => {
+    // Avoid "99.99" appearing when fractional arithmetic produces
+    // 99.99500001 style values — regression guard for floating noise.
+    const view = formatUptimeChip({
+      total: 10000, up: 9999, down: 0, unknown: 1, uptimePct: 100,
+    })
+    expect(view).toEqual({ label: '100', tone: 'operational' })
+  })
+})
+
+describe('HeartbeatUptimeChip component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders nothing for empty history', () => {
+    render(html`<${HeartbeatUptimeChip} history=${[]} />`, container)
+    expect(container.querySelector('[data-heartbeat-uptime-chip]')).toBeNull()
+  })
+
+  it('renders nothing when history has only unknown samples', () => {
+    // New connector that's never been observed up/down yet — chip stays
+    // invisible so the tile is not polluted with a fake "0%".
+    render(
+      html`<${HeartbeatUptimeChip} history=${['unknown', 'unknown', 'unknown']} />`,
+      container,
+    )
+    expect(container.querySelector('[data-heartbeat-uptime-chip]')).toBeNull()
+  })
+
+  it('renders percentage + operational tone for 100% history', () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${['up', 'up', 'up']} />`,
+      container,
+    )
+    const el = container.querySelector('[data-heartbeat-uptime-chip]') as HTMLElement
+    expect(el).toBeTruthy()
+    expect(el.textContent).toContain('100%')
+    expect(el.className).toContain('emerald')
+    expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('operational')
+    expect(el.getAttribute('data-heartbeat-uptime-pct')).toBe('100')
+  })
+
+  it('tone class reflects degraded band (amber) for 95-99%', () => {
+    const hist = [...Array(19).fill('up'), 'down']
+    render(
+      html`<${HeartbeatUptimeChip} history=${hist} />`,
+      container,
+    )
+    const el = container.querySelector('[data-heartbeat-uptime-chip]')!
+    expect(el.className).toContain('amber')
+    expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('degraded')
+  })
+
+  it('tone class reflects unhealthy band (rose) for < 95%', () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${['up', 'up', 'up', 'down']} />`,
+      container,
+    )
+    const el = container.querySelector('[data-heartbeat-uptime-chip]')!
+    expect(el.className).toContain('rose')
+    expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('unhealthy')
+  })
+
+  it('title + aria-label include observed-sample fraction (hover tooltip parity)', () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${['up', 'up', 'up', 'down']} />`,
+      container,
+    )
+    const el = container.querySelector('[data-heartbeat-uptime-chip]')!
+    expect(el.getAttribute('title')).toBe('75.0% uptime · 3/4 observed')
+    expect(el.getAttribute('aria-label')).toBe('75.0% uptime · 3/4 observed')
+  })
+
+  it('uses tabular-nums so chips align when stacked in a row', () => {
+    // Regression guard — 4 connector tiles side-by-side, a "100" vs
+    // "95.0" width mismatch makes the row dance visually.
+    render(
+      html`<${HeartbeatUptimeChip} history=${['up']} />`,
+      container,
+    )
+    expect(container.querySelector('[data-heartbeat-uptime-chip]')!.className)
+      .toContain('tabular-nums')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${HeartbeatUptimeChip} history=${['up']} testId="discord-uptime" />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="discord-uptime"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -1,0 +1,74 @@
+// HeartbeatUptimeChip — rolling uptime % as a small threshold-toned badge.
+//
+// Reference UIs (Uptime Kuma status page "Overall uptime 99.87%" card,
+// Statuspage "Uptime last 90 days" ring): reliability-at-a-glance is a
+// distinct operator question from the current-state streak. "UP × 22" +
+// "100%" together answer both "is it up right now?" and "has it been
+// reliable over the window?" in one row.
+//
+// The strip tooltip already exposes the same number, but only on hover —
+// this chip surfaces it so a flaky connector reads as "85%" in peripheral
+// vision, not as "looks fine, probably".
+
+import { html } from 'htm/preact'
+import type { HeartbeatState } from '../../lib/heartbeat-history'
+import { summarizeHistory, type HeartbeatSummary } from './heartbeat-strip'
+
+export type UptimeTone = 'operational' | 'degraded' | 'unhealthy'
+
+export interface UptimeChipView {
+  /** Integer percent (0-100) as a string — 99.87 → "99.87", 100 → "100". */
+  label: string
+  tone: UptimeTone
+}
+
+/** Pure: classify a heartbeat summary into a chip view. Returns null
+    when there are no observed (up+down) samples so the tile renders
+    nothing instead of a meaningless "N/A%". Thresholds match Uptime
+    Kuma's default "operational / degraded / down" color ramp — two
+    nines (≥99) is quiet green, 95-99 is warning amber, below 95 is
+    alarming rose. */
+export function formatUptimeChip(summary: HeartbeatSummary): UptimeChipView | null {
+  if (summary.uptimePct === null) return null
+  const pct = summary.uptimePct
+  const label = pct >= 99.995 ? '100' : pct.toFixed(pct >= 99 ? 2 : 1)
+  const tone: UptimeTone =
+    pct >= 99 ? 'operational' : pct >= 95 ? 'degraded' : 'unhealthy'
+  return { label, tone }
+}
+
+const TONE_CLASS: Record<UptimeTone, string> = {
+  operational: 'text-emerald-200 border-emerald-400/30 bg-emerald-500/10',
+  degraded: 'text-amber-200 border-amber-400/30 bg-amber-500/10',
+  unhealthy: 'text-rose-200 border-rose-400/30 bg-rose-500/10',
+}
+
+export interface HeartbeatUptimeChipProps {
+  history: HeartbeatState[]
+  class?: string
+  testId?: string
+}
+
+export function HeartbeatUptimeChip({
+  history,
+  class: cx,
+  testId,
+}: HeartbeatUptimeChipProps) {
+  const summary = summarizeHistory(history)
+  const view = formatUptimeChip(summary)
+  if (view === null) return null
+  const tone = TONE_CLASS[view.tone]
+  const title = `${view.label}% uptime · ${summary.up}/${summary.up + summary.down} observed`
+  const chipClass = cx ?? ''
+  return html`<span
+    class=${`inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    title=${title}
+    aria-label=${title}
+    data-heartbeat-uptime-chip
+    data-heartbeat-uptime-tone=${view.tone}
+    data-heartbeat-uptime-pct=${view.label}
+    data-testid=${testId}
+  >
+    <span>${view.label}%</span>
+  </span>`
+}

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -18,6 +18,7 @@ import { openConnectorConfig } from './connector-config-form'
 import { formatElapsedCompact } from '../lib/format-time'
 import { HeartbeatStrip } from './common/heartbeat-strip'
 import { HeartbeatStreakChip } from './common/heartbeat-streak-chip'
+import { HeartbeatUptimeChip } from './common/heartbeat-uptime-chip'
 import { recordHeartbeat, useHeartbeatHistory, type HeartbeatState } from '../lib/heartbeat-history'
 
 /** Sampling cadence for the heartbeat ring buffer. Chosen so 45 bars
@@ -202,11 +203,16 @@ function TileHeartbeatStrip({ id }: { id: KnownConnectorId }) {
   const history = useHeartbeatHistory(id)
   return html`
     <div class="flex flex-col gap-1">
-      <${HeartbeatStreakChip}
-        history=${history}
-        class="self-start"
-        testId=${`heartbeat-streak-${id}`}
-      />
+      <div class="flex items-center gap-1">
+        <${HeartbeatStreakChip}
+          history=${history}
+          testId=${`heartbeat-streak-${id}`}
+        />
+        <${HeartbeatUptimeChip}
+          history=${history}
+          testId=${`heartbeat-uptime-${id}`}
+        />
+      </div>
       <${HeartbeatStrip}
         history=${history}
         slots=${45}


### PR DESCRIPTION
## Summary
- **HeartbeatUptimeChip** — small threshold-toned badge showing rolling uptime % per connector tile (Uptime Kuma "Overall uptime 99.87%" + Statuspage "Uptime last 90 days" convention).
- Pairs with #8052's streak chip so each tile now answers **both** operator questions in one row: current-state duration (\`UP × 22\`) + reliability (\`100%\`).
- Pure \`formatUptimeChip(summary)\` classifies into operational/degraded/unhealthy bands (≥99 emerald / 95–99 amber / <95 rose), mirroring Uptime Kuma's default color ramp.

## Reference UIs
- **Uptime Kuma status page** — "Overall uptime" card with threshold-colored percentage is the #1 reliability signal on the page.
- **Statuspage** — "Uptime last 90 days" ring gate: green 99.9+, yellow <99.9, red <95.
- The strip tooltip already exposed the same number, but only on hover. This chip surfaces it so a flaky connector reads as \"85%\" in peripheral vision instead of looking fine until the operator hovers.

## Visual placement
\`\`\`
┌─ Overview Tile ───────────────────────┐
│ 🟢 Discord — ⌁ 5m                     │
│ [pills · readiness rail]              │
│ [▲ UP × 22] [💯 100%]   ← new chip    │
│ ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰ (heartbeat strip)│
└───────────────────────────────────────┘
\`\`\`

## Thresholds (Uptime Kuma parity)
| Band | Rule | Tone | Example label |
|---|---|---|---|
| operational | ≥ 99% | emerald | \`100\`, \`99.87\` |
| degraded | 95–99% | amber | \`96.5\`, \`95.0\` |
| unhealthy | < 95% | rose | \`75.0\`, \`50.0\` |

- \`uptimePct === null\` (no observed up/down samples) → chip renders nothing. New connectors stay clean.
- \`99.995+\` rounds to exact \"100\" string (floating-noise regression guard).
- Unknown samples excluded from denominator (matches Uptime Kuma's \"ignore pending\").

## Test plan
- [x] Pure \`formatUptimeChip\` — null/100/≥99/95-99/<95 bands, unknown exclusion, floating \"100\" rounding.
- [x] Component — null on empty, null on unknown-only, tone class by band, tabular-nums alignment, title/aria-label tooltip parity, testId.
- [x] Typecheck clean, 471/471 vitest green.
- [ ] Manual smoke: \`npm run dev\` → \`#section=connector-status\` → stop a sidecar → watch uptime % drift into amber, keep stopping → rose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)