### PR TITLE
feat(dashboard): 🫀 LivePulseDot — Datadog-style live-polling indicator

### DIFF
--- a/dashboard/src/components/common/live-pulse-dot.test.ts
+++ b/dashboard/src/components/common/live-pulse-dot.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { LivePulseDot, classifyLivePulse } from './live-pulse-dot'
+
+const INTERVAL = 30_000
+const NOW = 1_000_000_000_000
+
+describe('classifyLivePulse (pure)', () => {
+  it('null tick → idle (never sampled)', () => {
+    const view = classifyLivePulse(null, NOW, INTERVAL)
+    expect(view.state).toBe('idle')
+    expect(view.label).toContain('대기')
+  })
+
+  it('tick within interval → live', () => {
+    expect(classifyLivePulse(NOW - 5_000, NOW, INTERVAL).state).toBe('live')
+  })
+
+  it('tick just under 2× interval → still live (tolerates one miss)', () => {
+    // 2× - 1ms = 59_999ms ago — Datadog "one missed heartbeat is fine".
+    expect(classifyLivePulse(NOW - (INTERVAL * 2 - 1), NOW, INTERVAL).state).toBe('live')
+  })
+
+  it('tick past 2× interval → stale', () => {
+    expect(classifyLivePulse(NOW - (INTERVAL * 2 + 1), NOW, INTERVAL).state).toBe('stale')
+  })
+
+  it('stale label includes seconds-ago for operator diagnostic', () => {
+    const view = classifyLivePulse(NOW - 120_000, NOW, INTERVAL)
+    expect(view.state).toBe('stale')
+    expect(view.label).toContain('120s')
+  })
+
+  it('very recent tick (0 ms ago) is live', () => {
+    expect(classifyLivePulse(NOW, NOW, INTERVAL).state).toBe('live')
+  })
+})
+
+describe('LivePulseDot component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('idle state: grey dot, no pulse animation', () => {
+    render(
+      html`<${LivePulseDot} lastTickMs=${null} nowMs=${NOW} sampleIntervalMs=${INTERVAL} />`,
+      container,
+    )
+    const el = container.querySelector('[data-live-pulse-dot]') as HTMLElement
+    expect(el.getAttribute('data-live-pulse-state')).toBe('idle')
+    expect(el.className).not.toContain('animate-pulse')
+  })
+
+  it('live state: emerald + animate-pulse (Datadog breathing dot)', () => {
+    render(
+      html`<${LivePulseDot} lastTickMs=${NOW - 1000} nowMs=${NOW} sampleIntervalMs=${INTERVAL} />`,
+      container,
+    )
+    const el = container.querySelector('[data-live-pulse-dot]') as HTMLElement
+    expect(el.getAttribute('data-live-pulse-state')).toBe('live')
+    expect(el.className).toContain('emerald')
+    expect(el.className).toContain('animate-pulse')
+  })
+
+  it('stale state: amber dot, no pulse (freeze signal stands still)', () => {
+    render(
+      html`<${LivePulseDot} lastTickMs=${NOW - 90_000} nowMs=${NOW} sampleIntervalMs=${INTERVAL} />`,
+      container,
+    )
+    const el = container.querySelector('[data-live-pulse-dot]') as HTMLElement
+    expect(el.getAttribute('data-live-pulse-state')).toBe('stale')
+    expect(el.className).toContain('amber')
+    // Regression guard: pulse animation MUST be off when stale — a
+    // frozen sampler must not look identical to a live one.
+    expect(el.className).not.toContain('animate-pulse')
+  })
+
+  it('title + aria-label carry the same narrative (hover + AT parity)', () => {
+    render(
+      html`<${LivePulseDot} lastTickMs=${NOW - 1000} nowMs=${NOW} sampleIntervalMs=${INTERVAL} />`,
+      container,
+    )
+    const el = container.querySelector('[data-live-pulse-dot]')!
+    expect(el.getAttribute('title')).toBe('Live polling · 샘플링 정상')
+    expect(el.getAttribute('aria-label')).toBe('Live polling · 샘플링 정상')
+  })
+
+  it('role=img so screen readers announce the decorative shape semantically', () => {
+    render(
+      html`<${LivePulseDot} lastTickMs=${null} nowMs=${NOW} sampleIntervalMs=${INTERVAL} />`,
+      container,
+    )
+    expect(container.querySelector('[data-live-pulse-dot]')!.getAttribute('role')).toBe('img')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${LivePulseDot}
+        lastTickMs=${NOW}
+        nowMs=${NOW}
+        sampleIntervalMs=${INTERVAL}
+        testId="overview-strip-live"
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="overview-strip-live"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/live-pulse-dot.ts
+++ b/dashboard/src/components/common/live-pulse-dot.ts
@@ -1,0 +1,84 @@
+// LivePulseDot — tiny pulsing dot that answers "is polling still live?".
+//
+// Reference UIs (Datadog host-list "live" column, Grafana dashboard
+// refresh indicator, GitHub Status page): a pulsing green dot beside
+// the section header says "data under this header is being refreshed
+// right now". When the dot stops pulsing (stale) or goes idle (never
+// sampled), the operator immediately sees that the view is frozen —
+// a frozen heartbeat strip looks identical to a legitimately stable
+// one, so this indicator is the only surface that tells them apart.
+//
+// Pure classifier — a test pins the threshold math so a future change
+// to HEARTBEAT_SAMPLE_MS doesn't silently break the stale banding.
+
+import { html } from 'htm/preact'
+
+export type LivePulseState = 'live' | 'stale' | 'idle'
+
+export interface LivePulseView {
+  state: LivePulseState
+  /** Human-readable status tucked into title/aria so hover + AT both
+      explain what the dot means without a separate tooltip chip. */
+  label: string
+}
+
+/** Pure: classify the pulse state from the last-tick timestamp.
+    - `idle`: sampler has never fired (null). Grey dot, no pulse.
+    - `live`: last tick within 2× the sample interval — the operator's
+      view is fresh. Green dot, breathing pulse.
+    - `stale`: last tick older than 2× interval — sampler is frozen or
+      tab was backgrounded. Amber dot, no pulse.
+    2× threshold mirrors Datadog's "missed one expected heartbeat →
+    still healthy; missed two → something's wrong" convention, robust
+    to one-off scheduling jitter. */
+export function classifyLivePulse(
+  lastTickMs: number | null,
+  nowMs: number,
+  sampleIntervalMs: number,
+): LivePulseView {
+  if (lastTickMs === null) {
+    return { state: 'idle', label: 'Live polling · 샘플 대기 중' }
+  }
+  const ageMs = nowMs - lastTickMs
+  if (ageMs > sampleIntervalMs * 2) {
+    const ageSec = Math.max(1, Math.floor(ageMs / 1000))
+    return { state: 'stale', label: `Live polling · 샘플 멈춤 (${ageSec}s ago)` }
+  }
+  return { state: 'live', label: 'Live polling · 샘플링 정상' }
+}
+
+const DOT_BASE = 'inline-block h-2 w-2 rounded-full'
+
+const DOT_TONE: Record<LivePulseState, string> = {
+  live: 'bg-emerald-400 animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.6)]',
+  stale: 'bg-amber-400',
+  idle: 'bg-[var(--white-10)]',
+}
+
+export interface LivePulseDotProps {
+  lastTickMs: number | null
+  nowMs: number
+  sampleIntervalMs: number
+  class?: string
+  testId?: string
+}
+
+export function LivePulseDot({
+  lastTickMs,
+  nowMs,
+  sampleIntervalMs,
+  class: cx,
+  testId,
+}: LivePulseDotProps) {
+  const view = classifyLivePulse(lastTickMs, nowMs, sampleIntervalMs)
+  const tone = DOT_TONE[view.state]
+  return html`<span
+    class=${`${DOT_BASE} ${tone} ${cx ?? ''}`}
+    role="img"
+    aria-label=${view.label}
+    title=${view.label}
+    data-live-pulse-dot
+    data-live-pulse-state=${view.state}
+    data-testid=${testId}
+  ></span>`
+}

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -19,12 +19,22 @@ import { formatElapsedCompact } from '../lib/format-time'
 import { HeartbeatStrip } from './common/heartbeat-strip'
 import { HeartbeatStreakChip } from './common/heartbeat-streak-chip'
 import { HeartbeatUptimeChip } from './common/heartbeat-uptime-chip'
-import { recordHeartbeat, useHeartbeatHistory, type HeartbeatState } from '../lib/heartbeat-history'
+import { LivePulseDot } from './common/live-pulse-dot'
+import { recordHeartbeat, useHeartbeatHistory, lastHeartbeatTickMs, type HeartbeatState } from '../lib/heartbeat-history'
 
 /** Sampling cadence for the heartbeat ring buffer. Chosen so 45 bars
     cover ~22 minutes of history — matches Uptime Kuma's default
     "last 45 checks at 30s interval" visual rhythm. */
 const HEARTBEAT_SAMPLE_MS = 30_000
+
+/** Wall-clock tick for the live-pulse indicator — updates every second
+    so the dot can flip from live to stale without needing a prop change.
+    Kept module-scope so every StatusSummaryLine instance shares one
+    timer instead of N. */
+const livePulseNowMs = signal<number>(Date.now())
+if (typeof window !== 'undefined') {
+  window.setInterval(() => { livePulseNowMs.value = Date.now() }, 1000)
+}
 
 /** Pure: derive the heartbeat state for a connector from the gate info
     that the overview strip already polls. No extra network calls. */
@@ -303,11 +313,19 @@ function StatusSummaryLine({ summary }: { summary: ConnectorStripSummary }) {
   // One quiet aggregate sentence — always on, never loud. Sits between
   // the loud banners (celebration / incident) and the action row, so the
   // operator always has baseline numbers even when neither banner fires.
+  const now = livePulseNowMs.value
+  const lastTick = lastHeartbeatTickMs.value
   return html`
     <div
       class="mb-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-[var(--text-dim)]"
       data-strip-summary
     >
+      <${LivePulseDot}
+        lastTickMs=${lastTick}
+        nowMs=${now}
+        sampleIntervalMs=${HEARTBEAT_SAMPLE_MS}
+        testId="overview-strip-live"
+      />
       <span>
         <span class="font-semibold text-[var(--text-body)]" data-strip-summary-sidecars>${summary.sidecarUp} of ${summary.sidecarTotal}</span>
         <span> sidecars running</span>

--- a/dashboard/src/lib/heartbeat-history.ts
+++ b/dashboard/src/lib/heartbeat-history.ts
@@ -17,6 +17,13 @@ export const HEARTBEAT_MAX_SAMPLES = 45
 
 const history = signal<Record<string, HeartbeatState[]>>({})
 
+/** Epoch ms of the most recent recordHeartbeat() call across all
+    connectors. Exposed so a global "live polling" indicator can detect
+    when the sampler itself has frozen — distinct from per-connector
+    up/down state. Starts null so a fresh page reads as "never sampled"
+    instead of "sampled 1970". */
+export const lastHeartbeatTickMs = signal<number | null>(null)
+
 /** Record one sample for a connector. Ring-buffers at HEARTBEAT_MAX_SAMPLES. */
 export function recordHeartbeat(connectorId: string, state: HeartbeatState): void {
   const current = history.value[connectorId] ?? []
@@ -24,6 +31,7 @@ export function recordHeartbeat(connectorId: string, state: HeartbeatState): voi
     ? [...current.slice(current.length - HEARTBEAT_MAX_SAMPLES + 1), state]
     : [...current, state]
   history.value = { ...history.value, [connectorId]: next }
+  lastHeartbeatTickMs.value = Date.now()
 }
 
 /** Read the current history for a connector. Returns [] for unknown ids. */
@@ -42,6 +50,7 @@ export function useHeartbeatHistory(connectorId: string): HeartbeatState[] {
 /** Clear all recorded history. For tests + "reset fleet view" flows. */
 export function resetHeartbeatHistory(): void {
   history.value = {}
+  lastHeartbeatTickMs.value = null
 }
 
 /** Current state + how many contiguous trailing samples share it.


### PR DESCRIPTION
## Summary
- **LivePulseDot** — tiny breathing dot beside StatusSummaryLine tells the operator whether polling is still live.
- Solves a hidden blind spot: a frozen HeartbeatStrip is **visually identical** to a stable one (same bars, same colors). Without a dedicated liveness surface, a page that has lost its sampler looks like a page that's calm.
- Emerald + animate-pulse when live, amber still when stale, grey still when never-sampled.

## Reference UIs
- **Datadog host-list** — \"live\" column shows a green dot that stops when the agent's reporting stalls. Operators scan for the absence of pulse, not its presence.
- **Grafana dashboard refresh indicator** — breathing dot + \"refreshed Xs ago\" tooltip.
- **GitHub Status page** — component rows pulse while \"this incident is being updated\".
- Common thread: **the dot's absence is the signal**, not its presence. When all dots are pulsing, the operator trusts the view; when one stops, attention snaps to it.

## State machine (pure classifier, tested)
| Condition | State | Visual | Why |
|---|---|---|---|
| \`lastTickMs === null\` | \`idle\` | Grey, no pulse | Never sampled yet — explicit \"no data\" vs fake health |
| \`ageMs ≤ 2 × interval\` | \`live\` | Emerald + animate-pulse | Datadog \"one missed heartbeat is fine\" tolerance |
| \`ageMs  > 2 × interval\` | \`stale\` | Amber, no pulse | Sampler frozen / tab backgrounded / network dead |

- 2× threshold handles scheduling jitter cleanly.
- Stale label includes \`Xs ago\` so operator can diagnose (30s = one miss, 5m = page stuck).

## Visual placement
\`\`\`
● 3 of 4 sidecars running · 12 bindings configured · 2 keepers online
│
└── LivePulseDot (new) — emerald pulse when live, amber still when stale
\`\`\`

## Plumbing
- \`lib/heartbeat-history.ts\` — exports \`lastHeartbeatTickMs\` signal. Bumped on every \`recordHeartbeat()\` call. Null on page load + \`resetHeartbeatHistory()\`.
- \`connector-overview-strip.ts\` — module-scope \`livePulseNowMs\` signal ticks every 1s, shared across all mounts (one timer, N subscribers).

## Regression guards (pinned by tests)
- \`stale\` state must NOT have \`animate-pulse\` — a frozen sampler must not visually impersonate a live one.
- \`title\` + \`aria-label\` narrative parity (hover + screen reader say the same thing).
- \`role=\"img\"\` on the decorative dot for proper AT announcement.

## Test plan
- [x] Pure \`classifyLivePulse\` — null/live/stale bands, 2× threshold edge cases, seconds-ago label composition.
- [x] Component — idle/live/stale class selection, title+aria parity, role=img, testId wiring, no-pulse-when-stale regression guard.
- [x] Typecheck clean, 39/39 vitest green across live-pulse-dot + connector-overview-strip tests.
- [ ] Manual smoke: \`npm run dev\` → watch dot pulse every 30s (sample cadence) → background tab for 90s → return, see amber stale state → next sample flips back to emerald live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)