### PR TITLE
fix(dashboard): recover observatory activity events

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -2,6 +2,7 @@ import { post, fetchWithTimeout } from './core'
 import { ACTIVITY_TIMEOUT_MS } from '../config/constants'
 import { callMcpTool } from './mcp'
 import {
+  ActionsActivitySchemaDriftError,
   parseActivityGraphResponse,
   parseSwimlaneResponse,
   type ActivityGraphResponse,
@@ -35,26 +36,32 @@ export async function fetchTaskHistory(taskId: string, limit = 20): Promise<stri
 // --- Activity Graph ---
 
 export async function fetchActivityGraph(since?: string): Promise<ActivityGraphResponse | null> {
+  const params = since ? `?since=${since}` : ''
   try {
-    const params = since ? `?since=${since}` : ''
     const resp = await fetchWithTimeout(`/api/v1/activity/graph${params}`, {}, ACTIVITY_TIMEOUT_MS)
-    if (!resp.ok) return null
+    if (!resp.ok) {
+      throw new Error(`GET /api/v1/activity/graph failed: ${resp.status} ${resp.statusText}`)
+    }
     return parseActivityGraphResponse(await resp.json())
   } catch (err) {
+    if (err instanceof ActionsActivitySchemaDriftError) throw err
     console.debug('[activity] graph fetch failed', err instanceof Error ? err.message : err)
-    return null
+    throw err
   }
 }
 
 export async function fetchSwimlane(since?: string): Promise<SwimlaneResponse | null> {
+  const params = since ? `?since=${since}` : ''
   try {
-    const params = since ? `?since=${since}` : ''
     const resp = await fetchWithTimeout(`/api/v1/activity/swimlane${params}`, {}, ACTIVITY_TIMEOUT_MS)
-    if (!resp.ok) return null
+    if (!resp.ok) {
+      throw new Error(`GET /api/v1/activity/swimlane failed: ${resp.status} ${resp.statusText}`)
+    }
     return parseSwimlaneResponse(await resp.json())
   } catch (err) {
+    if (err instanceof ActionsActivitySchemaDriftError) throw err
     console.debug('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)
-    return null
+    throw err
   }
 }
 
@@ -69,4 +76,3 @@ export async function deleteTask(taskId: string): Promise<boolean> {
   const resp = await post<{ ok: boolean }>('/api/v1/dashboard/tasks/delete', { task_id: taskId })
   return resp.ok
 }
-

--- a/dashboard/src/api/schemas/actions-activity.test.ts
+++ b/dashboard/src/api/schemas/actions-activity.test.ts
@@ -36,15 +36,14 @@ function validGraph(overrides: Record<string, unknown> = {}): Record<string, unk
     timeline: [
       {
         kind: 'task.done',
-        actor: { agent: 'claude' },
-        summary: 'finished something',
-        subject: { id: 'task:abc', type: 'task' },
-        ts: 1_712_000_000,
+        actor: { id: 'claude', kind: 'agent' },
+        subject: { id: 'task:abc', kind: 'task' },
+        ts_ms: 1_712_000_000,
         ts_iso: '2026-04-01T00:00:00Z',
         seq: 1,
         room_id: 'main',
         tags: ['done'],
-        payload: { note: 'ok' },
+        payload: { task_title: 'finished something', note: 'ok' },
       },
     ],
     generated_at: '2026-04-17T00:00:00Z',
@@ -78,6 +77,10 @@ describe('parseActivityGraphResponse', () => {
     expect(out.edges).toHaveLength(1)
     expect(out.stats.event_count).toBe(42)
     expect(out.stats_history).toBeUndefined()
+    expect(out.timeline[0]!.actor).toEqual({ id: 'claude', kind: 'agent' })
+    expect(out.timeline[0]!.subject).toEqual({ id: 'task:abc', type: 'task' })
+    expect(out.timeline[0]!.summary).toBe('finished something')
+    expect(out.timeline[0]!.ts).toBe(1_712_000_000)
   })
 
   it('accepts optional stats_history and node.semantic_weight', () => {
@@ -134,6 +137,30 @@ describe('parseActivityGraphResponse', () => {
       heatmap: { matrix: [['not-a-number']], max: 0, total: 0 },
     })
     expect(() => parseActivityGraphResponse(bad)).toThrow(ActionsActivitySchemaDriftError)
+  })
+
+  it('normalizes null actor and derives summary from payload', () => {
+    const out = parseActivityGraphResponse(
+      validGraph({
+        timeline: [
+          {
+            kind: 'tool.called',
+            actor: null,
+            subject: { id: 'keeper_shell', kind: 'tool' },
+            ts_ms: 1_712_100_000,
+            ts_iso: '2026-04-01T00:16:40Z',
+            seq: 2,
+            room_id: 'default',
+            tags: ['tool'],
+            payload: { tool_name: 'keeper_shell', cmd: 'pr create --draft' },
+          },
+        ],
+      }),
+    )
+    expect(out.timeline[0]!.actor).toEqual({})
+    expect(out.timeline[0]!.subject).toEqual({ id: 'keeper_shell', type: 'tool' })
+    expect(out.timeline[0]!.summary).toBe('pr create --draft')
+    expect(out.timeline[0]!.ts).toBe(1_712_100_000)
   })
 
   it('throws on non-object payload', () => {

--- a/dashboard/src/api/schemas/actions-activity.ts
+++ b/dashboard/src/api/schemas/actions-activity.ts
@@ -22,9 +22,11 @@ import {
   number,
   object,
   optional,
+  pipe,
   record,
   safeParse,
   string,
+  transform,
   unknown,
   type BaseIssue,
   type InferOutput,
@@ -61,23 +63,90 @@ export const ActivityGraphEdgeSchema = object({
 // `payload`, `tags` are passed through to renderers that treat them as
 // display-only / diagnostic. Enforcing a stricter shape would force
 // the schema to track every backend event variant.
-export const ActivityGraphTimelineEventSchema = object({
+const ActivityGraphTimelineEventRawSchema = object({
   kind: string(),
-  actor: record(string(), unknown()),
-  summary: string(),
-  subject: nullable(
-    object({
-      id: string(),
-      type: string(),
-    }),
-  ),
-  ts: number(),
+  actor: optional(nullable(record(string(), unknown()))),
+  summary: optional(string()),
+  subject: optional(nullable(record(string(), unknown()))),
+  ts: optional(number()),
+  ts_ms: optional(number()),
   ts_iso: string(),
   seq: number(),
   room_id: string(),
   tags: array(string()),
   payload: record(string(), unknown()),
 })
+
+function firstString(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  }
+  return null
+}
+
+function normalizeActivitySubject(
+  value: Record<string, unknown> | null | undefined,
+): { id: string; type: string } | null {
+  if (!value) return null
+  const id = typeof value.id === 'string' ? value.id.trim() : ''
+  if (id === '') return null
+  const type =
+    (typeof value.type === 'string' && value.type.trim() !== '' ? value.type.trim() : null)
+    ?? (typeof value.kind === 'string' && value.kind.trim() !== '' ? value.kind.trim() : null)
+    ?? 'entity'
+  return { id, type }
+}
+
+function deriveActivitySummary(
+  kind: string,
+  payload: Record<string, unknown>,
+  subject: { id: string; type: string } | null,
+): string {
+  return firstString(payload, [
+    'summary',
+    'message',
+    'content',
+    'task_title',
+    'title',
+    'reason',
+    'notes',
+    'cmd',
+    'tool_args_preview',
+    'tool_name',
+    'verification_id',
+    'contract_id',
+    'run_id',
+    'target_id',
+    'task_id',
+  ])
+    ?? subject?.id
+    ?? kind
+}
+
+export const ActivityGraphTimelineEventSchema = pipe(
+  ActivityGraphTimelineEventRawSchema,
+  transform((raw: InferOutput<typeof ActivityGraphTimelineEventRawSchema>) => {
+    const actor = raw.actor ?? {}
+    const subject = normalizeActivitySubject(raw.subject ?? null)
+    const payload = raw.payload
+    return {
+      kind: raw.kind,
+      actor,
+      summary: raw.summary?.trim() || deriveActivitySummary(raw.kind, payload, subject),
+      subject,
+      ts: raw.ts ?? raw.ts_ms ?? Date.parse(raw.ts_iso),
+      ts_iso: raw.ts_iso,
+      seq: raw.seq,
+      room_id: raw.room_id,
+      tags: raw.tags,
+      payload,
+    }
+  }),
+)
 
 // `stats` and `kind_counts` are open number-valued maps — the backend
 // adds new counters (per-tool, per-category) without coordinating the

--- a/dashboard/src/components/activity-graph-groups.test.ts
+++ b/dashboard/src/components/activity-graph-groups.test.ts
@@ -4,6 +4,7 @@ import {
   buildCategoryCounts,
   buildRawCategoryCounts,
   categoryForActivityKind,
+  eventDetail,
 } from './activity-graph-groups'
 import type { ActivityGraphTimelineEvent } from '../types'
 
@@ -39,11 +40,27 @@ describe('categoryForActivityKind', () => {
     expect(categoryForActivityKind('message.broadcast')).toBe('message')
     expect(categoryForActivityKind('board.posted')).toBe('board')
     expect(categoryForActivityKind('policy.approved')).toBe('governance')
+    expect(categoryForActivityKind('keeper.contract_verdict')).toBe('governance')
     expect(categoryForActivityKind('agent.joined')).toBe('lifecycle')
   })
 
   it('falls back to other for unknown kinds', () => {
     expect(categoryForActivityKind('mystery.kind')).toBe('other')
+  })
+
+  it('surfaces tool and verification payload details in summaries', () => {
+    const toolEvent = makeEvent(1, 'tool.called', {
+      actor: 'claude',
+      payload: { tool_name: 'keeper_shell', cmd: 'gh pr create --draft' },
+    })
+    const verifyEvent = makeEvent(2, 'task.submit_for_verification', {
+      actor: 'claude',
+      subjectId: 'task-9',
+      payload: { verification_id: 'vrf-77' },
+    })
+
+    expect(eventDetail(toolEvent)).toBe('gh pr create --draft')
+    expect(eventDetail(verifyEvent)).toBe('vrf-77')
   })
 })
 

--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -28,7 +28,12 @@ export function categoryForActivityKind(kind: string): ActivityCategory {
   ) return 'session'
   if (kind.startsWith('message.')) return 'message'
   if (kind.startsWith('board.')) return 'board'
-  if (kind.startsWith('decision.') || kind.startsWith('policy.')) return 'governance'
+  if (
+    kind.startsWith('decision.')
+    || kind.startsWith('policy.')
+    || kind === 'keeper.contract_verdict'
+    || kind === 'keeper.friction'
+  ) return 'governance'
   if (
     kind === 'agent.joined'
     || kind === 'agent.left'
@@ -70,6 +75,9 @@ export function eventKindLabel(kind: string): string {
     case 'task.done': return '완료'
     case 'task.released': return '반환'
     case 'task.cancelled': return '취소'
+    case 'task.submit_for_verification': return '검증 요청'
+    case 'task.approved': return '검증 승인'
+    case 'task.rejected': return '검증 반려'
     case 'board.posted': return '게시'
     case 'board.commented': return '댓글'
     case 'board.voted': return '투표'
@@ -87,8 +95,11 @@ export function eventKindLabel(kind: string): string {
     case 'policy.denied': return '정책 거절'
     case 'keeper.autonomy_started': return '자율 시작'
     case 'keeper.autonomy_completed': return '자율 완료'
+    case 'keeper.contract_verdict': return '계약 판정'
+    case 'keeper.friction': return '마찰 신호'
     case 'keeper.compaction': return '컴팩션'
     case 'keeper.guardrail': return '가드레일'
+    case 'tool.called': return '툴 호출'
     default: return kind
   }
 }
@@ -131,7 +142,21 @@ function payloadString(event: ActivityGraphTimelineEvent, keys: string[]): strin
 }
 
 export function eventDetail(event: ActivityGraphTimelineEvent, max = 120): string {
-  const text = payloadString(event, ['message', 'content', 'task_title', 'title', 'reason'])
+  const text = payloadString(event, [
+    'message',
+    'content',
+    'task_title',
+    'title',
+    'reason',
+    'notes',
+    'cmd',
+    'tool_args_preview',
+    'tool_name',
+    'verification_id',
+    'contract_id',
+    'run_id',
+    'target_id',
+  ])
   const base = text || eventSubjectId(event) || event.kind
   return base.length > max ? `${base.slice(0, max - 3)}...` : base
 }

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -309,19 +309,57 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   (* Track in-memory call counter for all declared tool names (including hidden). *)
   Tool_registry.record_call_if_known ~source:External_mcp ~tool_name:name ~success ~duration_ms ();
 
+  let tool_args_preview =
+    Observability_redact.redact_tool_input ~tool_name:name arguments
+  in
+  let activity_string_field key =
+    match Safe_ops.json_string_opt key arguments with
+    | Some value when String.trim value <> "" ->
+        Some (key, `String (Observability_redact.redact_preview value))
+    | _ -> None
+  in
+  let activity_int_field key =
+    match Safe_ops.json_int_opt key arguments with
+    | Some value -> Some (key, `Int value)
+    | None -> None
+  in
+  let activity_payload =
+    `Assoc
+      ([
+         ("tool_name", `String name);
+         ("success", `Bool success);
+         ("duration_ms", `Int duration_ms);
+         ("source", `String (Tool_registry.string_of_source External_mcp));
+         ("error", match error_detail with Some e -> `String e | None -> `Null);
+         ( "tool_args_preview",
+           match tool_args_preview with
+           | Some preview -> `String preview
+           | None -> `Null );
+       ]
+       @ List.filter_map activity_string_field
+           [
+             "cmd";
+             "task_id";
+             "repo";
+             "path";
+             "message";
+             "branch";
+             "branch_name";
+             "title";
+             "session_id";
+             "operation_id";
+             "verification_id";
+           ]
+       @ List.filter_map activity_int_field [ "pr_number"; "issue_number" ])
+  in
+
   (* Emit activity graph event for tool call — enables real-time dashboard tracking *)
   (try
     ignore (Activity_graph.emit state.Mcp_server.room_config
       ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
       ~subject:(Activity_graph.entity ~kind:"tool" name)
       ~kind:"tool.called"
-      ~payload:(`Assoc [
-        ("tool_name", `String name);
-        ("success", `Bool success);
-        ("duration_ms", `Int duration_ms);
-        ("source", `String (Tool_registry.string_of_source External_mcp));
-        ("error", match error_detail with Some e -> `String e | None -> `Null);
-      ])
+      ~payload:activity_payload
       ~tags:(if success then ["tool"; "success"] else ["tool"; "failure"])
       ())
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->


### PR DESCRIPTION
## Summary
- normalize activity graph timeline events to the backend JSON shape instead of silently treating schema drift as empty data
- surface verification and keeper governance events in observatory grouping/labels
- enrich `tool.called` activity payloads with redacted argument previews so PR/gh flows are visible in the observatory

## Product impact
- observatory activity no longer reports a false empty state when `activity-events` already contains recent runtime events
- PR / gh-driven tool activity is more legible in the activity timeline because redacted command and argument previews are attached to `tool.called`
- verification transitions and keeper verdict/friction events now appear under meaningful observatory labels instead of falling into generic buckets

## Evidence
- confirmed recent `tool.called` events existed in `.masc/activity-events/2026-04/17.jsonl`
- reproduced the mismatch between backend event JSON (`actor`, `subject.kind`, `ts_ms`) and the dashboard parser contract (`summary`, `subject.type`, `ts`)

## Review evidence
- `pnpm exec vitest run src/api/schemas/actions-activity.test.ts src/components/activity-graph-groups.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- checked PR review threads with GitHub GraphQL: no unresolved inline review threads were present; only the PR hygiene warning remained

## Linked issue
- Refs #8058
