### PR TITLE
[codex] honor resolved config root for keeper runtime

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -136,7 +136,7 @@ are intentionally excluded from this TOML surface.
 | `[alert]` | 16 | `slack_enabled`, `slack_dm_user_id`, `github_enabled` |
 | `[debug]` | 1 | `enabled` |
 
-**Example** (`<base_path>/.masc/config/keeper_runtime.toml`):
+**Example** (`<active config root>/keeper_runtime.toml`):
 
 ```toml
 [autonomous]

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -1,7 +1,7 @@
 (** Env_config_keeper — keeper runtime parameters from environment.
 
     All [MASC_KEEPER_*] env vars in this module can also be set
-    declaratively in [<base_path>/.masc/config/keeper_runtime.toml].
+    declaratively in [<resolved config root>/keeper_runtime.toml].
     The TOML loader ({!Keeper_runtime_config.load_and_apply}) runs at
     server startup and records unset values in the process-local boot
     override store before this module initializes.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -7,7 +7,7 @@
 
     [MASC_KEEPER_*] env vars read here (semaphore timeout, concurrency,
     fairness cooldown, autoboot max) can also be set in
-    [<base_path>/.masc/config/keeper_runtime.toml].
+    [<resolved config root>/keeper_runtime.toml].
     See {!Keeper_runtime_config} and [docs/BOOT-ENV-STATE-INVENTORY.md]
     section 1.3. *)
 

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -1,5 +1,5 @@
 (** Keeper_runtime_config — load startup keeper env seeding from
-    [<base_path>/.masc/config/keeper_runtime.toml].  See [.mli] for design. *)
+    [<resolved config root>/keeper_runtime.toml].  See [.mli] for design. *)
 
 (* TOML key → env var name. Every keeper runtime knob maps here so
    that TOML is the SSOT and env vars become CI/test overrides.
@@ -86,8 +86,16 @@ let key_to_env =
     "debug.enabled",                    "MASC_KEEPER_DEBUG";
   ]
 
+let resolved_config_root ~base_path =
+  let inputs = Config_dir_resolver.inputs_from_env () in
+  let resolution =
+    Config_dir_resolver.resolve_with
+      { inputs with env_base_path = Some base_path }
+  in
+  resolution.Config_dir_resolver.config_root.path
+
 let toml_path ~base_path =
-  Filename.concat base_path ".masc/config/keeper_runtime.toml"
+  Filename.concat (resolved_config_root ~base_path) "keeper_runtime.toml"
 
 let read_file path =
   try Ok (In_channel.with_open_text path In_channel.input_all)

--- a/lib/keeper/keeper_runtime_config.mli
+++ b/lib/keeper/keeper_runtime_config.mli
@@ -1,5 +1,5 @@
 (** Keeper_runtime_config — load startup keeper env seeding from
-    [<base_path>/.masc/config/keeper_runtime.toml].
+    [<resolved config root>/keeper_runtime.toml].
 
     Per-base-path config for keeper turn budgets, semaphore timeouts, and
     other runtime parameters that previously lived only in environment
@@ -8,7 +8,7 @@
 
     Precedence (highest first):
       1. Process env var (caller override, e.g. CI/test)
-      2. TOML value from [<base_path>/.masc/config/keeper_runtime.toml]
+      2. TOML value from [<resolved config root>/keeper_runtime.toml]
       3. Hardcoded default in [Env_config_keeper.KeeperKeepalive].
 
     The TOML loader runs at server startup, before any module that reads
@@ -19,8 +19,11 @@
 
     @since 0.7.1 *)
 
-(** Load TOML from [<base_path>/.masc/config/keeper_runtime.toml] and
+(** Load TOML from [<resolved config root>/keeper_runtime.toml] and
     record any overrides in the process-local boot override store.
+
+    The resolved config root honors [MASC_CONFIG_DIR] when set; otherwise it
+    follows the standard base-path/home fallback chain.
 
     Process-level env vars set by the caller take precedence — the TOML
     value is only applied when the env var is unset. This preserves the

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -181,8 +181,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Unix.putenv "MASC_BASE_PATH_INPUT" (Option.value ~default:"" input_base_path);
   Unix.putenv "MASC_BASE_PATH" base_path;
   bootstrap_base_path_config_root ~base_path;
-  (* Apply per-base-path keeper runtime overrides from
-     config/keeper_runtime.toml. Must run before any module that reads
+  (* Apply keeper runtime overrides from the resolved config root's
+     keeper_runtime.toml. Must run before any module that reads
      [Env_config_keeper.KeeperKeepalive] env vars at init time. Existing
      process env vars take precedence — TOML only fills unset slots. *)
   (match Keeper_runtime_config.load_and_apply ~base_path with

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -1,5 +1,5 @@
 (** Tests for [Keeper_runtime_config] — per-base-path keeper runtime
-    tuning loaded from [<base_path>/.masc/config/keeper_runtime.toml].
+    tuning loaded from [<resolved config root>/keeper_runtime.toml].
 
     Uses [resolve_overrides] with injected env_lookup to avoid global
     process env dependence. The load_and_apply integration path records
@@ -23,6 +23,9 @@ let with_base_path f =
   Unix.mkdir dir 0o755;
   Unix.mkdir (Filename.concat dir ".masc") 0o755;
   Unix.mkdir (Filename.concat dir ".masc/config") 0o755;
+  let oc = open_out (Filename.concat dir ".masc/config/cascade.json") in
+  output_string oc "{}\n";
+  close_out oc;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
 let write_toml base_path content =
@@ -214,6 +217,34 @@ let test_load_and_apply_records_disabled_turn_cost_override () =
       None
       (Keeper_config.keeper_tool_cost_max_usd ())
 
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let test_explicit_config_dir_wins_over_base_path () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  with_base_path @@ fun override_root ->
+  write_toml base_path "[budget]\ndaily_usd = 0.42\n";
+  write_toml override_root "[budget]\ndaily_usd = 0.99\n";
+  let override_config_dir = Filename.concat override_root ".masc/config" in
+  with_env "MASC_CONFIG_DIR" (Some override_config_dir) @@ fun () ->
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Error msg -> failf "unexpected error: %s" msg
+  | Ok n ->
+    check int "applied count" 1 n;
+    check (option string) "explicit config dir stored"
+      (Some "0.99")
+      (Config_boot_overrides.get_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD")
+
 let test_float_value_round_trip () =
   let doc = parse_or_fail
     "[autonomous]\nsemaphore_wait_timeout_sec = 120.5\n"
@@ -239,6 +270,7 @@ let () =
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override
         ; test_case "load_and_apply records turn cost override" `Quick test_load_and_apply_records_turn_cost_override
         ; test_case "load_and_apply records disabled turn cost override" `Quick test_load_and_apply_records_disabled_turn_cost_override
+        ; test_case "explicit MASC_CONFIG_DIR wins over base path" `Quick test_explicit_config_dir_wins_over_base_path
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ] )
     ]


### PR DESCRIPTION
## Summary
Use the resolved config root when loading `keeper_runtime.toml` instead of always reading `<base_path>/.masc/config/keeper_runtime.toml`.

## Root Cause
`Keeper_runtime_config` bypassed `Config_dir_resolver` and hardcoded the keeper runtime path off `base_path`. That made `MASC_CONFIG_DIR` ineffective for this loader even though the rest of the config system already treated the resolved config root as the SSOT.

## Changes
- resolve the active config root through `Config_dir_resolver` before loading `keeper_runtime.toml`
- update surrounding docs/comments to refer to the resolved config root instead of a hardcoded base-path config path
- add a regression test proving explicit `MASC_CONFIG_DIR` wins over the base path for keeper runtime overrides

## Impact
Keeper runtime boot overrides now follow the same config-root precedence as the rest of the server startup path. This removes one remaining config-root bypass in live startup behavior.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-runtime-config-dir`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-runtime-config-dir/_build/default/test/test_keeper_runtime_toml.exe`