### PR TITLE
feat(dashboard): ⚫ StatusDot primitive — consolidate 8 colored-dot indicators

### DIFF
--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  StatusDot,
+  statusDotClasses,
+  statusDotSizeClass,
+} from './status-dot'
+
+describe('statusDotSizeClass (pure)', () => {
+  it('default size is sm (8px — baseline row marker)', () => {
+    expect(statusDotSizeClass()).toBe('w-2 h-2')
+  })
+
+  it('produces the expected Tailwind pair for each named variant', () => {
+    expect(statusDotSizeClass('xs')).toBe('w-1.5 h-1.5')
+    expect(statusDotSizeClass('sm')).toBe('w-2 h-2')
+    expect(statusDotSizeClass('md')).toBe('w-2.5 h-2.5')
+    expect(statusDotSizeClass('lg')).toBe('w-3 h-3')
+  })
+})
+
+describe('statusDotClasses (pure)', () => {
+  it('always includes the invariant base (rounded-full + shrink-0 + inline-block)', () => {
+    const cls = statusDotClasses()
+    expect(cls).toContain('rounded-full')
+    expect(cls).toContain('shrink-0')
+    expect(cls).toContain('inline-block')
+  })
+
+  it('tone class is appended after size (caller controls color)', () => {
+    const cls = statusDotClasses('sm', 'bg-emerald-500')
+    expect(cls).toMatch(/w-2 h-2.*bg-emerald-500/)
+  })
+
+  it('empty / undefined tone does not leave trailing whitespace', () => {
+    expect(statusDotClasses('sm', '')).not.toMatch(/\s$/)
+    expect(statusDotClasses('sm', undefined)).not.toMatch(/\s$/)
+  })
+
+  it('extra class appended after tone (margin, ring, etc.)', () => {
+    expect(statusDotClasses('sm', 'bg-rose-500', 'ml-1'))
+      .toMatch(/bg-rose-500.*ml-1/)
+  })
+})
+
+describe('StatusDot component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a span with data-status-dot + size attribute', () => {
+    render(html`<${StatusDot} />`, container)
+    const el = container.querySelector('[data-status-dot]') as HTMLElement
+    expect(el.tagName).toBe('SPAN')
+    expect(el.getAttribute('data-status-dot-size')).toBe('sm')
+  })
+
+  it('tone class (passed via `class`) ends up on the span', () => {
+    render(html`<${StatusDot} class="bg-emerald-500" />`, container)
+    expect(container.querySelector('[data-status-dot]')!.className).toContain('bg-emerald-500')
+  })
+
+  it('default (no ariaLabel) is decorative — aria-hidden=true, no role', () => {
+    // Regression guard: dot must NOT announce itself when paired with
+    // a text label, otherwise AT users hear "dot, running, dot, stopped"
+    // for every row. See governance / transport-health tables.
+    render(html`<${StatusDot} />`, container)
+    const el = container.querySelector('[data-status-dot]') as HTMLElement
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('role')).toBeNull()
+  })
+
+  it('ariaLabel promotes to semantic mode: role=img, no aria-hidden', () => {
+    render(
+      html`<${StatusDot} ariaLabel="running" class="bg-emerald-500" />`,
+      container,
+    )
+    const el = container.querySelector('[data-status-dot]')!
+    expect(el.getAttribute('role')).toBe('img')
+    expect(el.getAttribute('aria-label')).toBe('running')
+    expect(el.getAttribute('aria-hidden')).toBeNull()
+  })
+
+  it('each size variant renders distinct Tailwind tokens', () => {
+    for (const size of ['xs', 'sm', 'md', 'lg'] as const) {
+      render(html`<${StatusDot} size=${size} />`, container)
+      const el = container.querySelector('[data-status-dot]') as HTMLElement
+      expect(el.getAttribute('data-status-dot-size')).toBe(size)
+      render(null, container)
+    }
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${StatusDot} testId="transport-sse-dot" class="bg-emerald-500" />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="transport-sse-dot"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -1,0 +1,84 @@
+// StatusDot — small colored circle indicator.
+//
+// Reference UIs (GitHub PR status dots, Vercel deployment row, Linear
+// issue state circle, Stripe subscription health): the 6-10px colored
+// dot is the single most scanned visual in an operational list. Rows
+// of dots let the eye catch "one of these is not like the others"
+// before it parses any text. A consistent primitive matters because
+// dots drift easily — different rows end up at w-1.5 / w-2 / w-2.5
+// and the eye loses the grid.
+//
+// Deliberately NOT prescriptive about tone: callers have their own
+// semantic tone helpers (statusDot / verdictTone / railPillTone) that
+// return Tailwind background classes. This primitive takes the tone
+// via `class` so it composes with existing helpers instead of
+// duplicating them — the shared invariants are size + shape + shrink.
+//
+// Distinct from LivePulseDot (animate-pulse "is polling live?"
+// indicator): StatusDot is the static per-row state marker. Pairing
+// them is expected (LivePulseDot for the top of a list, StatusDot
+// per row).
+
+import { html } from 'htm/preact'
+
+export type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
+
+/** Pure: Tailwind size tokens for each named variant. Exposed so
+    a caller that wraps its own <span> (legacy code in a hot render
+    path avoiding an extra component) stays pixel-identical. */
+export function statusDotSizeClass(size: StatusDotSize = 'sm'): string {
+  switch (size) {
+    case 'xs': return 'w-1.5 h-1.5'  // 6px — inline legend dots
+    case 'sm': return 'w-2 h-2'      // 8px — default row marker
+    case 'md': return 'w-2.5 h-2.5'  // 10px — prominent card marker
+    case 'lg': return 'w-3 h-3'      // 12px — hero status pill
+  }
+}
+
+const BASE = 'inline-block rounded-full shrink-0'
+
+/** Pure: full class string for a dot. Exposed so callers can pre-build
+    the string in a loop without mounting N components. */
+export function statusDotClasses(
+  size: StatusDotSize = 'sm',
+  toneClass?: string,
+  extra?: string,
+): string {
+  const parts = [BASE, statusDotSizeClass(size)]
+  if (toneClass !== undefined && toneClass !== '') parts.push(toneClass)
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface StatusDotProps {
+  size?: StatusDotSize
+  /** Additional Tailwind classes for tone, margin, etc. Caller-owned
+      because per-file helpers (`statusDot(status)`, `verdictTone(v)`,
+      etc.) already own the semantic color mapping. */
+  class?: string
+  /** Override the decorative default. Renders role="img" when set.
+      Without it, the dot is `aria-hidden` — correct for the common
+      case where the dot sits next to a text label that already
+      carries the narrative. */
+  ariaLabel?: string
+  testId?: string
+}
+
+export function StatusDot({
+  size = 'sm',
+  class: cx,
+  ariaLabel,
+  testId,
+}: StatusDotProps) {
+  const cls = statusDotClasses(size, cx)
+  const semantic = ariaLabel !== undefined
+  return html`<span
+    class=${cls}
+    role=${semantic ? 'img' : undefined}
+    aria-label=${ariaLabel}
+    aria-hidden=${semantic ? undefined : 'true'}
+    data-status-dot
+    data-status-dot-size=${size}
+    data-testid=${testId}
+  ></span>`
+}

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -7,6 +7,7 @@ import { Card } from './common/card'
 import { KpiCard } from './common/stat-row'
 import { TimeAgo } from './common/time-ago'
 import { EmptyState } from './common/empty-state'
+import { StatusDot } from './common/status-dot'
 import { JsonViewerCard } from './common/json-viewer'
 import { ActionButton } from './common/button'
 import {
@@ -94,7 +95,7 @@ function JudgeStatusBar() {
   return html`
     <div class="mb-4 flex items-center gap-3 rounded-lg border border-white/5 bg-white/3 px-3.5 py-2 text-[12px]" data-testid="judge-status">
       <span class="flex items-center gap-1.5">
-        <span class="inline-block w-2 h-2 rounded-full ${dotClass}"></span>
+        <${StatusDot} size="sm" class=${dotClass} />
         <span class="font-medium text-text-muted">평가 모델 ${label}</span>
       </span>
       ${judge.model_used ? html`<span class="text-text-dim">${judge.model_used}</span>` : null}

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -7,6 +7,7 @@ import { navigate } from '../router'
 import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
 import { CopyIdButton } from './common/copy-id-button'
+import { StatusDot } from './common/status-dot'
 import type {
   RailStatus,
   GateDistribution,
@@ -384,7 +385,7 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
                   ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
                 </div>
               </div>
-              <span class=${`inline-block h-2.5 w-2.5 rounded-full ${verdictTone(item.verdict)}`} />
+              <${StatusDot} size="md" class=${verdictTone(item.verdict)} />
             </div>
             <div class="mt-2 text-sm text-[var(--text-body)]">${verdictSummary(item.verdict)}</div>
             ${item.fallback_reason ? html`

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -13,6 +13,7 @@ import {
 } from '../api/transport-health'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { TextInput } from './common/input'
+import { StatusDot } from './common/status-dot'
 import { CopyIdButton } from './common/copy-id-button'
 
 type StatusTone = 'ok' | 'warn' | 'bad'
@@ -281,7 +282,7 @@ function SectionCard({
     <div class="rounded-xl border border-card-border bg-bg-1/60 p-4">
       <div class="flex items-center justify-between gap-3 mb-3">
         <div class="flex items-center gap-2 min-w-0">
-          <span class=${`w-2 h-2 rounded-full shrink-0 ${statusDot(status)}`}></span>
+          <${StatusDot} size="sm" class=${statusDot(status)} />
           <span class="text-xs font-semibold text-text-strong uppercase tracking-wider truncate">${title}</span>
         </div>
         ${eyebrow ? html`<span class=${`text-[10px] uppercase tracking-wider ${toneClass(status)}`}>${eyebrow}</span>` : null}
@@ -391,11 +392,11 @@ export function TransportHealthPanel() {
         <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
           <span>트랜스포트 상세</span>
           <span class="ml-auto flex items-center gap-2 text-[11px] font-normal text-text-muted">
-            <span class="inline-flex items-center gap-1"><span class=${`w-1.5 h-1.5 rounded-full ${statusDot(sseStatus)}`}></span>SSE</span>
-            <span class="inline-flex items-center gap-1"><span class=${`w-1.5 h-1.5 rounded-full ${statusDot(grpcStatus)}`}></span>gRPC</span>
-            <span class="inline-flex items-center gap-1"><span class=${`w-1.5 h-1.5 rounded-full ${statusDot(wsStatus)}`}></span>WS</span>
-            <span class="inline-flex items-center gap-1"><span class=${`w-1.5 h-1.5 rounded-full ${statusDot(webrtcStatus)}`}></span>RTC</span>
-            <span class="inline-flex items-center gap-1"><span class=${`w-1.5 h-1.5 rounded-full ${statusDot(h2Status)}`}></span>HTTP</span>
+            <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(sseStatus)} />SSE</span>
+            <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(grpcStatus)} />gRPC</span>
+            <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(wsStatus)} />WS</span>
+            <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(webrtcStatus)} />RTC</span>
+            <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(h2Status)} />HTTP</span>
           </span>
         </summary>
         <div class="p-4">


### PR DESCRIPTION
## Summary
- **StatusDot primitive** — the tiny colored-circle state indicator as a reusable \`common/\` primitive with 4 size variants. Consolidates **8 inline call sites** across 3 files that were already drifting (w-1.5 / w-2 / w-2.5 used inconsistently).
- Reference UIs: GitHub PR status dots, Vercel deployment row, Linear issue state circle, Stripe subscription health. The dot is the single most-scanned visual in an operational list — rows of dots let the eye catch \"one of these is not like the others\" before it parses any text.

## Why now (drift was real)
Pre-change, 8 call sites used 3 different size tokens with no shared source of truth:
\`\`\`
transport-health.ts × 6   →  w-2 h-2 + w-1.5 h-1.5 (mixed)
harness-health-sections.ts → h-2.5 w-2.5
governance.ts              → w-2 h-2
\`\`\`
A new operator looking at the fleet could end up reading two different columns of dots at different sizes and not realize they meant the same thing. One primitive fixes both drift and future inconsistency.

## Four sizes map to observed usage
| Size | Tailwind | Context |
|---|---|---|
| \`xs\` | \`w-1.5 h-1.5\` (6px) | Inline legend dots (trans. 상세 pills) |
| \`sm\` | \`w-2 h-2\` (8px) **default** | Default row marker |
| \`md\` | \`w-2.5 h-2.5\` (10px) | Prominent card state marker |
| \`lg\` | \`w-3 h-3\` (12px) | Hero status pill |

## Deliberately NOT prescriptive about tone
Callers keep their own semantic helpers (\`statusDot(status)\`, \`verdictTone(verdict)\`, etc.) that return Tailwind bg classes. Primitive takes the tone via \`class\` prop, shared invariants are **size + shape + inline-block + shrink-0**. This avoids duplicating N domain-specific color mappings inside the primitive.

## Distinct from LivePulseDot
| | StatusDot | LivePulseDot |
|---|---|---|
| Role | Static per-row state | \"Is polling live?\" |
| Animation | None | animate-pulse |
| Input | \`class\` (tone) | \`lastTickMs\` + \`nowMs\` |
| Pairing | Per row | One per dashboard section |

Both often coexist (LivePulseDot at the strip header + StatusDot per row below).

## Accessibility
- **Default decorative** — \`aria-hidden=true\`, no role. Without this, AT users hear \"dot, running, dot, stopped\" for every row since the dot is always paired with a text label.
- \`ariaLabel\` prop promotes to semantic mode (\`role=\"img\"\`, no aria-hidden) for standalone usage.
- Regression guard: a test pins the default behavior.

## Wiring (8 call sites)
| File | Count | Size |
|---|---|---|
| \`transport-health.ts\` (SectionCard title) | 1 | sm |
| \`transport-health.ts\` (\"상세\" mini-legend × 5) | 5 | xs |
| \`harness-health-sections.ts\` (verdict list) | 1 | md |
| \`governance.ts\` (judge header) | 1 | sm |

Tone helpers (\`statusDot\`, \`verdictTone\`) preserved as-is — no semantic churn.

## Test plan
- [x] Pure \`statusDotSizeClass\` + \`statusDotClasses\` — default sm, each size's Tailwind pair, base invariants, trailing whitespace cleanup.
- [x] Component — data-status-dot + data-status-dot-size, tone via class, decorative default (aria-hidden+no role), ariaLabel semantic promotion, per-size attribute, testId.
- [x] Typecheck clean; 12 new tests + 107 tests green across transport-health + governance-monitor + harness-health-sections.
- [ ] Manual smoke: \`npm run dev\` → #transport-health, #governance, #harness-health → all dot sizes visually unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)