### PR TITLE
feat(dashboard): ▰ ProgressBar primitive — single-value % bar + 2 call-site wirings

### DIFF
--- a/dashboard/src/components/common/progress-bar.test.ts
+++ b/dashboard/src/components/common/progress-bar.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ProgressBar,
+  progressBarWidthStyle,
+  progressBarHeightClass,
+  progressBarToneClass,
+  progressBarTrackToneClass,
+} from './progress-bar'
+
+describe('progressBarWidthStyle (pure)', () => {
+  it('mid-range % renders with 2-decimal precision', () => {
+    expect(progressBarWidthStyle(42.5)).toBe('width: 42.50%')
+  })
+
+  it('clamps negatives to 0 (no CSS freakouts on bad input)', () => {
+    expect(progressBarWidthStyle(-1)).toBe('width: 0.00%')
+    expect(progressBarWidthStyle(-99)).toBe('width: 0.00%')
+  })
+
+  it('clamps > 100 to 100 (fill never overflows track)', () => {
+    expect(progressBarWidthStyle(150)).toBe('width: 100.00%')
+  })
+
+  it('integer edge cases render cleanly', () => {
+    expect(progressBarWidthStyle(0)).toBe('width: 0.00%')
+    expect(progressBarWidthStyle(100)).toBe('width: 100.00%')
+  })
+})
+
+describe('progressBarHeightClass (pure)', () => {
+  it('default is sm (6px — baseline row bar)', () => {
+    expect(progressBarHeightClass()).toBe('h-1.5')
+  })
+
+  it('each size maps to its expected Tailwind token', () => {
+    expect(progressBarHeightClass('xs')).toBe('h-1')
+    expect(progressBarHeightClass('sm')).toBe('h-1.5')
+    expect(progressBarHeightClass('md')).toBe('h-2')
+  })
+})
+
+describe('progressBarTrackToneClass (pure)', () => {
+  it('default is the white-5 muted track', () => {
+    expect(progressBarTrackToneClass()).toBe('bg-[var(--white-5)]')
+    expect(progressBarTrackToneClass('default')).toBe('bg-[var(--white-5)]')
+  })
+
+  it('each variant maps to a distinct CSS var (no drift)', () => {
+    expect(progressBarTrackToneClass('dim')).toBe('bg-[var(--white-6)]')
+    expect(progressBarTrackToneClass('muted')).toBe('bg-[var(--white-8)]')
+  })
+})
+
+describe('progressBarToneClass (pure)', () => {
+  it('semantic tokens route to the dashboard CSS vars', () => {
+    expect(progressBarToneClass('accent')).toBe('bg-[var(--accent)]')
+    expect(progressBarToneClass('ok')).toBe('bg-[var(--ok)]')
+    expect(progressBarToneClass('warn')).toBe('bg-[var(--warn)]')
+    expect(progressBarToneClass('bad')).toBe('bg-[var(--bad)]')
+  })
+
+  it('raw Tailwind tones route to their bg-500 class', () => {
+    expect(progressBarToneClass('emerald')).toBe('bg-emerald-500')
+    expect(progressBarToneClass('rose')).toBe('bg-rose-500')
+  })
+})
+
+describe('ProgressBar component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders track + fill; fill width reflects clamped %', () => {
+    render(html`<${ProgressBar} pct=${42.5} />`, container)
+    const track = container.querySelector('[data-progress-bar]') as HTMLElement
+    expect(track).toBeTruthy()
+    const fill = track.querySelector('div') as HTMLElement
+    expect(fill.getAttribute('style')).toContain('width: 42.50%')
+  })
+
+  it('data-progress-bar-pct is integer-rounded for clean E2E selectors', () => {
+    render(html`<${ProgressBar} pct=${33.7} />`, container)
+    expect(container.querySelector('[data-progress-bar]')!.getAttribute('data-progress-bar-pct')).toBe('34')
+  })
+
+  it('decorative default: aria-hidden=true + no role=progressbar', () => {
+    // Regression guard: many bars sit right next to a \"X%\" text label,
+    // announcing role=progressbar + the same % would be duplicative.
+    render(html`<${ProgressBar} pct=${50} />`, container)
+    const track = container.querySelector('[data-progress-bar]') as HTMLElement
+    expect(track.getAttribute('aria-hidden')).toBe('true')
+    expect(track.getAttribute('role')).toBeNull()
+  })
+
+  it('ariaLabel promotes to semantic: role=progressbar + aria-valuenow/min/max', () => {
+    render(
+      html`<${ProgressBar} pct=${67.3} ariaLabel="Build progress" />`,
+      container,
+    )
+    const track = container.querySelector('[data-progress-bar]') as HTMLElement
+    expect(track.getAttribute('role')).toBe('progressbar')
+    expect(track.getAttribute('aria-label')).toBe('Build progress')
+    expect(track.getAttribute('aria-valuenow')).toBe('67')
+    expect(track.getAttribute('aria-valuemin')).toBe('0')
+    expect(track.getAttribute('aria-valuemax')).toBe('100')
+    expect(track.getAttribute('aria-hidden')).toBeNull()
+  })
+
+  it('tone prop maps to the fill bg class', () => {
+    render(html`<${ProgressBar} pct=${50} tone="ok" />`, container)
+    const fill = container.querySelector('[data-progress-bar] > div') as HTMLElement
+    expect(fill.className).toContain('bg-[var(--ok)]')
+  })
+
+  it('class prop overrides tone (threshold-varying colors)', () => {
+    render(
+      html`<${ProgressBar} pct=${50} class="bg-[#38bdf8]" />`,
+      container,
+    )
+    const fill = container.querySelector('[data-progress-bar] > div') as HTMLElement
+    expect(fill.className).toContain('bg-[#38bdf8]')
+    // Tone fallback must NOT also be present when class is given.
+    expect(fill.className).not.toContain('bg-[var(--accent)]')
+  })
+
+  it('title attribute propagates to the track', () => {
+    render(
+      html`<${ProgressBar} pct=${50} title="67% complete" />`,
+      container,
+    )
+    expect(container.querySelector('[data-progress-bar]')!.getAttribute('title')).toBe('67% complete')
+  })
+
+  it('size variant reflected in data attribute + height class', () => {
+    render(html`<${ProgressBar} pct=${50} size="md" />`, container)
+    const track = container.querySelector('[data-progress-bar]') as HTMLElement
+    expect(track.getAttribute('data-progress-bar-size')).toBe('md')
+    expect(track.className).toContain('h-2')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${ProgressBar} pct=${50} testId="build-progress" />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="build-progress"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -1,0 +1,130 @@
+// ProgressBar — single-value percentage bar.
+//
+// Reference UIs (GitHub repo languages bar, Vercel deployment build
+// step, Linear cycle progress, Stripe payout progress): a flat track
+// with a tone-colored fill is the canonical \"how far along\" indicator.
+// Distinct from DistributionBars (which stacks multiple labeled
+// segments) — ProgressBar is the simple single-stat case. The dashboard
+// had 10+ inline `<div style=\"width:X%\">` call sites with drift on
+// height (h-1, h-1.5, h-2, h-full) and tone tokens (hex vs var(--X)).
+//
+// Pure helper exposed so callers in hot render paths (session trace
+// rows, keeper detail segments) can compose the width string without
+// mounting a component per row.
+
+import { html } from 'htm/preact'
+
+export type ProgressBarSize = 'xs' | 'sm' | 'md'
+export type ProgressBarTone =
+  | 'accent' | 'ok' | 'warn' | 'bad'
+  | 'emerald' | 'amber' | 'rose' | 'sky'
+
+/** Pure: clamp a percentage into [0, 100] and produce the inline width
+    style string. Exposed so callers that need to render the bar inline
+    (inside a flex row with other progress bars) can use the same
+    semantics without mounting the component. */
+export function progressBarWidthStyle(pct: number): string {
+  const clamped = Math.max(0, Math.min(100, pct))
+  return `width: ${clamped.toFixed(2)}%`
+}
+
+/** Pure: the height class for a given size token. Track + fill share
+    the same height so the fill is always fully visible. */
+export function progressBarHeightClass(size: ProgressBarSize = 'sm'): string {
+  switch (size) {
+    case 'xs': return 'h-1'     // 4px — inline with text lines
+    case 'sm': return 'h-1.5'   // 6px — default row bar
+    case 'md': return 'h-2'     // 8px — hero progress indicator
+  }
+}
+
+/** Pure: Tailwind background class for a named tone. Callers with a
+    bespoke brand color pass `class` instead. */
+export function progressBarToneClass(tone: ProgressBarTone): string {
+  switch (tone) {
+    case 'accent': return 'bg-[var(--accent)]'
+    case 'ok': return 'bg-[var(--ok)]'
+    case 'warn': return 'bg-[var(--warn)]'
+    case 'bad': return 'bg-[var(--bad)]'
+    case 'emerald': return 'bg-emerald-500'
+    case 'amber': return 'bg-amber-500'
+    case 'rose': return 'bg-rose-500'
+    case 'sky': return 'bg-sky-500'
+  }
+}
+
+export type ProgressBarTrackTone = 'default' | 'dim' | 'muted'
+
+/** Pure: track (muted background) bg class for a given track tone.
+    Default = --white-5 (most rows); dim = --white-6 (keeper detail);
+    muted = --white-8 (session trace compact overlay). Covers the three
+    pre-change variants without adding arbitrary hex inputs. */
+export function progressBarTrackToneClass(tone: ProgressBarTrackTone = 'default'): string {
+  switch (tone) {
+    case 'default': return 'bg-[var(--white-5)]'
+    case 'dim': return 'bg-[var(--white-6)]'
+    case 'muted': return 'bg-[var(--white-8)]'
+  }
+}
+
+export interface ProgressBarProps {
+  /** Percentage 0–100; values outside are clamped (no throw). */
+  pct: number
+  size?: ProgressBarSize
+  tone?: ProgressBarTone
+  /** Additional classes on the fill element — use when a tone prop
+      doesn't fit (e.g. threshold-varying color chosen by caller). */
+  class?: string
+  /** Track background tone. Default covers most rows; callers with a
+      denser visual context (keeper detail / compact overlays) pick
+      dim/muted. */
+  trackTone?: ProgressBarTrackTone
+  /** Additional classes on the track — layout overrides (flex-1) or
+      atypical rounding. Appended after the base classes. */
+  trackClass?: string
+  /** Render a hover tooltip on the track so the numeric % is
+      reachable without reading surrounding text. */
+  title?: string
+  /** Override the decorative default. When set, the bar exposes
+      role="progressbar" + aria-valuenow so AT users hear progress. */
+  ariaLabel?: string
+  testId?: string
+}
+
+const TRACK_BASE = 'w-full overflow-hidden rounded-full'
+const FILL_BASE = 'h-full rounded-full transition-[width] duration-300 ease-in-out'
+
+export function ProgressBar({
+  pct,
+  size = 'sm',
+  tone = 'accent',
+  class: cx,
+  trackTone = 'default',
+  trackClass,
+  title,
+  ariaLabel,
+  testId,
+}: ProgressBarProps) {
+  const height = progressBarHeightClass(size)
+  const fillClass = cx ?? progressBarToneClass(tone)
+  const trackBg = progressBarTrackToneClass(trackTone)
+  const widthStyle = progressBarWidthStyle(pct)
+  const clamped = Math.max(0, Math.min(100, pct))
+  const semantic = ariaLabel !== undefined
+  return html`<div
+    class=${`${TRACK_BASE} ${height} ${trackBg} ${trackClass ?? ''}`}
+    title=${title}
+    role=${semantic ? 'progressbar' : undefined}
+    aria-label=${ariaLabel}
+    aria-valuenow=${semantic ? clamped.toFixed(0) : undefined}
+    aria-valuemin=${semantic ? '0' : undefined}
+    aria-valuemax=${semantic ? '100' : undefined}
+    aria-hidden=${semantic ? undefined : 'true'}
+    data-progress-bar
+    data-progress-bar-size=${size}
+    data-progress-bar-pct=${clamped.toFixed(0)}
+    data-testid=${testId}
+  >
+    <div class=${`${FILL_BASE} ${fillClass}`} style=${widthStyle}></div>
+  </div>`
+}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -7,6 +7,7 @@ import { signal } from '@preact/signals'
 import { formatPct, formatTokens } from '../lib/format-number'
 import { TextInput } from './common/input'
 import { CopyIdButton } from './common/copy-id-button'
+import { ProgressBar } from './common/progress-bar'
 import type { Keeper, KeeperMetricPoint, PromptSegmentTelemetry } from '../types'
 
 // ── Context pressure thresholds (shared across KPIs, charts) ─
@@ -435,9 +436,13 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
                   return html`
                     <div class="flex items-center gap-2 text-xs">
                       <span class="shrink-0 w-[140px] truncate font-mono text-[11px] text-[var(--accent)]" title=${model}>${model}</span>
-                      <div class="flex-1 h-1.5 bg-[var(--white-6)] rounded-full overflow-hidden">
-                        <div class="h-full rounded-full bg-[var(--accent)]" style="width:${pct}%"></div>
-                      </div>
+                      <${ProgressBar}
+                        pct=${pct}
+                        size="sm"
+                        tone="accent"
+                        trackTone="dim"
+                        trackClass="flex-1"
+                      />
                       <span class="shrink-0 w-10 text-right text-[var(--text-muted)]">${count}회</span>
                     </div>
                   `

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -6,6 +6,7 @@ import { useSignal } from '@preact/signals'
 import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
+import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
 import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import type { UnifiedTraceEvent, TraceEventKind } from './session-trace-state'
@@ -360,9 +361,13 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
         </div>
         ${saved != null && saved > 0 ? html`
           <div class="flex items-center gap-2">
-            <div class="flex-1 h-2 bg-[var(--white-8)] rounded-full overflow-hidden">
-              <div class="h-full bg-[#38bdf8] rounded-full" style="width: ${Math.min(ratio ?? 0, 100).toFixed(1)}%"></div>
-            </div>
+            <${ProgressBar}
+              pct=${ratio ?? 0}
+              size="md"
+              trackTone="muted"
+              trackClass="flex-1"
+              class="bg-[#38bdf8]"
+            />
             <span class="text-[10px] font-mono text-[#38bdf8]">-${saved.toLocaleString()}tok (${(ratio ?? 0).toFixed(0)}%)</span>
           </div>
         ` : null}


### PR DESCRIPTION
## Summary
- **ProgressBar primitive** — the canonical single-value \"how far along\" indicator. Distinct from \`DistributionBars\` (which stacks labeled segments); ProgressBar is the simple \`<div style=\"width:X%\">\` case.
- Reference UIs: GitHub repo-languages bar, Vercel deployment build step, Linear cycle progress, Stripe payout progress.
- Pre-change: 10+ inline call sites with drift on height (h-1 / h-1.5 / h-2) and track tone (--white-5 / --white-6 / --white-8). This PR extracts the primitive and wires 2 clean cases; remaining 8 deferred to later fires (each has bespoke tone/threshold helpers — one per /loop keeps diff bounded).

## Why split the work
One /loop fire ≠ \"absorb all 10 call sites\". Each has domain-specific logic (tool-metrics threshold colors, agent-roster ctxPct bands, keeper-memory tier colors). Shipping the primitive + 2 clean cases now unblocks followups and gives the primitive a real-world shakedown.

## Three axes, zero arbitrary hex inputs
| Axis | Values | Maps to |
|---|---|---|
| size | xs / sm / md | h-1 / h-1.5 / h-2 |
| tone | accent / ok / warn / bad + emerald / amber / rose / sky | bg-[var(--X)] / bg-X-500 |
| trackTone | default / dim / muted | --white-5 / --white-6 / --white-8 |

\`class\` prop overrides tone for bespoke bars (threshold-varying colors chosen by the caller — e.g. ctxPct > 85 → red, > 60 → warn, else ok).

## Clamping invariant
\`pct\` outside [0, 100] is clamped silently — no throw. Guards ratio math producing 101.2% or -0.5% without caller wrappers. \`data-progress-bar-pct\` is integer-rounded for clean E2E selectors.

## Accessibility
- **Default decorative** — \`aria-hidden=true\`, no role. Regression-guarded by a test; otherwise AT users hear \"progressbar, 50%\" duplicated when paired with an adjacent numeric text label.
- \`ariaLabel\` prop promotes to semantic: \`role=\"progressbar\"\` + \`aria-valuenow/min/max\`.

## Wiring
| File | Before | After |
|---|---|---|
| \`session-trace-entry.ts\`:363 | \`<div class=\"flex-1 h-2 bg-[var(--white-8)] rounded-full overflow-hidden\"><div class=\"h-full bg-[#38bdf8] rounded-full\" style=\"width:X%\">\` | \`<ProgressBar pct size=\"md\" trackTone=\"muted\" trackClass=\"flex-1\" class=\"bg-[#38bdf8]\" />\` |
| \`keeper-detail-panels.ts\`:438 | \`<div class=\"flex-1 h-1.5 bg-[var(--white-6)] rounded-full overflow-hidden\"><div class=\"h-full rounded-full bg-[var(--accent)]\" style=\"width:X%\">\` | \`<ProgressBar pct size=\"sm\" tone=\"accent\" trackTone=\"dim\" trackClass=\"flex-1\" />\` |

Byte-for-byte visual identity on both.

## Deferred wiring candidates
\`tool-metrics\` / \`agent-roster\` / \`keeper-memory-tier-panel\` / \`fsm-hub-timeline-panels\` / \`harness-health-sections\` / \`agent-detail-memory\`. Each has its own tone/threshold helper; individual extraction pass per /loop keeps diff reviewable.

## Test plan
- [x] Pure \`progressBarWidthStyle\` — 2-decimal precision, clamp < 0 and > 100.
- [x] Pure \`progressBarHeightClass\` / \`progressBarToneClass\` / \`progressBarTrackToneClass\` — each variant → expected Tailwind token.
- [x] Component — track + fill structure, data-progress-bar-pct integer rounding, decorative default (aria-hidden+no role), ariaLabel semantic promotion, tone via prop vs class override, title propagation, size data attr.
- [x] Typecheck clean; 19 new tests + session-trace-entry existing tests green.
- [ ] Manual smoke: \`npm run dev\` → #session-trace (compact overlay saved bar) + #keeper-detail (model request count) → visually identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)