### PR TITLE
feat(oas-drift): DX polish — auto-discover repo + surface status in doctor output

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -149,3 +149,56 @@ Use this checklist when reviewing boundary-touching PRs:
 2. If the problem is “room, board, governance, operator, workflow semantics”, keep it in MASC.
 3. If a bridge is lossy, fix the MASC-side adapter first before proposing OAS API expansion.
 4. Do not claim a subsystem is “migrated” if the runtime path works but key semantics are still dropped.
+
+## OAS API Surface Drift — Detection & Repair
+
+Two complementary mechanisms keep the OAS/MASC type boundary honest. Both are normal-path tools; neither requires remembering env vars for common usage.
+
+### Layer 1 — Fingerprint gate (`scripts/oas-drift-check.sh`)
+
+Dumps OAS public types at the pinned SHA (Event_bus variants / Http_client error variants / Metrics.t fields) and diffs against `scripts/oas-api-surface.json`. Runs automatically as a one-line summary inside `make doctor-oas-pin`:
+
+```
+OAS pin verified: main@92c3077a (base version v0.155.1)
+OAS API surface: ✓ matches fingerprint
+```
+
+Drift shows as `⚠ drift (added N, removed M) — run 'make doctor-oas-drift' for detail`. `make doctor-oas-drift` prints the section-grouped added/removed lists and the repair sequence.
+
+### Layer 2 — Type adapter (`lib/oas_compat/`)
+
+Consumer-side pattern matches against OAS variants and record literals against OAS records are consolidated in `lib/oas_compat/oas_compat.ml` (Http_client + Metrics so far; Event_bus pending). When OAS adds a variant or field, only this module fails to compile, not every consumer. Adding a new surface to the adapter requires both:
+
+1. Extend `oas_compat.mli` / `.ml` with the new projection
+2. Migrate call sites to use the adapter (one line each, usually)
+
+### Repair flow when drift is reported
+
+```bash
+# 1. Investigate: what actually changed upstream?
+make doctor-oas-drift                  # section-grouped added/removed
+
+# 2. Fix the consumer side (usually: update lib/oas_compat/oas_compat.ml
+#    so the adapter compiles against the new OAS; migrate any remaining
+#    call sites that match OAS types directly)
+
+# 3. Verify build is clean
+dune build @check
+
+# 4. Refresh the fingerprint and commit it together with the consumer change
+bash scripts/oas-drift-check.sh --regenerate
+git add scripts/oas-api-surface.json lib/
+git commit -m 'chore(oas): adopt <variant/field>, refresh surface fingerprint'
+```
+
+Regenerate-before-fix is an anti-pattern: the fingerprint must always describe a state where MASC consumers compile cleanly.
+
+### Source resolution (no manual config for common cases)
+
+`oas-drift-check.sh` auto-discovers the OAS checkout in this order:
+
+1. `$AGENT_SDK_LOCAL_REPO` (explicit override)
+2. `<masc-mcp-parent>/oas` (sibling checkout)
+3. `$HOME/me/workspace/yousleepwhen/oas` (workspace convention)
+
+Each candidate must be a git checkout at the pinned SHA. If none qualifies, the script falls back to `git fetch` into a temp bare clone from the upstream URL. Network is required only for that fallback.

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -210,3 +210,24 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
 else
   echo "OAS pin verified via override: ${pin_source}"
 fi
+
+# API surface summary (non-fatal). A full drift diff with repair
+# guidance is available via `make doctor-oas-drift` or
+# `bash scripts/oas-drift-check.sh`. Here we emit one line so that
+# every doctor-oas-pin run surfaces surface-level drift without
+# requiring the operator to remember a second command.
+if [[ -x "${SCRIPT_DIR}/oas-drift-check.sh" ]]; then
+  if drift_output="$(bash "${SCRIPT_DIR}/oas-drift-check.sh" 2>&1)"; then
+    echo "OAS API surface: ✓ matches fingerprint"
+  else
+    drift_exit=$?
+    if [[ "${drift_exit}" -eq 2 ]]; then
+      # Count delta entries across all sections for a one-line summary.
+      added_n="$(printf '%s\n' "${drift_output}" | grep -c '^      + ' || true)"
+      removed_n="$(printf '%s\n' "${drift_output}" | grep -c '^      - ' || true)"
+      echo "OAS API surface: ⚠ drift (added ${added_n}, removed ${removed_n}) — run 'make doctor-oas-drift' for detail"
+    else
+      echo "OAS API surface: (could not compute — ${drift_exit}; run 'bash scripts/oas-drift-check.sh' for detail)"
+    fi
+  fi
+fi

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -49,16 +49,38 @@ command -v jq >/dev/null 2>&1 || { echo "jq required" >&2; exit 1; }
 resolve_source_dir() {
   local out_var="$1"
 
+  # Candidate local repo paths, checked in order:
+  #   1. $AGENT_SDK_LOCAL_REPO (explicit opt-in)
+  #   2. Sibling checkout: <masc-mcp-parent>/oas
+  #   3. Workspace convention: $HOME/me/workspace/yousleepwhen/oas
+  # Each must be a git checkout at the pinned SHA to qualify.
+  local masc_parent
+  masc_parent="$(cd "${REPO_ROOT}/.." && pwd)"
+  local -a candidates=(
+    "${AGENT_SDK_LOCAL_REPO:-}"
+    "${masc_parent}/oas"
+    "${HOME}/me/workspace/yousleepwhen/oas"
+  )
+  local candidate head
+  for candidate in "${candidates[@]}"; do
+    [[ -n "${candidate}" && -d "${candidate}" ]] || continue
+    git -C "${candidate}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
+    head="$(git -C "${candidate}" rev-parse HEAD 2>/dev/null || true)"
+    if [[ "${head}" == "${OAS_AGENT_SDK_SHA}" ]]; then
+      printf -v "${out_var}" '%s' "${candidate}"
+      return 0
+    fi
+  done
+
+  # If $AGENT_SDK_LOCAL_REPO was set but at the wrong SHA, that's a
+  # deliberate override — surface it so the user can fix the checkout
+  # rather than silently falling through to network fetch.
   if [[ -n "${AGENT_SDK_LOCAL_REPO:-}" ]] \
      && git -C "${AGENT_SDK_LOCAL_REPO}" rev-parse --is-inside-work-tree \
         >/dev/null 2>&1; then
-    local head
-    head="$(git -C "${AGENT_SDK_LOCAL_REPO}" rev-parse HEAD 2>/dev/null || true)"
-    if [[ "${head}" == "${OAS_AGENT_SDK_SHA}" ]]; then
-      printf -v "${out_var}" '%s' "${AGENT_SDK_LOCAL_REPO}"
-      return 0
-    fi
-    echo "AGENT_SDK_LOCAL_REPO=${AGENT_SDK_LOCAL_REPO} is at ${head:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
+    local wrong_head
+    wrong_head="$(git -C "${AGENT_SDK_LOCAL_REPO}" rev-parse HEAD 2>/dev/null || true)"
+    echo "AGENT_SDK_LOCAL_REPO=${AGENT_SDK_LOCAL_REPO} is at ${wrong_head:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
     return 1
   fi
 
@@ -245,11 +267,13 @@ case "${MODE}" in
     echo
     echo "OAS API surface drift detected against ${FINGERPRINT_FILE}." >&2
     echo "  Review the delta above against MASC consumer sites:" >&2
-    echo "    lib/oas_sse_bridge.ml             (Event_bus payload matches)" >&2
-    echo "    lib/cascade/cascade_health_filter.ml  (http_error matches)" >&2
-    echo "    lib/oas_worker_cascade.ml         (Metrics.t literals)" >&2
-    echo "  After consumer changes land:" >&2
+    echo "    lib/oas_compat/oas_compat.ml      (Http_client + Metrics — single source)" >&2
+    echo "    lib/oas_sse_bridge.ml             (Event_bus payload matches — until adapter covers it)" >&2
+    echo
+    echo "  Repair flow (after consumer changes compile clean):" >&2
     echo "    bash scripts/oas-drift-check.sh --regenerate" >&2
+    echo "    git add scripts/oas-api-surface.json" >&2
+    echo "    git commit -m 'chore(oas): refresh API surface fingerprint'" >&2
     echo "    and commit the updated fingerprint." >&2
     exit 2
     ;;


### PR DESCRIPTION
## Summary

Three DX improvements layered on top of the drift gate (#8023) and Oas_compat adapter (#8037):

1. Auto-discover OAS repo (no more mandatory `$AGENT_SDK_LOCAL_REPO`)
2. Surface status line in `make doctor-oas-pin`
3. `docs/OAS-MASC-BOUNDARY.md` gains a self-documenting repair flow

## Product impact

- First run of `make doctor-oas-drift` just works from a normal masc-mcp checkout sibling-adjacent to an `oas/` checkout. Removes the "must read script source to find env var" friction.
- `make doctor-oas-pin` now reports surface drift as a one-liner — operators discover drift through their existing workflow, not a new one.
- Clearer repair message includes the full git add/commit sequence so drift PRs have a uniform shape.

## Why

Tool adoption scales with DX, not capability. PR #8023 gave us capability (variant diff). Without auto-discovery + integrated surface status, operators would have to remember (a) the command name, (b) the env var, (c) the regenerate flow. Each extra fact is an adoption tax. This PR eliminates a-c for the common case.

Claude Code's `mcpInstructionsDelta.ts` — the design reference for the fingerprint gate — reached adoption because the delta was surfaced by default, not by opt-in. Same principle here.

## Evidence

\`\`\`
$ make doctor-oas-pin | tail -2
OAS pin verified: main@92c3077a (base version v0.155.1)
OAS API surface: ✓ matches fingerprint

$ # simulate drift → restore
$ jq '.surfaces.http_error_variants += ["FakeError"]' scripts/oas-api-surface.json > /tmp/x && mv /tmp/x scripts/oas-api-surface.json
$ make doctor-oas-pin | tail -2
OAS pin verified: main@92c3077a (base version v0.155.1)
OAS API surface: ⚠ drift (added 0, removed 1) — run 'make doctor-oas-drift' for detail

$ # Auto-discover: no env var, sibling path works
$ (unset AGENT_SDK_LOCAL_REPO; bash scripts/oas-drift-check.sh)
OAS API surface matches fingerprint (pinned_sha=92c3077a...)
\`\`\`

## Review evidence

- Self-review; scripts + docs only, no runtime code changes
- Reviewer focus request:
  - Verify the candidate path list in `resolve_source_dir` doesn't accidentally pick up a wrong-SHA checkout (each candidate gates on `git rev-parse HEAD == pinned_sha`)
  - Confirm the non-fatal exit semantics in `check-oas-pin.sh` — a drift report should NOT fail the doctor command (the dedicated `make doctor-oas-drift` fails-hard; the combined pin doctor only informs)

## Scope boundaries

- No CI workflow changes — adoption stays voluntary until the team normalizes on the regenerate flow
- No new Makefile targets — the existing `make doctor-oas-pin` gains the informational line
- OAS-side changes: none

## Linked issue

Refs PR #8023 (fingerprint gate — DX this PR improves)
Refs PR #8037 (type adapter — repair message now points at it)
Refs \`memory/feedback_oas-pin-bump-drift-gate.md\`

## Test plan

- [x] Clean path reports "✓ matches fingerprint"
- [x] Simulated drift reports "⚠ drift (added N, removed M)"
- [x] Auto-discover works without AGENT_SDK_LOCAL_REPO
- [x] Doctor exit code remains 0 on drift (non-fatal as designed)
- [ ] CI lint on modified scripts
- [ ] Reviewer sanity-check candidate path ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)