### PR TITLE
feat(dashboard): ▶ explicit Start/Stop button on every connector tile

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -12,6 +12,7 @@ import {
   updateStripMemory,
   detectRecentDrops,
   summarizeConnectorStrip,
+  tilePrimaryActionView,
 } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
@@ -334,5 +335,100 @@ describe('stripMemory pure helpers', () => {
       60_000,
     )
     expect(dropped).toEqual([])
+  })
+})
+
+describe('tilePrimaryActionView (pure)', () => {
+  it('sidecar down, not inflight → Start (emerald), not busy', () => {
+    expect(tilePrimaryActionView(false, false)).toEqual({
+      label: '▶ Start', tone: 'start', busy: false,
+    })
+  })
+
+  it('sidecar down, inflight → 시작 중... (start tone, busy)', () => {
+    expect(tilePrimaryActionView(false, true)).toEqual({
+      label: '시작 중...', tone: 'start', busy: true,
+    })
+  })
+
+  it('sidecar up, not inflight → Stop (rose), not busy', () => {
+    expect(tilePrimaryActionView(true, false)).toEqual({
+      label: '■ Stop', tone: 'stop', busy: false,
+    })
+  })
+
+  it('sidecar up, inflight → 정지 중... (stop tone, busy)', () => {
+    expect(tilePrimaryActionView(true, true)).toEqual({
+      label: '정지 중...', tone: 'stop', busy: true,
+    })
+  })
+})
+
+describe('TilePrimaryAction component (rendered inside ConnectorOverviewStrip)', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetBulkInflight()
+    _testResetStripMemory()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a Start button (emerald) for a down sidecar', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: false })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const btn = container.querySelector('[data-tile-primary-action="discord"]') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    expect(btn.getAttribute('data-tile-primary-action-tone')).toBe('start')
+    expect(btn.textContent?.trim()).toBe('▶ Start')
+    expect(btn.className).toContain('emerald')
+  })
+
+  it('renders a Stop button (rose) for an up sidecar', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'discord', available: true })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const btn = container.querySelector('[data-tile-primary-action="discord"]') as HTMLButtonElement
+    expect(btn.getAttribute('data-tile-primary-action-tone')).toBe('stop')
+    expect(btn.textContent?.trim()).toBe('■ Stop')
+    expect(btn.className).toContain('rose')
+  })
+
+  it('aria-label names the connector + action (screen-reader parity)', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ connector_id: 'slack', available: false })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const btn = container.querySelector('[data-tile-primary-action="slack"]')!
+    expect(btn.getAttribute('aria-label')).toBe('slack sidecar 시작')
+  })
+
+  it('every known tile gets a primary action button (no missing rows)', () => {
+    // Regression guard: adding a 5th bridge must not leave three tiles
+    // with buttons and one tile without (asymmetric view that would
+    // be hard to spot visually).
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.querySelectorAll('[data-tile-primary-action]').length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -201,8 +201,73 @@ function OverviewTile({ id, connector, keeperCount }: {
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
+      <${TilePrimaryAction} id=${id} sidecarUp=${sidecarUp} />
       <${TileHeartbeatStrip} id=${id} />
     </div>
+  `
+}
+
+/** Pure: derive the primary-action button label/tone from the sidecar
+    state + inflight flag. Exposed so tests pin the four combinations
+    without mounting the component. */
+export interface TilePrimaryActionView {
+  label: string
+  tone: 'start' | 'stop'
+  busy: boolean
+}
+export function tilePrimaryActionView(
+  sidecarUp: boolean,
+  inflight: boolean,
+): TilePrimaryActionView {
+  if (sidecarUp) {
+    return {
+      label: inflight ? '정지 중...' : '■ Stop',
+      tone: 'stop',
+      busy: inflight,
+    }
+  }
+  return {
+    label: inflight ? '시작 중...' : '▶ Start',
+    tone: 'start',
+    busy: inflight,
+  }
+}
+
+const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
+  // Emerald tokens match BulkActions "Start All" — one color vocabulary
+  // across per-tile + bulk controls. The per-tile button is deliberately
+  // block-width and text-[12px] so it reads as the primary action of the
+  // tile, distinct from the smaller pill row above.
+  start: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-100 hover:bg-emerald-500/25',
+  stop: 'border-rose-400/40 bg-rose-500/15 text-rose-100 hover:bg-rose-500/25',
+}
+
+/** The prominent per-tile Start/Stop button. Reference UIs (Vercel
+    service card, Railway deployment card, Uptime Kuma monitor row):
+    the tile's primary action should live as a full-width button near
+    the tile footer, not buried inside a process/readiness pill. The
+    readiness rail pills above still toggle process state for
+    keyboard-forward operators, but a new operator scanning the page
+    reads "Start" as the obvious next step. */
+function TilePrimaryAction({ id, sidecarUp }: { id: KnownConnectorId; sidecarUp: boolean }) {
+  const inflight = getRailInflight(id).process === true
+  const view = tilePrimaryActionView(sidecarUp, inflight)
+  const tone = TILE_ACTION_TONE_CLASS[view.tone]
+  return html`
+    <button
+      type="button"
+      class=${`w-full cursor-pointer rounded-md border px-2 py-1.5 text-[12px] font-semibold tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${tone}`}
+      disabled=${view.busy}
+      aria-busy=${view.busy ? 'true' : 'false'}
+      aria-label=${sidecarUp ? `${id} sidecar 정지` : `${id} sidecar 시작`}
+      onClick=${() => {
+        void withRailInflight(id, 'process', () =>
+          sidecarUp ? stopSidecar(id) : startSidecar(id),
+        )
+      }}
+      data-tile-primary-action=${id}
+      data-tile-primary-action-tone=${view.tone}
+    >${view.label}</button>
   `
 }
 


### PR DESCRIPTION
## Summary
- Full-width **Start/Stop button** on every connector overview tile. Was: toggle buried inside the readiness rail \"process\" pill — invisible to new operators. Now: the tile's primary action reads as an obvious CTA just above the heartbeat strip.
- **잘 보이고 잘 입력** — feedback-driven: dashboard의 목표는 meta-discoverability가 아니라 명확한 CTA. 이 PR은 숨어있던 action을 노출만.

## Reference UIs
- **Vercel service card** — full-width primary deploy button.
- **Railway deployment card** — clear Start/Stop control at tile footer.
- **Uptime Kuma monitor row** — explicit Pause/Resume button.
- **Common thread**: the tile's primary action is a block-level, tone-coded button; decorative pills/rails come above it but don't replace it.

## Visual placement
\`\`\`
┌───── Overview Tile ──────┐
│ 🟢 Discord · 5m uptime   │
│ [Ready] [Gate] [Proc]    │  ← readiness rail (unchanged)
│ ┌─────────────────────┐  │
│ │  ▶ Start            │  │  ← NEW: primary action
│ └─────────────────────┘  │
│ [▲ UP × 22] [💯 100%]   │
│ ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰        │
└──────────────────────────┘
\`\`\`

## Four states (pure helper + tests)
\`tilePrimaryActionView(sidecarUp, inflight)\` pinned by 4 tests:

| sidecarUp | inflight | label | tone | busy |
|---|---|---|---|---|
| false | false | \`▶ Start\` | start (emerald) | false |
| false | true  | \`시작 중...\` | start | true |
| true  | false | \`■ Stop\` | stop (rose) | false |
| true  | true  | \`정지 중...\` | stop | true |

## Inflight wiring
Reuses existing \`withRailInflight(id, 'process', …)\` so the pill + the new button share one inflight flag — no divergent loading states between the two affordances.

When busy:
- \`disabled={true}\` — click-locked.
- \`aria-busy={true}\` — screen reader hears \"busy\" not just silence.

## Color vocabulary
Emerald/rose tokens match existing **BulkActions** (\"Start All\" / \"Stop All\") so per-tile + bulk buttons speak the same color language. No new tone invented.

## Additive, not replacing
The readiness rail pills above are preserved. Keyboard-forward operators who already learned the pill toggle keep it; new operators scanning the page now see an obvious CTA.

## Regression guards
- Emerald Start for down sidecar.
- Rose Stop for up sidecar.
- \`aria-label\`: \"{id} sidecar {시작|정지}\" — screen reader parity with visible label.
- Every known tile gets a button (guard against adding a 5th bridge that accidentally leaves one tile asymmetric).

## Test plan
- [x] 8 new tests (4 pure + 4 component), connector-overview-strip suite 27 → 35 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → stop discord sidecar → tile goes down → \"▶ Start\" button appears emerald → click → \"시작 중...\" + disabled during boot → button flips to rose \"■ Stop\" when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)