### PR TITLE
feat(dashboard): ⚠ surface connector.error + stale on each tile

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -16,6 +16,7 @@ import {
   formatTileIdentityLine,
   offlineConnectorNames,
   formatOfflineConnectorLabel,
+  deriveTileNotice,
 } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
@@ -631,5 +632,134 @@ describe('StatusSummaryLine offline annotation (rendered inside ConnectorOvervie
     expect(annotation).toBeTruthy()
     expect(annotation.textContent).toContain('Slack offline')
     expect(annotation.className).toContain('rose')
+  })
+})
+
+describe('deriveTileNotice (pure)', () => {
+  it('null connector → null notice (empty grid cell, no ribbon)', () => {
+    expect(deriveTileNotice(null)).toBeNull()
+  })
+
+  it('clean connector (no error, not stale) → null', () => {
+    expect(deriveTileNotice(mkConnector({ error: '', stale: false }))).toBeNull()
+  })
+
+  it('non-empty error → rose notice with the error text', () => {
+    const notice = deriveTileNotice(mkConnector({
+      error: 'Discord gateway timeout',
+      stale: false,
+    }))
+    expect(notice).toEqual({
+      tone: 'error',
+      label: 'Error',
+      detail: 'Discord gateway timeout',
+    })
+  })
+
+  it('whitespace-only error is ignored (no false positives)', () => {
+    expect(deriveTileNotice(mkConnector({ error: '   ' }))).toBeNull()
+  })
+
+  it('stale without error → amber notice with threshold hint', () => {
+    const notice = deriveTileNotice(mkConnector({
+      error: '',
+      stale: true,
+      stale_after_sec: 60,
+    }))
+    expect(notice).toEqual({
+      tone: 'stale',
+      label: 'Stale',
+      detail: '데이터 오래됨 (60s threshold)',
+    })
+  })
+
+  it('stale without threshold → amber notice, no (Xs threshold) suffix', () => {
+    const notice = deriveTileNotice(mkConnector({
+      error: '',
+      stale: true,
+      stale_after_sec: 0,
+    }))
+    expect(notice?.detail).toBe('데이터 오래됨')
+  })
+
+  it('error beats stale when both truthy (explicit error is more diagnostic)', () => {
+    // Regression guard: an explicit error message is strictly more
+    // diagnostic than a generic \"data is old\" flag. If both fire, the
+    // operator sees the error first.
+    const notice = deriveTileNotice(mkConnector({
+      error: 'auth failed',
+      stale: true,
+    }))
+    expect(notice?.tone).toBe('error')
+    expect(notice?.detail).toBe('auth failed')
+  })
+})
+
+describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetBulkInflight()
+    _testResetStripMemory()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a rose notice ribbon when the connector reports an error', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({
+          connector_id: 'discord',
+          available: true,
+          error: 'WebSocket closed 4004',
+        })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const notice = container.querySelector('[data-tile-notice="error"]') as HTMLElement
+    expect(notice).toBeTruthy()
+    expect(notice.textContent).toContain('Error')
+    expect(notice.textContent).toContain('WebSocket closed 4004')
+    expect(notice.className).toContain('rose')
+    expect(notice.getAttribute('role')).toBe('alert')
+  })
+
+  it('renders an amber notice ribbon when the connector is stale without error', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({
+          connector_id: 'discord',
+          available: true,
+          error: '',
+          stale: true,
+          stale_after_sec: 30,
+        })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const notice = container.querySelector('[data-tile-notice="stale"]') as HTMLElement
+    expect(notice.textContent).toContain('Stale')
+    expect(notice.className).toContain('amber')
+  })
+
+  it('renders nothing when connector is clean (no ribbon clutter)', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({
+          connector_id: 'discord',
+          available: true,
+          error: '',
+          stale: false,
+        })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-tile-notice]')).toBeNull()
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -212,6 +212,7 @@ function OverviewTile({ id, connector, keeperCount }: {
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
       <${TilePrimaryAction} id=${id} sidecarUp=${sidecarUp} />
+      <${TileErrorNotice} connector=${connector} />
       <${TileHeartbeatStrip} id=${id} />
     </div>
   `
@@ -301,6 +302,77 @@ function TilePrimaryAction({ id, sidecarUp }: { id: KnownConnectorId; sidecarUp:
       data-tile-primary-action=${id}
       data-tile-primary-action-tone=${view.tone}
     >${view.label}</button>
+  `
+}
+
+/** Pure: derive a single notice view from the connector runtime state.
+    Returns null when nothing notable is happening. Priority:
+    error (non-empty) > stale (stale=true). Error beats stale because
+    an explicit error message is strictly more diagnostic than a
+    \"data is old\" flag; callers that want both must render both. */
+export interface TileNoticeView {
+  tone: 'error' | 'stale'
+  label: string
+  detail: string
+}
+export function deriveTileNotice(
+  connector: GateConnectorInfo | null,
+): TileNoticeView | null {
+  if (connector === null) return null
+  const err = connector.error?.trim() ?? ''
+  if (err !== '') {
+    return {
+      tone: 'error',
+      label: 'Error',
+      detail: err,
+    }
+  }
+  if (connector.stale === true) {
+    const secs = connector.stale_after_sec
+    const ageHint = secs > 0 ? ` (${secs}s threshold)` : ''
+    return {
+      tone: 'stale',
+      label: 'Stale',
+      detail: `데이터 오래됨${ageHint}`,
+    }
+  }
+  return null
+}
+
+const TILE_NOTICE_TONE_CLASS: Record<'error' | 'stale', string> = {
+  // Rose for hard errors (sidecar reported an explicit failure),
+  // amber for stale (data hasn't refreshed but no explicit error).
+  // Matches Sentry \"issue\" rose + Vercel \"warning\" amber convention.
+  error: 'border-rose-400/40 bg-rose-500/10 text-rose-100',
+  stale: 'border-amber-400/40 bg-amber-500/10 text-amber-100',
+}
+
+const TILE_NOTICE_GLYPH: Record<'error' | 'stale', string> = {
+  error: '⚠',
+  stale: '⧗',
+}
+
+/** Surfaces connector.error / connector.stale on the tile so operators
+    scanning the page see them without drilling into the detailed
+    panel. Currently these fields are only visible in the per-connector
+    live-panel below — easy to miss until you click into it. */
+function TileErrorNotice({ connector }: { connector: GateConnectorInfo | null }) {
+  const notice = deriveTileNotice(connector)
+  if (notice === null) return null
+  const tone = TILE_NOTICE_TONE_CLASS[notice.tone]
+  const glyph = TILE_NOTICE_GLYPH[notice.tone]
+  return html`
+    <div
+      class=${`flex min-w-0 items-center gap-1.5 rounded-md border px-2 py-1 text-[10px] ${tone}`}
+      role="alert"
+      aria-label=${`${notice.label}: ${notice.detail}`}
+      title=${notice.detail}
+      data-tile-notice=${notice.tone}
+    >
+      <span aria-hidden="true" class="shrink-0">${glyph}</span>
+      <span class="shrink-0 font-semibold uppercase tracking-[0.1em]">${notice.label}</span>
+      <span class="min-w-0 truncate font-normal normal-case tracking-normal opacity-80">${notice.detail}</span>
+    </div>
   `
 }
 


### PR DESCRIPTION
## Summary
- The backend already reports \`connector.error\` (auth failures, gateway closed, etc.) and \`connector.stale\` (data hasn't refreshed within the connector's threshold). Both were only visible inside the per-connector live panel (one click away).
- This PR hoists both fields into a small inline ribbon on each overview tile so scanning the page surfaces the state immediately. **잘 보이고 잘 입력** — if the source of truth already carries the bad news, the overview surface shows it.

## Reference UIs
- **Sentry issue row** — rose error ribbon with the failure reason.
- **Vercel deployment card** — amber warning banner when a build is degraded.
- **Uptime Kuma monitor** — last-failure reason inline with the monitor row.
- **Common thread**: operators should never have to click into details to learn something bad is happening.

## Visual placement
\`\`\`
┌───── Overview Tile ──────┐
│ 🟢 Discord · 5m uptime   │
│ [Ready] [Gate] [Proc]    │
│ ┌─ ⚠ Error: WS closed ─┐ │  ← NEW: rose ribbon on error
│ │ ▶ Start              │ │
│ │ [▲ UP × 22] [💯]    │ │
│ │ ▰▰▰▰▰▰▰▰▰▰▰▰       │ │
└──────────────────────────┘
\`\`\`

## Pure \`deriveTileNotice(connector)\` — 7 invariants pinned by tests

| Condition | Output |
|---|---|
| \`connector === null\` | \`null\` |
| clean (no error, not stale) | \`null\` |
| \`error = 'WS 4004'\` | \`{ tone: 'error', label: 'Error', detail: 'WS 4004' }\` |
| whitespace-only error | \`null\` (no false positives) |
| \`stale=true, stale_after_sec=60\` | \`{ tone: 'stale', label: 'Stale', detail: '데이터 오래됨 (60s threshold)' }\` |
| \`stale=true, stale_after_sec=0\` | \`detail: '데이터 오래됨'\` (no \"(0s)\" noise) |
| error + stale both truthy | error wins (explicit > generic) |

## Tone vocabulary
- **Rose** for hard \`error\` — Sentry convention.
- **Amber** for \`stale\` — Vercel warning convention.
- Matches the existing incident banner (rose) + stale indicators elsewhere in the codebase.

## Accessibility
- \`role=\"alert\"\` — screen readers announce new errors as they appear.
- \`aria-label\` carries the full narrative (\"Error: WebSocket closed 4004\"), not just \"alert\".
- \`title\` duplicates detail for hover — long error strings cross-checkable without truncation.

## Test plan
- [x] 10 new tests (7 pure + 3 component), connector-overview-strip suite 27 → 37 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → kill discord sidecar network briefly → tile ribbon appears with error text → restore → ribbon clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)