### PR TITLE
chore(dashboard): purge 3 dead normalizers/factories (-77 LOC)

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -196,27 +196,6 @@ export function normalizeGovernanceTimelineEvent(raw: unknown): GovernanceTimeli
   }
 }
 
-export function normalizeGovernanceExecutionOrder(raw: unknown): {
-  id: string
-  case_id: string
-  status: string
-  risk_class?: string
-  created_at?: string
-  actor?: string
-} | null {
-  if (!isRecord(raw)) return null
-  const id = asNullableString(raw.id)
-  const case_id = asNullableString(raw.case_id)
-  if (!id || !case_id) return null
-  return {
-    id,
-    case_id,
-    status: asNullableString(raw.status) ?? 'blocked',
-    risk_class: asNullableString(raw.risk_class) ?? undefined,
-    created_at: asNullableString(raw.created_at) ?? undefined,
-    actor: asNullableString(raw.actor) ?? undefined,
-  }
-}
 
 export function normalizeGovernanceJudgeSummary(raw: unknown): GovernanceJudgeSummary | undefined {
   if (!isRecord(raw)) return undefined

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -3,7 +3,7 @@ import type {
   Agent, Task, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
   DashboardExecutionQueueItem, DashboardExecutionSessionBrief,
-  DashboardExecutionOperationBrief, DashboardExecutionWorkerSupportBrief,
+  DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
@@ -242,28 +242,6 @@ export function normalizeExecutionSessionBrief(raw: unknown): DashboardExecution
   }
 }
 
-export function normalizeExecutionOperationBrief(raw: unknown): DashboardExecutionOperationBrief | null {
-  if (!isRecord(raw)) return null
-  const operationId = asString(raw.operation_id)
-  const objective = asString(raw.objective)
-  if (!operationId || !objective) return null
-  return {
-    operation_id: operationId,
-    objective,
-    status: asString(raw.status),
-    stage: asString(raw.stage) ?? null,
-    assigned_unit_id: asString(raw.assigned_unit_id) ?? null,
-    assigned_unit_label: asString(raw.assigned_unit_label) ?? null,
-    linked_session_id: asString(raw.linked_session_id) ?? null,
-    linked_detachment_id: asString(raw.linked_detachment_id) ?? null,
-    blocker_summary: asString(raw.blocker_summary) ?? null,
-    search_status: asString(raw.search_status) ?? null,
-    next_tool: asString(raw.next_tool) ?? null,
-    updated_at: asString(raw.updated_at) ?? null,
-    top_handoff: normalizeExecutionHandoff(raw.top_handoff),
-    command_handoff: normalizeExecutionHandoff(raw.command_handoff),
-  }
-}
 
 export function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExecutionWorkerSupportBrief | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -202,39 +202,6 @@ export function createMissionWorkflowContext(
   }
 }
 
-export function createExecutionWorkflowContext({
-  targetType,
-  targetId,
-  focusKind,
-  sourceLabel = 'Execution 진단',
-  summary,
-  operationId = null,
-}: {
-  targetType: string
-  targetId: string
-  focusKind: string
-  sourceLabel?: string
-  summary: string
-  operationId?: string | null
-}): DashboardWorkflowContext {
-  const createdAt = new Date().toISOString()
-  return {
-    id: workflowContextId('execution', sourceLabel, null, targetType, targetId, focusKind, operationId, createdAt),
-    source_surface: 'execution',
-    source_label: sourceLabel,
-    action_type: null,
-    target_type: targetType,
-    target_id: targetId,
-    focus_kind: focusKind,
-    operation_id: operationId,
-    summary,
-    payload_preview: null,
-    suggested_payload: null,
-    preview: null,
-    evidence: null,
-    created_at: createdAt,
-  }
-}
 
 function matchesRouteParams(
   context: DashboardWorkflowContext,


### PR DESCRIPTION
## Summary

`/loop 20m` Gen48. Strict scan(total refs=1)으로 확정한 **3개 dead function**을 3개 파일에서 surgical 제거. 각 함수는 legacy pipeline의 잔재.

## 제거 대상

| 파일 | 함수 | LOC | 배경 |
|---|---|---|---|
| `api/board.ts` | `normalizeGovernanceExecutionOrder` | -21 | Gen43 legacy decoders 제거 후 잔여 normalizer |
| `store-normalizers.ts` | `normalizeExecutionOperationBrief` | -22 | Gen37에서 executionOperationBriefs signal 제거 후 orphan |
| `workflow-context.ts` | `createExecutionWorkflowContext` | -33 | Execution 진단 factory — 호출자 0 (mission variant만 alive) |
| (bonus) `store-normalizers.ts` | type import | -1 | `DashboardExecutionOperationBrief` orphan |
| **합계** | | **-77** | |

## 연쇄 정리 맥락

3 함수 모두 이전 cycle의 **cleanup fallout**:
- Gen37 (#8027): writeonly execution signals 제거 → `normalizeExecutionOperationBrief`가 caller 0 됨
- Gen43 (#8051): legacy gate decoders 제거 → `normalizeGovernanceExecutionOrder` 동일 패턴 잔여
- Gen47 (#8069): mission-utils purge → `createExecutionWorkflowContext`(execution sibling) 만 남음

이번 Gen48이 세 개를 묶어 파이널라이즈.

## 검증

- `tsc --noEmit`: ✅ error 0 (orphan type import 1건 추가 정리)
- `bun run build`: ✅ 7.39s
- `bun run test`: ✅ **3538 tests pass**
  - `saved-signal.test.ts` 9 fails: pre-existing (PR #8014)

## 검증 근거

```
$ grep -rn "\b<sym>\b" dashboard/src/
normalizeGovernanceExecutionOrder: 1 (declaration only)
normalizeExecutionOperationBrief: 1 (declaration only)
createExecutionWorkflowContext: 1 (declaration only)
```

## /loop 스택 (Gen36~48)

Gen36-46 MERGED. Gen47 (#8069) OPEN. Gen48 (이 PR) Draft.

## 다음 cycle 후보

Strict scan 재실행 필요 — Gen47/48 머지 후 어떤 함수가 새로 drop될지 확인. 특히 `createMissionWorkflowContext`의 비대칭 (mission만 alive)이 남아있으면 다음 cleanup target.

- Gen49: `runtime-monitor.ts` 4 fns 재검증 (이전에 non-test=1 오판 가능성)
- Gen50: CSS 중복 블록 통합
- Gen51: strict scan 재실행으로 새 타깃 발굴

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)