### PR TITLE
feat(dashboard): 🪪 identity line on tile — "as @bot · N guilds" subtitle

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -13,6 +13,7 @@ import {
   detectRecentDrops,
   summarizeConnectorStrip,
   tilePrimaryActionView,
+  formatTileIdentityLine,
 } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
@@ -430,5 +431,99 @@ describe('TilePrimaryAction component (rendered inside ConnectorOverviewStrip)',
       container,
     )
     expect(container.querySelectorAll('[data-tile-primary-action]').length).toBeGreaterThanOrEqual(4)
+  })
+})
+
+describe('formatTileIdentityLine (pure)', () => {
+  it('null connector → null (no row rendered)', () => {
+    expect(formatTileIdentityLine(null)).toBeNull()
+  })
+
+  it('bot only → \"as @bot\"', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: 'claude-bot',
+      guild_count: 0,
+    }))).toBe('as @claude-bot')
+  })
+
+  it('guilds only → \"N guilds\" (plural)', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: '',
+      guild_count: 3,
+    }))).toBe('3 guilds')
+  })
+
+  it('singular guild → \"1 guild\" (no plural suffix)', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: '',
+      guild_count: 1,
+    }))).toBe('1 guild')
+  })
+
+  it('bot + guilds → joined with bullet separator', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: 'claude-bot',
+      guild_count: 4,
+    }))).toBe('as @claude-bot · 4 guilds')
+  })
+
+  it('whitespace-only bot is ignored (no \"as @\" ghost)', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: '   ',
+      guild_count: 0,
+    }))).toBeNull()
+  })
+
+  it('both empty → null (no clutter row when nothing to show)', () => {
+    expect(formatTileIdentityLine(mkConnector({
+      bot_user_name: '',
+      guild_count: 0,
+    }))).toBeNull()
+  })
+})
+
+describe('Tile identity line (rendered inside ConnectorOverviewStrip)', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetBulkInflight()
+    _testResetStripMemory()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders identity line when bot_user_name is set', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({
+          connector_id: 'discord',
+          bot_user_name: 'claude-bot',
+          guild_count: 2,
+        })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const line = container.querySelector('[data-tile-identity="discord"]')!
+    expect(line.textContent).toBe('as @claude-bot · 2 guilds')
+    expect(line.getAttribute('title')).toBe('as @claude-bot · 2 guilds')
+  })
+
+  it('omits identity line when both fields are empty', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({
+          connector_id: 'discord',
+          bot_user_name: '',
+          guild_count: 0,
+        })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-tile-identity="discord"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -198,6 +198,16 @@ function OverviewTile({ id, connector, keeperCount }: {
                 `
               : null}
           </span>
+          ${(() => {
+            const identity = formatTileIdentityLine(connector)
+            return identity !== null
+              ? html`<span
+                  class="block truncate text-[10px] text-[var(--text-dim)]"
+                  data-tile-identity=${id}
+                  title=${identity}
+                >${identity}</span>`
+              : null
+          })()}
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
@@ -205,6 +215,29 @@ function OverviewTile({ id, connector, keeperCount }: {
       <${TileHeartbeatStrip} id=${id} />
     </div>
   `
+}
+
+/** Pure: single-line identity summary for the tile — \"as @bot · N guilds\"
+    style. Composes bot_user_name + guild_count into one truncate-safe
+    string. Returns null when neither field has anything to show, so
+    the caller renders nothing instead of an empty row.
+
+    Why both on one line: tile vertical space is tight. A dedicated
+    \"reach\" chip would add a whole new visual band; a compact subtitle
+    line sits inside the existing header block. Reference: Stripe row
+    subtitle \"paid · \$12.50\" / Linear issue row \"in Backlog · 3h\". */
+export function formatTileIdentityLine(
+  connector: GateConnectorInfo | null,
+): string | null {
+  if (connector === null) return null
+  const parts: string[] = []
+  const bot = connector.bot_user_name?.trim() ?? ''
+  if (bot !== '') parts.push(`as @${bot}`)
+  const guilds = connector.guild_count ?? 0
+  if (guilds > 0) {
+    parts.push(`${guilds} ${guilds === 1 ? 'guild' : 'guilds'}`)
+  }
+  return parts.length === 0 ? null : parts.join(' · ')
 }
 
 /** Pure: derive the primary-action button label/tone from the sidecar


### PR DESCRIPTION
## Summary
- **Compact subtitle line** under each tile's status row: \`as @bot_user_name · N guilds\`. Surfaces identity + reach fields that previously only lived in the per-connector live panel.
- **잘 보이고 잘 입력** — operators scanning the strip can now answer \"which identity is connected?\" and \"how many workspaces does this cover?\" without drilling down.

## Reference UIs
- **Stripe row subtitle** — \"paid · \$12.50\".
- **Linear issue row** — \"in Backlog · 3h\".
- **Slack sidebar workspace card** — \"username · 3 channels\".
- **Common thread**: a tight subtitle beneath title/status gives context without adding a new visual band. Tiles are vertically scarce, so a dedicated \"reach\" chip would bloat the grid.

## Visual placement
\`\`\`
┌───── Overview Tile ──────┐
│ 🟢 Discord               │
│ connected · up 5m        │
│ as @claude-bot · 2 guilds│  ← NEW subtitle
│ [Ready] [Gate] [Proc]    │
│ ▶ Start                  │
│ ...                      │
└──────────────────────────┘
\`\`\`

## Pure \`formatTileIdentityLine(connector)\` — 7 invariants pinned

| Condition | Output |
|---|---|
| \`connector === null\` | \`null\` (no ghost row) |
| both empty | \`null\` |
| \`bot_user_name = 'claude-bot'\`, \`guild_count = 0\` | \`'as @claude-bot'\` |
| \`bot_user_name = ''\`, \`guild_count = 3\` | \`'3 guilds'\` (plural) |
| \`guild_count = 1\` | \`'1 guild'\` (singular) |
| both present | \`'as @claude-bot · 4 guilds'\` |
| whitespace-only bot | \`null\` (no false-positive \"as @\" ghost) |

## Rendering details
- Single-line, \`block truncate\` — long bot names don't wrap into a multi-line row.
- \`title\` attribute duplicates full text for hover — long bot names survive overflow without losing the narrative.
- \`data-tile-identity=<id>\` attribute for E2E selectors.

## Test plan
- [x] 9 new tests (7 pure + 2 component). Suite 35 → 44 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → connector panel → each tile's subtitle shows the bot identity and guild count matching the panel's detail block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)