### PR TITLE
feat(dashboard): 🏷 name the offline connectors inline on the strip summary

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -14,6 +14,8 @@ import {
   summarizeConnectorStrip,
   tilePrimaryActionView,
   formatTileIdentityLine,
+  offlineConnectorNames,
+  formatOfflineConnectorLabel,
 } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
@@ -525,5 +527,109 @@ describe('Tile identity line (rendered inside ConnectorOverviewStrip)', () => {
       container,
     )
     expect(container.querySelector('[data-tile-identity="discord"]')).toBeNull()
+  })
+})
+
+describe('offlineConnectorNames (pure)', () => {
+  it('empty connectors → []', () => {
+    expect(offlineConnectorNames([])).toEqual([])
+  })
+
+  it('all up → [] (no offline to annotate)', () => {
+    expect(offlineConnectorNames([
+      mkConnector({ connector_id: 'discord', available: true }),
+      mkConnector({ connector_id: 'slack', available: true }),
+    ])).toEqual([])
+  })
+
+  it('marks observed-but-offline connectors by display name', () => {
+    expect(offlineConnectorNames([
+      mkConnector({ connector_id: 'discord', available: true }),
+      mkConnector({ connector_id: 'slack', available: false }),
+    ])).toEqual(['Slack'])
+  })
+
+  it('multiple offline returned in canonical tile order (not input order)', () => {
+    // Input order: [slack, discord] (reversed from KNOWN_CONNECTOR_IDS).
+    // Expected output: canonical order [Discord, Slack] — matches the
+    // visual scan path below the summary line.
+    expect(offlineConnectorNames([
+      mkConnector({ connector_id: 'slack', available: false }),
+      mkConnector({ connector_id: 'discord', available: false }),
+    ])).toEqual(['Discord', 'Slack'])
+  })
+
+  it('connector not yet observed (absent from array) is not marked offline', () => {
+    // Regression guard: \"missing\" is ambiguous — could be bootstrapping.
+    // Only mark offline when we've actually seen available=false.
+    expect(offlineConnectorNames([])).toEqual([])
+  })
+})
+
+describe('formatOfflineConnectorLabel (pure)', () => {
+  it('empty → null (no annotation when all are up)', () => {
+    expect(formatOfflineConnectorLabel([])).toBeNull()
+  })
+
+  it('single → \"Name offline\"', () => {
+    expect(formatOfflineConnectorLabel(['Slack'])).toBe('Slack offline')
+  })
+
+  it('two → \"A · B offline\" (both listed)', () => {
+    expect(formatOfflineConnectorLabel(['Discord', 'Slack'])).toBe('Discord · Slack offline')
+  })
+
+  it('three+ → first two listed + \"+N offline\" overflow (Statuspage convention)', () => {
+    expect(formatOfflineConnectorLabel(['Discord', 'Slack', 'Telegram']))
+      .toBe('Discord · Slack · +1 offline')
+    expect(formatOfflineConnectorLabel(['Discord', 'Slack', 'Telegram', 'iMessage']))
+      .toBe('Discord · Slack · +2 offline')
+  })
+})
+
+describe('StatusSummaryLine offline annotation (rendered inside ConnectorOverviewStrip)', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetBulkInflight()
+    _testResetStripMemory()
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('omits the annotation when all connectors are up', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[
+          mkConnector({ connector_id: 'discord', available: true }),
+          mkConnector({ connector_id: 'slack', available: true }),
+          mkConnector({ connector_id: 'telegram', available: true }),
+          mkConnector({ connector_id: 'imessage', available: true }),
+        ]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-strip-summary-offline-names]')).toBeNull()
+  })
+
+  it('annotates offline connector by name', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[
+          mkConnector({ connector_id: 'discord', available: true }),
+          mkConnector({ connector_id: 'slack', available: false }),
+        ]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    const annotation = container.querySelector('[data-strip-summary-offline-names]') as HTMLElement
+    expect(annotation).toBeTruthy()
+    expect(annotation.textContent).toContain('Slack offline')
+    expect(annotation.className).toContain('rose')
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -441,12 +441,48 @@ export function summarizeConnectorStrip(
   }
 }
 
-function StatusSummaryLine({ summary }: { summary: ConnectorStripSummary }) {
+/** Pure: list the display names of KNOWN connectors that are currently
+    offline, in the canonical tile order. Returns [] when everything is
+    up, or when a connector isn't advertised yet (we only mark
+    offline once we've observed the connector being non-available —
+    \"missing from the connectors array\" is ambiguous, could be
+    bootstrapping rather than offline).
+
+    Why this exists: StatusSummaryLine says \"3 of 4 sidecars running\"
+    but doesn't name the missing 1 — the operator has to scan four
+    tiles below to find it. This lets the summary line annotate which
+    specific connector(s) are offline, matching Statuspage's
+    \"2 components degraded: Payments, API\" convention. */
+export function offlineConnectorNames(
+  connectors: GateConnectorInfo[],
+): string[] {
+  const out: string[] = []
+  for (const id of KNOWN_CONNECTOR_IDS) {
+    const c = findConnector(connectors, id)
+    if (c === null) continue // not yet observed — don't assert \"offline\"
+    if (c.available === true) continue
+    out.push(CONNECTOR_DISPLAY_NAMES[id] ?? id)
+  }
+  return out
+}
+
+/** Pure: compact label for the offline-connector annotation. Returns
+    null when nothing to annotate. */
+export function formatOfflineConnectorLabel(
+  offlineNames: readonly string[],
+): string | null {
+  if (offlineNames.length === 0) return null
+  if (offlineNames.length <= 2) return `${offlineNames.join(' · ')} offline`
+  return `${offlineNames.slice(0, 2).join(' · ')} · +${offlineNames.length - 2} offline`
+}
+
+function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSummary; connectors: GateConnectorInfo[] }) {
   // One quiet aggregate sentence — always on, never loud. Sits between
   // the loud banners (celebration / incident) and the action row, so the
   // operator always has baseline numbers even when neither banner fires.
   const now = livePulseNowMs.value
   const lastTick = lastHeartbeatTickMs.value
+  const offlineLabel = formatOfflineConnectorLabel(offlineConnectorNames(connectors))
   return html`
     <div
       class="mb-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-[var(--text-dim)]"
@@ -461,6 +497,13 @@ function StatusSummaryLine({ summary }: { summary: ConnectorStripSummary }) {
       <span>
         <span class="font-semibold text-[var(--text-body)]" data-strip-summary-sidecars>${summary.sidecarUp} of ${summary.sidecarTotal}</span>
         <span> sidecars running</span>
+        ${offlineLabel !== null
+          ? html`<span
+              class="ml-1 text-rose-300/80"
+              data-strip-summary-offline-names
+              title="현재 offline인 커넥터 이름"
+            > · ${offlineLabel}</span>`
+          : null}
       </span>
       <span aria-hidden="true" class="text-[var(--white-10)]">·</span>
       <span>
@@ -539,7 +582,7 @@ export function ConnectorOverviewStrip({ connectors, keeperCount }: OverviewProp
     >
       <${IncidentBanner} droppedIds=${droppedIds} />
       <${CelebrationBanner} connectedCount=${connectedCount} />
-      <${StatusSummaryLine} summary=${summary} />
+      <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
       <${BulkActions} connectors=${connectors} />
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         ${KNOWN_CONNECTOR_IDS.map(id => html`


### PR DESCRIPTION
## Summary
- \`3 of 4 sidecars running\` now annotates which specific connector(s) are offline. **Slack offline** / **Discord · Slack offline** / **Discord · Slack · +2 offline**.
- Operator scanning the header now learns \"what is wrong\" in one glance instead of scanning four tiles below for the one with the sad face.
- **잘 보이고 잘 입력** — same bits, more visible.

## Reference UIs
- **Statuspage** — \"2 components degraded: Payments, API\" directly above the grid.
- **GitHub status** — \"API · Actions · Pages degraded\".
- **Common thread**: when a fleet has N items and k are down, name the k — don't leave the operator to hunt.

## Visual placement
\`\`\`
Before:
  ● 3 of 4 sidecars running · 12 bindings configured · 2 keepers online

After:
  ● 3 of 4 sidecars running · Slack offline · 12 bindings configured · 2 keepers online
                             ───────────────
                             rose annotation
\`\`\`

## Overflow rule (Statuspage convention)
| offline count | label |
|---|---|
| 0 | (no annotation) |
| 1 | \`Slack offline\` |
| 2 | \`Discord · Slack offline\` |
| 3+ | \`Discord · Slack · +N offline\` |

## Two pure helpers, isolated
1. \`offlineConnectorNames(connectors)\` — KNOWN connectors in **canonical tile order** (not input order). Regression-guarded so the API returning slack-before-discord still produces \`[Discord, Slack]\` so the annotation matches the operator's visual scan path below.
2. \`formatOfflineConnectorLabel(names)\` — produces the compact string with overflow rule.

## Bootstrapping guard
Connector **absent** from the array ≠ offline. A brief gap between page load and first gate fetch must not render every connector as red. Tests pin this.

## Tone vocabulary
\`text-rose-300/80\` matches the existing incident banner palette — one color vocabulary across strip + incident + tile error notice.

## Test plan
- [x] 11 new tests (9 pure + 2 component). Suite 35 → 46 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → stop one sidecar → summary line gains \"X offline\" annotation → restart → annotation clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)