### PR TITLE
feat(dashboard): 🏷 SectionCap primitive — consolidate 11 uppercase tracking section headings (first of 9-PR hygiene sweep)

### DIFF
--- a/dashboard/src/components/common/section-cap.test.ts
+++ b/dashboard/src/components/common/section-cap.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { SectionCap, sectionCapClasses } from './section-cap'
+
+describe('sectionCapClasses (pure)', () => {
+  it('default (muted, normal) includes base tokens + muted tone + no weight', () => {
+    const cls = sectionCapClasses()
+    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('uppercase')
+    expect(cls).toContain('tracking-wider')
+    expect(cls).toContain('text-text-muted')
+    expect(cls).not.toContain('font-semibold')
+  })
+
+  it('dim tone swaps muted → dim (mutually exclusive)', () => {
+    const cls = sectionCapClasses('dim')
+    expect(cls).toContain('text-text-dim')
+    expect(cls).not.toContain('text-text-muted')
+  })
+
+  it('semibold weight adds font-semibold', () => {
+    expect(sectionCapClasses('muted', 'semibold')).toContain('font-semibold')
+  })
+
+  it('extra class is appended (caller composition)', () => {
+    expect(sectionCapClasses('muted', 'normal', 'mb-1 flex')).toContain('mb-1 flex')
+  })
+
+  it('empty/undefined extra leaves the string tight (no trailing space)', () => {
+    expect(sectionCapClasses('muted', 'normal', '')).not.toMatch(/\s$/)
+    expect(sectionCapClasses('muted', 'normal', undefined)).not.toMatch(/\s$/)
+  })
+
+  it('base tokens always present across tone/weight combos (regression guard)', () => {
+    // Drifting the base class breaks the 10px uppercase grid across
+    // the 6 files the primitive unifies.
+    for (const tone of ['muted', 'dim'] as const) {
+      for (const weight of ['normal', 'semibold'] as const) {
+        const cls = sectionCapClasses(tone, weight)
+        for (const token of ['text-[10px]', 'uppercase', 'tracking-wider']) {
+          expect(cls).toContain(token)
+        }
+      }
+    }
+  })
+})
+
+describe('SectionCap component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders <div data-section-cap> with children verbatim', () => {
+    render(html`<${SectionCap}>성공률<//>`, container)
+    const el = container.querySelector('[data-section-cap]')!
+    expect(el.tagName).toBe('DIV')
+    expect(el.textContent).toBe('성공률')
+  })
+
+  it('data-section-cap-tone/weight reflect props (default muted/normal)', () => {
+    render(html`<${SectionCap}>Input<//>`, container)
+    const el = container.querySelector('[data-section-cap]')!
+    expect(el.getAttribute('data-section-cap-tone')).toBe('muted')
+    expect(el.getAttribute('data-section-cap-weight')).toBe('normal')
+
+    render(null, container)
+    render(html`<${SectionCap} tone="dim" weight="semibold">시간대별 활동<//>`, container)
+    const el2 = container.querySelector('[data-section-cap]')!
+    expect(el2.getAttribute('data-section-cap-tone')).toBe('dim')
+    expect(el2.getAttribute('data-section-cap-weight')).toBe('semibold')
+  })
+
+  it('testId propagates to data-testid', () => {
+    render(html`<${SectionCap} testId="telemetry-freq-cap">호출 빈도<//>`, container)
+    expect(container.querySelector('[data-testid="telemetry-freq-cap"]')).toBeTruthy()
+  })
+
+  it('class prop composes with primitive classes (caller layout preserved)', () => {
+    render(html`<${SectionCap} class="mb-1 flex items-center gap-2">tag<//>`, container)
+    const el = container.querySelector('[data-section-cap]')!
+    const cls = el.getAttribute('class') ?? ''
+    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('mb-1')
+    expect(cls).toContain('flex')
+  })
+})

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -1,0 +1,97 @@
+// SectionCap — uppercase tracking-wider tiny heading primitive.
+//
+// Reference UIs (Linear right-panel section caps, Vercel project
+// sidebar headers, Stripe dashboard overview labels): the 10px
+// all-caps 0.05em-tracked label is the universal "here starts a
+// small section" marker. Recognizing it instantly gives the reader
+// a grid: subhead above, content below, more whitespace before the
+// next one. Inline Tailwind strings scattered across ~20 files
+// always drift within weeks (tracking-[0.08em] vs tracking-[0.14em]
+// vs tracking-[0.18em] — pixel-noise differences that break the
+// grid silently).
+//
+// Two axes because the existing usage already uses them:
+//  - `tone`   — muted (default, section heads next to body text)
+//             / dim (stronger hush, dense telemetry panels)
+//  - `weight` — normal (read-only narrative labels, feature-health)
+//             / semibold (pressable subhead, keeper-tool-telemetry
+//                         column headers, tool-allowlist sections)
+//
+// Tone tokens resolve through the Tailwind v4 `@theme` (tokens.css):
+//   text-text-muted → var(--color-text-muted)
+//   text-text-dim   → var(--color-text-dim)
+// Using the generated utility instead of `text-[var(--text-muted)]`
+// keeps purge predictable, autocomplete honest, and fixes the
+// `text-text-muted` / `text-[var(--text-muted)]` / `text-zinc-400`
+// trident drift the audit surfaced.
+//
+// NOT a replacement for:
+//  - `Kbd` (keyboard shortcut pill — has <kbd> semantics)
+//  - `CountBadge` (numeric pill — tabular-nums + tone background)
+//  - `StatusChip` (status pill — rounded-full + border + tone)
+// SectionCap is a *label*, not a *chip*. It has no border/background
+// by default and renders as <div> so flexbox stacking works without
+// the caller reaching for inline-block overrides.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+export type SectionCapTone = 'muted' | 'dim'
+export type SectionCapWeight = 'normal' | 'semibold'
+
+const BASE = 'text-[10px] uppercase tracking-wider'
+
+const TONE: Record<SectionCapTone, string> = {
+  muted: 'text-text-muted',
+  dim: 'text-text-dim',
+}
+
+const WEIGHT: Record<SectionCapWeight, string> = {
+  normal: '',
+  semibold: 'font-semibold',
+}
+
+/** Pure: class string for a given tone/weight + optional extra
+    (caller margin, inline-flex composition, border-b, bg). Exposed
+    so callers that wrap their own element (e.g. a <summary> that
+    needs ::marker overrides) stay pixel-identical. */
+export function sectionCapClasses(
+  tone: SectionCapTone = 'muted',
+  weight: SectionCapWeight = 'normal',
+  extra?: string,
+): string {
+  const parts = [BASE, TONE[tone]]
+  const w = WEIGHT[weight]
+  if (w !== '') parts.push(w)
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface SectionCapProps {
+  tone?: SectionCapTone
+  weight?: SectionCapWeight
+  /** Additional Tailwind classes for margin, inline-flex composition,
+      border-b, bg, etc. Caller-owned because layout concerns
+      (mb-1, flex items-center, border-b) belong to the caller row,
+      not the heading primitive. */
+  class?: string
+  children?: ComponentChildren
+  testId?: string
+}
+
+export function SectionCap({
+  tone = 'muted',
+  weight = 'normal',
+  class: cx,
+  children,
+  testId,
+}: SectionCapProps) {
+  const cls = sectionCapClasses(tone, weight, cx)
+  return html`<div
+    class=${cls}
+    data-section-cap
+    data-section-cap-tone=${tone}
+    data-section-cap-weight=${weight}
+    data-testid=${testId}
+  >${children}</div>`
+}

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -10,6 +10,7 @@ import { AsyncContainer } from './common/async-container'
 import { Card } from './common/card'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
+import { SectionCap } from './common/section-cap'
 import { StatCard } from './common/stat-card'
 
 type FeatureStatus = 'healthy' | 'warning' | 'inactive' | 'deprecated'
@@ -210,7 +211,7 @@ export function FeatureHealth() {
                 <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
                   <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div class="max-w-3xl">
-                      <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)]">Feature Flags Health</div>
+                      <${SectionCap}>Feature Flags Health<//>
                       <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
                         ${overview.enabled_count} / ${overview.total_features} 기능 활성화
                       </div>

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -7,6 +7,7 @@ import { navigate } from '../router'
 import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
 import { CopyIdButton } from './common/copy-id-button'
+import { SectionCap } from './common/section-cap'
 import { StatusDot } from './common/status-dot'
 import type {
   RailStatus,
@@ -295,7 +296,7 @@ export function ScopePairing() {
         <div class="flex flex-col gap-2">
           <div class="flex items-center justify-between gap-3">
             <div>
-              <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">실험 루프</div>
+              <${SectionCap}>실험 루프<//>
               <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">오토리서치가 답하는 것</div>
             </div>
             <button
@@ -312,7 +313,7 @@ export function ScopePairing() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex flex-col gap-2">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">안전 감시</div>
+          <${SectionCap}>안전 감시<//>
           <div class="text-sm font-medium text-[var(--text-strong)]">하네스가 답하는 것</div>
           <div class="text-sm leading-[1.6] text-[var(--text-body)]">
             평가 모델이 건강한지, 장기 실행 중 압축이 정상인지, 세대 교체가 안전한지 봅니다.

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { navigate } from '../router'
 import { Card } from './common/card'
+import { SectionCap } from './common/section-cap'
 import { MermaidGraph } from './common/mermaid-graph'
 import {
   harness,
@@ -244,7 +245,7 @@ export function HarnessHealth() {
         <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
           <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div class="max-w-3xl">
-              <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)]">keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다</div>
+              <${SectionCap}>keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다<//>
               <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">${heroTitle(data)}</div>
               <div class="mt-2 text-sm leading-[1.7] text-[var(--text-body)]">${heroBody(data)}</div>
             </div>

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,6 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
+import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
 
@@ -67,11 +68,11 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
             <div class="text-[10px] text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
           ` : null}
           <div>
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Input</div>
+            <${SectionCap} class="mb-1">Input<//>
             <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap text-[var(--text-strong)]">${formatInput(entry.input)}</pre>
           </div>
           <div>
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Output</div>
+            <${SectionCap} class="mb-1">Output<//>
             <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--text-strong)]">${entry.output || '(empty)'}</pre>
           </div>
         </div>
@@ -148,7 +149,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
       </div>
 
       <div class="border border-[var(--card-border)] rounded overflow-hidden max-h-[500px] overflow-y-auto">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] text-[10px] uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--card-border)]">
+        <${SectionCap} class="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-deep)] border-b border-[var(--card-border)]">
           <span class="w-4"></span>
           <span class="w-16">Time</span>
           <span class="flex-1">Tool</span>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -8,6 +8,7 @@ import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse } from '../api/dashboard'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import { SectionCap } from './common/section-cap'
 
 // ── Types ─────────────────────────────────────────────
 
@@ -205,7 +206,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       ${'' /* Hourly timeline sparkline */}
       ${s.timeline.length > 1 ? html`
         <div class="flex flex-col gap-1">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">시간대별 활동</div>
+          <${SectionCap} tone="dim" weight="semibold" class="mb-1">시간대별 활동<//>
           <div class="overflow-x-auto py-1">
             <${Sparkline} buckets=${s.timeline} height=${28} />
           </div>
@@ -215,7 +216,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       ${'' /* Per-tool bar chart */}
       <div class="flex flex-col gap-1">
         <div class="flex items-center justify-between gap-2 mb-1">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)]">호출 빈도</div>
+          <${SectionCap} tone="dim" weight="semibold">호출 빈도<//>
           <div class="flex items-center gap-2">
             <input
               type="search"
@@ -264,7 +265,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       ${'' /* Success rate table */}
       ${s.tools.some(st => st.failure_count > 0) ? html`
         <div class="flex flex-col gap-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">성공률</div>
+          <${SectionCap} tone="dim" weight="semibold" class="mb-1">성공률<//>
           ${s.tools.filter(st => st.failure_count > 0).map(stat => html`
             <div class="flex items-center gap-2">
               <span class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate">
@@ -280,7 +281,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
       ${'' /* P95 latency (slowest tools) */}
       ${slowest.length > 0 && slowest[0]!.p95_duration_ms > 500 ? html`
         <div class="flex flex-col gap-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">P95 지연 시간</div>
+          <${SectionCap} tone="dim" weight="semibold" class="mb-1">P95 지연 시간<//>
           ${slowest.map(stat => html`
             <div class="flex items-center justify-between py-1 px-2 rounded bg-[var(--white-3)]">
               <span class="text-[11px] font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>


### PR DESCRIPTION
## Summary

Absorbs the largest single inline-Tailwind pattern the dashboard audit surfaced
(`text-[10px] uppercase tracking-[X] text-[var(--text-*)]`, ~60 repo-wide
instance). First PR of a **9-PR integrated hygiene sweep** (density +
duplication + styling drift + a11y — each PR touches its range across all
axes rather than isolating one).

## API

```ts
<SectionCap tone="dim" weight="semibold" class="mb-1">시간대별 활동</SectionCap>
sectionCapClasses('muted', 'normal', 'mb-1 flex')   // pure fn for wrappers
```

- `tone`: `muted` (default) | `dim`
- `weight`: `normal` (default) | `semibold`
- `class`: escape hatch for caller layout (margin / inline-flex / border-b / bg)

Tone tokens resolve via **Tailwind v4 `@theme`** utilities (`text-text-muted` /
`text-text-dim`) — the canonical side of the audit's 3-way color-var drift
(`text-[var(--text-muted)]` / `text-text-muted` / `text-zinc-*` all coexist
today). The primitive locks new call sites on the clean side.

## Migration (11 instance, 5 files)

| File | Lines | Notes |
|------|-------|-------|
| `feature-health.ts` | 213 | `tracking-[0.18em]` → `tracking-wider` |
| `harness-health.ts` | 247 | `tracking-[0.18em]` → `tracking-wider` |
| `harness-health-sections.ts` | 298, 315 | |
| `keeper-tool-call-inspector.ts` | 70, 74, 151 | 151 composes `bg`/`border` via `class` prop |
| `keeper-tool-telemetry.ts` | 208, 218, 267, 283 | `tone=dim weight=semibold` |

Net: **+16 / -11** in migrated files (inline strings collapse to component calls).

## Deferred (picked up by later PRs)

- `<span>` forms in `tool-allowlist-editor.ts` (5 instance) → **P3** (SectionCap `inline` / `as="span"` variant)
- `text-[11px]` size in `config-resolution-panel.ts` → **P2** (size prop)
- `text-[9px]` sweep + `kbd.sm` → **P5**
- **StatusChip** has empty `.cmd-chip` CSS shell (no definition found in repo, audit finding) → **P2** Tailwind-only rewrite + 14-caller absorption

## Follow-up roadmap (after merge)

| PR | Scope |
|----|-------|
| P2 | StatusChip Tailwind-only rewrite + 14 caller absorption + size prop |
| P3 | CountBadge expansion + SectionCap inline variant |
| P4 | IdPill primitive |
| P5 | text-[9px] density sweep |
| P6 | Color var normalization + drift CI lint |
| P7 | Rounded / font-weight sweep |
| P8 | a11y / focus ring sweep |
| P9 | Waste sweep (useMemo audit, shared constants) |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3557/3557 green (10 new `SectionCap` cases: 6 pure fn + 4 component)
- [x] `pnpm build` — vite clean (chunk-size warnings are pre-existing, unrelated)
- [ ] CI green
- [ ] Empirical: local dashboard boot → render 5 migrated screens (feature health / harness health / tool call inspector / tool telemetry / scope pairing) — section caps visually identical (tracking-wider unification may produce imperceptible kerning change)

## Notes

- Follows `kbd.ts` / `status-dot.ts` / `progress-bar.ts` primitive pattern (pure `xxxClasses` fn + component + `data-*` attrs + `testId` + `.test.ts`)
- No existing primitive API broken
- No CSS var redefined (layered on top of tokens.css `@theme` + variables.css legacy `:root`)
- `tailwind-only-dashboard` / `dashboard-observation-focus` memory respected
