### PR TITLE
feat(dashboard): ┈ DashedNotice primitive — 4 fsm-hub timeline empty states consolidated

### DIFF
--- a/dashboard/src/components/common/dashed-notice.test.ts
+++ b/dashboard/src/components/common/dashed-notice.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { DashedNotice, dashedNoticeClasses } from './dashed-notice'
+
+describe('dashedNoticeClasses (pure)', () => {
+  it('default is sm + card (the most common pre-change variant)', () => {
+    const cls = dashedNoticeClasses()
+    expect(cls).toBe(dashedNoticeClasses('sm', 'card'))
+  })
+
+  it('always includes base invariants (dashed border, center text, text-dim)', () => {
+    // Regression guard: drifting any of these tokens breaks visual
+    // consistency across the 9 call sites the primitive unifies.
+    const cls = dashedNoticeClasses()
+    expect(cls).toContain('border-dashed')
+    expect(cls).toContain('text-center')
+    expect(cls).toContain('text-[var(--text-dim)]')
+  })
+
+  it('sm size: 10px text + rounded-lg + tight padding (matches fsm-hub timeline panels)', () => {
+    const cls = dashedNoticeClasses('sm')
+    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('rounded-lg')
+    expect(cls).toContain('px-4')
+    expect(cls).toContain('py-2')
+  })
+
+  it('md size: 12px text + rounded-lg + generous padding', () => {
+    const cls = dashedNoticeClasses('md')
+    expect(cls).toContain('text-[12px]')
+    expect(cls).toContain('rounded-lg')
+    expect(cls).toContain('px-4')
+    expect(cls).toContain('py-6')
+  })
+
+  it('card border tone uses --card-border', () => {
+    expect(dashedNoticeClasses('sm', 'card')).toContain('border-[var(--card-border)]')
+  })
+
+  it('subtle border tone uses --white-8 (dimmer)', () => {
+    expect(dashedNoticeClasses('sm', 'subtle')).toContain('border-[var(--white-8)]')
+  })
+
+  it('extra class is appended (caller composition)', () => {
+    expect(dashedNoticeClasses('sm', 'card', 'mt-3')).toContain('mt-3')
+  })
+
+  it('empty/undefined extra class leaves no trailing whitespace', () => {
+    expect(dashedNoticeClasses('sm', 'card', '')).not.toMatch(/\s$/)
+    expect(dashedNoticeClasses('sm', 'card', undefined)).not.toMatch(/\s$/)
+  })
+})
+
+describe('DashedNotice component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a div with data-dashed-notice + attribute annotations', () => {
+    render(html`<${DashedNotice}>still empty<//>`, container)
+    const el = container.querySelector('[data-dashed-notice]') as HTMLElement
+    expect(el.tagName).toBe('DIV')
+    expect(el.getAttribute('data-dashed-notice-size')).toBe('sm')
+    expect(el.getAttribute('data-dashed-notice-border')).toBe('card')
+    expect(el.textContent).toBe('still empty')
+  })
+
+  it('size + borderTone reflect in data attributes', () => {
+    render(
+      html`<${DashedNotice} size="md" borderTone="subtle">big empty<//>`,
+      container,
+    )
+    const el = container.querySelector('[data-dashed-notice]') as HTMLElement
+    expect(el.getAttribute('data-dashed-notice-size')).toBe('md')
+    expect(el.getAttribute('data-dashed-notice-border')).toBe('subtle')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${DashedNotice} testId="runs-empty">no runs<//>`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="runs-empty"]')).toBeTruthy()
+  })
+
+  it('accepts arbitrary preact children (markup, not just strings)', () => {
+    render(
+      html`<${DashedNotice}>
+        <strong>heads up</strong> — nothing yet
+      <//>`,
+      container,
+    )
+    const el = container.querySelector('[data-dashed-notice]') as HTMLElement
+    expect(el.querySelector('strong')?.textContent).toBe('heads up')
+  })
+})

--- a/dashboard/src/components/common/dashed-notice.ts
+++ b/dashboard/src/components/common/dashed-notice.ts
@@ -1,0 +1,68 @@
+// DashedNotice — inline dashed-border \"nothing to show\" panel.
+//
+// Reference UIs (Linear empty list region, Vercel \"no deployments yet\"
+// card, GitHub \"No workflow runs\"): when a small region of the page
+// has no rows to render, a dashed-border placeholder says \"this area
+// is intentionally empty\" — strictly better than a collapsed
+// zero-height slot (operator thinks the surface is broken) or a big
+// illustration (visual weight for nothing).
+//
+// Distinct from <EmptyState> (which has an icon + vertical layout
+// for full-panel emptiness, e.g. \"no results\"). DashedNotice is the
+// *inline* case: a single-line / two-line hint inside a tile, row,
+// or inner card. The dashboard had 9 pre-change call sites with 3
+// different padding schemes + 2 different border tones; this
+// primitive pins the canonical two variants.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+export type DashedNoticeSize = 'sm' | 'md'
+export type DashedNoticeBorderTone = 'card' | 'subtle'
+
+/** Pure: Tailwind size tokens. Exposed so callers in a hot render path
+    (e.g. a repeated fsm-hub sub-panel) can pre-build the string once. */
+export function dashedNoticeClasses(
+  size: DashedNoticeSize = 'sm',
+  border: DashedNoticeBorderTone = 'card',
+  extra?: string,
+): string {
+  const borderClass = border === 'subtle'
+    ? 'border-[var(--white-8)]'
+    : 'border-[var(--card-border)]'
+  const sized = size === 'md'
+    ? 'rounded-lg px-4 py-6 text-[12px]'
+    : 'rounded-lg px-4 py-2 text-[10px]'
+  const parts = [
+    'border border-dashed text-center text-[var(--text-dim)]',
+    sized,
+    borderClass,
+  ]
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface DashedNoticeProps {
+  children?: ComponentChildren
+  size?: DashedNoticeSize
+  borderTone?: DashedNoticeBorderTone
+  class?: string
+  testId?: string
+}
+
+export function DashedNotice({
+  children,
+  size = 'sm',
+  borderTone = 'card',
+  class: cx,
+  testId,
+}: DashedNoticeProps) {
+  const cls = dashedNoticeClasses(size, borderTone, cx)
+  return html`<div
+    class=${cls}
+    data-dashed-notice
+    data-dashed-notice-size=${size}
+    data-dashed-notice-border=${borderTone}
+    data-testid=${testId}
+  >${children}</div>`
+}

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { DashedNotice } from './common/dashed-notice'
 
 import {
   type CompositeObservation,
@@ -127,9 +128,9 @@ export function SwimlaneTimeline({
 }) {
   if (observations.length === 0) {
     return html`
-      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+      <${DashedNotice} borderTone="subtle">
         30초 폴링 사이클에서 관측을 수집중 — 2회 이상 스냅샷이 쌓이면 5개 레인의 시간 흐름이 표시됩니다
-      </div>
+      <//>
     `
   }
   const first = observations[0]
@@ -376,9 +377,9 @@ export function TransitionTrail({
 
   if (history.length === 0) {
     return html`
-      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+      <${DashedNotice} borderTone="subtle">
         아직 상태 전이가 관측되지 않았습니다 — 키퍼가 턴을 시작하거나 phase가 변경되면 자동으로 기록됩니다
-      </div>
+      <//>
     `
   }
 
@@ -447,9 +448,9 @@ export function TopTransitionsPanel({
 }) {
   if (transitions.length === 0) {
     return html`
-      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+      <${DashedNotice} borderTone="subtle">
         반복되는 전이가 없습니다 — 관측이 더 쌓이거나 lane 변화가 발생하면 표시됩니다
-      </div>
+      <//>
     `
   }
 
@@ -513,9 +514,9 @@ export function DwellHistogramPanel({
 }) {
   if (histograms.length === 0) {
     return html`
-      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+      <${DashedNotice} borderTone="subtle">
         관측 데이터가 아직 없습니다 — 키퍼가 상태를 유지하면 체류 시간이 표시됩니다
-      </div>
+      <//>
     `
   }
 


### PR DESCRIPTION
## Summary
- **DashedNotice primitive** for the inline dashed-border \"nothing to show yet\" panel. Consolidates 4 byte-for-byte identical empty-state blocks in fsm-hub timeline panels.
- Reference UIs: Linear empty list region, Vercel \"no deployments yet\" card, GitHub \"No workflow runs\" — a dashed placeholder tells the operator \"this area is intentionally empty\" without a full illustration or a broken-looking collapsed slot.

## Distinct from \`<EmptyState>\`
| | EmptyState | DashedNotice |
|---|---|---|
| Context | Full-panel empty | Inline inside tile/row/inner card |
| Layout | Vertical (icon + text + action) | Single line / two lines |
| Padding | Generous (py-8) | Tight (py-2) or medium (py-6) |
| Has icon | Yes | No |

## Two sizes, two border tones — zero arbitrary inputs
| Axis | Values | Tailwind |
|---|---|---|
| size | sm (default) / md | sm = \`rounded-lg px-4 py-2 text-[10px]\`; md = \`rounded-lg px-4 py-6 text-[12px]\` |
| borderTone | card (default) / subtle | \`border-[var(--card-border)]\` / \`border-[var(--white-8)]\` |

## Wiring (4 of 9 call sites — the cleanest identical block)
\`fsm-hub-timeline-panels.ts\` × 4 (SwimlaneTimeline + TransitionTrail + DwellHistogram + phase-history empty). All used byte-for-byte identical Tailwind strings pre-change, now:
\`\`\`tsx
<${DashedNotice} borderTone=\"subtle\">
  … empty-state message …
<//>
\`\`\`

## Deferred wiring candidates (for future /loop fires)
\`harness-health-sections.ts EmptySignal\`, \`prompt-registry-panel.ts\` × 2, \`connector-keeper-matrix.ts\`, \`keeper-detail-runtime.ts\`, \`connector-quick-bind.ts\`, \`connector-status.ts\`. Each has a slightly different padding/tone mix — individual extraction per /loop keeps the diff reviewable.

## Regression guards (tests)
- Base invariants pinned — \`border-dashed\` + \`text-center\` + \`text-[var(--text-dim)]\` — drift of any breaks consistency across the 9 call sites.
- Per-size Tailwind tokens pinned; per-border-tone tokens pinned.
- Empty/undefined extra class leaves no trailing whitespace.

## Test plan
- [x] 12 new tests (8 pure + 4 component). Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → \`#fsm-hub\` → clear all observations (fresh state) → 4 panels all render the dashed \"관측 수집중\" / \"전이 없음\" etc. message byte-for-byte identical to pre-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)