### PR TITLE
feat(dashboard): 🔗 link commit hash in BuildIdentityBadge to GitHub

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { githubCommitUrl } from './dashboard-shell'
+
+describe('githubCommitUrl (pure)', () => {
+  it('returns null for null / undefined / empty string', () => {
+    expect(githubCommitUrl(null)).toBeNull()
+    expect(githubCommitUrl(undefined)).toBeNull()
+    expect(githubCommitUrl('')).toBeNull()
+    expect(githubCommitUrl('   ')).toBeNull()
+  })
+
+  it('returns null for non-hex-looking strings (dev labels, semver, free text)', () => {
+    // Regression guard: dev builds produce label strings like "dev" or
+    // "v1.2.3-dirty"; we must NOT link them to
+    // github.com/.../commit/dev (a 404).
+    expect(githubCommitUrl('dev')).toBeNull()
+    expect(githubCommitUrl('v1.2.3')).toBeNull()
+    expect(githubCommitUrl('v1.2.3-dirty')).toBeNull()
+    expect(githubCommitUrl('not-a-commit')).toBeNull()
+  })
+
+  it('rejects too-short hex (< 7 chars) — ambiguous, could collide', () => {
+    // Git's default `--short` is 7. Anything under that is almost
+    // never a real commit reference.
+    expect(githubCommitUrl('abc123')).toBeNull()
+    expect(githubCommitUrl('a1b2c3')).toBeNull()
+  })
+
+  it('accepts a 7-char short hex hash', () => {
+    expect(githubCommitUrl('abc1234')).toBe(
+      'https://github.com/jeong-sik/masc-mcp/commit/abc1234',
+    )
+  })
+
+  it('accepts a full 40-char hex hash', () => {
+    const sha = 'a'.repeat(40)
+    expect(githubCommitUrl(sha)).toBe(
+      `https://github.com/jeong-sik/masc-mcp/commit/${sha}`,
+    )
+  })
+
+  it('accepts uppercase hex (some tooling emits uppercase)', () => {
+    expect(githubCommitUrl('ABC1234')).toBe(
+      'https://github.com/jeong-sik/masc-mcp/commit/ABC1234',
+    )
+  })
+
+  it('rejects > 40 chars (not a real SHA)', () => {
+    expect(githubCommitUrl('a'.repeat(41))).toBeNull()
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(githubCommitUrl('  abc1234  ')).toBe(
+      'https://github.com/jeong-sik/masc-mcp/commit/abc1234',
+    )
+  })
+})

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -72,6 +72,29 @@ function shortCommit(commit: string | null | undefined): string {
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
+/** Canonical upstream repo. Used to resolve commit-hash text into a
+    clickable GitHub permalink. Hard-coded because this is the only
+    origin the dashboard is ever built from — a future fork would
+    override this via a build-time constant, not a runtime flag. */
+const UPSTREAM_REPO = 'jeong-sik/masc-mcp'
+
+/** Pure: turn a raw commit hash into a GitHub commit URL. Returns
+    null for empty / non-hex-looking input so the dropdown renders
+    the plain string for dev builds without creating a bogus link.
+    Reference: Vercel / Railway / Render deployment dashboards always
+    link commit hashes out to the source host — operators who land
+    on the build identity dropdown usually want the diff, not the
+    hash itself. */
+export function githubCommitUrl(commit: string | null | undefined): string | null {
+  const value = commit?.trim() ?? ''
+  if (value === '') return null
+  // Accept full (40-char) or short (≥ 7 char) hex SHAs only. Anything
+  // else (dev labels, semver, free text) gets rendered as plain text
+  // so we never produce a link to github.com/.../commit/dev.
+  if (!/^[0-9a-f]{7,40}$/i.test(value)) return null
+  return `https://github.com/${UPSTREAM_REPO}/commit/${value}`
+}
+
 export function BuildIdentityBadge() {
   const status = serverStatus.value
   const build = status?.build
@@ -103,7 +126,20 @@ export function BuildIdentityBadge() {
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>커밋</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${build?.commit ?? 'git 미감지 (dev)'}</strong>
+                ${(() => {
+                  const url = githubCommitUrl(build?.commit)
+                  const text = build?.commit ?? 'git 미감지 (dev)'
+                  return url !== null
+                    ? html`<a
+                        href=${url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-right font-bold text-[color:var(--text-strong)] underline decoration-dotted underline-offset-2 decoration-[color:var(--text-dim)] hover:decoration-[color:var(--accent)] hover:text-[color:var(--accent)]"
+                        data-build-commit-link
+                        title="GitHub에서 이 커밋 보기"
+                      >${text} ↗</a>`
+                    : html`<strong class="text-[color:var(--text-strong)] text-right">${text}</strong>`
+                })()}
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>서버 시작</span>


### PR DESCRIPTION
## Summary
- **Clickable commit hash** in the build-identity dropdown. One click → GitHub commit diff for what's running in production.
- Was: plain \`<strong>commit-hash</strong>\` text. Now: \`<a href=\"github.com/.../commit/SHA\" target=\"_blank\">hash ↗</a>\`.
- **잘 보이고 잘 입력** — operator no longer has to copy-paste the hash into a browser manually.

## Reference UIs
- **Vercel deployment dashboard** — commit hash always linked to git host.
- **Railway build logs** — commit link opens the diff in a new tab.
- **Render** — same pattern.
- **Common thread**: someone who opens a build-identity panel wants the diff, not the hash.

## Pure \`githubCommitUrl(commit)\` — 8 invariants pinned
| Input | Output |
|---|---|
| null / undefined / empty / whitespace | \`null\` |
| \`\"dev\"\` / \`\"v1.2.3\"\` / \`\"not-a-commit\"\` | \`null\` (no github.com/.../commit/dev 404) |
| \`\"abc123\"\` (6 chars) | \`null\` (git's --short default is 7) |
| \`\"abc1234\"\` (7 chars) | \`https://github.com/jeong-sik/masc-mcp/commit/abc1234\` |
| 40-char hex | full commit URL |
| uppercase hex | preserved |
| \`\"  abc1234  \"\` | trimmed + linked |
| 41+ chars | \`null\` (not a real SHA) |

## Repo hard-coded
\`jeong-sik/masc-mcp\` is the only origin this dashboard is ever built from. A future fork would override this via a build-time constant, not a runtime flag — keeps the helper pure.

## Visual
\`\`\`
Before:
  커밋    a7b3d1c4  ← plain bold text
After:
  커밋    a7b3d1c4 ↗  ← dotted-underline link + new-tab glyph
\`\`\`
- \`target=\"_blank\" rel=\"noopener noreferrer\"\` — safe new-tab open.
- Dotted underline + hover-accent tone so the link affordance is visible without shouting.
- \`title=\"GitHub에서 이 커밋 보기\"\` for hover tooltip.
- Dev builds / invalid hashes render the original \`<strong>\` unchanged — never produce a broken link.

## Test plan
- [x] 8 pure helper tests (no component tests — visual change is trivial).
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → click build badge → click commit hash in dropdown → opens https://github.com/jeong-sik/masc-mcp/commit/SHA in new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)