### PR TITLE
feat(dashboard): 🏷 StatusChip Tailwind-only rewrite + 11 inline chip absorptions (P2/9 hygiene sweep)

### DIFF
--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { StatusChip, statusChipClasses, isSemanticTone } from './status-chip'
+
+describe('isSemanticTone (pure)', () => {
+  it('accepts the 6 enum members', () => {
+    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', ''] as const) {
+      expect(isSemanticTone(tone)).toBe(true)
+    }
+  })
+
+  it('rejects raw Tailwind class strings (they pass through as extras)', () => {
+    expect(isSemanticTone('bg-[var(--ok)]')).toBe(false)
+    expect(isSemanticTone('text-accent')).toBe(false)
+  })
+})
+
+describe('statusChipClasses (pure)', () => {
+  it('default (no tone) uses neutral mapping + base tokens', () => {
+    const cls = statusChipClasses()
+    expect(cls).toContain('inline-flex')
+    expect(cls).toContain('rounded-full')
+    expect(cls).toContain('border')
+    expect(cls).toContain('px-2')
+    expect(cls).toContain('py-0.5')
+    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('uppercase')
+    expect(cls).toContain('tracking-wider')
+    // neutral fallback
+    expect(cls).toContain('text-[var(--text-muted)]')
+  })
+
+  it("semantic 'ok' maps to ok CSS-var palette", () => {
+    const cls = statusChipClasses('ok')
+    expect(cls).toContain('text-[var(--ok)]')
+    expect(cls).toContain('bg-[var(--ok-10)]')
+  })
+
+  it("semantic 'bad' maps to bad palette (text-[var(--bad-light)])", () => {
+    const cls = statusChipClasses('bad')
+    expect(cls).toContain('text-[var(--bad-light)]')
+  })
+
+  it('raw Tailwind class string passes through verbatim', () => {
+    const cls = statusChipClasses('bg-[var(--ok)]')
+    // Raw tone gets appended; no semantic-palette leakage.
+    expect(cls).toContain('bg-[var(--ok)]')
+    expect(cls).not.toContain('text-[var(--ok)]') // not expanded
+  })
+
+  it('extra class appended (caller composition)', () => {
+    expect(statusChipClasses('warn', 'shrink-0 ml-2')).toContain('shrink-0 ml-2')
+  })
+
+  it('empty extra leaves the string tight (no trailing space)', () => {
+    expect(statusChipClasses('ok', '')).not.toMatch(/\s$/)
+    expect(statusChipClasses('ok', undefined)).not.toMatch(/\s$/)
+  })
+
+  it('base tokens present for every tone (regression guard)', () => {
+    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', '', 'bg-[var(--ok)]']) {
+      const cls = statusChipClasses(tone)
+      for (const token of ['rounded-full', 'text-[10px]', 'uppercase', 'tracking-wider']) {
+        expect(cls).toContain(token)
+      }
+    }
+  })
+})
+
+describe('StatusChip component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders <span data-status-chip> with children verbatim', () => {
+    render(html`<${StatusChip}>approved<//>`, container)
+    const el = container.querySelector('[data-status-chip]')!
+    expect(el.tagName).toBe('SPAN')
+    expect(el.textContent).toBe('approved')
+  })
+
+  it('label prop renders when children absent (legacy API)', () => {
+    render(html`<${StatusChip} label="present" />`, container)
+    expect(container.querySelector('[data-status-chip]')!.textContent).toBe('present')
+  })
+
+  it('children win over label when both are set', () => {
+    render(html`<${StatusChip} label="legacy">actual<//>`, container)
+    expect(container.querySelector('[data-status-chip]')!.textContent).toBe('actual')
+  })
+
+  it('data-status-chip-tone reflects tone prop', () => {
+    render(html`<${StatusChip} tone="warn">heads up<//>`, container)
+    expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-tone')).toBe('warn')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(html`<${StatusChip} testId="approve-chip">ok<//>`, container)
+    expect(container.querySelector('[data-testid="approve-chip"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -1,15 +1,97 @@
-// StatusChip -- read-only badge for status, model, tags
-// Replaces 90+ inline `<span class="cmd-chip rounded-full ${tone}">` patterns.
+// StatusChip — rounded-full status/tag pill.
+//
+// Reference UIs (GitHub label, Linear state badge, Stripe API key
+// badge, Vercel deployment state): a 10px uppercase pill with a
+// semantic tone background is the universal "this is a tag, not
+// prose" visual. The reader's eye picks them out of a row before
+// reading content.
+//
+// Rewrite note: the previous version composed a `cmd-chip` class
+// that has no CSS definition anywhere in the repo (audit verified
+// with `rg cmd-chip`: zero hits outside this file). The tone param
+// was a bare string passed straight into `class=`, which meant
+// calls like `<StatusChip tone="warn">` rendered with no styling
+// at all, while calls like `<StatusChip tone="bg-[var(--ok)]">`
+// (verdictTone helper) rendered correctly. This rewrite closes the
+// gap without breaking either caller shape:
+//   - Semantic tones ('ok'|'warn'|'bad'|'info'|'neutral'|'') map
+//     to Tailwind classes inside the primitive.
+//   - Raw Tailwind class strings (e.g. "bg-[var(--ok)]") pass
+//     through unchanged as extra classes.
+// Caller helpers continue to work without audit.
+//
+// Also adds `children` support. The prior API was label-only but
+// ~12 caller sites already pass children (cascade-config-panel,
+// verification-requests-panel.test mocks). Accepting both keeps
+// every existing usage compiling while the caller mix converges.
 
 import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
 
-interface StatusChipProps {
-  label: string
-  tone?: string
-  class?: string
+export type StatusChipTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral' | ''
+
+const BASE =
+  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider'
+
+const SEMANTIC_TONE: Record<StatusChipTone, string> = {
+  ok: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
+  warn: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
+  bad: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
+  info: 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--accent)]',
+  neutral: 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
+  '': 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
 }
 
-export function StatusChip({ label, tone = '', class: extraClass = '' }: StatusChipProps) {
-  const cls = `cmd-chip rounded-full ${tone} ${extraClass}`.replace(/\s+/g, ' ').trim()
-  return html`<span class="${cls}">${label}</span>`
+/** Pure: true when `tone` is one of the semantic enum members. Raw
+    Tailwind class strings (`bg-[var(--ok)]`) fall through and are
+    composed as-is. Exposed so higher-level helpers can branch. */
+export function isSemanticTone(tone: string): tone is StatusChipTone {
+  return tone in SEMANTIC_TONE
+}
+
+/** Pure: class string for given tone + optional extra. Handles the
+    semantic/raw dichotomy so callers never have to. Base Tailwind
+    tokens (rounded-full + border + px-2 py-0.5 + uppercase +
+    tracking-wider) are always present — they are what makes the
+    chip visually consistent across the dashboard regardless of
+    which tone helper the caller chose. */
+export function statusChipClasses(
+  tone: string = '',
+  extra?: string,
+): string {
+  const toneClass = isSemanticTone(tone) ? SEMANTIC_TONE[tone] : tone
+  const parts = [BASE]
+  if (toneClass !== '') parts.push(toneClass)
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface StatusChipProps {
+  /** Legacy API — plain text label. Prefer `children` for new
+      call sites. When both are set, `children` wins. */
+  label?: string
+  /** One of the semantic enum members, OR a raw Tailwind class
+      string (e.g. the output of `verdictTone()`). Both are valid. */
+  tone?: string
+  /** Extra Tailwind classes for caller layout (margin, shrink-0). */
+  class?: string
+  children?: ComponentChildren
+  testId?: string
+}
+
+export function StatusChip({
+  label,
+  tone = '',
+  class: cx,
+  children,
+  testId,
+}: StatusChipProps) {
+  const cls = statusChipClasses(tone, cx)
+  const content = children ?? label ?? ''
+  return html`<span
+    class=${cls}
+    data-status-chip
+    data-status-chip-tone=${tone}
+    data-testid=${testId}
+  >${content}</span>`
 }

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -8,6 +8,7 @@ import { formatTimeAgo, formatTimestampKo } from '../lib/format-time'
 import { SurfaceCard } from './common/card'
 import { CopyIdButton } from './common/copy-id-button'
 import { SectionCap } from './common/section-cap'
+import { StatusChip } from './common/status-chip'
 import { StatusDot } from './common/status-dot'
 import type {
   RailStatus,
@@ -226,9 +227,7 @@ export function railFreshness(data: HarnessHealthData, rail: 'evaluator' | 'pre_
 
 export function StatusPill({ status }: { status: RailStatus }) {
   return html`
-    <span class=${`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusChipClass(status)}`}>
-      ${railStatusLabel(status)}
-    </span>
+    <${StatusChip} tone=${statusChipClass(status)} class="font-semibold">${railStatusLabel(status)}<//>
   `
 }
 

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
 import { Card } from '../common/card'
+import { StatusChip } from '../common/status-chip'
 
 /**
  * Pure filter for runtime diagnostics entries.
@@ -144,9 +145,7 @@ function ConfigRow({
     <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3" title=${item.path}>
       <div class="mb-2 flex flex-wrap items-center gap-2">
         <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
-        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}">
-          ${item.exists ? 'present' : 'missing'}
-        </span>
+        <${StatusChip} tone=${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}>${item.exists ? 'present' : 'missing'}<//>
         ${showSourceBadge
           ? html`
               <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">
@@ -212,14 +211,10 @@ function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
   return html`
     <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3">
       <div class="mb-1 flex flex-wrap items-center gap-2">
-        <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
-          ${item.kind}
-        </span>
+        <${StatusChip} tone="neutral">${item.kind}<//>
         ${item.signal
           ? html`
-              <span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">
-                ${item.signal}
-              </span>
+              <${StatusChip} tone="warn">${item.signal}<//>
             `
           : null}
         <span class="text-[11px] text-[var(--text-muted)]">${item.ts}</span>
@@ -310,9 +305,7 @@ function RuntimeProbePanel() {
     <div class="mt-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
         <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">ollama warm / kv probe</div>
-        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${probeTone(signal, probe?.probe_ok)}">
-          ${probeSignalLabel(signal)}
-        </span>
+        <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
               <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">
@@ -441,9 +434,7 @@ export function ConfigResolutionPanel({
         ? html`
             <div class="mb-6">
               <div class="mb-3 flex flex-wrap items-center gap-2">
-                <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(resolution.status)}">
-                  ${resolution.status}
-                </span>
+                <${StatusChip} tone=${toneClass(resolution.status)}>${resolution.status}<//>
                 <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
                   ${sourceLabel(resolution.config_root.source)}
                 </span>
@@ -495,15 +486,11 @@ export function ConfigResolutionPanel({
         ? html`
             <div>
               <div class="mb-3 flex flex-wrap items-center gap-2">
-                <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(runtimeResolution.status)}">
-                  ${runtimeResolution.status}
-                </span>
+                <${StatusChip} tone=${toneClass(runtimeResolution.status)}>${runtimeResolution.status}<//>
                 <span class="text-[12px] text-[var(--text-muted)]">runtime path resolution</span>
                 ${runtimeResolution.source_mismatch
                   ? html`
-                      <span class="rounded-full border border-[rgba(244,63,94,0.28)] bg-[rgba(244,63,94,0.10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fecdd3]">
-                        source mismatch
-                      </span>
+                      <${StatusChip} tone="bad">source mismatch<//>
                     `
                   : null}
               </div>

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -14,6 +14,7 @@ import { ErrorState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { TextArea, TextInput } from '../common/input'
 import { FilterChips } from '../common/filter-chips'
+import { StatusChip } from '../common/status-chip'
 
 export type PromptSourceFilter = 'all' | PromptSource
 
@@ -224,7 +225,7 @@ export function PromptRegistryPanel() {
               >
                 <div class="mb-1 flex items-start justify-between gap-2">
                   <div class="font-mono text-[12px] text-[var(--text-strong)]">${prompt.key}</div>
-                  <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceBadgeClass(prompt.source)}">${prompt.source}</span>
+                  <${StatusChip} tone=${sourceBadgeClass(prompt.source)}>${prompt.source}<//>
                 </div>
                 <div class="mb-1 text-[11px] text-[var(--text-muted)]">${prompt.category}</div>
                 <div class="text-[12px] text-[var(--text-body)] leading-relaxed">${prompt.description}</div>
@@ -237,9 +238,9 @@ export function PromptRegistryPanel() {
           ${selectedPrompt ? html`
             <div class="mb-4 flex flex-wrap items-center gap-2">
               <div class="font-mono text-[13px] text-[var(--text-strong)]">${selectedPrompt.key}</div>
-              <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceBadgeClass(selectedPrompt.source)}">${selectedPrompt.source}</span>
+              <${StatusChip} tone=${sourceBadgeClass(selectedPrompt.source)}>${selectedPrompt.source}<//>
               ${selectedPrompt.has_override
-                ? html`<span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[var(--warn-10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">오버라이드 활성</span>`
+                ? html`<${StatusChip} tone="warn">오버라이드 활성<//>`
                 : null}
             </div>
 


### PR DESCRIPTION
## Summary

Fixes the silently-broken StatusChip primitive and absorbs **11 inline chip
call sites** (3 files) into it. **P2 of the 9-PR dashboard hygiene sweep**
started with #8076 (SectionCap).

### Silent 50% breakage, surfaced

The previous `StatusChip` composed a `cmd-chip` class that has **no CSS
definition anywhere in the repo** (`rg cmd-chip` returns only the primitive
file itself). The `tone` param was a bare string passed straight into
`class=`, which meant:

- `<StatusChip tone="warn">` → rendered with no styling (tone = semantic
  string, no Tailwind match)
- `<StatusChip tone="bg-[var(--ok)]">` → rendered correctly (tone = raw
  Tailwind class, passthrough worked)

~half the caller helpers (`toneClass`, `sourceBadgeClass`, `probeTone`,
`statusChipClass`, `categoryTone`) returned semantic strings, so ~half the
chips in the dashboard had been quietly invisible.

## Rewrite

- Drop the `.cmd-chip` dead reference. **Base Tailwind tokens** always
  present: `inline-flex items-center rounded-full border px-2 py-0.5
  text-[10px] uppercase tracking-wider`
- **Semantic tones** (`'ok'|'warn'|'bad'|'info'|'neutral'|''`) map to
  Tailwind classes inside the primitive:
  ```
  ok     → border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]
  warn   → border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]
  bad    → border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]
  info   → border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--accent)]
  neutral/'' → border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]
  ```
- **Raw Tailwind class strings** pass through unchanged. `verdictTone()`,
  `toneClass()`, `sourceBadgeClass()`, `probeTone()`, `statusChipClass()`,
  `categoryTone()` — all existing helpers keep working without audit.
- `children` support (~12 caller sites already pass children, test mocks
  assume it). `children` wins over legacy `label`.
- `data-status-chip` + `data-status-chip-tone` + `testId` for
  deterministic selectors.

## Migration (11 absorptions, 3 files)

| File | Lines | Pattern absorbed |
|------|-------|-------------------|
| `tools/config-resolution-panel.ts` | 147, 216, 221, 313, 444, 498, 504 | 7 inline chips (toneClass / probeTone / custom rgba) |
| `tools/prompt-registry-panel.ts` | 227, 240, 242 | 3 inline chips (sourceBadgeClass / rgba warn) |
| `harness-health-sections.ts` | 228 | `StatusPill` — `statusChipClass` + font-semibold |

Custom rgba chips collapsed to semantic tone where equivalent:
- `rgba(250,204,21)` = yellow-400 = `var(--warn)` → `tone="warn"`
- `rgba(244,63,94)` = red-500 = `var(--bad)` → `tone="bad"`

Visually equivalent, token-backed.

## Existing callers untouched

All 7 files that already `import { StatusChip }` (mission-briefing-card,
runtime-monitor, verification-specs-panel, verification-requests-panel,
mission-session-flow, cascade-config-panel, governance-monitor) continue to
compile and render. Semantic-tone callers that were silently broken now
render correctly — a user-visible fix independent of the absorption.

## Deferred (B2 follow-ups)

- 4 non-uppercase chip variants in `config-resolution-panel.ts`
  (lines 152, 159, 318, 447) — CountBadge-style labels, not StatusChips → **P3**
- `text-[11px]` label size in `config-resolution-panel.ts` → **P2.5** (size prop)
- `focus-visible:ring-1` on StatusChip → **P8** a11y sweep

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3560/3560 green (13 new `StatusChip` cases: 2 `isSemanticTone` + 6 `statusChipClasses` + 5 component)
- [x] `pnpm build` — vite clean (pre-existing chunk warnings unrelated)
- [ ] CI green
- [ ] Empirical: local dashboard boot → config-resolution panel / prompt
      registry chips visually filled in (previously quietly invisible for
      semantic tones)

## Follow-up roadmap (from #8076 plan)

| PR | Scope |
|----|-------|
| P3 | CountBadge expansion + SectionCap inline variant + non-uppercase chip variants |
| P4 | IdPill primitive |
| P5 | text-[9px] density sweep |
| P6 | Color var normalization + drift CI lint |
| P7 | Rounded / font-weight sweep |
| P8 | a11y / focus ring sweep |
| P9 | Waste sweep |
