### PR TITLE
chore(dashboard): purge createMissionWorkflowContext cascade orphan (-31 LOC)

### DIFF
--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals'
-import type { OperatorAttentionItem, OperatorRecommendedAction, RouteState } from './types'
+import type { OperatorRecommendedAction, RouteState } from './types'
 import { isRecord } from './components/common/normalize'
 import { isRootTarget } from './components/ops/helpers'
 
@@ -172,36 +172,6 @@ function workflowContextId(
     createdAt,
   ].join(':')
 }
-
-export function createMissionWorkflowContext(
-  action?: OperatorRecommendedAction | null,
-  incident?: OperatorAttentionItem | null,
-  sourceLabel = '상황판 추천 액션',
-): DashboardWorkflowContext {
-  const createdAt = new Date().toISOString()
-  const payload = extractActionPayload(action)
-  const targetType = action?.target_type ?? incident?.target_type ?? null
-  const targetId = action?.target_id ?? incident?.target_id ?? null
-  const focusKind = incident?.kind ?? action?.action_type ?? null
-  const summary = action?.reason ?? incident?.summary ?? sourceLabel
-  return {
-    id: workflowContextId('mission', sourceLabel, action?.action_type ?? null, targetType, targetId, focusKind, null, createdAt),
-    source_surface: 'mission',
-    source_label: sourceLabel,
-    action_type: action?.action_type ?? null,
-    target_type: targetType,
-    target_id: targetId,
-    focus_kind: focusKind,
-    operation_id: null,
-    summary,
-    payload_preview: summarizePayloadPreview(payload),
-    suggested_payload: payload,
-    preview: action?.preview ?? null,
-    evidence: incident?.evidence ?? null,
-    created_at: createdAt,
-  }
-}
-
 
 function matchesRouteParams(
   context: DashboardWorkflowContext,


### PR DESCRIPTION
## Summary

`/loop 20m` Gen50. Gen49(#8081) 머지 후 strict scan에서 확인한 **마지막 cascade orphan**.

## 제거

`createMissionWorkflowContext` — action/incident → DashboardWorkflowContext factory. Gen47이 incident 계열 navigate를 제거하면서 일부 caller 소실, Gen49가 action 계열까지 제거하면서 마지막 consumer가 사라짐. 이제 `total refs=1` (declaration only).

부수: `OperatorAttentionItem` type import orphan 제거 (이 factory 외에 사용처 없음).

## 변경

| 파일 | LOC |
|---|---|
| `dashboard/src/workflow-context.ts` (314 → 285) | **-31** |

## Gen47 → Gen49 → Gen50 cascade chain

| Gen | 제거 | Cascade 효과 |
|---|---|---|
| 47 | incident/command navigate 4 fns | `openActionIntervene` still alive |
| 49 | action navigate 3 fns + navigateWithContext + signals + 2 files | `createMissionWorkflowContext` becomes dead |
| **50** | **createMissionWorkflowContext 1 fn** | **mission workflow factory chain fully retired** |

## 남은 workflow-context.ts

- **Alive via 2+ non-test callers**: `missionInterveneParams`, `persistWorkflowContext`, `workflowActionLabel`, `workflowContextForRoute`, `workflowTargetLabel`
- **Tested internal helpers** (test-exposed, internally used): `extractActionPayload`, `summarizePayloadPreview`, `dashboardWorkflowContext`, `workflowInterveneParams`

## 검증

- `tsc --noEmit`: ✅ error 0 (orphan type import 1건 추가 정리)
- `bun run build`: ✅ 12.53s
- `bun run test`: ✅ **3544 tests pass**
  - `saved-signal.test.ts` 9 fails: pre-existing (PR #8014)

## /loop 세션 현황

Gen36-49 전부 MERGED. Gen50 (이 PR) Draft.

누적: **~-3,607 LOC dashboard dead code**

## 다음 cycle 후보

Strict scan 재실행해서 추가 cascade 탐색. 지금까지 `runtime-monitor.ts`, `proof-helpers.ts` dead 의심은 모두 tested-but-internal 패턴일 가능성 높음 — total refs 기준으로 재확인 필요.

- Gen51: CSS 중복 블록 통합
- Gen52: strict scan + 새 target 탐색

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)