### PR TITLE
feat(dashboard): ⏱ human-format server uptime in BuildIdentityBadge

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { githubCommitUrl, currentSectionShareUrl } from './dashboard-shell'
+import {
+  githubCommitUrl,
+  currentSectionShareUrl,
+  formatUptimeSecondsHuman,
+} from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
   it('returns null for null / undefined / empty string', () => {
@@ -98,5 +102,42 @@ describe('currentSectionShareUrl (pure)', () => {
     } finally {
       windowSpy.mockRestore()
     }
+  })
+})
+
+describe('formatUptimeSecondsHuman (pure)', () => {
+  it('null / undefined → "알 수 없음"', () => {
+    expect(formatUptimeSecondsHuman(null)).toBe('알 수 없음')
+    expect(formatUptimeSecondsHuman(undefined)).toBe('알 수 없음')
+  })
+
+  it('NaN → "알 수 없음" (no "NaNs" in the dropdown)', () => {
+    expect(formatUptimeSecondsHuman(Number.NaN)).toBe('알 수 없음')
+  })
+
+  it('negative → "알 수 없음" (no "-5s" — clock skew guard)', () => {
+    expect(formatUptimeSecondsHuman(-5)).toBe('알 수 없음')
+  })
+
+  it('sub-minute → "Xs" compact', () => {
+    expect(formatUptimeSecondsHuman(3)).toBe('3s')
+    expect(formatUptimeSecondsHuman(45)).toBe('45s')
+  })
+
+  it('sub-hour → "Xm Ys" compact', () => {
+    expect(formatUptimeSecondsHuman(125)).toBe('2m 5s')
+    expect(formatUptimeSecondsHuman(3599)).toBe('59m 59s')
+  })
+
+  it('hour+ → "Xh Ym" compact (regression over the raw "3600s" pre-fix)', () => {
+    // The whole point of this helper: 3600 stopped reading as
+    // "3600s" (cognitive load) and now reads as "1h 0m".
+    expect(formatUptimeSecondsHuman(3600)).toBe('1h 0m')
+    expect(formatUptimeSecondsHuman(9000)).toBe('2h 30m')
+    expect(formatUptimeSecondsHuman(86_400)).toBe('24h 0m')
+  })
+
+  it('zero seconds → "0s" (fresh boot, still valid)', () => {
+    expect(formatUptimeSecondsHuman(0)).toBe('0s')
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -20,6 +20,7 @@ import { RouteLink } from './common/route-link'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
 import { CopyIdButton } from './common/copy-id-button'
+import { formatElapsedCompact } from '../lib/format-time'
 
 const buildIdentityOpen = signal(false)
 
@@ -96,6 +97,20 @@ export function githubCommitUrl(commit: string | null | undefined): string | nul
   return `https://github.com/${UPSTREAM_REPO}/commit/${value}`
 }
 
+/** Pure: render uptime seconds as a human-readable duration for the
+    build-identity dropdown. Delegates to formatElapsedCompact ("3s",
+    "5m 10s", "2h 30m"). Negative / NaN / non-number inputs return
+    \"알 수 없음\" so the dropdown never prints \"NaNs\" or \"-5s\". */
+export function formatUptimeSecondsHuman(
+  seconds: number | null | undefined,
+): string {
+  if (typeof seconds !== 'number' || Number.isNaN(seconds) || seconds < 0) {
+    return '알 수 없음'
+  }
+  return formatElapsedCompact(seconds)
+}
+
+
 export function BuildIdentityBadge() {
   const status = serverStatus.value
   const build = status?.build
@@ -148,7 +163,10 @@ export function BuildIdentityBadge() {
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>업타임</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s` : '알 수 없음'}</strong>
+                <strong
+                  class="text-[color:var(--text-strong)] text-right tabular-nums"
+                  title=${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s raw` : undefined}
+                >${formatUptimeSecondsHuman(build?.uptime_seconds)}</strong>
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>쉘 스냅샷</span>


### PR DESCRIPTION
## Summary
- Dashboard BuildIdentityBadge dropdown's uptime field: raw \`\"3600s\"\` → readable \`\"1h 0m\"\`. Cognitive load for zero benefit removed; exact seconds still accessible via hover title.
- Tiny visible chip, no plumbing — delegates to the existing \`formatElapsedCompact\` helper so the dashboard's time-format vocabulary stays single-source-of-truth.

## Before / After
\`\`\`
Before:
  업타임    3600s        ← raw integer, no scan value
After:
  업타임    1h 0m        ← compact human duration
  (hover title: \"3600s raw\" ← exact seconds one hover away)
\`\`\`

## Pure \`formatUptimeSecondsHuman(seconds)\` — 7 invariants pinned
| Input | Output |
|---|---|
| null / undefined / NaN / negative | \`\"알 수 없음\"\` (guard against \"NaNs\" / \"-5s\") |
| 0 | \`\"0s\"\` (fresh boot) |
| < 60 | \`\"Xs\"\` |
| < 3600 | \`\"Xm Ys\"\` |
| ≥ 3600 | \`\"Xh Ym\"\` |

## Regression guards
- Clock skew could produce negative uptime → \"알 수 없음\" instead of \"-5s\".
- NaN handled explicitly → never \"NaNs\" in the dropdown.
- \`tabular-nums\` on the rendered value so 2-digit → 3-digit transitions don't shift the row.

## Test plan
- [x] 7 pure helper tests. Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → click build badge → dropdown shows \"1h 3m\" (or similar) instead of \"3783s\"; hover the value → title shows \"3783s raw\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)