### PR TITLE
chore(dashboard): purge 8 dead constants (-11 LOC)

### DIFF
--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -20,13 +20,10 @@ export const RECONNECT_MAX_MS = 15_000
 
 // --- Refresh & debounce (milliseconds) ---
 export const SHELL_TTL_MS = 5_000
-export const EXECUTION_TTL_MS = 30_000
 export const HEARTBEAT_STALE_MS = 120_000
 export const UI_REFRESH_TTL_MS = 1_000
-export const COMMAND_HELP_TTL_MS = 60_000
 export const MISSION_BRIEFING_POLL_DELAY_MS = 1_500
 export const SSE_DEFAULT_DEBOUNCE_MS = 500
-export const SSE_OPERATOR_DEBOUNCE_MS = 300
 export const SSE_ACTIVITY_DEBOUNCE_MS = 2_000
 export const SSE_KEEPER_OPERATOR_DEBOUNCE_MS = 600
 export const SSE_KEEPER_THREAD_DEBOUNCE_MS = 800
@@ -41,19 +38,11 @@ export const TELEMETRY_AUTO_REFRESH_MS = 30_000
 export const CONTEXT_RATIO_CRITICAL = 0.85  // handoff-imminent
 export const CONTEXT_RATIO_WARN = 0.70      // preparing
 export const CONTEXT_RATIO_COMPACTING = 0.50 // compacting
-// Fleet overview coloring (intermediate between warn and compacting)
-export const CONTEXT_RATIO_FLEET_WARN = 0.60
-
-// --- Trajectory timeline ---
-export const TRAJECTORY_HEARTBEAT_STALE_MS = 30_000
-export const LIVENESS_TICK_MS = 5_000
 
 // --- Keeper UI/runtime limits ---
-export const KEEPER_STATUS_TAIL_MESSAGES = 50
 export const KEEPER_HISTORY_TAIL_MESSAGES = 200
 export const KEEPER_STREAM_IDLE_TIMEOUT_MS = 120_000
 export const KEEPER_STREAM_IDLE_POLL_MS = 5_000
-export const KEEPER_REPLY_PREVIEW_MAX = 200
 
 // --- Buffer & cache sizes ---
 export const MAX_JOURNAL_ENTRIES = 200


### PR DESCRIPTION
## Summary

`/loop 20m` Gen51. `config/constants.ts` strict scan(total refs=1)에서 **8개 dead constants** 확인. 각 상수의 소비처가 이전 cycle들에서 retired됨.

## 제거 상수 (+ 각 맥락)

| 상수 | Dead 사유 |
|---|---|
| `EXECUTION_TTL_MS` | Gen37 writeonly execution signals 삭제 후 orphan |
| `COMMAND_HELP_TTL_MS` | retired command help 패널 |
| `SSE_OPERATOR_DEBOUNCE_MS` | retired operator page SSE debounce |
| `CONTEXT_RATIO_FLEET_WARN` | retired fleet overview 컬러링 |
| `TRAJECTORY_HEARTBEAT_STALE_MS` | Gen41 keeper-trajectory-timeline shrink 후 orphan |
| `LIVENESS_TICK_MS` | 동일 (Gen41 cascade) |
| `KEEPER_STATUS_TAIL_MESSAGES` | retired status tail 제한 |
| `KEEPER_REPLY_PREVIEW_MAX` | retired reply preview 제한 |

+ orphan comment separator (`"// --- Trajectory timeline ---"`) 2개 제거.

## 변경

| 파일 | LOC |
|---|---|
| `dashboard/src/config/constants.ts` (80 → 69) | **-11** |

## Scan 방법론 확장

지금까지 strict scan은 **functions만** 검사했음. 이번 cycle에서 **const/interface/type**까지 확장:
```
find dashboard/src -type f | grep export | check total refs == 1
```
결과 14개 dead symbols 발견. 이 PR은 그 중 config/constants 클러스터 (8개) 처리.

다음 cycle 후보(나머지 6개):
- `dashboard-execution.ts::DashboardExecutionOperationBrief` type
- `types/core.ts::BoardHearth`, `BoardFlair` — 2 type orphans
- `mission-utils.ts::EnrichedKeeperRow`, `EnrichedAgentRow` — 2 type orphans
- `api/schemas/keeper-composite.ts::KeeperCompositeCircuitBreakerState`
- `store.ts::keeperLifecycles` signal

## 검증

- `tsc --noEmit`: ✅ error 0
- `bun run build`: ✅ 7.70s
- `bun run test`: ✅ **3556 tests pass**
  - `saved-signal.test.ts` 9 fails: pre-existing (PR #8014)

## /loop 세션

Gen36-49 MERGED. Gen50, Gen51 Draft.
누적 dashboard dead code: **~-3,618 LOC**

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)