### PR TITLE
[codex] fix worker runtime image build

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -5,12 +5,14 @@ WORKDIR /src
 COPY . .
 
 RUN sudo apt-get update \
- && sudo apt-get install -y --no-install-recommends pkg-config libssl-dev libsqlite3-dev zlib1g-dev curl git \
- && rm -rf /var/lib/apt/lists/*
+ && sudo apt-get install -y --no-install-recommends pkg-config libssl-dev libsqlite3-dev zlib1g-dev curl git libgmp-dev libprotobuf-dev protobuf-compiler libffi-dev \
+ && sudo rm -rf /var/lib/apt/lists/*
 
-RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test -y && dune build @install"
+RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . --deps-only -y && dune build @install"
 
 FROM ocaml/opam:debian-12-ocaml-5.4 AS runtime
+
+USER root
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl git libsqlite3-0 libssl3 zlib1g \


### PR DESCRIPTION
## What changed
- make the build-stage apt cleanup run under `sudo`
- install the missing build-stage system dependencies: `libgmp-dev`, `libprotobuf-dev`, `protobuf-compiler`, and `libffi-dev`
- drop `--with-test` from the worker runtime image dependency install so the runtime image does not pull test-only solver conflicts
- make the runtime stage run package installation as `root`

## Why
`Dockerfile.worker-runtime` did not build cleanly as written.

There were three separate failure modes:
- the runtime stage tried to run `apt-get` without root privileges
- the build stage cleaned `/var/lib/apt/lists/*` without root privileges
- the build stage was missing system packages required by opam `conf-*` packages
- the image build installed test-only opam dependencies, which introduced an avoidable solver conflict for a runtime image

## Impact
- `masc-worker-runtime:dev` can now be built locally from the fixed Dockerfile
- this unblocks Docker-backed worker sandbox execution when `worker_spawn.backend = docker`

## Validation
- built `masc-worker-runtime:dev` successfully with `docker build -f Dockerfile.worker-runtime -t masc-worker-runtime:dev ...`
- verified the resulting image entrypoint is `/usr/local/bin/masc-worker-run`
- separately verified local server reachability from Docker via `host.docker.internal:8935`

## Notes
- this PR only includes the Dockerfile fix required to make the worker runtime image buildable
- local runtime config and server env changes used for smoke verification were not included in this PR