### PR TITLE
feat(dashboard): 🔗 copy-current-section-URL button next to the page title

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { githubCommitUrl } from './dashboard-shell'
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { githubCommitUrl, currentSectionShareUrl } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
   it('returns null for null / undefined / empty string', () => {
@@ -53,5 +54,49 @@ describe('githubCommitUrl (pure)', () => {
     expect(githubCommitUrl('  abc1234  ')).toBe(
       'https://github.com/jeong-sik/masc-mcp/commit/abc1234',
     )
+  })
+})
+
+describe('currentSectionShareUrl (pure)', () => {
+  const originalHref = typeof window !== 'undefined' ? window.location.href : ''
+
+  beforeEach(() => {
+    if (typeof window !== 'undefined') {
+      window.history.pushState({}, '', '/')
+    }
+  })
+
+  afterEach(() => {
+    if (typeof window !== 'undefined') {
+      window.history.pushState({}, '', originalHref)
+    }
+  })
+
+  it('returns window.location.href when available', () => {
+    window.history.pushState({}, '', '/?tab=connectors&section=connector-discord')
+    expect(currentSectionShareUrl()).toContain('?tab=connectors&section=connector-discord')
+  })
+
+  it('preserves hash fragments (router hash-based flow)', () => {
+    window.history.pushState({}, '', '/#section=discord')
+    const url = currentSectionShareUrl()
+    expect(url).toContain('#section=discord')
+  })
+
+  it('returns the full absolute URL (not a relative path) — paste-into-Slack safety', () => {
+    // Regression guard: callers paste this into Slack / docs — relative
+    // paths would land the reader on the wrong origin.
+    const url = currentSectionShareUrl()
+    expect(url.startsWith('http')).toBe(true)
+  })
+
+  it('returns empty string when window is undefined (SSR guard)', () => {
+    const windowSpy = vi.spyOn(globalThis, 'window', 'get')
+    windowSpy.mockReturnValue(undefined as unknown as Window & typeof globalThis)
+    try {
+      expect(currentSectionShareUrl()).toBe('')
+    } finally {
+      windowSpy.mockRestore()
+    }
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -19,6 +19,7 @@ import {
 import { RouteLink } from './common/route-link'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
+import { CopyIdButton } from './common/copy-id-button'
 
 const buildIdentityOpen = signal(false)
 
@@ -343,18 +344,43 @@ export function TabContent() {
   }
 }
 
+/** Pure: build the shareable URL for the current section. Uses
+    window.location as the truth source (the router writes to it
+    already) so we never diverge from what the browser address bar
+    shows. Returns empty string when window is unavailable
+    (SSR/happy-dom without location) so the caller can hide the
+    share affordance gracefully. */
+export function currentSectionShareUrl(): string {
+  if (typeof window === 'undefined' || window.location === undefined) {
+    return ''
+  }
+  return window.location.href
+}
+
 function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
 
   const description = currentSection?.description ?? currentView?.description ?? null
+  const title = currentSection?.label ?? currentView?.label ?? '홈'
+  const shareUrl = currentSectionShareUrl()
 
   return html`
     <div class="mb-3 flex flex-col gap-1.5">
-      <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
-        ${currentSection?.label ?? currentView?.label ?? '홈'}
-      </h2>
+      <div class="flex items-center gap-2">
+        <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
+          ${title}
+        </h2>
+        ${shareUrl !== ''
+          ? html`<${CopyIdButton}
+              value=${shareUrl}
+              label=${`섹션 링크 (${title})`}
+              ariaLabel="현재 섹션 URL 복사"
+              size=${14}
+            />`
+          : null}
+      </div>
       ${description ? html`<p class="m-0 text-[13px] leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
     </div>
   `


### PR DESCRIPTION
## Summary
- Small copy-link button next to every page's \`<h2>\` title in SurfaceLead. One click → full shareable URL for the current section is in the clipboard, toast confirms.
- **잘 보이고 잘 입력** — the share flow no longer leaves the dashboard surface (no more \"click in address bar, select all, copy\").

## Reference UIs
- **GitHub** — \`#\` anchor-link button on headings.
- **Notion** — inline \"Copy link\" on heading hover.
- **Linear** — compact copy-URL icon in page titlebar.
- **Common thread**: the share action lives **next to the content**, not in the browser chrome.

## Visual placement
\`\`\`
Before:
  커넥터 상태                   ← h2 title alone

After:
  커넥터 상태  📋              ← h2 + compact copy-URL button
\`\`\`
The button uses the same \`CopyIdButton\` primitive that already surfaces on connector id / keeper id copy flows. **One copy vocabulary across the dashboard** — hover affordance, icon swap on click, and toast all match.

## Pure \`currentSectionShareUrl()\` — 4 invariants pinned
- Returns \`window.location.href\` when available (router already writes to it, never diverges from address bar).
- Returns \`\"\"\` in a non-DOM context (SSR / node-only env) so the caller can hide the share button gracefully.
- Preserves hash fragments (the router's hash-based flow still round-trips cleanly).
- Returned URL starts with \`http\` — regression guard so callers pasting into Slack / docs never get a relative path that lands on the wrong origin.

## Toast behavior
\`label = \"섹션 링크 ({section title})\"\` so operators who copy several section URLs in quick succession see which one they just grabbed without checking the clipboard.

## Test plan
- [x] 4 new pure helper tests (window.location.href, hash preservation, SSR guard via \`vi.spyOn(globalThis, 'window')\`, http-prefix regression guard). Suite 8 → 12 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → visit \`#section=connector-discord\` → click the copy button next to \"Discord\" title → toast → paste into a text box → full URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)