### PR TITLE
feat(dashboard): 🧭 breadcrumb trail on drilldown sections — Connectors › Discord

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -4,6 +4,7 @@ import {
   githubCommitUrl,
   currentSectionShareUrl,
   formatUptimeSecondsHuman,
+  deriveBreadcrumbTrail,
 } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
@@ -139,5 +140,48 @@ describe('formatUptimeSecondsHuman (pure)', () => {
 
   it('zero seconds → "0s" (fresh boot, still valid)', () => {
     expect(formatUptimeSecondsHuman(0)).toBe('0s')
+  })
+})
+
+describe('deriveBreadcrumbTrail (pure)', () => {
+  it('both null → [] (home / unknown, no crumb)', () => {
+    expect(deriveBreadcrumbTrail(null, null, null)).toEqual([])
+  })
+
+  it('tab only, no section → single non-navigable crumb (standing on tab default)', () => {
+    // A newcomer on \"Connectors\" default view sees \"Connectors\" as
+    // the title already; duplicating it in a crumb above would be
+    // pure noise, so the SurfaceLead consumer hides the trail in
+    // this case — the pure helper still returns a single crumb so
+    // other callers (e.g. future titlebar) can render it.
+    expect(deriveBreadcrumbTrail('Connectors', null, 'connectors')).toEqual([
+      { label: 'Connectors', navigableTab: null },
+    ])
+  })
+
+  it('section only, no tab → single non-navigable crumb with section label', () => {
+    expect(deriveBreadcrumbTrail(null, 'Discord', null)).toEqual([
+      { label: 'Discord', navigableTab: null },
+    ])
+  })
+
+  it('drilldown: tab + section → parent crumb navigable, leaf not', () => {
+    // The parent tab is clickable so operator can bounce back up to
+    // the grid; the leaf is where we currently stand, so clicking it
+    // would be a no-op (marked non-navigable).
+    expect(deriveBreadcrumbTrail('Connectors', 'Discord', 'connectors')).toEqual([
+      { label: 'Connectors', navigableTab: 'connectors' },
+      { label: 'Discord', navigableTab: null },
+    ])
+  })
+
+  it('drilldown without tab id → parent crumb still rendered, but non-navigable', () => {
+    // Regression guard: a section-only route that somehow doesn't
+    // carry the parent tab id should still show the parent label,
+    // just without a clickable link. Never throws.
+    expect(deriveBreadcrumbTrail('Connectors', 'Discord', null)).toEqual([
+      { label: 'Connectors', navigableTab: null },
+      { label: 'Discord', navigableTab: null },
+    ])
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -375,6 +375,45 @@ export function currentSectionShareUrl(): string {
   return window.location.href
 }
 
+/** Pure: derive the navigation trail rendered above the section title.
+    Each crumb is either a clickable ancestor (tab) or the terminal
+    leaf (current section label, non-navigable). Returns a flat array:
+    [] when both tab + section are absent (home / unknown),
+    [tab] when only tab is active (no section drilldown),
+    [tab, section] when the operator has drilled into a per-section view.
+
+    Why this exists: SurfaceLead previously rendered only the leaf
+    label (\"Discord\"). The parent tab (\"Connectors\") was implied by
+    the left nav but not surfaced in the content area — a newcomer
+    opening a deep link had to infer the hierarchy. Every modern web
+    app (GitHub / Linear / Notion / Vercel) renders the trail above
+    the page title for exactly this reason. */
+export interface BreadcrumbCrumb {
+  label: string
+  navigableTab: string | null
+}
+export function deriveBreadcrumbTrail(
+  tabLabel: string | null,
+  sectionLabel: string | null,
+  tabId: string | null,
+): BreadcrumbCrumb[] {
+  if (tabLabel === null && sectionLabel === null) return []
+  if (sectionLabel === null) {
+    return tabLabel !== null ? [{ label: tabLabel, navigableTab: null }] : []
+  }
+  if (tabLabel === null) {
+    return [{ label: sectionLabel, navigableTab: null }]
+  }
+  // Drilldown view — tab becomes a clickable parent crumb, section is
+  // the non-navigable leaf (you're already there, clicking it would
+  // be a no-op).
+  return [
+    { label: tabLabel, navigableTab: tabId },
+    { label: sectionLabel, navigableTab: null },
+  ]
+}
+
+
 function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
@@ -383,9 +422,39 @@ function SurfaceLead() {
   const description = currentSection?.description ?? currentView?.description ?? null
   const title = currentSection?.label ?? currentView?.label ?? '홈'
   const shareUrl = currentSectionShareUrl()
+  // Only surface a trail when the operator has drilled into a section —
+  // otherwise the crumb would be \"Connectors\" right above a \"Connectors\"
+  // title, pure duplication.
+  const trail = currentSection !== null
+    ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
+    : []
 
   return html`
     <div class="mb-3 flex flex-col gap-1.5">
+      ${trail.length > 0
+        ? html`<nav
+            class="flex items-center gap-1 text-[11px] text-[var(--text-dim)]"
+            aria-label="페이지 경로"
+            data-surface-breadcrumb
+          >
+            ${trail.map((crumb, i) => {
+              const isLast = i === trail.length - 1
+              const sep = i > 0
+                ? html`<span aria-hidden="true" class="text-[var(--white-10)]">›</span>`
+                : null
+              const crumbEl = crumb.navigableTab !== null && !isLast
+                ? html`<${RouteLink}
+                    tab=${crumb.navigableTab}
+                    class="cursor-pointer rounded px-1 py-0.5 hover:bg-[var(--white-5)] hover:text-[var(--text-body)]"
+                  >${crumb.label}<//>`
+                : html`<span
+                    class="px-1 py-0.5 ${isLast ? 'text-[var(--text-body)]' : ''}"
+                    aria-current=${isLast ? 'page' : undefined}
+                  >${crumb.label}</span>`
+              return html`${sep}${crumbEl}`
+            })}
+          </nav>`
+        : null}
       <div class="flex items-center gap-2">
         <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
           ${title}


### PR DESCRIPTION
## Summary
- Above every drilldown section title (e.g. \`#section=connector-discord\` → \"Discord\"), a small navigation trail renders: **Connectors › Discord**. The parent tab label is a clickable \`RouteLink\`; the leaf is a non-navigable terminal crumb marked \`aria-current=\"page\"\`.
- **잘 보이고 잘 입력** — hierarchy is explicit, and the parent tab is one click away without hunting in the side nav.

## Reference UIs
- **GitHub** — \"masc-mcp › src › components\" above file views.
- **Linear** — \"MASC › Backlog › Issue\" above issue detail.
- **Notion** — breadcrumb in page header next to title.
- **Vercel** — project breadcrumb at deployment detail top.
- **Common thread**: the trail lives **above the content title**, always clickable ancestors + non-clickable leaf.

## Visual placement
\`\`\`
Before:
  Discord                                    ← leaf alone, parent implied

After:
  Connectors › Discord                       ← crumb trail
  Discord                                    ← title unchanged
\`\`\`

## Pure \`deriveBreadcrumbTrail(tabLabel, sectionLabel, tabId)\` — 5 invariants pinned
| Input | Output |
|---|---|
| both null | \`[]\` (home / unknown) |
| \`tab=\"Connectors\"\`, section=null | \`[{tab, navigable: null}]\` (standing on tab default) |
| section only | \`[{section, navigable: null}]\` |
| tab + section drilldown | \`[{tab, navigable: tabId}, {section, navigable: null}]\` |
| section present but no tab id | both rendered, both non-navigable (never throws) |

## Rendering rules
- SurfaceLead renders the trail **only** when \`currentSection !== null\` — standing on a tab default would duplicate the title into the crumb (pure noise). The pure helper still returns a single crumb for that case so future callers (titlebar, share preview) can reuse it.
- Parent crumb uses the existing \`RouteLink\` primitive → one navigation vocabulary across the app.
- Separator glyph is \`›\` — matches the existing readiness rail + path strip micro-graphics.
- Leaf crumb carries \`aria-current=\"page\"\` so AT users hear \"you are here\".

## Test plan
- [x] 5 new pure helper tests. Suite 8 → 13 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → click sidebar Connectors → Discord section → breadcrumb \"Connectors › Discord\" visible above title → click \"Connectors\" → jumps back to grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)