### PR TITLE
feat(dashboard): 🏷 dynamic browser tab title — MASC · {section} per page

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -5,6 +5,7 @@ import {
   currentSectionShareUrl,
   formatUptimeSecondsHuman,
   deriveBreadcrumbTrail,
+  composeDocumentTitle,
 } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
@@ -183,5 +184,44 @@ describe('deriveBreadcrumbTrail (pure)', () => {
       { label: 'Connectors', navigableTab: null },
       { label: 'Discord', navigableTab: null },
     ])
+  })
+})
+
+describe('composeDocumentTitle (pure)', () => {
+  it('both null → fallback to default brand title', () => {
+    expect(composeDocumentTitle(null, null)).toBe('MASC Dashboard')
+  })
+
+  it('whitespace-only labels fall back to default (no ghost \"MASC · \")', () => {
+    expect(composeDocumentTitle('   ', null)).toBe('MASC Dashboard')
+    expect(composeDocumentTitle(null, '   ')).toBe('MASC Dashboard')
+  })
+
+  it('tab only → \"MASC · {tab}\"', () => {
+    expect(composeDocumentTitle('Connectors', null)).toBe('MASC · Connectors')
+  })
+
+  it('section only → \"MASC · {section}\"', () => {
+    expect(composeDocumentTitle(null, 'Discord')).toBe('MASC · Discord')
+  })
+
+  it('section takes precedence over tab (deeper drill wins the tab title)', () => {
+    // The rationale: if an operator has 4 tabs open — Connectors,
+    // Connectors/Discord, Connectors/Slack, Monitoring — the browser
+    // tab list should distinguish the three Connectors-variants by
+    // their leaf section, not repeat \"MASC · Connectors\" three times.
+    expect(composeDocumentTitle('Connectors', 'Discord')).toBe('MASC · Discord')
+  })
+
+  it('returned string always starts with \"MASC\" brand prefix (or is plain brand on fallback)', () => {
+    // Regression guard: a future refactor must not accidentally drop
+    // the brand prefix — operators scanning the browser tab bar look
+    // for \"MASC\" first.
+    const titles = [
+      composeDocumentTitle('Connectors', 'Discord'),
+      composeDocumentTitle('Connectors', null),
+      composeDocumentTitle(null, null),
+    ]
+    for (const t of titles) expect(t.startsWith('MASC')).toBe(true)
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
+import { useEffect } from 'preact/hooks'
 import { route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
@@ -414,6 +415,25 @@ export function deriveBreadcrumbTrail(
 }
 
 
+/** Pure: compose the browser tab title from the current surface +
+    section. Reference: every polished SPA (GitHub / Linear / Notion /
+    Vercel) sets document.title so operators with multiple tabs open
+    can distinguish them from the browser's tab list. Without this,
+    4 dashboard tabs all say \"MASC Dashboard\" — users lose track.
+
+    Format: \"MASC · {section}\" when drilled into a section,
+            \"MASC · {tab}\" when on a tab default,
+            \"MASC Dashboard\" on home / unknown (original fallback). */
+export function composeDocumentTitle(
+  tabLabel: string | null,
+  sectionLabel: string | null,
+): string {
+  const leaf = sectionLabel ?? tabLabel
+  if (leaf === null || leaf.trim() === '') return 'MASC Dashboard'
+  return `MASC · ${leaf}`
+}
+
+
 function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
@@ -428,6 +448,13 @@ function SurfaceLead() {
   const trail = currentSection !== null
     ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
     : []
+
+  // Sync document.title — syncing to an external system (the browser
+  // tab title) is a legitimate useEffect. Keyed on the two labels so
+  // the effect only re-runs on actual navigation, not every render.
+  useEffect(() => {
+    document.title = composeDocumentTitle(currentView?.label ?? null, currentSection?.label ?? null)
+  }, [currentView?.label, currentSection?.label])
 
   return html`
     <div class="mb-3 flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary
- \`document.title\` now reflects the current surface/section: **MASC · Discord** / **MASC · Observatory** / etc. instead of the static \"MASC Dashboard\".
- Operators with multiple dashboard tabs open can finally distinguish them in the browser tab bar + OS switcher.
- **잘 보이고 잘 입력** — tab bar becomes a usable navigation surface instead of four identical strings.

## Reference UIs
- **GitHub** — title changes to match the current repo/issue/PR.
- **Linear** — title changes to \"MyProject · Issue #123\".
- **Notion** — page title drives tab title.
- **Vercel** — \"ProjectName · Deployments\" etc.
- **Common thread**: the browser tab list is free real estate that most SPAs waste on a static brand string.

## Before / After
\`\`\`
Before (all 4 tabs):                 After:
  MASC Dashboard                       MASC · Discord
  MASC Dashboard                       MASC · Slack
  MASC Dashboard                       MASC · Observatory
  MASC Dashboard                       MASC · Overview
\`\`\`

## Pure \`composeDocumentTitle(tabLabel, sectionLabel)\` — 7 invariants pinned
| Input | Output |
|---|---|
| both null | \`\"MASC Dashboard\"\` (default fallback) |
| \`\"   \"\` whitespace | fallback (no \"MASC · \" ghost) |
| tab only | \`\"MASC · Connectors\"\` |
| section only | \`\"MASC · Discord\"\` |
| tab + section | \`\"MASC · Discord\"\` (**leaf wins** — distinguisher matters more) |
| every non-empty return | starts with \`MASC\` (regression guard for future refactors) |

## Why leaf wins on drilldown
If an operator has 4 tabs open — Connectors, Connectors/Discord, Connectors/Slack, Monitoring — the browser tab list distinguishes them by leaf section. Showing \"MASC · Connectors\" three times would defeat the whole point.

## Wiring (SurfaceLead useEffect)
- Syncing to an external system (the browser tab title) is a legitimate useEffect use-case — the kind we keep, not the kind our project conventions flag.
- Effect keyed on both label signals so it re-runs only on actual navigation, not every render.
- No explicit cleanup: subsequent navigations overwrite, and when the tab closes the title dies with it.

## Test plan
- [x] 7 new pure helper tests. Suite 8 → 14 green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → open 2 tabs (Connectors, Connectors/Discord) → browser tab bar shows distinct titles → click between them → titles update live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)