### PR TITLE
chore(dashboard): purge 7 dead types/signals across 5 files (-79 LOC)

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -153,7 +153,6 @@ export type KeeperCompositeTurnPhase = InferOutput<typeof KeeperCompositeTurnPha
 export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDecisionStageSchema>
 export type KeeperCompositeCascadeState = InferOutput<typeof KeeperCompositeCascadeStateSchema>
 export type KeeperCompositeCompactionStage = InferOutput<typeof KeeperCompositeCompactionStageSchema>
-export type KeeperCompositeCircuitBreakerState = InferOutput<typeof KeeperCompositeCircuitBreakerStateSchema>
 
 export class CompositeSchemaDriftError extends SchemaDriftError {
   constructor(issues: readonly BaseIssue<unknown>[]) {

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,9 +1,3 @@
-import type {
-  Agent,
-  DashboardMissionAgentBrief,
-  DashboardMissionKeeperBrief,
-  Keeper,
-} from '../types'
 import { relativeTime as relativeTimeBase, formatDuration } from '../lib/format-time'
 import { trimText } from '../lib/truncate'
 import { toneClass } from '../lib/tone'
@@ -13,30 +7,6 @@ export { formatDuration, trimText, toneClass, statusLabel }
 
 export function relativeTime(iso?: string | null): string {
   return relativeTimeBase(iso, '방금')
-}
-
-export type EnrichedKeeperRow = {
-  brief: DashboardMissionKeeperBrief
-  keeper: Keeper | null
-  currentWork: string
-  recentInput: string | null
-  recentOutput: string | null
-  recentEvent: string | null
-  recentTools: string[]
-}
-
-export type EnrichedAgentRow = {
-  brief: DashboardMissionAgentBrief
-  agent: Agent | null
-  keeper: Keeper | null
-  where: string
-  withWhom: string[]
-  currentWork: string
-  how: string | null
-  recentInput: string | null
-  recentOutput: string | null
-  recentEvent: string | null
-  recentTools: string[]
 }
 
 export function missionTargetTypeLabel(value?: string | null): string {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -3,8 +3,6 @@
 // subscribing components re-render automatically.
 
 import { signal, computed, type ReadonlySignal } from '@preact/signals'
-import { isOfflineStatus } from './lib/status-utils'
-import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import type {
   Agent,
   Task,
@@ -13,7 +11,6 @@ import type {
   BoardPost,
   ServerStatus,
   BoardSortMode,
-  KeeperLifecycleState,
   Goal,
   DashboardExecutionSessionBrief,
   DashboardExecutionWorkerSupportBrief,
@@ -33,7 +30,6 @@ import {
 import { journal } from './sse'
 import { showToast } from './components/common/toast'
 import {
-  deriveLifecycleState,
   keeperFreshnessTs,
   normalizeKeepers,
 } from './keeper-store-normalize'
@@ -320,21 +316,6 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
         },
       ),
     )
-  }
-  return map
-})
-
-export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>> = computed(() => {
-  const map = new Map<string, KeeperLifecycleState>()
-  for (const k of keepers.value) {
-    const status = k.status?.toLowerCase() ?? ''
-    if (isOfflineStatus(status)) {
-      const refined = keeperDisplayStatus(k) as KeeperLifecycleState
-      map.set(k.name, refined)
-      continue
-    }
-    if (!k.metrics_series || k.metrics_series.length === 0) continue
-    map.set(k.name, deriveLifecycleState(k))
   }
   return map
 })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -136,18 +136,6 @@ export interface BoardComment {
   created_at: string
 }
 
-export interface BoardHearth {
-  post_id: string
-  agent: string
-  created_at: string
-}
-
-export interface BoardFlair {
-  name: string
-  emoji: string
-  color: string
-}
-
 // --- Keeper Metrics ---
 
 export interface InferenceTelemetry {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -261,23 +261,6 @@ export interface DashboardExecutionSessionBrief {
   command_handoff?: DashboardExecutionHandoff | null
 }
 
-export interface DashboardExecutionOperationBrief {
-  operation_id: string
-  objective: string
-  status?: string
-  stage?: string | null
-  assigned_unit_id?: string | null
-  assigned_unit_label?: string | null
-  linked_session_id?: string | null
-  linked_detachment_id?: string | null
-  blocker_summary?: string | null
-  search_status?: string | null
-  next_tool?: string | null
-  updated_at?: string | null
-  top_handoff?: DashboardExecutionHandoff | null
-  command_handoff?: DashboardExecutionHandoff | null
-}
-
 export interface DashboardExecutionWorkerSupportBrief {
   name: string
   agent_name?: string


### PR DESCRIPTION
## Summary

`/loop 20m` Gen52. Gen51 scan(const/interface/type 확장)에서 발견된 **나머지 7개 dead 심볼** 일괄 제거. 5개 파일 횡단.

## 제거 대상

| 파일 | 심볼 | 종류 |
|---|---|---|
| `types/dashboard-execution.ts` | `DashboardExecutionOperationBrief` | interface |
| `types/core.ts` | `BoardHearth`, `BoardFlair` | 2 interfaces |
| `components/mission-utils.ts` | `EnrichedKeeperRow`, `EnrichedAgentRow` | 2 types |
| `api/schemas/keeper-composite.ts` | `KeeperCompositeCircuitBreakerState` | type alias |
| `store.ts` | `keeperLifecycles` | ReadonlySignal |

## 부수 cascade 정리

tsc --noEmit 재실행으로 잡힌 orphan imports:

**mission-utils.ts**: `Agent`, `DashboardMissionAgentBrief`, `DashboardMissionKeeperBrief`, `Keeper` 타입 import 전체 제거 (위 2 types가 유일 소비자였음).

**store.ts**:
- value imports: `isOfflineStatus`, `keeperDisplayStatus`, `deriveLifecycleState` (keeperLifecycles가 유일 consumer)
- type import: `KeeperLifecycleState`

## 변경

| 파일 | LOC |
|---|---|
| 5 source files | **-79** |

## 연쇄 분석

각 symbol의 dead 사유:
- `DashboardExecutionOperationBrief`: Gen37/Gen48에서 execution signal/normalizer 제거 후 orphan
- `BoardHearth`/`BoardFlair`: board UI 리팩터링 잔여
- `EnrichedKeeperRow`/`EnrichedAgentRow`: mission-utils가 pure static util로 전환되며 orphan (Gen47/49/50)
- `KeeperCompositeCircuitBreakerState`: schema 변경 잔여
- `keeperLifecycles`: 0 consumer, 전체 helper chain(isOfflineStatus/keeperDisplayStatus/deriveLifecycleState) 같이 drop

## 검증

- `tsc --noEmit`: ✅ error 0 (orphan cascade 완전 해결)
- `bun run build`: ✅ 10.35s
- `bun run test`: ✅ **3568 tests pass**
  - `saved-signal.test.ts` 9 fails: pre-existing (PR #8014)

## /loop 세션 통계

**Gen36~52**: Gen36-49 MERGED(누적 -3,576 LOC), Gen50/51 Draft(-42), Gen52 Draft(-79).
세션 누적 dashboard dead code: **~-3,697 LOC**

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)