### PR TITLE
feat(dashboard): ⏸ pause toast dismiss clock on hover (Sonner/Sentry convention)

### DIFF
--- a/dashboard/src/components/common/toast.test.ts
+++ b/dashboard/src/components/common/toast.test.ts
@@ -8,6 +8,8 @@ import {
   ToastContainer,
   MAX_VISIBLE_TOASTS,
   defaultToastDuration,
+  pauseToastTimer,
+  resumeToastTimer,
   _testResetToasts,
   _testGetToasts,
 } from './toast'
@@ -165,5 +167,66 @@ describe('showToast duration fallbacks', () => {
     showToast('quick', 'error', 500)
     vi.advanceTimersByTime(501)
     expect(_testGetToasts().length).toBe(0)
+  })
+})
+
+describe('pauseToastTimer / resumeToastTimer', () => {
+  beforeEach(() => { _testResetToasts(); vi.useFakeTimers() })
+  afterEach(() => { _testResetToasts(); vi.useRealTimers() })
+
+  it('pause stops the auto-dismiss clock; toast survives past its original deadline', () => {
+    showToast('hover me', 'error', 1000)
+    const id = _testGetToasts()[0]!.id
+    vi.advanceTimersByTime(500)
+    pauseToastTimer(id)
+    vi.advanceTimersByTime(10_000) // well past 1000ms
+    // Toast is still on screen — the timer was paused before it fired.
+    expect(_testGetToasts().length).toBe(1)
+  })
+
+  it('resume dismisses after the remaining time, not the full duration', () => {
+    // Regression guard: a Sonner-style pause-on-hover that restarts
+    // the full duration on leave would annoy operators who hovered
+    // briefly. Resume must fire at \"remaining\", not at \"duration\".
+    showToast('linger then leave', 'error', 1000)
+    const id = _testGetToasts()[0]!.id
+    vi.advanceTimersByTime(600) // 400ms remaining
+    pauseToastTimer(id)
+    vi.advanceTimersByTime(5000) // hover lingers, nothing happens
+    expect(_testGetToasts().length).toBe(1)
+    resumeToastTimer(id)
+    vi.advanceTimersByTime(399)
+    expect(_testGetToasts().length).toBe(1) // still there, 1ms short
+    vi.advanceTimersByTime(2)
+    expect(_testGetToasts().length).toBe(0) // dismissed at ~400ms after resume
+  })
+
+  it('double-pause is a no-op (Sonner behaviour: child hover does not restart)', () => {
+    showToast('nested hover', 'error', 1000)
+    const id = _testGetToasts()[0]!.id
+    vi.advanceTimersByTime(500) // 500ms remaining
+    pauseToastTimer(id)
+    // Child element enters → second pause call. Remaining should NOT
+    // jump back to the full 1000 or reset elapsed tracking.
+    pauseToastTimer(id)
+    resumeToastTimer(id)
+    vi.advanceTimersByTime(499)
+    expect(_testGetToasts().length).toBe(1)
+    vi.advanceTimersByTime(2)
+    expect(_testGetToasts().length).toBe(0)
+  })
+
+  it('resume without prior pause is a no-op (does not double-schedule)', () => {
+    showToast('not paused', 'error', 1000)
+    const id = _testGetToasts()[0]!.id
+    resumeToastTimer(id) // spurious resume — must not schedule a 2nd timer
+    vi.advanceTimersByTime(1001)
+    expect(_testGetToasts().length).toBe(0) // exactly one dismissal
+  })
+
+  it('pause on a dismissed toast id is a no-op (no throw)', () => {
+    // Regression guard: a stale mouseenter event after the toast has
+    // already auto-dismissed must not throw or create a zombie entry.
+    expect(() => pauseToastTimer(999_999)).not.toThrow()
   })
 })

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -73,24 +73,76 @@ export function defaultToastDuration(type: ToastType): number {
   }
 }
 
+/** Per-toast dismiss bookkeeping — one entry while the toast is
+    visible. `paused === true` means the timer has been cleared and
+    the remaining ms should resume on the next resume call. Tracked
+    here (module scope) instead of on the Toast record so we don't
+    re-render the whole stack every time a timer advances. */
+interface ToastTimer {
+  remainingMs: number
+  startedAt: number
+  timerId: number
+  paused: boolean
+}
+const toastTimers = new Map<number, ToastTimer>()
+
+function scheduleToastDismiss(id: number, ms: number): void {
+  const timerId = (typeof window === 'undefined'
+    ? setTimeout(() => finalizeDismiss(id), ms)
+    : window.setTimeout(() => finalizeDismiss(id), ms)) as unknown as number
+  toastTimers.set(id, { remainingMs: ms, startedAt: Date.now(), timerId, paused: false })
+}
+
+function finalizeDismiss(id: number): void {
+  toasts.value = toasts.value.filter(t => t.id !== id)
+  toastTimers.delete(id)
+}
+
+/** Pause the dismiss timer for a toast — called on hover enter.
+    Computes the elapsed time and stores the remainder so resume can
+    schedule the same wall-clock deadline. Idempotent: calling twice
+    is a no-op (Sonner / Sentry behaviour: nested hover from a child
+    does not restart the clock). */
+export function pauseToastTimer(id: number): void {
+  const t = toastTimers.get(id)
+  if (t === undefined || t.paused) return
+  if (typeof window !== 'undefined') window.clearTimeout(t.timerId)
+  else clearTimeout(t.timerId)
+  const elapsed = Date.now() - t.startedAt
+  const remaining = Math.max(0, t.remainingMs - elapsed)
+  toastTimers.set(id, { remainingMs: remaining, startedAt: 0, timerId: -1, paused: true })
+}
+
+/** Resume a previously-paused dismiss. If the remaining time has
+    already elapsed (e.g. paused at 0s left, mouse lingered forever),
+    dismisses immediately. Idempotent on already-running timers. */
+export function resumeToastTimer(id: number): void {
+  const t = toastTimers.get(id)
+  if (t === undefined || !t.paused) return
+  if (t.remainingMs <= 0) { finalizeDismiss(id); return }
+  scheduleToastDismiss(id, t.remainingMs)
+}
+
 export function showToast(message: string, type: ToastType = 'success', durationMs?: number) {
   const id = ++_nextId
   const dismissMs = durationMs ?? defaultToastDuration(type)
   enqueueToast({ id, message, type })
-  setTimeout(() => {
-    toasts.value = toasts.value.filter(t => t.id !== id)
-  }, dismissMs)
+  scheduleToastDismiss(id, dismissMs)
 }
 
 export function showActionToast(message: string, action: ToastAction, type: ToastType = 'error', durationMs = 12000) {
   const id = ++_nextId
   enqueueToast({ id, message, type, action })
-  setTimeout(() => {
-    toasts.value = toasts.value.filter(t => t.id !== id)
-  }, durationMs)
+  scheduleToastDismiss(id, durationMs)
 }
 
 function dismissToast(id: number) {
+  const t = toastTimers.get(id)
+  if (t !== undefined) {
+    if (typeof window !== 'undefined') window.clearTimeout(t.timerId)
+    else clearTimeout(t.timerId)
+    toastTimers.delete(id)
+  }
   toasts.value = toasts.value.filter(t => t.id !== id)
 }
 
@@ -122,6 +174,11 @@ export function ToastContainer() {
           key=${t.id}
           role=${t.type === 'error' ? 'alert' : 'status'}
           class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+          onMouseEnter=${() => pauseToastTimer(t.id)}
+          onMouseLeave=${() => resumeToastTimer(t.id)}
+          onFocusIn=${() => pauseToastTimer(t.id)}
+          onFocusOut=${() => resumeToastTimer(t.id)}
+          data-toast-id=${t.id}
         >
           <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]()}</span>
           <span class="flex-1 text-[13px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>


### PR DESCRIPTION
## Summary
- Hover a toast → the auto-dismiss clock pauses. Leave → it resumes with the **remaining** time, not the full duration. Standard behaviour for Sonner, react-hot-toast, Sentry notifications, Linear toasts, every polished modern library.
- **잘 보이고 잘 입력** — operators reading / copying a toast (error id, retry token, stack) no longer get it yanked out from under them mid-read.

## Reference UIs
- **Sonner** — \`pauseOnHover\` is default on.
- **react-hot-toast** — same, plus optional \`pauseOnFocus\`.
- **Sentry** — in-app notifications pause on hover.
- **Linear** — toasts pause while the pointer is over them.
- **Common thread**: auto-dismiss is a fallback for fire-and-forget, not a race the user loses when trying to read.

## Mechanism
Module-scope \`Map<toastId, { remainingMs, startedAt, timerId, paused }>\` — bookkeeping off the signal so timer ticks don't re-render the whole stack.

\`\`\`
showToast → scheduleToastDismiss(id, ms)
hover enter → pauseToastTimer(id): clear timer, snapshot remaining
hover leave → resumeToastTimer(id): schedule new timer with remaining
click X → dismissToast(id): clear timer, delete entry
\`\`\`

## Keyboard parity
\`onFocusIn\` / \`onFocusOut\` also pause/resume — a Tab-stop into the close button shouldn't dismiss mid-navigation.

## Regression guards (5 new tests)
| Case | Why |
|---|---|
| Resume fires at **remaining**, not duration | Brief hover must not reset — Sonner spec |
| Double-pause is idempotent | Nested child hover doesn't reset elapsed |
| Spurious resume is a no-op | Doesn't double-schedule a 2nd timer |
| Pause on stale id doesn't throw | Late mouseenter after auto-dismiss |
| Pause survives past original deadline | The whole point — timer actually off while paused |

## No API surface changes
\`showToast\` / \`showActionToast\` signatures unchanged. Callers see identical behaviour when the operator doesn't hover. The new functions \`pauseToastTimer\` / \`resumeToastTimer\` are exposed for tests but are used internally by the container's mouse handlers.

## Test plan
- [x] 14 toast tests green (5 new).
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → trigger an error toast → hover for 15s (past 8s default) → toast stays → leave → dismisses in ~2s (remaining time). Leave before hover → dismisses in ~8s (original time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)