### PR TITLE
fix(dashboard+test): unbreak main — mission-briefing-card stub + drop proof-sections source_guard assertion

### DIFF
--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -1,3 +1,8 @@
+// Shim for the legacy barrel import in mission-cards.ts. The real
+// MissionBriefingCard component was removed in #8081 when the mission
+// navigation cascade was purged. mission-cards.ts still re-exports the
+// symbol, so dropping this file breaks the TypeScript typecheck on
+// main (TS2307: Cannot find module './mission-briefing-card').
 export function MissionBriefingCard() {
   return null
 }

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -388,9 +388,8 @@ let test_dashboard_component_split_contracts () =
   check bool "proof helpers export worker run evidence tone" true
     (file_contains_pattern "dashboard/src/components/proof-helpers.ts"
        "export function workerRunEvidenceTone");
-  check bool "proof sections export worker run evidence row" true
-    (file_contains_pattern "dashboard/src/components/proof-sections.ts"
-       "export function WorkerRunEvidenceRow");
+  (* proof-sections.ts was removed in #8081; the surviving pure
+     helpers live in proof-helpers.ts (asserted above). *)
   check bool "mission cards re-export briefing card" true
     (file_contains_pattern "dashboard/src/components/mission-cards.ts"
        "export { MissionBriefingCard } from './mission-briefing-card'");


### PR DESCRIPTION
## Problem

Main is broken on two axes:

1. **Dashboard typecheck** fails with `TS2307: Cannot find module './mission-briefing-card'` in `mission-cards.ts` (the shim re-exports `MissionBriefingCard` from a file that was deleted in #8081).
2. **Build and Test** (`test_ci_hardening_source` → `test_dashboard_component_split_contracts`, assertion #15) fails because `proof-sections.ts` was also removed in #8081 but the contract assertion is still present.

Both failures block **every** OCaml-touching PR from landing (10+ PRs backed up: #8030, #8037, #8063, #8067, #8071, #8074, #8079, #8080, #8083, #8085, #8087, #8093).

## Fix

1. **Add `dashboard/src/components/mission-briefing-card.ts`** as a minimal stub that exports `MissionBriefingCard`, mirroring the existing `mission-attention-card.ts` stub pattern. This resolves the broken barrel import in `mission-cards.ts` and satisfies the source_guard contract.
2. **Drop the `proof-sections export worker run evidence row` assertion** (the file is fully removed; the surviving pure helpers live in `proof-helpers.ts`, still asserted).

## Why not delete `mission-cards.ts` instead

Deleting the barrel is a bigger behavioural change — callers (if any remain) would break. Matching the existing `mission-attention-card.ts` stub pattern is the minimally invasive path: re-exports keep resolving, TS is happy, the contract is honoured, and future cleanup can collapse both stubs together.

## Impact

Unblocks the full backlog of OCaml-touching PRs.