### PR TITLE
feat(dashboard): ⟳ InlineSpinner primitive — 4 border-spinners consolidated

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -4,6 +4,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type cytoscape from 'cytoscape'
+import { InlineSpinner } from './inline-spinner'
 
 // Types for graph spec (consumed by all 3 FSM builders)
 export interface FsmNode {
@@ -289,7 +290,7 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
     <div class=${`relative rounded-xl border border-[var(--white-8)] bg-[rgba(9,12,20,0.7)] overflow-hidden ${className}`.trim()}>
       ${loading ? html`
         <div class="absolute inset-0 flex items-center justify-center text-[11px] text-[var(--text-dim)]">
-          <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin mr-2" aria-hidden="true"></span>
+          <${InlineSpinner} class="mr-2" />
           그래프 로딩중
         </div>
       ` : null}

--- a/dashboard/src/components/common/inline-spinner.test.ts
+++ b/dashboard/src/components/common/inline-spinner.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  InlineSpinner,
+  inlineSpinnerClasses,
+  inlineSpinnerSizeClass,
+  inlineSpinnerToneClass,
+} from './inline-spinner'
+
+describe('inlineSpinnerSizeClass (pure)', () => {
+  it('default is sm — the most common pre-change variant (h-3 w-3)', () => {
+    expect(inlineSpinnerSizeClass()).toBe('h-2.5 w-2.5 border-2'.replace('h-2.5 w-2.5', 'h-3 w-3'))
+    // equivalent assertion without the string surgery:
+    expect(inlineSpinnerSizeClass('sm')).toBe('h-3 w-3 border-2')
+  })
+
+  it('each size maps to its expected Tailwind triple', () => {
+    expect(inlineSpinnerSizeClass('xs')).toBe('h-2.5 w-2.5 border-2')
+    expect(inlineSpinnerSizeClass('sm')).toBe('h-3 w-3 border-2')
+    expect(inlineSpinnerSizeClass('md')).toBe('h-4 w-4 border-2')
+  })
+})
+
+describe('inlineSpinnerToneClass (pure)', () => {
+  it('accent tone uses the --accent CSS var (the dashboard brand hue)', () => {
+    expect(inlineSpinnerToneClass('accent')).toContain('var(--accent)')
+    expect(inlineSpinnerToneClass('accent')).toContain('border-t-transparent')
+  })
+
+  it('muted tone uses --text-dim for background-sync contexts', () => {
+    expect(inlineSpinnerToneClass('muted')).toContain('var(--text-dim)')
+    expect(inlineSpinnerToneClass('muted')).toContain('border-t-transparent')
+  })
+})
+
+describe('inlineSpinnerClasses (pure)', () => {
+  it('always includes invariant base (inline-block, rounded-full, animate-spin, shrink-0)', () => {
+    // Regression guard: drifting any of these breaks visual consistency
+    // across the 5 call sites the primitive unifies.
+    const cls = inlineSpinnerClasses()
+    expect(cls).toContain('inline-block')
+    expect(cls).toContain('rounded-full')
+    expect(cls).toContain('animate-spin')
+    expect(cls).toContain('shrink-0')
+  })
+
+  it('extra class is appended (caller composition)', () => {
+    expect(inlineSpinnerClasses('sm', 'accent', 'mr-2')).toContain('mr-2')
+  })
+
+  it('empty/undefined extra leaves no trailing whitespace', () => {
+    expect(inlineSpinnerClasses('sm', 'accent', '')).not.toMatch(/\s$/)
+    expect(inlineSpinnerClasses('sm', 'accent', undefined)).not.toMatch(/\s$/)
+  })
+})
+
+describe('InlineSpinner component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders a span with data-inline-spinner + annotation attributes', () => {
+    render(html`<${InlineSpinner} />`, container)
+    const el = container.querySelector('[data-inline-spinner]') as HTMLElement
+    expect(el.tagName).toBe('SPAN')
+    expect(el.getAttribute('data-inline-spinner-size')).toBe('sm')
+    expect(el.getAttribute('data-inline-spinner-tone')).toBe('accent')
+  })
+
+  it('size + tone reflect in data attributes', () => {
+    render(html`<${InlineSpinner} size="md" tone="muted" />`, container)
+    const el = container.querySelector('[data-inline-spinner]') as HTMLElement
+    expect(el.getAttribute('data-inline-spinner-size')).toBe('md')
+    expect(el.getAttribute('data-inline-spinner-tone')).toBe('muted')
+  })
+
+  it('default (no ariaLabel) is decorative — aria-hidden, no role', () => {
+    // Regression guard: most callers sit the spinner next to an inline
+    // text label (\"loading...\"). Announcing role=\"status\" here AND the
+    // surrounding text is duplicative; operators rarely need the
+    // spinner itself read out loud.
+    render(html`<${InlineSpinner} />`, container)
+    const el = container.querySelector('[data-inline-spinner]') as HTMLElement
+    expect(el.getAttribute('aria-hidden')).toBe('true')
+    expect(el.getAttribute('role')).toBeNull()
+  })
+
+  it('ariaLabel promotes to semantic: role="status" + no aria-hidden', () => {
+    render(
+      html`<${InlineSpinner} ariaLabel="Loading tool metrics" />`,
+      container,
+    )
+    const el = container.querySelector('[data-inline-spinner]')!
+    expect(el.getAttribute('role')).toBe('status')
+    expect(el.getAttribute('aria-label')).toBe('Loading tool metrics')
+    expect(el.getAttribute('aria-hidden')).toBeNull()
+  })
+
+  it('testId renders as data-testid', () => {
+    render(
+      html`<${InlineSpinner} testId="refresh-spinner" />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="refresh-spinner"]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/common/inline-spinner.ts
+++ b/dashboard/src/components/common/inline-spinner.ts
@@ -1,0 +1,88 @@
+// InlineSpinner — tiny border-based spinner that sits inline with text.
+//
+// Reference UIs (GitHub PR checks \"pending\" spinner, Vercel deployment
+// log row inline spinner, Linear sync dot, Stripe in-flight inline):
+// a small border-circle-with-transparent-top-border is the canonical
+// \"something is happening right here\" indicator. Distinct from
+// LoadingState (a large centered Loader2 with breathing room) and
+// LivePulseDot (an animate-pulse state marker). This primitive is the
+// spin-in-the-middle-of-a-sentence variant.
+//
+// Pre-change the dashboard had 5+ call sites with near-identical
+// Tailwind strings:
+//   inline-block h-3 w-3 rounded-full border-2
+//     border-[var(--accent)] border-t-transparent animate-spin
+// This primitive pins the canonical 3 sizes + 2 tones.
+
+import { html } from 'htm/preact'
+
+export type InlineSpinnerSize = 'xs' | 'sm' | 'md'
+export type InlineSpinnerTone = 'accent' | 'muted'
+
+/** Pure: Tailwind size tokens for each variant. Exposed so a hot-path
+    render (timeline rows, log tail, iterating progress lists) can
+    compose the class once without mounting N components. */
+export function inlineSpinnerSizeClass(size: InlineSpinnerSize = 'sm'): string {
+  switch (size) {
+    case 'xs': return 'h-2.5 w-2.5 border-2'
+    case 'sm': return 'h-3 w-3 border-2'
+    case 'md': return 'h-4 w-4 border-2'
+  }
+}
+
+/** Pure: Tailwind tone classes. Accent is the default (\"I'm working
+    on it\" confirmation); muted is the subtle \"background sync\"
+    variant for when the spinner is secondary to the row it lives in. */
+export function inlineSpinnerToneClass(tone: InlineSpinnerTone = 'accent'): string {
+  return tone === 'accent'
+    ? 'border-[var(--accent)] border-t-transparent'
+    : 'border-[var(--text-dim)] border-t-transparent'
+}
+
+const BASE = 'inline-block rounded-full animate-spin shrink-0'
+
+/** Pure: full class string. Exposed so callers that wrap their own
+    span (e.g. conditionally-rendered inside a denser flex row) stay
+    pixel-identical to the primitive. */
+export function inlineSpinnerClasses(
+  size: InlineSpinnerSize = 'sm',
+  tone: InlineSpinnerTone = 'accent',
+  extra?: string,
+): string {
+  const parts = [BASE, inlineSpinnerSizeClass(size), inlineSpinnerToneClass(tone)]
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+export interface InlineSpinnerProps {
+  size?: InlineSpinnerSize
+  tone?: InlineSpinnerTone
+  class?: string
+  /** Override the decorative default. Setting this flips to role=\"status\"
+      (screen-reader announces the loading state) instead of
+      aria-hidden. Use when the spinner is the ONLY indication of
+      progress — otherwise a nearby text label already carries it. */
+  ariaLabel?: string
+  testId?: string
+}
+
+export function InlineSpinner({
+  size = 'sm',
+  tone = 'accent',
+  class: cx,
+  ariaLabel,
+  testId,
+}: InlineSpinnerProps) {
+  const cls = inlineSpinnerClasses(size, tone, cx)
+  const semantic = ariaLabel !== undefined
+  return html`<span
+    class=${cls}
+    role=${semantic ? 'status' : undefined}
+    aria-label=${ariaLabel}
+    aria-hidden=${semantic ? undefined : 'true'}
+    data-inline-spinner
+    data-inline-spinner-size=${size}
+    data-inline-spinner-tone=${tone}
+    data-testid=${testId}
+  ></span>`
+}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'preact/hooks'
+import { InlineSpinner } from './common/inline-spinner'
 
 import {
   fetchKeeperComposite,
@@ -693,7 +694,7 @@ function StatusBar({
             ${density === 'compact' ? '▣ 조밀' : '▢ 여유'}
           </button>
           ${liveBadge}
-          ${loading ? html`<span class="inline-block h-2.5 w-2.5 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin"></span>` : null}
+          ${loading ? html`<${InlineSpinner} size="xs" />` : null}
           ${paused ? html`
             <span
               class="px-1.5 py-0.5 rounded border text-[9px] font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -8,6 +8,7 @@ import {
   type MemoryKindUsageEntry,
 } from '../api/keeper'
 import { EmptyState } from './common/empty-state'
+import { InlineSpinner } from './common/inline-spinner'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { FilterChips } from './common/filter-chips'
 import { buildCompactionSpec } from './keeper-fsm-specs'
@@ -104,7 +105,7 @@ export function KeeperMemoryTierPanel({
   if (loading) {
     return html`
       <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
-        <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
+        <${InlineSpinner} />
         메모리 티어 로딩중
       </div>
     `

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -8,6 +8,7 @@ import {
   type KeeperTransition,
 } from '../api/keeper'
 import { EmptyState } from './common/empty-state'
+import { InlineSpinner } from './common/inline-spinner'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
 import type { KeeperPhase } from '../types'
@@ -134,7 +135,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
   if (loading) {
     return html`
       <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
-        <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
+        <${InlineSpinner} />
         composite lifecycle 로딩중
       </div>
     `


### PR DESCRIPTION
## Summary
- **InlineSpinner primitive** for the small \"border-circle-with-transparent-top-border\" spinner that sits inline with text. Consolidates 4 near-identical Tailwind strings across keeper / fsm-hub / cytoscape panels.
- Reference UIs: GitHub PR checks pending spinner, Vercel deployment log inline spinner, Linear sync dot, Stripe in-flight indicator.

## Distinct from existing primitives
| Primitive | Context | Animation | Tailwind flavor |
|---|---|---|---|
| \`LoadingState\` | Full-panel empty state | Loader2 icon | 24px, centered, padded |
| \`LivePulseDot\` | \"Is polling live?\" marker | animate-pulse | bg dot |
| **\`InlineSpinner\`** | Spin in the middle of a sentence | animate-spin (border) | 10–16px, inline |

## Three sizes + two tones
| Axis | Values |
|---|---|
| size | xs (h-2.5) · **sm** (h-3, default) · md (h-4) |
| tone | **accent** (default, \"I'm working on it\") · muted (\"background sync\") |

Callers compose extra classes via \`class\` prop (e.g. \`mr-2\` for inline-with-text spacing).

## Wiring (4 call sites)
| File | Line | Size / Tone |
|---|---|---|
| \`keeper-state-diagram.ts\` | 137 | sm / accent (default) |
| \`keeper-memory-tier-panel.ts\` | 107 | sm / accent |
| \`common/cytoscape-fsm.ts\` | 292 | sm / accent + class=\"mr-2\" |
| \`fsm-hub.ts\` | 696 | xs (h-2.5) / accent |

## Accessibility
- **Default decorative** — \`aria-hidden\`, no role. Most callers sit the spinner next to a Korean text label (\"로딩중\", \"그래프 로딩중\"); announcing \`role=status\` + the text would be duplicate.
- \`ariaLabel\` prop promotes to semantic: \`role=\"status\"\` + no aria-hidden. Use when the spinner stands alone.

## Regression guards (tests)
- Base invariants (\`inline-block\`, \`rounded-full\`, \`animate-spin\`, \`shrink-0\`) pinned — drift of any breaks visual consistency across call sites.
- Per-size Tailwind triples pinned.
- Per-tone classes include \`border-t-transparent\` (the transparent-top-border trick that makes the spin visible).

## Test plan
- [x] 12 new tests (3 pure helper blocks + 5 component). 71 related tests green.
- [x] Typecheck clean.
- [ ] Manual smoke: \`npm run dev\` → trigger any loading state (\`#keeper-detail\` memory tier, \`#fsm-hub\` graph) → spinner visually identical to pre-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)