### PR TITLE
feat(dashboard): reconnecting badge with elapsed + retry diagnostics

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -6,6 +6,7 @@ import {
   formatUptimeSecondsHuman,
   deriveBreadcrumbTrail,
   composeDocumentTitle,
+  describeReconnecting,
 } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
@@ -223,5 +224,77 @@ describe('composeDocumentTitle (pure)', () => {
       composeDocumentTitle(null, null),
     ]
     for (const t of titles) expect(t.startsWith('MASC')).toBe(true)
+  })
+})
+
+describe('describeReconnecting (pure)', () => {
+  it('disconnectedAt=0 → bare \"재연결 중...\" label, empty title', () => {
+    // Fresh page load / never disconnected state: nothing to show
+    // yet. Regression guard: no ghost \"0s\" suffix.
+    const r = describeReconnecting({ disconnectedAt: 0, now: 1_000_000, reconnects: 0 })
+    expect(r.label).toBe('재연결 중...')
+    expect(r.title).toBe('')
+  })
+
+  it('sub-5s disconnect → suppress elapsed (flicker noise floor)', () => {
+    // Discord / Slack both debounce reconnect UI — a 2-second blip
+    // shouldn't yank the operator's attention with a running timer.
+    const now = 10_000_000
+    const r = describeReconnecting({ disconnectedAt: now - 2_000, now, reconnects: 0 })
+    expect(r.label).toBe('재연결 중')
+    // Title also suppresses the \"연결 끊김\" timestamp below 5s since
+    // the elapsed reading itself isn't shown.
+    expect(r.title).toBe('')
+  })
+
+  it('5–59s disconnect → compact seconds suffix', () => {
+    const now = 10_000_000
+    const r = describeReconnecting({ disconnectedAt: now - 15_000, now, reconnects: 0 })
+    expect(r.label).toBe('재연결 중 · 15s')
+  })
+
+  it('≥60s disconnect → rounded minutes', () => {
+    const now = 10_000_000
+    const r = describeReconnecting({ disconnectedAt: now - 125_000, now, reconnects: 0 })
+    // 125s → 2m (Math.round)
+    expect(r.label).toBe('재연결 중 · 2m')
+  })
+
+  it('title includes disconnect timestamp + cumulative reconnect count', () => {
+    // Regression guard: operator diagnosing a reconnect loop needs
+    // both \"when did we lose it\" and \"how many times have we
+    // bounced so far\" — drop either and the badge loses its
+    // diagnostic value.
+    const now = 10_000_000
+    const r = describeReconnecting({
+      disconnectedAt: now - 30_000,
+      now,
+      reconnects: 3,
+    })
+    expect(r.title).toMatch(/연결 끊김 \d{2}:\d{2}:\d{2}/)
+    expect(r.title).toContain('누적 재연결 3회')
+  })
+
+  it('reconnects=0 suppresses the cumulative counter (no \"누적 재연결 0회\")', () => {
+    // \"Zero reconnects so far\" is the expected state for the first
+    // disconnect — printing it as \"0회\" is noise, not signal.
+    const now = 10_000_000
+    const r = describeReconnecting({ disconnectedAt: now - 30_000, now, reconnects: 0 })
+    expect(r.title).not.toContain('0회')
+    expect(r.title).not.toContain('누적 재연결')
+  })
+
+  it('clock skew (now < disconnectedAt) → floors elapsed to 0, no negative display', () => {
+    // Regression guard: system-clock drift between browser tab and
+    // NTP-resynced OS can briefly produce now < disconnectedAt.
+    // We must not render \"재연결 중 · -3s\".
+    const now = 10_000_000
+    const r = describeReconnecting({
+      disconnectedAt: now + 3_000,
+      now,
+      reconnects: 0,
+    })
+    expect(r.label).toBe('재연결 중')
+    expect(r.label).not.toContain('-')
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -37,13 +37,43 @@ function lazyTabFallback(label: string) {
   return html`<${LoadingState}>${label} 불러오는 중...<//>`
 }
 
-function formatDisconnectDuration(): string {
-  const ts = lastDisconnectedAt.value
-  if (ts === 0) return ''
-  const sec = Math.round((Date.now() - ts) / 1000)
-  if (sec < 5) return ''
-  if (sec < 60) return ` (${sec}s)`
-  return ` (${Math.round(sec / 60)}m)`
+/** Pure: describe a "reconnecting" state as a user-facing label plus
+    tooltip. Reference UIs: Discord shows "Reconnecting... (5s · try 3)";
+    Slack shows "Trying to reconnect..." with timestamp on hover;
+    Linear flashes a subtle red dot + tooltip. Goal here: operator can
+    tell at a glance whether a flicker (sub-5s) is worth noticing and,
+    on hover, see when the last successful session ended + cumulative
+    reconnect count — so a reconnect loop is diagnosable without
+    opening devtools.
+
+    Inputs are all primitives so the helper is trivially testable. */
+export function describeReconnecting(args: {
+  disconnectedAt: number
+  now: number
+  reconnects: number
+}): { label: string; title: string } {
+  const { disconnectedAt, now, reconnects } = args
+  if (disconnectedAt === 0) {
+    return { label: '재연결 중...', title: '' }
+  }
+  const sec = Math.max(0, Math.round((now - disconnectedAt) / 1000))
+  const elapsed = sec < 5
+    ? ''
+    : sec < 60
+      ? ` · ${sec}s`
+      : ` · ${Math.round(sec / 60)}m`
+  const label = `재연결 중${elapsed}`
+  const titleParts: string[] = []
+  if (sec >= 5) {
+    const d = new Date(disconnectedAt)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const when = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+    titleParts.push(`연결 끊김 ${when}`)
+  }
+  if (reconnects > 0) {
+    titleParts.push(`누적 재연결 ${reconnects}회`)
+  }
+  return { label, title: titleParts.join(' · ') }
 }
 
 export function ConnectionStatus() {
@@ -54,10 +84,24 @@ export function ConnectionStatus() {
 
   const statusLabel = isConnected
     ? reconn > 0 ? '재연결됨' : '연결됨'
-    : `재연결 중...${formatDisconnectDuration()}`
+    : describeReconnecting({
+        disconnectedAt: lastDisconnectedAt.value,
+        now: Date.now(),
+        reconnects: reconn,
+      }).label
+  const titleAttr = isConnected
+    ? reconn > 0 ? `누적 재연결 ${reconn}회` : ''
+    : describeReconnecting({
+        disconnectedAt: lastDisconnectedAt.value,
+        now: Date.now(),
+        reconnects: reconn,
+      }).title
 
   return html`
-    <div class="flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}">
+    <div
+      class="flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
+      title=${titleAttr || undefined}
+    >
       <span class="inline-block size-[8px] rounded-full ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--bad)]'}"></span>
       <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`


### PR DESCRIPTION
## What
Header 우측의 `재연결 중...` 배지가 지금은 scrollspinner + 괄호 안 시간만 보여주고, operator가 \"지금 막 끊어진 건지 vs 몇 분째 루프 중인지\" 시각적으로 구분 못 합니다.

## Why
Vision-driven /loop pass (2026-04-18, `/dashboard/#overview`)에서 발견:
- 헤더 우측에 `재연결 중... (23s)` 과 `버전 정보 없음`이 나란히 보이는데 어느 쪽도 **누적 재시도 횟수** 나 **마지막 성공 시각** 을 제공 안 함
- Discord, Slack, Linear 모두 이 상태를 "elapsed + cumulative + last-connected tooltip"의 3축으로 표기

## How
`describeReconnecting({ disconnectedAt, now, reconnects })` pure helper 추출 (입력 전부 primitive — 테스트 trivial):

- **label**: sub-5s flicker → `재연결 중`(elapsed 숨김), 5–59s → `재연결 중 · 15s`, ≥60s → `재연결 중 · 2m`
- **title (tooltip)**: 연결 끊김 HH:MM:SS + 누적 재연결 N회 — 둘 다 0일 때 생략해 \`0회\` / 고스트 타임스탬프 노이즈 방지

## Tests (6 new, all pass)
- disconnectedAt=0 → bare label, empty title
- sub-5s noise floor suppresses elapsed
- 5–59s → \`Xs\`, ≥60s → rounded \`Xm\`
- title includes timestamp + cumulative count when > 0
- reconnects=0 → title never says \`0회\`
- clock skew (now < disconnectedAt) → no \`-3s\` display

Timezone-stable \`HH:MM:SS\` formatter vs \`toLocaleTimeString('ko-KR')\` (happy-dom emits \"11시 46분 10초\" — regex 불안정).

## Reference UIs
Discord client reconnect banner · Slack \"Trying to reconnect...\" · Linear subtle red-dot + hover timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)