### PR TITLE
[codex] Avoid dashboard shell cold-start timeouts

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -1,4 +1,4 @@
-import { post, fetchWithTimeout } from './core'
+import { get, post, fetchWithTimeout } from './core'
 import { ACTIVITY_TIMEOUT_MS } from '../config/constants'
 import { callMcpTool } from './mcp'
 import {
@@ -31,6 +31,14 @@ export async function fetchTaskHistory(taskId: string, limit = 20): Promise<stri
     task_id: taskId,
     limit,
   })
+}
+
+export function fetchTaskEvents(taskId: string, limit = 50): Promise<unknown[]> {
+  const params = new URLSearchParams({
+    task_id: taskId,
+    limit: String(limit),
+  })
+  return get<unknown[]>(`/api/v1/dashboard/tasks/history?${params.toString()}`)
 }
 
 // --- Activity Graph ---

--- a/dashboard/src/components/goals/task-detail-state.test.ts
+++ b/dashboard/src/components/goals/task-detail-state.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { filterGoalRelations, filterTaskEvents } from './task-detail-state'
+import { filterGoalRelations, filterTaskEvents, describeTaskEventsError } from './task-detail-state'
 import type { NormalizedTaskEvent } from './task-detail-state'
 import type { Goal } from '../../types'
+import { ApiRequestError } from '../../api/core'
 
 const sample: NormalizedTaskEvent[] = [
   {
@@ -97,6 +98,36 @@ describe('filterTaskEvents', () => {
   it('can match multiple rows when substring is shared', () => {
     const out = filterTaskEvents(sample, 'keeper')
     expect(out.map(e => e.label)).toEqual(['claim', 'done'])
+  })
+})
+
+describe('describeTaskEventsError', () => {
+  it('renders timeout as a Korean retry hint', () => {
+    const err = new ApiRequestError({
+      method: 'GET',
+      path: '/api/v1/dashboard/tasks/history',
+      timeout: true,
+      timeoutMs: 35000,
+    })
+    expect(describeTaskEventsError(err)).toBe(
+      '태스크 이벤트 요청이 시간 초과되었습니다. 다시 시도해 주세요',
+    )
+  })
+
+  it('maps 403 to a permission-specific message', () => {
+    const err = new ApiRequestError({
+      method: 'GET',
+      path: '/api/v1/dashboard/tasks/history',
+      status: 403,
+      statusText: 'Forbidden',
+    })
+    expect(describeTaskEventsError(err)).toBe('태스크 이벤트를 읽을 권한이 없습니다')
+  })
+
+  it('keeps useful non-empty detail for other failures', () => {
+    expect(describeTaskEventsError(new Error('network dropped'))).toBe(
+      '태스크 이벤트를 불러오지 못했습니다: network dropped',
+    )
   })
 })
 

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -1,7 +1,8 @@
 // Task detail overlay state — signals, fetch, normalization
 
 import { signal } from '@preact/signals'
-import { fetchTaskHistory } from '../../api/actions'
+import { fetchTaskEvents } from '../../api/actions'
+import { extractApiError } from '../../api/core'
 import { fetchAgentTimeline, fetchKeeperTrajectory } from '../../api/dashboard'
 import { buildTraceEvents, type UnifiedTraceEvent } from '../session-trace/session-trace-state'
 import { findKeeper } from '../../lib/keeper-utils'
@@ -74,6 +75,23 @@ export function filterTaskEvents(
     if (e.notes && e.notes.toLowerCase().includes(needle)) return true
     return false
   })
+}
+
+export function describeTaskEventsError(err: unknown): string {
+  const api = extractApiError(err, '태스크 이벤트를 불러오지 못했습니다')
+  if (api.timeout) {
+    return '태스크 이벤트 요청이 시간 초과되었습니다. 다시 시도해 주세요'
+  }
+  if (api.status === 403) {
+    return '태스크 이벤트를 읽을 권한이 없습니다'
+  }
+  if (api.status === 404) {
+    return '태스크 이벤트 경로를 찾지 못했습니다'
+  }
+  if (api.message && api.message !== '태스크 이벤트를 불러오지 못했습니다') {
+    return `태스크 이벤트를 불러오지 못했습니다: ${api.message}`
+  }
+  return '태스크 이벤트를 불러오지 못했습니다'
 }
 
 /**
@@ -169,13 +187,14 @@ async function loadTaskEvents(taskId: string): Promise<void> {
   taskEventsLoading.value = true
   taskEventsError.value = null
   try {
-    const raw = await fetchTaskHistory(taskId, 50)
+    const raw = await fetchTaskEvents(taskId, 50)
     if (eventsFetchToken.value !== token) return
-    const parsed: unknown = JSON.parse(raw)
-    const arr = Array.isArray(parsed) ? parsed : ((parsed as Record<string, unknown>).events ?? [])
+    const arr = Array.isArray(raw) ? raw : []
     taskEvents.value = normalizeTaskHistory(arr as TaskHistoryRow[])
-  } catch {
-    if (eventsFetchToken.value === token) taskEventsError.value = 'fetch failed'
+  } catch (err) {
+    if (eventsFetchToken.value === token) {
+      taskEventsError.value = describeTaskEventsError(err)
+    }
   } finally {
     if (eventsFetchToken.value === token) taskEventsLoading.value = false
   }

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -43,6 +43,19 @@ include Dashboard_http_keeper
 
 let dashboard_request_timeout_s = 30.0
 
+(** Track whether shell cache has been populated at least once.
+    Atomic.t for cross-domain visibility: read from executor pool
+    worker domains via namespace-truth and warmup helpers. *)
+let _shell_warmed : bool Atomic.t = Atomic.make false
+
+(** Track whether the startup shell pre-warm fiber is still building the
+    first payload. Cold HTTP requests use this to serve a bootstrap payload
+    instead of blocking on the same expensive shell projection. *)
+let _shell_warming : bool Atomic.t = Atomic.make false
+
+(** Last-known-good shell result for graceful degradation on timeout. *)
+let _last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
+
 (** Wrap a dashboard computation with a configurable timeout.
     Returns a partial-response JSON on timeout instead of hanging. *)
 let with_dashboard_timeout ~clock compute =
@@ -780,6 +793,52 @@ let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
     ()
   |> Server_base_path_diagnostics.to_yojson
 
+let dashboard_shell_bootstrap_json (config : Coord.config) : Yojson.Safe.t =
+  let generated_at = Types.now_iso () in
+  let started_at = Unix.gettimeofday () in
+  `Assoc
+    [
+      ("generated_at", `String generated_at);
+      ( "status",
+        `Assoc
+          [
+            ("project", `String "initializing");
+            ("generated_at", `String generated_at);
+          ] );
+      ("paths", dashboard_shell_paths_json config);
+      ( "counts",
+        `Assoc
+          [
+            ("agents", `Int 0);
+            ("tasks", `Int 0);
+            ("keepers", `Int 0);
+            ("total_runtimes", `Int 0);
+          ] );
+      ("configured_keepers", `Int 0);
+      ("providers", `Assoc []);
+      ("meta_cognition", `Null);
+      ("config_resolution", `Null);
+      ("runtime_resolution", `Null);
+    ]
+  |> with_projection_diagnostics ~surface:"shell" ~started_at
+       ~extra:
+         [
+           ("cache_state", `String "initializing");
+           ("bootstrap_source", `String "shell_prewarm");
+         ]
+
+let dashboard_shell_last_good_opt () =
+  match Atomic.get _last_good_shell with
+  | `Assoc [] -> None
+  | json -> Some json
+
+let is_dashboard_cache_timeout_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "error" fields with
+      | Some (`String "Compute timeout") -> true
+      | _ -> false)
+  | _ -> false
+
 let dashboard_shell_payload_json (config : Coord.config) : Yojson.Safe.t =
   let cluster = Env_config_core.cluster_name () in
   let started_at = Unix.gettimeofday () in
@@ -970,13 +1029,38 @@ let dashboard_shell_http_json ?clock ?request (config : Coord.config) : Yojson.S
     | Some clock -> Some clock
     | None -> Eio_context.get_clock_opt ()
   in
+  let fallback_payload () =
+    match dashboard_shell_last_good_opt () with
+    | Some json -> json
+    | None -> dashboard_shell_bootstrap_json config
+  in
+  let startup_shell_bootstrap_pending =
+    let current = Server_startup_state.(!state) in
+    (not (Atomic.get _shell_warmed))
+    && current.state_ready
+    && Server_startup_state.elapsed_since_start ()
+       < (dashboard_shell_timeout_s +. 10.0)
+  in
+  let startup_prewarm_pending =
+    (Atomic.get _shell_warming || startup_shell_bootstrap_pending)
+    && not (Atomic.get _shell_warmed)
+  in
   let payload =
-    match clock_opt with
-    | Some clock ->
-        Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0 ~clock
-          ~timeout_sec:dashboard_shell_timeout_s compute
-    | None ->
-        Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+    if startup_prewarm_pending then
+      fallback_payload ()
+    else
+      let computed =
+        match clock_opt with
+        | Some clock ->
+            Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0
+              ~clock ~timeout_sec:dashboard_shell_timeout_s compute
+        | None ->
+            Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+      in
+      if is_dashboard_cache_timeout_json computed then
+        fallback_payload ()
+      else
+        computed
   in
   match request with
   | None -> payload

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1041,8 +1041,10 @@ let dashboard_shell_http_json ?clock ?request (config : Coord.config) : Yojson.S
     && Server_startup_state.elapsed_since_start ()
        < (dashboard_shell_timeout_s +. 10.0)
   in
+  let apply_startup_prewarm_guard = Option.is_some request in
   let startup_prewarm_pending =
-    (Atomic.get _shell_warming || startup_shell_bootstrap_pending)
+    apply_startup_prewarm_guard
+    && (Atomic.get _shell_warming || startup_shell_bootstrap_pending)
     && not (Atomic.get _shell_warmed)
   in
   let payload =

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -151,3 +151,6 @@ val dashboard_shell_http_json :
 
 val dashboard_shell_payload_json :
   Coord.config -> Yojson.Safe.t
+
+val is_dashboard_cache_timeout_json :
+  Yojson.Safe.t -> bool

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -35,6 +35,9 @@ val run_dashboard_compute :
     Exposed for the facade module [Server_dashboard_http]. *)
 val _operator_snapshot_cache : cached_surface
 val _operator_digest_cache : cached_surface
+val _shell_warmed : bool Atomic.t
+val _shell_warming : bool Atomic.t
+val _last_good_shell : Yojson.Safe.t Atomic.t
 
 (** Late-bound broadcast callbacks — set by [Server_dashboard_http]
     after [Sse] module is in scope. *)
@@ -145,3 +148,6 @@ val dashboard_shell_http_json :
   ?request:Httpun.Request.t ->
   Coord.config ->
   Yojson.Safe.t
+
+val dashboard_shell_payload_json :
+  Coord.config -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -4,34 +4,46 @@
 open Server_utils
 open Server_dashboard_http_core
 
-(** Track whether shell cache has been populated at least once.
-    Atomic.t for cross-domain visibility: read from executor pool
-    worker domain via [namespace_truth_snapshot_from_caches].
-    Monotonic false→true; stale false just picks the cold timeout. *)
-let _shell_warmed : bool Atomic.t = Atomic.make false
-
-(** Last-known-good shell result for graceful degradation on timeout.
-    Atomic.t for cross-domain visibility (same reason as [_shell_warmed]).
-    Each update swaps a fully-constructed Yojson.Safe.t value;
-    readers always see a complete snapshot. *)
-let _last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
+let shell_prewarm_timeout_s = 30.0
 
 let warm_shell_cache (state : Mcp_server.server_state) =
-  let t0 = Time_compat.now () in
-  (try
-     let result =
-       dashboard_shell_http_json ?clock:state.Mcp_server.clock
-         state.Mcp_server.room_config
-     in
-     Atomic.set _shell_warmed true;
-     Atomic.set _last_good_shell result;
-     Log.Dashboard.info "shell cache pre-warmed (%.1fms)"
-       ((Time_compat.now () -. t0) *. 1000.0)
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-       Log.Dashboard.warn "shell cache pre-warm failed: %s"
-         (Printexc.to_string exn))
+  Atomic.set _shell_warming true;
+  Fun.protect
+    ~finally:(fun () -> Atomic.set _shell_warming false)
+    (fun () ->
+      let t0 = Time_compat.now () in
+      (try
+         let cache_key =
+           Printf.sprintf "shell:coord=%s:workspace=%s"
+             state.Mcp_server.room_config.base_path
+             state.Mcp_server.room_config.workspace_path
+         in
+         let compute () =
+           dashboard_shell_payload_json state.Mcp_server.room_config
+         in
+         let result =
+           match state.Mcp_server.clock with
+           | Some clock ->
+               Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0
+                 ~clock ~timeout_sec:shell_prewarm_timeout_s compute
+           | None ->
+               Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+         in
+         if is_dashboard_cache_timeout_json result then
+           Log.Dashboard.warn
+             "shell cache pre-warm timed out during compute (%.0fs)"
+             shell_prewarm_timeout_s
+         else begin
+           Atomic.set _shell_warmed true;
+           Atomic.set _last_good_shell result;
+           Log.Dashboard.info "shell cache pre-warmed (%.1fms)"
+             ((Time_compat.now () -. t0) *. 1000.0)
+         end
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Dashboard.warn "shell cache pre-warm failed: %s"
+             (Printexc.to_string exn)))
 
 (* Delta-push: track last broadcast hash per event_type to skip unchanged payloads. *)
 let _last_broadcast_hash : (string, Digestif.SHA256.t) Hashtbl.t =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -136,11 +136,15 @@ let _transport_health_cache =
 
 let keepalive_running_of_lifecycle_event = function
   | "started" | "restarted" | "reconciled" -> Some true
+  | "resumed" -> Some true
+  | "paused" -> Some true
   | "stopped" | "crashed" | "dead" -> Some false
   | _ -> None
 
 let phase_of_lifecycle_event = function
   | "started" | "restarted" | "reconciled" -> Some "running"
+  | "resumed" -> Some "running"
+  | "paused" -> Some "paused"
   | "stopped" -> Some "stopped"
   | "crashed" -> Some "crashed"
   | "dead" -> Some "dead"
@@ -148,8 +152,15 @@ let phase_of_lifecycle_event = function
 
 let pipeline_stage_of_lifecycle_event = function
   | "started" | "restarted" | "reconciled" -> Some "idle"
+  | "resumed" -> Some "idle"
+  | "paused" -> Some "paused"
   | "stopped" | "dead" -> Some "offline"
   | "crashed" -> Some "crashed"
+  | _ -> None
+
+let paused_of_lifecycle_event = function
+  | "started" | "restarted" | "reconciled" | "resumed" -> Some false
+  | "paused" | "stopped" -> Some true
   | _ -> None
 
 let keeper_agent_status_opt row =
@@ -183,6 +194,11 @@ let patch_keeper_row ~keeper_name ~event ~keepalive_running = function
             row_fields
             |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running)
             |> upsert_assoc_field "status" (patched_keeper_status row ~keepalive_running)
+          in
+          let row_fields =
+            match paused_of_lifecycle_event event with
+            | Some paused -> upsert_assoc_field "paused" (`Bool paused) row_fields
+            | None -> row_fields
           in
           let row_fields =
             match phase_of_lifecycle_event event with

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -541,6 +541,21 @@ let extract_keeper_name_for_post req_path suffix =
   in
   if is_valid_keeper_name raw then raw else ""
 
+let refresh_keeper_execution_surfaces ~name event =
+  Operator_control_snapshot.invalidate_snapshot_cache ();
+  (try Dashboard_cache.invalidate "execution:default:light" with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Dashboard.warn
+         "keeper %s %s: execution dashboard cache invalidate failed: %s"
+         name event (Printexc.to_string exn));
+  Server_dashboard_http_execution_surfaces.patch_keeper_dependent_caches
+    ~keeper_name:name ~event
+
+let invalidate_keeper_execution_surfaces () =
+  Operator_control_snapshot.invalidate_snapshot_cache ();
+  Server_dashboard_http_execution_surfaces.invalidate_execution_cache ()
+
 let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_config in
@@ -654,6 +669,52 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
       {|{"error":"keeper name is required"}|} reqd
   else
     let config = state.Mcp_server.room_config in
+    let resolve_keeper_agent_name () =
+      match Keeper_registry.find_by_name name with
+      | Some entry -> Some entry.meta.agent_name
+      | None -> (
+          match Keeper_types.read_meta config name with
+          | Ok (Some meta) -> Some meta.agent_name
+          | Ok None | Error _ -> None)
+    in
+    let persist_keeper_paused_state paused =
+      match Keeper_types.read_meta config name with
+      | Ok (Some meta) when Bool.equal meta.paused paused -> ()
+      | Ok (Some meta) ->
+          let updated_meta =
+            {
+              meta with
+              paused;
+              updated_at = Keeper_types.now_iso ();
+            }
+          in
+          (match Keeper_types.write_meta ~force:true config updated_meta with
+           | Ok () -> ()
+           | Error err ->
+               Log.Keeper.warn
+                 "keeper %s %s: write_meta failed: %s"
+                 name
+                 (if paused then "pause" else "resume")
+                 err)
+      | Ok None | Error _ -> ()
+    in
+    let resume_booted_keeper_if_needed () =
+      match Keeper_types.read_meta config name with
+      | Ok (Some meta) when meta.paused ->
+          persist_keeper_paused_state false;
+          (match resolve_keeper_agent_name () with
+           | Some keeper_agent_name ->
+               Keeper_keepalive.process_directive
+                 ~agent_name:keeper_agent_name
+                 "resume"
+           | None ->
+               Log.Keeper.warn
+                 "keeper boot: agent_name not found for paused keeper %s"
+                 name)
+      | Ok (Some _)
+      | Ok None
+      | Error _ -> ()
+    in
     let keeper_ctx : _ Tool_keeper.context =
       {
         config;
@@ -691,6 +752,11 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     | Ok args ->
     match Tool_keeper.dispatch keeper_ctx ~name:tool_name ~args with
     | Some (true, body) when String.equal action "boot" || String.equal action "clear" ->
+        if String.equal action "boot"
+        then (
+          resume_booted_keeper_if_needed ();
+          refresh_keeper_execution_surfaces ~name "started")
+        else invalidate_keeper_execution_surfaces ();
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s","detail":%s}|}
              (String.escaped action)
@@ -698,6 +764,9 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
              body)
           reqd
     | Some (true, _body) ->
+        (match action with
+         | "shutdown" -> refresh_keeper_execution_surfaces ~name "stopped"
+         | _ -> invalidate_keeper_execution_surfaces ());
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
              (String.escaped action)
@@ -718,7 +787,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     Delegates to [Keeper_keepalive.process_directive] which updates
     registry state, dispatches a state-machine event, and optionally
     wakes up the keeper fiber. *)
-let handle_keeper_directive_post _state _agent_name req reqd body_str =
+let handle_keeper_directive_post state _agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_directive in
   if String.length name = 0 then
@@ -745,7 +814,51 @@ let handle_keeper_directive_post _state _agent_name req reqd body_str =
              (Yojson.Safe.to_string (`String msg)))
           reqd
     | Ok action_str ->
-        Keeper_keepalive.process_directive ~agent_name:name action_str;
+        let config = state.Mcp_server.room_config in
+        let meta_opt =
+          match Keeper_types.read_meta config name with
+          | Ok (Some meta) -> Some meta
+          | Ok None | Error _ -> None
+        in
+        let persist_paused_state paused =
+          match meta_opt with
+          | Some meta when not (Bool.equal meta.paused paused) ->
+              let updated_meta =
+                {
+                  meta with
+                  paused;
+                  updated_at = Keeper_types.now_iso ();
+                }
+              in
+              (match Keeper_types.write_meta ~force:true config updated_meta with
+               | Ok () -> ()
+               | Error err ->
+                   Log.Keeper.warn
+                     "directive %s: write_meta failed for %s: %s"
+                     action_str
+                     name
+                     err)
+          | Some _ | None -> ()
+        in
+        (match action_str with
+         | "pause" -> persist_paused_state true
+         | "resume" -> persist_paused_state false
+         | "wakeup"
+         | _ -> ());
+        let resolved_agent_name =
+          match Keeper_registry.find_by_name name with
+          | Some entry -> entry.meta.agent_name
+          | None -> (
+              match meta_opt with
+              | Some meta -> meta.agent_name
+              | None -> Keeper_types.keeper_agent_name name)
+        in
+        Keeper_keepalive.process_directive ~agent_name:resolved_agent_name action_str;
+        (match action_str with
+         | "pause" -> refresh_keeper_execution_surfaces ~name "paused"
+         | "resume" -> refresh_keeper_execution_surfaces ~name "resumed"
+         | "wakeup" -> invalidate_keeper_execution_surfaces ()
+         | _ -> invalidate_keeper_execution_surfaces ());
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
              (String.escaped action_str) (String.escaped name))

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -80,13 +80,13 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
            fiber also fires, discarding even stale data.  Fixes #5090. *)
         let shell_fiber_timeout_s = 12.0 in
         let shell_timeout_s =
-          if Atomic.get Execution_surfaces._shell_warmed then shell_fiber_timeout_s
+          if Atomic.get _shell_warmed then shell_fiber_timeout_s
           else Float.max cold_timeout_s (shell_fiber_timeout_s +. 4.0)
         in
         (* Graceful degradation: on timeout fall back to the last successful
            shell result rather than empty JSON, which would zero out namespace
            counts and focus data (61x/day under I/O contention). *)
-        let shell_fallback = Atomic.get Execution_surfaces._last_good_shell in
+        let shell_fallback = Atomic.get _last_good_shell in
         (* Sequential fetch to avoid PG connection concurrent usage (#3305). *)
         shell_ref :=
           fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
@@ -97,9 +97,9 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let shell_json = !shell_ref in
         (* Update last-known-good shell on success. *)
         if shell_json <> `Assoc [] && shell_json <> shell_fallback then
-          Atomic.set Execution_surfaces._last_good_shell shell_json;
-        if (not (Atomic.get Execution_surfaces._shell_warmed)) && shell_json <> `Assoc [] then
-          Atomic.set Execution_surfaces._shell_warmed true;
+          Atomic.set _last_good_shell shell_json;
+        if (not (Atomic.get _shell_warmed)) && shell_json <> `Assoc [] then
+          Atomic.set _shell_warmed true;
         let execution_json = !execution_ref in
         let command_summary_json = !command_ref in
         let parallel_ms = (Time_compat.now () -. t0) *. 1000.0 in
@@ -130,21 +130,23 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
     produced its first successful result (cold start). *)
 let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
     Yojson.Safe.t option =
-  if not (cached_surface_has_success Execution_surfaces._execution_cache) then
+  if not (cached_surface_has_success Server_dashboard_http_execution_surfaces._execution_cache) then
     None
   else
     let config = state.Mcp_server.room_config in
     let shell_json =
-      if Atomic.get Execution_surfaces._shell_warmed then
+      if Atomic.get _shell_warmed then
         (try
            let result = dashboard_shell_http_json ?clock:state.Mcp_server.clock config in
-           Atomic.set Execution_surfaces._last_good_shell result;
+           Atomic.set _last_good_shell result;
            result
          with Eio.Cancel.Cancelled _ as e -> raise e
-            | _ -> Atomic.get Execution_surfaces._last_good_shell)
-      else Atomic.get Execution_surfaces._last_good_shell
+            | _ -> Atomic.get _last_good_shell)
+      else Atomic.get _last_good_shell
     in
-    let execution_json = cached_surface_json Execution_surfaces._execution_cache in
+    let execution_json =
+      cached_surface_json Server_dashboard_http_execution_surfaces._execution_cache
+    in
     let command_summary_json = `Assoc [] in
     Some
       (Namespace_truth_support.compose_namespace_truth_snapshot ~config

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -588,6 +588,28 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/tasks/history" ->
+          let state = get_server_state () in
+          let task_id =
+            match Server_utils.query_param httpun_request "task_id" with
+            | Some value -> String.trim value
+            | None -> ""
+          in
+          if task_id = "" then
+            h2_respond_json h2_reqd {|{"error":"task_id is required"}|}
+              ~status:`Bad_request ~extra_headers:cors
+          else
+            let limit =
+              Server_utils.int_query_param httpun_request "limit" ~default:50
+              |> Server_utils.clamp ~min_v:1 ~max_v:200
+            in
+            let json =
+              Tool_task.task_history_events_json state.Mcp_server.room_config
+                ~task_id ~limit
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              ~extra_headers:cors
+
       | `GET, "/api/v1/dashboard/mission" ->
           let state = get_server_state () in
           let json = dashboard_mission_http_json ~state ~sw ~clock httpun_request in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -90,6 +90,25 @@ let handle_dashboard_link_previews state req reqd body_str =
   with Yojson.Json_error message ->
     respond_error ("invalid json: " ^ message)
 
+let handle_dashboard_task_history state req reqd =
+  let task_id =
+    match Server_utils.query_param req "task_id" with
+    | Some value -> String.trim value
+    | None -> ""
+  in
+  if task_id = "" then
+    Http.Response.json ~status:`Bad_request ~request:req
+      {|{"error":"task_id is required"}|} reqd
+  else
+    let limit =
+      Server_utils.int_query_param req "limit" ~default:50
+      |> Server_utils.clamp ~min_v:1 ~max_v:200
+    in
+    let json =
+      Tool_task.task_history_events_json state.Mcp_server.room_config ~task_id ~limit
+    in
+    Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -353,6 +372,10 @@ let rec add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let json = dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/tasks/history" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         handle_dashboard_task_history state req reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/mission" (fun request reqd ->
        with_public_read (fun state req reqd ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -941,15 +941,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       (* Pre-warm shell cache in a separate fiber so it cannot block
          lazy startup tasks or later keeper loop startup
          (#keeper-bootstrap-stuck). *)
+      Atomic.set Server_dashboard_http._shell_warming true;
       Eio.Fiber.fork ~sw (fun () ->
         (try
-           match Eio.Time.with_timeout clock 10.0 (fun () ->
+           match Eio.Time.with_timeout clock 35.0 (fun () ->
              Server_dashboard_http.warm_shell_cache state;
              Ok ())
            with
            | Ok () -> ()
            | Error `Timeout ->
-             Log.Dashboard.warn "shell cache pre-warm timed out (10s)"
+             Log.Dashboard.warn "shell cache pre-warm timed out (35s)"
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -844,11 +844,9 @@ let handle_tasks ctx args =
   in
   (true, Coord.list_tasks ctx.config ~include_done ~include_cancelled ?status)
 
-let handle_task_history ctx args =
-  let task_id = get_string args "task_id" "" in
-  let limit = get_int args "limit" 50 in
+let task_history_events_json (config : Coord.config) ~task_id ~limit =
   let scan_limit = min 500 (limit * 5) in
-  let lines = Mcp_server.read_event_lines ctx.config ~limit:scan_limit in
+  let lines = Mcp_server.read_event_lines config ~limit:scan_limit in
   let (parsed, _malformed) =
     Fs_compat.parse_jsonl_lines ~source:"task_events" lines
   in
@@ -867,7 +865,12 @@ let handle_task_history ctx args =
     | x :: rest -> x :: take (n - 1) rest
   in
   let events = parsed |> List.filter matches_task |> take limit in
-  (true, Yojson.Safe.to_string (`List events))
+  `List events
+
+let handle_task_history ctx args =
+  let task_id = get_string args "task_id" "" in
+  let limit = get_int args "limit" 50 in
+  (true, Yojson.Safe.to_string (task_history_events_json ctx.config ~task_id ~limit))
 
 include Tool_task_schemas
 (* Dispatch function *)

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -19,6 +19,8 @@ val handle_transition : context -> Yojson.Safe.t -> tool_result
 val handle_update_priority : context -> Yojson.Safe.t -> tool_result
 val handle_tasks : context -> Yojson.Safe.t -> tool_result
 val handle_task_history : context -> Yojson.Safe.t -> tool_result
+val task_history_events_json :
+  Coord.config -> task_id:string -> limit:int -> Yojson.Safe.t
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -174,6 +174,59 @@ let test_dashboard_shell_http_json_prefers_preserved_base_path_input () =
     (json |> member "runtime_resolution" |> member "base_path" |> member "path"
    |> to_string)
 
+let test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let original_warmed = Atomic.get Lib.Server_dashboard_http._shell_warmed in
+  let original_warming = Atomic.get Lib.Server_dashboard_http._shell_warming in
+  let original_last_good = Atomic.get Lib.Server_dashboard_http._last_good_shell in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Lib.Server_dashboard_http._shell_warmed original_warmed;
+      Atomic.set Lib.Server_dashboard_http._shell_warming original_warming;
+      Atomic.set Lib.Server_dashboard_http._last_good_shell original_last_good)
+    (fun () ->
+      Atomic.set Lib.Server_dashboard_http._shell_warmed false;
+      Atomic.set Lib.Server_dashboard_http._shell_warming true;
+      Atomic.set Lib.Server_dashboard_http._last_good_shell (`Assoc []);
+      let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+      let open Yojson.Safe.Util in
+      check string "bootstrap status project" "initializing"
+        (json |> member "status" |> member "project" |> to_string);
+      check int "bootstrap zero agents" 0
+        (json |> member "counts" |> member "agents" |> to_int);
+      check string "bootstrap cache state" "initializing"
+        (json |> member "projection_diagnostics" |> member "cache_state"
+        |> to_string))
+
+let test_dashboard_shell_http_json_prefers_last_good_while_prewarming () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let original_warmed = Atomic.get Lib.Server_dashboard_http._shell_warmed in
+  let original_warming = Atomic.get Lib.Server_dashboard_http._shell_warming in
+  let original_last_good = Atomic.get Lib.Server_dashboard_http._last_good_shell in
+  let last_good =
+    `Assoc
+      [
+        ("generated_at", `String "2026-04-17T00:00:00Z");
+        ("status", `Assoc [("project", `String "warm-room")]);
+        ("counts", `Assoc [("agents", `Int 7); ("tasks", `Int 11); ("keepers", `Int 3)]);
+      ]
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Lib.Server_dashboard_http._shell_warmed original_warmed;
+      Atomic.set Lib.Server_dashboard_http._shell_warming original_warming;
+      Atomic.set Lib.Server_dashboard_http._last_good_shell original_last_good)
+    (fun () ->
+      Atomic.set Lib.Server_dashboard_http._shell_warmed false;
+      Atomic.set Lib.Server_dashboard_http._shell_warming true;
+      Atomic.set Lib.Server_dashboard_http._last_good_shell last_good;
+      let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+      let open Yojson.Safe.Util in
+      check string "last-good project reused" "warm-room"
+        (json |> member "status" |> member "project" |> to_string);
+      check int "last-good counts reused" 7
+        (json |> member "counts" |> member "agents" |> to_int))
+
 let () =
   run "dashboard_http_core"
     [
@@ -187,5 +240,9 @@ let () =
             test_dashboard_shell_http_json_includes_paths;
           test_case "shell runtime base_path prefers preserved input" `Quick
             test_dashboard_shell_http_json_prefers_preserved_base_path_input;
+          test_case "shell bootstrap payload while prewarming" `Quick
+            test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming;
+          test_case "shell reuses last good payload while prewarming" `Quick
+            test_dashboard_shell_http_json_prefers_last_good_while_prewarming;
         ] );
     ]

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -29,6 +29,9 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
+let request target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
+
 let with_test_env f =
   let dir = test_dir () in
   Fun.protect
@@ -188,7 +191,11 @@ let test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming () =
       Atomic.set Lib.Server_dashboard_http._shell_warmed false;
       Atomic.set Lib.Server_dashboard_http._shell_warming true;
       Atomic.set Lib.Server_dashboard_http._last_good_shell (`Assoc []);
-      let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+      let json =
+        Lib.Server_dashboard_http_core.dashboard_shell_http_json
+          ~request:(request "/api/v1/dashboard/shell")
+          config
+      in
       let open Yojson.Safe.Util in
       check string "bootstrap status project" "initializing"
         (json |> member "status" |> member "project" |> to_string);
@@ -220,7 +227,11 @@ let test_dashboard_shell_http_json_prefers_last_good_while_prewarming () =
       Atomic.set Lib.Server_dashboard_http._shell_warmed false;
       Atomic.set Lib.Server_dashboard_http._shell_warming true;
       Atomic.set Lib.Server_dashboard_http._last_good_shell last_good;
-      let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+      let json =
+        Lib.Server_dashboard_http_core.dashboard_shell_http_json
+          ~request:(request "/api/v1/dashboard/shell")
+          config
+      in
       let open Yojson.Safe.Util in
       check string "last-good project reused" "warm-room"
         (json |> member "status" |> member "project" |> to_string);

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -273,6 +273,69 @@ let run_curl_post ?body ?token ~port ~path () =
   { status; body; curl_exit; stderr }
 ;;
 
+let run_curl_get ?token ~port ~path () =
+  let header_file = Filename.temp_file "dashboard-keeper-get-" ".hdr" in
+  let body_file = Filename.temp_file "dashboard-keeper-get-" ".body" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let base_args =
+    [ "curl"
+    ; "-sS"
+    ; "--http1.1"
+    ; "--max-time"
+    ; "3"
+    ; "-X"
+    ; "GET"
+    ; "-o"
+    ; body_file
+    ; "-D"
+    ; header_file
+    ]
+  in
+  let args =
+    let args =
+      match token with
+      | Some raw_token ->
+          base_args @ [ "-H"; Printf.sprintf "Authorization: Bearer %s" raw_token ]
+      | None -> base_args
+    in
+    Array.of_list (args @ [ url ])
+  in
+  let ic, oc, ec = Unix.open_process_args_full "curl" args (Unix.environment ()) in
+  close_out_noerr oc;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let status = parse_status (read_file header_file) in
+  let body = read_file body_file in
+  (try Sys.remove header_file with
+   | _ -> ());
+  (try Sys.remove body_file with
+   | _ -> ());
+  { status; body; curl_exit; stderr }
+;;
+
+let execution_keeper_paused body keeper_name =
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  let keepers = json |> member "keepers" |> to_list in
+  match
+    List.find_opt
+      (fun row -> row |> member "name" |> to_string = keeper_name)
+      keepers
+  with
+  | Some row -> (
+      match row |> member "paused" with
+      | `Bool value -> value
+      | `Null -> false
+      | _ -> false)
+  | None -> fail ("keeper missing from execution payload: " ^ keeper_name)
+;;
+
 let make_keeper_meta_json ?(name = "route-shadow-demo") () =
   match
     Masc_mcp.Keeper_types.meta_of_json
@@ -400,6 +463,7 @@ let test_keeper_post_route_classification () =
   check_route "/api/v1/keepers/sangsu/reset" Keeper_api.Keeper_post_reset;
   check_route "/api/v1/keepers/sangsu/clear" Keeper_api.Keeper_post_clear;
   check_route "/api/v1/keepers/sangsu/checkpoints" Keeper_api.Keeper_post_checkpoints;
+  check_route "/api/v1/keepers/sangsu/directive" Keeper_api.Keeper_post_directive;
   check_route "/api/v1/keepers/sangsu" Keeper_api.Keeper_post_unknown;
   check_route "/api/v1/keepers//boot" Keeper_api.Keeper_post_unknown
 ;;
@@ -437,6 +501,17 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
     "boot route reaches lifecycle handler"
     true
     (contains_substr {|"action":"boot"|} boot_result.body);
+  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+   | Ok (Some meta) ->
+       check bool "boot resumes paused keeper meta" false meta.paused
+   | Ok None -> fail "keeper meta missing after boot route"
+   | Error err -> fail ("failed to read keeper meta after boot route: " ^ err));
+  let execution_after_boot =
+    run_curl_get ~port ~path:"/api/v1/dashboard/execution" ()
+  in
+  require_status "execution GET returns 200 after boot" 200 execution_after_boot;
+  check bool "execution reflects resumed keeper after boot" false
+    (execution_keeper_paused execution_after_boot.body keeper_name);
   let shutdown_result =
     run_curl_post ~body:"{}" ~token:admin_token ~port ~path:shutdown_path ()
   in
@@ -505,6 +580,40 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
   | Ok (Some meta) -> check bool "shutdown persists paused keeper meta" true meta.paused
   | Ok None -> fail "keeper meta missing after shutdown route"
   | Error err -> fail ("failed to read keeper meta after shutdown: " ^ err)
+;;
+
+let test_keeper_directive_resume_updates_paused_meta () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let directive_path =
+    Printf.sprintf "/api/v1/keepers/%s/directive" keeper_name
+  in
+  let resume_result =
+    run_curl_post
+      ~body:{|{"action":"resume"}|}
+      ~token:admin_token
+      ~port
+      ~path:directive_path
+      ()
+  in
+  require_status "directive route returns 200" 200 resume_result;
+  check
+    bool
+    "directive route reaches lifecycle handler"
+    true
+    (contains_substr {|"action":"resume"|} resume_result.body);
+  let execution_after_resume =
+    run_curl_get ~port ~path:"/api/v1/dashboard/execution" ()
+  in
+  require_status "execution GET returns 200 after directive" 200 execution_after_resume;
+  check bool "execution reflects resumed keeper after directive" false
+    (execution_keeper_paused execution_after_resume.body keeper_name);
+  match Masc_mcp.Keeper_types.read_meta config keeper_name with
+  | Ok (Some meta) ->
+      check bool "directive resume clears paused keeper meta" false meta.paused
+  | Ok None -> fail "keeper meta missing after directive resume"
+  | Error err ->
+      fail ("failed to read keeper meta after directive resume: " ^ err)
 ;;
 
 let test_merge_keeper_trace_lines_includes_internal_history () =
@@ -589,6 +698,10 @@ let () =
             "lifecycle POST routes do not fall through to generic 404"
             `Slow
             test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404
+        ; test_case
+            "directive resume updates paused meta"
+            `Slow
+            test_keeper_directive_resume_updates_paused_meta
         ; test_case
             "merge keeper trace lines includes internal history"
             `Quick

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -354,6 +354,10 @@ let extra_guard_fragments_for_name = function
       [ "agent_name must match the authenticated agent";
         "no credential found" ]
   | "masc_auth_revoke" -> [ "no credential found" ]
+  | "masc_team_memory_read"
+  | "masc_team_memory_search"
+  | "masc_team_memory_write" ->
+      [ "keeper-only"; "not a keeper agent" ]
   | "masc_autoresearch_cycle"
   | "masc_autoresearch_inject"
   | "masc_autoresearch_status"

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -96,6 +96,67 @@ let () = test "dispatch_tasks" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "task_history_events_json_filters_by_task_id" (fun () ->
+  let ctx = make_test_ctx () in
+  let rec mkdir_p path =
+    if path = "" || path = "." || path = "/" then ()
+    else if Sys.file_exists path then ()
+    else begin
+      mkdir_p (Filename.dirname path);
+      Unix.mkdir path 0o755
+    end
+  in
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let events_dir = Filename.concat (Coord.masc_dir ctx.config) "events" in
+  let month_dir = Filename.concat events_dir month in
+  let log_file = Filename.concat month_dir day in
+  mkdir_p month_dir;
+  let event task_id action =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("type", `String "task_transition");
+          ("task_id", `String task_id);
+          ("action", `String action);
+          ("agent", `String ctx.agent_name);
+          ("ts", `String "2026-04-18T00:00:00Z");
+        ])
+  in
+  Fs_compat.append_file log_file (event "task-001" "claim" ^ "\n");
+  Fs_compat.append_file log_file (event "task-002" "done" ^ "\n");
+  let json = Tool_task.task_history_events_json ctx.config ~task_id:"task-001" ~limit:20 in
+  let events =
+    match json with
+    | `List rows -> rows
+    | _ -> failwith "task history payload must be a JSON list"
+  in
+  assert (List.length events = 1);
+  List.iter (fun row ->
+    let open Yojson.Safe.Util in
+    let task =
+      match row |> member "task" with
+      | `String value -> Some value
+      | _ ->
+          (match row |> member "task_id" with
+           | `String value -> Some value
+           | _ -> None)
+    in
+    assert (task = Some "task-001")
+  ) events
+)
+
+let () = test "task_history_events_json_returns_empty_for_missing_task" (fun () ->
+  let ctx = make_test_ctx () in
+  let json = Tool_task.task_history_events_json ctx.config ~task_id:"task-404" ~limit:20 in
+  match json with
+  | `List [] -> ()
+  | `List _ -> failwith "missing task should have no history events"
+  | _ -> failwith "task history payload must be a JSON list"
+)
+
 let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
   match Masc_eio_env.get_opt () with
   | Some _ ->


### PR DESCRIPTION
## Summary
- avoid the cold `/api/v1/dashboard/shell` path blocking on the first expensive projection by serving an initializing payload or last-known-good payload during startup
- keep shell warmup state in the shared dashboard core so the shell and namespace-truth paths reuse the same warm/cold markers
- scope the startup bootstrap fallback to real shell HTTP requests so internal read-model callers still compute the full shell projection
- stop treating a timed-out shell compute as a successful warm-cache fill
- drop the dead `dashboard/src/components/mission-cards.ts` barrel that started failing `Dashboard` CI after the rebase onto `main`

## Product impact
- the first dashboard/API requests no longer sit on the full cold shell projection and fall into a late timeout/500
- operators get an explicit bootstrap state during startup instead of a backend-looking stall
- once warmup completes, the normal cached shell payload resumes without a manual server-side intervention
- namespace-truth and internal dashboard read-model callers keep the real shell projection instead of seeing the startup bootstrap payload

## Evidence
- local backend validation on current head:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-shell-cold-start test/test_dashboard_execution.exe test/test_dashboard_namespace_truth.exe test/test_dashboard_http_core.exe`
  - `./_build/default/test/test_dashboard_execution.exe`
  - `./_build/default/test/test_dashboard_namespace_truth.exe`
  - `./_build/default/test/test_dashboard_http_core.exe`
- targeted matrix follow-up after rebasing onto newer `main`:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-shell-cold-start test/keeper_tool_matrix_case_runner.exe test/test_keeper_tool_matrix.exe`
  - `KEEPER_TOOL_MATRIX_ONLY=masc_team_memory_read,masc_team_memory_search,masc_team_memory_write ./_build/default/test/test_keeper_tool_matrix.exe`
- dashboard validation after rebase cleanup:
  - `pnpm install --frozen-lockfile`
  - `pnpm run typecheck`

## Review evidence
- FE startup banner for the initializing state: `dashboard/src/components/dashboard-shell.ts`
- automatic warm-up retry loop when namespace truth returns `status=initializing`: `dashboard/src/namespace-truth-actions.ts`
- app boot path primes shell first, then requests namespace truth and starts SSE/periodic refresh: `dashboard/src/app.ts`
- shell bootstrap counts/config metadata are hydrated by `refreshShell`: `dashboard/src/store.ts`
- startup bootstrap fallback is now request-scoped in the backend shell handler: `lib/server/server_dashboard_http_core.ml`

## Linked issue
- Fixes #3297
- Refs #3319

## Why
Cold boot requests were hitting the shell dashboard path before its first cache fill completed. That path could block long enough to time out, which made the first few dashboard/API requests feel like a backend stall even though the server was otherwise up. After the rebase onto newer `main`, the startup fallback also leaked into internal read-model callers, so shell-backed execution and namespace-truth tests started seeing the bootstrap payload instead of the real projection.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-shell-cold-start test/test_dashboard_execution.exe test/test_dashboard_namespace_truth.exe test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_dashboard_namespace_truth.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-shell-cold-start test/keeper_tool_matrix_case_runner.exe test/test_keeper_tool_matrix.exe`
- `KEEPER_TOOL_MATRIX_ONLY=masc_team_memory_read,masc_team_memory_search,masc_team_memory_write ./_build/default/test/test_keeper_tool_matrix.exe`