### PR TITLE
feat(dashboard): overview freshness 4-tier dot (green/amber/red)

### DIFF
--- a/dashboard/src/components/overview/overview-freshness.test.ts
+++ b/dashboard/src/components/overview/overview-freshness.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import {
+  classifyFreshness,
+  freshnessTierToneClass,
+  freshnessTierAriaLabel,
+} from './overview'
+
+describe('classifyFreshness (pure)', () => {
+  it('null / undefined / NaN → "unknown" (never loaded)', () => {
+    // Regression guard: the freshness strip must NOT green-flash
+    // during first boot before the mission snapshot arrives.
+    expect(classifyFreshness(null)).toBe('unknown')
+    expect(classifyFreshness(undefined)).toBe('unknown')
+    expect(classifyFreshness(Number.NaN)).toBe('unknown')
+  })
+
+  it('negative age (clock skew) → "fresh" (treat as brand new)', () => {
+    // Clock-skew guard: a browser tab whose OS just resynced NTP can
+    // momentarily produce future-dated timestamps. That's noise, not
+    // a problem — render fresh.
+    expect(classifyFreshness(-5_000)).toBe('fresh')
+  })
+
+  it('0 → "fresh" (just generated)', () => {
+    expect(classifyFreshness(0)).toBe('fresh')
+  })
+
+  it('sub-60s → "fresh" (green dot)', () => {
+    expect(classifyFreshness(30_000)).toBe('fresh')
+    expect(classifyFreshness(59_999)).toBe('fresh')
+  })
+
+  it('exactly 60s → "warn" (threshold crossing)', () => {
+    // Strict < WARN, >= WARN moves up a tier. No 1-pixel dead zone.
+    expect(classifyFreshness(60_000)).toBe('warn')
+  })
+
+  it('60–300s → "warn" (amber dot, card stays quiet)', () => {
+    expect(classifyFreshness(120_000)).toBe('warn')
+    expect(classifyFreshness(299_999)).toBe('warn')
+  })
+
+  it('exactly 300s → "stale" (triggers existing 5-min badge)', () => {
+    expect(classifyFreshness(300_000)).toBe('stale')
+  })
+
+  it('≥ 300s → "stale"', () => {
+    expect(classifyFreshness(600_000)).toBe('stale')
+    expect(classifyFreshness(3_600_000)).toBe('stale')
+  })
+})
+
+describe('freshnessTierToneClass (pure)', () => {
+  it('each tier maps to a non-empty, distinct Tailwind string', () => {
+    // Guards against a future refactor accidentally collapsing two
+    // tiers onto the same tone (the #1 way a traffic-light indicator
+    // silently stops being readable).
+    const tones = new Set([
+      freshnessTierToneClass('unknown'),
+      freshnessTierToneClass('fresh'),
+      freshnessTierToneClass('warn'),
+      freshnessTierToneClass('stale'),
+    ])
+    expect(tones.size).toBe(4)
+    for (const tone of tones) {
+      expect(tone.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('fresh uses the ok token, stale uses the bad token', () => {
+    expect(freshnessTierToneClass('fresh')).toContain('bg-ok')
+    expect(freshnessTierToneClass('stale')).toContain('bg-bad')
+    expect(freshnessTierToneClass('warn')).toContain('bg-warn')
+  })
+})
+
+describe('freshnessTierAriaLabel (pure)', () => {
+  it('every tier has a distinct Korean label (no raw enum strings leaked to AT users)', () => {
+    // Regression guard: if a refactor forgets a case, TS exhaustiveness
+    // will catch it — but a stringly-typed enum ("fresh") leaking to
+    // a screen reader is the soft failure. Pin the labels.
+    expect(freshnessTierAriaLabel('unknown')).toBe('상태 알 수 없음')
+    expect(freshnessTierAriaLabel('fresh')).toBe('신선함')
+    expect(freshnessTierAriaLabel('warn')).toBe('오래됨 (1분 이상)')
+    expect(freshnessTierAriaLabel('stale')).toBe('stale (5분 이상)')
+  })
+})

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -7,6 +7,7 @@ import { useMemo } from 'preact/hooks'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
 import { TimeAgo } from '../common/time-ago'
+import { StatusDot } from '../common/status-dot'
 import { missionLoading, missionSnapshot, refreshMissionSnapshot } from '../../mission-store'
 import { topActiveAgents } from '../../observatory-store'
 import { namespaceTruth, namespaceTruthLoading, refreshNamespaceTruth } from '../../namespace-truth-store'
@@ -34,6 +35,50 @@ import type {
 import type { ReadonlySignal } from '@preact/signals'
 
 const OVERVIEW_STALE_MS = 300_000
+/** Warn tier threshold: 1 minute. Matches Vercel deployment row "Last
+    updated" turn-amber gate. Picked by convention — most observability
+    dashboards use a ~60s boundary between "fresh" and "getting old". */
+const OVERVIEW_WARN_MS = 60_000
+
+export type FreshnessTier = 'unknown' | 'fresh' | 'warn' | 'stale'
+
+/** Pure: classify snapshot age into a 4-tier health reading that maps
+    1:1 to StatusDot tones (unknown=muted, fresh=ok, warn=amber, stale=bad).
+    Reference UIs: Vercel / Uptime Kuma / Linear cycle row dots all
+    use this same 4-tier pattern so operators can scan a grid of rows
+    for \"one of these is not like the others\" in sub-second time. */
+export function classifyFreshness(ageMs: number | null | undefined): FreshnessTier {
+  if (ageMs == null || Number.isNaN(ageMs)) return 'unknown'
+  if (ageMs < 0) return 'fresh' // clock-skew guard: treat future timestamps as fresh
+  if (ageMs < OVERVIEW_WARN_MS) return 'fresh'
+  if (ageMs < OVERVIEW_STALE_MS) return 'warn'
+  return 'stale'
+}
+
+/** Pure: Tailwind tone class for a freshness tier. Shared with any
+    caller that wants to render a consistent indicator (future dashboard
+    surfaces, log viewer header, etc.). */
+export function freshnessTierToneClass(tier: FreshnessTier): string {
+  switch (tier) {
+    case 'unknown': return 'bg-[var(--text-muted)]'
+    case 'fresh':   return 'bg-ok shadow-[0_0_6px_rgba(74,222,128,0.55)]'
+    case 'warn':    return 'bg-warn shadow-[0_0_6px_rgba(255,176,32,0.5)]'
+    case 'stale':   return 'bg-bad shadow-[0_0_6px_rgba(248,113,113,0.55)]'
+  }
+}
+
+/** Pure: aria-label for screen readers. The StatusDot itself is
+    aria-hidden by default, but we expose this so the caller can wrap
+    it in role=\"img\" when the dot appears standalone (no adjacent
+    text like the \"마지막 갱신\" line that already narrates the state). */
+export function freshnessTierAriaLabel(tier: FreshnessTier): string {
+  switch (tier) {
+    case 'unknown': return '상태 알 수 없음'
+    case 'fresh':   return '신선함'
+    case 'warn':    return '오래됨 (1분 이상)'
+    case 'stale':   return 'stale (5분 이상)'
+  }
+}
 
 /** Pure: is an Op Hub tile "active" (non-zero count, draws the eye)?
     Single-seam helper so the tile style decisions below — number
@@ -88,7 +133,9 @@ function OverviewFreshnessStrip() {
     namespaceTruth.value?.generated_at ?? null,
   )
   const generatedMs = timestampToMs(generatedAt)
-  const isStale = generatedMs != null && Date.now() - generatedMs > OVERVIEW_STALE_MS
+  const ageMs = generatedMs != null ? Date.now() - generatedMs : null
+  const tier = classifyFreshness(ageMs)
+  const isStale = tier === 'stale'
   const refreshing = missionLoading.value || namespaceTruthLoading.value
 
   return html`
@@ -96,7 +143,16 @@ function OverviewFreshnessStrip() {
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
+            <${StatusDot}
+              size="sm"
+              class=${freshnessTierToneClass(tier)}
+              ariaLabel=${freshnessTierAriaLabel(tier)}
+              testId="overview-freshness-dot"
+            />
             <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Overview Freshness</span>
+            ${tier === 'warn'
+              ? html`<span class="rounded-full border border-warn/25 bg-warn/10 px-2 py-0.5 text-[11px] font-medium text-warn">1분 이상 경과</span>`
+              : null}
             ${isStale
               ? html`<span class="rounded-full border border-warn/30 bg-warn/15 px-2 py-0.5 text-[11px] font-semibold text-warn">5분 이상 stale</span>`
               : null}


### PR DESCRIPTION
## What
Overview Freshness 카드에 `unknown / fresh / warn / stale` 4-tier 건강도를 표시하는 StatusDot 추가.

## Why
Vision-driven /loop pass 2번째 fire에서 발견:
- 현재 \"마지막 갱신: 23초 전\"은 plain text — operator가 \"23초가 좋은 건가?\" 매번 머릿속 계산
- Vercel / Uptime Kuma / Linear 모두 작은 점(녹/황/적)으로 tier를 시각화 → 한 번의 스캔으로 건강도 파악
- 현재는 5분 초과 시에만 카드가 amber — \"fresh/warn\" 구분 자체가 없음

## How
3개 pure helper 추출:
- \`classifyFreshness(ageMs): 'unknown' | 'fresh' | 'warn' | 'stale'\` (60s / 300s boundary)
- \`freshnessTierToneClass(tier)\` → Tailwind \`bg-ok/warn/bad\` + glow shadow
- \`freshnessTierAriaLabel(tier)\` → \"신선함\" / \"오래됨 (1분 이상)\" 등 AT 친화 라벨

StatusDot을 Overview Freshness 라벨 앞에 배치. Warn 구간(1-5분)엔 작은 \"1분 이상 경과\" pill 추가 — 기존 5분 stale pill 과 톤 구분.

## Design Notes
- 기존 5분 stale 시점의 카드 border/bg 애버mber는 그대로 유지 → 큰 경고는 여전히 5분부터
- 클록 skew guard: future timestamp → fresh (NTP 재동기화 순간 false alarm 방지)
- 첫 부팅 unknown 상태 → green-flash 안 함 (neutral muted dot)

## Tests (11 new, all pass)
- null/undefined/NaN → unknown (never-loaded 가드)
- 0 / sub-60s → fresh, 60–299s → warn, ≥300s → stale (경계 명시)
- 4 tone class distinct (future refactor collapse 방지)
- aria-label fingerprint

## Reference UIs
Vercel deployment row freshness · Uptime Kuma status page · Linear cycle row dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)