### PR TITLE
feat(dashboard): Op Hub tiles dim when zero (Stripe $0 / Linear backlog pattern)

### DIFF
--- a/dashboard/src/components/overview/op-hub-tile.test.ts
+++ b/dashboard/src/components/overview/op-hub-tile.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import {
+  opHubTileIsActive,
+  opHubTileNumberClass,
+  opHubTileBorderClass,
+} from './overview'
+
+describe('opHubTileIsActive (pure)', () => {
+  it('0 → inactive (the operator has nothing to do here right now)', () => {
+    expect(opHubTileIsActive(0)).toBe(false)
+  })
+
+  it('positive count → active', () => {
+    expect(opHubTileIsActive(1)).toBe(true)
+    expect(opHubTileIsActive(42)).toBe(true)
+  })
+
+  it('negative count → inactive (defensive — backend should never send this, but never surface it)', () => {
+    // If an upstream bug produces -1, dimming is the correct fail-safe:
+    // the operator sees "nothing to do" rather than a bright attention-
+    // grabbing anomaly tile they can't actually act on.
+    expect(opHubTileIsActive(-1)).toBe(false)
+  })
+
+  it('NaN / Infinity → inactive (never light up on garbage input)', () => {
+    expect(opHubTileIsActive(Number.NaN)).toBe(false)
+    expect(opHubTileIsActive(Number.POSITIVE_INFINITY)).toBe(false)
+  })
+})
+
+describe('opHubTileNumberClass (pure)', () => {
+  it('active uses strong text, inactive uses dim text', () => {
+    // Regression guard: if a future refactor makes zero tiles as bold
+    // as active ones, the operator loses the \"one of these is not
+    // like the others\" scan. Stripe $0 cards and Linear zero counters
+    // both rely on this contrast drop.
+    expect(opHubTileNumberClass(0)).toContain('text-[var(--text-dim)]')
+    expect(opHubTileNumberClass(1)).toContain('text-[var(--text-strong)]')
+  })
+
+  it('both variants keep the same size + weight (layout invariant)', () => {
+    // The 24px bold glyph is the visual anchor — only the color
+    // changes between tiers, never the size.
+    for (const count of [0, 1, 99]) {
+      expect(opHubTileNumberClass(count)).toContain('text-[24px]')
+      expect(opHubTileNumberClass(count)).toContain('font-bold')
+    }
+  })
+})
+
+describe('opHubTileBorderClass (pure)', () => {
+  it('active gets an accent-tinted border; inactive keeps the card-border default', () => {
+    expect(opHubTileBorderClass(0)).toContain('border-card-border')
+    expect(opHubTileBorderClass(1)).toContain('border-accent')
+  })
+
+  it('both variants keep the same p-3 padding + rounded-lg (layout invariant)', () => {
+    for (const count of [0, 1]) {
+      expect(opHubTileBorderClass(count)).toContain('rounded-lg')
+      expect(opHubTileBorderClass(count)).toContain('p-3')
+    }
+  })
+})

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -35,6 +35,37 @@ import type { ReadonlySignal } from '@preact/signals'
 
 const OVERVIEW_STALE_MS = 300_000
 
+/** Pure: is an Op Hub tile "active" (non-zero count, draws the eye)?
+    Single-seam helper so the tile style decisions below — number
+    color, border, footnote mute — share one truth source. Reference
+    UIs (Stripe dashboard "$0" customer cards, Linear backlog zero
+    counters, GitHub PR-review counters): when the count is zero the
+    whole tile dims; when non-zero it snaps back to full contrast.
+    The operator's eye then skips the quiet tiles without consciously
+    parsing them. */
+export function opHubTileIsActive(count: number): boolean {
+  return Number.isFinite(count) && count > 0
+}
+
+/** Pure: Tailwind class for the giant count number.
+    Active tile → full strong text; zero/idle → muted so three zero
+    tiles don't collectively shout. */
+export function opHubTileNumberClass(count: number): string {
+  return opHubTileIsActive(count)
+    ? 'mt-1 text-[24px] font-bold text-[var(--text-strong)]'
+    : 'mt-1 text-[24px] font-bold text-[var(--text-dim)]'
+}
+
+/** Pure: Tailwind class for the tile border + background. Active tile
+    gets a gentle accent ring so the eye catches the \"not like the
+    others\" without the tile screaming. Zero tile falls back to the
+    existing subdued card style. */
+export function opHubTileBorderClass(count: number): string {
+  return opHubTileIsActive(count)
+    ? 'rounded-lg border border-accent/30 bg-accent/5 p-3'
+    : 'rounded-lg border border-card-border/35 bg-card/55 p-3'
+}
+
 function timestampToMs(timestamp?: string | null): number | null {
   if (!timestamp) return null
   const value = Date.parse(timestamp)
@@ -584,19 +615,19 @@ function OperationsHubCard() {
               `
             : null}
           <div class="mt-4 grid grid-cols-3 gap-3 max-[720px]:grid-cols-1">
-            <div class="rounded-lg border border-card-border/35 bg-card/55 p-3">
+            <div class=${opHubTileBorderClass(pendingApprovals)}>
               <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">정책 승인</div>
-              <div class="mt-1 text-[24px] font-bold text-[var(--text-strong)]">${pendingApprovals}</div>
+              <div class=${opHubTileNumberClass(pendingApprovals)}>${pendingApprovals}</div>
               <div class="mt-1 text-[11px] text-[var(--text-muted)]">pending approvals</div>
             </div>
-            <div class="rounded-lg border border-card-border/35 bg-card/55 p-3">
+            <div class=${opHubTileBorderClass(pendingConfirms)}>
               <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">운영 확인</div>
-              <div class="mt-1 text-[24px] font-bold text-[var(--text-strong)]">${pendingConfirms}</div>
+              <div class=${opHubTileNumberClass(pendingConfirms)}>${pendingConfirms}</div>
               <div class="mt-1 text-[11px] text-[var(--text-muted)]">operator confirm queue</div>
             </div>
-            <div class="rounded-lg border border-card-border/35 bg-card/55 p-3">
+            <div class=${opHubTileBorderClass(attentionCount)}>
               <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">주의 신호</div>
-              <div class="mt-1 text-[24px] font-bold text-[var(--text-strong)]">${attentionCount}</div>
+              <div class=${opHubTileNumberClass(attentionCount)}>${attentionCount}</div>
               <div class="mt-1 text-[11px] text-[var(--text-muted)]">operator attention summary</div>
             </div>
           </div>


### PR DESCRIPTION
## What
Operator Hub 3-tile strip (정책 승인 / 운영 확인 / 주의 신호)에서 **count가 0인 타일**은 text/border 대비를 낮춰 조용히 만들고, **non-zero 타일**만 accent tint로 시선을 끌게 재처리.

## Why
Vision pass 4번째 fire에서 관찰:
- 현재 상태: 0 · 0 · 1 (주의 신호만 1) — 세 숫자 모두 동일 강한 볼드, 동일 무광 border
- 결과: operator의 눈이 세 개를 전부 parse 후에야 \"1\"을 찾음
- Stripe \$0-customer cards, Linear zero-backlog counters, GitHub PR-review counters — 전부 zero 상태 대비 drop으로 active 타일 자동 surface

## How
3개 pure helper 추출:
- \`opHubTileIsActive(count)\` — single truth for active/idle
- \`opHubTileNumberClass(count)\` — 24px bold text, color only 변경 (layout invariant)
- \`opHubTileBorderClass(count)\` — rounded-lg + p-3 유지, active만 accent/30 ring

Accent tint는 \"quiet\" 강조: \"1 thing to look at\"은 경보가 아니라 prompt — alarming하지 않게.

## Tests (8 new, all pass)
- 0 → inactive, positive → active
- Negative / NaN / Infinity → **fail-safe inactive** (backend 가비지가 tile을 밝히지 않음)
- size/weight invariant 보장 (color만 변경)
- border class가 항상 rounded-lg + p-3 유지 (tier 전환 시 레이아웃 jitter 방지)

## Reference UIs
Stripe dashboard \$0 customer cards · Linear backlog zero counter · GitHub PR \"0 review requests\" · Vercel deployment \"0 errors\" card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)