### PR TITLE
chore(dashboard): unexport 8 internal-only interfaces (API surface narrowing)

### DIFF
--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -80,7 +80,7 @@ export interface GovernanceDecisionItem {
   evidence_refs: string[]
 }
 
-export interface GovernancePetition {
+interface GovernancePetition {
   id: string
   case_id: string
   title: string
@@ -92,7 +92,7 @@ export interface GovernancePetition {
   created_at?: string | null
 }
 
-export interface GovernanceCaseBrief {
+interface GovernanceCaseBrief {
   id: string
   author: string
   stance: 'support' | 'oppose' | 'neutral' | string
@@ -101,7 +101,7 @@ export interface GovernanceCaseBrief {
   created_at?: string | null
 }
 
-export interface GovernanceExecutionOrder {
+interface GovernanceExecutionOrder {
   id: string
   case_id: string
   status: 'queued_auto' | 'needs_human_gate' | 'auto_executed' | 'done' | 'denied' | 'blocked' | string

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -11,7 +11,7 @@ interface OasAgentEventBase {
   timestamp: number
 }
 
-export interface OasAgentSelectedEvent extends OasAgentEventBase {
+interface OasAgentSelectedEvent extends OasAgentEventBase {
   type: 'selected'
   actor_kind: 'agent'
   trigger?: string
@@ -19,14 +19,14 @@ export interface OasAgentSelectedEvent extends OasAgentEventBase {
   final_score?: number
 }
 
-export interface OasAgentDecisionEvent extends OasAgentEventBase {
+interface OasAgentDecisionEvent extends OasAgentEventBase {
   type: 'decision'
   actor_kind: 'agent'
   action?: string
   trigger_reason?: string
 }
 
-export interface OasAgentActionExecutedEvent extends OasAgentEventBase {
+interface OasAgentActionExecutedEvent extends OasAgentEventBase {
   type: 'action_executed'
   actor_kind: 'agent'
   action?: string
@@ -42,14 +42,14 @@ export interface OasKeeperLifecycleEvent extends OasAgentEventBase {
   detail?: string
 }
 
-export interface OasTrustUpdatedEvent extends OasAgentEventBase {
+interface OasTrustUpdatedEvent extends OasAgentEventBase {
   type: 'trust_updated'
   actor_kind: 'agent'
   secondary_agent?: string
   trust_score?: number
 }
 
-export interface OasReputationChangedEvent extends OasAgentEventBase {
+interface OasReputationChangedEvent extends OasAgentEventBase {
   type: 'reputation_changed'
   actor_kind: 'agent'
   old_score?: number


### PR DESCRIPTION
## Summary

`/loop 20m` Gen58. **새 scan axis 도입**: unexport candidates (external refs=0, internal >=2). 외부 소비자 0이면서 파일 내부에서만 쓰이는 types/interfaces — 삭제 아니라 **`export` 키워드 제거**로 API surface 축소.

## 새 Scan 방법론

```
for each ^export <type|interface|const|function>:
  total_refs = grep across src/
  internal_refs = grep in declaring file
  external_refs = total - internal
  if external == 0 AND internal >= 2:
    → UNEXPORT candidate (alive internally, no external consumer)
```

이는 기존 4개 scan(symbol/file-import/CSS-class/@utility)이 다 공백인 뒤 발견한 **5번째 axis**.

## 제거된 `export` (8 interfaces)

**types/oas.ts (5)** — 모두 `OasAgentEvent` 디스크리미네이티드 유니온의 멤버로만 사용:
- `OasAgentSelectedEvent`
- `OasAgentDecisionEvent`
- `OasAgentActionExecutedEvent`
- `OasTrustUpdatedEvent`
- `OasReputationChangedEvent`

유니온 자체(`OasAgentEvent`)는 외부 소비자 있음 → alive export 유지.

**types/governance.ts (3)** — 모두 `GovernanceCaseBundle`의 필드 타입으로만 사용:
- `GovernancePetition`
- `GovernanceCaseBrief`
- `GovernanceExecutionOrder`

## 변경

| 파일 | 줄 |
|---|---|
| `types/oas.ts` | 5 export 제거 |
| `types/governance.ts` | 3 export 제거 |
| **합계** | **8 lines touched** |

## 효과

- **API surface 축소**: 외부 모듈이 `import type { ... } from '../types'`로 개별 내부 타입 참조 불가
- **IDE 자동완성 청소**: 잘못된 새 코드가 이 interfaces를 참조할 위험 차단
- **Shape change 영향 범위 축소**: interface rename 시 외부 영향 없음 (파일 내부만)

## 검증

- `tsc --noEmit`: ✅ error 0
- `bun run build`: ✅ 7.43s

## Scan axis 5-method 요약

| # | Axis | Gen | LOC harvested |
|---|---|---|---|
| 1 | symbol (fn/const/type/interface) | 36-50 | ~-3,300 |
| 2 | file-import | 53 | -1,004 |
| 3 | CSS class | 54-56 | -147 |
| 4 | @utility directive | 57 | -135 |
| **5** | **unexport candidate** | **58** | **-0 (API surface)** |

## /loop 세션

누적 dashboard dead code: **~-4,982 LOC**

## 다음 cycle 후보

- 나머지 unexport candidates (RefreshTask, RuntimeCountSource, Operator* types 등 10+개)
- 남은 dashboard-execution/mission/core 의 dead types
- config 파일의 unused options
- JSX 중 conditional dead branch

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)