### PR TITLE
chore(cascade): extract ollama port needle to Masc_network_defaults SSOT

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -203,24 +203,7 @@ let () =
 
 (* ── Heuristic auto-registration for ollama-like URLs ───────────── *)
 
-(* Fast substring check without pulling in [Re]. *)
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 || nlen > hlen then false
-  else
-    let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else loop (i + 1)
-    in
-    loop 0
-
-let looks_like_ollama url =
-  (* Port 11434 is Ollama's well-known default port.  The string
-     match is intentionally permissive (works for http://, https://,
-     127.0.0.1, localhost, bare host:port). *)
-  contains_substring url ":11434"
+let looks_like_ollama = Masc_network_defaults.is_ollama_url
 
 let cli_sentinel_prefix = "cli:"
 

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -9,28 +9,16 @@ type event = {
   active_after : int;
 }
 
-(* ── Classifier (copy of Dashboard_cascade.classify_capacity_key) ─
-
-   We copy-paste instead of extracting into a shared helper because:
-   - Both copies are ~12 lines and unlikely to drift meaningfully
-     (the classifier is anchored to two literal substrings).
-   - The dashboard module would otherwise need to depend on this
-     module (for classify_key in JSON projections) or vice versa,
-     and neither direction feels natural.
-   Any drift here will be caught by the [test_snapshot_kind_filter]
-   coverage below + existing Dashboard_cascade tests. *)
+(* ── Classifier (shares [Masc_network_defaults.is_ollama_url] with
+      {!Dashboard_cascade.classify_capacity_key}).  The [cli:] prefix
+      is a local sentinel; classifier agreement between the two call
+      sites is anchored to the SSOT helper rather than a duplicated
+      substring literal.  [test_snapshot_kind_filter] below and the
+      existing [Dashboard_cascade] tests still cover the mapping. *)
 let classify_key url =
   if String.length url > 4 && String.sub url 0 4 = "cli:" then "cli"
-  else
-    let len = String.length url in
-    let needle = ":11434" in
-    let nlen = String.length needle in
-    let rec scan i =
-      if i + nlen > len then false
-      else if String.sub url i nlen = needle then true
-      else scan (i + 1)
-    in
-    if scan 0 then "ollama" else "other"
+  else if Masc_network_defaults.is_ollama_url url then "ollama"
+  else "other"
 
 (* ── Ring buffer configuration ─────────────────────────────── *)
 

--- a/lib/cascade/cascade_ollama_probe.ml
+++ b/lib/cascade/cascade_ollama_probe.ml
@@ -2,21 +2,10 @@
 
 (* ── URL classification ─────────────────────────────────────── *)
 
-(* Substring helper — duplicated from Cascade_client_capacity to
-   avoid a hard dependency on a sibling module's private function.
-   Both spellings agree on the [:11434] heuristic. *)
-let contains_substring haystack needle =
-  let hl = String.length haystack and nl = String.length needle in
-  if nl = 0 || nl > hl then false
-  else
-    let rec loop i =
-      if i + nl > hl then false
-      else if String.sub haystack i nl = needle then true
-      else loop (i + 1)
-    in
-    loop 0
-
-let is_ollama_url url = contains_substring url ":11434"
+(* Re-export the shared heuristic from [Masc_network_defaults].  Keeping
+   the symbol here preserves this module's public [.mli] surface while
+   eliminating the substring literal duplicated across cascade modules. *)
+let is_ollama_url = Masc_network_defaults.is_ollama_url
 
 (* ── Cache ──────────────────────────────────────────────────── *)
 

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -20,6 +20,28 @@ let ollama_default_port = 11434
 let ollama_default_url =
   Printf.sprintf "http://127.0.0.1:%d" ollama_default_port
 
+(** Substring used by Ollama URL heuristics: [":<port>"].  Keeps the
+    heuristic anchored to {!ollama_default_port} so changing the port
+    updates every classifier in one place. *)
+let ollama_port_needle =
+  Printf.sprintf ":%d" ollama_default_port
+
+(** [is_ollama_url url] returns [true] when [url] contains
+    {!ollama_port_needle}.  Permissive on scheme/host so it works for
+    [http://], [https://], [127.0.0.1], [localhost], or a bare
+    [host:port]. *)
+let is_ollama_url url =
+  let hlen = String.length url in
+  let nlen = String.length ollama_port_needle in
+  if nlen = 0 || nlen > hlen then false
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub url i nlen = ollama_port_needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (** Default URL for the local OpenAI-compatible runtime.
     Override order: OAS_LOCAL_LLM_URL -> OAS_LOCAL_QWEN_URL -> local runtime. *)
 let local_llm_default_url =

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -150,21 +150,15 @@ let health_json () =
 (* ── Client capacity projection ─────────────────────── *)
 
 (** Classify a capacity registry key for the dashboard.  CLI sentinels
-    use the [cli:] prefix; ollama uses the well-known [:11434] port.
-    Everything else is reported as [other] so operators can spot
-    surprise registrations (e.g. a manually-registered HTTP slot). *)
+    use the [cli:] prefix; ollama URLs are detected by
+    {!Masc_network_defaults.is_ollama_url} (matches the well-known
+    port).  Everything else is reported as [other] so operators can
+    spot surprise registrations (e.g. a manually-registered HTTP
+    slot). *)
 let classify_capacity_key url =
   if String.length url > 4 && String.sub url 0 4 = "cli:" then "cli"
-  else
-    let len = String.length url in
-    let needle = ":11434" in
-    let nlen = String.length needle in
-    let rec scan i =
-      if i + nlen > len then false
-      else if String.sub url i nlen = needle then true
-      else scan (i + 1)
-    in
-    if scan 0 then "ollama" else "other"
+  else if Masc_network_defaults.is_ollama_url url then "ollama"
+  else "other"
 
 let client_capacity_entry_to_json (url, info : string * Cascade_throttle.capacity_info)
   : Yojson.Safe.t =


### PR DESCRIPTION
## Why

`:11434` (Ollama default port) needle was duplicated as a substring literal
across **4 cascade/dashboard modules**, each with its own copy of a
`contains_substring` helper. `Masc_network_defaults.ollama_default_port`
already exists as the SSOT, so this is a clear "AI-generated hardcoded
scatter" anti-pattern: a port change in the SSOT would silently skip the
4 classifiers.

`cascade_client_capacity_history.ml` even carried a docblock explaining why
"copy-paste is intentional" — the rationale (drift is unlikely) is precisely
what the SSOT discipline rejects.

## What

- Add `ollama_port_needle` + `is_ollama_url` in `masc_network_defaults.ml`,
  derived from `ollama_default_port` via `Printf.sprintf ":%d"`.
- Replace scattered substring scans in:
  - `cascade_ollama_probe.ml` — preserves the `.mli`-exported `is_ollama_url`
    via a thin alias.
  - `cascade_client_capacity.ml` — removes local `contains_substring` +
    `looks_like_ollama` (rebound to the shared helper).
  - `cascade_client_capacity_history.ml` — drops the "copy-paste intentional"
    comment block, replaces the classifier body.
  - `dashboard_cascade.ml` — same classifier reduction.

## Verification

- `rg ":11434" lib/ -tml` → zero hits outside the SSOT module.
- `dune build @check` clean.
- `test/test_cascade_ollama_probe.exe` → **10/10 OK** (includes
  `is_ollama_url 0 positive matches` + `1 negative cases`).
- `test/test_dashboard_cascade.exe` → **14/14 OK** (classifier JSON projections).

## Scope

Intentionally narrow. Still duplicated but left for follow-up:
- `"cli:"` sentinel prefix appears in 3 sites (`cascade_client_capacity.ml`
  has `cli_sentinel_prefix` but it is not shared with the two classifiers).
- Port `5173` (Vite dev) hardcoded 3× in `server/server_auth.ml` allowed-origin list.

Net: **+42 / -66 LOC**.
