### PR TITLE
chore(dashboard): unexport 7 more internal-only types across 4 files

### DIFF
--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -1,13 +1,13 @@
 import type { DashboardNamespaceTruthResponse, DashboardShellResponse } from './types'
 
-export type RuntimeCountSource =
+type RuntimeCountSource =
   | 'execution'
   | 'namespace-truth'
   | 'shell'
   | 'partial'
   | 'unknown'
 
-export interface RuntimeCounts {
+interface RuntimeCounts {
   agents: number
   keepers: number
   tasks: number

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -39,7 +39,7 @@ async function refreshServerConfigSurface(): Promise<void> {
   await refreshServerConfig()
 }
 
-export type RefreshTask =
+type RefreshTask =
   | 'shell'
   | 'namespaceTruth'
   | 'missionSnapshot'

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -131,7 +131,7 @@ export interface DashboardNamespaceTruthMetaCognitionDigest {
   provenance?: string | null
 }
 
-export interface DashboardNamespaceTruthMetaCognition {
+interface DashboardNamespaceTruthMetaCognition {
   summary?: DashboardShellMetaCognitionSummary | null
   latest_digest?: DashboardNamespaceTruthMetaCognitionDigest | null
   provenance?: string | null
@@ -188,7 +188,7 @@ export interface ServerBuildIdentity {
   uptime_seconds: number
 }
 
-export type DashboardExecutionTone = 'ok' | 'warn' | 'bad'
+type DashboardExecutionTone = 'ok' | 'warn' | 'bad'
 export type DashboardExecutionWorkerState = 'working' | 'watching' | 'quiet' | 'offline'
 export type DashboardExecutionContinuityState = 'healthy' | 'warning' | 'critical'
 export type DashboardExecutionQueueKind = 'session' | 'operation'

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -525,7 +525,7 @@ export interface OperatorSnapshot {
   available_actions: OperatorActionDescriptor[]
 }
 
-export type OperatorActionType =
+type OperatorActionType =
   | 'broadcast'
   | 'namespace_pause'
   | 'namespace_resume'
@@ -537,7 +537,7 @@ export type OperatorActionType =
   | 'keeper_probe'
   | 'keeper_recover'
 
-export type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper'
+type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper'
 
 export interface OperatorActionRequest {
   actor: string


### PR DESCRIPTION
## Summary

`/loop 20m` Gen59. Gen58 unexport scan 연속선. 남은 7 unexport candidates 일괄 처리. API surface 축소 (LOC 변경 없음).

## 제거된 `export` (7 types/interfaces)

| 파일 | 심볼 | Internal uses |
|---|---|---|
| `tab-refresh.ts` | `RefreshTask` | 3 |
| `runtime-counts.ts` | `RuntimeCountSource` | 3 |
| `runtime-counts.ts` | `RuntimeCounts` | 2 |
| `types/dashboard-mission.ts` | `OperatorActionType` | 2 |
| `types/dashboard-mission.ts` | `OperatorTargetType` | 2 |
| `types/dashboard-execution.ts` | `DashboardNamespaceTruthMetaCognition` | 2 |
| `types/dashboard-execution.ts` | `DashboardExecutionTone` | 4 |

## 각 심볼의 "internal-only" 특성

- **`RefreshTask`** — refresh pipeline task 이름 유니온. `REFRESHERS` record의 key type으로만 쓰임.
- **`RuntimeCountSource`/`RuntimeCounts`** — runtime-counts.ts 내부 로직 타입. 외부는 `runtimeCountsSignal` 같은 파생 값만 import.
- **`OperatorActionType`/`OperatorTargetType`** — OperatorRecommendedAction interface의 필드 타입. interface 자체(외부 노출)가 유일 consumer.
- **`DashboardNamespaceTruthMetaCognition`** — `DashboardNamespaceTruth`의 mtcg 필드 내부 타입.
- **`DashboardExecutionTone`** — Execution* interfaces의 tone 필드 type union.

## Gen58+59 누적 API surface narrowing

| Gen | 파일 | 제거 export 수 |
|---|---|---|
| 58 | types/oas.ts, types/governance.ts | 8 |
| 59 | tab-refresh, runtime-counts, dashboard-mission, dashboard-execution | 7 |
| **합계** | 6 파일 | **15 API surface narrowed** |

## 변경

7 lines (export keyword 제거만)

## 검증

- `tsc --noEmit`: ✅ error 0
- `bun run build`: ✅ 8.84s

## /loop 세션

누적 dashboard dead code: **~-4,982 LOC** + 15 API surface narrowed (누적).

## 다음 cycle 후보

- 더 남은 unexport candidates (dashboard-execution의 *QueueKind, *ContinuityState, core의 TaskContract 등)
- scan 다시 돌려 확인

## Test plan

- [ ] CI Dashboard check pass
- [ ] 리뷰 후 Ready 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)