### PR TITLE
feat(dashboard): rotating chevron for 인프라 상태 disclosure

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -4,6 +4,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useMemo } from 'preact/hooks'
+import { ChevronRight } from 'lucide-preact'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
 import { TimeAgo } from '../common/time-ago'
@@ -913,8 +914,15 @@ export function Overview() {
 
       ${toolHealth ? html`<div class=${OVERVIEW_CARD}>${toolHealth}</div>` : null}
 
-      <details class=${OVERVIEW_CARD}>
-        <summary class="cursor-pointer text-xs font-semibold text-[var(--text-strong)] uppercase tracking-wider select-none list-none flex items-center gap-2">
+      <details class=${`group ${OVERVIEW_CARD}`}>
+        <summary
+          class="cursor-pointer text-xs font-semibold text-[var(--text-strong)] uppercase tracking-wider select-none list-none flex items-center gap-2"
+          data-testid="infra-status-disclosure"
+        >
+          <${ChevronRight}
+            size=${14}
+            class="shrink-0 text-[var(--text-muted)] transition-transform duration-150 group-open:rotate-90"
+          />
           인프라 상태
           <span class="text-[10px] font-normal normal-case tracking-normal text-[var(--text-muted)]">Transport · 성능</span>
         </summary>


### PR DESCRIPTION
## What
Overview 페이지 하단 \`인프라 상태\` <details> 요소에 rotating chevron 추가.

## Why
Vision pass (cron fire 2026-04-18):
- 현재 \"인프라 상태 Transport · 성능\" 한 줄만 보임
- 브라우저 기본 ▶ 마커가 \`list-none\`으로 숨겨졌는데 대체 chevron 미추가
- Operator는 이게 클릭 가능한지, 그냥 collapsed footer title인지 구분 불가
- GitHub issue description fold, Notion toggle block, Linear activity expander 전부 chevron rotation으로 expand 상태 signal

## How
14px \`ChevronRight\` 아이콘을 summary 앞에 배치 + Tailwind \`group-open:rotate-90\` variant로 details 열림 상태에서 90° 회전. \`<details class=\"group\">\`가 Tailwind의 native \`group-open:\` selector를 활성화하는 handle.

## Why no test
순수 CSS + markup 변경 (브라우저 native \`<details>\`), 런타임 로직 없음. Integration 테스트로 rotation을 pin하려면 전체 Overview 렌더 필요한데 overview.test.ts의 integration 테스트들은 happy-dom에서 이미 pre-existing하게 timeout 중 — 순수 presentation change를 위해 그 test file을 건드리는 건 잘못된 trade.

## Reference UIs
GitHub issue description disclosure · Notion toggle block · Linear activity expander · MDN <details> native pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)