### PR TITLE
chore(cascade): extract cli: sentinel prefix to Masc_network_defaults SSOT

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -205,11 +205,7 @@ let () =
 
 let looks_like_ollama = Masc_network_defaults.is_ollama_url
 
-let cli_sentinel_prefix = "cli:"
-
-let looks_like_cli_sentinel url =
-  let plen = String.length cli_sentinel_prefix in
-  String.length url > plen && String.sub url 0 plen = cli_sentinel_prefix
+let looks_like_cli_sentinel = Masc_network_defaults.is_cli_sentinel_url
 
 let auto_register_for_candidates ~base_urls =
   let max_concurrent = ollama_default_max () in

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -9,14 +9,14 @@ type event = {
   active_after : int;
 }
 
-(* ── Classifier (shares [Masc_network_defaults.is_ollama_url] with
-      {!Dashboard_cascade.classify_capacity_key}).  The [cli:] prefix
-      is a local sentinel; classifier agreement between the two call
-      sites is anchored to the SSOT helper rather than a duplicated
-      substring literal.  [test_snapshot_kind_filter] below and the
-      existing [Dashboard_cascade] tests still cover the mapping. *)
+(* ── Classifier (shares {!Masc_network_defaults.is_cli_sentinel_url}
+      and {!Masc_network_defaults.is_ollama_url} with
+      {!Dashboard_cascade.classify_capacity_key}).  Both call sites
+      resolve to the same SSOT predicates; [test_snapshot_kind_filter]
+      below and the existing [Dashboard_cascade] tests still cover the
+      mapping. *)
 let classify_key url =
-  if String.length url > 4 && String.sub url 0 4 = "cli:" then "cli"
+  if Masc_network_defaults.is_cli_sentinel_url url then "cli"
   else if Masc_network_defaults.is_ollama_url url then "ollama"
   else "other"
 

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -42,6 +42,20 @@ let is_ollama_url url =
     in
     loop 0
 
+(** Sentinel prefix marking a CLI-backed transport (e.g. [cli:codex]).
+    Used by capacity classifiers to distinguish CLI endpoints from HTTP
+    ones. *)
+let cli_sentinel_prefix = "cli:"
+
+(** [is_cli_sentinel_url url] returns [true] when [url] starts with
+    {!cli_sentinel_prefix}.  The check is a strict prefix match rather
+    than a substring scan because [cli:] is meaningful only at the
+    start of the sentinel string. *)
+let is_cli_sentinel_url url =
+  let plen = String.length cli_sentinel_prefix in
+  String.length url > plen
+  && String.sub url 0 plen = cli_sentinel_prefix
+
 (** Default URL for the local OpenAI-compatible runtime.
     Override order: OAS_LOCAL_LLM_URL -> OAS_LOCAL_QWEN_URL -> local runtime. *)
 let local_llm_default_url =

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -149,14 +149,16 @@ let health_json () =
 
 (* ── Client capacity projection ─────────────────────── *)
 
-(** Classify a capacity registry key for the dashboard.  CLI sentinels
-    use the [cli:] prefix; ollama URLs are detected by
+(** Classify a capacity registry key for the dashboard.  Both sentinel
+    predicates come from {!Masc_network_defaults}: CLI transports via
+    {!Masc_network_defaults.is_cli_sentinel_url} (matches the [cli:]
+    prefix) and ollama endpoints via
     {!Masc_network_defaults.is_ollama_url} (matches the well-known
     port).  Everything else is reported as [other] so operators can
     spot surprise registrations (e.g. a manually-registered HTTP
     slot). *)
 let classify_capacity_key url =
-  if String.length url > 4 && String.sub url 0 4 = "cli:" then "cli"
+  if Masc_network_defaults.is_cli_sentinel_url url then "cli"
   else if Masc_network_defaults.is_ollama_url url then "ollama"
   else "other"
 


### PR DESCRIPTION
## Why

Follow-up to #8125.  The `"cli:"` transport sentinel prefix was
hardcoded in 3 classifiers:
- `cascade_client_capacity.ml` — `cli_sentinel_prefix` + `looks_like_cli_sentinel` (private).
- `cascade_client_capacity_history.ml` — inline `String.length url > 4 && String.sub url 0 4 = "cli:"`.
- `dashboard_cascade.ml` — identical inline predicate.

Neither copy was reachable from the others because
`cascade_client_capacity` already imports
`cascade_client_capacity_history` (`.record/2` at lines 81/90/102);
placing the helper in the capacity module would create a cycle.

## What

- Add `cli_sentinel_prefix` + `is_cli_sentinel_url` to
  `masc_network_defaults.ml` alongside `is_ollama_url` — the same
  lower layer iter 1 used.
- `cascade_client_capacity.ml`: rebind `looks_like_cli_sentinel` to the
  SSOT; delete the now-redundant `cli_sentinel_prefix` alias
  (zero external consumers, no `.mli` exposure).
- `cascade_client_capacity_history.ml` + `dashboard_cascade.ml`:
  replace the inline substring check with
  `Masc_network_defaults.is_cli_sentinel_url`.

## Verification

- `rg '"cli:"' lib/ -tml` → single hit in the SSOT module.
- `dune build @check` clean (warn-error 32 guard passed).
- `test/test_cascade_ollama_probe.exe` → **10/10 OK**.
- `test/test_dashboard_cascade.exe` → **14/14 OK** (covers classifier
  JSON projections that feed the dashboard).

Follow-up to #8125 (already merged).  Targets main directly.