### PR TITLE
chore(dashboard): purge 3 dead symbols + 2 orphan helpers (Gen60)

### DIFF
--- a/dashboard/src/components/common/action-bar.ts
+++ b/dashboard/src/components/common/action-bar.ts
@@ -2,7 +2,6 @@
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { ActionButton } from './button'
 
 interface ActionBarProps {
   children: ComponentChildren
@@ -14,19 +13,5 @@ export function ActionBar({ children, class: className }: ActionBarProps) {
     <div class="flex gap-3 flex-wrap mt-3 ${className ?? ''}">
       ${children}
     </div>
-  `
-}
-
-interface ActionBtnProps {
-  label: string
-  onClick: (e: Event) => void
-  disabled?: boolean
-}
-
-export function ActionBtn({ label, onClick, disabled }: ActionBtnProps) {
-  return html`
-    <${ActionButton} variant="ghost" size="lg" onClick=${onClick} disabled=${disabled}>
-      ${label}
-    <//>
   `
 }

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -48,16 +48,6 @@ function normalizePayload(value: unknown): Record<string, unknown> | null {
   return isRecord(value) ? value : null
 }
 
-function serializeContext(value: DashboardWorkflowContext | null): string | null {
-  if (!value) return null
-  try {
-    return JSON.stringify(value)
-  }
-  catch {
-    return null
-  }
-}
-
 function parseStoredContext(raw: string | null): DashboardWorkflowContext | null {
   if (!raw) return null
   try {
@@ -107,20 +97,6 @@ function initialContext(): DashboardWorkflowContext | null {
 }
 
 export const dashboardWorkflowContext = signal<DashboardWorkflowContext | null>(initialContext())
-
-export function persistWorkflowContext(context: DashboardWorkflowContext | null): void {
-  const freshContext = context && contextIsFresh(context) ? context : null
-  dashboardWorkflowContext.value = freshContext
-  const storage = safeStorage()
-  if (!storage) return
-  if (!freshContext) {
-    storage.removeItem(STORAGE_KEY)
-    return
-  }
-  const serialized = serializeContext(freshContext)
-  if (!serialized) return
-  storage.setItem(STORAGE_KEY, serialized)
-}
 
 export function extractActionPayload(
   action?: OperatorRecommendedAction | null,


### PR DESCRIPTION
## Summary

2 truly dead exports (refs=1) + 2 orphan helpers auto-flagged by tsc strict mode.

| 파일 | 제거 대상 | 성격 |
|------|-----------|------|
| `common/action-bar.ts` | `ActionBtn` | unreferenced function |
| `workflow-context.ts` | `persistWorkflowContext` | unreferenced function |
| `action-bar.ts` | `import { ActionButton }` | orphan import (ActionBtn만 사용) |
| `workflow-context.ts` | `serializeContext` | orphan helper (persistWorkflowContext만 호출) |

Cascade: 함수 삭제 → caller 유일 helper 고아화 → `noUnusedLocals` 포착.

**Note**: 초안에 있던 `proof-sections.ts` 삭제는 철회 — main이 최근 hidden div + `data-component` placeholder로 교체한 파일이라 트레이싱 목적 가능성 존중.

## Verification
- `bunx tsc --noEmit`: green (after rebase onto main)
- -39 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)