### PR TITLE
fix(keeper_types): establish proactive_cycle_outcome round-trip invariant

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -249,12 +249,48 @@ let proactive_cycle_outcome_to_string = function
 let proactive_cycle_outcome_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
   | "never_started" -> Proactive_never_started
+  | "unknown" -> Proactive_unknown
   | "silent" -> Proactive_silent
   | "text_response" -> Proactive_text_response
   | "tool_use" -> Proactive_tool_use
   | "mixed_response" -> Proactive_mixed_response
   | "error" -> Proactive_error
   | _ -> Proactive_unknown
+;;
+
+(* Round-trip guard: [proactive_cycle_outcome_to_string] already fails to
+   compile when a new variant is added (its match has no wildcard).  This
+   assertion enforces the other direction — if a new variant's label is
+   not wired through [proactive_cycle_outcome_of_string], the round-trip
+   silently collapses the new case to [Proactive_unknown] and leaks it at
+   runtime.  The exhaustive pattern inside [assert_roundtrip] makes
+   adding a variant a compile error until the parser is extended too. *)
+let () =
+  let assert_roundtrip v =
+    (match v with
+     | Proactive_never_started
+     | Proactive_unknown
+     | Proactive_silent
+     | Proactive_text_response
+     | Proactive_tool_use
+     | Proactive_mixed_response
+     | Proactive_error -> ());
+    let s = proactive_cycle_outcome_to_string v in
+    if proactive_cycle_outcome_of_string s <> v then
+      failwith
+        (Printf.sprintf
+           "keeper_types: proactive round-trip broken for label %S" s)
+  in
+  List.iter
+    assert_roundtrip
+    [ Proactive_never_started
+    ; Proactive_unknown
+    ; Proactive_silent
+    ; Proactive_text_response
+    ; Proactive_tool_use
+    ; Proactive_mixed_response
+    ; Proactive_error
+    ]
 ;;
 
 let scheduled_autonomous_cycle_outcome_to_string =


### PR DESCRIPTION
## Why

`proactive_cycle_outcome_of_string` (in `lib/keeper/keeper_types.ml`)
used `_ -> Proactive_unknown` to handle three distinct inputs as one:

1. The explicit string `"unknown"` (emitted by
   `proactive_cycle_outcome_to_string Proactive_unknown`).
2. Genuinely unparseable labels (e.g. corrupted JSON from disk).
3. **Silent drift** — a newly-added variant `Proactive_foo` with
   `to_string "foo"` but no matching parser arm would round-trip to
   `Proactive_unknown` and leak nowhere-visible data loss.

The `to_string` side already has an exhaustive `_`-free match, so new
variants force a compile error there.  The parser side did not.  This
is the "Unknown → Permissive Default" anti-pattern documented in the
MASC AI-codegen feedback catalog (`feedback_no-heuristic-category`).

## What

- Add `"unknown" -> Proactive_unknown` as an explicit parser case, so
  the explicit label and the fallback are no longer conflated.  The
  `_` fallback is kept (callers rely on a total function) but its
  semantic contract is now purely "unparseable input → collapse to
  unknown", not "explicit or unparseable".
- Add a module-load-time `let () = List.iter assert_roundtrip [...]`
  guard:
  - An inner exhaustive pattern enumerates every variant (no wildcard).
    Extending the variant type now fails to compile here until the
    parser is extended too.
  - For each concrete value, the guard asserts
    `of_string (to_string v) = v` and fails with a descriptive
    message on drift.  Overhead: 7 string ops per module load.

## Verification

- `dune build @check` clean.
- `dune build test/test_keeper_rollover_gate.exe` clean — the binary
  loads `Keeper_types` at start-up, so the assertion runs; any broken
  round-trip would raise before tests execute.
- `test_keeper_rollover_gate` → **10/10 OK**, confirming the guard
  didn't regress the round-trip for any existing variant.

Net: **1 file, +36 / -0 LOC**.

## Follow-up (deferred)

The internal caller at `lib/keeper/keeper_types.ml:1110` still does
`Option.value ~default:"unknown" |> proactive_cycle_outcome_of_string`
— this remains the cleanest place to express the "missing field means
unknown" semantic and was not touched.  Exposing a
`..._opt : string -> proactive_cycle_outcome option` variant would
let callers distinguish parse-failure from explicit-unknown but is a
breaking signature change, intentionally out of scope for this PR.
