### PR TITLE
feat(dashboard): sidebar health dot — hover reveals top-3 attention items

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -7,6 +7,8 @@ import {
   deriveBreadcrumbTrail,
   composeDocumentTitle,
   describeReconnecting,
+  summarizeAttentionPreview,
+  composeHealthIndicatorTitle,
 } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
@@ -296,5 +298,101 @@ describe('describeReconnecting (pure)', () => {
     })
     expect(r.label).toBe('재연결 중')
     expect(r.label).not.toContain('-')
+  })
+})
+
+describe('summarizeAttentionPreview (pure)', () => {
+  it('empty list → empty preview (health dot reads green with no tooltip clutter)', () => {
+    expect(summarizeAttentionPreview([])).toEqual([])
+  })
+
+  it('uses item.summary when available', () => {
+    const items = [
+      { summary: 'CI gate failed on main', kind: 'ci_failure' },
+      { summary: 'Session 42 blocker: network timeout', kind: 'session_blocker' },
+    ]
+    expect(summarizeAttentionPreview(items)).toEqual([
+      'CI gate failed on main',
+      'Session 42 blocker: network timeout',
+    ])
+  })
+
+  it('falls back to kind when summary is empty / null / undefined', () => {
+    // Backend occasionally sends a kind without a summary (e.g., a
+    // new attention_kind not yet narrativized). Showing the kind string
+    // is strictly better than dropping the item silently.
+    const items = [
+      { summary: null, kind: 'keeper_silence' },
+      { summary: '', kind: 'config_drift' },
+      { kind: 'untyped_event' },
+    ]
+    expect(summarizeAttentionPreview(items)).toEqual([
+      'keeper_silence',
+      'config_drift',
+      'untyped_event',
+    ])
+  })
+
+  it('skips items with no summary AND no kind (pure noise)', () => {
+    const items = [
+      { summary: 'Real issue', kind: 'real' },
+      { summary: null, kind: null },
+      { summary: '', kind: '' },
+      { summary: 'Another', kind: 'x' },
+    ]
+    expect(summarizeAttentionPreview(items)).toEqual(['Real issue', 'Another'])
+  })
+
+  it('truncates over-long lines at 60 chars with ellipsis', () => {
+    // Regression guard: a 500-char blocker_summary dumped into title
+    // would render as a wall of wrapped text in the native tooltip —
+    // operators want a hint, not an essay.
+    const long = 'x'.repeat(200)
+    const [line] = summarizeAttentionPreview([{ summary: long, kind: 'bulk' }])
+    expect(line).not.toBeUndefined()
+    expect(line!.length).toBeLessThanOrEqual(60)
+    expect(line!.endsWith('...')).toBe(true)
+  })
+
+  it('respects max=3 and appends a "외 Nbrought-over" tail when there are more', () => {
+    const items = Array.from({ length: 7 }, (_, i) => ({
+      summary: `item-${i}`,
+      kind: 'generic',
+    }))
+    const preview = summarizeAttentionPreview(items, 3)
+    expect(preview.slice(0, 3)).toEqual(['item-0', 'item-1', 'item-2'])
+    // 7 - 3 = 4 more
+    expect(preview[3]).toBe('… 외 4건')
+  })
+
+  it('no tail when we rendered every item (exact fit)', () => {
+    const items = [
+      { summary: 'a', kind: 'k' },
+      { summary: 'b', kind: 'k' },
+    ]
+    const preview = summarizeAttentionPreview(items, 3)
+    expect(preview).toEqual(['a', 'b'])
+    expect(preview.some(l => l.startsWith('… 외'))).toBe(false)
+  })
+})
+
+describe('composeHealthIndicatorTitle (pure)', () => {
+  it('no attention lines → bare label (tooltip stays terse when state is boring)', () => {
+    expect(composeHealthIndicatorTitle('정상', [])).toBe('정상')
+    expect(composeHealthIndicatorTitle('신호 없음', [])).toBe('신호 없음')
+  })
+
+  it('label on line 1, attention items indented beneath', () => {
+    const title = composeHealthIndicatorTitle('주의 2건', ['foo blocker', 'bar gate fail'])
+    expect(title).toBe('주의 2건\n  · foo blocker\n  · bar gate fail')
+  })
+
+  it('newlines (not <br>) — native title tooltips render \\n verbatim on Chrome/Safari/Firefox', () => {
+    // Regression guard: a well-meaning future refactor might swap \n
+    // for <br> thinking this is an HTML attribute. Title is plain text;
+    // <br> would render as literal "<br>" in the tooltip.
+    const title = composeHealthIndicatorTitle('주의 1건', ['x'])
+    expect(title.split('\n')).toHaveLength(2)
+    expect(title).not.toContain('<br>')
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -227,6 +227,46 @@ export function BuildIdentityBadge() {
 
 
 
+/** Pure: gather the top-N attention-item summaries as tooltip lines so
+    hovering the bottom-left health dot answers "what are the N
+    things?" without a click. Reference UIs: Datadog monitor rollup
+    tooltip, Vercel deployment status footer, Gmail "2 unread" with
+    sender preview — all reveal the contributing items on hover so the
+    operator decides whether to navigate. Exposed for tests. */
+export function summarizeAttentionPreview(
+  items: ReadonlyArray<{ summary?: string | null; kind?: string | null }>,
+  max = 3,
+): string[] {
+  // Two-pass: first filter to valid (non-empty summary or kind), then
+  // cap. This separates "skipped for noise" from "truncated for max"
+  // so the tail count only reflects genuinely pending items that
+  // didn't fit — never padding from null/empty rows.
+  const valid: string[] = []
+  for (const item of items) {
+    if (!item) continue
+    const summary = item.summary?.trim()
+    const kind = item.kind?.trim()
+    const raw = (summary && summary !== '') ? summary : (kind && kind !== '' ? kind : '')
+    if (raw === '') continue
+    valid.push(raw.length > 60 ? `${raw.slice(0, 57)}...` : raw)
+  }
+  if (valid.length <= max) return valid
+  return [...valid.slice(0, max), `… 외 ${valid.length - max}건`]
+}
+
+/** Pure: compose the full title-attribute string for the health
+    indicator — label on the first line, attention previews indented
+    under it. Newlines render in native title tooltips on all major
+    browsers, so no HTML escaping or markup is needed. */
+export function composeHealthIndicatorTitle(
+  label: string,
+  attentionLines: ReadonlyArray<string>,
+): string {
+  if (attentionLines.length === 0) return label
+  const indented = attentionLines.map(line => `  · ${line}`)
+  return [label, ...indented].join('\n')
+}
+
 function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   const live = connected.value
   const snap = missionSnapshot.value
@@ -235,7 +275,8 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   for (let i = 0; i < sessions.length; i++) {
     if (sessions[i]?.blocker_summary) blockers++
   }
-  const attentionCount = (snap?.attention_queue ?? []).length
+  const attentionQueue = snap?.attention_queue ?? []
+  const attentionCount = attentionQueue.length
 
   let dotClass: string
   let label: string
@@ -255,14 +296,17 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
     label = '정상'
   }
 
+  const attentionLines = attentionCount > 0 ? summarizeAttentionPreview(attentionQueue) : []
+  const titleText = composeHealthIndicatorTitle(label, attentionLines)
+
   const dot = html`<span class="block size-2 shrink-0 rounded-full ${dotClass} shadow-[0_0_6px_rgba(0,0,0,0.4)]"></span>`
 
   if (collapsed) {
-    return html`<div class="flex justify-center" title=${label} role="img" aria-label=${label}>${dot}</div>`
+    return html`<div class="flex justify-center" title=${titleText} role="img" aria-label=${label}>${dot}</div>`
   }
 
   return html`
-    <div class="flex items-center gap-2 px-1" role="status" aria-label=${label}>
+    <div class="flex items-center gap-2 px-1" role="status" aria-label=${label} title=${titleText}>
       ${dot}
       <span class="text-[11px] text-[var(--text-muted)] truncate">${label}</span>
     </div>


### PR DESCRIPTION
## Summary
사이드바 하단 health dot hover 시 \`주의 N건\`의 상위 3개 item 내용을 tooltip으로 노출.

## Product impact
- Operator가 사이드바에서 \"무엇이 주의 대상인지\" 1초 안에 확인 가능 → Overview 탭 이동 전에 필터링 결정 가능
- 작은 변경, 큰 의사결정 cost 감소

## Evidence
Vision-driven observation of bottom-left 사이드바 health indicator (2026-04-18 cron fire). Datadog/Vercel/Gmail의 hover preview 패턴 참조.

## Review evidence
- 10 new tests, 47/47 green
- Pure helper 2개 (summarizeAttentionPreview, composeHealthIndicatorTitle)
- 60-char truncation + \`외 N건\` tail
- \`<br>\` regression guard (title attr는 plain text)

## Linked issue
N/A (UX iteration from /loop reference-UI sweep)

## How
2개 pure helper:
- \`summarizeAttentionPreview(items, max=3)\` — valid(summary 또는 kind 비어있지 않은) item만 filter → max로 cap → 60자 초과 시 ellipsis
- \`composeHealthIndicatorTitle(label, lines)\` — native \`title\` 속성용 multi-line plain text

## Reference UIs
Datadog monitor rollup tooltip · Vercel deployment footer · Gmail "2 unread" sender preview · GitHub notifications dropdown teaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)