### PR TITLE
feat(dashboard): emphasize pending HITL approval count in governance KPI

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -77,7 +77,13 @@ function GovernanceSummaryStrip() {
       <${KpiCard} label="Judge 상태" value=${liveJudgeState} hint=${judge?.keeper_name?.trim() || 'live judge'} />
       <${KpiCard} label="Judge 모델" value=${liveJudgeModel} hint=${judge?.model_used?.trim() ? 'runtime reported' : 'unknown'} />
       <${KpiCard} label="최근 판단" value=${judgmentCount} hint="live" />
-      <${KpiCard} label="관리자 승인 대기" value=${approvalCount} hint="live" />
+      <${KpiCard}
+        label="관리자 승인 대기"
+        value=${approvalCount}
+        hint=${approvalCount > 0 ? '검토 필요' : 'live'}
+        tone=${approvalCount > 0 ? 'text-warn' : undefined}
+        class=${approvalCount > 0 ? 'border-warn/40 bg-warn/5 ring-1 ring-warn/25' : ''}
+      />
     </div>
     <${JudgeStatusBar} />
     ${governanceError.value ? html`<div class="mb-5 rounded-lg border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}


### PR DESCRIPTION
## Summary

사용자 피드백 직접 반영 — **Keeper HITL 승인 대기가 눈에 잘 안 띈다**는 지적.

현재: \`관리자 승인 대기\` KPI 카드는 다른 3개(Judge 상태/모델/최근 판단)와 **동일한 neutral 스타일**이라 건수 8이어도 구분이 어려움.

변경: \`approvalCount > 0\`일 때 KpiCard를 warn 톤으로 승격.

| 상태 | 카드 스타일 |
|------|------------|
| \`approvalCount === 0\` | 기존 neutral (그대로) |
| \`approvalCount > 0\` | text-warn + border-warn/40 + bg-warn/5 + ring-warn/25 |

추가 변경: \`hint\`도 \`live\` → \`검토 필요\`로 전환해 텍스트 레벨에서도 상태 표현.

## Why

- 사용자가 \"Keeper HITL 승인 대기 ... 이거 더 잘 보이게 하시고\"라고 명시
- 기존 \`KeeperApprovalAlertBanner\`(line 267)는 queue 섹션 **내부 상단**에만 존재 → 상단 Live Judge 요약 영역에서는 여전히 드러나지 않음
- \`KpiCard\`의 \`tone\` + \`class\` prop이 이미 존재 → 컴포넌트 API 확장 없이 가능

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest run governance.test.ts\`: 18/18 pass
- \`bun run build\`: green (7.55s)
- +7/-1 LOC (1 파일)

## Test plan

- [x] governance.test.ts 18 tests
- [x] tsc strict
- [x] vite build
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)