### PR TITLE
feat(dashboard): type icons for 공감대/긴장/욕구 epistemics cards

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useMemo } from 'preact/hooks'
-import { ChevronRight } from 'lucide-preact'
+import { ChevronRight, Users, Zap, Target } from 'lucide-preact'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
 import { TimeAgo } from '../common/time-ago'
@@ -370,7 +370,10 @@ function MetaCognitionCard() {
         ? html`
             <div class="grid grid-cols-3 gap-3 max-[960px]:grid-cols-1">
               <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
-                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">공감대</div>
+                <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  <${Users} size=${12} class="shrink-0" aria-hidden="true" />
+                  공감대
+                </div>
                 <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
                   ${belief?.claim ?? '아직 강한 belief가 드러나지 않았습니다.'}
                 </div>
@@ -380,7 +383,10 @@ function MetaCognitionCard() {
               </div>
 
               <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
-                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">긴장</div>
+                <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  <${Zap} size=${12} class="shrink-0" aria-hidden="true" />
+                  긴장
+                </div>
                 <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
                   ${tension?.topic ?? '아직 우세한 tension이 없습니다.'}
                 </div>
@@ -392,7 +398,10 @@ function MetaCognitionCard() {
               </div>
 
               <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
-                <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">욕구</div>
+                <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  <${Target} size=${12} class="shrink-0" aria-hidden="true" />
+                  욕구
+                </div>
                 <div class="mt-2 text-[13px] font-medium leading-relaxed text-[var(--text-strong)]" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden">
                   ${desire?.desired_state ?? '아직 뚜렷한 collective desire가 없습니다.'}
                 </div>


### PR DESCRIPTION
## Summary
집단 에피넥지 3 sub-card (공감대/긴장/욕구)에 type-specific lucide icon 추가 — 동일 스타일로 나열되던 카드를 한 눈에 구분 가능하게.

## Product impact
- Operator가 caption을 읽지 않고도 카드 type을 즉시 식별
- 반복 스캔 시 인지 부하 감소 (caption → icon로 first-pass 판별)

## Evidence
Vision pass (2026-04-18, cron fire): 3 sub-card 모두 동일 styled rectangle, 오로지 텍스트 caption으로만 구별. Linear/Notion/GitHub 전부 type 카드에 icon 기본.

## Review evidence
- lucide import 1 lines (Users, Zap, Target 추가)
- 3 caption 영역에 12px icon inline
- aria-hidden (caption이 이미 narrate)
- TS typecheck pass
- No runtime logic change — 순수 visual

## Linked issue
N/A (UX iteration from /loop reference-UI sweep)

## How
Semantic mapping:
- 공감대 (shared belief) → \`Users\` — group agreement
- 긴장 (tension/friction) → \`Zap\` — conflict spark
- 욕구 (collective desire) → \`Target\` — goal aim

## Reference UIs
Linear issue-status row icon · Notion database property type icon · GitHub Actions job kind icon · Stripe customer attribute icon prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)