### PR TITLE
feat(rfc-v5-A2): capability_check walker — Shell_ir to Capability list

### DIFF
--- a/lib/exec/capability_check.ml
+++ b/lib/exec/capability_check.ml
@@ -1,0 +1,50 @@
+(* A2 walker — Shell_ir.t -> Capability.t list.
+
+   Exhaustive match on Shell_ir variants.  New arm in Shell_ir forces a
+   compile error here, so policy decisions are never silently dropped. *)
+
+let lit_of_arg = function
+  | Shell_ir.Lit s -> Some s
+  | Shell_ir.Var _ | Shell_ir.Concat _ -> None
+
+let all_lits_opt (args : Shell_ir.arg list) : string list option =
+  let rec go acc = function
+    | [] -> Some (List.rev acc)
+    | a :: rest ->
+      (match lit_of_arg a with
+       | Some s -> go (s :: acc) rest
+       | None -> None)
+  in
+  go [] args
+
+let head_cap (bin : Bin.t) (args : Shell_ir.arg list) : Capability.t =
+  if String.equal (Bin.to_string bin) "git" then
+    match all_lits_opt args with
+    | Some lit_argv ->
+      (match Git_op.of_argv ("git" :: lit_argv) with
+       | Ok git_op -> Capability.Git git_op
+       | Error (`Unknown_subcmd _) -> Capability.Exec_bin (bin, args))
+    | None -> Capability.Exec_bin (bin, args)
+  else
+    Capability.Exec_bin (bin, args)
+
+let redirect_cap = function
+  | Redirect_scope.File { target; mode = Redirect_scope.Read; _ } ->
+    [ Capability.Read_path target ]
+  | Redirect_scope.File { target; mode = (Redirect_scope.Write | Redirect_scope.Append) as m; _ } ->
+    [ Capability.Write_path (target, m) ]
+  | Redirect_scope.Fd_to_fd _ -> []
+
+let of_simple (s : Shell_ir.simple) : Capability.t list =
+  let env_caps =
+    List.map (fun (k, v) -> Capability.Env_set (k, v)) s.env
+  in
+  let head = head_cap s.bin s.args in
+  let redir_caps = List.concat_map redirect_cap s.redirects in
+  env_caps @ (head :: redir_caps)
+
+let rec of_ir : Shell_ir.t -> Capability.t list = function
+  | Shell_ir.Simple s -> of_simple s
+  | Shell_ir.Pipeline stages ->
+    let per_stage = List.concat_map of_ir stages in
+    [ Capability.Pipeline_fold per_stage ]

--- a/lib/exec/capability_check.mli
+++ b/lib/exec/capability_check.mli
@@ -1,0 +1,20 @@
+(** A2 — exhaustive walker from [Shell_ir.t] to [Capability.t list].
+
+    Invariant: adding a new [Shell_ir] arm forces a compile error here
+    (exhaustive match on closed sum).  The walker is the single point
+    where every shell construct is mapped to the policy vocabulary.
+
+    Fail-closed rule: if a construct would produce {e nothing}, the
+    walker never silently drops it.  Either it maps to a capability
+    (possibly [Exec_bin] on the unknown-bin path) or the parser should
+    have rejected it upstream as [Parsed.Too_complex _]. *)
+
+val of_simple : Shell_ir.simple -> Capability.t list
+(** Walk a single command.  Order of emitted caps:
+    1. [Env_set] for every [FOO=bar] prefix, in source order.
+    2. [Exec_bin] or [Git] for the command itself.
+    3. [Read_path]/[Write_path] for every redirect, in source order. *)
+
+val of_ir : Shell_ir.t -> Capability.t list
+(** Walk a full [Shell_ir.t].  For [Pipeline], emits a single
+    [Pipeline_fold] wrapping the concatenated per-stage caps. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,3 +1,3 @@
-(test
- (name test_exec_types)
+(tests
+ (names test_exec_types test_capability_check)
  (libraries masc_exec))

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -9,7 +9,7 @@ open Masc_exec
 let bin_ok name =
   match Bin.of_string name with
   | Ok b -> b
-  | Error _ -> failwith ("bin must classify: " ^ name)
+  | Error _ -> assert false
 
 let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = []) bin
     : Shell_ir.simple =
@@ -22,7 +22,7 @@ let test_ls_emits_exec_bin () =
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin (b, []) ] ->
     assert (Bin.to_string b = "ls")
-  | _ -> failwith "ls must produce single Exec_bin cap"
+  | _ -> assert false
 
 let test_git_status_classified_as_git_read () =
   let ir =
@@ -30,7 +30,7 @@ let test_git_status_classified_as_git_read () =
   in
   match Capability_check.of_ir ir with
   | [ Capability.Git (Git_op.Read `Status) ] -> ()
-  | _ -> failwith "git status must produce Git (Read Status)"
+  | _ -> assert false
 
 let test_git_push_force_destructive () =
   let ir =
@@ -41,7 +41,7 @@ let test_git_push_force_destructive () =
   in
   match Capability_check.of_ir ir with
   | [ Capability.Git (Git_op.Destructive `Push_force) ] -> ()
-  | _ -> failwith "git push --force must produce Destructive Push_force"
+  | _ -> assert false
 
 let test_git_with_var_falls_back_to_exec_bin () =
   (* git ${REMOTE} push — can't classify statically, falls back. *)
@@ -52,7 +52,7 @@ let test_git_with_var_falls_back_to_exec_bin () =
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin (b, _) ] ->
     assert (Bin.to_string b = "git")
-  | _ -> failwith "git with Var arg must fall back to Exec_bin"
+  | _ -> assert false
 
 let test_env_set_prefix_emitted_first () =
   let ir =
@@ -64,7 +64,7 @@ let test_env_set_prefix_emitted_first () =
   match Capability_check.of_ir ir with
   | [ Capability.Env_set ("FOO", _); Capability.Env_set ("BAZ", _);
       Capability.Exec_bin _ ] -> ()
-  | _ -> failwith "env prefix caps must precede head cap in order"
+  | _ -> assert false
 
 let test_redirect_write_becomes_write_path () =
   let p = Path_scope.classify ~raw:"/tmp/out.log" ~cwd:"/tmp" in
@@ -77,7 +77,7 @@ let test_redirect_write_becomes_write_path () =
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin _; Capability.Write_path (_, Redirect_scope.Write) ]
     -> ()
-  | _ -> failwith "> redirect must produce Write_path after Exec_bin"
+  | _ -> assert false
 
 let test_redirect_read_becomes_read_path () =
   let p = Path_scope.classify ~raw:"/etc/passwd" ~cwd:"/tmp" in
@@ -89,7 +89,7 @@ let test_redirect_read_becomes_read_path () =
   in
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin _; Capability.Read_path _ ] -> ()
-  | _ -> failwith "< redirect must produce Read_path"
+  | _ -> assert false
 
 let test_fd_dup_emits_no_path_cap () =
   let redir = Redirect_scope.Fd_to_fd { src = 2; dst = 1 } in
@@ -98,7 +98,7 @@ let test_fd_dup_emits_no_path_cap () =
   in
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin _ ] -> ()
-  | _ -> failwith "2>&1 must emit no path cap, only head cap"
+  | _ -> assert false
 
 let test_pipeline_folds_caps () =
   let stage1 = Shell_ir.Simple (simple (bin_ok "ls")) in
@@ -111,8 +111,8 @@ let test_pipeline_folds_caps () =
      | [ Capability.Exec_bin (b1, _); Capability.Exec_bin (b2, _) ] ->
        assert (Bin.to_string b1 = "ls");
        assert (Bin.to_string b2 = "cat")
-     | _ -> failwith "pipeline inner caps wrong shape")
-  | _ -> failwith "Pipeline must produce single Pipeline_fold"
+     | _ -> assert false)
+  | _ -> assert false
 
 let () =
   test_ls_emits_exec_bin ();

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -1,0 +1,127 @@
+(** A2 walker tests — Shell_ir -> Capability mapping.
+
+    Walker is exhaustive over Shell_ir variants, so adding a new arm
+    (say [Shell_ir.Group of t list] someday) forces a compile error in
+    [capability_check.ml] first, then here when new tests are added. *)
+
+open Masc_exec
+
+let bin_ok name =
+  match Bin.of_string name with
+  | Ok b -> b
+  | Error _ -> failwith ("bin must classify: " ^ name)
+
+let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = []) bin
+    : Shell_ir.simple =
+  { bin; args; env; cwd; redirects }
+
+let lit s = Shell_ir.Lit s
+
+let test_ls_emits_exec_bin () =
+  let ir = Shell_ir.Simple (simple (bin_ok "ls")) in
+  match Capability_check.of_ir ir with
+  | [ Capability.Exec_bin (b, []) ] ->
+    assert (Bin.to_string b = "ls")
+  | _ -> failwith "ls must produce single Exec_bin cap"
+
+let test_git_status_classified_as_git_read () =
+  let ir =
+    Shell_ir.Simple (simple ~args:[ lit "status" ] (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Read `Status) ] -> ()
+  | _ -> failwith "git status must produce Git (Read Status)"
+
+let test_git_push_force_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
+         (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_force) ] -> ()
+  | _ -> failwith "git push --force must produce Destructive Push_force"
+
+let test_git_with_var_falls_back_to_exec_bin () =
+  (* git ${REMOTE} push — can't classify statically, falls back. *)
+  let ir =
+    Shell_ir.Simple
+      (simple ~args:[ Shell_ir.Var "REMOTE"; lit "push" ] (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Exec_bin (b, _) ] ->
+    assert (Bin.to_string b = "git")
+  | _ -> failwith "git with Var arg must fall back to Exec_bin"
+
+let test_env_set_prefix_emitted_first () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~env:[ ("FOO", lit "bar"); ("BAZ", lit "qux") ]
+         (bin_ok "ls"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Env_set ("FOO", _); Capability.Env_set ("BAZ", _);
+      Capability.Exec_bin _ ] -> ()
+  | _ -> failwith "env prefix caps must precede head cap in order"
+
+let test_redirect_write_becomes_write_path () =
+  let p = Path_scope.classify ~raw:"/tmp/out.log" ~cwd:"/tmp" in
+  let redir =
+    Redirect_scope.File { fd = 1; target = p; mode = Redirect_scope.Write }
+  in
+  let ir =
+    Shell_ir.Simple (simple ~redirects:[ redir ] (bin_ok "echo"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Exec_bin _; Capability.Write_path (_, Redirect_scope.Write) ]
+    -> ()
+  | _ -> failwith "> redirect must produce Write_path after Exec_bin"
+
+let test_redirect_read_becomes_read_path () =
+  let p = Path_scope.classify ~raw:"/etc/passwd" ~cwd:"/tmp" in
+  let redir =
+    Redirect_scope.File { fd = 0; target = p; mode = Redirect_scope.Read }
+  in
+  let ir =
+    Shell_ir.Simple (simple ~redirects:[ redir ] (bin_ok "cat"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Exec_bin _; Capability.Read_path _ ] -> ()
+  | _ -> failwith "< redirect must produce Read_path"
+
+let test_fd_dup_emits_no_path_cap () =
+  let redir = Redirect_scope.Fd_to_fd { src = 2; dst = 1 } in
+  let ir =
+    Shell_ir.Simple (simple ~redirects:[ redir ] (bin_ok "ls"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Exec_bin _ ] -> ()
+  | _ -> failwith "2>&1 must emit no path cap, only head cap"
+
+let test_pipeline_folds_caps () =
+  let stage1 = Shell_ir.Simple (simple (bin_ok "ls")) in
+  let stage2 = Shell_ir.Simple (simple (bin_ok "cat")) in
+  let ir = Shell_ir.Pipeline [ stage1; stage2 ] in
+  match Capability_check.of_ir ir with
+  | [ Capability.Pipeline_fold inner ] ->
+    assert (List.length inner = 2);
+    (match inner with
+     | [ Capability.Exec_bin (b1, _); Capability.Exec_bin (b2, _) ] ->
+       assert (Bin.to_string b1 = "ls");
+       assert (Bin.to_string b2 = "cat")
+     | _ -> failwith "pipeline inner caps wrong shape")
+  | _ -> failwith "Pipeline must produce single Pipeline_fold"
+
+let () =
+  test_ls_emits_exec_bin ();
+  test_git_status_classified_as_git_read ();
+  test_git_push_force_destructive ();
+  test_git_with_var_falls_back_to_exec_bin ();
+  test_env_set_prefix_emitted_first ();
+  test_redirect_write_becomes_write_path ();
+  test_redirect_read_becomes_read_path ();
+  test_fd_dup_emits_no_path_cap ();
+  test_pipeline_folds_caps ();
+  print_endline "[test_capability_check] all tests passed"


### PR DESCRIPTION
## Summary

RFC v5 Phase A2 — exhaustive walker from `Shell_ir.t` to `Capability.t list` for typed capability substrate.

Single point where every shell construct maps to the policy vocabulary. New `Shell_ir` arm forces a compile error here first, so policy decisions are never silently dropped.

## Walker rules

| Construct | Emits |
|-----------|-------|
| `Simple` | `Env_set*` → (`Exec_bin` \| `Git`) → redirect path caps, in source order |
| `Pipeline` | single `Pipeline_fold` wrapping concatenated per-stage caps |
| `git <known subcmd>` (all-Lit args) | `Capability.Git (Git_op.t)` |
| `git <Var arg>` or unknown subcmd | `Exec_bin` fallback (policy decides) |
| `Redirect_scope.Fd_to_fd` | no path cap emitted |
| `Redirect_scope.File` (Read) | `Read_path` |
| `Redirect_scope.File` (Write/Append) | `Write_path` |

## Test plan

- [x] `dune runtest lib/exec` green (19/19: 10 A0 + 9 A2)
- [x] 9/9 new tests pass
- [ ] CI Build and Test green on PR
- [ ] A3 exec_gate consumes `Capability.t list` (next PR)

Closes a step in RFC v5 plan (see #8104 / docs/rfc/RFC-0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)