### PR TITLE
chore(dashboard): sync Ops Queue description with current surface reality

### DIFF
--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -28,7 +28,7 @@ const FOCUS_SURFACES: FocusSurface[] = [
   },
   {
     title: 'Ops Queue',
-    description: '자동 판단, review queue, 승인 대기, 실행 경로를 한 화면에서 확인합니다.',
+    description: '빠른 개입(QuickIntervene), 흐름 제어, 최근 운영 활동을 한 화면에서 확인합니다. Live Judge·HITL 승인은 거버넌스 페이지에 있습니다.',
     action: '운영 큐로 이동',
     tab: 'command',
     params: { section: 'operations' },

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -168,7 +168,7 @@ let all_entries =
       exposure_status = "main";
       hidden_from_nav = false;
       meets_main_gate = true;
-      rationale = "review queue, 추천 액션, 승인 대기를 한 화면에서 처리하는 canonical operator surface라 메인에 유지합니다.";
+      rationale = "QuickIntervene, 흐름 제어, 최근 운영 활동을 한 화면에서 다루는 canonical operator surface라 메인에 유지합니다. review queue · Live Judge · HITL 승인은 거버넌스 페이지 관할입니다.";
       route_hash = Some "#command?section=intervene";
       refs =
         {


### PR DESCRIPTION
## Summary

\"Ops Queue\" focus card + dashboard_surface_readiness rationale가 현재 실제 UI와 어긋남 → 사용자가 **운영 큐에서 review queue를 찾다가 없어서 헷갈림**.

| SSOT | Before | After |
|------|--------|-------|
| \`lab-inspector.ts:31\` | \"자동 판단, review queue, 승인 대기, 실행 경로를 한 화면에서 확인합니다.\" | \"빠른 개입(QuickIntervene), 흐름 제어, 최근 운영 활동을 한 화면에서 확인합니다. Live Judge·HITL 승인은 거버넌스 페이지에 있습니다.\" |
| \`dashboard_surface_readiness.ml:171\` | \"review queue, 추천 액션, 승인 대기를 한 화면에서 처리하는 canonical operator surface…\" | \"QuickIntervene, 흐름 제어, 최근 운영 활동을 한 화면에서 다루는 canonical operator surface… review queue · Live Judge · HITL 승인은 거버넌스 페이지 관할입니다.\" |

## Why this matters

- Ops 페이지의 실제 콘텐츠는 QuickIntervene + FlowControlPanel + 운영 활동 timeline. review queue / Live Judge / HITL은 governance 페이지로 이주됨 (\`ops/index.test.ts:124-128\` 주석 참조).
- 그런데 카드 description과 rationale은 마이그레이션 이전 용어를 그대로 유지 → 사용자가 \"룸 전략 돌아가는지 모르겠고\", \"review_item ... 이런거 걍 없애버리고\" 같이 혼란 표현.
- 문구 하나를 현실에 맞추는 것만으로 cognitive mismatch 해소.

## Verification

- \`bunx tsc --noEmit\`: green
- \`dune build @check\`: green
- \`vitest control.test.ts + operations-panel.test.ts\`: 10/10 pass
- +2/-2 LOC (2 파일, 각 1줄)

## Test plan

- [x] tsc noEmit
- [x] dune check
- [x] lab-inspector 소비자 tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)