### PR TITLE
fix(loopback): consolidate is_loopback_host via Masc_network_defaults SSOT

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -16,4 +16,4 @@
    masc_time_constants
    playground_paths)
  (wrapped false)
- (libraries masc_core masc_log yojson uri))
+ (libraries masc_core masc_log yojson uri ipaddr))

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -74,6 +74,29 @@ let masc_http_default_port_s =
 (** Default host for the MASC HTTP server. *)
 let masc_http_default_host = "127.0.0.1"
 
+(** [is_loopback_host host] returns [true] when [host] resolves to any
+    IPv4/IPv6 loopback address (via {!Ipaddr}).  Treats the literal
+    "localhost" (after trim + lowercase) as loopback.  Malformed
+    addresses return [false] — unlike a plain string prefix match,
+    which would wrongly accept garbage like "127.invalid". *)
+let is_loopback_host host =
+  let normalized = String.trim host |> String.lowercase_ascii in
+  match normalized with
+  | "localhost" -> true
+  | _ -> (
+      match Ipaddr.of_string normalized with
+      | Ok ip -> (
+          match ip with
+          | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.localhost = 0
+          | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0)
+      | Error _ -> false)
+
+(** Convenience wrapper for [Uri.host]-style inputs.  Returns [false]
+    when the host is absent. *)
+let is_loopback_host_opt = function
+  | Some host -> is_loopback_host host
+  | None -> false
+
 (** Default port for SearXNG local search. *)
 let searxng_default_port = 8888
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1031,16 +1031,12 @@ let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider
   | Llm_provider.Provider_config.Codex_cli
   | Llm_provider.Provider_config.Ollama -> []
 
-let is_loopback_host = function
-  | Some "localhost" | Some "127.0.0.1" -> true
-  | Some host when String.starts_with ~prefix:"127." host -> true
-  | _ -> false
-
 let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t) : string list =
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
     let uri = Uri.of_string cfg.base_url in
-    if is_loopback_host (Uri.host uri) then [] else auth_env_keys_of_provider_kind cfg.kind
+    if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then []
+    else auth_env_keys_of_provider_kind cfg.kind
   | Llm_provider.Provider_config.Gemini -> [ "GEMINI_API_KEY" ]
   | _ -> auth_env_keys_of_provider_kind cfg.kind
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -22,14 +22,7 @@ let ipaddr_is_unspecified = function
   | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0
   | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
 
-let is_loopback_host host =
-  let normalized = String.trim host |> String.lowercase_ascii in
-  match normalized with
-  | "localhost" -> true
-  | _ -> (
-      match Ipaddr.of_string normalized with
-      | Ok ip -> ipaddr_is_loopback ip
-      | Error _ -> false)
+let is_loopback_host = Masc_network_defaults.is_loopback_host
 
 let is_unspecified_host host =
   match Ipaddr.of_string (String.trim host) with

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -160,14 +160,9 @@ let path_within ~root path =
 let host_is_linux () =
   Sys.os_type = "Unix" && Sys.file_exists "/proc/version"
 
-let is_loopback_host = function
-  | Some "localhost" | Some "127.0.0.1" -> true
-  | Some host when String.starts_with ~prefix:"127." host -> true
-  | _ -> false
-
 let rewrite_loopback_url value =
   let uri = Uri.of_string value in
-  if is_loopback_host (Uri.host uri) then
+  if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then
     Uri.with_host uri (Some docker_host_alias) |> Uri.to_string
   else value
 


### PR DESCRIPTION
## Why

Two modules carried byte-identical copies of the loopback predicate
against `string option`:

- `lib/provider_adapter.ml` (skips credential env keys on loopback URLs).
- `lib/worker_runtime_docker.ml` (rewrites loopback URLs to `host.docker.internal`).

Both copies matched only `Some "localhost" | Some "127.0.0.1"` plus a
`127.*` prefix.  The prefix fallback is lenient ("127.invalid" was
wrongly classified as loopback) and neither copy recognised `::1`
(IPv6 loopback).  A third implementation in `server_auth.ml` already
used `Ipaddr` to handle both issues correctly — so the codebase shipped
two semantically different loopback checks.

## What

- Add `is_loopback_host` + `is_loopback_host_opt` to
  `lib/config/masc_network_defaults.ml` with the richer Ipaddr-based
  semantics (handles IPv4/IPv6 loopback, rejects malformed strings).
- Extend `lib/config/dune` to link `ipaddr` (peer of the already-linked
  `uri`).
- `server_auth.ml` `is_loopback_host` becomes a thin alias to the SSOT.
- `provider_adapter.ml` and `worker_runtime_docker.ml` delete their
  duplicates and call `Masc_network_defaults.is_loopback_host_opt`.

## Why masc_config (and not server_auth)

First attempt placed the helper in `Server_auth`.  That triggered:

```
Worker_verification -> Cascade_runtime -> Provider_adapter -> Config
-> Anti_rationalization -> Oas_worker -> Cascade_runtime
```

`masc_config` is a leaf lib, so every downstream consumer can depend on
it without cycle risk.  Same lower-layer reasoning as #8125 and #8128.

## Semantic upgrade (not regression)

- `provider_adapter`: `::1` URLs now correctly skip credential env keys
  (IPv6 loopback counts as local).
- `worker_runtime_docker`: `::1` URLs now get rewritten to the docker
  host alias (containers can't reach their own `::1`).
- Both: malformed `"127.arbitrary"` strings no longer false-positive
  as loopback.

## Verification

- `dune build @check` clean (cycle resolved).
- `test_provider_adapter` → **22/22 OK**.
- `test_dashboard_link_preview` → **3/3 OK** (exercises
  `Server_auth.is_loopback_host` via the delegation alias).

Net: **5 files, +28 / -21 LOC**.
