### PR TITLE
feat(dashboard): hover tooltip on build identity badge

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -9,6 +9,7 @@ import {
   describeReconnecting,
   summarizeAttentionPreview,
   composeHealthIndicatorTitle,
+  composeBuildBadgeTitle,
 } from './dashboard-shell'
 
 describe('githubCommitUrl (pure)', () => {
@@ -394,5 +395,63 @@ describe('composeHealthIndicatorTitle (pure)', () => {
     const title = composeHealthIndicatorTitle('주의 1건', ['x'])
     expect(title.split('\n')).toHaveLength(2)
     expect(title).not.toContain('<br>')
+  })
+})
+
+describe('composeBuildBadgeTitle (pure)', () => {
+  it('no build / no fallback → "버전 정보 없음" (matches existing label)', () => {
+    expect(composeBuildBadgeTitle(null, null)).toBe('버전 정보 없음')
+    expect(composeBuildBadgeTitle(undefined, undefined)).toBe('버전 정보 없음')
+    expect(composeBuildBadgeTitle(null, '')).toBe('버전 정보 없음')
+  })
+
+  it('fallback version only → uses it + "dev" suffix (loose build info)', () => {
+    const t = composeBuildBadgeTitle(null, '0.9.13')
+    expect(t).toContain('서버 빌드')
+    expect(t).toContain('· v0.9.13 · dev')
+    expect(t).toContain('클릭하여 상세 보기')
+  })
+
+  it('full build (version + commit + uptime) → all three lines', () => {
+    const t = composeBuildBadgeTitle(
+      { release_version: '0.9.13', commit: 'a8b7412a3', uptime_seconds: 9000 },
+      null,
+    )
+    expect(t).toContain('· v0.9.13 · a8b7412a3')
+    // 9000s → 2h 30m per formatUptimeSecondsHuman
+    expect(t).toContain('업타임 2h 30m')
+    expect(t).toContain('클릭하여 상세 보기')
+  })
+
+  it('unknown uptime (null / negative) → skips the 업타임 line (no ghost "알 수 없음")', () => {
+    // Regression guard: we explicitly filter out the "unknown" sentinel
+    // so the hover tooltip stays compact during pre-boot / clock-skew.
+    const t = composeBuildBadgeTitle(
+      { release_version: '0.9.13', commit: 'abc1234', uptime_seconds: null },
+      null,
+    )
+    expect(t).not.toContain('업타임')
+    expect(t).not.toContain('알 수 없음')
+  })
+
+  it('newline separated (native title tooltip plain text)', () => {
+    // Same contract as composeHealthIndicatorTitle — never emit <br>;
+    // this is a title attribute, not HTML markup.
+    const t = composeBuildBadgeTitle(
+      { release_version: '0.9.13', commit: 'abc1234', uptime_seconds: 60 },
+      null,
+    )
+    expect(t).not.toContain('<br>')
+    expect(t.split('\n').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('commit missing / empty → " · dev" suffix (not " · undefined")', () => {
+    const t1 = composeBuildBadgeTitle({ release_version: '0.9.13', commit: null }, null)
+    const t2 = composeBuildBadgeTitle({ release_version: '0.9.13', commit: '' }, null)
+    for (const t of [t1, t2]) {
+      expect(t).toContain('· v0.9.13 · dev')
+      expect(t).not.toContain('undefined')
+      expect(t).not.toContain('null')
+    }
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -157,6 +157,33 @@ export function formatUptimeSecondsHuman(
 }
 
 
+/** Pure: compose a multi-line native-title tooltip for the build
+    identity badge so hovering reveals version + commit + uptime
+    without needing to open the dropdown. Reference UIs: Vercel
+    deployment pill, Render build badge, Railway service chip — all
+    surface the one-glance summary on hover and reserve the click for
+    \"deep details\". \n renders verbatim in native tooltips. */
+export function composeBuildBadgeTitle(
+  build: { release_version?: string | null; commit?: string | null; uptime_seconds?: number | null } | null | undefined,
+  fallbackVersion: string | null | undefined,
+): string {
+  if (!build && !fallbackVersion) return '버전 정보 없음'
+  const lines: string[] = ['서버 빌드']
+  const version = build?.release_version ?? fallbackVersion
+  if (version != null && version !== '') {
+    const commit = build?.commit != null && build.commit !== ''
+      ? ` · ${shortCommit(build.commit)}`
+      : ' · dev'
+    lines.push(`  · v${version}${commit}`)
+  }
+  const uptime = formatUptimeSecondsHuman(build?.uptime_seconds)
+  if (uptime !== '알 수 없음') {
+    lines.push(`  · 업타임 ${uptime}`)
+  }
+  lines.push('  · 클릭하여 상세 보기')
+  return lines.join('\n')
+}
+
 export function BuildIdentityBadge() {
   const status = serverStatus.value
   const build = status?.build
@@ -165,6 +192,7 @@ export function BuildIdentityBadge() {
     : status?.version
       ? `v${status.version} · dev`
       : '버전 정보 없음'
+  const hoverTitle = composeBuildBadgeTitle(build, status?.version)
 
   return html`
     <div class="relative">
@@ -172,7 +200,7 @@ export function BuildIdentityBadge() {
         class="cursor-pointer rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
-        title="서버 빌드 정보"
+        title=${hoverTitle}
         onClick=${() => {
           buildIdentityOpen.value = !buildIdentityOpen.value
         }}


### PR DESCRIPTION
## Summary
헤더 build badge(v0.9.13 · a8b7412a3)의 \`title\` 속성을 vague \"서버 빌드 정보\"에서 version + 업타임 + 클릭 안내까지 multi-line tooltip으로 확장.

## Product impact
- Operator가 클릭 없이 hover만으로 버전/업타임 파악
- \"클릭하여 상세 보기\" 명시적 prompt로 dropdown 존재감 전달

## Evidence
Vercel deployment pill, Render build badge, Railway service chip — 모두 hover 요약 + click 상세 패턴. 현재 dashboard는 title이 redundant.

## Review evidence
- composeBuildBadgeTitle 1 pure helper (multi-line plain text)
- 6 new tests, 53/53 green
- \"알 수 없음\" uptime sentinel 필터링 (pre-boot noise 방지)
- \`<br>\` regression guard (title은 plain text)
- commit empty/null → \" · dev\" fallback (undefined leak 방지)

## Linked issue
N/A (UX iteration from /loop reference-UI sweep)

## How
\`composeBuildBadgeTitle(build, fallbackVersion): string\` — null/빈 입력 \"버전 정보 없음\", 유효 입력 \"서버 빌드\\n  · v0.9.13 · a8b7412a3\\n  · 업타임 2h 30m\\n  · 클릭하여 상세 보기\".

## Reference UIs
Vercel deployment pill · Render build badge · Railway service chip · GitHub commit hover card · Datadog build info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)