### PR TITLE
ux(dashboard): inline reject form + approve confirm (follow-up to #8114)

### DIFF
--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -70,10 +70,26 @@ const statusFilter = signal<StatusFilter>('all')
 const searchQuery = signal('')
 
 // Per-request mutation state. Signal-valued Map avoids component-local
-// state plumbing: the row reads `inFlight.value.get(request_id)` and the
+// state plumbing: the row reads `rowActions.value.get(request_id)` and the
 // action handler mutates a new Map to preserve signal identity semantics.
+//
+// State machine:
+//   idle
+//     → confirm-approve    (first click on 승인)
+//     → compose-reject     (first click on 반려)
+//   confirm-approve
+//     → pending(approve)   (click 확정)
+//     → idle               (click 취소)
+//   compose-reject
+//     → pending(reject)    (submit with reason)
+//     → idle               (click 취소)
+//   pending
+//     → idle               (on success)
+//     → error              (on failure; user can retry from idle)
 type RowActionState =
   | { kind: 'idle' }
+  | { kind: 'confirm-approve' }
+  | { kind: 'compose-reject'; reason: string }
   | { kind: 'pending'; decision: 'approve' | 'reject' }
   | { kind: 'error'; message: string }
 
@@ -160,17 +176,12 @@ function relativeTime(ts: string): string {
 
 // ── Action handler ────────────────────────────────────
 
-async function handleResolve(
+async function submitResolve(
   row: VerificationRequest,
   decision: 'approve' | 'reject',
+  reason: string,
   refresh: () => void,
 ): Promise<void> {
-  let reason = ''
-  if (decision === 'reject') {
-    const answer = window.prompt('반려 사유를 입력하세요 (선택).')
-    if (answer === null) return
-    reason = answer
-  }
   setRowAction(row.request_id, { kind: 'pending', decision })
   try {
     await resolveVerificationRequest({
@@ -187,6 +198,105 @@ async function handleResolve(
   }
 }
 
+// ── Row actions (approve/reject UI) ───────────────────
+
+const BTN_PRIMARY =
+  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+
+const BTN_SECONDARY =
+  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-body)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+
+function RowActions({
+  row,
+  state,
+  refresh,
+}: {
+  row: VerificationRequest
+  state: RowActionState
+  refresh: () => void
+}) {
+  const requestId = row.request_id
+
+  if (state.kind === 'pending') {
+    return html`
+      <span class="text-[11px] text-[var(--text-muted)]">
+        ${state.decision === 'approve' ? '승인 중…' : '반려 중…'}
+      </span>
+    `
+  }
+
+  if (state.kind === 'confirm-approve') {
+    return html`
+      <div class="flex items-center gap-1 flex-wrap">
+        <span class="text-[11px] text-[var(--text-strong)]">승인 확정?</span>
+        <button
+          class=${BTN_PRIMARY}
+          onClick=${() => void submitResolve(row, 'approve', '', refresh)}
+        >예</button>
+        <button
+          class=${BTN_SECONDARY}
+          onClick=${() => setRowAction(requestId, { kind: 'idle' })}
+        >취소</button>
+      </div>
+    `
+  }
+
+  if (state.kind === 'compose-reject') {
+    const reason = state.reason
+    const canSubmit = reason.trim().length > 0
+    return html`
+      <div class="flex items-center gap-1 flex-wrap">
+        <input
+          type="text"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-body)] w-[200px]"
+          placeholder="반려 사유 (필수)"
+          value=${reason}
+          autofocus
+          onInput=${(e: Event) => setRowAction(requestId, {
+            kind: 'compose-reject',
+            reason: (e.target as HTMLInputElement).value,
+          })}
+          onKeyDown=${(e: KeyboardEvent) => {
+            if (e.key === 'Enter' && canSubmit) {
+              void submitResolve(row, 'reject', reason.trim(), refresh)
+            } else if (e.key === 'Escape') {
+              setRowAction(requestId, { kind: 'idle' })
+            }
+          }}
+        />
+        <button
+          class=${BTN_PRIMARY}
+          disabled=${!canSubmit}
+          onClick=${() => void submitResolve(row, 'reject', reason.trim(), refresh)}
+        >확정</button>
+        <button
+          class=${BTN_SECONDARY}
+          onClick=${() => setRowAction(requestId, { kind: 'idle' })}
+        >취소</button>
+      </div>
+    `
+  }
+
+  // idle or error — show primary action buttons; error surfaces retry hint
+  return html`
+    <div class="flex items-center gap-1 flex-wrap">
+      <button
+        class=${BTN_PRIMARY}
+        onClick=${() => setRowAction(requestId, { kind: 'confirm-approve' })}
+      >승인</button>
+      <button
+        class=${BTN_SECONDARY}
+        onClick=${() => setRowAction(requestId, { kind: 'compose-reject', reason: '' })}
+      >반려</button>
+      ${state.kind === 'error'
+        ? html`<span class="text-[10px] text-[var(--text-bad)]" title=${state.message}>
+            실패 · 다시 시도
+          </span>`
+        : null}
+    </div>
+  `
+}
+
 // ── Row ───────────────────────────────────────────────
 
 function VerificationRow({
@@ -196,8 +306,7 @@ function VerificationRow({
   const hasContract = row.completion_contract.length > 0
   const hasEvidence = row.required_evidence.length > 0
   const hasDetails = hasContract || hasEvidence || row.verdict_reason !== ''
-  const actionState = rowActions.value.get(row.request_id) ?? { kind: 'idle' }
-  const disabled = actionState.kind === 'pending'
+  const actionState = rowActions.value.get(row.request_id) ?? { kind: 'idle' as const }
 
   return html`
     <tr class="border-b border-[var(--card-border)] last:border-b-0 align-top">
@@ -235,33 +344,7 @@ function VerificationRow({
       </td>
       <td class="py-2 pr-2">
         ${row.status === 'pending'
-          ? html`
-              <div class="flex items-center gap-1 flex-wrap">
-                <button
-                  class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled=${disabled}
-                  onClick=${() => void handleResolve(row, 'approve', refresh)}
-                >
-                  ${actionState.kind === 'pending' && actionState.decision === 'approve'
-                    ? '승인 중…'
-                    : '승인'}
-                </button>
-                <button
-                  class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-body)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled=${disabled}
-                  onClick=${() => void handleResolve(row, 'reject', refresh)}
-                >
-                  ${actionState.kind === 'pending' && actionState.decision === 'reject'
-                    ? '반려 중…'
-                    : '반려'}
-                </button>
-                ${actionState.kind === 'error'
-                  ? html`<span class="text-[10px] text-[var(--text-bad)]" title=${actionState.message}>
-                      실패
-                    </span>`
-                  : null}
-              </div>
-            `
+          ? html`<${RowActions} row=${row} state=${actionState} refresh=${refresh} />`
           : html`<span class="text-[var(--text-muted)]">—</span>`}
       </td>
       <td class="py-2">


### PR DESCRIPTION
## 요약

PR #8114 머지 후 남겨진 UX 개선 건. 원래 같은 PR에 commit `2bee765ac`로 포함시켰으나 squash merge 타이밍에 해당 커밋이 브랜치 head 이후로 밀려 main에 반영되지 않았음 (feedback_no-push-after-squash-merge.md 패턴).

## 배경

#8114에서 오너 본인이 남긴 advocate 시점 리뷰의 3가지 UX 지적:

1. \`window.prompt\`는 대시보드 다른 UI와 일관성 없음, 빈 사유 반려가 구조적으로 가능
2. 승인에 확인 단계 없음 (오클릭 되돌릴 수 없음)
3. 병렬 resolve 중 일부 실패 시 사용자에게 어떻게 보이는가

## 변경

- \`window.prompt\` 제거 → pending 행 내부의 인라인 \`<input>\` + 확정/취소. \`reason.trim().length > 0\` 아닐 때 확정 버튼 disabled. Enter submit, Escape cancel.
- 승인 2단계 확정. 첫 클릭은 "승인 확정? 예/취소" state로 전환, 예 클릭 시 POST.
- 실패 시 "실패 · 다시 시도" + 에러 메시지 툴팁. 버튼은 disabled 유지하지 않아 같은 자리에서 재시도 가능.

## State machine

\`\`\`
idle
  → confirm-approve        (첫 승인 클릭)
  → compose-reject{reason} (첫 반려 클릭)
confirm-approve
  → pending(approve)       (예)
  → idle                   (취소)
compose-reject
  → pending(reject)        (확정)
  → idle                   (취소)
pending
  → idle                   (on success)
  → error                  (on failure; 같은 UI로 돌아와 재시도 가능)
\`\`\`

## Test

- \`tsc --noEmit\` 통과
- \`vitest run verification-requests-panel.test.ts\` 21/21 통과
- 로컬 서버 재시작 + 브라우저 smoke test는 main 머지 후 수행 예정

## Linked

- Follows up #8114 (backend POST /api/v1/verification/resolve + initial UI)
- Related: #8116 (masc_join auth bug), #8117 (FSM/store ID drift)