### PR TITLE
feat(dashboard): TimeAgo title shows human-readable ko-KR, not raw ISO

### DIFF
--- a/dashboard/src/components/common/time-ago.test.ts
+++ b/dashboard/src/components/common/time-ago.test.ts
@@ -8,6 +8,7 @@ import {
   toIsoDatetime,
   toAccessibleLabel,
   pickDisplayText,
+  toHumanTooltip,
 } from './time-ago'
 
 const flushUi = async () => {
@@ -108,10 +109,17 @@ describe('TimeAgo component', () => {
     expect(label).toMatch(/\(.+\)/) // absolute part in parens
   })
 
-  it('title attr contains the ISO timestamp (hover tooltip)', () => {
+  it('title attr is human-readable (ko-KR form, NOT ISO — GitHub/Linear pattern)', () => {
+    // ISO stays on `datetime` for crawlers/dev tools; title gets the
+    // ko-KR form so mouse users can read the timestamp without
+    // parsing \"2024-11-14T22:13:20.000Z\" in their head.
     render(html`<${TimeAgo} timestamp=${1_700_000_000_000} />`, container)
     const el = container.querySelector('time')!
-    expect(el.getAttribute('title')).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    const title = el.getAttribute('title')
+    expect(title).not.toBeNull()
+    expect(title).not.toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    // datetime attr still carries the ISO form
+    expect(el.getAttribute('datetime')).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   it('mode="absolute" renders only the absolute fragment', () => {
@@ -173,5 +181,61 @@ describe('TimeAgo component', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('toHumanTooltip (pure)', () => {
+  it('matches the aria-label shape (relative + absolute) for hover/SR parity', () => {
+    // The tooltip and the aria-label must tell the same story — a
+    // mouse user hovering and a screen-reader user arrowing should
+    // both get \"2분 전 (04. 17. 18:30)\", not two different strings.
+    const t = '2026-04-18T00:01:00.000Z'
+    expect(toHumanTooltip(t)).toBe(toAccessibleLabel(t))
+  })
+
+  it('is NOT the raw ISO string (GitHub/Linear pattern: humans get ko-KR, dev tools get ISO via datetime attr)', () => {
+    // Regression guard: a well-meaning refactor might "simplify" by
+    // passing the ISO to both datetime= and title=, regressing the
+    // hover UX. Pin the difference.
+    const t = '2026-04-18T00:01:00.000Z'
+    const tooltip = toHumanTooltip(t)
+    expect(tooltip).not.toBe(toIsoDatetime(t))
+    expect(tooltip).not.toContain('T00:01:00')
+  })
+
+  it('accepts unix seconds and unix ms — same result (normalization is via toMs)', () => {
+    const sec = 1_745_000_000
+    const ms = sec * 1000
+    expect(toHumanTooltip(sec)).toBe(toHumanTooltip(ms))
+  })
+})
+
+describe('<TimeAgo/> title attribute (integration)', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders human-readable title (not ISO) so hover users get ko-KR', async () => {
+    // Regression guard covering the 2026-04-18 chip that swapped
+    // title from iso → toHumanTooltip. Hovering over any \"2분 전\"
+    // in the dashboard must reveal a Korean-formatted timestamp.
+    const timestamp = '2026-04-18T00:00:00.000Z'
+    render(html`<${TimeAgo} timestamp=${timestamp} />`, container)
+    await flushUi()
+    const el = container.querySelector('time')
+    expect(el).toBeTruthy()
+    const title = el!.getAttribute('title')
+    expect(title).not.toBeNull()
+    // datetime still the ISO form (crawlers / dev tools)
+    expect(el!.getAttribute('datetime')).toBe(toIsoDatetime(timestamp))
+    // title is human-readable — equals toHumanTooltip
+    expect(title).toBe(toHumanTooltip(timestamp))
+    expect(title).not.toBe(toIsoDatetime(timestamp))
   })
 })

--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -65,6 +65,18 @@ export function toAccessibleLabel(ts: string | number): string {
   return `${formatTimeAgo(ts)} (${formatTimestampKo(toUnixSeconds(ts))})`
 }
 
+/** Pure: the hover-tooltip string for the <time> element. GitHub,
+    Linear, Notion — all render a HUMAN-readable timestamp on hover,
+    not the machine-readable ISO form. ISO stays on `datetime` attr
+    where crawlers / dev tools want it; `title` gets the ko-KR form
+    so a mouse user can read \"04. 17. 18:30\" without squinting at
+    \"2026-04-18T01:05:33.000Z\". Same shape as toAccessibleLabel —
+    relative + absolute together — so hovering confirms whatever
+    you'd hear with a screen reader. */
+export function toHumanTooltip(ts: string | number): string {
+  return `${formatTimeAgo(ts)} (${formatTimestampKo(toUnixSeconds(ts))})`
+}
+
 /** Pick the displayed text based on mode. */
 export function pickDisplayText(ts: string | number, mode: TimeAgoMode): string {
   const rel = formatTimeAgo(ts)
@@ -89,8 +101,9 @@ export function TimeAgo({ timestamp, mode = 'relative', class: cx }: TimeAgoProp
   const text = pickDisplayText(timestamp, mode)
   const iso = toIsoDatetime(timestamp)
   const label = toAccessibleLabel(timestamp)
+  const tooltip = toHumanTooltip(timestamp)
   const cls = cx ? `time-ago ${cx}` : 'time-ago'
-  return html`<time class=${cls} datetime=${iso} title=${iso} aria-label=${label}>${text}</time>`
+  return html`<time class=${cls} datetime=${iso} title=${tooltip} aria-label=${label}>${text}</time>`
 }
 
 export { formatTimeAgo }


### PR DESCRIPTION
## Summary
\`<time>\` 요소의 \`title\` 속성을 machine-readable ISO에서 human-readable ko-KR 형식으로 교체 (GitHub/Linear 패턴). \`datetime=\` attr에는 ISO 유지 (크롤러/devtool용).

## Product impact
- Dashboard 전체 \"2분 전\" 호버 시 \"2026-04-18T01:05:33.000Z\" 대신 \"2분 전 (04. 18. 오전 02:30)\" 표시
- Mouse 사용자가 timestamp 읽기 즉시 가능

## Evidence
GitHub relative-time tooltip, Linear activity log, Notion last-edited, Slack message timestamp — 전부 human-readable locale 형식. ISO는 \`datetime=\` 또는 \`data-*\`에 machine-readable로 보존.

## Review evidence
- \`toHumanTooltip(ts)\` pure helper 추가
- 기존 \`title=\${iso}\` → \`title=\${toHumanTooltip(timestamp)}\`
- 3 new pure helper tests + 1 integration test + 1 updated test (ISO regression → human regression)
- 기존 pre-existing 2 failures (/전/ regex matching \"오전\") 그대로 — 이 chip 범위 밖

## Linked issue
N/A (UX iteration from /loop reference-UI sweep)

## Invariants pinned
- \`datetime=\` 은 ISO 유지 (crawler/devtool)
- \`title=\` 은 ko-KR (human)
- \`aria-label=\` 은 human (SR)
- 세 attr이 각자 타겟 audience를 향함

## Reference UIs
GitHub relative-time tooltip · Linear activity log timestamp · Notion last-edited hover · Slack message timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)