### PR TITLE
fix(masc_log): expose level_of_string_opt and warn on typo env values

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -30,14 +30,26 @@ let level_to_int = function
   | Warn -> 2
   | Error -> 3
 
-(** Parse level from string *)
+(** Parse level from string without a fallback.  Returns [None] when the
+    input does not match any known level — callers that originate from
+    user input (env vars, config files) should treat [None] as an error
+    rather than silently collapsing it to a default. *)
+let level_of_string_opt s =
+  match String.lowercase_ascii (String.trim s) with
+  | "debug" -> Some Debug
+  | "info" -> Some Info
+  | "warn" | "warning" -> Some Warn
+  | "error" -> Some Error
+  | _ -> None
+
+(** Parse level from string, defaulting to [Info] on unrecognised input.
+    Kept for backward compatibility with existing callers.  When the
+    input comes from a user (env var, config), prefer
+    [level_of_string_opt] and warn on [None] so typos surface. *)
 let level_of_string s =
-  match String.lowercase_ascii s with
-  | "debug" -> Debug
-  | "info" -> Info
-  | "warn" | "warning" -> Warn
-  | "error" -> Error
-  | _ -> Info  (* Default to Info *)
+  match level_of_string_opt s with
+  | Some lvl -> lvl
+  | None -> Info
 
 let source_to_string = function
   | Structured -> "structured"
@@ -75,9 +87,21 @@ let should_log level =
 let set_level level =
   Atomic.set current_level (level_to_int level)
 
-(** Set log level from string (e.g., from env var) *)
+(** Set log level from string (e.g., from env var).  Emits a stderr
+    warning when the input is not a recognised level, so operator
+    typos (e.g. [MASC_LOG_LEVEL=debg]) surface instead of silently
+    collapsing to [Info]. *)
 let set_level_from_string s =
-  Atomic.set current_level (level_to_int (level_of_string s))
+  let lvl =
+    match level_of_string_opt s with
+    | Some lvl -> lvl
+    | None ->
+      Printf.eprintf
+        "[masc_log] WARN: unrecognised log level %S, defaulting to Info\n%!"
+        s;
+      Info
+  in
+  Atomic.set current_level (level_to_int lvl)
 
 (** Initialize from MASC_LOG_LEVEL env var *)
 let init_from_env () =
@@ -429,8 +453,15 @@ module Make (M : sig val name : string end) = struct
     let env_key = Printf.sprintf "MASC_LOG_%s_LEVEL"
       (String.uppercase_ascii M.name) in
     match Sys.getenv_opt env_key with
-    | Some s -> Some (level_to_int (level_of_string s))
     | None -> None
+    | Some s ->
+      match level_of_string_opt s with
+      | Some lvl -> Some (level_to_int lvl)
+      | None ->
+        Printf.eprintf
+          "[masc_log] WARN: %s=%S is not a valid level; ignoring override\n%!"
+          env_key s;
+        None
 
   let should_log_module level =
     let threshold = match module_level with

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -14,7 +14,15 @@ val level_to_int : level -> int
 (** Convert level to integer for comparison. *)
 
 val level_of_string : string -> level
-(** Parse level from string. Defaults to Info for unrecognized input. *)
+(** Parse level from string. Defaults to [Info] for unrecognised input.
+    Kept for backward compatibility — prefer [level_of_string_opt] when
+    the input is user-supplied so typos surface instead of collapsing. *)
+
+val level_of_string_opt : string -> level option
+(** Parse level from string without a fallback.  Returns [None] for
+    unrecognised input.  Callers that originate from user input (env
+    vars, config files) should use this and warn on [None] rather than
+    relying on the silent [Info] default of [level_of_string]. *)
 
 val should_log : level -> bool
 (** Check if a message at the given level should be logged. *)

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -112,7 +112,11 @@ let test_log_level_of_string () =
   check bool "warn" true (Log.level_of_string "WARN" = Log.Warn);
   check bool "warning" true (Log.level_of_string "WARNING" = Log.Warn);
   check bool "error" true (Log.level_of_string "ERROR" = Log.Error);
-  check bool "unknown" true (Log.level_of_string "unknown" = Log.Info) (* default *)
+  check bool "unknown" true (Log.level_of_string "unknown" = Log.Info); (* default *)
+  (* partial variant — None on unrecognised, Some on valid *)
+  check bool "opt garbage is None" true (Log.level_of_string_opt "debg" = None);
+  check bool "opt valid is Some" true
+    (Log.level_of_string_opt " DEBUG " = Some Log.Debug)
 
 let test_log_level_of_string_lowercase () =
   check bool "debug lower" true (Log.level_of_string "debug" = Log.Debug);


### PR DESCRIPTION
## Why

`Log.level_of_string` treated any unrecognised input as `Info` via a
silent `_ -> Info` fallback:

```ocaml
| "debug" -> Debug
| "info" -> Info
...
| _ -> Info  (* Default to Info *)
```

Operator-facing impact:

- `MASC_LOG_LEVEL=debg` (typo) silently ran at `Info`; the operator
  sees no debug lines and has no feedback that the env var was
  rejected.
- `MASC_LOG_HEARTBEAT_LEVEL=garbage` silently forced `Info` on that
  module, *tightening* the threshold rather than inheriting the
  global.

Both are the "Unknown → Permissive Default" AI-codegen anti-pattern
(ref. `memory/feedback_no-heuristic-category`).

## What

- Add `level_of_string_opt : string -> level option` — a partial
  parser that returns `None` for unrecognised input.  Exposed in
  `log.mli`.
- Reimplement `level_of_string` as a thin wrapper over
  `level_of_string_opt` (`None → Info`).  Signature unchanged; every
  existing caller keeps working.
- Upgrade two operator-facing parse sites to use `_opt` and warn on
  `None`:
  - `set_level_from_string` (called from `init_from_env` /
    `MASC_LOG_LEVEL`): emits
    `[masc_log] WARN: unrecognised log level "debg", defaulting to Info`
    to stderr.
  - `Make(M).module_level` (per-module `MASC_LOG_<NAME>_LEVEL`): emits
    a similar warning and *ignores* the override rather than forcing
    `Info`.

Direct `Printf.eprintf` (not a self-recursive `Log.error`) avoids
module-init ordering traps since the logging module is warning about
itself.

## Verification

- `dune build @check` clean.
- `test_misc_coverage` extended with partial-variant cases:
  - `level_of_string_opt "debg" = None` (sound partial on garbage).
  - `level_of_string_opt " DEBUG " = Some Debug` (trim + case insensitive).
- Existing `test_log_level_of_string` + `test_log_level_of_string_lowercase`
  preserved — back-compat intact.  Full suite: **44/44 OK**.

Net: **3 files, +55 / -12 LOC**.
