### PR TITLE
chore(dashboard): unexport 5 internal-only common/ symbols (Gen64)

### DIFF
--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -5,11 +5,11 @@ import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { SectionHeader } from './section-header'
 
-// ── Exported class constants for non-component usage ──
-export const CARD_BASE = 'card'
+// ── Class constants (CARD_STANDARD exported for inline section usage) ──
+const CARD_BASE = 'card'
 export const CARD_STANDARD = `${CARD_BASE}`
-export const CARD_LIGHT = `${CARD_BASE} !bg-transparent !backdrop-blur-none`
-export const CARD_COMPACT = `${CARD_BASE} !p-3.5 !shadow-[0_1px_2px_rgba(0,0,0,0.14)]`
+const CARD_LIGHT = `${CARD_BASE} !bg-transparent !backdrop-blur-none`
+const CARD_COMPACT = `${CARD_BASE} !p-3.5 !shadow-[0_1px_2px_rgba(0,0,0,0.14)]`
 
 type CardVariant = 'standard' | 'light' | 'compact'
 

--- a/dashboard/src/components/common/rich-content-utils.ts
+++ b/dashboard/src/components/common/rich-content-utils.ts
@@ -4,7 +4,7 @@ const STANDALONE_URL_PATTERN = /^<?(https?:\/\/\S+)>?$/
 
 const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.avif']
 
-export function isImageUrl(url: string): boolean {
+function isImageUrl(url: string): boolean {
   const normalized = url.toLowerCase()
   return IMAGE_EXTENSIONS.some(ext => normalized.endsWith(ext))
 }

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -24,7 +24,7 @@ const LABEL_STYLES = {
   warn: 'text-[var(--warn)]',
 } as const
 
-export function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
+function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
   return html`
     <div class="flex flex-col items-center gap-0.5 rounded-lg border px-4 py-3 ${VARIANT_STYLES[variant]}">
       <span class="text-base font-bold tabular-nums leading-tight">${value}</span>


### PR DESCRIPTION
## Summary

Public surface area 축소 — refs==0(external) && refs>0(internal) 인 심볼 5개에서 \`export\` 키워드만 제거. 심볼 자체와 내부 동작은 변경 없음.

| 파일 | 심볼 | 내부 사용처 |
|------|------|------------|
| \`card.ts\` | \`CARD_BASE\` | 같은 파일의 \`\${CARD_BASE}\` 문자열 보간 |
| \`card.ts\` | \`CARD_LIGHT\` | 같은 파일 \`VARIANT_CLASSES\` map |
| \`card.ts\` | \`CARD_COMPACT\` | 같은 파일 \`VARIANT_CLASSES\` map |
| \`stat-tile.ts\` | \`StatTile\` | 같은 파일 \`StatGrid\`의 items.map |
| \`rich-content-utils.ts\` | \`isImageUrl\` | 같은 파일 \`cleanUrl\` 및 markdown extractors 3곳 |

## Kept as export (외부 참조 있음)

- \`card.ts::CARD_STANDARD\` — \`ops/index.ts\`, \`ops/quick-intervene.ts\`
- \`stat-tile.ts::StatGrid\` — \`agent-profile.ts\` (cols/items 시그니처)
- \`stat-row.ts::KpiCard\`, \`StatGrid\` (이름 중복) — governance.ts 등

## Why

Public surface를 좁히면 future consumer가 \"어떤 걸 써야 하지?\" 혼란이 줄고 해당 심볼을 다른 파일로 이동/rename할 때 refactor 비용이 낮아짐. TypeScript strict에서 \`exported but unused\` 경고는 안 주지만, 의도치 않은 re-export는 bundle graph에 불필요한 엣지를 만듦.

## Verification

- \`bunx tsc --noEmit\`: green
- \`bun run build\`: green (7.53s)
- 6+/6- LOC (3 파일, 5 keyword 제거 + 1 주석 업데이트)

## Test plan

- [x] tsc strict
- [x] vite build
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)