### PR TITLE
fix(autoresearch_knowledge): expose confidence_of_string_opt and warn on typo

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -29,10 +29,30 @@ type finding = {
 let confidence_to_string = function
   | High -> "high" | Medium -> "medium" | Low -> "low"
 
-let confidence_of_string s =
+(** Partial parser for confidence labels.  Returns [None] when the input
+    does not match a known level — callers that originate from user
+    input (tool args, on-disk JSON) can distinguish "explicit medium"
+    from "garbage or stale label" instead of silently coercing both to
+    [Medium]. *)
+let confidence_of_string_opt s =
   match String.lowercase_ascii (String.trim s) with
-  | "high" -> High | "medium" -> Medium | "low" -> Low
-  | _ -> Medium
+  | "high" -> Some High
+  | "medium" -> Some Medium
+  | "low" -> Some Low
+  | _ -> None
+
+(** Total parser kept for backward compatibility.  Falls back to
+    [Medium] on unrecognised input and writes a one-line warning to
+    stderr so operator typos (e.g. [confidence=hihg]) or data drift
+    in stored findings surface instead of silently collapsing. *)
+let confidence_of_string s =
+  match confidence_of_string_opt s with
+  | Some c -> c
+  | None ->
+    Printf.eprintf
+      "[autoresearch] WARN: unrecognised confidence %S, defaulting to medium\n%!"
+      s;
+    Medium
 
 let finding_to_yojson (f : finding) : Yojson.Safe.t =
   `Assoc [


### PR DESCRIPTION
## Why

Sibling to #8142.  `Autoresearch_knowledge.confidence_of_string`
silently collapsed any unrecognised label to `Medium` via the same
`_ -> Medium` anti-pattern.  Two call sites feed user-sourced strings
into it:

- `finding_of_yojson` (on-disk finding reload) — corrupted stored
  `"confidence"` became `Medium`, masking data drift.
- `tool_autoresearch.ml:451` (MCP tool handler) — a typo like
  `confidence: "hihg"` silently collapsed, losing caller intent.

## What

- Add `confidence_of_string_opt : string -> confidence option` — a
  sound partial parser returning `None` on unrecognised input.
  `autoresearch_knowledge.ml` has no `.mli`, so the new top-level
  binding is implicitly public.
- Keep `confidence_of_string` total for back-compat.  It now
  delegates to `_opt` and, when falling through to `Medium`, emits:

  ```
  [autoresearch] WARN: unrecognised confidence "hihg", defaulting to medium
  ```

Both current callers handle user input, so warning inside the total
parser covers every drift case without touching caller code.

## Verification

- `dune build @check` clean.
- `test_autoresearch_knowledge` → **3/3 OK** (finding JSON round-trip
  exercises the parser path).

Net: **1 file, +23 / -3 LOC**.
