### PR TITLE
chore(config): route MASC_HTTP_HOST default through masc_http_default_host SSOT

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -63,7 +63,8 @@ let server_entries =
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";
     entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
-    entry ~default:"127.0.0.1" "MASC_HTTP_HOST" "HTTP server listen host";
+    entry ~default:Masc_network_defaults.masc_http_default_host
+      "MASC_HTTP_HOST" "HTTP server listen host";
     entry ~default:"128" "MASC_HTTP_MAX_CONNECTIONS" "HTTP server max connections";
   ]
 

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -15,7 +15,10 @@ type config = {
 
 let default_config = {
   port = Env_config_core.masc_http_port_int ();
-  host = Env_config_core.get_string ~default:"127.0.0.1" "MASC_HTTP_HOST";
+  host =
+    Env_config_core.get_string
+      ~default:Masc_network_defaults.masc_http_default_host
+      "MASC_HTTP_HOST";
   max_connections = Env_config_core.get_int ~default:128 "MASC_HTTP_MAX_CONNECTIONS";
 }
 

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -51,7 +51,7 @@ let is_canonical_loopback_alias host =
 let normalize_advertised_host host =
   let trimmed = String.trim host in
   if is_unspecified_host trimmed || is_canonical_loopback_alias trimmed then
-    "127.0.0.1"
+    Masc_network_defaults.masc_http_default_host
   else
     trimmed
 


### PR DESCRIPTION
## Why

Three sites carried the literal `"127.0.0.1"` as the `MASC_HTTP_HOST`
default while `Masc_network_defaults.masc_http_default_host` already
defined it as the SSOT.  Changing the bind-host default in one place
should propagate everywhere; the literals made that a silent drift
vector and produced an inconsistent operator surface.

## What

- `lib/transport_read_model.ml` — `normalize_advertised_host` now
  rewrites unspecified/loopback hosts to
  `Masc_network_defaults.masc_http_default_host` instead of the
  inline literal.
- `lib/config/env_config_snapshot.ml` — the operator-facing env
  snapshot surfaces the SSOT instead of its own literal.
- `lib/http_server_eio.ml` — `default_config.host` reads from the
  SSOT via `Env_config_core.get_string ~default:...`.

`VOICE_MCP_HOST` in `env_config_runtime.ml` uses a different service
boundary and is intentionally untouched.

## Verification

- `dune build @check` clean.
- `test_transport_read_model` → **9/9 OK** (includes
  `normalize ipv6 loopback` + `preserve noncanonical 127 alias`).
- `test_http_server_eio` → **25/25 OK**.
- `test_env_config_coverage` → **70/70 OK**.

Net: **3 files, +7 / -3 LOC**.
