### PR TITLE
chore(dashboard): unexport 6 internal-only tool-call-shared symbols (Gen65)

### DIFF
--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -5,8 +5,8 @@ import { truncate } from '../lib/truncate'
 
 // ── Constants ────────────────────────────────────────────
 
-export const DURATION_FAST_MS = 500
-export const DURATION_SLOW_MS = 2000
+const DURATION_FAST_MS = 500
+const DURATION_SLOW_MS = 2000
 
 const ARGS_PREVIEW_MAX_CHARS = 80
 const ARGS_VALUE_MAX_CHARS = 30
@@ -15,14 +15,14 @@ const ARGS_MAX_KEYS = 3
 // ── Tool categories ─────────────────────────────────────
 // Order matters: first match wins. More specific patterns before general ones.
 
-export type ToolCategoryEntry = {
+type ToolCategoryEntry = {
   match: (n: string) => boolean
   icon: string
   color: string
   label: string
 }
 
-export const TOOL_CATEGORIES: ToolCategoryEntry[] = [
+const TOOL_CATEGORIES: ToolCategoryEntry[] = [
   // Shell / Bash — execution tools
   { match: n => n.includes('bash') || n.includes('shell'),
     icon: '>', color: 'text-[var(--ok)]', label: 'shell' },
@@ -63,11 +63,11 @@ export const TOOL_CATEGORIES: ToolCategoryEntry[] = [
   { match: n => n.includes('read'),
     icon: 'R', color: 'text-[#60a5fa]', label: 'read' },
 ]
-export const DEFAULT_TOOL_STYLE: Omit<ToolCategoryEntry, 'match'> = { icon: 'T', color: 'text-[#94a3b8]', label: 'tool' }
+const DEFAULT_TOOL_STYLE: Omit<ToolCategoryEntry, 'match'> = { icon: 'T', color: 'text-[#94a3b8]', label: 'tool' }
 
 // ── Functions ───────────────────────────────────────────
 
-export type ToolCategoryResult = { icon: string; color: string; label: string }
+type ToolCategoryResult = { icon: string; color: string; label: string }
 
 export function toolCategory(name: string): ToolCategoryResult {
   const found = TOOL_CATEGORIES.find(c => c.match(name))


### PR DESCRIPTION
## Summary

\`tool-call-shared.ts\`의 6개 심볼이 외부 참조 0건, 내부 참조만. Gen64와 동일 패턴으로 \`export\` 키워드만 제거 (심볼 유지).

| 심볼 | 내부 사용처 |
|------|------------|
| \`DURATION_FAST_MS\` | \`durationColor()\` (line 101) |
| \`DURATION_SLOW_MS\` | \`durationColor()\` (line 102) |
| \`ToolCategoryEntry\` (type) | \`TOOL_CATEGORIES\`, \`DEFAULT_TOOL_STYLE\` |
| \`TOOL_CATEGORIES\` | \`toolCategory()\` (line 73) |
| \`DEFAULT_TOOL_STYLE\` | \`toolCategory()\` fallback (line 74) |
| \`ToolCategoryResult\` (type) | \`toolCategory()\` 반환 타입 |

## Kept as export

외부 consumer가 실제로 쓰는 함수들:
- \`toolCategory\`, \`formatDuration\`, \`durationColor\`, \`formatArgs\`, \`summarizeEntries\`, \`prettyArgs\`

External imports (8 파일): keeper-tool-telemetry, tool-metrics, logs, keeper-tool-call-inspector, agent-detail-timeline, session-trace/session-trace-entry, keeper-detail-runtime, tool-call-shared.test.

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest tool-call-shared.test.ts\`: 38/38 pass
- \`bun run build\`: green (7.65s)
- +6/-6 LOC (단일 파일, 6 keyword 제거)

## Test plan

- [x] tsc strict
- [x] tool-call-shared 전체 테스트
- [x] vite build
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)