### PR TITLE
chore(config): route Vite dev port through vite_dev_default_port SSOT

### DIFF
--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -97,6 +97,21 @@ let is_loopback_host_opt = function
   | Some host -> is_loopback_host host
   | None -> false
 
+(** Default port for the dashboard's Vite dev server.  Used by
+    [Server_auth.default_loopback_dev_mutation_origins] to whitelist
+    the frontend dev origin on each loopback variant. *)
+let vite_dev_default_port = 5173
+
+(** Loopback dev-server origins for the Vite frontend on
+    {!vite_dev_default_port}.  Ordered [127.0.0.1 → localhost → ::1]
+    to match the historical CORS allowlist. *)
+let vite_dev_default_origins =
+  [
+    Printf.sprintf "http://127.0.0.1:%d" vite_dev_default_port;
+    Printf.sprintf "http://localhost:%d" vite_dev_default_port;
+    Printf.sprintf "http://[::1]:%d" vite_dev_default_port;
+  ]
+
 (** Default port for SearXNG local search. *)
 let searxng_default_port = 8888
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -187,11 +187,7 @@ let allow_anonymous_mutations =
   | _ -> false
 
 let default_loopback_dev_mutation_origins =
-  [
-    "http://127.0.0.1:5173";
-    "http://localhost:5173";
-    "http://[::1]:5173";
-  ]
+  Masc_network_defaults.vite_dev_default_origins
 
 let configured_loopback_dev_mutation_origins () =
   match Sys.getenv_opt "MASC_HTTP_DEV_MUTATION_ORIGINS" with


### PR DESCRIPTION
## Why

`Server_auth.default_loopback_dev_mutation_origins` hardcoded the
Vite frontend dev port (5173) as three separate string literals —
one for each loopback variant:

```ocaml
let default_loopback_dev_mutation_origins = [
  "http://127.0.0.1:5173";
  "http://localhost:5173";
  "http://[::1]:5173";
]
```

Changing the Vite port (or adding a new loopback variant) would have
required hand-editing every literal with nothing structural catching
drift.  Same class of hardcoded-scatter anti-pattern #8125, #8128,
#8137, #8145 addressed.

## What

- Add `vite_dev_default_port = 5173` + `vite_dev_default_origins` to
  `lib/config/masc_network_defaults.ml`.  The origin list is derived
  via `Printf.sprintf "http://...:%d" vite_dev_default_port`, so the
  port value lives in a single place.
- `Server_auth.default_loopback_dev_mutation_origins` now aliases the
  SSOT list directly.

The trailing doc comment in `server_auth.ml:236` (`flow (5173 →
backend)`) is prose context, not a code reference — left as-is.

## Verification

- `dune build @check` clean.
- `test_auth_coverage` → **86/86 OK** (exercises tunnel/generic
  connector auth + origin checks).
- `test_ci_hardening_source` → **33/33 OK** (scans
  `server_auth.ml` for required symbols + contracts).
- `rg "5173" lib/ -tml` → only the SSOT definition and an unrelated
  doc-comment reference remain.

Net: **2 files, +16 / -5 LOC**.
