### PR TITLE
chore(dashboard): unexport 2 internal-only governance helpers (Gen66)

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -121,7 +121,7 @@ function JudgeStatusBar() {
   `
 }
 
-export function judgmentsEmptyStateMessage(): { message: string; tone: 'warn' | 'default' } {
+function judgmentsEmptyStateMessage(): { message: string; tone: 'warn' | 'default' } {
   const judge = governanceData.value?.judge
   const summary = governanceData.value?.summary
   const lastError = judge?.last_error?.trim()
@@ -329,7 +329,7 @@ function KeeperApprovalEmptyState() {
   `
 }
 
-export function keeperHitlEmptyContext(): {
+function keeperHitlEmptyContext(): {
   primary: string
   secondary: string | null
   lastActivity: string | null


### PR DESCRIPTION
## Summary

\`governance.ts\`의 두 helper 함수는 자기 파일 내부에서만 호출됨. Gen64/65 패턴과 동일하게 \`export\` 키워드만 제거.

| 심볼 | 정의 | 내부 호출 |
|------|------|----------|
| \`judgmentsEmptyStateMessage\` | line 124 | line 147 (LiveJudgeJudgmentsList empty state) |
| \`keeperHitlEmptyContext\` | line 332 | line 306 (KeeperApprovalEmptyState) |

외부 참조 0건 (governance.test.ts 포함 어떤 파일도 import 안 함).

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest governance.test.ts\`: 18/18 pass
- +2/-2 LOC (1 파일, 2 keyword 제거)

## Test plan

- [x] tsc strict
- [x] governance 18 tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)