### PR TITLE
chore(dashboard): unexport 4 internal-only goals/ symbols (Gen67)

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -8,10 +8,10 @@ import type { Goal, Task } from '../../types'
 
 // -- Filter state ------------------------------------------------
 
-export type HorizonFilter = 'all' | 'short' | 'mid' | 'long'
+type HorizonFilter = 'all' | 'short' | 'mid' | 'long'
 export type StatusFilter = 'all' | 'active' | 'completed' | 'paused'
 
-export const horizonFilter = signal<HorizonFilter>('all')
+const horizonFilter = signal<HorizonFilter>('all')
 export const statusFilter = signal<StatusFilter>('all')
 
 // -- Task-level search (case-insensitive, title + description + assignee) --
@@ -51,7 +51,7 @@ export function toggleTaskExpand(id: string) {
 
 // -- Derived data ------------------------------------------------
 
-export const filteredGoals = computed(() => {
+const filteredGoals = computed(() => {
   let list = goals.value
   if (horizonFilter.value !== 'all') {
     list = list.filter(g => g.horizon === horizonFilter.value)

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -71,7 +71,7 @@ function taskLink(task: Task): { href: string; label: string } {
   }
 }
 
-export function KanbanCard({ task }: { task: Task }) {
+function KanbanCard({ task }: { task: Task }) {
   const p = task.priority ?? 4
   const isExpanded = expandedTasks.value.has(task.id)
   const hasDescription = Boolean(task.description)


### PR DESCRIPTION
## Summary

\`components/goals/\` 하위 4개 심볼이 자기 파일 내부에서만 참조됨. Gen64-66 패턴과 동일하게 \`export\` 키워드만 제거.

| 파일 | 심볼 | 내부 사용처 |
|------|------|------------|
| \`goal-helpers.ts\` | \`HorizonFilter\` (type) | \`signal<HorizonFilter>\` generic 인자 |
| \`goal-helpers.ts\` | \`horizonFilter\` (signal) | \`filteredGoals\` / \`groupedByHorizon\` computeds |
| \`goal-helpers.ts\` | \`filteredGoals\` (computed) | \`groupedByHorizon\` computed의 source |
| \`kanban-components.ts\` | \`KanbanCard\` (component) | 같은 파일 \`TaskBacklog\`에서 3 JSX call sites |

## Kept as export

- \`StatusFilter\`, \`statusFilter\`, \`taskSearchQuery\`, \`resetTaskSearch\`, \`filterTasksByQuery\`, \`expandedTasks\`, \`toggleTaskExpand\`, \`groupedByHorizon\` 등 (외부 참조 있음)

## Note on signals

signal/computed는 외부에서 subscribe 가능하므로 unexport 전 \`rg\`로 확인:
- \`horizonFilter\` — goal-helpers.ts 외부 참조 0건
- \`filteredGoals\` — goal-helpers.ts 외부 참조 0건

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/goals/\`: 82/82 pass (5 test files)
- +4/-4 LOC (2 파일, 4 keyword 제거)

## Test plan

- [x] tsc strict
- [x] goals 전체 (82 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)