### PR TITLE
chore(dashboard): unexport 3 internal-only observatory interfaces (Gen68)

### DIFF
--- a/dashboard/src/components/observatory/anomaly-utils.ts
+++ b/dashboard/src/components/observatory/anomaly-utils.ts
@@ -6,7 +6,7 @@
 
 import type { ToolQualityHourlyPoint } from '../../api/dashboard'
 
-export interface AnomalyResult {
+interface AnomalyResult {
   point: ToolQualityHourlyPoint
   ts: number
   zScore: number

--- a/dashboard/src/components/observatory/cursor-store.ts
+++ b/dashboard/src/components/observatory/cursor-store.ts
@@ -4,7 +4,7 @@
 
 import { signal, type Signal } from '@preact/signals'
 
-export interface CursorPosition {
+interface CursorPosition {
   /** Cursor's time in ms since epoch. */
   ts: number
   /** Normalized x position within track (0.0 - 1.0). */

--- a/dashboard/src/components/observatory/observatory-utils.ts
+++ b/dashboard/src/components/observatory/observatory-utils.ts
@@ -25,7 +25,7 @@ export function isToolCall(entry: TelemetryEntry): boolean {
   return src === 'tool_call_io' || src === 'tool_usage'
 }
 
-export interface TelemetryMarkerBucket {
+interface TelemetryMarkerBucket {
   entry: TelemetryEntry
   ts: number
   count: number


### PR DESCRIPTION
## Summary

\`components/observatory/\` 하위 3개 interface가 각각 자기 파일 return/parameter 타입으로만 사용됨. Gen64-67 패턴 계속.

| 파일 | 심볼 | 내부 사용처 |
|------|------|------------|
| \`cursor-store.ts\` | \`CursorPosition\` | \`Signal<CursorPosition \\| null>\` 타입 변수 (같은 파일) |
| \`anomaly-utils.ts\` | \`AnomalyResult\` | \`detectAnomalies()\` 반환 타입 (같은 파일) |
| \`observatory-utils.ts\` | \`TelemetryMarkerBucket\` | 함수 반환 + \`Map<number, _>\` generic (같은 파일) |

## Why kept as unexport (not deleted)

세 interface 모두 내부 타입 주석에서 **명시적 사용** 중이라 삭제하면 `Signal<{...}>`, `{...}[]` 같은 inline object type literal로 회귀. 가독성 저하. export만 제거.

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/observatory/\`: 11/11 pass (3 test files)
- +3/-3 LOC (3 파일, 3 keyword 제거)

## Test plan

- [x] tsc strict
- [x] observatory 전체 (11 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)