### PR TITLE
fix(oas_worker): propagate approval/slot_id/summarizer/priority on resume

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -505,6 +505,7 @@ let resume_from_checkpoint
     yield_on_tool = config.yield_on_tool;
     context_compact_ratio = config.compact_ratio;
     priority = config.priority;
+    exit_condition = config.exit_condition;
   } in
   let tool_names =
     List.map (fun (t : Oas.Tool.t) -> t.schema.name) config.tools in
@@ -516,6 +517,13 @@ let resume_from_checkpoint
           if tool_names <> [] then Oas.Guardrails.AllowList tool_names
           else Oas.Guardrails.AllowAll }
   in
+  (* Parity with [build]: every Agent.options field that [build] threads
+     from [config] via the Builder must also be threaded here. Missing
+     fields cause silent behavioral drift on resume — e.g. dropping
+     [approval] makes OAS log "ApprovalRequired but no approval callback
+     — executing" on the first ApprovalRequired tool, dropping
+     [summarizer] leaks raw STATE blocks into compaction, dropping
+     [slot_id] desyncs admission queue accounting. *)
   let options : Oas.Agent.options = {
     Oas.Agent.default_options with
     provider = Some config.provider;
@@ -530,6 +538,10 @@ let resume_from_checkpoint
     tool_retry_policy = config.tool_retry_policy;
     allowed_paths = config.allowed_paths;
     description = config.description;
+    approval = config.approval;
+    slot_id = config.slot_id;
+    summarizer = config.summarizer;
+    priority = config.priority;
   } in
   match non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg with
   | Error _ as e -> e

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -707,6 +707,127 @@ let test_oas_worker_exec_build_applies_priority () =
       Oas.Agent.close agent
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
+(* Resume parity: fields that [build] threads from [config] via the
+   Builder must also propagate through [resume_from_checkpoint]. Each
+   missing field used to fail silently — the run continued with
+   [default_options.<field>] (= [None]). The [approval] regression was
+   the loud signal: OAS logged "ApprovalRequired but no approval
+   callback — executing" on the first ApprovalRequired tool of a
+   resumed keeper. *)
+
+let test_resume_propagates_approval () =
+  let approval_called = ref false in
+  let approval : Oas.Hooks.approval_callback =
+    fun ~tool_name:_ ~input:_ ->
+      approval_called := true;
+      Oas.Hooks.Approve
+  in
+  let base_config =
+    Oas_worker_exec.default_config
+      ~name:"resume-approval"
+      ~provider_cfg:(make_local_provider_cfg ())
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  let config = { base_config with approval = Some approval } in
+  let checkpoint = make_checkpoint () in
+  Eio.Switch.run @@ fun sw ->
+  match
+    Oas_worker_exec.resume_from_checkpoint
+      ~sw ~net:(require_test_net ()) ~config ~checkpoint
+  with
+  | Ok agent ->
+      let approval_opt = (Oas.Agent.options agent).approval in
+      Alcotest.(check bool) "approval is propagated through resume" true
+        (Option.is_some approval_opt);
+      (match approval_opt with
+       | Some cb ->
+           let _ = cb ~tool_name:"x" ~input:`Null in
+           Alcotest.(check bool) "callback identity preserved" true
+             !approval_called
+       | None -> ());
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resume_propagates_slot_id () =
+  let base_config =
+    Oas_worker_exec.default_config
+      ~name:"resume-slot-id"
+      ~provider_cfg:(make_local_provider_cfg ())
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  let config = { base_config with slot_id = Some 7 } in
+  let checkpoint = make_checkpoint () in
+  Eio.Switch.run @@ fun sw ->
+  match
+    Oas_worker_exec.resume_from_checkpoint
+      ~sw ~net:(require_test_net ()) ~config ~checkpoint
+  with
+  | Ok agent ->
+      let slot = (Oas.Agent.options agent).slot_id in
+      Alcotest.(check (option int)) "slot_id is propagated" (Some 7) slot;
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resume_propagates_summarizer () =
+  let summarizer_called = ref false in
+  let summarizer (_msgs : Oas.Types.message list) =
+    summarizer_called := true;
+    "summary"
+  in
+  let base_config =
+    Oas_worker_exec.default_config
+      ~name:"resume-summarizer"
+      ~provider_cfg:(make_local_provider_cfg ())
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  let config = { base_config with summarizer = Some summarizer } in
+  let checkpoint = make_checkpoint () in
+  Eio.Switch.run @@ fun sw ->
+  match
+    Oas_worker_exec.resume_from_checkpoint
+      ~sw ~net:(require_test_net ()) ~config ~checkpoint
+  with
+  | Ok agent ->
+      let s = (Oas.Agent.options agent).summarizer in
+      Alcotest.(check bool) "summarizer is propagated" true (Option.is_some s);
+      (match s with
+       | Some f ->
+           let _ = f [] in
+           Alcotest.(check bool) "summarizer identity preserved" true
+             !summarizer_called
+       | None -> ());
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resume_propagates_priority () =
+  let base_config =
+    Oas_worker_exec.default_config
+      ~name:"resume-priority"
+      ~provider_cfg:(make_local_provider_cfg ())
+      ~system_prompt:"system"
+      ~tools:[ make_noop_tool () ]
+  in
+  let config =
+    { base_config with priority = Some Llm_provider.Request_priority.Proactive }
+  in
+  let checkpoint = make_checkpoint () in
+  Eio.Switch.run @@ fun sw ->
+  match
+    Oas_worker_exec.resume_from_checkpoint
+      ~sw ~net:(require_test_net ()) ~config ~checkpoint
+  with
+  | Ok agent ->
+      let priority = (Oas.Agent.state agent).config.priority in
+      Alcotest.(check bool) "priority propagated through resume" true
+        (match priority with
+         | Some Llm_provider.Request_priority.Proactive -> true
+         | _ -> false);
+      Oas.Agent.close agent
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
 let test_resolve_provider_of_label_rejects_invalid_explicit_label () =
   match Oas_worker_exec.resolve_provider_config_of_label "not-a-model-label" with
   | Ok _ ->
@@ -1928,6 +2049,14 @@ let () =
         test_oas_worker_exec_build_default_priority_unset;
       Alcotest.test_case "oas_worker applies explicit priority" `Quick
         test_oas_worker_exec_build_applies_priority;
+      Alcotest.test_case "resume propagates approval (no silent ApprovalRequired drift)" `Quick
+        test_resume_propagates_approval;
+      Alcotest.test_case "resume propagates slot_id" `Quick
+        test_resume_propagates_slot_id;
+      Alcotest.test_case "resume propagates summarizer" `Quick
+        test_resume_propagates_summarizer;
+      Alcotest.test_case "resume propagates priority" `Quick
+        test_resume_propagates_priority;
       Alcotest.test_case "invalid explicit model label is rejected" `Quick
         test_resolve_provider_of_label_rejects_invalid_explicit_label;
       Alcotest.test_case "run_model_with_masc_tools rejects invalid explicit model label" `Quick


### PR DESCRIPTION
## Why

Resumed keeper runs were silently fail-opening governance approval. Logs showed:

```
[ERROR] [oas:agent_tools] ApprovalRequired but no approval callback — executing agent=oas-keeper_unified
[INFO]  [Keeper] keeper:janitor tool_call tool=keeper_board_delete params=[post_id] outcome=ok
```

\`oas_log_bridge.ml\` promotes that WARN→ERROR, so every keeper that resumed from checkpoint and then called an \`ApprovalRequired\` tool was bypassing HITL with a noisy fail-open.

## Root cause

\`lib/oas_worker_exec.ml::resume_from_checkpoint\` built \`Oas.Agent.options\` directly via \`{ default_options with … }\` and dropped four fields that the fresh-build path threads via the Builder:

| field | impact when dropped |
|---|---|
| \`approval\` | OAS warns + fail-opens on \`ApprovalRequired\` tools |
| \`slot_id\` | Admission queue / concurrency accounting desync |
| \`summarizer\` | \`Keeper_summarizer\` lost — raw \`[STATE]\` blocks leak into compaction |
| \`priority\` | Request priority not honored on resumed turn |

Plus \`exit_condition\` was missing from the resume \`agent_config\` — keepers don't currently use it (mutation_boundary commit removed it), but parity matters for OAS-side opt-in callers.

OCaml's \`{ record with field = … }\` syntax happily ignores fields you forget to mention — there's no compile-time check forcing the resume options builder to track new \`build\` Builder steps. That's the structural reason this drifted.

## Patch

Adds the missing fields to \`resume_from_checkpoint\` and threads \`exit_condition\` into \`agent_config\`. No behavioral change to fresh-build path.

## Tests

Four \`resume_config\` Alcotest cases (\`test/test_oas_worker.ml\`):

- \`resume propagates approval (no silent ApprovalRequired drift)\` — verifies callback identity by invoking the recovered callback after resume.
- \`resume propagates slot_id\` — \`Some 7\` round-trip.
- \`resume propagates summarizer\` — verifies callback identity by invoking the summarizer after resume.
- \`resume propagates priority\` — \`Proactive\` propagated into \`agent_state.config.priority\`.

\`dune build --root .\` + \`dune test --root . test/test_oas_worker.exe\` — all 4 new cases pass alongside existing 14 \`resume_config\` cases. (Pre-existing \`keeper_tool_matrix\` team-memory failures are unrelated to this diff.)

## Why no fresh PR for the structural issue

A follow-up could refactor \`resume_from_checkpoint\` to share the same Builder pipeline as \`build\`, which would make this category of drift impossible. Filing as a separate concern — this PR is the surgical fix for the production bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)