### PR TITLE
feat(rfc-v5-A3): approval_policy + exec_gate skeleton — Capability to Verdict to gate

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -1,0 +1,94 @@
+(* A3 approval_policy — pure decide (Capability.t list -> Verdict.t).
+
+   Fail-closed: the rule cascade never produces [Allow] on an unknown
+   construct.  [Ask] is always the default bucket when no explicit
+   rule has fired. *)
+
+type t = {
+  raw_source : string;
+  summary : string;
+}
+
+(* Scan the cap list for a Destructive git op.  Returned first because
+   it short-circuits the policy — the approval UI cannot "yes" its way
+   past this one. *)
+let find_destructive_git (caps : Capability.t list) : Git_op.t option =
+  let rec scan = function
+    | [] -> None
+    | Capability.Git (Git_op.Destructive _ as g) :: _ -> Some g
+    | Capability.Pipeline_fold inner :: rest ->
+      (match scan inner with
+       | Some _ as found -> found
+       | None -> scan rest)
+    | _ :: rest -> scan rest
+  in
+  scan caps
+
+(* Scan for a Write_path that escapes the worktree.  Returned next
+   because write-outside is the "is this supposed to touch the host?"
+   smell. *)
+let find_write_escape (caps : Capability.t list) : Path_scope.t option =
+  let escapes (ps : Path_scope.t) : bool =
+    match Path_scope.scope ps with
+    | Outside_worktree _ | Absolute_unknown _ -> true
+    | Inside_worktree _ | Inside_sandbox _ -> false
+  in
+  let rec scan = function
+    | [] -> None
+    | Capability.Write_path (ps, _) :: _ when escapes ps -> Some ps
+    | Capability.Pipeline_fold inner :: rest ->
+      (match scan inner with
+       | Some _ as found -> found
+       | None -> scan rest)
+    | _ :: rest -> scan rest
+  in
+  scan caps
+
+(* Highest bin risk observed in the full cap tree. *)
+let max_risk (caps : Capability.t list) : Bin.risk_class =
+  let bump (acc : Bin.risk_class) (r : Bin.risk_class) : Bin.risk_class =
+    match acc, r with
+    | `Privileged, _ | _, `Privileged -> `Privileged
+    | `Audited, _ | _, `Audited -> `Audited
+    | `Safe, `Safe -> `Safe
+  in
+  let rec scan acc = function
+    | [] -> acc
+    | Capability.Exec_bin (b, _) :: rest ->
+      scan (bump acc (Bin.risk_class b)) rest
+    | Capability.Git _ :: rest ->
+      (* git is Audited by vocabulary; already classified through
+         Bin above for the Exec_bin fallback path.  Kept explicit
+         here so a future refactor of Git_op doesn't lose the risk
+         contribution. *)
+      scan (bump acc `Audited) rest
+    | Capability.Pipeline_fold inner :: rest ->
+      scan (bump (scan acc inner) `Safe) rest
+    | (Capability.Read_path _ | Capability.Write_path _
+      | Capability.Env_set _) :: rest ->
+      scan acc rest
+  in
+  scan `Safe caps
+
+let ask_of policy ~caps ~bin : Verdict.t =
+  Verdict.Ask
+    {
+      caps;
+      summary = policy.summary;
+      bin;
+      raw_source = policy.raw_source;
+    }
+
+let decide (policy : t) ~(caps : Capability.t list)
+    ~(simple : Shell_ir.simple) : Verdict.t =
+  match find_destructive_git caps with
+  | Some g ->
+    Verdict.Deny { caps; reason = Destructive_git g }
+  | None ->
+    match find_write_escape caps with
+    | Some ps ->
+      Verdict.Deny { caps; reason = Path_escape ps }
+    | None ->
+      match max_risk caps with
+      | `Privileged | `Audited -> ask_of policy ~caps ~bin:simple.bin
+      | `Safe -> Verdict.Allow (Verdict.trust ~caps simple)

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -1,0 +1,33 @@
+(** A3 — pure decide function from a walked capability list to a
+    three-way [Verdict.t].
+
+    The policy is intentionally conservative (fail-closed).  Any
+    capability it does not recognise maps to [Ask], never to [Allow].
+
+    [decide] is the {i only} call site that may mint a
+    [Verdict.Trusted_argv.t] (via [Verdict.trust]).  Downstream code —
+    notably the exec gate — refuses anything that is not a
+    [Trusted_argv.t], so forgery is rejected at the type level.
+
+    This initial A3-PR-1 module ships the decision skeleton with the
+    baseline rules below.  The per-agent TOML overlay and the
+    [Approval_context.t] threading come in a follow-up PR. *)
+
+type t = {
+  raw_source : string;  (** original pre-parse string, for the Ask UI *)
+  summary : string;     (** human-readable one-liner, for the Ask UI *)
+}
+
+val decide : t -> caps:Capability.t list -> simple:Shell_ir.simple -> Verdict.t
+(** Pure policy decision.  The rule cascade (checked top to bottom):
+
+    - [Destructive] git op anywhere in the cap list → [Deny Destructive_git].
+    - [Write_path] whose scope is [Outside_worktree] or
+      [Absolute_unknown] → [Deny Path_escape].
+    - [Exec_bin] on a [Privileged] [Bin.t] (also the unknown-bin path) →
+      [Ask].
+    - [Exec_bin] on an [Audited] [Bin.t] → [Ask].
+    - Any construct we explicitly match but do not have a rule for →
+      [Ask] (never [Allow]).
+    - Otherwise (all-Safe caps under the worktree) →
+      [Allow (Verdict.trust ~caps simple)]. *)

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -1,0 +1,16 @@
+(* A3 exec_gate — single privileged entry, dispatches Verdict arms.
+
+   The Ok payload returns the Trusted_argv itself today.  A4 wires
+   this into Process_eio.run_argv_with_status and drops the 87 direct
+   call sites; at that point the Ok payload becomes the command
+   output record and this module becomes the sole invoker. *)
+
+type error =
+  [ `Ask_required of Verdict.request
+  | `Denied of Verdict.deny_reason
+  ]
+
+let run : Verdict.t -> (Verdict.Trusted_argv.t, error) result = function
+  | Verdict.Allow trusted -> Ok trusted
+  | Verdict.Ask request -> Error (`Ask_required request)
+  | Verdict.Deny { reason; _ } -> Error (`Denied reason)

--- a/lib/exec/exec_gate.mli
+++ b/lib/exec/exec_gate.mli
@@ -1,0 +1,29 @@
+(** A3 — the single privileged exec entry point.
+
+    The gate refuses any input that is not a [Verdict.Trusted_argv.t]
+    at the type level — [Verdict.Allow] is the only verdict arm that
+    carries one.  [Verdict.Ask] and [Verdict.Deny] come back as a
+    structured outcome rather than a shell invocation.
+
+    This A3-PR-1 module is a dispatcher skeleton.  The wired-through
+    call to [Process_eio.run_argv_with_status] lands in the A4 cutover
+    PRs alongside the 87-site migration; today [run] on [Allow] simply
+    reports [`Allowed] so callers can thread the surface and tests can
+    lock the shape. *)
+
+type error =
+  [ `Ask_required of Verdict.request
+  | `Denied of Verdict.deny_reason
+  ]
+(** Non-allow outcomes.  [Ask_required] carries the approval request
+    so the caller may route it through the approval queue.  [Denied]
+    is terminal — no user-approved override exists. *)
+
+val run : Verdict.t -> (Verdict.Trusted_argv.t, error) result
+(** [run verdict] dispatches on the three verdict arms.
+
+    On [Allow trusted], returns [Ok trusted].  A follow-up A4 PR wires
+    this into the single [Process_eio.run_argv_with_status] call site,
+    producing the actual command output.  Today the Ok payload is the
+    trusted argv itself so downstream tests can read [bin], [args],
+    and [redirects] through the [Trusted_argv] accessors. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,3 +1,4 @@
 (tests
- (names test_exec_types test_capability_check test_bash_parser)
+ (names test_exec_types test_capability_check test_bash_parser
+        test_approval_policy)
  (libraries masc_exec masc_exec_bash_parser))

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -1,0 +1,111 @@
+(** A3 approval_policy + exec_gate tests — policy decides, gate
+    dispatches.  Tests use [assert false] on the error arm so the
+    lib-scope ratchet on Stdlib.failwith stays green. *)
+
+open Masc_exec
+
+let bin_ok name =
+  match Bin.of_string name with
+  | Ok b -> b
+  (* bin must classify *)
+  | Error _ -> assert false
+
+let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = []) bin
+    : Shell_ir.simple =
+  { bin; args; env; cwd; redirects }
+
+let lit s = Shell_ir.Lit s
+
+let default_policy : Approval_policy.t =
+  { raw_source = "(test)"; summary = "(test summary)" }
+
+(* -- policy decide -------------------------------------------------- *)
+
+let test_safe_bin_allowed () =
+  let s = simple (bin_ok "ls") in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Allow t ->
+    assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "ls")
+  | _ -> assert false
+
+let test_privileged_bin_asks () =
+  let s = simple (bin_ok "sudo") in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Ask req ->
+    assert (Bin.to_string req.bin = "sudo")
+  | _ -> assert false
+
+let test_audited_bin_asks () =
+  let s = simple (bin_ok "git") ~args:[ lit "status" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Ask _ -> ()
+  | _ -> assert false
+
+let test_destructive_git_denies () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_force); _ } ->
+    ()
+  | _ -> assert false
+
+let test_write_outside_denies () =
+  let target = Path_scope.classify ~raw:"/etc/motd" ~cwd:"/tmp" in
+  let redir =
+    Redirect_scope.File
+      { fd = 1; target; mode = Redirect_scope.Write }
+  in
+  let s = simple (bin_ok "echo") ~redirects:[ redir ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Deny { reason = Path_escape _; _ } -> ()
+  | _ -> assert false
+
+(* -- exec_gate dispatch -------------------------------------------- *)
+
+let test_gate_allow_returns_trusted_argv () =
+  let s = simple (bin_ok "ls") in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~caps ~simple:s with
+  | Verdict.Allow _ as v ->
+    (match Exec_gate.run v with
+     | Ok t ->
+       assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "ls")
+     | Error _ -> assert false)
+  | _ -> assert false
+
+let test_gate_ask_surfaces_as_error () =
+  let s = simple (bin_ok "sudo") in
+  let caps = Capability_check.of_simple s in
+  let v = Approval_policy.decide default_policy ~caps ~simple:s in
+  match Exec_gate.run v with
+  | Error (`Ask_required _) -> ()
+  | _ -> assert false
+
+let test_gate_deny_surfaces_as_error () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  let v = Approval_policy.decide default_policy ~caps ~simple:s in
+  match Exec_gate.run v with
+  | Error (`Denied (Destructive_git _)) -> ()
+  | _ -> assert false
+
+let () =
+  test_safe_bin_allowed ();
+  test_privileged_bin_asks ();
+  test_audited_bin_asks ();
+  test_destructive_git_denies ();
+  test_write_outside_denies ();
+  test_gate_allow_returns_trusted_argv ();
+  test_gate_ask_surfaces_as_error ();
+  test_gate_deny_surfaces_as_error ();
+  print_endline "[test_approval_policy] all tests passed"


### PR DESCRIPTION
## Summary

RFC v5 Phase A3 — the policy that mints `Verdict.Trusted_argv.t` and the gate that refuses to touch anything else.

Two modules ship together because the gate's whole job is to refuse anything that is not a `Trusted_argv.t`, and the policy is the only site that can mint one (via `Verdict.trust`).

## approval_policy.decide

Pure function `Approval_policy.t -> caps:Capability.t list -> simple:Shell_ir.simple -> Verdict.t`.

Rule cascade (top to bottom, short-circuiting):

| Rank | Trigger | Verdict |
|------|---------|---------|
| 1 | `Git_op.Destructive _` anywhere in caps | `Deny Destructive_git` |
| 2 | `Write_path` with `Outside_worktree` or `Absolute_unknown` scope | `Deny Path_escape` |
| 3 | any `Privileged` or `Audited` bin risk | `Ask` |
| 4 | otherwise (all-Safe caps under the worktree) | `Allow (Verdict.trust ...)` |

`Pipeline_fold` is scanned recursively so nested Destructive/Path_escape still land on `Deny`.

## exec_gate.run

```
val run : Verdict.t -> (Verdict.Trusted_argv.t, error) result
```

- `Allow trusted` → `Ok trusted` (A4 wires this into `Process_eio.run_argv_with_status`)
- `Ask request` → `Error (Ask_required request)`
- `Deny reason` → `Error (Denied reason)`

## Test plan

- [x] `dune runtest lib/exec` green — 35/35 cumulative (A0:10 + A1:8 + A2:9 + A3:8)
- [x] 8/8 new tests pass locally
- [ ] CI Build and Test green on PR
- [ ] A4 cutover wires `Exec_gate.run` into the 87 existing `Process_eio.run_argv` sites (next PR)

Follows RFC v5 plan (docs/rfc/RFC-0005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)