### PR TITLE
chore(operator): drop dead _session_recent_event_limit constant

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -677,7 +677,6 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
-let _session_recent_event_limit = 3
 let _snapshot_session_window_seconds () =
   Dashboard_http_helpers.operator_snapshot_session_window_seconds ()
 


### PR DESCRIPTION
## Why

`_session_recent_event_limit = 3` in
`lib/operator/operator_control_snapshot.ml:680` is bound and never
referenced.

The file uses a common OCaml pattern to suppress
`unused-value-declaration` warnings on intentionally-bound side-effect
values:

```ocaml
ignore (initialized, _snapshot_session_window_seconds (), _snapshot_session_limit ());
```

The two neighbouring `_snapshot_*` functions appear in that tuple.
`_session_recent_event_limit` does **not** — it is absent from the
ignore line and has zero read sites elsewhere in `lib/` or `test/`.
Verified via `rg`:

```
rg -n "_session_recent_event_limit" lib/ test/
  → lib/operator/operator_control_snapshot.ml:680:let _session_recent_event_limit = 3
```

(single hit = definition only)

## What

Remove the one-line dead binding.  No behavioural change.

## Verification

- `dune build @check` clean.
- `test/test_operator_control.exe` builds clean (the dead binding
  never crossed a `.mli` boundary, so no downstream caller to break).

Net: **1 file, -1 LOC**.

## Scope

Intentionally narrow.  The file has 5 other `_`-prefixed top-level
symbols (`_keeper_sem`, `_snapshot_mu`, etc.) — all **actively
referenced**.  Unprefixing them is a separate concern from removing
genuinely dead code and would risk touching the warning-suppression
contract at line 913; out of scope here.
