### PR TITLE
chore(dashboard): unexport 3 internal-only matrix types (Gen69)

### DIFF
--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -27,9 +27,9 @@ import {
 } from './connector-status'
 import { openConnectorConfig } from './connector-config-form'
 
-export type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
+type MatrixCellState = 'bound' | 'unbound' | 'na' | 'unknown'
 
-export interface MatrixCell {
+interface MatrixCell {
   connectorId: KnownConnectorId
   keeperName: string
   state: MatrixCellState
@@ -57,7 +57,7 @@ export interface MatrixData {
     matrices render these as trailing chips so the operator can scan
     "this keeper's coverage" or "this connector's adoption" without
     counting cells. */
-export interface MatrixStateCounts {
+interface MatrixStateCounts {
   bound: number
   unbound: number
   na: number


### PR DESCRIPTION
## Summary

\`connector-keeper-matrix.ts\`의 3개 타입 심볼이 자기 파일 내부에서만 사용됨. Gen64-68 패턴 계속.

| 심볼 | 내부 사용처 |
|------|------------|
| \`MatrixCellState\` (type) | \`MatrixCell.state\`, state classification switch, \`CELL_TONE\`/\`CELL_GLYPH\` record keys |
| \`MatrixCell\` (interface) | \`MatrixRow.cells\`, render mapping, \`MatrixCellButton\` prop |
| \`MatrixStateCounts\` (interface) | \`summarizeMatrixRow\`/\`summarizeColumn\` 반환 타입, \`ColumnTotalsCell\` prop |

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest connector-keeper-matrix\`: 18/18 pass
- +3/-3 LOC (1 파일, 3 keyword 제거)

## Test plan

- [x] tsc strict
- [x] 18 matrix tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)