### PR TITLE
chore(dashboard): unexport 2 internal-only chat primitives (Gen70)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -5,7 +5,7 @@ import { ActionButton } from '../common/button'
 import { formatTimeHms } from '../../lib/format-time'
 import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
-export type ChatTranscriptVariant = 'default' | 'messenger'
+type ChatTranscriptVariant = 'default' | 'messenger'
 
 function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
@@ -104,7 +104,7 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
   ].filter((row): row is { label: string; value: string } => Boolean(row))
 }
 
-export function ChatMessageBubble({
+function ChatMessageBubble({
   entry,
   showMetadata = true,
   variant = 'default',


### PR DESCRIPTION
## Summary

\`components/chat/primitives.ts\`의 2개 심볼. Gen64-69 unexport 패턴 계속.

| 심볼 | 내부 사용처 |
|------|------------|
| \`ChatTranscriptVariant\` (type) | \`showDeliveryBadge\` param, \`ChatMessageBubble\` prop, \`ChatTranscript\` prop |
| \`ChatMessageBubble\` (component) | \`ChatTranscript\`의 entries.map 렌더링 (같은 파일) |

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/chat/\`: 4/4 pass
- +2/-2 LOC (1 파일, 2 keyword 제거)

## Test plan

- [x] tsc strict
- [x] chat 전체 (4 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)