### PR TITLE
feat(dashboard): surface failing providers — red border + error-first sort

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { providerTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics } from './runtime-monitor'
+import { providerTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency } from './runtime-monitor'
 import type { DashboardRuntimeProviderSnapshot, DashboardRuntimeModelMetric } from '../api/dashboard'
 
 function makeProvider(overrides: Partial<DashboardRuntimeProviderSnapshot> = {}): DashboardRuntimeProviderSnapshot {
@@ -220,5 +220,57 @@ describe('filterModelMetrics', () => {
     ]
     const result = filterModelMetrics(data, 'x:y')
     expect(result).toHaveLength(1)
+  })
+})
+
+// ── sortModelMetricsByUrgency ──
+
+describe('sortModelMetricsByUrgency', () => {
+  it('puts models with more errors first', () => {
+    const sample = [
+      makeMetric({ model_id: 'healthy', entry_count: 50, success_count: 50, error_count: 0 }),
+      makeMetric({ model_id: 'broken', entry_count: 11, success_count: 0, error_count: 11 }),
+      makeMetric({ model_id: 'flaky', entry_count: 10, success_count: 7, error_count: 3 }),
+    ]
+    const result = sortModelMetricsByUrgency(sample)
+    expect(result.map(m => m.model_id)).toEqual(['broken', 'flaky', 'healthy'])
+  })
+
+  it('breaks ties on error_count by entry_count desc', () => {
+    const sample = [
+      makeMetric({ model_id: 'idle', entry_count: 0, error_count: 0 }),
+      makeMetric({ model_id: 'busy', entry_count: 100, success_count: 100, error_count: 0 }),
+      makeMetric({ model_id: 'medium', entry_count: 20, success_count: 20, error_count: 0 }),
+    ]
+    const result = sortModelMetricsByUrgency(sample)
+    expect(result.map(m => m.model_id)).toEqual(['busy', 'medium', 'idle'])
+  })
+
+  it('falls back to model_id alpha order when everything else is equal', () => {
+    const sample = [
+      makeMetric({ model_id: 'zebra', entry_count: 5, success_count: 5, error_count: 0 }),
+      makeMetric({ model_id: 'alpha', entry_count: 5, success_count: 5, error_count: 0 }),
+    ]
+    const result = sortModelMetricsByUrgency(sample)
+    expect(result.map(m => m.model_id)).toEqual(['alpha', 'zebra'])
+  })
+
+  it('does not mutate the input array', () => {
+    const sample: readonly DashboardRuntimeModelMetric[] = [
+      makeMetric({ model_id: 'a', error_count: 0 }),
+      makeMetric({ model_id: 'b', error_count: 10 }),
+    ]
+    const before = sample.map(m => m.model_id)
+    sortModelMetricsByUrgency(sample)
+    expect(sample.map(m => m.model_id)).toEqual(before)
+  })
+
+  it('treats undefined error_count / entry_count as 0', () => {
+    const sample = [
+      makeMetric({ model_id: 'unknown' }),
+      makeMetric({ model_id: 'with-errors', error_count: 1 }),
+    ]
+    const result = sortModelMetricsByUrgency(sample)
+    expect(result.map(m => m.model_id)).toEqual(['with-errors', 'unknown'])
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -39,6 +39,27 @@ export function filterModelMetrics(
   })
 }
 
+/**
+ * Sorts model metrics so failing providers surface first. Order:
+ * 1. error_count desc (a model with 11 errors appears before one with 0)
+ * 2. entry_count desc (more-exercised models appear above idle ones)
+ * 3. model_id asc (stable tiebreaker)
+ * Returns a new array; does not mutate the input.
+ */
+export function sortModelMetricsByUrgency(
+  models: readonly DashboardRuntimeModelMetric[],
+): readonly DashboardRuntimeModelMetric[] {
+  return [...models].sort((a, b) => {
+    const ae = a.error_count ?? 0
+    const be = b.error_count ?? 0
+    if (ae !== be) return be - ae
+    const ac = a.entry_count ?? 0
+    const bc = b.entry_count ?? 0
+    if (ac !== bc) return bc - ac
+    return a.model_id.localeCompare(b.model_id)
+  })
+}
+
 interface RuntimeData {
   providers: DashboardRuntimeProvidersResponse | null
   metrics: DashboardRuntimeModelMetricsResponse | null
@@ -257,8 +278,8 @@ export function RuntimeMonitor() {
           : null}
         <div class="flex flex-col gap-3">
           ${(metrics?.models ?? []).length > 0
-            ? filterModelMetrics(metrics?.models ?? [], modelSearch.value).map(metric => html`
-                <article key=${metric.model_id} class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
+            ? sortModelMetricsByUrgency(filterModelMetrics(metrics?.models ?? [], modelSearch.value)).map(metric => html`
+                <article key=${metric.model_id} class=${`p-4 rounded-xl border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2 ${(metric.error_count ?? 0) > 0 ? 'border-[var(--status-bad)]' : 'border-card-border'}`}>
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-[13px] text-text-strong">${metric.model_id}</strong>


### PR DESCRIPTION
## Context

Today I noticed the providers runtime view (`/dashboard#monitoring?section=runtime&view=providers`) treated `success 0 / errors 11` identically to `entries 0` at the card level. Live snapshot:

```json
{"model_id": "glm-coding:glm-5-turbo", "entries": 11, "success_count": 0, "error_count": 11}
{"model_id": "claude_code:claude-haiku-4-5-20251001", "entries": 14, "success_count": 14, "error_count": 0}
```

Both rendered with the same neutral card border, and the failing card landed mid-list — so "this model is 100% broken" was not visually distinguishable from "this model hasn't run" without a close read.

## Changes

`dashboard/src/components/runtime-monitor.ts`

1. New pure function `sortModelMetricsByUrgency` — order by `error_count` desc, `entry_count` desc, `model_id` asc. Applied after `filterModelMetrics` so search results stay urgency-ordered.
2. Card `<article>` uses `border-[var(--status-bad)]` when `error_count > 0`; keeps `border-card-border` otherwise. Tailwind utility only; reuses existing `--status-bad` CSS variable.

## What this does NOT change

- `fmtSuccessRate` math stays as-is: `0/N → 0.0%` is mathematically correct. The UX disambiguation comes from the border + the existing `errors N / success 0` red text (line 317–319) + the new sort order.
- `modelMetricTone` already returns `'bad'` when success rate < 0.85, which already drives the status chip color. Not touched.

## Tests

45 cases pass (5 new). New tests cover:
- error_count priority over entry_count
- entry_count tiebreak when error counts equal
- model_id alpha fallback
- no-mutation invariant
- undefined-field handling (treats as 0)

```
RUN v4.1.4
Test Files  1 passed (1)
Tests       45 passed (45)
```

## Out of scope (followup)

- Backend `lib/model_inference_metrics.ml` exposes `last_error` / `error_reasons` in the API response schema but always returns `null` — so the dashboard cannot show *why* a provider is failing. Aggregating those from decisions.jsonl is a separate PR.
- Track A: `gemini:gemini-2.5-flash` cascade entry routes through `kind=OpenAI_compat` at runtime (log shows `HTTP 404 from openai (model=gemini-2.5-flash base_url=https://generativelanguage.googleapis.com/v1beta)`) despite `parse_model_string` and `to_provider_config` both correctly mapping to `Gemini` kind. There is a third code path I haven't yet located — tracked separately.

Generated from /loop 30m in `~/me/workspace/yousleepwhen/masc-mcp` at 2026-04-18 03:50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)