### PR TITLE
fix(verification): pass verification_id as request_id to eliminate drift

### DIFF
--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -309,8 +309,8 @@ let list_requests base_path =
 
 (** High-level API *)
 
-let create_request ~base_path ~task_id ~output ~criteria ~worker ?verifier () =
-  let id = generate_id () in
+let create_request ~base_path ~task_id ~output ~criteria ~worker ?verifier ?request_id () =
+  let id = match request_id with Some rid -> rid | None -> generate_id () in
   let req = {
     id;
     task_id;

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -69,6 +69,7 @@ val create_request :
   criteria:criterion list ->
   worker:string ->
   ?verifier:string ->
+  ?request_id:string ->
   unit ->
   (verification_request, string) result
 

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -18,7 +18,7 @@ let on_submit_for_verification ~(config : Coord.config)
      | Some c -> c.verify_gate_evidence
      | None -> []) in
   let _req =
-    Verification.create_request ~base_path ~task_id:task.id
+    Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
       ~output:(`Assoc [
         ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
         ("task_title", `String task.title);


### PR DESCRIPTION
Fixes #8117. FSM verification_id와 Verification store request_id drift 수정. create_request에 ?request_id optional param 추가. 3 files changed, 4 insertions, 3 deletions.