### PR TITLE
chore(local_runtime): route OpenAI /v1 paths through masc_network_defaults

### DIFF
--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -16,6 +16,16 @@ let nonempty_env name =
 (** Default port for Ollama (OpenAI-compatible at /v1). *)
 let ollama_default_port = 11434
 
+(** OpenAI-compatible API path suffixes.  Shared by every local-runtime
+    client/verifier/benchmark that concatenates [base_url] with a
+    well-known endpoint — anchoring the path in one place avoids drift
+    if the provider ever versions the API (e.g. [/v2/...]). *)
+let openai_chat_completions_path = "/v1/chat/completions"
+
+(** OpenAI-compatible model listing path.  See
+    {!openai_chat_completions_path}. *)
+let openai_models_path = "/v1/models"
+
 (** Default URL for Ollama. *)
 let ollama_default_url =
   Printf.sprintf "http://127.0.0.1:%d" ollama_default_port

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -17,7 +17,10 @@ let pctl percentile values =
       List.nth_opt sorted index
 
 let raw_completion_at ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec () =
-  let url = String.trim server_url ^ "/v1/chat/completions" in
+  let url =
+    String.trim server_url
+    ^ Masc_network_defaults.openai_chat_completions_path
+  in
   let request_body =
     `Assoc
       [

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -163,7 +163,9 @@ let discover_processes () =
       Error (Printf.sprintf "ps stopped by signal %d" sig_num)
 
 let fetch_models_at base_url =
-  let url = String.trim base_url ^ "/v1/models" in
+  let url =
+    String.trim base_url ^ Masc_network_defaults.openai_models_path
+  in
   let status, body =
     Process_eio.run_argv_with_status ~timeout_sec:15.0
       [ "curl"; "-sS"; "--max-time"; "10"; url ]

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -4,7 +4,9 @@ include Tool_local_runtime_core
 
 let runtime_snapshot_to_yojson ~include_models
     (snapshot : Local_runtime_pool.runtime_snapshot) =
-  let endpoint = String.trim snapshot.base_url ^ "/v1/models" in
+  let endpoint =
+    String.trim snapshot.base_url ^ Masc_network_defaults.openai_models_path
+  in
   let fetched_models =
     if not include_models then []
     else
@@ -94,7 +96,10 @@ let runtime_status_json ?(include_models = true) () =
   `Assoc
     [
       ("server_url", `String Env_config.Llama.server_url);
-      ("endpoint", `String (Env_config.Llama.server_url ^ "/v1/models"));
+      ("endpoint",
+       `String
+         (Env_config.Llama.server_url
+          ^ Masc_network_defaults.openai_models_path));
       ("source", `String "llama.cpp runtime");
       ("models", `List (List.map (fun model -> `String model) models));
       ("model_count", `Int (List.length models));

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -151,7 +151,8 @@ let probe_chat_completion_compatible
       let provider_config =
         Llm_provider.Provider_config.make
           ~kind:Llm_provider.Provider_config.OpenAI_compat
-          ~model_id ~base_url:endpoint.url ~request_path:"/v1/chat/completions"
+          ~model_id ~base_url:endpoint.url
+          ~request_path:Masc_network_defaults.openai_chat_completions_path
           ~max_tokens:1 ~temperature:Oas_worker_cascade.deterministic_temperature ()
       in
       let messages =
@@ -414,7 +415,9 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
         let provider_url = base_url ^ "/health" in
         let slot_url = base_url ^ "/slots" in
         let props_url = base_url ^ "/props" in
-        let models_url = base_url ^ "/v1/models" in
+        let models_url =
+          base_url ^ Masc_network_defaults.openai_models_path
+        in
         let provider_status, provider_body, provider_err =
           match http_get_text_with_status provider_url with
           | Ok (status_code, payload) -> (status_code, Some payload, None)
@@ -480,7 +483,9 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
           match probe_model with
           | None -> (None, None, Some "chat contract probe skipped: no model id available")
           | Some model_id ->
-              let url = base_url ^ "/v1/chat/completions" in
+              let url =
+                base_url ^ Masc_network_defaults.openai_chat_completions_path
+              in
               let body_json = chat_contract_probe_body ~model_id in
               match http_post_json_text_with_status ~timeout_sec:15 ~url ~body_json with
               | Ok (status_code, payload) -> (status_code, Some payload, None)


### PR DESCRIPTION
## Why

Six call sites across `lib/tool_local_runtime_*.ml` concatenated the
well-known OpenAI-compatible API suffixes onto a `base_url`:

| site | literal |
|---|---|
| `tool_local_runtime_status.ml:7` (endpoint label) | `"/v1/models"` |
| `tool_local_runtime_status.ml:99` (JSON snapshot) | `"/v1/models"` |
| `tool_local_runtime_core.ml:166` (`fetch_models_at`) | `"/v1/models"` |
| `tool_local_runtime_verify.ml:154` (provider_config request_path) | `"/v1/chat/completions"` |
| `tool_local_runtime_verify.ml:418` (health probe models_url) | `"/v1/models"` |
| `tool_local_runtime_verify.ml:486` (chat contract probe) | `"/v1/chat/completions"` |
| `tool_local_runtime_bench.ml:20` (`raw_completion_at`) | `"/v1/chat/completions"` |

Had the provider versioned the API to `"/v2/..."`, every site would
have needed a manual edit.  Standard hardcoded-scatter anti-pattern,
same class as #8125 / #8128 / #8137 / #8145 / #8147.

## What

- Add `openai_chat_completions_path` + `openai_models_path` to
  `lib/config/masc_network_defaults.ml` alongside the existing
  network/port SSOT constants.
- Rewrite all 6 active concatenation sites to reference the SSOT.

`cascade_config.ml:77` passes `"/v1/chat/completions"` as a **default
value** for a user-configurable `~request_path` field on the cascade
config type — that literal is a default surface rather than a
hardcoded call site, and is intentionally left alone to preserve the
config schema.

## Verification

- `dune build @check` clean.
- `rg '"/v1/(chat/completions|models)"' lib/ -tml` → only the SSOT
  definitions + the `cascade_config.ml` default remain.
- `test_tool_local_runtime_verify` → **5/5 OK** (exercises chat
  contract probe + health probe + model listing).
- `test_tool_local_runtime_probe` → **10/10 OK**.
- `test_local_runtime_pool` → **9/9 OK**.

Net: **5 files, +32 / -7 LOC**.
