### PR TITLE
fix(keeper): structured error UX for pr_not_found and path rejections

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -165,6 +165,26 @@ let absolute_allowed_paths_result ~(config : Coord.config)
   else
     Ok normalized
 
+(** Build a [path_not_in_allowed_paths] error message that teaches the LLM
+    *why* the path was rejected — not just *that* it was. Bare "X not allowed"
+    triggers retry loops; including the resolved candidate plus the
+    project-root anchor rule lets the keeper correct on the next call without
+    re-trying the same broken interpretation. See
+    [memory/feedback_tool-error-messages-teach-llm.md]. *)
+let format_path_rejection ~(raw : string) ~(resolved : string)
+    ~(allowed_norms : string list) : string =
+  let resolved_hint =
+    if Filename.is_relative raw && resolved <> raw then
+      Printf.sprintf
+        "; relative paths anchor at project root, not playground (resolved=%s)"
+        resolved
+    else
+      ""
+  in
+  Printf.sprintf
+    "path_not_in_allowed_paths: %s%s (allowed: [%s])"
+    raw resolved_hint (String.concat ", " allowed_norms)
+
 let resolve_keeper_target_path ~(config : Coord.config)
     ~(allowed_paths : string list) ~(raw_path : string)
     : (string, string) result =
@@ -202,9 +222,7 @@ let resolve_keeper_target_path ~(config : Coord.config)
       if matches_any then Ok candidate
       else
         Error
-          (Printf.sprintf
-             "path_not_in_allowed_paths: %s (allowed: [%s])"
-             raw (String.concat ", " allowed_norms))
+          (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
 
 (* Playground path SSOT lives in [Playground_paths] (masc_config). These
    names preserve the historical keeper-facing API. Do not re-implement
@@ -295,15 +313,11 @@ let resolve_keeper_read_path ~(config : Coord.config)
            | Ok (Some resolved) -> Ok resolved
            | Ok None ->
                Error
-                 (Printf.sprintf
-                    "path_not_in_allowed_paths: %s (allowed: [%s])"
-                    raw (String.concat ", " allowed_norms))
+                 (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
            | Error e -> Error e)
         else
           Error
-            (Printf.sprintf
-               "path_not_in_allowed_paths: %s (allowed: [%s])"
-               raw (String.concat ", " allowed_norms))
+            (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
       else if path_exists candidate || allows_missing_leaf_read ~raw ~candidate then
         Ok candidate
       else if Filename.is_relative raw then

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -11,6 +11,32 @@ let pr_number_of_args args =
   if from_pr <> 0 then from_pr
   else Safe_ops.json_int ~default:0 "number" args
 
+(** Detect "PR not found" in [gh] CLI output. Strings stable across [gh]
+    versions; covers both REST 404 and GraphQL "Could not resolve". When
+    matched, the keeper sees a structured error and a redirect hint instead
+    of having to parse a raw stderr blob, which avoids the "tool error
+    messages teach LLM" retry loop documented in
+    [memory/feedback_tool-error-messages-teach-llm.md]. *)
+let pr_not_found_in_output (s : string) : bool =
+  let needles = [
+    "HTTP 404: Not Found";
+    "no pull requests found";
+    "could not resolve to a pullrequest";
+    "could not resolve to a node";
+  ] in
+  let lower = String.lowercase_ascii s in
+  List.exists (fun n ->
+    let nl = String.lowercase_ascii n in
+    let len_s = String.length lower and len_n = String.length nl in
+    if len_n > len_s then false
+    else
+      let rec scan i =
+        if i + len_n > len_s then false
+        else if String.sub lower i len_n = nl then true
+        else scan (i + 1)
+      in
+      scan 0) needles
+
 let handle_keeper_pr_review_read
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -39,15 +65,26 @@ let handle_keeper_pr_review_read
       Process_eio.run_argv_with_status ~timeout_sec:15.0
         [ "/bin/zsh"; "-lc"; diff_cmd ] in
     let diff_truncated = String.length out_diff >= Common.max_tool_output_bytes in
-    Yojson.Safe.to_string
-      (`Assoc
-          [ "ok", `Bool (st_meta = Unix.WEXITED 0)
-          ; "pr_number", `Int pr_number
-          ; "metadata", `String out_meta
-          ; "diff", `String out_diff
-          ; "diff_truncated", `Bool diff_truncated
-          ; "diff_status", `Bool (st_diff = Unix.WEXITED 0)
-          ])
+    let meta_ok = (st_meta = Unix.WEXITED 0) in
+    if not meta_ok && (pr_not_found_in_output out_meta || pr_not_found_in_output out_diff) then
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String "pr_not_found"
+            ; "pr_number", `Int pr_number
+            ; "repo", `String repo
+            ; "hint", `String "PR may have been closed/deleted or the number is wrong. Use keeper_pr_list (or `gh pr list`) to see open PRs before retrying."
+            ])
+    else
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool meta_ok
+            ; "pr_number", `Int pr_number
+            ; "metadata", `String out_meta
+            ; "diff", `String out_diff
+            ; "diff_truncated", `Bool diff_truncated
+            ; "diff_status", `Bool (st_diff = Unix.WEXITED 0)
+            ])
 ;;
 
 let handle_keeper_pr_review_comment

--- a/lib/keeper/keeper_tool_pr_review.mli
+++ b/lib/keeper/keeper_tool_pr_review.mli
@@ -2,6 +2,11 @@
 
     Extracted from keeper_exec_github.ml. *)
 
+(** Detect "PR not found" markers in [gh] CLI output (REST 404 + GraphQL
+    "could not resolve"). Exposed for unit testing the parser; keepers
+    consume the structured JSON returned by [handle_keeper_pr_review_read]. *)
+val pr_not_found_in_output : string -> bool
+
 val handle_keeper_pr_review_read :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -59,6 +59,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_pr_review
         test_keeper_execution_scope
         test_playground_paths
         test_keeper_llama_only
@@ -161,6 +162,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_pr_review
           test_keeper_execution_scope
           test_playground_paths
           test_keeper_llama_only

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -206,6 +206,45 @@ let test_default_roots_use_playground_with_full_access () =
       ~allowed_paths:["*"] ~name:"keeper" () in
   check_default_roots_use_playground meta
 
+(* Error UX: rejection messages must teach the LLM why the path failed,
+   not just that it failed. The relative-path case is the common one — bare
+   "X not allowed" sends the keeper into a retry loop guessing alternatives.
+   See memory/feedback_tool-error-messages-teach-llm.md. *)
+
+let contains_substring ~haystack ~needle =
+  let h = String.length haystack and n = String.length needle in
+  if n = 0 then true
+  else if n > h then false
+  else
+    let rec scan i =
+      if i + n > h then false
+      else if String.sub haystack i n = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+
+let test_path_rejection_explains_relative_anchor () =
+  let meta = make_meta ~execution_scope:"workspace" ~name:"ani1999" () in
+  with_temp_config (fun config ->
+    match KES.resolve_keeper_path ~config ~meta ~raw_path:"repos/masc-mcp" with
+    | Ok path -> fail ("expected rejection for repos/masc-mcp, got: " ^ path)
+    | Error err ->
+      check bool "preserves machine-readable prefix" true
+        (String.starts_with ~prefix:"path_not_in_allowed_paths:" err);
+      check bool "includes relative-anchor explanation" true
+        (contains_substring ~haystack:err
+           ~needle:"relative paths anchor at project root");
+      check bool "includes resolved candidate" true
+        (contains_substring ~haystack:err ~needle:"resolved="))
+
+let test_path_rejection_omits_resolved_for_absolute () =
+  let meta = make_meta ~execution_scope:"workspace" ~name:"ani1999" () in
+  with_temp_config (fun config ->
+    match KES.resolve_keeper_path ~config ~meta
+            ~raw_path:"/etc/passwd" with
+    | Ok path -> fail ("expected absolute path rejection, got: " ^ path)
+    | Error _ -> check bool "absolute path rejected" true true)
+
 let test_resolve_keeper_path_blocks_workspace_repo_write_default () =
   let meta = make_meta ~execution_scope:"workspace" ~name:"keeper" () in
   with_temp_config (fun config ->
@@ -429,6 +468,10 @@ let () =
             test_default_roots_use_playground_with_explicit_paths;
           test_case "default roots stay in playground with full access" `Quick
             test_default_roots_use_playground_with_full_access;
+          test_case "rejection explains relative-anchor + resolved candidate" `Quick
+            test_path_rejection_explains_relative_anchor;
+          test_case "absolute path rejection still works" `Quick
+            test_path_rejection_omits_resolved_for_absolute;
           test_case "workspace repo writes blocked by default" `Quick
             test_resolve_keeper_path_blocks_workspace_repo_write_default;
           test_case "bare writes default into playground" `Quick

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -1,0 +1,50 @@
+(** Unit tests for [Keeper_tool_pr_review] error-shape helpers.
+
+    Focused on the [pr_not_found] detection that turns an opaque
+    [HTTP 404] string into a structured error keepers can act on
+    without retry loops.  Background:
+    [memory/feedback_tool-error-messages-teach-llm.md]. *)
+
+open Alcotest
+
+module KTPR = Masc_mcp.Keeper_tool_pr_review
+
+let test_detects_rest_404 () =
+  let sample =
+    "failed to run git: HTTP 404: Not Found \
+     (https://api.github.com/repos/jeong-sik/masc-mcp/pulls/8116)" in
+  check bool "REST 404 detected" true
+    (KTPR.pr_not_found_in_output sample)
+
+let test_detects_graphql_could_not_resolve () =
+  let sample =
+    "GraphQL: Could not resolve to a PullRequest with the number of 9999." in
+  check bool "GraphQL resolution failure detected" true
+    (KTPR.pr_not_found_in_output sample)
+
+let test_detects_no_pull_requests_found () =
+  check bool "gh pr list empty wording detected" true
+    (KTPR.pr_not_found_in_output "no pull requests found in this repo")
+
+let test_passes_through_unrelated_errors () =
+  check bool "rate limit not flagged" false
+    (KTPR.pr_not_found_in_output
+       "API rate limit exceeded for user (60 / 5000)");
+  check bool "auth error not flagged" false
+    (KTPR.pr_not_found_in_output
+       "HTTP 401: Unauthorized");
+  check bool "empty output not flagged" false
+    (KTPR.pr_not_found_in_output "")
+
+let () =
+  Alcotest.run "Keeper PR review error UX" [
+    "pr_not_found_in_output", [
+      test_case "REST 404 (HTTP 404: Not Found)" `Quick test_detects_rest_404;
+      test_case "GraphQL Could not resolve" `Quick
+        test_detects_graphql_could_not_resolve;
+      test_case "no pull requests found wording" `Quick
+        test_detects_no_pull_requests_found;
+      test_case "unrelated errors are not false positives" `Quick
+        test_passes_through_unrelated_errors;
+    ]
+  ]


### PR DESCRIPTION
## Why

Two recurring keeper retry-loop sources, both rooted in error messages that tell the LLM *what failed* but not *why* or *how to recover*. From the live keeper log (last 10 minutes):

\`\`\`
[Keeper] keeper:ani1999 tool_call tool=keeper_pr_review_read params=[pr_number,repo,number] outcome=error
  → ...HTTP 404: Not Found (https://api.github.com/repos/jeong-sik/masc-mcp/pulls/8116)
[Keeper] tool masc_code_search returned error result (1/3):
  {\"error\":\"path_not_in_allowed_paths: repos/masc-mcp (allowed: [...playground/ani1999, .../mind, .../repos])\"}
\`\`\`

In both cases the keeper sees the failure but not what to do next, so it retries the same dead PR number / same bare relative path on the next turn — burning tool retry budget against an immutable failure.

This pattern is documented as a memory rule: \`feedback_tool-error-messages-teach-llm.md\` (terse "X not allowed" → retry loop; informative redirect → convergence).

## What changes

### A. \`keeper_pr_review_read\` (\`lib/keeper/keeper_tool_pr_review.ml\`)

Detect \"PR not found\" markers in \`gh\` CLI output and short-circuit to a structured error instead of stuffing the raw stderr into \`metadata\` / \`diff\` strings:

\`\`\`json
{
  \"ok\": false,
  \"error\": \"pr_not_found\",
  \"pr_number\": 8116,
  \"repo\": \"jeong-sik/masc-mcp\",
  \"hint\": \"PR may have been closed/deleted or the number is wrong. Use keeper_pr_list (or \`gh pr list\`) to see open PRs before retrying.\"
}
\`\`\`

Match strings (lowercase substring): \`HTTP 404: Not Found\`, \`could not resolve to a pullrequest\`, \`could not resolve to a node\`, \`no pull requests found\`. Stable across \`gh\` versions in current use.

Happy path response shape unchanged — only the not-found branch diverts.

### B. \`resolve_keeper_target_path\` / \`resolve_keeper_read_path\` (\`lib/keeper/keeper_alerting_path.ml\`)

Centralized rejection formatter \`format_path_rejection\`. Old:

\`\`\`
path_not_in_allowed_paths: repos/masc-mcp (allowed: [...])
\`\`\`

New (relative input):

\`\`\`
path_not_in_allowed_paths: repos/masc-mcp; relative paths anchor at project root, not playground (resolved=/Users/dancer/me/repos/masc-mcp) (allowed: [...])
\`\`\`

Absolute inputs unchanged — no resolved-hint suffix when raw is already absolute.

The leading \`path_not_in_allowed_paths:\` token is preserved so root-cause classifiers (\`meta_cognition_rules\`, \`dashboard_http_tool_quality\`, \`keeper_failure_circuit_breaker\`) keep matching.

## Tests

\`test/test_keeper_pr_review.ml\` (new):
- REST 404 detected
- GraphQL \"Could not resolve\" detected
- \"no pull requests found\" wording detected
- False-positive guard (rate limit, auth error, empty)

\`test/test_keeper_allowed_paths.ml\` (added 2 cases):
- Relative-input rejection includes \`relative paths anchor at project root\` and \`resolved=\` substrings; machine-readable prefix preserved
- Absolute-input rejection still rejected (no regression in absolute path)

\`dune build --root . @check\` clean. \`test_keeper_pr_review\`: 4/4 pass. \`test_keeper_allowed_paths\`: 29/29 pass (27 existing + 2 new).

## Why no \"smarter resolution\"

Originally considered auto-resolving \`repos/masc-mcp\` against the keeper's playground prefix. Rejected: that would silently grant the keeper paths it isn't actually allowlisted for, breaking the playground sandbox invariant. The right keeper response to this error is either \"use a playground-rooted absolute path\" or \"ask operator to widen allowed_paths\" — both of which the new error message points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)