### PR TITLE
a11y(dashboard): screen reader + colorblind cues for failing provider cards

### DIFF
--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -278,8 +278,21 @@ export function RuntimeMonitor() {
           : null}
         <div class="flex flex-col gap-3">
           ${(metrics?.models ?? []).length > 0
-            ? sortModelMetricsByUrgency(filterModelMetrics(metrics?.models ?? [], modelSearch.value)).map(metric => html`
-                <article key=${metric.model_id} class=${`p-4 rounded-xl border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2 ${(metric.error_count ?? 0) > 0 ? 'border-[var(--status-bad)]' : 'border-card-border'}`}>
+            ? sortModelMetricsByUrgency(filterModelMetrics(metrics?.models ?? [], modelSearch.value)).map(metric => {
+                const isFailing = (metric.error_count ?? 0) > 0
+                const articleClass = isFailing
+                  ? 'p-4 rounded-xl border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-md shadow-sm flex flex-col gap-2'
+                  : 'p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2'
+                const ariaLabel = isFailing
+                  ? `Provider failing: ${metric.model_id}, ${metric.error_count ?? 0} errors out of ${metric.entry_count ?? 0}`
+                  : undefined
+                return html`
+                <article
+                  key=${metric.model_id}
+                  class=${articleClass}
+                  role=${isFailing ? 'alert' : undefined}
+                  aria-label=${ariaLabel}
+                >
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-[13px] text-text-strong">${metric.model_id}</strong>
@@ -375,7 +388,8 @@ export function RuntimeMonitor() {
                     `
                     : null}
                 </article>
-              `)
+              `
+              })
             : html`<${EmptyState} message="최근 model inference metrics가 없습니다." compact />`}
         </div>
       <//>


### PR DESCRIPTION
## Summary

Follow-up to merged #8158. Two reviewer feedback items are addressed here as a separate PR (original branch was already squash-merged before these changes were pushed — per workflow rules, follow-up goes in a fresh PR).

## Changes

`dashboard/src/components/runtime-monitor.ts` — failing provider cards only, healthy cards unchanged:

1. `role="alert"` on the `<article>` so assistive tech announces the state change.
2. `aria-label="Provider failing: <model_id>, <errors> errors out of <total>"` giving screen readers a concrete, human-readable summary.
3. `bg-[var(--status-bad)]/5` — subtle background tint as a second visual cue beyond border color, so users with red-green color deficiency have a secondary signal (WCAG 2.1 Success Criterion 1.4.1 "Use of Color").

No new CSS variables. Reuses `--status-bad` already used by `modelMetricTone`.

## Product impact

**P3** — operator experience improvement. failing providers remain legible for:
- Screen reader users (previously: no semantic signal, border-color invisible)
- Red-green color deficient users (previously: sole cue was border color)

## Evidence

- Tests: 45/45 pass (no new cases — the a11y attributes are declarative on the render path, covered by the existing render-smoke).
- `tsc --noEmit`: 0 errors.
- Visual check on live dashboard http://127.0.0.1:8935/dashboard#monitoring?section=runtime&view=providers pending (after merge).

## Review evidence

Reviewer comments on #8158 that motivated this PR:

> **nick0cave review** (#8158)
> Minor observation: error_count undefined handling is a safe fallback.

> **advocate review** (#8158)
> 접근성 고려: screen reader 사용자에게는 어떻게 보이는가? `<article>` 요소에 시맨틱한 속성(`aria-label` 또는 `role="alert"`)이 추가되면, screen reader가 "glm-5-turbo — 오류 발생"을 읽어줄 수 있다.

> **(auto review)**
> 적색녹색맹 사용자에게 border color 차이를 인지하기 어려울 수 있음 ... WCAG 2.1 Success Criterion 1.4.1 (Use of Color): "색상만으로 정보를 전달하지 마라"

## Linked issue

Refs #8159 (gemini cascade routing mystery — unrelated but tracked in the same /loop session).

## Out of scope

- Populating `last_error` / `error_reasons` in the backend aggregation (`lib/model_inference_metrics.ml`) — still waiting on `decisions.jsonl inference_telemetry` schema to include error text.

Generated from /loop 30m session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)