### PR TITLE
chore(dashboard): unexport 3 internal-only agent-roster helpers (Gen71)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -235,7 +235,7 @@ function matchesKeeperFilter(
   return keeperFilter === 'keeper-only' ? isKeeper : !isKeeper
 }
 
-export function scopeAgentsByKeeperFilter(
+function scopeAgentsByKeeperFilter(
   agentList: Agent[],
   keeperList: Keeper[],
   keeperBriefs: DashboardMissionKeeperBrief[],
@@ -296,7 +296,7 @@ export function mergeRosterAgent(existing: Agent | undefined, next: Agent): Agen
   }
 }
 
-export function buildAgentRoster(
+function buildAgentRoster(
   agentList: Agent[],
   keeperList: Keeper[],
   keeperBriefs: DashboardMissionKeeperBrief[],
@@ -316,7 +316,7 @@ export function buildAgentRoster(
   return Array.from(roster.values())
 }
 
-export function countAgentsByStatus(
+function countAgentsByStatus(
   agentList: Agent[],
   keeperList: Keeper[],
 ): Record<StatusFilter, number> {


### PR DESCRIPTION
## Summary

\`components/agent-roster.ts\`의 3개 helper 함수 모두 자기 파일 renderer 로직에서만 호출됨.

| 심볼 | 내부 사용 |
|------|----------|
| \`scopeAgentsByKeeperFilter\` | 4 call sites (keeper count, agent count, scoped filtering) |
| \`buildAgentRoster\` | 2 memoized useMemo call sites |
| \`countAgentsByStatus\` | 1 call site (status counts) |

## Why test still passes

\`agent-roster.test.ts\`는 이 helper들을 직접 import하지 않고 UI 렌더 레벨에서 검증 (49 tests). export 키워드만 제거해도 테스트 영향 없음.

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/agent-roster\`: 49/49 pass
- +3/-3 LOC

## Test plan

- [x] tsc strict
- [x] agent-roster 전체 (49 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)