### PR TITLE
chore(dashboard): unexport 3 internal-only session-trace helpers (Gen72)

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -23,7 +23,7 @@ export type TraceEventKind =
 
 export type TraceStatus = 'success' | 'failure' | 'gate_rejected'
 
-export type TraceSourceLane = 'masc' | 'oas'
+type TraceSourceLane = 'masc' | 'oas'
 
 export interface UnifiedTraceEvent {
   id: string
@@ -131,7 +131,7 @@ export function getTraceSearchQuery(agent: string): string {
 
 // ── Status classification ────────────────────────────────
 
-export function getEventStatus(e: UnifiedTraceEvent): TraceStatus | null {
+function getEventStatus(e: UnifiedTraceEvent): TraceStatus | null {
   if (e.gate?.status === 'reject') return 'gate_rejected'
   if (e.error) return 'failure'
   if (e.kind === 'tool_call' || e.kind === 'oas_tool') return 'success'
@@ -563,7 +563,7 @@ export function appendLiveOasEvent(
   })
 }
 
-export function appendLiveTraceEvent(agentName: string, event: UnifiedTraceEvent): void {
+function appendLiveTraceEvent(agentName: string, event: UnifiedTraceEvent): void {
   if (!traceSlots.value[agentName] && !liveTraceFeeds.value[agentName]) return
   const prev = liveTraceFeeds.value[agentName] ?? []
   const historical = traceSlots.value[agentName]?.events ?? []


### PR DESCRIPTION
## Summary

\`components/session-trace/session-trace-state.ts\`의 3개 심볼이 자기 파일 내부에서만 참조됨.

| 심볼 | 내부 사용 |
|------|----------|
| \`TraceSourceLane\` (type) | \`UnifiedTraceEvent.sourceLane\` field type |
| \`getEventStatus\` | 2 call sites (status filter, aggregate) |
| \`appendLiveTraceEvent\` | 2 call sites (live masc/oas append) |

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/session-trace/\`: 26/26 pass (2 test files)
- +3/-3 LOC

## Test plan

- [x] tsc strict
- [x] session-trace 전체 (26 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)