### PR TITLE
[codex] Restore OAS worker runtime helper execution

### DIFF
--- a/bin/masc_worker_run.ml
+++ b/bin/masc_worker_run.ml
@@ -38,6 +38,7 @@ let main_result () =
             },
           1 )
     | Ok spec ->
+        Mirage_crypto_rng_unix.use_default ();
         Eio_main.run @@ fun env ->
         Eio_guard.enable ();
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -62,9 +63,9 @@ let main_result () =
                 Eio_guard.disable ())
               (fun () ->
                 match
-                  (* Worker_run_once removed *)
-                  ignore (sw, spec);
-                  (Error "Worker_run_once removed (team session layer)" : (Lib.Worker_container.run_result, string) result)
+                  Lib.Worker_runtime.run_worker_oas ~sw
+                    ~net:(Eio.Stdenv.net env)
+                    ~room_config:None spec ()
                 with
                 | Ok run_result ->
                     ( Lib.Worker_runtime_helper_protocol.success_json run_result,

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -2,6 +2,8 @@
 
 include Worker_container
 
+let ( let* ) = Result.bind
+
 let resolve_net ?net () =
   match net with
   | Some net -> Ok net
@@ -42,12 +44,123 @@ let build_execution_spec ~base_path ~worker_name ~model_label
     timeout_sec;
   }
 
+let workspace_path_of_spec (spec : Worker_execution_spec.t) =
+  match spec.working_dir with
+  | Some dir when String.trim dir <> "" -> dir
+  | _ -> spec.base_path
+
+let effective_model_of_resume ~existing_meta spec =
+  match existing_meta with
+  | Some meta when String.trim meta.effective_model <> "" ->
+      Ok meta.effective_model
+  | _ ->
+      resolve_oas_provider_of_label spec.Worker_execution_spec.model_label
+      |> Result.map snd
+
+let filter_tools_by_name names (tools : Oas.Tool.t list) =
+  match unique_preserve_order names with
+  | [] -> tools
+  | allowed ->
+      List.filter
+        (fun (tool : Oas.Tool.t) -> List.mem tool.schema.name allowed)
+        tools
+
+let dedupe_tools_by_name (tools : Oas.Tool.t list) =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | ((tool : Oas.Tool.t) :: rest) ->
+        if List.mem tool.schema.name seen then
+          loop seen acc rest
+        else
+          loop (tool.schema.name :: seen) (tool :: acc) rest
+  in
+  loop [] [] tools
+
+let create_raw_trace ~base_path ~worker_name =
+  try
+    ensure_worker_container_dirs ~base_path ~worker_name;
+    match
+      Oas.Raw_trace.create
+        ~path:(worker_raw_trace_path ~base_path ~worker_name)
+        ()
+    with
+    | Ok raw_trace -> Ok raw_trace
+    | Error err -> Error (Oas.Error.to_string err)
+  with Sys_error msg ->
+    Error
+      (Printf.sprintf "failed to create worker raw trace for %s: %s"
+         worker_name msg)
+
 let run_worker_oas ~sw ?net ~room_config
     (spec : Worker_execution_spec.t) : unit -> (run_result, string) result =
   fun () ->
-    (* Worker_run_once removed — return error *)
-    ignore (sw, net, room_config, spec);
-    Error "Worker_run_once removed (team session layer)"
+    let* net = resolve_net ?net () in
+    let execution_scope =
+      resolve_execution_scope ?execution_scope:spec.execution_scope ()
+    in
+    let worker_name = spec.worker_name in
+    let base_path = spec.base_path in
+    let workspace_path = workspace_path_of_spec spec in
+    let mcp_session_id =
+      resolved_mcp_session_id ~base_path ~worker_name
+    in
+    let existing_meta = load_worker_meta ~base_path ~worker_name in
+    let checkpoint = load_worker_checkpoint ~base_path ~worker_name in
+    let* effective_model =
+      match checkpoint with
+      | Some _ -> effective_model_of_resume ~existing_meta spec
+      | None ->
+          resolve_oas_provider_of_label spec.model_label
+          |> Result.map snd
+    in
+    let meta =
+      make_worker_meta ~base_path ~workspace_path ~worker_name
+        ~mcp_session_id ~role:spec.role
+        ~selection_note:spec.selection_note
+        ~execution_scope ~worker_class:spec.worker_class
+        ~effective_model ~thinking_enabled:spec.thinking_enabled
+        ~max_turns_override:(Some spec.max_turns)
+        ~timeout_seconds:(Some spec.timeout_sec)
+    in
+    let* auth_token =
+      worker_auth_token ~base_path ~worker_name
+    in
+    let* masc_tools =
+      build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
+        ~worker_name ~prompt:spec.prompt
+        ~allowed_tools:spec.allowed_tools
+    in
+    let* shell_tools =
+      build_local_shell_tools ~room_config ~worker_name ~execution_scope
+        ~workdir:workspace_path
+    in
+    let shell_tools =
+      filter_tools_by_name spec.allowed_shell_tools shell_tools
+    in
+    let tools = dedupe_tools_by_name (masc_tools @ shell_tools) in
+    let* raw_trace = create_raw_trace ~base_path ~worker_name in
+    match checkpoint with
+    | Some checkpoint ->
+        Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~auth_token
+          ~meta ~checkpoint ~prompt:spec.prompt ~tools ~raw_trace
+          ?worker_run_id:spec.worker_run_id ()
+    | None ->
+        let* provider, model_id =
+          resolve_oas_provider_of_label spec.model_label
+        in
+        let system_prompt =
+          default_system_prompt ~worker_name ~model_id
+            ?role:spec.role
+            ?selection_note:spec.selection_note ()
+        in
+        let gate_config =
+          Worker_oas.gate_config_of_execution_scope execution_scope
+        in
+        Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~auth_token
+          ~meta:{ meta with effective_model = model_id }
+          ~provider ~system_prompt ~prompt:spec.prompt ~tools
+          ~raw_trace ~gate_config
+          ?worker_run_id:spec.worker_run_id ()
 
 
 let preflight_spawn_batch ?clock_opt specs =

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -508,6 +508,7 @@ let rec run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(base_path : string)
+    ~(auth_token : string option)
     ~(meta : Worker_container_types.worker_container_meta)
     ~(provider : Oas.Provider.config)
     ~(system_prompt : string)
@@ -520,9 +521,6 @@ let rec run_worker_via_oas
     () : (Worker_container_types.run_result, string) result =
   let session_id = meta.mcp_session_id in
   let worker_name = meta.worker_name in
-  let* auth_token =
-    Worker_container_types.worker_auth_token ~base_path ~worker_name
-  in
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
@@ -562,6 +560,7 @@ and resume_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(base_path : string)
+    ~(auth_token : string option)
     ~(meta : Worker_container_types.worker_container_meta)
     ~(checkpoint : Oas.Checkpoint.t)
     ~(prompt : string)
@@ -572,9 +571,6 @@ and resume_worker_via_oas
     () : (Worker_container_types.run_result, string) result =
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in
-  let* auth_token =
-    Worker_container_types.worker_auth_token ~base_path ~worker_name
-  in
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -187,6 +187,49 @@ let test_run_process_with_timeout_returns_124_on_timeout () =
   in
   check int "timeout exit code" 124 result.exit_code
 
+let test_run_worker_oas_rejects_invalid_explicit_model_label () =
+  with_temp_dir "worker-runtime-local" @@ fun root ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Time_compat.set_clock (Eio.Stdenv.clock env);
+  Fun.protect
+    ~finally:(fun () -> Time_compat.clear_clock ())
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      let spec : Lib.Worker_execution_spec.t =
+        {
+          base_path = root;
+          worker_name = "worker-local";
+          model_label = "not-a-model-label";
+          working_dir = None;
+          worker_class = Some Worker_types.Worker_executor;
+          execution_scope = Some Worker_types.Observe_only;
+          thinking_enabled = Some false;
+          max_turns = 2;
+          worker_run_id = Some "run-local";
+          role = Some "worker";
+          selection_note = Some "invalid label";
+          prompt = "Say hello.";
+          allowed_tools = [];
+          allowed_shell_tools = [];
+          timeout_sec = 30;
+        }
+      in
+      match
+        Lib.Worker_runtime.run_worker_oas ~sw
+          ~net:(Eio.Stdenv.net env)
+          ~room_config:None spec ()
+      with
+      | Ok _ ->
+          fail "expected invalid explicit model label to fail before execution"
+      | Error err ->
+          check bool "mentions rejected label" true
+            (String.contains err 'n' && String.contains err '-');
+          check bool "does not use removed team-session stub" false
+            (Astring.String.is_infix
+               ~affix:"Worker_run_once removed (team session layer)"
+               err))
+
 let () =
   Alcotest.run "worker_runtime"
     [
@@ -208,4 +251,8 @@ let () =
       ( "process_timeout",
         [ test_case "timeout maps to exit code 124" `Quick
             test_run_process_with_timeout_returns_124_on_timeout ] );
+      ( "local_runtime",
+        [ test_case "invalid explicit model label fails before local worker execution"
+            `Quick
+            test_run_worker_oas_rejects_invalid_explicit_model_label ] );
     ]


### PR DESCRIPTION
## Summary
- reconnect `worker_container_runners` and `masc-worker-run` to the real OAS worker runtime instead of returning the removed team-session stub error
- reuse a single worker auth token across tool dispatch, join/leave, and heartbeat so local/Docker worker tool calls do not invalidate themselves
- initialize Mirage Crypto RNG in the helper binary and add a worker-runtime regression test for invalid explicit model labels

## Product impact
- local worker execution and the Docker helper can run real tool-using worker sessions again
- worker helper runs no longer fail immediately with `Worker_run_once removed (team session layer)`
- helper startup no longer crashes on uninitialized RNG
- worker tool calls no longer self-break with token mismatch after auth bootstrap

## Evidence
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-worker-oas-runtime test/test_worker_runtime.exe`
- local helper smoke:
  - `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-worker-oas-runtime bin/masc_worker_run.exe -- --spec-stdin`
  - spec used `model_label=ollama:qwen3.5:9b-nvfp4`, `allowed_tools=["masc_status"]`
  - result: successful `masc_status` call and one-line `RESULT:` output
- Docker helper smoke:
  - rebuilt image: `masc-worker-runtime:dev-codex`
  - `docker run ... masc-worker-runtime:dev-codex --spec-stdin`
  - spec used `model_label=custom:qwen3.5:9b-nvfp4@http://host.docker.internal:11434`, `allowed_tools=["masc_status"]`
  - result: successful `masc_status` call and one-line `RESULT:` output from inside the container

## Follow-up
- Repro uncovered two separate Docker follow-ups that are not fixed in this PR: `#8161`
  - legacy `Dockerfile.worker` / `scripts/build-worker-image.sh` still point at a dead Alpine base image tag
  - plain `ollama:<model>` labels inside Docker still route to loopback unless an explicit `custom:...@http://host.docker.internal:11434` label is used
