### PR TITLE
chore(ollama): route /api/ps and /api/generate through masc_network_defaults

### DIFF
--- a/lib/cascade/cascade_ollama_probe.ml
+++ b/lib/cascade/cascade_ollama_probe.ml
@@ -89,7 +89,7 @@ let probe_endpoint_of base_url =
     then String.sub base_url 0 (String.length base_url - 1)
     else base_url
   in
-  stripped ^ "/api/ps"
+  stripped ^ Masc_network_defaults.ollama_api_ps_path
 
 let try_probe ~sw ~net ?(timeout_s = 0.5) ?now url =
   let _ = sw in

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -26,6 +26,17 @@ let ollama_default_url =
 let ollama_port_needle =
   Printf.sprintf ":%d" ollama_default_port
 
+(** Ollama native API path for the running-models ("process status")
+    endpoint.  Used by both {!Cascade_ollama_probe} (cascade-level
+    capacity probe) and {!Tool_local_runtime_probe} (tool-level KV
+    assessment); anchoring the suffix in one place prevents the two
+    call sites from drifting if Ollama ever renames the route. *)
+let ollama_api_ps_path = "/api/ps"
+
+(** Ollama native API path for text generation.  Used by the
+    tool-level probe path that exercises a model end-to-end. *)
+let ollama_api_generate_path = "/api/generate"
+
 (** [is_ollama_url url] returns [true] when [url] contains
     {!ollama_port_needle}.  Permissive on scheme/host so it works for
     [http://], [https://], [127.0.0.1], [localhost], or a bare

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -50,10 +50,12 @@ let normalize_ollama_server_url raw =
   strip_trailing_slashes trimmed
 
 let ollama_ps_url server_url =
-  normalize_ollama_server_url server_url ^ "/api/ps"
+  normalize_ollama_server_url server_url
+  ^ Masc_network_defaults.ollama_api_ps_path
 
 let ollama_generate_url server_url =
-  normalize_ollama_server_url server_url ^ "/api/generate"
+  normalize_ollama_server_url server_url
+  ^ Masc_network_defaults.ollama_api_generate_path
 
 let ollama_http_error operation http_status =
   match http_status with


### PR DESCRIPTION
## Why

Three call sites concatenated Ollama native API suffixes onto a
normalised base URL:

| site | literal |
|---|---|
| `lib/cascade/cascade_ollama_probe.ml:92` (capacity probe) | `"/api/ps"` |
| `lib/tool_local_runtime_probe.ml:53` (`ollama_ps_url`) | `"/api/ps"` |
| `lib/tool_local_runtime_probe.ml:56` (`ollama_generate_url`) | `"/api/generate"` |

`"/api/ps"` appears twice, so any future Ollama rename (e.g. to
`"/v1/ps"`) would silently break at one site while still "working" at
the other — the classic drift vector the earlier `Masc_network_defaults`
constants (#8125, #8162) already guard against for other endpoint
families.

## What

- Add `ollama_api_ps_path` + `ollama_api_generate_path` to
  `lib/config/masc_network_defaults.ml`, adjacent to the existing
  `ollama_*` constants.
- Rewrite the three call sites to reference the SSOT.

`"/slots"` and `"/props"` in `lib/tool_local_runtime_verify.ml:415-416`
are llama.cpp-specific (not Ollama) and each appears only once, so
there is no drift vector — intentionally left alone.

## Verification

- `dune build @check` clean.
- `rg '"/api/(ps|generate)"' lib/ -tml` → only the SSOT definitions
  remain.
- `test/test_tool_local_runtime_probe.exe` → **10/10 OK** (covers
  kv_assessment + generate branching).
- `test/test_cascade_ollama_probe.exe` → **10/10 OK** (covers capacity
  probe JSON parsing + cache).

Net: **3 files, +16 / -3 LOC**.
