### PR TITLE
feat(rfc-v5-A1): add pipeline production to bash grammar

### DIFF
--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -8,20 +8,40 @@ let make_parse_error (lexbuf : Lexing.lexbuf) : Parsed.parse_error =
   let token = Lexing.lexeme lexbuf in
   { pos; token; expected = [] (* populated in later PR *) }
 
-let to_shell_ir (bin_str, args_str) : Shell_ir.t Parsed.t =
+let raw_to_simple (bin_str, args_str) : (Shell_ir.simple, Parsed.parse_error) result =
   match Bin.of_string bin_str with
   | Error (`Unknown _) ->
     (* A0 guarantees Bin.of_string only errors on empty input.  That
        cannot happen downstream of the current grammar (WORD+ accepts
        at least one token), so this branch is defensive. *)
-    Parsed.Parse_error
-      { pos = Lexing.dummy_pos; token = bin_str; expected = [] }
+    Error { Parsed.pos = Lexing.dummy_pos; token = bin_str; expected = [] }
   | Ok bin ->
     let args = List.map (fun s -> Shell_ir.Lit s) args_str in
-    let simple : Shell_ir.simple =
-      { bin; args; env = []; cwd = None; redirects = [] }
-    in
-    Parsed.Parsed (Shell_ir.Simple simple)
+    Ok { Shell_ir.bin; args; env = []; cwd = None; redirects = [] }
+
+let rec map_stages = function
+  | [] -> Ok []
+  | stage :: rest ->
+    (match raw_to_simple stage with
+     | Error e -> Error e
+     | Ok simple ->
+       (match map_stages rest with
+        | Error e -> Error e
+        | Ok tail -> Ok (simple :: tail)))
+
+let to_shell_ir (stages : (string * string list) list)
+    : Shell_ir.t Parsed.t =
+  match map_stages stages with
+  | Error e -> Parsed.Parse_error e
+  | Ok [ single ] -> Parsed.Parsed (Shell_ir.Simple single)
+  | Ok (_ :: _ :: _ as many) ->
+    let ir_stages = List.map (fun s -> Shell_ir.Simple s) many in
+    Parsed.Parsed (Shell_ir.Pipeline ir_stages)
+  | Ok [] ->
+    (* Unreachable: the grammar uses separated_nonempty_list so
+       stages is always length >= 1.  Defensive. *)
+    Parsed.Parse_error
+      { pos = Lexing.dummy_pos; token = ""; expected = [ "command" ] }
 
 let parse_string (source : string) : Shell_ir.t Parsed.t =
   Bash_lexer.reset_tokens ();

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -27,6 +27,7 @@ let word = word_char+
 rule token = parse
   | [' ' '\t']+    { token lexbuf }
   | '\n'           { incr_tokens (); Lexing.new_line lexbuf; token lexbuf }
+  | '|'            { incr_tokens (); PIPE }
   | word as w      { incr_tokens (); WORD w }
   | eof            { EOF }
   | _ as c         { raise (Failure (Printf.sprintf "unexpected char %c" c)) }

--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -1,23 +1,27 @@
-/* A1 bash subset grammar — Menhir LR(1), minimal skeleton.
+/* A1 bash subset grammar — Menhir LR(1).
 
-   Current productions cover a single simple command (bin + args).
-   Subsequent PRs extend to:
+   Productions now cover simple commands and pipelines.  Subsequent
+   PRs extend to:
    - env prefix (FOO=bar cmd)
    - redirects (> < >>, with fd number)
-   - pipeline (cmd | cmd | cmd)
    - subset guards that mint Parsed.Too_complex rather than matching.
 
-   The grammar emits a raw (bin, args) pair of strings.  bash.ml
-   adapts it to Shell_ir.t via Bin.of_string + Shell_ir.Lit for args.
+   The grammar emits a list of raw (bin, args) pairs, one per
+   pipeline stage.  bash.ml adapts the singleton case to
+   Shell_ir.Simple and the multi-stage case to Shell_ir.Pipeline.
 
    See RFC v5 (docs/rfc/RFC-0005). */
 
 %token <string> WORD
+%token PIPE
 %token EOF
 
-%start <string * string list> command
+%start <(string * string list) list> command
 
 %%
 
+stage:
+  | bin = WORD args = list(WORD) { (bin, args) }
+
 command:
-  | bin = WORD args = list(WORD) EOF { (bin, args) }
+  | stages = separated_nonempty_list(PIPE, stage) EOF { stages }

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -47,13 +47,48 @@ let test_leading_whitespace_ignored () =
   (* "leading/trailing whitespace must be skipped" *)
   | _ -> assert false
 
-let test_pipe_rejected_in_skeleton () =
-  (* Pipeline production not in A1-PR-1.  Pipe metachar makes the
-     lexer reject; wrap at facade into Parse_error.  A follow-up PR
-     adds the Pipeline production and flips this to Parsed.Parsed. *)
+let test_two_stage_pipeline () =
   match Bash.parse_string "ls | cat" with
+  | Parsed.Parsed (Shell_ir.Pipeline [
+      Shell_ir.Simple s1; Shell_ir.Simple s2
+    ]) ->
+    assert (Bin.to_string s1.bin = "ls");
+    assert (Bin.to_string s2.bin = "cat");
+    assert (s1.args = []);
+    assert (s2.args = [])
+  (* "ls | cat must parse to Pipeline of two Simple" *)
+  | _ -> assert false
+
+let test_three_stage_pipeline_with_args () =
+  match Bash.parse_string "ls -la | grep foo | wc -l" with
+  | Parsed.Parsed (Shell_ir.Pipeline stages) ->
+    assert (List.length stages = 3);
+    (match stages with
+     | [ Shell_ir.Simple s1; Shell_ir.Simple s2; Shell_ir.Simple s3 ] ->
+       assert (Bin.to_string s1.bin = "ls");
+       assert (Bin.to_string s2.bin = "grep");
+       assert (Bin.to_string s3.bin = "wc");
+       assert (s2.args = [ Shell_ir.Lit "foo" ])
+     (* "3-stage pipeline inner shape wrong" *)
+     | _ -> assert false)
+  (* "3-stage pipeline must parse" *)
+  | _ -> assert false
+
+let test_single_command_is_simple_not_pipeline () =
+  (* length-1 pipelines collapse to Simple — distinguishes from
+     Shell_ir.Pipeline which requires length >= 2. *)
+  match Bash.parse_string "ls" with
+  | Parsed.Parsed (Shell_ir.Simple _) -> ()
+  (* "single command must be Simple, not Pipeline" *)
+  | _ -> assert false
+
+let test_logic_or_rejected () =
+  (* '||' is subset-excluded (Parsed.Too_complex.Logic_op in a
+     follow-up PR).  Today surfaces as Parse_error because the
+     grammar has no production for consecutive PIPE tokens. *)
+  match Bash.parse_string "ls || cat" with
   | Parsed.Parse_error _ -> ()
-  (* "pipe must reject in skeleton grammar" *)
+  (* "|| must reject" *)
   | _ -> assert false
 
 let test_redirect_rejected_in_skeleton () =
@@ -79,7 +114,10 @@ let () =
   test_ls_with_args ();
   test_echo_message ();
   test_leading_whitespace_ignored ();
-  test_pipe_rejected_in_skeleton ();
+  test_two_stage_pipeline ();
+  test_three_stage_pipeline_with_args ();
+  test_single_command_is_simple_not_pipeline ();
+  test_logic_or_rejected ();
   test_redirect_rejected_in_skeleton ();
   test_empty_input_rejected ();
   test_whitespace_only_rejected ();


### PR DESCRIPTION
## Summary

RFC v5 Phase A1 growth — extends the Menhir LR(1) grammar with the pipeline construct. `cmd1 | cmd2 | cmd3` now parses to `Shell_ir.Pipeline [Simple; Simple; Simple]`.

## Grammar

New PIPE token + `separated_nonempty_list(PIPE, stage)` start symbol. Single commands still parse to `Simple` (length-1 collapses in `bash.ml`).

## Test plan

- [x] `dune runtest lib/exec` green — 38 cumulative (A0:10 + A1:11 + A2:9 + A3:8)
- [x] 4 new pipeline tests pass
- [ ] CI green

Parallel with Track B (#8155? approval_config) and Track C (#8156? approval_context). Follows RFC v5 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)