### PR TITLE
feat(rfc-v5): approval_config policy overlay (pure data, no I/O)

### DIFF
--- a/lib/exec/approval_config.ml
+++ b/lib/exec/approval_config.ml
@@ -1,0 +1,33 @@
+(* Approval_config — pure data.  No I/O.  *)
+
+type agent_overlay = {
+  allow_safe_in_worktree : bool;
+  ask_audited : bool;
+  deny_destructive_git : bool;
+}
+
+type t = {
+  defaults : agent_overlay;
+  per_agent : (string * agent_overlay) list;
+}
+
+let strict_default : agent_overlay =
+  {
+    allow_safe_in_worktree = false;
+    ask_audited = true;
+    deny_destructive_git = true;
+  }
+
+let permissive_default : agent_overlay =
+  {
+    allow_safe_in_worktree = true;
+    ask_audited = true;
+    deny_destructive_git = true;
+  }
+
+let empty : t = { defaults = strict_default; per_agent = [] }
+
+let lookup t ~actor =
+  match List.assoc_opt actor t.per_agent with
+  | Some overlay -> overlay
+  | None -> t.defaults

--- a/lib/exec/approval_config.mli
+++ b/lib/exec/approval_config.mli
@@ -1,0 +1,57 @@
+(** Approval_config — declarative policy settings per agent.
+
+    This module defines the shape of the policy overlay that governs
+    [Approval_policy.decide] behavior.  It carries {i only} data —
+    no I/O.  Loading from TOML (or any other source) happens outside
+    lib/exec to keep the sub-library closed to storage concerns.
+
+    The per-agent bag is looked up at decide time; keys are agent
+    names matching [Approval_context.t.actor].  Missing agent keys
+    fall through to [defaults]. *)
+
+type agent_overlay = {
+  allow_safe_in_worktree : bool;
+  (** If true, Safe bins whose write caps stay [Inside_worktree] or
+      [Inside_sandbox] short-circuit to [Verdict.Allow] without asking.
+      Set false for strict agents that should Ask even on Safe bins. *)
+
+  ask_audited : bool;
+  (** If true, [Audited] bins produce [Verdict.Ask].
+      If false, they produce [Verdict.Allow] (for experienced agents
+      the operator has granted broader trust). *)
+
+  deny_destructive_git : bool;
+  (** If true, [Git_op.Destructive _] emits [Verdict.Deny] outright.
+      If false, the agent may Ask its way through.  Default true; a
+      future operator UI may flip this per-session for planned
+      history rewrites. *)
+}
+(** Per-agent knobs.  Intentionally narrow — add fields only when a
+    policy rule actually reads them, not "for future flexibility". *)
+
+type t = {
+  defaults : agent_overlay;
+  per_agent : (string * agent_overlay) list;
+}
+(** The whole config.  [per_agent] is an association list rather than
+    a hashtable so the whole config can be compared structurally in
+    tests.  Lookup is linear but the list is tiny (one entry per
+    keeper / worker). *)
+
+val strict_default : agent_overlay
+(** Strictest possible overlay: never allows Safe in worktree, always
+    asks on Audited, always denies Destructive git.  The safe landing
+    pad for agents we have not yet profiled. *)
+
+val permissive_default : agent_overlay
+(** Conventional default for well-trusted keeper agents in a dev
+    worktree.  [allow_safe_in_worktree = true], [ask_audited = true],
+    [deny_destructive_git = true]. *)
+
+val empty : t
+(** [empty] has [defaults = strict_default] and no per-agent entries.
+    Fail-closed bootstrap for CI and new agents. *)
+
+val lookup : t -> actor:string -> agent_overlay
+(** [lookup cfg ~actor] returns the per-agent overlay if one is
+    registered for [actor]; otherwise [cfg.defaults]. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,4 +1,4 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
-        test_approval_policy)
+        test_approval_policy test_approval_config)
  (libraries masc_exec masc_exec_bash_parser))

--- a/lib/exec/test/test_approval_config.ml
+++ b/lib/exec/test/test_approval_config.ml
@@ -1,0 +1,41 @@
+(** Approval_config type + lookup smoke tests. *)
+
+open Masc_exec
+
+let test_strict_is_fail_closed () =
+  let o = Approval_config.strict_default in
+  assert (o.allow_safe_in_worktree = false);
+  assert (o.ask_audited = true);
+  assert (o.deny_destructive_git = true)
+
+let test_permissive_default_allows_safe () =
+  let o = Approval_config.permissive_default in
+  assert (o.allow_safe_in_worktree = true);
+  assert (o.deny_destructive_git = true)
+
+let test_empty_uses_strict_defaults () =
+  let cfg = Approval_config.empty in
+  assert (cfg.per_agent = []);
+  let o = Approval_config.lookup cfg ~actor:"anybody" in
+  assert (o = Approval_config.strict_default)
+
+let test_lookup_matches_registered_agent () =
+  let cfg : Approval_config.t =
+    {
+      defaults = Approval_config.strict_default;
+      per_agent = [
+        ("keeper/alpha", Approval_config.permissive_default);
+      ];
+    }
+  in
+  let alpha = Approval_config.lookup cfg ~actor:"keeper/alpha" in
+  assert (alpha = Approval_config.permissive_default);
+  let other = Approval_config.lookup cfg ~actor:"keeper/beta" in
+  assert (other = Approval_config.strict_default)
+
+let () =
+  test_strict_is_fail_closed ();
+  test_permissive_default_allows_safe ();
+  test_empty_uses_strict_defaults ();
+  test_lookup_matches_registered_agent ();
+  print_endline "[test_approval_config] all tests passed"


### PR DESCRIPTION
## Summary

RFC v5 Phase A-support — adds `Approval_config.t`, the declarative bag of per-agent policy knobs that `Approval_policy.decide` will consult. Pure data; loading from TOML stays out of `lib/exec`.

## Shape

`agent_overlay = { allow_safe_in_worktree; ask_audited; deny_destructive_git }`.
`t = { defaults; per_agent }`. `strict_default`, `permissive_default`, `empty`, `lookup`.

## Test plan

- [x] 4/4 tests pass
- [x] `dune runtest lib/exec` green

Parallel with Track A (pipeline) and Track C (approval_context). Follows RFC v5 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)