### PR TITLE
feat(rfc-v5): approval_context runtime state record

### DIFF
--- a/lib/exec/approval_context.ml
+++ b/lib/exec/approval_context.ml
@@ -1,0 +1,11 @@
+(* Approval_context — runtime state record. *)
+
+type t = {
+  actor : string;
+  session_id : string;
+  worktree_root : string;
+  now : float;
+}
+
+let make ~actor ~session_id ~worktree_root ~now =
+  { actor; session_id; worktree_root; now }

--- a/lib/exec/approval_context.mli
+++ b/lib/exec/approval_context.mli
@@ -1,0 +1,42 @@
+(** Approval_context — runtime state the policy consults at decision
+    time (but does not capture into the Verdict itself).
+
+    The context names the actor, the session, and the worktree root so
+    the policy can thread them into subsequent layers (approval queue
+    source field, audit log, drawer UI) without plumbing them through
+    every call site.
+
+    Fields are intentionally narrow.  This module is additive in
+    follow-ups: a per-agent TOML overlay will land alongside
+    Approval_config but only after we can point at a real consumer. *)
+
+type t = {
+  actor : string;
+  (** Human-readable identifier for who is triggering the exec.  "keeper/alpha"
+      for the alpha keeper, "worker/foo" for a named worker, "operator" for
+      a direct operator action.  Not a security principal — that stays with
+      the token/session on the transport layer. *)
+
+  session_id : string;
+  (** Opaque session id threaded from the transport.  The approval queue
+      uses this to route Ask outcomes back to the originating client. *)
+
+  worktree_root : string;
+  (** Absolute canonical path to the MASC worktree root.  Policy uses it
+      to decide whether a [Path_scope.Inside_worktree] is this worktree or
+      some other one the caller might have mounted. *)
+
+  now : float;
+  (** Wall-clock at decision time, seconds since epoch.  Fed from the
+      caller's Eio clock rather than [Unix.gettimeofday] so tests can
+      inject a deterministic value. *)
+}
+
+val make :
+  actor:string ->
+  session_id:string ->
+  worktree_root:string ->
+  now:float ->
+  t
+(** Plain smart constructor; no validation yet (the policy layer
+    that actually consumes these fields will add it). *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,4 +1,4 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
-        test_approval_policy)
+        test_approval_policy test_approval_context)
  (libraries masc_exec masc_exec_bash_parser))

--- a/lib/exec/test/test_approval_context.ml
+++ b/lib/exec/test/test_approval_context.ml
@@ -1,0 +1,36 @@
+(** Approval_context sanity — record shape + accessor round-trip. *)
+
+open Masc_exec
+
+let test_make_and_read () =
+  let ctx =
+    Approval_context.make
+      ~actor:"keeper/alpha"
+      ~session_id:"sess-42"
+      ~worktree_root:"/tmp/mascwt"
+      ~now:123.5
+  in
+  assert (ctx.actor = "keeper/alpha");
+  assert (ctx.session_id = "sess-42");
+  assert (ctx.worktree_root = "/tmp/mascwt");
+  assert (ctx.now = 123.5)
+
+let test_distinct_sessions_are_independent () =
+  let a =
+    Approval_context.make
+      ~actor:"keeper/alpha" ~session_id:"A"
+      ~worktree_root:"/wt" ~now:0.0
+  in
+  let b =
+    Approval_context.make
+      ~actor:"keeper/beta" ~session_id:"B"
+      ~worktree_root:"/wt" ~now:10.0
+  in
+  assert (a.session_id <> b.session_id);
+  assert (a.actor <> b.actor);
+  assert (a.worktree_root = b.worktree_root)
+
+let () =
+  test_make_and_read ();
+  test_distinct_sessions_are_independent ();
+  print_endline "[test_approval_context] all tests passed"


### PR DESCRIPTION
## Summary

RFC v5 Phase A-support — adds `Approval_context.t`, the narrow runtime bag (actor, session_id, worktree_root, now) that `Approval_policy.decide` will read once config threading lands.

## Test plan

- [x] 2/2 tests pass
- [x] `dune runtest lib/exec` green

Parallel with Track A (pipeline) and Track B (approval_config). Follows RFC v5 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)