### PR TITLE
chore(dashboard): unexport 2 internal-only fleet-data helpers (Gen73)

### DIFF
--- a/dashboard/src/components/fleet-data-core.ts
+++ b/dashboard/src/components/fleet-data-core.ts
@@ -47,7 +47,7 @@ export const sharedToolQualityError: Signal<string | null> = signal(null)
 let toolQualityRequestId = 0
 let toolQualityController: AbortController | null = null
 
-export interface RefreshSharedOptions {
+interface RefreshSharedOptions {
   signal?: AbortSignal
   /** Override default n=5000 for tool-quality fetches. */
   n?: number
@@ -141,7 +141,7 @@ export async function refreshSharedTelemetrySummary(opts: { signal?: AbortSignal
   }
 }
 
-export function cancelSharedTelemetrySummary(): void {
+function cancelSharedTelemetrySummary(): void {
   summaryRequestId += 1
   summaryController?.abort()
   summaryController = null


### PR DESCRIPTION
## Summary

\`components/fleet-data-core.ts\`의 2개 심볼이 자기 파일 내부에서만 사용됨.

| 심볼 | 내부 사용 |
|------|----------|
| \`RefreshSharedOptions\` (interface) | \`refreshSharedToolQuality(opts: RefreshSharedOptions = {})\` param type |
| \`cancelSharedTelemetrySummary\` (function) | \`cancelSharedToolQuality\`에서 line 156 호출 |

## Verification

- \`bunx tsc --noEmit\`: green
- +2/-2 LOC (1 파일, 2 keyword 제거)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)