### PR TITLE
chore(dashboard): unexport 2 internal-only tool-executor signals (Gen74)

### DIFF
--- a/dashboard/src/components/tool-executor/tool-executor-state.ts
+++ b/dashboard/src/components/tool-executor/tool-executor-state.ts
@@ -4,10 +4,10 @@ import { listAllMcpTools, callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
 import { buildDefaults, stripEmptyOptionals, validateRequired } from './schema-form'
 
-export const allToolSchemas = signal<McpToolSchema[]>([])
+const allToolSchemas = signal<McpToolSchema[]>([])
 export const schemasLoading = signal(false)
 export const schemasError = signal<string | null>(null)
-export const schemasLoadedAt = signal<number>(0)
+const schemasLoadedAt = signal<number>(0)
 
 export const searchQuery = signal('')
 export const tierFilter = signal<string>('all')


### PR DESCRIPTION
## Summary

\`tool-executor/tool-executor-state.ts\`의 2개 signal이 내부 cache/fetcher 로직에서만 참조됨.

| 심볼 | 내부 사용 |
|------|----------|
| \`allToolSchemas\` | fetcher 결과 저장, filter/default 선택 computed에서 read |
| \`schemasLoadedAt\` | cache TTL 체크 (line 40) + fetcher 성공 시 업데이트 (line 50) |

## Kept as export

\`schemasLoading\`, \`schemasError\` — Tool Executor UI가 loading spinner / error chip 렌더링에 직접 참조.

## Verification

- \`bunx tsc --noEmit\`: green
- \`bunx vitest src/components/tool-executor/\`: 20/20 pass
- +2/-2 LOC

## Test plan

- [x] tsc strict
- [x] tool-executor 전체 (20 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)