### PR TITLE
chore(config): consolidate bool env parsers onto Env_config_core.get_bool

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -46,8 +46,8 @@ let get_bool ~default name =
   match raw_value_opt name with
   | Some v ->
       (match String.trim v |> String.lowercase_ascii with
-       | "true" | "1" | "yes" -> true
-       | "false" | "0" | "no" -> false
+       | "true" | "1" | "yes" | "on" -> true
+       | "false" | "0" | "no" | "off" -> false
        | "" -> default
        | _ -> default)
   | None -> default

--- a/lib/goal/goal_guard.ml
+++ b/lib/goal/goal_guard.ml
@@ -17,11 +17,7 @@ let int_env name ~default ~min_v ~max_v =
         max min_v (min max_v parsed)
       with Failure _ -> default)
 
-let bool_env name ~default =
-  match Sys.getenv_opt name with
-  | Some "1" | Some "true" | Some "TRUE" | Some "yes" | Some "on" -> true
-  | Some "0" | Some "false" | Some "FALSE" | Some "no" | Some "off" -> false
-  | Some _ | None -> default
+let bool_env name ~default = Env_config_core.get_bool ~default name
 
 let load_budget () =
   {

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -31,18 +31,13 @@ let load_config () =
     | Some v -> Safe_ops.int_of_string_with_default ~default v
     | None -> default
   in
-  let get_env_bool name default =
-    match Sys.getenv_opt name with
-    | Some "1" | Some "true" | Some "yes" -> true
-    | Some "0" | Some "false" | Some "no" -> false
-    | _ -> default
-  in
   {
     check_interval_s = get_env_float "MASC_ORCHESTRATOR_INTERVAL" 300.0;
     min_priority = get_env_int "MASC_ORCHESTRATOR_MIN_PRIORITY" 2;
     agent_timeout_s = get_env_int "MASC_ORCHESTRATOR_TIMEOUT" 300;
     orchestrator_agent = Env_config.Orchestrator.agent_name;
-    enabled = get_env_bool "MASC_ORCHESTRATOR_ENABLED" false;
+    enabled =
+      Env_config_core.get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED";
     port = Env_config_core.masc_http_port_int ();
   }
 


### PR DESCRIPTION
## Why

Two modules duplicated the `Some "1" | Some "true" | Some "yes"` env-var
bool parsing pattern while `Env_config_core.get_bool` already centralised
it — with **subtly different truth tables**:

| site | accepted true values | accepted false values |
|---|---|---|
| `Env_config_core.get_bool` (SSOT) | `true/1/yes` (case-insensitive via `lowercase_ascii`) | `false/0/no` |
| `lib/orchestrator.ml` `get_env_bool` | `1/true/yes` (**case-sensitive**) | `0/false/no` |
| `lib/goal/goal_guard.ml` `bool_env` | `1/true/TRUE/yes/on` | `0/false/FALSE/no/off` |

`goal_guard` accepted `on/off` and explicit `TRUE/FALSE`; the SSOT did
not.  This is the exact drift the SSOT was meant to prevent —
an operator-visible truth table that silently disagrees between call
sites.

## What

- Extend `Env_config_core.get_bool` to accept `on`/`off` alongside the
  existing set.  Every previously-accepted string still parses the
  same way; the matcher pipes through `lowercase_ascii` so
  `TRUE`/`FALSE` already collapsed to `true`/`false` in the SSOT.
- Rewrite `orchestrator.load_config` to call
  `Env_config_core.get_bool` directly; delete the local `get_env_bool`
  helper.
- Collapse `goal_guard.bool_env` into a one-line delegate to the SSOT.

## Behavioural notes

- **Orchestrator** now additionally accepts `TRUE`/`FALSE` (via
  case-insensitivity) and `on`/`off`.  Strict relaxation — no
  previously-accepted string changes semantics.
- **Goal_guard** keeps the same truth table
  ({`true`,`false`,`yes`,`no`,`on`,`off`} × case variants); the SSOT
  path reaches identical behaviour now that `on`/`off` are added.

## Verification

- `dune build @check` clean.
- `test_env_config_coverage` → **70/70 OK**.
- `test_orchestrator_coverage` → **33/33 OK**.

Net: **3 files, +5 / -14 LOC**.
