### PR TITLE
feat(dashboard): opt-in paper theme (Anyang Sleepers bridge)

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -7,6 +7,11 @@ import './styles/variables.css'
 import './styles/base.css'
 import './styles/keyframes.css'
 
+// Opt-in paper theme — activated by ?theme=paper or
+// localStorage.dashboardTheme = "paper". Component code is unchanged;
+// the theme only swaps the values behind existing --color-* tokens.
+import './styles/paper-theme.css'
+
 // Global utilities and layout
 import './styles/global.css'
 
@@ -23,6 +28,32 @@ import './styles/tools.css'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { App } from './app'
+
+// Theme resolution precedence: ?theme= URL param (session scoped) >
+// localStorage.dashboardTheme (persistent) > default (unset).
+// Invalid values are silently dropped so a typo cannot break layout.
+function resolveTheme(): string | null {
+  const valid = new Set(['paper'])
+  const fromUrl = new URLSearchParams(window.location.search).get('theme')
+  if (fromUrl && valid.has(fromUrl)) {
+    try { localStorage.setItem('dashboardTheme', fromUrl) } catch { /* quota */ }
+    return fromUrl
+  }
+  if (fromUrl === '') {
+    try { localStorage.removeItem('dashboardTheme') } catch { /* quota */ }
+    return null
+  }
+  try {
+    const stored = localStorage.getItem('dashboardTheme')
+    if (stored && valid.has(stored)) return stored
+  } catch { /* access denied */ }
+  return null
+}
+
+const theme = resolveTheme()
+if (theme) {
+  document.documentElement.dataset.theme = theme
+}
 
 const root = document.getElementById('app')
 if (root) {

--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -1,0 +1,115 @@
+/* =========================================================================
+   MASC Dashboard — Paper Theme (opt-in preview)
+   Activate with ?theme=paper or localStorage.dashboardTheme = "paper".
+
+   Source: Anyang Sleepers Design System (colors_and_type.css).
+   That spec calls itself "the paper inversion of MASC" and maps every
+   current semantic role to warm-paper tokens. This file scopes those
+   tokens under [data-theme="paper"] and bridges them to the existing
+   --color-* semantic variables that components already consume, so
+   enabling the theme swaps the palette with zero component edits.
+
+   Components whose classes (.btn, .card etc) collide with the design
+   system are NOT imported — only tokens. Component migration is a
+   follow-up phase.
+   ========================================================================= */
+
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+[data-theme="paper"] {
+  color-scheme: light;
+
+  /* ───── Paper & ink (design system source of truth) ──────── */
+  --paper:        #F5F2EA;
+  --paper-2:      #EFEBE0;
+  --paper-3:      #E5E0D1;
+  --paper-4:      #D8D2BF;
+
+  --ink:          #151515;
+  --ink-2:        #2E2E2C;
+  --ink-3:        #515049;
+  --ink-4:        #74726A;
+  --ink-5:        #9A978D;
+  --ink-6:        #BCB8AC;
+
+  /* ───── Accent scale ─────────────────────────────────────── */
+  --forest:       #2D5F4E;   --forest-fill:#CFDFD7;  --forest-line:#4E8773;
+  --brass:        #8C6A1E;   --brass-fill: #E9DDB8;  --brass-line: #B8933A;
+  --brick:        #8B3A3A;   --brick-fill: #E8CFCB;  --brick-line: #B45C5C;
+  --ember:        #B35A1F;   --ember-fill: #ECD5BD;  --ember-line: #D07A3A;
+  --slate:        #3E4A5C;   --slate-fill: #D6DBE2;  --slate-line: #6B7A8E;
+  --plum:         #5C3E56;   --plum-fill:  #E0D4DE;  --plum-line:  #855E7D;
+  --teal:         #236874;   --teal-fill:  #CEDEE2;  --teal-line:  #4C94A3;
+
+  /* ───── Borders ──────────────────────────────────────────── */
+  --border-1-paper: #1A1A1A;
+  --border-2-paper: rgba(21, 21, 21, 0.48);
+  --border-3-paper: rgba(21, 21, 21, 0.22);
+  --border-4-paper: rgba(21, 21, 21, 0.12);
+  --border-5-paper: rgba(21, 21, 21, 0.06);
+
+  /* ───── Typography ───────────────────────────────────────── */
+  --font-sans-paper: 'Noto Sans KR', 'Pretendard', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono-paper: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* =====================================================================
+     Bridge to existing MASC semantic tokens.
+     Each line overrides a variable declared in tokens.css so every
+     component that reads --color-* or --color-ff-* picks up paper values
+     without edits.
+     ===================================================================== */
+
+  /* Cards / surfaces */
+  --color-card: var(--paper-2);
+  --color-card-border: var(--border-3-paper);
+  --color-ff-panel: var(--paper-2);
+  --color-ff-navy: var(--paper);
+  --color-ff-navy-light: var(--paper-2);
+  --color-ff-border: var(--border-2-paper);
+  --color-ff-border-subtle: var(--border-4-paper);
+  --color-ff-border-hover: var(--border-1-paper);
+
+  /* Text */
+  --color-text-strong: var(--ink);
+  --color-text-body: var(--ink-2);
+  --color-text-muted: var(--ink-4);
+
+  /* Accents (brass replaces FF gold per design system "selected" role) */
+  --color-accent: var(--forest);
+  --color-accent-soft: var(--forest-fill);
+  --color-ff-gold: var(--brass);
+  --color-ff-gold-bright: var(--brass-line);
+  --color-ff-gold-dim: var(--brass-fill);
+  --color-ff-crystal: var(--slate);
+
+  /* Status roles — keeper FSM mapping from design system */
+  --color-ok: var(--forest);
+  --color-warn: var(--ember);
+  --color-bad: var(--brick);
+  --color-agent-working: var(--forest);
+  --color-agent-idle: var(--ink-4);
+  --color-agent-offline: var(--ink-5);
+  --color-agent-busy: var(--brass);
+
+  --bad-light: var(--brick-line);
+  --warn-bright: var(--ember-line);
+}
+
+/* Base surface + text when paper theme is active.
+   Scoped to html[data-theme="paper"] so non-theme pages stay unaffected. */
+html[data-theme="paper"],
+html[data-theme="paper"] body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-sans-paper);
+}
+
+/* Mono elements in paper theme should use JetBrains Mono with
+   tabular-nums, per design system rule #5. */
+html[data-theme="paper"] code,
+html[data-theme="paper"] pre,
+html[data-theme="paper"] .tabular-nums,
+html[data-theme="paper"] [class*="font-mono"] {
+  font-family: var(--font-mono-paper);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## 요약

Anyang Sleepers Design System이 MASC dashboard의 \"paper inversion\" (다크 네이비 → 웜 페이퍼)을 명시적으로 스펙했습니다. 이 PR은 해당 시스템을 **옵트인 프리뷰**로 도입해 UI 전체 마이그레이션 위험 없이 비교/검증할 수 있게 합니다.

## 디자인 시스템 개요

README 인용:
> Tokens and a handful of details are lifted from jeong-sik/masc-mcp's dashboard — the keeper state machine, the 12 life-cycle states, the pixel-avatar palettes, the vocabulary (관찰소, 게시판, 작업대). The original dashboard is dark-navy. This system is the paper inversion of it: same structure, same vocabulary, opposite surface.

- 웜 페이퍼 base `#F5F2EA` / 잉크 `#151515` (pure white/black 금지)
- 7 accent (forest/brass/brick/ember/slate/plum/teal), 각 solid/fill/line 트리플
- 12 keeper state → 5 시각 그룹 고정 매핑
- radius 최대 4px (pill UI 금지), JetBrains Mono + tabular-nums 필수
- Bloomberg density + Grafana rigor 지향

## 변경 (2 파일, +146 LOC)

| 파일 | 역할 |
|---|---|
| \`dashboard/src/styles/paper-theme.css\` | 디자인 시스템 토큰을 \`[data-theme=\"paper\"]\` scope에 선언 + 기존 \`--color-*\` semantic 변수로 브릿지 |
| \`dashboard/src/main.ts\` | \`?theme=paper\` URL 파라미터 감지 → localStorage 영속 → \`document.documentElement.dataset.theme\` 설정 |

컴포넌트 코드 변경 **0**. 디자인 시스템의 \`components.css\`는 \`.btn\`/\`.card\` 클래스명 충돌로 import하지 않음 — 토큰만 스왑.

## 활성화

- \`?theme=paper\` → localStorage에 저장되어 이후 세션 유지
- \`?theme=\` (빈 값) → 설정 제거
- 그 외/미지정 → 기본(다크 네이비) 유지
- invalid 값은 조용히 드롭되어 레이아웃을 깨뜨리지 않음

## Phase 계획 (이 PR은 Phase 0)

| Phase | 범위 | 이 PR |
|---|---|---|
| **0. 옵트인 프리뷰** | 토큰 브릿지, 컴포넌트 변경 0 | ✅ |
| 1. 파일럿 마이그레이션 | StatusChip + verification-requests-panel을 새 디자인 스펙대로 재작성 | 후속 |
| 2. 전면 전환 | FF 토큰 제거 + 전체 card/table/badge/chart 팔레트 교체 | 후속 다중 PR |

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [ ] 브라우저에서 \`?theme=paper\` 추가 후 dashboard 로드 — 배경이 웜 페이퍼로, 텍스트가 잉크색으로 렌더링되는지 확인
- [ ] \`?theme=\`로 해제 후 기본 테마 복귀 확인
- [ ] invalid \`?theme=foo\`로 접근 시 기본 테마 유지 확인

## 참고 소스

로컬 경로: \`/Users/dancer/Downloads/Anyang Sleepers Design System/\`
- \`README.md\` 213 LOC — 설계 철학, 팔레트, 타이포 규약, 차트 규칙, 금지 사항
- \`colors_and_type.css\` — 토큰 SSOT
- \`preview/*.html\` 15개 — status-chips, metric-widgets, pattern-keeper-detail 등 기준 샘플