### PR TITLE
chore(dashboard): unexport 2 internal-only dashboard-shell symbols (Gen75)

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -433,7 +433,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
   `
 }
 
-export function TabContent() {
+function TabContent() {
   const tab = route.value.tab
 
   switch (tab) {
@@ -506,7 +506,7 @@ export function currentSectionShareUrl(): string {
     opening a deep link had to infer the hierarchy. Every modern web
     app (GitHub / Linear / Notion / Vercel) renders the trail above
     the page title for exactly this reason. */
-export interface BreadcrumbCrumb {
+interface BreadcrumbCrumb {
   label: string
   navigableTab: string | null
 }


### PR DESCRIPTION
## Summary

\`dashboard-shell.ts\`의 2개 심볼이 자기 파일에서만 사용됨.

| 심볼 | 내부 사용 |
|------|----------|
| \`TabContent\` (component) | \`DashboardShell\`의 하나의 JSX 호출 (line 643) |
| \`BreadcrumbCrumb\` (interface) | \`buildBreadcrumbs()\` 반환 타입 (line 517) |

## Verification

- \`bunx tsc --noEmit\`: green
- +2/-2 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)