### PR TITLE
chore(dashboard): unexport 4 single-symbol type aliases (Gen76)

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -39,7 +39,7 @@ export const mentionText = signal('')
 export const sendingMention = signal(false)
 
 // Agent fitness
-export type AgentFitness = {
+type AgentFitness = {
   completion_rate?: number
   reliability_score?: number
   speed_score?: number

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -4,7 +4,7 @@ import { namespaceTruth, namespaceTruthInitializing } from '../../namespace-trut
 import { serverStatus } from '../../store'
 import { showToast } from '../common/toast'
 
-export type FlowState = 'unknown' | 'initializing' | 'running' | 'paused'
+type FlowState = 'unknown' | 'initializing' | 'running' | 'paused'
 export const flowState = signal<FlowState>('unknown')
 export const flowLoading = signal(false)
 

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -18,7 +18,7 @@ import { PrometheusMetrics } from './prometheus-metrics'
 import { CascadeConfigPanel } from './cascade-config-panel'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 
-export type RuntimeView = 'default' | 'cascade' | 'providers' | 'prometheus' | 'verification'
+type RuntimeView = 'default' | 'cascade' | 'providers' | 'prometheus' | 'verification'
 
 const RUNTIME_VIEWS: RuntimeView[] = ['default', 'cascade', 'providers', 'prometheus', 'verification']
 

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -20,7 +20,7 @@ interface LogResponse {
   lines: string[]
 }
 
-export type LogLevel = 'all' | 'debug' | 'info' | 'warn' | 'error'
+type LogLevel = 'all' | 'debug' | 'info' | 'warn' | 'error'
 
 const LEVEL_PATTERNS: Record<Exclude<LogLevel, 'all'>, RegExp> = {
   error: /\bERROR\b/i,


### PR DESCRIPTION
## Summary

4개 서로 다른 파일의 type alias/interface가 각각 자기 파일 내부에서만 사용됨. 단일 심볼 파일들을 misc batch로 묶음.

| 파일 | 심볼 | 내부 사용 |
|------|------|----------|
| \`runtime-panel.ts\` | \`RuntimeView\` | \`RUNTIME_VIEWS\`, \`isRuntimeView\`, \`activeView\`, \`VIEW_CHIPS\`, \`updateViewParam\` |
| \`sidecar-log-viewer.ts\` | \`LogLevel\` | \`LEVEL_PATTERNS\`, \`selectLogs\`, \`LEVELS\`, \`LEVEL_LABEL\`, \`LevelPills\` |
| \`flow-control/flow-control-state.ts\` | \`FlowState\` | \`flowState\` signal's generic |
| \`agent-detail-state.ts\` | \`AgentFitness\` | \`agentFitness\` signal + fetcher JSON cast |

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC (4 파일, 각 1 keyword 제거)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)