### PR TITLE
chore(level4_config): delegate env helpers to Env_config_core SSOT

### DIFF
--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -11,17 +11,20 @@
     @since MASC v3.1 (Level 4)
 *)
 
-(** {1 Environment Helpers} *)
+(** {1 Environment Helpers}
+
+    Thin delegates to the [Env_config_core] SSOT so Swarm/Flocking
+    config reads the same env-var semantics (trim + malformed-value
+    fallback) as the rest of the codebase.  The positional [default]
+    argument is kept for call-site compatibility with the many
+    [Swarm.*] / [Flocking.*] thunks below and with
+    [test_level4_config_coverage]. *)
 
 let get_env_float name default =
-  match Sys.getenv_opt name with
-  | Some s -> Safe_ops.float_of_string_with_default ~default s
-  | None -> default
+  Env_config_core.get_float ~default name
 
 let get_env_int name default =
-  match Sys.getenv_opt name with
-  | Some s -> Safe_ops.int_of_string_with_default ~default s
-  | None -> default
+  Env_config_core.get_int ~default name
 
 (** {1 Random Number Generator} *)
 


### PR DESCRIPTION
## Why

`lib/level4_config.ml` defined a local pair of env-var parsers:

```ocaml
let get_env_float name default =
  match Sys.getenv_opt name with
  | Some s -> Safe_ops.float_of_string_with_default ~default s
  | None -> default

let get_env_int name default = (* same shape *)
```

`Env_config_core.get_float` / `get_int` already centralise this exact
behaviour (trim + malformed-value fallback) for every other `MASC_*`
env var in the repo.  Swarm / Flocking / Foraging config reads
`MASC_SWARM_*` and `MASC_FLOCK_*` through the local pair, silently
bypassing the SSOT and any future invariant added there (e.g. telemetry,
warn-on-typo — cf. #8142 / #8144).

Same class as #8176's bool-parser consolidation.

## What

- Rewrite `get_env_float` / `get_env_int` as one-line delegates to
  `Env_config_core.get_float` / `get_int`.
- Keep the **positional** `default` argument intact (the SSOT uses a
  labelled `~default`).  Every call site in the module's 16
  Swarm/Flocking/Foraging thunks passes `~default` positionally, and
  `test_level4_config_coverage` calls both helpers directly with
  positional args — zero caller-side change.

## Behavioural note

`Env_config_core.get_float/get_int` build on the same
`Safe_ops.*_of_string_with_default` call, and `raw_value_opt` trims
the input before parsing.  The parsed values are identical on every
previously accepted input; this is a pure plumbing change.

## Verification

- `dune build @check` clean.
- `test_level4_config_coverage` → **58/58 OK** (includes direct
  positional-arg calls to `get_env_float` / `get_env_int` + RNG +
  Normalized/Fitness round-trip).

Net: **1 file, +10 / -7 LOC**.
