### PR TITLE
feat(dashboard): ThemeSwitch in header — discover paper theme

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -24,6 +24,7 @@ import {
   DashboardMain,
   SideRail,
 } from './components/dashboard-shell'
+import { ThemeSwitch } from './components/theme-switch'
 import { KeeperDetailOverlay } from './components/keeper-detail'
 import { AgentDetailOverlay } from './components/agent-detail'
 import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
@@ -136,6 +137,7 @@ export function App() {
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
             <${AuthStatus} />
             <${ConnectionStatus} />
+            <${ThemeSwitch} />
             <${BuildIdentityBadge} />
           </div>
         </div>

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -1,0 +1,67 @@
+// ThemeSwitch — compact header toggle for opt-in paper theme (#8177).
+//
+// Cycles between the default dark palette and the "paper" palette.
+// The actual token swap lives in styles/paper-theme.css; this component
+// only flips document.documentElement.dataset.theme and persists the
+// choice to localStorage so reloads are stable.
+//
+// The switch is intentionally unobtrusive — a 2-letter mono label in
+// the same visual register as BuildIdentityBadge and ConnectionStatus.
+// It does not try to preview, animate, or decorate the flip; the
+// cascade handles rerender.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+
+type ThemeId = 'paper' | null
+
+function readDomTheme(): ThemeId {
+  const attr = document.documentElement.dataset.theme
+  return attr === 'paper' ? 'paper' : null
+}
+
+// Single source of truth: mirrors the DOM attribute so Preact renders
+// the button label in sync with however main.ts initialised the theme.
+const currentTheme = signal<ThemeId>(
+  typeof document === 'undefined' ? null : readDomTheme(),
+)
+
+function applyTheme(next: ThemeId): void {
+  if (next === null) {
+    delete document.documentElement.dataset.theme
+    try { localStorage.removeItem('dashboardTheme') } catch { /* quota / privacy */ }
+  } else {
+    document.documentElement.dataset.theme = next
+    try { localStorage.setItem('dashboardTheme', next) } catch { /* quota / privacy */ }
+  }
+  currentTheme.value = next
+}
+
+function toggleTheme(): void {
+  applyTheme(currentTheme.value === 'paper' ? null : 'paper')
+}
+
+const LABEL: Record<'default' | 'paper', string> = {
+  default: 'DARK',
+  paper: 'PAPER',
+}
+
+const TITLE: Record<'default' | 'paper', string> = {
+  default: '현재 테마: Dark · 클릭하여 Paper 테마로 전환',
+  paper: '현재 테마: Paper · 클릭하여 Dark 테마로 전환',
+}
+
+export function ThemeSwitch() {
+  const key = currentTheme.value === 'paper' ? 'paper' : 'default'
+  return html`
+    <button
+      type="button"
+      class="cursor-pointer rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      aria-label=${TITLE[key]}
+      title=${TITLE[key]}
+      onClick=${toggleTheme}
+    >
+      ${LABEL[key]}
+    </button>
+  `
+}


### PR DESCRIPTION
## 요약

#8177 머지 후 paper theme은 \`?theme=paper\` URL 파라미터로만 활성화됐습니다. 발견성이 없어 옵트인 프리뷰의 가치를 거의 못 살리고 있어서 헤더에 compact toggle을 추가합니다.

## 변경

- \`dashboard/src/components/theme-switch.ts\` (신규, 65 LOC) — Preact signal 기반 토글, \`document.documentElement.dataset.theme\` + \`localStorage.dashboardTheme\` 동기화
- \`dashboard/src/app.ts\` (+2 LOC) — 헤더 우측 영역(\`AuthStatus\` / \`ConnectionStatus\` / \`BuildIdentityBadge\` 라인)에 \`<ThemeSwitch />\` 배치

## UI 기대 동작

| 현재 | 버튼 라벨 | 클릭 결과 |
|---|---|---|
| 기본(다크) | \`DARK\` | \`?theme=paper\`와 동일 효과 + localStorage 저장 |
| Paper 활성 | \`PAPER\` | 해제 + localStorage 삭제 |

- 폰트: mono uppercase (BuildIdentityBadge 대칭)
- aria-label / title: 현재 상태 + 다음 동작 명시

## 비스코프 (의식적 제외)

- 아이콘 추가 없음 — 기존 헤더는 텍스트 뱃지가 기본 패턴
- 애니메이션 없음 — 테마 전환은 CSS variable cascade 한 번에 완료
- \`matchMedia(prefers-color-scheme)\` 자동 감지 없음 — 현재 paper는 명시 \"warm paper\" 모드지 OS 다크모드의 대립 아님

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [ ] 버튼 클릭 → 데이터 속성 토글 + 새로고침 후 유지
- [ ] main.ts의 \`?theme=\` 빈 값 플로우와 충돌 없는지 확인

## Related

- Follows #8177 (paper theme bridge)
- Reference spec: Anyang Sleepers Design System (\`/Users/dancer/Downloads/...\`)