### PR TITLE
chore(dashboard): unexport 4 single-symbol internals (Gen77)

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -39,7 +39,7 @@ export function timelineEventLabel(type: string): string {
 // deliberately coarse so chips stay compact even as new event types
 // are added server-side.
 
-export type TimelineEventCategory = 'all' | 'task' | 'tool_call' | 'broadcast' | 'joined' | 'other'
+type TimelineEventCategory = 'all' | 'task' | 'tool_call' | 'broadcast' | 'joined' | 'other'
 
 export function timelineEventCategory(type: string): Exclude<TimelineEventCategory, 'all'> {
   if (type.startsWith('task_')) return 'task'

--- a/dashboard/src/components/task-manage/task-manage-state.ts
+++ b/dashboard/src/components/task-manage/task-manage-state.ts
@@ -6,7 +6,7 @@ import { refreshExecution } from '../../store'
 export const showTaskCreate = signal(false)
 export const taskCreating = signal(false)
 
-export interface TaskCreateInput { title: string; description: string; priority?: number }
+interface TaskCreateInput { title: string; description: string; priority?: number }
 
 export async function createTask(input: TaskCreateInput): Promise<boolean> {
   if (!input.title.trim()) { showToast('제목을 입력하세요', 'error'); return false }

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -16,7 +16,7 @@ import { TextArea, TextInput } from '../common/input'
 import { FilterChips } from '../common/filter-chips'
 import { StatusChip } from '../common/status-chip'
 
-export type PromptSourceFilter = 'all' | PromptSource
+type PromptSourceFilter = 'all' | PromptSource
 
 const SOURCE_CHIP_ORDER: PromptSourceFilter[] = ['all', 'file', 'override', 'default', 'missing']
 

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -32,7 +32,7 @@ let inflightTransportHealthRefresh: Promise<void> | null = null
 
 // Module-scoped search state for the hot-sessions list (stale-filter-carryover
 // bug guard: must be cleared in resetTransportHealthState).
-export const hotSessionsSearchQuery = signal('')
+const hotSessionsSearchQuery = signal('')
 
 /**
  * Case-insensitive substring filter over hot sessions.


### PR DESCRIPTION
## Summary

2번째 misc batch — 4개 서로 다른 파일의 internal-only export 일괄 축소.

| 파일 | 심볼 | 내부 사용 |
|------|------|----------|
| \`tools/prompt-registry-panel.ts\` | \`PromptSourceFilter\` (type) | SOURCE_CHIP_ORDER, SOURCE_LABELS record keys, filter helper param, counts record, sourceFilter signal |
| \`agent-detail-timeline.ts\` | \`TimelineEventCategory\` (type) | classifier return, filter param, counter type, 6 chip tuples |
| \`task-manage/task-manage-state.ts\` | \`TaskCreateInput\` (interface) | \`createTask()\` param type |
| \`transport-health.ts\` | \`hotSessionsSearchQuery\` (signal) | resetter, search input, filter predicate |

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC (4 파일, 각 1 keyword 제거)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)