### PR TITLE
chore(keeper): drop legacy try/with idiom in configured_* env readers

### DIFF
--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -20,14 +20,26 @@ let default_lookback_days = 7
 let min_success_rate = 0.3
 let recency_lambda = 0.01
 
+(* [Safe_ops.int_of_string_with_default] is built on the
+   exception-free [int_of_string_opt], so these readers no longer need
+   a hand-rolled [try ... with Eio.Cancel.Cancelled -> raise | _ ->
+   default] block.  The clamp runs after parsing, so a malformed env
+   value returns [default] unmodified. *)
 let configured_max_k () =
   match Sys.getenv_opt "MASC_KEEPER_TOOL_AFFINITY_K" with
-  | Some s -> (try max 0 (min 20 (int_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> default_max_k)
+  | Some s ->
+    max 0
+      (min 20
+         (Safe_ops.int_of_string_with_default ~default:default_max_k s))
   | None -> default_max_k
 
 let configured_lookback_days () =
   match Sys.getenv_opt "MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS" with
-  | Some s -> (try max 1 (min 30 (int_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> default_lookback_days)
+  | Some s ->
+    max 1
+      (min 30
+         (Safe_ops.int_of_string_with_default
+            ~default:default_lookback_days s))
   | None -> default_lookback_days
 
 (* ================================================================ *)


### PR DESCRIPTION
## Why

`lib/keeper/keeper_tool_affinity.ml` still uses an OCaml4-era idiom
in two env readers:

```ocaml
match Sys.getenv_opt "MASC_KEEPER_TOOL_AFFINITY_K" with
| Some s ->
    (try max 0 (min 20 (int_of_string s))
     with Eio.Cancel.Cancelled _ as e -> raise e
        | _ -> default_max_k)
| None -> default_max_k
```

The `try ... with ... | _ -> default` block is defensive scaffolding
against `int_of_string`'s `Failure _` exception.  The Cancel-preserving
first arm is only necessary **because** the broad `| _ -> default`
exists — without the wildcard, there's nothing that swallows `Cancelled`.

`Safe_ops.int_of_string_with_default` wraps the exception-free
`int_of_string_opt` internally, so there is nothing to throw and nothing
to guard.  MASC's `memory/feedback_dont-overgeneralize-review-findings`
+ general broad-catch anti-pattern norms flag this exact shape as
scaffolding worth retiring.

## What

- Replace `int_of_string` + `try/with` with
  `Safe_ops.int_of_string_with_default ~default`.
- Keep the `max / min` clamp around the parsed value.  On unparseable
  input the SSOT returns `default`, and the clamp window in both
  readers includes the respective default (`0 ≤ 5 ≤ 20`, `1 ≤ 7 ≤ 30`)
  — so the clamp is idempotent on the fallback.

Behaviourally identical on every input previously accepted.

## Verification

- `dune build @check` clean.
- `test_keeper_tool_affinity` → **8/8 OK** (covers `configured_max_k
  default` explicitly).

Net: **1 file, +14 / -2 LOC**.
