### PR TITLE
chore(dashboard): unexport 3 types in types/dashboard-execution.ts (Gen78)

### DIFF
--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -189,9 +189,9 @@ export interface ServerBuildIdentity {
 }
 
 type DashboardExecutionTone = 'ok' | 'warn' | 'bad'
-export type DashboardExecutionWorkerState = 'working' | 'watching' | 'quiet' | 'offline'
-export type DashboardExecutionContinuityState = 'healthy' | 'warning' | 'critical'
-export type DashboardExecutionQueueKind = 'session' | 'operation'
+type DashboardExecutionWorkerState = 'working' | 'watching' | 'quiet' | 'offline'
+type DashboardExecutionContinuityState = 'healthy' | 'warning' | 'critical'
+type DashboardExecutionQueueKind = 'session' | 'operation'
 
 export interface DashboardExecutionSummary {
   active_sessions?: number


### PR DESCRIPTION
## Summary

\`types/dashboard-execution.ts\`의 3개 string-literal type alias가 자기 파일 interface field로만 참조됨.

| 심볼 | 사용 |
|------|------|
| \`DashboardExecutionWorkerState\` | \`DashboardExecutionWorker.state\` field |
| \`DashboardExecutionContinuityState\` | \`DashboardExecutionContinuityPanel.state\` field |
| \`DashboardExecutionQueueKind\` | \`DashboardExecutionQueue.kind\` field |

External consumers는 containing interface 필드만 destructure — structural typing 덕분에 type alias export가 불필요.

## Verification

- \`bunx tsc --noEmit\`: green
- +3/-3 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)