### PR TITLE
chore(dashboard): unexport 5 Task sub-interfaces in types/core.ts (Gen79)

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -41,13 +41,13 @@ export interface Task {
   execution_links?: TaskExecutionLinks | null
 }
 
-export interface TaskExecutionLinks {
+interface TaskExecutionLinks {
   operation_id?: string | null
   session_id?: string | null
   autoresearch_loop_id?: string | null
 }
 
-export interface TaskContract {
+interface TaskContract {
   strict?: boolean
   completion_contract?: string[]
   required_evidence?: string[]
@@ -56,7 +56,7 @@ export interface TaskContract {
   links?: TaskExecutionLinks | null
 }
 
-export interface TaskHandoffContext {
+interface TaskHandoffContext {
   summary: string
   reason?: string | null
   next_step?: string | null
@@ -66,7 +66,7 @@ export interface TaskHandoffContext {
   updated_by?: string | null
 }
 
-export interface TaskGateCheck {
+interface TaskGateCheck {
   evidence: string
   outcome: 'satisfied' | 'missing' | 'failed' | 'unsupported'
   detail: string
@@ -78,7 +78,7 @@ export interface TaskGateEvaluation {
   reasons?: string[]
 }
 
-export interface TaskGateSnapshot {
+interface TaskGateSnapshot {
   strict?: boolean
   completion_contract?: string[]
   unmet_completion_contract?: string[]


### PR DESCRIPTION
## Summary

\`types/core.ts\`의 Task sub-interface 5개가 외부 명시적 import 없이 nested field type으로만 사용됨.

| 심볼 | 상위 참조 |
|------|----------|
| \`TaskExecutionLinks\` | \`Task.execution_links\`, \`TaskContract.links\` |
| \`TaskContract\` | \`Task.contract\` |
| \`TaskHandoffContext\` | \`Task.handoff_context\` |
| \`TaskGateCheck\` | \`TaskGateEvaluation.checks\` |
| \`TaskGateSnapshot\` | \`Task.gate\` |

## Kept as export

- \`Task\` — 대시보드 전반 consumer
- \`TaskGateEvaluation\` — \`task-detail-overlay.ts\`가 명시적 import (gate prop 타입)

## Why structural typing is enough

External consumers는 \`task.contract?.strict\`, \`task.gate?.done\` 같이 field-chain으로 접근. TypeScript는 structural이라 nested interface 이름 알 필요 없음. \`Task\` export만으로 전체 trail 추론 가능.

## Barrel note

\`dashboard/src/types.ts\`가 \`export * from './types/core'\` 재export. 이 5개 심볼은 export 제거로 barrel에서도 surface 제거되지만, 외부 consumer가 실제로 그 barrel 경로로 이 심볼을 import한 적 없어 영향 0.

## Verification

- \`bunx tsc --noEmit\`: green (barrel 영향 포함 전체 컴파일 pass)
- +5/-5 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)