### PR TITLE
chore(dashboard): unexport 11 KeeperConfig sub-interfaces (Gen80)

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -733,7 +733,7 @@ export interface KeeperSupervisorDiagnostics {
 
 // --- Keeper Config (structured read-only view) ---
 
-export interface KeeperConfigPrompt {
+interface KeeperConfigPrompt {
   goal: string
   short_goal: string
   mid_goal: string
@@ -762,13 +762,13 @@ export interface KeeperConfigPrompt {
   effective_system_prompt: string
 }
 
-export interface KeeperConfigExecution {
+interface KeeperConfigExecution {
   models: string[]
   active_model: string
   verify: boolean
 }
 
-export interface KeeperConfigCompaction {
+interface KeeperConfigCompaction {
   profile: string
   ratio_gate: number
   message_gate: number
@@ -776,7 +776,7 @@ export interface KeeperConfigCompaction {
   cooldown_sec: number
 }
 
-export interface KeeperConfigProactive {
+interface KeeperConfigProactive {
   enabled: boolean
   idle_sec: number
   cooldown_sec: number
@@ -784,7 +784,7 @@ export interface KeeperConfigProactive {
 
 export type KeeperFeatureStatus = 'wired' | 'source_only' | 'unwired'
 
-export interface KeeperConfigDrift {
+interface KeeperConfigDrift {
   status: KeeperFeatureStatus
   enabled: boolean | null
   min_turn_gap: number | null
@@ -792,18 +792,18 @@ export interface KeeperConfigDrift {
   last_reason: string | null
 }
 
-export interface KeeperConfigHandoff {
+interface KeeperConfigHandoff {
   auto: boolean
   threshold: number
   cooldown_sec: number
 }
 
-export interface KeeperConfigAutoTeamSession {
+interface KeeperConfigAutoTeamSession {
   status: KeeperFeatureStatus
   enabled: boolean | null
 }
 
-export interface KeeperConfigRuntime {
+interface KeeperConfigRuntime {
   paused: boolean
   registered: boolean
   keepalive_running: boolean
@@ -824,7 +824,7 @@ export interface KeeperConfigRuntime {
   runtime_blocker_continue_gate?: boolean | null
 }
 
-export interface KeeperConfigCoordination {
+interface KeeperConfigCoordination {
   room_scope: string
   mention_targets: string[]
   joined_room_ids: string[]
@@ -843,7 +843,7 @@ export interface KeeperConfigTools {
   total_active: number
 }
 
-export interface KeeperConfigSources {
+interface KeeperConfigSources {
   live_meta_path: string
   default_manifest_path: string | null
   default_source_kind: 'toml' | 'persona' | null
@@ -852,7 +852,7 @@ export interface KeeperConfigSources {
   override_fields: string[]
 }
 
-export interface KeeperConfigMetrics {
+interface KeeperConfigMetrics {
   generation: number
   total_turns: number
   total_input_tokens: number


### PR DESCRIPTION
## Summary

\`types/core.ts\`의 \`KeeperConfig\` sub-interface 11개 모두 외부 명시적 import 0건. indexed-access(\`KeeperConfig['runtime']['runtime_blocker_class']\`) 또는 field destructuring으로만 소비.

## Unexported (11)

KeeperConfigPrompt, Execution, Compaction, Proactive, Drift, Handoff, AutoTeamSession, Runtime, Coordination, Sources, Metrics.

## Kept as export

- \`KeeperConfig\` — \`api/dashboard.ts\`, \`keeper-detail-source.test.ts\` 등 wide import
- \`KeeperConfigTools\` — \`keeper-detail-source.ts\`가 \`preset: KeeperConfigTools['tool_preset']\` prop 타입으로 명시 import

## Why safe

외부 consumer들이 \`config.runtime.xxx\` / \`config.prompt.yyy\` 같이 destructure하거나 \`KeeperConfig['runtime']\` indexed-access로 접근. Sub-interface 이름을 bare로 참조하지 않으므로 export 제거해도 영향 없음. TypeScript structural typing + indexed access types가 지원.

## Verification

- \`bunx tsc --noEmit\`: green (api/dashboard.ts의 \`KeeperConfig['tools']['tool_preset']\` 등 indexed access 모두 통과)
- +11/-11 LOC (1 파일)

## Test plan

- [x] tsc strict (indexed access 경로 포함 전체)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)