### PR TITLE
chore(dashboard): unexport 6 Keeper state/reason types (Gen81)

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -228,9 +228,9 @@ export interface Goal {
 
 // --- Keeper ---
 
-export type KeeperHealthState = 'healthy' | 'idle' | 'stale' | 'degraded' | 'offline'
+type KeeperHealthState = 'healthy' | 'idle' | 'stale' | 'degraded' | 'offline'
 
-export type KeeperQuietReason =
+type KeeperQuietReason =
   | 'quiet_hours'
   | 'min_gap'
   | 'no_recent_activity'
@@ -241,13 +241,13 @@ export type KeeperQuietReason =
   | 'never_started'
   | 'unknown'
 
-export type KeeperNextActionPath =
+type KeeperNextActionPath =
   | 'direct_message'
   | 'manual_social_sweep'
   | 'probe'
   | 'recover'
 
-export type KeeperReplyStatus =
+type KeeperReplyStatus =
   | 'never'
   | 'awaiting_reply'
   | 'delivered'
@@ -256,7 +256,7 @@ export type KeeperReplyStatus =
   | 'error'
   | 'unknown'
 
-export type KeeperContinuityState =
+type KeeperContinuityState =
   | 'not_running'
   | 'recovering'
   | 'healthy'
@@ -298,7 +298,7 @@ export type KeeperConversationDelivery =
   | 'timeout'
   | 'error'
 
-export interface KeeperConversationUsage {
+interface KeeperConversationUsage {
   inputTokens?: number | null
   outputTokens?: number | null
   totalTokens?: number | null


### PR DESCRIPTION
## Summary

\`types/core.ts\`의 Keeper state/reason 6개 type alias/interface가 자기 파일 내부 interface field로만 참조됨.

| 심볼 | 상위 field |
|------|-----------|
| \`KeeperHealthState\` | \`Keeper.health_state\` |
| \`KeeperQuietReason\` | \`Keeper.quiet_reason\` |
| \`KeeperNextActionPath\` | \`Keeper.next_action_path\` |
| \`KeeperReplyStatus\` | \`Keeper.last_reply_status\` |
| \`KeeperContinuityState\` | \`Keeper.continuity_state\` |
| \`KeeperConversationUsage\` | \`KeeperConversation.usage\` |

External은 \`keeper.health_state\`처럼 union string 값 직접 read — structural typing이 alias 이름 의존성 없이 작동.

## Verification

- \`bunx tsc --noEmit\`: green
- +6/-6 LOC (1 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)