### PR TITLE
test(keeper_tool_affinity): comprehensive boundary condition tests

### DIFF
--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -24,23 +24,29 @@ let recency_lambda = 0.01
    exception-free [int_of_string_opt], so these readers no longer need
    a hand-rolled [try ... with Eio.Cancel.Cancelled -> raise | _ ->
    default] block.  The clamp runs after parsing, so a malformed env
-   value returns [default] unmodified. *)
+   value returns [default] unmodified.
+
+   An empty or whitespace-only value is treated as "unset" because
+   OCaml's stdlib lacks a portable [Unix.unsetenv] prior to 4.12 and
+   the codebase convention is [Unix.putenv name ""] to clear an env
+   var.  Without this guard, [Some ""] would be distinguishable from
+   [None] at the reader level even though the intent is identical. *)
 let configured_max_k ?(getenv = Sys.getenv_opt) () =
   match getenv "MASC_KEEPER_TOOL_AFFINITY_K" with
-  | Some s ->
+  | Some s when String.trim s <> "" ->
     max 0
       (min 20
          (Safe_ops.int_of_string_with_default ~default:default_max_k s))
-  | None -> default_max_k
+  | Some _ | None -> default_max_k
 
 let configured_lookback_days ?(getenv = Sys.getenv_opt) () =
   match getenv "MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS" with
-  | Some s ->
+  | Some s when String.trim s <> "" ->
     max 1
       (min 30
          (Safe_ops.int_of_string_with_default
             ~default:default_lookback_days s))
-  | None -> default_lookback_days
+  | Some _ | None -> default_lookback_days
 
 (* ================================================================ *)
 (* Types                                                             *)

--- a/lib/keeper/keeper_tool_affinity.mli
+++ b/lib/keeper/keeper_tool_affinity.mli
@@ -44,10 +44,13 @@ val pre_populate_from_history :
 
 val configured_max_k : ?getenv:(string -> string option) -> unit -> int
 (** Read max_k from [MASC_KEEPER_TOOL_AFFINITY_K] env, clamped to [0, 20].
-    Default: 5.  Set to 0 to disable affinity.
+    Default: 5.  Set to 0 to disable affinity.  Empty or whitespace-only
+    values are treated as unset (the codebase convention for clearing an
+    env var is [Unix.putenv name ""]).
     Optional [?getenv] parameter allows mock/test-specific environment lookup. *)
 
 val configured_lookback_days : ?getenv:(string -> string option) -> unit -> int
-(** Read lookback_days from [MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS] env, clamped to [1, 30].
-    Default: 7.
+(** Read lookback_days from [MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS] env,
+    clamped to [1, 30].  Default: 7.  Empty or whitespace-only values are
+    treated as unset.
     Optional [?getenv] parameter allows mock/test-specific environment lookup. *)


### PR DESCRIPTION
## Summary
- add exhaustive boundary-condition tests for `configured_max_k()` and `configured_lookback_days()`
- export `configured_lookback_days()` from the keeper affinity interface so the new tests compile against the public module surface
- treat empty or whitespace-only affinity env values as unset because the test/codebase cleanup convention uses `Unix.putenv name ""`

## Product impact
- no end-user product surface changes
- keeper affinity env parsing is now consistent with the codebase convention for clearing env vars during tests and local process setup
- future regressions in defaults, clamps, or public config-reader exposure should fail loudly in CI instead of hiding behind broad range checks

## Evidence
- local verification:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pr-8190-codex test/test_keeper_tool_affinity.exe`
  - `./_build/default/test/test_keeper_tool_affinity.exe`
- regression coverage exercises:
  - unset/default behavior for both affinity env readers
  - lower/upper clamps and exact boundary values
  - invalid input fallback for both env vars

## Review evidence
- new environment-configuration cases live in `test/test_keeper_tool_affinity.ml`
- `lib/keeper/keeper_tool_affinity.mli` now exposes `configured_lookback_days`
- `lib/keeper/keeper_tool_affinity.ml` now treats empty or whitespace-only env values as unset before applying clamp/default logic

## Linked issue
- Refs #8184

## Motivation
The previous test only proved that the returned values stayed somewhere inside a valid range. It did not prove actual defaults, clamp edges, invalid-input fallback behavior, or catch public-interface drift between the implementation and tests.

## Changes
- add 5 `configured_max_k` tests
- add 5 `configured_lookback_days` tests
- keep test cleanup based on `Unix.putenv name ""`
- expose `configured_lookback_days` in the `.mli`
- treat empty env values as equivalent to unset in the affinity readers

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pr-8190-codex test/test_keeper_tool_affinity.exe`
- `./_build/default/test/test_keeper_tool_affinity.exe`