### PR TITLE
chore(server_bootstrap): replace two simple Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -24,7 +24,7 @@ let ensure_default_oas_cascade_timeout_env () =
 
 let project_root_from_executable () =
   let raw_exe =
-    try Sys.executable_name with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
+    Safe_ops.protect ~default:"" (fun () -> Sys.executable_name)
   in
   let exe =
     if String.equal raw_exe "" then ""
@@ -351,7 +351,7 @@ let legacy_room_candidates rooms_dir =
   if not (Sys.file_exists rooms_dir) then
     []
   else
-    try
+    Safe_ops.protect ~default:[] (fun () ->
       Sys.readdir rooms_dir
       |> Array.to_list
       |> List.filter_map (fun room_id ->
@@ -372,8 +372,7 @@ let legacy_room_candidates rooms_dir =
                    msg;
                    None
            else
-             None)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+             None))
 
 let infer_current_room_from_legacy_dirs rooms_dir =
   match legacy_room_candidates rooms_dir with


### PR DESCRIPTION
## Why

`lib/server/server_runtime_bootstrap.ml` has 16 Cancel-preserving
try/with blocks; **2** of them fit the exact shape
`Safe_ops.protect` already centralises (pure "absorb into default"
with no per-case logging):

```ocaml
(* line 27 *)
try Sys.executable_name with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""

(* line 376 *)
try Sys.readdir ... |> List.filter_map (...)
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
```

Both are pure `Sys.*` IO with no failure-site logging — identical to
the `parse_*` sites swept in #8187.

## What

- Rewrite both sites to
  `Safe_ops.protect ~default:... (fun () -> ...)`.
- `raise_with_backtrace` inside the SSOT is a strict improvement over
  the previous bare `raise e` on the Cancel path — original backtrace
  is preserved for diagnostics.

## Scope discipline

The remaining **14** Cancel-preserving blocks in this file pair Cancel
with per-case `Log.Misc.error "<context> failed: %s" (Printexc.to_string
exn)` logging.  Those need per-site context strings, so the correct
swap is `Safe_ops.try_with_log` (or `try_with_default`), not `protect`
— intentionally left for a future pass.

## Verification

- `dune build @check` clean.
- `rg "Eio.Cancel.Cancelled _ as e -> raise e" lib/server/server_runtime_bootstrap.ml`
  → 14 hits remaining (the compound logging set, as documented).
- `test_server_runtime_bootstrap` 35/36 pass; the one failure
  (`main_eio_serves_health_before_lazy`) is a pre-existing e2e flake
  unrelated to this PR — confirmed by stashing my changes locally
  and observing the same failure against `origin/main`.

Net: **1 file, +3 / -4 LOC**.
