### PR TITLE
fix: add missing autoresearch swarm_start permissions to legacy_permission_entries

### DIFF
--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -66,6 +66,8 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_policy_approve", CanBroadcast);
     ("masc_cleanup_zombies", CanBroadcast);
     ("masc_autoresearch_start", CanAdmin);
+    ("masc_autoresearch_swarm_start", CanAdmin);
+    ("masc_repo_synthesis_swarm_start", CanAdmin);
     ("masc_autoresearch_cycle", CanAdmin);
     ("masc_autoresearch_inject", CanAdmin);
     ("masc_autoresearch_stop", CanAdmin);


### PR DESCRIPTION
## Summary\n\nFix permission bypass in autoresearch tools by adding missing entries\nto  in .\n\n## Problem\n\n and \nwere missing from . When catalog metadata is\nunavailable (startup ordering, shard fallback), these tools bypassed\npermission checks entirely.\n\nThe module-level  correctly\nassigns  to these tools, but the legacy fallback path in\n had no corresponding entries.\n\n## Fix\n\nAdd both tools to  with  permission,\nmatching the pattern used by .\n\n## Test\n\n-  passes\n- Added sync comment noting the triple-path permission contract\n\nCloses task-222