### PR TITLE
chore(dashboard): unexport 4 remaining internal types in core.ts (Gen82)

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -98,7 +98,7 @@ export interface Message {
 
 // --- Board ---
 
-export type BoardPostMeta = Record<string, unknown> & {
+type BoardPostMeta = Record<string, unknown> & {
   source?: string | null
   state_block?: string | null
   classification_reason?: string | null
@@ -363,7 +363,7 @@ export type PipelineStage =
 
 // Aggregated metrics computed by the backend over a sliding window.
 // Fields mirror dashboard_http_keeper_detail.ml summary output.
-export interface MetricsWindowTopItem {
+interface MetricsWindowTopItem {
   tool?: string
   kind?: string
   model?: string
@@ -720,7 +720,7 @@ export interface KeeperSupervisorCrashLogEntry {
   reason?: string
 }
 
-export interface KeeperSupervisorDiagnostics {
+interface KeeperSupervisorDiagnostics {
   restart_count?: number
   max_restarts?: number
   crash_log?: KeeperSupervisorCrashLogEntry[]
@@ -877,7 +877,7 @@ export interface KeeperHookSlot {
   features?: string[]
 }
 
-export interface KeeperHookIntrospection {
+interface KeeperHookIntrospection {
   slots: Record<string, KeeperHookSlot>
   deny_list: string[]
   deny_list_count: number


### PR DESCRIPTION
## Summary

\`types/core.ts\` 남은 4개 dead export 정리. Gen79-81의 sweep 마무리.

| 심볼 | 상위 field |
|------|-----------|
| \`BoardPostMeta\` (type) | \`BoardPost.meta\` |
| \`MetricsWindowTopItem\` (interface) | \`MetricsWindow.top_work_kinds\` 외 6개 top_* 필드 |
| \`KeeperSupervisorDiagnostics\` (interface) | \`Keeper.supervisor_diagnostics\` |
| \`KeeperHookIntrospection\` (interface) | \`KeeperConfig.hooks\` |

외부 import 0건. Structural typing으로 충분.

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)