### PR TITLE
chore(dashboard): unexport 6 internal-only navigation types (Gen83)

### DIFF
--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -1,7 +1,7 @@
 import type { RouteState, TabId } from '../types'
 
-export type SurfaceId = TabId
-export type SurfaceSectionId =
+type SurfaceId = TabId
+type SurfaceSectionId =
   // monitoring
   | 'observatory'
   | 'agents'
@@ -28,7 +28,7 @@ export type SurfaceSectionId =
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
-export interface DashboardNavGroup {
+interface DashboardNavGroup {
   id: SurfaceId
   label: string
   icon: string
@@ -39,7 +39,7 @@ export interface DashboardNavGroup {
   hidden?: boolean
 }
 
-export interface DashboardNavItem {
+interface DashboardNavItem {
   id: TabId
   label: string
   icon: string
@@ -47,7 +47,7 @@ export interface DashboardNavItem {
   defaultParams?: Record<string, string>
 }
 
-export interface DashboardSectionNavItem {
+interface DashboardSectionNavItem {
   id: SurfaceSectionId
   label: string
   description: string
@@ -282,7 +282,7 @@ export function visibleSectionItemsForTab(tabId: TabId): DashboardSectionNavItem
  *   - Cross-surface redirects are not supported (normalizeRouteParams returns
  *     params for the same tab). Cross-surface routing lives in the router.
  */
-export interface SectionRedirect {
+interface SectionRedirect {
   section: string
   view?: string
 }


### PR DESCRIPTION
## Summary

\`config/navigation.ts\`의 6개 type/interface가 자기 파일 내부에서만 참조. 외부는 exported 상수(\`DASHBOARD_SURFACES\`, \`DASHBOARD_NAV_ITEMS\`, \`DASHBOARD_SECTION_ITEMS\`, \`SECTION_REDIRECTS\`)와 helper 함수로만 소비.

| 심볼 | 자기 파일 사용처 |
|------|-----------------|
| \`SurfaceId\` (type) | \`DashboardNavGroup.id\`, validSectionIds 헬퍼 |
| \`SurfaceSectionId\` (type) | \`DashboardSectionNavItem.id\`, 2개 helper |
| \`DashboardNavGroup\` (interface) | \`DASHBOARD_SURFACES\` 배열 요소 |
| \`DashboardNavItem\` (interface) | \`DASHBOARD_NAV_ITEMS\` 배열 요소 |
| \`DashboardSectionNavItem\` (interface) | \`DASHBOARD_SECTION_ITEMS\` 값 + 헬퍼 반환 |
| \`SectionRedirect\` (interface) | \`SECTION_REDIRECTS\` 값 |

## Verification

- \`bunx tsc --noEmit\`: green
- +6/-6 LOC (1 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)