### PR TITLE
chore(agent_timeline): replace 4 Cancel-preserving try/with with Safe_ops JSON helpers

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -232,24 +232,16 @@ let tool_call_events (config : Coord.config) ~agent_name ~limit :
        | None -> false)
   |> List.filter_map (fun (e : Activity_graph.event) ->
        let ts = Float.of_int e.ts_ms /. 1000.0 in
-       let open Yojson.Safe.Util in
        let tool_name =
-         try e.payload |> member "tool_name" |> to_string
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unknown"
+         Safe_ops.json_string ~default:"unknown" "tool_name" e.payload
        in
        let success =
-         try e.payload |> member "success" |> to_bool
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> true
+         Safe_ops.json_bool ~default:true "success" e.payload
        in
        let duration_ms =
-         try e.payload |> member "duration_ms" |> to_int
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 0
+         Safe_ops.json_int ~default:0 "duration_ms" e.payload
        in
-       let error_str =
-         try match e.payload |> member "error" with
-             | `String s -> Some s | _ -> None
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-       in
+       let error_str = Safe_ops.json_string_opt "error" e.payload in
        Some
          {
            ts;


### PR DESCRIPTION
## Why

`lib/tool_agent_timeline.ml` used the Cancel-preserving try/with
idiom for four `Yojson.Safe.Util` field lookups inside the
per-event lambda of `keeper_tool_events`:

```ocaml
try e.payload |> member "tool_name" |> to_string
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unknown"
```

`Safe_ops` already exposes purpose-built JSON accessors with the
exact same "return default on missing/wrong-type" semantics —
`Safe_ops.json_string`, `json_bool`, `json_int`,
`json_string_opt`.  Each replaces a full try/with block with a
single call.

Same class as #8187 / #8191; specialises the catch-then-default
pattern to its strongly-typed SSOT.

## What

| field | before | after |
|---|---|---|
| `tool_name` | `try ... to_string with ... "unknown"` | `Safe_ops.json_string ~default:"unknown" "tool_name" ...` |
| `success` | `try ... to_bool with ... true` | `Safe_ops.json_bool ~default:true "success" ...` |
| `duration_ms` | `try ... to_int with ... 0` | `Safe_ops.json_int ~default:0 "duration_ms" ...` |
| `error` | `try match ... \| \`String s -> Some s \| _ -> None with ... None` | `Safe_ops.json_string_opt "error" ...` |

Drop the `let open Yojson.Safe.Util in` header — it was only
providing `member` / `to_*` for the four blocks.

## Behavioural note

`Safe_ops.json_string_opt` returns `None` on both "missing field"
and "wrong type" — exactly the behaviour of the previous
`try match ... with | \`String s -> Some s | _ -> None with ...
-> None` two-level dispatch.  All other accessors preserve default
semantics bit-for-bit.

## Verification

- `dune build @check` clean.
- `rg "Eio.Cancel.Cancelled _ as e -> raise e" lib/tool_agent_timeline.ml`
  → 0 hits (file now fully cleaned).
- `test_mcp_server_eio` → **59/59 OK** (includes MCP session
  persistence + tool call logging paths that exercise
  `Tool_agent_timeline`).

Net: **1 file, +4 / -12 LOC**.
