### PR TITLE
chore(grpc): replace 3 Cancel-preserving stream-close try/with with Safe_ops.protect

### DIFF
--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -176,12 +176,12 @@ let heartbeat_stream t ~sw ~env =
        [with _ -> ()] would swallow a cancel racing with [Stream.close],
        leaving the fork fiber alive past the cancel boundary. *)
     let close_request_stream () =
-      try Grpc_eio.Stream.close request_stream
-      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+      Safe_ops.protect ~default:() (fun () ->
+        Grpc_eio.Stream.close request_stream)
     in
     let close_raw_requests () =
-      try Grpc_eio.Stream.close raw_requests
-      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+      Safe_ops.protect ~default:() (fun () ->
+        Grpc_eio.Stream.close raw_requests)
     in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -323,7 +323,8 @@ module Reflection_bridge = struct
       let process_loop () =
         Eio.Switch.run @@ fun loop_sw ->
         Eio.Switch.on_release loop_sw (fun () ->
-            (try Grpc_eio.Stream.close response_stream with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()));
+            Safe_ops.protect ~default:() (fun () ->
+              Grpc_eio.Stream.close response_stream));
             let rec loop () =
               let request_bytes = Grpc_eio.Stream.take request_stream in
               let services = Grpc_eio.Server.list_services !server_ref in


### PR DESCRIPTION
## Why

Three sites in the gRPC transport hand-rolled the same
Cancel-preserving stream-close idiom:

```ocaml
try Grpc_eio.Stream.close ...
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
```

- `lib/grpc/masc_grpc_client.ml` — `close_request_stream` +
  `close_raw_requests` inside a fork fiber's stream pair-up shim.
- `lib/grpc/masc_grpc_server.ml` — the `Switch.on_release` cleanup
  for the response stream.

The block comment above `close_request_stream` documents the Cancel
invariant:

> Both helpers must re-raise `Eio.Cancel.Cancelled` — they are called
> from the `End_of_file` and generic-`exn` branches of the enclosing
> loop, neither of which is a cancel handler.  `with _ -> ()` would
> swallow a cancel racing with `Stream.close`, leaving the fork fiber
> alive past the cancel boundary.

`Safe_ops.protect` is built exactly for this contract and internally
uses `Printexc.raise_with_backtrace` — a strict diagnostics upgrade
over the previous bare `raise e`.  Same class as #8187 / #8191 /
#8195.

## What

- Rewrite all three sites as
  `Safe_ops.protect ~default:() (fun () -> Grpc_eio.Stream.close ...)`.
- The Cancel invariant now lives in one library function (`Safe_ops`)
  rather than three hand-rolled copies across two gRPC files.

## Verification

- `dune build @check` clean.
- `test_grpc_client` → **15/15 OK**.
- `test_grpc_coordination` → **19/19 OK** (includes
  `server_config.registers_health_service` which exercises the
  response-stream lifecycle).

Net: **2 files, +6 / -5 LOC**.
