### PR TITLE
chore(dashboard): unexport 11 internal-only common/ types (Gen84)

### DIFF
--- a/dashboard/src/components/common/dashed-notice.ts
+++ b/dashboard/src/components/common/dashed-notice.ts
@@ -17,8 +17,8 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-export type DashedNoticeSize = 'sm' | 'md'
-export type DashedNoticeBorderTone = 'card' | 'subtle'
+type DashedNoticeSize = 'sm' | 'md'
+type DashedNoticeBorderTone = 'card' | 'subtle'
 
 /** Pure: Tailwind size tokens. Exposed so callers in a hot render path
     (e.g. a repeated fsm-hub sub-panel) can pre-build the string once. */
@@ -42,7 +42,7 @@ export function dashedNoticeClasses(
   return parts.join(' ')
 }
 
-export interface DashedNoticeProps {
+interface DashedNoticeProps {
   children?: ComponentChildren
   size?: DashedNoticeSize
   borderTone?: DashedNoticeBorderTone

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -14,9 +14,9 @@ import { html } from 'htm/preact'
 import type { HeartbeatState } from '../../lib/heartbeat-history'
 import { summarizeHistory, type HeartbeatSummary } from './heartbeat-strip'
 
-export type UptimeTone = 'operational' | 'degraded' | 'unhealthy'
+type UptimeTone = 'operational' | 'degraded' | 'unhealthy'
 
-export interface UptimeChipView {
+interface UptimeChipView {
   /** Integer percent (0-100) as a string — 99.87 → "99.87", 100 → "100". */
   label: string
   tone: UptimeTone
@@ -43,7 +43,7 @@ const TONE_CLASS: Record<UptimeTone, string> = {
   unhealthy: 'text-rose-200 border-rose-400/30 bg-rose-500/10',
 }
 
-export interface HeartbeatUptimeChipProps {
+interface HeartbeatUptimeChipProps {
   history: HeartbeatState[]
   class?: string
   testId?: string

--- a/dashboard/src/components/common/status-dot.ts
+++ b/dashboard/src/components/common/status-dot.ts
@@ -21,7 +21,7 @@
 
 import { html } from 'htm/preact'
 
-export type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
+type StatusDotSize = 'xs' | 'sm' | 'md' | 'lg'
 
 /** Pure: Tailwind size tokens for each named variant. Exposed so
     a caller that wraps its own <span> (legacy code in a hot render
@@ -50,7 +50,7 @@ export function statusDotClasses(
   return parts.join(' ')
 }
 
-export interface StatusDotProps {
+interface StatusDotProps {
   size?: StatusDotSize
   /** Additional Tailwind classes for tone, margin, etc. Caller-owned
       because per-file helpers (`statusDot(status)`, `verdictTone(v)`,

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -3,9 +3,9 @@ import { signal } from '@preact/signals'
 import type { ComponentChildren } from 'preact'
 import { CheckCircle2, AlertTriangle, XCircle, X } from 'lucide-preact'
 
-export type ToastType = 'success' | 'warning' | 'error'
+type ToastType = 'success' | 'warning' | 'error'
 
-export interface ToastAction {
+interface ToastAction {
   label: string
   onClick: () => void
 }

--- a/dashboard/src/components/common/tool-audit.ts
+++ b/dashboard/src/components/common/tool-audit.ts
@@ -2,7 +2,7 @@ import type { Keeper } from '../../types'
 import { isOfflineStatus } from '../../lib/status-utils'
 import { navigate } from '../../router'
 
-export type ToolAuditEmptyState =
+type ToolAuditEmptyState =
   | 'offline'
   | 'not_collected'
   | 'none_recent'


### PR DESCRIPTION
## Summary

\`components/common/\`의 5개 파일 11 심볼 unexport. 모두 자기 파일 component/helper에서만 참조.

| 파일 | 심볼 | 비고 |
|------|------|------|
| \`dashed-notice.ts\` | DashedNoticeSize, DashedNoticeBorderTone, DashedNoticeProps | DashedNotice 컴포넌트 prop shape |
| \`status-dot.ts\` | StatusDotSize, StatusDotProps | StatusDot 컴포넌트 prop shape |
| \`tool-audit.ts\` | ToolAuditEmptyState | 3개 helper 반환 타입, external는 discriminated string으로 소비 |
| \`heartbeat-uptime-chip.ts\` | UptimeTone, UptimeChipView, HeartbeatUptimeChipProps | component + format helper 내부 |
| \`toast.ts\` | ToastType, ToastAction | showToast 시그니처 + Toast 내부 state |

## Verification

- \`bunx tsc --noEmit\`: green
- +11/-11 LOC (5 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)