### PR TITLE
chore(sweep): replace 4 simple Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -15,12 +15,11 @@ open Coord_broadcast
     Reads at most 200 bytes to avoid OOM on large/corrupt files. *)
 let agent_parse_error_snapshot ~agent_name ~agent_file =
   let raw_head =
-    try
+    Safe_ops.protect ~default:"" (fun () ->
       In_channel.with_open_text agent_file (fun ic ->
         let buf = Bytes.create 200 in
         let n = In_channel.input ic buf 0 200 in
-        Bytes.sub_string buf 0 n)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
+        Bytes.sub_string buf 0 n))
   in
   `Assoc [
     ("agent_name", `String agent_name);

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -60,7 +60,7 @@ let get_tasks_safe config =
   else (read_backlog config).tasks
 
 let safe_yield () =
-  try Eio.Fiber.yield () with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+  Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
 
 let take_first n xs =
   if n <= 0 then []

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -33,7 +33,7 @@ let sweep_result_to_yojson r =
 
 (** Parse ISO 8601 timestamp to Unix epoch seconds. *)
 let parse_iso_ts s =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     Scanf.sscanf s "%d-%d-%dT%d:%d:%d" (fun y mo d h mi se ->
       let tm = {
         Unix.tm_sec = se; tm_min = mi; tm_hour = h;
@@ -41,8 +41,7 @@ let parse_iso_ts s =
         tm_wday = 0; tm_yday = 0; tm_isdst = false;
       } in
       let epoch, _ = Unix.mktime tm in
-      Some epoch)
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+      Some epoch))
 
 let days_since_update (goal : Goal_store.goal) ~now =
   match parse_iso_ts goal.updated_at with

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -181,7 +181,7 @@ let read_metrics_file file : task_metric list =
     ) lines
 
 let safe_yield () =
-  try Eio.Fiber.yield () with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+  Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
 
 let month_key ~year ~month =
   (year * 12) + (month - 1)


### PR DESCRIPTION
## Why

Four independent files still carried the one-line
Cancel-preserving absorb-into-default idiom that `Safe_ops.protect`
already centralises:

| file | site | body | default |
|---|---|---|---|
| `lib/coord/coord_query.ml` | `safe_yield` | `Eio.Fiber.yield ()` | `()` |
| `lib/metrics_store_eio.ml` | `safe_yield` | `Eio.Fiber.yield ()` | `()` |
| `lib/coord/coord_lifecycle.ml` | `agent_parse_error_snapshot` | bounded 200-byte `In_channel` read for diagnostic snapshots | `""` |
| `lib/goal/goal_janitor.ml` | `parse_iso_ts` | `Scanf.sscanf` ISO-8601 timestamp parse | `None` |

The two `safe_yield` copies are byte-identical but never shared — a
classic hand-rolled-duplicate drift vector.  Same anti-pattern class
as #8187 / #8191 / #8195 / #8196.

## What

- Rewrite all four sites as
  `Safe_ops.protect ~default:... (fun () -> ...)`.
- Each preserves the original default value unchanged.
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade over the previous bare
  `raise e`.

## Scope

Intentionally leaves three adjacent targets:

- `lib/masc_http_client/masc_http_client.ml` — same idiom but the
  sub-library does not link `masc_core`; swapping it in would widen
  the dep graph.
- The two `safe_yield` copies could be consolidated into one shared
  `Safe_ops.safe_yield` or `Eio_guard.yield`, but merging their
  homes crosses a library boundary (`masc_core` + `masc_coord`
  callers) best handled in a dedicated refactor.

## Verification

- `dune build @check` clean.
- `test_goal_janitor` → **4/4 OK** (includes `parse_iso_ts` coverage
  via the `prune` path).
- `test_metrics_store_eio` → **9/9 OK**.

Net: **4 files, +6 / -8 LOC**.
