### PR TITLE
chore(dashboard): unexport 11 common/ 2nd-round internal types (Gen85)

### DIFF
--- a/dashboard/src/components/common/copy-id-button.ts
+++ b/dashboard/src/components/common/copy-id-button.ts
@@ -8,7 +8,7 @@ import { useState } from 'preact/hooks'
 import { showToast } from './toast'
 import { copyToClipboard } from './copyable-code'
 
-export interface CopyIdButtonProps {
+interface CopyIdButtonProps {
   value: string
   label?: string
   ariaLabel?: string

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -7,9 +7,9 @@ import { Copy, Check } from 'lucide-preact'
 import { useState } from 'preact/hooks'
 import { showToast } from './toast'
 
-export type CopyableVariant = 'primary' | 'secondary'
+type CopyableVariant = 'primary' | 'secondary'
 
-export interface CopyableCodeProps {
+interface CopyableCodeProps {
   command: string
   label?: string
   ariaLabel?: string

--- a/dashboard/src/components/common/live-pulse-dot.ts
+++ b/dashboard/src/components/common/live-pulse-dot.ts
@@ -13,9 +13,9 @@
 
 import { html } from 'htm/preact'
 
-export type LivePulseState = 'live' | 'stale' | 'idle'
+type LivePulseState = 'live' | 'stale' | 'idle'
 
-export interface LivePulseView {
+interface LivePulseView {
   state: LivePulseState
   /** Human-readable status tucked into title/aria so hover + AT both
       explain what the dot means without a separate tooltip chip. */
@@ -55,7 +55,7 @@ const DOT_TONE: Record<LivePulseState, string> = {
   idle: 'bg-[var(--white-10)]',
 }
 
-export interface LivePulseDotProps {
+interface LivePulseDotProps {
   lastTickMs: number | null
   nowMs: number
   sampleIntervalMs: number

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -14,7 +14,7 @@
 
 import { html } from 'htm/preact'
 
-export type ProgressBarSize = 'xs' | 'sm' | 'md'
+type ProgressBarSize = 'xs' | 'sm' | 'md'
 export type ProgressBarTone =
   | 'accent' | 'ok' | 'warn' | 'bad'
   | 'emerald' | 'amber' | 'rose' | 'sky'

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -36,8 +36,8 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-export type SectionCapTone = 'muted' | 'dim'
-export type SectionCapWeight = 'normal' | 'semibold'
+type SectionCapTone = 'muted' | 'dim'
+type SectionCapWeight = 'normal' | 'semibold'
 
 const BASE = 'text-[10px] uppercase tracking-wider'
 
@@ -67,7 +67,7 @@ export function sectionCapClasses(
   return parts.join(' ')
 }
 
-export interface SectionCapProps {
+interface SectionCapProps {
   tone?: SectionCapTone
   weight?: SectionCapWeight
   /** Additional Tailwind classes for margin, inline-flex composition,

--- a/dashboard/src/components/common/sparkline.ts
+++ b/dashboard/src/components/common/sparkline.ts
@@ -31,7 +31,7 @@ interface SparklineProps {
 
 /** Stats derived from the series — exposed for callers that want to
     render their own trend badges AND for unit tests (no canvas needed). */
-export interface SparklineStats {
+interface SparklineStats {
   first: number
   latest: number
   min: number


### PR DESCRIPTION
## Summary

\`components/common/\` 2차 batch — Gen84의 후속. 6 파일 11 심볼.

| 파일 | 심볼 | 비고 |
|------|------|------|
| \`live-pulse-dot.ts\` | LivePulseState, LivePulseView, LivePulseDotProps | component props + classification union |
| \`section-cap.ts\` | SectionCapTone, SectionCapWeight, SectionCapProps | tone/weight enum + props |
| \`copyable-code.ts\` | CopyableVariant, CopyableCodeProps | variant union + props |
| \`sparkline.ts\` | SparklineStats | \`sparklineStats()\` helper 반환 타입 |
| \`progress-bar.ts\` | ProgressBarSize | helper size 파라미터 타입 |
| \`copy-id-button.ts\` | CopyIdButtonProps | component props |

Kept as export: 모든 상위 component 함수 (LivePulseDot, SectionCap, CopyableCode, Sparkline, ProgressBar helpers, CopyIdButton) + ProgressBarTone/Tone/Props (external ref 있음).

## Verification

- \`bunx tsc --noEmit\`: green
- +11/-11 LOC (6 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)