### PR TITLE
chore(dashboard): unexport 5 top-level internal-only symbols (Gen86)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -38,11 +38,11 @@ import { Menu, X } from 'lucide-preact'
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
 // future per-user preference that might use plain \"sidebar-collapsed\".
-export const sidebarCollapsed = persistentSignal<boolean>({
+const sidebarCollapsed = persistentSignal<boolean>({
   key: 'dashboard:sidebar-collapsed',
   defaultValue: false,
 })
-export const mobileMenuOpen = signal(false)
+const mobileMenuOpen = signal(false)
 
 export function App() {
   useEffect(() => {

--- a/dashboard/src/composite-signals.ts
+++ b/dashboard/src/composite-signals.ts
@@ -8,7 +8,7 @@
 
 import { signal } from '@preact/signals'
 
-export interface CompositeTickEnvelope {
+interface CompositeTickEnvelope {
   name: string
   ts_unix: number
 }

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -70,7 +70,7 @@ function scheduleNamespaceWarmRetry(): void {
 
 // --- Scheduler instance ---
 
-export const namespaceTruthScheduler = new FetchScheduler(doFetchNamespaceTruth, {
+const namespaceTruthScheduler = new FetchScheduler(doFetchNamespaceTruth, {
   cooldownMs: 2_000,
   debounceMs: 300,
 })

--- a/dashboard/src/pending-confirm.ts
+++ b/dashboard/src/pending-confirm.ts
@@ -71,7 +71,7 @@ export function normalizePendingConfirmEnvelope(raw: unknown): PendingConfirmEnv
   }
 }
 
-export interface PendingConfirmSource {
+interface PendingConfirmSource {
   pending_confirm_envelope?: PendingConfirmEnvelope | null
   pending_confirms?: PendingConfirmation[] | null
   pending_confirm_summary?: PendingConfirmSummary | null


### PR DESCRIPTION
## Summary

dashboard/src 최상위 4 파일의 5 심볼 unexport. 모두 자기 파일 내부 UI state 또는 helper.

| 파일 | 심볼 | 사용처 |
|------|------|--------|
| \`app.ts\` | \`sidebarCollapsed\` (persistent signal) | SideRail collapsed prop |
| \`app.ts\` | \`mobileMenuOpen\` (signal) | 햄버거 메뉴 toggle |
| \`pending-confirm.ts\` | \`PendingConfirmSource\` (interface) | \`selectPendingConfirmState\` param |
| \`namespace-truth-actions.ts\` | \`namespaceTruthScheduler\` (FetchScheduler) | 6 internal uses (requestNow, dispose 등) |
| \`composite-signals.ts\` | \`CompositeTickEnvelope\` (interface) | \`compositeTick\` signal generic |

외부 import 0건.

## Verification

- \`bunx tsc --noEmit\`: green
- +5/-5 LOC (4 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)