### PR TITLE
chore(dashboard): unexport 11 common/ 3rd-round internal types (Gen87)

### DIFF
--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { AlertTriangle, AlertCircle, Info } from 'lucide-preact'
 
-export type ConfirmTone = 'danger' | 'warning' | 'info'
+type ConfirmTone = 'danger' | 'warning' | 'info'
 
 interface ConfirmState {
   isOpen: boolean

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 
-export type DistributionTone = 'accent' | 'ok' | 'warn' | 'bad' | 'muted'
+type DistributionTone = 'accent' | 'ok' | 'warn' | 'bad' | 'muted'
 
 export interface DistributionItem {
   label: string

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { Component, type ComponentChildren } from 'preact'
 import { AlertOctagon, RefreshCcw } from 'lucide-preact'
 
-export interface ErrorBoundaryInfo {
+interface ErrorBoundaryInfo {
   componentStack?: string
 }
 

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -42,7 +42,7 @@ export function formatStreakLabel(streak: HeartbeatStreak | null): string {
   return `${STATE_LABEL[streak.state]} for ${streak.samples} ${unit}`
 }
 
-export interface HeartbeatStreakChipProps {
+interface HeartbeatStreakChipProps {
   history: HeartbeatState[]
   class?: string
   testId?: string

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -17,7 +17,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-export type KbdSize = 'sm' | 'md'
+type KbdSize = 'sm' | 'md'
 
 const BASE = 'inline-flex items-center justify-center rounded border font-mono text-center'
 
@@ -34,7 +34,7 @@ export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
     : `${BASE} ${sized} ${extra}`
 }
 
-export interface KbdProps {
+interface KbdProps {
   /** Key label — e.g. "⌘K", "?", "1", "Ctrl+P". Supports multi-char
       strings because the primitive deliberately doesn't parse chords;
       callers that want auto-split key chords should compose several

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -15,7 +15,7 @@
 import { html } from 'htm/preact'
 
 type ProgressBarSize = 'xs' | 'sm' | 'md'
-export type ProgressBarTone =
+type ProgressBarTone =
   | 'accent' | 'ok' | 'warn' | 'bad'
   | 'emerald' | 'amber' | 'rose' | 'sky'
 
@@ -53,7 +53,7 @@ export function progressBarToneClass(tone: ProgressBarTone): string {
   }
 }
 
-export type ProgressBarTrackTone = 'default' | 'dim' | 'muted'
+type ProgressBarTrackTone = 'default' | 'dim' | 'muted'
 
 /** Pure: track (muted background) bg class for a given track tone.
     Default = --white-5 (most rows); dim = --white-6 (keeper detail);
@@ -67,7 +67,7 @@ export function progressBarTrackToneClass(tone: ProgressBarTrackTone = 'default'
   }
 }
 
-export interface ProgressBarProps {
+interface ProgressBarProps {
   /** Percentage 0–100; values outside are clamped (no throw). */
   pct: number
   size?: ProgressBarSize

--- a/dashboard/src/components/common/skeleton.ts
+++ b/dashboard/src/components/common/skeleton.ts
@@ -66,7 +66,7 @@ export function Skeleton({
   ></div>`
 }
 
-export interface SkeletonTextProps {
+interface SkeletonTextProps {
   /** Number of stacked lines. Default 3 — enough for a paragraph preview. */
   lines?: number
   class?: string
@@ -111,7 +111,7 @@ export function SkeletonText({
   >${widths.map(w => html`<div class=${`${SKELETON_BASE} ${w} h-3`} aria-hidden="true"></div>`)}</div>`
 }
 
-export interface SkeletonCircleProps {
+interface SkeletonCircleProps {
   /** Tailwind size (e.g. "h-6 w-6"). Default h-8 w-8. */
   size?: string
   class?: string


### PR DESCRIPTION
## Summary

common/ 3차 batch. 7 파일 11 심볼. Gen84/85 sweep 마무리.

| 파일 | 심볼 | 비고 |
|------|------|------|
| \`progress-bar.ts\` | ProgressBarTone, ProgressBarTrackTone, ProgressBarProps | helper param/return + component props |
| \`distribution-bars.ts\` | DistributionTone | paletteFor helper param |
| \`heartbeat-streak-chip.ts\` | HeartbeatStreakChipProps | component props |
| \`error-boundary.ts\` | ErrorBoundaryInfo | Component\<Props, State\> 내부 field |
| \`confirm-dialog.ts\` | ConfirmTone | requestConfirm 파라미터 |
| \`kbd.ts\` | KbdSize, KbdProps | helper size + component props |
| \`skeleton.ts\` | SkeletonTextProps, SkeletonCircleProps | sibling component props |

외부 consumer는 상위 component/helper 함수만 쓰고 type 이름을 bare import하지 않음.

## Verification

- \`bunx tsc --noEmit\`: green
- +11/-11 LOC (7 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)