### PR TITLE
chore(dashboard): unexport 4 internal-only config types (Gen88)

### DIFF
--- a/dashboard/src/config/avatar-palettes.ts
+++ b/dashboard/src/config/avatar-palettes.ts
@@ -1,7 +1,7 @@
 // MASC Dashboard — Deterministic agent name -> avatar palette mapping
 // Uses a simple string hash to pick colors and template from agent name.
 
-export type AvatarTemplate = 'humanoid' | 'robot' | 'animal' | 'abstract'
+type AvatarTemplate = 'humanoid' | 'robot' | 'animal' | 'abstract'
 
 export interface AvatarPalette {
   skin: string
@@ -57,7 +57,7 @@ export function templateForAgent(name: string, traits?: string[]): AvatarTemplat
 // 8x8 pixel templates: 1 = skin, 2 = hair, 3 = point, 4 = highlight, 0 = transparent
 // Each template is a flat 64-element array (8 rows x 8 cols)
 
-export type PixelGrid = readonly number[]
+type PixelGrid = readonly number[]
 
 export const PIXEL_TEMPLATES: Record<AvatarTemplate, PixelGrid> = {
   humanoid: [

--- a/dashboard/src/config/telemetry-sources.ts
+++ b/dashboard/src/config/telemetry-sources.ts
@@ -2,7 +2,7 @@
 // Used by telemetry-unified, fleet-telemetry-panel, and any view rendering
 // the append-only JSONL telemetry stores.
 
-export type TelemetrySourceKey =
+type TelemetrySourceKey =
   | 'keeper_metric'
   | 'agent_event'
   | 'tool_call_io'
@@ -10,7 +10,7 @@ export type TelemetrySourceKey =
   | 'oas_event'
   | 'tool_metric'
 
-export interface TelemetrySourceMeta {
+interface TelemetrySourceMeta {
   label: string
   sublabel: string
   color: string


### PR DESCRIPTION
## Summary

\`config/\`의 2 파일 4 type alias 정리.

| 파일 | 심볼 |
|------|------|
| \`telemetry-sources.ts\` | TelemetrySourceKey, TelemetrySourceMeta |
| \`avatar-palettes.ts\` | AvatarTemplate, PixelGrid |

외부 consumer는 helper 함수만 호출 (\`telemetrySourceLabel\`, \`telemetrySourceMeta\`, \`paletteForAgent\`, \`templateForAgent\`). 내부 alias 이름 참조 0.

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)