### PR TITLE
chore(dashboard_execution_helpers): consolidate 12 Cancel-preserving JSON reads onto Safe_ops

### DIFF
--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -323,22 +323,19 @@ let load_persona_profile (persona_name : string) : agent_profile option =
     | Ok json ->
         let open Yojson.Safe.Util in
         let name_val =
-          (try Some (json |> member "name" |> to_string) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+          Safe_ops.json_string_opt "name" json
           |> Option.value ~default:persona_name
         in
         let keeper_json =
-          try Some (json |> member "keeper") with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+          Safe_ops.protect ~default:None (fun () ->
+            Some (json |> member "keeper"))
         in
         let model =
           match keeper_json with
-          | Some kj -> (
-              try Some (kj |> member "active_model" |> to_string)
-              with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+          | Some kj -> Safe_ops.json_string_opt "active_model" kj
           | None -> None
         in
-        let trait =
-          try Some (json |> member "trait" |> to_string) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-        in
+        let trait = Safe_ops.json_string_opt "trait" json in
         let traits = match trait with Some t -> [t] | None -> [] in
         Some
           {
@@ -383,41 +380,27 @@ let populate_neo4j_identity_cache_locked () =
         List.iter
           (fun edge ->
             let node = edge |> member "node" in
-            let name =
-              try node |> member "name" |> to_string with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
-            in
+            let name = Safe_ops.json_string ~default:"" "name" node in
             if name <> "" then begin
               let emoji =
-                (try Some (node |> member "emoji" |> to_string)
-                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+                Safe_ops.json_string_opt "emoji" node
                 |> Option.value ~default:"🤖"
               in
               let korean_name =
-                (try Some (node |> member "koreanName" |> to_string)
-                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+                Safe_ops.json_string_opt "koreanName" node
                 |> Option.value ~default:name
               in
-              let model =
-                try Some (node |> member "model" |> to_string)
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-              in
+              let model = Safe_ops.json_string_opt "model" node in
               let traits =
-                try node |> member "traits" |> to_list |> List.map to_string
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+                Safe_ops.protect ~default:[] (fun () ->
+                  node |> member "traits" |> to_list |> List.map to_string)
               in
               let interests =
-                try
-                  node |> member "interests" |> to_list |> List.map to_string
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+                Safe_ops.protect ~default:[] (fun () ->
+                  node |> member "interests" |> to_list |> List.map to_string)
               in
-              let activity_level =
-                try Some (node |> member "activityLevel" |> to_float)
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-              in
-              let primary_value =
-                try Some (node |> member "primaryValue" |> to_string)
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
-              in
+              let activity_level = Safe_ops.json_float_opt "activityLevel" node in
+              let primary_value = Safe_ops.json_string_opt "primaryValue" node in
               Hashtbl.replace neo4j_identity_cache name
                 {
                   emoji;


### PR DESCRIPTION
## Why

`lib/dashboard/dashboard_execution_helpers.ml` had 13
Cancel-preserving try/with blocks across two closely-related
sections:

1. `lookup_persona_profile` — reads the persona JSON file for
   `name` / `keeper.active_model` / `trait`.
2. `populate_neo4j_identity_cache_locked` — reads each GraphQL node
   for `name` / `emoji` / `koreanName` / `model` / `traits` /
   `interests` / `activityLevel` / `primaryValue`.

Every inner `try ... with Eio.Cancel.Cancelled _ as e -> raise e | _ ->
<default>` block does exactly what a purpose-built `Safe_ops.json_*`
helper does — same class as #8195.

## What

Rewrite 12 of the 13 inner blocks onto SSOT helpers:

| field shape | SSOT call |
|---|---|
| `Some (member k \|> to_string)` / default `None` | `Safe_ops.json_string_opt k` |
| `member k \|> to_string` / default `""` | `Safe_ops.json_string ~default:"" k` |
| `Some (member k \|> to_float)` / default `None` | `Safe_ops.json_float_opt k` |
| `member k \|> to_list \|> List.map to_string` / default `[]` | `Safe_ops.protect ~default:[] (fun () -> ...)` |

The remaining `with Eio.Cancel... \| exn -> Log.Dashboard.warn ...` at
line 433 (outer catch for the cache-load loop) is intentionally left:
it pairs Cancel with a context-specific warn branch, so the correct
swap is `Safe_ops.try_with_log`, scoped out of this PR.

## Behavioural equivalence

- `Safe_ops.json_string_opt` returns `None` on missing field + wrong
  type + parse error — same as the previous
  `try Some (member k \|> to_string) with ... -> None`.
- `Safe_ops.json_float_opt` covers JSON `Float` + `Int` widening —
  strictly more permissive than the previous `to_float`, which would
  previously have collapsed to `None` on a JSON integer.  Net: safer
  on upstream schema drift; no existing test was relying on the
  stricter behaviour.

## Verification

- `dune build @check` clean.
- `rg "Eio.Cancel.Cancelled _ as e -> raise e" lib/dashboard/dashboard_execution_helpers.ml`
  → 1 hit (the documented outer logging catch).
- `test_dashboard_execution` → **12/12 OK** (exercises the
  `running_keeper_patch` / `patch_keeper_row` paths that consume
  these helpers' agent_profile output).

Net: **1 file, +15 / -32 LOC**.
