### PR TITLE
chore(dashboard): unexport 7 common/ 4th-round internal types (Gen89)

### DIFF
--- a/dashboard/src/components/common/heartbeat-strip.ts
+++ b/dashboard/src/components/common/heartbeat-strip.ts
@@ -71,7 +71,7 @@ export function formatHeartbeatLabel(summary: HeartbeatSummary): string {
   return `Heartbeat: ${pct}% uptime · ${summary.up}/${summary.up + summary.down} observed`
 }
 
-export interface HeartbeatStripProps {
+interface HeartbeatStripProps {
   history: HeartbeatState[]
   /** Number of bar slots to render. Defaults to 45 (Uptime Kuma parity). */
   slots?: number

--- a/dashboard/src/components/common/inline-spinner.ts
+++ b/dashboard/src/components/common/inline-spinner.ts
@@ -16,8 +16,8 @@
 
 import { html } from 'htm/preact'
 
-export type InlineSpinnerSize = 'xs' | 'sm' | 'md'
-export type InlineSpinnerTone = 'accent' | 'muted'
+type InlineSpinnerSize = 'xs' | 'sm' | 'md'
+type InlineSpinnerTone = 'accent' | 'muted'
 
 /** Pure: Tailwind size tokens for each variant. Exposed so a hot-path
     render (timeline rows, log tail, iterating progress lists) can
@@ -54,7 +54,7 @@ export function inlineSpinnerClasses(
   return parts.join(' ')
 }
 
-export interface InlineSpinnerProps {
+interface InlineSpinnerProps {
   size?: InlineSpinnerSize
   tone?: InlineSpinnerTone
   class?: string

--- a/dashboard/src/components/common/scroll-to-top.ts
+++ b/dashboard/src/components/common/scroll-to-top.ts
@@ -30,7 +30,7 @@ export function shouldShowScrollToTop(scrollY: number, thresholdPx = 400): boole
   return scrollY >= thresholdPx
 }
 
-export interface ScrollToTopButtonProps {
+interface ScrollToTopButtonProps {
   /** Threshold in pixels before the button fades in. Default 400
       matches Gmail / YouTube; callers with a denser layout can
       lower it. */

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -28,7 +28,7 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-export type StatusChipTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral' | ''
+type StatusChipTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral' | ''
 
 const BASE =
   'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider'
@@ -66,7 +66,7 @@ export function statusChipClasses(
   return parts.join(' ')
 }
 
-export interface StatusChipProps {
+interface StatusChipProps {
   /** Legacy API — plain text label. Prefer `children` for new
       call sites. When both are set, `children` wins. */
   label?: string


### PR DESCRIPTION
## Summary

common/ 4차. 4 파일 7 심볼.

| 파일 | 심볼 |
|------|------|
| \`heartbeat-strip.ts\` | HeartbeatStripProps |
| \`scroll-to-top.ts\` | ScrollToTopButtonProps |
| \`status-chip.ts\` | StatusChipTone, StatusChipProps |
| \`inline-spinner.ts\` | InlineSpinnerSize, InlineSpinnerTone, InlineSpinnerProps |

Kept as export: \`HeartbeatSummary\` (padHistory/summarizeHistory/formatHeartbeatLabel의 공유 반환 타입, external 참조 있음), 모든 component 함수 및 helper.

## Verification

- \`bunx tsc --noEmit\`: green
- +7/-7 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)