### PR TITLE
chore(dashboard): unexport 5 components/ single-file internals (Gen90)

### DIFF
--- a/dashboard/src/components/connector-overview-skeleton.ts
+++ b/dashboard/src/components/connector-overview-skeleton.ts
@@ -66,7 +66,7 @@ function TileSkeleton() {
   `
 }
 
-export interface ConnectorOverviewSkeletonProps {
+interface ConnectorOverviewSkeletonProps {
   class?: string
   testId?: string
 }

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -160,7 +160,7 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 
 // ── Turn Budget ──────────────────────────────────────────
 
-export function hasTurnBudgetDivergence(keeper: Keeper): boolean {
+function hasTurnBudgetDivergence(keeper: Keeper): boolean {
   const b = keeper.turn_budget
   if (!b) return false
   return (
@@ -246,7 +246,7 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   `
 }
 
-export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
+function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   const budget = keeper.turn_budget
   if (!budget) {
     return html`

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -18,7 +18,7 @@ interface KeeperMemoryTierPanelProps {
   currentPhase?: string | null
 }
 
-export type MemoryTierFilter = 'all' | 'saturated'
+type MemoryTierFilter = 'all' | 'saturated'
 
 /**
  * Pure filter for memory-tier rows.

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -10,7 +10,7 @@ import { Governance } from './governance'
 import { LabInspector } from './lab-inspector'
 import { route } from '../router'
 
-export type OpsView = 'default' | 'ops' | 'governance' | 'inspector'
+type OpsView = 'default' | 'ops' | 'governance' | 'inspector'
 
 const VALID_VIEWS: OpsView[] = ['default', 'ops', 'governance', 'inspector']
 


### PR DESCRIPTION
## Summary

components/ 5 심볼 4 파일 정리.

| 파일 | 심볼 |
|------|------|
| \`keeper-memory-tier-panel.ts\` | MemoryTierFilter |
| \`operations-panel.ts\` | OpsView |
| \`keeper-detail-runtime.ts\` | hasTurnBudgetDivergence, TurnBudgetPanel |
| \`connector-overview-skeleton.ts\` | ConnectorOverviewSkeletonProps |

외부 import 0건.

## Verification

- \`bunx tsc --noEmit\`: green
- +5/-5 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)