### PR TITLE
chore(dash+tele): replace 4 simple Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/dashboard/dashboard_agent_relations.ml
+++ b/lib/dashboard/dashboard_agent_relations.ml
@@ -61,14 +61,14 @@ let json ~agent_name () : Yojson.Safe.t =
   let interests = match agent_data with
     | Some agent ->
       let open Yojson.Safe.Util in
-      (try agent |> member "interests" |> to_list
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> [])
+      Safe_ops.protect ~default:[] (fun () ->
+        agent |> member "interests" |> to_list)
     | None -> []
   in
   let relations = match agent_data with
     | Some agent ->
       let open Yojson.Safe.Util in
-      (try
+      Safe_ops.protect ~default:[] (fun () ->
         agent |> member "relations" |> member "edges" |> to_list
         |> List.map (fun edge ->
           let node = edge |> member "node" in
@@ -88,8 +88,7 @@ let json ~agent_name () : Yojson.Safe.t =
             ("confidence", member "confidence" node);
             ("note", member "note" node);
             ("participants", `List participants);
-          ])
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> [])
+          ]))
     | None -> []
   in
   `Assoc [

--- a/lib/dashboard/dashboard_governance_metrics.ml
+++ b/lib/dashboard/dashboard_governance_metrics.ml
@@ -63,8 +63,8 @@ let reset_for_testing () =
   ring := []
 
 let snapshot_ring () =
-  try Eio.Mutex.use_ro ring_mu (fun () -> !ring)
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+  Safe_ops.protect ~default:[] (fun () ->
+    Eio.Mutex.use_ro ring_mu (fun () -> !ring))
 
 let inject_for_testing ~keeper_name ~tool_name ~reason_code ~ts =
   let event = { ts; tool_name; reason_code; keeper_name } in

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -76,8 +76,8 @@ let discover_keeper_metric_dirs masc_root : (string * string) list =
   if not (Sys.file_exists keepers_dir) then []
   else
     let entries =
-      try Array.to_list (Sys.readdir keepers_dir)
-      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+      Safe_ops.protect ~default:[] (fun () ->
+        Array.to_list (Sys.readdir keepers_dir))
     in
     List.filter_map (fun name ->
       let metrics_dir = Filename.concat keepers_dir (name ^ "/metrics") in


### PR DESCRIPTION
## Why

Three files still carried the one-line Cancel-preserving absorb
idiom that `Safe_ops.protect` already centralises:

| file | site | body | default |
|---|---|---|---|
| `lib/dashboard/dashboard_agent_relations.ml` | `interests` list | `agent.member "interests" \|> to_list` | `[]` |
| `lib/dashboard/dashboard_agent_relations.ml` | `relations` tree | GraphQL edges → node list | `[]` |
| `lib/dashboard/dashboard_governance_metrics.ml` | `snapshot_ring` | mutex-guarded ring read | `[]` |
| `lib/telemetry_unified.ml` | `keepers_dir` scan | `Array.to_list (Sys.readdir ...)` | `[]` |

Every site had identical shape
```ocaml
try <expr>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204.

## What

Rewrite all four sites as
`Safe_ops.protect ~default:[] (fun () -> <expr>)`.  The SSOT's
`Printexc.raise_with_backtrace` on the Cancel path is a strict
diagnostics upgrade over the previous bare `raise e`.

## Verification

- `dune build @check` clean.
- `test_dashboard_governance_metrics` → **6/6 OK** (covers
  `snapshot_ring` via every aggregate + JSON shape test).
- `test_telemetry_unified` → **17/17 OK** (covers the cluster keeper
  metrics path that walks `keepers_dir`).

Net: **3 files, +8 / -9 LOC**.
