### PR TITLE
chore(dashboard): unexport 10 components/ mixed internals (Gen91)

### DIFF
--- a/dashboard/src/components/autoresearch-state.ts
+++ b/dashboard/src/components/autoresearch-state.ts
@@ -17,7 +17,7 @@ import {
 // --- Loops list (deduplication via AsyncResource) ---
 
 export const loopsResource = createAsyncResource<AutoresearchLoopsResponse>()
-export const loopsLimit = signal(100)
+const loopsLimit = signal(100)
 
 export const hasMoreLoops = computed(() => {
   const state = loopsResource.state.value

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -129,7 +129,7 @@ export function buildCompositeFsmMermaid(): string {
   return MERMAID_COMPOSITE
 }
 
-export interface CompositeFsmFlowchartProps {
+interface CompositeFsmFlowchartProps {
   class?: string
 }
 

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -61,7 +61,7 @@ function activeConnectorFilter(): string | null {
 // Per-connector lifecycle hints. All four sidecars now ship a run.sh wrapper
 // (discord/imessage/slack/telegram) — see sidecars/<id>-bot/run.sh.
 // Source of truth: docs/CONNECTOR-CONFIG-SCHEMA.md.
-export interface SidecarCommands {
+interface SidecarCommands {
   start: string
   tail: string
   status: string

--- a/dashboard/src/components/fleet-trend-store.ts
+++ b/dashboard/src/components/fleet-trend-store.ts
@@ -12,7 +12,7 @@ export type MetricKey = 'context_ratio' | 'tool_success_pct' | 'tool_calls' | 'l
 
 export type TrendDirection = 'up' | 'down' | 'flat'
 
-export interface TrendInfo {
+interface TrendInfo {
   direction: TrendDirection
   delta: number
   deltaPercent: number

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -89,7 +89,7 @@ interface Divergence {
   reason: string
 }
 
-export function computeDivergences(
+function computeDivergences(
   conditions: KeeperConditions,
   phase: KeeperPhase | null | undefined,
 ): Divergence[] {

--- a/dashboard/src/components/keeper-detail-source.ts
+++ b/dashboard/src/components/keeper-detail-source.ts
@@ -17,7 +17,7 @@ export function resolveKeeperMissionBrief(
     ?? null
 }
 
-export interface KeeperToolPolicySnapshot {
+interface KeeperToolPolicySnapshot {
   source: 'keeper_config' | 'loading' | 'error' | 'none'
   mode: 'preset' | 'custom' | string
   preset: KeeperConfigTools['tool_preset']
@@ -79,7 +79,7 @@ export function resolveKeeperToolPolicy(
   }
 }
 
-export interface KeeperObservedToolAuditSnapshot {
+interface KeeperObservedToolAuditSnapshot {
   source: 'mission_brief' | 'dashboard_summary' | 'none'
   latestToolNames: string[]
   latestToolCallCount: number | null

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -14,7 +14,7 @@ import type { FsmGraphSpec, FsmNode, FsmEdge } from './common/cytoscape-fsm'
 // simultaneously". No cross-cluster edges — causal ordering between
 // sub-FSMs is captured by the invariants panel, not the graph edges.
 
-export interface CompositeFsmParams {
+interface CompositeFsmParams {
   phase: string            // KSM — Running | Failing | Overflowed | Compacting | HandingOff | Draining | Stable
   turnPhase: string        // KTC — idle | prompting | executing | compacting | finalizing
   decisionStage: string    // KDP — undecided | guard_ok | gate_rejected | tool_policy_selected

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -10,7 +10,7 @@ import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
 import { GoalTree } from './goals/goal-tree'
 
-export type PlanningView = 'default' | 'goal-tree'
+type PlanningView = 'default' | 'goal-tree'
 
 const PLANNING_VIEWS: PlanningView[] = ['default', 'goal-tree']
 

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -46,7 +46,7 @@ export function countCompletedSteps(
   return n
 }
 
-export type SetupGuideTone = 'idle' | 'in-progress' | 'complete'
+type SetupGuideTone = 'idle' | 'in-progress' | 'complete'
 
 /** Pure: 0..100 integer progress. Total=0 returns 0 (no div by zero). */
 export function setupGuideProgressPct(done: number, total: number): number {


### PR DESCRIPTION
## Summary

9 파일 10 심볼 mixed batch. 모두 같은 파일 내부 consumer만.

| 파일 | 심볼 |
|------|------|
| keeper-detail-source.ts | KeeperToolPolicySnapshot, KeeperObservedToolAuditSnapshot |
| planning-panel.ts | PlanningView |
| keeper-conditions-divergent.ts | computeDivergences |
| setup-guide-card.ts | SetupGuideTone |
| composite-fsm-flowchart.ts | CompositeFsmFlowchartProps |
| autoresearch-state.ts | loopsLimit |
| keeper-fsm-specs.ts | CompositeFsmParams |
| connector-status.ts | SidecarCommands |
| fleet-trend-store.ts | TrendInfo |

## Verification

- \`bunx tsc --noEmit\`: green
- +10/-10 LOC (9 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)