### PR TITLE
chore(gate_keeper_backend): replace 3 Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -4,7 +4,7 @@
 (* ── Keeper response parsing ─────────────────────────────────── *)
 
 let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
     let model =
@@ -19,11 +19,10 @@ let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
     let tok = json |> member "total_tokens" |> to_int_option
               |> Option.value ~default:0 in
     if model = "" && dur = 0 && tok = 0 then None
-    else Some { Gate_protocol.model_used = model; duration_ms = dur; tokens_used = tok }
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+    else Some { Gate_protocol.model_used = model; duration_ms = dur; tokens_used = tok })
 
 let extract_reply_text (body : string) : string =
-  try
+  Safe_ops.protect ~default:body (fun () ->
     let json = Yojson.Safe.from_string body in
     let open Yojson.Safe.Util in
     match json |> member "reply" |> to_string_option with
@@ -31,16 +30,14 @@ let extract_reply_text (body : string) : string =
     | None ->
         (match json |> member "text" |> to_string_option with
          | Some t -> t
-         | None -> body)
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> body
+         | None -> body))
 
 let extract_structured (body : string) : Yojson.Safe.t option =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     let json = Yojson.Safe.from_string body in
     match Yojson.Safe.Util.member "structured" json with
     | `Null -> None
-    | v -> Some v
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+    | v -> Some v)
 
 (* ── Dispatch ────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Why

`lib/gate_keeper_backend.ml` had three parse helpers that all
followed the same Cancel-preserving absorb idiom already centralised
by `Safe_ops.protect`:

| helper | default on parse failure |
|---|---|
| `extract_turn_stats` | `None` |
| `extract_reply_text` | original `body` string |
| `extract_structured` | `None` |

Each had the shape
```ocaml
try <Yojson parse> with Eio.Cancel.Cancelled _ as e -> raise e | _ -> <default>
```

Same anti-pattern class as #8187 / #8191 / #8195 / #8196 / #8198 /
#8202 / #8204 / #8207.

## What

- Rewrite all three helpers as
  `Safe_ops.protect ~default:<default> (fun () -> ...)`.
- The `let open Yojson.Safe.Util in` inside each body is
  intentionally preserved — every helper needs `member` and
  `to_*_option`, and a per-field `Safe_ops.json_*` swap would
  fracture the intentional fallback chain in `extract_turn_stats`
  (`model_used → model → ""`).
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade over bare `raise e`.

## Verification

- `dune build @check` clean.
- `rg "Eio.Cancel.Cancelled _ as e -> raise e" lib/gate_keeper_backend.ml`
  → 0 hits (file fully cleaned).
- `test_gate_keeper_backend` → **6/6 OK** (includes
  `stream request accepts connector context` + connector-context
  rejection cases that exercise the parse path).

Net: **1 file, +6 / -9 LOC**.
