### PR TITLE
chore(dashboard): unexport 4 internal-only connector/fleet types (Gen92)

### DIFF
--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -316,7 +316,7 @@ export function formatTileIdentityLine(
 /** Pure: derive the primary-action button label/tone from the sidecar
     state + inflight flag. Exposed so tests pin the four combinations
     without mounting the component. */
-export interface TilePrimaryActionView {
+interface TilePrimaryActionView {
   label: string
   tone: 'start' | 'stop'
   busy: boolean
@@ -382,7 +382,7 @@ function TilePrimaryAction({ id, sidecarUp }: { id: KnownConnectorId; sidecarUp:
     error (non-empty) > stale (stale=true). Error beats stale because
     an explicit error message is strictly more diagnostic than a
     \"data is old\" flag; callers that want both must render both. */
-export interface TileNoticeView {
+interface TileNoticeView {
   tone: 'error' | 'stale'
   label: string
   detail: string

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -260,7 +260,7 @@ const formatUptime = formatElapsedCompact
 
 // ── Header stat strip helpers (Grafana Stat-panel style big-number + label) ──
 
-export type HeaderStatTone = 'ok' | 'partial' | 'bad' | 'default'
+type HeaderStatTone = 'ok' | 'partial' | 'bad' | 'default'
 
 /** Pure: threshold tone for "N of M connected" header stat. Grafana
     Stat-panel convention — emerald when all up, amber when partial,

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -225,7 +225,7 @@ export function tallyInvariantViolations(
   return counts
 }
 
-export interface FleetFsmMatrixProps {
+interface FleetFsmMatrixProps {
   onSelectKeeper?: (name: string) => void
   // Injectable for tests.
   fetcher?: () => Promise<FleetCompositeSnapshot>


### PR DESCRIPTION
## Summary

3 파일 4 심볼 정리.

| 파일 | 심볼 |
|------|------|
| connector-status.ts | HeaderStatTone (headerConnectedTone/headerSuccessTone 반환 타입) |
| fleet-fsm-matrix.ts | FleetFsmMatrixProps |
| connector-overview-strip.ts | TilePrimaryActionView, TileNoticeView |

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)