### PR TITLE
chore(keeper_toml_loader): replace 2 nested Cancel-preserving try/with in atomic_write_file

### DIFF
--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -506,10 +506,10 @@ let atomic_write_file ~(path : string) (content : string) : (unit, string) resul
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->
-      (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+      Safe_ops.protect ~default:() (fun () -> Sys.remove tmp);
       raise e
   | exn ->
-      (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+      Safe_ops.protect ~default:() (fun () -> Sys.remove tmp);
       Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
 
 (** Update a field in a keeper TOML file on disk.


### PR DESCRIPTION
## Why

`atomic_write_file` in `lib/keeper/keeper_toml_loader.ml` performs a
write-temp-then-rename sequence with cleanup-on-failure:

```ocaml
with
| Eio.Cancel.Cancelled _ as e ->
    (try Sys.remove tmp
     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
    raise e
| exn ->
    (try Sys.remove tmp
     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
    Error (...)
```

Both cleanup arms had an identical nested Cancel-preserving absorb:
a second cancel racing with `Sys.remove` (e.g. the enclosing switch
being torn down while cleanup runs) would otherwise be silently
absorbed by the `| _ -> ()` arm, leaking a cancel past its boundary.
`Safe_ops.protect ~default:()` provides exactly that contract via
`Printexc.raise_with_backtrace`.

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209.

## What

- Rewrite both inner cleanup sites as
  `Safe_ops.protect ~default:() (fun () -> Sys.remove tmp)`.
- The outer `| Eio.Cancel... as e -> ... raise e` frame is
  preserved — it carries semantic meaning (differentiating cancel-path
  from exn→Error), not scaffolding.

## Verification

- `dune build @check` clean.
- `test_keeper_runtime_toml` → **13/13 OK** (exercises the atomic
  write/rename path via `resolve_overrides` float round-trip).

Net: **1 file, +2 / -2 LOC**.
