### PR TITLE
chore(dashboard): unexport 8 connector-related internals (Gen93)

### DIFF
--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -39,7 +39,7 @@ if (typeof window !== 'undefined') {
 
 /** Pure: derive the heartbeat state for a connector from the gate info
     that the overview strip already polls. No extra network calls. */
-export function deriveHeartbeatState(
+function deriveHeartbeatState(
   connector: GateConnectorInfo | null,
 ): HeartbeatState {
   if (connector === null) return 'unknown'
@@ -499,7 +499,7 @@ function TileHeartbeatStrip({ id }: { id: KnownConnectorId }) {
     Uses Tailwind's 400-weight hex literals for parity with the
     chip border/bg tones. Returns muted token for empty/sparse
     series so a new connector doesn't leak a stale hue. */
-export function deriveTrendColor(series: readonly number[]): string {
+function deriveTrendColor(series: readonly number[]): string {
   if (series.length === 0) return '#ffffff22'
   const last = series[series.length - 1]!
   // Tailwind emerald-400 / amber-400 / rose-400 hex codes — matches
@@ -551,7 +551,7 @@ export function countConnectedSidecars(connectors: GateConnectorInfo[]): number 
   return KNOWN_CONNECTOR_IDS.filter(id => findConnector(connectors, id)?.available === true).length
 }
 
-export interface ConnectorStripSummary {
+interface ConnectorStripSummary {
   runningCount: number
   healthyCount: number
   connectorTotal: number

--- a/dashboard/src/components/connector-setup-guides.ts
+++ b/dashboard/src/components/connector-setup-guides.ts
@@ -4,13 +4,13 @@
 // renderer lives in setup-guide-card.ts. Source of truth for the steps:
 // docs/CONNECTOR-CONFIG-SCHEMA.md.
 
-export interface SetupStep {
+interface SetupStep {
   text: string
   // Optional inline external link rendered after the step text.
   link?: { href: string; label: string }
 }
 
-export interface ConnectorSetupGuide {
+interface ConnectorSetupGuide {
   title: string
   intro: string
   steps: SetupStep[]

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -373,7 +373,7 @@ function truncateMiddle(value: string, limit = 18): string {
   return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`
 }
 
-export function humanizeChannel(names: ConnectorNames | undefined, channelId: string): string {
+function humanizeChannel(names: ConnectorNames | undefined, channelId: string): string {
   if (!names) return ''
   const channelName = names.channel_names[channelId]
   const guildId = names.channel_to_guild[channelId]
@@ -489,7 +489,7 @@ function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownC
   return connectors.find(connector => connector.connector_id === connectorId) ?? null
 }
 
-export function connectorFocusScore(
+function connectorFocusScore(
   connector: GateConnectorInfo | null,
   keeperCount: number,
 ): number {
@@ -505,7 +505,7 @@ export function connectorFocusScore(
   return 20
 }
 
-export function resolveConnectorFocusId(
+function resolveConnectorFocusId(
   connectors: GateConnectorInfo[],
   keeperCount: number,
   preferredId: KnownConnectorId | null,


### PR DESCRIPTION
## Summary

connector-* 3 파일 8 심볼.

| 파일 | 심볼 |
|------|------|
| connector-status.ts | humanizeChannel, connectorFocusScore, resolveConnectorFocusId |
| connector-overview-strip.ts | deriveHeartbeatState, deriveTrendColor, ConnectorStripSummary |
| connector-setup-guides.ts | SetupStep, ConnectorSetupGuide |

## Verification

- \`bunx tsc --noEmit\`: green
- +8/-8 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)