### PR TITLE
chore(keeper_evidence): replace 2 simple Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -46,11 +46,10 @@ let set_latest_hash ~keeper_name ~trace_id hash =
 
 (** Snapshot git status before a turn. Returns hash of status lines. *)
 let snapshot_before_turn ~base_path ~keeper_name:_ : string option =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     let root = repo_root ~base_path in
     let lines = git_status_lines ~repo_root:root in
-    Some (hash_lines lines)
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+    Some (hash_lines lines))
 
 (** Capture turn evidence after a turn completes.
     Compares before_hash with current state to detect delta. *)
@@ -227,7 +226,7 @@ let latest_evidence ~base_path ~keeper_name ~trace_id
   in
   if not (Fs_compat.file_exists evidence_dir) then None
   else
-    try
+    Safe_ops.protect ~default:None (fun () ->
       let entries = Sys.readdir evidence_dir |> Array.to_list in
       let json_files =
         List.filter (fun f -> Filename.check_suffix f ".json") entries
@@ -238,5 +237,4 @@ let latest_evidence ~base_path ~keeper_name ~trace_id
       | latest :: _ ->
         let path = Filename.concat evidence_dir latest in
         let content = Fs_compat.load_file path in
-        Some (Yojson.Safe.from_string content)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+        Some (Yojson.Safe.from_string content))


### PR DESCRIPTION
## Why

`lib/keeper/keeper_evidence.ml` had two Cancel-preserving absorb
sites that fit the `Safe_ops.protect` contract bit-for-bit:

| site | default | purpose |
|---|---|---|
| `snapshot_before_turn` | `None` | git status hash — fails gracefully if the repo root lookup or status read breaks |
| `read_latest_evidence` | `None` | disk scan + JSON parse of the most recent evidence file — fails gracefully on missing dir / malformed JSON |

Each had the shape
```ocaml
try <body returning Some ...>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 /
#8204 / #8207 / #8209 / #8211.

## What

- Rewrite both sites as
  `Safe_ops.protect ~default:None (fun () -> ...)`.
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade.

A third Cancel/exn split at line 152-153 remains — it pairs Cancel
with `| exn -> Log.Misc.error "...: %s" (Printexc.to_string exn)`,
which is the **compound-logging** shape that needs
`Safe_ops.try_with_log` with a site-specific context string.
Intentionally scoped out.

## Verification

- `dune build @check` clean.
- `test_keeper_mutex_coverage` → **4/4 OK** (includes the
  `keeper_evidence` mutex-protected hot path).

Net: **1 file, +4 / -6 LOC**.
