### PR TITLE
chore(dashboard): unexport 12 internal-only mixed symbols (Gen94)

### DIFF
--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -15,7 +15,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 
-export type RailState = 'ok' | 'warn' | 'bad' | 'idle'
+type RailState = 'ok' | 'warn' | 'bad' | 'idle'
 export type RailKey = 'token' | 'process' | 'gate' | 'bindings'
 
 /** Per-connector × per-pill in-flight tracker. Subscribed by deriveRail
@@ -185,7 +185,7 @@ export function ConnectorReadinessRail({ pills }: { pills: RailPill[] }) {
  * Inputs are passed in flat instead of taking a GateConnectorInfo so
  * the helper stays unit-testable without the full Gate API shape.
  */
-export interface RailInputs {
+interface RailInputs {
   /** Sidecar process is up and reachable. */
   sidecarUp: boolean
   /** Channel Gate /health responded healthy. null = unknown. */

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -30,7 +30,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
 import { useSavedSignal } from '../lib/saved-signal'
 
-export type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
+type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
 
 export const A2A_EVENT_TYPES = [
   'agent_started',
@@ -65,7 +65,7 @@ export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
   unknown: 'bg-zinc-500',
 }
 
-export interface TimelineChip {
+interface TimelineChip {
   ts: number
   eventType: string
   kind: A2aEventKind

--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -11,7 +11,7 @@ export interface GateDistribution {
   [gate: string]: number
 }
 
-export interface CalibrationStats {
+interface CalibrationStats {
   total_verdicts: number
   approve_count: number
   reject_count: number
@@ -24,7 +24,7 @@ export interface CalibrationStats {
   recent_fallback_reasons?: string[]
 }
 
-export interface HarnessOverview {
+interface HarnessOverview {
   evaluator_status: RailStatus
   pre_compact_status: RailStatus
   handoff_status: RailStatus

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -92,14 +92,14 @@ export const selectedPostIds = signal<Set<string>>(new Set())
 export const bulkDeleting = signal(false)
 
 // ── Helper: default comment author ─────────────────────────────────
-export function defaultCommentAuthor(): string {
+function defaultCommentAuthor(): string {
   const params = new URLSearchParams(window.location.search)
   return params.get('agent')?.trim()
     || params.get('agent_name')?.trim()
     || 'dashboard-user'
 }
 
-export const commentAuthor = signal(defaultCommentAuthor())
+const commentAuthor = signal(defaultCommentAuthor())
 
 // ── Utility functions ──────────────────────────────────────────────
 export function isUpdated(post: BoardPost): boolean {
@@ -161,7 +161,7 @@ export function categoryBadgeColor(cat: ContentCategory): string {
 }
 
 // ── Grouped posts by content category ─────────────────────────────
-export type CategoryGroup = { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number }
+type CategoryGroup = { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number }
 
 export type VisibleBoardGroups = {
   groups: CategoryGroup[]

--- a/dashboard/src/lib/async-state.ts
+++ b/dashboard/src/lib/async-state.ts
@@ -57,7 +57,7 @@ export interface AsyncResource<T> {
   reset(): void
 }
 
-export interface ManagedAsyncState<T> {
+interface ManagedAsyncState<T> {
   readonly data: T | null
   readonly loading: boolean
   readonly error: string | null

--- a/dashboard/src/lib/fetch-scheduler.ts
+++ b/dashboard/src/lib/fetch-scheduler.ts
@@ -13,7 +13,7 @@
 type FetchFn = () => Promise<void>
 type Priority = 'none' | 'normal' | 'urgent'
 
-export interface FetchSchedulerConfig {
+interface FetchSchedulerConfig {
   /** Minimum ms between consecutive fetches. Prevents burst after rapid events. */
   cooldownMs: number
   /** Trailing-edge debounce window. Batches rapid invalidations into one fetch. */

--- a/dashboard/src/lib/persistent-signal.ts
+++ b/dashboard/src/lib/persistent-signal.ts
@@ -20,7 +20,7 @@
 
 import { signal, effect, type Signal } from '@preact/signals'
 
-export interface PersistentSignalOptions<T> {
+interface PersistentSignalOptions<T> {
   /** localStorage key. Choose something namespaced like \"dashboard:sidebar-collapsed\". */
   key: string
   /** Value to use when the key is absent / unparseable / storage


### PR DESCRIPTION
## Summary

7 파일 12 심볼 mixed batch. lib/ 3 + components/ 9.

| 파일 | 심볼 |
|------|------|
| lib/fetch-scheduler.ts | FetchSchedulerConfig |
| lib/async-state.ts | ManagedAsyncState |
| lib/persistent-signal.ts | PersistentSignalOptions |
| components/memory-state.ts | defaultCommentAuthor, commentAuthor, CategoryGroup |
| components/harness-health-state.ts | CalibrationStats, HarnessOverview |
| components/handoff-timeline.ts | A2aEventKind, TimelineChip |
| components/connector-readiness-rail.ts | RailState, RailInputs |

## Verification

- \`bunx tsc --noEmit\`: green
- +12/-12 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)