### PR TITLE
chore(coord): replace 2 activity_emit Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -194,18 +194,17 @@ let () = Atomic.set Coord_hooks.hebbian_on_task_done_fn (fun config ~assignee ~a
         (try Hebbian_eio.strengthen config ~from_agent:assignee ~to_agent:peer ()
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Coord.warn "hebbian strengthen failed: %s" (Printexc.to_string exn));
-        (try
-           (Atomic.get Coord_hooks.activity_emit_fn) config
-             ~actor:Coord_hooks.{ kind = "agent"; id = assignee }
-             ~subject:Coord_hooks.{ kind = "agent"; id = peer }
-             ~kind:"hebbian.strengthen"
-             ~payload:(`Assoc [
-               ("from_agent", `String assignee);
-               ("to_agent", `String peer);
-             ])
-             ~tags:[ "hebbian"; "strengthen"; "memory" ]
-             ()
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+        Safe_ops.protect ~default:() (fun () ->
+          (Atomic.get Coord_hooks.activity_emit_fn) config
+            ~actor:Coord_hooks.{ kind = "agent"; id = assignee }
+            ~subject:Coord_hooks.{ kind = "agent"; id = peer }
+            ~kind:"hebbian.strengthen"
+            ~payload:(`Assoc [
+              ("from_agent", `String assignee);
+              ("to_agent", `String peer);
+            ])
+            ~tags:[ "hebbian"; "strengthen"; "memory" ]
+            ())
       end
     ) active_agents)
 
@@ -216,18 +215,17 @@ let () = Atomic.set Coord_hooks.hebbian_on_task_cancelled_fn (fun config ~agent_
         (try Hebbian_eio.weaken config ~from_agent:agent_name ~to_agent:peer ()
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Coord.warn "hebbian weaken failed: %s" (Printexc.to_string exn));
-        (try
-           (Atomic.get Coord_hooks.activity_emit_fn) config
-             ~actor:Coord_hooks.{ kind = "agent"; id = agent_name }
-             ~subject:Coord_hooks.{ kind = "agent"; id = peer }
-             ~kind:"hebbian.weaken"
-             ~payload:(`Assoc [
-               ("from_agent", `String agent_name);
-               ("to_agent", `String peer);
-             ])
-             ~tags:[ "hebbian"; "weaken"; "memory" ]
-             ()
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+        Safe_ops.protect ~default:() (fun () ->
+          (Atomic.get Coord_hooks.activity_emit_fn) config
+            ~actor:Coord_hooks.{ kind = "agent"; id = agent_name }
+            ~subject:Coord_hooks.{ kind = "agent"; id = peer }
+            ~kind:"hebbian.weaken"
+            ~payload:(`Assoc [
+              ("from_agent", `String agent_name);
+              ("to_agent", `String peer);
+            ])
+            ~tags:[ "hebbian"; "weaken"; "memory" ]
+            ())
       end
     ) active_agents)
 


### PR DESCRIPTION
## Why

`lib/coord.ml` had two Cancel-preserving absorb blocks inside the
hebbian `strengthen` / `weaken` hook registrations, wrapping a
best-effort telemetry emit:

```ocaml
(try
   (Atomic.get Coord_hooks.activity_emit_fn) config
     ~actor:... ~subject:... ~kind:"hebbian.strengthen"
     ~payload:... ~tags:... ()
 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
```

Both sites are telemetry-only — if the hooked emitter fails, Cancel
must propagate but any other exception should be swallowed.  Exact
semantics centralised by `Safe_ops.protect ~default:()`.

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209 / #8211 / #8215.

## What

- Rewrite both sites as
  `Safe_ops.protect ~default:() (fun () -> <emit call>)`.
- The sibling `try Hebbian_eio.(strengthen|weaken) ... with ... | exn ->
  Log.Coord.warn ...` blocks are intentionally left — they pair
  Cancel with a context-specific warn branch, so the correct swap is
  `Safe_ops.try_with_log`, scoped out of this PR.

## Verification

- `dune build @check` clean.
- `test_hebbian_eio` → **14/14 OK** (covers weight_history JSON
  round-trip + cap/order invariants; the hebbian emit paths feed
  into these).

Net: **1 file, +22 / -24 LOC**.
