### PR TITLE
chore(dashboard): unexport 12 internal-only symbols (Gen95)

### DIFF
--- a/dashboard/src/components/activity-graph-groups.ts
+++ b/dashboard/src/components/activity-graph-groups.ts
@@ -324,7 +324,7 @@ export function buildActionTimelineGroups(events: ActivityGraphTimelineEvent[]):
     .sort((a, b) => b.latestTsMs - a.latestTsMs)
 }
 
-export function emptyCategoryCounts(): Record<ActivityCategory, number> {
+function emptyCategoryCounts(): Record<ActivityCategory, number> {
   return {
     task: 0,
     session: 0,

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -102,7 +102,7 @@ function fmtCooldownExpiry(expiresAt: number | null): string {
   return `${Math.ceil(delta / 60)}분 후`
 }
 
-export interface KeeperCascadeRow {
+interface KeeperCascadeRow {
   keeper: string
   /** Declared cascade name from TOML / runtime JSON (pre-canonicalize). */
   raw_cascade_name: string

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -10,7 +10,7 @@ const patternsResource = createAsyncResource<ExcusePattern[]>()
 const saving = signal(false)
 const saveMessage = signal('')
 
-export function refreshExcusePatterns(): Promise<void> {
+function refreshExcusePatterns(): Promise<void> {
   patternsResource.reset()
   return patternsResource.load(fetchExcusePatterns)
 }

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -12,7 +12,7 @@ import { FleetTelemetryPanel } from './fleet-telemetry-panel'
 import { ToolQualityPanel } from './tool-quality-panel'
 import { GovernanceMonitor } from './governance-monitor'
 
-export type FleetHealthView = 'default' | 'event-log' | 'comparison' | 'tool-quality' | 'governance'
+type FleetHealthView = 'default' | 'event-log' | 'comparison' | 'tool-quality' | 'governance'
 
 const FLEET_VIEWS: FleetHealthView[] = ['default', 'event-log', 'comparison', 'tool-quality', 'governance']
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -41,7 +41,7 @@ const OVERVIEW_STALE_MS = 300_000
     dashboards use a ~60s boundary between "fresh" and "getting old". */
 const OVERVIEW_WARN_MS = 60_000
 
-export type FreshnessTier = 'unknown' | 'fresh' | 'warn' | 'stale'
+type FreshnessTier = 'unknown' | 'fresh' | 'warn' | 'stale'
 
 /** Pure: classify snapshot age into a 4-tier health reading that maps
     1:1 to StatusDot tones (unknown=muted, fresh=ok, warn=amber, stale=bad).

--- a/dashboard/src/lib/error-reporter.ts
+++ b/dashboard/src/lib/error-reporter.ts
@@ -11,7 +11,7 @@
  * the reporter would send is exposed via `buildErrorPayload` so that
  * wiring it in later is a single-site change.
  */
-export interface ReporterInfo {
+interface ReporterInfo {
   componentStack?: string
 }
 

--- a/dashboard/src/lib/keeper-chat-access.ts
+++ b/dashboard/src/lib/keeper-chat-access.ts
@@ -1,6 +1,6 @@
 import type { DashboardShellAuthSummary } from '../types'
 
-export interface KeeperDirectChatAccess {
+interface KeeperDirectChatAccess {
   blocked: boolean
   message: string | null
 }

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -3,19 +3,19 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
-export interface RuntimeBandMeta {
+interface RuntimeBandMeta {
   key: RuntimeBand
   label: string
   description: string
 }
 
-export interface PhaseMeta {
+interface PhaseMeta {
   key: string
   label: string
   description: string
 }
 
-export interface StageMeta {
+interface StageMeta {
   key: string
   label: string
   description: string
@@ -303,7 +303,7 @@ function agentBand(status: string | undefined | null): RuntimeBand {
   return 'active'
 }
 
-export function runtimeBandForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBand {
+function runtimeBandForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBand {
   if (keeper) return summarizeKeeperMonitoring(keeper).band.key
   return agentBand(agent.status)
 }

--- a/dashboard/src/lib/tool-blob-marker.ts
+++ b/dashboard/src/lib/tool-blob-marker.ts
@@ -14,7 +14,7 @@
  * with `]` as the last character.
  */
 
-export const SENTINEL_PREFIX = '[masc:blob '
+const SENTINEL_PREFIX = '[masc:blob '
 
 export interface ToolBlobMarker {
   sha256: string


### PR DESCRIPTION
## Summary

9 파일 12 심볼 정리. lib/ 7 + components/ 5.

| 파일 | 심볼 |
|------|------|
| lib/monitoring-runtime.ts | RuntimeBandMeta, PhaseMeta, StageMeta, runtimeBandForAgent |
| lib/keeper-chat-access.ts | KeeperDirectChatAccess |
| lib/tool-blob-marker.ts | SENTINEL_PREFIX |
| lib/error-reporter.ts | ReporterInfo |
| components/fleet-health-panel.ts | FleetHealthView |
| components/overview/overview.ts | FreshnessTier |
| components/excuse-patterns.ts | refreshExcusePatterns |
| components/activity-graph-groups.ts | emptyCategoryCounts |
| components/cascade-config-panel.ts | KeeperCascadeRow |

## Kept as export (shim / barrel-required)

- \`proof-sections.ts::WorkerRunEvidenceRow\` — hidden-div placeholder with data-component attr
- \`mission-briefing-card.ts::MissionBriefingCard\` — legacy barrel shim (mission-cards.ts re-exports; 파일 삭제 시 TS2307)

스캔이 잠깐 dead로 잡았지만 내부 주석에 근거 명시된 intentional shim — unexport하면 \`TS6133\` 오류로 드러나 되돌림.

## Verification

- \`bunx tsc --noEmit\`: green
- +12/-12 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)