### PR TITLE
chore(keeper_voice_loop): replace 2 Cancel-preserving JSON try/with with Safe_ops.protect

### DIFF
--- a/lib/keeper/keeper_voice_loop.ml
+++ b/lib/keeper/keeper_voice_loop.ml
@@ -13,25 +13,23 @@
 (** Extract transcribed text from STT JSON response.
     Returns None if no text or if status is "no_audio". *)
 let extract_text_from_stt (json : Yojson.Safe.t) : string option =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     let open Yojson.Safe.Util in
     match member "status" json with
     | `String "no_audio" -> None
     | _ ->
         (match member "text" json with
         | `String s when String.trim s <> "" -> Some (String.trim s)
-        | _ -> None)
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+        | _ -> None))
 
 (** Extract reply text from keeper_msg tool_result.
     The result_str is JSON with ["reply"]. *)
 let extract_reply_text (result_str : string) : string option =
-  try
+  Safe_ops.protect ~default:None (fun () ->
     let json = Yojson.Safe.from_string result_str in
     match Yojson.Safe.Util.member "reply" json with
     | `String s when String.trim s <> "" -> Some (String.trim s)
-    | _ -> None
-  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+    | _ -> None)
 
 let parse_reply_text (result_str : string) : (string, string) result =
   try


### PR DESCRIPTION
## Why

`lib/keeper/keeper_voice_loop.ml` had two parse helpers with the
same Cancel-preserving absorb shape already centralised by
`Safe_ops.protect`:

| helper | default | purpose |
|---|---|---|
| `extract_text_from_stt` | `None` | parse `{status, text}` from STT response |
| `extract_reply_text` | `None` | parse `{reply}` from `keeper_msg` tool_result |

Both had the shape
```ocaml
try <Yojson body>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209 / #8211 / #8215 / #8217.

A third helper `parse_reply_text` uses a **narrower** catch —
`Yojson.Json_error msg -> Error ...` — intentionally untouched because
it distinguishes JSON-specific errors from structural ones, which
`Safe_ops.protect` would collapse into a single default.

## What

- Rewrite both `extract_*` sites as
  `Safe_ops.protect ~default:None (fun () -> <body>)`.
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade.

## Verification

- `dune build @check` clean.
- `test_keeper_voice_loop` → **18/18 OK** (includes
  `run.7 malformed reply is error` and the STT happy-path cases
  that exercise both helpers).

Net: **1 file, +4 / -6 LOC**.
