### PR TITLE
chore(dashboard): unexport 11 api/lib types + delete 1 truly-dead interface (Gen96)

### DIFF
--- a/dashboard/src/api/attribution.ts
+++ b/dashboard/src/api/attribution.ts
@@ -27,7 +27,7 @@ export interface AttributionEvent {
   recorded_at: number
 }
 
-export interface AttributionRecentResponse {
+interface AttributionRecentResponse {
   events: AttributionEvent[]
   count: number
 }

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -82,7 +82,7 @@ export async function fetchLogs(opts?: {
   return parseLogsResponse(raw)
 }
 
-export interface ToolHostFailureReport {
+interface ToolHostFailureReport {
   agent_name?: string
   client_name?: string
   tool_name: string
@@ -163,7 +163,7 @@ export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise
   return get('/api/v1/dashboard/execution', { signal: opts?.signal })
 }
 
-export type ToolQualityToolStat = {
+type ToolQualityToolStat = {
   name: string
   calls: number
   success_pct: number
@@ -172,13 +172,13 @@ export type ToolQualityToolStat = {
   avg_output_chars?: number
 }
 
-export type ToolQualityKeeperStat = {
+type ToolQualityKeeperStat = {
   name: string
   calls: number
   success_pct: number
 }
 
-export type ToolQualityFailureCategory = {
+type ToolQualityFailureCategory = {
   category: string
   count: number
 }
@@ -276,7 +276,7 @@ export function fetchDashboardPerf(): Promise<DashboardPerfResponse> {
   return get('/api/v1/dashboard/perf')
 }
 
-export interface FetchDashboardMemoryOptions {
+interface FetchDashboardMemoryOptions {
   excludeSystem?: boolean
   excludeAutomation?: boolean
   author?: string
@@ -418,7 +418,7 @@ export function fetchDashboardMissionSession(
   return get(`/api/v1/dashboard/session${query}`, { signal: opts?.signal })
 }
 
-export interface DashboardRuntimeProviderDiscovery {
+interface DashboardRuntimeProviderDiscovery {
   healthy?: boolean
   discovered_model?: string | null
   ctx_size?: number | null
@@ -710,12 +710,12 @@ export interface DashboardToolInventoryItem {
   reason?: string | null
 }
 
-export interface SurfaceSummaryEntry {
+interface SurfaceSummaryEntry {
   count: number
   tools: string[]
 }
 
-export interface DashboardToolInventoryResponse {
+interface DashboardToolInventoryResponse {
   count: number
   tools: DashboardToolInventoryItem[]
   surface_summary?: Record<string, SurfaceSummaryEntry>

--- a/dashboard/src/api/tool-blob.ts
+++ b/dashboard/src/api/tool-blob.ts
@@ -9,17 +9,11 @@
 
 import { get } from './core'
 
-export interface ToolBlobResponse {
+interface ToolBlobResponse {
   sha256: string
   bytes: number
   mime: string
   content: string
-}
-
-export interface ToolBlobError {
-  error: string
-  reason?: string
-  sha256?: string
 }
 
 /**

--- a/dashboard/src/lib/unified-status.ts
+++ b/dashboard/src/lib/unified-status.ts
@@ -3,7 +3,7 @@
 
 import { statusLabel } from './status-label.js'
 
-export interface UnifiedStatusResult {
+interface UnifiedStatusResult {
   canonical: string
   label: string
   description: string


### PR DESCRIPTION
## Summary

4 파일. 11 unexport + 1 삭제.

## Unexported (11)

| 파일 | 심볼 |
|------|------|
| lib/unified-status.ts | UnifiedStatusResult |
| api/attribution.ts | AttributionRecentResponse |
| api/tool-blob.ts | ToolBlobResponse |
| api/dashboard.ts | ToolHostFailureReport, ToolQualityToolStat, ToolQualityKeeperStat, ToolQualityFailureCategory, FetchDashboardMemoryOptions, DashboardRuntimeProviderDiscovery, SurfaceSummaryEntry, DashboardToolInventoryResponse |

## Deleted (truly dead)

- \`api/tool-blob.ts::ToolBlobError\` — interface 정의만 되고 내부도 외부도 참조 0. tsc noUnusedLocals가 포착.

## Verification

- \`bunx tsc --noEmit\`: green
- +11/-17 LOC

## Test plan

- [x] tsc strict (tsc noUnusedLocals가 truly-dead interface 1건 발견→삭제로 대응)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)