### PR TITLE
chore(approval_queue): replace 2 Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -87,8 +87,8 @@ let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
       ("risk", `String (risk_level_to_string risk_level));
       ("decision", `String decision);
     ] in
-    (try Dated_jsonl.append store json
-     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+    Safe_ops.protect ~default:() (fun () ->
+      Dated_jsonl.append store json)
 
 let generate_id () =
   let entropy =
@@ -222,9 +222,8 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
   Fun.protect
     (fun () -> Eio.Promise.await promise)
     ~finally:(fun () ->
-      (try
-         atomic_update pending (fun map -> SMap.remove id map)
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()))
+      Safe_ops.protect ~default:() (fun () ->
+        atomic_update pending (fun map -> SMap.remove id map)))
 
 let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
   : string =


### PR DESCRIPTION
## Why

`lib/keeper/keeper_approval_queue.ml` had two Cancel-preserving
absorb sites that fit `Safe_ops.protect` exactly:

| site | body | rationale |
|---|---|---|
| `append store json` (line 90-91) | `Dated_jsonl.append` audit log write | log is best-effort — Cancel must propagate, but log-rotation races should not crash the approval |
| `atomic_update pending (SMap.remove id)` inside `Fun.protect` finally (line 225-227) | post-resolution pending-map cleanup | removal is idempotent — Cancel must still escape `finally`, but non-Cancel failures must not mask the original resolution |

Both used the shape
```ocaml
try <body>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209 / #8211 / #8215 / #8217 / #8219.

## What

- Rewrite both sites as
  `Safe_ops.protect ~default:() (fun () -> <body>)`.
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade over the previous bare
  `raise e`.

## Verification

- `dune build @check` clean.
- `test_hitl_approval` → **18/18 OK** (includes
  `callback_integration.1 production keeper write` +
  `callback_integration.2 production keeper_shell` paths that
  exercise both the audit log append and the pending-map cleanup).

Net: **1 file, +4 / -5 LOC**.
