### PR TITLE
chore(eval): replace 2 Pcre Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -151,10 +151,9 @@ let evasion_indicators : (string * string) list = [
 let detect_evasion (command : string) : (string * string) option =
   let cmd_lower = String.lowercase_ascii command in
   List.find_opt (fun (pattern, _desc) ->
-    try
+    Safe_ops.protect ~default:false (fun () ->
       let re = Re.Pcre.re pattern |> Re.compile in
-      Re.execp re cmd_lower
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
+      Re.execp re cmd_lower)
   ) evasion_indicators
 
 (** Check if a bash command contains destructive patterns.

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -131,10 +131,9 @@ let apply_deterministic_grader (g : deterministic_grader) (value : string) : gra
         in
         find_at 0
     | Regex pattern ->
-        (try
-           let re = Re.Pcre.re pattern |> Re.compile in
-           Re.execp re value
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false)
+        Safe_ops.protect ~default:false (fun () ->
+          let re = Re.Pcre.re pattern |> Re.compile in
+          Re.execp re value)
     | NotContains ->
         let v_lower = String.lowercase_ascii value in
         let e_lower = String.lowercase_ascii g.expected in


### PR DESCRIPTION
## Why

Two independent evaluation helpers compiled a `Re.Pcre` pattern and
ran `.execp` inside a Cancel-preserving absorb:

| site | purpose | default-on-failure |
|---|---|---|
| `lib/eval_harness.ml` `grade` (Regex branch) | grader-side regex match | `false` → "no match" |
| `lib/eval_gate.ml` `detect_evasion` | scan commands against evasion bypass patterns | `false` → "no evasion for this pattern" |

Both used the shape
```ocaml
try <Re.Pcre compile + execp>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209 / #8211 / #8215 / #8217 / #8219 / #8221.

## What

- Rewrite both sites as
  `Safe_ops.protect ~default:false (fun () -> <body>)`.
- `Safe_ops.protect` uses `Printexc.raise_with_backtrace` on the
  Cancel path — strict diagnostics upgrade.

The `default:false` preserves two operationally important
invariants:
- The grader reports "no match" on regex failure (not crash).
- The evasion detector reports "no evasion for this pattern" on
  regex failure (does not block the entire scan — other patterns in
  `evasion_indicators` still run).

## Verification

- `dune build @check` clean.
- `test_eval_harness` → **22/22 OK**.
- `test_eval_gate` → **24/24 OK**.
- `test_eval_gate_evasion` → **23/23 OK** (covers the
  `detect_evasion` happy path and known-safe command allowlist).

Net: **2 files, +5 / -7 LOC**.
