### PR TITLE
chore(dashboard): unexport 4 more api types (Gen98)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1871,7 +1871,7 @@ interface ResolveVerificationRequestOptions {
   reason?: string
 }
 
-export interface ResolveVerificationResponse {
+interface ResolveVerificationResponse {
   ok: boolean
   task_id: string
   verification_id: string
@@ -1954,13 +1954,13 @@ export function fetchCascadeStrategyTrace(opts?: {
 
 export type CascadeSloStatus = 'ok' | 'warn' | 'violated'
 
-export interface CascadeSloTargets {
+interface CascadeSloTargets {
   ordered_ratio_min: number
   exhaustion_count_max: number
   burn_rate_max: number
 }
 
-export interface CascadeSloCurrent {
+interface CascadeSloCurrent {
   ordered_ratio: number
   exhaustion_count: number
   burn_rate: number

--- a/dashboard/src/api/schemas/operator-action.ts
+++ b/dashboard/src/api/schemas/operator-action.ts
@@ -21,7 +21,7 @@ import {
 
 import { SchemaDriftError, parseOrThrow } from './drift-error'
 
-export const OperatorActionResultSchema = object({
+const OperatorActionResultSchema = object({
   status: string(),
   confirm_required: optional(boolean()),
   confirm_token: optional(string()),


### PR DESCRIPTION
## Summary

2 파일 4 심볼.

| 파일 | 심볼 |
|------|------|
| api/dashboard.ts | ResolveVerificationResponse, CascadeSloTargets, CascadeSloCurrent |
| api/schemas/operator-action.ts | OperatorActionResultSchema |

OperatorActionResultSchema는 같은 파일 OperatorActionResponseSchema에 composed 될 뿐 외부 consumer는 composite schema만 사용.

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)