### PR TITLE
chore(keeper_audit): replace 4 Cancel-preserving try/with with Safe_ops.protect

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -179,8 +179,7 @@ let flush_if_needed ~base_path ~keeper_name =
             (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
         in
         let parent = Filename.dirname dir in
-        (try Fs_compat.mkdir_p parent
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        Safe_ops.protect ~default:() (fun () -> Fs_compat.mkdir_p parent);
         let cap = Array.length ring.buf in
         let start = ((ring.pos - ring.unflushed) mod cap + cap) mod cap in
         let flush_lines =

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -37,14 +37,13 @@ let handle_keeper_preflight_check
       let ok = st = Unix.WEXITED 0 in
       (* Extract default branch from JSON if available *)
       (if ok then
-         try
+         Safe_ops.protect ~default:() (fun () ->
            let json = Yojson.Safe.from_string out in
            let branch_ref =
              Yojson.Safe.Util.(
                json |> member "defaultBranchRef" |> member "name" |> to_string)
            in
-           default_branch := branch_ref
-         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+           default_branch := branch_ref));
       add_check "repo_access" ok out
   in
   (* Check 3: keeper identity *)

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -69,7 +69,7 @@ let append_to_sink ~keeper_name (rec_ : transition_record) =
   match sink_path () with
   | None -> ()
   | Some path ->
-    (try
+    Safe_ops.protect ~default:() (fun () ->
        let line =
          Yojson.Safe.to_string
            (`Assoc [
@@ -82,12 +82,8 @@ let append_to_sink ~keeper_name (rec_ : transition_record) =
        in
        Fun.protect
          ~finally:(fun () ->
-           try close_out oc
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | _ -> ())
-         (fun () -> output_string oc (line ^ "\n"))
-     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+           Safe_ops.protect ~default:() (fun () -> close_out oc))
+         (fun () -> output_string oc (line ^ "\n")))
 
 let record_transition ~keeper_name (rec_ : transition_record) =
   let ring = get_or_create_ring keeper_name in


### PR DESCRIPTION
## Why

Three audit-adjacent keeper modules each carried a Cancel-preserving
absorb idiom for best-effort side effects already centralised by
`Safe_ops.protect`:

| file | site | body |
|---|---|---|
| `keeper_decision_audit.ml` | `Fs_compat.mkdir_p parent` | parent-dir creation for audit flush |
| `keeper_transition_audit.ml` | outer `append_to_sink` body | open/write/close to transition sink |
| `keeper_transition_audit.ml` | inner `close_out oc` in `Fun.protect` finally | best-effort close |
| `keeper_exec_preflight.ml` | JSON parse of gh-cli output | populates `default_branch` iff probe succeeded |

All four sites had default `()` and the canonical Cancel-preserving
shape
```ocaml
try <body>
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
```

Same class as #8187 / #8191 / #8195 / #8196 / #8198 / #8202 / #8204
/ #8207 / #8209 / #8211 / #8215 / #8217 / #8219 / #8221 / #8223.

## What

- Rewrite all four sites as
  `Safe_ops.protect ~default:() (fun () -> <body>)`.
- The nested `close_out` inside `Fun.protect` finally still uses
  `Safe_ops.protect` — `Fun.protect`'s finally raises
  `Finally_raised` on re-raise, so preserving Cancel via
  `Printexc.raise_with_backtrace` keeps the original exception
  visible.

## Verification

- `dune build @check` clean.
- No dedicated tests for these specific audit/preflight modules;
  indirect callers are exercised by the broader keeper test suite
  that the full `@check` builds.

Net: **3 files, +6 / -12 LOC**.
