### PR TITLE
chore(dashboard): unexport 4 more internal-only schemas (Gen100)

### DIFF
--- a/dashboard/src/api/schemas/agent-timeline.ts
+++ b/dashboard/src/api/schemas/agent-timeline.ts
@@ -20,7 +20,7 @@ import {
   type InferOutput,
 } from 'valibot'
 
-export const AgentTimelineEventSchema = object({
+const AgentTimelineEventSchema = object({
   ts: string(),
   type: string(),
   detail: record(string(), unknown()),
@@ -40,7 +40,7 @@ const AgentTimelineSummarySchema = object({
   total_events: number(),
 })
 
-export const AgentTimelineResponseSchema = object({
+const AgentTimelineResponseSchema = object({
   agent: string(),
   period: AgentTimelinePeriodSchema,
   events: array(AgentTimelineEventSchema),

--- a/dashboard/src/api/schemas/keeper-transitions.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.ts
@@ -17,7 +17,7 @@ import {
   type InferOutput,
 } from 'valibot'
 
-export const KeeperTransitionSchema = object({
+const KeeperTransitionSchema = object({
   prev_phase: string(),
   new_phase: string(),
   selected_event: unknown(),
@@ -25,7 +25,7 @@ export const KeeperTransitionSchema = object({
   transition_outcome: string(),
 })
 
-export const KeeperTransitionsResponseSchema = object({
+const KeeperTransitionsResponseSchema = object({
   keeper: string(),
   current_phase: nullable(string()),
   count: number(),


### PR DESCRIPTION
## Summary

Gen99 패턴 이어가기. 2 파일 4 schema.

| 파일 | 심볼 |
|------|------|
| api/schemas/agent-timeline.ts | AgentTimelineEventSchema, AgentTimelineResponseSchema |
| api/schemas/keeper-transitions.ts | KeeperTransitionSchema, KeeperTransitionsResponseSchema |

외부는 parse* 헬퍼 + inferred type 만 import.

## Verification

- \`bunx tsc --noEmit\`: green
- +4/-4 LOC

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)