### PR TITLE
chore(board_types): route Limits env reader through Env_config_core SSOT

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -139,10 +139,7 @@ type comment = {
 (** {1 Limits - Enforced, Not Optional} *)
 
 module Limits = struct
-  let env_int name default =
-    match Sys.getenv_opt name with
-    | Some s -> (match int_of_string_opt s with Some n -> n | None -> default)
-    | None -> default
+  let env_int name default = Env_config_core.get_int ~default name
 
   let max_posts = env_int "MASC_BOARD_MAX_POSTS" 10_000
   let max_comments_per_post = env_int "MASC_BOARD_MAX_COMMENTS_PER_POST" 1_000

--- a/lib/board_types/dune
+++ b/lib/board_types/dune
@@ -10,5 +10,6 @@
    re.str
    re.pcre
    eio
-   masc_random_id)
+   masc_random_id
+   masc_mcp.config)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))


### PR DESCRIPTION
## Why

`lib/board_types/board_types.ml` defined a private `env_int`
duplicate of `Env_config_core.get_int` inside `module Limits`:

```ocaml
let env_int name default =
  match Sys.getenv_opt name with
  | Some s -> (match int_of_string_opt s with Some n -> n | None -> default)
  | None -> default
```

It fed 8 `MASC_BOARD_*` env reads (max_posts,
max_comments_per_post, max_content_length, automation_ttl_hours,
max_ttl_hours, sweeper_interval_sec, sweeper_batch_size,
author_post_cap).  `Env_config_core.get_int` already centralises the
same behaviour (trim + `int_of_string_opt` + fallback) for every
other `MASC_*` env var — same class as #8176 / #8180.

## What

- Collapse `Limits.env_int` into a one-line delegate to
  `Env_config_core.get_int`.  All 8 call sites keep their existing
  positional `(name, default)` shape.
- Extend `lib/board_types/dune` to link `masc_mcp.config`.  Dep is
  safe: `masc_config` is a leaf lib and `masc_board` has no existing
  reverse reference.

## Behavioural note

`Env_config_core.get_int` pipes the raw value through
`raw_value_opt`, which trims the string before parsing, and returns
`default` on both missing and unparseable — identical to the
previous local helper on every input.  Extra benefit: any future
invariant added to `get_int` (e.g. WARN-on-typo, like #8142 for
`get_bool`) automatically propagates to `MASC_BOARD_*` readers.

## Verification

- `dune build @check` clean.
- `test_board_ttl` → **9/9 OK** (covers TTL/sweeper config that
  consumes `Limits.*`).
- `test_board_dispatch` → **27/27 OK**.

Net: **2 files, +3 / -5 LOC**.
