### PR TITLE
chore(dashboard): unexport 17 api internals (Gen101)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -52,7 +52,7 @@ export { KeeperTransitionsSchemaDriftError } from './schemas/keeper-transitions'
 
 // --- Types ---
 
-export interface KeeperToolReply {
+interface KeeperToolReply {
   text: string
   details: KeeperConversationDetails | null
 }
@@ -251,7 +251,7 @@ export async function fetchKeeperChatHistory(
 
 // --- Keeper lifecycle (boot / shutdown) ---
 
-export interface KeeperLifecycleResponse {
+interface KeeperLifecycleResponse {
   ok: boolean
   action?: 'boot' | 'shutdown' | 'reset' | 'clear'
   name?: string
@@ -363,7 +363,7 @@ export function resetKeeper(name: string): Promise<KeeperLifecycleResponse> {
   )
 }
 
-export interface KeeperClearRequest {
+interface KeeperClearRequest {
   reason: string
   preserve_system_prompt?: boolean
 }
@@ -407,7 +407,7 @@ export interface KeeperCheckpointInventory {
   legacy_shadow_count: number
 }
 
-export interface KeeperCheckpointDeleteResponse {
+interface KeeperCheckpointDeleteResponse {
   ok: boolean
   action: 'delete_history' | string
   keeper: string
@@ -473,7 +473,7 @@ export function resumeKeeper(name: string): Promise<KeeperLifecycleResponse> {
 }
 // --- Keeper tool policy editing ---
 
-export interface KeeperToolPolicyInput {
+interface KeeperToolPolicyInput {
   action: 'set_policy'
   mode: 'preset' | 'custom' | 'full'
   preset?: 'minimal' | 'messaging' | 'coding' | 'research' | 'full'
@@ -523,7 +523,7 @@ export interface MemoryKindUsageEntry {
   priority: number
 }
 
-export interface KeeperStateDiagramResponse {
+interface KeeperStateDiagramResponse {
   keeper: string
   current_phase: string
   mermaid: string

--- a/dashboard/src/api/schemas/agent-relations.ts
+++ b/dashboard/src/api/schemas/agent-relations.ts
@@ -37,7 +37,7 @@ const AgentRelationSchema = object({
   participants: array(AgentRelationParticipantSchema),
 })
 
-export const AgentRelationsResponseSchema = object({
+const AgentRelationsResponseSchema = object({
   agent_name: string(),
   collaborators: array(AgentCollaboratorSchema),
   interests: array(string()),

--- a/dashboard/src/api/schemas/autoresearch.ts
+++ b/dashboard/src/api/schemas/autoresearch.ts
@@ -45,7 +45,7 @@ const AutoresearchCycleDecisionSchema = fallback(
   'discard',
 )
 
-export const AutoresearchCycleRecordSchema = object({
+const AutoresearchCycleRecordSchema = object({
   cycle: number(),
   hypothesis: string(),
   score_before: number(),
@@ -58,7 +58,7 @@ export const AutoresearchCycleRecordSchema = object({
   timestamp: number(),
 })
 
-export const AutoresearchLoopSummarySchema = object({
+const AutoresearchLoopSummarySchema = object({
   loop_id: string(),
   author: nullable(string()),
   goal: string(),
@@ -91,14 +91,14 @@ export const AutoresearchLoopSummarySchema = object({
   queued_hypothesis: nullable(string()),
 })
 
-export const AutoresearchLoopsResponseSchema = object({
+const AutoresearchLoopsResponseSchema = object({
   loops: array(AutoresearchLoopSummarySchema),
   total: number(),
   offset: number(),
   limit: number(),
 })
 
-export const AutoresearchLoopDetailSchema = object({
+const AutoresearchLoopDetailSchema = object({
   ...AutoresearchLoopSummarySchema.entries,
   history: array(AutoresearchCycleRecordSchema),
   history_count: number(),
@@ -107,7 +107,7 @@ export const AutoresearchLoopDetailSchema = object({
 // Action responses are heterogeneous (retry/delete/start each set a
 // different subset of fields). Every field past `ok` is optional on
 // purpose — the backend contract documents that.
-export const AutoresearchLoopActionResponseSchema = object({
+const AutoresearchLoopActionResponseSchema = object({
   ok: fallback(boolean(), false),
   action: optional(picklist(['retry', 'delete', 'start'])),
   loop_id: optional(string()),

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -99,19 +99,19 @@ const KeeperCompositeAutoRulesSchema = object({
   goal_drift: number(),
 })
 
-export const KeeperCompositeMeasurementSchema = object({
+const KeeperCompositeMeasurementSchema = object({
   captured: boolean(),
   auto_rules: optional(KeeperCompositeAutoRulesSchema),
 })
 
-export const KeeperCompositeInvariantsSchema = object({
+const KeeperCompositeInvariantsSchema = object({
   phase_turn_alignment: boolean(),
   no_cascade_before_measurement: boolean(),
   compaction_atomicity: boolean(),
   event_priority_monotone: boolean(),
 })
 
-export const KeeperLastOutcomeSchema = object({
+const KeeperLastOutcomeSchema = object({
   turn_id: number(),
   ended_at: number(),
   decision_stage: KeeperCompositeDecisionStageSchema,

--- a/dashboard/src/api/schemas/link-previews.ts
+++ b/dashboard/src/api/schemas/link-previews.ts
@@ -29,9 +29,9 @@ import {
   type SafeParseResult,
 } from 'valibot'
 
-export const LinkPreviewKindSchema = picklist(['link', 'image'])
+const LinkPreviewKindSchema = picklist(['link', 'image'])
 
-export const LinkPreviewSchema = object({
+const LinkPreviewSchema = object({
   url: string(),
   kind: LinkPreviewKindSchema,
   canonical_url: optional(nullable(string())),


### PR DESCRIPTION
## Summary

5 파일 17 심볼. schemas 11 + keeper.ts interface 6.

## Schemas (11)

| 파일 | 심볼 |
|------|------|
| api/schemas/keeper-composite.ts | KeeperCompositeMeasurementSchema, InvariantsSchema, LastOutcomeSchema |
| api/schemas/agent-relations.ts | AgentRelationsResponseSchema |
| api/schemas/autoresearch.ts | AutoresearchCycleRecordSchema, LoopSummarySchema, LoopsResponseSchema, LoopDetailSchema, LoopActionResponseSchema |
| api/schemas/link-previews.ts | LinkPreviewKindSchema, LinkPreviewSchema |

## API interfaces (6)

| 파일 | 심볼 |
|------|------|
| api/keeper.ts | KeeperToolReply, KeeperLifecycleResponse, KeeperClearRequest, KeeperCheckpointDeleteResponse, KeeperToolPolicyInput, KeeperStateDiagramResponse |

## Verification

- \`bunx tsc --noEmit\`: green
- +17/-17 LOC (5 파일)

## Test plan

- [x] tsc strict
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)