### PR TITLE
feat(dashboard): filter ops activity timeline to last 3 days

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -41,11 +41,14 @@ describe('Ops surface', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-31T11:00:00Z'))
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
+    vi.useRealTimers()
     vi.resetModules()
     vi.clearAllMocks()
     vi.doUnmock('./quick-intervene')
@@ -262,7 +265,69 @@ describe('Ops surface', () => {
 
     const empty = container.querySelector('[data-testid="ops-activity-timeline-empty"]')
     expect(empty).toBeTruthy()
-    expect(empty?.textContent).toContain('최근 운영 활동이 없습니다')
+    expect(empty?.textContent).toContain('최근 3일 내 운영 활동이 없습니다')
     expect(empty?.textContent).not.toContain('일시정지')
+  }, 60000)
+
+  it('filters out entries older than 3 days so stale reviews stop showing', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    vi.setSystemTime(new Date('2026-04-18T10:00:00Z'))
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+    operatorRoomDigest.value = {
+      target_type: 'namespace',
+      attention_items: [],
+      recommended_actions: [],
+      recent_reviews: [
+        {
+          item_id: 'review-stale',
+          fingerprint: 'fp-stale',
+          decision: 'deferred',
+          actor: 'reviewer-1',
+          reason: '18일 전 보류',
+          at: '2026-03-31T10:05:00Z',
+          target_type: 'namespace',
+        },
+        {
+          item_id: 'review-fresh',
+          fingerprint: 'fp-fresh',
+          decision: 'resolved',
+          actor: 'reviewer-2',
+          reason: '방금 전 해결',
+          at: '2026-04-18T09:30:00Z',
+          target_type: 'namespace',
+        },
+      ],
+    } as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const items = Array.from(container.querySelectorAll('[data-testid="ops-activity-item"]'))
+    expect(items).toHaveLength(1)
+    expect(items[0]?.textContent).toContain('방금 전 해결')
+    expect(container.textContent).not.toContain('18일 전 보류')
   }, 60000)
 })

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -31,6 +31,8 @@ import { FlowControlPanel } from '../flow-control/flow-control-panel'
 
 type ActivityTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
 
+export const ACTIVITY_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000
+
 interface OpsActivityTimelineEntry {
   key: string
   kind: 'review' | 'intervention'
@@ -120,7 +122,9 @@ function timelineEntries(limit = 10): OpsActivityTimelineEntry[] {
     tone: actionLogTone(entry),
   }))
 
+  const cutoff = Date.now() - ACTIVITY_MAX_AGE_MS
   return [...reviews, ...interventions]
+    .filter(entry => parseTimestamp(entry.at) >= cutoff)
     .sort((left, right) => parseTimestamp(right.at) - parseTimestamp(left.at))
     .slice(0, limit)
 }
@@ -137,7 +141,7 @@ export function activityTimelineEmptyState(): { message: string; hint: string | 
     }
   }
   return {
-    message: '최근 운영 활동이 없습니다. 개입이 실행되거나 검토가 처리되면 자동 기록됩니다.',
+    message: '최근 3일 내 운영 활동이 없습니다. 개입이 실행되거나 검토가 처리되면 자동 기록됩니다.',
     hint: null,
   }
 }


### PR DESCRIPTION
## Summary
- filter the ops activity timeline to only show entries from the last 3 days
- keep the fix frontend-scoped because this is a dashboard presentation policy, not a transport contract change
- update the empty-state copy so the recency window is explicit to operators

## Product impact
- the `최근 운영 활동` card stops surfacing stale 2+ week-old review decisions as if they were current operator activity
- low-activity periods now show a truthful empty state instead of misleading surviving history
- operators get a clearer signal about whether anything happened recently on the ops surface

## Evidence
- local test evidence:
  - `npx vitest run src/components/ops/index.test.ts`
  - expected result: `5/5` passing, including the new `filters out entries older than 3 days` case
- reproduction evidence before the fix:
  - the card could show entries like `검토 보류 ... 17일 전` and `검토 해결 ... 17일 전` at the top of `최근 운영 활동`

## Review evidence
- timeline recency cutoff is applied in `dashboard/src/components/ops/index.ts` via `ACTIVITY_MAX_AGE_MS` and `timelineEntries()` filtering
- test coverage for stale review filtering lives in `dashboard/src/components/ops/index.test.ts`
- the empty-state wording is updated in `activityTimelineEmptyState()` so the 3-day policy is visible in the UI

## Linked issue
- Refs #8233

## Why
`최근 운영 활동` was bounded only by item count. When the room was quiet, that meant old review-decision entries could survive indefinitely and look like current operator work.

## What changed
- added `ACTIVITY_MAX_AGE_MS = 3 * 24h`
- filtered merged review/intervention timeline entries by timestamp before sorting and slicing
- updated empty-state copy from `최근 운영 활동이 없습니다` to `최근 3일 내 운영 활동이 없습니다`
- added a regression test with frozen time to prove stale reviews are dropped while fresh reviews stay visible

## Alternatives considered
| Option | Decision | Why |
|---|---|---|
| backend filtering | not chosen | this is a UI policy and backend/CLI consumers may want the raw feed |
| remove the card | not chosen | `recent_reviews` and `operatorActionLog` are still useful once the stale-history problem is fixed |
| frontend recency cutoff | chosen | minimal, explicit, and directly addresses the operator confusion |

## Validation
- `npx vitest run src/components/ops/index.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)