### PR TITLE
feat(dashboard): StatusChip paused/select tones + keeperStateTone helper

### DIFF
--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -2,11 +2,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { StatusChip, statusChipClasses, isSemanticTone } from './status-chip'
+import { StatusChip, statusChipClasses, isSemanticTone, keeperStateTone } from './status-chip'
 
 describe('isSemanticTone (pure)', () => {
-  it('accepts the 6 enum members', () => {
-    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', ''] as const) {
+  it('accepts the 8 enum members', () => {
+    for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', 'paused', 'select', ''] as const) {
       expect(isSemanticTone(tone)).toBe(true)
     }
   })
@@ -14,6 +14,28 @@ describe('isSemanticTone (pure)', () => {
   it('rejects raw Tailwind class strings (they pass through as extras)', () => {
     expect(isSemanticTone('bg-[var(--ok)]')).toBe(false)
     expect(isSemanticTone('text-accent')).toBe(false)
+  })
+})
+
+describe('keeperStateTone (pure)', () => {
+  it('maps the 12 keeper FSM states per Anyang Sleepers spec', () => {
+    expect(keeperStateTone('running')).toBe('ok')
+    expect(keeperStateTone('compacting')).toBe('info')
+    expect(keeperStateTone('handing_off')).toBe('info')
+    expect(keeperStateTone('draining')).toBe('info')
+    expect(keeperStateTone('failing')).toBe('warn')
+    expect(keeperStateTone('overflowed')).toBe('warn')
+    expect(keeperStateTone('restarting')).toBe('warn')
+    expect(keeperStateTone('paused')).toBe('paused')
+    expect(keeperStateTone('crashed')).toBe('bad')
+    expect(keeperStateTone('dead')).toBe('bad')
+    expect(keeperStateTone('stopped')).toBe('neutral')
+    expect(keeperStateTone('offline')).toBe('neutral')
+  })
+
+  it('unknown states fall through to neutral rather than throwing', () => {
+    expect(keeperStateTone('some_future_state')).toBe('neutral')
+    expect(keeperStateTone('')).toBe('neutral')
   })
 })
 

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -28,7 +28,15 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
-type StatusChipTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral' | ''
+type StatusChipTone =
+  | 'ok'
+  | 'warn'
+  | 'bad'
+  | 'info'
+  | 'neutral'
+  | 'paused'
+  | 'select'
+  | ''
 
 const BASE =
   'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider'
@@ -39,7 +47,48 @@ const SEMANTIC_TONE: Record<StatusChipTone, string> = {
   bad: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
   info: 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--accent)]',
   neutral: 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
+  paused: 'border-[var(--paused-20)] bg-[var(--paused-10)] text-[var(--paused)]',
+  select: 'border-[var(--select-20)] bg-[var(--select-10)] text-[var(--select)]',
   '': 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
+}
+
+/** 12 keeper lifecycle states → StatusChip tone.
+ *
+ * Mapping follows the Anyang Sleepers design system: twelve runtime
+ * states collapse into five visual groups because an operator
+ * reading a row doesn't need crashed vs. dead separated in color —
+ * both read as "error". Compaction / handing_off / draining all
+ * read as "working", which is the slate/info tone.
+ *
+ * Exported so every surface that renders keeper status uses the
+ * same palette. Takes an unknown string and returns 'neutral' for
+ * unrecognised input rather than throwing — a new state added to
+ * the backend FSM will render as neutral until this map is updated,
+ * which beats a runtime error in a row of 40 keepers.
+ */
+export function keeperStateTone(state: string): StatusChipTone {
+  switch (state) {
+    case 'running':
+      return 'ok'
+    case 'compacting':
+    case 'handing_off':
+    case 'draining':
+      return 'info'
+    case 'failing':
+    case 'overflowed':
+    case 'restarting':
+      return 'warn'
+    case 'paused':
+      return 'paused'
+    case 'crashed':
+    case 'dead':
+      return 'bad'
+    case 'stopped':
+    case 'offline':
+      return 'neutral'
+    default:
+      return 'neutral'
+  }
 }
 
 /** Pure: true when `tone` is one of the semantic enum members. Raw

--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -93,6 +93,16 @@
 
   --bad-light: var(--brick-line);
   --warn-bright: var(--ember-line);
+
+  /* Paused (plum) + selected (brass) — under paper theme both map
+     to the design system's solid accent, letting the 20% fill sit
+     on warm paper with the intended weight. */
+  --paused: var(--plum);
+  --paused-10: var(--plum-fill);
+  --paused-20: var(--plum-fill);
+  --select: var(--brass);
+  --select-10: var(--brass-fill);
+  --select-20: var(--brass-fill);
 }
 
 /* Base surface + text when paper theme is active.

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -51,6 +51,21 @@
   --bad-10: rgba(239, 68, 68, 0.10);
   --bad-20: rgba(239, 68, 68, 0.20);
 
+  /* Semantic - Paused (Plum). Introduced for the 12-keeper-state spec
+     in the Anyang Sleepers design system. On dark theme a lightened
+     plum keeps the chip legible against navy; the paper theme
+     overrides this to the solid plum #5C3E56 via paper-theme.css. */
+  --paused: #a789a2;
+  --paused-10: rgba(167, 137, 162, 0.10);
+  --paused-20: rgba(167, 137, 162, 0.22);
+
+  /* Semantic - Selected (Brass). Reuses the existing FF gold hue as
+     the "selected / highlighted" role the design system reserves for
+     brass. Paper theme overrides to #8C6A1E. */
+  --select: #c8a84e;
+  --select-10: rgba(200, 168, 78, 0.10);
+  --select-20: rgba(200, 168, 78, 0.22);
+
   /* Overlays (White Alpha) — bumped from 3/5 to 4/6 for clearer surface elevation */
   --white-3: rgba(255, 255, 255, 0.04);
   --white-5: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## 요약

Phase 1 파일럿. Anyang Sleepers design system이 정의한 12 keeper lifecycle state의 \"paused\" 그룹과 \"selected\" 강조 역할을 StatusChip primitive가 받아들이게 합니다. 기존 6개 톤(ok/warn/bad/info/neutral/'')은 그대로. 추가 2개 톤 + keeper state → tone 헬퍼만 순수 additive.

## 변경

- \`variables.css\` (+15 LOC) — \`--paused\` (plum), \`--select\` (brass) + \`-10\`/\`-20\` alpha
- \`paper-theme.css\` (+10 LOC) — 동일 토큰을 디자인 시스템 solid plum/brass로 override
- \`status-chip.ts\` (+51 LOC) — \`StatusChipTone\` union 확장 + \`SEMANTIC_TONE\` 맵 엔트리 2개 + \`keeperStateTone(state)\` pure 헬퍼 신규
- \`status-chip.test.ts\` (+28 LOC) — 8개 enum 검증 + 12 keeper state + 미지 state fallback

## keeperStateTone 매핑 근거

디자인 시스템 README 인용:
> The original dashboard has 12 runtime states. They collapse into five visual groups — the distinction between compacting and handing_off matters to an operator reading a log line, not to a 6px status dot across the room.

| 그룹 | states | tone |
|---|---|---|
| ok | \`running\` | ok |
| working | \`compacting\` \`handing_off\` \`draining\` | info (slate) |
| warn | \`failing\` \`overflowed\` \`restarting\` | warn (ember) |
| paused | \`paused\` | paused (plum) |
| error | \`crashed\` \`dead\` | bad (brick) |
| inactive | \`stopped\` \`offline\` | neutral |

미지 state는 throw 대신 neutral로 fall-through — 백엔드 FSM이 새 state를 추가해도 row가 깨지지 않음.

## 비스코프 (의식적 제외)

- 콜사이트 마이그레이션 없음 — 헬퍼만 노출. keeper-detail, fleet-data, ops 등은 PR 별도 분리해서 스코프별 리뷰.
- pill 라운드(rounded-full) 유지 — 디자인 시스템은 radius 0-4px만 허용하지만 전체 chip 모양 변경은 시각적 회귀가 커서 Phase 2로 미룸.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [x] \`vitest run status-chip\` 16/16 (기존 14 + 새 2 테스트)

## Related

- #8177 (paper theme bridge)
- #8181 (ThemeSwitch header)
- Reference: \`/Users/dancer/Downloads/Anyang Sleepers Design System/README.md\` 112-127 (keeper state table)