### PR TITLE
feat(dashboard): 🏷 StatusChip uppercase prop + absorb last 4 non-uppercase chips in config-resolution (P3/9)

### DIFF
--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -59,10 +59,35 @@ describe('statusChipClasses (pure)', () => {
     expect(statusChipClasses('ok', undefined)).not.toMatch(/\s$/)
   })
 
-  it('base tokens present for every tone (regression guard)', () => {
+  it('base shape tokens present for every tone (regression guard, uppercase=true default)', () => {
     for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', '', 'bg-[var(--ok)]']) {
       const cls = statusChipClasses(tone)
       for (const token of ['rounded-full', 'text-[10px]', 'uppercase', 'tracking-wider']) {
+        expect(cls).toContain(token)
+      }
+    }
+  })
+})
+
+describe('statusChipClasses uppercase flag', () => {
+  it('uppercase=false drops uppercase + tracking-wider (plain pill)', () => {
+    const cls = statusChipClasses('neutral', undefined, false)
+    expect(cls).not.toContain('uppercase')
+    expect(cls).not.toContain('tracking-wider')
+    // shape + tone still present
+    expect(cls).toContain('rounded-full')
+    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-[var(--text-muted)]')
+  })
+
+  it('uppercase=true (explicit) matches the default', () => {
+    expect(statusChipClasses('ok', undefined, true)).toBe(statusChipClasses('ok'))
+  })
+
+  it('shape tokens always present regardless of uppercase flag', () => {
+    for (const uppercase of [true, false]) {
+      const cls = statusChipClasses('warn', undefined, uppercase)
+      for (const token of ['inline-flex', 'rounded-full', 'border', 'px-2', 'py-0.5', 'text-[10px]']) {
         expect(cls).toContain(token)
       }
     }
@@ -105,5 +130,14 @@ describe('StatusChip component', () => {
   it('testId renders as data-testid', () => {
     render(html`<${StatusChip} testId="approve-chip">ok<//>`, container)
     expect(container.querySelector('[data-testid="approve-chip"]')).toBeTruthy()
+  })
+
+  it('uppercase prop reflects on data-status-chip-uppercase (default true)', () => {
+    render(html`<${StatusChip}>ok<//>`, container)
+    expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-uppercase')).toBe('true')
+
+    render(null, container)
+    render(html`<${StatusChip} uppercase=${false} tone="neutral">path.kind<//>`, container)
+    expect(container.querySelector('[data-status-chip]')!.getAttribute('data-status-chip-uppercase')).toBe('false')
   })
 })

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -24,14 +24,26 @@
 // ~12 caller sites already pass children (cascade-config-panel,
 // verification-requests-panel.test mocks). Accepting both keeps
 // every existing usage compiling while the caller mix converges.
+//
+// P3 update — `uppercase` prop (default true) splits the shape
+// tokens (rounded-full + border + px-2 py-0.5 + text-[10px]) from
+// the uppercase/tracking-wider pair. `uppercase={false}` renders
+// a plain (non-uppercase, non-tracked) neutral pill — the shape
+// used by config-resolution-panel's 4 "inline tag" call sites
+// (sourceLabel / pathInfo.kind / cache age / resolved config
+// root). Those sites were inline Tailwind strings with the exact
+// same shape minus the uppercase/tracking — folding them into
+// StatusChip removes the last remaining chip-shape duplication
+// from that file.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
 type StatusChipTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral' | ''
 
-const BASE =
-  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider'
+const BASE_SHAPE =
+  'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px]'
+const UPPERCASE_CLASS = 'uppercase tracking-wider'
 
 const SEMANTIC_TONE: Record<StatusChipTone, string> = {
   ok: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
@@ -49,18 +61,22 @@ export function isSemanticTone(tone: string): tone is StatusChipTone {
   return tone in SEMANTIC_TONE
 }
 
-/** Pure: class string for given tone + optional extra. Handles the
-    semantic/raw dichotomy so callers never have to. Base Tailwind
-    tokens (rounded-full + border + px-2 py-0.5 + uppercase +
-    tracking-wider) are always present — they are what makes the
-    chip visually consistent across the dashboard regardless of
-    which tone helper the caller chose. */
+/** Pure: class string for given tone + optional extra + optional
+    uppercase flag (default true). Handles the semantic/raw tone
+    dichotomy so callers never have to.
+
+    Shape tokens (rounded-full + border + px-2 py-0.5 + text-[10px])
+    are always present. `uppercase + tracking-wider` is conditional
+    on the `uppercase` flag — callers rendering plain tag pills
+    (no all-caps) pass `uppercase={false}` to drop both together. */
 export function statusChipClasses(
   tone: string = '',
   extra?: string,
+  uppercase: boolean = true,
 ): string {
   const toneClass = isSemanticTone(tone) ? SEMANTIC_TONE[tone] : tone
-  const parts = [BASE]
+  const parts = [BASE_SHAPE]
+  if (uppercase) parts.push(UPPERCASE_CLASS)
   if (toneClass !== '') parts.push(toneClass)
   if (extra !== undefined && extra !== '') parts.push(extra)
   return parts.join(' ')
@@ -75,6 +91,11 @@ interface StatusChipProps {
   tone?: string
   /** Extra Tailwind classes for caller layout (margin, shrink-0). */
   class?: string
+  /** Render with `uppercase tracking-wider` (default true). Set
+      false for plain tag pills (e.g. neutral "inline label" chips
+      where uppercase would change the visual grammar — typically
+      file paths, enum values, short textual tags). */
+  uppercase?: boolean
   children?: ComponentChildren
   testId?: string
 }
@@ -83,15 +104,17 @@ export function StatusChip({
   label,
   tone = '',
   class: cx,
+  uppercase = true,
   children,
   testId,
 }: StatusChipProps) {
-  const cls = statusChipClasses(tone, cx)
+  const cls = statusChipClasses(tone, cx, uppercase)
   const content = children ?? label ?? ''
   return html`<span
     class=${cls}
     data-status-chip
     data-status-chip-tone=${tone}
+    data-status-chip-uppercase=${uppercase ? 'true' : 'false'}
     data-testid=${testId}
   >${content}</span>`
 }

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -161,16 +161,12 @@ function ConfigRow({
         <${StatusChip} tone=${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}>${item.exists ? 'present' : 'missing'}<//>
         ${showSourceBadge
           ? html`
-              <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">
-                ${sourceLabel(item.source)}
-              </span>
+              <${StatusChip} tone="neutral" uppercase=${false}>${sourceLabel(item.source)}<//>
             `
           : null}
         ${pathInfo.kind
           ? html`
-              <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">
-                ${pathInfo.kind}
-              </span>
+              <${StatusChip} tone="neutral" uppercase=${false}>${pathInfo.kind}<//>
             `
           : null}
       </div>
@@ -326,9 +322,7 @@ function RuntimeProbePanel() {
         <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
-              <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">
-                ${state.value.data.cache_hit ? 'cached' : 'fresh'} · age ${fmtNumber(state.value.data.cache_age_sec, 1)}s
-              </span>
+              <${StatusChip} tone="neutral" uppercase=${false}>${state.value.data.cache_hit ? 'cached' : 'fresh'} · age ${fmtNumber(state.value.data.cache_age_sec, 1)}s<//>
             `
           : null}
         <button
@@ -453,9 +447,7 @@ export function ConfigResolutionPanel({
             <div class="mb-6">
               <div class="mb-3 flex flex-wrap items-center gap-2">
                 <${StatusChip} tone=${toneClass(resolution.status)}>${resolution.status}<//>
-                <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
-                  ${sourceLabel(resolution.config_root.source)}
-                </span>
+                <${StatusChip} tone="neutral" uppercase=${false}>${sourceLabel(resolution.config_root.source)}<//>
                 <span class="text-[12px] text-[var(--text-muted)]">resolved config root</span>
               </div>
 


### PR DESCRIPTION
## Summary

Extends `StatusChip` with an `uppercase` flag and absorbs the **last 4
non-uppercase chip shapes** in `config-resolution-panel.ts` — the file
that opened the dashboard hygiene audit with 15+ inline chip spans now
has **zero**.

P3 of the 9-PR hygiene sweep (after #8076 SectionCap + #8086 StatusChip
Tailwind-only rewrite).

## Change

Split the primitive's class tokens:
```
BASE_SHAPE      = inline-flex items-center rounded-full border px-2 py-0.5 text-[10px]
UPPERCASE_CLASS = uppercase tracking-wider   (opt-in via the new flag)
```

- `uppercase=true` (default) — existing callers unchanged, pixel-identical
- `uppercase=false` — plain tag pill (no all-caps, no tracking-wider).
  This is the shape the 4 remaining inline spans were reimplementing.

`data-status-chip-uppercase` attribute added for deterministic test
selectors.

## Migration (4 chips, 1 file)

| Line | Content | Was |
|------|---------|-----|
| 164 | `sourceLabel(item.source)` | `<span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] tracking-[0.08em] text-[var(--text-muted)]">…</span>` |
| 171 | `pathInfo.kind` | (same shape) |
| 329 | `cache_hit ? 'cached' : 'fresh' · age …s` | (same shape) |
| 456 | `sourceLabel(resolution.config_root.source)` | (same shape, no tracking) |

All 4 become `<${StatusChip} tone="neutral" uppercase=${false}>…<//>`,
collapsing 3-line span blocks to single-line component calls.
**`config-resolution-panel.ts` now has zero inline chip shapes.**

## Explicitly deferred

SectionCap `inline` variant for `connector-readiness-rail.ts:161` and
`observatory/cross-signal-readout.ts:96` — those use raw tone color
classes (`tone.text`, `text-accent`) that can't fold into SectionCap's
`muted`/`dim` tone enum without bloating the API. Those are color-var
drift, handled better in **P6** (color normalization) than forced into
SectionCap today.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3739/3739 green (4 new uppercase-flag cases: 3 pure fn + 1 component)
- [x] `pnpm build` — vite clean
- [ ] CI green
- [ ] Empirical: local dashboard boot → config-resolution panel visually identical (4 chips preserve shape + background + no-uppercase rendering)

## Roadmap status

| PR | Status |
|----|--------|
| P1 SectionCap | ✅ #8076 merged |
| P2 StatusChip Tailwind-only | ✅ #8086 merged |
| **P3 StatusChip uppercase + 4 chips** | **this PR** |
| P4 IdPill primitive | pending |
| P5 text-[9px] density sweep | pending |
| P6 Color var normalization + drift lint | pending (absorbs connector-readiness + cross-signal-readout spans) |
| P7 Rounded / font-weight sweep | pending |
| P8 a11y / focus ring sweep | pending |
| P9 Waste sweep | pending |
