### PR TITLE
[codex] Split operator control out of quick suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,7 @@ jobs:
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
+          MASC_INCLUDE_OPERATOR_CONTROL: "false"
           CI_TEST_TIMEOUT_SEC: 1200
           CI_TEST_HEARTBEAT_SEC: 30
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
@@ -399,6 +400,20 @@ jobs:
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune test"
+
+      - name: Run operator control suite
+        env:
+          ME_ROOT: /tmp/me
+          ALCOTEST_QUICK_TESTS: "1"
+          CI_TEST_TIMEOUT_SEC: 600
+          CI_TEST_HEARTBEAT_SEC: 15
+          MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
+          MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
+          MASC_E2E_TESTS: "true"
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune exec ./test/test_operator_control.exe"
 
       - name: Run SSE reconnect e2e
         env:

--- a/test/dune
+++ b/test/dune
@@ -821,7 +821,8 @@
           test_operator_control_judgment
           test_operator_control_swarm
           test_operator_control_keeper)
- (libraries masc_test_deps))
+ (libraries masc_test_deps)
+ (enabled_if (= %{env:MASC_INCLUDE_OPERATOR_CONTROL=true} "true")))
 
 ; Normalized actor (operator_pending_confirm)
 (test

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -69,7 +69,16 @@ let test_health_and_ci_runner_diagnostics () =
     (file_contains_pattern "scripts/ci-run-tests.sh"
        "detected dune RPC/lock failure; retrying once with isolated build dir");
   check bool "ci runner tracks active build dir for diagnostics" true
-    (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR")
+    (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR");
+  check bool "quick suite excludes operator control from monolithic dune test" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "MASC_INCLUDE_OPERATOR_CONTROL: \"false\"");
+  check bool "ci workflow runs operator control in dedicated step" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "dune exec ./test/test_operator_control.exe");
+  check bool "operator control test is env-gated in dune" true
+    (file_contains_pattern "test/dune"
+       "(enabled_if (= %{env:MASC_INCLUDE_OPERATOR_CONTROL=true} \"true\"))")
 
 let test_release_truth_contracts () =
   check bool "ci workflow defines doc truth job" true


### PR DESCRIPTION
## Summary
- exclude `test_operator_control` from the monolithic quick-suite `dune test` run via an env gate
- run `test_operator_control.exe` in its own CI step with the same quick-test environment
- lock the split contract with `test_ci_hardening_source`

## Root Cause
`Build and Test -> Run tests (quick suite)` has been timing out without a concrete failure marker. The latest successful suite output before the stall is consistently `Operator_control`, so the quickest safe experiment is to isolate that executable from the monolithic `dune test` run.

## Product impact
- no product/runtime behavior change
- CI should fail faster and with a narrower culprit if `operator_control` is the hanging executable
- if the hang is caused by interaction with the aggregate `dune test` run, this should unblock the quick suite entirely

## Evidence
- merged follow-up issue: `#8231`
- recent failing runs: `24572810603` and `24574102732`
- both runs timed out with empty failure markers; latest emitted suite output included `Operator_control`

## Review evidence
- workflow YAML parses successfully
- source-guard contract updated for the new CI split
- full OCaml build not completed locally before push; new CI run is the primary verification lane for this change

## Linked issue
Refs #8231
