### PR TITLE
feat(dashboard): keeperStateTone accepts dashboard-layer state names

### DIFF
--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -37,6 +37,19 @@ describe('keeperStateTone (pure)', () => {
     expect(keeperStateTone('some_future_state')).toBe('neutral')
     expect(keeperStateTone('')).toBe('neutral')
   })
+
+  it('also accepts dashboard-layer state names (KeeperLifecycleState + agent status)', () => {
+    // types/core.ts KeeperLifecycleState
+    expect(keeperStateTone('active')).toBe('ok')
+    expect(keeperStateTone('preparing')).toBe('info')
+    expect(keeperStateTone('handoff-imminent')).toBe('info')
+    expect(keeperStateTone('idle')).toBe('neutral')
+    expect(keeperStateTone('unbooted')).toBe('neutral')
+    // agent.status union
+    expect(keeperStateTone('busy')).toBe('warn')
+    expect(keeperStateTone('listening')).toBe('info')
+    expect(keeperStateTone('inactive')).toBe('neutral')
+  })
 })
 
 describe('statusChipClasses (pure)', () => {

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -52,39 +52,59 @@ const SEMANTIC_TONE: Record<StatusChipTone, string> = {
   '': 'border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-muted)]',
 }
 
-/** 12 keeper lifecycle states → StatusChip tone.
+/** Keeper lifecycle state → StatusChip tone.
  *
- * Mapping follows the Anyang Sleepers design system: twelve runtime
- * states collapse into five visual groups because an operator
- * reading a row doesn't need crashed vs. dead separated in color —
- * both read as "error". Compaction / handing_off / draining all
- * read as "working", which is the slate/info tone.
+ * Accepts both vocabularies in use across the codebase:
  *
- * Exported so every surface that renders keeper status uses the
- * same palette. Takes an unknown string and returns 'neutral' for
- * unrecognised input rather than throwing — a new state added to
- * the backend FSM will render as neutral until this map is updated,
- * which beats a runtime error in a row of 40 keepers.
+ *   1. Design-system / backend FSM names from the Anyang Sleepers
+ *      spec: running, compacting, handing_off, draining, failing,
+ *      overflowed, restarting, paused, stopped, crashed, dead,
+ *      offline.
+ *
+ *   2. Dashboard-layer names defined in `types/core.ts#KeeperLifecycleState`
+ *      and the live agent `status` union: active, preparing,
+ *      handoff-imminent, idle, unbooted, busy, listening, inactive.
+ *
+ * Both collapse into the same five visual groups the design system
+ * prescribes (ok / working / warn / paused / error), with inactive
+ * variants landing in neutral. Unknown strings return 'neutral'
+ * rather than throwing so a backend-added state renders as muted
+ * until this map is updated — a row of 40 keepers should not crash
+ * on vocabulary drift.
  */
 export function keeperStateTone(state: string): StatusChipTone {
   switch (state) {
+    // ok — live and serving
     case 'running':
+    case 'active':
       return 'ok'
+    // working — in flight, not actionable
     case 'compacting':
     case 'handing_off':
+    case 'handoff-imminent':
     case 'draining':
+    case 'preparing':
+    case 'listening':
       return 'info'
+    // warn — degraded but not yet dead
     case 'failing':
     case 'overflowed':
     case 'restarting':
+    case 'busy':
       return 'warn'
+    // paused — human or governor paused
     case 'paused':
       return 'paused'
+    // error — crash / lost
     case 'crashed':
     case 'dead':
       return 'bad'
+    // inactive — offline / stopped / never started
     case 'stopped':
     case 'offline':
+    case 'idle':
+    case 'unbooted':
+    case 'inactive':
       return 'neutral'
     default:
       return 'neutral'


### PR DESCRIPTION
## 요약

#8235 에서 landed한 \`keeperStateTone()\`은 Anyang Sleepers 스펙의 12 backend FSM 이름만 인식했습니다. 하지만 dashboard는 \`types/core.ts#KeeperLifecycleState\` + 별도 agent \`status\` union 으로 다른 어휘를 씁니다 (active/preparing/handoff-imminent/idle/unbooted/busy/listening/inactive). 이들이 default 'neutral' 브랜치로 빠져 실제 keeper 데이터에 helper를 써도 의도한 톤이 안 나왔습니다.

## 변경

\`keeperStateTone()\` switch에 8개 alias 추가. 5개 시각 그룹(ok/info/warn/paused/bad/neutral)은 그대로.

| Dashboard state | → tone | 이유 |
|---|---|---|
| \`active\` | ok | backend \`running\`과 동일 의미 |
| \`preparing\`, \`listening\` | info | 작업 준비 / 대기 중 (non-actionable) |
| \`handoff-imminent\` | info | \`handing_off\`의 dashboard 표기 |
| \`busy\` | warn | 과부하 (pressed) |
| \`idle\`, \`unbooted\`, \`inactive\` | neutral | 활성 상태 아님 |

- 미지 state → 여전히 neutral fall-through
- 기존 backend FSM 매핑 변경 없음

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`vitest run status-chip\` 17/17 (#8235의 16 + 새 1)

## Related

- #8235 \`keeperStateTone\` 도입 PR
- \`types/core.ts#KeeperLifecycleState\` (line 203-211)
- agent \`status\` union (line 8)