### PR TITLE
fix(tool-policy): recognise admin-dispatched keeper tools in validator (#7696)

### DIFF
--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -37,6 +37,12 @@ val core_discovery_tools : string list
 (** Returns [core_discovery_tools].  Discovery mode is the default. *)
 val effective_core_tools : unit -> string list
 
+(** Keeper tools dispatched by the server but withheld from the visible
+    keeper tool set (admin/opt-in only — see [optional] group in
+    [config/tool_policy.toml]).  Exported so startup validators can
+    recognise them as runtime rather than orphan config. *)
+val keeper_admin_dispatched_tools : string list
+
 (** Keeper-local read-only tools that do not always flow through Tool_spec. *)
 val keeper_read_only_tools : string list
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -83,6 +83,19 @@ let core_discovery_tools =
 
 let effective_core_tools () = core_discovery_tools
 
+(** Keeper tools that the dispatcher accepts but that are intentionally
+    withheld from the visible/core set — served only when a keeper
+    opts in via [policy_config.also_allow] (e.g. the [optional] group
+    in [config/tool_policy.toml]).
+
+    Must stay in sync with [Keeper_exec_tools.execute_keeper_tool_call]
+    match arms.  Exported so [Tool_registration_check] can recognise
+    them as legitimate runtime names instead of flagging them as
+    orphan toml entries (#7696). *)
+let keeper_admin_dispatched_tools =
+  List.map Tool_name.to_string
+    Tool_name.[ Keeper Board_cleanup; Keeper Board_delete ]
+
 let core_always_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length core_always_tools) in
   List.iter (fun name -> Hashtbl.replace tbl name ()) core_always_tools;

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -17,6 +17,7 @@ let runtime_keeper_tool_names () =
   Hashtbl.create 512
   |> add_names Keeper_exec_tools.keeper_internal_candidate_tool_names
   |> add_names (Keeper_exec_tools.effective_core_tools ())
+  |> add_names Keeper_exec_tools.keeper_admin_dispatched_tools
   |> add_names
        (Keeper_tool_policy.keeper_supported_masc_tool_names_from_schemas
           Config.raw_all_tool_schemas)

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -230,6 +230,23 @@ let test_docs_do_not_reintroduce_removed_mode_surface () =
             "masc_tool_disable" ])
     paths
 
+let test_admin_dispatched_keeper_tools_not_orphaned () =
+  (* #7696: keeper_board_cleanup/delete are dispatched by Keeper_exec_tools
+     but withheld from the visible/core set. The validator must recognise
+     them as runtime so the [optional] group in tool_policy.toml does not
+     trigger a false-positive "unknown tool names" WARN. *)
+  match Keeper_exec_tools.init_policy_config ~base_path:(repo_root ()) with
+  | Error msg ->
+      Alcotest.failf "failed to load tool policy config: %s" msg
+  | Ok () ->
+      let validation = Tool_registration_check.validate () in
+      List.iter (fun name ->
+        if List.mem name validation.Tool_registration_check.orphan_toml then
+          Alcotest.failf
+            "admin-dispatched keeper tool %s must not be reported as orphan_toml"
+            name)
+        [ "keeper_board_cleanup"; "keeper_board_delete" ]
+
 let test_tool_registration_check_does_not_depend_on_injected_masc_schemas () =
   match Keeper_exec_tools.init_policy_config ~base_path:(repo_root ()) with
   | Error msg ->
@@ -350,6 +367,10 @@ let () =
             "tool registration check does not depend on injected masc schemas"
             `Quick
             test_tool_registration_check_does_not_depend_on_injected_masc_schemas;
+          Alcotest.test_case
+            "admin-dispatched keeper tools not flagged as orphan_toml (#7696)"
+            `Quick
+            test_admin_dispatched_keeper_tools_not_orphaned;
           Alcotest.test_case "keeper_backend_tool_name matches keeper_internal_replacement" `Quick
             test_keeper_alias_ssot_consistency;
         ] );


### PR DESCRIPTION
## Summary

Fix false-positive orphan WARN in `Tool_registration_check` for 2 admin-only keeper tools that the validator never listed as runtime sources. Closes #7696.

- `keeper_board_cleanup` / `keeper_board_delete` — real runtime tools dispatched by `Keeper_exec_tools` (see `keeper_exec_tools.ml:191-192`) and kept admin-only via the `[optional]` group in `config/tool_policy.toml:79`. Intentionally withheld from `effective_core_tools` (see `keeper_tool_registry.ml:47-48`, #4309). Validator saw no match in any of its 3 runtime sources → WARN.
- `keeper_pr_submit` / `keeper_pr_workflow` — no references anywhere in `lib/` or `config/` on current main. `rg` returns empty. Already cleaned up in prior work.

## Linked issue

Closes #7696.

## Product impact

- Startup log noise reduction: the 4-name WARN `tool_policy unknown tool names (4): ...` stops firing every boot. Operators currently have to visually ignore it or investigate on every restart.
- No behaviour change: admin/opt-in dispatching is unchanged; the change is purely the validator recognising these names as runtime rather than orphan.

## Change

1. `lib/keeper/keeper_tool_registry.ml` — add `keeper_admin_dispatched_tools`, derived from `Tool_name.Keeper.{Board_cleanup,Board_delete}` so a rename is a compile error rather than silent drift.
2. `lib/keeper/keeper_exec_tools.mli` — export the new list.
3. `lib/tool_registration_check.ml` — include it as the fourth runtime source.
4. `test/test_tool_registration_consistency.ml` — regression test asserting neither name appears in `validation.orphan_toml`.

## Why a named list instead of pulling from the toml `optional` group directly

Pulling the admin set from `tool_policy.toml` would make the validator self-confirm: any future orphan added to `optional` would be hidden. The named list in code keeps the validator honest — orphans in `optional` still fail if they lack a code-side declaration.

## Evidence

- `rg 'keeper_pr_submit|keeper_pr_workflow' lib/ config/` → empty (both names already deleted upstream).
- `rg 'keeper_board_cleanup|keeper_board_delete' lib/` → 16 hits, all within `Keeper_exec_tools` dispatcher, `Tool_name` enum, and telemetry.
- `dune build --root . @check` passes on dev profile.

## Review evidence

- New test `admin-dispatched keeper tools not flagged as orphan_toml (#7696)` asserts the post-fix invariant; the existing 11 tests in the suite stay green (12/12 OK). Test derives the name list from `Tool_name` so a rename is a compile-time failure.

## Test plan

- [x] `dune build --root . @check` — clean
- [x] `dune exec test/test_tool_registration_consistency.exe` — 12/12 OK
- [ ] CI green (build ✓ / TLA+ pending)