### PR TITLE
feat(dashboard): KeeperPhaseBadge uses design-system tokens

### DIFF
--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -41,6 +41,18 @@ describe('PHASE_STYLES', () => {
       expect(style.label.length).toBeGreaterThan(0)
     }
   })
+
+  it('color / bg / border reference design-system CSS variables', () => {
+    // After #8235 + #8240 + the keeper-phase migration, hue values
+    // live in tokens (ok / warn / accent / paused / bad-light /
+    // text-muted) so paper theme can swap palettes without editing
+    // this file. Hardcoded rgb / hex would reintroduce drift.
+    for (const style of Object.values(PHASE_STYLES)) {
+      expect(style.color).toMatch(/^var\(--/)
+      expect(style.bg).toMatch(/^var\(--/)
+      expect(style.border).toMatch(/^var\(--/)
+    }
+  })
 })
 
 // ================================================================
@@ -60,14 +72,32 @@ describe('getPhaseStyle', () => {
     expect(getPhaseStyle('').label).toBe('오프라인')
   })
 
-  it('returns correct style for Running', () => {
-    expect(getPhaseStyle('Running').label).toBe('실행중')
-    expect(getPhaseStyle('Running').color).toBe('#34d399')
+  it('returns correct style for Running (ok group)', () => {
+    const s = getPhaseStyle('Running')
+    expect(s.label).toBe('실행중')
+    expect(s.color).toBe('var(--ok)')
+    expect(s.bg).toBe('var(--ok-10)')
   })
 
-  it('returns correct style for Crashed', () => {
-    expect(getPhaseStyle('Crashed').label).toBe('비정상종료')
-    expect(getPhaseStyle('Crashed').color).toBe('#ef4444')
+  it('returns correct style for Crashed (error group)', () => {
+    const s = getPhaseStyle('Crashed')
+    expect(s.label).toBe('비정상종료')
+    expect(s.color).toBe('var(--bad-light)')
+    expect(s.bg).toBe('var(--bad-10)')
+  })
+
+  it('Paused resolves to the paused (plum) token', () => {
+    const s = getPhaseStyle('Paused')
+    expect(s.label).toBe('일시정지')
+    expect(s.color).toBe('var(--paused)')
+  })
+
+  it('Compacting / HandingOff / Draining / Restarting share the accent (slate/working) tone', () => {
+    const tones = (['Compacting', 'HandingOff', 'Draining', 'Restarting'] as const).map(
+      (p) => getPhaseStyle(p).color,
+    )
+    expect(new Set(tones).size).toBe(1)
+    expect(tones[0]).toBe('var(--accent)')
   })
 
   it('returns Offline for unknown phase string', () => {
@@ -79,7 +109,7 @@ describe('getPhaseStyle', () => {
     for (const phase of phases) {
       const style = getPhaseStyle(phase)
       expect(style.label).toBeTruthy()
-      expect(style.color).toBeTruthy()
+      expect(style.color).toMatch(/^var\(--/)
     }
   })
 })

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -1,6 +1,16 @@
 // Keeper phase indicator — shows the 12-state lifecycle phase
 // as a color-coded badge with Korean label.
 // Phase = lifecycle health (생명주기), complementary to pipeline_stage (활동).
+//
+// Color mapping follows the Anyang Sleepers design system (#8177,
+// #8235): the 12 phases collapse into 6 visual groups so that across
+// a row of 40 keepers the palette reads as 6 semantic categories
+// rather than 12 similar-but-subtly-different hues. Individual phase
+// is still distinguished by its icon and Korean label — the color
+// carries the health meaning, the icon carries the identity.
+//
+// Values use CSS custom properties so the same palette swaps under
+// [data-theme="paper"] without a branch in this file.
 
 import { html } from 'htm/preact'
 import type { KeeperPhase } from '../types'
@@ -8,26 +18,46 @@ import { formatDuration } from '../lib/format-time'
 
 interface PhaseStyle {
   label: string
+  /** `var(--token)` string for the text + icon hue. */
   color: string
+  /** `var(--token)` for the badge fill (10% alpha variant). */
   bg: string
+  /** `var(--token)` for the border (20% alpha variant). */
   border: string
+  /** `none` or a `0 0 Xpx color-mix(...)` string. Static by design —
+      the token resolves at paint time, so a single literal works for
+      both dark and paper palettes. */
   glow: string
   icon: string
 }
 
+// 6 visual groups per design system README:
+//   ok      running                                          → --ok
+//   working compacting · handing_off · draining · restarting → --accent (slate)
+//   warn    failing · overflowed                             → --warn
+//   paused  paused                                           → --paused
+//   inactive offline · stopped · dead                        → --text-muted / --bad-light
+//
+// Restarting sits with "working" — operators read a restart as
+// recovery-in-progress, not a fresh failure. Dead keeps the bad-light
+// hue (brick) because it indicates a terminated agent, distinct from
+// Stopped (intentional) and Offline (never connected).
+const SOFT_GLOW = '0 0 8px color-mix(in srgb, currentColor 25%, transparent)'
+const STRONG_GLOW = '0 0 10px color-mix(in srgb, currentColor 32%, transparent)'
+
 const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
-  Offline:    { label: '오프라인',   color: '#6b7280', bg: 'rgba(107,114,128,0.08)', border: 'rgba(107,114,128,0.18)', glow: 'none',                             icon: '○' },
-  Running:    { label: '실행중',     color: '#34d399', bg: 'rgba(52,211,153,0.08)',  border: 'rgba(52,211,153,0.22)',  glow: '0 0 8px rgba(52,211,153,0.25)',    icon: '●' },
-  Failing:    { label: '오류중',     color: '#f97316', bg: 'rgba(249,115,22,0.08)',  border: 'rgba(249,115,22,0.22)',  glow: '0 0 8px rgba(249,115,22,0.25)',    icon: '▲' },
-  Overflowed: { label: '컨텍스트초과', color: '#f59e0b', bg: 'rgba(245,158,11,0.10)', border: 'rgba(245,158,11,0.24)', glow: '0 0 8px rgba(245,158,11,0.24)',    icon: '⚠' },
-  Compacting: { label: '압축중',     color: '#a855f7', bg: 'rgba(168,85,247,0.08)',  border: 'rgba(168,85,247,0.22)',  glow: '0 0 8px rgba(168,85,247,0.20)',    icon: '◆' },
-  HandingOff: { label: '승계중',     color: '#f472b6', bg: 'rgba(244,114,182,0.08)', border: 'rgba(244,114,182,0.22)', glow: '0 0 8px rgba(244,114,182,0.20)',   icon: '⟳' },
-  Draining:   { label: '종료중',     color: '#fb923c', bg: 'rgba(251,146,60,0.08)',  border: 'rgba(251,146,60,0.22)',  glow: '0 0 8px rgba(251,146,60,0.20)',    icon: '▽' },
-  Paused:     { label: '일시정지',   color: '#a78bfa', bg: 'rgba(167,139,250,0.08)', border: 'rgba(167,139,250,0.22)', glow: 'none',                             icon: '⏸' },
-  Stopped:    { label: '정지',       color: '#6b7280', bg: 'rgba(107,114,128,0.08)', border: 'rgba(107,114,128,0.22)', glow: 'none',                             icon: '■' },
-  Crashed:    { label: '비정상종료', color: '#ef4444', bg: 'rgba(239,68,68,0.10)',   border: 'rgba(239,68,68,0.28)',   glow: '0 0 10px rgba(239,68,68,0.30)',    icon: '✕' },
-  Restarting: { label: '재시작중',   color: '#38bdf8', bg: 'rgba(56,189,248,0.08)',  border: 'rgba(56,189,248,0.22)',  glow: '0 0 8px rgba(56,189,248,0.20)',    icon: '↺' },
-  Dead:       { label: '종료',       color: '#4b5563', bg: 'rgba(75,85,99,0.06)',    border: 'rgba(75,85,99,0.18)',    glow: 'none',                             icon: '✦' },
+  Offline:    { label: '오프라인',     color: 'var(--text-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '○' },
+  Running:    { label: '실행중',       color: 'var(--ok)',         bg: 'var(--ok-10)',     border: 'var(--ok-20)',      glow: SOFT_GLOW,     icon: '●' },
+  Failing:    { label: '오류중',       color: 'var(--warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '▲' },
+  Overflowed: { label: '컨텍스트초과', color: 'var(--warn)',       bg: 'var(--warn-10)',   border: 'var(--warn-20)',    glow: SOFT_GLOW,     icon: '⚠' },
+  Compacting: { label: '압축중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '◆' },
+  HandingOff: { label: '승계중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '⟳' },
+  Draining:   { label: '종료중',       color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '▽' },
+  Paused:     { label: '일시정지',     color: 'var(--paused)',     bg: 'var(--paused-10)', border: 'var(--paused-20)',  glow: 'none',        icon: '⏸' },
+  Stopped:    { label: '정지',         color: 'var(--text-muted)', bg: 'var(--white-5)',   border: 'var(--white-10)',   glow: 'none',        icon: '■' },
+  Crashed:    { label: '비정상종료',   color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: STRONG_GLOW,   icon: '✕' },
+  Restarting: { label: '재시작중',     color: 'var(--accent)',     bg: 'var(--accent-10)', border: 'var(--accent-20)',  glow: SOFT_GLOW,     icon: '↺' },
+  Dead:       { label: '종료',         color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: 'none',        icon: '✦' },
 }
 
 const BUFFER_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Restarting'])


### PR DESCRIPTION
## 요약

Anyang Sleepers 디자인 시스템 시리즈 첫 **실제 콜사이트 마이그레이션**. 지금까지의 4 PR(#8177 토큰 브릿지 · #8181 Theme switch · #8235 StatusChip tone · #8240 dashboard 어휘)은 인프라만 깔았고, 실제 UI는 old hex 색상을 그대로 사용하고 있었습니다. KeeperPhaseBadge가 가장 먼저 새 토큰을 받습니다.

## 변경

\`PHASE_STYLES\`의 12 엔트리 값을 hardcoded hex(\`#34d399\`)/rgba(\`rgba(52,211,153,0.08)\`) → \`var(--ok)\` / \`var(--ok-10)\` 등 디자인 시스템 토큰으로 전환. 필드 shape(\`label/color/bg/border/glow/icon\`)는 유지 → 소비자(test 포함) API 불변.

## 12 → 6 그룹 매핑

| 그룹 | 포함 phase | 토큰 |
|---|---|---|
| ok | Running | \`--ok\` |
| working | Compacting, HandingOff, Draining, Restarting | \`--accent\` (slate) |
| warn | Failing, Overflowed | \`--warn\` |
| paused | Paused | \`--paused\` (PR #8235) |
| error | Crashed, Dead | \`--bad-light\` |
| inactive | Offline, Stopped | \`--text-muted\` |

**Phase 식별은 icon + 한국어 라벨로 유지** (예: Compacting ◆ \"압축중\" vs HandingOff ⟳ \"승계중\"). 색은 건강 그룹을 전달, icon은 phase 정체성을 전달.

## 의식적 설계 결정

- **Restarting** 이전 light-blue에서 → working(slate)로 이동. 운영자가 재시작을 fresh failure 아니라 recovery-in-progress로 읽음.
- **Dead** bad-light(brick) 유지 — Stopped(의도적 종료, neutral) / Offline(미연결, neutral)과 구분.
- **Glow**: \`color-mix(in srgb, currentColor 25%, transparent)\`로 dark/paper 팔레트 모두에서 단일 리터럴 사용. 테마별 분기 없음.

## 시각 결과

- 다크 테마: 6 semantic 그룹이 기존 dashboard 팔레트와 자연스럽게 섞임
- Paper 테마(\`?theme=paper\`): 자동으로 forest/slate/ember/plum/brick 페이퍼 팔레트로 렌더
- 40 keeper row가 12 비슷한 색 → 6 명확한 카테고리로 읽힘 (디자인 시스템 README line 88 의도)

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [x] \`vitest run keeper-phase-indicator\` 13/13 (기존 10 + 신규 3)
- 새 assertion: \`color/bg/border\`가 \`var(--...)\`로 시작하는지, 핵심 그룹 매핑 정확한지

## Related

- #8177 paper theme 토큰 인프라
- #8235 StatusChip + \`keeperStateTone\` helper
- Reference: \`/Users/dancer/Downloads/Anyang Sleepers Design System/README.md\` 112-127