### PR TITLE
fix(dashboard): honour promised namespace-truth env knobs (#7908)

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -302,6 +302,14 @@ let dashboard_entries =
       "Duration after which a signal is stale (seconds, 20 min)";
     entry ~default:"8" "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S"
       "Transport health timeout";
+    entry ~default:"15.0" "MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S"
+      "Namespace-truth fiber base timeout on cold start (seconds, 1-120)";
+    entry ~default:"4.0" "MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S"
+      "Extra margin added to shell fiber timeout on cold start (seconds, 0-60)";
+    entry ~default:"12.0" "MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S"
+      "Namespace-truth shell fiber timeout after warm-up (seconds, 1-120)";
+    entry ~default:"8.0" "MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S"
+      "Namespace-truth fiber base timeout after warm-up (seconds, 1-120)";
   ]
 
 (* --- New categories for the 229 missing env vars --- *)

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -51,10 +51,18 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let shell_ref = ref (`Assoc []) in
         let execution_ref = ref (`Assoc []) in
         let command_ref = ref (`Assoc []) in
-        (* Single env var for namespace-truth fiber timeouts.
-           Cold start uses higher defaults to allow shell/namespace reads to warm up. *)
-        let warm_timeout_s = 8.0 in
-        let cold_timeout_s = 15.0 in
+        (* Namespace-truth fiber timeouts.  Cold start uses higher defaults to
+           allow shell/namespace reads to warm up.  Tunable via env for fleets
+           whose observed fetch latency drifts above the literal defaults (see
+           #7908 — fleet p50 ≈ 17s made the 12s shell cap misfire). *)
+        let warm_timeout_s =
+          float_of_env_default "MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S"
+            ~default:8.0 ~min_v:1.0 ~max_v:120.0
+        in
+        let cold_timeout_s =
+          float_of_env_default "MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S"
+            ~default:15.0 ~min_v:1.0 ~max_v:120.0
+        in
         let is_cold =
           not (cached_surface_has_success Execution_surfaces._execution_cache)
         in
@@ -78,10 +86,17 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
            (dashboard_shell_timeout_s, default 8s) to avoid the double-timeout
            race where the inner cache returns timeout-error JSON while the outer
            fiber also fires, discarding even stale data.  Fixes #5090. *)
-        let shell_fiber_timeout_s = 12.0 in
+        let shell_fiber_timeout_s =
+          float_of_env_default "MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S"
+            ~default:12.0 ~min_v:1.0 ~max_v:120.0
+        in
+        let cold_safety_margin_s =
+          float_of_env_default "MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S"
+            ~default:4.0 ~min_v:0.0 ~max_v:60.0
+        in
         let shell_timeout_s =
           if Atomic.get _shell_warmed then shell_fiber_timeout_s
-          else Float.max cold_timeout_s (shell_fiber_timeout_s +. 4.0)
+          else Float.max cold_timeout_s (shell_fiber_timeout_s +. cold_safety_margin_s)
         in
         (* Graceful degradation: on timeout fall back to the last successful
            shell result rather than empty JSON, which would zero out namespace


### PR DESCRIPTION
## Summary

Close #7908. The comment at `server_dashboard_http_namespace_truth.ml:54` promised a "single env var for namespace-truth fiber timeouts" but none of the 3 literals plus the cold-start safety margin were ever read from the environment. Fleet p50 fetch latency is ~17s, so the 12s shell cap misfired and polluted the log steadily.

Wire the 4 literals through `float_of_env_default` with validated ranges and register them in `env_config_snapshot.dashboard_entries`.

## Linked issue

Closes #7908.

## Product impact

- Operators can tune the 4 timeouts via env without recompiling. This stops the spurious `namespace-truth fiber shell timed out (12s)` WARN noise on fleets where observed fetch latency is above the literal default.
- No default change. Pure knob-exposure PR. Any fleet-wide default revision is a separate decision.

## Env vars (all optional, defaults preserve current behaviour)

| var | default | range |
|---|---|---|
| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | `8.0` | `[1, 120]` |
| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | `15.0` | `[1, 120]` |
| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | `12.0` | `[1, 120]` |
| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | `4.0` | `[0, 60]` |

## Intentionally not changed

- Defaults are not raised. The issue suggested Option B (bump defaults to fleet p50), but that is a behaviour shift that belongs in a separate PR after measurement.

## Evidence

- Issue cites 5 fleet samples with fetch times 12.2s-33.9s — 12s shell cap too tight.
- Old code: `let warm_timeout_s = 8.0 in ...` (3 literals + `+. 4.0` margin), zero env reads. `rg 'NAMESPACE_TRUTH|warm_timeout_s|cold_timeout_s|shell_fiber_timeout_s' lib/` returned only self-references pre-change.
- New code: each literal now `float_of_env_default NAME ~default ~min_v ~max_v`. Same helper used by 3+ other dashboard HTTP surfaces.

## Review evidence

- `dune build --root . @check` passes on dev profile.
- `dashboard_entries` in `env_config_snapshot.ml` gains 4 entries so the MASC_* inventory stays truthful with the code.

## Test plan

- [x] Build clean.
- [x] Snapshot entries registered.
- [ ] CI green.