### PR TITLE
chore(env-config): remove orphan Control-Plane config surface (#7807)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -213,14 +213,6 @@ module Timeout = struct
     get_float ~default:15.0 "MASC_TIMEOUT_GCLOUD_AUTH_SEC"
 end
 
-(** {1 Control Plane Cleanup Configuration} *)
-
-module Cp = struct
-  (** Number of days before dead/stale CP data is eligible for cleanup (default 14) *)
-  let cleanup_days =
-    get_int ~default:14 "MASC_CP_CLEANUP_DAYS"
-end
-
 (** {1 Message GC Configuration} *)
 
 module Message = struct

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -400,14 +400,6 @@ let compaction_entries =
       "Absolute ceiling for compaction ratio_gate (clamped 0.80-0.99)";
   ]
 
-let control_plane_entries =
-  [
-    entry ~default:"14" "MASC_CP_CLEANUP_DAYS"
-      "Days before dead/stale CP data is eligible for cleanup";
-    entry ~default:"(none)" "MASC_CP_SUMMARY_REFRESH_DISABLED"
-      "Disable CP summary refresh loop (1=disabled)";
-  ]
-
 let decision_entries =
   [
     entry ~default:"50" "MASC_DECISION_AUDIT_RING_CAPACITY"
@@ -948,7 +940,7 @@ let zombie_cleanup_entries =
 let all_categories () =
   [
     category "server"
-      (server_entries @ path_entries @ control_plane_entries
+      (server_entries @ path_entries
        @ docker_playground_entries @ test_entries);
     category "auth" auth_entries;
     category "transport" transport_entries;


### PR DESCRIPTION
## Summary

Partial close of #7807 — remove the 2 code-level residuals of the Control-Plane retirement (#7337/#7349).

- `env_config_runtime.Cp.cleanup_days` — zero callers in `lib/` or `bin/`.
- `env_config_snapshot.control_plane_entries` (`MASC_CP_CLEANUP_DAYS`, `MASC_CP_SUMMARY_REFRESH_DISABLED`) — both env vars are unread anywhere in the tree.

## Linked issue

Addresses #7807 (code portion). Issue stays open for the `.masc/` filesystem archival path discussed in the issue body.

## Product impact

- Env-config snapshot stops documenting 2 env vars the code does not honour. Operators who set `MASC_CP_*` expecting behaviour would have been silently misled.
- No runtime behaviour change — the Cp module had zero callers; removing it cannot alter execution.

## Explicitly out of scope

- `.masc/repair_loops/` and `.masc/control-plane/` state directories — per-environment, not tracked in git. The issue's Option B (archive with `ORPHAN.md`) is operator tooling, not a code PR.

## Evidence

```
$ rg 'Cp\.cleanup_days|Env_config_runtime\.Cp' lib/ bin/
# empty

$ rg 'MASC_CP_CLEANUP_DAYS|MASC_CP_SUMMARY_REFRESH_DISABLED' lib/ bin/
lib/config/env_config_snapshot.ml:405:    entry ~default:"14" "MASC_CP_CLEANUP_DAYS"
lib/config/env_config_snapshot.ml:407:    entry ~default:"(none)" "MASC_CP_SUMMARY_REFRESH_DISABLED"
lib/config/env_config_runtime.ml:221:    get_int ~default:14 "MASC_CP_CLEANUP_DAYS"
# Last remaining reader is Cp.cleanup_days itself, which has zero callers.
```

## Review evidence

- `dune build --root . @check` passes after deletion.
- Diff stats: `lib/config/env_config_runtime.ml` 8 lines deleted, `lib/config/env_config_snapshot.ml` 10 lines deleted / 1 inserted.

## Test plan

- [x] Build clean.
- [ ] CI green.