### PR TITLE
feat(dashboard): 🪪 IdPill primitive + absorb 3 accent-pill shapes in agent-detail (P4/9)

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -12,6 +12,7 @@ import { resolveUnifiedStatus } from '../lib/unified-status'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { keeperIdentityHint } from './common/keeper-identity'
+import { IdPill } from './common/id-pill'
 import { AgentJournalStream } from './agent-detail-journal'
 import { AgentSessionReport } from './agent-detail-session-report'
 import { AgentTimelineSection } from './agent-detail-timeline'
@@ -114,7 +115,7 @@ export function filterTaskHistories(
 function TaskSummary({ task }: { task: Task }) {
   return html`
     <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded-xl shadow-sm">
-      <span class="text-[10px] font-medium py-1 px-2.5 border border-accent/20 bg-[var(--accent-10)] text-accent whitespace-nowrap rounded-md shadow-sm">${task.id}</span>
+      <${IdPill}>${task.id}<//>
       <span class="flex-1 text-[13px] text-text-strong font-medium truncate">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
@@ -125,7 +126,7 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
     <div class="border border-card-border rounded-xl bg-card/40 p-4 shadow-sm hover:border-accent/30 transition-colors group">
       <div class="mb-3">
-        <span class="text-[10px] font-medium py-1 px-2.5 border border-accent/20 bg-[var(--accent-10)] text-accent whitespace-nowrap rounded-md shadow-sm group-hover:bg-accent/20 transition-colors">${row.taskId}</span>
+        <${IdPill} class="group-hover:bg-accent/20 transition-colors">${row.taskId}<//>
       </div>
       <pre class="m-0 whitespace-pre-wrap text-[12px] leading-relaxed text-text-body font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
     </div>
@@ -226,7 +227,7 @@ export function AgentDetailOverlay() {
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
                   ${unified.description !== unified.label ? html`<span class="text-[10px] font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded-md" title=${unified.description}>${unified.description}</span>` : null}
-                  ${isArchivedParticipant ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-[var(--accent-10)] text-accent whitespace-nowrap rounded-md shadow-sm">이전 세션 참여자</span>` : null}
+                  ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
                   ${agent?.model ? html`<span class="font-mono text-[10px] font-medium bg-white/10 border border-white/5 px-2 py-1 rounded-md text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`

--- a/dashboard/src/components/common/id-pill.test.ts
+++ b/dashboard/src/components/common/id-pill.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { IdPill, idPillClasses } from './id-pill'
+
+describe('idPillClasses (pure)', () => {
+  it('default (no mono, no extra) carries shape + accent tone', () => {
+    const cls = idPillClasses()
+    for (const token of [
+      'inline-flex',
+      'items-center',
+      'text-[10px]',
+      'font-medium',
+      'py-1',
+      'px-2.5',
+      'rounded-md',
+      'whitespace-nowrap',
+      'shadow-sm',
+      'border',
+      'border-accent/20',
+      'bg-[var(--accent-10)]',
+      'text-accent',
+    ]) {
+      expect(cls).toContain(token)
+    }
+  })
+
+  it('mono=true appends font-mono, keeps font-medium (Tailwind composes weight + family)', () => {
+    const cls = idPillClasses(true)
+    expect(cls).toContain('font-mono')
+    expect(cls).toContain('font-medium')
+  })
+
+  it('mono=false (default) omits font-mono', () => {
+    expect(idPillClasses(false)).not.toContain('font-mono')
+  })
+
+  it('extra class appended (caller composition — hover states, margin)', () => {
+    const cls = idPillClasses(false, 'group-hover:bg-accent/20 transition-colors')
+    expect(cls).toContain('group-hover:bg-accent/20')
+    expect(cls).toContain('transition-colors')
+  })
+
+  it('empty extra leaves the string tight (no trailing space)', () => {
+    expect(idPillClasses(false, '')).not.toMatch(/\s$/)
+    expect(idPillClasses(false, undefined)).not.toMatch(/\s$/)
+  })
+
+  it('shape tokens present regardless of mono flag (regression guard)', () => {
+    for (const mono of [true, false]) {
+      const cls = idPillClasses(mono)
+      for (const token of ['rounded-md', 'text-[10px]', 'px-2.5', 'py-1', 'text-accent']) {
+        expect(cls).toContain(token)
+      }
+    }
+  })
+})
+
+describe('IdPill component', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders <span data-id-pill> with children verbatim', () => {
+    render(html`<${IdPill}>task-42<//>`, container)
+    const el = container.querySelector('[data-id-pill]')!
+    expect(el.tagName).toBe('SPAN')
+    expect(el.textContent).toBe('task-42')
+  })
+
+  it('data-id-pill-mono reflects mono prop (default false)', () => {
+    render(html`<${IdPill}>plain<//>`, container)
+    expect(container.querySelector('[data-id-pill]')!.getAttribute('data-id-pill-mono')).toBe('false')
+
+    render(null, container)
+    render(html`<${IdPill} mono=${true}>abc123def<//>`, container)
+    expect(container.querySelector('[data-id-pill]')!.getAttribute('data-id-pill-mono')).toBe('true')
+  })
+
+  it('title renders as HTML title attribute', () => {
+    render(html`<${IdPill} title="full tooltip">short<//>`, container)
+    expect(container.querySelector('[data-id-pill]')!.getAttribute('title')).toBe('full tooltip')
+  })
+
+  it('testId renders as data-testid', () => {
+    render(html`<${IdPill} testId="task-id-pill">t1<//>`, container)
+    expect(container.querySelector('[data-testid="task-id-pill"]')).toBeTruthy()
+  })
+
+  it('class prop composes into the class attribute (hover state pass-through)', () => {
+    render(
+      html`<${IdPill} class="group-hover:bg-accent/20 transition-colors">t1<//>`,
+      container,
+    )
+    const cls = container.querySelector('[data-id-pill]')!.getAttribute('class') ?? ''
+    expect(cls).toContain('group-hover:bg-accent/20')
+    expect(cls).toContain('transition-colors')
+    expect(cls).toContain('rounded-md')
+  })
+})

--- a/dashboard/src/components/common/id-pill.ts
+++ b/dashboard/src/components/common/id-pill.ts
@@ -1,0 +1,97 @@
+// IdPill — rounded-md accent pill for identifier-style tokens
+// (task ids, agent run tokens, object handles). Distinct from
+// StatusChip (rounded-full semantic status badge) and Kbd (keyboard
+// shortcut pill): IdPill is *flat value surface* — the reader sees
+// it and knows "this is the ID of the thing", not its status.
+//
+// Reference UIs (Linear issue id badge, GitHub commit SHA pill,
+// Vercel deployment hash, Stripe object id chip): small accent-
+// tinted rounded-md badges with monospace option for hashes/SHAs.
+//
+// Before this primitive, agent-detail.ts had three sites re-
+// implementing the same accent-tinted identifier pill shape
+// (TaskSummary task.id, TaskHistoryPanel row.taskId, archived-
+// participant label). Subtle drift across them: lines 117/128
+// used `py-1 px-2.5 shadow-sm`, line 229 had drifted to `py-1
+// px-2` (tighter). Primitive normalises to px-2.5 + shadow-sm —
+// 229 widens ~4px which the flex-wrap parent absorbs without
+// overflow. P4 of the 9-PR dashboard hygiene sweep.
+//
+// Scope note — what IdPill is NOT absorbing in this PR:
+// • agent-detail:224 (secondaryLabel) — `px-2 py-0.5` no border,
+//   different pill shape (name tag, not id badge). P7 rounded
+//   sweep.
+// • agent-detail:228 (unified.description) — neutral tone with
+//   drifted opacities (bg-white/5 border-white/10). Needs a
+//   neutral tone variant which itself has drift vs line 230
+//   (mono version: reversed bg-white/10 border-white/5). Both
+//   belong in P6 color normalisation.
+// • agent-detail:230 (agent.model) — mono neutral pill with
+//   reversed opacities to 228. P6.
+// • agent-detail-worker:45 (signal_truth) — `rounded-full` with
+//   raw `rgba(71,184,255,0.36)` border. That is StatusChip
+//   shape with an untypeable border, not IdPill shape. P6 when
+//   raw rgba colors resolve to CSS vars.
+//
+// Keeping the primitive single-axis (mono flag only) avoids
+// variant sprawl; neutral-tone expansion lands in P6 where the
+// opacity drift itself gets audited.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+const BASE =
+  'inline-flex items-center text-[10px] font-medium py-1 px-2.5 rounded-md whitespace-nowrap shadow-sm border'
+const TONE_ACCENT =
+  'border-accent/20 bg-[var(--accent-10)] text-accent'
+const MONO_CLASS = 'font-mono'
+
+/** Pure: class string for an IdPill, with optional monospace and
+    extra class composition. Exposed so callers that wrap the pill
+    in a non-span element (e.g. a `<button>` with IdPill shape)
+    stay visually consistent without mounting the component. */
+export function idPillClasses(
+  mono: boolean = false,
+  extra?: string,
+): string {
+  const parts = [BASE, TONE_ACCENT]
+  if (mono) parts.push(MONO_CLASS)
+  if (extra !== undefined && extra !== '') parts.push(extra)
+  return parts.join(' ')
+}
+
+interface IdPillProps {
+  /** The identifier text (task id, hash, token). Children win
+      over implicit whitespace — callers typically pass a string. */
+  children?: ComponentChildren
+  /** Render with `font-mono` (for hashes, SHAs, tokens, paths).
+      Default false (proportional font matches ID convention for
+      task slugs and agent runtime names). */
+  mono?: boolean
+  /** Extra Tailwind classes for caller composition — parent group-
+      hover states (`group-hover:bg-accent/20 transition-colors`),
+      margin/width, custom title attribute. The primitive
+      deliberately does not know about parent `group` context. */
+  class?: string
+  /** HTML title attribute — tooltip on hover. Matches the existing
+      `title={unified.description}` usage in agent-detail.ts:228. */
+  title?: string
+  testId?: string
+}
+
+export function IdPill({
+  children,
+  mono = false,
+  class: cx,
+  title,
+  testId,
+}: IdPillProps) {
+  const cls = idPillClasses(mono, cx)
+  return html`<span
+    class=${cls}
+    data-id-pill
+    data-id-pill-mono=${mono ? 'true' : 'false'}
+    title=${title}
+    data-testid=${testId}
+  >${children}</span>`
+}


### PR DESCRIPTION
## Summary

New `IdPill` primitive (rounded-md accent-tone badge for
identifier-style tokens) absorbs the **3 accent-shape
inline spans** in `agent-detail.ts` that were
reimplementing the same pill.

P4 of the 9-PR hygiene sweep (after #8076 SectionCap,
#8086 StatusChip Tailwind-only, #8238 StatusChip
uppercase prop).

## The primitive

`common/id-pill.ts` + `common/id-pill.test.ts` — follows
the kbd.ts / status-chip.ts / section-cap.ts pattern
(pure fn + component + `data-*` attrs + `testId` +
isolated test file).

Shape:

```
BASE         inline-flex items-center text-[10px] font-medium
             py-1 px-2.5 rounded-md whitespace-nowrap shadow-sm
             border
TONE_ACCENT  border-accent/20 bg-[var(--accent-10)] text-accent
MONO         font-mono   (opt-in via `mono` flag)
```

Semantically distinct from sibling primitives:

| Primitive | Shape | Purpose |
|-----------|-------|---------|
| `StatusChip` | rounded-full | semantic status badge (ok/warn/bad) |
| `Kbd` | rounded border | keyboard shortcut pill |
| **`IdPill`** | **rounded-md accent** | **flat value surface for identifiers** |

## Migration (3 chips, 1 file)

| Line | Content | Composition note |
|------|---------|------------------|
| 117 | `task.id` | default accent shape |
| 128 | `row.taskId` | + `class="group-hover:bg-accent/20 transition-colors"` |
| 229 | archived-participant label | px-2→px-2.5 normalised (4px widen, flex-wrap absorbs) |

Line 128 parent has `class="... group"` — the hover
compound is caller-context dependent, so it stays in the
caller via the primitive's `class` prop escape hatch
rather than becoming an IdPill variant.

## Explicitly deferred

| Site | Why | Plan slot |
|------|-----|-----------|
| `agent-detail.ts:224` (secondaryLabel) | `px-2 py-0.5` no border — different pill shape (name tag, not id badge) | P7 rounded sweep |
| `agent-detail.ts:228` (unified.description) | neutral tone with drifted opacities (bg-white/5 border-white/10) vs line 230's reversed ones | P6 color normalisation |
| `agent-detail.ts:230` (agent.model) | mono neutral — reversed opacities to 228 | P6 |
| `agent-detail-worker.ts:45` (signal_truth) | `rounded-full` + raw rgba border — StatusChip shape, not IdPill | P6 (raw rgba → CSS vars) |

Keeping IdPill single-axis (mono flag only) avoids
creating two drift-bearing neutral variants before P6
has normalised the white/5 vs white/10 bg/border
question. Adding a `tone='neutral'` prop here would
freeze the current drift in primitive API.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3750/3750 green (11 new IdPill cases: 6 pure fn + 5 component)
- [x] `pnpm build` — vite clean
- [ ] CI green
- [ ] Empirical: local dashboard boot → agent-detail overlay visually identical (3 pills preserve accent tint + shape)

## Roadmap status

| PR | Status |
|----|--------|
| P1 SectionCap | ✅ #8076 merged |
| P2 StatusChip Tailwind-only | ✅ #8086 merged |
| P3 StatusChip uppercase | ✅ #8238 merged |
| **P4 IdPill + 3 chips** | **this PR** |
| P5 text-[9px] → text-[10px] | pending |
| P6 Color var normalisation + drift lint | pending (absorbs 228/230/worker:45) |
| P7 Rounded / font-weight sweep | pending (absorbs 224) |
| P8 a11y / focus ring sweep | pending |
| P9 Waste sweep | pending |