### PR TITLE
feat(dashboard): fleet-telemetry color helpers use design-system tokens

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -125,19 +125,19 @@ describe('uniqueStrings', () => {
 })
 
 describe('successClass', () => {
-  it('returns emerald for >=97', () => {
-    expect(successClass(97)).toContain('emerald')
-    expect(successClass(100)).toContain('emerald')
+  it('returns ok for >=97', () => {
+    expect(successClass(97)).toContain('var(--ok)')
+    expect(successClass(100)).toContain('var(--ok)')
   })
 
-  it('returns yellow for 90-96', () => {
-    expect(successClass(90)).toContain('yellow')
-    expect(successClass(96)).toContain('yellow')
+  it('returns warn for 90-96', () => {
+    expect(successClass(90)).toContain('var(--warn)')
+    expect(successClass(96)).toContain('var(--warn)')
   })
 
-  it('returns red for <90', () => {
-    expect(successClass(89)).toContain('red')
-    expect(successClass(50)).toContain('red')
+  it('returns bad-light for <90', () => {
+    expect(successClass(89)).toContain('var(--bad-light)')
+    expect(successClass(50)).toContain('var(--bad-light)')
   })
 
   it('returns dim for null/non-finite', () => {
@@ -224,31 +224,35 @@ describe('compareFleetRows', () => {
 })
 
 describe('pressureClass', () => {
-  it('returns red for hot ratio', () => {
-    expect(pressureClass(PRESSURE_HOT_RATIO)).toContain('red')
+  // After the Anyang Sleepers token migration, pressureClass returns
+  // semantic design-system tokens (--bad-light / --warn / --ok)
+  // rather than hardcoded Tailwind colors, so the chip recolors
+  // automatically under [data-theme="paper"].
+  it('returns bad-light for hot ratio', () => {
+    expect(pressureClass(PRESSURE_HOT_RATIO)).toContain('var(--bad-light)')
   })
 
-  it('returns yellow for warn ratio', () => {
-    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('yellow')
+  it('returns warn for warn ratio', () => {
+    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('var(--warn)')
   })
 
-  it('returns emerald for low ratio', () => {
-    expect(pressureClass(0.1)).toContain('emerald')
+  it('returns ok for low ratio', () => {
+    expect(pressureClass(0.1)).toContain('var(--ok)')
   })
 })
 
 describe('statusClass', () => {
-  it('returns red for offline/stopped', () => {
-    expect(statusClass(makeRow({ keepalive_running: false }))).toContain('red')
-    expect(statusClass(makeRow({ status: 'stopped' }))).toContain('red')
+  it('returns bad-light for offline/stopped', () => {
+    expect(statusClass(makeRow({ keepalive_running: false }))).toContain('var(--bad-light)')
+    expect(statusClass(makeRow({ status: 'stopped' }))).toContain('var(--bad-light)')
   })
 
-  it('returns yellow for runtime blocker', () => {
-    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('yellow')
+  it('returns warn for runtime blocker', () => {
+    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--warn)')
   })
 
-  it('returns emerald for healthy', () => {
-    expect(statusClass(makeRow())).toContain('emerald')
+  it('returns ok for healthy', () => {
+    expect(statusClass(makeRow())).toContain('var(--ok)')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -143,9 +143,9 @@ function keeperLastLatencyMs(keeper: Keeper): number {
 
 export function successClass(rate: number | null): string {
   if (rate == null || !Number.isFinite(rate)) return 'text-[var(--text-dim)]'
-  if (rate >= 97) return 'text-emerald-400'
-  if (rate >= 90) return 'text-yellow-400'
-  return 'text-red-400'
+  if (rate >= 97) return 'text-[var(--ok)]'
+  if (rate >= 90) return 'text-[var(--warn)]'
+  return 'text-[var(--bad-light)]'
 }
 
 function keeperMetricsWindowTools(keeper: Keeper): string[] {
@@ -358,16 +358,16 @@ export function toneForPressure(hot: number, warn: number): 'neutral' | 'ok' | '
 }
 
 export function pressureClass(ratio: number): string {
-  if (ratio >= PRESSURE_HOT_RATIO) return 'text-red-400'
-  if (ratio >= PRESSURE_WARN_RATIO) return 'text-yellow-400'
-  return 'text-emerald-400'
+  if (ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--bad-light)]'
+  if (ratio >= PRESSURE_WARN_RATIO) return 'text-[var(--warn)]'
+  return 'text-[var(--ok)]'
 }
 
 export function statusClass(row: FleetRow): string {
-  if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-red-400'
-  if (row.runtime_blocker_class != null) return 'text-yellow-400'
-  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-yellow-400'
-  return 'text-emerald-400'
+  if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-[var(--bad-light)]'
+  if (row.runtime_blocker_class != null) return 'text-[var(--warn)]'
+  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--warn)]'
+  return 'text-[var(--ok)]'
 }
 
 export function formatPercent(value: number | null, digits = 0): string {
@@ -396,11 +396,11 @@ function formatSourceAge(seconds: number | null | undefined): string | null {
 }
 
 export function sourceCountClass(source: TelemetrySourceSummary): string {
-  if (source.exists === false) return 'text-red-400'
+  if (source.exists === false) return 'text-[var(--bad-light)]'
   if (source.entry_count <= 0) return 'text-[var(--text-dim)]'
   const age = numericAge(source.latest_age_s)
-  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-amber-300'
-  return 'text-emerald-400'
+  if (age != null && age >= TELEMETRY_SOURCE_STALE_SEC) return 'text-[var(--warn)]'
+  return 'text-[var(--ok)]'
 }
 
 export function sourceDetail(source: TelemetrySourceSummary): string {


### PR DESCRIPTION
## 요약

두 번째 callsite migration. \`fleet-telemetry-utils.ts\`의 4개 class helper가 hardcoded Tailwind 색상(\`text-red-400\`, \`text-yellow-400\`, \`text-emerald-400\`, \`text-amber-300\`)을 반환하고 있어 paper theme 아래에서 재렌더되지 않고 dashboard의 나머지가 이동 중인 semantic token 팔레트와 drift했습니다.

## 변경

| Helper | 이전 → 신규 |
|---|---|
| \`successClass\` | emerald/yellow/red → \`--ok\`/\`--warn\`/\`--bad-light\` |
| \`pressureClass\` | 동일 매핑 (context pressure) |
| \`statusClass\` | 동일 매핑 (fleet row) |
| \`sourceCountClass\` | red/amber/emerald → \`--bad-light\`/\`--warn\`/\`--ok\` |

심각도 순서(bad → warn → ok)는 그대로. 매핑 직접적이므로 의미 변화 없음.

## Test plan

테스트가 \`'emerald'\` 같은 raw 색상 이름 presence를 assert했음. 이를 \`'var(--ok)'\` presence check로 교체 — 팔레트가 다시 바뀌어도 stale test가 silent pass하는 현상 방지.

- [x] \`tsc --noEmit\` 통과
- [x] \`vitest run fleet-telemetry-utils.test.ts\` 60/60 통과
- [x] \`pnpm build\` 통과

## Related

- #8242 KeeperPhaseBadge 토큰 migration (첫 callsite)
- #8235 StatusChip paused/select + keeperStateTone
- #8177 paper theme 인프라