### PR TITLE
fix(autoboot): use synchronous is_registered check after start_keepalive (#7889)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -348,12 +348,26 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                 net = state.net;
               } in
               Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m;
-              let running = Keeper_registry.is_running ~base_path:config.base_path m.name in
-              if running then
+              (* start_keepalive registers the keeper synchronously via
+                 register_offline and then forks the keepalive fiber.  The
+                 fiber flips the registry to running asynchronously on the
+                 next Eio tick, so querying is_running here is a race that
+                 keepers with a larger proactive-warmup idx lose
+                 deterministically (verdict=165s / sojin=150s / sangsu=135s
+                 produced the bulk of the false-positive "not in registry"
+                 WARNs).  Check the synchronous is_registered predicate
+                 instead — the running transition is observed later by the
+                 retry loop.  See #7889. *)
+              let registered =
+                Keeper_registry.is_registered ~base_path:config.base_path m.name
+              in
+              if registered then
                 Log.Keeper.info "autoboot: started keepalive for %s" m.name
               else
-                Log.Keeper.warn "autoboot: start_keepalive returned but %s not in registry" m.name;
-              running
+                Log.Keeper.warn
+                  "autoboot: start_keepalive returned but %s not registered"
+                  m.name;
+              registered
             end
         with
         | Eio.Cancel.Cancelled _ as e -> raise e

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -67,6 +67,10 @@ let test_register_offline_and_start () =
   let entry = R.register_offline ~base_path:bp "k1-offline" (make_meta "k1-offline") in
   check string "offline phase" "offline" (KSM.phase_to_string entry.phase);
   check bool "not running yet" false (R.is_running ~base_path:bp "k1-offline");
+  (* #7889: register_offline must make is_registered true synchronously even
+     before the keepalive fiber has transitioned the entry to running. *)
+  check bool "registered synchronously after register_offline" true
+    (R.is_registered ~base_path:bp "k1-offline");
   ignore (R.dispatch_event ~base_path:bp "k1-offline" KSM.Fiber_started);
   match R.get ~base_path:bp "k1-offline" with
   | None -> fail "expected k1-offline"


### PR DESCRIPTION
## Summary

Closes #7889.

`server_bootstrap_loops.try_boot_one` queried `Keeper_registry.is_running` the instant `Keeper_keepalive.start_keepalive` returned.  That call path is synchronous only up to `register_offline`; the running flip happens in the forked keepalive fiber, so bootstrap was racing scheduler ticks and losing for any keeper with a non-trivial warmup idx.

Switch the predicate to `is_registered` — which `register_offline` makes true synchronously — so the first-pass log entry reflects bootstrap progress, not Eio scheduler order.  The retry loop downstream still uses `is_running` for the authoritative running check.

## Linked issue

Closes #7889.

## Product impact

- Eliminates the misleading `start_keepalive returned but <name> not in registry` WARN; recent 2h window counted 17 (verdict=6 / sojin=6 / sangsu=5 — the three highest-warmup keepers).
- Telemetry readers no longer read this line as "keeper absent" when the keeper is in fact `register_offline` and about to flip running.

## Evidence

- `lib/keeper/keeper_keepalive.ml:1961-1986` — `start_keepalive` → `register_offline` synchronous, then `Eio.Fiber.fork` transitions to running asynchronously.
- `lib/server/server_bootstrap_loops.ml:351` — old `is_running` check 1 tick after fork.
- WARN-vs-warmup correlation in 2026-04-17 logs: frequency rises monotonically with `proactive_warmup_sec`.
- `is_registered` + `is_running` have both been in the registry API (`keeper_registry.mli:270-274`) since before this regression surfaced, so no new surface is introduced.

## Review evidence

- `test/test_keeper_registry.ml:test_register_offline_and_start` now asserts `is_registered=true` right after `register_offline` (before `Fiber_started`).  Without this PR's code change the autoboot WARN would still fire, but the registry-level invariant this fix depends on is locked in.
- `./_build/default/test/test_keeper_registry.exe` — 52/52 OK.
- `dune build --root . @check` — clean.

## Test plan

- [x] registry test suite
- [x] dev build
- [ ] CI green