### PR TITLE
[codex] Fix cluster-aware fleet telemetry stores

### DIFF
--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -81,8 +81,15 @@ let get_turn_context ~keeper_name () =
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
-let init ~base_path =
-  let dir = Filename.concat base_path ".masc/tool_calls" in
+let init ?cluster_name ~base_path () =
+  let cluster_name =
+    Option.value ~default:(Env_config_core.cluster_name ()) cluster_name
+  in
+  let dir =
+    Filename.concat
+      (Coord_utils.masc_root_dir_from ~base_path ~cluster_name)
+      "tool_calls"
+  in
   (try
      let store = Dated_jsonl.create ~base_dir:dir () in
      store_ref := Some store
@@ -185,16 +192,17 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       let json =
         `Assoc
           ([ ("ts", `Float (Time_compat.now ()))
-          ; ("keeper", `String keeper_name)
-          ; ("tool", `String tool_name)
-          ; ("input", safe_input)
-          ; ("output", `String safe_output)
-          ; ("success", `Bool success)
-          ; ("duration_ms", `Float duration_ms)
-          ] @ model_field @ lane_field @ tool_choice_field
-            @ thinking_enabled_field @ thinking_budget_field
-            @ trace_id_field @ session_id_field @ turn_field
-            @ result_bytes_field @ truncated_to_field)
+           ; ("keeper", `String keeper_name)
+           ; ("tool", `String tool_name)
+           ; ("input", safe_input)
+           ; ("output", `String safe_output)
+           ; ("success", `Bool success)
+           ; ("duration_ms", `Float duration_ms)
+           ]
+           @ model_field @ lane_field @ tool_choice_field
+           @ thinking_enabled_field @ thinking_budget_field
+           @ trace_id_field @ session_id_field @ turn_field
+           @ result_bytes_field @ truncated_to_field)
       in
       (* Sanitize UTF-8 before persisting.  Tool output may contain invalid
          byte sequences (truncated UTF-8, binary output from subprocess

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -49,8 +49,9 @@ val get_turn_context :
     session_id, turn)] for the keeper, or [None] values when no turn context
     has been recorded. *)
 
-val init : base_path:string -> unit
-(** [init ~base_path] creates the Dated_jsonl store. Call once at startup. *)
+val init : ?cluster_name:string -> base_path:string -> unit -> unit
+(** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl
+    store. Call once at startup. *)
 
 val log_call :
   keeper_name:string ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -424,10 +424,16 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Tool_metrics_persist.start_flush_fiber ~sw ~clock
     ~base_path:state.room_config.base_path;
   (* System_internal tool usage log: durable JSONL for pruning evidence (#5120) *)
-  Tool_usage_log.init ~base_path:state.room_config.base_path;
+  Tool_usage_log.init
+    ~base_path:state.room_config.base_path
+    ~cluster_name:state.room_config.backend_config.Backend_types.cluster_name
+    ();
   Tool_usage_log.install ();
   (* Keeper tool call I/O log: full input/output for dashboard inspector *)
-  Keeper_tool_call_log.init ~base_path:state.room_config.base_path;
+  Keeper_tool_call_log.init
+    ~base_path:state.room_config.base_path
+    ~cluster_name:state.room_config.backend_config.Backend_types.cluster_name
+    ();
   Otel_dispatch_hook.install ();
   Otel_spans.setup_exporter ~sw env;
   Shutdown.register ~name:"otel_exporter" ~priority:20 Otel_spans.shutdown;

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -24,8 +24,15 @@ let is_system_internal name = StringSet.mem name system_internal_set
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
-let init ~base_path =
-  let dir = Filename.concat base_path ".masc/tool_usage" in
+let init ?cluster_name ~base_path () =
+  let cluster_name =
+    Option.value ~default:(Env_config_core.cluster_name ()) cluster_name
+  in
+  let dir =
+    Filename.concat
+      (Coord_utils.masc_root_dir_from ~base_path ~cluster_name)
+      "tool_usage"
+  in
   (try
      Fs_compat.mkdir_p dir;
      let store = Dated_jsonl.create ~base_dir:dir () in

--- a/lib/tool_usage_log.mli
+++ b/lib/tool_usage_log.mli
@@ -6,9 +6,9 @@
 
     @since 2.190.0 -- Issue #5120 *)
 
-val init : base_path:string -> unit
-(** [init ~base_path] creates the Dated_jsonl store under
-    [base_path/.masc/tool_usage/]. Must be called before [install]. *)
+val init : ?cluster_name:string -> base_path:string -> unit -> unit
+(** [init ?cluster_name ~base_path ()] creates the Dated_jsonl store under the
+    cluster-aware [.masc/tool_usage/] root. Must be called before [install]. *)
 
 val install : unit -> unit
 (** [install ()] registers a {!Tool_dispatch} post-hook that logs

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -18,7 +18,7 @@ let with_tmp_log f =
        (int_of_float (Unix.gettimeofday () *. 1000.0))) in
   Fs_compat.mkdir_p dir;
   Keeper_tool_call_log.reset_for_testing ();
-  Keeper_tool_call_log.init ~base_path:dir;
+  Keeper_tool_call_log.init ~base_path:dir ();
   Fun.protect
     ~finally:(fun () ->
       Keeper_tool_call_log.reset_for_testing ();
@@ -33,7 +33,7 @@ let with_tmp_log_dir f =
        (int_of_float (Unix.gettimeofday () *. 1000.0))) in
   Fs_compat.mkdir_p dir;
   Keeper_tool_call_log.reset_for_testing ();
-  Keeper_tool_call_log.init ~base_path:dir;
+  Keeper_tool_call_log.init ~base_path:dir ();
   Fun.protect
     ~finally:(fun () ->
       Keeper_tool_call_log.reset_for_testing ();

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -393,6 +393,61 @@ let test_keeper_paths_use_cluster_root () =
           Alcotest.(check bool) "keeper dir under cluster root" true
             (String.starts_with ~prefix:expected_root keeper_dir)))
 
+let test_tool_usage_log_uses_cluster_root () =
+  with_temp_dir "startup-tool-usage-cluster" (fun dir ->
+      with_env "MASC_CLUSTER_NAME" (Some "cluster-alpha") (fun () ->
+          Tool_usage_log.init ~base_path:dir ~cluster_name:"cluster-alpha" ();
+          Tool_usage_log.log_call
+            ~tool_name:"keeper_tasks_list" ~success:true
+            ~caller:(Some "oracle");
+          let expected_dir =
+            Filename.concat
+              (Filename.concat
+                 (Filename.concat (Filename.concat dir ".masc") "clusters")
+                 "cluster-alpha")
+              "tool_usage"
+          in
+          let legacy_dir =
+            Filename.concat (Filename.concat dir ".masc") "tool_usage"
+          in
+          Alcotest.(check bool) "cluster tool_usage dir exists" true
+            (Sys.file_exists expected_dir && Sys.is_directory expected_dir);
+          Alcotest.(check bool) "legacy tool_usage dir absent" false
+            (Sys.file_exists legacy_dir);
+          Alcotest.(check int) "tool_usage row readable from cluster store" 1
+            (List.length (Tool_usage_log.read_recent ~n:10 ()))))
+
+let test_keeper_tool_call_log_uses_cluster_root () =
+  with_temp_dir "startup-tool-call-cluster" (fun dir ->
+      with_env "MASC_CLUSTER_NAME" (Some "cluster-alpha") (fun () ->
+          Keeper_tool_call_log.reset_for_testing ();
+          Fun.protect
+            ~finally:Keeper_tool_call_log.reset_for_testing
+            (fun () ->
+              Keeper_tool_call_log.init ~base_path:dir
+                ~cluster_name:"cluster-alpha" ();
+              Keeper_tool_call_log.log_call
+                ~keeper_name:"oracle" ~tool_name:"keeper_tasks_list"
+                ~input:(`Assoc []) ~output_text:"ok"
+                ~success:true ~duration_ms:1.0 ();
+              let expected_dir =
+                Filename.concat
+                  (Filename.concat
+                     (Filename.concat (Filename.concat dir ".masc") "clusters")
+                     "cluster-alpha")
+                  "tool_calls"
+              in
+              let legacy_dir =
+                Filename.concat (Filename.concat dir ".masc") "tool_calls"
+              in
+              Alcotest.(check bool) "cluster tool_calls dir exists" true
+                (Sys.file_exists expected_dir && Sys.is_directory expected_dir);
+              Alcotest.(check bool) "legacy tool_calls dir absent" false
+                (Sys.file_exists legacy_dir);
+              Alcotest.(check int) "tool_call row readable from cluster store"
+                1
+                (List.length (Keeper_tool_call_log.read_recent ~n:10 ())))))
+
 let test_room_init_bootstraps_keeper_runtime_dirs () =
   with_temp_dir "startup-keeper-dirs" (fun dir ->
       let config = Coord.default_config dir in
@@ -1015,6 +1070,10 @@ let () =
             `Quick test_restore_persisted_sessions_uses_flat_agents_dir;
           Alcotest.test_case "keeper paths use cluster root" `Quick
             test_keeper_paths_use_cluster_root;
+          Alcotest.test_case "tool usage log uses cluster root" `Quick
+            test_tool_usage_log_uses_cluster_root;
+          Alcotest.test_case "keeper tool call log uses cluster root" `Quick
+            test_keeper_tool_call_log_uses_cluster_root;
           Alcotest.test_case "room init bootstraps keeper runtime dirs" `Quick
             test_room_init_bootstraps_keeper_runtime_dirs;
           Alcotest.test_case "otel exporter setup failure is soft" `Quick


### PR DESCRIPTION
## What changed
- route `tool_usage` and `tool_calls` durable logs through the cluster-aware `.masc` root instead of always writing to the repository root `.masc`
- pass the active cluster name during server bootstrap when initializing those stores
- add regression coverage proving both logs write into `.masc/clusters/<name>/...` and are readable from the same cluster-scoped store

## Why
Fleet telemetry's durable diagnosis panel reads from the cluster-aware telemetry roots, but these two writers were still initialized against `base_path/.masc/...`. In a non-default cluster, live OAS cards could still show activity while the durable Fleet telemetry sections stayed empty.

## Impact
- Fleet telemetry durable sections now see `tool_usage` and `tool_calls` data in clustered deployments
- new cluster-scoped telemetry keeps the write/read paths aligned
- no change to default-cluster behavior beyond using the shared path helper

## Root cause
The read side used `Coord.masc_root_dir` / cluster-aware store resolution, while the write side for `Tool_usage_log` and `Keeper_tool_call_log` hardcoded `base_path/.masc/...`.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-fleet-telemetry ./test/test_server_runtime_bootstrap.exe ./test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`

Note: `test_server_runtime_bootstrap` still has one pre-existing environment-dependent failure at `main_eio executable not found`; the new cluster-root regression cases passed in that run.