### PR TITLE
feat(keeper): consume overflow event-bus signal

### DIFF
--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -179,8 +179,9 @@ type event =
     (** Provider rejected prompt for exceeding max context.
         [`Prompt_rejected] is sourced from a failed unified turn
         (see [Keeper_unified_turn.is_context_overflow]);
-        [`Oas_signal] is reserved for the future OAS event_bus
-        subscription feature (masc.overflow.source=event_bus). *)
+        [`Oas_signal] is sourced either from structured OAS overflow
+        diagnostics or from the drained OAS [Event_bus]
+        [ContextOverflowImminent] signal for the same turn. *)
   | Auto_compact_triggered
     (** Emitted as part of [Overflowed] entry actions to mark the
         start of auto-recovery. Sets [compaction_active] so the next

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -246,6 +246,36 @@ type overflow_retry_plan = {
   compaction : compaction_event;
 }
 
+type turn_event_bus_overflow = {
+  estimated_tokens : int;
+  limit_tokens : int;
+}
+
+type turn_event_bus_summary = {
+  correlation_id : string option;
+  overflow_imminent : turn_event_bus_overflow option;
+}
+
+let empty_turn_event_bus_summary =
+  {
+    correlation_id = None;
+    overflow_imminent = None;
+  }
+
+let merge_turn_event_bus_summary
+    (left : turn_event_bus_summary)
+    (right : turn_event_bus_summary) : turn_event_bus_summary =
+  {
+    correlation_id =
+      (match left.correlation_id with
+       | Some _ -> left.correlation_id
+       | None -> right.correlation_id);
+    overflow_imminent =
+      (match right.overflow_imminent with
+       | Some _ -> right.overflow_imminent
+       | None -> left.overflow_imminent);
+  }
+
 (** Recover from context overflow by compacting and reducing max_context.
 
     Extracts the token limit directly from the structured [ContextOverflow]
@@ -302,31 +332,63 @@ let recover_context_overflow_retry
         meta.name (short_preview (Oas.Error.to_string error));
       None
 
+let summarize_turn_event_bus
+    (events : Agent_sdk.Event_bus.event list) : turn_event_bus_summary =
+  List.fold_left
+    (fun acc (evt : Agent_sdk.Event_bus.event) ->
+      let correlation_id =
+        match acc.correlation_id with
+        | Some _ -> acc.correlation_id
+        | None -> Some evt.meta.correlation_id
+      in
+      match evt.payload with
+      | Agent_sdk.Event_bus.ContextOverflowImminent
+          { estimated_tokens; limit_tokens; _ } ->
+          {
+            correlation_id;
+            overflow_imminent =
+              Some { estimated_tokens; limit_tokens };
+          }
+      | _ -> { acc with correlation_id })
+    empty_turn_event_bus_summary
+    events
+
 let context_overflow_event_of_error
     ~(fallback_tokens : int)
+    ?(turn_event_bus : turn_event_bus_summary =
+      { correlation_id = None; overflow_imminent = None })
     (err : Oas.Error.sdk_error) : Keeper_state_machine.event =
-  match err with
-  | Oas.Error.Agent (TokenBudgetExceeded { kind = "Input"; used; limit }) ->
+  match turn_event_bus.overflow_imminent with
+  | Some { estimated_tokens; limit_tokens } ->
       Keeper_state_machine.Context_overflow_detected
         {
           source = `Oas_signal;
-          token_count = used;
-          limit_tokens = Some limit;
+          token_count = max 0 estimated_tokens;
+          limit_tokens = Some limit_tokens;
         }
-  | Oas.Error.Api (ContextOverflow { limit; _ }) ->
-      Keeper_state_machine.Context_overflow_detected
-        {
-          source = `Prompt_rejected;
-          token_count = Option.value ~default:(max 0 fallback_tokens) limit;
-          limit_tokens = limit;
-        }
-  | _ ->
-      Keeper_state_machine.Context_overflow_detected
-        {
-          source = `Oas_signal;
-          token_count = max 0 fallback_tokens;
-          limit_tokens = None;
-        }
+  | None ->
+      match err with
+      | Oas.Error.Agent (TokenBudgetExceeded { kind = "Input"; used; limit }) ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Oas_signal;
+              token_count = used;
+              limit_tokens = Some limit;
+            }
+      | Oas.Error.Api (ContextOverflow { limit; _ }) ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Prompt_rejected;
+              token_count = Option.value ~default:(max 0 fallback_tokens) limit;
+              limit_tokens = limit;
+            }
+      | _ ->
+          Keeper_state_machine.Context_overflow_detected
+            {
+              source = `Oas_signal;
+              token_count = max 0 fallback_tokens;
+              limit_tokens = None;
+            }
 
 let pause_keeper_for_overflow
     ~(config : Coord.config)
@@ -1547,10 +1609,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~filter:(Agent_sdk.Event_bus.filter_agent meta.name) bus)
         | None -> None
       in
+      let turn_event_bus = ref empty_turn_event_bus_summary in
       let evidence_before_hash =
         try Keeper_evidence.snapshot_before_turn
           ~base_path:config.base_path ~keeper_name:meta.name
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+      in
+      let drain_turn_event_bus () =
+        let summary =
+          match event_bus_sub, Keeper_event_bus.get () with
+          | Some sub, Some _bus ->
+              summarize_turn_event_bus (Agent_sdk.Event_bus.drain sub)
+          | _ -> empty_turn_event_bus_summary
+        in
+        turn_event_bus :=
+          merge_turn_event_bus_summary !turn_event_bus summary;
+        !turn_event_bus
       in
       let unsubscribe_event_bus () =
         match event_bus_sub, Keeper_event_bus.get () with
@@ -1763,11 +1837,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ~attempt:(attempt + 1)
                     ~is_retry:true ~overflow_retry_used
                 end else if is_context_overflow err then begin
+                  let current_turn_event_bus = drain_turn_event_bus () in
                   dispatch_keeper_phase_event
                     ~config
                     ~keeper_name:meta.name
                     (context_overflow_event_of_error
                        ~fallback_tokens:max_context
+                       ~turn_event_bus:current_turn_event_bus
                        err);
                   if not overflow_retry_used then
                     match
@@ -1922,18 +1998,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Error (Oas.Error.Internal msg)
             end)))
       in
-      (* Drain correlation_id from the subscription created before the
-         turn. Unsubscribe is handled by [unsubscribe_event_bus] in the
-         Fun.protect ~finally above, so this path only drains. *)
-      (match event_bus_sub, Keeper_event_bus.get () with
-       | Some sub, Some _bus ->
-         (match Agent_sdk.Event_bus.drain sub with
-          | ev :: _ ->
-            Keeper_registry.set_last_correlation_id
-              ~base_path:config.base_path meta.name
-              ev.Agent_sdk.Event_bus.meta.correlation_id
-          | [] -> ())
-       | _ -> ());
+      let turn_event_bus = drain_turn_event_bus () in
+      (match turn_event_bus.correlation_id with
+       | Some correlation_id ->
+           Keeper_registry.set_last_correlation_id
+             ~base_path:config.base_path meta.name
+             correlation_id
+       | None -> ());
       match run_result with
       | Error err ->
           finalize_trajectory_acc trajectory_acc

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -121,6 +121,33 @@ val is_ambiguous_side_effect_error : Oas.Error.sdk_error -> bool
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Oas.Error.sdk_error -> bool
 
+(** Turn-local overflow hint published by the OAS event bus before a
+    proactive compaction attempt. Exposed for regression tests. *)
+type turn_event_bus_overflow = {
+  estimated_tokens : int;
+  limit_tokens : int;
+}
+
+(** Summary of event-bus signals observed during a single keeper turn.
+    Exposed for regression tests. *)
+type turn_event_bus_summary = {
+  correlation_id : string option;
+  overflow_imminent : turn_event_bus_overflow option;
+}
+
+(** Fold the drained OAS event-bus events for a single keeper turn into
+    the signals MASC currently consumes. *)
+val summarize_turn_event_bus :
+  Agent_sdk.Event_bus.event list -> turn_event_bus_summary
+
+(** Build the keeper overflow event from either a drained event-bus
+    signal or the structured OAS error fallback. Exposed for tests. *)
+val context_overflow_event_of_error :
+  fallback_tokens:int ->
+  ?turn_event_bus:turn_event_bus_summary ->
+  Oas.Error.sdk_error ->
+  Keeper_state_machine.event
+
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
 val is_cascade_exhausted_error : Oas.Error.sdk_error -> bool

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1801,6 +1801,87 @@ let test_is_context_overflow_only_for_overflow_errors () =
     (UT.is_context_overflow
        (Agent_sdk.Error.Agent (TokenBudgetExceeded { kind = "Total"; used = 300000; limit = 250000 })))
 
+let test_summarize_turn_event_bus_extracts_overflow_signal () =
+  let events =
+    [
+      Agent_sdk.Event_bus.mk_event
+        ~correlation_id:"cid-123"
+        ~run_id:"run-1"
+        (Agent_sdk.Event_bus.TurnStarted
+           { agent_name = minimal_meta.name; turn = 1 });
+      Agent_sdk.Event_bus.mk_event
+        ~correlation_id:"cid-123"
+        ~run_id:"run-1"
+        (Agent_sdk.Event_bus.ContextOverflowImminent
+           {
+             agent_name = minimal_meta.name;
+             estimated_tokens = 205_000;
+             limit_tokens = 200_000;
+             ratio = 1.025;
+           });
+    ]
+  in
+  let summary = UT.summarize_turn_event_bus events in
+  check (option string) "correlation id from first event" (Some "cid-123")
+    summary.correlation_id;
+  match summary.overflow_imminent with
+  | Some overflow ->
+      check int "estimated tokens" 205_000 overflow.estimated_tokens;
+      check int "limit tokens" 200_000 overflow.limit_tokens
+  | None -> fail "expected overflow_imminent summary"
+
+let test_context_overflow_event_prefers_event_bus_signal () =
+  let turn_event_bus : UT.turn_event_bus_summary =
+    {
+      correlation_id = Some "cid-123";
+      overflow_imminent =
+        Some
+          {
+            estimated_tokens = 205_000;
+            limit_tokens = 200_000;
+          };
+    }
+  in
+  match
+    UT.context_overflow_event_of_error
+      ~fallback_tokens:32_768
+      ~turn_event_bus
+      (Agent_sdk.Error.Api
+         (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
+  with
+  | KP.Context_overflow_detected
+      {
+        source = `Oas_signal;
+        token_count;
+        limit_tokens = Some limit_tokens;
+      } ->
+      check int "estimated tokens win" 205_000 token_count;
+      check int "event bus limit wins" 200_000 limit_tokens
+  | event ->
+      fail
+        ("expected oas_signal overflow event, got "
+        ^ KP.event_to_string event)
+
+let test_context_overflow_event_falls_back_without_event_bus_signal () =
+  match
+    UT.context_overflow_event_of_error
+      ~fallback_tokens:32_768
+      (Agent_sdk.Error.Api
+         (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
+  with
+  | KP.Context_overflow_detected
+      {
+        source = `Prompt_rejected;
+        token_count;
+        limit_tokens = Some limit_tokens;
+      } ->
+      check int "fallback uses error limit" 32_768 token_count;
+      check int "fallback preserves limit" 32_768 limit_tokens
+  | event ->
+      fail
+        ("expected prompt_rejected overflow event, got "
+        ^ KP.event_to_string event)
+
 let test_metrics_persist_social_state_fields () =
   let result =
     make_run_result
@@ -3489,6 +3570,12 @@ let () =
             test_context_overflow_limit_parses_common_oas_errors;
           test_case "is_context_overflow only matches ContextOverflow" `Quick
             test_is_context_overflow_only_for_overflow_errors;
+          test_case "summarize_turn_event_bus extracts overflow signal" `Quick
+            test_summarize_turn_event_bus_extracts_overflow_signal;
+          test_case "context_overflow_event prefers event bus signal" `Quick
+            test_context_overflow_event_prefers_event_bus_signal;
+          test_case "context_overflow_event falls back without event bus signal" `Quick
+            test_context_overflow_event_falls_back_without_event_bus_signal;
         ] );
       ( "phase_gate",
         [


### PR DESCRIPTION
## Summary
- drain keeper turn event-bus signals into a turn-local summary instead of reading only the first correlation id
- use `ContextOverflowImminent` as the preferred source for `Context_overflow_detected { source = `Oas_signal }` when the same turn later fails with context overflow
- add regression tests for event-bus summary extraction and overflow event fallback behavior

## Why
The keeper already subscribed to the OAS event bus, but only used the drained stream to persist `correlation_id`. That left the remaining event-bus subscription path effectively unimplemented for overflow signaling. This change wires the drained `ContextOverflowImminent` signal into the keeper overflow event without changing the existing post-turn compaction lifecycle contract.

## Test plan
- [x] `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-keeper-event-bus-subscription test/test_keeper_unified.exe`
- [x] `./_build/default/test/test_keeper_unified.exe test context_overflow`
