### PR TITLE
feat(dashboard): progressive disclosure for runtime default view

### DIFF
--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -63,15 +63,51 @@ describe('RuntimePanel', () => {
     vi.doUnmock('./common/filter-chips')
   })
 
-  it('renders all 3 panels by default', async () => {
+  it('renders all 5 panels by default (Signal + collapsed Diagnostic/Raw)', async () => {
     route.value.params = {}
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     expect(container.textContent).toContain('OasHealthChip')
+    expect(container.textContent).toContain('CascadeConfigPanel')
     expect(container.textContent).toContain('RuntimeMonitor')
     expect(container.textContent).toContain('PrometheusMetrics')
+    expect(container.textContent).toContain('VerificationSpecsPanel')
+  })
+
+  it('default view uses progressive disclosure: Signal open, Diagnostic/Raw in collapsed <details>', async () => {
+    route.value.params = {}
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    const oas = container.querySelector('[data-testid="oas-health"]')
+    expect(oas).not.toBeNull()
+    expect(oas?.closest('details')).toBeNull()
+
+    const detailIds = [
+      'runtime-details-cascade',
+      'runtime-details-providers',
+      'runtime-details-prometheus',
+      'runtime-details-verification',
+    ]
+    for (const id of detailIds) {
+      const el = container.querySelector(`[data-testid="${id}"]`)
+      expect(el, `missing ${id}`).not.toBeNull()
+      expect((el as HTMLDetailsElement).open).toBe(false)
+    }
+  })
+
+  it('explicit drill-down views bypass progressive disclosure', async () => {
+    route.value.params = { view: 'cascade' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    const cascade = container.querySelector('[data-testid="cascade-config"]')
+    expect(cascade).not.toBeNull()
+    expect(cascade?.closest('details')).toBeNull()
   })
 
   it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -85,25 +85,25 @@ export function RuntimePanel() {
         : html`
             <${OasHealthChip} />
             <details class=${DETAILS_CLASS} data-testid="runtime-details-cascade">
-              <summary class=${SUMMARY_CLASS}>Cascade 설정 · Health · Capacity · SLO</summary>
+              <summary class=${SUMMARY_CLASS}>Cascade</summary>
               <div class="p-3 border-t border-[var(--card-border)]">
                 <${CascadeConfigPanel} />
               </div>
             </details>
             <details class=${DETAILS_CLASS} data-testid="runtime-details-providers">
-              <summary class=${SUMMARY_CLASS}>프로바이더 & 모델 메트릭</summary>
+              <summary class=${SUMMARY_CLASS}>프로바이더</summary>
               <div class="p-3 border-t border-[var(--card-border)]">
                 <${RuntimeMonitor} />
               </div>
             </details>
             <details class=${DETAILS_CLASS} data-testid="runtime-details-prometheus">
-              <summary class=${SUMMARY_CLASS}>Raw Prometheus 메트릭</summary>
+              <summary class=${SUMMARY_CLASS}>메트릭</summary>
               <div class="p-3 border-t border-[var(--card-border)]">
                 <${PrometheusMetrics} />
               </div>
             </details>
             <details class=${DETAILS_CLASS} data-testid="runtime-details-verification">
-              <summary class=${SUMMARY_CLASS}>형식 검증 Specs</summary>
+              <summary class=${SUMMARY_CLASS}>형식검증</summary>
               <div class="p-3 border-t border-[var(--card-border)]">
                 <${VerificationSpecsPanel} />
               </div>

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -1,11 +1,19 @@
 // RuntimePanel — Phase 4 runtime section with FilterChips toggle.
-// Wraps OasHealthChip, RuntimeMonitor, CascadeConfigPanel, PrometheusMetrics
-// with view switching.
-// Views:
-//   default    — all (cascade config + providers + prometheus)
+// Wraps OasHealthChip, RuntimeMonitor, CascadeConfigPanel, PrometheusMetrics,
+// VerificationSpecsPanel with view switching.
+//
+// Progressive-disclosure default view (density reduction, 2026-04):
+//   Signal layer     — OasHealthChip always expanded (summary StatCells)
+//   Diagnostic layer — Cascade, Providers & Models in <details> (closed)
+//   Raw layer        — Prometheus metrics, Formal specs in <details> (closed)
+// NN/g progressive disclosure: respect working-memory limits, defer detail.
+//
+// Explicit drill-down via FilterChips remains unchanged:
+//   default    — Signal strip + collapsed diagnostic/raw accordions
 //   cascade    — cascade config + health only (설정 ↔ 실측)
 //   providers  — OAS health chip + runtime monitor only
 //   prometheus — raw Prometheus metrics only
+//   verification — formal specs only
 // Pattern: mirrors fleet-health-panel.ts (unidirectional flow via URL).
 
 import { html } from 'htm/preact'
@@ -47,6 +55,11 @@ function updateViewParam(view: RuntimeView): void {
   window.dispatchEvent(new HashChangeEvent('hashchange'))
 }
 
+const SUMMARY_CLASS =
+  'cursor-pointer select-none rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 text-sm font-medium text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] marker:text-[var(--text-muted)]'
+
+const DETAILS_CLASS = 'group rounded border border-[var(--card-border)] bg-transparent'
+
 export function RuntimePanel() {
   const view = activeView.value
 
@@ -70,11 +83,31 @@ export function RuntimePanel() {
         : view === 'verification'
           ? html`<${VerificationSpecsPanel} />`
         : html`
-            <${CascadeConfigPanel} />
             <${OasHealthChip} />
-            <${RuntimeMonitor} />
-            <${PrometheusMetrics} />
-            <${VerificationSpecsPanel} />
+            <details class=${DETAILS_CLASS} data-testid="runtime-details-cascade">
+              <summary class=${SUMMARY_CLASS}>Cascade 설정 · Health · Capacity · SLO</summary>
+              <div class="p-3 border-t border-[var(--card-border)]">
+                <${CascadeConfigPanel} />
+              </div>
+            </details>
+            <details class=${DETAILS_CLASS} data-testid="runtime-details-providers">
+              <summary class=${SUMMARY_CLASS}>프로바이더 & 모델 메트릭</summary>
+              <div class="p-3 border-t border-[var(--card-border)]">
+                <${RuntimeMonitor} />
+              </div>
+            </details>
+            <details class=${DETAILS_CLASS} data-testid="runtime-details-prometheus">
+              <summary class=${SUMMARY_CLASS}>Raw Prometheus 메트릭</summary>
+              <div class="p-3 border-t border-[var(--card-border)]">
+                <${PrometheusMetrics} />
+              </div>
+            </details>
+            <details class=${DETAILS_CLASS} data-testid="runtime-details-verification">
+              <summary class=${SUMMARY_CLASS}>형식 검증 Specs</summary>
+              <div class="p-3 border-t border-[var(--card-border)]">
+                <${VerificationSpecsPanel} />
+              </div>
+            </details>
           `}
       </div>
     </div>


### PR DESCRIPTION
## Summary
`#monitoring?section=runtime` 기본 뷰를 Progressive Disclosure로 재구성. 5개 패널을 동시 스택하는 대신 Signal layer(`OasHealthChip`)만 상시 노출하고, Diagnostic/Raw 4개는 `<details open=false>` accordion으로 축약. 명시적 drill-down(`?view=...`)은 그대로.

## Product impact
- 기본 뷰 첫 스크롤에 보이는 LOC: 약 1,926 → `OasHealthChip` ~176 수준으로 축약 (91% 감축).
- drill-down 경로 변화 없음 — URL permalink, FilterChips 키보드 네비게이션 모두 기존 동작 유지.
- 접힌 상태에서도 `<details>` 자식은 DOM에 존재하므로 Ctrl+F 페이지 검색 계속 작동.

## Evidence
- `pnpm exec vitest run src/components/runtime-panel.test.ts` — 8/8 passed (기존 6 + 신규 2).
- `pnpm typecheck` — clean (0 errors).
- `pnpm lint src` — clean (0 errors).
- CI: `Dashboard` 체크 SUCCESS.
- 신규 테스트:
  - `default view uses progressive disclosure` — Signal은 `<details>` 밖, Diagnostic/Raw 4개는 `<details open=false>`
  - `explicit drill-down views bypass progressive disclosure` — `?view=cascade`는 평면 렌더

## Review evidence
- 자체 adversarial 재검토로 accordion 라벨이 chip 라벨과 불일치 발견 → `441a36193`에서 "Cascade"/"프로바이더"/"메트릭"/"형식검증"으로 정렬.
- 중복 정보(Provider 건강 3곳, Model 2곳, 에러 3곳)는 본 PR 범위 밖으로 유지 (2단계 후속 PR에서 SSOT 처리).

## Linked issue
Refs #8262 — dashboard(runtime): reduce information density 3-stage plan.

## 근거 (UX 패턴)
- NN/g Progressive Disclosure: 작업 기억(4~7 chunks) 보호, 세부는 on-demand.
- 관찰 대시보드 "신호 vs 노이즈" 원칙: 파생 가능한 값은 한 번만 표시.

## 시각적 확인 필요 (사용자)
- `pnpm --filter masc-dashboard dev`로 띄워서 `#monitoring?section=runtime`의 첫 스크롤 분량이 `OasHealthChip`만 남는지
- 각 accordion 클릭 시 이전 패널 내용이 그대로 열리는지
- drill-down chip("전체"/"Cascade"/"프로바이더"/"메트릭"/"형식검증")은 기존과 동일하게 동작하는지

## 후속 (별도 PR)
1. **Stage 2**: `composite-signals.ts`에 `derivedProviderHealth` SSOT. `HealthTable` 단일 소비자, `RuntimeMonitor.Provider Runtime`은 설정 축(endpoint/default_model/discovery) 중심으로 재구성.
2. **Stage 3**: `OasHealthSummary.totalErrors > 0`일 때 Providers/Cascade accordion 자동 펼침 (Exception-first).
3. **Stage 4 (optional)**: `VerificationSpecsPanel`을 Runtime → Specs 섹션으로 이동.