### PR TITLE
fix(coord_gc): quarantine broken agent files instead of deleting (#7947)

### DIFF
--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -69,16 +69,30 @@ let cleanup_zombies
               zombie_entries := (agent.name, path) :: !zombie_entries
           | Ok _ -> () (* not a zombie, skip *)
           | Error err ->
-              Log.Gc.warn "removing broken agent file %s: %s" name err;
+              (* #7947: previously deleted the file outright, losing
+                 current_task/meta with no postmortem trail.  Quarantine
+                 to path.broken-<unix_ms> so operators can inspect the
+                 parse failure.  The .json suffix guard above already
+                 makes the next scan skip .broken-* siblings. *)
+              let ts_ms =
+                int_of_float (Unix.gettimeofday () *. 1000.0)
+              in
+              let quarantine_path =
+                Printf.sprintf "%s.broken-%d" path ts_ms
+              in
+              Log.Gc.warn
+                "quarantining broken agent file %s: %s -> %s"
+                name err
+                (Filename.basename quarantine_path);
               (try
-                 delete_path config path;
-                 (* delete_path removes the entry from the configured backend.
-                    For non-filesystem backends that dual-write a local mirror
-                    (should_dual_write_local), explicitly remove the local file
-                    as well to avoid repeated GC warnings on each scan cycle. *)
-                 (try Sys.remove path with Sys_error _ -> ())
+                 (try Sys.rename path quarantine_path
+                  with Sys_error _ ->
+                    (* Non-filesystem backend: fall back to delete so the
+                       scan does not loop forever on an unreadable entry. *)
+                    delete_path config path);
+                 ()
                with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-                 Log.Gc.warn "failed to remove broken agent %s: %s"
+                 Log.Gc.warn "failed to quarantine broken agent %s: %s"
                    path (Printexc.to_string exn))
         end
       )

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -171,33 +171,63 @@ let iso8601_of_unix_seconds ts =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
-let normalize_agent_last_seen = function
+let normalize_agent_last_seen ~joined_at = function
   | `String _ as value -> Some value
   | `Int seconds ->
       Some (`String (iso8601_of_unix_seconds (float_of_int seconds)))
   | `Float seconds ->
       Some (`String (iso8601_of_unix_seconds seconds))
+  | `Null -> joined_at  (* bootstrap from joined_at — see #7947 *)
   | _ -> None
+
+let short_json_repr = function
+  | `Null -> "null"
+  | `Bool b -> Printf.sprintf "%b" b
+  | `Int i -> string_of_int i
+  | `Float f -> Printf.sprintf "%g" f
+  | `String s ->
+      if String.length s <= 40 then Printf.sprintf "\"%s\"" s
+      else Printf.sprintf "\"%s...\"" (String.sub s 0 37)
+  | `Assoc _ -> "<object>"
+  | `List _ -> "<array>"
+  | `Intlit s -> s
+  | `Tuple _ -> "<tuple>"
+  | `Variant _ -> "<variant>"
 
 let agent_of_yojson json =
   match agent_of_yojson_generated json with
   | Ok _ as ok -> ok
   | Error original_error -> (
       match json with
-      | `Assoc fields -> (
-          match
-            List.assoc_opt "last_seen" fields
-            |> function
-            | Some value -> normalize_agent_last_seen value
-            | None -> None
-          with
+      | `Assoc fields ->
+          let joined_at_value =
+            match List.assoc_opt "joined_at" fields with
+            | Some (`String _ as v) -> Some v
+            | _ -> None
+          in
+          let last_seen_raw = List.assoc_opt "last_seen" fields in
+          let annotated_error () =
+            let last_seen_repr =
+              match last_seen_raw with
+              | Some v -> short_json_repr v
+              | None -> "<missing>"
+            in
+            Printf.sprintf "%s (last_seen=%s)" original_error last_seen_repr
+          in
+          (match
+             match last_seen_raw with
+             | Some value -> normalize_agent_last_seen ~joined_at:joined_at_value value
+             | None -> joined_at_value  (* missing last_seen → bootstrap *)
+           with
           | Some normalized_last_seen ->
               let normalized_fields =
                 ("last_seen", normalized_last_seen)
                 :: List.remove_assoc "last_seen" fields
               in
-              agent_of_yojson_generated (`Assoc normalized_fields)
-          | None -> Error original_error)
+              (match agent_of_yojson_generated (`Assoc normalized_fields) with
+               | Ok _ as ok -> ok
+               | Error _ -> Error (annotated_error ()))
+          | None -> Error (annotated_error ()))
       | _ -> Error original_error)
 
 (* ============================================ *)

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -146,6 +146,63 @@ let test_agent_of_yojson_accepts_numeric_last_seen () =
         (String.length agent.last_seen > 0 && String.contains agent.last_seen 'T')
   | Error msg -> fail ("expected numeric last_seen compatibility: " ^ msg)
 
+let test_agent_of_yojson_bootstraps_null_last_seen_from_joined_at () =
+  (* #7947 Layer 2: null last_seen must be repaired from joined_at rather than
+     dropping the whole agent record (which loses current_task/meta). *)
+  let json =
+    `Assoc
+      [
+        ("name", `String "gemini-cool-whale");
+        ("agent_type", `String "gemini");
+        ("status", `String "busy");
+        ("capabilities", `List []);
+        ("current_task", `String "task-208");
+        ("joined_at", `String "2026-04-15T03:00:00Z");
+        ("last_seen", `Null);
+      ]
+  in
+  match Types.agent_of_yojson json with
+  | Ok agent ->
+      check string "agent parsed" "gemini-cool-whale" agent.name;
+      check (option string) "current_task preserved"
+        (Some "task-208") agent.current_task;
+      check string "last_seen bootstrapped from joined_at"
+        "2026-04-15T03:00:00Z" agent.last_seen
+  | Error msg ->
+      fail ("null last_seen should bootstrap from joined_at: " ^ msg)
+
+let test_agent_of_yojson_annotates_invalid_last_seen () =
+  (* #7947 Layer 1: when repair is not possible, the error message must
+     include the actual offending value so operators can diagnose the
+     schema drift instead of seeing only the field path. *)
+  let json =
+    `Assoc
+      [
+        ("name", `String "gemini-cool-whale");
+        ("agent_type", `String "gemini");
+        ("status", `String "busy");
+        ("capabilities", `List []);
+        ("current_task", `Null);
+        ("joined_at", `Bool true);
+        ("last_seen", `Bool false);
+      ]
+  in
+  match Types.agent_of_yojson json with
+  | Ok _ -> fail "bool last_seen should not succeed without a usable joined_at"
+  | Error msg ->
+      let contains needle =
+        let n = String.length needle in
+        let h = String.length msg in
+        let rec loop i =
+          if i + n > h then false
+          else if String.sub msg i n = needle then true
+          else loop (i + 1)
+        in
+        loop 0
+      in
+      check bool "error mentions last_seen value" true
+        (contains "last_seen=")
+
 let test_heartbeat_repairs_legacy_agent_last_seen () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -198,6 +255,10 @@ let () =
             test_read_state_filters_invalid_active_agent_entries;
           test_case "agent parser accepts numeric last_seen" `Quick
             test_agent_of_yojson_accepts_numeric_last_seen;
+          test_case "agent parser bootstraps null last_seen from joined_at (#7947)" `Quick
+            test_agent_of_yojson_bootstraps_null_last_seen_from_joined_at;
+          test_case "agent parser error annotates invalid last_seen (#7947)" `Quick
+            test_agent_of_yojson_annotates_invalid_last_seen;
           test_case "heartbeat repairs legacy agent last_seen" `Quick
             test_heartbeat_repairs_legacy_agent_last_seen;
         ] );


### PR DESCRIPTION
## Summary

Closes #7947. Three-layer fix so `coord_gc` stops silently deleting agent JSON on the first parse failure.

## Linked issue

Closes #7947.

## Product impact

- Agent file whose `last_seen` is `null` or missing is no longer thrown away; `current_task` / `meta` / `status` survive. The field bootstraps from `joined_at` (semantically: "has not been seen since join"). Zombie check still fires on the resulting timestamp.
- When repair is not possible, the WARN now carries the actual offending value, e.g. `Types_core.agent.last_seen (last_seen=null)` or `... (last_seen=<missing>)`, so operators can diagnose schema drift instead of guessing.
- The file is renamed to `path.broken-<unix_ms>` instead of deleted. `coord_gc` only scans `*.json`, so the quarantined sibling is skipped on the next cycle without starving the loop. Fallback to the original `delete_path` only when `Sys.rename` is not available (non-filesystem backends).

## Change

1. `lib/types/types_core.ml` — `normalize_agent_last_seen` adds a `` `Null `` branch that reuses `joined_at`; `agent_of_yojson` annotates `original_error` with the actual `last_seen` fragment; missing `last_seen` also bootstraps from `joined_at`.
2. `lib/coord/coord_gc.ml` — error arm renames the file to `path.broken-<unix_ms>` and falls back to delete only on `Sys_error`.
3. `test/test_room_state_recovery.ml` — two new cases: null → joined_at bootstrap, and error annotation format.

## Evidence

- Existing `test_heartbeat_repairs_legacy_agent_last_seen` still passes, so the legacy int → ISO string rewrite is unchanged.
- `_build/default/test/test_room_state_recovery.exe` — 7/7 OK including the two new cases.
- `dune build --root . @check` — clean.

## Review evidence

- The new tests fail on pre-fix main because `| `Null -> None` would drop the whole record.
- The error annotation test fails on pre-fix main because the original error string was just the field path.
- Scan-loop safety: `Filename.check_suffix name ".json"` in `coord_gc` already excludes `.broken-*`, so the quarantined file will not be re-read.

## Test plan

- [x] room-state recovery suite green
- [x] dev build
- [ ] CI green