### PR TITLE
fix(keeper): honour declared max_checkpoint_messages default on create (#7859)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -313,7 +313,13 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           message_gate = compaction_message_gate;
           token_gate = compaction_token_gate;
           cooldown_sec = continuity_compaction_cooldown_sec;
-          max_checkpoint_messages = 80;
+          (* Honour [Keeper_context_core.default_max_checkpoint_messages]
+             instead of the 80 literal that used to ship here.  The
+             literal shadowed the declared default (120) for 13/15
+             keepers.  Per-keeper overrides set by the operator via the
+             keeper JSON still win.  See #7859. *)
+          max_checkpoint_messages =
+            Keeper_context_core.default_max_checkpoint_messages;
         };
         auto_handoff;
         handoff_threshold;


### PR DESCRIPTION
## Summary

Closes #7859. `keeper_turn_up_create` hardcoded `max_checkpoint_messages = 80` in the newly-built `compaction` record, shadowing the declared default (`Keeper_context_core.default_max_checkpoint_messages = 120`). 13/15 production keepers carry the literal; every new keeper inherits the 33%-tighter cap.

Replace the literal with the declared default. Operator-supplied overrides on the keeper JSON still win because JSON fallback happens only when the field is absent.

## Linked issue

Closes #7859.

## Product impact

- Newly created keepers gain back the 33% message budget the declared default advertised. Reduces adversary's vicious sanitize cycle described in the companion #7755 (large `continuity_summary` blocks were getting dropped because the effective cap was 80 instead of 120).
- Per-keeper JSON overrides unchanged — sangsu (120), janitor (30) are operator decisions and stay untouched. Operators who want a different default can keep setting it per keeper.

## Evidence

- `lib/keeper/keeper_context_core.ml:24` declares `default_max_checkpoint_messages = 120`.
- `test/test_oas_worker.ml` already uses `max_checkpoint_messages:120` in 10+ call sites; the runtime path now matches.
- Issue cites 13/15 production keepers carrying 80 and adversary dropping 15,607-char `continuity_summary` blocks every ~30 min due to the shadow cap.

## Review evidence

- 1 literal replacement, 7 lines added (mostly the explanatory comment).
- No new env surface introduced — the issue suggested `MASC_KEEPER_MAX_CHECKPOINT_MESSAGES` as an optional Option 2; that is a separate knob-exposure concern and kept out of this PR.
- `dune build --root . @check` passes.

## Test plan

- [x] dev build clean
- [ ] CI green