### PR TITLE
feat(dashboard-auth): auto-provision shared loopback dev token for /mcp

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -134,8 +134,9 @@ describe('dev-token bootstrap', () => {
 
     expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token')
     const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
-    expect(calls[0][0]).toBe('/api/v1/dashboard/dev-token')
-    expect(calls[1][0]).toBe('/mcp')
+    expect(calls.length).toBeGreaterThanOrEqual(2)
+    expect(calls[0]?.[0]).toBe('/api/v1/dashboard/dev-token')
+    expect(calls[1]?.[0]).toBe('/mcp')
   }, 60_000)
 
   it('swallows dev-token fetch failures so strict-auth servers still reach the 401 path', async () => {

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,10 +1,22 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { fetchWithTimeout, reportToolHostFailure, authHeaders, currentDashboardActor } = vi.hoisted(() => ({
+const {
+  fetchWithTimeout,
+  reportToolHostFailure,
+  authHeaders,
+  currentDashboardActor,
+  getStoredToken,
+  setStoredToken,
+} = vi.hoisted(() => ({
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
   authHeaders: vi.fn().mockReturnValue({}),
   currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
+  // Default to a non-empty stored token so ensureDevToken() short-circuits
+  // without consuming a fetchWithTimeout mock. Individual tests that want
+  // to exercise the dev-token bootstrap can override this.
+  getStoredToken: vi.fn().mockReturnValue('test-stored-token'),
+  setStoredToken: vi.fn(),
 }))
 
 vi.mock('./core', () => ({
@@ -12,11 +24,23 @@ vi.mock('./core', () => ({
   DEFAULT_MCP_TIMEOUT_MS: 30000,
   authHeaders,
   currentDashboardActor,
+  getStoredToken,
+  setStoredToken,
 }))
 
 vi.mock('./dashboard', () => ({
   reportToolHostFailure,
 }))
+
+beforeEach(() => {
+  // Re-assert default return values because vi.clearAllMocks() in afterEach
+  // wipes any per-test `.mockReturnValueOnce` queue and can clash with
+  // mocks whose `vi.hoisted` defaults have been overwritten by an earlier
+  // test (e.g. authHeaders). The dev-token bootstrap must stay inert unless
+  // a test explicitly exercises it.
+  getStoredToken.mockReturnValue('test-stored-token')
+  authHeaders.mockReturnValue({})
+})
 
 afterEach(async () => {
   const { resetMcpClientState } = await import('./mcp')
@@ -83,6 +107,55 @@ describe('mcpHeaders auth integration', () => {
     const noAuthHeaders = initCall![1].headers as Record<string, string>
     expect(noAuthHeaders['Authorization']).toBeUndefined()
     expect(noAuthHeaders['Content-Type']).toBe('application/json')
+  }, 60_000)
+})
+
+describe('dev-token bootstrap', () => {
+  it('fetches /api/v1/dashboard/dev-token once when no token is stored and persists the response', async () => {
+    getStoredToken.mockReturnValue(null)
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'loopback-dev-token' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      // MCP initialize + initialized + tools/call
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-dev' } }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token')
+    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
+    expect(calls[0][0]).toBe('/api/v1/dashboard/dev-token')
+    expect(calls[1][0]).toBe('/mcp')
+  }, 60_000)
+
+  it('swallows dev-token fetch failures so strict-auth servers still reach the 401 path', async () => {
+    getStoredToken.mockReturnValue(null)
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response('not found', { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-nok' } }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(setStoredToken).not.toHaveBeenCalled()
+    const initCall = findCallByMethod('initialize')
+    expect(initCall).toBeDefined()
   }, 60_000)
 })
 

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,6 +1,13 @@
 // MASC Dashboard — MCP-over-HTTP client with session lifecycle
 
-import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS, authHeaders, currentDashboardActor } from './core'
+import {
+  fetchWithTimeout,
+  DEFAULT_MCP_TIMEOUT_MS,
+  authHeaders,
+  currentDashboardActor,
+  getStoredToken,
+  setStoredToken,
+} from './core'
 import {
   MCP_INIT_COOLDOWN_MS,
   MCP_INITIALIZE_TIMEOUT_MS,
@@ -13,10 +20,40 @@ import { showActionToast } from '../components/common/toast'
 
 const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
 const MCP_SESSION_BLOCKED = '__blocked__'
+const DEV_TOKEN_FETCH_TIMEOUT_MS = 3000
 
 let mcpSessionId: string | null = null
 let initPromise: Promise<void> | null = null
 let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
+let devTokenBootstrapPromise: Promise<void> | null = null
+
+/** Fetch the loopback-only dev token once per page load and stash it so
+    subsequent `/mcp` requests include `Authorization: Bearer …`. The server
+    only exposes `/api/v1/dashboard/dev-token` when bound to loopback with
+    strict-auth overrides disabled; in every other case this quietly no-ops
+    and existing flows (URL `?token=…`, manual paste) continue to work. */
+async function ensureDevToken(): Promise<void> {
+  if (getStoredToken()) return
+  if (devTokenBootstrapPromise) return devTokenBootstrapPromise
+  devTokenBootstrapPromise = (async () => {
+    try {
+      const res = await fetchWithTimeout(
+        '/api/v1/dashboard/dev-token',
+        { method: 'GET', headers: { Accept: 'application/json' } },
+        DEV_TOKEN_FETCH_TIMEOUT_MS,
+      )
+      if (!res.ok) return
+      const payload = (await res.json()) as { token?: unknown }
+      if (typeof payload.token === 'string' && payload.token.length > 0) {
+        setStoredToken(payload.token)
+      }
+    } catch {
+      /* Loopback endpoint unavailable (LAN bind, strict auth, offline).
+         Leave auth headers empty; caller will surface the 401 as before. */
+    }
+  })()
+  return devTokenBootstrapPromise
+}
 
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
@@ -103,6 +140,7 @@ async function ensureSession(): Promise<void> {
   if (mcpSessionId) return
   if (initPromise) return initPromise
   initPromise = (async () => {
+    await ensureDevToken()
     try {
       const res = await fetchWithTimeout('/mcp', {
         method: 'POST',
@@ -157,6 +195,7 @@ async function ensureSession(): Promise<void> {
 export function resetMcpClientState(): void {
   mcpSessionId = null
   initPromise = null
+  devTokenBootstrapPromise = null
   if (initCooldownTimer) {
     clearTimeout(initCooldownTimer)
     initCooldownTimer = null

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -149,6 +149,64 @@ let rec add_routes ~sw ~clock router =
          in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  (* Dev-only shared bearer for the dashboard UI. Served exclusively when the
+     server binds to loopback and strict-auth env overrides are disabled, so
+     that a LAN deployment never hands out a token over the wire. On first
+     hit the token is auto-provisioned via Auth.create_token (role=Admin) and
+     persisted to .masc/auth/dashboard-dev.token for reuse across restarts.
+     The dashboard fetches this once per page load and sends it as
+     Authorization: Bearer <token> on all /mcp calls. *)
+  |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
+       if (not (http_auth_bind_is_loopback ()))
+          || http_auth_strict_enabled () then
+         Http.Response.json ~status:`Not_found ~request:request
+           {|{"error":"dev-token endpoint disabled (non-loopback bind or strict auth)"}|}
+           reqd
+       else
+         with_public_read (fun state req reqd ->
+           let base_path = state.Mcp_server.room_config.base_path in
+           let token_file =
+             Filename.concat base_path ".masc/auth/dashboard-dev.token"
+           in
+           let raw_result : (string, string) result =
+             if Fs_compat.file_exists token_file then
+               try Ok (String.trim (Fs_compat.load_file token_file))
+               with exn ->
+                 Error
+                   (Printf.sprintf "read dev-token: %s"
+                      (Printexc.to_string exn))
+             else
+               begin
+                 match
+                   Auth.create_token base_path
+                     ~agent_name:"dashboard-dev" ~role:Types.Admin
+                 with
+                 | Ok (raw, _cred) ->
+                   (try
+                      Auth.save_private_text_file token_file raw;
+                      Ok raw
+                    with exn ->
+                      Error
+                        (Printf.sprintf "persist dev-token: %s"
+                           (Printexc.to_string exn)))
+                 | Error err ->
+                   Error (Types.masc_error_to_string err)
+               end
+           in
+           begin
+             match raw_result with
+             | Ok raw ->
+               let body =
+                 Yojson.Safe.to_string (`Assoc [ ("token", `String raw) ])
+               in
+               Http.Response.json ~request:req body reqd
+             | Error msg ->
+               let body =
+                 Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
+               in
+               Http.Response.json ~status:`Internal_server_error
+                 ~request:req body reqd
+           end) request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-probe" (fun request reqd ->
        let force = Server_utils.bool_query_param request "force" ~default:false in
        let handle _state req reqd =


### PR DESCRIPTION
## Problem

대시보드가 `/mcp` 요청에 Authorization 헤더를 전혀 붙이지 않아, `require_token=true`로 설정된 로컬 서버에서 모든 tool call이 401로 거절된다. 화면에서는 "최근 태스크 이벤트 → fetch failed"처럼 빈 상태만 반복해서 뜬다. 지금까지는 `?token=…` URL 파라미터로 매번 수동 주입해 우회했다.

## Change

로컬 개발 한정으로 공용 bearer를 자동 공급한다.

**Backend (`lib/server/server_routes_http_routes_dashboard.ml`)**
- `GET /api/v1/dashboard/dev-token` 라우트 추가.
- bind=loopback이고 `http_auth_strict_enabled()`가 false일 때만 live. 그 외(LAN bind, `MASC_HTTP_AUTH_STRICT=true`, 비-loopback `MASC_HTTP_BASE_URL`)는 그대로 404.
- 첫 호출 시 `Auth.create_token base_path ~agent_name:"dashboard-dev" ~role:Types.Admin`으로 credential을 생성하고 raw 토큰을 `.masc/auth/dashboard-dev.token`으로 0o600 저장. 이후 호출은 파일만 읽는다.

**Frontend (`dashboard/src/api/mcp.ts`)**
- `ensureDevToken()` 도입. `getStoredToken()`이 비면 `/api/v1/dashboard/dev-token`을 최대 3초 안에 fetch하고 `setStoredToken()`으로 기존 sessionStorage 슬롯에 저장. 404/타임아웃은 silent no-op이라 strict-auth 환경에서도 기존 401 경로가 그대로 노출된다.
- `ensureSession()`이 MCP `initialize` 전에 `await ensureDevToken()`하여 첫 POST부터 Bearer를 달고 나간다.
- `resetMcpClientState()`가 dev-token bootstrap promise도 같이 비워 "재연결" 토스트에서 재발급이 가능하도록 한다.

## Security posture

- loopback + non-strict 조건을 모두 만족해야 토큰을 내준다. 둘 중 하나라도 깨지면 endpoint는 404. LAN 바인드에서는 실수로라도 토큰이 네트워크에 나가지 않는다.
- 파일은 `Auth.save_private_text_file`로 0o600로 저장. 기존 `.masc/auth/` 레이아웃을 그대로 따른다.
- 권한은 Admin (기존 `codex-local-admin.token`과 동급). role은 `Types.Worker`로 내리는 후속 안이 있지만, 현재 dashboard가 priority 업데이트/브로드캐스트 등 admin 레벨 tool을 함께 쓰므로 일단 Admin로 시작.

## Tests

`dashboard/src/api/mcp.test.ts`
- `dev-token bootstrap > fetches … once when no token is stored and persists the response`: GET `/api/v1/dashboard/dev-token` 호출 → 200 응답 → `setStoredToken`에 토큰이 들어가고, 이후 초기화 post가 이어진다.
- `dev-token bootstrap > swallows dev-token fetch failures so strict-auth servers still reach the 401 path`: 404 응답에도 `setStoredToken`이 호출되지 않고 initialize가 정상 진행.
- 기존 8 케이스 그대로 통과. `beforeEach`에서 `getStoredToken`/`authHeaders` 기본 리턴을 재세팅해 test 간 누수를 차단.

## Manual verification (예정)

- [ ] 로컬 서버 재빌드/바운스 후 브라우저에서 `http://127.0.0.1:8935/dashboard` → 태스크 상세 "최근 태스크 이벤트"가 `fetch failed` 대신 목록으로 채워지는지 확인.
- [ ] `curl -sI http://127.0.0.1:8935/api/v1/dashboard/dev-token`으로 200 + `token` 필드 확인.
- [ ] `MASC_HTTP_AUTH_STRICT=true`로 띄워서 404가 정상적으로 나오는지 확인.