### PR TITLE
feat(dashboard): 📏 text-[9px] → text-[10px] sweep (97 instances / 29 files, P5/9)

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -102,7 +102,7 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
           ${cat.icon}
         </div>
         <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[200px]" title=${toolName}>${toolName}</span>
-        <span class="text-[9px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
+        <span class="text-[10px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
         ${durationMs != null
           ? html`<span class="text-[11px] font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
           : null}

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -243,7 +243,7 @@ function CharacterPlate({ name }: { name: string }) {
           activityAge=${lastActivity}
           signalTruth=${signalTruth}
         />
-        ${isKeeper ? html`<div class="text-[9px] font-bold tracking-[1.5px] text-[var(--ff-gold)] uppercase text-center">KEEPER</div>` : null}
+        ${isKeeper ? html`<div class="text-[10px] font-bold tracking-[1.5px] text-[var(--ff-gold)] uppercase text-center">KEEPER</div>` : null}
       </div>
 
       <div class="flex flex-col gap-1.5 min-w-0">

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -63,7 +63,7 @@ export function HeartbeatStreakChip({
   const label = formatStreakLabel(streak)
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
     title=${label}
     aria-label=${label}
     data-heartbeat-streak-chip

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -61,7 +61,7 @@ export function HeartbeatUptimeChip({
   const title = `${view.label}% uptime · ${summary.up}/${summary.up + summary.down} observed`
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
     title=${title}
     aria-label=${title}
     data-heartbeat-uptime-chip

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -16,9 +16,9 @@ describe('kbdClasses (pure)', () => {
     expect(cls).toContain('text-[var(--text-body)]')
   })
 
-  it('sm variant: 9px text + 1px horizontal padding + dimmed color', () => {
+  it('sm variant: 10px text + tight padding (px-1 py-0) + dimmed color', () => {
     const cls = kbdClasses('sm')
-    expect(cls).toContain('text-[9px]')
+    expect(cls).toContain('text-[10px]')
     expect(cls).toContain('px-1')
     expect(cls).toContain('text-[var(--text-dim)]')
   })

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -12,7 +12,9 @@
 //  - `md` (default) — shortcut-sheet rows, inline hints beside actions.
 //                     16-18px tall pill, matches 13px body text baseline.
 //  - `sm`           — dense inline hints (\"press ?\" micro-badge, status
-//                     bar). 11-12px tall, sits without pushing text lines.
+//                     bar). Same 10px text as `md` (P5 density sweep
+//                     upgraded `sm` from 9px → 10px for legibility),
+//                     but tighter padding (px-1 py-0 vs px-1.5 py-[1px]).
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -27,7 +29,7 @@ const BASE = 'inline-flex items-center justify-center rounded border font-mono t
 export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
   const sized =
     size === 'sm'
-      ? 'text-[9px] px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
+      ? 'text-[10px] px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
       : 'text-[10px] px-1.5 py-[1px] border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
   return extra === undefined || extra === ''
     ? `${BASE} ${sized}`

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -515,7 +515,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
             <label class="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
               <span>${field.name}</span>
               ${field.required ? html`<span class="text-rose-400" aria-label="required">*</span>` : null}
-              <span class="text-[9px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
+              <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
             </label>
             <${FieldWidget}
               id=${connectorId}

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -255,11 +255,11 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         <span class="min-w-0 flex-1">
           <span class="flex items-center gap-2">
             <span class="block truncate text-[13px] font-semibold text-[var(--text-body)]">${displayName}</span>
-            <span class=${`rounded-full border px-2 py-0.5 text-[9px] font-medium ${summary.badgeClass}`}>${summary.badge}</span>
+            <span class=${`rounded-full border px-2 py-0.5 text-[10px] font-medium ${summary.badgeClass}`}>${summary.badge}</span>
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[9px] font-normal text-emerald-200/80"
+                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[10px] font-normal text-emerald-200/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -320,7 +320,7 @@ export function HeaderMiniStat({
       data-testid=${testId}
     >
       <span class=${`text-sm font-semibold tabular-nums leading-tight ${valueTone}`}>${value}</span>
-      <span class="mt-0.5 text-[9px] uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
+      <span class="mt-0.5 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
     </div>
   `
 }
@@ -946,7 +946,7 @@ function ConnectorLivePanel({
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
@@ -965,7 +965,7 @@ function ConnectorLivePanel({
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
@@ -1000,7 +1000,7 @@ function ConnectorLivePanel({
                 <div class="mb-1 flex items-center justify-between gap-2">
                   <div class="flex items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
@@ -1026,7 +1026,7 @@ function ConnectorLivePanel({
                   <${CopyableCode} label="start" command=${cmds.start} variant="primary" />
                 </div>
                 <div class="mt-2">
-                  <div class="mb-1 text-[9px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
+                  <div class="mb-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
                     Or for diagnostics
                   </div>
                   <div class="grid grid-cols-1 gap-1.5" data-sidecar-secondary-cmds>

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -148,11 +148,11 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
             <code class="text-xs font-medium text-[var(--text-strong)]">${item.env_name}</code>
             <${StatusPill} status=${item.status} />
             ${item.is_enabled ? html`
-              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-[9px] font-semibold text-[var(--ok)]">
+              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--ok)]">
                 ON
               </span>
             ` : html`
-              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-[9px] font-semibold text-[var(--text-muted)]">
+              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--text-muted)]">
                 OFF
               </span>
             `}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -200,7 +200,7 @@ function TrendCell({ name, metric, value, valueClass }: {
     <td class="py-1.5 text-right">
       <div class="flex items-center justify-end gap-1">
         <span class="font-mono ${valueClass}">${value}</span>
-        ${arrow ? html`<span class="text-[9px] ${colorClass}">${arrow}</span>` : null}
+        ${arrow ? html`<span class="text-[10px] ${colorClass}">${arrow}</span>` : null}
       </div>
       ${trend && trend.values.length >= 2
         ? html`<div class="mt-0.5 flex justify-end"><${Sparkline} values=${trend.values} width=${48} height=${14} color=${sColor} /></div>`
@@ -278,10 +278,10 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-red-300" title="TOML override가 범위를 벗어남">ERR</span>`
+                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-red-300" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-amber-300" title="TOML override 적용됨">OVR</span>`
-                    : html`<span class="text-[9px] text-[var(--text-dim)]">\u2014</span>`}
+                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300" title="TOML override 적용됨">OVR</span>`
+                    : html`<span class="text-[10px] text-[var(--text-dim)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -54,7 +54,7 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
             >drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
           </div>
           ${m.auto_rules.guardrail_reason ? html`
-            <div class="text-[9px] text-[#f59e0b] mt-0.5">사유: ${m.auto_rules.guardrail_reason}</div>
+            <div class="text-[10px] text-[#f59e0b] mt-0.5">사유: ${m.auto_rules.guardrail_reason}</div>
           ` : null}
         </div>
       ` : html`
@@ -123,7 +123,7 @@ export function InvariantsPanel({
           Safety
         </div>
         <span
-          class=${`rounded-full border px-2 py-0.5 text-[9px] font-mono tabular-nums ${
+          class=${`rounded-full border px-2 py-0.5 text-[10px] font-mono tabular-nums ${
             allOk
               ? 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
               : 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -108,14 +108,14 @@ export function OperationalMeaningPanel({
 
       <div class="mt-2 flex flex-wrap gap-1.5">
         ${insight.evidence.map(item => html`
-          <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[9px] font-mono text-[var(--text-dim)]">
+          <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[10px] font-mono text-[var(--text-dim)]">
             ${item}
           </span>
         `)}
       </div>
 
       <div class="mt-4 flex items-center justify-between gap-2">
-        <div class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           관찰 레인
         </div>
         <input
@@ -135,14 +135,14 @@ export function OperationalMeaningPanel({
             ${visibleLanes.map(lane => html`
               <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
                 <div class="flex items-center justify-between gap-2">
-                  <span class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
+                  <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
                   <span class=${`rounded-full border px-1.5 py-0.5 text-[8px] font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
                     ${fmtDuration(lane.observedForSec)}
                   </span>
                 </div>
                 <div class="mt-1 font-mono text-[13px] font-semibold text-[var(--text-strong)]">${lane.value}</div>
-                <div class="mt-0.5 text-[9px] text-[var(--text-dim)]">${lane.label}</div>
-                <div class="mt-1.5 text-[9px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
+                <div class="mt-0.5 text-[10px] text-[var(--text-dim)]">${lane.label}</div>
+                <div class="mt-1.5 text-[10px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
                 <div class="mt-1 text-[8px] font-mono text-[var(--text-dim)]">
                   ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
                 </div>
@@ -296,7 +296,7 @@ export function HeroPhase({
           <div class=${`mt-1 font-mono text-[32px] font-bold tracking-tight ${color}`} aria-labelledby="ksm-label">
             ${displayState(snapshot.phase)}
           </div>
-          <div class="mt-0.5 text-[9px] font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
+          <div class="mt-0.5 text-[10px] font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
           ${heldFor ? html`
             <div class="mt-1 text-[10px] font-mono text-[var(--text-dim)]" aria-hidden="true">
               유지 <span class="text-[var(--text-body)]">${heldFor}</span>
@@ -378,11 +378,11 @@ export function PipelineStep({
         <div class="flex items-center justify-between gap-1.5">
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[#818cf8] ${activePulse} shrink-0"></span>` : null}
-            <span class="text-[9px] font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
+            <span class="text-[10px] font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
             ${limited ? html`<span class="text-[7px] font-mono text-[var(--text-dim)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
           </div>
           ${heldFor ? html`
-            <span class=${`text-[9px] font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
+            <span class=${`text-[10px] font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
           ` : null}
         </div>
         <div class=${`mt-0.5 font-mono text-[13px] font-semibold ${isActive ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'} ${flash ? 'animate-pulse' : ''}`}>

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -172,7 +172,7 @@ export function SwimlaneTimeline({
             const isBusiest = busiestLane === lane.short && count > 0
             return html`
               <span
-                class=${`rounded-full border px-1.5 py-0.5 text-[9px] font-mono tabular-nums ${
+                class=${`rounded-full border px-1.5 py-0.5 text-[10px] font-mono tabular-nums ${
                   count === 0
                     ? 'text-[var(--text-dim)] border-[var(--white-8)]'
                     : isBusiest
@@ -184,7 +184,7 @@ export function SwimlaneTimeline({
             `
           })}
         </div>
-        <div class="text-[9px] font-mono text-[var(--text-dim)]">
+        <div class="text-[10px] font-mono text-[var(--text-dim)]">
           <span>${fmtAbs(spanStart)}</span>
           <span class="mx-1 text-[var(--text-muted)]">→</span>
           <span>${fmtAbs(spanEnd)}</span>
@@ -197,7 +197,7 @@ export function SwimlaneTimeline({
           const segments = deriveSwimlaneSegments(observations, lane.key, spanEnd)
           return html`
             <div class="flex items-center gap-2">
-              <div class="w-[44px] shrink-0 text-[9px] font-mono font-semibold text-[var(--text-muted)]">
+              <div class="w-[44px] shrink-0 text-[10px] font-mono font-semibold text-[var(--text-muted)]">
                 ${lane.short}
               </div>
               <div class="flex h-4 flex-1 overflow-hidden rounded border border-[var(--white-8)]" role="group" aria-label=${`${lane.label} swimlane with ${segments.length} segments`}>
@@ -290,7 +290,7 @@ export function SwimlaneTimeline({
           </div>
         </div>
       ` : null}
-      <div class="mt-2 flex flex-wrap items-center gap-2 text-[9px] text-[var(--text-dim)]">
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(129,140,248,0.45)]"></span>active</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(245,158,11,0.45)]"></span>compact</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(167,139,250,0.5)]"></span>handoff</span>
@@ -386,7 +386,7 @@ export function TransitionTrail({
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 flex items-center justify-between gap-2">
-        <div class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Transition History (${isFiltering ? `${visibleHistory.length}/${history.length}` : history.length})
         </div>
         <input
@@ -458,7 +458,7 @@ export function TopTransitionsPanel({
 
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         Top Transitions (${transitions.length})
       </div>
       <div class="flex flex-col gap-0.5">
@@ -522,7 +522,7 @@ export function DwellHistogramPanel({
 
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         State Dwell Time
       </div>
       <div class="flex flex-col gap-2">
@@ -534,8 +534,8 @@ export function DwellHistogramPanel({
           return html`
             <div class=${`transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''}`}>
               <div class="flex items-center gap-1.5 mb-0.5">
-                <span class=${`text-[9px] font-semibold ${color}`}>${lane.field}</span>
-                <span class="text-[9px] text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
+                <span class=${`text-[10px] font-semibold ${color}`}>${lane.field}</span>
+                <span class="text-[10px] text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
               </div>
               <div class="flex flex-col gap-px">
                 ${lane.entries.map((entry) => {
@@ -557,7 +557,7 @@ export function DwellHistogramPanel({
                           style=${`width: ${Math.max(2, entry.pct)}%`}
                         ></span>
                       </span>
-                      <span class="w-[36px] shrink-0 text-right text-[9px] text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
+                      <span class="w-[36px] shrink-0 text-right text-[10px] text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
                     </div>
                   `
                 })}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -686,7 +686,7 @@ function StatusBar({
             ${refreshFlash ? '✓' : '↻'}
           </button>
           <button
-            class="text-[9px] font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)] cursor-pointer"
+            class="text-[10px] font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)] cursor-pointer"
             onClick=${onDensityToggle}
             title=${`현재 밀도: ${density === 'compact' ? '조밀' : '여유'} (단축키 d)`}
             aria-label=${`밀도 토글: 현재 ${density === 'compact' ? '조밀' : '여유'}`}
@@ -697,18 +697,18 @@ function StatusBar({
           ${loading ? html`<${InlineSpinner} size="xs" />` : null}
           ${paused ? html`
             <span
-              class="px-1.5 py-0.5 rounded border text-[9px] font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
+              class="px-1.5 py-0.5 rounded border text-[10px] font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
               title="탭이 백그라운드 상태 — 폴링 중지됨. 탭으로 돌아오면 즉시 갱신됩니다."
             >
               ⏸ 일시 중지
             </span>
           ` : null}
           ${staleSec > 120 ? html`
-            <span class="text-[9px] font-mono text-red-400 animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
+            <span class="text-[10px] font-mono text-red-400 animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : staleSec > 60 ? html`
-            <span class="text-[9px] font-mono text-amber-400" title="마지막 관측이 1분 이상 경과">
+            <span class="text-[10px] font-mono text-amber-400" title="마지막 관측이 1분 이상 경과">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : null}
@@ -766,7 +766,7 @@ function StatusBar({
         </div>
       </div>
       ${snapshot ? html`
-        <div class="mt-1.5 flex items-center gap-2 text-[9px] font-mono flex-wrap">
+        <div class="mt-1.5 flex items-center gap-2 text-[10px] font-mono flex-wrap">
           ${/* KPI micro-metrics */ ''}
           <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-body)]">
             턴 ${snapshot.last_outcome ? `#${snapshot.last_outcome.turn_id}` : '—'}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -760,7 +760,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
                     ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
                       <div class="flex flex-wrap gap-1 mt-1">
                         ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                          <span class="text-[9px] px-1.5 py-0.5 rounded-md ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
+                          <span class="text-[10px] px-1.5 py-0.5 rounded-md ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
                         `)}
                       </div>
                     ` : null}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -169,26 +169,26 @@ function OperationalHealth({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
         ${hb ? html`
           <div class="p-2 rounded-lg border ${KPI_TONE[hbTone]} flex flex-col gap-0.5">
-            <span class="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">Heartbeat</span>
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Heartbeat</span>
             <span class="text-xs font-mono ${KPI_VALUE_TONE[hbTone]}">${hb.replace('T', ' ').slice(0, 19)}</span>
           </div>
         ` : null}
         ${compSavedRatio != null ? html`
           <div class="p-2 rounded-lg border ${KPI_TONE[compTone]} flex flex-col gap-0.5">
-            <span class="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">압축 절감률</span>
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">압축 절감률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[compTone]}">${(compSavedRatio * 100).toFixed(1)}%</span>
-            ${avgSaved != null ? html`<span class="text-[9px] text-[var(--text-dim)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
+            ${avgSaved != null ? html`<span class="text-[10px] text-[var(--text-dim)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
           </div>
         ` : null}
         ${dropRatio != null ? html`
           <div class="p-2 rounded-lg border ${KPI_TONE[dropTone]} flex flex-col gap-0.5">
-            <span class="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">메모리 손실률</span>
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">메모리 손실률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[dropTone]}">${(dropRatio * 100).toFixed(1)}%</span>
           </div>
         ` : null}
         ${lastCompAgo != null ? html`
           <div class="p-2 rounded-lg border ${KPI_TONE['default']} flex flex-col gap-0.5">
-            <span class="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">마지막 압축</span>
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">마지막 압축</span>
             <span class="text-xs font-mono text-[var(--text-strong)]">${formatDuration(lastCompAgo)} 전</span>
           </div>
         ` : null}
@@ -621,7 +621,7 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">In/Out 비율</span>
           <span class="text-lg font-mono tabular-nums text-[var(--accent)]">${avgRatio.toFixed(1)}x</span>
-          <span class="text-[9px] text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
+          <span class="text-[10px] text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
         </div>
       </div>
     </div>
@@ -679,7 +679,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
         <span class="text-[10px] text-[var(--text-dim)]">${promptPoints.length} snapshots</span>
         ${latest?.prompt_fingerprint
           ? html`<span class="inline-flex items-center gap-1">
-              <span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
+              <span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
               <${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${10} />
             </span>`
           : null}
@@ -693,7 +693,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="#f59e0b" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="mt-1 flex flex-wrap gap-2 text-[9px] text-[var(--text-dim)]">
+          <div class="mt-1 flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)]">
             <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
             <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
@@ -703,7 +703,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${fingerprintTransitions}</span>
-          <span class="text-[9px] text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
+          <span class="text-[10px] text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
         </div>
 
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
@@ -712,7 +712,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
             <span class="text-sm font-mono break-all text-[var(--text-strong)]" title=${latest?.prompt_fingerprint ?? ''}>${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
             ${latest?.prompt_fingerprint ? html`<${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${12} />` : null}
           </div>
-          <span class="text-[9px] text-[var(--text-dim)]">${latestSegments.length} segments</span>
+          <span class="text-[10px] text-[var(--text-dim)]">${latestSegments.length} segments</span>
         </div>
       </div>
 
@@ -723,17 +723,17 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
               <div class="flex items-center justify-between gap-2 mb-2">
                 <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
                 <span class="inline-flex items-center gap-1">
-                  <span class="text-[9px] font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
+                  <span class="text-[10px] font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
               <div class="grid grid-cols-2 gap-2 text-xs">
                 <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
+                  <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
                   <div class="mt-1 font-mono tabular-nums text-[var(--accent)]">${formatTokens(segment.estimated_tokens)}</div>
                 </div>
                 <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
+                  <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
                   <div class="mt-1 font-mono tabular-nums text-[var(--text-strong)]">${segment.bytes.toLocaleString()}</div>
                 </div>
               </div>
@@ -809,7 +809,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
               ></div>`
             })}
           </div>
-          <div class="mt-2 flex flex-wrap gap-2 text-[9px] text-[var(--text-dim)]">
+          <div class="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)]">
             ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
             <span>known ${formatTokens(latestKnown)}</span>
             <span>${Math.round(knownRatio * 100)}% attributed</span>
@@ -828,7 +828,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">residual</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${formatTokens(unattributedTokens)}</span>
-          <span class="text-[9px] text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
+          <span class="text-[10px] text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
         </div>
       </div>
 
@@ -865,7 +865,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between gap-2 mb-2">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
-            <span class="text-[9px] font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
+            <span class="text-[10px] font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
           </div>
           <input
             type="search"
@@ -961,7 +961,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center gap-2 mb-2">
         <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Inference Telemetry</span>
         <span class="text-[10px] text-[var(--text-dim)]">${telemetryPoints.length} points</span>
-        ${lastFp ? html`<span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
+        ${lastFp ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
       </div>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         ${'' /* tok/s sparkline */}
@@ -973,7 +973,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
             ${tpsLine ? html`<polyline points="${tpsLine}" fill="none" stroke="#4ade80" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="text-[9px] text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
+          <div class="text-[10px] text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
         </div>
 
         ${'' /* request latency */}
@@ -991,14 +991,14 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
           <span class="text-lg font-mono tabular-nums text-[var(--purple)]">${totalCacheN > 0 ? totalCacheN.toLocaleString() : '-'}</span>
-          <span class="text-[9px] text-[var(--text-dim)]">cumulative tokens</span>
+          <span class="text-[10px] text-[var(--text-dim)]">cumulative tokens</span>
         </div>
 
         ${'' /* reasoning tokens */}
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
-          <span class="text-[9px] text-[var(--text-dim)]">total tokens</span>
+          <span class="text-[10px] text-[var(--text-dim)]">total tokens</span>
         </div>
       </div>
     </div>
@@ -1040,7 +1040,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
         <div class="flex items-center justify-between mb-1.5">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
           <span class="flex items-center gap-2">
-            ${fallbackCount > 0 ? html`<span class="text-[9px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.15)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
+            ${fallbackCount > 0 ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.15)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </span>
         </div>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -220,13 +220,13 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   let pill
   if (isInvalid) {
     valueClass = 'text-red-300 underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-red-300">invalid</span>`
+    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-300">invalid</span>`
   } else if (isOverride) {
     valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
   } else {
     valueClass = 'text-[var(--text-muted)] cursor-help'
-    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
+    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
   }
 
   return html`
@@ -271,10 +271,10 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
           턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
-          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
+          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
           : hasOverride
-            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
-            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
+            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형"
@@ -303,7 +303,7 @@ export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
       <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-amber-400' : 'bg-accent/50'}"></span>
         턴 예산
-        ${diverges ? html`<span class="text-[9px] text-amber-300 font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
+        ${diverges ? html`<span class="text-[10px] text-amber-300 font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
       </summary>
       <div class="mt-3">
         <${TurnBudgetPanel} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -768,7 +768,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                     <div class="flex items-center gap-2">
                       <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
                       <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
-                      ${r.shallow ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
+                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
                     </div>
                     <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
@@ -787,7 +787,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
                   <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
                   <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${pr.branch}</span>
-                  ${pr.draft ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">draft</span>` : null}
+                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">draft</span>` : null}
                   <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -175,14 +175,14 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
         <div class="flex items-center gap-2">
           <span class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Eval Quality</span>
           ${allPassed
-            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[9px] font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
-            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[9px] font-semibold bg-[rgba(239,68,68,0.12)] text-[var(--bad)]">FAIL</span>`
+            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[10px] font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
+            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[10px] font-semibold bg-[rgba(239,68,68,0.12)] text-[var(--bad)]">FAIL</span>`
           }
           ${baseline ? html`<span class="text-[10px] font-medium ${baseline.cls}">${baseline.text}</span>` : null}
         </div>
         <button
           type="button"
-          class="text-[9px] text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
+          class="text-[10px] text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
           onClick=${() => void loadEvalData(keeperName)}
           title="새로고침"
         >${loading ? '...' : '\u21bb'}</button>
@@ -203,7 +203,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Layer Results */}
       ${layers.length > 0 ? html`
         <div class="mb-3">
-          <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)] mb-1.5">Layer Results</div>
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)] mb-1.5">Layer Results</div>
           <div class="flex flex-col gap-0.5">
             ${layers.map((layer: EvalLayerResult) => html`<${LayerResultRow} layer=${layer} />`)}
           </div>
@@ -213,7 +213,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* 24h Trend */}
       ${trend ? html`
         <div class="flex items-center gap-2 pt-2 border-t border-[var(--white-8)]">
-          <span class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
           <span class="text-[11px] font-mono tabular-nums text-[var(--text-muted)]">
             ${trend.oldCoverage.toFixed(2)} \u2192 ${trend.newCoverage.toFixed(2)}
           </span>
@@ -224,7 +224,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ` : null}
 
       ${'' /* Snapshot count */}
-      <div class="mt-2 text-[9px] text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
+      <div class="mt-2 text-[10px] text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -242,7 +242,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           const barWidth = (stat.call_count / maxCount) * 100
           return html`
             <div class="flex items-center gap-2 py-1 group">
-              <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-[9px] font-mono font-bold ${cat.color}">
+              <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-[10px] font-mono font-bold ${cat.color}">
                 ${cat.icon}
               </div>
               <div class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate" title=${stat.name}>

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -60,7 +60,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
           </div>
         ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
         ${anomalyCount > 0 ? html`
-          <div class="text-[9px] font-mono text-red-400">${anomalyCount} anomaly</div>
+          <div class="text-[10px] font-mono text-red-400">${anomalyCount} anomaly</div>
         ` : null}
       </div>
       <div

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -61,10 +61,10 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
           ${!isDefault ? html`
-            <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
+            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
           ${entry.sensitive ? html`
-            <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">sensitive</span>
+            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">sensitive</span>
           ` : null}
         </div>
         <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -203,7 +203,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
       <div class="flex items-center justify-between mb-1">
         <span class="text-[10px] font-semibold uppercase tracking-wider ${titleColor}">${titleLabel}</span>
         ${hint !== 'plain' ? html`
-          <span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
+          <span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
         ` : null}
       </div>
       <div class="rounded-lg border ${borderColor} ${bgColor} overflow-hidden">

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-emerald-200"
+                  class="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-200"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -146,7 +146,7 @@ function LevelPills({ connectorId, active }: { connectorId: string; active: LogL
     <div class="flex items-center gap-1" role="radiogroup" aria-label="log level filter">
       ${LEVELS.map(level => {
         const isActive = level === active
-        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em]'
+        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]'
         const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--text-body)]'
         const idleCls = 'border-[var(--white-8)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
         return html`

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -74,7 +74,7 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
         return html`
           <div class="tool-bar-row" key=${item.name}>
             <div class="flex items-center gap-1.5 overflow-hidden">
-              <span class="flex-shrink-0 size-4 rounded text-[9px] font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
+              <span class="flex-shrink-0 size-4 rounded text-[10px] font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
               <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px]" title=${item.name}>${item.name}</span>
             </div>
             <span class="px-1.5 py-px rounded-[3px] text-[10px] font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -175,7 +175,7 @@ function ToolTable({
               : 'border-b border-[var(--card-border)] border-opacity-30'
             return html`
               <tr class=${rowClass} ref=${isHighlighted ? ((el: HTMLElement | null) => el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })) : undefined}>
-                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-[9px] text-[var(--warn)]">◀ selected</span>` : null}</td>
+                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-[10px] text-[var(--warn)]">◀ selected</span>` : null}</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
                 <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.avg_ms.toFixed(0)}</td>
@@ -323,17 +323,17 @@ export function ToolQualityPanel() {
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div class="text-center">
           <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
-          <div class="text-[9px] text-[var(--text-dim)] uppercase">성공률</div>
+          <div class="text-[10px] text-[var(--text-dim)] uppercase">성공률</div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
-          <div class="text-[9px] text-[var(--text-dim)] uppercase">
+          <div class="text-[10px] text-[var(--text-dim)] uppercase">
             ${d.sampling_mode === 'recent_n' ? 'Sampled Calls' : 'Window Calls'}
           </div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--bad-light)]/80">${d.failure}</div>
-          <div class="text-[9px] text-[var(--text-dim)] uppercase">Failures</div>
+          <div class="text-[10px] text-[var(--text-dim)] uppercase">Failures</div>
         </div>
       </div>
 

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -230,7 +230,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
               const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
               return html`
               <div class="flex flex-col gap-1">
-                <span class="text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
+                <span class="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
                 <div class="flex flex-wrap gap-1">
                   ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
                   ${!expanded && hiddenToolCount > 0
@@ -361,7 +361,7 @@ function ToolSearchPicker({
           ${showMenu && filtered.length > 0
             ? Array.from(groupedFiltered.entries()).map(([cat, names]) => html`
               ${groupedFiltered.size > 1
-                ? html`<li class="px-3 pt-2 pb-0.5 text-[9px] font-bold uppercase tracking-widest text-[var(--text-muted)] select-none" aria-hidden="true">${cat}</li>`
+                ? html`<li class="px-3 pt-2 pb-0.5 text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)] select-none" aria-hidden="true">${cat}</li>`
                 : null}
               ${names.map(name => {
                 const idx = filtered.indexOf(name)
@@ -376,7 +376,7 @@ function ToolSearchPicker({
                     }`}
                   >
                     <span class="text-[11px] text-[var(--text-body)] font-medium shrink-0">${name}</span>
-                    ${usage ? html`<span class="text-[9px] text-[var(--text-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
+                    ${usage ? html`<span class="text-[10px] text-[var(--text-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
                     ${descMap.has(name)
                       ? html`<span class="text-[10px] text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
                       : null}


### PR DESCRIPTION
## Summary

Collapses the dashboard's **9px micro-tier** into the
existing 10px tier — **97 instances across 29 files**,
all 1:1 Tailwind class token replacement.

9px is effectively sub-pixel stem thickness after hi-DPI
subpixel rendering, and the dashboard already uses 10px
as the dominant "tiny label" size (300+ sites). Two sizes
below body text meant two anti-aliasing regimes and two
baselines per row. One tier is enough.

P5 of the 9-PR hygiene sweep (after #8076 SectionCap,
#8086 StatusChip Tailwind-only, #8238 StatusChip
uppercase, #8245 IdPill).

## Change

```
text-[9px] → text-[10px]     (every use site, 97 instances)
```

Plus Kbd primitive upgrade (`common/kbd.ts`): `sm` size
goes from `text-[9px] px-1 py-0` to `text-[10px] px-1
py-0`. Its distinct identity from `md` now rides on
padding alone (px-1 py-0 vs px-1.5 py-[1px]), which
stays a legible visual difference.

## Touched files (29)

**Densest panels** (≥5 instances each):
- `keeper-detail-panels.ts` (21)
- `fsm-hub-timeline-panels.ts` (10)
- `fsm-hub-pipeline-panels.ts` (8)
- `keeper-detail-runtime.ts` (7)
- `keeper-eval-quality.ts` (6)
- `fsm-hub.ts` (5)
- `connector-status.ts` (5)

**Remaining**: `fleet-telemetry-panel.ts`, `tool-quality-panel.ts`,
`tools/tool-allowlist-editor.ts`, `feature-health.ts`,
`fsm-hub-health-panels.ts`, `keeper-tool-telemetry.ts`,
`connector-overview-strip.ts`, `server-config.ts`,
`keeper-detail.ts`, `fsm-hub-health-panels.ts`,
`setup-guide-card.ts`, `connector-config-form.ts`,
`agent-detail-timeline.ts`, `agent-profile.ts`,
`sidecar-log-viewer.ts`, `session-trace/session-trace-entry.ts`,
`keeper-config-panel.ts`, `observatory/metric-track.ts`,
`tool-metrics.ts`, `common/heartbeat-uptime-chip.ts`,
`common/heartbeat-streak-chip.ts`, `common/kbd.ts`,
`common/kbd.test.ts`.

## Risk model

Deterministic class token replacement — no logic changes,
no conditional swaps, no prop shape changes.

Layout risk: ~11% y-height bump on the 97 use sites.
Most are in dense panels where 10px is the sibling label
size, so the bump aligns rather than disrupts. Flex-wrap
parents absorb the millisecond vertical reflow without
overflow.

Kbd.sm is the only semantic delta (public API unchanged:
`size='sm'` prop still accepted; test IDs / data-attrs
unchanged). Call sites get a legibility upgrade for free;
padding keeps `sm` visually distinguishable from `md`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — full suite green (kbd.test.ts updated)
- [x] `pnpm build` — vite clean
- [ ] CI green
- [ ] Empirical: local dashboard boot → spot-check keeper-detail-panels, fsm-hub, connector-overview (densest sites)

## Roadmap status

| PR | Status |
|----|--------|
| P1 SectionCap | ✅ #8076 merged |
| P2 StatusChip Tailwind-only | ✅ #8086 merged |
| P3 StatusChip uppercase | ✅ #8238 merged |
| P4 IdPill primitive | 🟡 #8245 auto-merge armed |
| **P5 text-[9px] → text-[10px]** | **this PR** |
| P6 Color var normalisation + drift lint | pending |
| P7 Rounded / font-weight sweep | pending |
| P8 a11y / focus ring sweep | pending |
| P9 Waste sweep | pending |