### PR TITLE
fix(oas_sse_bridge): surface keeper_name on envelope agent_name (#7827)

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -42,9 +42,18 @@ let payload_int_opt key = function
   | _ -> None
 
 let payload_agent_name payload =
+  (* Check [agent_name], [agent], then [keeper_name] for Custom events
+     whose publisher stores the per-agent attribution under the
+     keeper-specific key (e.g. [masc:keeper:snapshot],
+     [masc:keeper:lifecycle]).  Without this fallback the top-level
+     envelope [agent_name] is Null for 9%+ of daily events, breaking
+     per-agent filters on [.masc/oas-events/*.jsonl].  See #7827. *)
   match payload_string_opt "agent_name" payload with
   | Some _ as value -> value
-  | None -> payload_string_opt "agent" payload
+  | None ->
+    (match payload_string_opt "agent" payload with
+     | Some _ as value -> value
+     | None -> payload_string_opt "keeper_name" payload)
 
 let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =
   let log message =

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -107,6 +107,64 @@ let test_event_bus_keeper_lifecycle_includes_phase () =
     Alcotest.(check string) "event" "started" event
   | _ -> Alcotest.fail "expected Custom masc:keeper:lifecycle event"
 
+let test_keeper_snapshot_envelope_agent_name () =
+  (* #7827: publish_keeper_snapshot stores the keeper's identity as
+     [keeper_name] inside the Custom payload.  native_event_to_json must
+     still populate the top-level envelope [agent_name] so that
+     [.masc/oas-events/*.jsonl] consumers can filter/group by agent
+     instead of silently dropping 9%+ of daily events. *)
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Oas_events.publish_keeper_snapshot bus
+    ~keeper_name:"sojin"
+    ~generation:4
+    ~context_ratio:0.25
+    ~message_count:47;
+  let events = Event_bus.drain sub in
+  Alcotest.(check int) "one event" 1 (List.length events);
+  match Oas_sse_bridge.native_event_to_json (List.hd events) with
+  | None -> Alcotest.fail "expected native_event_to_json to emit"
+  | Some (`Assoc fields) ->
+    let field_string name =
+      match List.assoc_opt name fields with
+      | Some (`String value) -> value
+      | Some `Null -> "<null>"
+      | _ -> ""
+    in
+    Alcotest.(check string) "event_type"
+      "masc:keeper:snapshot" (field_string "event_type");
+    Alcotest.(check string) "envelope agent_name"
+      "sojin" (field_string "agent_name")
+  | Some _ -> Alcotest.fail "unexpected JSON shape"
+
+let test_keeper_lifecycle_envelope_agent_name () =
+  (* #7827 sibling: masc:keeper:lifecycle carries the same attribution
+     through keeper_name. *)
+  Eio_main.run @@ fun _env ->
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Oas_events.publish_keeper_lifecycle bus
+    ~event:"started"
+    ~keeper_name:"masc-improver"
+    ~phase:Masc_mcp.Keeper_state_machine.Running
+    ~detail:"supervised"
+    ();
+  let events = Event_bus.drain sub in
+  Alcotest.(check int) "one event" 1 (List.length events);
+  match Oas_sse_bridge.native_event_to_json (List.hd events) with
+  | None -> Alcotest.fail "expected native_event_to_json to emit"
+  | Some (`Assoc fields) ->
+    let field_string name =
+      match List.assoc_opt name fields with
+      | Some (`String value) -> value
+      | Some `Null -> "<null>"
+      | _ -> ""
+    in
+    Alcotest.(check string) "envelope agent_name"
+      "masc-improver" (field_string "agent_name")
+  | Some _ -> Alcotest.fail "unexpected JSON shape"
+
 let test_oas_sse_bridge_persists_native_events () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -520,6 +578,10 @@ let () =
         test_event_bus_task_transition;
       Alcotest.test_case "keeper lifecycle includes phase" `Quick
         test_event_bus_keeper_lifecycle_includes_phase;
+      Alcotest.test_case "keeper snapshot envelope carries agent_name (#7827)" `Quick
+        test_keeper_snapshot_envelope_agent_name;
+      Alcotest.test_case "keeper lifecycle envelope carries agent_name (#7827)" `Quick
+        test_keeper_lifecycle_envelope_agent_name;
       Alcotest.test_case "sse bridge persists native events" `Quick
         test_oas_sse_bridge_persists_native_events;
       Alcotest.test_case "sse bridge sends lifecycle to observers" `Quick


### PR DESCRIPTION
## Summary

Closes #7827. `payload_agent_name` in `oas_sse_bridge.ml` now falls back to `keeper_name` when neither `agent_name` nor `agent` is present on the payload. This is the single SSOT the `Custom` branch of `native_event_to_json` consults for the envelope `agent_name`, so extending the lookup fixes `masc:keeper:snapshot` and `masc:keeper:lifecycle` in one place.

## Linked issue

Closes #7827.

## Product impact

- 9% of daily `.masc/oas-events/*.jsonl` records gain a non-null top-level `agent_name`. Dashboards and analytic queries that filter/group on `agent_name` no longer silently drop keeper snapshot + lifecycle attribution.
- No payload, schema, or publisher-signature changes. Existing consumers that already parse `payload.keeper_name` continue to work; the new envelope field is additive.

## Change

1. `lib/oas_sse_bridge.ml` — `payload_agent_name` checks `agent_name` → `agent` → `keeper_name` in that order.
2. `test/test_oas_integration.ml` — two new cases drive `publish_keeper_snapshot` and `publish_keeper_lifecycle` through `native_event_to_json` and assert the envelope `agent_name` carries the keeper name.

## Evidence

- Issue filing cites 386/4129 (9.3%) events with `agent_name: null` for the two affected event types on 2026-04-17.
- Pre-fix: both new tests fail (returns `<null>` or empty string for the envelope `agent_name`). Post-fix: both pass.
- `test_oas_integration.exe`: 18/18 OK.
- `dune build --root . @check`: clean.

## Review evidence

- This stays inside masc-mcp and does not require an OAS envelope or publisher API change.
- The fallback order remains explicit and deterministic: `agent_name` first, then legacy `agent`, then keeper-specific `keeper_name`.
- The two new tests exercise the exact affected event families instead of a broader snapshot fixture.

## Alternative considered

Option A in the issue suggested extending `mk_event`'s signature to take `~agent_name` at the OAS layer. Rejected here because it would force a downstream OAS pin bump and ripple through every Custom publisher. Extending the masc-mcp-side payload lookup keeps the fix local and respects the OAS boundary memory rule (masc-mcp should not mutate OAS's envelope shape).

## Test plan

- [x] `test_oas_integration.exe` — 18/18 including 2 new cases
- [x] dev build
- [ ] CI green