### PR TITLE
[codex] Avoid blocking dashboard shell cold start

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -336,6 +336,14 @@ let get_or_compute key ~ttl compute =
   if Eio_guard.is_ready () then get_or_compute_eio key ~ttl compute
   else get_or_compute_simple key ~ttl compute
 
+let peek key =
+  let ts = now () in
+  let map = Atomic.get table in
+  match SMap.find_opt key map with
+  | Some (Ready entry) when entry.stale_until > ts -> Some entry.value
+  | Some (Computing { stale = Some stale_value; _ }) -> Some stale_value
+  | _ -> None
+
 let timeout_error_json ?(waiting = false) key timeout_sec =
   let message =
     if waiting then

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -26,6 +26,12 @@ val get_or_compute : string -> ttl:float -> (unit -> Yojson.Safe.t) -> Yojson.Sa
     deadlocking.  Concurrent requests for the same key are serialised — only
     one [f] runs; others wait for the result (stampede protection). *)
 
+val peek : string -> Yojson.Safe.t option
+(** [peek key] returns the currently cached value for [key] when a fresh or
+    stale-ready entry exists. Unlike [get_or_compute], it never triggers a
+    synchronous compute. Returns [None] on cache miss or when the key is
+    currently computing without any stale fallback. *)
+
 exception Compute_timeout of string * bool
 (** Raised internally when the compute function exceeds [timeout_sec].
     Callers of [get_or_compute_with_timeout] do not need to handle this —

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -775,14 +775,59 @@ let dashboard_shell_timeout_s = 16.0
    belief/tension/desire rule evaluation. On a room with 450+ posts this
    regularly exceeds 8s, which was the previous shell timeout and caused
    repeat "cache compute timeout: shell:..." + "cache bg-revalidate failed"
-   noise in the log. Give it its own cache with a longer TTL so the shell
-   path does not block on it every refresh cycle. *)
+   noise in the log. Give it its own cache with a longer TTL, and on a cold
+   miss warm it in the background so the shell path never blocks on the
+   initial full JSONL scan. *)
 let meta_cognition_summary_ttl = 120.0
+let meta_cognition_warm_mu = Eio.Mutex.create ()
+let meta_cognition_warm_inflight : (string, unit) Hashtbl.t = Hashtbl.create 4
+
+let meta_cognition_summary_key (config : Coord.config) =
+  Printf.sprintf "meta_cognition_summary:%s" config.base_path
+
+let clear_meta_cognition_warm_flag key =
+  Eio_guard.with_mutex meta_cognition_warm_mu (fun () ->
+      Hashtbl.remove meta_cognition_warm_inflight key)
+
+let schedule_meta_cognition_summary_warm (config : Coord.config) =
+  let key = meta_cognition_summary_key config in
+  let should_start =
+    Eio_guard.with_mutex meta_cognition_warm_mu (fun () ->
+        if Hashtbl.mem meta_cognition_warm_inflight key then
+          false
+        else (
+          Hashtbl.replace meta_cognition_warm_inflight key ();
+          true))
+  in
+  if should_start then
+    match Eio_context.get_switch_opt () with
+    | Some sw ->
+        Eio.Fiber.fork ~sw (fun () ->
+            Fun.protect
+              ~finally:(fun () -> clear_meta_cognition_warm_flag key)
+              (fun () ->
+                try
+                  ignore
+                    (Dashboard_cache.get_or_compute key
+                       ~ttl:meta_cognition_summary_ttl
+                       (fun () -> Meta_cognition.summary_json config))
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                    Log.Server.warn
+                      "dashboard shell meta_cognition warm failed: %s"
+                      (Printexc.to_string exn)))
+    | None -> clear_meta_cognition_warm_flag key
 
 let meta_cognition_summary_cached (config : Coord.config) : Yojson.Safe.t =
-  let key = Printf.sprintf "meta_cognition_summary:%s" config.base_path in
-  Dashboard_cache.get_or_compute key ~ttl:meta_cognition_summary_ttl (fun () ->
-    Meta_cognition.summary_json config)
+  let key = meta_cognition_summary_key config in
+  match Dashboard_cache.peek key with
+  | Some _ ->
+      Dashboard_cache.get_or_compute key ~ttl:meta_cognition_summary_ttl
+        (fun () -> Meta_cognition.summary_json config)
+  | None ->
+      schedule_meta_cognition_summary_warm config;
+      `Null
 
 let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -782,6 +782,14 @@ let meta_cognition_summary_ttl = 120.0
 let meta_cognition_warm_mu = Eio.Mutex.create ()
 let meta_cognition_warm_inflight : (string, unit) Hashtbl.t = Hashtbl.create 4
 
+let dashboard_shell_cache_prefix (config : Coord.config) =
+  Printf.sprintf "shell:coord=%s:" config.base_path
+
+let dashboard_shell_cache_key (config : Coord.config) =
+  Printf.sprintf "%sworkspace=%s"
+    (dashboard_shell_cache_prefix config)
+    config.workspace_path
+
 let meta_cognition_summary_key (config : Coord.config) =
   Printf.sprintf "meta_cognition_summary:%s" config.base_path
 
@@ -811,6 +819,11 @@ let schedule_meta_cognition_summary_warm (config : Coord.config) =
                     (Dashboard_cache.get_or_compute key
                        ~ttl:meta_cognition_summary_ttl
                        (fun () -> Meta_cognition.summary_json config))
+                  (* Drop cached shell payloads that were rendered while the
+                     meta-cognition summary was still warming. *)
+                  ;
+                  Dashboard_cache.invalidate_prefix
+                    (dashboard_shell_cache_prefix config)
                 with
                 | Eio.Cancel.Cancelled _ as e -> raise e
                 | exn ->
@@ -1060,10 +1073,7 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
     ]
 
 let dashboard_shell_http_json ?clock ?request (config : Coord.config) : Yojson.Safe.t =
-  let cache_key =
-    Printf.sprintf "shell:coord=%s:workspace=%s"
-      config.base_path config.workspace_path
-  in
+  let cache_key = dashboard_shell_cache_key config in
   let compute () =
     (* Shell endpoint is read-only; use config directly without isolation
        since state is not available in this context. *)

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -57,6 +57,17 @@ let test_cache_hit () =
   check_json "same value" v1 v2;
   Alcotest.(check int) "compute once" 1 !counter
 
+let test_peek_returns_cached_value () =
+  Dashboard_cache.invalidate_all ();
+  let seeded =
+    Dashboard_cache.get_or_compute "peek-hit" ~ttl:5.0 (fun () ->
+        `String "cached")
+  in
+  let peeked = Dashboard_cache.peek "peek-hit" in
+  Alcotest.(check bool) "peek returns some" true (Option.is_some peeked);
+  check_json "peeked value" seeded
+    (Option.value ~default:`Null peeked)
+
 (* -- 4. Invalidate removes entry -------------------------------------------- *)
 
 let test_invalidate () =
@@ -309,6 +320,8 @@ let () =
       ( "correctness",
         [
           test_case "cache hit" `Quick test_cache_hit;
+          test_case "peek returns cached value" `Quick
+            test_peek_returns_cached_value;
           test_case "invalidate" `Quick test_invalidate;
           test_case "invalidate_prefix" `Quick test_invalidate_prefix;
           test_case "stats" `Quick test_stats;

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -78,6 +78,14 @@ let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
       ("votes_down", `Int 0);
     ]
 
+let warm_meta_cognition_summary (config : Lib.Coord.config) =
+  let key = Printf.sprintf "meta_cognition_summary:%s" config.base_path in
+  ignore
+    (Lib.Dashboard_cache.get_or_compute key ~ttl:120.0 (fun () ->
+         Lib.Meta_cognition.summary_json config));
+  Lib.Dashboard_cache.invalidate_prefix
+    (Printf.sprintf "shell:coord=%s:" config.base_path)
+
 let with_execution_cache json f =
   let surface = Lib.Server_dashboard_http._execution_cache in
   let original_json = surface.json in
@@ -348,8 +356,15 @@ let test_dashboard_shell_includes_meta_cognition_summary () =
               "This contradicts the uniform block hypothesis. Access may be per-agent."
             ~created_at:1010.0 ();
         ];
-      let json = Lib.Server_dashboard_http.dashboard_shell_http_json config in
+      Lib.Dashboard_cache.invalidate_all ();
+      Atomic.set Lib.Server_dashboard_http._shell_warmed false;
+      Atomic.set Lib.Server_dashboard_http._last_good_shell (`Assoc []);
+      let cold_json = Lib.Server_dashboard_http.dashboard_shell_http_json config in
       let open Yojson.Safe.Util in
+      check bool "cold shell defers meta cognition while warming" true
+        (cold_json |> member "meta_cognition" = `Null);
+      warm_meta_cognition_summary config;
+      let json = Lib.Server_dashboard_http.dashboard_shell_http_json config in
       let meta = json |> member "meta_cognition" in
       check int "meta belief count" 2
         (meta |> member "belief_count" |> to_int);

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -97,6 +97,14 @@ let warm_execution_cache () =
     Lib.Server_dashboard_http._execution_cache
     (`Assoc [("status", `String "ok")])
 
+let warm_meta_cognition_summary (config : Lib.Coord.config) =
+  let key = Printf.sprintf "meta_cognition_summary:%s" config.base_path in
+  ignore
+    (Lib.Dashboard_cache.get_or_compute key ~ttl:120.0 (fun () ->
+         Lib.Meta_cognition.summary_json config));
+  Lib.Dashboard_cache.invalidate_prefix
+    (Printf.sprintf "shell:coord=%s:" config.base_path)
+
 let expire_execution_warmup () =
   let surface = Lib.Server_dashboard_http._execution_cache in
   Lib.Server_dashboard_http_cache.invalidate_cached_surface surface;
@@ -358,6 +366,10 @@ let test_dashboard_namespace_truth_promotes_meta_cognition_focus () =
         ];
       warm_execution_cache ();
       Eio.Switch.run (fun sw ->
+        Lib.Dashboard_cache.invalidate_all ();
+        Atomic.set Lib.Server_dashboard_http._shell_warmed false;
+        Atomic.set Lib.Server_dashboard_http._last_good_shell (`Assoc []);
+        warm_meta_cognition_summary config;
         let json =
           Lib.Server_dashboard_http.dashboard_namespace_truth_http_json
             ~state ~sw ~clock:(Eio.Stdenv.clock env)
@@ -384,8 +396,7 @@ let test_dashboard_namespace_truth_promotes_meta_cognition_focus () =
           (json |> member "focus" |> member "suggested_tab" |> to_string);
         check bool "focus params stay empty for overview"
           true
-          (json |> member "focus" |> member "suggested_params" = `Assoc []);
-      ))
+          (json |> member "focus" |> member "suggested_params" = `Assoc [])))
 
 let test_dashboard_namespace_truth_exposes_latest_meta_digest () =
   let dir = test_dir () in
@@ -419,6 +430,10 @@ let test_dashboard_namespace_truth_exposes_latest_meta_digest () =
         ];
       warm_execution_cache ();
       Eio.Switch.run (fun sw ->
+        Lib.Dashboard_cache.invalidate_all ();
+        Atomic.set Lib.Server_dashboard_http._shell_warmed false;
+        Atomic.set Lib.Server_dashboard_http._last_good_shell (`Assoc []);
+        warm_meta_cognition_summary config;
         let first_json =
           Lib.Server_dashboard_http.dashboard_namespace_truth_http_json
             ~state ~sw ~clock:(Eio.Stdenv.clock env)
@@ -448,8 +463,7 @@ let test_dashboard_namespace_truth_exposes_latest_meta_digest () =
            |> member "matches_summary" |> to_bool);
         check string "meta latest digest hearth" "meta-cognition"
           (json |> member "meta_cognition" |> member "latest_digest"
-           |> member "hearth" |> to_string);
-      ))
+           |> member "hearth" |> to_string)))
 
 let test_dashboard_namespace_truth_does_not_auto_post_meta_digest () =
   let dir = test_dir () in


### PR DESCRIPTION
## Summary
- avoid blocking `/api/v1/dashboard/shell` on a cold `meta_cognition` cache miss
- add a non-blocking dashboard cache peek and warm `meta_cognition` in the background
- cover the new cache access path with a regression test

## Problem
The shell payload path synchronously computed `meta_cognition` on cold start. On large workspace state this could keep the first dashboard load stuck for minutes even though the rest of the shell payload was ready.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-fleet-telemetry ./test/test_dashboard_cache.exe ./test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_cache.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-fleet-telemetry ./bin/main_eio.exe`
- patched local server measurement: `/api/v1/dashboard/shell` ~`0.052s`, `/health/live` ~`0.030s`
