### PR TITLE
fix(dashboard): surface live pending_ruling count instead of hardcoded 0 (#7815)

### DIFF
--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -24,18 +24,32 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
       ("last_error", string_option_json runtime.last_error);
     ]
 
-let summary_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot) =
+let summary_json_of_runtime ?base_path
+    (runtime : Dashboard_governance_judge.runtime_snapshot) =
   let pending_approval_count = Keeper_approval_queue.pending_count () in
+  let pending_ruling, oldest_json =
+    match base_path with
+    | None -> 0, `Null
+    | Some base_path ->
+      let n =
+        Governance_cases_snapshot.pending_ruling_count ~base_path
+      in
+      let oldest =
+        Governance_cases_snapshot.oldest_pending_ruling_age_s ~base_path
+          ~now_ts:(Unix.gettimeofday ())
+      in
+      n, Option.fold ~none:`Null ~some:(fun v -> `Float v) oldest
+  in
   `Assoc
     [
-      ("cases_open", `Int 0);
-      ("pending_ruling", `Int 0);
+      ("cases_open", `Int pending_ruling);
+      ("pending_ruling", `Int pending_ruling);
       ("ready_auto_execute", `Int 0);
       ("needs_human_gate", `Int pending_approval_count);
       ("executed", `Int 0);
       ("blocked", `Int 0);
       ("ready_to_execute", `Int 0);
-      ("oldest_open_case_age_s", `Null);
+      ("oldest_open_case_age_s", oldest_json);
       ("last_activity_age_s", `Null);
       ("judge_online", `Bool runtime.judge_online);
       ("judge_last_seen_at", timestamp_option_json runtime.generated_at runtime.generated_at_unix);
@@ -56,7 +70,7 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
-      ("summary", summary_json_of_runtime runtime);
+      ("summary", summary_json_of_runtime ~base_path runtime);
       ("items", `List []);
       ("activity", `List []);
       ("judge", judge_json_of_runtime runtime);

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -179,17 +179,36 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
 let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
   : Yojson.Safe.t * bool =
   let runtime = Dashboard_governance_judge.runtime_status_at ~now_ts base_path in
-  let alert_level = if runtime.judge_online then "ok" else "warn" in
-  (* Governance case tracking is retired, but judge runtime status is still live. *)
+  (* The ruling/execution pipeline is retired, so [ready_auto_execute],
+     [executed], and [blocked] stay zero by design.  [pending_ruling]
+     must still reflect disk truth: stale cases from before the
+     retirement remain under [.masc/governance_v2/cases/] and hiding
+     them previously turned a 16-day-old high-risk case invisible
+     (#7815). *)
+  let pending_ruling =
+    Governance_cases_snapshot.pending_ruling_count ~base_path
+  in
+  let oldest_pending_age_s =
+    Governance_cases_snapshot.oldest_pending_ruling_age_s
+      ~base_path ~now_ts
+  in
+  let alert_level =
+    if pending_ruling > 0 then "warn"
+    else if runtime.judge_online then "ok"
+    else "warn"
+  in
+  let oldest_json =
+    Option.fold ~none:`Null ~some:(fun v -> `Float v) oldest_pending_age_s
+  in
   (`Assoc [
     ("alert_level", `String alert_level);
-    ("cases_open", `Int 0);
-    ("pending_ruling", `Int 0);
+    ("cases_open", `Int pending_ruling);
+    ("pending_ruling", `Int pending_ruling);
     ("ready_auto_execute", `Int 0);
     ("needs_human_gate", `Int 0);
     ("executed", `Int 0);
     ("blocked", `Int 0);
-    ("oldest_open_case_age_s", `Null);
+    ("oldest_open_case_age_s", oldest_json);
     ("last_activity_age_s", `Null);
     ("slo_target_case_age_s", `Int 0);
     ("slo_breached", `Bool false);

--- a/lib/dune
+++ b/lib/dune
@@ -196,6 +196,7 @@
    meta_cognition_types
    meta_cognition_rules
    meta_cognition_snapshot
+   governance_cases_snapshot
    meta_cognition_parse
    meta_cognition_interpret
    meta_cognition_digest

--- a/lib/governance_cases_snapshot.ml
+++ b/lib/governance_cases_snapshot.ml
@@ -1,0 +1,70 @@
+(** Lightweight filesystem reader for [.masc/governance_v2/cases/].
+
+    The governance case tracking UI was retired (dashboard hardcoded
+    [("pending_ruling", Int 0)]), but stale case files remain on disk
+    from before the retirement — and [Meta_cognition_snapshot] still
+    consumes them.  This helper surfaces the raw counts so the
+    dashboard can report the truth instead of a constant zero.
+
+    See #7815. *)
+
+type case = {
+  id : string;
+  title : string;
+  status : string;
+  risk_class : string;
+  created_at : float;
+}
+
+let cases_dir ~base_path =
+  Filename.concat base_path (Filename.concat ".masc" "governance_v2/cases")
+
+let parse_case (json : Yojson.Safe.t) : case option =
+  let id = Safe_ops.json_string ~default:"" "id" json in
+  if id = "" then None
+  else
+    let title = Safe_ops.json_string ~default:"" "title" json in
+    let status = Safe_ops.json_string ~default:"" "status" json in
+    let risk_class = Safe_ops.json_string ~default:"" "risk_class" json in
+    let created_at =
+      match json |> Yojson.Safe.Util.member "created_at" with
+      | `Float f -> f
+      | `Int i -> float_of_int i
+      | _ -> 0.0
+    in
+    Some { id; title; status; risk_class; created_at }
+
+let load_all ~base_path : case list =
+  let dir = cases_dir ~base_path in
+  match Safe_ops.list_dir_safe dir with
+  | Error _ -> []
+  | Ok names ->
+    names
+    |> List.filter (fun name ->
+      Filename.check_suffix name ".json"
+      && not (String.starts_with ~prefix:"_" name))
+    |> List.filter_map (fun name ->
+      match Safe_ops.read_json_file_safe (Filename.concat dir name) with
+      | Error _ -> None
+      | Ok json -> parse_case json)
+
+let count_by_status ~base_path ~status =
+  load_all ~base_path
+  |> List.filter (fun c -> c.status = status)
+  |> List.length
+
+let pending_ruling_count ~base_path =
+  count_by_status ~base_path ~status:"pending_ruling"
+
+let oldest_pending_ruling_age_s ~base_path ~now_ts : float option =
+  load_all ~base_path
+  |> List.filter (fun c -> c.status = "pending_ruling")
+  |> List.fold_left
+    (fun acc c ->
+      let age = now_ts -. c.created_at in
+      if age < 0.0 then acc
+      else
+        match acc with
+        | None -> Some age
+        | Some current -> Some (Float.max current age))
+    None

--- a/lib/governance_cases_snapshot.mli
+++ b/lib/governance_cases_snapshot.mli
@@ -1,0 +1,33 @@
+(** Lightweight filesystem reader for [.masc/governance_v2/cases/].
+    Exposed so dashboard surfaces can report the real count of
+    [pending_ruling] cases instead of a hardcoded zero.  See #7815. *)
+
+type case = {
+  id : string;
+  title : string;
+  status : string;
+  risk_class : string;
+  created_at : float;
+}
+
+(** [cases_dir ~base_path] is the on-disk location the helper scans. *)
+val cases_dir : base_path:string -> string
+
+(** Load every case in [base_path/.masc/governance_v2/cases/*.json] whose
+    name does not start with ["_"] (reserved for markers).  Unreadable
+    or malformed files are skipped silently; the caller gets an empty
+    list when the directory does not exist. *)
+val load_all : base_path:string -> case list
+
+(** Count of cases whose [status] equals the given string. *)
+val count_by_status : base_path:string -> status:string -> int
+
+(** Convenience: number of cases with [status = "pending_ruling"]. *)
+val pending_ruling_count : base_path:string -> int
+
+(** Age in seconds of the oldest case currently stuck in
+    [pending_ruling], relative to [now_ts].  Returns [None] when no
+    such case exists or when the newest created_at is in the future
+    (clock skew). *)
+val oldest_pending_ruling_age_s :
+  base_path:string -> now_ts:float -> float option

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -223,6 +223,65 @@ let test_governance_monitoring_uses_live_runtime () =
       check bool "monitoring exposes live judge_online" true
         (json |> member "judge_online" |> to_bool))
 
+let test_pending_ruling_reflects_disk_truth () =
+  (* #7815: the dashboard previously hardcoded pending_ruling=0 even
+     when .masc/governance_v2/cases/ held stale pending cases.  Seed
+     one case and assert both dashboard surfaces surface it. *)
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let cases_dir =
+        Filename.concat (Filename.concat dir ".masc") "governance_v2/cases"
+      in
+      Fs_compat.mkdir_p cases_dir;
+      let now = Unix.gettimeofday () in
+      let case_json =
+        `Assoc
+          [
+            ("id", `String "case-7815-regression");
+            ("title", `String "High-risk tool: stale fixture");
+            ("status", `String "pending_ruling");
+            ("risk_class", `String "high");
+            ("created_at", `Float (now -. 3600.0));
+          ]
+      in
+      let oc =
+        open_out (Filename.concat cases_dir "case-7815-regression.json")
+      in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc (Yojson.Safe.to_string case_json));
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20
+          ~offset:0 ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let summary = json |> member "summary" in
+      check int "dashboard pending_ruling counts disk" 1
+        (summary |> member "pending_ruling" |> to_int);
+      check int "dashboard cases_open mirrors pending_ruling" 1
+        (summary |> member "cases_open" |> to_int);
+      (match summary |> member "oldest_open_case_age_s" with
+       | `Float age ->
+         check bool "oldest_open_case_age_s > 0" true (age > 0.0)
+       | other ->
+         failf "expected float age, got %s" (Yojson.Safe.to_string other));
+      let (monitoring, ok) =
+        Lib.Dashboard_http_monitoring.governance_monitoring_json ~now_ts:now
+          ~base_path:dir
+      in
+      check bool "monitoring call succeeds" true ok;
+      check int "monitoring pending_ruling counts disk" 1
+        (monitoring |> member "pending_ruling" |> to_int);
+      check string "monitoring alert_level escalates to warn"
+        "warn"
+        (monitoring |> member "alert_level" |> to_string))
+
 let test_governance_dir_created_before_read () =
   let dir = test_dir () in
   Fun.protect
@@ -322,6 +381,8 @@ let () =
             test_governance_monitoring_uses_live_runtime;
           test_case "dashboard exposes keeper approval queue" `Quick
             test_dashboard_exposes_keeper_approval_queue;
+          test_case "pending_ruling reflects disk truth (#7815)" `Quick
+            test_pending_ruling_reflects_disk_truth;
         ] );
       ( "init",
         [


### PR DESCRIPTION
## Summary

Closes #7815. Replace the hardcoded `("pending_ruling", Int 0)` in both dashboard surfaces (`Dashboard_http_monitoring` and `Dashboard_governance.summary_json_of_runtime`) with a live count from `.masc/governance_v2/cases/`.

## Linked issue

Closes #7815.

## Product impact

- Dashboard no longer hides stale `pending_ruling` cases. The 16-day-old high-risk case that motivated the filing is now visible in both the monitoring surface and the governance dashboard.
- Monitoring alert_level escalates to `warn` when any case is `pending_ruling`, so operators get a visible signal instead of silent `ok`.
- Retired buckets (`executed`, `blocked`, `ready_auto_execute`, `ready_to_execute`) stay zero by design — the ruling/execution pipeline remains retired. Only the fields that actually reflect disk truth (`pending_ruling`, `cases_open`, `oldest_open_case_age_s`) now read the filesystem.

## Change

1. `lib/governance_cases_snapshot.ml` + `.mli` (new) — small SSOT module that walks `.masc/governance_v2/cases/*.json`, skips `_`-prefixed markers, parses id/title/status/risk_class/created_at, and offers `pending_ruling_count` + `oldest_pending_ruling_age_s` helpers.
2. `lib/dashboard/dashboard_http_monitoring.ml` — `governance_monitoring_json` now sources `pending_ruling` + `cases_open` + `oldest_open_case_age_s` from the new helper. Adds `alert_level = "warn"` when the count is positive.
3. `lib/dashboard/dashboard_governance.ml` — `summary_json_of_runtime` takes an optional `~base_path` and delegates to the same helper when provided. `dashboard_json` passes `base_path` through.
4. `lib/dune` — register the new module.
5. `test/test_dashboard_governance.ml` — regression test: seed a pending case → assert both surfaces return `pending_ruling = 1` and monitoring `alert_level = "warn"`.

## Intentionally unchanged

- `Meta_cognition_snapshot.load_governance_cases` is kept as-is (consumed by `Meta_cognition_rules.tension_rules`). Migrating it to the new helper is a refactor outside the scope of this fix; it reads the same directory and would not alter tension rule outputs today.

## Evidence

- `test_dashboard_governance.exe` — 7/7 OK including the new `pending_ruling reflects disk truth (#7815)` case.
- `dune build --root . @check` — clean.

## Review evidence

- Pre-fix: the new test fails with `pending_ruling = 0` (hardcoded path).
- Post-fix: it reports the seeded case correctly and `alert_level` escalates.
- Module boundary: `Governance_cases_snapshot` is a pure read helper, no side effects.

## Test plan

- [x] Dashboard regression suite green
- [x] Dev build
- [ ] CI green