### PR TITLE
feat(dashboard): semantic color sweep — 19 files → design-system tokens

### DIFF
--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -229,10 +229,10 @@ export function AgentDetailMemory({ agentName }: Props) {
                               : '○'
                         const outcomeColor =
                           ep.outcome === 'success'
-                            ? 'text-emerald-400'
+                            ? 'text-[var(--ok)]'
                             : ep.outcome === 'partial'
-                              ? 'text-amber-400'
-                              : 'text-red-400'
+                              ? 'text-[var(--warn)]'
+                              : 'text-[var(--bad-light)]'
                         return html`
                           <div class="border border-zinc-800 rounded px-2 py-1.5 text-xs">
                             <div class="flex items-center justify-between gap-2">

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -47,10 +47,10 @@ function outcomeLabel(a: Attribution): string {
 
 function outcomeToneClass(kind: Attribution['outcome']['kind']): string {
   switch (kind) {
-    case 'passed': return 'text-emerald-400'
-    case 'policy_failed': return 'text-rose-400'
-    case 'transition_blocked': return 'text-rose-400'
-    case 'partial_pass': return 'text-amber-400'
+    case 'passed': return 'text-[var(--ok)]'
+    case 'policy_failed': return 'text-[var(--bad-light)]'
+    case 'transition_blocked': return 'text-[var(--bad-light)]'
+    case 'partial_pass': return 'text-[var(--warn)]'
   }
 }
 
@@ -143,10 +143,10 @@ function GateCard({
             <span class="text-[10px] text-[var(--text-muted)]">${total}건</span>
           </div>
           <div class="grid grid-cols-2 gap-1 text-[11px]">
-            <span class="text-emerald-400">✓ ${passed}</span>
-            <span class="text-amber-400">◐ ${partial}</span>
-            <span class="text-rose-400">✗ ${policyFailed}</span>
-            <span class="text-rose-400">⊘ ${blocked}</span>
+            <span class="text-[var(--ok)]">✓ ${passed}</span>
+            <span class="text-[var(--warn)]">◐ ${partial}</span>
+            <span class="text-[var(--bad-light)]">✗ ${policyFailed}</span>
+            <span class="text-[var(--bad-light)]">⊘ ${blocked}</span>
           </div>
         </div>
       </${SurfaceCard}>

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -514,7 +514,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
           <div class="flex flex-col gap-1">
             <label class="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
               <span>${field.name}</span>
-              ${field.required ? html`<span class="text-rose-400" aria-label="required">*</span>` : null}
+              ${field.required ? html`<span class="text-[var(--bad-light)]" aria-label="required">*</span>` : null}
               <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
             </label>
             <${FieldWidget}

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -80,7 +80,7 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   Stopped:      'bg-zinc-800 text-zinc-400 border-zinc-700',
   Crashed:      'bg-red-950 text-red-300 border-red-800',
   Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
-  Dead:         'bg-black text-red-400 border-red-900',
+  Dead:         'bg-black text-[var(--bad-light)] border-red-900',
   Offline:      'bg-zinc-900 text-zinc-500 border-zinc-800',
   // KTC
   idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -88,7 +88,7 @@ function trendArrow(direction: TrendDirection): string {
 function trendColorClass(direction: TrendDirection, metric: MetricKey): string {
   if (direction === 'flat') return 'text-[var(--text-dim)]'
   const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
-  return bad ? 'text-red-400' : 'text-emerald-400'
+  return bad ? 'text-[var(--bad-light)]' : 'text-[var(--ok)]'
 }
 
 function sparklineColor(metric: MetricKey, direction: TrendDirection): string {
@@ -285,7 +285,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               </td>
               <td class="py-1.5 text-center">
                 <button
-                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-[var(--bad-light)] hover:bg-red-400/10 transition-colors"
                   onClick=${() => onReset(row.name)}
                   title="초기화"
                   aria-label=${`${row.name} 초기화`}
@@ -466,7 +466,7 @@ export function FleetTelemetryPanel() {
   }
 
   if (value.error) {
-    return html`<div class="p-4 text-[11px] text-red-400">${value.error}</div>`
+    return html`<div class="p-4 text-[11px] text-[var(--bad-light)]">${value.error}</div>`
   }
 
   const handleReset = async (name: string) => {
@@ -499,8 +499,8 @@ export function FleetTelemetryPanel() {
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
           <div class="flex items-center gap-2 text-[10px]">
-            ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-emerald-400">${activeCount} 가동</span>` : null}
-            ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-400">${attentionCount} 주의</span>` : null}
+            ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
+            ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
             ${offlineCount > 0 ? html`<span class="rounded-full bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
             ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-300">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -275,11 +275,11 @@ export function HeroPhase({
   }, [snapshot.phase])
 
   const phaseColor: Record<string, string> = {
-    Running: 'text-emerald-400',
-    Overflowed: 'text-amber-400',
-    Compacting: 'text-amber-400',
+    Running: 'text-[var(--ok)]',
+    Overflowed: 'text-[var(--warn)]',
+    Compacting: 'text-[var(--warn)]',
     HandingOff: 'text-violet-400',
-    Failing: 'text-red-400',
+    Failing: 'text-[var(--bad-light)]',
     Stable: 'text-[var(--text-dim)]',
   }
   const color = phaseColor[snapshot.phase] ?? 'text-[var(--accent)]'

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -648,7 +648,7 @@ function StatusBar({
     && (now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)) > 300
   const liveBadge = snapshot
     ? snapshot.is_live
-      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-emerald-400 border-emerald-500/40 bg-emerald-500/10 animate-pulse">● 실행 중</span>`
+      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-[var(--ok)] border-emerald-500/40 bg-emerald-500/10 animate-pulse">● 실행 중</span>`
       : html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-amber-500/30' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-[8px] opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
 
@@ -704,11 +704,11 @@ function StatusBar({
             </span>
           ` : null}
           ${staleSec > 120 ? html`
-            <span class="text-[10px] font-mono text-red-400 animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
+            <span class="text-[10px] font-mono text-[var(--bad-light)] animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : staleSec > 60 ? html`
-            <span class="text-[10px] font-mono text-amber-400" title="마지막 관측이 1분 이상 경과">
+            <span class="text-[10px] font-mono text-[var(--warn)]" title="마지막 관측이 1분 이상 경과">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : null}

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -321,7 +321,7 @@ export function HandoffTimeline({
         />
       </div>
       ${error !== null
-        ? html`<p class="text-[11px] text-red-400">오류: ${error}</p>`
+        ? html`<p class="text-[11px] text-[var(--bad-light)]">오류: ${error}</p>`
         : rows.length === 0
           ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
           : isFiltering && visibleRows.length === 0

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -274,7 +274,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
           ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
           : hasOverride
             ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
-            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
+            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형"

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -440,7 +440,7 @@ function CheckpointSummaryCard({
           ${summary.message_count} msgs
         </span>
         ${summary.system_prompt_present
-          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">system kept</span>`
+          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-[var(--ok)]">system kept</span>`
           : null}
       </div>
       <div class="mt-2 text-[11px] text-[var(--text-muted)]">
@@ -622,7 +622,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                           ${item.message_count} msgs
                         </span>
                         ${item.system_prompt_present
-                          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">system kept</span>`
+                          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-[var(--ok)]">system kept</span>`
                           : null}
                       </div>
                       <div class="mt-1 text-[11px] text-[var(--text-muted)]">
@@ -768,7 +768,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                     <div class="flex items-center gap-2">
                       <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
                       <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
-                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
+                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-[var(--warn)] border border-amber-500/20">shallow</span>` : null}
                     </div>
                     <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
@@ -787,7 +787,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
                   <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
                   <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${pr.branch}</span>
-                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">draft</span>` : null}
+                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-[var(--warn)] border border-amber-500/20">draft</span>` : null}
                   <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}
@@ -940,9 +940,9 @@ export function lineageTransitionLabel(parentGeneration: number | null | undefin
 function verdictBadgeClass(verdict: string | undefined): string {
   switch (verdict) {
     case 'verified':
-      return 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+      return 'bg-emerald-500/10 text-[var(--ok)] border border-emerald-500/20'
     case 'drift_detected':
-      return 'bg-amber-500/10 text-amber-400 border border-amber-500/20'
+      return 'bg-amber-500/10 text-[var(--warn)] border border-amber-500/20'
     case 'unavailable':
       return 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
     default:
@@ -1262,7 +1262,7 @@ export function KeeperDetailOverlay() {
                   return html`
                     <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold uppercase tracking-wide
                       ${canPR
-                        ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
+                        ? 'bg-emerald-500/10 text-[var(--ok)] border border-emerald-500/20'
                         : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
                       }"
                       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -359,8 +359,8 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
               </div>
               <span class="text-zinc-300 w-10 text-right">${pct}%</span>
               <${WeightSparkline} history=${s.weight_history} />
-              <span class="text-emerald-400 w-8 text-right">${s.success_count}</span>
-              <span class="text-red-400 w-8 text-right">${s.failure_count}</span>
+              <span class="text-[var(--ok)] w-8 text-right">${s.success_count}</span>
+              <span class="text-[var(--bad-light)] w-8 text-right">${s.failure_count}</span>
             </div>
           `
         })}
@@ -394,8 +394,8 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
           <span class="text-zinc-300 w-10 text-right">${pct}%</span>
         </div>
       </td>
-      <td class="py-1.5 px-2 text-sm text-emerald-400 text-center">${s.success_count}</td>
-      <td class="py-1.5 px-2 text-sm text-red-400 text-center">${s.failure_count}</td>
+      <td class="py-1.5 px-2 text-sm text-[var(--ok)] text-center">${s.success_count}</td>
+      <td class="py-1.5 px-2 text-sm text-[var(--bad-light)] text-center">${s.failure_count}</td>
       <td class="py-1.5 px-2 text-xs text-zinc-500">${formatTimeAgo(s.last_updated * 1000)}</td>
     </tr>
   `
@@ -404,10 +404,10 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
 function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
   const outcomeColor =
     ep.outcome === 'success'
-      ? 'text-emerald-400'
+      ? 'text-[var(--ok)]'
       : ep.outcome === 'partial'
-        ? 'text-amber-400'
-        : 'text-red-400'
+        ? 'text-[var(--warn)]'
+        : 'text-[var(--bad-light)]'
   const outcomeIcon =
     ep.outcome === 'success' ? '●' : ep.outcome === 'partial' ? '◐' : '○'
   return html`
@@ -504,7 +504,7 @@ export function MemorySubsystems() {
   const { loading, error, data } = state.value
   if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
   if (error && !data)
-    return html`<div class="p-4 text-red-400">Error: ${error}</div>`
+    return html`<div class="p-4 text-[var(--bad-light)]">Error: ${error}</div>`
 
   const synapses = data?.hebbian?.synapses ?? []
   const lastConsolidation = data?.hebbian?.last_consolidation ?? 0

--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -54,9 +54,9 @@ function Row({
   tone?: 'neutral' | 'ok' | 'warn' | 'bad'
 }) {
   const toneClass =
-    tone === 'ok' ? 'text-emerald-400'
+    tone === 'ok' ? 'text-[var(--ok)]'
       : tone === 'warn' ? 'text-amber-300'
-      : tone === 'bad' ? 'text-red-400'
+      : tone === 'bad' ? 'text-[var(--bad-light)]'
       : 'text-text-strong'
   return html`
     <div class="flex items-center justify-between gap-4 text-[11px]">

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -46,9 +46,9 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
   const lastRate = windowed[windowed.length - 1]?.point.success_rate ?? null
   const lastRateColor =
     lastRate == null ? 'text-text-dim'
-      : lastRate >= 97 ? 'text-emerald-400'
+      : lastRate >= 97 ? 'text-[var(--ok)]'
       : lastRate >= 90 ? 'text-text-strong'
-      : 'text-red-400'
+      : 'text-[var(--bad-light)]'
 
   return html`
     <div class="flex items-center gap-3">
@@ -60,7 +60,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
           </div>
         ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
         ${anomalyCount > 0 ? html`
-          <div class="text-[10px] font-mono text-red-400">${anomalyCount} anomaly</div>
+          <div class="text-[10px] font-mono text-[var(--bad-light)]">${anomalyCount} anomaly</div>
         ` : null}
       </div>
       <div
@@ -116,7 +116,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
                   cy="${y.toFixed(1)}"
                   r=${r.isAnomaly ? '3' : '1.5'}
                   fill="currentColor"
-                  class=${r.isAnomaly ? (r.zScore < 0 ? 'text-red-400' : 'text-amber-400') : 'text-accent'}
+                  class=${r.isAnomaly ? (r.zScore < 0 ? 'text-[var(--bad-light)]' : 'text-[var(--warn)]') : 'text-accent'}
                   stroke=${r.isAnomaly ? 'currentColor' : 'none'}
                   stroke-width=${r.isAnomaly ? '0.5' : '0'}
                 >

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -283,7 +283,7 @@ export function Observatory() {
               type="button"
               class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
                 liveMode.value
-                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-[var(--ok)]'
                   : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
               }"
               onClick=${() => {

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -94,9 +94,9 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
       <div class="w-24 shrink-0">
         <div class="text-[11px] font-semibold text-text-muted">도구 호출</div>
         <div class="text-[10px] text-text-dim">
-          <span class="text-emerald-400">${successCount}</span>
+          <span class="text-[var(--ok)]">${successCount}</span>
           <span class="text-text-dim/60 mx-0.5">·</span>
-          <span class="text-red-400">${failureCount}</span>
+          <span class="text-[var(--bad-light)]">${failureCount}</span>
         </div>
       </div>
       <div

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -357,7 +357,7 @@ export function PrometheusMetrics() {
                   ${catMetrics.length} metrics
                 </span>
                 ${activeSamples > 0 && html`
-                  <span class="rounded-full bg-emerald-900/30 px-2 py-0.5 text-[10px] text-emerald-400">
+                  <span class="rounded-full bg-emerald-900/30 px-2 py-0.5 text-[10px] text-[var(--ok)]">
                     ${activeSamples} active
                   </span>
                 `}
@@ -394,7 +394,7 @@ export function PrometheusMetrics() {
                                 ${i === 0 && html`<div class="text-[10px] text-[var(--text-muted)] font-sans">${m.help}</div>`}
                               </td>
                               <td class="py-1.5">${i === 0 ? typeBadge(m.type) : null}</td>
-                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-emerald-400' : 'text-[var(--text-muted)]'}">
+                              <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--ok)]' : 'text-[var(--text-muted)]'}">
                                 ${fmtValue(s.value, m.type, s.name)}
                               </td>
                             </tr>

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -64,7 +64,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
             <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
           ${entry.sensitive ? html`
-            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">sensitive</span>
+            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-[var(--warn)]">sensitive</span>
           ` : null}
         </div>
         <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -440,7 +440,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
 }
 
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
-  const toneColor = tone === 'ok' ? 'text-emerald-400' : tone === 'warn' ? 'text-amber-400' : 'text-[var(--text-muted)]'
+  const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'
   return html`
     <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
       <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
@@ -476,7 +476,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
           ${timeAgoSafe(ts)}
         </span>
         ${success != null ? html`
-          <span class="flex-shrink-0 w-4 ${success ? 'text-green-400' : 'text-red-400'}">
+          <span class="flex-shrink-0 w-4 ${success ? 'text-[var(--ok)]' : 'text-[var(--bad-light)]'}">
             ${success ? 'O' : 'X'}
           </span>
         ` : html`<span class="w-4"></span>`}
@@ -841,7 +841,7 @@ export function TelemetryUnified() {
       </div>
 
       ${error ? html`
-        <div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+        <div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-[var(--bad-light)]">
           ${error}
         </div>
       ` : null}

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -424,7 +424,7 @@ function TextModeToggle({
   return html`
     <div class="flex gap-2">
       <button type="button"
-        class="text-[10px] text-emerald-400 hover:text-emerald-300 cursor-pointer transition-colors"
+        class="text-[10px] text-[var(--ok)] hover:text-emerald-300 cursor-pointer transition-colors"
         onClick=${() => {
           listSig.value = parseToolList(textInputBuffer.value)
           textInputSection.value = null
@@ -688,7 +688,7 @@ export function ToolAllowlistEditor({
         ? html`<span class="text-[10px] text-[var(--bad)]">${lastError.value}</span>`
         : null}
       ${lastSuccess.value
-        ? html`<span class="text-[10px] text-emerald-400">${lastSuccess.value}</span>`
+        ? html`<span class="text-[10px] text-[var(--ok)]">${lastSuccess.value}</span>`
         : null}
     </div>
   `


### PR DESCRIPTION
## 요약

Anyang Sleepers 디자인 시스템 토큰 마이그레이션 배치 PR. 이전 callsite PRs(#8242 · #8246 · #8257)은 파일 단위로 1-2개씩 처리했지만, 나머지 \`text-{red,rose,emerald,green,yellow,amber}-400\` hardcoded Tailwind 색상은 의미가 동일하고 패턴이 단순하므로 19개 파일을 한 번에 일괄 치환합니다.

## 매핑

| 이전 | → | 이후 |
|---|---|---|
| text-red-400, text-rose-400 | → | text-[var(--bad-light)] |
| text-emerald-400, text-green-400 | → | text-[var(--ok)] |
| text-yellow-400, text-amber-400 | → | text-[var(--warn)] |

amber+yellow, emerald+green, red+rose는 severity 역할이 동일한 팔레트 쌍. 한 토큰으로 통합해도 시각 회귀 의도 없음.

## Files (19)

\`\`\`
agent-detail-memory.ts   attribution-panel.ts        connector-config-form.ts
cross-signal-readout.ts  fleet-fsm-matrix.ts         fleet-telemetry-panel.ts
fsm-hub.ts               fsm-hub-pipeline-panels.ts  handoff-timeline.ts
keeper-detail.ts         keeper-detail-runtime.ts    memory-subsystems.ts
metric-track.ts          observatory.ts              prometheus-metrics.ts
server-config.ts         telemetry-unified.ts        tool-allowlist-editor.ts
tool-call-track.ts
\`\`\`

## 비스코프 (의식적 제외)

- \`-100\`, \`-200\`, \`-300\`, \`-500\` 변형 (legend, pill 배경 등 — 단일 semantic 토큰으로 환원 시 detail 손실 가능)
- \`bg-emerald-500/10\` 같은 background variants
- 이들은 후속 PR에서 case-by-case 검토

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] 단일 파일 단위 vitest는 모두 통과 (telemetry-unified 21/21 등)
- 병렬 full suite는 5s timeout hit (기존 flakiness, 이 PR과 무관)

## Related

- #8177 paper theme 인프라 (semantic 토큰 SSOT)
- #8242 #8246 #8257 1-file callsite migrations