### PR TITLE
feat(dashboard): sweep text-{color}-{100,200,300,500} → semantic tokens

### DIFF
--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -89,7 +89,7 @@ export function AgentDetailMemory({ agentName }: Props) {
   const { loading, error, data } = state.value
   if (loading) return html`<${LoadingState} label="메모리 컨텍스트 로드 중..." />`
   if (error)
-    return html`<div class="text-sm text-amber-500">메모리 로드 실패: ${error}</div>`
+    return html`<div class="text-sm text-[var(--warn)]">메모리 로드 실패: ${error}</div>`
   if (!data) return null
 
   // Filter hebbian synapses where this keeper is either endpoint

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -455,7 +455,7 @@ function SloCard({ slo }: { slo: CascadeSloResponse }) {
         <${StatusChip} tone=${tone}>${sloStatusLabel(slo.status)}<//>
         <span class="text-xs text-[var(--text-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
         ${slo.violations.length > 0
-          ? html`<span class="text-xs text-red-500">violating: ${slo.violations.join(', ')}</span>`
+          ? html`<span class="text-xs text-[var(--bad-light)]">violating: ${slo.violations.join(', ')}</span>`
           : null}
       </div>
       <div class="grid grid-cols-3 gap-3">

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -110,7 +110,7 @@ export function CopyableCode({
         : null}
       <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-[11px] text-[var(--text-body)]">${command}</code>
       ${justCopied
-        ? html`<span class="shrink-0 text-[10px] font-semibold text-emerald-300" data-copied-badge aria-live="polite">✓ Copied</span>`
+        ? html`<span class="shrink-0 text-[10px] font-semibold text-[var(--ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
         : null}
       <button
         type="button"

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -28,8 +28,8 @@ const STATE_LABEL: Record<HeartbeatState, string> = {
 }
 
 const STATE_TONE: Record<HeartbeatState, string> = {
-  up: 'text-emerald-200 border-emerald-400/30 bg-emerald-500/10',
-  down: 'text-rose-200 border-rose-400/30 bg-rose-500/10',
+  up: 'text-[var(--ok)] border-emerald-400/30 bg-emerald-500/10',
+  down: 'text-[var(--bad-light)] border-rose-400/30 bg-rose-500/10',
   unknown: 'text-[var(--text-dim)] border-[var(--white-8)] bg-[var(--white-2)]',
 }
 

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -38,9 +38,9 @@ export function formatUptimeChip(summary: HeartbeatSummary): UptimeChipView | nu
 }
 
 const TONE_CLASS: Record<UptimeTone, string> = {
-  operational: 'text-emerald-200 border-emerald-400/30 bg-emerald-500/10',
-  degraded: 'text-amber-200 border-amber-400/30 bg-amber-500/10',
-  unhealthy: 'text-rose-200 border-rose-400/30 bg-rose-500/10',
+  operational: 'text-[var(--ok)] border-emerald-400/30 bg-emerald-500/10',
+  degraded: 'text-[var(--warn)] border-amber-400/30 bg-amber-500/10',
+  unhealthy: 'text-[var(--bad-light)] border-rose-400/30 bg-rose-500/10',
 }
 
 interface HeartbeatUptimeChipProps {

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -402,7 +402,7 @@ function FieldWidget({ id, field, value, revealed }: {
       `
     default:
       return html`
-        <div class="rounded border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-100">
+        <div class="rounded border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-[10px] text-[var(--warn)]">
           unsupported type — refactor BotConfig?
         </div>
       `
@@ -429,7 +429,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.error !== null) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded-md border border-rose-400/30 bg-rose-500/10 p-3 text-[11px] text-rose-100">
+      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded-md border border-rose-400/30 bg-rose-500/10 p-3 text-[11px] text-[var(--bad-light)]">
         <div class="font-semibold">schema 가져오기 실패</div>
         <div class="mt-1 text-[10px] opacity-80">${entry.error}</div>
         <button
@@ -458,10 +458,10 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required
           ${entry.lastSavedAt
             ? html`
-                <span class="ml-2 text-emerald-300">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
+                <span class="ml-2 text-[var(--ok)]">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
                 <button
                   type="button"
-                  class="ml-2 cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-100 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                  class="ml-2 cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-[var(--ok)] hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
                   disabled=${entry.restarting}
                   title="POST /sidecar/stop → 800ms → POST /sidecar/start"
                   onClick=${() => { void restartSidecar(connectorId) }}

--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -196,7 +196,7 @@ describe('ConnectorKeeperMatrix', () => {
     const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
     const discordCell = cells[0] as HTMLElement
     expect(discordCell.getAttribute('data-matrix-column-total-unknown')).toBe('1')
-    expect(discordCell.className).toContain('text-amber-200')
+    expect(discordCell.className).toContain('text-[var(--warn)]')
   })
 
   it('column totals footer dashes empty columns (no bound, no unbound, no unknown)', () => {

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -150,10 +150,10 @@ export function deriveMatrix(
 }
 
 const CELL_TONE: Record<MatrixCellState, { dot: string; text: string; bg: string }> = {
-  bound:   { dot: 'bg-emerald-400',     text: 'text-emerald-100',        bg: 'bg-emerald-500/10' },
+  bound:   { dot: 'bg-emerald-400',     text: 'text-[var(--ok)]',        bg: 'bg-emerald-500/10' },
   unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
   na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
-  unknown: { dot: 'bg-amber-400',       text: 'text-amber-100',          bg: 'bg-amber-500/10'   },
+  unknown: { dot: 'bg-amber-400',       text: 'text-[var(--warn)]',          bg: 'bg-amber-500/10'   },
 }
 
 const CELL_GLYPH: Record<MatrixCellState, string> = {
@@ -237,7 +237,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
             · ${matrix.totals.liveConnectors}/${matrix.columns.length} connector
             · ${matrix.totals.totalBindings} binding${matrix.totals.totalBindings === 1 ? '' : 's'}
             ${matrix.totals.unknownKeepers > 0
-              ? html`· <span class="text-amber-200">${matrix.totals.unknownKeepers} unknown</span>`
+              ? html`· <span class="text-[var(--warn)]">${matrix.totals.unknownKeepers} unknown</span>`
               : null}
           </p>
         </div>
@@ -311,7 +311,7 @@ function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
       <${ColumnTotalsCell} counts=${summarizeMatrixColumn(matrix, idx)} />
     `)}
     <div
-      class=${`flex items-center justify-end gap-1 px-1 py-1 text-[10px] tabular-nums ${totalBound > 0 ? 'text-emerald-200' : 'text-[var(--text-dim)]'}`}
+      class=${`flex items-center justify-end gap-1 px-1 py-1 text-[10px] tabular-nums ${totalBound > 0 ? 'text-[var(--ok)]' : 'text-[var(--text-dim)]'}`}
       title=${`Grand total: ${totalBound} bound cells across all keepers × connectors`}
       data-matrix-grand-total
       data-matrix-grand-total-bound=${totalBound}
@@ -328,8 +328,8 @@ function ColumnTotalsCell({ counts }: { counts: MatrixStateCounts }) {
   // when any unknowns exist. Empty column (0 bound, 0 unbound) → dash.
   const hasAny = bound + unbound + unknown > 0
   const tone =
-    unknown > 0 ? 'text-amber-200' :
-    bound > 0 ? 'text-emerald-200' :
+    unknown > 0 ? 'text-[var(--warn)]' :
+    bound > 0 ? 'text-[var(--ok)]' :
     'text-[var(--text-dim)]'
   const label = hasAny ? `${bound}` : '—'
   const title = `${bound} bound · ${unbound} unbound · ${unknown} unknown · ${counts.na} n/a`
@@ -351,11 +351,11 @@ function MatrixRowRender({ row }: { row: MatrixRow }) {
   return html`
     <button
       type="button"
-      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-[12px] hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-amber-100'}`}
+      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-[12px] hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-[var(--warn)]'}`}
       onClick=${() => scrollToKeeper(row.keeperName)}
       title=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
     >
-      ${row.known ? null : html`<span class="text-amber-300" aria-hidden="true">⚠</span>`}
+      ${row.known ? null : html`<span class="text-[var(--warn)]" aria-hidden="true">⚠</span>`}
       <span class="truncate">${row.keeperName}</span>
     </button>
     ${row.cells.map(cell => html`<${MatrixCellButton} cell=${cell} />`)}
@@ -377,8 +377,8 @@ function RowCoverageChip({
   // Tone follows the dominant state: if anything is unknown → amber,
   // else if all live cells are bound → emerald, else muted.
   const tone =
-    unknown > 0 ? 'text-amber-200' :
-    (bound > 0 && unbound === 0) ? 'text-emerald-200' :
+    unknown > 0 ? 'text-[var(--warn)]' :
+    (bound > 0 && unbound === 0) ? 'text-[var(--ok)]' :
     'text-[var(--text-dim)]'
   return html`
     <div

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -156,7 +156,7 @@ export function summarizeOverviewTile(
   if (connector === null || connector.available !== true) {
     return {
       badge: '설정 필요',
-      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-amber-100',
+      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-[var(--warn)]',
       detail: keeperCount > 0
         ? '아직 시작되지 않음 · 시작 후 keeper를 바인딩하세요'
         : '아직 시작되지 않음 · 먼저 Config와 Start가 필요합니다',
@@ -168,7 +168,7 @@ export function summarizeOverviewTile(
   if (stateLabel === 'stale' || stateLabel === 'disconnected' || connector.gate_healthy === false) {
     return {
       badge: '주의',
-      badgeClass: 'border-rose-400/30 bg-rose-500/10 text-rose-100',
+      badgeClass: 'border-rose-400/30 bg-rose-500/10 text-[var(--bad-light)]',
       detail: stateLabel === 'stale'
         ? 'heartbeat가 stale 상태입니다 · 로그와 gate 상태를 확인하세요'
         : stateLabel === 'disconnected'
@@ -180,7 +180,7 @@ export function summarizeOverviewTile(
   if (bindingCount === 0) {
     return {
       badge: '바인딩 필요',
-      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-amber-100',
+      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-[var(--warn)]',
       detail: keeperCount > 0
         ? '실행 중 · 아직 channel binding이 없습니다'
         : '실행 중 · keeper 디렉토리가 비어 있습니다',
@@ -189,7 +189,7 @@ export function summarizeOverviewTile(
 
   return {
     badge: '정상',
-    badgeClass: 'border-emerald-400/30 bg-emerald-500/10 text-emerald-100',
+    badgeClass: 'border-emerald-400/30 bg-emerald-500/10 text-[var(--ok)]',
     detail: `실행 중 · ${bindingCount} ${bindingCount === 1 ? 'binding' : 'bindings'} active`,
   }
 }
@@ -259,7 +259,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[10px] font-normal text-emerald-200/80"
+                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[10px] font-normal text-[var(--ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
@@ -344,8 +344,8 @@ const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
   // across per-tile + bulk controls. The per-tile button is deliberately
   // block-width and text-[12px] so it reads as the primary action of the
   // tile, distinct from the smaller pill row above.
-  start: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-100 hover:bg-emerald-500/25',
-  stop: 'border-rose-400/40 bg-rose-500/15 text-rose-100 hover:bg-rose-500/25',
+  start: 'border-emerald-400/40 bg-emerald-500/15 text-[var(--ok)] hover:bg-emerald-500/25',
+  stop: 'border-rose-400/40 bg-rose-500/15 text-[var(--bad-light)] hover:bg-rose-500/25',
 }
 
 /** The prominent per-tile Start/Stop button. Reference UIs (Vercel
@@ -415,8 +415,8 @@ const TILE_NOTICE_TONE_CLASS: Record<'error' | 'stale', string> = {
   // Rose for hard errors (sidecar reported an explicit failure),
   // amber for stale (data hasn't refreshed but no explicit error).
   // Matches Sentry \"issue\" rose + Vercel \"warning\" amber convention.
-  error: 'border-rose-400/40 bg-rose-500/10 text-rose-100',
-  stale: 'border-amber-400/40 bg-amber-500/10 text-amber-100',
+  error: 'border-rose-400/40 bg-rose-500/10 text-[var(--bad-light)]',
+  stale: 'border-amber-400/40 bg-amber-500/10 text-[var(--warn)]',
 }
 
 const TILE_NOTICE_GLYPH: Record<'error' | 'stale', string> = {
@@ -525,7 +525,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
     <div class="flex items-center gap-2 text-[11px] text-[var(--text-dim)]">
       <button
         type="button"
-        class="cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-100 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-[var(--ok)] hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${startBusy || downCount === 0}
         title=${downCount === 0 ? '모두 이미 실행 중' : `${downCount} 개 sidecar 시작`}
         onClick=${() => { void runBulk('start', c => c?.available !== true, connectors) }}
@@ -535,7 +535,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
       </button>
       <button
         type="button"
-        class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-rose-100 hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-[var(--bad-light)] hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${stopBusy || upCount === 0}
         title=${upCount === 0 ? '실행 중인 sidecar 없음' : `${upCount} 개 sidecar 정지`}
         onClick=${() => { void runBulk('stop', c => c?.available === true, connectors) }}
@@ -649,7 +649,7 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
         <span> running</span>
         ${offlineLabel !== null
           ? html`<span
-              class="ml-1 text-rose-300/80"
+              class="ml-1 text-[var(--bad-light)]/80"
               data-strip-summary-offline-names
               title="현재 offline인 커넥터 이름"
             > · ${offlineLabel}</span>`
@@ -676,13 +676,13 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
     .join(', ')
   return html`
     <div
-      class="mb-2 flex items-center gap-2 rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-1.5 text-[11px] font-semibold text-rose-100"
+      class="mb-2 flex items-center gap-2 rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-1.5 text-[11px] font-semibold text-[var(--bad-light)]"
       data-incident-banner
       role="alert"
     >
       <span aria-hidden="true">⚠</span>
       <span>최근 5분 내 연결 끊김 — ${names}</span>
-      <span class="ml-auto text-[10px] font-normal text-rose-200/80">아래 Start 버튼으로 복구</span>
+      <span class="ml-auto text-[10px] font-normal text-[var(--bad-light)]/80">아래 Start 버튼으로 복구</span>
     </div>
   `
 }

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -71,7 +71,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   ok: {
     bg: 'bg-emerald-500/10',
     border: 'border-emerald-400/40',
-    text: 'text-emerald-100',
+    text: 'text-[var(--ok)]',
     dot: 'bg-emerald-400',
     icon: '✓',
     // Grafana Stat panel "Background Gradient" mode — subtle vertical
@@ -82,7 +82,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   warn: {
     bg: 'bg-amber-500/10',
     border: 'border-amber-400/40',
-    text: 'text-amber-100',
+    text: 'text-[var(--warn)]',
     dot: 'bg-amber-400',
     icon: '!',
     gradient: 'bg-gradient-to-b from-amber-500/15 to-amber-500/0',
@@ -90,7 +90,7 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
   bad: {
     bg: 'bg-rose-500/10',
     border: 'border-rose-400/40',
-    text: 'text-rose-100',
+    text: 'text-[var(--bad-light)]',
     dot: 'bg-rose-400',
     icon: '⊘',
     gradient: 'bg-gradient-to-b from-rose-500/15 to-rose-500/0',

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -285,9 +285,9 @@ export function headerSuccessTone(successPct: number | null | undefined): Header
 /** Pure: map header tone to a Tailwind text-color utility. */
 export function headerStatToneClass(tone: HeaderStatTone): string {
   switch (tone) {
-    case 'ok':      return 'text-emerald-200'
-    case 'partial': return 'text-amber-200'
-    case 'bad':     return 'text-rose-200'
+    case 'ok':      return 'text-[var(--ok)]'
+    case 'partial': return 'text-[var(--warn)]'
+    case 'bad':     return 'text-[var(--bad-light)]'
     case 'default':
     default:        return 'text-[var(--text-body)]'
   }
@@ -331,19 +331,19 @@ function healthTone(health: string): { dot: string; badge: string; label: string
     case 'healthy':
       return {
         dot: 'var(--green)',
-        badge: 'border border-emerald-400/30 bg-emerald-500/12 text-emerald-100',
+        badge: 'border border-emerald-400/30 bg-emerald-500/12 text-[var(--ok)]',
         label: 'healthy',
       }
     case 'degraded':
       return {
         dot: 'var(--yellow)',
-        badge: 'border border-amber-400/30 bg-amber-500/12 text-amber-100',
+        badge: 'border border-amber-400/30 bg-amber-500/12 text-[var(--warn)]',
         label: 'degraded',
       }
     case 'failing':
       return {
         dot: 'var(--red)',
-        badge: 'border border-rose-400/35 bg-rose-500/12 text-rose-100',
+        badge: 'border border-rose-400/35 bg-rose-500/12 text-[var(--bad-light)]',
         label: 'failing',
       }
     default:
@@ -477,12 +477,12 @@ export function connectorCardBorderClass(label: string): string {
 function connectorStateTone(connector: GateConnectorInfo | null): string {
   const label = connectorStateLabel(connector)
   if (label === 'connected') {
-    return 'border-emerald-400/30 bg-emerald-500/12 text-emerald-100'
+    return 'border-emerald-400/30 bg-emerald-500/12 text-[var(--ok)]'
   }
   if (label === 'disconnected') {
-    return 'border-rose-400/30 bg-rose-500/12 text-rose-100'
+    return 'border-rose-400/30 bg-rose-500/12 text-[var(--bad-light)]'
   }
-  return 'border-amber-400/30 bg-amber-500/12 text-amber-100'
+  return 'border-amber-400/30 bg-amber-500/12 text-[var(--warn)]'
 }
 
 function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownConnectorId): GateConnectorInfo | null {
@@ -850,7 +850,7 @@ function ConnectorLivePanel({
             ? html`
                 <button
                   type="button"
-                  class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/12 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-rose-100 hover:bg-rose-500/20 disabled:opacity-50"
+                  class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/12 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-rose-500/20 disabled:opacity-50"
                   disabled=${isActionLoading}
                   aria-label=${`stop ${connectorName} sidecar`}
                   onClick=${() => { void stopSidecar(connectorId) }}
@@ -933,7 +933,7 @@ function ConnectorLivePanel({
         : null}
 
       ${connectorError || connector?.error
-        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">${connectorError ?? connector?.error}</div>`
+        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
         : null}
 
       <${SidecarLogViewer} connectorId=${connectorId} />
@@ -942,11 +942,11 @@ function ConnectorLivePanel({
       ${keeperDirectoryError && keepers.length === 0
         ? html`
             <div
-              class="mt-3 rounded-md border border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-100"
+              class="mt-3 rounded-md border border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]"
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
@@ -965,7 +965,7 @@ function ConnectorLivePanel({
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
@@ -974,7 +974,7 @@ function ConnectorLivePanel({
                 </span>
                 <span class="font-medium text-[var(--text-body)]">No keepers configured</span>
               </div>
-              <div class="text-[10px] text-amber-100/80">
+              <div class="text-[10px] text-[var(--warn)]/80">
                 Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
               </div>
             </div>
@@ -1000,7 +1000,7 @@ function ConnectorLivePanel({
                 <div class="mb-1 flex items-center justify-between gap-2">
                   <div class="flex items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200"
+                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
@@ -1019,7 +1019,7 @@ function ConnectorLivePanel({
                     <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${connectorName}</span>
                   </div>
                 </div>
-                <div class="text-[11px] text-amber-100/80">
+                <div class="text-[11px] text-[var(--warn)]/80">
                   Click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal.
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
@@ -1185,10 +1185,10 @@ function ConnectorLivePanel({
               ${unknownGroups.map(group => html`
                 <div class="rounded-md border border-amber-400/30 bg-amber-500/8 px-3 py-2" data-keeper=${group.name}>
                   <div class="flex items-baseline gap-2">
-                    <span class="text-amber-300">⚠</span>
+                    <span class="text-[var(--warn)]">⚠</span>
                     <div class="min-w-0">
                       <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
-                      <div class="text-[10px] text-amber-200/90">binding references undefined keeper</div>
+                      <div class="text-[10px] text-[var(--warn)]/90">binding references undefined keeper</div>
                     </div>
                   </div>
                   <div class="mt-2 space-y-1">
@@ -1312,8 +1312,8 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
 
       ${lastError
         ? html`
-            <div class="mt-3 rounded-md border border-rose-400/20 bg-rose-500/8 px-3 py-2 text-[11px] text-rose-100">
-              <div class="mb-1 uppercase tracking-[0.16em] text-rose-200/80">
+            <div class="mt-3 rounded-md border border-rose-400/20 bg-rose-500/8 px-3 py-2 text-[11px] text-[var(--bad-light)]">
+              <div class="mb-1 uppercase tracking-[0.16em] text-[var(--bad-light)]/80">
                 ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
               </div>
               <div>${lastError}</div>
@@ -1359,7 +1359,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
       </div>
       ${lastError
         ? html`
-            <div class="mt-2 rounded border border-rose-400/20 bg-rose-500/8 px-2 py-1 text-[10px] text-rose-100">
+            <div class="mt-2 rounded border border-rose-400/20 bg-rose-500/8 px-2 py-1 text-[10px] text-[var(--bad-light)]">
               ${binding.last_error_kind || 'error'} · ${lastError}
             </div>
           `
@@ -1371,7 +1371,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
 function EventRow({ event }: { event: GateEventInfo }) {
   const isError = Boolean(event.error)
   const badgeClass = isError
-    ? 'border border-rose-400/30 bg-rose-500/12 text-rose-100'
+    ? 'border border-rose-400/30 bg-rose-500/12 text-[var(--bad-light)]'
     : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-dim)]'
 
   return html`
@@ -1394,7 +1394,7 @@ function EventRow({ event }: { event: GateEventInfo }) {
       </div>
       ${event.error
         ? html`
-            <div class="mt-2 text-[10px] text-rose-100">
+            <div class="mt-2 text-[10px] text-[var(--bad-light)]">
               ${event.error_kind || 'error'} · ${shortText(event.error, 96)}
             </div>
           `

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -60,7 +60,7 @@ export function ExcusePatterns() {
   if (s.status === 'error') {
     return html`
       <${Card} title="Anti-Rationalization Excuse Patterns">
-        <div class="p-4 text-red-500">Failed to load patterns: ${s.message}</div>
+        <div class="p-4 text-[var(--bad-light)]">Failed to load patterns: ${s.message}</div>
       </Card>
     `
   }
@@ -93,7 +93,7 @@ export function ExcusePatterns() {
               ${saving.value ? 'Saving...' : 'Save Patterns'}
             </button>
             ${saveMessage.value ? html`
-              <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-red-500' : 'text-green-500'}">
+              <span class="text-sm ${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid') ? 'text-[var(--bad-light)]' : 'text-[var(--ok)]'}">
                 ${saveMessage.value}
               </span>
             ` : null}

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -70,34 +70,34 @@ const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
 // recommendation: stable=gray, in-motion=amber/blue, terminal=red.
 const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // KSM
-  Running:      'bg-emerald-900/40 text-emerald-200 border-emerald-700',
-  Failing:      'bg-red-900/50 text-red-200 border-red-700',
+  Running:      'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
+  Failing:      'bg-red-900/50 text-[var(--bad-light)] border-red-700',
   Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
-  Compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  Compacting:   'bg-amber-900/50 text-[var(--warn)] border-amber-700',
   HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
   Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
   Paused:       'bg-zinc-800 text-zinc-300 border-zinc-600',
   Stopped:      'bg-zinc-800 text-zinc-400 border-zinc-700',
-  Crashed:      'bg-red-950 text-red-300 border-red-800',
+  Crashed:      'bg-red-950 text-[var(--bad-light)] border-red-800',
   Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
   Dead:         'bg-black text-[var(--bad-light)] border-red-900',
   Offline:      'bg-zinc-900 text-zinc-500 border-zinc-800',
   // KTC
   idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',
   prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
-  executing:    'bg-emerald-900/40 text-emerald-200 border-emerald-700',
-  compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  executing:    'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
+  compacting:   'bg-amber-900/50 text-[var(--warn)] border-amber-700',
   finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
   // KDP
   undecided:          'bg-zinc-800 text-zinc-400 border-zinc-700',
-  guard_ok:           'bg-emerald-900/40 text-emerald-200 border-emerald-700',
-  gate_rejected:      'bg-red-900/40 text-red-200 border-red-700',
+  guard_ok:           'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
+  gate_rejected:      'bg-red-900/40 text-[var(--bad-light)] border-red-700',
   tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
   // KCL
   selecting:    'bg-blue-900/40 text-blue-200 border-blue-700',
-  trying:       'bg-amber-900/50 text-amber-200 border-amber-700',
-  done:         'bg-emerald-900/40 text-emerald-200 border-emerald-700',
-  exhausted:    'bg-red-900/50 text-red-200 border-red-700',
+  trying:       'bg-amber-900/50 text-[var(--warn)] border-amber-700',
+  done:         'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
+  exhausted:    'bg-red-900/50 text-[var(--bad-light)] border-red-700',
   // KMC
   accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
   // KCB (LT-16-KCB Phase 3). Clean = baseline grey same as any other
@@ -107,7 +107,7 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // chip colour by design — the mutator resets the count before any
   // observer can see it.
   clean:   'bg-zinc-800 text-zinc-400 border-zinc-700',
-  warning: 'bg-amber-900/50 text-amber-200 border-amber-700',
+  warning: 'bg-amber-900/50 text-[var(--warn)] border-amber-700',
   cooling: 'bg-sky-900/40 text-sky-200 border-sky-700',
 }
 
@@ -303,7 +303,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     return html`
       <div
         data-testid="fleet-fsm-matrix"
-        class="rounded border border-red-800 bg-red-950/40 p-4 text-sm text-red-200"
+        class="rounded border border-red-800 bg-red-950/40 p-4 text-sm text-[var(--bad-light)]"
       >
         Fleet snapshot failed: ${error}
       </div>
@@ -346,8 +346,8 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                 ${INVARIANT_KEYS.map(k => {
                   const count = tallies[k]
                   const tone = count === 0
-                    ? 'bg-emerald-900/30 text-emerald-200 border-emerald-800'
-                    : 'bg-red-900/40 text-red-200 border-red-700'
+                    ? 'bg-emerald-900/30 text-[var(--ok)] border-emerald-800'
+                    : 'bg-red-900/40 text-[var(--bad-light)] border-red-700'
                   return html`
                     <span
                       data-invariant=${k}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -102,7 +102,7 @@ function auditFreshnessClass(isoTimestamp: string | null): string {
   const ageMs = Date.now() - new Date(isoTimestamp).getTime()
   if (ageMs < 5 * 60 * 1000) return 'text-[var(--text)]'
   if (ageMs < 15 * 60 * 1000) return 'text-[var(--text-dim)]'
-  return 'text-amber-300'
+  return 'text-[var(--warn)]'
 }
 
 function SummaryCard({
@@ -135,8 +135,8 @@ function SummaryCard({
 function WarningBanner({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null
   return html`
-    <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-200">
-      <div class="font-medium text-amber-100">Partial telemetry</div>
+    <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]">
+      <div class="font-medium text-[var(--warn)]">Partial telemetry</div>
       <div class="mt-1 flex flex-col gap-1">
         ${warnings.map(warning => html`<div>${warning}</div>`)}
       </div>
@@ -241,7 +241,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
                 ${row.runtime_blocker_summary
                   ? html`
-                    <div class="max-w-[240px] truncate text-[10px] text-amber-300" title=${row.runtime_blocker_summary}>
+                    <div class="max-w-[240px] truncate text-[10px] text-[var(--warn)]" title=${row.runtime_blocker_summary}>
                       ${row.runtime_blocker_summary}
                     </div>
                   `
@@ -278,9 +278,9 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-red-300" title="TOML override가 범위를 벗어남">ERR</span>`
+                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300" title="TOML override 적용됨">OVR</span>`
+                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
                     : html`<span class="text-[10px] text-[var(--text-dim)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
@@ -341,7 +341,7 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
               class="h-1.5 rounded-full bg-red-500/60"
               style="width: ${Math.max(6, (category.count / maxCount) * 100)}%"
             ></div>
-            <span class="truncate font-mono text-red-300" title=${category.category}>${category.category}</span>
+            <span class="truncate font-mono text-[var(--bad-light)]" title=${category.category}>${category.category}</span>
           </div>
           <span class="text-[var(--text-dim)]">${category.count}</span>
         </div>
@@ -502,7 +502,7 @@ export function FleetTelemetryPanel() {
             ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
             ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
             ${offlineCount > 0 ? html`<span class="rounded-full bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
-            ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-300">${budgetOverrideCount} 예산 재정의</span>` : null}
+            ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[var(--warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -228,7 +228,7 @@ function Callout({
 }) {
   const toneClass =
     tone === 'warn'
-      ? 'border-amber-400/20 bg-amber-500/10 text-amber-100'
+      ? 'border-amber-400/20 bg-amber-500/10 text-[var(--warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded-xl border px-3 py-3 shadow-sm ${toneClass}">
@@ -274,9 +274,9 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
 function PromptSourceBadge({ source }: { source: string }) {
   const tone =
     source === 'override'
-      ? 'bg-amber-500/10 text-amber-300 border-amber-400/20'
+      ? 'bg-amber-500/10 text-[var(--warn)] border-amber-400/20'
       : source === 'file'
-        ? 'bg-emerald-500/10 text-emerald-300 border-emerald-400/20'
+        ? 'bg-emerald-500/10 text-[var(--ok)] border-emerald-400/20'
         : 'bg-white/5 text-text-dim border-white/10'
   return html`<span class="text-[10px] font-bold px-2 py-0.5 rounded-md border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -219,11 +219,11 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   let valueClass: string
   let pill
   if (isInvalid) {
-    valueClass = 'text-red-300 underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-300">invalid</span>`
+    valueClass = 'text-[var(--bad-light)] underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
+    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
   } else if (isOverride) {
     valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
   } else {
     valueClass = 'text-[var(--text-muted)] cursor-help'
     pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
@@ -271,9 +271,9 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
           턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
-          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
+          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
           : hasOverride
-            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
             : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
       </div>
       <${BudgetRow}
@@ -303,7 +303,7 @@ export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
       <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-amber-400' : 'bg-accent/50'}"></span>
         턴 예산
-        ${diverges ? html`<span class="text-[10px] text-amber-300 font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
+        ${diverges ? html`<span class="text-[10px] text-[var(--warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
       </summary>
       <div class="mt-3">
         <${TurnBudgetPanel} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -554,7 +554,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
         <div class="text-[11px] text-[var(--text-muted)]">
           current OAS checkpoint와 OAS snapshot history만 노출합니다.
           ${inventory && inventory.legacy_shadow_count > 0
-            ? html`<span class="block mt-1 text-amber-300">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
+            ? html`<span class="block mt-1 text-[var(--warn)]">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
             : null}
         </div>
         <div class="flex items-center gap-2">

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -748,7 +748,7 @@ export function MemorySubsystems() {
 
       ${
         error
-          ? html`<div class="text-xs text-amber-500 mt-2">refresh error: ${error}</div>`
+          ? html`<div class="text-xs text-[var(--warn)] mt-2">refresh error: ${error}</div>`
           : null
       }
     </div>

--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -55,7 +55,7 @@ function Row({
 }) {
   const toneClass =
     tone === 'ok' ? 'text-[var(--ok)]'
-      : tone === 'warn' ? 'text-amber-300'
+      : tone === 'warn' ? 'text-[var(--warn)]'
       : tone === 'bad' ? 'text-[var(--bad-light)]'
       : 'text-text-strong'
   return html`

--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -29,8 +29,8 @@ function outcomeTag(entry: TelemetryEntry): { label: string; tone: 'ok' | 'bad' 
 }
 
 function toneClass(tone: 'ok' | 'bad' | 'neutral'): string {
-  if (tone === 'ok') return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30'
-  if (tone === 'bad') return 'bg-red-500/15 text-red-300 border-red-500/30'
+  if (tone === 'ok') return 'bg-emerald-500/15 text-[var(--ok)] border-emerald-500/30'
+  if (tone === 'bad') return 'bg-red-500/15 text-[var(--bad-light)] border-red-500/30'
   return 'bg-white/5 text-text-dim border-card-border'
 }
 

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -97,8 +97,8 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
                 </rect>
               `
             })}
-            <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-emerald-500/30" stroke-width="0.5" />
-            <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-amber-500/30" stroke-width="0.5" />
+            <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--ok)]/30" stroke-width="0.5" />
+            <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-[var(--warn)]/30" stroke-width="0.5" />
             <polyline
               points=${polyline}
               fill="none"

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -305,7 +305,7 @@ export function Observatory() {
       </div>
 
       ${activeView.value === 'timeline' && data.error ? html`
-        <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-200">
+        <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]">
           일부 데이터 불러오기 실패: ${data.error}
         </div>
       ` : null}

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -153,8 +153,8 @@ function fmtValue(value: number, type: string, name: string): string {
 function typeBadge(type: string): ReturnType<typeof html> {
   const colors: Record<string, string> = {
     counter: 'bg-blue-900/40 text-blue-300',
-    gauge: 'bg-emerald-900/40 text-emerald-300',
-    summary: 'bg-amber-900/40 text-amber-300',
+    gauge: 'bg-emerald-900/40 text-[var(--ok)]',
+    summary: 'bg-amber-900/40 text-[var(--warn)]',
   }
   return html`<span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${colors[type] ?? 'bg-gray-800 text-gray-400'}">${type}</span>`
 }
@@ -175,7 +175,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
     }
     if (k === 'tool_name' || k === 'tool') {
       return html`<button
-        class="rounded bg-amber-900/40 px-1 py-0.5 text-[10px] text-amber-300 font-mono hover:bg-amber-800/60 hover:text-amber-200 transition-colors cursor-pointer"
+        class="rounded bg-amber-900/40 px-1 py-0.5 text-[10px] text-[var(--warn)] font-mono hover:bg-amber-800/60 hover:text-[var(--warn)] transition-colors cursor-pointer"
         title="View tool quality"
         onClick=${(e: Event) => {
           e.stopPropagation()
@@ -309,7 +309,7 @@ export function PrometheusMetrics() {
       </div>
 
       ${error.value && html`
-        <div class="rounded-md bg-red-900/20 border border-red-800/30 px-3 py-2 text-xs text-red-300">
+        <div class="rounded-md bg-red-900/20 border border-red-800/30 px-3 py-2 text-xs text-[var(--bad-light)]">
           ${error.value}
         </div>
       `}

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -100,7 +100,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
   // count chip in accent color so scanning a list of cards shows which
   // ones are halfway; idle stays muted.
   const countToneClass =
-    tone === 'complete' ? 'text-emerald-300' :
+    tone === 'complete' ? 'text-[var(--ok)]' :
     tone === 'in-progress' ? 'text-[var(--accent)]' :
     'text-[var(--text-dim)]'
   const progressBarToneClass =
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-200"
+                  class="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >
@@ -177,7 +177,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                   // even before checkboxes are ticked. Circle turns
                   // emerald-filled when the step is complete.
                   const circleToneClass = done
-                    ? 'border-emerald-400 bg-emerald-500/20 text-emerald-200'
+                    ? 'border-emerald-400 bg-emerald-500/20 text-[var(--ok)]'
                     : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
                   return html`
                     <li class="flex items-start gap-2.5" data-setup-step-item=${idx}>

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -239,7 +239,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           `
         : null}
       ${entry.error
-        ? html`<div class="rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-rose-100">${entry.error}</div>`
+        ? html`<div class="rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-[var(--bad-light)]">${entry.error}</div>`
         : entry.loading && entry.lines.length === 0
           ? html`
               <div class="rounded bg-[var(--bg-0)] p-2">

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -95,7 +95,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
 
   return html`
     <div
-      class="mt-2 flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-100"
+      class="mt-2 flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-[11px] text-[var(--warn)]"
       data-startup-warning=${connectorId}
     >
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
@@ -108,7 +108,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       </div>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-amber-400/30 bg-amber-500/15 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-amber-100 hover:bg-amber-500/25"
+        class="shrink-0 cursor-pointer rounded border border-amber-400/30 bg-amber-500/15 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-amber-500/25"
         onClick=${() => {
           openSidecarLogs(connectorId)
           // Don't clear startAt yet — operator might toggle logs back closed
@@ -118,7 +118,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       >📋 로그 열기</button>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-amber-400/20 px-1.5 py-0.5 text-[14px] leading-none text-amber-100/70 hover:text-amber-100"
+        class="shrink-0 cursor-pointer rounded border border-amber-400/20 px-1.5 py-0.5 text-[14px] leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
         aria-label="dismiss startup warning"
         onClick=${() => clearStartAttempt(connectorId)}
       >×</button>

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -424,7 +424,7 @@ function TextModeToggle({
   return html`
     <div class="flex gap-2">
       <button type="button"
-        class="text-[10px] text-[var(--ok)] hover:text-emerald-300 cursor-pointer transition-colors"
+        class="text-[10px] text-[var(--ok)] hover:text-[var(--ok)] cursor-pointer transition-colors"
         onClick=${() => {
           listSig.value = parseToolList(textInputBuffer.value)
           textInputSection.value = null


### PR DESCRIPTION
## 요약

#8271 follow-up. -400 shade만 처리했던 것에 비해 이번 PR은 \`-100\`, \`-200\`, \`-300\`, \`-500\` shades까지 전부 semantic token으로 수렴. 27 파일 118 인스턴스 일괄 처리.

## 매핑

| 이전 (여러 shade) | → | 이후 (단일 token) |
|---|---|---|
| \`text-{red,rose}-{100,200,300,500}\` | → | \`text-[var(--bad-light)]\` |
| \`text-{emerald,green}-{100,200,300,500}\` | → | \`text-[var(--ok)]\` |
| \`text-{yellow,amber}-{100,200,300,500}\` | → | \`text-[var(--warn)]\` |

Shade drift를 의식적으로 제거: 기존에는 동일 semantic을 여러 컴포넌트가 \`amber-200\`/\`amber-300\`으로 혼용했음. Single token으로 수렴.

## 비스코프

- \`bg-{color}-{shade}/NN\` 배경 + alpha variant — \`-10\`/\`-20\` 토큰 매핑이 깔끔하지 않아 case-by-case 검토 필요
- \`border-{color}-{shade}/NN\` 같음

## Test plan

- [x] \`tsc --noEmit\` 통과
- 단일 파일 vitest 통과 (색상 string 아닌 behavioural tests)

## Related

- #8271 -400 sweep
- #8177 paper theme 인프라