### PR TITLE
refactor(dashboard): rename runtime-monitor providerTone -> runtimeProviderTone

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { providerTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency } from './runtime-monitor'
+import { runtimeProviderTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency } from './runtime-monitor'
 import type { DashboardRuntimeProviderSnapshot, DashboardRuntimeModelMetric } from '../api/dashboard'
 
 function makeProvider(overrides: Partial<DashboardRuntimeProviderSnapshot> = {}): DashboardRuntimeProviderSnapshot {
@@ -17,31 +17,31 @@ function makeMetric(overrides: Partial<DashboardRuntimeModelMetric> = {}): Dashb
   }
 }
 
-// ── providerTone ──
+// ── runtimeProviderTone ──
 
-describe('providerTone', () => {
+describe('runtimeProviderTone', () => {
   it('returns bad when available is false', () => {
-    expect(providerTone(makeProvider({ available: false }))).toBe('bad')
+    expect(runtimeProviderTone(makeProvider({ available: false }))).toBe('bad')
   })
 
   it('returns warn when discovery is not healthy', () => {
-    expect(providerTone(makeProvider({ available: true, discovery: { healthy: false } }))).toBe('warn')
+    expect(runtimeProviderTone(makeProvider({ available: true, discovery: { healthy: false } }))).toBe('warn')
   })
 
   it('returns ok when available is true and healthy', () => {
-    expect(providerTone(makeProvider({ available: true, discovery: { healthy: true } }))).toBe('ok')
+    expect(runtimeProviderTone(makeProvider({ available: true, discovery: { healthy: true } }))).toBe('ok')
   })
 
   it('returns ok when available is true without discovery', () => {
-    expect(providerTone(makeProvider({ available: true }))).toBe('ok')
+    expect(runtimeProviderTone(makeProvider({ available: true }))).toBe('ok')
   })
 
   it('returns warn when available is undefined', () => {
-    expect(providerTone(makeProvider())).toBe('warn')
+    expect(runtimeProviderTone(makeProvider())).toBe('warn')
   })
 
   it('returns warn when available is true but discovery is null', () => {
-    expect(providerTone(makeProvider({ available: true, discovery: null }))).toBe('ok')
+    expect(runtimeProviderTone(makeProvider({ available: true, discovery: null }))).toBe('ok')
   })
 })
 

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -75,7 +75,11 @@ async function loadRuntimeData(resource: ManagedAsyncResource<RuntimeData>, wind
   })
 }
 
-export function providerTone(provider: DashboardRuntimeProviderSnapshot): string {
+// Current-reachability axis: does the provider respond right now?
+// Orthogonal to cascade-config-panel.ts:providerTone which scores historical
+// performance (success_rate, cooldown). Both signals can be shown together
+// without being duplicates.
+export function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string {
   if (provider.available === false) return 'bad'
   if (provider.discovery?.healthy === false) return 'warn'
   if (provider.available === true) return 'ok'
@@ -221,7 +225,7 @@ export function RuntimeMonitor() {
                     </div>
                     <${StatusChip}
                       label=${provider.status ?? (provider.available ? 'available' : 'unknown')}
-                      tone=${providerTone(provider)}
+                      tone=${runtimeProviderTone(provider)}
                     />
                   </div>
                   <div class="grid grid-cols-2 gap-3 text-[12px] text-text-body">


### PR DESCRIPTION
## Summary
Two sibling dashboard files both exported `providerTone` with different input types and semantics. Rename the runtime-monitor one to `runtimeProviderTone` and document the axis distinction.

## Product impact
- **No behaviour change.** Pure rename + 4-line explanatory comment.
- Removes a name collision that made Stage-1 triage (PR #8252) misread two orthogonal signals as a "3-way SSOT duplicate".

## Evidence
- `cascade-config-panel.ts:providerTone(CascadeHealthProvider)` — **historical** axis (cooldown, success_rate).
- `runtime-monitor.ts:runtimeProviderTone(DashboardRuntimeProviderSnapshot)` — **current reachability** axis (available, discovery.healthy).
- Tests: 53/53 passed (`runtime-monitor.test.ts` + `runtime-panel.test.ts`).
- `pnpm typecheck` clean.
- `pnpm lint` clean.

## Review evidence
- Grep confirmed `runtime-monitor.ts:providerTone` had exactly 1 definition + 1 in-file usage. No external consumers.
- `cascade-config-panel.ts:providerTone` is only used inside its own file, so no cross-contamination.

## Linked issue
Refs #8262 — Stage 2 scope **revised**: naming disambiguation, not SSOT merge. The two `providerTone` functions represent orthogonal time axes (past vs present) of provider health and should remain separate.

## Follow-up
- Stage 3 (exception-first auto-open) still pending user approval.
- Stage 4 (VerificationSpecsPanel section move) still pending user approval.