### PR TITLE
feat(verification-protocol): warn on missing-contract submit (#8272 step 1)

### DIFF
--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -22,6 +22,23 @@
 let on_submit_for_verification ~(config : Coord.config)
     ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
   let base_path = config.Coord.base_path in
+  (* Observability for #8272: tasks submitted without a contract land in
+     storage with empty completion_contract + empty evidence, which the
+     dashboard renders as "—". Surface this as a warn so operators can
+     trace the gap back to the task creation site instead of only
+     noticing it in the UI. No behavior change. *)
+  (match task.contract with
+   | None ->
+     Log.Task.warn
+       "[verification-submit] task=%s has no contract — completion_contract \
+        and evidence will be empty in the verification record"
+       task.id
+   | Some c when c.completion_contract = [] && c.verify_gate_evidence = [] ->
+     Log.Task.warn
+       "[verification-submit] task=%s has a contract but both \
+        completion_contract and verify_gate_evidence are empty"
+       task.id
+   | Some _ -> ());
   let criteria = List.map (fun s -> Verification.Custom s)
     (match task.contract with
      | Some c -> c.completion_contract


### PR DESCRIPTION
## Summary

`verification_protocol.on_submit_for_verification`이 `task.contract = None` 또는 `completion_contract + verify_gate_evidence` 모두 빈 상태로 호출되면 `Log.Task.warn`으로 경고 — 관측만, 동작 불변.

## Product impact

- 운영자가 서버 로그에서 "어느 task 생성 site가 contract를 안 심는지" 추적 가능.
- Dashboard legacy-rows 배너(#8259)와 쌍으로 운영자에게 **UI + log** 두 축 신호 제공.
- 무기능 변화 · 무 behavioral regression. rollback도 로그 한 줄 제거.

## Evidence

- Change: +17, 1 파일 (`lib/verification_protocol.ml`).
- warn 두 갈래: ① contract=None ② contract 있지만 completion_contract와 verify_gate_evidence 모두 빈 경우.

## Review evidence

- `test_verification_fsm` 9/9 green (기존 테스트 regression 없음).
- `dune build @check` clean.
- 빌드/컴파일 경고 없음.
- log-level change라 추가 unit test 없음 (log capture harness 불요). 수동 확인: `add_strict_task` 사용하는 기존 테스트는 contract 채운 상태라 warn branch 미트리거.

## Linked issue

Relates #8272

## Rollout

- Draft. CI green 확인 후 Ready 전환.
- 병합 후 `MASC_BASE_PATH/logs`에서 `[verification-submit] task=... has no contract` 패턴이 보이기 시작하면 #8272의 실제 영향 범위(무 contract task 수)를 정량화 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)