### PR TITLE
feat(dashboard-cascade): expose hard_quota_cooldown_sec in /api/v1/cascade/health

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -144,6 +144,7 @@ let health_json () =
     ("window_sec", `Float Health.window_sec);
     ("cooldown_threshold", `Int Health.cooldown_threshold);
     ("cooldown_sec", `Float Health.cooldown_sec);
+    ("hard_quota_cooldown_sec", `Float Health.hard_quota_cooldown_sec);
     ("providers", `List (List.map provider_info_to_json providers));
   ]
 

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -61,6 +61,7 @@ val keeper_profile_fields :
         "window_sec": 300.0,
         "cooldown_threshold": 3,
         "cooldown_sec": 60.0,
+        "hard_quota_cooldown_sec": 3600.0,
         "providers": [
           { "provider_key": "glm:glm-5.1",
             "success_rate": 0.87,


### PR DESCRIPTION
## Summary

One-line observability gap from #8249. The [Cascade_health_tracker.hard_quota_cooldown_sec] config field (default 3600s, env MASC_CASCADE_HARD_QUOTA_COOLDOWN_SEC) was shipped but not exposed in the `/api/v1/cascade/health` JSON. Dashboard operators had no way to see the active hard-quota cooldown value.

## Change

`lib/dashboard_cascade.ml:147` — +1 tuple between `cooldown_sec` and `providers`:

```ocaml
("hard_quota_cooldown_sec", `Float Health.hard_quota_cooldown_sec);
```

`lib/dashboard_cascade.mli:63` — mli shape docstring updated to match.

## Before / after

Before (live `curl /api/v1/cascade/health`):
```json
{"window_sec":300.0,"cooldown_threshold":3,"cooldown_sec":60.0,"providers":[...]}
```

After:
```json
{"window_sec":300.0,"cooldown_threshold":3,"cooldown_sec":60.0,"hard_quota_cooldown_sec":3600.0,"providers":[...]}
```

## Test plan
- [x] `dune build` clean
- [x] No behavior change — purely additive JSON key; backward-compatible with any existing dashboard consumer
- [x] SSOT remains `Cascade_health_tracker` (same pattern as the other three keys; no env re-read, no default redefinition)