### PR TITLE
feat(dashboard): final Tailwind severity sweep — text/bg/border 34 files

### DIFF
--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -141,7 +141,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.to_agent)}</span>
                                     <div class="w-16 bg-zinc-800 rounded h-1.5">
                                       <div
-                                        class="${s.weight >= 0.7 ? 'bg-emerald-500' : s.weight >= 0.4 ? 'bg-amber-500' : 'bg-red-400'} rounded h-1.5"
+                                        class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>
@@ -166,7 +166,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.from_agent)}</span>
                                     <div class="w-16 bg-zinc-800 rounded h-1.5">
                                       <div
-                                        class="${s.weight >= 0.7 ? 'bg-emerald-500' : s.weight >= 0.4 ? 'bg-amber-500' : 'bg-red-400'} rounded h-1.5"
+                                        class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -28,8 +28,8 @@ const STATE_LABEL: Record<HeartbeatState, string> = {
 }
 
 const STATE_TONE: Record<HeartbeatState, string> = {
-  up: 'text-[var(--ok)] border-emerald-400/30 bg-emerald-500/10',
-  down: 'text-[var(--bad-light)] border-rose-400/30 bg-rose-500/10',
+  up: 'text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
+  down: 'text-[var(--bad-light)] border-[var(--bad-20)] bg-[var(--bad-10)]',
   unknown: 'text-[var(--text-dim)] border-[var(--white-8)] bg-[var(--white-2)]',
 }
 

--- a/dashboard/src/components/common/heartbeat-strip.ts
+++ b/dashboard/src/components/common/heartbeat-strip.ts
@@ -10,8 +10,8 @@ import type { HeartbeatState } from '../../lib/heartbeat-history'
 
 const COLOR: Record<HeartbeatState, string> = {
   // Emerald 500 / Rose 500 / Zinc 700 — matches the dashboard token palette.
-  up: 'bg-emerald-500',
-  down: 'bg-rose-500',
+  up: 'bg-[var(--ok-10)]',
+  down: 'bg-[var(--bad-10)]',
   unknown: 'bg-[var(--white-8)]',
 }
 

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -38,9 +38,9 @@ export function formatUptimeChip(summary: HeartbeatSummary): UptimeChipView | nu
 }
 
 const TONE_CLASS: Record<UptimeTone, string> = {
-  operational: 'text-[var(--ok)] border-emerald-400/30 bg-emerald-500/10',
-  degraded: 'text-[var(--warn)] border-amber-400/30 bg-amber-500/10',
-  unhealthy: 'text-[var(--bad-light)] border-rose-400/30 bg-rose-500/10',
+  operational: 'text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)]',
+  degraded: 'text-[var(--warn)] border-[var(--warn-20)] bg-[var(--warn-10)]',
+  unhealthy: 'text-[var(--bad-light)] border-[var(--bad-20)] bg-[var(--bad-10)]',
 }
 
 interface HeartbeatUptimeChipProps {

--- a/dashboard/src/components/common/live-pulse-dot.ts
+++ b/dashboard/src/components/common/live-pulse-dot.ts
@@ -50,8 +50,8 @@ export function classifyLivePulse(
 const DOT_BASE = 'inline-block h-2 w-2 rounded-full'
 
 const DOT_TONE: Record<LivePulseState, string> = {
-  live: 'bg-emerald-400 animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.6)]',
-  stale: 'bg-amber-400',
+  live: 'bg-[var(--ok-10)] animate-pulse shadow-[0_0_6px_rgba(52,211,153,0.6)]',
+  stale: 'bg-[var(--warn-10)]',
   idle: 'bg-[var(--white-10)]',
 }
 

--- a/dashboard/src/components/common/progress-bar.test.ts
+++ b/dashboard/src/components/common/progress-bar.test.ts
@@ -63,8 +63,8 @@ describe('progressBarToneClass (pure)', () => {
   })
 
   it('raw Tailwind tones route to their bg-500 class', () => {
-    expect(progressBarToneClass('emerald')).toBe('bg-emerald-500')
-    expect(progressBarToneClass('rose')).toBe('bg-rose-500')
+    expect(progressBarToneClass('emerald')).toBe('bg-[var(--ok-10)]')
+    expect(progressBarToneClass('rose')).toBe('bg-[var(--bad-10)]')
   })
 })
 

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -46,9 +46,9 @@ export function progressBarToneClass(tone: ProgressBarTone): string {
     case 'ok': return 'bg-[var(--ok)]'
     case 'warn': return 'bg-[var(--warn)]'
     case 'bad': return 'bg-[var(--bad)]'
-    case 'emerald': return 'bg-emerald-500'
-    case 'amber': return 'bg-amber-500'
-    case 'rose': return 'bg-rose-500'
+    case 'emerald': return 'bg-[var(--ok-10)]'
+    case 'amber': return 'bg-[var(--warn-10)]'
+    case 'rose': return 'bg-[var(--bad-10)]'
     case 'sky': return 'bg-sky-500'
   }
 }

--- a/dashboard/src/components/common/status-dot.test.ts
+++ b/dashboard/src/components/common/status-dot.test.ts
@@ -30,8 +30,9 @@ describe('statusDotClasses (pure)', () => {
   })
 
   it('tone class is appended after size (caller controls color)', () => {
-    const cls = statusDotClasses('sm', 'bg-emerald-500')
-    expect(cls).toMatch(/w-2 h-2.*bg-emerald-500/)
+    const cls = statusDotClasses('sm', 'bg-[var(--ok-10)]')
+    expect(cls).toContain('w-2 h-2')
+    expect(cls).toContain('bg-[var(--ok-10)]')
   })
 
   it('empty / undefined tone does not leave trailing whitespace', () => {
@@ -40,8 +41,10 @@ describe('statusDotClasses (pure)', () => {
   })
 
   it('extra class appended after tone (margin, ring, etc.)', () => {
-    expect(statusDotClasses('sm', 'bg-rose-500', 'ml-1'))
-      .toMatch(/bg-rose-500.*ml-1/)
+    const cls = statusDotClasses('sm', 'bg-[var(--bad-10)]', 'ml-1')
+    expect(cls).toContain('bg-[var(--bad-10)]')
+    expect(cls).toContain('ml-1')
+    expect(cls.indexOf('bg-[var(--bad-10)]')).toBeLessThan(cls.indexOf('ml-1'))
   })
 })
 
@@ -64,8 +67,8 @@ describe('StatusDot component', () => {
   })
 
   it('tone class (passed via `class`) ends up on the span', () => {
-    render(html`<${StatusDot} class="bg-emerald-500" />`, container)
-    expect(container.querySelector('[data-status-dot]')!.className).toContain('bg-emerald-500')
+    render(html`<${StatusDot} class="bg-[var(--ok-10)]" />`, container)
+    expect(container.querySelector('[data-status-dot]')!.className).toContain('bg-[var(--ok-10)]')
   })
 
   it('default (no ariaLabel) is decorative — aria-hidden=true, no role', () => {
@@ -80,7 +83,7 @@ describe('StatusDot component', () => {
 
   it('ariaLabel promotes to semantic mode: role=img, no aria-hidden', () => {
     render(
-      html`<${StatusDot} ariaLabel="running" class="bg-emerald-500" />`,
+      html`<${StatusDot} ariaLabel="running" class="bg-[var(--ok-10)]" />`,
       container,
     )
     const el = container.querySelector('[data-status-dot]')!
@@ -100,7 +103,7 @@ describe('StatusDot component', () => {
 
   it('testId renders as data-testid', () => {
     render(
-      html`<${StatusDot} testId="transport-sse-dot" class="bg-emerald-500" />`,
+      html`<${StatusDot} testId="transport-sse-dot" class="bg-[var(--ok-10)]" />`,
       container,
     )
     expect(container.querySelector('[data-testid="transport-sse-dot"]')).toBeTruthy()

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -402,7 +402,7 @@ function FieldWidget({ id, field, value, revealed }: {
       `
     default:
       return html`
-        <div class="rounded border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-[10px] text-[var(--warn)]">
+        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-[10px] text-[var(--warn)]">
           unsupported type — refactor BotConfig?
         </div>
       `
@@ -429,12 +429,12 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.error !== null) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded-md border border-rose-400/30 bg-rose-500/10 p-3 text-[11px] text-[var(--bad-light)]">
+      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded-md border border-[var(--bad-20)] bg-[var(--bad-10)] p-3 text-[11px] text-[var(--bad-light)]">
         <div class="font-semibold">schema 가져오기 실패</div>
         <div class="mt-1 text-[10px] opacity-80">${entry.error}</div>
         <button
           type="button"
-          class="mt-2 cursor-pointer rounded border border-rose-400/40 px-2 py-1 text-[10px] hover:bg-rose-500/20"
+          class="mt-2 cursor-pointer rounded border border-[var(--bad-20)] px-2 py-1 text-[10px] hover:bg-[var(--bad-10)]"
           onClick=${() => fetchSchema(connectorId)}
         >다시 시도</button>
       </div>
@@ -461,7 +461,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
                 <span class="ml-2 text-[var(--ok)]">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
                 <button
                   type="button"
-                  class="ml-2 cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-[var(--ok)] hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                  class="ml-2 cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-50"
                   disabled=${entry.restarting}
                   title="POST /sidecar/stop → 800ms → POST /sidecar/start"
                   onClick=${() => { void restartSidecar(connectorId) }}

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -150,10 +150,10 @@ export function deriveMatrix(
 }
 
 const CELL_TONE: Record<MatrixCellState, { dot: string; text: string; bg: string }> = {
-  bound:   { dot: 'bg-emerald-400',     text: 'text-[var(--ok)]',        bg: 'bg-emerald-500/10' },
+  bound:   { dot: 'bg-[var(--ok-10)]',     text: 'text-[var(--ok)]',        bg: 'bg-[var(--ok-10)]' },
   unbound: { dot: 'bg-[var(--white-8)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
   na:      { dot: 'bg-[var(--white-4)]', text: 'text-[var(--text-dim)]', bg: 'bg-transparent'    },
-  unknown: { dot: 'bg-amber-400',       text: 'text-[var(--warn)]',          bg: 'bg-amber-500/10'   },
+  unknown: { dot: 'bg-[var(--warn-10)]',       text: 'text-[var(--warn)]',          bg: 'bg-[var(--warn-10)]'   },
 }
 
 const CELL_GLYPH: Record<MatrixCellState, string> = {
@@ -242,10 +242,10 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
           </p>
         </div>
         <div class="text-[10px] text-[var(--text-dim)]">
-          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>bound</span>
+          <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--ok-10)]"></span>bound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-8)]"></span>unbound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-4)]"></span>n/a</span>
-          <span><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-amber-400"></span>unknown</span>
+          <span><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--warn-10)]"></span>unknown</span>
         </div>
       </header>
 

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -156,7 +156,7 @@ export function summarizeOverviewTile(
   if (connector === null || connector.available !== true) {
     return {
       badge: '설정 필요',
-      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-[var(--warn)]',
+      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
       detail: keeperCount > 0
         ? '아직 시작되지 않음 · 시작 후 keeper를 바인딩하세요'
         : '아직 시작되지 않음 · 먼저 Config와 Start가 필요합니다',
@@ -168,7 +168,7 @@ export function summarizeOverviewTile(
   if (stateLabel === 'stale' || stateLabel === 'disconnected' || connector.gate_healthy === false) {
     return {
       badge: '주의',
-      badgeClass: 'border-rose-400/30 bg-rose-500/10 text-[var(--bad-light)]',
+      badgeClass: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
       detail: stateLabel === 'stale'
         ? 'heartbeat가 stale 상태입니다 · 로그와 gate 상태를 확인하세요'
         : stateLabel === 'disconnected'
@@ -180,7 +180,7 @@ export function summarizeOverviewTile(
   if (bindingCount === 0) {
     return {
       badge: '바인딩 필요',
-      badgeClass: 'border-amber-400/30 bg-amber-500/10 text-[var(--warn)]',
+      badgeClass: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
       detail: keeperCount > 0
         ? '실행 중 · 아직 channel binding이 없습니다'
         : '실행 중 · keeper 디렉토리가 비어 있습니다',
@@ -189,7 +189,7 @@ export function summarizeOverviewTile(
 
   return {
     badge: '정상',
-    badgeClass: 'border-emerald-400/30 bg-emerald-500/10 text-[var(--ok)]',
+    badgeClass: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
     detail: `실행 중 · ${bindingCount} ${bindingCount === 1 ? 'binding' : 'bindings'} active`,
   }
 }
@@ -259,7 +259,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-full border border-emerald-400/20 bg-emerald-500/5 px-1.5 py-[1px] text-[10px] font-normal text-[var(--ok)]/80"
+                    class="rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-[1px] text-[10px] font-normal text-[var(--ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
@@ -344,8 +344,8 @@ const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
   // across per-tile + bulk controls. The per-tile button is deliberately
   // block-width and text-[12px] so it reads as the primary action of the
   // tile, distinct from the smaller pill row above.
-  start: 'border-emerald-400/40 bg-emerald-500/15 text-[var(--ok)] hover:bg-emerald-500/25',
-  stop: 'border-rose-400/40 bg-rose-500/15 text-[var(--bad-light)] hover:bg-rose-500/25',
+  start: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)] hover:bg-[var(--ok-10)]',
+  stop: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-10)]',
 }
 
 /** The prominent per-tile Start/Stop button. Reference UIs (Vercel
@@ -415,8 +415,8 @@ const TILE_NOTICE_TONE_CLASS: Record<'error' | 'stale', string> = {
   // Rose for hard errors (sidecar reported an explicit failure),
   // amber for stale (data hasn't refreshed but no explicit error).
   // Matches Sentry \"issue\" rose + Vercel \"warning\" amber convention.
-  error: 'border-rose-400/40 bg-rose-500/10 text-[var(--bad-light)]',
-  stale: 'border-amber-400/40 bg-amber-500/10 text-[var(--warn)]',
+  error: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
+  stale: 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
 }
 
 const TILE_NOTICE_GLYPH: Record<'error' | 'stale', string> = {
@@ -525,7 +525,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
     <div class="flex items-center gap-2 text-[11px] text-[var(--text-dim)]">
       <button
         type="button"
-        class="cursor-pointer rounded border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-[var(--ok)] hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-[11px] text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${startBusy || downCount === 0}
         title=${downCount === 0 ? '모두 이미 실행 중' : `${downCount} 개 sidecar 시작`}
         onClick=${() => { void runBulk('start', c => c?.available !== true, connectors) }}
@@ -535,7 +535,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
       </button>
       <button
         type="button"
-        class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-[var(--bad-light)] hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[11px] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${stopBusy || upCount === 0}
         title=${upCount === 0 ? '실행 중인 sidecar 없음' : `${upCount} 개 sidecar 정지`}
         onClick=${() => { void runBulk('stop', c => c?.available === true, connectors) }}
@@ -676,7 +676,7 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
     .join(', ')
   return html`
     <div
-      class="mb-2 flex items-center gap-2 rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-1.5 text-[11px] font-semibold text-[var(--bad-light)]"
+      class="mb-2 flex items-center gap-2 rounded-md border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[var(--bad-light)]"
       data-incident-banner
       role="alert"
     >

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -69,10 +69,10 @@ export interface RailPill {
 
 const TONE: Record<RailState, { bg: string; border: string; text: string; dot: string; icon: string; gradient: string }> = {
   ok: {
-    bg: 'bg-emerald-500/10',
-    border: 'border-emerald-400/40',
+    bg: 'bg-[var(--ok-10)]',
+    border: 'border-[var(--ok-20)]',
     text: 'text-[var(--ok)]',
-    dot: 'bg-emerald-400',
+    dot: 'bg-[var(--ok-10)]',
     icon: '✓',
     // Grafana Stat panel "Background Gradient" mode — subtle vertical
     // fade from the state's tone into the card surface so the pill
@@ -80,18 +80,18 @@ const TONE: Record<RailState, { bg: string; border: string; text: string; dot: s
     gradient: 'bg-gradient-to-b from-emerald-500/15 to-emerald-500/0',
   },
   warn: {
-    bg: 'bg-amber-500/10',
-    border: 'border-amber-400/40',
+    bg: 'bg-[var(--warn-10)]',
+    border: 'border-[var(--warn-20)]',
     text: 'text-[var(--warn)]',
-    dot: 'bg-amber-400',
+    dot: 'bg-[var(--warn-10)]',
     icon: '!',
     gradient: 'bg-gradient-to-b from-amber-500/15 to-amber-500/0',
   },
   bad: {
-    bg: 'bg-rose-500/10',
-    border: 'border-rose-400/40',
+    bg: 'bg-[var(--bad-10)]',
+    border: 'border-[var(--bad-20)]',
     text: 'text-[var(--bad-light)]',
-    dot: 'bg-rose-400',
+    dot: 'bg-[var(--bad-10)]',
     icon: '⊘',
     gradient: 'bg-gradient-to-b from-rose-500/15 to-rose-500/0',
   },

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -419,7 +419,7 @@ describe('ConnectorStatusPanel', () => {
     // treatment from #8038 for cross-panel consistency.
     const dirPanel = container.querySelector('[data-keeper-directory-error-panel]') as HTMLElement | null
     expect(dirPanel).toBeTruthy()
-    expect(dirPanel!.className).toContain('bg-amber-500/5')
+    expect(dirPanel!.className).toContain('bg-[var(--warn-10)]')
     expect(dirPanel!.className).toContain('border-l-amber-500')
     // Named chip: "Directory error" is what AT hears.
     const dirChip = dirPanel!.querySelector('[aria-label]')
@@ -642,7 +642,7 @@ describe('ConnectorStatusPanel', () => {
     // parent connector's brand color.
     const panel = container.querySelector('[data-sidecar-not-started-panel]') as HTMLElement | null
     expect(panel).toBeTruthy()
-    expect(panel!.className).toContain('bg-amber-500/5')
+    expect(panel!.className).toContain('bg-[var(--warn-10)]')
     expect(panel!.className).toContain('border-l-amber-500')
     // And the explicit "Not running" status chip is the one AT users hear.
     const chip = panel!.querySelector('[data-sidecar-status-chip]')
@@ -682,7 +682,7 @@ describe('ConnectorStatusPanel', () => {
     // green) doesn't paint a "no keepers" panel as success.
     const emptyPanel = container.querySelector('[data-no-keepers-empty-panel]') as HTMLElement | null
     expect(emptyPanel).toBeTruthy()
-    expect(emptyPanel!.className).toContain('bg-amber-500/5')
+    expect(emptyPanel!.className).toContain('bg-[var(--warn-10)]')
     expect(emptyPanel!.className).toContain('border-l-amber-500')
     const chip = emptyPanel!.querySelector('[data-no-keepers-status-chip]')
     expect(chip).toBeTruthy()

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -331,19 +331,19 @@ function healthTone(health: string): { dot: string; badge: string; label: string
     case 'healthy':
       return {
         dot: 'var(--green)',
-        badge: 'border border-emerald-400/30 bg-emerald-500/12 text-[var(--ok)]',
+        badge: 'border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]',
         label: 'healthy',
       }
     case 'degraded':
       return {
         dot: 'var(--yellow)',
-        badge: 'border border-amber-400/30 bg-amber-500/12 text-[var(--warn)]',
+        badge: 'border border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]',
         label: 'degraded',
       }
     case 'failing':
       return {
         dot: 'var(--red)',
-        badge: 'border border-rose-400/35 bg-rose-500/12 text-[var(--bad-light)]',
+        badge: 'border border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]',
         label: 'failing',
       }
     default:
@@ -395,11 +395,11 @@ interface LivenessDot {
 function dotClass(state: LivenessState): string {
   switch (state) {
     case 'ok':
-      return 'bg-emerald-400'
+      return 'bg-[var(--ok-10)]'
     case 'warn':
-      return 'bg-amber-400'
+      return 'bg-[var(--warn-10)]'
     case 'down':
-      return 'bg-rose-400'
+      return 'bg-[var(--bad-10)]'
     default:
       return 'bg-[var(--text-dim)]'
   }
@@ -408,11 +408,11 @@ function dotClass(state: LivenessState): string {
 function dotClassForLabel(label: string): string {
   switch (label) {
     case 'connected':
-      return 'bg-emerald-400'
+      return 'bg-[var(--ok-10)]'
     case 'stale':
-      return 'bg-amber-400'
+      return 'bg-[var(--warn-10)]'
     case 'disconnected':
-      return 'bg-rose-400'
+      return 'bg-[var(--bad-10)]'
     default:
       return 'bg-[var(--text-dim)]'
   }
@@ -477,12 +477,12 @@ export function connectorCardBorderClass(label: string): string {
 function connectorStateTone(connector: GateConnectorInfo | null): string {
   const label = connectorStateLabel(connector)
   if (label === 'connected') {
-    return 'border-emerald-400/30 bg-emerald-500/12 text-[var(--ok)]'
+    return 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
   }
   if (label === 'disconnected') {
-    return 'border-rose-400/30 bg-rose-500/12 text-[var(--bad-light)]'
+    return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
   }
-  return 'border-amber-400/30 bg-amber-500/12 text-[var(--warn)]'
+  return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
 }
 
 function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownConnectorId): GateConnectorInfo | null {
@@ -850,7 +850,7 @@ function ConnectorLivePanel({
             ? html`
                 <button
                   type="button"
-                  class="cursor-pointer rounded border border-rose-400/30 bg-rose-500/12 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-rose-500/20 disabled:opacity-50"
+                  class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
                   disabled=${isActionLoading}
                   aria-label=${`stop ${connectorName} sidecar`}
                   onClick=${() => { void stopSidecar(connectorId) }}
@@ -933,7 +933,7 @@ function ConnectorLivePanel({
         : null}
 
       ${connectorError || connector?.error
-        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
+        ? html`<div class="mt-3 rounded-md border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
         : null}
 
       <${SidecarLogViewer} connectorId=${connectorId} />
@@ -942,11 +942,11 @@ function ConnectorLivePanel({
       ${keeperDirectoryError && keepers.length === 0
         ? html`
             <div
-              class="mt-3 rounded-md border border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]"
+              class="mt-3 rounded-md border border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]"
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                class="mr-2 inline-flex items-center gap-1 rounded-full border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
@@ -960,12 +960,12 @@ function ConnectorLivePanel({
       ${showNoKeeperEmpty
         ? html`
             <div
-              class="mt-3 rounded-md border border-dashed border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-3 text-[12px]"
+              class="mt-3 rounded-md border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-[12px]"
               data-no-keepers-empty-panel
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                  class="inline-flex items-center gap-1 rounded-full border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
@@ -994,13 +994,13 @@ function ConnectorLivePanel({
             // on the outer card for vertical scannability.
             return html`
               <div
-                class="mt-3 rounded-md border border-dashed border-amber-400/30 border-l-4 border-l-amber-500 bg-amber-500/5 px-3 py-3 text-[12px]"
+                class="mt-3 rounded-md border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-[12px]"
                 data-sidecar-not-started-panel
               >
                 <div class="mb-1 flex items-center justify-between gap-2">
                   <div class="flex items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                      class="inline-flex items-center gap-1 rounded-full border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
@@ -1183,7 +1183,7 @@ function ConnectorLivePanel({
         ? html`
             <div class="mt-3 space-y-2">
               ${unknownGroups.map(group => html`
-                <div class="rounded-md border border-amber-400/30 bg-amber-500/8 px-3 py-2" data-keeper=${group.name}>
+                <div class="rounded-md border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2" data-keeper=${group.name}>
                   <div class="flex items-baseline gap-2">
                     <span class="text-[var(--warn)]">⚠</span>
                     <div class="min-w-0">
@@ -1312,7 +1312,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
 
       ${lastError
         ? html`
-            <div class="mt-3 rounded-md border border-rose-400/20 bg-rose-500/8 px-3 py-2 text-[11px] text-[var(--bad-light)]">
+            <div class="mt-3 rounded-md border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-[11px] text-[var(--bad-light)]">
               <div class="mb-1 uppercase tracking-[0.16em] text-[var(--bad-light)]/80">
                 ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
               </div>
@@ -1359,7 +1359,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
       </div>
       ${lastError
         ? html`
-            <div class="mt-2 rounded border border-rose-400/20 bg-rose-500/8 px-2 py-1 text-[10px] text-[var(--bad-light)]">
+            <div class="mt-2 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[10px] text-[var(--bad-light)]">
               ${binding.last_error_kind || 'error'} · ${lastError}
             </div>
           `
@@ -1371,7 +1371,7 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
 function EventRow({ event }: { event: GateEventInfo }) {
   const isError = Boolean(event.error)
   const badgeClass = isError
-    ? 'border border-rose-400/30 bg-rose-500/12 text-[var(--bad-light)]'
+    ? 'border border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
     : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-dim)]'
 
   return html`

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -70,10 +70,10 @@ const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
 // recommendation: stable=gray, in-motion=amber/blue, terminal=red.
 const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // KSM
-  Running:      'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
-  Failing:      'bg-red-900/50 text-[var(--bad-light)] border-red-700',
+  Running:      'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
+  Failing:      'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
   Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
-  Compacting:   'bg-amber-900/50 text-[var(--warn)] border-amber-700',
+  Compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
   Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
   Paused:       'bg-zinc-800 text-zinc-300 border-zinc-600',
@@ -85,19 +85,19 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // KTC
   idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',
   prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
-  executing:    'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
-  compacting:   'bg-amber-900/50 text-[var(--warn)] border-amber-700',
+  executing:    'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
+  compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
   // KDP
   undecided:          'bg-zinc-800 text-zinc-400 border-zinc-700',
-  guard_ok:           'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
-  gate_rejected:      'bg-red-900/40 text-[var(--bad-light)] border-red-700',
+  guard_ok:           'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
+  gate_rejected:      'bg-red-900/40 text-[var(--bad-light)] border-[var(--bad-20)]',
   tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
   // KCL
   selecting:    'bg-blue-900/40 text-blue-200 border-blue-700',
-  trying:       'bg-amber-900/50 text-[var(--warn)] border-amber-700',
-  done:         'bg-emerald-900/40 text-[var(--ok)] border-emerald-700',
-  exhausted:    'bg-red-900/50 text-[var(--bad-light)] border-red-700',
+  trying:       'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
+  done:         'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
+  exhausted:    'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
   // KMC
   accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
   // KCB (LT-16-KCB Phase 3). Clean = baseline grey same as any other
@@ -107,7 +107,7 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // chip colour by design — the mutator resets the count before any
   // observer can see it.
   clean:   'bg-zinc-800 text-zinc-400 border-zinc-700',
-  warning: 'bg-amber-900/50 text-[var(--warn)] border-amber-700',
+  warning: 'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   cooling: 'bg-sky-900/40 text-sky-200 border-sky-700',
 }
 
@@ -347,7 +347,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                   const count = tallies[k]
                   const tone = count === 0
                     ? 'bg-emerald-900/30 text-[var(--ok)] border-emerald-800'
-                    : 'bg-red-900/40 text-[var(--bad-light)] border-red-700'
+                    : 'bg-red-900/40 text-[var(--bad-light)] border-[var(--bad-20)]'
                   return html`
                     <span
                       data-invariant=${k}
@@ -387,7 +387,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
           <tbody>
             ${visibleSnapshots.map(snap => {
               const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
-              const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
+              const rowTone = anyViolated ? 'border-l-2 border-[var(--bad-20)]' : ''
               const name = inferKeeperNameFrom(snap)
               return html`
                 <tr

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -118,9 +118,9 @@ function SummaryCard({
 }) {
   const toneClass =
     tone === 'ok'
-      ? 'border-emerald-500/20 bg-emerald-500/5'
+      ? 'border-[var(--ok-20)] bg-[var(--ok-10)]'
       : tone === 'warn'
-        ? 'border-amber-500/20 bg-amber-500/5'
+        ? 'border-[var(--warn-20)] bg-[var(--warn-10)]'
         : 'border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]'
 
   return html`
@@ -135,7 +135,7 @@ function SummaryCard({
 function WarningBanner({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null
   return html`
-    <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]">
+    <div class="rounded-lg border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">
       <div class="font-medium text-[var(--warn)]">Partial telemetry</div>
       <div class="mt-1 flex flex-col gap-1">
         ${warnings.map(warning => html`<div>${warning}</div>`)}
@@ -278,14 +278,14 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
+                  ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
+                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
                     : html`<span class="text-[10px] text-[var(--text-dim)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button
-                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-[var(--bad-light)] hover:bg-red-400/10 transition-colors"
+                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-[var(--bad-light)] hover:bg-[var(--bad-10)] transition-colors"
                   onClick=${() => onReset(row.name)}
                   title="초기화"
                   aria-label=${`${row.name} 초기화`}
@@ -338,7 +338,7 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
         <div class="flex items-center gap-2 text-[11px]">
           <div class="flex min-w-0 flex-1 items-center gap-1.5">
             <div
-              class="h-1.5 rounded-full bg-red-500/60"
+              class="h-1.5 rounded-full bg-[var(--bad-10)]"
               style="width: ${Math.max(6, (category.count / maxCount) * 100)}%"
             ></div>
             <span class="truncate font-mono text-[var(--bad-light)]" title=${category.category}>${category.category}</span>
@@ -499,10 +499,10 @@ export function FleetTelemetryPanel() {
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
           <div class="flex items-center gap-2 text-[10px]">
-            ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
-            ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
+            ${activeCount > 0 ? html`<span class="rounded-full bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
+            ${attentionCount > 0 ? html`<span class="rounded-full bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
             ${offlineCount > 0 ? html`<span class="rounded-full bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
-            ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[var(--warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
+            ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--warn)]">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -648,8 +648,8 @@ function StatusBar({
     && (now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)) > 300
   const liveBadge = snapshot
     ? snapshot.is_live
-      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-[var(--ok)] border-emerald-500/40 bg-emerald-500/10 animate-pulse">● 실행 중</span>`
-      : html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-amber-500/30' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-[8px] opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
+      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
+      : html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-[var(--warn-20)]' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-[8px] opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
 
   const staleSec = lastFetchAt > 0 ? Math.max(0, now - lastFetchAt) : 0

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -57,8 +57,8 @@ export function kindOfEventType(eventType: string): A2aEventKind {
 }
 
 export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
-  lifecycle: 'bg-emerald-400',
-  failure: 'bg-red-400',
+  lifecycle: 'bg-[var(--ok-10)]',
+  failure: 'bg-[var(--bad-10)]',
   tool: 'bg-sky-400',
   handoff: 'bg-orange-400',
   context: 'bg-purple-400',
@@ -294,7 +294,7 @@ export function HandoffTimeline({
         </div>
         <div class="flex gap-2 text-[10px] text-text-muted">
           <span class="flex items-center gap-1">
-            <span class="w-2 h-2 rounded-full bg-emerald-400"></span>lifecycle
+            <span class="w-2 h-2 rounded-full bg-[var(--ok-10)]"></span>lifecycle
           </span>
           <span class="flex items-center gap-1">
             <span class="w-2 h-2 rounded-full bg-sky-400"></span>tool
@@ -306,7 +306,7 @@ export function HandoffTimeline({
             <span class="w-2 h-2 rounded-full bg-purple-400"></span>context
           </span>
           <span class="flex items-center gap-1">
-            <span class="w-2 h-2 rounded-full bg-red-400"></span>failure
+            <span class="w-2 h-2 rounded-full bg-[var(--bad-10)]"></span>failure
           </span>
         </div>
       </header>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -228,7 +228,7 @@ function Callout({
 }) {
   const toneClass =
     tone === 'warn'
-      ? 'border-amber-400/20 bg-amber-500/10 text-[var(--warn)]'
+      ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded-xl border px-3 py-3 shadow-sm ${toneClass}">
@@ -274,9 +274,9 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
 function PromptSourceBadge({ source }: { source: string }) {
   const tone =
     source === 'override'
-      ? 'bg-amber-500/10 text-[var(--warn)] border-amber-400/20'
+      ? 'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]'
       : source === 'file'
-        ? 'bg-emerald-500/10 text-[var(--ok)] border-emerald-400/20'
+        ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
         : 'bg-white/5 text-text-dim border-white/10'
   return html`<span class="text-[10px] font-bold px-2 py-0.5 rounded-md border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -220,10 +220,10 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   let pill
   if (isInvalid) {
     valueClass = 'text-[var(--bad-light)] underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
+    pill = html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
   } else if (isOverride) {
     valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
+    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
   } else {
     valueClass = 'text-[var(--text-muted)] cursor-help'
     pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
@@ -271,10 +271,10 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
           턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
-          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
+          ? html`<span class="rounded-full bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
           : hasOverride
-            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
-            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
+            ? html`<span class="rounded-full bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
+            : html`<span class="rounded-full bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형"
@@ -301,7 +301,7 @@ export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
   return html`
     <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${diverges}>
       <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
-        <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-amber-400' : 'bg-accent/50'}"></span>
+        <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-[var(--warn-10)]' : 'bg-accent/50'}"></span>
         턴 예산
         ${diverges ? html`<span class="text-[10px] text-[var(--warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
       </summary>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -440,7 +440,7 @@ function CheckpointSummaryCard({
           ${summary.message_count} msgs
         </span>
         ${summary.system_prompt_present
-          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-[var(--ok)]">system kept</span>`
+          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
           : null}
       </div>
       <div class="mt-2 text-[11px] text-[var(--text-muted)]">
@@ -622,7 +622,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                           ${item.message_count} msgs
                         </span>
                         ${item.system_prompt_present
-                          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-[var(--ok)]">system kept</span>`
+                          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
                           : null}
                       </div>
                       <div class="mt-1 text-[11px] text-[var(--text-muted)]">
@@ -768,7 +768,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                     <div class="flex items-center gap-2">
                       <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
                       <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
-                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-[var(--warn)] border border-amber-500/20">shallow</span>` : null}
+                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">shallow</span>` : null}
                     </div>
                     <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
@@ -787,7 +787,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
                   <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
                   <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${pr.branch}</span>
-                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-[var(--warn)] border border-amber-500/20">draft</span>` : null}
+                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">draft</span>` : null}
                   <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}
@@ -940,9 +940,9 @@ export function lineageTransitionLabel(parentGeneration: number | null | undefin
 function verdictBadgeClass(verdict: string | undefined): string {
   switch (verdict) {
     case 'verified':
-      return 'bg-emerald-500/10 text-[var(--ok)] border border-emerald-500/20'
+      return 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
     case 'drift_detected':
-      return 'bg-amber-500/10 text-[var(--warn)] border border-amber-500/20'
+      return 'bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]'
     case 'unavailable':
       return 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
     default:
@@ -1262,7 +1262,7 @@ export function KeeperDetailOverlay() {
                   return html`
                     <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold uppercase tracking-wide
                       ${canPR
-                        ? 'bg-emerald-500/10 text-[var(--ok)] border border-emerald-500/20'
+                        ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
                         : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
                       }"
                       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -91,9 +91,9 @@ const WEIGHT_RAMP: ReadonlyArray<{
   tw: string
   label: string
 }> = [
-  { floor: 0.7, svg: '#10b981', tw: 'bg-emerald-500', label: '70%+' },
-  { floor: 0.4, svg: '#f59e0b', tw: 'bg-amber-500', label: '40%+' },
-  { floor: 0,   svg: '#f87171', tw: 'bg-red-400',    label: '<40%' },
+  { floor: 0.7, svg: '#10b981', tw: 'bg-[var(--ok-10)]', label: '70%+' },
+  { floor: 0.4, svg: '#f59e0b', tw: 'bg-[var(--warn-10)]', label: '40%+' },
+  { floor: 0,   svg: '#f87171', tw: 'bg-[var(--bad-10)]',    label: '<40%' },
 ]
 
 const LEGEND_STOPS = [1.0, 0.75, 0.5, 0.25, 0.05] as const

--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -29,8 +29,8 @@ function outcomeTag(entry: TelemetryEntry): { label: string; tone: 'ok' | 'bad' 
 }
 
 function toneClass(tone: 'ok' | 'bad' | 'neutral'): string {
-  if (tone === 'ok') return 'bg-emerald-500/15 text-[var(--ok)] border-emerald-500/30'
-  if (tone === 'bad') return 'bg-red-500/15 text-[var(--bad-light)] border-red-500/30'
+  if (tone === 'ok') return 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
+  if (tone === 'bad') return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
   return 'bg-white/5 text-text-dim border-card-border'
 }
 

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -14,7 +14,7 @@ import { bucketTelemetryEntries, entryTimestampMs, useTrackBucketCount } from '.
 function sourceColor(source: string | undefined): string {
   switch (source) {
     case 'oas_event': return 'bg-accent'
-    case 'agent_event': return 'bg-emerald-400'
+    case 'agent_event': return 'bg-[var(--ok-10)]'
     case 'tool_call_io': return 'bg-blue-400'
     case 'tool_usage': return 'bg-sky-400'
     case 'keeper_metrics': return 'bg-purple-400'

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -283,7 +283,7 @@ export function Observatory() {
               type="button"
               class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
                 liveMode.value
-                  ? 'border-emerald-500/40 bg-emerald-500/10 text-[var(--ok)]'
+                  ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
                   : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
               }"
               onClick=${() => {
@@ -294,8 +294,8 @@ export function Observatory() {
             >
               ${liveMode.value ? html`
                 <span class="relative flex h-2 w-2">
-                  <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-                  <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-400"></span>
+                  <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--ok-10)] opacity-75"></span>
+                  <span class="relative inline-flex rounded-full h-2 w-2 bg-[var(--ok-10)]"></span>
                 </span>
                 자동 갱신
               ` : '자동 갱신'}
@@ -305,7 +305,7 @@ export function Observatory() {
       </div>
 
       ${activeView.value === 'timeline' && data.error ? html`
-        <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-[var(--warn)]">
+        <div class="rounded-lg border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">
           일부 데이터 불러오기 실패: ${data.error}
         </div>
       ` : null}

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -20,8 +20,8 @@ function toolCallOutcome(entry: TelemetryEntry): 'success' | 'failure' | 'unknow
 
 function outcomeColor(outcome: ReturnType<typeof toolCallOutcome>): string {
   switch (outcome) {
-    case 'success': return 'bg-emerald-400'
-    case 'failure': return 'bg-red-400'
+    case 'success': return 'bg-[var(--ok-10)]'
+    case 'failure': return 'bg-[var(--bad-10)]'
     default: return 'bg-text-dim'
   }
 }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -618,7 +618,7 @@ function ToolCallHealthPanel() {
     ? (successRate >= 95 ? 'text-ok' : successRate >= 90 ? 'text-warn' : 'text-bad-light')
     : 'text-text-dim'
   const barColor = successRate != null
-    ? (successRate >= 95 ? 'bg-emerald-500' : successRate >= 90 ? 'bg-yellow-500' : 'bg-red-500')
+    ? (successRate >= 95 ? 'bg-[var(--ok-10)]' : successRate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]')
     : 'bg-gray-500'
 
   return html`

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -64,7 +64,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
             <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
           ${entry.sensitive ? html`
-            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-[var(--warn)]">sensitive</span>
+            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)]">sensitive</span>
           ` : null}
         </div>
         <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>

--- a/dashboard/src/components/setup-guide-card.test.ts
+++ b/dashboard/src/components/setup-guide-card.test.ts
@@ -152,7 +152,7 @@ describe('SetupGuideCard', () => {
     await flushUi()
     const firstCircle = container.querySelector('[data-setup-step-circle="discord:0"]') as HTMLElement
     expect(firstCircle.textContent).toBe('✓')
-    expect(firstCircle.className).toContain('border-emerald-400')
+    expect(firstCircle.className).toContain('border-[var(--ok-20)]')
   })
 
   it('Complete badge appears + tone flips to complete when all steps done', async () => {

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -104,7 +104,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
     tone === 'in-progress' ? 'text-[var(--accent)]' :
     'text-[var(--text-dim)]'
   const progressBarToneClass =
-    tone === 'complete' ? 'bg-emerald-400' :
+    tone === 'complete' ? 'bg-[var(--ok-10)]' :
     tone === 'in-progress' ? 'bg-[var(--accent)]' :
     'bg-[var(--white-10)]'
 
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
+                  class="inline-flex items-center gap-1 rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >
@@ -177,7 +177,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                   // even before checkboxes are ticked. Circle turns
                   // emerald-filled when the step is complete.
                   const circleToneClass = done
-                    ? 'border-emerald-400 bg-emerald-500/20 text-[var(--ok)]'
+                    ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
                     : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
                   return html`
                     <li class="flex items-start gap-2.5" data-setup-step-item=${idx}>

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -239,7 +239,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           `
         : null}
       ${entry.error
-        ? html`<div class="rounded border border-rose-400/30 bg-rose-500/10 px-2 py-1 text-[11px] text-[var(--bad-light)]">${entry.error}</div>`
+        ? html`<div class="rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[11px] text-[var(--bad-light)]">${entry.error}</div>`
         : entry.loading && entry.lines.length === 0
           ? html`
               <div class="rounded bg-[var(--bg-0)] p-2">

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -95,7 +95,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
 
   return html`
     <div
-      class="mt-2 flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-[11px] text-[var(--warn)]"
+      class="mt-2 flex items-center gap-2 rounded-md border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]"
       data-startup-warning=${connectorId}
     >
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
@@ -108,7 +108,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       </div>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-amber-400/30 bg-amber-500/15 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-amber-500/25"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-[var(--warn-10)]"
         onClick=${() => {
           openSidecarLogs(connectorId)
           // Don't clear startAt yet — operator might toggle logs back closed
@@ -118,7 +118,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       >📋 로그 열기</button>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-amber-400/20 px-1.5 py-0.5 text-[14px] leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] px-1.5 py-0.5 text-[14px] leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
         aria-label="dismiss startup warning"
         onClick=${() => clearStartAttempt(connectorId)}
       >×</button>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -841,7 +841,7 @@ export function TelemetryUnified() {
       </div>
 
       ${error ? html`
-        <div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-[var(--bad-light)]">
+        <div class="rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-xs text-[var(--bad-light)]">
           ${error}
         </div>
       ` : null}

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -117,7 +117,7 @@ export function filterTools<T extends Pick<ToolStat, 'name'>>(tools: T[], query:
 }
 
 function RateGauge({ rate, label }: { rate: number; label: string }) {
-  const color = rate >= 95 ? 'bg-emerald-500' : rate >= 90 ? 'bg-yellow-500' : 'bg-red-500'
+  const color = rate >= 95 ? 'bg-[var(--ok-10)]' : rate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
   return html`
     <div class="flex flex-col gap-1">
       <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider">${label}</div>
@@ -171,7 +171,7 @@ function ToolTable({
               : t.success_pct >= 80 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'
             const isHighlighted = highlightTool && t.name === highlightTool
             const rowClass = isHighlighted
-              ? 'border-b border-amber-500/60 bg-amber-900/20 ring-1 ring-amber-500/40'
+              ? 'border-b border-[var(--warn-20)] bg-amber-900/20 ring-1 ring-amber-500/40'
               : 'border-b border-[var(--card-border)] border-opacity-30'
             return html`
               <tr class=${rowClass} ref=${isHighlighted ? ((el: HTMLElement | null) => el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })) : undefined}>
@@ -242,7 +242,7 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
   return html`
     <div class="flex flex-col gap-1.5">
       ${keepers.map(k => {
-        const color = k.success_pct >= 95 ? 'bg-emerald-500' : k.success_pct >= 90 ? 'bg-yellow-500' : 'bg-red-500'
+        const color = k.success_pct >= 95 ? 'bg-[var(--ok-10)]' : k.success_pct >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
         const textColor = k.success_pct >= 95 ? 'text-[var(--ok)]' : k.success_pct >= 90 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'
         return html`
           <div class="flex items-center gap-2 text-[11px]">


### PR DESCRIPTION
## 요약

Anyang Sleepers 디자인 시스템 Tailwind 마이그레이션 마무리. #8271 (-400 text), #8273 (-{100,200,300,500} text)에 이어 이번 PR은 **bg/border variants + 남은 text 인스턴스**를 일괄 처리. 34 files, 154 insertions.

## 매핑

| 카테고리 | 이전 패턴 | 이후 |
|---|---|---|
| text | \`text-{red,rose}-{any}\` | \`text-[var(--bad-light)]\` |
| text | \`text-{emerald,green}-{any}\` | \`text-[var(--ok)]\` |
| text | \`text-{yellow,amber}-{any}\` | \`text-[var(--warn)]\` |
| bg | \`bg-{red,rose}-{any}[/NN]\` | \`bg-[var(--bad-10)]\` |
| bg | \`bg-{emerald,green}-{any}[/NN]\` | \`bg-[var(--ok-10)]\` |
| bg | \`bg-{yellow,amber}-{any}[/NN]\` | \`bg-[var(--warn-10)]\` |
| border | \`border-{red,rose}-{any}[/NN]\` | \`border-[var(--bad-20)]\` |
| border | \`border-{emerald,green}-{any}[/NN]\` | \`border-[var(--ok-20)]\` |
| border | \`border-{yellow,amber}-{any}[/NN]\` | \`border-[var(--warn-20)]\` |

## Alpha 수렴 결정

/5, /10, /15, /60 등 다양한 opacity → 단일 -10 semantic 토큰으로 통합. 운영자가 실제 readability 차이를 느끼면 finer-grained 토큰 추가. 선제적 도입하지 않음 (YAGNI).

## Test 수정

- \`status-dot.test.ts\`: \`toMatch(/bg-[...]/)\` regex literal이 \`[var(--...)]\` 내부 \`--\` 때문에 TS1517 "Range out of order in character class" 에러. \`toContain\` + positional \`indexOf\`로 재작성 (semantic 의도는 그대로).
- \`progress-bar\`, \`setup-guide-card\`, \`connector-status\` 테스트들은 이미 \`toContain\` 사용 중이라 변경 없음.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] status-dot + progress-bar + setup-guide-card + connector-status vitest 72/72 통과
- [x] 마이그레이션 후 \`rg\` 결과: text/bg/border × {red,rose,emerald,green,yellow,amber} × {100-700} zero hits

## Related

- #8271 19-file text-400 sweep
- #8273 27-file text-{100,200,300,500} sweep
- #8177 paper theme 인프라