### PR TITLE
fix(dashboard-tests): realign 3 assertions to semantic tokens after #8273

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -651,7 +651,10 @@ describe('StatusSummaryLine offline annotation (rendered inside ConnectorOvervie
     const annotation = container.querySelector('[data-strip-summary-offline-names]') as HTMLElement
     expect(annotation).toBeTruthy()
     expect(annotation.textContent).toContain('Slack offline')
-    expect(annotation.className).toContain('rose')
+    // #8273 swapped the raw rose utility for the --bad-light semantic token
+    // on this annotation (start/stop buttons and error notices still carry
+    // the border/bg rose classes, only the bare text class changed here).
+    expect(annotation.className).toContain('--bad')
   })
 })
 

--- a/dashboard/src/components/header-stat-trio.test.ts
+++ b/dashboard/src/components/header-stat-trio.test.ts
@@ -65,9 +65,11 @@ describe('headerSuccessTone (pure)', () => {
 
 describe('headerStatToneClass (pure)', () => {
   it('maps each tone to a distinct text-color utility', () => {
-    expect(headerStatToneClass('ok')).toContain('emerald')
-    expect(headerStatToneClass('partial')).toContain('amber')
-    expect(headerStatToneClass('bad')).toContain('rose')
+    // After #8273 migrated raw Tailwind colors to semantic CSS vars,
+    // the utility is `text-[var(--<tone>)]`.
+    expect(headerStatToneClass('ok')).toContain('--ok')
+    expect(headerStatToneClass('partial')).toContain('--warn')
+    expect(headerStatToneClass('bad')).toContain('--bad')
     expect(headerStatToneClass('default')).toContain('text-')
   })
 
@@ -109,12 +111,12 @@ describe('HeaderMiniStat component', () => {
     expect(el.getAttribute('data-header-mini-stat-tone')).toBe('default')
   })
 
-  it('value carries the tone text-color class (bad → rose)', () => {
+  it('value carries the tone text-color class (bad → --bad-light)', () => {
     render(html`<${HeaderMiniStat} label="x" value="0/4" tone="bad" />`, container)
     const el = container.querySelector('[data-header-mini-stat="x"]')!
     // Value is the first <span> child.
     const valueSpan = el.querySelector('span')!
-    expect(valueSpan.className).toContain('rose')
+    expect(valueSpan.className).toContain('--bad')
   })
 
   it('testId renders as data-testid', () => {


### PR DESCRIPTION
## Summary

#8273 semantic-token sweep 이후 main CI Dashboard job이 3 assertion에서 red. 소스는 `text-[var(--ok)]` / `text-[var(--bad-light)]`로 전환됐는데 테스트는 여전히 `emerald` / `rose`를 기대하고 있어 발생한 뒤처짐.

## Product impact

- Main CI Dashboard job green 복구. 이후 모든 PR이 정상 gating 받음.
- 소스 변경 없음, 테스트 assertion만 업데이트.
- 관련 PR #8276 도 이 fix가 merge되면 rebase 후 green 기대.

## Evidence

3 assertion fix:

| 위치 | 변경 |
|---|---|
| `header-stat-trio.test.ts:68-71` | `emerald/amber/rose` → `--ok/--warn/--bad` |
| `header-stat-trio.test.ts:112-118` | `rose` → `--bad` |
| `connector-overview-strip.test.ts:654` | `rose` → `--bad` |

Button/notice border+bg 클래스는 여전히 raw color utility(`border-emerald-400/40` 등)를 유지하므로 그 쪽 assertion은 건드리지 않음.

## Review evidence

- `vitest run src/components/header-stat-trio.test.ts src/components/connector-overview-strip.test.ts`: **83/83 passed**.
- 소스 파일 수정 없음.

## Linked issue

Relates #8273 (pre-existing regression from color migration)
Unblocks #8276

🤖 Generated with [Claude Code](https://claude.com/claude-code)