### PR TITLE
test(dashboard): sync rose/emerald assertions with CSS var tokens

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -651,7 +651,7 @@ describe('StatusSummaryLine offline annotation (rendered inside ConnectorOvervie
     const annotation = container.querySelector('[data-strip-summary-offline-names]') as HTMLElement
     expect(annotation).toBeTruthy()
     expect(annotation.textContent).toContain('Slack offline')
-    expect(annotation.className).toContain('rose')
+    expect(annotation.className).toContain('var(--bad-light)')
   })
 })
 

--- a/dashboard/src/components/header-stat-trio.test.ts
+++ b/dashboard/src/components/header-stat-trio.test.ts
@@ -65,9 +65,9 @@ describe('headerSuccessTone (pure)', () => {
 
 describe('headerStatToneClass (pure)', () => {
   it('maps each tone to a distinct text-color utility', () => {
-    expect(headerStatToneClass('ok')).toContain('emerald')
-    expect(headerStatToneClass('partial')).toContain('amber')
-    expect(headerStatToneClass('bad')).toContain('rose')
+    expect(headerStatToneClass('ok')).toContain('var(--ok)')
+    expect(headerStatToneClass('partial')).toContain('var(--warn)')
+    expect(headerStatToneClass('bad')).toContain('var(--bad-light)')
     expect(headerStatToneClass('default')).toContain('text-')
   })
 
@@ -109,12 +109,12 @@ describe('HeaderMiniStat component', () => {
     expect(el.getAttribute('data-header-mini-stat-tone')).toBe('default')
   })
 
-  it('value carries the tone text-color class (bad → rose)', () => {
+  it('value carries the tone text-color class (bad → var(--bad-light))', () => {
     render(html`<${HeaderMiniStat} label="x" value="0/4" tone="bad" />`, container)
     const el = container.querySelector('[data-header-mini-stat="x"]')!
     // Value is the first <span> child.
     const valueSpan = el.querySelector('span')!
-    expect(valueSpan.className).toContain('rose')
+    expect(valueSpan.className).toContain('var(--bad-light)')
   })
 
   it('testId renders as data-testid', () => {


### PR DESCRIPTION
## 문제

#8271, #8273, #8274의 design-system color sweep이 구현(`connector-status.ts`, `connector-overview-strip.ts`)을 CSS var 토큰(`var(--ok)`, `var(--bad-light)` 등)으로 전환했지만 다음 테스트 파일이 여전히 예전 Tailwind 유틸(`emerald`, `rose`)을 기대해 main이 broken 상태.

## 증거

- `dashboard/src/components/header-stat-trio.test.ts:68-71,117`
- `dashboard/src/components/connector-overview-strip.test.ts:654`

#8275, #8276 등 최근 Draft/Ready PR 여러 개가 같은 이유로 Dashboard CI 실패.

예시 에러:
```
AssertionError: expected 'ml-1 text-[var(--bad-light)]/80' to contain 'rose'
AssertionError: expected 'text-[var(--ok)]' to contain 'emerald'
```

## 변경

- `emerald` → `var(--ok)`
- `rose` → `var(--bad-light)`
- `amber` → `var(--warn)` (partial tone)

구현 쪽 변경 없음. 테스트만 최신 토큰 가정에 맞춤.

## 테스트

`pnpm test -- --run src/components/header-stat-trio.test.ts src/components/connector-overview-strip.test.ts` — 이전 3개 rose/emerald 실패 모두 제거. 잔여 1건은 `ops/quick-intervene.test.ts` 타임아웃으로 이 PR 범위 밖.
