### PR TITLE
feat(dashboard): neutral-gray sweep — zinc/gray/neutral/stone → tokens

### DIFF
--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -139,13 +139,13 @@ export function AgentDetailMemory({ agentName }: Props) {
                                 (s: MemorySubsystemsSynapse) => html`
                                   <div class="flex items-center gap-2 text-xs">
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.to_agent)}</span>
-                                    <div class="w-16 bg-zinc-800 rounded h-1.5">
+                                    <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
                                       <div
                                         class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>
-                                    <span class="text-zinc-400 w-10 text-right">${Math.round(s.weight * 100)}%</span>
+                                    <span class="text-[var(--text-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
                                   </div>
                                 `,
                               )}
@@ -164,13 +164,13 @@ export function AgentDetailMemory({ agentName }: Props) {
                                 (s: MemorySubsystemsSynapse) => html`
                                   <div class="flex items-center gap-2 text-xs">
                                     <span class="font-mono flex-1 truncate">${normalizeKeeperName(s.from_agent)}</span>
-                                    <div class="w-16 bg-zinc-800 rounded h-1.5">
+                                    <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
                                       <div
                                         class="${s.weight >= 0.7 ? 'bg-[var(--ok-10)]' : s.weight >= 0.4 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'} rounded h-1.5"
                                         style="width:${Math.round(s.weight * 100)}%"
                                       ></div>
                                     </div>
-                                    <span class="text-zinc-400 w-10 text-right">${Math.round(s.weight * 100)}%</span>
+                                    <span class="text-[var(--text-muted)] w-10 text-right">${Math.round(s.weight * 100)}%</span>
                                   </div>
                                 `,
                               )}
@@ -234,16 +234,16 @@ export function AgentDetailMemory({ agentName }: Props) {
                               ? 'text-[var(--warn)]'
                               : 'text-[var(--bad-light)]'
                         return html`
-                          <div class="border border-zinc-800 rounded px-2 py-1.5 text-xs">
+                          <div class="border border-[var(--white-10)] rounded px-2 py-1.5 text-xs">
                             <div class="flex items-center justify-between gap-2">
                               <div class="flex items-center gap-2 min-w-0">
                                 <span class="${outcomeColor}">${outcomeIcon}</span>
-                                <span class="truncate text-zinc-300">${highlightMatch(ep.summary, episodeQuery.value)}</span>
+                                <span class="truncate text-[var(--text-muted)]">${highlightMatch(ep.summary, episodeQuery.value)}</span>
                               </div>
-                              <span class="text-[10px] text-zinc-500 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+                              <span class="text-[10px] text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
                             </div>
                             ${ep.learnings.length > 0
-                              ? html`<div class="mt-1 text-[11px] text-zinc-400 pl-3 border-l border-zinc-700">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
+                              ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
                               : null}
                           </div>
                         `

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -22,7 +22,7 @@
 //   text-text-dim   → var(--color-text-dim)
 // Using the generated utility instead of `text-[var(--text-muted)]`
 // keeps purge predictable, autocomplete honest, and fixes the
-// `text-text-muted` / `text-[var(--text-muted)]` / `text-zinc-400`
+// `text-text-muted` / `text-[var(--text-muted)]` / `text-[var(--text-muted)]`
 // trident drift the audit surfaced.
 //
 // NOT a replacement for:

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -137,15 +137,15 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
   return html`
     <section
       data-testid="composite-fsm-flowchart"
-      class="rounded border border-zinc-800 bg-zinc-950 ${props.class ?? ''}"
+      class="rounded border border-[var(--white-10)] bg-[var(--white-5)] ${props.class ?? ''}"
     >
-      <header class="border-b border-zinc-800 p-3">
-        <h2 class="text-sm font-semibold text-zinc-100">
+      <header class="border-b border-[var(--white-10)] p-3">
+        <h2 class="text-sm font-semibold text-[var(--text-muted)]">
           Composite FSM flowchart (TLA+ spec)
         </h2>
-        <p class="mt-1 text-xs text-zinc-400">
+        <p class="mt-1 text-xs text-[var(--text-muted)]">
           6 orthogonal axes rendered as Harel parallel regions. Source:
-          <code class="text-zinc-300">specs/keeper-state-machine/*.tla</code>.
+          <code class="text-[var(--text-muted)]">specs/keeper-state-machine/*.tla</code>.
           Transitions here are the common-case edges; the TLA+
           model-checker owns the exhaustive enumeration.
         </p>

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -57,7 +57,7 @@ describe('chipClassFor', () => {
 
   it('falls back to the default chip for unknown states', () => {
     const cls = chipClassFor('unknown_state_variant')
-    expect(cls).toContain('bg-zinc-800')
+    expect(cls).toContain('bg-[var(--white-5)]')
   })
 })
 
@@ -114,7 +114,7 @@ describe('sparkClassFor', () => {
   })
 
   it('falls back to a grey shade on unknown states', () => {
-    // DEFAULT_CHIP carries `bg-zinc-800`; sparkClassFor preserves it.
+    // DEFAULT_CHIP carries `bg-[var(--white-5)]`; sparkClassFor preserves it.
     expect(sparkClassFor('__not_a_state__')).toMatch(/^bg-zinc-(700|800)/)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -76,20 +76,20 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   Compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
   Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
-  Paused:       'bg-zinc-800 text-zinc-300 border-zinc-600',
-  Stopped:      'bg-zinc-800 text-zinc-400 border-zinc-700',
+  Paused:       'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
+  Stopped:      'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   Crashed:      'bg-red-950 text-[var(--bad-light)] border-red-800',
   Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
   Dead:         'bg-black text-[var(--bad-light)] border-red-900',
-  Offline:      'bg-zinc-900 text-zinc-500 border-zinc-800',
+  Offline:      'bg-[var(--white-5)] text-[var(--text-muted)]0 border-[var(--white-10)]',
   // KTC
-  idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',
+  idle:         'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
   executing:    'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
   // KDP
-  undecided:          'bg-zinc-800 text-zinc-400 border-zinc-700',
+  undecided:          'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   guard_ok:           'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   gate_rejected:      'bg-red-900/40 text-[var(--bad-light)] border-[var(--bad-20)]',
   tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
@@ -99,19 +99,19 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   done:         'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   exhausted:    'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
   // KMC
-  accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
+  accumulating: 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   // KCB (LT-16-KCB Phase 3). Clean = baseline grey same as any other
   // "nothing happening" state; warning = amber (partial failure
   // streak); cooling = blue (at least one past trip, currently
   // recovered). "tripped" is unobservable at snapshot time and has no
   // chip colour by design — the mutator resets the count before any
   // observer can see it.
-  clean:   'bg-zinc-800 text-zinc-400 border-zinc-700',
+  clean:   'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   warning: 'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   cooling: 'bg-sky-900/40 text-sky-200 border-sky-700',
 }
 
-const DEFAULT_CHIP = 'bg-zinc-800 text-zinc-300 border-zinc-700'
+const DEFAULT_CHIP = 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]'
 
 export function chipClassFor(value: string): string {
   return CHIP_CLASS_BY_STATE[value] ?? DEFAULT_CHIP
@@ -125,7 +125,7 @@ export function chipClassFor(value: string): string {
 export function sparkClassFor(value: string): string {
   const full = chipClassFor(value)
   const m = /\bbg-[a-z0-9/-]+/i.exec(full)
-  return m?.[0] ?? 'bg-zinc-700'
+  return m?.[0] ?? 'bg-[var(--white-5)]'
 }
 
 /** Per-axis observation ring keyed by keeper name. */
@@ -292,7 +292,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     return html`
       <div
         data-testid="fleet-fsm-matrix"
-        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--text-muted)]"
       >
         Loading fleet composite snapshot…
       </div>
@@ -314,7 +314,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     return html`
       <div
         data-testid="fleet-fsm-matrix"
-        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+        class="rounded border border-[var(--white-10)] bg-[var(--white-5)] p-4 text-sm text-[var(--text-muted)]"
       >
         No keepers registered.
       </div>
@@ -324,11 +324,11 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   return html`
     <section
       data-testid="fleet-fsm-matrix"
-      class="rounded border border-zinc-800 bg-zinc-950"
+      class="rounded border border-[var(--white-10)] bg-[var(--white-5)]"
     >
-      <header class="flex flex-wrap items-baseline gap-3 border-b border-zinc-800 p-3">
-        <h2 class="text-sm font-semibold text-zinc-100">Fleet composite (KSM × KTC × KDP × KCL × KMC)</h2>
-        <span class="text-xs text-zinc-500">
+      <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--white-10)] p-3">
+        <h2 class="text-sm font-semibold text-[var(--text-muted)]">Fleet composite (KSM × KTC × KDP × KCL × KMC)</h2>
+        <span class="text-xs text-[var(--text-muted)]0">
           ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
         </span>
         <input
@@ -338,7 +338,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
           aria-label="Keeper 필터"
           data-testid="fleet-fsm-matrix-filter"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[160px] max-w-[260px] rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-200 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
+          class="min-w-[160px] max-w-[260px] rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--text-muted)] placeholder:text-[var(--text-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
         />
         ${tallies
           ? html`
@@ -366,7 +366,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         ? html`
             <div
               data-testid="fleet-fsm-matrix-empty"
-              class="p-4 text-center text-xs text-zinc-500"
+              class="p-4 text-center text-xs text-[var(--text-muted)]0"
             >
               필터 결과 없음 (${data.snapshots.length} keepers)
             </div>
@@ -374,12 +374,12 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         : null}
       <div class="overflow-x-auto">
         <table class="min-w-full text-xs">
-          <thead class="bg-zinc-900 text-zinc-300">
+          <thead class="bg-[var(--white-5)] text-[var(--text-muted)]">
             <tr>
               <th class="px-3 py-2 text-left font-semibold">Keeper</th>
               ${AXES.map(a => html`
                 <th class="px-3 py-2 text-left font-semibold" title=${a.label}>
-                  ${a.acronym} <span class="text-zinc-500">${a.label}</span>
+                  ${a.acronym} <span class="text-[var(--text-muted)]0">${a.label}</span>
                 </th>
               `)}
             </tr>
@@ -392,10 +392,10 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
               return html`
                 <tr
                   data-keeper=${name}
-                  class="border-t border-zinc-800 hover:bg-zinc-900 ${rowTone}"
+                  class="border-t border-[var(--white-10)] hover:bg-[var(--white-5)] ${rowTone}"
                   onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
                 >
-                  <td class="px-3 py-2 font-mono text-zinc-200">${name}</td>
+                  <td class="px-3 py-2 font-mono text-[var(--text-muted)]">${name}</td>
                   ${AXES.map(a => {
                     const raw = extractLaneValue(snap, a.key)
                     const cls = chipClassFor(raw)
@@ -411,7 +411,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                           <div
                             data-spark
                             data-axis=${a.key}
-                            class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
+                            class="flex h-2 overflow-hidden rounded-sm border border-[var(--white-10)] bg-[var(--white-5)]"
                             title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
                           >
                             ${series.map((v, i) => html`

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -62,7 +62,7 @@ export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
   tool: 'bg-sky-400',
   handoff: 'bg-orange-400',
   context: 'bg-purple-400',
-  unknown: 'bg-zinc-500',
+  unknown: 'bg-[var(--white-5)]0',
 }
 
 interface TimelineChip {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -186,7 +186,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   const height = topPad + n * cell + 30
 
   return html`
-    <div class="bg-zinc-900 rounded-lg p-3 overflow-x-auto">
+    <div class="bg-[var(--white-5)] rounded-lg p-3 overflow-x-auto">
       <svg viewBox="0 0 ${width} ${height}" class="w-full h-auto" style="max-height:560px">
         ${agents.map(
           (name, i) => html`
@@ -250,7 +250,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
                   stroke=${active ? '#f1f5f9' : isDiag ? '#64748b' : '#0f172a'}
                   stroke-dasharray=${isDiag ? '2 2' : ''}
                   stroke-width=${active ? '1.5' : '0.5'}
-                  class="cursor-pointer hover:stroke-zinc-300"
+                  class="cursor-pointer hover:stroke-[var(--text-muted)]"
                   role="button"
                   aria-label=${`${from} to ${to}: ${pct}% — filter episodes for this pair`}
                   aria-pressed=${active ? 'true' : 'false'}
@@ -286,7 +286,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
           )}
         </g>
       </svg>
-      <div class="mt-2 text-xs text-zinc-500 text-center">
+      <div class="mt-2 text-xs text-[var(--text-muted)]0 text-center">
         행 = from · 열 = to · 셀 = 시냅스 가중치 · 정렬 = 활동량 내림차순
       </div>
     </div>
@@ -297,7 +297,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
 // the backend; reverse for chronological left-to-right rendering.
 function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
   if (!history || history.length < 2) {
-    return html`<span class="text-zinc-700 text-[10px] w-20 text-center">—</span>`
+    return html`<span class="text-[var(--text-muted)] text-[10px] w-20 text-center">—</span>`
   }
   const chronological = [...history].reverse()
   const { width: sw, height: sh, strokeWidth } = SPARKLINE
@@ -331,33 +331,33 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
   if (synapses.length === 0) return null
   const top = [...synapses].sort((a, b) => b.weight - a.weight).slice(0, TOP_LINK_COUNT)
   return html`
-    <div class="bg-zinc-900 rounded-lg p-3 mt-3">
-      <div class="text-xs text-zinc-500 mb-2">강한 연결 Top ${TOP_LINK_COUNT} · sparkline = 학습 궤적</div>
+    <div class="bg-[var(--white-5)] rounded-lg p-3 mt-3">
+      <div class="text-xs text-[var(--text-muted)]0 mb-2">강한 연결 Top ${TOP_LINK_COUNT} · sparkline = 학습 궤적</div>
       <div class="space-y-1.5">
         ${top.map(s => {
           const pct = Math.round(s.weight * 100)
           const active = isActivePair(s.from_agent, s.to_agent)
           return html`
             <div
-              class="flex items-center gap-2 text-xs font-mono px-1 py-0.5 rounded cursor-pointer ${active ? 'ring-1 ring-zinc-300 bg-zinc-800/50' : 'hover:bg-zinc-800/30'}"
+              class="flex items-center gap-2 text-xs font-mono px-1 py-0.5 rounded cursor-pointer ${active ? 'ring-1 ring-[var(--white-10)] bg-[var(--white-5)]' : 'hover:bg-[var(--white-5)]'}"
               role="button"
               aria-pressed=${active ? 'true' : 'false'}
               title="클릭: 이 쌍의 에피소드만 필터"
               onClick=${() => toggleSynapsePairFilter(s.from_agent, s.to_agent)}
             >
               <button
-                class="text-zinc-300 hover:text-sky-400 truncate w-32 text-right"
+                class="text-[var(--text-muted)] hover:text-sky-400 truncate w-32 text-right"
                 onClick=${(e: Event) => { e.stopPropagation(); openAgentDetail(s.from_agent) }}
               >${shortAgentLabel(s.from_agent)}</button>
-              <span class="text-zinc-600">→</span>
+              <span class="text-[var(--text-muted)]">→</span>
               <button
-                class="text-zinc-300 hover:text-sky-400 truncate w-32 text-left"
+                class="text-[var(--text-muted)] hover:text-sky-400 truncate w-32 text-left"
                 onClick=${(e: Event) => { e.stopPropagation(); openAgentDetail(s.to_agent) }}
               >${shortAgentLabel(s.to_agent)}</button>
-              <div class="flex-1 bg-zinc-800 rounded h-1.5 min-w-[60px]">
+              <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-[60px]">
                 <div class="${weightBarClass(s.weight)} rounded h-1.5" style="width:${pct}%"></div>
               </div>
-              <span class="text-zinc-300 w-10 text-right">${pct}%</span>
+              <span class="text-[var(--text-muted)] w-10 text-right">${pct}%</span>
               <${WeightSparkline} history=${s.weight_history} />
               <span class="text-[var(--ok)] w-8 text-right">${s.success_count}</span>
               <span class="text-[var(--bad-light)] w-8 text-right">${s.failure_count}</span>
@@ -372,14 +372,14 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
 function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
   const pct = Math.round(s.weight * 100)
   return html`
-    <tr class="border-b border-zinc-800">
+    <tr class="border-b border-[var(--white-10)]">
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
           class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
           onClick=${() => openAgentDetail(s.from_agent)}
         >${s.from_agent}</button>
       </td>
-      <td class="py-1.5 px-2 text-sm text-zinc-400 text-center">→</td>
+      <td class="py-1.5 px-2 text-sm text-[var(--text-muted)] text-center">→</td>
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
           class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
@@ -388,15 +388,15 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
       </td>
       <td class="py-1.5 px-2 text-sm text-right">
         <div class="flex items-center gap-2 justify-end">
-          <div class="w-16 bg-zinc-800 rounded h-1.5">
+          <div class="w-16 bg-[var(--white-5)] rounded h-1.5">
             <div class="${weightBarClass(s.weight)} rounded h-1.5" style="width:${pct}%"></div>
           </div>
-          <span class="text-zinc-300 w-10 text-right">${pct}%</span>
+          <span class="text-[var(--text-muted)] w-10 text-right">${pct}%</span>
         </div>
       </td>
       <td class="py-1.5 px-2 text-sm text-[var(--ok)] text-center">${s.success_count}</td>
       <td class="py-1.5 px-2 text-sm text-[var(--bad-light)] text-center">${s.failure_count}</td>
-      <td class="py-1.5 px-2 text-xs text-zinc-500">${formatTimeAgo(s.last_updated * 1000)}</td>
+      <td class="py-1.5 px-2 text-xs text-[var(--text-muted)]0">${formatTimeAgo(s.last_updated * 1000)}</td>
     </tr>
   `
 }
@@ -411,20 +411,20 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
   const outcomeIcon =
     ep.outcome === 'success' ? '●' : ep.outcome === 'partial' ? '◐' : '○'
   return html`
-    <div class="border border-zinc-800 rounded-lg p-3 mb-2 hover:border-zinc-700 transition-colors">
+    <div class="border border-[var(--white-10)] rounded-lg p-3 mb-2 hover:border-[var(--white-10)] transition-colors">
       <div class="flex items-start justify-between gap-2 mb-1">
         <div class="flex items-center gap-2 min-w-0">
           <span class="${outcomeColor} text-xs">${outcomeIcon}</span>
-          <span class="text-sm font-medium text-zinc-200 truncate">${ep.summary}</span>
+          <span class="text-sm font-medium text-[var(--text-muted)] truncate">${ep.summary}</span>
         </div>
-        <span class="text-xs text-zinc-500 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+        <span class="text-xs text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
       </div>
-      <div class="flex items-center gap-2 text-xs text-zinc-500 mb-1 flex-wrap">
-        <span class="bg-zinc-800 px-1.5 py-0.5 rounded">${ep.event_type}</span>
+      <div class="flex items-center gap-2 text-xs text-[var(--text-muted)]0 mb-1 flex-wrap">
+        <span class="bg-[var(--white-5)] px-1.5 py-0.5 rounded">${ep.event_type}</span>
         ${ep.participants.map(
           (p: string) => html`<span class="font-mono">${p}</span>`,
         )}
-        <span class="text-zinc-600 font-mono text-[10px]">${ep.id}</span>
+        <span class="text-[var(--text-muted)] font-mono text-[10px]">${ep.id}</span>
       </div>
       ${
         ep.learnings.length > 0
@@ -432,7 +432,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
               <div class="mt-1.5 space-y-0.5">
                 ${ep.learnings.map(
                   (l: string) =>
-                    html`<div class="text-xs text-zinc-400 pl-3 border-l border-zinc-700">${l}</div>`,
+                    html`<div class="text-xs text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${l}</div>`,
                 )}
               </div>
             `
@@ -444,7 +444,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
               <div class="mt-1 flex gap-2 flex-wrap">
                 ${Object.entries(ep.context).map(
                   ([k, v]) =>
-                    html`<span class="text-xs bg-zinc-800/50 px-1.5 py-0.5 rounded text-zinc-500"
+                    html`<span class="text-xs bg-[var(--white-5)] px-1.5 py-0.5 rounded text-[var(--text-muted)]0"
                       >${k}: ${v}</span
                     >`,
                 )}
@@ -552,8 +552,8 @@ export function MemorySubsystems() {
 
   return html`
     <div class="space-y-6">
-      <div class="rounded-lg border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-xs text-zinc-400">
-        이 화면은 <span class="text-zinc-200 font-medium">global memory surface</span>만 보여줍니다.
+      <div class="rounded-lg border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-2 text-xs text-[var(--text-muted)]">
+        이 화면은 <span class="text-[var(--text-muted)] font-medium">global memory surface</span>만 보여줍니다.
         institution episodes와 Hebbian graph는 여기서 보고,
         keeper checkpoint/history/memory bank는 Keeper Detail에서 확인합니다.
       </div>
@@ -562,20 +562,20 @@ export function MemorySubsystems() {
       <section>
         <button
           onClick=${() => (showArch.value = !showArch.value)}
-          class="w-full flex items-center justify-between p-2 bg-zinc-900 rounded-lg hover:bg-zinc-800 transition-colors"
+          class="w-full flex items-center justify-between p-2 bg-[var(--white-5)] rounded-lg hover:bg-[var(--white-5)] transition-colors"
         >
-          <span class="text-sm font-semibold text-zinc-200 flex items-center gap-2">
+          <span class="text-sm font-semibold text-[var(--text-muted)] flex items-center gap-2">
             <span class="text-xs">${showArch.value ? '▼' : '▶'}</span>
             아키텍처 — 데이터 흐름도
           </span>
-          <span class="text-xs text-zinc-500">
+          <span class="text-xs text-[var(--text-muted)]0">
             Keeper turn → episodes / task_done → Hebbian. Keeper memory bank와 checkpoint는 다른 패널에서 본다.
           </span>
         </button>
         ${
           showArch.value
             ? html`
-                <div class="mt-2 bg-zinc-900 rounded-lg p-3">
+                <div class="mt-2 bg-[var(--white-5)] rounded-lg p-3">
                   <${MermaidGraph}
                     source=${ARCHITECTURE_FLOW}
                     prefix="memory-arch"
@@ -590,8 +590,8 @@ export function MemorySubsystems() {
       <!-- Hebbian Synapses -->
       <section>
         <div class="flex items-center justify-between mb-3">
-          <h3 class="text-base font-semibold text-zinc-200">Hebbian 시냅스 그래프</h3>
-          <div class="flex items-center gap-3 text-xs text-zinc-500">
+          <h3 class="text-base font-semibold text-[var(--text-muted)]">Hebbian 시냅스 그래프</h3>
+          <div class="flex items-center gap-3 text-xs text-[var(--text-muted)]0">
             <span>${synapses.length}개 시냅스</span>
             ${
               lastConsolidation > 0
@@ -610,7 +610,7 @@ export function MemorySubsystems() {
         }
         ${
           synapses.length === 0
-            ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+            ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded-lg p-4 text-center">
                 시냅스 데이터 없음. keeper task 완료 시 자동 생성됩니다.
               </div>`
             : html`
@@ -623,23 +623,23 @@ export function MemorySubsystems() {
                     onInput=${(e: Event) => {
                       synapseQuery.value = (e.target as HTMLInputElement).value
                     }}
-                    class="flex-1 min-w-[200px] bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+                    class="flex-1 min-w-[200px] bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
                   />
                   ${
                     isSynapseFiltering
-                      ? html`<span class="text-xs text-zinc-500">${visibleSynapses.length}/${synapses.length}</span>`
+                      ? html`<span class="text-xs text-[var(--text-muted)]0">${visibleSynapses.length}/${synapses.length}</span>`
                       : null
                   }
                 </div>
                 ${
                   isSynapseFiltering && visibleSynapses.length === 0
-                    ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+                    ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded-lg p-4 text-center">
                         필터 결과 없음 (${synapses.length} items)
                       </div>`
                     : html`<div class="overflow-x-auto">
                         <table class="w-full text-left">
                           <thead>
-                            <tr class="border-b border-zinc-700 text-xs text-zinc-500">
+                            <tr class="border-b border-[var(--white-10)] text-xs text-[var(--text-muted)]0">
                               <th class="py-1.5 px-2">From</th>
                               <th class="py-1.5 px-2"></th>
                               <th class="py-1.5 px-2">To</th>
@@ -664,19 +664,19 @@ export function MemorySubsystems() {
       <!-- Episodes -->
       <section>
         <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-          <h3 class="text-base font-semibold text-zinc-200">에피소드 기록</h3>
-          <span class="text-xs text-zinc-500">
+          <h3 class="text-base font-semibold text-[var(--text-muted)]">에피소드 기록</h3>
+          <span class="text-xs text-[var(--text-muted)]0">
             총 ${totalEpisodes}개 · 필터 ${filteredTotal}개 · 표시 ${visibleEpisodes.length}개
           </span>
         </div>
 
         ${
           pairFilter
-            ? html`<div class="flex items-center gap-2 mb-2 px-2 py-1 bg-zinc-800/60 border border-zinc-700 rounded text-xs">
-                <span class="text-zinc-500">시냅스 쌍 필터</span>
-                <span class="text-zinc-300 font-mono">${shortAgentLabel(pairFilter.from)} → ${shortAgentLabel(pairFilter.to)}</span>
+            ? html`<div class="flex items-center gap-2 mb-2 px-2 py-1 bg-[var(--white-5)] border border-[var(--white-10)] rounded text-xs">
+                <span class="text-[var(--text-muted)]0">시냅스 쌍 필터</span>
+                <span class="text-[var(--text-muted)] font-mono">${shortAgentLabel(pairFilter.from)} → ${shortAgentLabel(pairFilter.to)}</span>
                 <button
-                  class="ml-auto text-zinc-400 hover:text-zinc-200"
+                  class="ml-auto text-[var(--text-muted)] hover:text-[var(--text-muted)]"
                   onClick=${() => setSynapsePairFilter(null)}
                   aria-label="시냅스 쌍 필터 해제"
                 >✕</button>
@@ -691,12 +691,12 @@ export function MemorySubsystems() {
             placeholder="검색 (summary, learnings, event_type...)"
             value=${searchQuery.value}
             onInput=${onSearchInput}
-            class="flex-1 min-w-[200px] bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+            class="flex-1 min-w-[200px] bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           />
           <select
             value=${keeperFilter.value}
             onChange=${(e: Event) => (keeperFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           >
             <option value="">모든 키퍼</option>
             ${knownKeepers.map(
@@ -706,7 +706,7 @@ export function MemorySubsystems() {
           <select
             value=${outcomeFilter.value}
             onChange=${(e: Event) => (outcomeFilter.value = (e.target as HTMLSelectElement).value)}
-            class="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+            class="bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           >
             <option value="">모든 결과</option>
             ${knownOutcomes.map(
@@ -717,7 +717,7 @@ export function MemorySubsystems() {
             hasFilter
               ? html`<button
                   onClick=${clearFilters}
-                  class="text-xs text-zinc-400 hover:text-zinc-200 px-2 py-1 border border-zinc-700 rounded hover:border-zinc-500"
+                  class="text-xs text-[var(--text-muted)] hover:text-[var(--text-muted)] px-2 py-1 border border-[var(--white-10)] rounded hover:border-[var(--white-10)]0"
                 >
                   필터 해제
                 </button>`
@@ -727,7 +727,7 @@ export function MemorySubsystems() {
 
         ${
           visibleEpisodes.length === 0
-            ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+            ? html`<div class="text-sm text-[var(--text-muted)]0 bg-[var(--white-5)] rounded-lg p-4 text-center">
                 ${hasFilter
                   ? '필터 조건에 맞는 에피소드가 없습니다.'
                   : '에피소드 없음. keeper [STATE] 출력 시 자동 기록됩니다.'}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -619,7 +619,7 @@ function ToolCallHealthPanel() {
     : 'text-text-dim'
   const barColor = successRate != null
     ? (successRate >= 95 ? 'bg-[var(--ok-10)]' : successRate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]')
-    : 'bg-gray-500'
+    : 'bg-[var(--white-5)]0'
 
   return html`
     <div>

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -156,7 +156,7 @@ function typeBadge(type: string): ReturnType<typeof html> {
     gauge: 'bg-emerald-900/40 text-[var(--ok)]',
     summary: 'bg-amber-900/40 text-[var(--warn)]',
   }
-  return html`<span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${colors[type] ?? 'bg-gray-800 text-gray-400'}">${type}</span>`
+  return html`<span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--text-muted)]'}">${type}</span>`
 }
 
 function labelPills(labels: Record<string, string>): ReturnType<typeof html> | null {
@@ -183,7 +183,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
         }}
       >${k}=${v}</button>`
     }
-    return html`<span class="rounded bg-gray-800/60 px-1 py-0.5 text-[10px] text-gray-400 font-mono">${k}=${v}</span>`
+    return html`<span class="rounded bg-[var(--white-5)] px-1 py-0.5 text-[10px] text-[var(--text-muted)] font-mono">${k}=${v}</span>`
   })}</span>`
 }
 


### PR DESCRIPTION
## 요약

디자인 시스템 migration의 neutral-gray 배치. 4개 Tailwind gray family(zinc/gray/neutral/stone) → 3개 semantic token. 9 파일 91 인스턴스.

## 매핑

| 이전 | → | 이후 |
|---|---|---|
| \`text-{zinc,gray,neutral,stone}-{any}[/NN]\` | → | \`text-[var(--text-muted)]\` |
| \`bg-*\` (동일 families) | → | \`bg-[var(--white-5)]\` |
| \`border-*\` | → | \`border-[var(--white-10)]\` |
| \`hover:bg-*\` | → | \`hover:bg-[var(--white-5)]\` |
| \`hover:text-*\` | → | \`hover:text-[var(--text-muted)]\` |
| \`hover:border-*\` | → | \`hover:border-[var(--white-10)]\` |
| \`stroke-*\` (SVG) | → | \`stroke-[var(--text-muted)]\` |
| \`ring-*\` | → | \`ring-[var(--white-10)]\` |

## 비스코프 (의식적 제외)

- \`sky/blue/violet/indigo/teal\` 등 working-state 표현 hue — 다음 배치에서 \`--accent\`로 수렴 예정
- \`orange\`는 severity(overflowed/warn)로 이미 #8278에서 처리됨

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] post-sweep \`rg\` zero hits for (text|bg|border|hover:|stroke|ring)-(zinc|gray|neutral|stone)-

## Related

- #8177 paper theme 인프라
- #8278 severity color sweep