### PR TITLE
test(dashboard): sync rose/emerald/amber assertions with CSS var tokens (Wave 2)

### DIFF
--- a/dashboard/src/components/common/heartbeat-streak-chip.test.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.test.ts
@@ -102,12 +102,12 @@ describe('HeartbeatStreakChip component', () => {
   it('tone class reflects state — emerald for up, rose for down, muted for unknown', () => {
     render(html`<${HeartbeatStreakChip} history=${['up', 'up']} />`, container)
     let el = container.querySelector('[data-heartbeat-streak-chip]')!
-    expect(el.className).toContain('emerald')
+    expect(el.className).toContain('var(--ok')
     render(null, container)
 
     render(html`<${HeartbeatStreakChip} history=${['down']} />`, container)
     el = container.querySelector('[data-heartbeat-streak-chip]')!
-    expect(el.className).toContain('rose')
+    expect(el.className).toContain('var(--bad')
     render(null, container)
 
     render(html`<${HeartbeatStreakChip} history=${['unknown']} />`, container)

--- a/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.test.ts
@@ -97,7 +97,7 @@ describe('HeartbeatUptimeChip component', () => {
     const el = container.querySelector('[data-heartbeat-uptime-chip]') as HTMLElement
     expect(el).toBeTruthy()
     expect(el.textContent).toContain('100%')
-    expect(el.className).toContain('emerald')
+    expect(el.className).toContain('var(--ok')
     expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('operational')
     expect(el.getAttribute('data-heartbeat-uptime-pct')).toBe('100')
   })
@@ -109,7 +109,7 @@ describe('HeartbeatUptimeChip component', () => {
       container,
     )
     const el = container.querySelector('[data-heartbeat-uptime-chip]')!
-    expect(el.className).toContain('amber')
+    expect(el.className).toContain('var(--warn')
     expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('degraded')
   })
 
@@ -119,7 +119,7 @@ describe('HeartbeatUptimeChip component', () => {
       container,
     )
     const el = container.querySelector('[data-heartbeat-uptime-chip]')!
-    expect(el.className).toContain('rose')
+    expect(el.className).toContain('var(--bad')
     expect(el.getAttribute('data-heartbeat-uptime-tone')).toBe('unhealthy')
   })
 

--- a/dashboard/src/components/common/live-pulse-dot.test.ts
+++ b/dashboard/src/components/common/live-pulse-dot.test.ts
@@ -66,7 +66,7 @@ describe('LivePulseDot component', () => {
     )
     const el = container.querySelector('[data-live-pulse-dot]') as HTMLElement
     expect(el.getAttribute('data-live-pulse-state')).toBe('live')
-    expect(el.className).toContain('emerald')
+    expect(el.className).toContain('var(--ok')
     expect(el.className).toContain('animate-pulse')
   })
 
@@ -77,7 +77,7 @@ describe('LivePulseDot component', () => {
     )
     const el = container.querySelector('[data-live-pulse-dot]') as HTMLElement
     expect(el.getAttribute('data-live-pulse-state')).toBe('stale')
-    expect(el.className).toContain('amber')
+    expect(el.className).toContain('var(--warn')
     // Regression guard: pulse animation MUST be off when stale — a
     // frozen sampler must not look identical to a live one.
     expect(el.className).not.toContain('animate-pulse')

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -413,7 +413,7 @@ describe('TilePrimaryAction component (rendered inside ConnectorOverviewStrip)',
     expect(btn).toBeTruthy()
     expect(btn.getAttribute('data-tile-primary-action-tone')).toBe('start')
     expect(btn.textContent?.trim()).toBe('▶ Start')
-    expect(btn.className).toContain('emerald')
+    expect(btn.className).toContain('var(--ok')
   })
 
   it('renders a Stop button (rose) for an up sidecar', () => {
@@ -427,7 +427,7 @@ describe('TilePrimaryAction component (rendered inside ConnectorOverviewStrip)',
     const btn = container.querySelector('[data-tile-primary-action="discord"]') as HTMLButtonElement
     expect(btn.getAttribute('data-tile-primary-action-tone')).toBe('stop')
     expect(btn.textContent?.trim()).toBe('■ Stop')
-    expect(btn.className).toContain('rose')
+    expect(btn.className).toContain('var(--bad')
   })
 
   it('aria-label names the connector + action (screen-reader parity)', () => {
@@ -747,7 +747,7 @@ describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', (
     expect(notice).toBeTruthy()
     expect(notice.textContent).toContain('Error')
     expect(notice.textContent).toContain('WebSocket closed 4004')
-    expect(notice.className).toContain('rose')
+    expect(notice.className).toContain('var(--bad')
     expect(notice.getAttribute('role')).toBe('alert')
   })
 
@@ -767,7 +767,7 @@ describe('TileErrorNotice component (rendered inside ConnectorOverviewStrip)', (
     )
     const notice = container.querySelector('[data-tile-notice="stale"]') as HTMLElement
     expect(notice.textContent).toContain('Stale')
-    expect(notice.className).toContain('amber')
+    expect(notice.className).toContain('var(--warn')
   })
 
   it('renders nothing when connector is clean (no ribbon clutter)', () => {


### PR DESCRIPTION
## Summary
PR #8278 (final Tailwind severity sweep) replaced literal color classes with CSS var tokens in 4 components. PR #8279 only patched 3 assertions. 11 more assertions still expect `rose`/`emerald`/`amber` and fail.

This Wave 2 patch updates them to match the new tokens.

## Product impact
- Dashboard CI green again — unblocks every open dashboard PR.
- No runtime behaviour change; test-only.

## Evidence
- 132/132 tests pass on the 5 affected files locally.
- Assertion updates:
  - `.toContain('emerald')` → `.toContain('var(--ok')`
  - `.toContain('rose')` → `.toContain('var(--bad')`
  - `.toContain('amber')` → `.toContain('var(--warn')`
- `var(--ok` substring matches both base (`var(--ok)`) and alpha variants (`var(--ok-10)`, `var(--ok-20)`).

## Review evidence
- Read each component source to verify which tokens the new class strings actually use.
- **Not** touching `connector-readiness-rail.test.ts` — its component `statToneGradient` still uses raw `from-emerald-500/15` literals (not migrated by #8278). Initially over-edited + reverted after local test run exposed the regression.
- Grep confirmed 14 `rose`/`emerald`/`amber` assertions remain in test files; 11 of them are inside the 4 files this PR touches; remaining 3 are in `connector-readiness-rail.test.ts` (legitimately paired with un-migrated source).

## Linked issue
Refs #8262.

Follows #8279. Un-blocks #8275.