### PR TITLE
feat(dashboard): working-hue sweep — sky/blue/violet/... → accent

### DIFF
--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -56,8 +56,8 @@ function outcomeToneClass(kind: Attribution['outcome']['kind']): string {
 
 function originBadgeClass(origin: Attribution['origin']): string {
   return origin === 'det'
-    ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
-    : 'bg-violet-500/20 text-violet-300 border border-violet-500/40'
+    ? 'bg-[var(--accent-10)]0/20 text-[var(--accent)] border border-[var(--accent-20)]0/40'
+    : 'bg-[var(--accent-10)]0/20 text-[var(--accent)] border border-[var(--accent-20)]0/40'
 }
 
 function formatTs(recordedAt: number): string {
@@ -133,7 +133,7 @@ function GateCard({
   return html`
     <button
       type="button"
-      class="text-left w-full focus:outline-none focus:ring-2 focus:ring-sky-500/50 rounded-xl ${toneClass}"
+      class="text-left w-full focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50 rounded-xl ${toneClass}"
       onClick=${onSelect}
     >
       <${SurfaceCard} variant="compact">
@@ -337,7 +337,7 @@ export function AttributionPanel() {
             query.value = (e.target as HTMLInputElement).value
             selectedEventIdx.value = null
           }}
-          class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--card-border)] bg-black/20 px-2 py-1 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--card-border)] bg-black/20 px-2 py-1 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
         />
       </div>
 

--- a/dashboard/src/components/common/progress-bar.ts
+++ b/dashboard/src/components/common/progress-bar.ts
@@ -49,7 +49,7 @@ export function progressBarToneClass(tone: ProgressBarTone): string {
     case 'emerald': return 'bg-[var(--ok-10)]'
     case 'amber': return 'bg-[var(--warn-10)]'
     case 'rose': return 'bg-[var(--bad-10)]'
-    case 'sky': return 'bg-sky-500'
+    case 'sky': return 'bg-[var(--accent-10)]0'
   }
 }
 

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -530,7 +530,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
               const hint = getFieldHint(field.name)
               if (hint === null) return null
               return html`
-                <div class="rounded border border-sky-400/20 bg-sky-500/5 px-2 py-1 text-[10px] text-sky-200" data-field-hint=${field.name}>
+                <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-10)]0/5 px-2 py-1 text-[10px] text-[var(--accent)]" data-field-hint=${field.name}>
                   <span class="mr-1" aria-hidden="true">📍</span>
                   <span>${hint.where}</span>
                   ${hint.url
@@ -539,7 +539,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
                           href=${hint.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          class="ml-1 underline hover:text-sky-100"
+                          class="ml-1 underline hover:text-[var(--accent)]"
                         >열기 ↗</a>
                       `
                     : null}

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -74,27 +74,27 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   Failing:      'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
   Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
   Compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
-  HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
-  Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
+  HandingOff:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
+  Draining:     'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   Paused:       'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   Stopped:      'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   Crashed:      'bg-red-950 text-[var(--bad-light)] border-red-800',
-  Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
+  Restarting:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   Dead:         'bg-black text-[var(--bad-light)] border-red-900',
   Offline:      'bg-[var(--white-5)] text-[var(--text-muted)]0 border-[var(--white-10)]',
   // KTC
   idle:         'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
-  prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  prompting:    'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   executing:    'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
-  finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
+  finalizing:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   // KDP
   undecided:          'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   guard_ok:           'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   gate_rejected:      'bg-red-900/40 text-[var(--bad-light)] border-[var(--bad-20)]',
-  tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
+  tool_policy_selected: 'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   // KCL
-  selecting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  selecting:    'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   trying:       'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   done:         'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   exhausted:    'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
@@ -108,7 +108,7 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // observer can see it.
   clean:   'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]',
   warning: 'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
-  cooling: 'bg-sky-900/40 text-sky-200 border-sky-700',
+  cooling: 'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
 }
 
 const DEFAULT_CHIP = 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--white-10)]'

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -278,7 +278,7 @@ export function HeroPhase({
     Running: 'text-[var(--ok)]',
     Overflowed: 'text-[var(--warn)]',
     Compacting: 'text-[var(--warn)]',
-    HandingOff: 'text-violet-400',
+    HandingOff: 'text-[var(--accent)]',
     Failing: 'text-[var(--bad-light)]',
     Stable: 'text-[var(--text-dim)]',
   }

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -59,9 +59,9 @@ export function kindOfEventType(eventType: string): A2aEventKind {
 export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
   lifecycle: 'bg-[var(--ok-10)]',
   failure: 'bg-[var(--bad-10)]',
-  tool: 'bg-sky-400',
+  tool: 'bg-[var(--accent-10)]',
   handoff: 'bg-orange-400',
-  context: 'bg-purple-400',
+  context: 'bg-[var(--accent-10)]',
   unknown: 'bg-[var(--white-5)]0',
 }
 
@@ -297,13 +297,13 @@ export function HandoffTimeline({
             <span class="w-2 h-2 rounded-full bg-[var(--ok-10)]"></span>lifecycle
           </span>
           <span class="flex items-center gap-1">
-            <span class="w-2 h-2 rounded-full bg-sky-400"></span>tool
+            <span class="w-2 h-2 rounded-full bg-[var(--accent-10)]"></span>tool
           </span>
           <span class="flex items-center gap-1">
             <span class="w-2 h-2 rounded-full bg-orange-400"></span>handoff
           </span>
           <span class="flex items-center gap-1">
-            <span class="w-2 h-2 rounded-full bg-purple-400"></span>context
+            <span class="w-2 h-2 rounded-full bg-[var(--accent-10)]"></span>context
           </span>
           <span class="flex items-center gap-1">
             <span class="w-2 h-2 rounded-full bg-[var(--bad-10)]"></span>failure

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -346,12 +346,12 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
               onClick=${() => toggleSynapsePairFilter(s.from_agent, s.to_agent)}
             >
               <button
-                class="text-[var(--text-muted)] hover:text-sky-400 truncate w-32 text-right"
+                class="text-[var(--text-muted)] hover:text-[var(--accent)] truncate w-32 text-right"
                 onClick=${(e: Event) => { e.stopPropagation(); openAgentDetail(s.from_agent) }}
               >${shortAgentLabel(s.from_agent)}</button>
               <span class="text-[var(--text-muted)]">→</span>
               <button
-                class="text-[var(--text-muted)] hover:text-sky-400 truncate w-32 text-left"
+                class="text-[var(--text-muted)] hover:text-[var(--accent)] truncate w-32 text-left"
                 onClick=${(e: Event) => { e.stopPropagation(); openAgentDetail(s.to_agent) }}
               >${shortAgentLabel(s.to_agent)}</button>
               <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-[60px]">
@@ -375,14 +375,14 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
     <tr class="border-b border-[var(--white-10)]">
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
-          class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
+          class="hover:text-[var(--accent)] hover:underline focus:outline-none focus:text-[var(--accent)]"
           onClick=${() => openAgentDetail(s.from_agent)}
         >${s.from_agent}</button>
       </td>
       <td class="py-1.5 px-2 text-sm text-[var(--text-muted)] text-center">→</td>
       <td class="py-1.5 px-2 text-sm font-mono">
         <button
-          class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
+          class="hover:text-[var(--accent)] hover:underline focus:outline-none focus:text-[var(--accent)]"
           onClick=${() => openAgentDetail(s.to_agent)}
         >${s.to_agent}</button>
       </td>

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -15,9 +15,9 @@ function sourceColor(source: string | undefined): string {
   switch (source) {
     case 'oas_event': return 'bg-accent'
     case 'agent_event': return 'bg-[var(--ok-10)]'
-    case 'tool_call_io': return 'bg-blue-400'
-    case 'tool_usage': return 'bg-sky-400'
-    case 'keeper_metrics': return 'bg-purple-400'
+    case 'tool_call_io': return 'bg-[var(--accent-10)]'
+    case 'tool_usage': return 'bg-[var(--accent-10)]'
+    case 'keeper_metrics': return 'bg-[var(--accent-10)]'
     default: return 'bg-text-dim'
   }
 }

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -152,7 +152,7 @@ function fmtValue(value: number, type: string, name: string): string {
 
 function typeBadge(type: string): ReturnType<typeof html> {
   const colors: Record<string, string> = {
-    counter: 'bg-blue-900/40 text-blue-300',
+    counter: 'bg-[var(--accent-10)] text-[var(--accent)]',
     gauge: 'bg-emerald-900/40 text-[var(--ok)]',
     summary: 'bg-amber-900/40 text-[var(--warn)]',
   }
@@ -165,7 +165,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
   return html`<span class="ml-2 inline-flex gap-1 flex-wrap">${entries.map(([k, v]) => {
     if (k === 'keeper') {
       return html`<button
-        class="rounded bg-blue-900/40 px-1 py-0.5 text-[10px] text-blue-300 font-mono hover:bg-blue-800/60 hover:text-blue-200 transition-colors cursor-pointer"
+        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-[10px] text-[var(--accent)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--accent)] transition-colors cursor-pointer"
         title="View keeper detail"
         onClick=${(e: Event) => {
           e.stopPropagation()

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -86,12 +86,12 @@ const CONDENSED_CATEGORY_META: Record<TelemetryCondensedCategory, {
   heartbeat: {
     label: 'Heartbeat',
     icon: 'H',
-    color: 'text-sky-400',
+    color: 'text-[var(--accent)]',
   },
   polling: {
     label: 'Polling / no-op',
     icon: 'P',
-    color: 'text-fuchsia-400',
+    color: 'text-[var(--accent)]',
   },
 }
 


### PR DESCRIPTION
## 요약

Working/info hue 배치. Tailwind의 9개 색 family(sky/blue/cyan/teal/indigo/violet/purple/pink/fuchsia)가 FSM chip, progress bar, 장식 등에서 "in-flight, not alarming" 역할을 분담했는데, Anyang Sleepers 스펙은 이를 모두 \`--accent\` 하나로 수렴.

## 매핑

| 이전 | → | 이후 |
|---|---|---|
| \`text-{sky,blue,cyan,teal,indigo,violet,purple,pink,fuchsia}-{any}[/NN]\` | → | \`text-[var(--accent)]\` |
| \`bg-*\` | → | \`bg-[var(--accent-10)]\` |
| \`border-*\` | → | \`border-[var(--accent-20)]\` |
| \`hover:bg/text/border\` | → | hover 등가 |
| \`stroke-*\`, \`ring-*\` | → | accent 토큰 |

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] post-sweep \`rg\` zero hits

10 files, 31 insertions.

## Related

- #8281 neutral gray sweep
- #8278 final severity sweep
- #8177 paper theme 인프라