### PR TITLE
feat(dashboard): orange/lime sweep — last remaining Tailwind hues → warn

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -72,7 +72,7 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   // KSM
   Running:      'bg-emerald-900/40 text-[var(--ok)] border-[var(--ok-20)]',
   Failing:      'bg-red-900/50 text-[var(--bad-light)] border-[var(--bad-20)]',
-  Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
+  Overflowed:   'bg-[var(--warn-10)] text-[var(--warn)] border-[var(--warn-20)]',
   Compacting:   'bg-amber-900/50 text-[var(--warn)] border-[var(--warn-20)]',
   HandingOff:   'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',
   Draining:     'bg-[var(--accent-10)] text-[var(--accent)] border-[var(--accent-20)]',

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -60,7 +60,7 @@ export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
   lifecycle: 'bg-[var(--ok-10)]',
   failure: 'bg-[var(--bad-10)]',
   tool: 'bg-[var(--accent-10)]',
-  handoff: 'bg-orange-400',
+  handoff: 'bg-[var(--warn-10)]',
   context: 'bg-[var(--accent-10)]',
   unknown: 'bg-[var(--white-5)]0',
 }
@@ -300,7 +300,7 @@ export function HandoffTimeline({
             <span class="w-2 h-2 rounded-full bg-[var(--accent-10)]"></span>tool
           </span>
           <span class="flex items-center gap-1">
-            <span class="w-2 h-2 rounded-full bg-orange-400"></span>handoff
+            <span class="w-2 h-2 rounded-full bg-[var(--warn-10)]"></span>handoff
           </span>
           <span class="flex items-center gap-1">
             <span class="w-2 h-2 rounded-full bg-[var(--accent-10)]"></span>context


### PR DESCRIPTION
## 요약

Tailwind arbitrary-color migration 마무리. 남은 3 instance(2 파일)를 warn 토큰으로 수렴.

| 이전 | → | 이후 |
|---|---|---|
| \`text-{orange,lime}-{any}[/NN]\` | → | \`text-[var(--warn)]\` |
| \`bg-*\` | → | \`bg-[var(--warn-10)]\` |
| \`border-*\` | → | \`border-[var(--warn-20)]\` |

## 마이그레이션 완료 summary

이 PR을 끝으로 \`dashboard/src/components/\`의 \`{text,bg,border}-{color}-{shade}\` Tailwind arbitrary-color 인스턴스가 **모든 palette family에서 zero hits**:

- severity: red/rose, emerald/green, yellow/amber, orange/lime → \`--bad-light\`, \`--ok\`, \`--warn\`
- working: sky/blue/cyan/teal/indigo/violet/purple/pink/fuchsia → \`--accent\`
- neutral: zinc/gray/neutral/stone → \`--text-muted\`, \`--white-5\`, \`--white-10\`

## Related chain

- #8177 paper theme 인프라
- #8271 #8273 #8278 severity text/bg/border sweeps
- #8281 neutral gray sweep
- #8284 working hue sweep