### PR TITLE
fix(tool_task): ignore underscore-prefixed internal markers in transition schema

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -593,9 +593,20 @@ let transition_known_args =
   ]
 
 let handle_transition ctx args =
+  (* Underscore-prefixed keys (e.g. "_agent_name") are internal protocol markers
+     injected by the HTTP transport and dashboard client for identity
+     propagation. They are consumed upstream in Agent_identity and must not
+     trigger the strict-schema "Unknown argument(s)" rejection here. *)
+  let is_internal_marker k =
+    String.length k > 0 && k.[0] = '_'
+  in
   let unknown = match args with
     | `Assoc kvs ->
-      List.filter (fun (k, _) -> not (List.mem k transition_known_args)) kvs
+      List.filter
+        (fun (k, _) ->
+          (not (is_internal_marker k))
+          && not (List.mem k transition_known_args))
+        kvs
     | _ -> []
   in
   if unknown <> [] then

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -533,6 +533,37 @@ let () = test "transition_claim_leaves_planning_current_task_unset" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 
+let () = test "transition_accepts_underscore_prefixed_internal_markers" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Marker test")]) in
+  let (success, result) =
+    Tool_task.handle_transition ctx
+      (`Assoc [
+        ("task_id", `String "task-001");
+        ("action", `String "claim");
+        ("_agent_name", `String "dashboard");
+        ("_session_marker", `String "sess-xyz");
+      ])
+  in
+  assert success;
+  assert (not (str_contains result "Unknown argument"))
+)
+
+let () = test "transition_still_rejects_plain_unknown_arguments" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Reject test")]) in
+  let (success, result) =
+    Tool_task.handle_transition ctx
+      (`Assoc [
+        ("task_id", `String "task-001");
+        ("action", `String "claim");
+        ("totally_bogus", `String "no");
+      ])
+  in
+  assert (not success);
+  assert (str_contains result "Unknown argument(s): totally_bogus")
+)
+
 (* Test handle_done returns owner guidance when another agent owns the task *)
 let () = test "handle_done_owned_by_other_guidance" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Summary
- `handle_transition` strict-schema가 `_agent_name`(HTTP transport + dashboard 양쪽이 주입하는 internal identity marker)을 "Unknown argument(s)"로 거부하던 문제 수정
- Underscore-prefixed 키는 `Agent_identity`가 이미 canonical identity marker로 소비하므로 strict-schema 검증에서 skip
- Plain-named unknown 인자는 여전히 거부 (회귀 방지 테스트 포함)

## Evidence
운영 로그 (2026-04-18 05:30:36):
```
tool call failed: masc_transition — Unknown argument(s): _agent_name.
  Valid: task_id, action, notes, reason, expected_version, agent_name,
         force, completion_contract, evaluator_cascade, handoff_context
```

`lib/server/server_mcp_transport_http.ml:115-133`의 `inject_agent_name_into_body`가 HTTP auth 식별자를 `_agent_name`으로 주입하고, `dashboard/src/api/mcp.ts`의 `callMcpTool`도 dashboard actor를 동일하게 주입하지만, `lib/tool_task.ml:581-604`의 유일한 strict-schema 툴인 `handle_transition`이 이 규약을 몰랐던 게 원인.

## Change
`lib/tool_task.ml:595-612` — `handle_transition`의 unknown-filter에 underscore prefix 예외 추가:
```ocaml
let is_internal_marker k =
  String.length k > 0 && k.[0] = '_'
in
```

## Test plan
- [x] `dune test test/test_tool_task_coverage.exe` — 43/43 pass
- [x] 회귀 테스트 2개 추가
  - `transition_accepts_underscore_prefixed_internal_markers` — `_agent_name`/`_session_marker` 포함해도 통과
  - `transition_still_rejects_plain_unknown_arguments` — `totally_bogus` 같은 plain-name은 여전히 거부
- [ ] 운영 서버 재시작 후 dashboard/keeper에서 `masc_transition` 호출 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)