### PR TITLE
fix(dashboard): paper-theme bridges --accent / --ok / --warn / --bad

### DIFF
--- a/dashboard/src/styles/paper-theme.css
+++ b/dashboard/src/styles/paper-theme.css
@@ -74,15 +74,48 @@
   --color-text-body: var(--ink-2);
   --color-text-muted: var(--ink-4);
 
-  /* Accents (brass replaces FF gold per design system "selected" role) */
-  --color-accent: var(--forest);
-  --color-accent-soft: var(--forest-fill);
+  /* ───── Semantic tokens used by the component sweeps
+     (#8271 #8273 #8278 #8281 #8284 #8285 #8288)
+     ────────────────────────────────────────────────────────────
+     The sweeps migrated every Tailwind arbitrary-color class to
+     `var(--token)` references drawn from variables.css. Under
+     [data-theme="paper"] each one must map to the design-system
+     warm-paper equivalent so the cascade rerenders correctly
+     without touching any component. Ordered by role. */
+
+  /* ok — Running, emerald-group */
+  --ok: var(--forest);
+  --ok-10: var(--forest-fill);
+  --ok-20: var(--forest-fill);
+
+  /* warn — Failing / Overflowed, amber-group */
+  --warn: var(--ember);
+  --warn-10: var(--ember-fill);
+  --warn-20: var(--ember-fill);
+  --warn-bright: var(--ember-line);
+
+  /* bad — Crashed / Dead, red-group */
+  --bad: var(--brick);
+  --bad-10: var(--brick-fill);
+  --bad-20: var(--brick-fill);
+  --bad-light: var(--brick);
+  --bad-soft: var(--brick-fill);
+
+  /* accent — Working / Info, slate-group.
+     #8284 sweep collapsed sky/blue/cyan/teal/indigo/violet/... here. */
+  --accent: var(--slate);
+  --accent-10: var(--slate-fill);
+  --accent-20: var(--slate-fill);
+  --accent-soft: var(--slate-fill);
+
+  /* Legacy FF-namespaced tokens — kept for any component the
+     sweeps haven't reached yet. */
+  --color-accent: var(--slate);
+  --color-accent-soft: var(--slate-fill);
   --color-ff-gold: var(--brass);
   --color-ff-gold-bright: var(--brass-line);
   --color-ff-gold-dim: var(--brass-fill);
   --color-ff-crystal: var(--slate);
-
-  /* Status roles — keeper FSM mapping from design system */
   --color-ok: var(--forest);
   --color-warn: var(--ember);
   --color-bad: var(--brick);
@@ -90,9 +123,6 @@
   --color-agent-idle: var(--ink-4);
   --color-agent-offline: var(--ink-5);
   --color-agent-busy: var(--brass);
-
-  --bad-light: var(--brick-line);
-  --warn-bright: var(--ember-line);
 
   /* Paused (plum) + selected (brass) — under paper theme both map
      to the design system's solid accent, letting the 20% fill sit


### PR DESCRIPTION
## 배경

이전 sweep들(#8271 #8273 #8278 #8281 #8284 #8285 #8288)이 모든 Tailwind 색상을 \`var(--token)\` 참조로 전환했음. 그런데 paper-theme.css는 **FF-namespaced 토큰(\`--color-accent\`, \`--color-ok\` 등)** 만 override했고 **sweeps가 실제로 쓰는 bare 토큰(\`--accent\`, \`--ok\`, \`--warn\`, \`--bad-light\`)** 은 다크 테마 값 그대로였음.

결과: \`?theme=paper\` 활성화해도 status chip, pressure indicator, FSM matrix 등이 FF-crystal blue(\`#47b8ff\`)로 렌더 → paper theme 인프라는 깔려있는데 sweeps의 결과가 전혀 보이지 않음.

## 수정

paper-theme.css에 sweep가 쓰는 bare 토큰 override 추가:

| 토큰 | → | paper 매핑 |
|---|---|---|
| \`--ok\`, \`--ok-10\`, \`--ok-20\` | → | \`--forest\` / \`--forest-fill\` |
| \`--warn\`, \`--warn-10\`, \`--warn-20\` | → | \`--ember\` / \`--ember-fill\` |
| \`--bad\`, \`--bad-10\`, \`--bad-20\`, \`--bad-light\` | → | \`--brick\` / \`--brick-fill\` |
| \`--accent\`, \`--accent-10\`, \`--accent-20\` | → | \`--slate\` / \`--slate-fill\` ⭐ |

또한 \`--color-accent\` (레거시) semantic 오류 수정: forest → slate. 디자인 시스템에서 forest는 오로지 "ok/running" 역할, slate가 "accent/working". 기존 매핑은 semantic 틀렸음.

## 영향

컴포넌트 코드 0변경. 순수 token plumbing. 이 PR 후 \`?theme=paper\` 활성화 시 **#8284 working sweep의 결과가 실제로 UI에 나타남** — 모든 working/info 영역이 slate 톤으로, severity 영역이 forest/ember/brick으로 바뀜.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] \`pnpm build\` 통과
- [ ] 브라우저 smoke: \`?theme=paper\` 활성화 → FSM chip, fleet telemetry, verification panel이 paper 팔레트로 재렌더 (수동 확인 필요)

## Related

#8177 paper theme 인프라 · #8284 working hue sweep · #8288 final color cleanup