### PR TITLE
feat(dashboard): sharp corners sweep — rounded-{xl,2xl,3xl} → rounded (74 files)

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -241,7 +241,7 @@ export function GraphView({ data }: GraphViewProps) {
   }
 
   return html`
-    <div class="relative w-full my-3 rounded-xl border border-[var(--card-border)] bg-[#0f1117]">
+    <div class="relative w-full my-3 rounded border border-[var(--card-border)] bg-[#0f1117]">
       <div ref=${containerRef} class="w-full h-[360px]"></div>
     </div>
     <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 px-1">
@@ -260,7 +260,7 @@ export function GraphView({ data }: GraphViewProps) {
     </div>
 
     ${selectedNode ? html`
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">
         <div class="flex items-center gap-3 mb-3">
           <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
           <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-[11px] text-[var(--text-slate)] rounded-md">${kindLabel(selectedNode.kind)}</span>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -94,7 +94,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
     return html`
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
         <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
@@ -172,7 +172,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-col gap-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]/50 p-4">
+      <div class="flex flex-col gap-3 rounded border border-[var(--card-border)] bg-[var(--card)]/50 p-4">
         <div class="flex flex-col gap-1">
           <div class="text-[14px] font-semibold text-[var(--text-strong)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
           <div class="text-[12px] text-[var(--text-muted)]">
@@ -210,7 +210,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
         : filteredGroups.map(group => {
             const expanded = expandedActionGroups.value.has(group.id)
             return html`
-              <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
+              <div class="rounded border border-[var(--card-border)] bg-[var(--card)]/55 p-4 shadow-sm shadow-black/8" key=${group.id}>
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
@@ -254,7 +254,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                   </div>
                 </div>
                 ${expanded ? html`
-                  <div class="mt-3 flex flex-col gap-2 rounded-xl border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
+                  <div class="mt-3 flex flex-col gap-2 rounded border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
                     ${group.rawEvents.map(event => html`
                       <div class="flex items-start gap-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)] px-3 py-2" key=${event.seq}>
                         <span class="inline-flex min-w-[72px] items-center rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -257,7 +257,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
       <div class="mb-2">
         <p class="text-[13px] text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
-      <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded-xl p-3">
+      <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3">
         <canvas ref=${canvasRef} class="block" />
       </div>
     <//>

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -234,7 +234,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
       <div class="mb-2">
         <p class="text-[13px] text-[var(--text-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
       </div>
-      <div class="w-full bg-[#0f1117] rounded-xl border border-[var(--card-border)] overflow-hidden swimlane-vis-container">
+      <div class="w-full bg-[#0f1117] rounded border border-[var(--card-border)] overflow-hidden swimlane-vis-container">
         <div ref=${containerRef} class="w-full"></div>
       </div>
       <div class="flex flex-wrap gap-3 mt-3 text-[11px] text-[var(--text-muted)]">

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -212,7 +212,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
     : report.content
 
   return html`
-    <div class="border border-card-border/60 rounded-xl bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
+    <div class="border border-card-border/60 rounded bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
       <div
         class="flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-card-border/40 cursor-pointer select-none"
         onClick=${() => setExpanded(!expanded)}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -114,7 +114,7 @@ export function filterTaskHistories(
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
-    <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded-xl shadow-sm">
+    <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded shadow-sm">
       <${IdPill}>${task.id}<//>
       <span class="flex-1 text-[13px] text-text-strong font-medium truncate">${task.title}</span>
       <${StatusBadge} status=${task.status} />
@@ -124,7 +124,7 @@ function TaskSummary({ task }: { task: Task }) {
 
 function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
-    <div class="border border-card-border rounded-xl bg-card/40 p-4 shadow-sm hover:border-accent/30 transition-colors group">
+    <div class="border border-card-border rounded bg-card/40 p-4 shadow-sm hover:border-accent/30 transition-colors group">
       <div class="mb-3">
         <${IdPill} class="group-hover:bg-accent/20 transition-colors">${row.taskId}<//>
       </div>
@@ -211,13 +211,13 @@ export function AgentDetailOverlay() {
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-2xl border border-card-border bg-bg-1/95 backdrop-blur-2xl shadow-2xl shadow-black/50 ring-1 ring-white/5"
+      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded border border-card-border bg-bg-1/95 backdrop-blur-2xl shadow-2xl shadow-black/50 ring-1 ring-white/5"
     >
       <div class="p-6 flex flex-col gap-5">
         <div class="flex justify-between items-start gap-4">
           <div class="flex flex-col gap-3 flex-1">
             <div class="flex items-center gap-4">
-              ${agentEmoji ? html`<div class="size-12 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
+              ${agentEmoji ? html`<div class="size-12 rounded bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
               <div>
                 <h2 id=${titleId} class="m-0 flex items-baseline gap-3 text-text-strong text-2xl font-bold tracking-tight">
                   ${displayName}
@@ -266,7 +266,7 @@ export function AgentDetailOverlay() {
             <${ActionButton}
               variant="ghost"
               size="lg"
-              class="px-4 py-2 text-[13px] rounded-xl bg-card/60 shadow-sm"
+              class="px-4 py-2 text-[13px] rounded bg-card/60 shadow-sm"
               onClick=${() => { void refreshAgentDetail() }}
               disabled=${loading.value}
             >
@@ -275,7 +275,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+              class="px-4 py-2 text-[13px] font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
               onClick=${closeAgentDetail}
             >
               닫기
@@ -316,7 +316,7 @@ export function AgentDetailOverlay() {
           <${Card} title="최근 활동">
             ${lines.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded-xl shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
+              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 
@@ -334,7 +334,7 @@ export function AgentDetailOverlay() {
                   ['속도', agentFitness.value.speed_score],
                   ['종합', agentFitness.value.overall_fitness],
                 ].map(([label, val]) => html`
-                  <div class="rounded-xl border border-card-border/50 bg-card/30 p-3 text-center">
+                  <div class="rounded border border-card-border/50 bg-card/30 p-3 text-center">
                     <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
                     <div class="text-lg font-bold ${(val as number) >= 0.7 ? 'text-ok' : (val as number) >= 0.4 ? 'text-[var(--warn)]' : 'text-bad'}">${val != null ? ((val as number) * 100).toFixed(0) + '%' : '-'}</div>
                   </div>
@@ -350,7 +350,7 @@ export function AgentDetailOverlay() {
           <${Card} title="직접 멘션">
             <div class="grid grid-cols-[1fr_auto] gap-3">
               <${TextInput}
-                class="px-4 py-2.5 rounded-xl bg-card/60 text-text-strong text-[13px] placeholder:text-text-dim shadow-inner"
+                class="px-4 py-2.5 rounded bg-card/60 text-text-strong text-[13px] placeholder:text-text-dim shadow-inner"
                 value=${mentionText.value}
                 name="agent_direct_mention"
                 ariaLabel="직접 멘션 메시지"

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -360,7 +360,7 @@ export function AgentProfile({ name }: { name: string }) {
 
       <div class="grid grid-cols-2 gap-4 mb-4">
         ${!isKeeper ? html`
-        <${Card} title="태스크 (${owned.length})" class="ff-card rounded-xl">
+        <${Card} title="태스크 (${owned.length})" class="ff-card rounded">
           ${owned.length === 0
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
@@ -381,7 +381,7 @@ export function AgentProfile({ name }: { name: string }) {
           const hasData = collabs.length > 0 || interests.length > 0
           if (!hasData) return null
           return html`
-            <${Card} title="관계 (${collabs.length})" class="ff-card rounded-xl">
+            <${Card} title="관계 (${collabs.length})" class="ff-card rounded">
               ${collabs.length > 0 ? html`
                 <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
@@ -409,7 +409,7 @@ export function AgentProfile({ name }: { name: string }) {
           `
         })()}
 
-        <${Card} title="타임라인" class="ff-card rounded-xl">
+        <${Card} title="타임라인" class="ff-card rounded">
           ${!timeline || (timeline.events ?? []).length === 0
             ? html`<${EmptyState} message="이벤트 없음" compact />`
             : html`<div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
@@ -425,11 +425,11 @@ export function AgentProfile({ name }: { name: string }) {
               })}</div>`}
         <//>
 
-        <${Card} title="실시간" class="ff-card rounded-xl">
+        <${Card} title="실시간" class="ff-card rounded">
           <${AgentLiveTimeline} name=${name} />
         <//>
 
-        <${Card} title="프로젝트 활동" class="ff-card rounded-xl">
+        <${Card} title="프로젝트 활동" class="ff-card rounded">
           ${lines.length === 0
             ? html`<${EmptyState} message="관련 활동 없음" compact />`
             : (() => {
@@ -455,7 +455,7 @@ export function AgentProfile({ name }: { name: string }) {
         <//>
 
         ${(profileData?.taskHistories ?? []).length > 0 ? html`
-          <${Card} title="태스크 이력" class="ff-card rounded-xl col-span-full">
+          <${Card} title="태스크 이력" class="ff-card rounded col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
                 <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-full">${row.taskId}</span></div>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -533,7 +533,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <label class="flex w-full flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
               <span>이름 / model / 작업</span>
               <${TextInput}
-                class="rounded-2xl bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+                class="rounded bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
                 ariaLabel="에이전트 이름 · 모델 · 작업 검색"
                 autoComplete="off"
@@ -562,7 +562,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           ${showExecutionFallbackState
             ? html`
-                <div class="rounded-2xl border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[var(--warn-10)]' : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
+                <div class="rounded border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[var(--warn-10)]' : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
                   <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap items-center gap-2">
                       <strong class="text-[12px] font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -133,7 +133,7 @@ function GateCard({
   return html`
     <button
       type="button"
-      class="text-left w-full focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50 rounded-xl ${toneClass}"
+      class="text-left w-full focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50 rounded ${toneClass}"
       onClick=${onSelect}
     >
       <${SurfaceCard} variant="compact">

--- a/dashboard/src/components/autoresearch-form.ts
+++ b/dashboard/src/components/autoresearch-form.ts
@@ -122,7 +122,7 @@ export function StartAutoresearchForm() {
       labelledBy="start-autoresearch-title"
       onClose=${closeStartForm}
       overlayClass="fixed inset-0 z-50 flex items-center justify-center bg-[var(--white-5)]/60 backdrop-blur-sm"
-      panelClass="w-full max-w-lg mx-4 rounded-xl border border-card-border bg-[var(--card-bg)] shadow-2xl p-6"
+      panelClass="w-full max-w-lg mx-4 rounded border border-card-border bg-[var(--card-bg)] shadow-2xl p-6"
     >
       <h2 id="start-autoresearch-title" class="text-sm font-semibold text-[var(--text-strong)] mb-4">
         새 오토리서치 루프

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -139,7 +139,7 @@ function ChatMessageBubble({
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
           <div
             class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-[11px] font-semibold uppercase tracking-[0.08em] ${
-              isMessenger ? 'size-8 rounded-[18px]' : 'size-10 rounded-2xl'
+              isMessenger ? 'size-8 rounded-[18px]' : 'size-10 rounded'
             }`}
           >
             ${avatarMonogram(entry)}
@@ -202,7 +202,7 @@ function ChatMessageBubble({
               <button
                 type="button"
                 class=${`border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
-                  isMessenger ? 'rounded-xl px-2.5 py-1' : 'rounded-full px-3 py-1'
+                  isMessenger ? 'rounded px-2.5 py-1' : 'rounded-full px-3 py-1'
                 }`}
                 onClick=${() => { setExpandedRaw(!expandedRaw) }}
               >
@@ -227,7 +227,7 @@ function ChatMessageBubble({
       </div>
       ${entry.error
         ? html`
-            <div class="rounded-2xl border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-[12px] leading-[1.55] text-[var(--bad-light)]">
+            <div class="rounded border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-[12px] leading-[1.55] text-[var(--bad-light)]">
               ${entry.error}
             </div>
           `
@@ -240,7 +240,7 @@ function ChatMessageBubble({
                 ? html`
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
-                        <div class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-3 py-2.5">
+                        <div class="rounded border border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-3 py-2.5">
                           <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
                           <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
@@ -250,7 +250,7 @@ function ChatMessageBubble({
                 : null}
               ${entry.details.skillPrimary
                 ? html`
-                    <div class="chat-detail-callout rounded-2xl border border-[rgba(76,181,137,0.18)] px-3 py-3">
+                    <div class="chat-detail-callout rounded border border-[rgba(76,181,137,0.18)] px-3 py-3">
                       <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#8fdcb3]">스킬 경로</div>
                       <div class="mt-1 text-[13px] font-semibold text-[#d8f7e6]">${entry.details.skillPrimary}</div>
                       ${entry.details.skillReason
@@ -265,7 +265,7 @@ function ChatMessageBubble({
                       <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
-                          <div class="rounded-2xl border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
+                          <div class="rounded border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
                             <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--accent)]">${item.label}</div>
                             <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-body)]">${item.value}</div>
                           </div>

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -1,5 +1,5 @@
 // SurfaceCard — reusable card container with Tailwind variants
-// Replaces 40+ inline `p-4 rounded-xl border border-[var(--card-border)]` patterns
+// Replaces 40+ inline `p-4 rounded border border-[var(--card-border)]` patterns
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -87,7 +87,7 @@ export function ConfirmDialogOverlay() {
 
   return html`
     <div class="fixed inset-0 z-[100] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-4 animate-in fade-in duration-200" onClick=${handleClose}>
-      <div class="w-full max-w-[400px] bg-[rgba(13,21,38,0.98)] rounded-xl border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+      <div class="w-full max-w-[400px] bg-[rgba(13,21,38,0.98)] rounded border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
         <div class="p-5">
           <div class="flex items-start gap-4">
             <div class="shrink-0 size-10 rounded-full border flex items-center justify-center ${iconBg} ${iconColor}">

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -287,7 +287,7 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
   }
 
   return html`
-    <div class=${`relative rounded-xl border border-[var(--white-8)] bg-[rgba(9,12,20,0.7)] overflow-hidden ${className}`.trim()}>
+    <div class=${`relative rounded border border-[var(--white-8)] bg-[rgba(9,12,20,0.7)] overflow-hidden ${className}`.trim()}>
       ${loading ? html`
         <div class="absolute inset-0 flex items-center justify-center text-[11px] text-[var(--text-dim)]">
           <${InlineSpinner} class="mr-2" />

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -74,7 +74,7 @@ export function DistributionBars({
   const maxValue = Math.max(...visibleItems.map(item => item.value), 1)
 
   return html`
-    <div class="rounded-xl border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
+    <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
             <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
@@ -132,7 +132,7 @@ export function SegmentedBar({
   const total = visibleItems.reduce((sum, item) => sum + item.value, 0)
 
   return html`
-    <div class="rounded-xl border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
+    <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
             <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>

--- a/dashboard/src/components/common/error-boundary.test.ts
+++ b/dashboard/src/components/common/error-boundary.test.ts
@@ -39,7 +39,7 @@ describe('ErrorBoundary', () => {
     const button = container.querySelector('button')
     expect(button).not.toBeNull()
     expect(button?.className).toContain('border-[var(--card-border)]')
-    expect(button?.className).not.toContain('card rounded-xl-border')
+    expect(button?.className).not.toContain('card rounded-border')
   })
 
   it('renders children untouched when no error is thrown', async () => {

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -39,7 +39,7 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback(this.state.error, this.reset)
       }
       return html`
-        <div class="error-card rounded-xl my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-md">
+        <div class="error-card rounded my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-md">
           <div class="shrink-0 text-[var(--bad)] mt-0.5">
             <${AlertOctagon} size=${24} />
           </div>

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -33,7 +33,7 @@ export function FilterChips<T extends string>({
 }: FilterChipsProps<T>) {
   const activeKey = active?.value ?? value
   const chipClass = size === 'md'
-    ? 'inline-flex min-h-9 items-center gap-1.5 rounded-2xl border px-3 py-2 text-[11px] font-medium'
+    ? 'inline-flex min-h-9 items-center gap-1.5 rounded border px-3 py-2 text-[11px] font-medium'
     : 'inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[length:var(--fs-xs)]'
   const activeToneClass = tone === 'accent'
     ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -93,7 +93,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
 export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
   return html`
-    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded-xl overflow-hidden flex flex-col max-h-[400px]" data-testid="json-viewer-card" data-title=${title ?? ''}>
+    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded overflow-hidden flex flex-col max-h-[400px]" data-testid="json-viewer-card" data-title=${title ?? ''}>
       ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-[11px] uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
       <div class="p-3 overflow-y-auto min-h-0 w-full">
         <${JsonViewer} data=${data} />

--- a/dashboard/src/components/common/observatory-filter-bar.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.ts
@@ -53,7 +53,7 @@ export function ObservatoryFilterBar() {
 
   return html`
     <div
-      class="mb-3 flex flex-wrap items-center gap-2 rounded-xl border border-card-border bg-bg-1/60 px-3 py-2"
+      class="mb-3 flex flex-wrap items-center gap-2 rounded border border-card-border bg-bg-1/60 px-3 py-2"
       role="region"
       aria-label="활성 관찰 필터"
     >

--- a/dashboard/src/components/common/rich-composer.ts
+++ b/dashboard/src/components/common/rich-composer.ts
@@ -25,7 +25,7 @@ export function RichComposer({
   const [mode, setMode] = useState<ComposerMode>('write')
 
   return html`
-    <div class="rounded-xl border border-[var(--card-border)] bg-[rgba(8,13,22,0.88)]">
+    <div class="rounded border border-[var(--card-border)] bg-[rgba(8,13,22,0.88)]">
       <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2">
         <div class="flex items-center gap-1.5">
           ${(['write', 'preview'] as ComposerMode[]).map(tab => html`

--- a/dashboard/src/components/common/rich-content.ts
+++ b/dashboard/src/components/common/rich-content.ts
@@ -24,7 +24,7 @@ function previewCard(preview: LinkPreview) {
       href=${href}
       target="_blank"
       rel="noreferrer"
-      class="group flex overflow-hidden rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] text-inherit no-underline transition-colors hover:border-[var(--accent-20)] hover:bg-[var(--white-5)]"
+      class="group flex overflow-hidden rounded border border-[var(--card-border)] bg-[var(--white-3)] text-inherit no-underline transition-colors hover:border-[var(--accent-20)] hover:bg-[var(--white-5)]"
     >
       ${imageUrl
         ? html`

--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -1,5 +1,5 @@
 // StatCell — label/value/detail stat box for mission cards and grids.
-// Replaces 12+ inline p-3 rounded-xl bg-[var(--white-4)] grid gap-1 patterns.
+// Replaces 12+ inline p-3 rounded bg-[var(--white-4)] grid gap-1 patterns.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -26,7 +26,7 @@ const VALUE_SIZE = {
 
 export function StatCell({ label, value, detail, tone, size = 'md', bg = 'white-4', class: className }: StatCellProps) {
   return html`
-    <div class="p-4 rounded-xl ${BG[bg]} border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
+    <div class="p-4 rounded ${BG[bg]} border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
       <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
       <strong class="text-[var(--text-strong)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
       ${detail != null ? html`<small class="text-[var(--text-muted)] text-[10px] leading-relaxed">${detail}</small>` : null}

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -44,7 +44,7 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
     }
   }
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] p-4" style=${connectorAccentStyle(connectorId)}>
+    <div class="rounded border border-[var(--white-8)] p-4" style=${connectorAccentStyle(connectorId)}>
       <div class="mb-2 flex items-center justify-between gap-2">
         <div class="flex items-center gap-2">
           <span class="text-base leading-none" aria-hidden="true">${channelIcon(connectorId)}</span>

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -136,7 +136,7 @@ describe('ConnectorOverviewStrip', () => {
     render(html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`, container)
     const root = container.querySelector('[data-overview-strip-root]') as HTMLElement
     expect(root).toBeTruthy()
-    expect(root.className).toContain('rounded-xl')
+    expect(root.className).toContain('rounded')
     expect(root.className).not.toContain('sticky')
   })
 

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -233,7 +233,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
 
   return html`
     <div
-      class=${`flex min-w-0 flex-col gap-3 rounded-xl border bg-[var(--bg-1)] p-3 transition-colors ${
+      class=${`flex min-w-0 flex-col gap-3 rounded border bg-[var(--bg-1)] p-3 transition-colors ${
         selected
           ? 'border-[var(--accent)] shadow-[0_0_0_1px_rgba(71,184,255,0.18)]'
           : 'border-[var(--white-8)] hover:border-[var(--white-10)]'
@@ -718,7 +718,7 @@ export function ConnectorOverviewStrip({
   const summary = summarizeConnectorStrip(connectors, keeperCount)
   return html`
     <div
-      class="mb-4 rounded-xl border border-[var(--card-border)] bg-[var(--bg-1)] p-3"
+      class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-3"
       data-overview-strip-root
     >
       <${IncidentBanner} droppedIds=${droppedIds} />

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -826,7 +826,7 @@ function ConnectorLivePanel({
   const headerIcon = channelIcon(connector?.channel ?? connectorId)
 
   return html`
-    <div id=${`connector-card-${connectorId}`} class=${`mb-4 scroll-mt-4 rounded-xl border border-[var(--card-border)] ${connectorCardBorderClass(directLabel)} p-4`} data-connector-card-state=${directLabel} style=${connectorAccentStyle(connectorId)}>
+    <div id=${`connector-card-${connectorId}`} class=${`mb-4 scroll-mt-4 rounded border border-[var(--card-border)] ${connectorCardBorderClass(directLabel)} p-4`} data-connector-card-state=${directLabel} style=${connectorAccentStyle(connectorId)}>
       <div class="flex flex-wrap items-center gap-2 text-[12px]">
         <span class="text-base leading-none" aria-hidden="true">${headerIcon}</span>
         <span class="text-sm font-semibold text-[var(--text-body)]">${connectorName}</span>
@@ -1415,7 +1415,7 @@ function DisclosurePanel({
   testId: string
 }) {
   return html`
-    <details class="mb-4 rounded-xl border border-[var(--card-border)] bg-[var(--bg-1)]" data-testid=${testId}>
+    <details class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)]" data-testid=${testId}>
       <summary class="cursor-pointer list-none px-3 py-2.5">
         <div class="flex items-center justify-between gap-3">
           <div>
@@ -1620,7 +1620,7 @@ export function ConnectorStatusPanel() {
         ? html`
             <div
               id="connector-detail-panel"
-              class="mb-4 rounded-xl border border-[var(--card-border)] bg-[var(--bg-0)]/40 p-3"
+              class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-0)]/40 p-3"
               data-testid="connector-detail-panel"
             >
               <div class="mb-3 flex items-center justify-between gap-3 text-[11px]">

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -376,7 +376,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center justify-center w-full rounded-xl border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
+                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
@@ -634,7 +634,7 @@ export function DashboardMain() {
 
   return html`
     ${namespaceTruthInitializing.value ? html`
-      <div class="mb-3 shrink-0 rounded-xl border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-4 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
+      <div class="mb-3 shrink-0 rounded border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-4 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
     <${SurfaceLead} />
     <${ObservatoryFilterBar} />

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -208,7 +208,7 @@ export function FeatureHealth() {
             const overview = data.overview
             return html`
               <div class="space-y-4">
-                <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+                <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
                   <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div class="max-w-3xl">
                       <${SectionCap}>Feature Flags Health<//>

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -34,7 +34,7 @@ const MEASUREMENT_FLAG_DESCRIPTIONS: Record<string, { on: string; off: string }>
 export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const m = snapshot.measurement
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
         Measurement
       </div>
@@ -117,7 +117,7 @@ export function InvariantsPanel({
   const allOk = okCount === total
   const badgeText = allOk ? `${total}/${total}` : `${okCount}/${total}`
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Safety

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -87,7 +87,7 @@ export function OperationalMeaningPanel({
 
   return html`
     <div
-      class=${`rounded-xl border p-4 transition-colors duration-300 ${panelCls}`}
+      class=${`rounded border p-4 transition-colors duration-300 ${panelCls}`}
       role=${isAlarm ? 'alert' : undefined}
       aria-live=${isAlarm ? 'polite' : undefined}
     >
@@ -286,7 +286,7 @@ export function HeroPhase({
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
 
   return html`
-    <div class=${`rounded-xl border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_rgba(71,184,255,0.2)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
+    <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_rgba(71,184,255,0.2)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
       role="status" aria-live="polite" aria-label=${`Keeper 상태: ${displayState(snapshot.phase)}${heldFor ? `, ${heldFor}` : ''}`}
       title=${STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase}
     >
@@ -405,7 +405,7 @@ export function TurnPipelineStrip({
   now: number
 }) {
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         턴 파이프라인
       </div>

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -161,7 +161,7 @@ export function SwimlaneTimeline({
   }
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
       <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           상태 타임라인
@@ -384,7 +384,7 @@ export function TransitionTrail({
   }
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 flex items-center justify-between gap-2">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Transition History (${isFiltering ? `${visibleHistory.length}/${history.length}` : history.length})
@@ -457,7 +457,7 @@ export function TopTransitionsPanel({
   const maxCount = transitions[0]?.count ?? 1
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         Top Transitions (${transitions.length})
       </div>
@@ -521,7 +521,7 @@ export function DwellHistogramPanel({
   }
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         State Dwell Time
       </div>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -527,7 +527,7 @@ export function FsmHub(props: FsmHubProps = {}) {
         <//>
 
         ${/* ── Zone 5: Collapsible Graph ── */ ''}
-        <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]"
+        <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]"
           open=${graphOpen}
           onToggle=${(e: Event) => setGraphOpen((e.target as HTMLDetailsElement).open)}
         >
@@ -571,7 +571,7 @@ function ShortcutsOverlay({
       aria-label="키보드 단축키"
     >
       <div
-        class="rounded-xl border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-[280px] shadow-2xl"
+        class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-[280px] shadow-2xl"
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">
@@ -668,7 +668,7 @@ function StatusBar({
 
   const containerPadding = density === 'compact' ? 'px-3 py-1.5' : 'px-4 py-2.5'
   return html`
-    <div class=${`sticky top-0 z-20 rounded-xl border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-md shadow-[0_4px_12px_rgba(0,0,0,0.25)] ${containerPadding}`}>
+    <div class=${`sticky top-0 z-20 rounded border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-md shadow-[0_4px_12px_rgba(0,0,0,0.25)] ${containerPadding}`}>
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <div class="flex items-center gap-3">
           <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>
@@ -813,7 +813,7 @@ function SkeletonLayout() {
   return html`
     <div class="flex flex-col gap-3" aria-hidden="true" aria-label="Loading composite snapshot">
       ${/* Operator Meaning skeleton */ ''}
-      <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-4">
         <${SkeletonBar} w="w-24" h="h-2" />
         <div class="mt-3"><${SkeletonBar} w="w-3/4" h="h-5" /></div>
         <div class="mt-2"><${SkeletonBar} w="w-full" h="h-3" /></div>
@@ -825,7 +825,7 @@ function SkeletonLayout() {
       </div>
 
       ${/* Hero Phase skeleton */ ''}
-      <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-5">
+      <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-5">
         <${SkeletonBar} w="w-32" h="h-2" />
         <div class="mt-2"><${SkeletonBar} w="w-40" h="h-8" /></div>
         <div class="mt-2"><${SkeletonBar} w="w-20" h="h-2" /></div>
@@ -835,7 +835,7 @@ function SkeletonLayout() {
       </div>
 
       ${/* Pipeline Strip skeleton */ ''}
-      <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+      <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
         <${SkeletonBar} w="w-24" h="h-2" />
         <div class="mt-2 flex gap-2">
           ${[1,2,3,4].map(i => html`
@@ -849,7 +849,7 @@ function SkeletonLayout() {
       </div>
 
       ${/* Swimlane skeleton */ ''}
-      <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+      <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
         <${SkeletonBar} w="w-28" h="h-2" />
         <div class="mt-2 flex flex-col gap-1.5">
           ${[1,2,3,4,5].map(i => html`
@@ -864,7 +864,7 @@ function SkeletonLayout() {
       ${/* Health Grid skeleton */ ''}
       <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         ${[1,2,3].map(i => html`
-          <div key=${i} class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+          <div key=${i} class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
             <${SkeletonBar} w="w-20" h="h-2" />
             <div class="mt-2 flex flex-wrap gap-1.5">
               <${SkeletonBar} w="w-14" h="h-5" />
@@ -924,7 +924,7 @@ function CollapsibleZone({
   }
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] overflow-hidden">
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] overflow-hidden">
       <button
         type="button"
         class="w-full flex items-center justify-between px-4 py-2 text-left hover:bg-[var(--white-3)] transition-colors cursor-pointer select-none"

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -149,23 +149,23 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
 function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
-      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_goals}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">전체 목표</div>
       </div>
-      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.active_goals}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">진행 중</div>
       </div>
-      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_tasks}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">연결 태스크</div>
       </div>
-      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.done_tasks}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
       </div>
-      <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3">
+      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3">
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
         <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
       </div>
@@ -198,7 +198,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   return html`
     <div class="flex flex-col" style="margin-left:${indent}px">
       <div
-        class="group flex items-start gap-3 rounded-xl border border-card-border/60 bg-[rgba(8,13,22,0.86)] p-3 transition-colors hover:border-card-border/90 ${hasContent ? 'cursor-pointer' : ''}"
+        class="group flex items-start gap-3 rounded border border-card-border/60 bg-[rgba(8,13,22,0.86)] p-3 transition-colors hover:border-card-border/90 ${hasContent ? 'cursor-pointer' : ''}"
         onClick=${hasContent ? () => toggleNode(node.id) : undefined}
       >
         ${hasContent ? html`
@@ -285,7 +285,7 @@ export function GoalTree() {
 
   return html`
     <div class="flex flex-col gap-5">
-      <section class="rounded-2xl border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
+      <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
           <div class="max-w-[760px]">
             <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -102,7 +102,7 @@ function KanbanCard({ task }: { task: Task }) {
   }
 
   return html`
-    <article class="flex flex-col gap-3 rounded-xl border border-card-border/60 border-l-4 bg-[rgba(7,12,20,0.92)] p-4 ${priorityToneClass(p)}">
+    <article class="flex flex-col gap-3 rounded border border-card-border/60 border-l-4 bg-[rgba(7,12,20,0.92)] p-4 ${priorityToneClass(p)}">
       <div class="flex items-start justify-between gap-3">
         <div class="flex flex-wrap items-center gap-2">
           <span class="rounded-md border border-current/20 px-2 py-0.5 text-[11px] font-semibold">${priorityLabel(p)}</span>
@@ -188,7 +188,7 @@ function TaskColumn({
   }, [listRef])
 
   return html`
-    <section class="flex min-h-[240px] flex-col gap-4 rounded-2xl border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
+    <section class="flex min-h-[240px] flex-col gap-4 rounded border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
       <div class="flex items-start justify-between gap-3 border-b border-card-border/50 pb-3">
         <div>
           <h3 class="text-[15px] font-semibold text-text-strong">${title}</h3>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -40,7 +40,7 @@ function PlanningStat({
           : 'text-text-strong'
 
   return html`
-    <div class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+    <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
       <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
       <div class="mt-2 text-[30px] font-bold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
@@ -81,7 +81,7 @@ function GuideCard({
   children?: ComponentChildren
 }) {
   return html`
-    <section class="flex flex-col gap-3 rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+    <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
       <div class="flex items-start justify-between gap-3">
         <div>
           <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${eyebrow}</div>
@@ -138,7 +138,7 @@ function KeeperToolActivity() {
   }, [keeperList])
 
   return html`
-    <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)]" open=${true}>
+    <details class="overview-section-collapsible group overflow-hidden rounded border border-card-border/60 bg-[rgba(9,14,24,0.82)]" open=${true}>
       <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-white/3">
         <div class="min-w-0">
           <div>도구 활동 요약</div>
@@ -211,7 +211,7 @@ export function Planning() {
 
   return html`
     <div class="flex flex-col gap-6">
-      <section class="rounded-2xl border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
+      <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div class="max-w-[760px]">
             <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Planning Status</div>
@@ -237,7 +237,7 @@ export function Planning() {
         </div>
 
         <div class="mt-5 grid gap-4 xl:grid-cols-2">
-          <section class="rounded-xl border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+          <section class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
             <div class="mb-3">
               <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Backlog Entry</div>
               <h3 class="mt-1 text-[15px] font-semibold text-text-strong">태스크 추가</h3>
@@ -265,7 +265,7 @@ export function Planning() {
 
       <${KeeperToolActivity} />
 
-      <section class="rounded-xl border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
+      <section class="rounded border border-card-border/60 bg-[rgba(9,14,24,0.82)] p-4">
         <div class="flex items-center justify-between gap-3">
           <div>
             <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Goal Pipeline</div>

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -135,7 +135,7 @@ function GateSection({
   if (!gate) return null
 
   return html`
-    <div class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
+    <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
       <div class="flex items-center justify-between gap-3">
         <div class="text-[12px] font-medium text-text-strong">${title}</div>
         <span class=${`rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${gateTone(gate.status)}`}>${gate.status}</span>
@@ -175,7 +175,7 @@ function ContractSection({ task }: { task: Task }) {
       </div>
 
       ${isAwaitingVerification ? html`
-        <div class="rounded-xl border border-accent/30 bg-[var(--accent-5)] px-4 py-3">
+        <div class="rounded border border-accent/30 bg-[var(--accent-5)] px-4 py-3">
           <div class="text-[12px] font-medium text-accent">Verifier Keeper 검증 중</div>
           <div class="mt-1 text-[11px] text-text-body">
             Submitter: <span class="font-mono">${verifierAssignee ?? '(unknown)'}</span>
@@ -192,7 +192,7 @@ function ContractSection({ task }: { task: Task }) {
       <${GateSection} title="Verify → Review" gate=${gate?.verify_to_review} />
 
       ${completionItems.length > 0 ? html`
-        <div class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
+        <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
           <div class="text-[12px] font-medium text-text-strong">Completion Contract</div>
           <div class="mt-2 flex flex-col gap-1">
             ${completionItems.map((item: string) => html`
@@ -203,7 +203,7 @@ function ContractSection({ task }: { task: Task }) {
       ` : null}
 
       ${requiredEvidence.length > 0 ? html`
-        <div class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
+        <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
           <div class="text-[12px] font-medium text-text-strong">Required Evidence</div>
           <div class="mt-2 flex flex-wrap gap-1.5">
             ${requiredEvidence.map((item: string) => html`
@@ -231,7 +231,7 @@ function ExecutionLinksSection({ task }: { task: Task }) {
       <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">연결된 실행</div>
       <div class="flex flex-col gap-2">
         ${items.map(([label, value]) => html`
-          <div key=${label} class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
+          <div key=${label} class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
             <div class="text-[10px] uppercase tracking-[0.12em] text-text-dim">${label}</div>
             <div class="mt-1 text-[12px] font-mono text-text-body break-all">${value}</div>
           </div>
@@ -248,7 +248,7 @@ function HandoffSection({ task }: { task: Task }) {
   return html`
     <div>
       <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 Handoff</div>
-      <div class="rounded-xl border border-warn/20 bg-warn/8 px-4 py-3">
+      <div class="rounded border border-warn/20 bg-warn/8 px-4 py-3">
         <div class="text-[13px] leading-relaxed text-text-body"><${RichContent} text=${handoff.summary} previewLimit=${2} /></div>
         ${handoff.reason ? html`<div class="mt-2 text-[11px] text-text-muted">reason: ${handoff.reason}</div>` : null}
         ${handoff.next_step ? html`<div class="mt-1 text-[11px] text-text-muted">next: ${handoff.next_step}</div>` : null}
@@ -333,7 +333,7 @@ export function TaskDetailOverlay() {
       onClose=${closeTaskDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded-2xl border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
+      panelClass="w-full max-w-[900px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
     >
       ${'' /* Sticky Header */}
       <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--card-border)] bg-[rgba(13,21,38,0.97)] backdrop-blur-md rounded-t-2xl">
@@ -379,7 +379,7 @@ export function TaskDetailOverlay() {
           ${task.description ? html`
             <div>
               <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">설명</div>
-              <div class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-[13px] leading-relaxed text-text-body">
+              <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-[13px] leading-relaxed text-text-body">
                 <${RichContent} text=${task.description} previewLimit=${2} />
               </div>
             </div>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -46,7 +46,7 @@ function GovernanceSummaryStrip() {
 
   return html`
     ${isStale ? html`
-      <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
+      <div class="mb-3.5 flex items-center gap-3 rounded border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
         <div class="shrink-0"><${AlertTriangle} size=${18} aria-hidden="true" /></div>
         <div>
           모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
@@ -280,7 +280,7 @@ function KeeperApprovalAlertBanner() {
 
   return html`
     <div
-      class="mb-3.5 flex items-center gap-4 rounded-xl border ${tone} p-4 shadow-sm ring-2 ${ringTone}"
+      class="mb-3.5 flex items-center gap-4 rounded border ${tone} p-4 shadow-sm ring-2 ${ringTone}"
       data-testid="keeper-hitl-alert-banner"
       role="status"
       aria-live="polite"
@@ -433,7 +433,7 @@ function KeeperApprovalQueueSection() {
               ${visibleItems.map(item => {
                 const disabled = actingId === item.id
                 return html`
-                  <div class="rounded-xl border border-card-border bg-card/34 p-4 shadow-sm" data-testid="governance-approval-item">
+                  <div class="rounded border border-card-border bg-card/34 p-4 shadow-sm" data-testid="governance-approval-item">
                     <div class="flex flex-wrap items-start gap-2.5">
                       <span class="inline-flex items-center rounded-md border border-white/10 bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-bold text-text-muted">
                         keeper ${item.keeper_name}

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -284,7 +284,7 @@ export function HandoffTimeline({
   const isFiltering = query.value.trim() !== ''
 
   return html`
-    <section class="rounded-xl border border-card-border bg-card-bg p-4 flex flex-col gap-3">
+    <section class="rounded border border-card-border bg-card-bg p-4 flex flex-col gap-3">
       <header class="flex items-baseline justify-between">
         <div>
           <h3 class="text-sm font-semibold text-text">A2A Event Timeline</h3>

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -277,7 +277,7 @@ export function HeroRailCard({
   freshness: string
 }) {
   return html`
-    <div class=${`rounded-xl border p-3 ${statusCardClass(status)}`}>
+    <div class=${`rounded border p-3 ${statusCardClass(status)}`}>
       <div class="flex items-start justify-between gap-3">
         <div class="text-sm font-medium text-[var(--text-strong)]">${label}</div>
         <${StatusPill} status=${status} />

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -242,7 +242,7 @@ export function HarnessHealth() {
   } else if (data) {
     overviewContent = html`
       <div class="space-y-4">
-        <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
           <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div class="max-w-3xl">
               <${SectionCap}>keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다<//>

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -114,7 +114,7 @@ export function KeeperConditionsDivergent({ keeper }: { keeper: Keeper }) {
   if (!first) return null
 
   return html`
-    <section class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
+    <section class="rounded border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
         <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--warn)]">
           ⚠️ 조건-Phase 불일치

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -201,7 +201,7 @@ export function peekKeeperConfigLoadStatus(
 
 function ConfigRow({ label, value }: { label: string; value: string }) {
   return html`
-    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+    <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
       <span class="text-[12px] font-medium text-text-muted">${label}</span>
       <span class="text-[12px] font-semibold text-text-strong">${value}</span>
     </div>
@@ -231,7 +231,7 @@ function Callout({
       ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
-    <div class="rounded-xl border px-3 py-3 shadow-sm ${toneClass}">
+    <div class="rounded border px-3 py-3 shadow-sm ${toneClass}">
       <div class="text-[11px] font-bold uppercase tracking-widest text-text-muted mb-1">${title}</div>
       <div class="text-[12px] leading-relaxed">${body}</div>
     </div>
@@ -267,7 +267,7 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
     truncateAt !== null && truncateAt >= 0 && text.length > truncateAt
       ? text.slice(0, truncateAt) + '...'
       : text
-  return html`<div class="text-[12px] text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-md p-3 rounded-xl mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
+  return html`<div class="text-[12px] text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-md p-3 rounded mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
 }
 
 
@@ -302,13 +302,13 @@ function PromptBlock({
   `
 }
 
-const fieldStyle = 'w-full bg-card/60 backdrop-blur-md text-text-strong text-[13px] border border-card-border rounded-xl py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
+const fieldStyle = 'w-full bg-card/60 backdrop-blur-md text-text-strong text-[13px] border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
 
 // ── Inline editing components for runtime config ────────
 
 function InlineToggleRow({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
   return html`
-    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+    <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
       <span class="text-[12px] font-medium text-text-muted">${label}</span>
       <button type="button"
         class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-pointer ${value ? 'bg-ok/60' : 'bg-white/10'}"
@@ -325,7 +325,7 @@ function InlineNumberRow({ label, value, onChange, min, max, step, suffix }: {
   min?: number; max?: number; step?: number; suffix?: string
 }) {
   return html`
-    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
+    <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
       <span class="text-[12px] font-medium text-text-muted">${label}</span>
       <div class="flex items-center gap-1.5">
         <input type="number"
@@ -716,7 +716,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       `}
 
       ${runtimeHasChanges ? html`
-        <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded-xl border border-accent/30 bg-accent/5">
+        <div class="flex gap-2 items-center mt-4 mb-2 p-3 rounded border border-accent/30 bg-accent/5">
           <button type="button"
             class="${btnBase} bg-[var(--ok)] text-[#000]"
             onClick=${saveRuntimeConfig}
@@ -750,7 +750,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
             ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
             : visibleEntries.map(([name, slot]) => html`
-                <div class="flex items-start gap-2 py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 mb-1.5">
+                <div class="flex items-start gap-2 py-2 px-3 rounded border border-card-border/50 bg-card/20 mb-1.5">
                   <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
                   <div class="flex-1 min-w-0">
                     <div class="flex justify-between">

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -128,7 +128,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
 }) {
   const icon = KPI_ICON[label] ?? ''
   return html`
-    <div class="p-3.5 rounded-xl border ${KPI_TONE[tone]} flex flex-col gap-1.5 transition-colors">
+    <div class="p-3.5 rounded border ${KPI_TONE[tone]} flex flex-col gap-1.5 transition-colors">
       <div class="flex items-center justify-between">
         <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
         ${icon ? html`<span class="text-[11px] opacity-60">${icon}</span>` : null}
@@ -164,7 +164,7 @@ function OperationalHealth({ keeper }: { keeper: Keeper }) {
   if (!hasAny) return null
 
   return html`
-    <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-3">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
       <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">운영 건강도</div>
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
         ${hb ? html`
@@ -346,7 +346,7 @@ function KpiSection({ title, question, children }: {
   children: unknown
 }) {
   return html`
-    <section class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-3">
+    <section class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
         <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">${title}</h3>
         <span class="text-[10px] text-[var(--text-dim)] truncate">${question}</span>
@@ -428,7 +428,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           </div>
           <${OperationalHealth} keeper=${keeper} />
           ${totalCalls > 0 ? html`
-            <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-3">
+            <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
               <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">모델 호출 분포</div>
               <div class="flex flex-col gap-1.5">
                 ${modelEntries.slice(0, 4).map(([model, count]) => {
@@ -508,7 +508,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
     const pct = ((keeper.context_ratio ?? keeper.context?.context_ratio ?? 0) * 100)
     const color = ctxColor(pct)
     return html`
-      <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
           <div class="h-full rounded-full transition-all duration-300" style="width:${pct.toFixed(1)}%;background:${color}"></div>
         </div>
@@ -528,7 +528,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   const lineColor = ctxColor(lastRatio)
 
   return html`
-    <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+    <div class="flex items-center gap-3 mb-5 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded" style="background:#0b1220;">
         <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - (CTX_WARN_PCT / 100) * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
@@ -600,7 +600,7 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
         ${'' /* Dual-line chart: input (cyan) + output (green) */}
-        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center gap-4 mb-1.5">
             <span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
               <span class="inline-block w-2.5 h-0.5 rounded bg-[#67e8f9]"></span> input
@@ -618,7 +618,7 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
         </div>
 
         ${'' /* Input/Output ratio */}
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">In/Out 비율</span>
           <span class="text-lg font-mono tabular-nums text-[var(--accent)]">${avgRatio.toFixed(1)}x</span>
           <span class="text-[10px] text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
@@ -685,7 +685,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
           : null}
       </div>
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">estimated prompt tokens</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
@@ -700,13 +700,13 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
           </div>
         </div>
 
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${fingerprintTransitions}</span>
           <span class="text-[10px] text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
         </div>
 
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest fingerprint</span>
           <div class="flex items-center gap-1.5">
             <span class="text-sm font-mono break-all text-[var(--text-strong)]" title=${latest?.prompt_fingerprint ?? ''}>${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
@@ -719,7 +719,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
       ${latestSegments.length > 0 ? html`
         <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
           ${latestSegments.map(([segmentKey, segment]) => html`
-            <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+            <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
               <div class="flex items-center justify-between gap-2 mb-2">
                 <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
                 <span class="inline-flex items-center gap-1">
@@ -795,7 +795,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         <span class="text-[10px] text-[var(--text-dim)]">${points.length} snapshots</span>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-2 gap-3">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest turn input</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${formatTokens(latestTotal)}</span>
@@ -817,7 +817,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           </div>
         </div>
 
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">largest bucket</span>
           <span class="text-sm font-medium text-[var(--text-strong)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
           <span class="text-[10px] font-mono text-[var(--text-dim)]">
@@ -825,7 +825,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           </span>
         </div>
 
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">residual</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${formatTokens(unattributedTokens)}</span>
           <span class="text-[10px] text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
@@ -833,7 +833,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
       </div>
 
       <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">stacked history</span>
             <span class="text-[10px] text-[var(--text-dim)]">${points.length} turns</span>
@@ -862,7 +862,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           </svg>
         </div>
 
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between gap-2 mb-2">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
             <span class="text-[10px] font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
@@ -965,7 +965,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
       </div>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         ${'' /* tok/s sparkline */}
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">tok/s</span>
             <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastTps.toFixed(1)}</span>
@@ -977,7 +977,7 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         ${'' /* request latency */}
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">API latency</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
@@ -988,14 +988,14 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         ${'' /* cache hits */}
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
           <span class="text-lg font-mono tabular-nums text-[var(--purple)]">${totalCacheN > 0 ? totalCacheN.toLocaleString() : '-'}</span>
           <span class="text-[10px] text-[var(--text-dim)]">cumulative tokens</span>
         </div>
 
         ${'' /* reasoning tokens */}
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
           <span class="text-[10px] text-[var(--text-dim)]">total tokens</span>
@@ -1036,7 +1036,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-5">
       ${'' /* Latency + fallback markers */}
-      <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
           <span class="flex items-center gap-2">
@@ -1054,7 +1054,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       </div>
 
       ${'' /* Cost */}
-      <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">비용</span>
           <span class="text-xs font-mono tabular-nums text-[var(--purple)]">$${totalCost.toFixed(4)}</span>
@@ -1066,7 +1066,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
 
       ${'' /* Model timeline */}
       ${modelSwitches.length > 0 ? html`
-        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">모델 전환</span>
             <span class="text-[10px] text-[var(--text-dim)]">${modelSwitches.length}회</span>
@@ -1083,7 +1083,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
 
       ${'' /* Cascade fallback events */}
       ${fallbackCount > 0 ? html`
-        <div class="md:col-span-2 p-3 rounded-xl border border-[rgba(239,68,68,0.2)] bg-[rgba(239,68,68,0.04)]">
+        <div class="md:col-span-2 p-3 rounded border border-[rgba(239,68,68,0.2)] bg-[rgba(239,68,68,0.04)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Cascade Fallback</span>
             <span class="text-[10px] text-[var(--bad)]">${fallbackCount}회</span>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -299,7 +299,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
 export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
   const diverges = hasTurnBudgetDivergence(keeper)
   return html`
-    <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${diverges}>
+    <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${diverges}>
       <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-[var(--warn-10)]' : 'bg-accent/50'}"></span>
         턴 예산

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -173,7 +173,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="px-6 pt-4">
-      <div class="rounded-xl border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[12px] text-[var(--text-body)]">
+      <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[12px] text-[var(--text-body)]">
         ${keeper.paused
           ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-[rgba(251,191,36,0.14)] text-[var(--warn)]">일시정지</span>
             <button
@@ -320,7 +320,7 @@ function KeeperClearContextDialog({
       onClose=${pending ? () => {} : onClose}
       initialFocusRef=${reasonRef}
       overlayClass="fixed inset-0 z-[80] bg-[var(--white-5)]/70 backdrop-blur-sm isolate flex items-center justify-center p-4"
-      panelClass="w-full max-w-[520px] rounded-2xl border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
+      panelClass="w-full max-w-[520px] rounded border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
     >
       <div class="p-5 flex flex-col gap-4">
         <div class="flex flex-col gap-1">
@@ -334,7 +334,7 @@ function KeeperClearContextDialog({
           <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
           <textarea
             ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[rgba(71,184,255,0.45)] focus:ring-2 focus:ring-[rgba(71,184,255,0.18)]"
+            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[rgba(71,184,255,0.45)] focus:ring-2 focus:ring-[rgba(71,184,255,0.18)]"
             placeholder="예: stale continuity replay 제거"
             disabled=${pending}
             value=${reason}
@@ -342,7 +342,7 @@ function KeeperClearContextDialog({
           ></textarea>
         </label>
 
-        <label class="flex items-start gap-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-body)]">
+        <label class="flex items-start gap-3 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             class="mt-0.5"
@@ -356,7 +356,7 @@ function KeeperClearContextDialog({
           </span>
         </label>
 
-        <div class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
+        <div class="rounded border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
           마지막 수단용 액션입니다. 잘못된 continuity가 재주입될 때만 쓰고, 실행 후 즉시 상태를 다시 확인하세요.
         </div>
 
@@ -423,14 +423,14 @@ function CheckpointSummaryCard({
 }) {
   if (!summary) {
     return html`
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
         ${title}: 저장된 checkpoint 없음
       </div>
     `
   }
 
   return html`
-    <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
       <div class="flex flex-wrap items-center gap-2">
         <span class="text-[12px] font-semibold text-[var(--text-strong)]">${title}</span>
         <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.18)]">
@@ -529,7 +529,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
   if (loading) {
     return html`
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
         checkpoint inventory 로딩 중...
       </div>
     `
@@ -537,7 +537,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
   if (error) {
     return html`
-      <div class="rounded-xl border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-[12px] text-[#fda4af]">
+      <div class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-[12px] text-[#fda4af]">
         ${error}
         <button
           type="button"
@@ -577,7 +577,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
         summary=${inventory?.current ?? null}
       />
 
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] px-3 py-2">
           <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
             OAS Snapshot History
@@ -656,7 +656,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
       <h3 class="m-0 mb-3 text-[13px] font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
 
       ${isOffline ? html`
-        <div class="px-4 py-3 rounded-xl border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-[13px] text-[var(--text-muted)]">
+        <div class="px-4 py-3 rounded border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-[13px] text-[var(--text-muted)]">
           이 키퍼는 현재 비활동 상태입니다. 기동 후 메시지를 보낼 수 있습니다.
         </div>
       ` : html`
@@ -675,7 +675,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
-    <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}
@@ -1233,13 +1233,13 @@ export function KeeperDetailOverlay() {
       onClose=${closeKeeperDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="keeper-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-full max-w-[1100px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded-2xl border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
+      panelClass="w-full max-w-[1100px] max-h-[90vh] overflow-y-auto bg-[#0d1526] rounded border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
     >
 
         ${'' /* ── Sticky Header ── */}
         <div class="sticky top-0 z-10 flex items-center justify-between px-6 py-4 border-b border-[var(--card-border)] bg-[rgba(13,21,38,0.97)] backdrop-blur-md rounded-t-2xl">
           <div class="flex items-center gap-4">
-            <div class="size-12 rounded-xl bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
+            <div class="size-12 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
             <div class="flex flex-col gap-0.5">
               <div class="flex items-center gap-2.5">
                 <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
@@ -1328,7 +1328,7 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Pipeline stage + Phase state diagram ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
-        <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]">
+        <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
           <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(71,184,255,0.5)]"></span>
             Phase State Machine
@@ -1338,7 +1338,7 @@ export function KeeperDetailOverlay() {
           </div>
         </details>
 
-        <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]">
+        <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
           <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(99,102,241,0.5)]"></span>
             Memory Tier & Compaction
@@ -1427,7 +1427,7 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Runtime diagnostics (supervisor + keeper diagnostics unified) ── */}
         <details
-          class="rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm"
+          class="rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm"
           open=${diagOpen}
           onToggle=${(e: Event) => setDiagOpen((e.currentTarget as HTMLDetailsElement).open)}
         >
@@ -1512,7 +1512,7 @@ export function KeeperDetailOverlay() {
             <//>
           </div>
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+          <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               품질 시그널 (고급 지표)
@@ -1523,7 +1523,7 @@ export function KeeperDetailOverlay() {
 
           <${TurnBudgetSection} keeper=${keeper} />
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+          <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               도구 정책
@@ -1535,7 +1535,7 @@ export function KeeperDetailOverlay() {
 
           <${PlaygroundReposPanel} keeperName=${keeper.name} />
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+          <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               설정
@@ -1545,7 +1545,7 @@ export function KeeperDetailOverlay() {
             </div>
           </details>
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+          <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               Checkpoint & Snapshots
@@ -1561,16 +1561,16 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Debug (journal + raw data) ── */}
         <details class="mt-4">
-          <summary class="cursor-pointer py-3 px-4 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
+          <summary class="cursor-pointer py-3 px-4 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
             디버그
           </summary>
           <div class="mt-2 flex flex-col gap-4">
-            <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md">
+            <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md">
               <h4 class="m-0 mb-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">저널</h4>
               <${AgentJournalStream} agentName=${keeper.name} />
             </div>
-            <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md">
+            <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md">
               <h4 class="m-0 mb-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">원시 데이터</h4>
               <${RawDataDebug} keeper=${keeper} />
             </div>

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -133,7 +133,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
   if (loading && !data) {
     return html`
-      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-[11px] text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
       </div>
@@ -142,7 +142,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
   if (error && !data) {
     return html`
-      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-[11px] text-[var(--text-dim)]">eval 데이터 없음</div>
       </div>
@@ -151,7 +151,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
   if (!data || data.count === 0) {
     return html`
-      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+      <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-[11px] text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
       </div>
@@ -169,7 +169,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   const trend = computeTrend(data.snapshots)
 
   return html`
-    <div class="p-4 rounded-xl border ${coverageTone(coverage)} transition-colors">
+    <div class="p-4 rounded border ${coverageTone(coverage)} transition-colors">
       ${'' /* Header */}
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -181,12 +181,12 @@ export function KeeperDiagnosticSummary({
   }
 
   return html`
-    <div class="py-3 px-4 rounded-xl border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
+    <div class="py-3 px-4 rounded border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">명시적 상태 조회</div>
         <button
           type="button"
-          class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
           disabled=${busy}
           onClick=${() => { void refreshStatus() }}
         >
@@ -307,14 +307,14 @@ export function KeeperConversationPanel({
           <div class="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
               onClick=${toggleMetadata}
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
             <button
               type="button"
-              class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
+              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
               onClick=${toggleInternal}
             >
               ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
@@ -323,7 +323,7 @@ export function KeeperConversationPanel({
               ? html`
                   <button
                     type="button"
-                    class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+                    class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
                     disabled=${hydrating}
                     onClick=${() => { void expandHistory() }}
                   >

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -14,7 +14,7 @@ export function KeeperSpawnPanel() {
     </div>`
   }
   return html`
-    <div class="mb-4 rounded-xl border border-[var(--card-border)] bg-[var(--bg-1)] p-4">
+    <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-4">
       <div class="flex items-center justify-between mb-3">
         <h3 class="text-[13px] text-[var(--text-strong)] font-medium">키퍼 생성</h3>
         <${ActionButton} variant="subtle" size="sm" onClick=${() => { showSpawnPanel.value = false }}>닫기<//>

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -38,7 +38,7 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
   const isSpawning = spawning.value && isConfirming
   const title = persona.displayName ?? persona.name
   return html`
-    <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-[180px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-[180px]">
       <div class="text-[14px] text-[var(--text-strong)] font-medium">${title}</div>
       ${persona.role ? html`<div class="text-[11px] text-[var(--text-muted)]">${persona.role}</div>` : null}
       ${persona.mode ? html`<div class="text-[10px] text-[var(--text-muted)]">모드: ${persona.mode}</div>` : null}

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -176,7 +176,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       </div>
 
       ${phaseMismatch ? html`
-        <div class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+        <div class="rounded border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
           keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다.
         </div>
       ` : null}
@@ -190,7 +190,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         ${INVARIANT_LABELS.map(([key, label]) => {
           const ok = snapshot.invariants[key]
           return html`
-            <div class=${`rounded-xl border px-3 py-2 text-[11px] leading-[1.5] ${badgeTone(ok)}`}>
+            <div class=${`rounded border px-3 py-2 text-[11px] leading-[1.5] ${badgeTone(ok)}`}>
               <div class="font-semibold">${label}</div>
               <div class="mt-1 font-mono">${ok ? 'ok' : 'violated'}</div>
             </div>
@@ -202,7 +202,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         <div class="grid gap-2">
           <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Observed transitions</div>
           ${transitions.map(transition => html`
-            <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
               <div class="flex flex-wrap items-center gap-2">
                 <span class="font-mono text-[var(--text-strong)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
                 <span class="text-[var(--text-dim)]">→</span>

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -24,7 +24,7 @@ const crashShowAll = signal<boolean>(false)
 
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
-    <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -178,7 +178,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   const trimmedQuery = query.trim()
 
   return html`
-    <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         도구 텔레메트리

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -80,13 +80,13 @@ function InspectorOverview() {
     <div class="grid gap-4">
       <${Card} title="Dashboard Focus" class="section">
         <div class="grid gap-3">
-          <div class="rounded-xl border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-[13px] leading-[1.7] text-[var(--text-body)]">
+          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-[13px] leading-[1.7] text-[var(--text-body)]">
             이제 대시보드는 <strong class="text-[var(--text-strong)]">핵심 운영 화면</strong>에 더 집중합니다.
             낮은 활용도의 화면은 줄이고, 진짜 자주 보는 상태/개입/근거 화면으로 빠르게 이동할 수 있게 정리했습니다.
           </div>
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
             ${FOCUS_SURFACES.map(surface => html`
-              <div class="rounded-xl border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3">
+              <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3">
                 <div class="text-[12px] font-semibold text-[var(--text-strong)]">${surface.title}</div>
                 <div class="mt-2 text-[11px] leading-[1.6] text-[var(--text-muted)]">${surface.description}</div>
                 <button

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -60,7 +60,7 @@ export function ActivityStream() {
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}
-              class="activity-item rounded-2xl border border-[var(--border-slate-12)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
+              class="activity-item rounded border border-[var(--border-slate-12)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
               <div class="activity-item-head flex items-center gap-2">
                 <span class="activity-kind-chip rounded-md px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -45,7 +45,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
           : list.map(agent => html`
             <div
               key=${agent.name}
-              class="focus-agent-card rounded-2xl border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -34,7 +34,7 @@ export function KeeperHealthStrip() {
   const alertCount = summary.warningCount + summary.criticalCount
 
   return html`
-    <div class="flex items-center gap-4 rounded-2xl border border-[var(--border-slate-12)] bg-[var(--white-3)] px-4 py-2.5">
+    <div class="flex items-center gap-4 rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] px-4 py-2.5">
       <div class="flex items-center gap-2 min-w-0">
         <span class="text-[13px] font-medium text-[var(--text-strong)] whitespace-nowrap">
           Keeper

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -18,14 +18,14 @@ export function PulseStrip() {
 
   if (pulses.length === 0) {
     return html`
-      <div class="pulse-strip rounded-xl">
+      <div class="pulse-strip rounded">
         <span class="text-[var(--text-dim)] text-[13px]">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
       </div>
     `
   }
 
   return html`
-    <div class="pulse-strip rounded-xl">
+    <div class="pulse-strip rounded">
       ${pulses.map(p => html`
         <button type="button"
           key=${p.name}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -362,7 +362,7 @@ export function LogViewer() {
 
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
-      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
+      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <select

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -148,7 +148,7 @@ function renderCategorySection(
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
     return html`
-      <div class="mb-3 px-3 py-2 rounded-xl border border-dashed border-[var(--border-slate-16)] text-[12px] text-[var(--text-muted)]">
+      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-[12px] text-[var(--text-muted)]">
         ${label} — ${hidden}건 숨김
       </div>
     `
@@ -196,7 +196,7 @@ function NewPostForm() {
   }
 
   return html`
-    <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-3">
+    <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] grid gap-3">
       <${TextInput}
         name="board_post_title"
         ariaLabel="새 글 제목"
@@ -233,7 +233,7 @@ function SortBar() {
   const current = boardSortMode.value
   const grouped = splitVisiblePosts(boardPosts.value)
   return html`
-    <div class="flex flex-col gap-3 mb-4 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+    <div class="flex flex-col gap-3 mb-4 p-3 rounded border border-[var(--card-border)] bg-[var(--card)]">
       <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
           <button type="button"
@@ -328,7 +328,7 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   return html`
-    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded-xl border border-[var(--card-border)] bg-[var(--card)] text-[12px] text-[var(--text-muted)]">
+    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--card-border)] bg-[var(--card)] text-[12px] text-[var(--text-muted)]">
       <span class="font-semibold text-[var(--text-strong)] tabular-nums text-[15px]">${visibleCount}</span>
       <span>개 표시 중</span>
       ${grouped.groups.map(g => {
@@ -386,7 +386,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
   return html`
     <div
-      class="board-post group flex gap-3 rounded-xl p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer"
+      class="board-post group flex gap-3 rounded p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer"
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->
@@ -506,7 +506,7 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${hint ? html`
-        <div class="mb-4 px-3 py-2 rounded-xl border border-[var(--border-slate-16)] bg-[var(--white-3)] text-[12px] text-[var(--text-muted)]">
+        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-[12px] text-[var(--text-muted)]">
           ${hint}
         </div>
       ` : null}

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -315,7 +315,7 @@ export function Observatory() {
         : !hasTrackData && data.loading
         ? html`<${LoadingState}>관찰소 데이터 불러오는 중...<//>`
         : html`
-            <div class="flex flex-col gap-2 rounded-xl border border-card-border bg-card/30 p-4">
+            <div class="flex flex-col gap-2 rounded border border-card-border bg-card/30 p-4">
               <${TimeAxis} windowStart=${data.windowStart} windowEnd=${data.windowEnd} />
               <${EventTrack}
                 events=${data.events}

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -165,7 +165,7 @@ function renderActivityTimeline() {
           key=${entry.key}
           data-testid="ops-activity-item"
           data-activity-kind=${entry.kind}
-          class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-3"
+          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3"
         >
           <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
             <${CountBadge} tone=${entry.tone}>${entry.label}<//>
@@ -209,11 +209,11 @@ export function Ops() {
 
   return html`
     <section class="flex flex-col gap-4">
-      ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
-      ${operatorDigestError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorDigestError.value}</section>` : null}
+      ${operatorError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
+      ${operatorDigestError.value ? html`<section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] error">${operatorDigestError.value}</section>` : null}
 
       ${workflowContext ? html`
-        <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] ${workflowReady ? 'info' : 'warn'} grid gap-2">
+        <section class="ops-banner rounded py-3 px-3.5 border border-[var(--card-border)] ${workflowReady ? 'info' : 'warn'} grid gap-2">
           <div class="flex gap-2 flex-wrap items-center text-[var(--text-body)]">
             <strong class="font-semibold">${workflowContext.source_label}</strong>
             <span>${workflowActionLabel(workflowContext.action_type)}</span>

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -99,7 +99,7 @@ export function QuickIntervene() {
 
       ${showAdvanced
         ? html`
-            <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
               <label class="block text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]" for="quick-intervene-actor">
                 기록 주체
               </label>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -140,7 +140,7 @@ function OverviewFreshnessStrip() {
   const refreshing = missionLoading.value || namespaceTruthLoading.value
 
   return html`
-    <div class="rounded-xl border px-4 py-3 shadow-sm shadow-black/8 ${isStale ? 'border-warn/35 bg-warn/10' : 'border-card-border/40 bg-card/24'}">
+    <div class="rounded border px-4 py-3 shadow-sm shadow-black/8 ${isStale ? 'border-warn/35 bg-warn/10' : 'border-card-border/40 bg-card/24'}">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
@@ -332,7 +332,7 @@ function MetaCognitionCard() {
   const hasNarrative = Boolean(belief || tension || desire)
 
   return html`
-    <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
+    <div class="rounded border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
       <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0">
           <${HomeSectionHeader} label="집단 메타인지" />
@@ -359,7 +359,7 @@ function MetaCognitionCard() {
 
       ${focus
         ? html`
-            <div class="mb-3 rounded-xl border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
+            <div class="mb-3 rounded border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
               <span class="font-semibold text-[var(--text-strong)]">namespace-truth focus</span>
               <span class="ml-2">${focus.reason}</span>
             </div>
@@ -369,7 +369,7 @@ function MetaCognitionCard() {
       ${hasNarrative
         ? html`
             <div class="grid grid-cols-3 gap-3 max-[960px]:grid-cols-1">
-              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+              <div class="rounded border border-card-border/50 bg-card/48 p-3">
                 <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   <${Users} size=${12} class="shrink-0" aria-hidden="true" />
                   공감대
@@ -382,7 +382,7 @@ function MetaCognitionCard() {
                 </div>
               </div>
 
-              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+              <div class="rounded border border-card-border/50 bg-card/48 p-3">
                 <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   <${Zap} size=${12} class="shrink-0" aria-hidden="true" />
                   긴장
@@ -397,7 +397,7 @@ function MetaCognitionCard() {
                 </div>
               </div>
 
-              <div class="rounded-xl border border-card-border/50 bg-card/48 p-3">
+              <div class="rounded border border-card-border/50 bg-card/48 p-3">
                 <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   <${Target} size=${12} class="shrink-0" aria-hidden="true" />
                   욕구
@@ -412,7 +412,7 @@ function MetaCognitionCard() {
             </div>
           `
         : html`
-            <div class="rounded-xl border border-dashed border-card-border/50 bg-card/40 px-4 py-5 text-[12px] text-[var(--text-muted)]">
+            <div class="rounded border border-dashed border-card-border/50 bg-card/40 px-4 py-5 text-[12px] text-[var(--text-muted)]">
               아직 namespace-level 서사를 만들 만큼 강한 social signal이 쌓이지 않았습니다.
             </div>
           `}
@@ -430,7 +430,7 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
     <${RouteLink}
       tab="monitoring"
       params=${{ section: 'agents', session_id: s.session_id }}
-      class="rounded-xl border bg-card/55 p-4 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
+      class="rounded border bg-card/55 p-4 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
       title=${primary}
     >
       <div class="mb-2.5 flex items-start gap-3">
@@ -563,7 +563,7 @@ function AgentPulse() {
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'agents', agent: a.name }}
-            class="flex items-start gap-3 p-4 rounded-xl border border-card-border bg-card/55 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 hover:border-accent/32 group"
+            class="flex items-start gap-3 p-4 rounded border border-card-border bg-card/55 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 hover:border-accent/32 group"
             title=${a.koreanName ?? a.name}
           >
             <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${40} />
@@ -666,7 +666,7 @@ function OperationsHubCard() {
         linkParams=${{ section: 'operations' }}
       />
       <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 max-[900px]:grid-cols-1">
-        <div class="rounded-xl border border-card-border/40 bg-card/40 p-4">
+        <div class="rounded border border-card-border/40 bg-card/40 p-4">
           <div class="text-[13px] leading-[1.7] text-[var(--text-body)]">
             판단 검토, 승인 대기, 운영자 개입을 한 화면군으로 묶었습니다.
             위험한 행동은 <strong class="text-[var(--text-strong)]">거버넌스</strong>에서 검토하고,
@@ -674,7 +674,7 @@ function OperationsHubCard() {
           </div>
           ${focus
             ? html`
-                <div class="mt-3 rounded-xl border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
+                <div class="mt-3 rounded border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
                   <span class="font-semibold text-[var(--text-strong)]">${focus.label}</span>
                   <span class="ml-2">${focus.reason}</span>
                 </div>
@@ -703,7 +703,7 @@ function OperationsHubCard() {
           <${RouteLink}
             tab="command"
             params=${{ section: 'operations' }}
-            class="rounded-xl border border-accent/25 bg-[var(--accent-10)] px-4 py-3 text-[13px] font-semibold text-accent transition-colors hover:bg-accent/18"
+            class="rounded border border-accent/25 bg-[var(--accent-10)] px-4 py-3 text-[13px] font-semibold text-accent transition-colors hover:bg-accent/18"
             title="거버넌스 열기"
           >
             거버넌스 열기
@@ -711,7 +711,7 @@ function OperationsHubCard() {
           <${RouteLink}
             tab="command"
             params=${{ section: 'operations' }}
-            class="rounded-xl border border-card-border/45 bg-card/45 px-4 py-3 text-[13px] font-semibold text-[var(--text-strong)] transition-colors hover:bg-card"
+            class="rounded border border-card-border/45 bg-card/45 px-4 py-3 text-[13px] font-semibold text-[var(--text-strong)] transition-colors hover:bg-card"
             title="실시간 개입 열기"
           >
             실시간 개입
@@ -800,7 +800,7 @@ function ConfigTruthCard() {
         linkParams=${{ section: 'tools' }}
       />
       <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 max-[920px]:grid-cols-1">
-        <div class="rounded-xl border border-card-border/40 bg-card/40 p-4">
+        <div class="rounded border border-card-border/40 bg-card/40 p-4">
           <div class="flex flex-wrap items-center gap-2">
             ${configResolution
               ? html`
@@ -865,7 +865,7 @@ function ConfigTruthCard() {
           <${RouteLink}
             tab="command"
             params=${{ section: 'operations', view: 'inspector' }}
-            class="rounded-xl border border-accent/25 bg-[var(--accent-10)] px-4 py-3 text-[13px] font-semibold text-accent transition-colors hover:bg-accent/18"
+            class="rounded border border-accent/25 bg-[var(--accent-10)] px-4 py-3 text-[13px] font-semibold text-accent transition-colors hover:bg-accent/18"
             title="운영 인스펙터 열기"
           >
             운영 인스펙터
@@ -873,7 +873,7 @@ function ConfigTruthCard() {
           <${RouteLink}
             tab="lab"
             params=${{ section: 'tools' }}
-            class="rounded-xl border border-card-border/45 bg-card/45 px-4 py-3 text-[13px] font-semibold text-[var(--text-strong)] transition-colors hover:bg-card"
+            class="rounded border border-card-border/45 bg-card/45 px-4 py-3 text-[13px] font-semibold text-[var(--text-strong)] transition-colors hover:bg-card"
             title="설정 경로 상세"
           >
             설정 경로 상세
@@ -886,7 +886,7 @@ function ConfigTruthCard() {
 
 // --- Overview (Home) ---
 
-const OVERVIEW_CARD = 'rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8'
+const OVERVIEW_CARD = 'rounded border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8'
 
 export function Overview() {
   const snap = missionSnapshot.value

--- a/dashboard/src/components/perf-snapshot.ts
+++ b/dashboard/src/components/perf-snapshot.ts
@@ -56,7 +56,7 @@ function PerfStat({
   detail?: string | null
 }) {
   return html`
-    <div class="rounded-xl border border-card-border/45 bg-[var(--white-5)]/10 px-3 py-3">
+    <div class="rounded border border-card-border/45 bg-[var(--white-5)]/10 px-3 py-3">
       <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${label}</div>
       <div class="mt-1 text-[20px] font-bold text-[var(--text-strong)]">${value}</div>
       ${detail ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${detail}</div>` : null}
@@ -196,11 +196,11 @@ export function PerfSnapshotPanel() {
       </div>
 
       ${error.value
-        ? html`<div class="rounded-xl border border-bad/35 bg-bad/10 px-3 py-3 text-[12px] text-[var(--bad)]">${error.value}</div>`
+        ? html`<div class="rounded border border-bad/35 bg-bad/10 px-3 py-3 text-[12px] text-[var(--bad)]">${error.value}</div>`
         : null}
 
       ${data?.status === 'empty'
-        ? html`<div class="rounded-xl border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3 text-[12px] text-[var(--text-muted)]">
+        ? html`<div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3 text-[12px] text-[var(--text-muted)]">
             benchmark artifact가 아직 없습니다. <code>benchmark.sh</code>를 한 번 돌리면 latest summary와 baseline diff가 여기에 나타납니다.
           </div>`
         : null}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -217,7 +217,7 @@ export function RuntimeMonitor() {
         <div class="flex flex-col gap-3">
           ${(providers?.providers ?? []).length > 0
             ? providers?.providers.map(provider => html`
-                <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
+                <article class="p-4 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-[13px] text-text-strong">${provider.provider}</strong>
@@ -285,8 +285,8 @@ export function RuntimeMonitor() {
             ? sortModelMetricsByUrgency(filterModelMetrics(metrics?.models ?? [], modelSearch.value)).map(metric => {
                 const isFailing = (metric.error_count ?? 0) > 0
                 const articleClass = isFailing
-                  ? 'p-4 rounded-xl border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-md shadow-sm flex flex-col gap-2'
-                  : 'p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2'
+                  ? 'p-4 rounded border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-md shadow-sm flex flex-col gap-2'
+                  : 'p-4 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2'
                 const ariaLabel = isFailing
                   ? `Provider failing: ${metric.model_id}, ${metric.error_count ?? 0} errors out of ${metric.entry_count ?? 0}`
                   : undefined

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -36,7 +36,7 @@ export function TaskCreateForm() {
   }
 
   return html`
-    <div class="rounded-xl border border-card-border/70 bg-[rgba(8,13,22,0.88)] p-4">
+    <div class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.88)] p-4">
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
           <h3 class="text-[14px] font-semibold text-text-strong">새 태스크</h3>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -720,7 +720,7 @@ export function TelemetryUnified() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <div class="rounded-xl border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-4">
+      <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-4">
         <div class="text-[12px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Runtime Diagnosis</div>
         <div class="mt-1 text-[14px] leading-relaxed text-[var(--text-body)]">
           MASC telemetry store (keeper/tool/agent) 진단 뷰.
@@ -846,7 +846,7 @@ export function TelemetryUnified() {
         </div>
       ` : null}
 
-      <div class="rounded-xl border border-[var(--card-border)] overflow-hidden">
+      <div class="rounded border border-[var(--card-border)] overflow-hidden">
         <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
           MASC telemetry store entries ${entries.length.toLocaleString()}건
           ${isFilteringEntries

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -218,7 +218,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
   const lineColor = lastRate >= 95 ? '#4ade80' : lastRate >= 90 ? '#fbbf24' : '#ef4444'
 
   return html`
-    <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-3">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
       <div class="flex items-center justify-between mb-1.5">
         <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">성공률 추이</span>
         <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -175,7 +175,7 @@ export function PromptRegistryPanel() {
       ${status ? html`<div class="mb-4 rounded-lg border border-[rgba(56,189,248,0.28)] bg-[rgba(56,189,248,0.08)] px-3 py-2 text-[12px] text-[#bae6fd]">${status}</div>` : null}
 
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
-        <div class="min-h-[260px] rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-2">
+        <div class="min-h-[260px] rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
             <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
               등록된 프롬프트
@@ -234,7 +234,7 @@ export function PromptRegistryPanel() {
           </div>
         </div>
 
-        <div class="min-w-0 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-4">
+        <div class="min-w-0 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-4">
           ${selectedPrompt ? html`
             <div class="mb-4 flex flex-wrap items-center gap-2">
               <div class="font-mono text-[13px] text-[var(--text-strong)]">${selectedPrompt.key}</div>

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -526,7 +526,7 @@ export function ToolAllowlistEditor({
   }
 
   return html`
-    <div class="flex flex-col gap-3 mt-2 p-3 rounded-xl border border-[var(--card-border)] bg-[rgba(11,18,32,0.6)]">
+    <div class="flex flex-col gap-3 mt-2 p-3 rounded border border-[var(--card-border)] bg-[rgba(11,18,32,0.6)]">
       <div class="flex items-center justify-between">
         <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">도구 정책 편집</span>
         <button type="button"

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -84,27 +84,27 @@ export function FullInventoryView({
   return html`
     <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--card-border)]">
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${publicCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
-        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+        <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -9,7 +9,7 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
   const categoryHint = item.category === 'uncategorized' ? ' (서버 미지정)' : ''
 
   return html`
-    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+    <article class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
         <div>
           <div class="text-[15px] font-bold text-[var(--text-strong)]">${item.name}</div>

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -279,7 +279,7 @@ function SectionCard({
   children: ComponentChildren
 }) {
   return html`
-    <div class="rounded-xl border border-card-border bg-bg-1/60 p-4">
+    <div class="rounded border border-card-border bg-bg-1/60 p-4">
       <div class="flex items-center justify-between gap-3 mb-3">
         <div class="flex items-center gap-2 min-w-0">
           <${StatusDot} size="sm" class=${statusDot(status)} />
@@ -296,7 +296,7 @@ function SectionCard({
 
 function CaseCard({ item, data }: { item: PracticalCase; data: TransportHealthData }) {
   return html`
-    <div class="rounded-xl border border-card-border/70 bg-card/40 p-4">
+    <div class="rounded border border-card-border/70 bg-card/40 p-4">
       <div class="flex items-center justify-between gap-3 mb-2">
         <div class="text-sm font-semibold text-text-strong">${item.title}</div>
         <div class="text-[10px] uppercase tracking-wider text-text-muted">${item.transport}</div>
@@ -388,7 +388,7 @@ export function TransportHealthPanel() {
         >새로고침</button>
       </div>
 
-      <details class="group rounded-xl border border-card-border/50 bg-card/18 overflow-hidden" open=${hasAnyBadTransport}>
+      <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden" open=${hasAnyBadTransport}>
         <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
           <span>트랜스포트 상세</span>
           <span class="ml-auto flex items-center gap-2 text-[11px] font-normal text-text-muted">
@@ -456,7 +456,7 @@ export function TransportHealthPanel() {
             const filtered = filterHotSessions(data.sse.hot_sessions, query)
             const isFiltered = query.trim() !== ''
             return html`
-            <details class="group rounded-xl border border-card-border/50 bg-card/18 overflow-hidden" open=${data.sse.hot_sessions.length >= 3}>
+            <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden" open=${data.sse.hot_sessions.length >= 3}>
               <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
                 <span>핫 큐</span>
                 <span class="ml-auto text-[11px] font-normal text-text-muted">${data.sse.hot_sessions.length}개 세션 -- SSE 백프레셔 위험</span>
@@ -505,7 +505,7 @@ export function TransportHealthPanel() {
           })()
         : null}
 
-      <details class="group rounded-xl border border-card-border/50 bg-card/18 overflow-hidden">
+      <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden">
         <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
           <span>실용 경로</span>
           <span class="ml-auto text-[11px] font-normal text-text-muted">각 트랜스포트의 실제 연결 방법 레퍼런스</span>


### PR DESCRIPTION
## 요약

Anyang Sleepers 디자인 시스템 README line 115 인용:
> Radii are 0-4px and one 999px for status dots. No 8px. No 12px. No 16px. If you reach for a big radius, you are soft-pedaling the design — don't.

Dashboard는 현재 \`rounded-xl\` (12px), \`rounded-2xl\` (16px), \`rounded-3xl\` (24px)를 카드/패널/오버레이에 광범위 사용. 전부 디자인 시스템 ceiling(4px) 바깥. 74 파일에 걸친 일괄 전환.

## 매핑

| 이전 | → | 이후 |
|---|---|---|
| \`rounded-xl\` (12px) | → | \`rounded\` (4px) |
| \`rounded-2xl\` (16px) | → | \`rounded\` (4px) |
| \`rounded-3xl\` (24px) | → | \`rounded\` (4px) |

\`rounded-full\`은 **의식적으로 제외** — status dot은 999px 정당 사용. chip/badge의 rounded-full은 별도 per-callsite 판단 필요하므로 후속 PR.

## 시각 영향

- 모든 card/panel/tooltip/overlay가 iOS softness 탈피
- Paper theme 활성 시 "printed document" 인상 강화 (디자인 시스템 의도 구현)
- 기능 변화 0, 레이아웃 변화 0 (오직 border-radius만 4px로 통일)

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] post-sweep \`rg "rounded-(xl|2xl|3xl)"\` zero hits
- 242 instances / 74 files

## Related

- #8290 paper theme bridge
- #8177 paper theme 인프라
- Anyang Sleepers README "Spacing, radii, borders" section