### PR TITLE
fix(tool_task): handoff_context.summary schema required + runtime example hint

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -164,7 +164,10 @@ let parse_handoff_context ~(agent_name : string) args =
       | Ok handoff_context ->
           let summary = String.trim handoff_context.summary in
           if summary = "" then
-            Error "handoff_context.summary is required"
+            Error
+              "handoff_context.summary is required (non-empty string). \
+               Example: {\"summary\": \"tests green, PR #123 pending review\", \
+               \"next_step\": \"wait for CI\", \"evidence_refs\": [\"PR#123\"]}"
           else
             Ok
               (Some

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -227,14 +227,32 @@ Use submit_for_verification to request cross-agent review; approve/reject for ve
         ]);
         ("handoff_context", `Assoc [
           ("type", `String "object");
-          ("description", `String "Typed handoff payload used when action='release' on strict contract tasks.");
+          ("description", `String "Typed handoff payload used when action='release' on strict contract tasks. 'summary' is REQUIRED and must be a non-empty string. Example: {\"summary\": \"tests green, PR #123 pending review\", \"next_step\": \"wait for CI\", \"evidence_refs\": [\"PR#123\"]}.");
           ("properties", `Assoc [
-            ("summary", `Assoc [ ("type", `String "string") ]);
-            ("reason", `Assoc [ ("type", `String "string") ]);
-            ("next_step", `Assoc [ ("type", `String "string") ]);
-            ("failure_mode", `Assoc [ ("type", `String "string") ]);
-            ("evidence_refs", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+            ("summary", `Assoc [
+              ("type", `String "string");
+              ("minLength", `Int 1);
+              ("description", `String "REQUIRED. Non-empty one-line summary of current state at release time. Example: 'tests green, PR #123 pending review'.");
+            ]);
+            ("reason", `Assoc [
+              ("type", `String "string");
+              ("description", `String "Why the task is being released (blocker, handoff, pause).");
+            ]);
+            ("next_step", `Assoc [
+              ("type", `String "string");
+              ("description", `String "What the next owner should do first.");
+            ]);
+            ("failure_mode", `Assoc [
+              ("type", `String "string");
+              ("description", `String "If released due to failure, describe the failure mode.");
+            ]);
+            ("evidence_refs", `Assoc [
+              ("type", `String "array");
+              ("items", `Assoc [ ("type", `String "string") ]);
+              ("description", `String "PR numbers, file paths, log links substantiating summary.");
+            ]);
           ]);
+          ("required", `List [`String "summary"]);
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"; `String "action"]);

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -396,6 +396,39 @@ let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun 
   | _ -> failwith "expected exactly one task"
 )
 
+let () = test "handle_transition_release_empty_summary_error_includes_example" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Strict release task");
+          ("contract", `Assoc [ ("strict", `Bool true) ]);
+        ])
+  in
+  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  (* Empty-string summary must also fail, and error must include a payload example
+     so the keeper LLM can self-correct instead of retrying the same partial payload. *)
+  let success_empty, result_empty =
+    Tool_task.handle_transition ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "release");
+          ( "handoff_context",
+            `Assoc
+              [
+                ("summary", `String "   ");
+                ("next_step", `String "re-check fixture");
+              ] );
+        ])
+  in
+  assert (not success_empty);
+  assert (str_contains result_empty "handoff_context.summary is required");
+  assert (str_contains result_empty "Example");
+  assert (str_contains result_empty "\"summary\"")
+)
+
 let () = test "handle_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim direct")]) in


### PR DESCRIPTION
## Context

Evidence (MASC task-237):
```
tool masc_transition returned error result (1/3): {"error":"handoff_context.summary is required"}
```
Keeper retried 3 times with the same partial `handoff_context`, then gave up.

## Root Cause

The `masc_transition` tool schema declared `handoff_context` as a nested object but:

1. `summary` inside `handoff_context` had **no `required` array** on the nested object.
2. `summary` had **no description** and **no `minLength`**.
3. The runtime error `"handoff_context.summary is required"` gave **no example payload** — the LLM retried by pattern matching and kept producing the same partial structure.

LLM-readable signals were missing in both the schema (structural hint) and the error (recovery hint). See feedback memory `gate-response-llm-readable`.

## Fix

- `lib/tool_task_schemas.ml`: add `"required": ["summary"]` inside `handoff_context`, `minLength: 1`, per-field descriptions, and an example payload in the object description.
- `lib/tool_task.ml`: expand the runtime error to embed a concrete example payload. Empty/whitespace-only `summary` still rejected — the invariant is preserved.
- `test/test_tool_task_coverage.ml`: regression test confirming whitespace-only summary still fails AND the error message carries the example string.

## Invariant

`String.trim summary = ""` still returns `Error`. The fix only improves the two LLM-readable surfaces (schema hint + error body). Do not loosen.

## Test

```
dune test --force test/test_tool_task_coverage.exe
42 tests run, all pass (including new `handle_transition_release_empty_summary_error_includes_example`).
```

## Files

- `lib/tool_task_schemas.ml` — masc_transition tool schema, handoff_context properties
- `lib/tool_task.ml` — `parse_handoff_context` runtime error
- `test/test_tool_task_coverage.ml` — regression test