### PR TITLE
feat(dashboard): ⌨ `<div onClick>` → `<button>` semantic sweep (8 sites, P8/9)

### DIFF
--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -213,9 +213,11 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
 
   return html`
     <div class="border border-card-border/60 rounded bg-card/30 overflow-hidden hover:border-accent/20 transition-colors">
-      <div
-        class="flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-card-border/40 cursor-pointer select-none"
+      <button
+        type="button"
+        class="w-full flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-card-border/40 cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
         onClick=${() => setExpanded(!expanded)}
+        aria-expanded=${expanded}
       >
         <div class="flex items-center gap-2">
           <span class="size-2 rounded-full ${index === 0 ? 'bg-accent' : 'bg-white/20'}"></span>
@@ -226,7 +228,7 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
             ${expanded ? '접기' : '펼치기'}
           </span>
         ` : null}
-      </div>
+      </button>
       <div class="px-4 py-3 text-[13px] leading-relaxed">
         <${Markdown} text=${expanded || !isLong ? report.content : preview} />
       </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -385,14 +385,13 @@ export function AgentProfile({ name }: { name: string }) {
               ${collabs.length > 0 ? html`
                 <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
-                    <div class="flex items-center gap-2 px-2 py-1.5 transition-colors duration-150 hover:bg-[rgba(255,215,0,0.08)] rounded" key=${c.name}
+                    <button type="button" class="w-full flex items-center gap-2 px-2 py-1.5 transition-colors duration-150 hover:bg-[rgba(255,215,0,0.08)] rounded text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent" key=${c.name}
                       onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}
-                      style="cursor:pointer;"
                     >
                       <span class="text-[var(--ff-gold)] font-semibold text-base flex-1">${c.name}</span>
                       <span class="text-[var(--white-50)] text-[13px] tabular-nums">${c.collaborations}회</span>
                       ${c.last_collab ? html`<span class="ff-relation-time"><${TimeAgo} timestamp=${c.last_collab} /></span>` : null}
-                    </div>
+                    </button>
                   `)}
                 </div>
               ` : null}

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -357,17 +357,20 @@ export function HandoffTimeline({
                     : 'text-text-muted hover:text-text hover:bg-bg-1/60'
                   const clickable = typeof onSelectKeeper === 'function'
                   const rowLabelCls =
-                    `w-32 shrink-0 truncate text-[11px] font-mono rounded px-1 ${labelCls}` +
-                    (clickable ? ' cursor-pointer' : '')
+                    `w-32 shrink-0 truncate text-[11px] font-mono rounded px-1 text-left ${labelCls}` +
+                    (clickable
+                      ? ' cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent'
+                      : '')
                   return html`
                   <div class="flex items-center gap-3">
-                    <div
-                      class=${rowLabelCls}
-                      title=${row.keeper}
-                      onClick=${() => onSelectKeeper?.(row.keeper)}
-                    >
-                      ${row.keeper}
-                    </div>
+                    ${clickable
+                      ? html`<button
+                          type="button"
+                          class=${rowLabelCls}
+                          title=${row.keeper}
+                          onClick=${() => onSelectKeeper?.(row.keeper)}
+                        >${row.keeper}</button>`
+                      : html`<div class=${rowLabelCls} title=${row.keeper}>${row.keeper}</div>`}
                     <div class="relative flex-1 h-6 rounded-md bg-bg-1/40 border border-card-border/50">
                       ${row.chips.map(chip => {
                         const pct = ((chip.ts - windowStart) / span) * 100

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -35,18 +35,11 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
     <div
       class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
     >
-      <div
-        class="flex items-center gap-2 px-3 py-2 text-xs cursor-pointer"
-        role="button"
-        tabIndex=${0}
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-2 text-xs cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
         aria-expanded=${expanded.value}
         onClick=${() => { expanded.value = !expanded.value }}
-        onKeyDown=${(e: KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            expanded.value = !expanded.value
-          }
-        }}
       >
         <span class="font-mono ${cat.color} w-4 text-center flex-shrink-0">${cat.icon}</span>
         <span class="font-mono text-[var(--text-strong)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
@@ -60,7 +53,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <span class="flex-shrink-0 w-4 text-[var(--text-muted)] text-center">
           ${expanded.value ? '-' : '+'}
         </span>
-      </div>
+      </button>
 
       ${expanded.value ? html`
         <div class="px-3 pb-3 space-y-2">

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -43,9 +43,10 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
         ${list.length === 0
           ? html`<div class="py-6 text-center text-[var(--text-muted)] text-[13px]">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
           : list.map(agent => html`
-            <div
+            <button
+              type="button"
               key=${agent.name}
-              class="focus-agent-card rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card w-full rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
@@ -69,7 +70,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}
               </div>
-            </div>
+            </button>
           `)}
       </div>
     </div>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -385,8 +385,9 @@ function PostCard({ post }: { post: BoardPost }) {
   }
 
   return html`
-    <div
-      class="board-post group flex gap-3 rounded p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer"
+    <button
+      type="button"
+      class="board-post group w-full flex gap-3 rounded p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[var(--accent-20)] transition-all duration-200 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Select checkbox -->
@@ -455,7 +456,7 @@ function PostCard({ post }: { post: BoardPost }) {
           </button>
         </div>
       </div>
-    </div>
+    </button>
   `
 }
 

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -344,7 +344,7 @@ describe('TelemetryUnified', () => {
     })
     await flushUi()
 
-    const groupRow = Array.from(container.querySelectorAll('[role="button"]'))
+    const groupRow = Array.from(container.querySelectorAll('button'))
       .find(node => node.textContent?.includes('Polling / no-op · masc_status · 3 events'))
     expect(groupRow).toBeTruthy()
     expect(groupRow?.getAttribute('aria-expanded')).toBe('false')

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -459,17 +459,11 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
 
   return html`
     <div class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors">
-      <div
-        class="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none"
-        role="button"
-        tabIndex=${0}
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
         onClick=${() => { expanded.value = !expanded.value }}
-        onKeyDown=${(e: KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            expanded.value = !expanded.value
-          }
-        }}
+        aria-expanded=${expanded.value}
       >
         <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
         <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
@@ -489,7 +483,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
           </span>
         ` : null}
         <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
-      </div>
+      </button>
       ${expanded.value ? html`
         <div class="px-3 pb-3 flex flex-col gap-2">
           ${scopeBadges.length > 0 ? html`
@@ -514,19 +508,12 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
 
   return html`
     <div class="border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors">
-      <div
-        class="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none"
-        role="button"
-        tabIndex=${0}
+      <button
+        type="button"
+        class="w-full flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
         aria-expanded=${expanded.value}
         aria-controls=${contentId}
         onClick=${() => { expanded.value = !expanded.value }}
-        onKeyDown=${(e: KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            expanded.value = !expanded.value
-          }
-        }}
       >
         <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
         <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${`${formatTs(item.oldestTs)} → ${formatTs(item.latestTs)}`}>
@@ -547,7 +534,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
           </span>
         ` : null}
         <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
-      </div>
+      </button>
       <div id=${contentId} class=${expanded.value ? 'px-3 pb-3 flex flex-col gap-2' : 'hidden'} role="region">
         ${expanded.value ? html`
           <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-[11px] text-[var(--text-dim)]">


### PR DESCRIPTION
## Summary

Converts **8 of 12 a11y-failing clickable divs** to native
`<button type="button">`, stripping manual `role="button"
tabIndex={0} onKeyDown={Enter/Space}` keyboard workarounds
where present, adding `focus-visible:ring-1
focus-visible:ring-accent` for visible keyboard focus.

Two classes of a11y bug existed in the dashboard:

| Class | Pattern | Count | PR scope |
|-------|---------|-------|----------|
| **B** — role=button workarounds | `<div role="button" tabIndex={0} onClick onKeyDown={Enter/Space handler}>` | 4 | **3 converted** (1 deferred, structural) |
| **C** — plain `<div onClick>` | no keyboard support | 6 | **5 converted** (1 deferred, htm fragment) |
| **A** — dialog backdrops | `<div onClick={onClose}>` — intentional click-outside | 4 | NOT touched (correct pattern) |
| **D** — already accessible | `<div role tabIndex onKeyDown>` | 1 | skipped (defensible) |

P8 of the 9-PR hygiene sweep.

## Converted sites (8)

**Category B** — native button replaces role=button workaround
(each conversion removes 6+ lines of keyboard plumbing):

- `telemetry-unified.ts` — EntryRow (2 sites: basic row + GroupRow)
- `keeper-tool-call-inspector.ts` — ToolCallRow

**Category C** — native button + focus ring added to genuine a11y fails:

- `handoff-timeline.ts` — keeper row label, now conditional: `<button>` when `onSelectKeeper` is provided, `<div>` when not (so tab-index only exposes actually-clickable rows)
- `agent-detail-session-report.ts` — expand/collapse header
- `agent-profile.ts` — collaborator navigate row
- `memory.ts` — board-post navigate row
- `live/focus-sidebar.ts` — agent card (open detail)

## Deferred (2 sites, reasons in PR)

- **`goals/goal-tree.ts:200`** — htm fragments cannot emit an opening tag conditionally without also emitting its closing. A clean fix requires restructuring the entire row template. Existing `onClick={hasContent ? fn : undefined}` at least guards the no-op case.
- **`memory-subsystems.ts:341`** — outer clickable div contains two nested `<button>` elements (from-agent / to-agent pills). HTML forbids nested buttons; converting the outer needs a row-layout restructure.

## Not touched (5 sites, intentional)

- `common/confirm-dialog.ts:89` — dialog backdrop (click-to-close)
- `common/dialog.ts:101` — dialog backdrop
- `fsm-hub.ts:566` — shortcut-help overlay
- `fsm-hub.ts:575` — inner content `e.stopPropagation()` pattern
- `overview/agent-avatar.ts:116` — already has role+tabindex+onKeyDown

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — vite clean
- [ ] `pnpm test` — CI
- [ ] CI green
- [ ] Empirical: local dashboard → tab-nav through keeper rows, board posts, agent cards (focus ring visible, Enter/Space activates)

## Roadmap status

| PR | Status |
|----|--------|
| P1 SectionCap | ✅ #8076 merged |
| P2 StatusChip Tailwind-only | ✅ #8086 merged |
| P3 StatusChip uppercase | ✅ #8238 merged |
| P4 IdPill primitive | ✅ #8245 merged |
| P5 text-[9px] → text-[10px] | 🟡 #8260 auto-merge armed |
| P6 Color var normalisation + drift lint | pending |
| P7 radius tokens | 🟡 #8291 auto-merge armed |
| **P8 `<div onClick>` → `<button>`** | **this PR** |
| P9 Waste sweep | pending |