### PR TITLE
feat(dashboard): flat shadows — shadow-{md,lg,xl,2xl} → shadow-sm

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -211,7 +211,7 @@ export function AgentDetailOverlay() {
       onClose=${closeAgentDetail}
       initialFocusRef=${closeButtonRef}
       overlayClass="agent-detail-overlay fixed inset-0 z-[60] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
-      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded border border-card-border bg-bg-1/95 backdrop-blur-2xl shadow-2xl shadow-black/50 ring-1 ring-white/5"
+      panelClass="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded border border-card-border bg-bg-1/95 backdrop-blur-2xl shadow-sm shadow-black/50 ring-1 ring-white/5"
     >
       <div class="p-6 flex flex-col gap-5">
         <div class="flex justify-between items-start gap-4">
@@ -363,7 +363,7 @@ export function AgentDetailOverlay() {
               <${ActionButton}
                 variant="primary"
                 size="lg"
-                class="px-5 py-2.5 text-[13px] shadow-md shadow-accent/20"
+                class="px-5 py-2.5 text-[13px] shadow-sm shadow-accent/20"
                 onClick=${() => { void submitMention() }}
                 disabled=${sendingMention.value || mentionText.value.trim() === ''}
               >

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -62,7 +62,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
   }
 
   return html`
-    <div class="absolute right-0 top-full mt-1.5 w-[280px] rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-xl backdrop-blur-xl p-3 z-50">
+    <div class="absolute right-0 top-full mt-1.5 w-[280px] rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-xl p-3 z-50">
       ${authenticated ? html`
         <div class="flex flex-col gap-2">
           <div class="text-[11px] text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>

--- a/dashboard/src/components/autoresearch-form.ts
+++ b/dashboard/src/components/autoresearch-form.ts
@@ -122,7 +122,7 @@ export function StartAutoresearchForm() {
       labelledBy="start-autoresearch-title"
       onClose=${closeStartForm}
       overlayClass="fixed inset-0 z-50 flex items-center justify-center bg-[var(--white-5)]/60 backdrop-blur-sm"
-      panelClass="w-full max-w-lg mx-4 rounded border border-card-border bg-[var(--card-bg)] shadow-2xl p-6"
+      panelClass="w-full max-w-lg mx-4 rounded border border-card-border bg-[var(--card-bg)] shadow-sm p-6"
     >
       <h2 id="start-autoresearch-title" class="text-sm font-semibold text-[var(--text-strong)] mb-4">
         새 오토리서치 루프

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -39,7 +39,7 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback(this.state.error, this.reset)
       }
       return html`
-        <div class="error-card rounded my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-md">
+        <div class="error-card rounded my-3 border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-5 flex gap-4 items-start shadow-sm">
           <div class="shrink-0 text-[var(--bad)] mt-0.5">
             <${AlertOctagon} size=${24} />
           </div>

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -173,7 +173,7 @@ export function ToastContainer() {
         <div
           key=${t.id}
           role=${t.type === 'error' ? 'alert' : 'status'}
-          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
           onMouseEnter=${() => pauseToastTimer(t.id)}
           onMouseLeave=${() => resumeToastTimer(t.id)}
           onFocusIn=${() => pauseToastTimer(t.id)}

--- a/dashboard/src/components/connector-keyboard-shortcuts.ts
+++ b/dashboard/src/components/connector-keyboard-shortcuts.ts
@@ -87,7 +87,7 @@ export function ConnectorKeyboardShortcuts() {
   if (!cheatsheetOpen.value) return null
   return html`
     <div
-      class="fixed bottom-4 right-4 z-50 rounded-lg border border-[var(--white-10)] bg-[var(--bg-1)] p-3 text-[11px] text-[var(--text-body)] shadow-lg"
+      class="fixed bottom-4 right-4 z-50 rounded-lg border border-[var(--white-10)] bg-[var(--bg-1)] p-3 text-[11px] text-[var(--text-body)] shadow-sm"
       data-connector-shortcut-cheatsheet
       role="dialog"
       aria-label="커넥터 단축키"

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -381,7 +381,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span class="text-[18px] drop-shadow-md" aria-hidden="true">${surface.icon}</span>
+                  <span class="text-[18px] drop-shadow-sm" aria-hidden="true">${surface.icon}</span>
                 <//>
               `
             }

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -571,7 +571,7 @@ function ShortcutsOverlay({
       aria-label="키보드 단축키"
     >
       <div
-        class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-[280px] shadow-2xl"
+        class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-[280px] shadow-sm"
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -675,7 +675,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -66,7 +66,7 @@ function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
         style="border-color: ${color}; background: ${color}33"
       />
       <div class="absolute bottom-full mb-2 hidden group-hover:flex flex-col items-center z-10">
-        <div class="rounded-lg border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-lg text-[11px] whitespace-nowrap">
+        <div class="rounded-lg border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-sm text-[11px] whitespace-nowrap">
           <div class="font-semibold">${t.prev_phase} → ${t.new_phase}</div>
           <div class="text-[var(--text-muted)] mt-0.5">${eventLabel(t.selected_event)}</div>
           <div class="text-[var(--text-muted)]"><${TimeAgo} timestamp=${t.wall_clock_at_decision * 1000} /></div>

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -24,7 +24,7 @@ const crashShowAll = signal<boolean>(false)
 
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -178,7 +178,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
   const trimmedQuery = query.trim()
 
   return html`
-    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
+    <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
       <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         도구 텔레메트리

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -430,7 +430,7 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
     <${RouteLink}
       tab="monitoring"
       params=${{ section: 'agents', session_id: s.session_id }}
-      class="rounded border bg-card/55 p-4 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
+      class="rounded border bg-card/55 p-4 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-sm hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
       title=${primary}
     >
       <div class="mb-2.5 flex items-start gap-3">
@@ -563,7 +563,7 @@ function AgentPulse() {
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'agents', agent: a.name }}
-            class="flex items-start gap-3 p-4 rounded border border-card-border bg-card/55 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 hover:border-accent/32 group"
+            class="flex items-start gap-3 p-4 rounded border border-card-border bg-card/55 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-sm hover:bg-card hover:-translate-y-0.5 hover:border-accent/32 group"
             title=${a.koreanName ?? a.name}
           >
             <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${40} />

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -355,7 +355,7 @@ function ToolSearchPicker({
 
         <ul ...${getMenuProps({
           class: showMenu && filtered.length > 0
-            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-[220px] overflow-y-auto rounded-lg border border-[var(--card-border)] bg-[rgba(11,18,32,0.97)] shadow-lg backdrop-blur-sm list-none m-0 p-0'
+            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-[220px] overflow-y-auto rounded-lg border border-[var(--card-border)] bg-[rgba(11,18,32,0.97)] shadow-sm backdrop-blur-sm list-none m-0 p-0'
             : 'hidden',
         })}>
           ${showMenu && filtered.length > 0


### PR DESCRIPTION
## 요약

Anyang Sleepers 디자인 시스템: "Shadows are printed, not glowing." Dashboard의 \`shadow-md/lg/xl/2xl\` (6-25px blur)가 glowing/lifted 느낌을 주는 원인. 14 파일 일괄 collapse.

## 매핑

| 이전 | → | 이후 |
|---|---|---|
| \`shadow-md\`, \`shadow-lg\`, \`shadow-xl\`, \`shadow-2xl\` | → | \`shadow-sm\` |
| \`hover:shadow-*\` 동일 variants | → | \`hover:shadow-sm\` |

\`shadow-sm\` (1-2px blur) 유지 — spec 이내.

## 비스코프 (의식적 제외)

- \`backdrop-blur-*\` (glassmorphism) — paper theme에선 retire해야 하지만 dark theme가 의존. 별도 결정 필요.
- \`shadow-stamp\` (design system 전용 2px offset, 0 blur) — Tailwind utility 없음. CSS 클래스로 별도 도입 가능.

## Test plan

- [x] \`tsc --noEmit\` 통과
- [x] post-sweep \`rg "shadow-(md|lg|xl|2xl)"\` zero hits

## Related

- #8292 sharp corners
- #8290 paper theme bridge
- Anyang Sleepers README "Spacing, radii, borders" + "Elevation" sections