### PR TITLE
diag(keeper-cb): name the 3 failures that tripped the breaker (task-240)

### DIFF
--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -100,7 +100,7 @@ let fingerprint_of_error ?(max_len = 120) (error_msg : string) : string =
     let n = String.length s in
     if n > 0 && s.[n - 1] = ' ' then String.sub s 0 (n - 1) else s
   in
-  if len > max_len then s ^ "…" else s
+  if !i < len then s ^ "…" else s
 
 (** Mutex protecting [states] and every per-keeper [breaker_state].
     Every production path goes through [Keeper_exec_tools.apply_circuit_breaker]

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -43,13 +43,64 @@ let error_class_to_string = function
 (* Per-keeper state                                                  *)
 (* ================================================================ *)
 
+(** A single failure signature captured for diagnostics.
+    [fingerprint] is a single-line, size-bounded slice of the raw
+    [error_msg] — enough for an operator to recognise the failure mode
+    without dumping full payloads into logs. *)
+type failure_signature = {
+  ts : float;
+  cls : error_class;
+  fingerprint : string;
+}
+
+(** Bounded ring-buffer capacity for [recent_failures]. Matches
+    [threshold] so a trip log can always name the three failures that
+    caused it. Not exposed — an operator-visible knob would imply a
+    policy change, which is out of scope for LT-16-KCB diagnostics. *)
+let recent_failures_capacity = 3
+
 type breaker_state = {
   mutable consecutive_class : error_class;
   mutable consecutive_count : int;
   mutable total_tripped : int;
+  (* Newest-first; length bounded by [recent_failures_capacity].
+     Retained across trips so "cooling" inspection still has context. *)
+  mutable recent_failures : failure_signature list;
 }
 
 let states : (string, breaker_state) Hashtbl.t = Hashtbl.create 16
+
+(** Collapse an error message into a fingerprint suitable for log lines
+    and JSON payloads. Strips newlines/tabs, collapses whitespace runs,
+    and truncates to [max_len] characters with an ellipsis marker so the
+    original length is still recognisable.
+
+    Not cryptographic — the goal is "operator pattern-matches failures
+    across keepers", not uniqueness. *)
+let fingerprint_of_error ?(max_len = 120) (error_msg : string) : string =
+  let len = String.length error_msg in
+  let buf = Buffer.create (min len max_len) in
+  let prev_space = ref false in
+  let i = ref 0 in
+  while !i < len && Buffer.length buf < max_len do
+    let c = error_msg.[!i] in
+    let is_space = c = ' ' || c = '\t' || c = '\n' || c = '\r' in
+    if is_space then begin
+      if not !prev_space && Buffer.length buf > 0 then Buffer.add_char buf ' ';
+      prev_space := true
+    end else begin
+      Buffer.add_char buf c;
+      prev_space := false
+    end;
+    incr i
+  done;
+  let s = Buffer.contents buf in
+  (* Trim trailing whitespace injected by the collapse above. *)
+  let s =
+    let n = String.length s in
+    if n > 0 && s.[n - 1] = ' ' then String.sub s 0 (n - 1) else s
+  in
+  if len > max_len then s ^ "…" else s
 
 (** Mutex protecting [states] and every per-keeper [breaker_state].
     Every production path goes through [Keeper_exec_tools.apply_circuit_breaker]
@@ -72,9 +123,44 @@ let get_or_create_locked keeper_name =
   | Some s -> s
   | None ->
     let s = { consecutive_class = Other; consecutive_count = 0;
-              total_tripped = 0 } in
+              total_tripped = 0; recent_failures = [] } in
     Hashtbl.replace states keeper_name s;
     s
+
+(* Caller must hold [states_mu]. Prepends [sig_] and trims the tail so
+   the list never exceeds [recent_failures_capacity]. *)
+let push_recent_failure_locked (s : breaker_state)
+    (sig_ : failure_signature) : unit =
+  let rec take n = function
+    | _ when n <= 0 -> []
+    | [] -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  s.recent_failures <- take recent_failures_capacity (sig_ :: s.recent_failures)
+
+let signature_to_string (sig_ : failure_signature) : string =
+  Printf.sprintf "%s:%s"
+    (error_class_to_string sig_.cls) sig_.fingerprint
+
+let signature_to_json (sig_ : failure_signature) : Yojson.Safe.t =
+  `Assoc [
+    "ts", `Float sig_.ts;
+    "class", `String (error_class_to_string sig_.cls);
+    "fingerprint", `String sig_.fingerprint;
+  ]
+
+let format_recent_failures (sigs : failure_signature list) : string =
+  match sigs with
+  | [] -> "<none>"
+  | _ ->
+    (* Oldest-first in the log for reading-order clarity. *)
+    let ordered = List.rev sigs in
+    let parts =
+      List.mapi (fun i s ->
+        Printf.sprintf "[%d] %s" (i + 1) (signature_to_string s)
+      ) ordered
+    in
+    String.concat " | " parts
 
 (* ================================================================ *)
 (* Record + hint generation                                         *)
@@ -87,8 +173,14 @@ let record_success ~keeper_name =
 
 let rec record_failure ~keeper_name ~(error_msg : string) : string option =
   let cls = classify_error error_msg in
+  let sig_ = {
+    ts = Time_compat.now ();
+    cls;
+    fingerprint = fingerprint_of_error error_msg;
+  } in
   with_states_rw (fun () ->
     let s = get_or_create_locked keeper_name in
+    push_recent_failure_locked s sig_;
     if cls = s.consecutive_class then
       s.consecutive_count <- s.consecutive_count + 1
     else begin
@@ -99,9 +191,12 @@ let rec record_failure ~keeper_name ~(error_msg : string) : string option =
       s.total_tripped <- s.total_tripped + 1;
       s.consecutive_count <- 0;
       let tripped = s.total_tripped in
+      let recent = s.recent_failures in
       Log.Keeper.warn
-        "circuit_breaker tripped for %s: %d consecutive %s failures (total trips: %d)"
-        keeper_name threshold (error_class_to_string cls) tripped;
+        "circuit_breaker tripped for %s: %d consecutive %s failures \
+         (total trips: %d) recent=%s"
+        keeper_name threshold (error_class_to_string cls) tripped
+        (format_recent_failures recent);
       Some (corrective_hint cls keeper_name)
     end else
       None)
@@ -178,15 +273,25 @@ let snapshot_json () : Yojson.Safe.t =
   let entries =
     with_states_ro (fun () ->
       Hashtbl.fold (fun name state acc ->
+        let recent_json =
+          `List (List.map signature_to_json state.recent_failures)
+        in
         `Assoc [
           "keeper", `String name;
           "consecutive_class", `String (error_class_to_string state.consecutive_class);
           "consecutive_count", `Int state.consecutive_count;
           "total_tripped", `Int state.total_tripped;
+          "recent_failures", recent_json;
         ] :: acc
       ) states [])
   in
   `List entries
+
+let recent_failures_of ~keeper_name : failure_signature list =
+  with_states_ro (fun () ->
+    match Hashtbl.find_opt states keeper_name with
+    | None -> []
+    | Some s -> s.recent_failures)
 
 (* ================================================================ *)
 (* Observable display state (LT-16-KCB Phase 1)                     *)

--- a/lib/keeper/keeper_failure_circuit_breaker.mli
+++ b/lib/keeper/keeper_failure_circuit_breaker.mli
@@ -25,7 +25,37 @@ val record_success : keeper_name:string -> unit
     unchanged if under threshold, or message + hint if tripped. *)
 val maybe_enrich_error : keeper_name:string -> error_msg:string -> string
 
-(** JSON snapshot of all breaker states for diagnostics. *)
+(** {1 Failure signature diagnostics (task-240)}
+
+    When the breaker trips, "3 consecutive other failures" on its own
+    gives an operator no handle on *which* three failures caused it.
+    To preserve that context, every [record_failure] call also writes a
+    bounded-size signature (timestamp + class + fingerprint of the
+    error message) to a per-keeper ring buffer. The trip log line
+    names the buffer contents, and downstream observers (dashboard,
+    snapshot JSON) can read them via [recent_failures_of]. *)
+
+type failure_signature = {
+  ts : float;
+  cls : error_class;
+  fingerprint : string;
+}
+
+(** Collapse an error message into a single-line, size-bounded
+    fingerprint suitable for logs and JSON payloads. Default
+    [max_len = 120]. Not cryptographic — pattern-matching only. *)
+val fingerprint_of_error : ?max_len:int -> string -> string
+
+(** Last-N failure signatures for [keeper_name] (newest first). Returns
+    [[]] for keepers that have never failed. N is bounded internally
+    (currently 3, matching the trip threshold). *)
+val recent_failures_of : keeper_name:string -> failure_signature list
+
+(** JSON snapshot of all breaker states for diagnostics.
+
+    Each entry adds a [recent_failures] array (newest first):
+    {[ { "ts": 1..., "class": "other", "fingerprint": "..." } ]}
+    *)
 val snapshot_json : unit -> Yojson.Safe.t
 
 (** {1 Observable display state (LT-16-KCB)}

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -209,6 +209,12 @@ let test_fingerprint_truncates () =
   check bool "truncated length bounded" true (String.length fp <= 60);
   check bool "has ellipsis" true (contains fp "…")
 
+let test_fingerprint_does_not_fake_truncation_after_space_collapse () =
+  let padded = (String.make 200 ' ') ^ "keeper_shell failed" in
+  let fp = CB.fingerprint_of_error ~max_len:50 padded in
+  check bool "keeps content" true (contains fp "keeper_shell failed");
+  check bool "no fake ellipsis" false (contains fp "…")
+
 let test_recent_failures_empty_for_unknown () =
   let r = CB.recent_failures_of ~keeper_name:"never-touched-sig-xyz" in
   check int "empty list" 0 (List.length r)
@@ -282,6 +288,8 @@ let () =
         `Quick test_fingerprint_collapses_whitespace;
       test_case "fingerprint truncates with ellipsis"
         `Quick test_fingerprint_truncates;
+      test_case "fingerprint does not fake truncation after space collapse"
+        `Quick test_fingerprint_does_not_fake_truncation_after_space_collapse;
       test_case "recent_failures empty for unknown"
         `Quick test_recent_failures_empty_for_unknown;
       test_case "recent_failures bounded, newest first"

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -195,12 +195,101 @@ let test_display_state_of_clears_after_success () =
   let s = CB.display_state_of ~keeper_name:name in
   check string "after success, back to clean" "clean" (display_state_str s)
 
+(* ── task-240: failure signature diagnostics ────────────────── *)
+
+let test_fingerprint_collapses_whitespace () =
+  let fp = CB.fingerprint_of_error "line1\n  line2\ttab" in
+  check bool "no newline" false (contains fp "\n");
+  check bool "no tab" false (contains fp "\t");
+  check bool "starts with line1" true (contains fp "line1")
+
+let test_fingerprint_truncates () =
+  let long = String.make 200 'x' in
+  let fp = CB.fingerprint_of_error ~max_len:50 long in
+  check bool "truncated length bounded" true (String.length fp <= 60);
+  check bool "has ellipsis" true (contains fp "…")
+
+let test_recent_failures_empty_for_unknown () =
+  let r = CB.recent_failures_of ~keeper_name:"never-touched-sig-xyz" in
+  check int "empty list" 0 (List.length r)
+
+let test_recent_failures_bounded_and_newest_first () =
+  let name = "sig-bounded" in
+  CB.record_success ~keeper_name:name;
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"err-1");
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"err-2");
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"err-3");
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"err-4");
+  let r = CB.recent_failures_of ~keeper_name:name in
+  check int "bounded to 3" 3 (List.length r);
+  (* newest first: err-4 is head *)
+  (match r with
+   | first :: _ ->
+     check bool "newest fingerprint is err-4" true
+       (contains first.CB.fingerprint "err-4")
+   | [] -> Alcotest.fail "expected entries")
+
+let test_snapshot_json_exposes_recent_failures () =
+  let name = "sig-snap" in
+  CB.record_success ~keeper_name:name;
+  ignore (CB.maybe_enrich_error
+            ~keeper_name:name ~error_msg:"uniq-signature-ABC");
+  let json = CB.snapshot_json () in
+  match json with
+  | `List entries ->
+    let found =
+      List.exists (fun e ->
+        match e with
+        | `Assoc fields ->
+          (match List.assoc_opt "keeper" fields,
+                 List.assoc_opt "recent_failures" fields with
+           | Some (`String n), Some (`List rs) when n = name ->
+             List.exists (fun r ->
+               match r with
+               | `Assoc rf ->
+                 (match List.assoc_opt "fingerprint" rf with
+                  | Some (`String fp) -> contains fp "uniq-signature-ABC"
+                  | _ -> false)
+               | _ -> false
+             ) rs
+           | _ -> false)
+        | _ -> false
+      ) entries
+    in
+    check bool "snapshot includes fingerprint" true found
+  | _ -> Alcotest.fail "expected top-level list"
+
+let test_recent_failures_survive_trip () =
+  (* After a trip, consecutive_count resets but recent_failures must
+     still hold the 3 signatures so operators can diagnose the trip. *)
+  let name = "sig-survive" in
+  CB.record_success ~keeper_name:name;
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"trip-a");
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"trip-b");
+  ignore (CB.maybe_enrich_error ~keeper_name:name ~error_msg:"trip-c");
+  let r = CB.recent_failures_of ~keeper_name:name in
+  check int "3 signatures retained post-trip" 3 (List.length r)
+
 let () =
   run "Circuit_breaker" [
     "classify", [
       test_case "path_not_found" `Quick test_classify_path_not_found;
       test_case "path_not_allowed" `Quick test_classify_path_not_allowed;
       test_case "other" `Quick test_classify_other;
+    ];
+    "signatures", [
+      test_case "fingerprint collapses whitespace"
+        `Quick test_fingerprint_collapses_whitespace;
+      test_case "fingerprint truncates with ellipsis"
+        `Quick test_fingerprint_truncates;
+      test_case "recent_failures empty for unknown"
+        `Quick test_recent_failures_empty_for_unknown;
+      test_case "recent_failures bounded, newest first"
+        `Quick test_recent_failures_bounded_and_newest_first;
+      test_case "snapshot_json exposes recent_failures"
+        `Quick test_snapshot_json_exposes_recent_failures;
+      test_case "recent_failures survive trip"
+        `Quick test_recent_failures_survive_trip;
     ];
     "threshold", [
       test_case "no hint under threshold" `Quick test_no_hint_under_threshold;


### PR DESCRIPTION
## Summary
- add a bounded per-keeper failure-signature ring buffer to the circuit breaker
- include recent failure fingerprints in the breaker trip log and `snapshot_json`
- expose `recent_failures_of` for direct observer lookup
- fix `fingerprint_of_error` so whitespace collapse does not falsely mark the output as truncated

## Product impact
Operators can see which three failures actually tripped the breaker without manually correlating tool-call logs. This reduces diagnosis time when a keeper flaps on `class=other` and keeps the diagnostic payload bounded enough for logs and dashboard consumers.

## Evidence
Operational log that motivated the change:

```text
ERROR  circuit_breaker tripped for sojin: 3 consecutive other failures (total trips: 1)
```

Before:
```text
circuit_breaker tripped for sojin: 3 consecutive other failures (total trips: 1)
```

After:
```text
circuit_breaker tripped for sojin: 3 consecutive other failures (total trips: 1) recent=[1] other:keeper_shell failed: exec_format_error | [2] other:keeper_shell failed: exec_format_error | [3] other:keeper_shell failed: no such process
```

## Review evidence
- `dune build --root . @test/runtest-test_circuit_breaker`
- `Circuit_breaker` now covers 25 tests, including:
  - fingerprint collapses whitespace
  - fingerprint truncates with ellipsis
  - fingerprint does not fake truncation after space collapse
  - `recent_failures_of` empty for unknown keeper
  - ring buffer bounded at 3, newest-first
  - `snapshot_json` exposes `recent_failures`
  - signatures survive a trip

## Linked issue
No dedicated GitHub issue exists for this change; it is tracked as MASC `task-240`.

## Change details
- Per-keeper bounded ring buffer (capacity 3, matches the trip threshold) of `{ts, class, fingerprint}`.
- `fingerprint_of_error` collapses whitespace and truncates to 120 chars with `…` only when the input was actually cut off.
- Trip log line now appends the oldest-first `recent=[1] ... | [2] ... | [3] ...` context for reading order.
- `snapshot_json` exposes a `recent_failures` array per entry.
- Ring buffer survives a trip so post-trip inspection still has context.

## Non-goals
- `threshold = 3`
- classification taxonomy (`Path_not_found | Path_not_allowed | Cwd_not_directory | Shell_exit_nonzero | Other`)
- `corrective_hint` wording
- breaker policy (when to trip / reset)

## Follow-up
- wire `snapshot_json` into the dashboard API so the operator UI can show recent failures for keepers in `warning` / `cooling` state