### PR TITLE
fix(discord): migrate runtime state into base path

### DIFF
--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -207,9 +207,10 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
   without a process restart
 - relative connector paths resolve from `MASC_BASE_PATH` when it is set; this
   keeps the bot on the same project data root as the MASC server
-- when the new default binding path is empty but the legacy sidecar-local
-  `.gate/discord_bindings.json` exists, the bot loads that legacy map as a
-  compatibility fallback and reports `binding_source=legacy-fallback`
+- when the new default runtime files are missing but the legacy
+  `.masc/connectors/discord/*` files still exist under the same
+  `MASC_BASE_PATH`, startup migrates them into `.gate/runtime/discord/*`
+  before the bot loads state
 
 ## Operations Upgrades
 

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -33,6 +33,7 @@ from .formatters import (
     strip_state_blocks,
 )
 from .gate_client import BreakerSnapshot, GateClient, GateResponse
+from .storage_migration import migrate_legacy_runtime_files
 from .status_store import (
     ConnectorRuntimeStatus,
     NamesSnapshot,
@@ -60,7 +61,9 @@ def attachment_lines(message: discord.Message) -> list[str]:
     return lines
 
 
-def channel_stats_for(status: dict[str, Any] | None, channel_name: str) -> dict[str, Any] | None:
+def channel_stats_for(
+    status: dict[str, Any] | None, channel_name: str
+) -> dict[str, Any] | None:
     """Extract one connector row from gate status."""
     if status is None:
         return None
@@ -85,6 +88,9 @@ class GateBot(discord.Client):
         self.tree = app_commands.CommandTree(self)
         self.gate = GateClient()
         self.cfg = get_config()
+        migrate_legacy_runtime_files(
+            self.cfg.legacy_runtime_migrations(), logger=logger
+        )
         self.binding_store = BindingStore(self.cfg.binding_store_path())
         self.audit_store = BindingAuditStore(self.cfg.binding_audit_path())
         self.status_store = StatusStore(self.cfg.status_path())
@@ -181,7 +187,9 @@ class GateBot(discord.Client):
             return self.keeper_bindings.get(str(channel.parent.id))
         return None
 
-    def channel_binding_debug(self, channel: discord.abc.Snowflake) -> tuple[str | None, str]:
+    def channel_binding_debug(
+        self, channel: discord.abc.Snowflake
+    ) -> tuple[str | None, str]:
         self._maybe_reload_bindings()
         channel_id = str(channel.id)
         direct = self.keeper_bindings.get(channel_id)
@@ -287,7 +295,11 @@ class GateBot(discord.Client):
         try:
             self.status_store.write(status)
         except OSError as exc:
-            logger.warning("Failed to write Discord status store %s: %s", self.status_store.path, exc)
+            logger.warning(
+                "Failed to write Discord status store %s: %s",
+                self.status_store.path,
+                exc,
+            )
 
     def _write_names_snapshot(self) -> None:
         """Snapshot guild and channel names for dashboard humanization.
@@ -459,7 +471,10 @@ class GateBot(discord.Client):
         member = interaction.user
         if not isinstance(member, discord.Member):
             return False
-        if member.guild_permissions.administrator or member.guild_permissions.manage_guild:
+        if (
+            member.guild_permissions.administrator
+            or member.guild_permissions.manage_guild
+        ):
             return True
         role_id = self.cfg.discord_admin_role_id.strip()
         if not role_id:
@@ -537,7 +552,9 @@ class GateBot(discord.Client):
             return
 
         # Strip keeper-internal [STATE] blocks before rendering
-        response = dataclasses.replace(response, reply=strip_state_blocks(response.reply))
+        response = dataclasses.replace(
+            response, reply=strip_state_blocks(response.reply)
+        )
 
         # Try structured rendering (from gate or auto-parsed markdown)
         structured = response.structured or markdown_to_structured(response.reply)
@@ -725,16 +742,16 @@ async def keeper_name_autocomplete(
     assert isinstance(bot, GateBot)
     names = await bot.gate.list_keepers()
     needle = current.strip().lower()
-    matches = [
-        name for name in names if not needle or needle in name.lower()
-    ][:25]
+    matches = [name for name in names if not needle or needle in name.lower()][:25]
     return [app_commands.Choice(name=name, value=name) for name in matches]
 
 
 # ── Slash Commands ──────────────────────────────────────────
 
 
-@app_commands.command(name="keeper-ask", description="Send a message to a specific keeper")
+@app_commands.command(
+    name="keeper-ask", description="Send a message to a specific keeper"
+)
 @app_commands.describe(
     keeper="Keeper name",
     message="Message to send",
@@ -857,7 +874,9 @@ async def keeper_status(
         else (None, "no-channel")
     )
     embed = connector_status_embed(
-        channel_id=str(interaction.channel_id) if interaction.channel_id is not None else None,
+        channel_id=str(interaction.channel_id)
+        if interaction.channel_id is not None
+        else None,
         channel_binding=channel_binding,
         gate_status=await bot.gate.gate_status(),
         breaker=bot.gate.breaker_snapshot(),
@@ -894,7 +913,9 @@ async def keeper_bind(
         return
 
     if interaction.channel is None:
-        await interaction.response.send_message("Channel context required.", ephemeral=True)
+        await interaction.response.send_message(
+            "Channel context required.", ephemeral=True
+        )
         return
 
     await interaction.response.defer(thinking=True, ephemeral=True)
@@ -965,7 +986,9 @@ async def keeper_unbind(interaction: discord.Interaction) -> None:
         return
 
     if interaction.channel is None:
-        await interaction.response.send_message("Channel context required.", ephemeral=True)
+        await interaction.response.send_message(
+            "Channel context required.", ephemeral=True
+        )
         return
 
     channel_id = str(interaction.channel.id)

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -27,11 +27,11 @@ DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/discord/status.json"
 DEFAULT_NAMES_PATH: Final[str] = ".gate/runtime/discord/names.json"
 
 # Legacy layout from the pre-v0.9.0 release (OCaml side migrated in
-# #7467/#7468 B3a/B3b). On first startup after upgrade, bot.py's 1-tier
-# fallback picks up data from the legacy location and the next write lands
-# at the new default. The even older `sidecars/discord-bot/.gate/discord_*`
-# cwd-relative layout is no longer auto-discovered; deployments still on it
-# must set explicit DISCORD_*_PATH env vars.
+# #7467/#7468 B3a/B3b). On startup the bot now migrates these files into the
+# new runtime layout when the operator still uses the default target paths.
+# The even older `sidecars/discord-bot/.gate/discord_*` cwd-relative layout is
+# no longer auto-discovered; deployments still on it must set explicit
+# DISCORD_*_PATH env vars.
 LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/discord/bindings.json"
 LEGACY_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/discord/binding_audit.jsonl"
 LEGACY_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
@@ -169,7 +169,9 @@ class BotConfig(BaseSettings):
     )
     gate_breaker_reset_sec: int = Field(
         default=30,
-        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
+        validation_alias=AliasChoices(
+            "GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"
+        ),
     )
     status_heartbeat_sec: int = Field(
         default=10,
@@ -289,6 +291,11 @@ class BotConfig(BaseSettings):
     def names_path(self) -> Path:
         return self._resolve_storage_path(self.discord_names_path)
 
+    def _matches_default_storage_path(self, raw_path: str, default_path: str) -> bool:
+        return self._resolve_storage_path(raw_path) == self._resolve_storage_path(
+            default_path
+        )
+
     # Legacy paths now resolve under the same base as the new defaults
     # (MASC_BASE_PATH or cwd), not under sidecars/discord-bot/, because the
     # pre-v0.9.0 layout was already MASC_BASE_PATH-relative.
@@ -303,6 +310,46 @@ class BotConfig(BaseSettings):
 
     def legacy_names_path(self) -> Path:
         return self._resolve_storage_path(LEGACY_NAMES_PATH)
+
+    def legacy_runtime_migrations(self) -> list[tuple[str, Path, Path]]:
+        migrations: list[tuple[str, Path, Path]] = []
+        candidates = [
+            (
+                "binding store",
+                self.discord_binding_store_path,
+                DEFAULT_BINDING_STORE_PATH,
+                self.legacy_binding_store_path(),
+                self.binding_store_path(),
+            ),
+            (
+                "binding audit",
+                self.discord_binding_audit_path,
+                DEFAULT_BINDING_AUDIT_PATH,
+                self.legacy_binding_audit_path(),
+                self.binding_audit_path(),
+            ),
+            (
+                "status",
+                self.discord_status_path,
+                DEFAULT_STATUS_PATH,
+                self.legacy_status_path(),
+                self.status_path(),
+            ),
+            (
+                "names",
+                self.discord_names_path,
+                DEFAULT_NAMES_PATH,
+                self.legacy_names_path(),
+                self.names_path(),
+            ),
+        ]
+        for label, raw_path, default_path, legacy_path, target_path in candidates:
+            if (
+                self._matches_default_storage_path(raw_path, default_path)
+                and legacy_path != target_path
+            ):
+                migrations.append((label, legacy_path, target_path))
+        return migrations
 
     def gate_message_url(self) -> str:
         base = self.gate_base_url.rstrip("/")

--- a/sidecars/discord-bot/src/storage_migration.py
+++ b/sidecars/discord-bot/src/storage_migration.py
@@ -1,0 +1,79 @@
+"""Helpers for migrating legacy Discord runtime files into the base-path layout."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+def _cleanup_stop_before(legacy_path: Path) -> Path:
+    for parent in legacy_path.parents:
+        if parent.name == ".masc":
+            return parent
+    return legacy_path.parent
+
+
+def _prune_empty_legacy_dirs(start_dir: Path, *, stop_before: Path) -> None:
+    current = start_dir
+    while current != stop_before and current.exists():
+        try:
+            current.rmdir()
+        except OSError:
+            break
+        current = current.parent
+
+
+def migrate_legacy_file(
+    *,
+    label: str,
+    legacy_path: Path,
+    target_path: Path,
+    logger: logging.Logger | None = None,
+) -> bool:
+    if legacy_path == target_path or not legacy_path.exists() or target_path.exists():
+        return False
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.replace(legacy_path, target_path)
+    except OSError as exc:
+        if logger is not None:
+            logger.warning(
+                "Failed to migrate Discord %s from %s to %s: %s",
+                label,
+                legacy_path,
+                target_path,
+                exc,
+            )
+        return False
+
+    _prune_empty_legacy_dirs(
+        legacy_path.parent, stop_before=_cleanup_stop_before(legacy_path)
+    )
+    if logger is not None:
+        logger.info(
+            "Migrated Discord %s from %s to %s",
+            label,
+            legacy_path,
+            target_path,
+        )
+    return True
+
+
+def migrate_legacy_runtime_files(
+    migrations: Iterable[tuple[str, Path, Path]],
+    *,
+    logger: logging.Logger | None = None,
+) -> list[Path]:
+    moved: list[Path] = []
+    for label, legacy_path, target_path in migrations:
+        if migrate_legacy_file(
+            label=label,
+            legacy_path=legacy_path,
+            target_path=target_path,
+            logger=logger,
+        ):
+            moved.append(target_path)
+    return moved

--- a/sidecars/discord-bot/tests/test_binding_store.py
+++ b/sidecars/discord-bot/tests/test_binding_store.py
@@ -102,13 +102,16 @@ def test_config_resolves_legacy_paths_from_base_path(tmp_path: Path) -> None:
         os.environ["MASC_BASE_PATH"] = str(base_path)
         os.chdir(tmp_path)
         assert cfg.legacy_binding_store_path() == (
-            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_bindings.json"
+            base_path / ".masc" / "connectors" / "discord" / "bindings.json"
         )
         assert cfg.legacy_binding_audit_path() == (
-            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_binding_audit.jsonl"
+            base_path / ".masc" / "connectors" / "discord" / "binding_audit.jsonl"
         )
         assert cfg.legacy_status_path() == (
-            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_status.json"
+            base_path / ".masc" / "connectors" / "discord" / "status.json"
+        )
+        assert cfg.legacy_names_path() == (
+            base_path / ".masc" / "connectors" / "discord" / "names.json"
         )
     finally:
         if previous_base_path is None:
@@ -118,7 +121,9 @@ def test_config_resolves_legacy_paths_from_base_path(tmp_path: Path) -> None:
         os.chdir(original_cwd)
 
 
-def test_config_resolves_legacy_paths_from_cwd_without_base_path(tmp_path: Path) -> None:
+def test_config_resolves_legacy_paths_from_cwd_without_base_path(
+    tmp_path: Path,
+) -> None:
     cfg = BotConfig(
         discord_bot_token="test-token",
         gate_api_token="test-api-token",
@@ -129,10 +134,58 @@ def test_config_resolves_legacy_paths_from_cwd_without_base_path(tmp_path: Path)
     try:
         os.environ.pop("MASC_BASE_PATH", None)
         os.chdir(tmp_path)
-        assert cfg.legacy_binding_store_path() == tmp_path / ".gate" / "discord_bindings.json"
-        assert cfg.legacy_binding_audit_path() == tmp_path / ".gate" / "discord_binding_audit.jsonl"
-        assert cfg.legacy_status_path() == tmp_path / ".gate" / "discord_status.json"
+        assert cfg.legacy_binding_store_path() == (
+            tmp_path / ".masc" / "connectors" / "discord" / "bindings.json"
+        )
+        assert cfg.legacy_binding_audit_path() == (
+            tmp_path / ".masc" / "connectors" / "discord" / "binding_audit.jsonl"
+        )
+        assert cfg.legacy_status_path() == (
+            tmp_path / ".masc" / "connectors" / "discord" / "status.json"
+        )
+        assert cfg.legacy_names_path() == (
+            tmp_path / ".masc" / "connectors" / "discord" / "names.json"
+        )
     finally:
         if previous_base_path is not None:
+            os.environ["MASC_BASE_PATH"] = previous_base_path
+        os.chdir(original_cwd)
+
+
+def test_config_plans_runtime_migration_only_for_default_paths(tmp_path: Path) -> None:
+    base_path = tmp_path / "workspace"
+    base_path.mkdir()
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        gate_api_token="test-api-token",
+        discord_status_path="custom/status.json",
+    )
+
+    previous_base_path = os.getenv("MASC_BASE_PATH")
+    original_cwd = Path.cwd()
+    try:
+        os.environ["MASC_BASE_PATH"] = str(base_path)
+        os.chdir(tmp_path)
+        assert cfg.legacy_runtime_migrations() == [
+            (
+                "binding store",
+                base_path / ".masc" / "connectors" / "discord" / "bindings.json",
+                base_path / ".gate" / "runtime" / "discord" / "bindings.json",
+            ),
+            (
+                "binding audit",
+                base_path / ".masc" / "connectors" / "discord" / "binding_audit.jsonl",
+                base_path / ".gate" / "runtime" / "discord" / "binding_audit.jsonl",
+            ),
+            (
+                "names",
+                base_path / ".masc" / "connectors" / "discord" / "names.json",
+                base_path / ".gate" / "runtime" / "discord" / "names.json",
+            ),
+        ]
+    finally:
+        if previous_base_path is None:
+            os.environ.pop("MASC_BASE_PATH", None)
+        else:
             os.environ["MASC_BASE_PATH"] = previous_base_path
         os.chdir(original_cwd)

--- a/sidecars/discord-bot/tests/test_storage_migration.py
+++ b/sidecars/discord-bot/tests/test_storage_migration.py
@@ -1,0 +1,47 @@
+"""Tests for legacy Discord runtime-file migration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.storage_migration import migrate_legacy_file
+
+
+def test_migrate_legacy_file_moves_runtime_state_and_prunes_empty_dirs(
+    tmp_path: Path,
+) -> None:
+    legacy_path = tmp_path / ".masc" / "connectors" / "discord" / "status.json"
+    target_path = tmp_path / ".gate" / "runtime" / "discord" / "status.json"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text('{"connected": true}\n', encoding="utf-8")
+
+    moved = migrate_legacy_file(
+        label="status",
+        legacy_path=legacy_path,
+        target_path=target_path,
+    )
+
+    assert moved is True
+    assert legacy_path.exists() is False
+    assert target_path.read_text(encoding="utf-8") == '{"connected": true}\n'
+    assert (tmp_path / ".masc").exists() is True
+    assert (tmp_path / ".masc" / "connectors").exists() is False
+
+
+def test_migrate_legacy_file_skips_when_target_already_exists(tmp_path: Path) -> None:
+    legacy_path = tmp_path / ".masc" / "connectors" / "discord" / "bindings.json"
+    target_path = tmp_path / ".gate" / "runtime" / "discord" / "bindings.json"
+    legacy_path.parent.mkdir(parents=True)
+    target_path.parent.mkdir(parents=True)
+    legacy_path.write_text('{"123":"legacy"}\n', encoding="utf-8")
+    target_path.write_text('{"123":"current"}\n', encoding="utf-8")
+
+    moved = migrate_legacy_file(
+        label="binding store",
+        legacy_path=legacy_path,
+        target_path=target_path,
+    )
+
+    assert moved is False
+    assert legacy_path.read_text(encoding="utf-8") == '{"123":"legacy"}\n'
+    assert target_path.read_text(encoding="utf-8") == '{"123":"current"}\n'


### PR DESCRIPTION
## Summary
- migrate legacy Discord runtime files from `.masc/connectors/discord/*` into `.gate/runtime/discord/*` before the sidecar loads state
- resolve migration targets through `BotConfig` using `MASC_BASE_PATH` plus env/runtime TOML config, not any hardcoded absolute path
- only auto-migrate when the operator is still using the default resolved runtime paths, so explicit custom paths keep working
- update Discord sidecar tests and README to match the current legacy/new path contract

## Product impact
- Discord sidecar startup now converges legacy runtime state into the current base-path-owned runtime layout instead of keeping the connector on `.masc/connectors/discord/*`
- operators who set explicit `DISCORD_*_PATH` values keep their configured storage locations unchanged
- existing stale local state under `~/me/.masc/connectors/discord/*` was moved into `~/me/.gate/runtime/discord/*` to match the runtime contract

## Evidence
- `ruff check sidecars/discord-bot/src/config.py sidecars/discord-bot/src/bot.py sidecars/discord-bot/src/storage_migration.py sidecars/discord-bot/tests/test_binding_store.py sidecars/discord-bot/tests/test_storage_migration.py`
- `ruff format --check sidecars/discord-bot/src/config.py sidecars/discord-bot/src/bot.py sidecars/discord-bot/src/storage_migration.py sidecars/discord-bot/tests/test_binding_store.py sidecars/discord-bot/tests/test_storage_migration.py`
- `cd sidecars/discord-bot && uv run --extra dev python -m pytest tests/test_binding_store.py tests/test_status_store.py tests/test_storage_migration.py -q`
- `cd sidecars/discord-bot && uv run python -m compileall src tests`
- `cd sidecars/discord-bot && uv run --extra dev --with pyright pyright --outputjson src/config.py src/storage_migration.py`

## Review evidence
- no unresolved review threads on `gh api graphql` for PR `#8302`
- PR hygiene bot requested `Product impact`, `Evidence`, `Review evidence`, and `Linked issue`; this PR body now includes them
- full `pyright` on `src/bot.py` still reports pre-existing type issues unrelated to this patch, so type evidence is scoped to the new path-resolution and migration helpers

## Linked issue
- Refs #4751
