### PR TITLE
[codex] Restore dashboard keeper sandbox controls

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -151,6 +151,20 @@ describe('fetchKeeperConfig', () => {
       sandbox_last_error: 'sandbox docker exec failed',
       effective_sandbox_image: 'ubuntu:24.04@sha256:test',
       private_workspace_root: '.masc/playground/keeper-sangsu',
+      sandbox_environment: {
+        base_path: '/tmp/project-root/.masc',
+        project_root: '/tmp/project-root',
+        docker_playground_enabled: 'true',
+        docker_container_name: 'keeper-playground',
+        container_playground_root: '/home/keeper/playground',
+        docker_image: 'ubuntu:24.04@sha256:test',
+        pids_limit: '128',
+        memory: '2g',
+        tmpfs_size: '256m',
+        seccomp_profile: '',
+        require_rootless: 'false',
+        require_userns: 'true',
+      },
       allowed_paths: '/tmp/workspace',
       effective_allowed_paths: ['/tmp/workspace'],
       prompt: {
@@ -287,6 +301,18 @@ describe('fetchKeeperConfig', () => {
     expect(result.sandbox_last_error).toBe('sandbox docker exec failed')
     expect(result.effective_sandbox_image).toBe('ubuntu:24.04@sha256:test')
     expect(result.private_workspace_root).toBe('.masc/playground/keeper-sangsu')
+    expect(result.sandbox_environment?.base_path).toBe('/tmp/project-root/.masc')
+    expect(result.sandbox_environment?.project_root).toBe('/tmp/project-root')
+    expect(result.sandbox_environment?.docker_playground_enabled).toBe(true)
+    expect(result.sandbox_environment?.docker_container_name).toBe('keeper-playground')
+    expect(result.sandbox_environment?.container_playground_root).toBe('/home/keeper/playground')
+    expect(result.sandbox_environment?.docker_image).toBe('ubuntu:24.04@sha256:test')
+    expect(result.sandbox_environment?.pids_limit).toBe(128)
+    expect(result.sandbox_environment?.memory).toBe('2g')
+    expect(result.sandbox_environment?.tmpfs_size).toBe('256m')
+    expect(result.sandbox_environment?.seccomp_profile).toBeNull()
+    expect(result.sandbox_environment?.require_rootless).toBe(false)
+    expect(result.sandbox_environment?.require_userns).toBe(true)
     expect(result.execution.models).toEqual(['llama:test-balanced'])
     expect(result.execution.verify).toBe(true)
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1022,6 +1022,26 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
   }
 }
 
+function normalizeKeeperSandboxEnvironment(
+  raw: unknown,
+): KeeperConfig['sandbox_environment'] {
+  if (!isRecord(raw)) return undefined
+  return {
+    base_path: asNullableString(raw.base_path),
+    project_root: asNullableString(raw.project_root),
+    docker_playground_enabled: asLooseBoolean(raw.docker_playground_enabled),
+    docker_container_name: asNullableString(raw.docker_container_name),
+    container_playground_root: asNullableString(raw.container_playground_root),
+    docker_image: asNullableString(raw.docker_image),
+    pids_limit: asInt(raw.pids_limit),
+    memory: asNullableString(raw.memory),
+    tmpfs_size: asNullableString(raw.tmpfs_size),
+    seccomp_profile: asNullableString(raw.seccomp_profile),
+    require_rootless: asLooseBoolean(raw.require_rootless),
+    require_userns: asLooseBoolean(raw.require_userns),
+  }
+}
+
 function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfig {
   const data = isRecord(raw) ? raw : {}
   const prompt = isRecord(data.prompt) ? data.prompt : {}
@@ -1038,6 +1058,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const tools = isRecord(data.tools) ? data.tools : {}
   const sources = isRecord(data.sources) ? data.sources : {}
   const metrics = isRecord(data.metrics) ? data.metrics : {}
+  const sandboxEnvironment = normalizeKeeperSandboxEnvironment(data.sandbox_environment)
 
   return {
     name: asNullableString(data.name) ?? requestedName,
@@ -1048,6 +1069,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     sandbox_last_error: asNullableString(data.sandbox_last_error),
     effective_sandbox_image: asNullableString(data.effective_sandbox_image),
     private_workspace_root: asNullableString(data.private_workspace_root),
+    sandbox_environment: sandboxEnvironment,
     allowed_paths: normalizeStringList(data.allowed_paths),
     effective_allowed_paths: normalizeStringList(data.effective_allowed_paths),
     prompt: {
@@ -1193,6 +1215,9 @@ export type KeeperConfigUpdatePayload = {
   // Scope
   execution_scope?: 'observe_only' | 'workspace' | 'local'
   allowed_paths?: string[]
+  sandbox_profile?: 'legacy_local' | 'docker_hardened'
+  network_mode?: 'none' | 'inherit'
+  shared_memory_scope?: 'disabled' | 'room'
   // Prompt fields
   goal?: string
   short_goal?: string

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { KeeperHookSlot } from '../types'
+import type { KeeperConfig, KeeperHookSlot } from '../types'
 import { filterHookSlots, type HookSlotEntry } from './keeper-config-panel'
 
 void vi
@@ -10,6 +10,144 @@ function makeSlot(overrides: Partial<KeeperHookSlot> = {}): KeeperHookSlot {
   return {
     active: true,
     source: 'default',
+    ...overrides,
+  }
+}
+
+function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
+  return {
+    name: 'keeper-sangsu',
+    execution_scope: 'workspace',
+    sandbox_profile: 'legacy_local',
+    network_mode: 'inherit',
+    shared_memory_scope: 'disabled',
+    sandbox_last_error: null,
+    effective_sandbox_image: 'ubuntu:24.04@sha256:test',
+    private_workspace_root: '/tmp/project-root/.masc/playground/keeper-sangsu',
+    sandbox_environment: {
+      base_path: '/tmp/project-root/.masc',
+      project_root: '/tmp/project-root',
+      docker_playground_enabled: true,
+      docker_container_name: 'keeper-playground',
+      container_playground_root: '/home/keeper/playground',
+      docker_image: 'ubuntu:24.04@sha256:test',
+      pids_limit: 128,
+      memory: '2g',
+      tmpfs_size: '256m',
+      seccomp_profile: null,
+      require_rootless: false,
+      require_userns: false,
+    },
+    allowed_paths: ['/tmp/workspace'],
+    effective_allowed_paths: ['/tmp/workspace'],
+    prompt: {
+      goal: 'Ship stable keeper ops',
+      short_goal: 'Diagnose agent liveness',
+      mid_goal: 'Reduce restart confusion',
+      long_goal: 'Keep coordination stable',
+      will: 'Stay on call',
+      needs: 'Accurate runtime state',
+      desires: 'Clear operator feedback',
+      instructions: 'Prefer direct remediation',
+      system_prompt_blocks: {
+        constitution: { key: 'keeper.constitution', source: 'file', text: 'constitution text' },
+        world: { key: 'keeper.world', source: 'override', text: 'world text' },
+        capabilities: { key: 'keeper.capabilities', source: 'file', text: 'capabilities text' },
+      },
+      effective_system_prompt: 'full prompt',
+    },
+    execution: {
+      models: ['llama:test-balanced'],
+      active_model: 'llama:test-balanced',
+      verify: true,
+    },
+    compaction: {
+      profile: 'balanced',
+      ratio_gate: 0.85,
+      message_gate: 16,
+      token_gate: 24000,
+      cooldown_sec: 120,
+    },
+    proactive: {
+      enabled: true,
+      idle_sec: 900,
+      cooldown_sec: 1800,
+    },
+    drift: {
+      status: 'wired',
+      enabled: true,
+      min_turn_gap: 4,
+      count_total: 2,
+      last_reason: 'board quiet',
+    },
+    auto_team_session: {
+      status: 'source_only',
+      enabled: null,
+    },
+    handoff: {
+      auto: true,
+      threshold: 0.85,
+      cooldown_sec: 300,
+    },
+    hooks: {
+      slots: {},
+      deny_list: [],
+      deny_list_count: 0,
+      destructive_check_tools: ['dynamic_boundary (Tool_dispatch.is_destructive)'],
+      cost_budget: {
+        active: false,
+      },
+    },
+    runtime: {
+      paused: false,
+      registered: true,
+      keepalive_running: true,
+      registry_state: 'running',
+      fiber_health: 'healthy',
+      presence_keepalive: true,
+      presence_keepalive_sec: 30,
+    },
+    coordination: {
+      room_scope: 'global',
+      mention_targets: ['sangsu'],
+      joined_room_ids: ['default'],
+    },
+    sources: {
+      live_meta_path: '/tmp/.masc/keepers/keeper-sangsu/live.json',
+      default_manifest_path: '/tmp/config/keepers/default.toml',
+      default_source_kind: 'toml',
+      precedence: ['live_meta', 'toml', 'persona'],
+      has_live_override: true,
+      override_fields: ['goal', 'instructions'],
+    },
+    tools: {
+      tool_access: { kind: 'preset', preset: 'coding' },
+      tool_policy_mode: 'preset',
+      tool_preset: 'coding',
+      tool_also_allow: ['keeper_board_post'],
+      tool_custom_allowlist: [],
+      resolved_allowlist: ['keeper_fs_read'],
+      tool_denylist: ['keeper_bash'],
+      active_masc_tool_count: 1,
+      active_keeper_tool_count: 2,
+      total_active: 3,
+    },
+    metrics: {
+      generation: 3,
+      total_turns: 12,
+      total_input_tokens: 1200,
+      total_output_tokens: 800,
+      total_tokens: 2000,
+      total_cost_usd: 0.12,
+      last_model_used: 'llama:test-balanced',
+      last_input_tokens: 120,
+      last_output_tokens: 80,
+      last_total_tokens: 200,
+      last_latency_ms: 2400,
+      last_total_tokens_per_sec: 22.4,
+      last_output_tokens_per_sec: 11.2,
+      compaction_count: 1,
+    },
     ...overrides,
   }
 }
@@ -79,105 +217,7 @@ describe('filterHookSlots', () => {
 })
 
 const mocks = vi.hoisted(() => ({
-  fetchKeeperConfig: vi.fn(async () => ({
-    name: 'keeper-sangsu',
-    prompt: {
-      goal: 'Ship stable keeper ops',
-      short_goal: 'Diagnose agent liveness',
-      mid_goal: 'Reduce restart confusion',
-      long_goal: 'Keep coordination stable',
-      will: 'Stay on call',
-      needs: 'Accurate runtime state',
-      desires: 'Clear operator feedback',
-      instructions: 'Prefer direct remediation',
-      system_prompt_blocks: {
-        constitution: { key: 'keeper.constitution', source: 'file', text: 'constitution text' },
-        world: { key: 'keeper.world', source: 'override', text: 'world text' },
-        capabilities: { key: 'keeper.capabilities', source: 'file', text: 'capabilities text' },
-      },
-      effective_system_prompt: 'full prompt',
-    },
-    execution: {
-      models: ['llama:test-balanced'],
-      active_model: 'llama:test-balanced',
-      verify: true,
-    },
-    compaction: {
-      profile: 'balanced',
-      ratio_gate: 0.85,
-      message_gate: 16,
-      token_gate: 24000,
-      cooldown_sec: 120,
-    },
-    proactive: {
-      enabled: true,
-      idle_sec: 900,
-      cooldown_sec: 1800,
-    },
-    drift: {
-      status: 'wired',
-      enabled: true,
-      min_turn_gap: 4,
-      count_total: 2,
-      last_reason: 'board quiet',
-    },
-    auto_team_session: {
-      status: 'source_only',
-      enabled: null,
-    },
-    handoff: {
-      auto: true,
-      threshold: 0.85,
-      cooldown_sec: 300,
-    },
-    hooks: {
-      slots: {},
-      deny_list: [],
-      deny_list_count: 0,
-      destructive_check_tools: 'dynamic_boundary (Tool_dispatch.is_destructive)',
-      cost_budget: {
-        active: false,
-      },
-    },
-    runtime: {
-      paused: false,
-      registered: true,
-      keepalive_running: true,
-      registry_state: 'running',
-      fiber_health: 'healthy',
-      presence_keepalive: true,
-      presence_keepalive_sec: 30,
-    },
-    coordination: {
-      room_scope: 'global',
-      mention_targets: ['sangsu'],
-      joined_room_ids: ['default'],
-    },
-    sources: {
-      live_meta_path: '/tmp/.masc/keepers/keeper-sangsu/live.json',
-      default_manifest_path: '/tmp/config/keepers/default.toml',
-      default_source_kind: 'toml' as const,
-      precedence: ['live_meta', 'toml', 'persona'],
-      has_live_override: true,
-      override_fields: ['goal', 'instructions'],
-    },
-    metrics: {
-      generation: 3,
-      total_turns: 12,
-      total_input_tokens: 1200,
-      total_output_tokens: 800,
-      total_tokens: 2000,
-      total_cost_usd: 0.12,
-      last_model_used: 'llama:test-balanced',
-      last_input_tokens: 120,
-      last_output_tokens: 80,
-      last_total_tokens: 200,
-      last_latency_ms: 2400,
-      last_total_tokens_per_sec: 22.4,
-      last_output_tokens_per_sec: 11.2,
-      compaction_count: 1,
-    },
-  })),
+  fetchKeeperConfig: vi.fn(async () => makeKeeperConfig()),
   patchKeeperConfig: vi.fn(),
 }))
 
@@ -200,6 +240,7 @@ describe('KeeperConfigPanel', () => {
     document.body.appendChild(container)
     resetKeeperConfig()
     mocks.fetchKeeperConfig.mockClear()
+    mocks.patchKeeperConfig.mockClear()
   })
 
   afterEach(() => {
@@ -222,6 +263,7 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('레지스트리 상태')
     expect(container.textContent).toContain('running')
     expect(container.textContent).toContain('dynamic_boundary (Tool_dispatch.is_destructive)')
+    expect(container.textContent).toContain('/tmp/project-root')
 
     const editButton = Array.from(container.querySelectorAll('button')).find(button =>
       button.textContent?.includes('편집'),
@@ -232,6 +274,55 @@ describe('KeeperConfigPanel', () => {
     const textareas = Array.from(container.querySelectorAll('textarea'))
     expect(textareas.length).toBeGreaterThan(0)
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
+  })
+
+  it('patches sandbox runtime controls from the dashboard panel', async () => {
+    mocks.patchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({
+        sandbox_profile: 'docker_hardened',
+        network_mode: 'none',
+        shared_memory_scope: 'room',
+      }),
+    )
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const sandboxProfile = container.querySelector('select[aria-label="sandbox_profile"]') as HTMLSelectElement | null
+    const networkMode = container.querySelector('select[aria-label="network_mode"]') as HTMLSelectElement | null
+    const sharedMemory = container.querySelector('select[aria-label="shared_memory_scope"]') as HTMLSelectElement | null
+    expect(sandboxProfile).not.toBeNull()
+    expect(networkMode).not.toBeNull()
+    expect(sharedMemory).not.toBeNull()
+
+    sandboxProfile!.value = 'docker_hardened'
+    sandboxProfile!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const hardenedNetworkMode = container.querySelector('select[aria-label="network_mode"]') as HTMLSelectElement | null
+    expect(hardenedNetworkMode).not.toBeNull()
+    hardenedNetworkMode!.value = 'none'
+    hardenedNetworkMode!.dispatchEvent(new Event('change', { bubbles: true }))
+    sharedMemory!.value = 'room'
+    sharedMemory!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
+    )
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      expect.objectContaining({
+        sandbox_profile: 'docker_hardened',
+        network_mode: 'none',
+        shared_memory_scope: 'room',
+      }),
+    )
   })
 
   it('supports forced config refresh for already-loaded keepers', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -98,9 +98,15 @@ function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdateP
 
 // Runtime config draft for proactive/compaction/handoff inline editing
 type ExecutionScope = 'observe_only' | 'workspace' | 'local'
+type SandboxProfile = 'legacy_local' | 'docker_hardened'
+type NetworkMode = 'inherit' | 'none'
+type SharedMemoryScope = 'disabled' | 'room'
 
 type RuntimeDraft = {
   execution_scope: ExecutionScope
+  sandbox_profile: SandboxProfile
+  network_mode: NetworkMode
+  shared_memory_scope: SharedMemoryScope
   allowed_paths_text: string
   proactive_enabled: boolean
   proactive_idle_sec: number
@@ -120,6 +126,9 @@ const runtimeSaving = signal(false)
 function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     execution_scope: (c.execution_scope as ExecutionScope) ?? 'workspace',
+    sandbox_profile: (c.sandbox_profile as SandboxProfile) ?? 'legacy_local',
+    network_mode: (c.network_mode as NetworkMode) ?? 'inherit',
+    shared_memory_scope: (c.shared_memory_scope as SharedMemoryScope) ?? 'disabled',
     allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
     proactive_enabled: c.proactive.enabled,
     proactive_idle_sec: c.proactive.idle_sec,
@@ -137,6 +146,9 @@ function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
 function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
   const payload: KeeperConfigUpdatePayload = {}
   if (draft.execution_scope !== (orig.execution_scope ?? 'workspace')) payload.execution_scope = draft.execution_scope
+  if (draft.sandbox_profile !== (orig.sandbox_profile ?? 'legacy_local')) payload.sandbox_profile = draft.sandbox_profile
+  if (draft.network_mode !== (orig.network_mode ?? 'inherit')) payload.network_mode = draft.network_mode
+  if (draft.shared_memory_scope !== (orig.shared_memory_scope ?? 'disabled')) payload.shared_memory_scope = draft.shared_memory_scope
   const newPaths = draft.allowed_paths_text.split('\n').map(s => s.trim()).filter(Boolean)
   const origPaths = orig.allowed_paths ?? []
   if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
@@ -156,7 +168,14 @@ function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperCon
 function updateRuntimeDraft(field: keyof RuntimeDraft, value: boolean | number | string) {
   const d = runtimeDraft.value
   if (!d) return
-  runtimeDraft.value = { ...d, [field]: value }
+  const next = { ...d, [field]: value } as RuntimeDraft
+  if (field === 'sandbox_profile' && next.sandbox_profile !== 'docker_hardened' && next.network_mode === 'none') {
+    next.network_mode = 'inherit'
+  }
+  if (field === 'network_mode' && next.sandbox_profile !== 'docker_hardened' && next.network_mode === 'none') {
+    next.network_mode = 'inherit'
+  }
+  runtimeDraft.value = next
 }
 
 export async function loadKeeperConfig(
@@ -345,6 +364,32 @@ function InlineNumberRow({ label, value, onChange, min, max, step, suffix }: {
   `
 }
 
+function InlineSelectRow({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (v: string) => void
+}) {
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5 gap-3">
+      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <select
+        aria-label=${label}
+        class="text-xs bg-card/60 border border-card-border rounded-lg px-2 py-1 text-text-strong"
+        value=${value}
+        onChange=${(e: Event) => onChange((e.target as HTMLSelectElement).value)}
+      >
+        ${options.map(option => html`<option value=${option}>${option}</option>`)}
+      </select>
+    </div>
+  `
+}
+
 // ── Edit field components ────────────────────────────────
 
 function updateDraft(field: keyof EditDraft, value: string | boolean | number) {
@@ -368,6 +413,18 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
       />
     </div>
   `
+}
+
+function sandboxAnchorText(c: KeeperConfig): string {
+  const basePath = c.sandbox_environment?.base_path ?? '--'
+  const projectRoot = c.sandbox_environment?.project_root ?? '--'
+  return `상대 allowed_paths는 project root ${projectRoot} 기준으로 해석됩니다. config base path는 ${basePath} 입니다.`
+}
+
+function dockerStatusLabel(c: KeeperConfig): string {
+  if (c.sandbox_profile === 'docker_hardened') return 'docker_hardened'
+  if (c.sandbox_environment?.docker_playground_enabled) return 'legacy_local + docker_playground'
+  return 'legacy_local'
 }
 
 // ── Main component ───────────────────────────────────────
@@ -540,7 +597,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="mt-2">
         <${Callout}
           title="런타임 설정"
-          body="프로액티브, 컴팩션, 핸드오프 섹션은 인라인 편집이 가능합니다. 소스/실행/런타임/조율은 읽기 전용입니다."
+          body="실행 범위 섹션에서 execution_scope, sandbox_profile, network_mode, shared_memory_scope, allowed_paths를 저장할 수 있습니다. 프로액티브, 컴팩션, 핸드오프도 인라인 편집 가능하고, 소스/실행/런타임/조율은 읽기 전용입니다."
         />
       </div>
 
@@ -598,16 +655,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${SectionHeader} title="실행 범위" />
       ${rd ? html`
-        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-          <span class="text-xs text-[var(--text-body)]">execution_scope</span>
-          <select class="text-xs bg-[var(--white-6)] border border-[var(--card-border)] rounded px-2 py-1 text-[var(--text-body)]"
-            value=${rd.execution_scope}
-            onChange=${(e: Event) => updateRuntimeDraft('execution_scope', (e.target as HTMLSelectElement).value as ExecutionScope)}>
-            <option value="observe_only">observe_only</option>
-            <option value="workspace">workspace</option>
-            <option value="local">local</option>
-          </select>
-        </div>
+        <${InlineSelectRow}
+          label="execution_scope"
+          value=${rd.execution_scope}
+          options=${['observe_only', 'workspace', 'local'] as const}
+          onChange=${(value: string) => updateRuntimeDraft('execution_scope', value as ExecutionScope)}
+        />
+        <${InlineSelectRow}
+          label="sandbox_profile"
+          value=${rd.sandbox_profile}
+          options=${['legacy_local', 'docker_hardened'] as const}
+          onChange=${(value: string) => updateRuntimeDraft('sandbox_profile', value as SandboxProfile)}
+        />
+        <${InlineSelectRow}
+          label="network_mode"
+          value=${rd.network_mode}
+          options=${rd.sandbox_profile === 'docker_hardened' ? ['inherit', 'none'] as const : ['inherit'] as const}
+          onChange=${(value: string) => updateRuntimeDraft('network_mode', value as NetworkMode)}
+        />
+        <${InlineSelectRow}
+          label="shared_memory_scope"
+          value=${rd.shared_memory_scope}
+          options=${['disabled', 'room'] as const}
+          onChange=${(value: string) => updateRuntimeDraft('shared_memory_scope', value as SharedMemoryScope)}
+        />
         <div class="py-2 px-3 rounded-lg bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs text-[var(--text-body)]">allowed_paths</span>
@@ -625,6 +696,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
             effective: ${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'}
           </div>
         ` : null}
+        <${Callout}
+          title="Base Path Anchor"
+          body=${sandboxAnchorText(c)}
+        />
       ` : html`
         <${ConfigRow} label="execution_scope" value=${c.execution_scope ?? 'workspace'} />
         <${ConfigRow} label="sandbox_profile" value=${c.sandbox_profile ?? 'legacy_local'} />
@@ -634,6 +709,32 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="allowed_paths" value=${(c.allowed_paths ?? []).join(', ') || '(computed default)'} />
         <${ConfigRow} label="effective_paths" value=${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'} />
         <${ConfigRow} label="private_workspace_root" value=${c.private_workspace_root || '--'} />
+      `}
+
+      ${c.sandbox_environment ? html`
+        <${SectionHeader} title="샌드박스 환경" />
+        <${ConfigRow} label="docker_status" value=${dockerStatusLabel(c)} />
+        <${ConfigRow} label="config_base_path" value=${c.sandbox_environment.base_path || '--'} />
+        <${ConfigRow} label="project_root" value=${c.sandbox_environment.project_root || '--'} />
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-muted)]">docker_playground</span>
+          <${BoolBadge} value=${c.sandbox_environment.docker_playground_enabled} />
+        </div>
+        <${ConfigRow} label="docker_container" value=${c.sandbox_environment.docker_container_name || '--'} />
+        <${ConfigRow} label="container_playground_root" value=${c.sandbox_environment.container_playground_root || '--'} />
+        <${ConfigRow} label="sandbox_docker_image" value=${c.sandbox_environment.docker_image || '--'} />
+        <${ConfigRow} label="sandbox_memory" value=${c.sandbox_environment.memory || '--'} />
+        <${ConfigRow} label="sandbox_pids_limit" value=${String(c.sandbox_environment.pids_limit ?? '--')} />
+        <${ConfigRow} label="sandbox_tmpfs_size" value=${c.sandbox_environment.tmpfs_size || '--'} />
+        <${ConfigRow} label="sandbox_seccomp_profile" value=${c.sandbox_environment.seccomp_profile || '--'} />
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-muted)]">require_rootless</span>
+          <${BoolBadge} value=${c.sandbox_environment.require_rootless} />
+        </div>
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-muted)]">require_userns</span>
+          <${BoolBadge} value=${c.sandbox_environment.require_userns} />
+        </div>
         ${c.sandbox_last_error ? html`
           <${Callout}
             title="Sandbox Error"
@@ -641,7 +742,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
             tone="warn"
           />
         ` : null}
-      `}
+      ` : null}
 
       <${SectionHeader} title="프로액티브" />
       ${rd ? html`

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -869,6 +869,21 @@ interface KeeperConfigMetrics {
   compaction_count: number
 }
 
+export interface KeeperSandboxEnvironment {
+  base_path?: string | null
+  project_root?: string | null
+  docker_playground_enabled: boolean
+  docker_container_name?: string | null
+  container_playground_root?: string | null
+  docker_image?: string | null
+  pids_limit?: number | null
+  memory?: string | null
+  tmpfs_size?: string | null
+  seccomp_profile?: string | null
+  require_rootless: boolean
+  require_userns: boolean
+}
+
 export interface KeeperHookSlot {
   active: boolean
   source: string
@@ -894,6 +909,7 @@ export interface KeeperConfig {
   sandbox_last_error?: string | null
   effective_sandbox_image?: string | null
   private_workspace_root?: string | null
+  sandbox_environment?: KeeperSandboxEnvironment
   allowed_paths: string[]
   effective_allowed_paths: string[]
   prompt: KeeperConfigPrompt

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1112,6 +1112,38 @@ let keeper_config_json (config : Coord.config) (name : string)
           (Keeper_alerting_path.project_root_of_config config)
           (Keeper_alerting_path.playground_path_of_keeper m.name)
       in
+      let sandbox_environment =
+        let string_or_null value =
+          let trimmed = String.trim value in
+          if trimmed = "" then `Null else `String trimmed
+        in
+        `Assoc [
+          ("base_path", `String config.base_path);
+          ("project_root",
+            `String (Keeper_alerting_path.project_root_of_config config));
+          ("docker_playground_enabled",
+            `Bool Env_config_keeper.DockerPlayground.enabled);
+          ("docker_container_name",
+            string_or_null Env_config_keeper.DockerPlayground.container_name);
+          ("container_playground_root",
+            string_or_null
+              Env_config_keeper.DockerPlayground.container_playground_root);
+          ("docker_image",
+            string_or_null (Env_config_keeper.KeeperSandbox.docker_image ()));
+          ("pids_limit", `Int (Env_config_keeper.KeeperSandbox.pids_limit ()));
+          ("memory",
+            string_or_null (Env_config_keeper.KeeperSandbox.memory ()));
+          ("tmpfs_size",
+            string_or_null (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
+          ("seccomp_profile",
+            string_or_null
+              (Env_config_keeper.KeeperSandbox.seccomp_profile ()));
+          ("require_rootless",
+            `Bool (Env_config_keeper.KeeperSandbox.require_rootless ()));
+          ("require_userns",
+            `Bool (Env_config_keeper.KeeperSandbox.require_userns ()));
+        ]
+      in
       (`OK,
        `Assoc [
          ("name", `String m.name);
@@ -1124,6 +1156,7 @@ let keeper_config_json (config : Coord.config) (name : string)
          ("effective_sandbox_image",
            Json_util.string_opt_to_json effective_sandbox_image);
          ("private_workspace_root", `String private_workspace_root);
+         ("sandbox_environment", sandbox_environment);
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));
          ("effective_allowed_paths",


### PR DESCRIPTION
## Summary
This restores the keeper sandbox controls in the dashboard and exposes the Docker/base-path environment details that operators need to understand keeper execution posture.

## What changed
- Reconnected keeper config editing for `sandbox_profile`, `network_mode`, and `shared_memory_scope` in the dashboard runtime settings panel.
- Added base-path/project-root anchor messaging so relative `allowed_paths` are understandable from the UI.
- Added a read-only sandbox environment block showing the current process-level Docker sandbox configuration.
- Extended dashboard keeper config normalization/types and regression tests for the new shape.

## Why
The backend already supported keeper-level sandbox posture updates, but the dashboard draft/payload layer had dropped those fields. That made the panel look like sandbox mode had disappeared even though keeper metadata still supported local vs Docker execution.

## Product impact
Operators can now switch one keeper to `legacy_local` and another to `docker_hardened` directly from the dashboard, while also seeing the effective base path and Docker runtime settings used by the current server.

## Root cause
The frontend keeper config draft and patch payload no longer included sandbox fields, and the panel only rendered them as read-only metadata.

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/keeper-config-panel.test.ts src/api/dashboard.test.ts --reporter=verbose --testTimeout=10000`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-230-dashboard-sandbox bin/main_eio.exe`

## Follow-up
This PR only restores keeper-level sandbox posture controls and visibility. Keeper-specific overrides for Docker image, memory, tmpfs, pids, and related runtime profile settings remain follow-up work because they are still process-global environment configuration today.

Refs #8305