### PR TITLE
fix(cascade): demote recovered-tier log noise (task-239)

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -720,14 +720,19 @@ let run
       let detail =
         enrich_idle_detail detail (Oas.Agent.state agent).messages
       in
+      (* Demoted from WARN to DEBUG (task-239): this fires once per tier,
+         but a cascade caller (Oas_worker_named.run_named) retries on the
+         next provider.  Emitting WARN/ERROR here creates noise on
+         recovered cascades.  The cascade layer logs [cascade-fallback] at
+         INFO when it retries and emits ERROR only on full exhaustion. *)
       (match proof with
        | Some p ->
-         Log.Misc.warn "oas_worker: agent errored with CDAL proof: run_id=%s status=%s error=%s"
+         Log.Misc.debug "oas_worker: agent errored with CDAL proof: run_id=%s status=%s error=%s"
            p.run_id
            (proof_result_status_to_string p.result_status)
            detail
        | None ->
-         Log.Misc.warn "oas_worker: agent errored (no proof): %s" detail);
+         Log.Misc.debug "oas_worker: agent errored (no proof): %s" detail);
       Error err)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -463,7 +463,10 @@ let run_named
            on_success ~provider_key:provider_cfg.model_id;
            Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
-           Log.Misc.warn "cascade %s: accept rejected %s (%s), trying next" cascade_name provider_cfg.model_id reason;
+           (* Demoted from WARN to INFO (task-239): cascade will retry the
+              next tier.  Tagged [cascade-fallback] so dashboard filters
+              can distinguish recovery-in-progress from hard failures. *)
+           Log.Misc.info "[cascade-fallback] cascade %s: accept rejected %s (%s), trying next" cascade_name provider_cfg.model_id reason;
            Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
              ~from_model:provider_cfg.model_id ~to_model:"next" ~reason;
            try_cascade ?resume_checkpoint:next_resume rest new_err
@@ -473,6 +476,8 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model) ~capture
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
+           Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last model=%s, reason=%s)"
+             cascade_name result.response.model reason;
            Error
              (sdk_error_of_masc_internal_error
                 (Accept_rejected
@@ -510,7 +515,14 @@ let run_named
          | Some outcome ->
            (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
             | Cascade_fsm.Try_next { last_err = new_err } ->
-              Log.Misc.warn "cascade %s: %s failed (%s), trying next" cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
+              (* Demoted from WARN to INFO (task-239): cascade will retry
+                 the next tier.  Tagged [cascade-fallback] so dashboards
+                 and log filters can distinguish recovery-in-progress
+                 from hard failures.  The exec layer's per-tier
+                 "agent errored" log was also demoted to DEBUG in the
+                 same change, so this INFO is the canonical per-tier
+                 signal. *)
+              Log.Misc.info "[cascade-fallback] cascade %s: %s failed (%s), trying next" cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
               Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
                 ~from_model:provider_cfg.model_id ~to_model:"next"
                 ~reason:(Oas.Error.to_string sdk_err);
@@ -521,6 +533,8 @@ let run_named
                   ~candidate_cfgs ~selected_model_raw:None ~capture
               in
               Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
+              Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
+                cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
               Error sdk_err
             | _ -> Error sdk_err)
          | None ->
@@ -530,6 +544,8 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:None ~capture
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
+           Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
+             cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
            Error sdk_err))
   in
   (* Pluggable strategy + cycle/backoff wrapper (since 0.9.6).


### PR DESCRIPTION
## Summary
- Task-239: cascade recovery path emitted WARN/ERROR even when the next tier succeeded.
- Per-tier failures now log `[cascade-fallback]` at INFO; ERROR is reserved for full cascade exhaustion.

## Change detail
- `lib/oas_worker_exec.ml` : the per-tier `agent errored (no proof|with CDAL proof)` log demoted from WARN to DEBUG. Exec layer has no visibility into cascade retry; the cascade layer classifies.
- `lib/oas_worker_named.ml` `try_cascade`:
  - `Try_next` (both `Accept_rejected` and API `Call_err` branches): WARN -> INFO with `[cascade-fallback]` prefix.
  - `Exhausted` branches: added `Log.Misc.error` summarising last model + reason, so full-cascade failure still emits a single ERROR.
  - Non-cascadable error (`None` outcome) promoted to ERROR as well — terminal config/agent errors stay visible.

Before (DNS outage, cascade recovers on next tier):
```
WARN  cascade keeper_unified: glm-5-turbo failed (Network error: failed to resolve hostname: api.z.ai), trying next
WARN  oas_worker: agent errored (no proof): Network error: failed to resolve hostname: api.z.ai
```

After:
```
INFO  [cascade-fallback] cascade keeper_unified: glm-5-turbo failed (Network error: failed to resolve hostname: api.z.ai), trying next
```

After (full cascade failure — no tier succeeds):
```
INFO  [cascade-fallback] cascade keeper_unified: glm-5-turbo failed (...), trying next
INFO  [cascade-fallback] cascade keeper_unified: sonnet-4 failed (...), trying next
ERROR cascade keeper_unified exhausted: all tiers failed (last model=haiku-3, error=...)
```

## Test plan
- [x] `dune build` clean
- [x] `dune build @runtest` passes (114 keeper_tool_matrix + full suite, 230s)
- [ ] Manual: trigger a DNS fail on tier 1 (`api.z.ai` offline) with a working tier 2 — verify only one INFO per tier and no WARN/ERROR reaches the dashboard.
- [ ] Manual: force all tiers to fail — verify a single `cascade ... exhausted` ERROR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)