### PR TITLE
feat(dashboard): 🚧 styling-drift ratchet gate (P6/9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,9 @@ jobs:
         working-directory: dashboard
         run: pnpm test
 
+      - name: Dashboard styling-drift gate
+        run: scripts/dashboard-drift-check.sh
+
   tla-specs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,18 @@ jobs:
         working-directory: dashboard
         run: pnpm test
 
-      - name: Dashboard styling-drift gate
+  dashboard-drift:
+    name: Dashboard Drift Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [pr-sync-check]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run drift gate
         run: scripts/dashboard-drift-check.sh
 
   tla-specs:
@@ -613,7 +624,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check, changes, build, lint, dashboard, health, doc-truth, oas-pin-check, tla-specs]
+    needs: [pr-sync-check, changes, build, lint, dashboard, dashboard-drift, health, doc-truth, oas-pin-check, tla-specs]
     if: ${{ !cancelled() }}
     timeout-minutes: 2
 
@@ -625,6 +636,7 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
+          DASHBOARD_DRIFT_RESULT: ${{ needs.dashboard-drift.result }}
           HEALTH_RESULT: ${{ needs.health.result }}
           DOC_TRUTH_RESULT: ${{ needs.doc-truth.result }}
           OAS_PIN_RESULT: ${{ needs.oas-pin-check.result }}
@@ -647,6 +659,7 @@ jobs:
           check "build"         "$BUILD_RESULT"
           check "lint"          "$LINT_RESULT"
           check "dashboard"     "$DASHBOARD_RESULT"
+          check "dashboard-drift" "$DASHBOARD_DRIFT_RESULT"
           check "health"        "$HEALTH_RESULT"
           check "doc-truth"     "$DOC_TRUTH_RESULT"
           check "oas-pin-check" "$OAS_PIN_RESULT"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -102,6 +102,16 @@ doctor-oas-pin:
 # modules. Regenerate with: bash scripts/oas-drift-check.sh --regenerate
 doctor-oas-drift:
 	bash scripts/oas-drift-check.sh
+
+# Dashboard styling-drift ratchet gate — fail if forbidden Tailwind patterns
+# (bg-white/N, border-white/N, rounded-[Npx], text-zinc-*, text-[9px], ...)
+# increase above the committed baseline. Regenerate baseline with the -regen
+# target after an intentional bulk-migration.
+dashboard-drift-check:
+	bash scripts/dashboard-drift-check.sh
+
+dashboard-drift-regen:
+	bash scripts/dashboard-drift-check.sh --regenerate
 
 # Development setup
 dev-setup: pin-external-deps install-deps

--- a/scripts/dashboard-drift-baseline.json
+++ b/scripts/dashboard-drift-baseline.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Dashboard styling-drift baseline. Regenerate with scripts/dashboard-drift-check.sh --regenerate.",
+  "_patterns": "See scripts/dashboard-drift-check.sh PATTERNS array.",
+  "bg-white-alpha": 49,
+  "border-white-alpha": 18,
+  "text-zinc": 0,
+  "bg-zinc": 0,
+  "border-zinc": 0,
+  "rounded-px-literal": 11,
+  "text-9px": 0
+}

--- a/scripts/dashboard-drift-check.sh
+++ b/scripts/dashboard-drift-check.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Dashboard styling-drift ratchet gate.
+#
+# Scans dashboard/src for forbidden Tailwind patterns whose canonical
+# replacement already exists (CSS vars in styles/variables.css, or tokens
+# in styles/tokens.css). Compares per-pattern counts against the
+# committed baseline at scripts/dashboard-drift-baseline.json.
+#
+# Pattern policy:
+#   - zero-tolerance = new occurrences always fail the gate (baseline: 0)
+#   - ratchet = existing drift frozen; new occurrences above baseline fail
+#
+# Usage:
+#   scripts/dashboard-drift-check.sh              # check; exit 0 ok / 2 drift up / 1 error
+#   scripts/dashboard-drift-check.sh --regenerate # rewrite baseline from current counts
+#   scripts/dashboard-drift-check.sh --print      # print current counts, no compare
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/scripts/dashboard-drift-baseline.json"
+SCAN_ROOT="${REPO_ROOT}/dashboard/src"
+
+# Pattern definitions: name|regex|policy|hint
+# policy: zero|ratchet
+PATTERNS=(
+  "bg-white-alpha|bg-white/[0-9]+|ratchet|Use bg-[var(--white-N)] (N in variables.css)"
+  "border-white-alpha|border-white/[0-9]+|ratchet|Use border-[var(--border-*)] or border-[var(--white-N)]"
+  "text-zinc|text-zinc-[0-9]+|zero|Use text-text-muted / text-text-dim / text-text-strong"
+  "bg-zinc|bg-zinc-[0-9]+|zero|Use bg-[var(--white-N)]"
+  "border-zinc|border-zinc-[0-9]+|zero|Use border-[var(--border-*)]"
+  "rounded-px-literal|rounded-\\[[0-9]+px\\]|ratchet|Use rounded-{xs,sm,md,lg,xl,card} (tokens.css)"
+  "text-9px|text-\\[9px\\]|zero|Use text-[10px] (kbd sm) or text-[11px]"
+)
+
+count_pattern() {
+  local regex="$1"
+  # rg exits 1 on zero matches under pipefail — tolerate via || true.
+  # Scan source only. Exclude: test files, styles/ (token definitions), docs.
+  local output
+  output=$(rg --count-matches \
+     --glob '!*.test.ts' \
+     --glob '!**/styles/**' \
+     --glob '!**/*.md' \
+     -e "$regex" \
+     "$SCAN_ROOT" 2>/dev/null || true)
+  echo "$output" | awk -F: '{sum += $NF} END { print (sum ? sum : 0) }'
+}
+
+current_counts_json() {
+  local out='{'
+  local first=1
+  for spec in "${PATTERNS[@]}"; do
+    local name="${spec%%|*}"
+    local rest="${spec#*|}"
+    local regex="${rest%%|*}"
+    local count
+    count=$(count_pattern "$regex")
+    if [[ $first -eq 1 ]]; then first=0; else out+=','; fi
+    out+="\"$name\":$count"
+  done
+  out+='}'
+  echo "$out"
+}
+
+baseline_value() {
+  local name="$1"
+  if [[ -f "$BASELINE_FILE" ]]; then
+    python3 -c "
+import json, sys
+with open('$BASELINE_FILE') as f:
+    data = json.load(f)
+print(data.get('$name', 0))
+"
+  else
+    echo 0
+  fi
+}
+
+print_counts() {
+  echo "pattern                    current  baseline  policy"
+  echo "-----------------------------------------------------"
+  for spec in "${PATTERNS[@]}"; do
+    local name="${spec%%|*}"
+    local rest="${spec#*|}"
+    local regex="${rest%%|*}"
+    local policy_rest="${rest#*|}"
+    local policy="${policy_rest%%|*}"
+    local current
+    current=$(count_pattern "$regex")
+    local baseline
+    baseline=$(baseline_value "$name")
+    printf "%-26s %7d  %8d  %s\n" "$name" "$current" "$baseline" "$policy"
+  done
+}
+
+regenerate() {
+  local tmpfile
+  tmpfile=$(mktemp)
+  {
+    echo '{'
+    echo '  "_comment": "Dashboard styling-drift baseline. Regenerate with scripts/dashboard-drift-check.sh --regenerate.",'
+    echo '  "_patterns": "See scripts/dashboard-drift-check.sh PATTERNS array.",'
+    local first=1
+    for spec in "${PATTERNS[@]}"; do
+      local name="${spec%%|*}"
+      local rest="${spec#*|}"
+      local regex="${rest%%|*}"
+      local count
+      count=$(count_pattern "$regex")
+      if [[ $first -eq 1 ]]; then first=0; else echo ','; fi
+      printf '  "%s": %s' "$name" "$count"
+    done
+    echo
+    echo '}'
+  } > "$tmpfile"
+  mv "$tmpfile" "$BASELINE_FILE"
+  echo "Baseline written to $BASELINE_FILE"
+  print_counts
+}
+
+check() {
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
+    echo "Run: $0 --regenerate" >&2
+    exit 1
+  fi
+
+  local drift=0
+  local drift_up=0
+  local drift_down=0
+
+  for spec in "${PATTERNS[@]}"; do
+    local name="${spec%%|*}"
+    local rest="${spec#*|}"
+    local regex="${rest%%|*}"
+    local policy_rest="${rest#*|}"
+    local policy="${policy_rest%%|*}"
+    local hint="${policy_rest#*|}"
+    local current
+    current=$(count_pattern "$regex")
+    local baseline
+    baseline=$(baseline_value "$name")
+
+    if [[ "$policy" == "zero" && "$current" -gt 0 ]]; then
+      echo "❌ $name: $current occurrences (zero-tolerance)" >&2
+      echo "   Fix: $hint" >&2
+      drift_up=$((drift_up + 1))
+    elif [[ "$current" -gt "$baseline" ]]; then
+      echo "❌ $name: $current > baseline $baseline (ratchet)" >&2
+      echo "   Fix: $hint" >&2
+      drift_up=$((drift_up + 1))
+    elif [[ "$current" -lt "$baseline" ]]; then
+      echo "✅ $name: $current < baseline $baseline — baseline can be lowered" >&2
+      drift_down=$((drift_down + 1))
+    fi
+  done
+
+  if [[ $drift_up -gt 0 ]]; then
+    echo >&2
+    echo "Drift gate: $drift_up pattern(s) exceeded baseline." >&2
+    echo "Fix the occurrences, or (if intentional) run: $0 --regenerate" >&2
+    exit 2
+  fi
+
+  if [[ $drift_down -gt 0 ]]; then
+    echo >&2
+    echo "Hint: $drift_down pattern(s) have dropped below baseline. Consider: $0 --regenerate" >&2
+  fi
+
+  echo "Dashboard drift gate: OK"
+  exit 0
+}
+
+case "${1:-check}" in
+  --regenerate) regenerate ;;
+  --print)      print_counts ;;
+  check|"")     check ;;
+  -h|--help)
+    sed -n '1,22p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "Unknown arg: $1" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a ratchet-pattern drift gate for dashboard styling. Seven patterns
are measured against a committed baseline; zero-tolerance patterns fail
on any occurrence, ratchet patterns fail only when the count exceeds the
baseline (existing drift frozen, not blocked).

Wired into CI via the existing `dashboard` job (only runs when
`dashboard/` changes). Local runs via `make dashboard-drift-check`.

## Scope

| Pattern | Policy | Baseline | Canonical |
|---------|--------|----------|-----------|
| `bg-white/N` | ratchet | 49 | `bg-[var(--white-N)]` |
| `border-white/N` | ratchet | 18 | `border-[var(--border-*)]` |
| `rounded-[Npx]` | ratchet | 11 | `rounded-{xs,sm,md,lg,xl,card}` |
| `text-zinc-N` | zero | 0 | `text-text-{muted,dim,strong}` |
| `bg-zinc-N` | zero | 0 | `bg-[var(--white-N)]` |
| `border-zinc-N` | zero | 0 | `border-[var(--border-*)]` |
| `text-[9px]` | zero | 0 | `text-[10px]` (sealed after P5) |

Excluded from scan: `*.test.ts`, `**/styles/**` (token definitions
reference the forbidden shapes as canonical sources), `**/*.md`.

## Changes

- `scripts/dashboard-drift-check.sh` — ratchet gate with three modes
  (default check, `--regenerate`, `--print`). Exit 0 ok / 2 drift up / 1 error.
- `scripts/dashboard-drift-baseline.json` — committed baseline. Comment
  fields document regen workflow.
- `.github/workflows/ci.yml` — drift gate step in the existing dashboard
  job, after tests (fails fast on local migrations that go backwards).
- `Makefile` — `dashboard-drift-check` + `dashboard-drift-regen` targets.

## Follow-ups (separate PRs)

- P6-migration sweep: migrate the 78 ratchet instances file-by-file so
  the baseline can ratchet down to 0, then flip those three patterns
  to zero-tolerance. Deliberately out of scope here — the gate ships
  first to prevent regression while migrations are queued.
- Deferred a11y sites from P8 (`goals/goal-tree.ts:200`,
  `memory-subsystems.ts:341`) are independent of this PR.

## Verification

```console
$ make dashboard-drift-check
Dashboard drift gate: OK

$ # inject a zero-tolerance violation to verify gate
$ echo 'const t = "text-zinc-400"' >> dashboard/src/components/common/id-pill.ts
$ make dashboard-drift-check
❌ text-zinc: 1 occurrences (zero-tolerance)
   Fix: Use text-text-muted / text-text-dim / text-text-strong
Drift gate: 1 pattern(s) exceeded baseline.
exit=2
```

## Test plan

- [x] `make dashboard-drift-check` — OK on clean tree
- [x] Regression-injection test (zero-tolerance): gate exits 2
- [x] `--regenerate` produces matching baseline
- [ ] CI runs the step on this PR and passes
