### PR TITLE
[codex] Normalize masc_transition alias inputs

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -788,6 +788,9 @@ let transition_task_r config ~agent_name ~task_id ~action
         | Types.Release, Types.Claimed { assignee; _ }
         | Types.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
             Ok (Types.Todo, None)
+        | Types.Release, Types.Todo ->
+            (* Idempotent: already in backlog, nothing to release. *)
+            Ok (task.task_status, None)
         | Types.Start, Types.Claimed { assignee; _ } when assignee = agent_name || force ->
             Ok (Types.InProgress {
               assignee = agent_name;

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -10,6 +10,87 @@
     Must be called after all tool schemas are registered (server init).
 
     Tools without a registered schema are allowed through (permissive). *)
+let normalize_transition_token (raw : string) : string =
+  raw
+  |> String.trim
+  |> String.lowercase_ascii
+  |> String.map (function
+       | ' ' | '-' -> '_'
+       | c -> c)
+
+let canonical_transition_action_string (raw : string) : string option =
+  match normalize_transition_token raw with
+  | "claim" | "claimed" -> Some "claim"
+  | "start" | "started" | "in_progress" | "inprogress" | "working" ->
+      Some "start"
+  | "done" | "complete" | "completed" | "finish" | "finished" ->
+      Some "done"
+  | "cancel" | "cancelled" | "canceled" -> Some "cancel"
+  | "release" | "released" | "todo" | "pending" | "backlog" | "open"
+    | "unclaimed" ->
+      Some "release"
+  | "submit_for_verification" | "awaiting_verification"
+    | "needs_verification" | "verification_requested" ->
+      Some "submit_for_verification"
+  | "approve" | "approved" | "verified" -> Some "approve"
+  | "reject" | "rejected" | "changes_requested" | "changesrequested" ->
+      Some "reject"
+  | _ -> None
+
+let upsert_assoc key value fields =
+  (key, value) :: List.remove_assoc key fields
+
+let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
+  match args with
+  | `Assoc fields ->
+      let action_override, consume_to =
+        match List.assoc_opt "action" fields with
+        | Some (`String raw) -> (
+            match canonical_transition_action_string raw with
+            | Some canonical when not (String.equal canonical raw) ->
+                (Some (`String canonical), false)
+            | _ -> (None, false))
+        | Some _ -> (None, false)
+        | None -> (
+            match List.assoc_opt "to" fields with
+            | Some (`String raw) -> (
+                match canonical_transition_action_string raw with
+                | Some canonical -> (Some (`String canonical), true)
+                | None -> (None, false))
+            | _ -> (None, false))
+      in
+      let notes_override, consume_note =
+        if List.mem_assoc "notes" fields then
+          (None, false)
+        else
+          match List.assoc_opt "note" fields with
+          | Some (`String value) -> (Some (`String value), true)
+          | _ -> (None, false)
+      in
+      if action_override = None && notes_override = None then
+        args
+      else
+        let filtered =
+          List.filter
+            (fun (key, _) ->
+              not
+                ((consume_to && String.equal key "to")
+                 || (consume_note && String.equal key "note")))
+            fields
+        in
+        let with_action =
+          match action_override with
+          | Some value -> upsert_assoc "action" value filtered
+          | None -> filtered
+        in
+        let with_notes =
+          match notes_override with
+          | Some value -> upsert_assoc "notes" value with_action
+          | None -> with_action
+        in
+        `Assoc with_notes
+  | _ -> args
+
 let register_pre_hook () =
   let lookup name =
     Option.map
@@ -18,7 +99,17 @@ let register_pre_hook () =
   in
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    match hook ~name ~args with
+    let compat_args =
+      if String.equal name "masc_transition" then
+        normalize_transition_args args
+      else
+        args
+    in
+    match hook ~name ~args:compat_args with
+    | Agent_sdk.Tool_middleware.Pass
+      when not (Yojson.Safe.equal compat_args args) ->
+      Log.info "tool_input_validation coerced args for %s" name;
+      Proceed compat_args
     | Agent_sdk.Tool_middleware.Pass -> Pass
     | Agent_sdk.Tool_middleware.Proceed coerced ->
       Log.info "tool_input_validation coerced args for %s" name;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -439,6 +439,18 @@ let test_transition_release () =
     | Error _ -> Alcotest.fail "Expected Ok"
   )
 
+let test_transition_release_todo_noop () =
+  with_test_env (fun config ->
+    let _ = Coord.add_task config ~title:"Test" ~priority:1 ~description:"" in
+
+    let result = Coord.release_task_r config ~agent_name:"claude" ~task_id:"task-001" () in
+    match result with
+    | Ok msg ->
+        Alcotest.(check bool) "release todo no-op" true
+          (str_contains msg "already todo")
+    | Error _ -> Alcotest.fail "Expected Ok no-op"
+  )
+
 let test_transition_invalid () =
   with_test_env (fun config ->
     let _ = Coord.add_task config ~title:"Test" ~priority:1 ~description:"" in
@@ -1077,6 +1089,8 @@ let () =
       Alcotest.test_case "claim" `Quick test_transition_claim;
       Alcotest.test_case "start" `Quick test_transition_start;
       Alcotest.test_case "release" `Quick test_transition_release;
+      Alcotest.test_case "release todo no-op" `Quick
+        test_transition_release_todo_noop;
       Alcotest.test_case "invalid" `Quick test_transition_invalid;
       Alcotest.test_case "version mismatch" `Quick test_transition_version_mismatch;
       Alcotest.test_case "done idempotent" `Quick test_transition_done_idempotent;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -305,6 +305,66 @@ let test_registered_hook_bypasses_empty_schema () =
   Alcotest.(check bool) "args unchanged" true
     (Yojson.Safe.equal forwarded args)
 
+let find_schema_exn name schemas =
+  match List.find_opt (fun (schema : Types.tool_schema) -> String.equal schema.name name) schemas with
+  | Some schema -> schema.input_schema
+  | None -> failwith ("missing schema: " ^ name)
+
+let masc_transition_schema =
+  find_schema_exn "masc_transition" Tool_task_schemas.schemas
+
+let assoc_string key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> value
+  | _ -> failwith ("expected string field: " ^ key)
+
+let test_registered_hook_transition_compat_to_and_note () =
+  let args =
+    `Assoc
+      [
+        ("agent_name", `String "codex-local-admin");
+        ("task_id", `String "task-239");
+        ("to", `String "claimed");
+        ("note", `String "PR #8308 Draft");
+      ]
+  in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:masc_transition_schema
+      ~tool_name:"masc_transition"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check string) "to -> action claim" "claim"
+    (assoc_string "action" forwarded);
+  Alcotest.(check string) "note -> notes" "PR #8308 Draft"
+    (assoc_string "notes" forwarded);
+  Alcotest.(check bool) "to removed" true
+    (Yojson.Safe.Util.member "to" forwarded = `Null);
+  Alcotest.(check bool) "note removed" true
+    (Yojson.Safe.Util.member "note" forwarded = `Null)
+
+let test_registered_hook_transition_compat_status_action () =
+  let args =
+    `Assoc
+      [
+        ("agent_name", `String "keeper-ani1999-agent");
+        ("task_id", `String "task-193");
+        ("action", `String "claimed");
+      ]
+  in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:masc_transition_schema
+      ~tool_name:"masc_transition"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check string) "claimed -> claim" "claim"
+    (assoc_string "action" forwarded)
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -345,5 +405,9 @@ let () =
         test_registered_hook_bypasses_unknown_tool;
       Alcotest.test_case "empty schema bypasses validation" `Quick
         test_registered_hook_bypasses_empty_schema;
+      Alcotest.test_case "masc_transition compat: to/note aliases" `Quick
+        test_registered_hook_transition_compat_to_and_note;
+      Alcotest.test_case "masc_transition compat: status-like action" `Quick
+        test_registered_hook_transition_compat_status_action;
     ]);
   ]


### PR DESCRIPTION
## Summary
This makes `masc_transition` more tolerant of target-state style inputs and removes avoidable `release(todo)` transition noise.

## What changed
- Added a `masc_transition` compatibility normalization step before OAS schema validation.
- Normalized common aliases such as `to="claimed"` -> `action="claim"`, `to="todo"` -> `action="release"`, and `note` -> `notes`.
- Canonicalized status-like action strings such as `action="claimed"` -> `action="claim"`.
- Made `release` on an already-`todo` task an idempotent no-op.
- Added targeted regression coverage for both the validation hook and the room/task FSM behavior.

## Why
Logs were showing two avoidable failure patterns:
- callers using `to`/`note` style transition payloads were rejected before dispatch because `action` was missing
- callers trying to release a task already in `todo` created invalid-transition noise even though the effective desired state was already satisfied

## Product impact
Keeper/operator task control becomes more robust against alias-shaped inputs, and task-control logs become less noisy for already-backlog release requests.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-masc-transition-input-compat test/test_tool_input_validation.exe test/test_room_coverage.exe`
- `./_build/default/test/test_tool_input_validation.exe`
- `./_build/default/test/test_room_coverage.exe`

Refs #8312