### PR TITLE
refactor(dashboard): inline rgba → CSS tokens (Phase A, exact match)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -100,7 +100,7 @@ export function App() {
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
-      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.36)] px-4 py-1.5 backdrop-blur-xl">
+      <header class="relative z-10 shrink-0 border-b border-[var(--white-5)] bg-[rgba(8,14,26,0.36)] px-4 py-1.5 backdrop-blur-xl">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[900px]:flex-col max-[900px]:items-stretch">
           <div class="min-w-0 flex items-center gap-3">
@@ -146,11 +146,11 @@ export function App() {
       <${RemoteWarningBanner} />
 
       <div class="flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col">
-        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 
-        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(10,15,26,0.68)] backdrop-blur-lg max-[1100px]:min-h-0">
+        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(10,15,26,0.68)] backdrop-blur-lg max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
             <${DashboardMain} />
           </div>

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -40,7 +40,7 @@ function edgeColor(kind: string, active: boolean): string {
     case 'governs': return 'rgba(251, 146, 60, 0.4)'
     case 'operates_on': return 'rgba(74, 222, 128, 0.45)'
     case 'participates_in': return 'rgba(251, 191, 36, 0.35)'
-    case 'belongs_to': return 'rgba(148, 163, 184, 0.12)'
+    case 'belongs_to': return 'var(--slate-gray-12)'
     default: return 'rgba(148, 163, 184, 0.25)'
   }
 }

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -51,7 +51,7 @@ type StatusFilter = 'all' | RuntimeBand
 
 export function runtimeBadgeClass(band: RuntimeBand): string {
   if (band === 'active') return 'border-[rgba(52,211,153,0.2)] bg-[rgba(52,211,153,0.12)] text-[var(--ok)]'
-  if (band === 'attention') return 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.12)] text-[var(--warn)]'
+  if (band === 'attention') return 'border-[var(--warn-20)] bg-[rgba(251,191,36,0.12)] text-[var(--warn)]'
   if (band === 'paused') return 'border-[rgba(167,139,250,0.2)] bg-[rgba(167,139,250,0.12)] text-[#a78bfa]'
   return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
 }
@@ -710,7 +710,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${isKeeper ? html`
-                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] px-3 py-2.5">
+                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),rgba(255,255,255,0.02))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
                     ${fsmPhaseKey

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -67,7 +67,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
         <div class="flex flex-col gap-2">
           <div class="text-[11px] text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>
           <button type="button"
-            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[var(--bad-soft)] cursor-pointer transition-colors"
             onClick=${handleClearToken}
           >토큰 제거</button>
         </div>
@@ -97,7 +97,7 @@ export function RemoteWarningBanner() {
   if (bannerDismissed.value || !isRemoteAccess() || getStoredToken()) return null
 
   return html`
-    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[rgba(251,191,36,0.2)] text-[12px] text-[var(--warn)]">
+    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-[12px] text-[var(--warn)]">
       <span>원격 접속이 감지되었습니다. Mutation 작업을 위해 Bearer token을 설정하세요.</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -157,7 +157,7 @@ function ChatMessageBubble({
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -176,7 +176,7 @@ function ChatMessageBubble({
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -185,7 +185,7 @@ function ChatMessageBubble({
                       : null}
                     ${timestamp
                       ? html`
-                          <span class="inline-flex items-center rounded-sm border border-[rgba(148,163,184,0.16)] bg-[rgba(148,163,184,0.08)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
+                          <span class="inline-flex items-center rounded-sm border border-[rgba(148,163,184,0.16)] bg-[var(--slate-gray-8)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
                             ${timestamp}
                           </span>
                         `
@@ -201,7 +201,7 @@ function ChatMessageBubble({
           ? html`
               <button
                 type="button"
-                class=${`border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
+                class=${`border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
                   isMessenger ? 'rounded px-2.5 py-1' : 'rounded-sm px-3 py-1'
                 }`}
                 onClick=${() => { setExpandedRaw(!expandedRaw) }}
@@ -215,7 +215,7 @@ function ChatMessageBubble({
       ${showMetadata && detailItems.length > 0
         ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
-              <span class="inline-flex items-center rounded-sm border border-[rgba(71,184,255,0.16)] bg-[var(--accent-10)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-strong)]">
+              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-strong)]">
                 ${item}
               </span>
             `)}
@@ -240,7 +240,7 @@ function ChatMessageBubble({
                 ? html`
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
-                        <div class="rounded border border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-3 py-2.5">
+                        <div class="rounded border border-[var(--slate-gray-12)] bg-[var(--white-3)] px-3 py-2.5">
                           <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
                           <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
@@ -279,7 +279,7 @@ function ChatMessageBubble({
                     <div class="flex flex-col gap-2">
                       <button
                         type="button"
-                        class="self-start rounded-sm border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
+                        class="self-start rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
                         onClick=${() => { setRawExpandedRaw(!rawExpandedRaw) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
@@ -386,7 +386,7 @@ export function ChatComposer({
         <div class="text-[11px] text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
-        class="control-textarea min-h-[96px] rounded-card border border-[rgba(148,163,184,0.16)] bg-[rgba(255,255,255,0.04)] px-3 py-3 text-[14px] leading-[1.6]"
+        class="control-textarea min-h-[96px] rounded-card border border-[rgba(148,163,184,0.16)] bg-[var(--white-3)] px-3 py-3 text-[14px] leading-[1.6]"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -44,7 +44,7 @@ const TONE_PALETTES: Record<DistributionTone, TonePalette> = {
   muted: {
     fill: 'rgba(148,163,184,0.85)',
     text: 'var(--text-muted)',
-    chipBg: 'rgba(148,163,184,0.12)',
+    chipBg: 'var(--slate-gray-12)',
     chipBorder: 'rgba(148,163,184,0.24)',
   },
 }

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -13,7 +13,7 @@ interface StatTileProps {
 const VARIANT_STYLES = {
   default: 'bg-[var(--white-4)] border-[var(--card-border)] text-[var(--text-strong)]',
   gold: 'bg-[rgba(200,168,78,0.05)] border-[var(--ff-gold-10)] text-[var(--text-strong)]',
-  accent: 'bg-[var(--accent-soft)] border-[rgba(71,184,255,0.2)] text-[var(--text-strong)]',
+  accent: 'bg-[var(--accent-soft)] border-[var(--accent-20)] text-[var(--text-strong)]',
   warn: 'bg-[rgba(230,167,0,0.06)] border-[rgba(230,167,0,0.2)] text-[var(--warn)]',
 } as const
 

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -61,7 +61,7 @@ const INSIGHT_PANEL_CLS: Record<InsightTone, string> = {
   ok: 'border-[var(--white-8)] bg-[var(--white-2)]',
   info: 'border-[var(--white-8)] bg-[var(--white-2)]',
   warn: 'border-[rgba(245,158,11,0.45)] bg-[rgba(245,158,11,0.04)] shadow-[0_0_0_1px_rgba(245,158,11,0.15)_inset]',
-  error: 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_rgba(239,68,68,0.2)_inset]',
+  error: 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_var(--bad-20)_inset]',
 }
 
 export function OperationalMeaningPanel({
@@ -286,7 +286,7 @@ export function HeroPhase({
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
 
   return html`
-    <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_rgba(71,184,255,0.2)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
+    <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_var(--accent-20)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
       role="status" aria-live="polite" aria-label=${`Keeper 상태: ${displayState(snapshot.phase)}${heldFor ? `, ${heldFor}` : ''}`}
       title=${STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase}
     >

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -295,7 +295,7 @@ export function SwimlaneTimeline({
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(245,158,11,0.45)]"></span>compact</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(167,139,250,0.5)]"></span>handoff</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(239,68,68,0.5)]"></span>alarm</span>
-        <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm border border-[var(--white-8)] bg-[rgba(255,255,255,0.04)]"></span>idle</span>
+        <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm border border-[var(--white-8)] bg-[var(--white-3)]"></span>idle</span>
       </div>
     </div>
   `
@@ -408,7 +408,7 @@ export function TransitionTrail({
           const inSegment = isTransitionInSegment(entry, hoveredSegment)
           const dimmed = hoveredSegment != null && !inSegment
           const rowCls = inSegment
-            ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-1'
+            ? 'bg-[var(--accent-10)] ring-1 ring-[var(--accent-30)] rounded px-1'
             : ''
           const reason = inferTransitionReason(entry.field, entry.from, entry.to)
           const tooltip = reason
@@ -469,7 +469,7 @@ export function TopTransitionsPanel({
           const dimmed = hoveredSegment != null && !matchesHover
           const widthPct = Math.max(4, Math.round((entry.count / maxCount) * 100))
           const rowCls = matchesHover
-            ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-1'
+            ? 'bg-[var(--accent-10)] ring-1 ring-[var(--accent-30)] rounded px-1'
             : ''
           return html`
             <div
@@ -543,7 +543,7 @@ export function DwellHistogramPanel({
                     && hoveredSegment.field === lane.field
                     && hoveredSegment.value === entry.value
                   const rowCls = highlighted
-                    ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-0.5'
+                    ? 'bg-[var(--accent-10)] ring-1 ring-[var(--accent-30)] rounded px-0.5'
                     : ''
                   return html`
                     <div

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -195,7 +195,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
 
   return html`
     <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
-      <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
+      <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
         <div class="min-w-[220px] flex-1">
           <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
           <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${name}</div>
@@ -213,7 +213,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
             value=${query}
             onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
           />
-          <span class="inline-flex items-center rounded-sm border border-[rgba(71,184,255,0.2)] bg-[var(--accent-10)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">
+          <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">
             ${hasQuery ? `${filteredMessages.length} / ${messages.length}개 메시지` : `${messages.length}개 메시지`}
           </span>
         </div>
@@ -236,7 +236,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
         ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-[12px] leading-[1.6] text-[var(--bad-light)]">${chatError.value}</div>`
         : null}
 
-      <div class="border-t border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-4 py-4">
+      <div class="border-t border-[var(--slate-gray-12)] bg-[var(--white-3)] px-4 py-4">
         <${ChatComposer}
           draft=${chatInput.value}
           placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : '메시지 입력...'}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -95,8 +95,8 @@ type KpiTone = 'default' | 'ok' | 'warn' | 'bad'
 
 const KPI_TONE: Record<KpiTone, string> = {
   default: 'border-[var(--card-border)] bg-[var(--white-3)]',
-  ok: 'border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.06)]',
-  warn: 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.06)]',
+  ok: 'border-[var(--ok-20)] bg-[rgba(74,222,128,0.06)]',
+  warn: 'border-[var(--warn-20)] bg-[rgba(251,191,36,0.06)]',
   bad: 'border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)]',
 }
 
@@ -260,9 +260,9 @@ function OutcomesLedger({ keeper, outcomes }: {
         </div>
         ${(successes.compactions_ok > 0 || successes.handoffs_ok > 0 || failures.compaction_failed > 0 || failures.handoff_failed > 0) ? html`
           <div class="mt-2 flex flex-wrap gap-1.5 text-[10px]">
-            ${successes.compactions_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.06)] text-[var(--ok)]">압축 ${successes.compactions_ok}</span>` : null}
+            ${successes.compactions_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[rgba(74,222,128,0.06)] text-[var(--ok)]">압축 ${successes.compactions_ok}</span>` : null}
             ${failures.compaction_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)] text-[var(--bad)]">압축 실패 ${failures.compaction_failed}</span>` : null}
-            ${successes.handoffs_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.06)] text-[var(--ok)]">인계 ${successes.handoffs_ok}</span>` : null}
+            ${successes.handoffs_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[rgba(74,222,128,0.06)] text-[var(--ok)]">인계 ${successes.handoffs_ok}</span>` : null}
             ${failures.handoff_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)] text-[var(--bad)]">인계 실패 ${failures.handoff_failed}</span>` : null}
           </div>
         ` : null}
@@ -316,9 +316,9 @@ function OutcomesLedger({ keeper, outcomes }: {
         <div class="flex flex-wrap gap-1.5 text-[11px]">
           <span class="px-2 py-0.5 rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] tabular-nums">세대 ${keeper.generation ?? '-'}</span>
           <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.crashes > 0 ? 'border border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)] text-[var(--bad)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>크래시 ${failures.crashes}회</span>
-          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.restarts > 0 ? 'border border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.06)] text-[var(--warn)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>재시작 ${failures.restarts}회</span>
+          <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.restarts > 0 ? 'border border-[var(--warn-20)] bg-[rgba(251,191,36,0.06)] text-[var(--warn)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>재시작 ${failures.restarts}회</span>
           ${failures.consecutive_fail_current > 0 ? html`
-            <span class="px-2 py-0.5 rounded-sm border border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.06)] text-[var(--warn)] tabular-nums">연속 실패 ${failures.consecutive_fail_current}</span>
+            <span class="px-2 py-0.5 rounded-sm border border-[var(--warn-20)] bg-[rgba(251,191,36,0.06)] text-[var(--warn)] tabular-nums">연속 실패 ${failures.consecutive_fail_current}</span>
           ` : null}
         </div>
       </div>
@@ -1040,7 +1040,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
         <div class="flex items-center justify-between mb-1.5">
           <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
           <span class="flex items-center gap-2">
-            ${fallbackCount > 0 ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(239,68,68,0.15)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
+            ${fallbackCount > 0 ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-soft)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </span>
         </div>
@@ -1083,14 +1083,14 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
 
       ${'' /* Cascade fallback events */}
       ${fallbackCount > 0 ? html`
-        <div class="md:col-span-2 p-3 rounded border border-[rgba(239,68,68,0.2)] bg-[rgba(239,68,68,0.04)]">
+        <div class="md:col-span-2 p-3 rounded border border-[var(--bad-20)] bg-[rgba(239,68,68,0.04)]">
           <div class="flex items-center justify-between mb-1.5">
             <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Cascade Fallback</span>
             <span class="text-[10px] text-[var(--bad)]">${fallbackCount}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${series.filter((p: KeeperMetricPoint) => p.fallback_applied).slice(-10).map((p: KeeperMetricPoint) => html`
-              <span class="text-[10px] px-2 py-0.5 rounded-sm bg-[rgba(239,68,68,0.1)] text-[var(--bad)] border border-[rgba(239,68,68,0.2)] font-mono">
+              <span class="text-[10px] px-2 py-0.5 rounded-sm bg-[var(--bad-10)] text-[var(--bad)] border border-[var(--bad-20)] font-mono">
                 ${p.fallback_from ?? '?'} -> ${p.fallback_to ?? p.model_used}${p.fallback_reason ? ` (${p.fallback_reason.length > 20 ? p.fallback_reason.slice(0, 20) + '...' : p.fallback_reason})` : ''}
               </span>
             `)}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -259,7 +259,7 @@ function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; e
 
   if (isRunning) return html`
     <button type="button"
-      class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+      class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[var(--bad-soft)] transition-colors"
       onClick=${() => {
         void (async () => {
           const confirmed = await requestConfirm({
@@ -565,7 +565,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
           >새로고침</button>
           <button
             type="button"
-            class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[#fb7185] hover:bg-[var(--bad-soft)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${deleting || selectedIds.length === 0}
             onClick=${deleteSelected}
           >${deleting ? '삭제 중...' : `선택 삭제 (${selectedIds.length})`}</button>
@@ -983,7 +983,7 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
 
         ${latestEntry
           ? html`
-            <div class="rounded border border-[rgba(71,184,255,0.2)] bg-[rgba(71,184,255,0.08)] p-3 mb-3">
+            <div class="rounded border border-[var(--accent-20)] bg-[rgba(71,184,255,0.08)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-1">
                 <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]">Latest Handoff</span>
                 <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">
@@ -1249,7 +1249,7 @@ export function KeeperDetailOverlay() {
                   const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
                   const display = lastUsed || keeper.active_model || keeper.model
                   return display ? html`
-                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.2)]"
+                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
                       title=${lastUsed && keeper.model ? `마지막 호출: ${lastUsed}\n설정: ${keeper.model}` : ''}
                     >${display}</span>
                   ` : null
@@ -1305,7 +1305,7 @@ export function KeeperDetailOverlay() {
           <div class="flex items-center gap-2">
             <button
               type="button"
-              class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+              class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[var(--bad-soft)] transition-colors"
               onClick=${() => setClearDialogOpen(true)}
             >비우기</button>
             <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -57,8 +57,8 @@ function coverageColor(coverage: number): string {
 }
 
 function coverageTone(coverage: number): string {
-  if (coverage >= 0.9) return 'border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.06)]'
-  if (coverage >= 0.6) return 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.06)]'
+  if (coverage >= 0.9) return 'border-[var(--ok-20)] bg-[rgba(74,222,128,0.06)]'
+  if (coverage >= 0.6) return 'border-[var(--warn-20)] bg-[rgba(251,191,36,0.06)]'
   return 'border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)]'
 }
 

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -143,7 +143,7 @@ export function KeeperMemoryTierPanel({
           KMC ${compactionStage}
         </span>
         ${isCompacting ? html`
-          <span class="inline-flex items-center rounded-sm border border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.1)] px-2 py-0.5 text-[#f59e0b]">
+          <span class="inline-flex items-center rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] px-2 py-0.5 text-[#f59e0b]">
             compacting
           </span>
         ` : null}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -138,7 +138,7 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
   if (hydrating) {
     return 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--text-strong)]'
   }
-  return 'border-[rgba(148,163,184,0.18)] bg-[rgba(148,163,184,0.08)] text-[var(--text-body)]'
+  return 'border-[rgba(148,163,184,0.18)] bg-[var(--slate-gray-8)] text-[var(--text-body)]'
 }
 
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
@@ -291,7 +291,7 @@ export function KeeperConversationPanel({
   return html`
     <div class="flex flex-col gap-3">
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
-        <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
+        <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
           <div class="min-w-[220px] flex-1">
             <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
@@ -362,7 +362,7 @@ export function KeeperConversationPanel({
             `
           : null}
 
-        <div class="border-t border-[rgba(148,163,184,0.12)] bg-[var(--white-3)] px-4 py-4">
+        <div class="border-t border-[var(--slate-gray-12)] bg-[var(--white-3)] px-4 py-4">
           <${ChatComposer}
             draft=${draft}
             placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : placeholder}
@@ -401,9 +401,9 @@ export function KeeperRuntimeActions({
 
   const btnBase = 'py-1.5 px-4 rounded text-xs font-medium cursor-pointer transition-colors border'
   const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`
-  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.2)]`
-  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[var(--warn)] hover:bg-[rgba(251,191,36,0.15)]`
-  const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[rgba(251,191,36,0.15)] text-[var(--warn)] hover:bg-[rgba(251,191,36,0.2)]`
+  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[var(--accent)] hover:bg-[var(--accent-20)]`
+  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[var(--warn-10)] text-[var(--warn)] hover:bg-[var(--warn-soft)]`
+  const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[var(--warn-soft)] text-[var(--warn)] hover:bg-[var(--warn-20)]`
 
   return html`
     <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -70,7 +70,7 @@ function transitionType(selectedEvent: unknown): string {
 function badgeTone(ok: boolean): string {
   return ok
     ? 'border-[rgba(34,197,94,0.24)] bg-[rgba(34,197,94,0.08)] text-[var(--ok)]'
-    : 'border-[rgba(239,68,68,0.24)] bg-[rgba(239,68,68,0.10)] text-[var(--bad)]'
+    : 'border-[rgba(239,68,68,0.24)] bg-[var(--bad-10)] text-[var(--bad)]'
 }
 
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -38,7 +38,7 @@ function registryStateBadge(state: string | null) {
   if (!state) return null
   const colors: Record<string, { bg: string; text: string }> = {
     Running: { bg: 'bg-[rgba(34,197,94,0.12)]', text: 'text-[var(--ok)]' },
-    Crashed: { bg: 'bg-[rgba(239,68,68,0.15)]', text: 'text-[var(--bad)]' },
+    Crashed: { bg: 'bg-[var(--bad-soft)]', text: 'text-[var(--bad)]' },
     Dead: { bg: 'bg-[rgba(100,116,139,0.15)]', text: 'text-[#94a3b8]' },
     Stopped: { bg: 'bg-[rgba(234,179,8,0.12)]', text: 'text-[var(--warn)]' },
     Paused: { bg: 'bg-[var(--white-10)]', text: 'text-[var(--purple)]' },
@@ -161,7 +161,7 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
           </div>
         ` : null}
         ${dead_since ? html`
-          <div class="py-2 px-3 rounded bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] text-xs text-[#fb7185]">
+          <div class="py-2 px-3 rounded bg-[rgba(239,68,68,0.06)] border border-[var(--bad-soft)] text-xs text-[#fb7185]">
             ${formatTimeAgo(dead_since)} 이후 중단됨. 재기동 필요.
           </div>
         ` : null}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -178,7 +178,7 @@ function sourceTone(source: string): string {
     case 'legacy_traceln':
       return 'text-[#ffd88a] bg-[rgba(230,167,0,0.12)] border-[rgba(230,167,0,0.18)]'
     default:
-      return 'text-[var(--text-muted)] bg-[rgba(255,255,255,0.04)] border-[var(--white-10)]'
+      return 'text-[var(--text-muted)] bg-[var(--white-3)] border-[var(--white-10)]'
   }
 }
 
@@ -267,7 +267,7 @@ function renderLogRow(entry: LogEntry) {
           ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
           : null}
         ${clientName
-          ? html`<span class="rounded-sm border border-[rgba(71,184,255,0.16)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
+          ? html`<span class="rounded-sm border border-[var(--accent-soft)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
           ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px]"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
@@ -363,12 +363,12 @@ export function LogViewer() {
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
       <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
-        <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
+        <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[var(--white-5)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <select
               name="log-level"
               aria-label="로그 레벨"
-              class="logs-select rounded border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${levelFilter.value}
               onChange=${(e: Event) => {
                 levelFilter.value = (e.target as HTMLSelectElement).value
@@ -405,7 +405,7 @@ export function LogViewer() {
             <select
               name="log-limit"
               aria-label="로그 개수"
-              class="logs-select rounded border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${String(logLimit.value)}
               onChange=${(e: Event) => {
                 logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -420,7 +420,7 @@ export function LogViewer() {
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
-            <span class="rounded-sm border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
+            <span class="rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
                 type="checkbox"

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -219,7 +219,7 @@ function NewPostForm() {
           onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
         >취소</button>
         <button type="button"
-          class="px-4 py-1.5 rounded text-[13px] font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[rgba(71,184,255,0.2)] disabled:opacity-50"
+          class="px-4 py-1.5 rounded text-[13px] font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
           disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
           onClick=${() => { void submitNewPost() }}
         >${newPostSubmitting.value ? '등록 중...' : '등록'}</button>
@@ -299,7 +299,7 @@ function SortBar() {
         <div class="ml-auto flex items-center gap-2">
           ${selectedPostIds.value.size > 0 ? html`
             <button type="button"
-              class="px-3 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[rgba(239,68,68,0.2)] disabled:opacity-50 disabled:cursor-not-allowed"
+              class="px-3 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[var(--bad-20)] disabled:opacity-50 disabled:cursor-not-allowed"
               onClick=${bulkDeleteSelected}
               disabled=${bulkDeleting.value}
             >
@@ -448,7 +448,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
           <!-- Delete button -->
           <button type="button"
-            class="ml-auto px-2 py-0.5 rounded text-[10px] font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[rgba(239,68,68,0.2)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="ml-auto px-2 py-0.5 rounded text-[10px] font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${handleDelete}
             disabled=${isDeleting}
           >

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -191,7 +191,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
 
   const titleLabel = isErr ? 'Error' : 'Result'
   const titleColor = isErr ? 'text-[var(--bad)]' : 'text-[var(--text-muted)]'
-  const borderColor = isErr ? 'border-[rgba(239,68,68,0.2)]' : 'border-[var(--white-8)]'
+  const borderColor = isErr ? 'border-[var(--bad-20)]' : 'border-[var(--white-8)]'
   const bgColor = isErr ? 'bg-[rgba(239,68,68,0.04)]' : 'bg-[var(--white-3)]'
 
   const MAX_TEXT_LEN = 100000
@@ -402,7 +402,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const responseText = typeof d.response_text === 'string' ? d.response_text : ''
     const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--ok)]' : 'text-[var(--warn)]'
     return html`
-      <div class="mt-2 px-3 py-2 rounded bg-[rgba(34,211,238,0.04)] border border-[rgba(34,211,238,0.12)] space-y-1">
+      <div class="mt-2 px-3 py-2 rounded bg-[rgba(34,211,238,0.04)] border border-[var(--cyan-12)] space-y-1">
         <div class="flex items-center gap-3 text-[12px] flex-wrap">
           <span><span class="text-[var(--text-dim)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
           <span><span class="text-[var(--text-dim)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
@@ -423,7 +423,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const domain = typeof d.error_domain === 'string' ? d.error_domain : 'unknown'
     const errorDetail = typeof d.detail === 'string' ? d.detail : ''
     return html`
-      <div class="mt-2 px-3 py-2 rounded bg-[rgba(239,68,68,0.04)] border border-[rgba(239,68,68,0.15)] space-y-1">
+      <div class="mt-2 px-3 py-2 rounded bg-[rgba(239,68,68,0.04)] border border-[var(--bad-soft)] space-y-1">
         <div class="text-[12px]"><span class="text-[var(--text-dim)]">도메인:</span> <span class="font-mono text-[var(--bad)]">${domain}</span></div>
         ${errorDetail ? html`<div class="text-[11px] font-mono text-[var(--text-body)] break-all">${errorDetail}</div>` : null}
       </div>

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -225,7 +225,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
       </div>
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
         ${bars.map(b => html`
-          <rect x="${b.x.toFixed(1)}" y="${b.y.toFixed(1)}" width="${b.w.toFixed(1)}" height="${b.h.toFixed(1)}" fill="${b.failures > 0 ? 'rgba(239,68,68,0.3)' : 'rgba(74,222,128,0.15)'}" rx="0.5" />
+          <rect x="${b.x.toFixed(1)}" y="${b.y.toFixed(1)}" width="${b.w.toFixed(1)}" height="${b.h.toFixed(1)}" fill="${b.failures > 0 ? 'rgba(239,68,68,0.3)' : 'var(--ok-soft)'}" rx="0.5" />
         `)}
         <polyline points="${rateLine}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
       </svg>


### PR DESCRIPTION
## Why
Anyang Sleepers Design System: 인라인 색상 리터럴은 디자인 시스템이 큐레이트하는 동일 semantic palette로 수렴해야 함. inline `rgba()` 산포 → CSS variable로 정리.

Phase A는 **가장 안전한 케이스**만 처리: 이미 `dashboard/src/styles/variables.css`에 정의된 변수와 RGB+alpha가 정확히 일치하는 경우.

## What
| Literal pattern | Token |
|-----------------|-------|
| `rgba(71,184,255, .10/.16/.20/.30)` | `--accent-{10,soft,20,30}` |
| `rgba(74,222,128, .10/.15/.20)` | `--ok-{10,soft,20}` |
| `rgba(251,191,36, .10/.15/.20)` | `--warn-{10,soft,20}` |
| `rgba(239,68,68,  .10/.15/.20)` | `--bad-{10,soft,20}` |
| `rgba(255,255,255, .04/.06/.11/.21/.50/.70/.80/.90)` | `--white-{3,5,10,20,50,70,80,90}` |
| `rgba(34,211,238, .12/.16)` | `--cyan-{12,16}` |
| `rgba(200,168,78, .08/.10/.15/.20)` | `--ff-gold-{8,10,15,20}` |
| `rgba(148,163,184, .08/.10/.12/.15/.20)` | `--slate-gray-{8,10,12,15,20}` |
| `rgba(10,22,40, .44/.60)` | `--ff-navy-{44,60}` |
| `rgba(96,165,250, .08/.15)` | `--blue-400-{8,15}` |
| `rgba(226,232,240, .72)` | `--frost-72` |
| `rgba(15,23,42, .60)` | `--panel-dark-60` |

**Scope:** 71 replacements / 21 files.

## Skipped (Phase B 대상)
정확 매칭 안 되는 off-alpha:
- `rgba(71,184,255,0.45)` ×14 — focus-ring 같은 강한 강조
- `rgba(71,184,255,0.36)` ×9, `0.18` ×5, `0.15` ×9 — 중간 강도
- `rgba(255,255,255,0.02)` ×11 — 매우 옅은 surface tint
- `rgba(7,12,20,0.82)`, `rgba(10,18,34,0.95)` — backdrop overlays
- `rgba(244,63,94,...)` — pink-red (slate-rose, 매핑 없음)

→ Phase B에서 신규 토큰 추가 또는 nearest existing으로 normalize.

## Verification
- `pnpm typecheck` ✅
- `pnpm test` — 235 files / **3790 tests** all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)