### PR TITLE
fix(governance-judge): emit cycle logs and bound build_facts by bridge timeout

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -304,11 +304,15 @@ let prompt_for_facts facts_json =
 let compute_judgments
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
-    ~factual_json =
+    ~build_facts =
   let timeout_s = Float.of_int Env_config.Inference.dashboard_governance_judge_timeout_seconds in
-  let prompt = prompt_for_facts factual_json in
   match
+    (* build_facts() is moved inside the bridge so a deadlock in
+       factual_snapshot_json / get_agents_status is bounded by [timeout_s]
+       rather than hanging the daemon fiber indefinitely (#8319). *)
     Masc_oas_bridge.run_safe ~timeout_s (fun () ->
+      let factual_json = build_facts () in
+      let prompt = prompt_for_facts factual_json in
       Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~approval:Approval_callbacks.auto_approve
@@ -365,7 +369,11 @@ let refresh_once ~sw ~net
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~base_path ~build_facts =
   let st = get_state base_path in
-  if should_backoff ~sw ~net then
+  (* Cycle-start log so an operator can confirm the daemon fiber is alive.
+     Previously every branch was silent in steady state — a hung daemon was
+     indistinguishable from a healthy one producing zero events (#8319). *)
+  Log.Governance.debug "refresh_once: cycle start";
+  if should_backoff ~sw ~net then begin
     let was_online =
       with_lock st (fun () ->
           let was_online = st.judge_online in
@@ -376,10 +384,16 @@ let refresh_once ~sw ~net
     in
     if was_online then
       Log.Governance.info "backoff: local slots saturated, skipping cycle"
+    else
+      Log.Governance.debug "backoff: local slots saturated (first cycle)"
+  end
   else begin
     with_lock st (fun () -> st.refreshing <- true);
-    match compute_judgments ~masc_tools ~dispatch ~factual_json:(build_facts ()) with
+    match compute_judgments ~masc_tools ~dispatch ~build_facts with
     | Ok (model_used, generated_at, expires_at, judgments) ->
+        Log.Governance.info
+          "refresh_once: ok model=%s judgments=%d"
+          model_used (List.length judgments);
         append_judgments base_path judgments;
         with_lock st (fun () ->
             st.refreshing <- false;
@@ -394,6 +408,9 @@ let refresh_once ~sw ~net
               (fun json -> Hashtbl.replace st.judgments (judgment_key json) json)
               judgments)
     | Error message ->
+        Log.Governance.warn
+          "refresh_once: compute_judgments failed: %s"
+          message;
         with_lock st (fun () ->
             st.refreshing <- false;
             st.judge_online <- false;


### PR DESCRIPTION
## 요약

Governance judge daemon이 Subsystem_health에는 `alive`로 찍히지만 실제로는 **refresh_once 본문에 진입하지 못하는 증상**을 해결. 관찰 근거:

- 직전 24시간 system_log의 `Governance` 모듈 엔트리 20건 **전부** startup `pipeline installed` — `dashboard_governance_judge.ml`에서 나온 cycle 로그 0건.
- `judge_online=false`, `last_error=null` 지속 → refresh_once의 backoff / success / error branch 전부 미실행.
- 여러 서버 인스턴스(06:14, 06:25, 06:38 UTC 재시작) 모두 동일 패턴.

## Root cause (2 layers)

### 1. refresh_once가 silent in every branch
- backoff 진입 시: `if was_online then Log.Governance.info ...` — 첫 cycle은 항상 was_online=false → 영영 로그 없음.
- compute_judgments Ok: 로그 없음.
- compute_judgments Error: `st.last_error <- Some message` — 로그 없음.

운영자는 daemon이 hang인지 정상 silence인지 구분 불가.

### 2. build_facts()가 bridge 타임아웃 밖에서 평가
```ocaml
(* 수정 전 *)
match compute_judgments ~factual_json:(build_facts ()) with
```

`build_facts()`는 `Dashboard_governance.factual_snapshot_json` + `Coord.get_agents_status`를 호출 — 둘 다 I/O heavy, shared mutex 가능성. `Masc_oas_bridge.run_safe`의 `Eio.Time.with_timeout_exn`은 OAS 호출만 감싸고, 인자 평가 시점의 build_facts는 안 감쌈. Deadlock 시 daemon이 timeout 없이 영영 hang, 그래서 Log.Governance도 끝까지 찍히지 않음.

## 변경

`lib/dashboard/dashboard_governance_judge.ml` 한 파일, +21/-4:

1. **compute_judgments 시그니처**: `~factual_json` → `~build_facts`. 호출 측은 refresh_once 한 곳뿐이라 영향 좁음.
2. **bridge closure 안에서 build_facts() 실행**: I/O phase도 `dashboard_governance_judge_timeout_seconds`로 bound.
3. **refresh_once에 로그 추가**:
   - 진입점 `debug "cycle start"`
   - 첫 cycle backoff `debug` (기존 info 트랜지션 로그는 유지)
   - 성공 `info "refresh_once: ok model=... judgments=..."`
   - 실패 `warn "refresh_once: compute_judgments failed: ..."`

## 검증

- `dune build @check` pass
- `dune exec test/test_ci_hardening_source.exe` — 33/33 pass (기존 pattern check 깨지지 않음)
- 기존 invariant: `local_capacity_for_selections ~sw ~net` 및 `[ "governance_judge" ]` 문자열 모두 유지

## 남은 후속 (별도 PR)

- `cascade.json`에 `governance_judge_*` 키 추가 필요 (현재 `default` cascade로 fallback — 내부 구성 따라 GLM DNS 실패 가능). 로컬 파일엔 임시 추가 상태.
- 기본 cascade fallback 자체에 warn 1회성 로그 추가 제안 (#8319에서 3차 layer로 언급).

Refs #8319

🤖 Generated with [Claude Code](https://claude.com/claude-code)