### PR TITLE
fix(coord_task): preserve observability for release-on-todo no-op

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -789,7 +789,12 @@ let transition_task_r config ~agent_name ~task_id ~action
         | Types.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
             Ok (Types.Todo, None)
         | Types.Release, Types.Todo ->
-            (* Idempotent: already in backlog, nothing to release. *)
+            (* Idempotent: already in backlog, nothing to release.
+               Logged at debug so that callers passing a wrong task_id
+               (e.g. confused the target of a multi-task release) can
+               still detect the no-op without seeing it as an error. *)
+            Log.RoomTask.debug
+              "release on already-todo task %s — no-op" task_id;
             Ok (task.task_status, None)
         | Types.Start, Types.Claimed { assignee; _ } when assignee = agent_name || force ->
             Ok (Types.InProgress {


### PR DESCRIPTION
## 동기

#8314 (`Normalize masc_transition alias inputs`) self-review red-team에서 지적한 silent-success path 보강.

`Release` on `Todo` task가 idempotent no-op으로 정의돼 노이즈는 줄지만, caller가 잘못된 task_id를 넘겼을 때(예: race로 이미 todo로 돌아간 다른 task) 호출자는 성공이라고 믿게 됨.

## 변경

`lib/coord/coord_task.ml`의 `Release, Todo` arm에 `Log.RoomTask.debug`를 추가해 idempotent 동작을 보존하면서 관찰 가능성을 회복.

```ocaml
| Types.Release, Types.Todo ->
    Log.RoomTask.debug
      "release on already-todo task %s — no-op" task_id;
    Ok (task.task_status, None)
```

- 정상적인 double-release: 호출자는 성공을 받음 (#8314 의도 유지)
- Wrong task_id를 받은 release: debug 로그로 흔적 남음 → 운영자가 패턴 매치로 감지 가능

근거: #8314의 self-review 코멘트 (https://github.com/jeong-sik/masc-mcp/pull/8314).

## 테스트

기존 `Release/Todo` no-op 테스트는 영향 없음 (return value 동일). debug 로그는 별도 assertion 없이 silent.
