### PR TITLE
[task-226] Fix masc_join nickname suffix breaking tool auth

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1629,8 +1629,10 @@ let keeper_name_from_agent_name agent_name =
     let keeper_name = String.sub agent_name plen (alen - plen - slen) in
     if validate_name keeper_name then Some keeper_name else None
   else
-    (* Fallback: treat agent_name as raw nickname (e.g., "claude-swift-fox") *)
-    if validate_name agent_name then Some agent_name else None
+    (* Only generated nicknames should alias directly to keeper names. *)
+    if Nickname.is_generated_nickname agent_name && validate_name agent_name
+    then Some agent_name
+    else None
 ;;
 
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1625,10 +1625,12 @@ let keeper_name_from_agent_name agent_name =
      && String.sub agent_name 0 plen = prefix
      && String.sub agent_name (alen - slen) slen = suffix
   then
+    (* Full keeper-xxx-agent format *)
     let keeper_name = String.sub agent_name plen (alen - plen - slen) in
     if validate_name keeper_name then Some keeper_name else None
   else
-    None
+    (* Fallback: treat agent_name as raw nickname (e.g., "claude-swift-fox") *)
+    if validate_name agent_name then Some agent_name else None
 ;;
 
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -288,6 +288,11 @@ let test_keeper_name_from_agent_name_roundtrip () =
     "agent alias resolves to keeper name" (Some "sangsu")
     (Keeper_types.keeper_name_from_agent_name "keeper-sangsu-agent")
 
+let test_keeper_name_from_generated_nickname () =
+  Alcotest.(check (option string))
+    "generated nickname resolves directly" (Some "claude-swift-fox")
+    (Keeper_types.keeper_name_from_agent_name "claude-swift-fox")
+
 let test_keeper_name_from_agent_name_rejects_plain_name () =
   Alcotest.(check (option string))
     "plain keeper name is not treated as agent alias" None
@@ -339,6 +344,8 @@ let () =
       Alcotest.test_case "agent_name prefixed" `Quick test_keeper_agent_name_prefixed;
       Alcotest.test_case "agent alias roundtrip" `Quick
         test_keeper_name_from_agent_name_roundtrip;
+      Alcotest.test_case "generated nickname is alias" `Quick
+        test_keeper_name_from_generated_nickname;
       Alcotest.test_case "plain name is not alias" `Quick
         test_keeper_name_from_agent_name_rejects_plain_name;
     ]);


### PR DESCRIPTION
## Summary
When masc_join generates nicknames (e.g., "claude-swift-fox"), the auth system fails because it expects "keeper-xxx-agent" format. This fix makes keeper_name_from_agent_name handle both formats:
- Full format: keeper-xxx-agent (old behavior)
- Raw nickname: xxx-yyy-zzz (new fallback)

## Testing
- Nicknames without suffix now pass auth validation
- Full keeper-xxx-agent format still supported (backward compat)
- validate_name() check preserved for both paths

## Related
Fixes #8116 (implied from task description)