### PR TITLE
refactor(dashboard): inline rgba → CSS tokens (Phase B, accent off-alpha)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -101,12 +101,12 @@ export function App() {
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
       <header class="relative z-10 shrink-0 border-b border-[var(--white-5)] bg-[rgba(8,14,26,0.36)] px-4 py-1.5 backdrop-blur-xl">
-        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
+        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
         <div class="flex w-full items-center justify-between gap-3 max-[900px]:flex-col max-[900px]:items-stretch">
           <div class="min-w-0 flex items-center gap-3">
             <div class="flex shrink-0 items-center gap-2">
               <button type="button"
-                class="hidden max-[768px]:flex size-9 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+                class="hidden max-[768px]:flex size-9 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 aria-controls="dashboard-side-rail"

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -142,11 +142,11 @@ export function AgentTimelineSection() {
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
-          ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
-          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+          ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
+          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
         </div>
       ` : null}
       ${events.length === 0

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -42,7 +42,7 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
           <div class="flex items-baseline gap-2 text-[13px]">
             <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
+            ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -275,7 +275,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-[13px] font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+              class="px-4 py-2 text-[13px] font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
               onClick=${closeAgentDetail}
             >
               닫기

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -365,7 +365,7 @@ export function AgentProfile({ name }: { name: string }) {
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
                 <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded" key=${t.id}>
-                  <span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${t.id}</span>
+                  <span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${t.id}</span>
                   <span class="flex-1 text-[var(--text-strong)]">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
@@ -457,7 +457,7 @@ export function AgentProfile({ name }: { name: string }) {
           <${Card} title="태스크 이력" class="ff-card rounded col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
-                <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
+                <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
                 <pre class="m-0 whitespace-pre-wrap text-[13px] leading-[1.5] text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -84,7 +84,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
             onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') handleSetToken() }}
           />
           <button type="button"
-            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
             onClick=${handleSetToken}
           >토큰 설정</button>
         </div>
@@ -101,7 +101,7 @@ export function RemoteWarningBanner() {
       <span>원격 접속이 감지되었습니다. Mutation 작업을 위해 Bearer token을 설정하세요.</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"
-          class="px-2 py-0.5 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[rgba(71,184,255,0.15)] cursor-pointer transition-colors"
+          class="px-2 py-0.5 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
           onClick=${() => { popoverOpen.value = true }}
         >토큰 입력</button>
         <button type="button"

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -29,7 +29,7 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   subtle: 'border-none bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)] hover:bg-[var(--white-6)]',
 }
 
-const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] active:scale-[0.97] active:opacity-90'
+const BASE = 'rounded cursor-pointer transition-all duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] active:scale-[0.97] active:opacity-90'
 
 interface ActionButtonProps {
   variant?: ButtonVariant

--- a/dashboard/src/components/common/checkbox.ts
+++ b/dashboard/src/components/common/checkbox.ts
@@ -12,7 +12,7 @@
 
 import { html } from 'htm/preact'
 
-const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
+const CHECKBOX_BASE = 'w-4 h-4 rounded border border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer transition-colors hover:bg-[var(--white-8)] hover:border-[var(--white-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] accent-[var(--accent)]'
 
 interface CheckboxProps {
   checked?: boolean

--- a/dashboard/src/components/common/id-pill.ts
+++ b/dashboard/src/components/common/id-pill.ts
@@ -29,7 +29,7 @@
 // • agent-detail:230 (agent.model) — mono neutral pill with
 //   reversed opacities to 228. P6.
 // • agent-detail-worker:45 (signal_truth) — `rounded-sm` with
-//   raw `rgba(71,184,255,0.36)` border. That is StatusChip
+//   raw `var(--accent-36)` border. That is StatusChip
 //   shape with an untypeable border, not IdPill shape. P6 when
 //   raw rgba colors resolve to CSS vars.
 //

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
+const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface TextInputProps {
   id?: string

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 
-const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
+const INPUT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] placeholder:text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]'
 
 interface NumberInputProps {
   value?: number | string

--- a/dashboard/src/components/common/scroll-to-top.ts
+++ b/dashboard/src/components/common/scroll-to-top.ts
@@ -70,7 +70,7 @@ export function ScrollToTopButton({
 
   return html`<button
     type="button"
-    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--bg-1)]/90 text-[var(--text-body)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)] cursor-pointer ${cx ?? ''}`}
+    class=${`fixed bottom-6 right-6 z-[var(--z-overlay-toast,3070)] flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--white-10)] bg-[var(--bg-1)]/90 text-[var(--text-body)] shadow-[0_6px_18px_rgba(0,0,0,0.32)] backdrop-blur transition-all duration-150 hover:border-[var(--accent-30)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)] cursor-pointer ${cx ?? ''}`}
     aria-label="맨 위로"
     title="맨 위로 (Home)"
     data-scroll-to-top

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -11,7 +11,7 @@
 
 import { html } from 'htm/preact'
 
-const SELECT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
+const SELECT_BASE = 'w-full rounded bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] transition-colors hover:bg-[var(--white-6)] focus-visible:bg-[var(--bg-0)] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.6)] focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] appearance-none cursor-pointer'
 
 interface SelectOption { value: string; label: string }
 

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -52,7 +52,7 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
         </div>
         <button
           type="button"
-          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-[10px] ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
+          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-[10px] ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
           disabled=${starting}
           aria-busy=${starting ? 'true' : 'false'}
           data-onboarding-start=${connectorId}

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -235,7 +235,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
     <div
       class=${`flex min-w-0 flex-col gap-3 rounded border bg-[var(--bg-1)] p-3 transition-colors ${
         selected
-          ? 'border-[var(--accent)] shadow-[0_0_0_1px_rgba(71,184,255,0.18)]'
+          ? 'border-[var(--accent)] shadow-[0_0_0_1px_var(--accent-18)]'
           : 'border-[var(--white-8)] hover:border-[var(--white-10)]'
       }`}
       data-overview-tile=${id}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -197,7 +197,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -356,7 +356,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+          class="flex size-7 items-center justify-center rounded text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -334,7 +334,7 @@ function KeeperClearContextDialog({
           <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
           <textarea
             ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[rgba(71,184,255,0.45)] focus:ring-2 focus:ring-[rgba(71,184,255,0.18)]"
+            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
             placeholder="예: stale continuity replay 제거"
             disabled=${pending}
             value=${reason}
@@ -433,7 +433,7 @@ function CheckpointSummaryCard({
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
       <div class="flex flex-wrap items-center gap-2">
         <span class="text-[12px] font-semibold text-[var(--text-strong)]">${title}</span>
-        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.18)]">
+        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
           gen ${summary.generation}
         </span>
         <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
@@ -615,7 +615,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                     <div class="min-w-0 flex-1">
                       <div class="flex flex-wrap items-center gap-2">
                         <span class="font-mono text-[var(--text-strong)]">${item.snapshot_id}</span>
-                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.18)]">
+                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
                           gen ${item.generation}
                         </span>
                         <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
@@ -767,7 +767,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
                       <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
-                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
+                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${r.branch}</span>
                       ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">shallow</span>` : null}
                     </div>
                     <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
@@ -786,7 +786,7 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
               ${prs.map(pr => html`
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                   <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
-                  <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${pr.branch}</span>
+                  <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${pr.branch}</span>
                   ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">draft</span>` : null}
                   <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
                 </div>
@@ -986,7 +986,7 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
             <div class="rounded border border-[var(--accent-20)] bg-[rgba(71,184,255,0.08)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-1">
                 <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]">Latest Handoff</span>
-                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">
+                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">
                   ${lineageTransitionLabel(latestEntry.parent_generation, latestEntry.generation)}
                 </span>
                 <span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(latestEntry.continuity_verdict)}">
@@ -1029,7 +1029,7 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-2">
                 <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Manifest</span>
-                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">gen ${manifest.generation}</span>
+                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${manifest.generation}</span>
                 ${continuity?.verdict
                   ? html`<span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(continuity.verdict)}">${continuityMeta.badgeLabel}</span>`
                   : null}
@@ -1095,9 +1095,9 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                   return html`
                   <div class=${`px-3 py-2 rounded border ${isLatest ? 'border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.08)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}>
                     <div class="flex flex-wrap items-center gap-2">
-                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">gen ${entry.generation}</span>
+                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${entry.generation}</span>
                       ${isLatest
-                        ? html`<span class="text-[10px] px-1.5 py-0.5 rounded border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.12)] text-[var(--accent)]">latest</span>`
+                        ? html`<span class="text-[10px] px-1.5 py-0.5 rounded border border-[var(--accent-18)] bg-[rgba(71,184,255,0.12)] text-[var(--accent)]">latest</span>`
                         : null}
                       ${entry.continuity_verdict
                         ? html`<span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(entry.continuity_verdict)}">${entryMeta.badgeLabel}</span>`
@@ -1313,7 +1313,7 @@ export function KeeperDetailOverlay() {
               ref=${closeButtonRef}
               type="button"
               onClick=${() => closeKeeperDetail()}
-              class="flex items-center justify-center size-8 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
+              class="flex items-center justify-center size-8 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1526]"
               aria-label="키퍼 상세 닫기"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -194,7 +194,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           <span class="font-mono font-medium text-[var(--text-strong)]">${s.totalEntries}</span> 호출
         </span>
         ${totalCost > 0 ? html`
-          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--accent-12)] border border-[rgba(71,184,255,0.15)] text-[var(--text-muted)]">
+          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--accent-12)] border border-[var(--accent-15)] text-[var(--text-muted)]">
             <span class="font-mono font-medium text-[var(--accent)]">$${totalCost.toFixed(3)}</span>
           </span>
         ` : null}

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -33,6 +33,17 @@
   --accent-10: rgba(71, 184, 255, 0.10);
   --accent-20: rgba(71, 184, 255, 0.20);
   --accent-30: rgba(71, 184, 255, 0.30);
+  /* Off-alpha accent tokens absorbed from Phase B inline-rgba sweep.
+     Same blue hue, opacity buckets that were already spread across
+     components. Naming follows the --accent-N (N = opacity %) convention.
+     Note: --accent-18 was previously pruned as unused; this PR reintroduces
+     it with 5 active callsites. */
+  --accent-15: rgba(71, 184, 255, 0.15);
+  --accent-18: rgba(71, 184, 255, 0.18);
+  --accent-36: rgba(71, 184, 255, 0.36);
+  /* --accent-45 reserved for focus-ring strength (high-contrast keyboard
+     focus halo). Distinct semantic from -30 so the role is grep-able. */
+  --accent-45: rgba(71, 184, 255, 0.45);
 
   /* Semantic - Success (Green) */
   --ok-soft: rgba(74, 222, 128, 0.15);


### PR DESCRIPTION
## Why
Phase A (#8321) handled exact-match `rgba` → 기존 token. 잔여 off-alpha 중 **가장 빈번한 4건** (accent 계열)을 정리.

신규 token 도입은 token bloat 위험이 있지만, 14×focus ring 같은 명확한 의미는 하드코드 산포보다 명명된 token이 더 안전.

## What
### 신규 token (variables.css)
| Token | Value | Callsites |
|-------|-------|-----------|
| `--accent-15` | `rgba(71, 184, 255, 0.15)` | 9 |
| `--accent-18` | `rgba(71, 184, 255, 0.18)` | 5 |
| `--accent-36` | `rgba(71, 184, 255, 0.36)` | 9 |
| `--accent-45` | `rgba(71, 184, 255, 0.45)` (focus ring) | 14 |

Naming: 기존 `--accent-{10,20,30}` 컨벤션 그대로 (N = opacity percentage).

### Sweep
- 37 replacements / 19 files
- `--accent-45`는 focus-ring strength로 의미적으로 구분 (-30과 별도 grep-able)

## Verification
- `pnpm typecheck` ✅
- `pnpm test` — 235 files / **3791 tests** all pass

## Phase C 잔여 (다음 사이클)
- backdrop overlays: `rgba(7,12,20,0.82)`, `rgba(10,18,34,0.95)` — `--backdrop-{soft,deep}`
- pink-rose: `rgba(244,63,94,*)` — `--rose-*` 신규 family
- warn off-alpha: `.08/.24`
- ok very light: `.06`
- white very light: `0.02` → 기존 `--white-2` alias로 normalize 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)