### PR TITLE
refactor(dashboard): inline rgba → CSS tokens (Phase C, surface overlays)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -710,7 +710,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${isKeeper ? html`
-                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),rgba(255,255,255,0.02))] px-3 py-2.5">
+                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
                     ${fsmPhaseKey

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -278,13 +278,13 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
             <table class="w-full text-xs">
               <thead>
                 <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">#</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">가설</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이전</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이후</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">변화</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-center py-2.5 px-3 font-medium">판정</th>
-                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-sm text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">#</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">가설</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이전</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이후</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">변화</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-center py-2.5 px-3 font-medium">판정</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
                 </tr>
               </thead>
               <tbody>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -322,7 +322,7 @@ export function ChatTranscript({
 
   return html`
     <div
-      class=${`chat-transcript flex min-h-[300px] max-h-[520px] flex-col overflow-y-auto border border-[rgba(148,163,184,0.14)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] ${
+      class=${`chat-transcript flex min-h-[300px] max-h-[520px] flex-col overflow-y-auto border border-[rgba(148,163,184,0.14)] shadow-[inset_0_1px_0_var(--white-3)] ${
         variant === 'messenger'
           ? 'gap-4 rounded-[26px] px-4 py-5 sm:px-5'
           : 'gap-3 rounded-[var(--radius-xl)] px-3 py-4'

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -121,7 +121,7 @@ function SummaryCard({
       ? 'border-[var(--ok-20)] bg-[var(--ok-10)]'
       : tone === 'warn'
         ? 'border-[var(--warn-20)] bg-[var(--warn-10)]'
-        : 'border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]'
+        : 'border-[var(--card-border)] bg-[var(--white-1)]'
 
   return html`
     <div class="rounded border ${toneClass} p-3">
@@ -157,14 +157,14 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
 
   if (watchlist.length === 0) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 text-[11px] text-[var(--text-dim)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-[11px] text-[var(--text-dim)]">
         No keepers are near context pressure or stale activity thresholds.
       </div>
     `
   }
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)]">
       ${watchlist.map(row => html`
         <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2 text-[11px] last:border-b-0">
           <div class="min-w-0">
@@ -310,7 +310,7 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
   return html`
     <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
       ${sorted.map(source => html`
-        <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3">
+        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3">
           <div class="flex items-center justify-between gap-3">
             <div class="text-[11px] font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
             <div class="font-mono text-[11px] ${sourceCountClass(source)}">

--- a/dashboard/src/components/fsm-hub-timeline-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.test.ts
@@ -18,10 +18,10 @@ describe('swimlaneSegmentColor', () => {
   })
 
   it('returns idle color for idle-like values', () => {
-    expect(swimlaneSegmentColor('idle')).toBe('bg-[rgba(255,255,255,0.07)]')
-    expect(swimlaneSegmentColor('undecided')).toBe('bg-[rgba(255,255,255,0.07)]')
-    expect(swimlaneSegmentColor('accumulating')).toBe('bg-[rgba(255,255,255,0.07)]')
-    expect(swimlaneSegmentColor('Stable')).toBe('bg-[rgba(255,255,255,0.07)]')
+    expect(swimlaneSegmentColor('idle')).toBe('bg-[var(--white-7)]')
+    expect(swimlaneSegmentColor('undecided')).toBe('bg-[var(--white-7)]')
+    expect(swimlaneSegmentColor('accumulating')).toBe('bg-[var(--white-7)]')
+    expect(swimlaneSegmentColor('Stable')).toBe('bg-[var(--white-7)]')
   })
 
   it('returns warn color for Compacting', () => {

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -55,7 +55,7 @@ const ALARM_VALUES = new Set([
 
 export function swimlaneSegmentColor(value: string): string {
   if (ALARM_VALUES.has(value)) return 'bg-[rgba(239,68,68,0.5)]'
-  if (IDLE_LIKE_VALUES.has(value)) return 'bg-[rgba(255,255,255,0.07)]'
+  if (IDLE_LIKE_VALUES.has(value)) return 'bg-[var(--white-7)]'
   if (value === 'Overflowed') return 'bg-[rgba(245,158,11,0.45)]'
   if (value === 'Compacting' || value === 'compacting') return 'bg-[rgba(245,158,11,0.45)]'
   if (value === 'HandingOff') return 'bg-[rgba(167,139,250,0.5)]'

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -786,7 +786,7 @@ function StatusBar({
               class=${`absolute inset-0 ${
                 observationCount >= MAX_OBSERVATIONS
                   ? 'bg-[rgba(245,158,11,0.08)]'
-                  : 'bg-[rgba(255,255,255,0.03)]'
+                  : 'bg-[var(--white-3)]'
               }`}
               style=${`width: ${Math.round((observationCount / MAX_OBSERVATIONS) * 100)}%`}
             ></span>

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -149,23 +149,23 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
 function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
-      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_goals}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">전체 목표</div>
       </div>
-      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.active_goals}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">진행 중</div>
       </div>
-      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_tasks}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">연결 태스크</div>
       </div>
-      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3 text-center">
+      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.done_tasks}</div>
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
       </div>
-      <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-3">
+      <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3">
         <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
         <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
       </div>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -40,7 +40,7 @@ function PlanningStat({
           : 'text-text-strong'
 
   return html`
-    <div class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+    <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
       <div class="mt-2 text-[30px] font-bold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
@@ -81,7 +81,7 @@ function GuideCard({
   children?: ComponentChildren
 }) {
   return html`
-    <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+    <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="flex items-start justify-between gap-3">
         <div>
           <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${eyebrow}</div>
@@ -237,7 +237,7 @@ export function Planning() {
         </div>
 
         <div class="mt-5 grid gap-4 xl:grid-cols-2">
-          <section class="rounded border border-card-border/60 bg-[rgba(7,12,20,0.82)] p-4">
+          <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
             <div class="mb-3">
               <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Backlog Entry</div>
               <h3 class="mt-1 text-[15px] font-semibold text-text-strong">태스크 추가</h3>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -450,7 +450,7 @@ function CheckpointSummaryCard({
         ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${summary.latest_preview}</div>`
         : null}
       ${summary.continuity_summary
-        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
+        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
         : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
     </div>
   `
@@ -633,7 +633,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                         ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${item.latest_preview}</div>`
                         : null}
                       ${item.continuity_summary
-                        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
+                        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
                         : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
                     </div>
                   </label>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -235,7 +235,7 @@ function renderLogRow(entry: LogEntry) {
   const failure = failureEnvelope(entry)
   const sourceClass = sourceTone(source)
   const renderedMessage = renderLogMessage(entry)
-  let backgroundClass = 'bg-[rgba(255,255,255,0.02)]'
+  let backgroundClass = 'bg-[var(--white-1)]'
   if (level === 'ERROR') {
     backgroundClass = 'bg-[rgba(224,80,80,0.08)]'
   } else if (level === 'WARN') {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -420,7 +420,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const hasData = src.entry_count > 0
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
       <div class="flex items-center gap-2 mb-1">
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
         <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
@@ -442,7 +442,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
   const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
       <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
       <div class="text-2xl font-bold ${toneColor}">${value}</div>
       <div class="text-[10px] text-[var(--text-dim)]">${detail}</div>
@@ -707,7 +707,7 @@ export function TelemetryUnified() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-4">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-4">
         <div class="text-[12px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Runtime Diagnosis</div>
         <div class="mt-1 text-[14px] leading-relaxed text-[var(--text-body)]">
           MASC telemetry store (keeper/tool/agent) 진단 뷰.
@@ -724,7 +724,7 @@ export function TelemetryUnified() {
 
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
+        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
           <div class="text-xs font-medium text-[var(--text-muted)] mb-1">전체</div>
           <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
         </div>
@@ -844,7 +844,7 @@ export function TelemetryUnified() {
             : ''}
         </div>
         ${condensed.groups > 0 ? html`
-          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] flex flex-wrap gap-2 text-[11px]">
+          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-1)] flex flex-wrap gap-2 text-[11px]">
             ${Array.from(condensed.byCategory.entries()).map(([category, count]) => {
               const meta = CONDENSED_CATEGORY_META[category]
               return html`

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -78,12 +78,20 @@
   --select-20: rgba(200, 168, 78, 0.22);
 
   /* Overlays (White Alpha) — bumped from 3/5 to 4/6 for clearer surface elevation */
+  --white-1: rgba(255, 255, 255, 0.02);
   --white-3: rgba(255, 255, 255, 0.04);
   --white-5: rgba(255, 255, 255, 0.06);
+  --white-7: rgba(255, 255, 255, 0.07);
   --white-10: rgba(255, 255, 255, 0.11);
   --white-20: rgba(255, 255, 255, 0.21);
   --white-50: rgba(255, 255, 255, 0.50);
   --white-80: rgba(255, 255, 255, 0.80);
+
+  /* Backdrop overlays — modal scrim & full-blocker. Distinct semantic
+     from --white-* (which are surface tints on top of dark). These are
+     dark scrims that dim the underlying content for modal/dialog focus. */
+  --backdrop-deep: rgba(7, 12, 20, 0.82);
+  --backdrop-modal: rgba(10, 18, 34, 0.95);
 
   /* Legacy Compatibility Variables — only aliases with active references kept.
      Dead aliases pruned: accent-8/12/14/18, ok-8/12/18/22/24/25/30/35/40/48,


### PR DESCRIPTION
## Why
Phase A/B (#8321/#8332)에 이어 surface overlay 계열 정리. 의미적으로 명확한 두 그룹 — surface tint(`--white-*`)와 modal scrim(`--backdrop-*`) 분리.

## What
### 신규 token (variables.css)
| Token | Value | Purpose | Callsites |
|-------|-------|---------|-----------|
| `--white-1` | `rgba(255,255,255,0.02)` | very-subtle surface lift | 11 |
| `--white-7` | `rgba(255,255,255,0.07)` | mid-light surface lift | 4+ |
| `--backdrop-deep` | `rgba(7,12,20,0.82)` | heavy modal scrim | 8 |
| `--backdrop-modal` | `rgba(10,18,34,0.95)` | opaque modal background | 7 |

### Sweep
- 31 replacements / 11 files

### Semantic distinction
Backdrop overlays는 `--white-*`와 의미가 다름:
- `--white-*`: dark surface 위에 **올리는** tint (elevation)
- `--backdrop-*`: 아래 content를 **가리는** scrim (modal/dialog focus)

같은 \"투명한 색\"이지만 역할이 반대 → 별도 token family.

### Test sync
- `fsm-hub-timeline-panels.test.ts` — `bg-[rgba(255,255,255,0.07)]` → `bg-[var(--white-7)]` (4 assertions)

## Verification
- `pnpm typecheck` ✅
- `pnpm test` — 235 files / 3791 tests pass

## Phase D 잔여
- pink-rose family: `rgba(244,63,94,*)` — needs `--rose-*`
- bad/warn/ok off-alpha: `.06/.08/.14/.24/.50`
- plum: `rgba(167,139,250,*)`
- emerald: `rgba(34,197,94,*)`
- pure black: `rgba(0,0,0,*)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)