### PR TITLE
refactor(keeper): single-source tool-call observability via OAS Event_bus

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -21,25 +21,6 @@ let on_keeper_tool_call
   =
   ref (fun ~tool_name:_ ~success:_ ~duration_ms:_ -> ())
 
-let tool_call_observers
-  : (keeper_name:string ->
-     tool_name:string ->
-     input:Yojson.Safe.t ->
-     success:bool ->
-     unit) list ref
-  = ref []
-
-let add_tool_call_observer fn =
-  tool_call_observers := fn :: !tool_call_observers
-
-let remove_tool_call_observer fn =
-  tool_call_observers := List.filter (fun f -> f != fn) !tool_call_observers
-
-let notify_tool_call_observers ~keeper_name ~tool_name ~input ~success =
-  List.iter
-    (fun f -> f ~keeper_name ~tool_name ~input ~success)
-    !tool_call_observers
-
 let tool_search_fn
   : (query:string -> max_results:int -> Yojson.Safe.t) ref
   =

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -101,34 +101,6 @@ val is_keeper_denied : string -> bool
 val on_keeper_tool_call :
   (tool_name:string -> success:bool -> duration_ms:int -> unit) ref
 
-(** Register a per-turn observer for tool call events.
-    Notifications are process-global, so observers that care about a specific
-    keeper turn must filter on [keeper_name]. *)
-val add_tool_call_observer :
-  (keeper_name:string ->
-   tool_name:string ->
-   input:Yojson.Safe.t ->
-   success:bool ->
-   unit) ->
-  unit
-
-(** Remove a previously registered observer (physical equality). *)
-val remove_tool_call_observer :
-  (keeper_name:string ->
-   tool_name:string ->
-   input:Yojson.Safe.t ->
-   success:bool ->
-   unit) ->
-  unit
-
-(** Notify all registered observers of a tool call event. *)
-val notify_tool_call_observers :
-  keeper_name:string ->
-  tool_name:string ->
-  input:Yojson.Safe.t ->
-  success:bool ->
-  unit
-
 (** Callback for keeper_tool_search BM25 search.
     Process-global fallback; prefer passing [~search_fn] to
     [execute_keeper_tool_call] for session-scoped, race-free search. *)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -222,11 +222,9 @@ let make_tools
                 Hashtbl.replace failure_counts key count;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
-                Keeper_exec_tools.notify_tool_call_observers
-                  ~keeper_name:meta.name
-                  ~tool_name:td.name
-                  ~input
-                  ~success:false;
+                (* Tool-call observability flows through the OAS Event_bus
+                   (ToolCalled + ToolCompleted). MASC-side observers removed
+                   in refactor/tool-call-single-source. *)
                 (let tr = Tool_result.{ tool_name = td.name; success = false;
                     duration_ms = Float.of_int duration_ms; data = `Null } in
                  ignore (Tool_dispatch.run_post_hooks tr));
@@ -271,11 +269,7 @@ let make_tools
                 Hashtbl.remove failure_counts key;
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:true ~duration_ms;
-                Keeper_exec_tools.notify_tool_call_observers
-                  ~keeper_name:meta.name
-                  ~tool_name:td.name
-                  ~input
-                  ~success:true;
+                (* Tool-call observability via OAS Event_bus. See above. *)
                 (let tr = Tool_result.{ tool_name = td.name; success = true;
                     duration_ms = Float.of_int duration_ms; data = `Null } in
                  ignore (Tool_dispatch.run_post_hooks tr));
@@ -358,11 +352,7 @@ let make_tools
               Hashtbl.replace failure_counts key count;
               Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
               !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
-              Keeper_exec_tools.notify_tool_call_observers
-                ~keeper_name:meta.name
-                ~tool_name:td.name
-                ~input
-                ~success:false;
+              (* Tool-call observability via OAS Event_bus. See above. *)
               (try Sse.broadcast
                 (`Assoc [
                   ("type", `String "keeper_tool_call");

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1657,22 +1657,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          produce duplicates. In that case, we propagate the error instead of
          retrying.
 
-         Uses a per-turn observer via [add_tool_call_observer] instead of
-         wrapping the global [on_keeper_tool_call] ref. Observer delivery is
-         process-global, so the callback must filter on [keeper_name] to avoid
-         cross-turn contamination when multiple keepers execute concurrently. *)
+         Uses the OAS Event_bus (ToolCalled + ToolCompleted) rather than
+         MASC-side observers. The per-turn subscription is scoped by
+         [filter_agent meta.name], so no cross-keeper contamination. *)
       let mutating_tools_committed = ref [] in
       let post_commit_failure_reason = ref None in
       let paused_meta_override = ref None in
       let current_turn_overflow_blocker = ref None in
-      let side_effect_observer ~keeper_name ~tool_name ~input ~success =
-        if success
-           && String.equal keeper_name meta.name
-           && Keeper_exec_tools.has_mutating_side_effect_with_input
-                ~tool_name ~input
-        then
-          mutating_tools_committed := tool_name :: !mutating_tools_committed
-      in
       let mark_paused_after_overflow ~run_meta ~reason =
         let paused_meta =
           pause_keeper_for_overflow
@@ -1682,7 +1673,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         in
         paused_meta_override := Some paused_meta
       in
-      Keeper_exec_tools.add_tool_call_observer side_effect_observer;
+      (* Side-effect tracking is driven by the OAS Event_bus (ToolCalled +
+         ToolCompleted) rather than MASC-side observers. Pairing is by
+         tool_name order within the per-turn subscription, which is safe
+         because the turn is single-fibered and filter_agent restricts to
+         this keeper. *)
       let event_bus_sub =
         match Keeper_event_bus.get () with
         | Some bus ->
@@ -1692,13 +1687,62 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         | None -> None
       in
       let turn_event_bus = ref empty_turn_event_bus_summary in
-      let drain_turn_event_bus () =
-        let summary =
-          match event_bus_sub, Keeper_event_bus.get () with
-          | Some sub, Some _bus ->
-              summarize_turn_event_bus (Oas_bus_instrument.drain sub)
-          | _ -> empty_turn_event_bus_summary
+      (* Per-tool-name queue of pending inputs from ToolCalled events.
+         ToolCompleted pops the oldest input for that tool_name. *)
+      let pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t =
+        Hashtbl.create 8
+      in
+      let push_pending_input tool_name input =
+        let q =
+          match Hashtbl.find_opt pending_tool_inputs tool_name with
+          | Some q -> q
+          | None ->
+              let q = Queue.create () in
+              Hashtbl.add pending_tool_inputs tool_name q;
+              q
         in
+        Queue.add input q
+      in
+      let pop_pending_input tool_name =
+        match Hashtbl.find_opt pending_tool_inputs tool_name with
+        | Some q when not (Queue.is_empty q) -> Some (Queue.pop q)
+        | _ -> None
+      in
+      let process_tool_events_for_side_effects
+          (events : Agent_sdk.Event_bus.event list) : unit =
+        List.iter
+          (fun (evt : Agent_sdk.Event_bus.event) ->
+            match evt.payload with
+            | Agent_sdk.Event_bus.ToolCalled { tool_name; input; _ } ->
+                push_pending_input tool_name input
+            | Agent_sdk.Event_bus.ToolCompleted
+                { tool_name; output = Ok _; _ } ->
+                let input_opt = pop_pending_input tool_name in
+                let input =
+                  match input_opt with Some i -> i | None -> `Null
+                in
+                if
+                  Keeper_exec_tools.has_mutating_side_effect_with_input
+                    ~tool_name ~input
+                then
+                  mutating_tools_committed :=
+                    tool_name :: !mutating_tools_committed
+            | Agent_sdk.Event_bus.ToolCompleted
+                { tool_name; output = Error _; _ } ->
+                (* Failed tool: drop the matching pending input. *)
+                let _ = pop_pending_input tool_name in
+                ignore tool_name
+            | _ -> ())
+          events
+      in
+      let drain_turn_event_bus () =
+        let events =
+          match event_bus_sub, Keeper_event_bus.get () with
+          | Some sub, Some _bus -> Oas_bus_instrument.drain sub
+          | _ -> []
+        in
+        process_tool_events_for_side_effects events;
+        let summary = summarize_turn_event_bus events in
         turn_event_bus :=
           merge_turn_event_bus_summary !turn_event_bus summary;
         !turn_event_bus
@@ -1725,7 +1769,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
        | _ -> ());
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
-          Keeper_exec_tools.remove_tool_call_observer side_effect_observer;
           unsubscribe_event_bus ();
           Keeper_registry.mark_turn_finished
             ~base_path:config.base_path meta.name)
@@ -1836,6 +1879,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_registry.Cascade_done;
                 Ok result
             | Error err ->
+                let _ = drain_turn_event_bus () in
                 let committed_tools =
                   committed_mutating_tools !mutating_tools_committed
                 in
@@ -2011,6 +2055,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 timeout_sec
             in
             Log.Keeper.error "%s: %s" meta.name msg;
+            let _ = drain_turn_event_bus () in
             let committed_tools =
               committed_mutating_tools !mutating_tools_committed
             in

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -269,31 +269,165 @@ let test_dangerous_gh_command_classifier () =
       (gh_dangerous_command cmd)
   ) cases
 
-let test_tool_call_observer_receives_keeper_context () =
-  let seen = ref None in
-  let observer ~keeper_name ~tool_name ~input ~success =
-    seen := Some (keeper_name, tool_name, input, success)
+(* Tool-call observability flows through the OAS Event_bus.
+   This test verifies a subscriber can receive the equivalent
+   signal that MASC-side observers previously emitted. *)
+let test_tool_call_observer_via_oas_event_bus () =
+  Eio_main.run @@ fun _env ->
+  let bus = Agent_sdk.Event_bus.create () in
+  let sub =
+    Agent_sdk.Event_bus.subscribe
+      ~filter:(Agent_sdk.Event_bus.filter_agent "keeper-a")
+      bus
   in
-  Keeper_exec_tools.add_tool_call_observer observer;
-  Fun.protect
-    ~finally:(fun () -> Keeper_exec_tools.remove_tool_call_observer observer)
-    (fun () ->
-      let input = mk_cmd "pr list" in
-      Keeper_exec_tools.notify_tool_call_observers
-        ~keeper_name:"keeper-a"
-        ~tool_name:"keeper_shell"
-        ~input
-        ~success:true;
-      match !seen with
-      | Some (keeper_name, tool_name, observed_input, success) ->
-          Alcotest.(check string) "keeper name" "keeper-a" keeper_name;
-          Alcotest.(check string) "tool name" "keeper_shell" tool_name;
-          Alcotest.(check bool) "success flag" true success;
-          Alcotest.(check string) "input payload"
-            (Yojson.Safe.to_string input)
-            (Yojson.Safe.to_string observed_input)
+  let input = mk_cmd "pr list" in
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCalled
+          { agent_name = "keeper-a";
+            tool_name = "keeper_shell";
+            input }));
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCompleted
+          { agent_name = "keeper-a";
+            tool_name = "keeper_shell";
+            output = Ok { Agent_sdk.Types.content = "ok" } }));
+  let events = Agent_sdk.Event_bus.drain sub in
+  Agent_sdk.Event_bus.unsubscribe bus sub;
+  Alcotest.(check int) "two tool events received" 2 (List.length events);
+  let called =
+    List.find_opt
+      (fun (evt : Agent_sdk.Event_bus.event) ->
+        match evt.payload with
+        | Agent_sdk.Event_bus.ToolCalled _ -> true
+        | _ -> false)
+      events
+  in
+  let completed =
+    List.find_opt
+      (fun (evt : Agent_sdk.Event_bus.event) ->
+        match evt.payload with
+        | Agent_sdk.Event_bus.ToolCompleted _ -> true
+        | _ -> false)
+      events
+  in
+  (match called with
+   | Some { payload = Agent_sdk.Event_bus.ToolCalled
+              { agent_name; tool_name; input = observed_input }; _ } ->
+       Alcotest.(check string) "agent name" "keeper-a" agent_name;
+       Alcotest.(check string) "tool name" "keeper_shell" tool_name;
+       Alcotest.(check string) "input payload"
+         (Yojson.Safe.to_string input)
+         (Yojson.Safe.to_string observed_input)
+   | _ -> Alcotest.fail "expected ToolCalled event");
+  (match completed with
+   | Some { payload = Agent_sdk.Event_bus.ToolCompleted
+              { agent_name; tool_name; output }; _ } ->
+       Alcotest.(check string) "agent name" "keeper-a" agent_name;
+       Alcotest.(check string) "tool name" "keeper_shell" tool_name;
+       Alcotest.(check bool) "output is Ok" true (Result.is_ok output)
+   | _ -> Alcotest.fail "expected ToolCompleted event")
+
+(* Replicate the Keeper_unified_turn side-effect tracking pattern:
+   pair ToolCalled + ToolCompleted (Ok) per tool_name queue, and
+   flag committed mutating tools via [has_mutating_side_effect_with_input]. *)
+let test_side_effect_tracking_via_event_bus () =
+  Eio_main.run @@ fun _env ->
+  let bus = Agent_sdk.Event_bus.create () in
+  let sub =
+    Agent_sdk.Event_bus.subscribe
+      ~filter:(Agent_sdk.Event_bus.filter_agent "keeper-a") bus
+  in
+  let mutating = ref [] in
+  let pending : (string, Yojson.Safe.t Queue.t) Hashtbl.t =
+    Hashtbl.create 4
+  in
+  let push_pending tool_name input =
+    let q =
+      match Hashtbl.find_opt pending tool_name with
+      | Some q -> q
       | None ->
-          Alcotest.fail "expected observer notification")
+          let q = Queue.create () in
+          Hashtbl.add pending tool_name q;
+          q
+    in
+    Queue.add input q
+  in
+  let pop_pending tool_name =
+    match Hashtbl.find_opt pending tool_name with
+    | Some q when not (Queue.is_empty q) -> Some (Queue.pop q)
+    | _ -> None
+  in
+  let process events =
+    List.iter
+      (fun (evt : Agent_sdk.Event_bus.event) ->
+        match evt.payload with
+        | Agent_sdk.Event_bus.ToolCalled { tool_name; input; _ } ->
+            push_pending tool_name input
+        | Agent_sdk.Event_bus.ToolCompleted
+            { tool_name; output = Ok _; _ } ->
+            let input =
+              match pop_pending tool_name with
+              | Some i -> i
+              | None -> `Null
+            in
+            if Keeper_exec_tools.has_mutating_side_effect_with_input
+                 ~tool_name ~input
+            then mutating := tool_name :: !mutating
+        | Agent_sdk.Event_bus.ToolCompleted
+            { tool_name; output = Error _; _ } ->
+            let _ = pop_pending tool_name in
+            ignore tool_name
+        | _ -> ())
+      events
+  in
+  (* A mutating success: keeper_shell gh pr merge *)
+  let mut_input =
+    `Assoc [ ("op", `String "gh"); ("cmd", `String "pr merge 123") ]
+  in
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCalled
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            input = mut_input }));
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCompleted
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            output = Ok { Agent_sdk.Types.content = "merged" } }));
+  (* A read-only success: keeper_shell gh pr list (should NOT be tracked) *)
+  let ro_input =
+    `Assoc [ ("op", `String "gh"); ("cmd", `String "pr list") ]
+  in
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCalled
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            input = ro_input }));
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCompleted
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            output = Ok { Agent_sdk.Types.content = "list" } }));
+  (* A failed mutating call: should NOT be tracked *)
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCalled
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            input = mut_input }));
+  Agent_sdk.Event_bus.publish bus
+    (Agent_sdk.Event_bus.mk_event
+       (Agent_sdk.Event_bus.ToolCompleted
+          { agent_name = "keeper-a"; tool_name = "keeper_shell";
+            output = Error { Agent_sdk.Types.message = "boom";
+                             recoverable = false } }));
+  let events = Agent_sdk.Event_bus.drain sub in
+  Agent_sdk.Event_bus.unsubscribe bus sub;
+  process events;
+  Alcotest.(check (list string))
+    "exactly one committed mutating tool (merge)"
+    [ "keeper_shell" ] !mutating
 
 (* ================================================================ *)
 (* Main-worktree mutation-boundary exemptions                        *)
@@ -425,8 +559,10 @@ let () =
             test_input_aware_mutation_detection;
           Alcotest.test_case "dangerous gh classifier" `Quick
             test_dangerous_gh_command_classifier;
-          Alcotest.test_case "tool observer receives keeper context" `Quick
-            test_tool_call_observer_receives_keeper_context;
+          Alcotest.test_case "tool observer via OAS event bus" `Quick
+            test_tool_call_observer_via_oas_event_bus;
+          Alcotest.test_case "side-effect tracking via OAS event bus" `Quick
+            test_side_effect_tracking_via_event_bus;
           Alcotest.test_case "task claim mutating but boundary exempt" `Quick
             test_task_claim_is_mutating_but_boundary_exempt;
           Alcotest.test_case "masc_code_git write actions bypass boundary" `Quick


### PR DESCRIPTION
## Summary

Tool-call observability had two parallel sources of truth in MASC:

- **Source A (MASC-side)**: `Keeper_exec_tools.notify_tool_call_observers` invoked from `keeper_tools_oas.ml` at the success-failure / success-ok / exception paths.
- **Source B (OAS-native)**: `Agent_sdk.Event_bus.publish` of `ToolCalled` + `ToolCompleted` from `oas/lib/agent/agent_tools.ml`.

OAS already fires both events for every keeper tool call (MASC tools are wrapped via `Tool_bridge.oas_tool_of_masc`, executed inside OAS's `find_and_execute_tool`). The MASC-side observer chain was redundant.

## Changes

- Delete `tool_call_observers`, `add_tool_call_observer`, `remove_tool_call_observer`, `notify_tool_call_observers` from `Keeper_exec_tools` (`.ml` + `.mli`).
- Drop the three `notify_tool_call_observers` call sites in `keeper_tools_oas.ml` (lines 225, 274, 361 in pre-refactor numbering).
- In `keeper_unified_turn.ml`, replace the `side_effect_observer` pattern with an OAS `Event_bus` drain. The drain pairs `ToolCalled.input` with `ToolCompleted` per tool_name FIFO queue, then feeds `has_mutating_side_effect_with_input` exactly like the old observer did. Drain is invoked before every `mutating_tools_committed` read in error/timeout branches so retry-blocking semantics are preserved.
- Tests: replace `test_tool_call_observer_receives_keeper_context` with two OAS-bus tests:
  1. Direct OAS `Event_bus` subscriber receives `ToolCalled` + `ToolCompleted`.
  2. End-to-end side-effect tracking pattern (mut success tracked, read-only ignored, failed mut ignored).

## Subscriber migration table

| Old call site | New mechanism |
|---|---|
| `keeper_unified_turn.side_effect_observer` (only real subscriber) | Per-turn `Event_bus.subscribe` with `filter_agent meta.name`; queue-paired `ToolCalled`/`ToolCompleted (Ok)`; same downstream `mutating_tools_committed` ref |
| `test_keeper_github_read_only.test_tool_call_observer_receives_keeper_context` | New `test_tool_call_observer_via_oas_event_bus` + `test_side_effect_tracking_via_event_bus` |

No subscribers required MASC-side data unavailable on the OAS bus (`agent_name`, `tool_name`, `input`, `output` cover everything).

## Test plan

- [x] `dune build --root .` clean
- [x] `dune runtest --root . test/test_keeper_github_read_only.ml` — 22 tests pass (incl. 2 new)
- [x] `dune runtest --root .` — full suite green (incl. 114-case keeper_tool_matrix at 148s)