### PR TITLE
feat(keeper): [keeper.oas_env] TOML table for per-keeper OAS transport env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,27 @@
   tighten approval surface per-deployment without an SDK change. See
   `docs/KEEPER-USER-MANUAL.md` §1.1.1 for the full table.
 
+- **Keeper `[keeper.oas_env]` TOML table.** Per-keeper OAS transport env
+  vars are now declarative. `config/keepers/<name>.toml` accepts a new
+  `[keeper.oas_env]` table whose entries are applied via `Unix.putenv`
+  at turn start, right before any OAS call. Keys must match
+  `^OAS_(CLAUDE|CODEX|GEMINI)_.+` — anything else is silently dropped
+  to block ambient env injection (e.g. a `PATH=/evil/bin` entry in a
+  TOML cannot reach the process). Bool / int TOML values coerce to
+  strings (`true` → `"1"`, `false` → `"0"`) so the OAS transport
+  build_args side reads them uniformly.
+  - Default applied to all four built-in keepers (`analyst`, `executor`,
+    `scholar`, `verifier`): `OAS_CLAUDE_STRICT_MCP=1` +
+    `OAS_GEMINI_NO_MCP=1` — keeper subprocess calls no longer pull in
+    ambient MCP servers from the operator's `~/.claude.json` /
+    `~/.gemini/settings.json`, keeping behaviour deterministic across
+    deployments.
+  - `merge_keeper_profile_defaults` merges `oas_env` key-by-key: a
+    persona-level base survives where the keeper TOML overlay doesn't
+    override.
+  - 5 new inline tests in `test_keeper_toml.ml` cover allowed / dropped
+    / absent / bool-coerced / unknown-keys-whitelist paths.
+
 - **Tool-task schema.**
   - `handoff_context.summary` declared required; runtime error surfaces
     example payload (#8293).

--- a/config/keepers/analyst.toml
+++ b/config/keepers/analyst.toml
@@ -4,3 +4,11 @@ execution_scope = "workspace"
 cascade_name = "keeper_unified"
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
+
+# OAS transport env (OAS 0.159+). Keys must match ^OAS_(CLAUDE|CODEX|GEMINI)_.+
+# Applied via Unix.putenv before each turn. Operators can override per
+# deployment by editing this block or via process-level env vars (this
+# table wins because it runs at turn start).
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"

--- a/config/keepers/executor.toml
+++ b/config/keepers/executor.toml
@@ -4,3 +4,11 @@ execution_scope = "workspace"
 cascade_name = "keeper_unified"
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
+
+# OAS transport env (OAS 0.159+). Keys must match ^OAS_(CLAUDE|CODEX|GEMINI)_.+
+# Applied via Unix.putenv before each turn. Operators can override per
+# deployment by editing this block or via process-level env vars (this
+# table wins because it runs at turn start).
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"

--- a/config/keepers/scholar.toml
+++ b/config/keepers/scholar.toml
@@ -4,3 +4,11 @@ execution_scope = "workspace"
 cascade_name = "keeper_unified"
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
+
+# OAS transport env (OAS 0.159+). Keys must match ^OAS_(CLAUDE|CODEX|GEMINI)_.+
+# Applied via Unix.putenv before each turn. Operators can override per
+# deployment by editing this block or via process-level env vars (this
+# table wins because it runs at turn start).
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -4,3 +4,11 @@ execution_scope = "workspace"
 cascade_name = "cross_verifier"
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
+
+# OAS transport env (OAS 0.159+). Keys must match ^OAS_(CLAUDE|CODEX|GEMINI)_.+
+# Applied via Unix.putenv before each turn. Operators can override per
+# deployment by editing this block or via process-level env vars (this
+# table wins because it runs at turn start).
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -53,6 +53,22 @@ OAS 0.159.0부터 비대화형 CLI transport(`transport_claude_code`, `transport
 - Gemini CLI는 hook 런타임 off 플래그가 없다. hook 제어가 필요하면 `gemini hooks <cmd>` subcommand로 keeper 기동 전에 비활성화한다.
 - "empty string = disable all" 구분이 필요한 MCP whitelist만 `OAS_GEMINI_NO_MCP` 불 env로 분리되어 있음(`Unix.putenv`로는 진짜 unset이 불가한 제약 반영).
 
+**선언적 설정 (권장)**: process env 대신 `config/keepers/<name>.toml`의 `[keeper.oas_env]` 테이블에 적어두면 턴 시작 시 `Unix.putenv`로 자동 적용된다. 4개 built-in keeper는 `OAS_CLAUDE_STRICT_MCP=1` + `OAS_GEMINI_NO_MCP=1` 기본값이 이미 들어있다. 예시:
+
+```toml
+[keeper]
+persona_name = "analyst"
+# ...
+
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"
+# Codex는 -c TOML override로만 제어 가능
+OAS_CODEX_CONFIG = "sandbox_mode=read-only"
+```
+
+키는 반드시 `^OAS_(CLAUDE|CODEX|GEMINI)_.+` 패턴에 맞아야 한다. 그 외 키(`PATH`, `LD_PRELOAD`, 임의 변수 등)는 silently 드롭되어 ambient env 주입을 차단한다. bool 값은 `true`→`"1"`, `false`→`"0"`으로 자동 변환된다.
+
 ### 1.2 MASC --- 조정 레이어
 
 MASC는 OAS 위에 멀티에이전트 협업 기능을 확장한다:

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -511,6 +511,10 @@ let run_turn
   in
   (* 3. Build base system prompt from meta *)
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
+  (* Apply per-keeper OAS transport env vars ([[keeper.oas_env]] table)
+     before any OAS call in this turn.  OAS 0.159+ transports read
+     these at build_args time; an empty [oas_env] list is a no-op. *)
+  Keeper_types_profile.apply_oas_env ~keeper_name:meta.name profile_defaults;
   let persona_extended =
     Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
       profile_defaults

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -219,6 +219,13 @@ type keeper_profile_defaults = {
      (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
+  (* Per-keeper OAS CLI transport env vars (OAS 0.159+).
+     Parsed from [[keeper.oas_env]] table.  Keys MUST match
+     ^OAS_(CLAUDE|CODEX|GEMINI)_.+ — any other entries are dropped with
+     a warning to avoid ambient env injection via keeper TOML.
+     Applied via Unix.putenv right before each turn so OAS transport
+     build_args picks them up.  Empty list = no overrides. *)
+  oas_env : (string * string) list;
 }
 
 type persona_summary = {
@@ -267,6 +274,7 @@ let empty_keeper_profile_defaults = {
   max_turns_per_call_scheduled_autonomous = None;
   cascade_name = None;
   models = None;
+  oas_env = [];
 }
 
 let personas_root_opt () =
@@ -301,6 +309,47 @@ let persona_profile_path_opt name =
 (* ================================================================ *)
 (* TOML -> keeper_profile_defaults conversion                        *)
 (* ================================================================ *)
+
+(** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only keys
+    matching ^OAS_(CLAUDE|CODEX|GEMINI)_.+ are accepted — any other
+    entries are dropped silently.  This guards against arbitrary
+    process env injection via keeper TOML.  Values are coerced to
+    strings via [string_of_toml_value_for_env] (bool → "1"/"0"), so
+    integers and booleans in TOML map to the string shapes the OAS
+    transport build_args already understand. *)
+let string_of_toml_value_for_env = function
+  | Keeper_toml_loader.Toml_string s -> Some s
+  | Keeper_toml_loader.Toml_int i -> Some (string_of_int i)
+  | Keeper_toml_loader.Toml_float f -> Some (string_of_float f)
+  | Keeper_toml_loader.Toml_bool true -> Some "1"
+  | Keeper_toml_loader.Toml_bool false -> Some "0"
+  | Keeper_toml_loader.Toml_string_array _ -> None
+
+let oas_env_key_prefix = "keeper.oas_env."
+
+let oas_env_key_is_allowed suffix =
+  let allowed_prefixes = [ "OAS_CLAUDE_"; "OAS_CODEX_"; "OAS_GEMINI_" ] in
+  String.length suffix
+    > (List.fold_left (fun acc p -> max acc (String.length p)) 0 allowed_prefixes)
+  && List.exists (fun p ->
+       String.length suffix >= String.length p
+       && String.sub suffix 0 (String.length p) = p)
+       allowed_prefixes
+
+let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
+    : (string * string) list =
+  let prefix_len = String.length oas_env_key_prefix in
+  List.filter_map
+    (fun (k, v) ->
+      if String.length k > prefix_len
+         && String.sub k 0 prefix_len = oas_env_key_prefix
+      then
+        let suffix = String.sub k prefix_len (String.length k - prefix_len) in
+        if oas_env_key_is_allowed suffix then
+          Option.map (fun sv -> (suffix, sv)) (string_of_toml_value_for_env v)
+        else None
+      else None)
+    doc
 
 let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     : (keeper_profile_defaults, string) result =
@@ -467,6 +516,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           (match strs "models" with
            | [] -> None
            | xs -> Some xs);
+        oas_env = extract_oas_env_from_doc doc;
       })
     result
 
@@ -527,9 +577,16 @@ let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
     canonical_keeper_toml_key_names
     |> List.map (fun k -> "keeper." ^ k)
   in
+  let oas_env_prefix = oas_env_key_prefix in
+  let oas_env_prefix_len = String.length oas_env_prefix in
+  let starts_with_oas_env k =
+    String.length k > oas_env_prefix_len
+    && String.sub k 0 oas_env_prefix_len = oas_env_prefix
+  in
   doc
   |> List.map fst
-  |> List.filter (fun key -> not (List.mem key known))
+  |> List.filter (fun key ->
+       not (List.mem key known) && not (starts_with_oas_env key))
   |> dedupe_keep_order
 
 let warn_unknown_keeper_toml_keys ~path (doc : Keeper_toml_loader.toml_doc) =
@@ -695,6 +752,10 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   (match Safe_ops.json_string_list "models" keeper_json with
                    | [] -> None
                    | xs -> Some xs);
+                (* oas_env lives only in keeper TOML, not persona JSON —
+                   persona profiles are a design-time artifact whereas
+                   transport env is an ops-time toggle. *)
+                oas_env = [];
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 
@@ -758,7 +819,36 @@ let merge_keeper_profile_defaults
     max_turns_per_call_scheduled_autonomous =
       prefer overlay.max_turns_per_call_scheduled_autonomous
         base.max_turns_per_call_scheduled_autonomous;
+    (* oas_env merges key-by-key: overlay wins per key, base keys that
+       overlay doesn't mention survive.  Preserves the natural intent
+       that a persona sets base defaults and keeper TOML layers its
+       own toggles on top. *)
+    oas_env =
+      (let overlay_keys = List.map fst overlay.oas_env in
+       let surviving_base =
+         List.filter (fun (k, _) -> not (List.mem k overlay_keys)) base.oas_env
+       in
+       surviving_base @ overlay.oas_env);
   }
+
+(** Apply [defaults.oas_env] to the process environment via [Unix.putenv].
+    Logs each applied key at info level for operator auditability.
+    Safe to call repeatedly — putenv is idempotent for identical values.
+
+    Scope note: [Unix.putenv] is process-global, so concurrent turns
+    from different keepers in the same process would race.  In the
+    current masc-mcp deployment each keeper lives in its own process,
+    which keeps this wiring simple; revisit if multiplexing is added. *)
+let apply_oas_env ~keeper_name (defaults : keeper_profile_defaults) : unit =
+  match defaults.oas_env with
+  | [] -> ()
+  | pairs ->
+    List.iter
+      (fun (k, v) ->
+        Unix.putenv k v;
+        Log.Keeper.info
+          "keeper %s applied OAS env %s=%s" keeper_name k v)
+      pairs
 
 let resolved_persona_name ~keeper_name
     (defaults : keeper_profile_defaults) : string =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -867,6 +867,98 @@ mention_targets = ["a"]
     check (list string) "surfaces dead config"
       ["keeper.room_scope"; "keeper.scope_kind"] unknown
 
+let test_oas_env_parses_allowed_keys () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"
+OAS_CODEX_CONFIG = "mcp_servers={}"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check int "oas_env count" 3 (List.length d.oas_env);
+      check string "strict_mcp value"
+        "1" (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
+      check string "no_mcp value"
+        "1" (List.assoc "OAS_GEMINI_NO_MCP" d.oas_env);
+      check string "codex_config value"
+        "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env)
+
+let test_oas_env_drops_non_oas_prefix () =
+  (* Guards against ambient env injection via keeper TOML: keys that
+     don't start with OAS_(CLAUDE|CODEX|GEMINI)_ are silently dropped. *)
+  let input = {|
+[keeper]
+persona_name = "analyst"
+[keeper.oas_env]
+PATH = "/evil/bin:/usr/bin"
+LD_PRELOAD = "/tmp/hack.so"
+OAS_CLAUDE_STRICT_MCP = "1"
+RANDOM_VAR = "nope"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check int "only OAS_* survives" 1 (List.length d.oas_env);
+      check bool "PATH dropped" false (List.mem_assoc "PATH" d.oas_env);
+      check bool "LD_PRELOAD dropped" false (List.mem_assoc "LD_PRELOAD" d.oas_env);
+      check bool "RANDOM_VAR dropped" false (List.mem_assoc "RANDOM_VAR" d.oas_env)
+
+let test_oas_env_absent_means_empty () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check int "no table → empty list" 0 (List.length d.oas_env)
+
+let test_oas_env_not_flagged_as_unknown () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check int "oas_env keys whitelisted" 0 (List.length unknown)
+
+let test_oas_env_coerces_bool_to_string () =
+  (* Bools in TOML become "1"/"0" string so OAS_*_STRICT_MCP = true works. *)
+  let input = {|
+[keeper]
+persona_name = "analyst"
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = true
+OAS_CODEX_SKIP_GIT = false
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    match KTP.profile_defaults_of_toml doc with
+    | Error e -> fail e
+    | Ok d ->
+      check string "true → 1" "1"
+        (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
+      check string "false → 0" "0"
+        (List.assoc "OAS_CODEX_SKIP_GIT" d.oas_env)
+
 let test_detect_unknown_keys_accepts_also_allow_alias () =
   let input = {|
 [keeper]
@@ -970,6 +1062,19 @@ let () =
             test_detect_unknown_keys_flags_legacy_dead_config;
           test_case "also_allow alias accepted" `Quick
             test_detect_unknown_keys_accepts_also_allow_alias;
+          test_case "oas_env keys not flagged as unknown" `Quick
+            test_oas_env_not_flagged_as_unknown;
+        ] );
+      ( "oas_env",
+        [
+          test_case "parses allowed OAS_* keys" `Quick
+            test_oas_env_parses_allowed_keys;
+          test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
+            test_oas_env_drops_non_oas_prefix;
+          test_case "empty when table absent" `Quick
+            test_oas_env_absent_means_empty;
+          test_case "coerces bool → \"1\"/\"0\" string" `Quick
+            test_oas_env_coerces_bool_to_string;
         ] );
       ( "file_loading",
         [


### PR DESCRIPTION
## Summary

Adds a declarative way to set `OAS_CLAUDE_*` / `OAS_CODEX_*` / `OAS_GEMINI_*` env vars per keeper, applied via `Unix.putenv` at turn start right before any OAS call. Complements the env-driven CLI flags in OAS 0.159.0 (jeong-sik/oas#997) by giving each keeper its own lockdown profile without relying on process-level env.

Follow-up to #8331 (OAS 0.159.0 pin bump).

## Surface additions

- `keeper_profile_defaults` gains `oas_env : (string * string) list` (empty list = no-op, preserves existing callers).
- `profile_defaults_of_toml` parses `[keeper.oas_env]` table. Only keys matching `^OAS_(CLAUDE|CODEX|GEMINI)_.+` are accepted; any other entry is silently dropped to **block ambient env injection** (e.g. `PATH=/evil` in a keeper TOML cannot reach the process).
- Bool / int TOML values coerce to strings (`true`→`"1"`, `false`→`"0"`) so the OAS transport build_args side reads them uniformly.
- `merge_keeper_profile_defaults` merges `oas_env` **key-by-key**: a persona-level base survives unless the keeper TOML overlay overrides.
- `apply_oas_env` helper: iterate + `Unix.putenv` with info log per key.
- `detect_unknown_keeper_toml_keys` prefix-whitelists `keeper.oas_env.*` so the table itself doesn't trip the unknown-keys warning.

## Wiring

`keeper_agent_run.run` calls `apply_oas_env` right after `load_keeper_profile_defaults`. Every turn refreshes the env from disk — operator TOML edits take effect on the next turn, no restart.

## Defaults for built-in keepers

All four `config/keepers/*.toml` (analyst, executor, scholar, verifier) now carry:

```toml
[keeper.oas_env]
OAS_CLAUDE_STRICT_MCP = "1"
OAS_GEMINI_NO_MCP = "1"
```

Keeper subprocess calls no longer inherit ambient MCP servers from the operator's `~/.claude.json` or `~/.gemini/settings.json`, keeping behaviour deterministic across deployments. Codex is left untouched — its `-c` TOML override channel is better set per-profile in `~/.codex/config.toml` than per-keeper in masc-mcp.

## Tests

5 new cases in `test/test_keeper_toml.ml` (new `oas_env` group + one case in `unknown_keys`):

- parses allowed `OAS_*` keys
- drops non-`OAS_*` keys (`PATH`, `LD_PRELOAD`, `RANDOM_VAR`) — ambient injection guard
- empty when `[keeper.oas_env]` table absent
- coerces bool → `"1"`/`"0"`
- oas_env keys not flagged by `detect_unknown_keeper_toml_keys`

All 64 tests in `test_keeper_toml` green. `dune build --root .` green.

## Scope note

`Unix.putenv` is process-global; concurrent turns from different keepers in the same process would race. Current masc-mcp runs one keeper per process so this is fine; documented in-line as a reminder for any future multiplexing work.

## Test plan

- [x] `dune build --root .` (local)
- [x] `dune exec test/test_keeper_toml.exe` → 64/64 green (5 new)
- [ ] CI: Build & Test, Lint, TLA+, Doc Truth
- [ ] Manual: restart a keeper and confirm `claude -p` / `gemini -p` subprocess argv includes `--strict-mcp-config` / `--allowed-mcp-server-names ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)