### PR TITLE
refactor(bus): separate MASC Event_bus from OAS Event_bus — masc.* naming

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -476,6 +476,7 @@
    keeper_coordination
    keeper_execution
    keeper_event_bus
+   masc_event_bus
    keeper_keepalive
    heartbeat_smart
    keeper_crash_persistence
@@ -635,6 +636,7 @@
   keeper_turn_lifecycle
   keeper_msg_async
   keeper_event_bus
+  masc_event_bus
   ;; worker_container sub-modules
   worker_container_types
   worker_container

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -119,7 +119,7 @@ let emit_gate_event
    | "override" | "approval_required" ->
        Keeper_registry.mark_turn_gate_rejected_by_name agent_name
    | _ -> ());
-  match Keeper_event_bus.get () with
+  match Masc_event_bus.get () with
   | None -> ()
   | Some bus ->
     let payload = `Assoc [
@@ -137,7 +137,7 @@ let emit_gate_event
     (try
       Oas_bus_instrument.publish bus
         (Agent_sdk.Event_bus.mk_event
-           (Agent_sdk.Event_bus.Custom ("masc:keeper_gate", payload)))
+           (Agent_sdk.Event_bus.Custom ("masc.keeper_gate", payload)))
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/masc_event_bus.ml
+++ b/lib/masc_event_bus.ml
@@ -1,0 +1,24 @@
+(** Masc_event_bus — Process-scoped MASC-owned Event_bus instance.
+
+    Domain boundary: MASC publishes domain-specific events (broadcasts,
+    heartbeats, task transitions, keeper lifecycle, etc.) on its own bus
+    rather than onto OAS's shared Event_bus. OAS's [event_bus.mli:103-107]
+    says: "External publishers should use their own Event_bus.t instance
+    for domain-specific events rather than publishing onto OAS's bus.
+    Treating OAS's Event_bus as a general-purpose telemetry channel
+    creates cross-layer coupling."
+
+    Same type as [Agent_sdk.Event_bus.t] — we re-use the library rather
+    than re-inventing the transport. Different instance, different
+    subscribers, different lifecycle.
+
+    Process-scoped singleton (same pattern as [Keeper_event_bus]): set
+    once at server bootstrap, read from publishers throughout the
+    process.
+
+    @since 2.353.0 *)
+
+let bus_ref : Agent_sdk.Event_bus.t option Atomic.t = Atomic.make None
+
+let set bus = Atomic.set bus_ref (Some bus)
+let get () = Atomic.get bus_ref

--- a/lib/masc_event_bus.mli
+++ b/lib/masc_event_bus.mli
@@ -1,0 +1,19 @@
+(** MASC-owned [Agent_sdk.Event_bus.t] instance.
+
+    Separate bus from the shared OAS Event_bus. MASC domain events
+    ([masc.broadcast], [masc.heartbeat], [masc.keeper.lifecycle], ...)
+    are published here, not onto OAS's bus. Enforces the OAS boundary
+    documented in [event_bus.mli:103-107] — OAS's Event_bus is not a
+    general-purpose telemetry channel.
+
+    Process-scoped singleton. [set] is called exactly once at server
+    bootstrap; publishers call [get ()] to obtain the bus.
+
+    @since 2.353.0 *)
+
+val set : Agent_sdk.Event_bus.t -> unit
+(** Install the MASC Event_bus instance. Called once at server bootstrap. *)
+
+val get : unit -> Agent_sdk.Event_bus.t option
+(** [get ()] returns the installed MASC Event_bus, or [None] before
+    bootstrap (e.g. in unit tests that skip server bringup). *)

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -1,65 +1,84 @@
-(** Agent_sdk Event_bus bridge for MASC runtime/social events.
+(** MASC Event_bus publishers for runtime/social events.
 
-    Publishes MASC coordination events (broadcasts, heartbeats, board posts)
-    to the shared Event_bus using [Custom("masc:<type>", json)] format.
-    This makes MASC orchestration events visible to Event_bus subscribers
-    (traces, metrics, debugging tools).
+    Publishes MASC coordination events (broadcasts, heartbeats, board
+    posts, task transitions, keeper lifecycle, trust/reputation) to the
+    MASC-owned Event_bus. Events follow dot-separated snake_case naming
+    per OAS Custom-name convention: [masc.broadcast], [masc.heartbeat],
+    [masc.keeper.lifecycle], ...
 
-    @since 2.90.0 *)
+    The [bus] argument is accepted for backward compatibility but
+    ignored: every publish routes to [Masc_event_bus.get ()] so the
+    OAS/MASC layer boundary is preserved regardless of the caller's
+    bus reference. OAS's [event_bus.mli:103-107] explicitly warns
+    against publishing domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators ("masc.broadcast")
+    for dashboard compatibility — the translation is done by the SSE
+    relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(* Route every publish to the MASC-owned bus. Caller-passed [bus] is
+   ignored — this closes the OAS boundary violation where MASC was
+   publishing Custom("masc:...") onto OAS's shared bus. *)
+let masc_publish event =
+  match Masc_event_bus.get () with
+  | Some mb -> Oas_bus_instrument.publish mb event
+  | None -> ()
 
 (** Publish a broadcast event to the shared Event_bus. *)
-let publish_broadcast (bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
+let publish_broadcast (_bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("content", `String content);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:broadcast", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.broadcast", payload)))
 
 (** Publish a heartbeat event to the shared Event_bus. *)
-let publish_heartbeat (bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_pct =
+let publish_heartbeat (_bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_pct =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("turn", `Int turn);
     ("context_pct", `Float context_pct);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.heartbeat", payload)))
 
 (** Publish a board post event to the shared Event_bus. *)
-let publish_board_post (bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
+let publish_board_post (_bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("post_id", `String post_id);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:board_post", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.board_post", payload)))
 
 (** Publish a task state change event to the shared Event_bus. *)
-let publish_task_transition (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~transition =
+let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~transition =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("task_id", `String task_id);
     ("transition", `String transition);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:task_transition", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.task_transition", payload)))
 
 (** Publish a heartbeat recovery event to the OAS Event_bus.
     Emitted when a previously timed-out agent re-activates. *)
-let publish_heartbeat_recovered (bus : Agent_sdk.Event_bus.t) ~agent_name ~previous_timeout_s =
+let publish_heartbeat_recovered (_bus : Agent_sdk.Event_bus.t) ~agent_name ~previous_timeout_s =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("previous_timeout_s", `Float previous_timeout_s);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat_recovered", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.heartbeat_recovered", payload)))
 
 (** {1 Autonomy Agent Lifecycle Events} *)
 
 (** Publish an agent selection event (Thompson Sampling result).
     Emitted after [select_agents_with_thompson] in keeper_heartbeat. *)
-let publish_agent_selected (bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
+let publish_agent_selected (_bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
     ~thompson_score ~final_score =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
@@ -68,12 +87,12 @@ let publish_agent_selected (bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
     ("final_score", `Float final_score);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_selected", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_selected", payload)))
 
 (** Publish an agent action decision event (MODEL decision result).
     Emitted after MODEL decides post/comment/upvote/skip. *)
-let publish_agent_decision (bus : Agent_sdk.Event_bus.t) ~agent_name ~action
+let publish_agent_decision (_bus : Agent_sdk.Event_bus.t) ~agent_name ~action
     ~trigger_reason =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
@@ -81,12 +100,12 @@ let publish_agent_decision (bus : Agent_sdk.Event_bus.t) ~agent_name ~action
     ("trigger_reason", `String trigger_reason);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_decision", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_decision", payload)))
 
 (** Publish an action execution result event.
     Emitted after an agent's action (post/comment/upvote) completes. *)
-let publish_agent_action_executed (bus : Agent_sdk.Event_bus.t) ~agent_name
+let publish_agent_action_executed (_bus : Agent_sdk.Event_bus.t) ~agent_name
     ~action ~success =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
@@ -94,14 +113,14 @@ let publish_agent_action_executed (bus : Agent_sdk.Event_bus.t) ~agent_name
     ("success", `Bool success);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_action_executed", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_action_executed", payload)))
 
 (** {1 Keeper Snapshot Events} *)
 
 (** Publish a keeper snapshot event to the OAS Event_bus.
     Emitted alongside SSE broadcast in keeper_keepalive. *)
-let publish_keeper_snapshot (bus : Agent_sdk.Event_bus.t) ~keeper_name
+let publish_keeper_snapshot (_bus : Agent_sdk.Event_bus.t) ~keeper_name
     ~generation ~context_ratio ~message_count =
   let payload = `Assoc [
     ("keeper_name", `String keeper_name);
@@ -110,14 +129,14 @@ let publish_keeper_snapshot (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("message_count", `Int message_count);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:snapshot", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.snapshot", payload)))
 
 (** {1 Keeper Lifecycle Events} *)
 
 (** Publish a keeper keepalive lifecycle event.
     Event names: "started", "stopped", "crashed", "restarted", "dead". *)
-let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ?phase ~event
+let publish_keeper_lifecycle (_bus : Agent_sdk.Event_bus.t) ?phase ~event
     ~keeper_name ~detail () =
   let phase_json =
     match phase with
@@ -132,23 +151,23 @@ let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ?phase ~event
     ("detail", `String detail);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:lifecycle", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.lifecycle", payload)))
 
 (** {1 Phase 4: Social Events} *)
 
 (** Publish a trust score update between two agents. *)
-let publish_trust_updated (bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust_score =
+let publish_trust_updated (_bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust_score =
   let payload = `Assoc [
     ("agent_a", `String agent_a);
     ("agent_b", `String agent_b);
     ("trust_score", `Float trust_score);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:trust_updated", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.trust_updated", payload)))
 
 (** Publish a reputation change event. *)
-let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
+let publish_reputation_changed (_bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("old_score", `Float old_score);
@@ -156,23 +175,23 @@ let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_sc
     ("trend", `String trend);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:reputation_changed", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.reputation_changed", payload)))
 
 (** Publish an institution episode event. *)
-let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event_type ~participants =
+let publish_institution_episode (_bus : Agent_sdk.Event_bus.t) ~episode_id ~event_type ~participants =
   let payload = `Assoc [
     ("episode_id", `String episode_id);
     ("event_type", `String event_type);
     ("participant_count", `Int (List.length participants));
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:institution_episode", payload)))
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.institution_episode", payload)))
 
 (** {1 Harness Observability Events (#3165)} *)
 
 (** Publish a verdict-recorded event.
     Emitted after [Eval_calibration.record_verdict] persists a verdict. *)
-let publish_verdict_recorded (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
+let publish_verdict_recorded (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
     ~gate ~verdict =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
@@ -181,12 +200,12 @@ let publish_verdict_recorded (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
     ("verdict", `String verdict);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:verdict_recorded", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.harness.verdict_recorded", payload)))
 
 (** Publish a pre-compaction observation event.
     Emitted before [Context_compact_oas.compact] runs in keeper. *)
-let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
+let publish_pre_compact (_bus : Agent_sdk.Event_bus.t) ~keeper_name
     ~context_ratio ~strategy_names ~active_agent_count ~context_window
     ~is_local_model =
   let payload = `Assoc [
@@ -198,5 +217,5 @@ let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("is_local_model", `Bool is_local_model);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Oas_bus_instrument.publish bus
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:pre_compact", payload)))
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.harness.pre_compact", payload)))

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -302,8 +302,19 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
   | Agent_sdk.Event_bus.Custom (name, payload) ->
+      (* Wire compatibility: dashboard consumers historically decoded
+         [masc:broadcast] / [masc:keeper:snapshot] (all colons).
+         Internally MASC now emits dot-separated names per OAS Custom
+         convention ([masc.broadcast], [masc.keeper.snapshot]).
+         Translate EVERY dot to colon for [masc.*] events so existing
+         SSE consumers continue to decode the full multi-segment name. *)
+      let event_type =
+        if String.length name > 5 && String.sub name 0 5 = "masc."
+        then String.map (fun c -> if c = '.' then ':' else c) name
+        else name
+      in
       Some
-        (wrap ~event_type:name ~payload
+        (wrap ~event_type ~payload
            ?agent_name:(payload_agent_name payload)
            ?task_id:(payload_string_opt "task_id" payload)
            ?turn:(payload_int_opt "turn" payload)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -221,16 +221,19 @@ let non_http_transport_of_provider
 (* Internal: event publishing                                        *)
 (* ================================================================ *)
 
-let publish_lifecycle bus ~name ~event ~detail =
-  Oas_bus_instrument.publish bus
-    (Oas.Event_bus.mk_event
-      (Custom
-        (Printf.sprintf "masc:oas_worker:%s" event,
-         `Assoc [
-           ("agent", `String name);
-           ("detail", `String detail);
-           ("timestamp", `Float (Time_compat.now ()));
-         ])))
+let publish_lifecycle _bus ~name ~event ~detail =
+  match Masc_event_bus.get () with
+  | None -> ()
+  | Some mb ->
+    Oas_bus_instrument.publish mb
+      (Oas.Event_bus.mk_event
+        (Custom
+          (Printf.sprintf "masc.oas_worker.%s" event,
+           `Assoc [
+             ("agent", `String name);
+             ("detail", `String detail);
+             ("timestamp", `Float (Time_compat.now ()));
+           ])))
 
 (* ================================================================ *)
 (* Internal: checkpoint persistence                                  *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -49,8 +49,17 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     in
     loop (Eio.Time.now clock)
   in
-  (* Event_bus → SSE bridge: relay masc:* events to dashboard *)
+  (* Create and install the MASC-owned Event_bus alongside OAS's.
+     MASC domain events (masc.broadcast, masc.heartbeat, masc.keeper.*,
+     masc.autonomy.*, masc.harness.*, masc.trust_updated, ...) publish
+     here per OAS event_bus.mli:103-107 boundary. Dashboard SSE consumers
+     see both channels as one stream — the relay translates masc.* →
+     masc:* on the wire for backward compatibility. *)
+  let masc_event_bus = Agent_sdk.Event_bus.create () in
+  Masc_event_bus.set masc_event_bus;
+  (* Event_bus → SSE bridge: relay both OAS and MASC buses to dashboard *)
   Oas_sse_bridge.start ~sw ~clock ~config:state.room_config ~bus:event_bus;
+  Oas_sse_bridge.start ~sw ~clock ~config:state.room_config ~bus:masc_event_bus;
   (* Compaction audit: subscribe to ContextCompactStarted/ContextCompacted and
      persist paired rows to [base_path/data/harness-compact/YYYY-MM/DD.jsonl]
      with rolling 14-day retention (override via
@@ -66,12 +75,12 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       ~purpose:"lifecycle_listener"
       ~filter:(fun (evt : Agent_sdk.Event_bus.event) ->
         match evt.payload with
-        | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", _) -> true
+        | Agent_sdk.Event_bus.Custom ("masc.keeper.lifecycle", _) -> true
         | _ -> false)
-      event_bus
+      masc_event_bus
   in
   Eio.Switch.on_release sw (fun () ->
-    Oas_bus_instrument.unsubscribe event_bus keeper_lifecycle_sub);
+    Oas_bus_instrument.unsubscribe masc_event_bus keeper_lifecycle_sub);
   (* Spawn the OAS bus depth sampler so warnings surface on stdout
      even when /metrics is not scraped. *)
   Oas_bus_instrument.start_sampler ~sw ~clock ();
@@ -82,7 +91,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         List.iter
           (fun (evt : Agent_sdk.Event_bus.event) ->
             match evt.payload with
-            | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload) ->
+            | Agent_sdk.Event_bus.Custom ("masc.keeper.lifecycle", payload) ->
                 (match
                    ( Safe_ops.json_string_opt "event" payload,
                      Safe_ops.json_string_opt "keeper_name" payload )

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -47,49 +47,53 @@ let test_event_bus_broadcast () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_broadcast bus ~agent_name:"test-agent" ~content:"hello";
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
-  | Event_bus.Custom ("masc:broadcast", payload) ->
+  | Event_bus.Custom ("masc.broadcast", payload) ->
     let agent = Yojson.Safe.Util.(member "agent_name" payload |> to_string) in
     Alcotest.(check string) "agent name" "test-agent" agent
-  | _ -> Alcotest.fail "expected Custom masc:broadcast event"
+  | _ -> Alcotest.fail "expected Custom masc.broadcast event"
 
 let test_event_bus_heartbeat () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_heartbeat bus ~agent_name:"keeper-runtime" ~turn:5 ~context_pct:0.42;
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
-  | Event_bus.Custom ("masc:heartbeat", payload) ->
+  | Event_bus.Custom ("masc.heartbeat", payload) ->
     let turn = Yojson.Safe.Util.(member "turn" payload |> to_int) in
     Alcotest.(check int) "turn" 5 turn
-  | _ -> Alcotest.fail "expected Custom masc:heartbeat event"
+  | _ -> Alcotest.fail "expected Custom masc.heartbeat event"
 
 let test_event_bus_task_transition () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_task_transition bus ~agent_name:"worker"
     ~task_id:"task-1" ~transition:"done";
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
-  | Event_bus.Custom ("masc:task_transition", payload) ->
+  | Event_bus.Custom ("masc.task_transition", payload) ->
     let tid = Yojson.Safe.Util.(member "task_id" payload |> to_string) in
     Alcotest.(check string) "task id" "task-1" tid
-  | _ -> Alcotest.fail "expected Custom masc:task_transition event"
+  | _ -> Alcotest.fail "expected Custom masc.task_transition event"
 
 let test_event_bus_keeper_lifecycle_includes_phase () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_keeper_lifecycle bus
     ~event:"started"
@@ -100,12 +104,12 @@ let test_event_bus_keeper_lifecycle_includes_phase () =
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
-  | Event_bus.Custom ("masc:keeper:lifecycle", payload) ->
+  | Event_bus.Custom ("masc.keeper.lifecycle", payload) ->
     let phase = Yojson.Safe.Util.(member "phase" payload |> to_string) in
     let event = Yojson.Safe.Util.(member "event" payload |> to_string) in
     Alcotest.(check string) "phase" "running" phase;
     Alcotest.(check string) "event" "started" event
-  | _ -> Alcotest.fail "expected Custom masc:keeper:lifecycle event"
+  | _ -> Alcotest.fail "expected Custom masc.keeper:lifecycle event"
 
 let test_keeper_snapshot_envelope_agent_name () =
   (* #7827: publish_keeper_snapshot stores the keeper's identity as
@@ -115,6 +119,7 @@ let test_keeper_snapshot_envelope_agent_name () =
      instead of silently dropping 9%+ of daily events. *)
   Eio_main.run @@ fun _env ->
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_keeper_snapshot bus
     ~keeper_name:"sojin"
@@ -143,6 +148,7 @@ let test_keeper_lifecycle_envelope_agent_name () =
      through keeper_name. *)
   Eio_main.run @@ fun _env ->
   let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_keeper_lifecycle bus
     ~event:"started"
@@ -225,6 +231,7 @@ let test_oas_sse_bridge_broadcasts_lifecycle_to_observers () =
     (fun () ->
       let config = Coord.default_config dir in
       let bus = Event_bus.create () in
+      Masc_event_bus.set bus;
       Masc_mcp.Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->


### PR DESCRIPTION
## Summary
- MASC is no longer a tenant of OAS's Event_bus. New `lib/masc_event_bus.{ml,mli}` holds a MASC-owned Agent_sdk.Event_bus instance installed at bootstrap.
- 16 `masc:*` Custom publishers (broadcast, heartbeat, task_transition, autonomy/*, harness/*, trust, reputation, keeper lifecycle/snapshot, keeper_gate, oas_worker/*) migrate to MASC bus with dot-separated naming per OAS Custom convention.
- SSE relay translates `masc.X.Y` → `masc:X:Y` on the wire so dashboard consumers keep decoding the historical format without schema change.

## Why
OAS `event_bus.mli:103-107`:
> "External publishers should use their own Event_bus.t instance for domain-specific events rather than publishing onto OAS's bus. Treating OAS's Event_bus as a general-purpose telemetry channel creates cross-layer coupling and makes OAS's public surface a dumping ground."

MASC was violating this for all 16 Custom events with colon-separated names (not per OAS Custom format requirement).

## Test plan
- [x] `dune build --root .` clean
- [x] `dune test --root . test/test_oas_integration.exe` — 18/18 pass (6 publisher tests updated to `Masc_event_bus.set`, SSE bridge tests keep colon format assertions)
- [ ] Runtime: confirm dashboard SSE continues to show all 16 event types after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)