### PR TITLE
test(keeper): narrow alias boundary regression

### DIFF
--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -332,13 +332,11 @@ let test_keeper_bash_still_opens_boundary () =
    blocked.  Lock the [masc_] and [keeper_] families to the same
    exemption semantics so the next rename does not silently drift. *)
 let test_masc_coordination_aliases_bypass_boundary () =
-  let check_pair name =
-    Alcotest.(check bool) (name ^ " is mutating") false
-      (is_ro ~tool_name:name ~input:(`Assoc []));
+  let check name =
     Alcotest.(check bool) (name ^ " bypasses boundary") true
       (is_boundary_exempt ~tool_name:name ~input:(`Assoc []))
   in
-  List.iter check_pair
+  List.iter check
     [ "masc_tasks"; "masc_add_task"; "masc_claim_next";
       "masc_batch_add_tasks"; "masc_plan_init"; "masc_plan_set_task";
       "masc_plan_update"; "masc_plan_get"; "masc_transition";


### PR DESCRIPTION
## Summary
- narrow `masc_* coordination aliases bypass boundary` so it checks only boundary exemption semantics
- stop asserting that the entire alias family is mutating, because several canonical aliases are intentionally read-only
- keep the regression focused on the boundary-drift bug class that originally blocked keeper turns

## Product impact
This removes a false CI blocker from `Build and Test`. PRs unrelated to keeper alias metadata no longer fail on a stale expectation in `test_keeper_github_read_only`, while the actual main-worktree boundary regression coverage stays intact.

## Evidence
- failing CI assertion before this change: `test/test_keeper_github_read_only.ml:336` (`masc_tasks is mutating`)
- local verification:
  - `dune build --root=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-context-sync test/test_keeper_github_read_only.exe test/test_oas_integration.exe`
  - `./_build/default/test/test_keeper_github_read_only.exe -q -e`
  - `./_build/default/test/test_oas_integration.exe -q -e`

## Review evidence
- checked current canonical metadata in `lib/tool_catalog.ml`, `lib/tool_permission_map.ml`, `lib/tool_plan.ml`, and `lib/tool_board.ml`
- confirmed the failing expectation was in the test only; runtime boundary logic in `lib/keeper/keeper_tool_registry.ml` did not need a code change

## Linked issue
- Refs #8341