### PR TITLE
feat(exec): extend A4a gate cutover across runtime paths

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -237,7 +237,12 @@ let fetch_remote_agent_card url :
         in
         try
           let (status, body) =
-            Process_eio.run_argv_with_status ~timeout_sec:Env_config_runtime.Timeout.gcloud_auth_sec argv
+            Masc_exec.Exec_gate.run_argv_with_status
+              ~actor:"tool/a2a_discovery"
+              ~raw_source:(String.concat " " (List.map Filename.quote argv))
+              ~summary:"a2a remote agent discovery"
+              ~timeout_sec:Env_config_runtime.Timeout.gcloud_auth_sec
+              argv
           in
           match status with
           | Unix.WEXITED 0 when String.length body > 0 -> (

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -102,10 +102,6 @@ let is_spawnable mention =
 
 (* --- CLI spawn (Spawn mode) --- *)
 
-let has_timeout =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    String.trim (Process_eio.run_argv ~timeout_sec:2.0 ["which"; "timeout"]) <> "")
-
 let build_response_prompt ~from_agent ~content ~mention =
   Printf.sprintf {|You received a mention in the MASC room from %s.
 
@@ -134,11 +130,15 @@ let run_cli_agent ~agent_type ~prompt =
     debug_log (Provider_adapter.bare_ollama_migration_message ())
   else
     let base = cli_argv_of_agent_type agent_type in
-    let argv = if Eio.Lazy.force has_timeout then ["timeout"; "120"] @ base else base in
+    let argv = base in
+    let raw_source = String.concat " " (List.map Filename.quote argv) in
     debug_log (Printf.sprintf "SPAWN argv=%s" (String.concat " " (List.map Filename.quote argv)));
     let (status, output) =
-      Process_eio.run_argv_with_stdin_and_status
-        ~timeout_sec:140.0
+      Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+        ~actor:"system/auto_responder"
+        ~raw_source
+        ~summary:"auto responder cli spawn"
+        ~timeout_sec:120.0
         ~stdin_content:prompt
         argv
     in

--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -21,13 +21,21 @@ let is_in_git_repo workdir =
   in
   try walk workdir with Sys_error _ -> false
 
-(** Run a shell command via Process_eio and capture stdout lines.
-    Non-blocking: delegates to Eio.Process instead of Unix.open_process_in. *)
-let run_capture_lines cmd =
-  let status, raw_output =
-    Process_eio.run_argv_with_status ~timeout_sec:30.0
-      ["sh"; "-c"; cmd]
-  in
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
+let run_git_with_status ?(timeout_sec = 30.0) ~workdir argv =
+  let full_argv = "git" :: "-C" :: workdir :: argv in
+  let raw_source = exec_gate_raw_source full_argv in
+  Masc_exec.Exec_gate.run_argv_with_status
+    ~actor:"autoresearch/git"
+    ~raw_source
+    ~summary:"autoresearch git"
+    ~timeout_sec
+    full_argv
+
+let run_capture_lines ~workdir ?(timeout_sec = 30.0) argv =
+  let status, raw_output = run_git_with_status ~timeout_sec ~workdir argv in
   let lines =
     if String.length raw_output = 0 then []
     else String.split_on_char '\n' raw_output
@@ -39,11 +47,8 @@ let run_capture_lines cmd =
 let git_head_short ~workdir =
   if not (is_in_git_repo workdir) then None
   else
-  let cmd = Printf.sprintf "cd %s && git rev-parse --short HEAD 2>/dev/null"
-    (Filename.quote workdir) in
   let status, raw_output =
-    Process_eio.run_argv_with_status ~timeout_sec:10.0
-      ["sh"; "-c"; cmd]
+    run_git_with_status ~timeout_sec:10.0 ~workdir [ "rev-parse"; "--short"; "HEAD" ]
   in
   match status with
   | Unix.WEXITED 0 ->
@@ -58,48 +63,55 @@ let git_commit ~workdir ~message
   if not (is_in_git_repo workdir) then
     Result.error "not inside a git repository"
   else
-  let check_cmd = Printf.sprintf
-    "cd %s && git add -A && git diff --cached --quiet"
-    (Filename.quote workdir) in
-  let check_status, _check_output =
-    Process_eio.run_argv_with_status ~timeout_sec:30.0
-      ["sh"; "-c"; check_cmd]
+  let add_status, add_output =
+    run_git_with_status ~timeout_sec:30.0 ~workdir [ "add"; "-A" ]
   in
-  match check_status with
-  | Unix.WEXITED 0 ->
+  match add_status with
+  | Unix.WEXITED 0 -> (
+    let check_status, _check_output =
+      run_git_with_status ~timeout_sec:30.0 ~workdir
+        [ "diff"; "--cached"; "--quiet" ]
+    in
+    match check_status with
+    | Unix.WEXITED 0 ->
     (* No staged changes -- nothing to commit *)
     Result.ok None
-  | _ ->
-    let commit_cmd = Printf.sprintf
-      "cd %s && git commit -m %s 2>&1 && git rev-parse --short HEAD"
-      (Filename.quote workdir) (Filename.quote message) in
+    | Unix.WEXITED 1 ->
     let status, raw_output =
-      Process_eio.run_argv_with_status ~timeout_sec:30.0
-        ["sh"; "-c"; commit_cmd]
-    in
-    let lines =
-      String.split_on_char '\n' raw_output
-      |> List.filter (fun s -> s <> "")
-      |> List.rev
+      run_git_with_status ~timeout_sec:30.0 ~workdir [ "commit"; "-m"; message ]
     in
     (match status with
-    | Unix.WEXITED 0 ->
-      (match lines with
-       | hash :: _ -> Result.ok (Some (String.trim hash))
-       | [] -> Result.error "git commit succeeded but no hash returned")
+     | Unix.WEXITED 0 ->
+       let hash_status, hash_output =
+         run_git_with_status ~timeout_sec:10.0 ~workdir
+           [ "rev-parse"; "--short"; "HEAD" ]
+       in
+       (match hash_status with
+        | Unix.WEXITED 0 ->
+          let trimmed = String.trim hash_output in
+          if trimmed = "" then
+            Result.error "git commit succeeded but no hash returned"
+          else Result.ok (Some trimmed)
+        | _ ->
+          Result.error "git commit succeeded but rev-parse failed")
+     | _ ->
+       Result.error (Printf.sprintf "git commit failed: %s" raw_output))
+    | Unix.WEXITED code ->
+      Result.error (Printf.sprintf "git diff --cached --quiet exited %d" code)
     | _ ->
-      let output = String.concat "\n" (List.rev lines) in
-      Result.error (Printf.sprintf "git commit failed: %s" output))
+      Result.error "git diff --cached --quiet terminated abnormally")
+  | _ ->
+    Result.error (Printf.sprintf "git add failed: %s" add_output)
 
 (** Restore worktree files to current HEAD without moving the branch. *)
 let git_restore_head ~workdir =
   if not (is_in_git_repo workdir) then ()
   else
-  let cmd = Printf.sprintf "cd %s && git reset --hard HEAD 2>/dev/null"
-    (Filename.quote workdir) in
   (try
-    let (status, _output) = Process_eio.run_argv_with_status ~timeout_sec:30.0
-      ["sh"; "-c"; cmd] in
+    let (status, _output) =
+      run_git_with_status ~timeout_sec:30.0 ~workdir
+        [ "reset"; "--hard"; "HEAD" ]
+    in
     match status with
     | Unix.WEXITED 0 -> ()
     | _ -> Log.Autoresearch.warn "git restore HEAD non-zero exit in %s" workdir
@@ -109,11 +121,11 @@ let git_restore_head ~workdir =
 let git_reset_last ~workdir =
   if not (is_in_git_repo workdir) then ()
   else
-  let cmd = Printf.sprintf "cd %s && git reset --hard HEAD~1 2>/dev/null"
-    (Filename.quote workdir) in
   (try
-    let (status, _output) = Process_eio.run_argv_with_status ~timeout_sec:30.0
-      ["sh"; "-c"; cmd] in
+    let (status, _output) =
+      run_git_with_status ~timeout_sec:30.0 ~workdir
+        [ "reset"; "--hard"; "HEAD~1" ]
+    in
     match status with
     | Unix.WEXITED 0 -> ()
     | _ -> Log.Autoresearch.warn "git reset HEAD~1 non-zero exit in %s" workdir
@@ -136,10 +148,10 @@ let git_tag_best ~workdir ~cycle ~score =
   if not (is_in_git_repo workdir) then ()
   else
   let tag = Printf.sprintf "ar-best-c%d-%.4f" cycle score in
-  let cmd = Printf.sprintf "cd %s && git tag -f %s 2>/dev/null"
-    (Filename.quote workdir) (Filename.quote tag) in
-  (try ignore (Process_eio.run_argv_with_status ~timeout_sec:10.0
-    ["sh"; "-c"; cmd])
+  (try
+     ignore
+       (run_git_with_status ~timeout_sec:10.0 ~workdir
+          [ "tag"; "-f"; tag ])
    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Autoresearch.warn "git tag failed in %s: %s" workdir (Printexc.to_string exn))
 
 (** Get the git top-level directory for a workdir. *)
@@ -147,11 +159,7 @@ let git_top_level ~workdir =
   if not (is_in_git_repo workdir) then
     Result.error "workdir is not inside a git repository"
   else
-  let cmd =
-    Printf.sprintf "cd %s && git rev-parse --show-toplevel 2>/dev/null"
-      (Filename.quote workdir)
-  in
-  match run_capture_lines cmd with
+  match run_capture_lines ~workdir [ "rev-parse"; "--show-toplevel" ] with
   | Unix.WEXITED 0, top :: _ ->
       let trimmed = String.trim top in
       if trimmed = "" then Result.error "git top-level was empty"
@@ -162,11 +170,7 @@ let git_top_level ~workdir =
 let git_current_branch ~workdir =
   if not (is_in_git_repo workdir) then None
   else
-  let cmd =
-    Printf.sprintf "cd %s && git rev-parse --abbrev-ref HEAD 2>/dev/null"
-      (Filename.quote workdir)
-  in
-  match run_capture_lines cmd with
+  match run_capture_lines ~workdir [ "rev-parse"; "--abbrev-ref"; "HEAD" ] with
   | Unix.WEXITED 0, branch :: _ ->
       let trimmed = String.trim branch in
       if trimmed = "" then None else Some trimmed
@@ -176,11 +180,7 @@ let git_current_branch ~workdir =
 let git_is_dirty ~workdir =
   if not (is_in_git_repo workdir) then false
   else
-  let cmd =
-    Printf.sprintf "cd %s && git status --porcelain 2>/dev/null"
-      (Filename.quote workdir)
-  in
-  match run_capture_lines cmd with
+  match run_capture_lines ~workdir [ "status"; "--porcelain" ] with
   | Unix.WEXITED 0, lines -> List.exists (fun line -> String.trim line <> "") lines
   | _ -> false
 
@@ -206,14 +206,10 @@ let prepare_managed_worktree ~base_path ~source_workdir ~loop_id =
       else begin
         Autoresearch_storage.ensure_dir (Filename.dirname workdir);
         let branch = managed_branch_name loop_id in
-        let cmd =
-          Printf.sprintf
-            "cd %s && git worktree add -b %s %s HEAD 2>&1"
-            (Filename.quote repo_root)
-            (Filename.quote branch)
-            (Filename.quote workdir)
-        in
-        match run_capture_lines cmd with
+        match
+          run_capture_lines ~workdir:repo_root
+            [ "worktree"; "add"; "-b"; branch; workdir; "HEAD" ]
+        with
         | Unix.WEXITED 0, _ ->
             Result.ok (workdir, repo_root, List.rev !warnings)
         | _, lines ->

--- a/lib/autoresearch/dune
+++ b/lib/autoresearch/dune
@@ -10,4 +10,14 @@
    autoresearch_metric
    autoresearch_git
    autoresearch_file)
- (libraries yojson unix time_compat fs_compat masc_log masc_core masc_process agent_sdk eio))
+ (libraries
+   yojson
+   unix
+   time_compat
+   fs_compat
+   masc_log
+   masc_core
+   masc_process
+   masc_mcp.masc_exec
+   agent_sdk
+   eio))

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -37,47 +37,35 @@ let executable_dir () =
   in
   Filename.dirname path
 
-(** Probe git commit via subprocess.
-    Offloaded to system thread to avoid blocking Eio scheduler. *)
 let git_capture_output ~repo_root args =
-  let argv = "git" :: "-C" :: repo_root :: args in
-  Exec_tap.record
-    ~kind:Exec_tap.Unix_open_process_args_full
-    ~argv ~cwd:repo_root ();
-  let channels =
-    Unix.open_process_args_full "git"
-      (Array.of_list argv)
-      (Unix.environment ())
-  in
-  let stdout, stdin, stderr = channels in
-  try
-    close_out_noerr stdin;
-    let output = In_channel.input_all stdout in
-    ignore (In_channel.input_all stderr);
-    match Unix.close_process_full channels with
-    | Unix.WEXITED 0 -> Some output
-    | _ -> None
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    ignore (try Unix.close_process_full channels with Unix.Unix_error _ -> Unix.WEXITED 1);
-    raise exn
+  let argv = [ "git"; "-C"; repo_root ] @ args in
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"system/build_identity"
+      ~raw_source
+      ~summary:"build identity git probe"
+      ~timeout_sec:5.0
+      argv
+  with
+  | Unix.WEXITED 0, output -> Some output
+  | _ -> None
+
 let git_probe_from_root repo_root =
-  let f () =
-    let output =
-      try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
-      | Sys_error msg ->
-          Log.Identity.warn "git_probe_from_root read failed: %s" msg;
-          None
-      | Unix.Unix_error (code, fn, arg) ->
-          Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
-            (Unix.error_message code) fn arg;
-          None
-      | exn ->
-          Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
-          None
-    in
-    Option.bind output trim_to_option
+  let output =
+    try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
+    | Sys_error msg ->
+        Log.Identity.warn "git_probe_from_root read failed: %s" msg;
+        None
+    | Unix.Unix_error (code, fn, arg) ->
+        Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
+          (Unix.error_message code) fn arg;
+        None
+    | exn ->
+        Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
+        None
   in
-  Eio_guard.run_in_systhread f
+  Option.bind output trim_to_option
 
 (** Pick the ordered list of directories to probe for a git repo,
     executable_dir first so the binary's own source tree wins over

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -6,26 +6,48 @@
 
 open Types
 
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
 (* ============================================ *)
 (* argv-based process helpers                   *)
 (* ============================================ *)
 
 (** Run argv and return first non-empty line. *)
 let run_argv_line (argv : string list) : string option =
-  let output = Process_eio.run_argv ~timeout_sec:30.0 argv in
+  let output =
+    Masc_exec.Exec_gate.run_argv
+      ~actor:"coord/git"
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"coord_git argv"
+      ~timeout_sec:30.0
+      argv
+  in
   match String.split_on_char '\n' output |> List.map String.trim |> List.filter (fun s -> s <> "") with
   | [] -> None
   | h :: _ -> Some h
 
 (** Run argv and return exit code. *)
 let run_argv_exit (argv : string list) : int =
-  match Process_eio.run_argv_with_status ~timeout_sec:30.0 argv with
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"coord/git"
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"coord_git argv"
+      ~timeout_sec:30.0
+      argv
+  with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
 
 let run_argv_lines (argv : string list) : string list =
-  Process_eio.run_argv ~timeout_sec:30.0 argv
+  Masc_exec.Exec_gate.run_argv
+    ~actor:"coord/git"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"coord_git argv"
+    ~timeout_sec:30.0
+    argv
   |> String.split_on_char '\n'
   |> List.map String.trim
   |> List.filter (fun s -> s <> "")

--- a/lib/coord/coord_identity.ml
+++ b/lib/coord/coord_identity.ml
@@ -18,7 +18,14 @@ let get_tty () =
     | None ->
         try
           if Unix.isatty Unix.stdin then
-            let output = Process_eio.run_argv ~timeout_sec:5.0 ["tty"] in
+            let output =
+              Masc_exec.Exec_gate.run_argv
+                ~actor:"coord/identity"
+                ~raw_source:"tty"
+                ~summary:"coord tty probe"
+                ~timeout_sec:5.0
+                [ "tty" ]
+            in
             let trimmed = String.trim output in
             if String.length trimmed > 0 then Some trimmed else None
           else None

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -9,15 +9,30 @@
 open Types
 open Coord_utils
 
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
 (** Run argv and get lines (Eio-native, no shell) *)
 let run_argv_lines argv =
-  Process_eio.run_argv ~timeout_sec:30.0 argv
+  Masc_exec.Exec_gate.run_argv
+    ~actor:"coord/worktree"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"coord_worktree argv"
+    ~timeout_sec:30.0
+    argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> s <> "")
 
 (** Run argv and get exit code (Eio-native, no shell) *)
 let run_argv_exit argv =
-  match Process_eio.run_argv_with_status ~timeout_sec:30.0 argv with
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"coord/worktree"
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"coord_worktree argv"
+      ~timeout_sec:30.0
+      argv
+  with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
@@ -271,7 +286,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                    check-delete-create and the permanent failure when keeper
                    branches are not cleaned up after worktree removal. *)
                 let exit_code, git_output =
-                  Process_eio.run_argv_with_status ~timeout_sec:30.0
+                  let argv =
                     [
                       "git";
                       "-C";
@@ -283,6 +298,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                       branch_name;
                       Printf.sprintf "origin/%s" resolved_base;
                     ]
+                  in
+                  Masc_exec.Exec_gate.run_argv_with_status
+                    ~actor:"coord/worktree"
+                    ~raw_source:(exec_gate_raw_source argv)
+                    ~summary:"coord_worktree worktree add"
+                    ~timeout_sec:30.0
+                    argv
                 in
 
                 if exit_code = Unix.WEXITED 0 then begin

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -39,6 +39,7 @@
   masc_backend
   masc_eio_context
   masc_process
+  masc_mcp.masc_exec
   time_compat
   fs_compat
   yojson

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -460,12 +460,10 @@ let validate_loop_id loop_id =
     Error "invalid loop_id"
 
 let git_branch_exists ~repo_root branch =
-  let cmd =
-    Printf.sprintf "cd %s && git show-ref --verify --quiet %s"
-      (Filename.quote repo_root)
-      (Filename.quote ("refs/heads/" ^ branch))
-  in
-  match Autoresearch.run_capture_lines cmd with
+  match
+    Autoresearch.run_capture_lines ~workdir:repo_root
+      [ "show-ref"; "--verify"; "--quiet"; "refs/heads/" ^ branch ]
+  with
   | Unix.WEXITED 0, _ -> true
   | _ -> false
 
@@ -489,21 +487,13 @@ let ensure_managed_worktree ~base_path ~source_workdir ~loop_id =
       else begin
         Autoresearch.ensure_dir (Filename.dirname workdir);
         let branch = Autoresearch.managed_branch_name loop_id in
-        let cmd =
+        let argv =
           if git_branch_exists ~repo_root branch then
-            Printf.sprintf
-              "cd %s && git worktree add %s %s 2>&1"
-              (Filename.quote repo_root)
-              (Filename.quote workdir)
-              (Filename.quote branch)
+            [ "worktree"; "add"; workdir; branch ]
           else
-            Printf.sprintf
-              "cd %s && git worktree add -b %s %s HEAD 2>&1"
-              (Filename.quote repo_root)
-              (Filename.quote branch)
-              (Filename.quote workdir)
+            [ "worktree"; "add"; "-b"; branch; workdir; "HEAD" ]
         in
-        match Autoresearch.run_capture_lines cmd with
+        match Autoresearch.run_capture_lines ~workdir:repo_root argv with
         | Unix.WEXITED 0, _ ->
             Ok (workdir, repo_root, List.rev !warnings)
         | _, lines ->
@@ -612,24 +602,18 @@ let delete_loop_json ~(base_path : string) ~(loop_id : string) ~(requester_agent
              Autoresearch.git_top_level ~workdir:state.source_workdir
            with
            | Ok repo_root ->
-               let workdir =
-                 Autoresearch.managed_worktree_dir ~base_path loop_id
-               in
+              let workdir =
+                Autoresearch.managed_worktree_dir ~base_path loop_id
+              in
               if Sys.file_exists workdir then
-                let remove_cmd =
-                  Printf.sprintf "cd %s && git worktree remove --force %s 2>&1"
-                    (Filename.quote repo_root)
-                    (Filename.quote workdir)
-                in
-                ignore (Autoresearch.run_capture_lines remove_cmd);
+                ignore
+                  (Autoresearch.run_capture_lines ~workdir:repo_root
+                     [ "worktree"; "remove"; "--force"; workdir ]);
               let branch = Autoresearch.managed_branch_name loop_id in
               if git_branch_exists ~repo_root branch then
-                let branch_cmd =
-                  Printf.sprintf "cd %s && git branch -D %s 2>&1"
-                    (Filename.quote repo_root)
-                    (Filename.quote branch)
-                in
-                ignore (Autoresearch.run_capture_lines branch_cmd)
+                ignore
+                  (Autoresearch.run_capture_lines ~workdir:repo_root
+                     [ "branch"; "-D"; branch ])
            | Error msg ->
                Log.Autoresearch.warn
                  "delete loop git cleanup skipped for %s: %s" loop_id msg);

--- a/lib/dune
+++ b/lib/dune
@@ -786,6 +786,8 @@
    masc_backend
    ;; Process execution + file locking (extracted sub-library)
    masc_process
+   ;; Typed exec approval substrate (RFC v5)
+   masc_mcp.masc_exec
    ;; Autoresearch leaf modules (types, serde, storage, metric, git, file)
    masc_autoresearch
    ;; Board types (extracted sub-library — first step toward board isolation)

--- a/lib/exec/approval_config.mli
+++ b/lib/exec/approval_config.mli
@@ -22,9 +22,9 @@ type agent_overlay = {
 
   deny_destructive_git : bool;
   (** If true, [Git_op.Destructive _] emits [Verdict.Deny] outright.
-      If false, the agent may Ask its way through.  Default true; a
-      future operator UI may flip this per-session for planned
-      history rewrites. *)
+      If false, the hard deny is removed and the command falls through
+      to the normal risk-class rules.  Default true; a future operator
+      UI may flip this per-session for planned history rewrites. *)
 }
 (** Per-agent knobs.  Intentionally narrow — add fields only when a
     policy rule actually reads them, not "for future flexibility". *)

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -79,16 +79,24 @@ let ask_of policy ~caps ~bin : Verdict.t =
       raw_source = policy.raw_source;
     }
 
-let decide (policy : t) ~(caps : Capability.t list)
+let decide (policy : t)
+    ~(overlay : Approval_config.agent_overlay)
+    ~(caps : Capability.t list)
     ~(simple : Shell_ir.simple) : Verdict.t =
   match find_destructive_git caps with
-  | Some g ->
+  | Some g when overlay.deny_destructive_git ->
     Verdict.Deny { caps; reason = Destructive_git g }
-  | None ->
+  | Some _ | None ->
     match find_write_escape caps with
     | Some ps ->
       Verdict.Deny { caps; reason = Path_escape ps }
     | None ->
       match max_risk caps with
-      | `Privileged | `Audited -> ask_of policy ~caps ~bin:simple.bin
-      | `Safe -> Verdict.Allow (Verdict.trust ~caps simple)
+      | `Privileged -> ask_of policy ~caps ~bin:simple.bin
+      | `Audited ->
+        if overlay.ask_audited then ask_of policy ~caps ~bin:simple.bin
+        else Verdict.Allow (Verdict.trust ~caps simple)
+      | `Safe ->
+        if overlay.allow_safe_in_worktree then
+          Verdict.Allow (Verdict.trust ~caps simple)
+        else ask_of policy ~caps ~bin:simple.bin

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -9,25 +9,31 @@
     notably the exec gate — refuses anything that is not a
     [Trusted_argv.t], so forgery is rejected at the type level.
 
-    This initial A3-PR-1 module ships the decision skeleton with the
-    baseline rules below.  The per-agent TOML overlay and the
-    [Approval_context.t] threading come in a follow-up PR. *)
+    The decision is overlay-aware: the caller supplies the
+    per-actor [Approval_config.agent_overlay] chosen for this exec. *)
 
 type t = {
   raw_source : string;  (** original pre-parse string, for the Ask UI *)
   summary : string;     (** human-readable one-liner, for the Ask UI *)
 }
 
-val decide : t -> caps:Capability.t list -> simple:Shell_ir.simple -> Verdict.t
+val decide :
+  t ->
+  overlay:Approval_config.agent_overlay ->
+  caps:Capability.t list ->
+  simple:Shell_ir.simple ->
+  Verdict.t
 (** Pure policy decision.  The rule cascade (checked top to bottom):
 
-    - [Destructive] git op anywhere in the cap list → [Deny Destructive_git].
+    - [Destructive] git op anywhere in the cap list + overlay deny on →
+      [Deny Destructive_git].
     - [Write_path] whose scope is [Outside_worktree] or
       [Absolute_unknown] → [Deny Path_escape].
     - [Exec_bin] on a [Privileged] [Bin.t] (also the unknown-bin path) →
       [Ask].
-    - [Exec_bin] on an [Audited] [Bin.t] → [Ask].
+    - [Exec_bin] on an [Audited] [Bin.t] →
+      [Ask] when [overlay.ask_audited], otherwise [Allow].
     - Any construct we explicitly match but do not have a rule for →
       [Ask] (never [Allow]).
     - Otherwise (all-Safe caps under the worktree) →
-      [Allow (Verdict.trust ~caps simple)]. *)
+      [Allow] when [overlay.allow_safe_in_worktree], otherwise [Ask]. *)

--- a/lib/exec/bin.ml
+++ b/lib/exec/bin.ml
@@ -13,12 +13,13 @@ let safe_bins =
   [ "ls"; "cat"; "pwd"; "echo"; "head"; "tail"; "grep"; "rg"; "find";
     "which"; "test"; "basename"; "dirname"; "stat"; "du"; "df";
     "sort"; "uniq"; "wc"; "cut"; "tr"; "date"; "env"; "printenv";
-    "hostname"; "whoami" ]
+    "hostname"; "whoami"; "uname"; "ps"; "tty" ]
 
 let audited_bins =
   [ "git"; "docker"; "curl"; "wget"; "ssh"; "scp"; "tar"; "rsync";
     "make"; "cmake"; "npm"; "yarn"; "pnpm"; "pip"; "opam"; "cargo";
-    "gh"; "glab" ]
+    "gh"; "glab"; "terminal-notifier"; "osascript"; "play"; "rec";
+    "ffplay"; "mpg123"; "open"; "claude"; "gemini"; "codex" ]
 
 let privileged_bins =
   [ "sudo"; "su"; "chmod"; "chown"; "rm"; "dd"; "mkfs" ]

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -3,5 +3,6 @@
 (include_subdirs no)
 (library
  (name masc_exec)
+ (public_name masc_mcp.masc_exec)
  (wrapped true)
- (libraries))
+ (libraries masc_process unix))

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -1,16 +1,238 @@
-(* A3 exec_gate — single privileged entry, dispatches Verdict arms.
-
-   The Ok payload returns the Trusted_argv itself today.  A4 wires
-   this into Process_eio.run_argv_with_status and drops the 87 direct
-   call sites; at that point the Ok payload becomes the command
-   output record and this module becomes the sole invoker. *)
+(* A4a exec_gate — typed verdict dispatch plus first production
+   wrappers around Process_eio.  Callers stay on explicit argv; this
+   module performs the typed check before the actual spawn. *)
 
 type error =
   [ `Ask_required of Verdict.request
   | `Denied of Verdict.deny_reason
   ]
 
+type mode =
+  | Off
+  | Parallel
+  | Enforced
+
+let internal_git_admin_overlay : Approval_config.agent_overlay =
+  {
+    allow_safe_in_worktree = true;
+    ask_audited = false;
+    deny_destructive_git = false;
+  }
+
+let notify_overlay : Approval_config.agent_overlay =
+  {
+    allow_safe_in_worktree = true;
+    ask_audited = false;
+    deny_destructive_git = true;
+  }
+
+let internal_observer_overlay : Approval_config.agent_overlay =
+  {
+    allow_safe_in_worktree = true;
+    ask_audited = false;
+    deny_destructive_git = true;
+  }
+
+let rollout_config : Approval_config.t =
+  {
+    defaults = Approval_config.strict_default;
+    per_agent =
+      [
+        ("coord/git", internal_git_admin_overlay);
+        ("coord/worktree", internal_git_admin_overlay);
+        ("system/task_sandbox", internal_git_admin_overlay);
+        ("system/notify", notify_overlay);
+        ("autoresearch/git", internal_git_admin_overlay);
+        ("voice/bridge", internal_observer_overlay);
+        ("voice/bridge_core", internal_observer_overlay);
+        ("system/graphql_client_eio", internal_observer_overlay);
+        ("system/build_identity", internal_observer_overlay);
+        ("system/runtime_info", internal_observer_overlay);
+        ("system/worktree_live_context", internal_observer_overlay);
+        ("system/startup_takeover", internal_observer_overlay);
+        ("system/worker_container_types", internal_observer_overlay);
+        ("system/worker_runtime_docker", internal_observer_overlay);
+        ("system/spawn", internal_observer_overlay);
+        ("system/auto_responder", internal_observer_overlay);
+        ("swarm/goal_loop", internal_observer_overlay);
+        ("coord/identity", internal_observer_overlay);
+        ("tool/local_runtime", internal_observer_overlay);
+        ("tool/local_runtime_bench", internal_observer_overlay);
+        ("tool/a2a_discovery", internal_observer_overlay);
+        ("tool/autoresearch_cycle", internal_git_admin_overlay);
+      ];
+  }
+
+let mode_of_env () =
+  match Sys.getenv_opt "MASC_EXEC_GATE" with
+  | Some ("parallel" | "shadow") -> Parallel
+  | Some ("enforced" | "true" | "1") -> Enforced
+  | _ -> Off
+
+let lit s = Shell_ir.Lit s
+
+let env_bindings_of_array env =
+  Array.to_list env
+  |> List.map (fun binding ->
+         match String.index_opt binding '=' with
+         | Some idx ->
+           let key = String.sub binding 0 idx in
+           let value =
+             String.sub binding (idx + 1) (String.length binding - idx - 1)
+           in
+           (key, lit value)
+         | None -> (binding, lit ""))
+
+let simple_of_argv ?env ?cwd (argv : string list) =
+  match argv with
+  | [] -> Error `Empty_argv
+  | bin_raw :: args_raw -> (
+    match Bin.of_string bin_raw with
+    | Error (`Unknown _) -> Error `Parse_failed
+    | Ok bin ->
+      let args = List.map lit args_raw in
+      let env =
+        match env with
+        | Some bindings -> env_bindings_of_array bindings
+        | None -> []
+      in
+      let cwd =
+        Option.map
+          (fun dir -> Path_scope.classify ~raw:dir ~cwd:dir)
+          cwd
+      in
+      Ok { Shell_ir.bin; args; env; cwd; redirects = [] })
+
+let verdict_to_string = function
+  | Verdict.Allow _ -> "allow"
+  | Verdict.Ask _ -> "ask"
+  | Verdict.Deny _ -> "deny"
+
+let error_to_string = function
+  | `Ask_required _ -> "ask_required"
+  | `Denied _ -> "denied"
+
+let blocked_output ~summary ~raw_source ~reason =
+  Printf.sprintf "exec_gate_blocked: %s (%s) [%s]" reason raw_source summary
+
+let record_decision ~actor ~raw_source ~summary ~mode ~verdict ~argv ?env ?cwd () =
+  match mode with
+  | Off -> ()
+  | Parallel | Enforced ->
+    Exec_tap.record_gate_decision
+      ~actor
+      ~raw_source
+      ~summary
+      ~gate_mode:
+        (match mode with
+         | Parallel -> "parallel"
+         | Enforced -> "enforced"
+         | Off -> "off")
+      ~gate_verdict:(verdict_to_string verdict)
+      ~gate_enforced:(mode = Enforced)
+      ~argv
+      ?env
+      ?cwd
+      ()
+
+let verdict_for_argv ~actor ~raw_source ~summary ~argv ?env ?cwd () =
+  match simple_of_argv ?env ?cwd argv with
+  | Error `Empty_argv ->
+    Error (`Denied Verdict.Parse_failed)
+  | Error `Parse_failed ->
+    Error (`Denied Verdict.Parse_failed)
+  | Ok simple ->
+    let caps = Capability_check.of_simple simple in
+    let overlay = Approval_config.lookup rollout_config ~actor in
+    let policy : Approval_policy.t = { raw_source; summary } in
+    let verdict = Approval_policy.decide policy ~overlay ~caps ~simple in
+    Ok verdict
+
+let with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+    ~(on_allow : unit -> 'a)
+    ~(on_blocked : string -> 'a) () =
+  match verdict_for_argv ~actor ~raw_source ~summary ~argv ?env ?cwd () with
+  | Error gate_error ->
+    let mode = mode_of_env () in
+    let verdict =
+      match gate_error with
+      | `Ask_required request -> Verdict.Ask request
+      | `Denied reason -> Verdict.Deny { caps = []; reason }
+    in
+    record_decision ~actor ~raw_source ~summary ~mode ~verdict ~argv ?env
+      ?cwd ();
+    (match mode with
+     | Off | Parallel -> on_allow ()
+     | Enforced -> on_blocked (error_to_string gate_error))
+  | Ok verdict ->
+    let mode = mode_of_env () in
+    record_decision ~actor ~raw_source ~summary ~mode ~verdict ~argv ?env
+      ?cwd ();
+    match verdict with
+    | Verdict.Allow _trusted -> on_allow ()
+    | Verdict.Ask request ->
+      let gate_error = (`Ask_required request : error) in
+      (match mode with
+       | Off | Parallel -> on_allow ()
+       | Enforced -> on_blocked (error_to_string gate_error))
+    | Verdict.Deny { reason; _ } ->
+      let gate_error = (`Denied reason : error) in
+      (match mode with
+       | Off | Parallel -> on_allow ()
+       | Enforced -> on_blocked (error_to_string gate_error))
+
 let run : Verdict.t -> (Verdict.Trusted_argv.t, error) result = function
   | Verdict.Allow trusted -> Ok trusted
   | Verdict.Ask request -> Error (`Ask_required request)
   | Verdict.Deny { reason; _ } -> Error (`Denied reason)
+
+let run_argv ~actor ~raw_source ~summary ?(timeout_sec = 60.0) ?env argv =
+  with_verdict ~actor ~raw_source ~summary ~argv ?env
+    ~on_allow:(fun () -> Process_eio.run_argv ~timeout_sec ?env argv)
+    ~on_blocked:(fun reason ->
+      blocked_output ~summary ~raw_source ~reason)
+    ()
+
+let run_argv_with_status ~actor ~raw_source ~summary ?(timeout_sec = 60.0)
+    ?env ?cwd argv =
+  with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+    ~on_allow:(fun () ->
+      Process_eio.run_argv_with_status ~timeout_sec ?env ?cwd argv)
+    ~on_blocked:(fun reason ->
+      ( Unix.WEXITED 126,
+        blocked_output ~summary ~raw_source ~reason ))
+    ()
+
+let run_argv_with_status_split ~actor ~raw_source ~summary
+    ?(timeout_sec = 60.0) ?env ?cwd argv =
+  with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+    ~on_allow:(fun () ->
+      Process_eio.run_argv_with_status_split ~timeout_sec ?env ?cwd argv)
+    ~on_blocked:(fun reason ->
+      ( Unix.WEXITED 126,
+        "",
+        blocked_output ~summary ~raw_source ~reason ))
+    ()
+
+let run_argv_with_stdin_and_status ~actor ~raw_source ~summary
+    ?(timeout_sec = 60.0) ?env ?cwd ~stdin_content argv =
+  with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+    ~on_allow:(fun () ->
+      Process_eio.run_argv_with_stdin_and_status ~timeout_sec ?env ?cwd
+        ~stdin_content argv)
+    ~on_blocked:(fun reason ->
+      ( Unix.WEXITED 126,
+        blocked_output ~summary ~raw_source ~reason ))
+    ()
+
+let run_argv_with_stdin_and_status_split ~actor ~raw_source ~summary
+    ?(timeout_sec = 60.0) ?env ?cwd ~stdin_content argv =
+  with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+    ~on_allow:(fun () ->
+      Process_eio.run_argv_with_stdin_and_status_split ~timeout_sec ?env ?cwd
+        ~stdin_content argv)
+    ~on_blocked:(fun reason ->
+      ( Unix.WEXITED 126,
+        "",
+        blocked_output ~summary ~raw_source ~reason ))
+    ()

--- a/lib/exec/exec_gate.mli
+++ b/lib/exec/exec_gate.mli
@@ -1,15 +1,11 @@
-(** A3 — the single privileged exec entry point.
+(** A4a — typed approval gate plus first production spawn wrappers.
 
-    The gate refuses any input that is not a [Verdict.Trusted_argv.t]
-    at the type level — [Verdict.Allow] is the only verdict arm that
-    carries one.  [Verdict.Ask] and [Verdict.Deny] come back as a
-    structured outcome rather than a shell invocation.
-
-    This A3-PR-1 module is a dispatcher skeleton.  The wired-through
-    call to [Process_eio.run_argv_with_status] lands in the A4 cutover
-    PRs alongside the 87-site migration; today [run] on [Allow] simply
-    reports [`Allowed] so callers can thread the surface and tests can
-    lock the shape. *)
+    [run] remains the typed dispatcher on an already-computed
+    [Verdict.t].  The new [run_argv*] helpers are the production entry
+    points used by the first cutover callers: they build a typed
+    [Shell_ir.simple] from explicit argv, consult the overlay-aware
+    approval policy, optionally emit shadow evidence, and only then
+    delegate to [Process_eio]. *)
 
 type error =
   [ `Ask_required of Verdict.request
@@ -22,8 +18,64 @@ type error =
 val run : Verdict.t -> (Verdict.Trusted_argv.t, error) result
 (** [run verdict] dispatches on the three verdict arms.
 
-    On [Allow trusted], returns [Ok trusted].  A follow-up A4 PR wires
-    this into the single [Process_eio.run_argv_with_status] call site,
-    producing the actual command output.  Today the Ok payload is the
-    trusted argv itself so downstream tests can read [bin], [args],
-    and [redirects] through the [Trusted_argv] accessors. *)
+    On [Allow trusted], returns [Ok trusted].  The production wrappers
+    below consume this to decide whether the eventual [Process_eio]
+    call is allowed to happen. *)
+
+val run_argv :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  string list ->
+  string
+(** Typed gate in front of [Process_eio.run_argv].  In [parallel] mode,
+    Ask/Deny verdicts are recorded but execution still proceeds.  In
+    [enforced] mode, Ask/Deny return a synthetic blocked output. *)
+
+val run_argv_with_status :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  string list ->
+  (Unix.process_status * string)
+(** Typed gate in front of [Process_eio.run_argv_with_status]. *)
+
+val run_argv_with_status_split :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Typed gate in front of [Process_eio.run_argv_with_status_split]. *)
+
+val run_argv_with_stdin_and_status :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  stdin_content:string ->
+  string list ->
+  (Unix.process_status * string)
+(** Typed gate in front of [Process_eio.run_argv_with_stdin_and_status]. *)
+
+val run_argv_with_stdin_and_status_split :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  stdin_content:string ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Typed gate in front of [Process_eio.run_argv_with_stdin_and_status_split]. *)

--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -11,8 +11,22 @@ type t =
 
 let has_flag args flag = List.mem flag args
 
+let rec strip_global_options = function
+  | "-C" :: _path :: rest -> strip_global_options rest
+  | "-c" :: _binding :: rest -> strip_global_options rest
+  | "--git-dir" :: _dir :: rest -> strip_global_options rest
+  | "--work-tree" :: _dir :: rest -> strip_global_options rest
+  | "--namespace" :: _ns :: rest -> strip_global_options rest
+  | "--no-pager" :: rest -> strip_global_options rest
+  | "--literal-pathspecs" :: rest -> strip_global_options rest
+  | args -> args
+
 let of_argv = function
-  | "git" :: sub :: rest ->
+  | "git" :: raw_args ->
+      let normalized = strip_global_options raw_args in
+      (match normalized with
+       | [] -> Error (`Unknown_subcmd "<missing git subcmd>")
+       | sub :: rest ->
       (match sub with
        | "status" -> Ok (Read `Status)
        | "log" -> Ok (Read `Log)
@@ -49,7 +63,7 @@ let of_argv = function
            (match rest with
             | "remove" :: _ -> Ok (Destructive `Worktree_remove)
             | _ -> Error (`Unknown_subcmd ("worktree " ^ String.concat " " rest)))
-       | other -> Error (`Unknown_subcmd other))
+       | other -> Error (`Unknown_subcmd other)))
   | _ -> Error (`Unknown_subcmd "<non-git argv>")
 
 let pp fmt = function

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,4 +1,5 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
-        test_approval_policy test_approval_context test_approval_config)
- (libraries masc_exec masc_exec_bash_parser))
+        test_approval_policy test_approval_context test_approval_config
+        test_exec_gate_runtime)
+ (libraries masc_exec masc_exec_bash_parser masc_process unix))

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -19,12 +19,29 @@ let lit s = Shell_ir.Lit s
 let default_policy : Approval_policy.t =
   { raw_source = "(test)"; summary = "(test summary)" }
 
+let strict_overlay = Approval_config.strict_default
+
+let internal_overlay : Approval_config.agent_overlay =
+  {
+    allow_safe_in_worktree = true;
+    ask_audited = false;
+    deny_destructive_git = false;
+  }
+
 (* -- policy decide -------------------------------------------------- *)
 
-let test_safe_bin_allowed () =
+let test_safe_bin_strict_asks () =
   let s = simple (bin_ok "ls") in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s with
+  | Verdict.Ask req ->
+    assert (Bin.to_string req.bin = "ls")
+  | _ -> assert false
+
+let test_safe_bin_allowed_with_overlay () =
+  let s = simple (bin_ok "ls") in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
   | Verdict.Allow t ->
     assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "ls")
   | _ -> assert false
@@ -32,7 +49,7 @@ let test_safe_bin_allowed () =
 let test_privileged_bin_asks () =
   let s = simple (bin_ok "sudo") in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s with
   | Verdict.Ask req ->
     assert (Bin.to_string req.bin = "sudo")
   | _ -> assert false
@@ -40,8 +57,27 @@ let test_privileged_bin_asks () =
 let test_audited_bin_asks () =
   let s = simple (bin_ok "git") ~args:[ lit "status" ] in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s with
   | Verdict.Ask _ -> ()
+  | _ -> assert false
+
+let test_audited_bin_allowed_with_overlay () =
+  let s = simple (bin_ok "git") ~args:[ lit "status" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
+  | Verdict.Allow t ->
+    assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "git")
+  | _ -> assert false
+
+let test_audited_bin_with_cwd_flag_allowed_with_overlay () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "-C"; lit "/tmp/repo"; lit "status" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
+  | Verdict.Allow t ->
+    assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "git")
   | _ -> assert false
 
 let test_destructive_git_denies () =
@@ -50,9 +86,20 @@ let test_destructive_git_denies () =
       ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
   in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s with
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_force); _ } ->
     ()
+  | _ -> assert false
+
+let test_destructive_git_allowed_with_overlay () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
+  | Verdict.Allow t ->
+    assert (Bin.to_string (Verdict.Trusted_argv.bin t) = "git")
   | _ -> assert false
 
 let test_write_outside_denies () =
@@ -63,7 +110,7 @@ let test_write_outside_denies () =
   in
   let s = simple (bin_ok "echo") ~redirects:[ redir ] in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
   | Verdict.Deny { reason = Path_escape _; _ } -> ()
   | _ -> assert false
 
@@ -72,7 +119,7 @@ let test_write_outside_denies () =
 let test_gate_allow_returns_trusted_argv () =
   let s = simple (bin_ok "ls") in
   let caps = Capability_check.of_simple s in
-  match Approval_policy.decide default_policy ~caps ~simple:s with
+  match Approval_policy.decide default_policy ~overlay:internal_overlay ~caps ~simple:s with
   | Verdict.Allow _ as v ->
     (match Exec_gate.run v with
      | Ok t ->
@@ -83,7 +130,7 @@ let test_gate_allow_returns_trusted_argv () =
 let test_gate_ask_surfaces_as_error () =
   let s = simple (bin_ok "sudo") in
   let caps = Capability_check.of_simple s in
-  let v = Approval_policy.decide default_policy ~caps ~simple:s in
+  let v = Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s in
   match Exec_gate.run v with
   | Error (`Ask_required _) -> ()
   | _ -> assert false
@@ -94,16 +141,20 @@ let test_gate_deny_surfaces_as_error () =
       ~args:[ lit "push"; lit "--force"; lit "origin"; lit "main" ]
   in
   let caps = Capability_check.of_simple s in
-  let v = Approval_policy.decide default_policy ~caps ~simple:s in
+  let v = Approval_policy.decide default_policy ~overlay:strict_overlay ~caps ~simple:s in
   match Exec_gate.run v with
   | Error (`Denied (Destructive_git _)) -> ()
   | _ -> assert false
 
 let () =
-  test_safe_bin_allowed ();
+  test_safe_bin_strict_asks ();
+  test_safe_bin_allowed_with_overlay ();
   test_privileged_bin_asks ();
   test_audited_bin_asks ();
+  test_audited_bin_allowed_with_overlay ();
+  test_audited_bin_with_cwd_flag_allowed_with_overlay ();
   test_destructive_git_denies ();
+  test_destructive_git_allowed_with_overlay ();
   test_write_outside_denies ();
   test_gate_allow_returns_trusted_argv ();
   test_gate_ask_surfaces_as_error ();

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -32,6 +32,15 @@ let test_git_status_classified_as_git_read () =
   | [ Capability.Git (Git_op.Read `Status) ] -> ()
   | _ -> assert false
 
+let test_git_status_with_cwd_flag_classified_as_git_read () =
+  let ir =
+    Shell_ir.Simple
+      (simple ~args:[ lit "-C"; lit "/tmp/repo"; lit "status" ] (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Read `Status) ] -> ()
+  | _ -> assert false
+
 let test_git_push_force_destructive () =
   let ir =
     Shell_ir.Simple
@@ -117,6 +126,7 @@ let test_pipeline_folds_caps () =
 let () =
   test_ls_emits_exec_bin ();
   test_git_status_classified_as_git_read ();
+  test_git_status_with_cwd_flag_classified_as_git_read ();
   test_git_push_force_destructive ();
   test_git_with_var_falls_back_to_exec_bin ();
   test_env_set_prefix_emitted_first ();

--- a/lib/exec/test/test_exec_gate_runtime.ml
+++ b/lib/exec/test/test_exec_gate_runtime.ml
@@ -1,0 +1,104 @@
+open Masc_exec
+
+let substring_contains ~haystack ~needle =
+  let hl = String.length haystack in
+  let nl = String.length needle in
+  if nl = 0 then true
+  else if nl > hl then false
+  else
+    let rec find i =
+      if i + nl > hl then false
+      else if String.sub haystack i nl = needle then true
+      else find (i + 1)
+    in
+    find 0
+
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let with_tap_capture f =
+  let captured = ref [] in
+  Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+  Fun.protect
+    ~finally:(fun () -> Exec_tap.disable ())
+    (fun () -> f captured)
+
+let find_gate_line lines =
+  List.find_opt
+    (fun line -> substring_contains ~haystack:line ~needle:"\"kind\":\"Exec_gate.decision\"")
+    lines
+
+let test_enforced_strict_safe_blocks () =
+  with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
+    let status, out =
+      Exec_gate.run_argv_with_status
+        ~actor:"unknown/strict"
+        ~raw_source:"pwd"
+        ~summary:"strict pwd"
+        ~timeout_sec:5.0
+        [ "pwd" ]
+    in
+    assert (status = Unix.WEXITED 126);
+    assert (substring_contains ~haystack:out ~needle:"ask_required"))
+
+let test_parallel_records_shadow_and_executes () =
+  with_tap_capture (fun captured ->
+    with_env "MASC_EXEC_GATE" (Some "parallel") (fun () ->
+      let out =
+        Exec_gate.run_argv
+          ~actor:"unknown/strict"
+          ~raw_source:"pwd"
+          ~summary:"strict pwd"
+          ~timeout_sec:5.0
+          [ "pwd" ]
+      in
+      assert (String.trim out <> "");
+      match find_gate_line !captured with
+      | None -> assert false
+      | Some line ->
+        assert (substring_contains ~haystack:line ~needle:"\"gate_mode\":\"parallel\"");
+        assert (substring_contains ~haystack:line ~needle:"\"gate_verdict\":\"ask\"");
+        assert (substring_contains ~haystack:line ~needle:"\"gate_enforced\":false")))
+
+let test_enforced_internal_audited_allows () =
+  with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
+    let status, out =
+      Exec_gate.run_argv_with_status
+        ~actor:"coord/git"
+        ~raw_source:"git --version"
+        ~summary:"coord git version"
+        ~timeout_sec:5.0
+        [ "git"; "--version" ]
+    in
+    assert (status = Unix.WEXITED 0);
+    assert (substring_contains ~haystack:out ~needle:"git version"))
+
+let test_enforced_internal_stdin_allows () =
+  with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
+    let status, out =
+      Exec_gate.run_argv_with_stdin_and_status
+        ~actor:"system/task_sandbox"
+        ~raw_source:"cat"
+        ~summary:"stdin cat"
+        ~timeout_sec:5.0
+        ~stdin_content:"hello\n"
+        [ "cat" ]
+    in
+    assert (status = Unix.WEXITED 0);
+    assert (substring_contains ~haystack:out ~needle:"hello"))
+
+let () =
+  test_enforced_strict_safe_blocks ();
+  test_parallel_records_shadow_and_executes ();
+  test_enforced_internal_audited_allows ();
+  test_enforced_internal_stdin_allows ();
+  print_endline "[test_exec_gate_runtime] all tests passed"

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -34,6 +34,11 @@ let test_git_op_read () =
   | Ok (Git_op.Read _) -> ()
   | _ -> failwith "status must be Read"
 
+let test_git_op_read_with_cwd_flag () =
+  match Git_op.of_argv [ "git"; "-C"; "/tmp/repo"; "status" ] with
+  | Ok (Git_op.Read _) -> ()
+  | _ -> failwith "git -C /tmp/repo status must be Read"
+
 let test_git_op_unknown () =
   match Git_op.of_argv [ "git"; "exotic-subcmd" ] with
   | Error (`Unknown_subcmd _) -> ()
@@ -83,6 +88,7 @@ let () =
   test_bin_empty_rejected ();
   test_git_op_destructive_detection ();
   test_git_op_read ();
+  test_git_op_read_with_cwd_flag ();
   test_git_op_unknown ();
   test_parsed_polymorphic ();
   test_path_scope_classify ();

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -37,7 +37,7 @@ let test_git_op_read () =
 let test_git_op_read_with_cwd_flag () =
   match Git_op.of_argv [ "git"; "-C"; "/tmp/repo"; "status" ] with
   | Ok (Git_op.Read _) -> ()
-  | _ -> failwith "git -C /tmp/repo status must be Read"
+  | _ -> assert false (* git -C /tmp/repo status must be Read *)
 
 let test_git_op_unknown () =
   match Git_op.of_argv [ "git"; "exotic-subcmd" ] with

--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -67,21 +67,35 @@ let request_curl ~timeout_sec body =
           in
           if Process_eio.is_initialized () then
             (try
-               let output = Process_eio.run_argv ~timeout_sec argv in
+               let output =
+                 Masc_exec.Exec_gate.run_argv
+                   ~actor:"system/graphql_client_eio"
+                   ~raw_source:(String.concat " " (List.map Filename.quote argv))
+                   ~summary:"graphql curl fallback"
+                   ~timeout_sec
+                   argv
+               in
                ensure_json_response output
              with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
           else
             (* Unix fallback when Eio loop not started *)
             (try
-               Exec_tap.record
-                 ~kind:Exec_tap.Unix_open_process_args_in ~argv ();
-               let ic = Unix.open_process_args_in "curl" (Array.of_list argv) in
-               let output =
-                 Fun.protect
-                   ~finally:(fun () -> ignore (Unix.close_process_in ic))
-                   (fun () -> In_channel.input_all ic)
-               in
-               ensure_json_response output
+               match
+                 Masc_exec.Exec_gate.run_argv_with_status
+                   ~actor:"system/graphql_client_eio"
+                   ~raw_source:(String.concat " " (List.map Filename.quote argv))
+                   ~summary:"graphql curl fallback"
+                   ~timeout_sec
+                   argv
+               with
+               | Unix.WEXITED 0, output ->
+                   ensure_json_response output
+               | Unix.WEXITED code, output ->
+                   Error (Printf.sprintf "curl exited %d: %s" code output)
+               | Unix.WSIGNALED code, _ ->
+                   Error (Printf.sprintf "curl signaled: %d" code)
+               | Unix.WSTOPPED code, _ ->
+                   Error (Printf.sprintf "curl stopped: %d" code)
              with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn))))
 
 (** Cohttp_eio primary transport with curl fallback. *)

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -234,10 +234,16 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
       | _ -> []
     in
     try
+      let argv = argv @ [ "--data-binary"; "@-" ] in
+      let raw_source = String.concat " " (List.map Filename.quote argv) in
       let status, raw_body =
-        Process_eio.run_argv_with_stdin_and_status
-          ~timeout_sec:20.0 ~stdin_content:request_body
-          (argv @ [ "--data-binary"; "@-" ])
+        Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+          ~actor:"system/worker_container_types"
+          ~raw_source
+          ~summary:"worker container curl fallback"
+          ~timeout_sec:20.0
+          ~stdin_content:request_body
+          argv
       in
       match status with
       | Unix.WEXITED 0 -> Ok raw_body

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -16,17 +16,34 @@ type focus_payload = {
   task_id: string option;
 }
 
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
 (** {1 Non-blocking Shell Execution} *)
 
 (** Run argv and get single line (Eio-native, no shell) *)
 let run_argv_line argv =
-  let output = Process_eio.run_argv ~timeout_sec:10.0 argv in
+  let output =
+    Masc_exec.Exec_gate.run_argv
+      ~actor:"system/notify"
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"notify argv"
+      ~timeout_sec:10.0
+      argv
+  in
   match String.split_on_char '\n' output with
   | [] -> ""
   | h :: _ -> String.trim h
 
 let run_argv_ignore argv =
-  (try ignore (Process_eio.run_argv_with_status ~timeout_sec:60.0 argv)
+  (try
+     ignore
+       (Masc_exec.Exec_gate.run_argv_with_status
+          ~actor:"system/notify"
+          ~raw_source:(exec_gate_raw_source argv)
+          ~summary:"notify argv"
+          ~timeout_sec:60.0
+          argv)
    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.error "run_argv_ignore failed: %s" (Printexc.to_string exn))
 
 (** Get non-empty environment variable *)

--- a/lib/process/exec_tap.ml
+++ b/lib/process/exec_tap.ml
@@ -11,6 +11,7 @@
     - Writer exceptions are swallowed.  Tap must not break production. *)
 
 type call_kind =
+  | Exec_gate_decision
   | Process_eio_run_argv
   | Process_eio_run_argv_with_stdin
   | Process_eio_run_argv_with_stdin_and_status
@@ -21,6 +22,7 @@ type call_kind =
   | Unix_open_process_args_full
 
 let kind_to_string = function
+  | Exec_gate_decision -> "Exec_gate.decision"
   | Process_eio_run_argv -> "Process_eio.run_argv"
   | Process_eio_run_argv_with_stdin -> "Process_eio.run_argv_with_stdin"
   | Process_eio_run_argv_with_stdin_and_status ->
@@ -76,6 +78,9 @@ let add_json_array_of_strings buf xs =
     xs;
   Buffer.add_char buf ']'
 
+let add_json_bool buf value =
+  Buffer.add_string buf (if value then "true" else "false")
+
 let env_keys = function
   | None -> None
   | Some arr ->
@@ -98,7 +103,12 @@ let now_iso8601 () =
 
 (* ── record ─────────────────────────────────────────────── *)
 
-let record ~kind ~argv ?env ?cwd () =
+type extra_field =
+  [ `String of string * string
+  | `Bool of string * bool
+  ]
+
+let write_line ~kind ~argv ?env ?cwd (extras : extra_field list) =
   match Atomic.get state with
   | Off -> ()
   | On { writer } ->
@@ -117,9 +127,37 @@ let record ~kind ~argv ?env ?cwd () =
       (match cwd with
        | None -> Buffer.add_string buf "null"
        | Some s -> add_json_string buf s);
+      List.iter
+        (function
+          | `String (name, value) ->
+            Buffer.add_char buf ',';
+            add_json_string buf name;
+            Buffer.add_char buf ':';
+            add_json_string buf value
+          | `Bool (name, value) ->
+            Buffer.add_char buf ',';
+            add_json_string buf name;
+            Buffer.add_char buf ':';
+            add_json_bool buf value)
+        extras;
       Buffer.add_string buf "}\n";
       let line = Buffer.contents buf in
       (try writer line with _exn -> ())
+
+let record ~kind ~argv ?env ?cwd () =
+  write_line ~kind ~argv ?env ?cwd []
+
+let record_gate_decision ~actor ~raw_source ~summary ~gate_mode
+    ~gate_verdict ~gate_enforced ~argv ?env ?cwd () =
+  write_line ~kind:Exec_gate_decision ~argv ?env ?cwd
+    [
+      `String ("actor", actor);
+      `String ("raw_source", raw_source);
+      `String ("summary", summary);
+      `String ("gate_mode", gate_mode);
+      `String ("gate_verdict", gate_verdict);
+      `Bool ("gate_enforced", gate_enforced);
+    ]
 
 (* ── install_from_env ─────────────────────────────────────────────── *)
 

--- a/lib/process/exec_tap.mli
+++ b/lib/process/exec_tap.mli
@@ -16,6 +16,7 @@
 (** Source of an exec call.  Report generator uses this to distinguish
     Process_eio wrappers from direct Unix.* callsites. *)
 type call_kind =
+  | Exec_gate_decision
   | Process_eio_run_argv
   | Process_eio_run_argv_with_stdin
   | Process_eio_run_argv_with_stdin_and_status
@@ -56,3 +57,20 @@ val record :
 (** Emit one JSONL line when enabled, no-op otherwise.  [env] is reduced
     to its keys (values stripped — avoids secret leakage).  [cwd] is the
     caller-provided working directory, not the process cwd. *)
+
+val record_gate_decision :
+  actor:string ->
+  raw_source:string ->
+  summary:string ->
+  gate_mode:string ->
+  gate_verdict:string ->
+  gate_enforced:bool ->
+  argv:string list ->
+  ?env:string array ->
+  ?cwd:string ->
+  unit ->
+  unit
+(** Emit one JSONL line describing an exec-gate decision.  This is
+    separate from the eventual [Process_eio.*] spawn record so shadow
+    mode can publish verdict evidence without mutating the actual spawn
+    path or double-counting spawns in downstream reports. *)

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -63,6 +63,22 @@ let close_quietly fd =
   try Unix.close fd with
   | Unix.Unix_error _ -> () (* intentional: best-effort cleanup *)
 
+let unix_cwd_mutex = Stdlib.Mutex.create ()
+
+let create_process_env ?cwd prog argv env stdin_fd stdout_fd stderr_fd =
+  match cwd with
+  | None -> Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd stderr_fd
+  | Some dir ->
+      Stdlib.Mutex.lock unix_cwd_mutex;
+      let original_dir = Sys.getcwd () in
+      Fun.protect
+        ~finally:(fun () ->
+          (try Sys.chdir original_dir with _ -> ());
+          Stdlib.Mutex.unlock unix_cwd_mutex)
+        (fun () ->
+          Sys.chdir dir;
+          Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd stderr_fd)
+
 let output_for_status ~(status : Unix.process_status) ~(stdout : string)
     ~(stderr : string) : string =
   let succeeded =
@@ -116,7 +132,7 @@ let captured_stderr_or_empty path_opt =
   | Some path -> read_stderr_capture path
   | None -> ""
 
-let with_unix_capture ?env ?stdin_content ?(capture_stderr = false)
+let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
     (argv : string list)
     ~(on_error : string -> string -> 'a)
     ~(on_success : Unix.process_status -> string -> string -> 'a) : 'a =
@@ -178,8 +194,7 @@ let with_unix_capture ?env ?stdin_content ?(capture_stderr = false)
          | None -> Unix.stdin
        in
        let pid =
-         Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_w
-           stderr_fd
+         create_process_env ?cwd prog argv env stdin_fd stdout_w stderr_fd
        in
        Option.iter close_quietly !stdin_r_ref;
        stdin_r_ref := None;
@@ -255,15 +270,15 @@ let run_unix_argv_fallback ?env (argv : string list) : string =
       process_error_output ~label ~reason ~stderr ())
     ~on_success:(fun _status stdout _stderr -> stdout)
 
-let run_unix_argv_with_status_fallback ?env (argv : string list) :
-    Unix.process_status * string =
+let run_unix_argv_with_status_split_fallback ?env ?cwd (argv : string list) :
+    Unix.process_status * string * string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env ~capture_stderr:true argv
+  with_unix_capture ?env ?cwd ~capture_stderr:true argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
-      (Unix.WEXITED 127, process_error_output ~label ~reason ~stderr ()))
+      (Unix.WEXITED 127, "", process_error_output ~label ~reason ~stderr ()))
     ~on_success:(fun status stdout stderr ->
-      (status, output_for_status ~status ~stdout ~stderr))
+      (status, stdout, stderr))
 
 let run_unix_argv_with_stdin_fallback ?env ~(stdin_content : string)
     (argv : string list) : string =
@@ -274,17 +289,18 @@ let run_unix_argv_with_stdin_fallback ?env ~(stdin_content : string)
       process_error_output ~label ~reason ~stderr ())
     ~on_success:(fun _status stdout _stderr -> stdout)
 
-let run_unix_argv_with_stdin_and_status_fallback
+let run_unix_argv_with_stdin_and_status_split_fallback
     ?env
+    ?cwd
     ~(stdin_content : string)
-    (argv : string list) : Unix.process_status * string =
+    (argv : string list) : Unix.process_status * string * string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env ~stdin_content ~capture_stderr:true argv
+  with_unix_capture ?env ?cwd ~stdin_content ~capture_stderr:true argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
-      (Unix.WEXITED 127, process_error_output ~label ~reason ~stderr ()))
+      (Unix.WEXITED 127, "", process_error_output ~label ~reason ~stderr ()))
     ~on_success:(fun status stdout stderr ->
-      (status, output_for_status ~status ~stdout ~stderr))
+      (status, stdout, stderr))
 
 (** ── Eio-native process execution (global refs) ─────────────────── *)
 
@@ -415,19 +431,27 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
                 (Printexc.to_string exn);
               process_error_output ~label ~reason:(reason_of_exn_for_output exn) ())
 
-let run_argv_with_stdin_and_status
+let run_argv_with_stdin_and_status_split
     ?(timeout_sec = 60.0)
     ?env
+    ?cwd
     ~(stdin_content : string)
-    (argv : string list) : Unix.process_status * string =
+    (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin_and_status ~argv ?env ();
   if not (is_initialized ()) then
-    run_unix_argv_with_stdin_and_status_fallback ?env ~stdin_content argv
+    run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd ~stdin_content
+      argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_stdin_and_status_fallback ?env ~stdin_content argv
-    | Ok pm, Ok clk, Ok cwd ->
+        run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd
+          ~stdin_content argv
+    | Ok pm, Ok clk, Ok default_cwd ->
+        let effective_cwd =
+          match cwd with
+          | None -> default_cwd
+          | Some dir -> Eio.Path.(default_cwd / dir)
+        in
         let stdout_buf = Buffer.create 1024 in
         let stderr_buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
@@ -436,53 +460,64 @@ let run_argv_with_stdin_and_status
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
               let unix_status =
                 Eio.Switch.run (fun sw ->
-                    spawn_and_drain_both ~sw pm ~cwd ?env ~stdin_source argv
-                      stdout_buf stderr_buf)
+                    spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
+                      ~stdin_source argv stdout_buf stderr_buf)
               in
-              ( unix_status
-              , output_for_status
-                  ~status:unix_status
-                  ~stdout:(Buffer.contents stdout_buf)
-                  ~stderr:(Buffer.contents stderr_buf) ))
+              (unix_status, Buffer.contents stdout_buf, Buffer.contents stderr_buf))
         with
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
             let timeout_status = Unix.WEXITED 124 in
-            let output =
-              output_for_status
-                ~status:timeout_status
-                ~stdout:(Buffer.contents stdout_buf)
-                ~stderr:(Buffer.contents stderr_buf)
-            in
-            ( timeout_status
-            , if String.trim output = "" then
+            let stdout = Buffer.contents stdout_buf in
+            let stderr = Buffer.contents stderr_buf in
+            let stderr =
+              if String.trim stdout = "" && String.trim stderr = "" then
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-              else output )
+              else stderr
+            in
+            (timeout_status, stdout, stderr)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_with_stdin_and_status_fallback ?env ~stdin_content
-                argv
+              run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd
+                ~stdin_content argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);
-              ( Unix.WEXITED 127
-              , process_error_output ~label ~reason:(reason_of_exn_for_output exn) () ))
+              ( Unix.WEXITED 127,
+                "",
+                process_error_output ~label
+                  ~reason:(reason_of_exn_for_output exn) () ))
 
-let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) : Unix.process_status * string =
+let run_argv_with_stdin_and_status
+    ?(timeout_sec = 60.0)
+    ?env
+    ?cwd
+    ~(stdin_content : string)
+    (argv : string list) : Unix.process_status * string =
+  let status, stdout, stderr =
+    run_argv_with_stdin_and_status_split ~timeout_sec ?env ?cwd ~stdin_content
+      argv
+  in
+  (status, output_for_status ~status ~stdout ~stderr)
+
+let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
+    (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status ~argv ?env ?cwd ();
-  if not (is_initialized ()) then run_unix_argv_with_status_fallback ?env argv
+  if not (is_initialized ()) then
+    run_unix_argv_with_status_split_fallback ?env ?cwd argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_status_fallback ?env argv
+        run_unix_argv_with_status_split_fallback ?env ?cwd argv
     | Ok pm, Ok clk, Ok default_cwd ->
-        let effective_cwd = match cwd with
+        let effective_cwd =
+          match cwd with
           | None -> default_cwd
           | Some dir -> Eio.Path.(default_cwd / dir)
         in
@@ -496,36 +531,39 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) : 
                     spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env argv
                       stdout_buf stderr_buf)
               in
-              ( unix_status
-              , output_for_status
-                  ~status:unix_status
-                  ~stdout:(Buffer.contents stdout_buf)
-                  ~stderr:(Buffer.contents stderr_buf) ))
+              (unix_status, Buffer.contents stdout_buf, Buffer.contents stderr_buf))
         with
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
             let timeout_status = Unix.WEXITED 124 in
-            let output =
-              output_for_status
-                ~status:timeout_status
-                ~stdout:(Buffer.contents stdout_buf)
-                ~stderr:(Buffer.contents stderr_buf)
-            in
-            ( timeout_status
-            , if String.trim output = "" then
+            let stdout = Buffer.contents stdout_buf in
+            let stderr = Buffer.contents stderr_buf in
+            let stderr =
+              if String.trim stdout = "" && String.trim stderr = "" then
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
-              else output )
+              else stderr
+            in
+            (timeout_status, stdout, stderr)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_with_status_fallback ?env argv
+              run_unix_argv_with_status_split_fallback ?env ?cwd argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);
-              ( Unix.WEXITED 127
-              , process_error_output ~label ~reason:(reason_of_exn_for_output exn) () ))
+              ( Unix.WEXITED 127,
+                "",
+                process_error_output ~label
+                  ~reason:(reason_of_exn_for_output exn) () ))
+
+let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd
+    (argv : string list) : Unix.process_status * string =
+  let status, stdout, stderr =
+    run_argv_with_status_split ~timeout_sec ?env ?cwd argv
+  in
+  (status, output_for_status ~status ~stdout ~stderr)

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -46,9 +46,20 @@ val run_argv_with_stdin : ?timeout_sec:float -> ?env:string array -> stdin_conte
 val run_argv_with_stdin_and_status :
   ?timeout_sec:float ->
   ?env:string array ->
+  ?cwd:string ->
   stdin_content:string ->
   string list ->
   (Unix.process_status * string)
+
+val run_argv_with_stdin_and_status_split :
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  stdin_content:string ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Like [run_argv_with_stdin_and_status], but returns
+    [(status, stdout, stderr)] without combining stderr into stdout. *)
 
 (** Run command with explicit argv, return (Unix.process_status, stdout).
     Uses spawn + await to get exit status without raising.
@@ -59,3 +70,12 @@ val run_argv_with_stdin_and_status :
            Ignored when falling back to Unix process execution.
     @since 2.45.0 *)
 val run_argv_with_status : ?timeout_sec:float -> ?env:string array -> ?cwd:string -> string list -> (Unix.process_status * string)
+
+val run_argv_with_status_split :
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Like [run_argv_with_status], but returns
+    [(status, stdout, stderr)] without combining stderr into stdout. *)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -63,28 +63,17 @@ let git_rev_parse_short path =
   | Some dir when not (Sys.file_exists dir) -> None
   | Some dir ->
       let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
-      Exec_tap.record
-        ~kind:Exec_tap.Unix_open_process_args_full
-        ~argv ~cwd:dir ();
-      let channels =
-        Unix.open_process_args_full "git"
-          (Array.of_list argv)
-          (Unix.environment ())
-      in
-      let stdout, stdin, stderr = channels in
-      (try
-         close_out_noerr stdin;
-         let output = In_channel.input_all stdout in
-         ignore (In_channel.input_all stderr);
-         match Unix.close_process_full channels with
-         | Unix.WEXITED 0 -> trim_to_option output
-         | _ -> None
+      let raw_source = String.concat " " (List.map Filename.quote argv) in
+      (match
+         Masc_exec.Exec_gate.run_argv_with_status
+           ~actor:"system/runtime_info"
+           ~raw_source
+           ~summary:"dashboard runtime git probe"
+           ~timeout_sec:5.0
+           argv
        with
-       | Sys_error _ | Unix.Unix_error _ ->
-           ignore
-             (try Unix.close_process_full channels
-              with Unix.Unix_error _ -> Unix.WEXITED 1);
-           None)
+       | Unix.WEXITED 0, output -> trim_to_option output
+       | _ -> None)
 
 let path_item_json ~source path =
   `Assoc

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -72,7 +72,11 @@ let looks_like_server_command command =
 
 let process_command pid =
   match
-    Process_eio.run_argv_with_status ~timeout_sec:1.0
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"system/startup_takeover"
+      ~raw_source:(Printf.sprintf "ps -p %d -o command=" pid)
+      ~summary:"startup takeover ps probe"
+      ~timeout_sec:1.0
       [ "ps"; "-p"; string_of_int pid; "-o"; "command=" ]
   with
   | Unix.WEXITED 0, output -> (

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -254,28 +254,6 @@ let parse_command cmd =
   let parts = String.split_on_char ' ' cmd in
   List.filter (fun s -> String.length s > 0) parts
 
-let close_quietly fd =
-  try Unix.close fd with
-  | Unix.Unix_error _ -> ()
-
-let remove_temp_file_quietly path =
-  try Sys.remove path with
-  | Sys_error _ -> ()
-
-let create_stderr_tempfile () =
-  let path = Filename.temp_file "masc_spawn_stderr" ".tmp" in
-  let fd =
-    Unix.openfile path [ Unix.O_WRONLY; Unix.O_TRUNC; Unix.O_CLOEXEC ] 0o600
-  in
-  (path, fd)
-
-let read_stderr_capture path =
-  try In_channel.with_open_bin path In_channel.input_all with
-  | _ ->
-    Printf.sprintf
-      "(stderr capture error) failed to read captured stderr file %s"
-      (Filename.basename path)
-
 let output_for_status ~(status : Unix.process_status) ~(stdout : string)
     ~(stderr : string) : string =
   match status with
@@ -290,59 +268,6 @@ let fallback_spawn_failure_output ~exit_code =
   Printf.sprintf
     "spawned agent exited with code %d without any stdout/stderr output"
     exit_code
-
-(** Mutex to serialize Sys.chdir + Unix.create_process.
-    Sys.chdir mutates process-global CWD; concurrent spawns without
-    serialization cause child processes to inherit the wrong directory. *)
-let chdir_mutex = Eio.Mutex.create ()
-
-(** Fork a subprocess with optional CWD change, holding [chdir_mutex]
-    only for the chdir-fork-restore window.  Returns the child pid, stdout
-    pipe, and a private stderr capture path. *)
-let fork_with_cwd ~cmd_array ~stdin_content ~working_dir ~config_working_dir =
-  Eio_guard.with_mutex chdir_mutex (fun () ->
-    let original_dir = Sys.getcwd () in
-    let target_dir = match working_dir with
-      | Some dir -> Some dir
-      | None -> config_working_dir
-    in
-    Option.iter Sys.chdir target_dir;
-    Fun.protect
-      ~finally:(fun () ->
-        if Option.is_some target_dir then Sys.chdir original_dir)
-      (fun () ->
-        let stdout_read, stdout_write = Unix.pipe ~cloexec:true () in
-        let stdin_read, stdin_write = Unix.pipe ~cloexec:true () in
-        let stderr_path, stderr_fd = create_stderr_tempfile () in
-        try
-          Exec_tap.record
-            ~kind:Exec_tap.Unix_create_process
-            ~argv:(Array.to_list cmd_array)
-            ?cwd:target_dir ();
-          let pid =
-            Unix.create_process (Array.get cmd_array 0) cmd_array stdin_read
-              stdout_write stderr_fd
-          in
-          Unix.close stdout_write;
-          Unix.close stdin_read;
-          Unix.close stderr_fd;
-          let rec write_all off len =
-            if len > 0 then begin
-              let written = Unix.write_substring stdin_write stdin_content off len in
-              write_all (off + written) (len - written)
-            end
-          in
-          write_all 0 (String.length stdin_content);
-          Unix.close stdin_write;
-          (pid, stdout_read, stderr_path)
-        with exn ->
-          close_quietly stdout_read;
-          close_quietly stdout_write;
-          close_quietly stdin_read;
-          close_quietly stdin_write;
-          close_quietly stderr_fd;
-          remove_temp_file_quietly stderr_path;
-          raise exn))
 
 let add_default_model_arg agent_name argv =
   match Provider_adapter.resolve_direct_adapter agent_name with
@@ -412,43 +337,29 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
        preventing --allowed-tools array values from leaking into
        positional query slot. Fixes gemini "Cannot use both a positional
        prompt and the --prompt (-p) flag together" error. (#5975) *)
-    let cmd_args =
-      [ "timeout"; string_of_int timeout ] @ base_args @ prompt_args @ mcp_args
-    in
-    let cmd_array = Array.of_list cmd_args in
-
+    let cmd_args = base_args @ prompt_args @ mcp_args in
     let stdin_content = if config.stdin_prompt then augmented_prompt else "" in
+    let cwd =
+      match working_dir with
+      | Some dir -> Some dir
+      | None -> config.working_dir
+    in
+    let raw_source = String.concat " " (List.map Filename.quote cmd_args) in
 
     try
-      (* Fork with chdir mutex to prevent CWD race between concurrent spawns *)
-      let (pid, stdout_read, stderr_path) =
-        fork_with_cwd ~cmd_array ~stdin_content
-          ~working_dir ~config_working_dir:config.working_dir
+      let raw_output, stderr_output, status =
+        let status, stdout, stderr =
+          Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
+            ~actor:"system/spawn"
+            ~raw_source
+            ~summary:"spawn agent cli"
+            ~timeout_sec:(float_of_int timeout)
+            ?cwd
+            ~stdin_content
+            cmd_args
+        in
+        (stdout, stderr, status)
       in
-
-      (* Read output + wait in systhread to avoid blocking the Eio event loop.
-         Without this, a long-running subprocess (e.g. fire_task) freezes the
-         entire server — health endpoint, SSE, all keeper fibers. *)
-      let (raw_output, stderr_output, status) =
-        Fun.protect
-          ~finally:(fun () -> remove_temp_file_quietly stderr_path)
-          (fun () ->
-            Eio_guard.run_in_systhread (fun () ->
-              let ic = Unix.in_channel_of_descr stdout_read in
-              let output =
-                Fun.protect
-                  ~finally:(fun () -> In_channel.close ic)
-                  (fun () -> In_channel.input_all ic)
-              in
-              let rec waitpid_retry () =
-                try Unix.waitpid [] pid
-                with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_retry ()
-              in
-              let (_, status) = waitpid_retry () in
-              (output, read_stderr_capture stderr_path, status)))
-      in
-
-      (* CWD already restored inside fork_with_cwd *)
 
       let elapsed_ms =
         int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
@@ -492,7 +403,6 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->
-    (* CWD already restored inside fork_with_cwd *)
     {
       success = false;
       output = Printf.sprintf "Spawn error: %s" (Printexc.to_string e);

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -16,17 +16,32 @@ type sandbox = {
   created_at : float;
 }
 
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
 (** Run git command in the given directory and collect stdout lines. *)
 let git_lines ~cwd args =
   let argv = ["git"; "-C"; cwd] @ args in
-  Process_eio.run_argv ~timeout_sec:30.0 argv
+  Masc_exec.Exec_gate.run_argv
+    ~actor:"system/task_sandbox"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"task_sandbox git"
+    ~timeout_sec:30.0
+    argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> String.trim s <> "")
 
 (** Run git command and get exit code. *)
 let git_exit ~cwd args =
   let argv = ["git"; "-C"; cwd] @ args in
-  match Process_eio.run_argv_with_status ~timeout_sec:30.0 argv with
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"system/task_sandbox"
+      ~raw_source:(exec_gate_raw_source argv)
+      ~summary:"task_sandbox git"
+      ~timeout_sec:30.0
+      argv
+  with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -199,9 +199,16 @@ let persist_discard_record
     ]
 
 let git_diff_patch ~workdir =
+  let argv =
+    [ "git"; "-C"; workdir; "diff"; "--no-ext-diff"; "--binary"; "--relative" ]
+  in
   let status, output =
-    Process_eio.run_argv_with_status ~timeout_sec:30.0
-      [ "git"; "-C"; workdir; "diff"; "--no-ext-diff"; "--binary"; "--relative" ]
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/autoresearch_cycle"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"autoresearch cycle git diff"
+      ~timeout_sec:30.0
+      argv
   in
   match status with
   | Unix.WEXITED 0 -> Ok output
@@ -212,9 +219,14 @@ let git_diff_patch ~workdir =
     Error (Printf.sprintf "git diff terminated with signal %d" signal)
 
 let sync_target_file_to_index ~workdir ~target_file =
+  let argv = [ "git"; "-C"; workdir; "add"; "--"; target_file ] in
   let status, output =
-    Process_eio.run_argv_with_status ~timeout_sec:10.0
-      [ "git"; "-C"; workdir; "add"; "--"; target_file ]
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/autoresearch_cycle"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"autoresearch cycle git add"
+      ~timeout_sec:10.0
+      argv
   in
   match status with
   | Unix.WEXITED 0 -> ()

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -41,24 +41,30 @@ let raw_completion_at ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec () 
   in
   let started = Time_compat.now () in
   try
+    let argv =
+      [
+        "curl";
+        "-sS";
+        "--http1.1";
+        "--max-time";
+        string_of_int (max 1 timeout_sec);
+        "-X";
+        "POST";
+        url;
+        "-H";
+        "content-type: application/json";
+        "--data-binary";
+        "@-";
+      ]
+    in
     let status, body =
-      Process_eio.run_argv_with_stdin_and_status
+      Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+        ~actor:"tool/local_runtime_bench"
+        ~raw_source:(String.concat " " (List.map Filename.quote argv))
+        ~summary:"tool local runtime raw completion"
         ~timeout_sec:(float_of_int (max 1 (timeout_sec + 2)))
         ~stdin_content:request_body
-        [
-          "curl";
-          "-sS";
-          "--http1.1";
-          "--max-time";
-          string_of_int (max 1 timeout_sec);
-          "-X";
-          "POST";
-          url;
-          "-H";
-          "content-type: application/json";
-          "--data-binary";
-          "@-";
-        ]
+        argv
     in
     let latency_ms =
       int_of_float ((Time_compat.now () -. started) *. 1000.0)

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -109,9 +109,14 @@ let process_matches_runtime_ports ports (process : llama_process) =
   | None -> false
 
 let discover_processes () =
+  let argv = [ "ps"; "-ax"; "-o"; "pid=,command=" ] in
   let status, body =
-    Process_eio.run_argv_with_status ~timeout_sec:5.0
-      [ "ps"; "-ax"; "-o"; "pid=,command=" ]
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/local_runtime"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"tool local runtime process discovery"
+      ~timeout_sec:5.0
+      argv
   in
   match status with
   | Unix.WEXITED 0 ->
@@ -166,9 +171,14 @@ let fetch_models_at base_url =
   let url =
     String.trim base_url ^ Masc_network_defaults.openai_models_path
   in
+  let argv = [ "curl"; "-sS"; "--max-time"; "10"; url ] in
   let status, body =
-    Process_eio.run_argv_with_status ~timeout_sec:15.0
-      [ "curl"; "-sS"; "--max-time"; "10"; url ]
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/local_runtime"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"tool local runtime fetch models"
+      ~timeout_sec:15.0
+      argv
   in
   match status with
   | Unix.WEXITED 0 -> (

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -28,20 +28,27 @@ let append_headers args headers =
   List.rev_append header_args_rev args
 
 let http_get_text_with_status_with_headers ?(timeout_sec = 10) ?(headers = []) url =
-  let status, body =
-    Process_eio.run_argv_with_status
-      (append_headers
-         [
-         "curl";
-         "-sS";
-         "--http1.1";
-         "--max-time";
-         string_of_int (max 1 timeout_sec);
+  let argv =
+    append_headers
+      [
+        "curl";
+        "-sS";
+        "--http1.1";
+        "--max-time";
+        string_of_int (max 1 timeout_sec);
         "-w";
         "\n%{http_code}";
-         url;
-       ]
-         headers)
+        url;
+      ]
+      headers
+  in
+  let status, body =
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/local_runtime"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"tool local runtime http get"
+      ~timeout_sec:(float_of_int (max 1 timeout_sec))
+      argv
   in
   match status with
   | Unix.WEXITED 0 ->
@@ -66,13 +73,12 @@ let http_get_json_with_status ?(timeout_sec = 10) url =
         Error (Printf.sprintf "invalid json from %s: %s" url msg))
 
 let http_post_json_text_with_status_with_headers ~timeout_sec ?(headers = []) ~url ~body_json () =
-  let status, body =
-    Process_eio.run_argv_with_status
-      (append_headers
-         [
-         "curl";
-         "-sS";
-         "--http1.1";
+  let argv =
+    append_headers
+      [
+        "curl";
+        "-sS";
+        "--http1.1";
         "--max-time";
         string_of_int (max 1 timeout_sec);
         "-H";
@@ -81,9 +87,17 @@ let http_post_json_text_with_status_with_headers ~timeout_sec ?(headers = []) ~u
         body_json;
         "-w";
         "\n%{http_code}";
-         url;
-       ]
-         headers)
+        url;
+      ]
+      headers
+  in
+  let status, body =
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"tool/local_runtime"
+      ~raw_source:(String.concat " " (List.map Filename.quote argv))
+      ~summary:"tool local runtime http post"
+      ~timeout_sec:(float_of_int (max 1 timeout_sec))
+      argv
   in
   match status with
   | Unix.WEXITED 0 ->

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -42,6 +42,18 @@ let resolve_api_key endpoint =
                adapter.canonical_name endpoint.id env_name) )
   | None -> Ok ""
 
+let exec_gate_raw_source argv =
+  String.concat " " (List.map Filename.quote argv)
+
+let run_voice_status ?(timeout_sec = 35.0) ?(stdin_content = "") argv =
+  Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+    ~actor:"voice/bridge"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"voice bridge exec"
+    ~timeout_sec
+    ~stdin_content
+    argv
+
 let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
   let body_file = Filename.temp_file "masc_voice_request" ".json" in
   Fun.protect
@@ -67,8 +79,7 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
         @ [ "--data-binary"; "@" ^ body_file; "-o"; output_file; "-w"; "%{http_code}" ]
       in
       let status, http_code_str =
-        Process_eio.run_argv_with_stdin_and_status ~timeout_sec:35.0
-          ~stdin_content:"" argv
+        run_voice_status ~timeout_sec:35.0 argv
       in
       match status with
       | Unix.WEXITED 0 ->
@@ -125,8 +136,7 @@ let run_stt_multipart_request (req : Provider_adapter.voice_stt_request) =
     @ header_args @ form_args @ file_arg
   in
   let status, body =
-    Process_eio.run_argv_with_stdin_and_status ~timeout_sec:35.0
-      ~stdin_content:"" argv
+    run_voice_status ~timeout_sec:35.0 argv
   in
   match status with
   | Unix.WEXITED 0 -> (
@@ -880,10 +890,10 @@ let health_check ~sw:_ ~clock:_ ~net () =
 
 let play_tone freq =
   try
-    ignore (Process_eio.run_argv_with_stdin_and_status
-      ~timeout_sec:2.0 ~stdin_content:""
-      [ "play"; "-qn"; "synth"; "0.15"; "sine";
-        Printf.sprintf "%.0f" freq ])
+    ignore
+      (run_voice_status ~timeout_sec:2.0
+         [ "play"; "-qn"; "synth"; "0.15"; "sine";
+           Printf.sprintf "%.0f" freq ])
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> ()
@@ -906,9 +916,7 @@ let record_and_transcribe ~agent_id ?(timeout_sec = 15.0)
     let record_result =
       try
         let status, _output =
-          Process_eio.run_argv_with_stdin_and_status
-            ~timeout_sec:(timeout_sec +. 5.0)
-            ~stdin_content:"" rec_argv
+          run_voice_status ~timeout_sec:(timeout_sec +. 5.0) rec_argv
         in
         match status with
         | Unix.WEXITED 0 -> Ok ()

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -220,8 +220,18 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
              | Some m -> record_playback ~agent_id ~message:m
              | None -> ());
             let t0 = Unix.gettimeofday () in
+            let raw_source =
+              String.concat " " (List.map Filename.quote argv)
+            in
             try
-              match Process_eio.run_argv_with_status ~timeout_sec:60.0 argv with
+              match
+                Masc_exec.Exec_gate.run_argv_with_status
+                  ~actor:"voice/bridge_core"
+                  ~raw_source
+                  ~summary:"voice local playback"
+                  ~timeout_sec:60.0
+                  argv
+              with
               | Unix.WEXITED 0, _ ->
                 let dur = Unix.gettimeofday () -. t0 in
                 log_info

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -16,134 +16,35 @@ let tail_text ?(max_chars = tail_display_max_chars) text =
   if len <= max_chars then text
   else String.sub text (len - max_chars) max_chars
 
-let close_fd_quietly fd =
-  try Unix.close fd with
-  | Unix.Unix_error _ -> ()
+let exit_code_of_status = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED code -> 128 + code
+  | Unix.WSTOPPED code -> 256 + code
 
-let remove_path_quietly path =
-  try Sys.remove path with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> ()
-
-let rec waitpid_nointr flags pid =
-  try Unix.waitpid flags pid with
-  | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_nointr flags pid
-
-let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
-  let start = Unix.gettimeofday () in
-  let rec loop () =
-    match waitpid_nointr [ Unix.WNOHANG ] pid with
-    | 0, _ ->
-        if Unix.gettimeofday () -. start >= float_of_int timeout_sec then
-          `Timeout
-        else (
-          (match clock_opt with
-          | Some clock -> Eio.Time.sleep clock 0.2
-          | None -> Time_compat.sleep 0.2);
-          loop ())
-    | _, status -> `Exited status
+let run_process_with_timeout ?stdin_content ~clock_opt:_ ~timeout_sec ~prog:_ ~argv
+    ~env () =
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  let status, stdout, stderr =
+    match stdin_content with
+    | Some content ->
+        Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
+          ~actor:"system/worker_runtime_docker"
+          ~raw_source
+          ~summary:"worker runtime docker subprocess"
+          ~timeout_sec:(float_of_int timeout_sec)
+          ~env
+          ~stdin_content:content
+          argv
+    | None ->
+        Masc_exec.Exec_gate.run_argv_with_status_split
+          ~actor:"system/worker_runtime_docker"
+          ~raw_source
+          ~summary:"worker runtime docker subprocess"
+          ~timeout_sec:(float_of_int timeout_sec)
+          ~env
+          argv
   in
-  loop ()
-
-let run_process_with_timeout ?stdin_content ~clock_opt ~timeout_sec ~prog ~argv ~env () =
-  let stdin_path_opt = ref None in
-  let stdin_fd_opt = ref None in
-  let stdout_fd_opt = ref None in
-  let stderr_fd_opt = ref None in
-  let stdout_path = Filename.temp_file "masc_docker_stdout_" ".log" in
-  let stderr_path = Filename.temp_file "masc_docker_stderr_" ".log" in
-  let cleanup_setup () =
-    Option.iter close_fd_quietly !stdin_fd_opt;
-    stdin_fd_opt := None;
-    Option.iter close_fd_quietly !stdout_fd_opt;
-    stdout_fd_opt := None;
-    Option.iter close_fd_quietly !stderr_fd_opt;
-    stderr_fd_opt := None;
-    Option.iter remove_path_quietly !stdin_path_opt;
-    stdin_path_opt := None;
-    remove_path_quietly stdout_path;
-    remove_path_quietly stderr_path
-  in
-  let pid =
-    try
-      let stdin_fd =
-        match stdin_content with
-        | None -> Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0
-        | Some content ->
-            let stdin_path, oc =
-              Filename.open_temp_file ~mode:[ Open_wronly; Open_creat; Open_trunc; Open_binary ]
-                ~perms:0o600 "masc_docker_stdin_" ".log"
-            in
-            stdin_path_opt := Some stdin_path;
-            Out_channel.output_string oc content;
-            close_out oc;
-            Unix.openfile stdin_path [ Unix.O_RDONLY ] 0
-      in
-      stdin_fd_opt := Some stdin_fd;
-      let stdout_fd =
-        Unix.openfile stdout_path
-          [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
-      in
-      stdout_fd_opt := Some stdout_fd;
-      let stderr_fd =
-        Unix.openfile stderr_path
-          [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
-      in
-      stderr_fd_opt := Some stderr_fd;
-      Exec_tap.record
-        ~kind:Exec_tap.Unix_create_process_env
-        ~argv ~env ();
-      let pid =
-        Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd
-          stderr_fd
-      in
-      close_fd_quietly stdin_fd;
-      stdin_fd_opt := None;
-      close_fd_quietly stdout_fd;
-      stdout_fd_opt := None;
-      close_fd_quietly stderr_fd;
-      stderr_fd_opt := None;
-      pid
-    with exn ->
-      cleanup_setup ();
-      raise exn
-  in
-  let finalize exit_code =
-    let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
-    let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in
-    (match !stdin_path_opt with
-    | Some stdin_path -> (
-        try Sys.remove stdin_path
-        with Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.LocalWorker.warn "failed to remove stdin tmpfile %s: %s" stdin_path
-               (Printexc.to_string exn))
-    | None -> ());
-    (try Sys.remove stdout_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      Log.LocalWorker.warn "failed to remove stdout tmpfile %s: %s" stdout_path (Printexc.to_string exn));
-    (try Sys.remove stderr_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      Log.LocalWorker.warn "failed to remove stderr tmpfile %s: %s" stderr_path (Printexc.to_string exn));
-    { exit_code; stdout; stderr }
-  in
-  match wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid with
-  | `Exited (Unix.WEXITED code) -> finalize code
-  | `Exited (Unix.WSIGNALED code) -> finalize (128 + code)
-  | `Exited (Unix.WSTOPPED code) -> finalize (256 + code)
-  | `Timeout ->
-      (try Unix.kill pid Sys.sigterm with
-       | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
-       | exn -> Log.LocalWorker.warn "sigterm pid %d: %s" pid (Printexc.to_string exn));
-      (match clock_opt with
-      | Some clock -> Eio.Time.sleep clock 1.0
-      | None -> Time_compat.sleep 1.0);
-      (match waitpid_nointr [ Unix.WNOHANG ] pid with
-      | 0, _ ->
-          (try Unix.kill pid Sys.sigkill with
-           | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
-           | exn -> Log.LocalWorker.warn "sigkill pid %d: %s" pid (Printexc.to_string exn));
-          ignore (waitpid_nointr [] pid)
-      | _, _ -> ());
-      finalize 124
+  { exit_code = exit_code_of_status status; stdout; stderr }
 
 let helper_binary = "masc-worker-run"
 let docker_host_alias = "host.docker.internal"

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,39 +1,22 @@
-(** Run git subprocess and capture stdout lines.
-    Offloaded to a system thread via Eio_unix.run_in_systhread to avoid
-    blocking the Eio scheduler. Falls back to direct execution when
-    called without Eio context (tests, signal handlers). *)
 let run_git_capture_lines ~workdir args =
-  let f () =
-    try
-      let argv = "git" :: "-C" :: workdir :: args in
-      Exec_tap.record
-        ~kind:Exec_tap.Unix_open_process_args_in
-        ~argv ~cwd:workdir ();
-      let ic =
-        Unix.open_process_args_in "git"
-          (Array.of_list argv)
-      in
-      (* Error-path close prevents pipe fd leak when [input_line] raises
-         mid-stream (Sys_error, Unix_error). Mirrors [build_identity.ml]
-         pattern. Issue #8538. *)
-      try
-        let rec loop acc =
-          match input_line ic with
-          | line -> loop (line :: acc)
-          | exception End_of_file -> List.rev acc
-        in
-        let lines = loop [] in
-        match Unix.close_process_in ic with
-        | Unix.WEXITED 0 -> Some lines
-        | _ -> None
-      with exn ->
-        ignore
-          (try Unix.close_process_in ic
-           with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
-        raise exn
-    with Sys_error _ | Unix.Unix_error _ -> None
-  in
-  Eio_guard.run_in_systhread f
+  try
+    let argv = [ "git"; "-C"; workdir ] @ args in
+    let raw_source = String.concat " " (List.map Filename.quote argv) in
+    match
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"system/worktree_live_context"
+        ~raw_source
+        ~summary:"worktree live context git capture"
+        ~timeout_sec:5.0
+        argv
+    with
+    | Unix.WEXITED 0, output ->
+        Some
+          (output
+          |> String.split_on_char '\n'
+          |> List.filter (fun line -> String.trim line <> ""))
+    | _ -> None
+  with Sys_error _ | Unix.Unix_error _ -> None
 
 let repo_root_for ~base_path =
   if not (Coord_git.has_git_marker base_path) then None

--- a/scripts/exec_corpus_report.py
+++ b/scripts/exec_corpus_report.py
@@ -39,20 +39,38 @@ BIN_AUDITED = {
     "docker", "curl", "wget", "ssh", "scp",
     "tar", "rsync", "make", "cmake",
     "npm", "yarn", "pnpm", "pip", "opam", "cargo",
-    "gh", "glab",
+    "gh", "glab", "terminal-notifier", "osascript", "play", "rec",
+    "ffplay", "mpg123", "open", "claude", "gemini", "codex",
 }
 BIN_SAFE = {
     "ls", "cat", "pwd", "echo", "head", "tail",
     "grep", "rg", "find", "which", "test", "file",
     "basename", "dirname", "stat", "du", "df",
     "sort", "uniq", "wc", "cut", "tr",
-    "date", "env", "printenv", "hostname", "whoami",
+    "date", "env", "printenv", "hostname", "whoami", "uname", "ps", "tty",
 }
+
+def normalize_git_args(argv):
+    if not argv or argv[0] != "git":
+        return argv
+    args = list(argv[1:])
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+            i += 2
+            continue
+        if token in {"--no-pager", "--literal-pathspecs"}:
+            i += 1
+            continue
+        break
+    return ["git"] + args[i:]
 
 
 def classify(argv):
     if not argv:
         return "bin_unknown"
+    argv = normalize_git_args(argv)
     head = argv[0]
     if head == "git" and len(argv) > 1:
         sub = argv[1]
@@ -90,7 +108,10 @@ def build_report(entries):
     bin_top = Counter()
     git_sub = Counter()
     for e in entries:
-        kinds[e.get("kind", "?")] += 1
+        kind = e.get("kind", "?")
+        kinds[kind] += 1
+        if kind == "Exec_gate.decision":
+            continue
         argv = e.get("argv") or []
         buckets[classify(argv)] += 1
         if argv:

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -44,6 +44,7 @@
    (re_export masc_mcp.tool_schemas)
    (re_export masc_mcp.masc_tool_blob_store)
    (re_export masc_process)
+   (re_export masc_mcp.masc_exec)
    (re_export masc_coord)
    (re_export masc_types)
    (re_export mirage-crypto)

--- a/test/test_exec_tap.ml
+++ b/test/test_exec_tap.ml
@@ -93,6 +93,26 @@ let test_multiple_calls_each_line () =
     !captured;
   Exec_tap.disable ()
 
+let test_gate_decision_shape () =
+  let captured = ref "" in
+  Exec_tap.enable ~writer:(fun line -> captured := line);
+  Exec_tap.record_gate_decision
+    ~actor:"coord/git"
+    ~raw_source:"git --version"
+    ~summary:"coord git version"
+    ~gate_mode:"parallel"
+    ~gate_verdict:"allow"
+    ~gate_enforced:false
+    ~argv:[ "git"; "--version" ]
+    ();
+  let line = !captured in
+  Exec_tap.disable ();
+  must_contain ~tag:"gate kind" line "\"kind\":\"Exec_gate.decision\"";
+  must_contain ~tag:"actor" line "\"actor\":\"coord/git\"";
+  must_contain ~tag:"mode" line "\"gate_mode\":\"parallel\"";
+  must_contain ~tag:"verdict" line "\"gate_verdict\":\"allow\"";
+  must_contain ~tag:"enforced" line "\"gate_enforced\":false"
+
 let () =
   test_off_is_noop ();
   test_on_emits_one_line ();
@@ -100,4 +120,5 @@ let () =
   test_defaults_are_null ();
   test_writer_exception_is_swallowed ();
   test_multiple_calls_each_line ();
+  test_gate_decision_shape ();
   print_endline "[test_exec_tap] all tests passed"


### PR DESCRIPTION
## Summary
- extend RFC v5 A4a exec-gate cutover from the first coord/task-sandbox slice into internal runtime, spawn, docker, autoresearch, and local-runtime paths
- add split `Process_eio` / `Exec_gate` status APIs so callers that need separate `stdout` and `stderr` can move off direct `Unix.create_process*`
- normalize `git -C ...` handling in typed git classification and update the exec corpus report accordingly

## What changed
- expanded `Masc_exec.Exec_gate` actor overlays and added `run_argv_with_status_split` / `run_argv_with_stdin_and_status_split`
- added split/cwd-aware `Process_eio` helpers and moved `spawn`, `worker_runtime_docker`, and `auto_responder` onto the gate path
- cut over internal explicit-argv callers in coord, autoresearch, dashboard runtime probes, graphql curl fallback, voice playback, worktree live context, startup takeover, local runtime probes/bench, A2A discovery, and autoresearch cycle git helpers
- taught typed git parsing to understand global options like `git -C <dir> ...`
- extended test coverage for exec-gate runtime behavior and `git -C` capability/policy classification

## Verification
- `./_build/default/lib/exec/test/test_exec_types.exe`
- `./_build/default/lib/exec/test/test_capability_check.exe`
- `./_build/default/lib/exec/test/test_approval_policy.exe`
- `./_build/default/lib/exec/test/test_exec_gate_runtime.exe`
- `./_build/default/test/test_process_eio_coverage.exe`
- `./_build/default/test/test_spawn.exe`
- `./_build/default/test/test_spawn_coverage.exe`
- `./_build/default/test/test_auto_responder_coverage.exe`
- `./_build/default/test/test_build_identity.exe`
- `./_build/default/test/test_worktree_live_context.exe`
- `./_build/default/test/test_server_startup_takeover.exe`
- `./_build/default/test/test_notify_coverage.exe`
- `./_build/default/test/test_graphql_api.exe`
- `./_build/default/test/test_tool_local_runtime_verify.exe`
- `./_build/default/test/test_tool_local_runtime_probe.exe`
- `./_build/default/test/test_a2a_tools_coverage.exe`
- `./_build/default/test/test_autoresearch_oas_primitives.exe`
- `./_build/default/test/test_autoresearch_target_score.exe`
- `./_build/default/test/test_swarm_goal_loop.exe`

## Remaining scope
- direct exec use is reduced to keeper/tool-code/sidecar-heavy paths
- remaining callsites now cluster in `keeper_exec_shell`, `keeper_tool_pr_review`, `keeper_alerting`, `tool_code_write`, `tool_code`, `tool_inline_dispatch_types`, and sidecar wrapper routes, which need the approval-path / queue work rather than another internal-observer slice