### PR TITLE
fix(governance): return 404 for stale approval ids instead of 400

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -355,7 +355,25 @@ let rec add_routes ~sw ~clock router =
              | Ok json ->
                  respond_json_with_cors request reqd (Yojson.Safe.to_string json)
              | Error message ->
-                 respond_json_with_cors ~status:`Bad_request request reqd
+                 (* Stale/expired approval ids → 404 so the dashboard can
+                    refresh the queue rather than treating it as a malformed
+                    request. Validation errors stay as 400. *)
+                 let is_stale =
+                   let s = String.lowercase_ascii message in
+                   let contains sub =
+                     let len_s = String.length s in
+                     let len_sub = String.length sub in
+                     let rec loop i =
+                       if i + len_sub > len_s then false
+                       else if String.sub s i len_sub = sub then true
+                       else loop (i + 1)
+                     in
+                     loop 0
+                   in
+                   contains "not found" || contains "already resolved"
+                 in
+                 let status = if is_stale then `Not_found else `Bad_request in
+                 respond_json_with_cors ~status request reqd
                    (Yojson.Safe.to_string (operator_error_json message))
            with Yojson.Json_error msg ->
              respond_json_with_cors ~status:`Bad_request request reqd


### PR DESCRIPTION
## Summary
Dashboard 운영행동 화면에서 stale 한 approval id로 POST `/api/v1/dashboard/governance/approvals/resolve` 를 호출하면 400 Bad Request 가 연속으로 토스트되던 문제. (스크린샷 동일 카드 3회)

원인: `Keeper_approval_queue.resolve` 가 "approval X not found or already resolved" Error를 반환할 때 router가 모든 Error를 `Bad_request` 로 매핑.

수정: 메시지에 "not found" 또는 "already resolved" 가 포함되면 `Not_found` (404) 로 응답. 진짜 validation 실패는 그대로 `Bad_request` (400). dashboard 는 이제 404를 큐 refresh 신호로 쓸 수 있다.

## Test plan
- [x] dune build @check 통과 (lib/server/server_routes_http_routes_dashboard.ml)
- [ ] 운영중인 인스턴스에서 stale id POST → 404 응답 확인
- [ ] 유효 id POST → 200 ok 확인
- [ ] dashboard SPA 가 404 받을 때 카드 제거 + queue refetch 동작 확인 (별도 PR 가능)

## Out of scope
- Dashboard SPA 의 stale-card 자동 refresh (후속)
- Approval entry expiry telemetry 강화

🤖 Generated with [Claude Code](https://claude.com/claude-code)