### PR TITLE
feat(masc_transition): accept target-state aliases via lenient parser (#8312)

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -546,6 +546,32 @@ and handle_transition ctx args =
   let is_internal_marker k =
     String.length k > 0 && k.[0] = '_'
   in
+  (* Issue #8312: small LLM keepers and operator UIs frequently send
+     - target-state aliases via [to] instead of canonical [action]
+     - singular [note] instead of [notes]
+     Normalize before strict-schema validation so callers do not have
+     to memorize canonical vocabulary. The Variant ([Types.task_action])
+     remains the SSOT — only the transport-level keys get rewritten.
+     Existing canonical keys are never overridden. *)
+  let normalize_args = function
+    | `Assoc kvs ->
+      let has k = List.exists (fun (k', _) -> String.equal k k') kvs in
+      let kvs =
+        if has "note" && not (has "notes") then
+          List.map (fun (k, v) -> if String.equal k "note" then ("notes", v) else (k, v)) kvs
+        else
+          List.filter (fun (k, _) -> not (String.equal k "note") || not (has "notes")) kvs
+      in
+      let kvs =
+        if has "to" && not (has "action") then
+          List.map (fun (k, v) -> if String.equal k "to" then ("action", v) else (k, v)) kvs
+        else
+          List.filter (fun (k, _) -> not (String.equal k "to") || not (has "action")) kvs
+      in
+      `Assoc kvs
+    | other -> other
+  in
+  let args = normalize_args args in
   let unknown = match args with
     | `Assoc kvs ->
       List.filter
@@ -568,7 +594,7 @@ and handle_transition ctx args =
   if action_raw = "" then
     (false, Printf.sprintf "action is required (%s)" (String.concat ", " Types.valid_task_action_strings))
   else
-  match Types.task_action_of_string action_raw with
+  match Types.task_action_of_string_lenient action_raw with
   | Error msg -> (false, msg)
   | Ok action ->
   let action_s = Types.task_action_to_string action in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -276,6 +276,36 @@ let task_action_of_string s =
   | "reject" -> Ok Reject_verification
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
+(** Issue #8312: callers (especially small LLM keepers) often pass target-state
+    aliases such as "claimed" or status verbs from the lifecycle vocabulary.
+    [task_action_of_alias] returns [Some action] when the input maps to a
+    canonical action via a documented alias, and [None] when it does not.
+    Compose with [task_action_of_string] for "permissive input, strict output":
+    canonical strings still parse via [task_action_of_string]; only foreign
+    inputs fall through to the alias map. *)
+let task_action_of_alias s =
+  match String.lowercase_ascii s with
+  | "claimed" -> Some Claim
+  | "started" | "in_progress" | "inprogress" | "running" -> Some Start
+  | "completed" | "complete" | "finished" -> Some Done_action
+  | "cancelled" | "canceled" | "abort" | "aborted" -> Some Cancel
+  | "todo" | "released" | "unclaim" | "unclaimed" -> Some Release
+  | "awaiting_verification" | "submit" -> Some Submit_for_verification
+  | "approved" -> Some Approve_verification
+  | "rejected" -> Some Reject_verification
+  | _ -> None
+
+(** Lenient parser: tries strict canonical first, then alias map.
+    Strict callers (registry validation, schema docs) keep using
+    [task_action_of_string]; user-facing tool dispatch uses this. *)
+let task_action_of_string_lenient s =
+  match task_action_of_string s with
+  | Ok _ as ok -> ok
+  | Error _ as err ->
+    (match task_action_of_alias s with
+     | Some action -> Ok action
+     | None -> err)
+
 let task_action_to_string = function
   | Claim -> "claim"
   | Start -> "start"

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -57,6 +57,43 @@ let test_parse_iso8601_epoch_utc () =
   let parsed = parse_iso8601 "1970-01-01T00:00:00Z" in
   Alcotest.(check (float 0.001)) "utc epoch" 0.0 parsed
 
+(* Issue #8312: lenient parser must accept target-state aliases without
+   widening canonical Variant SSOT. *)
+let action_to_canonical = function
+  | Claim -> "claim"
+  | Start -> "start"
+  | Done_action -> "done"
+  | Cancel -> "cancel"
+  | Release -> "release"
+  | Submit_for_verification -> "submit_for_verification"
+  | Approve_verification -> "approve"
+  | Reject_verification -> "reject"
+
+let check_lenient input expected =
+  match task_action_of_string_lenient input with
+  | Ok a -> Alcotest.(check string) input expected (action_to_canonical a)
+  | Error e -> Alcotest.failf "expected %s for %s, got error: %s" expected input e
+
+let test_action_alias_claimed () = check_lenient "claimed" "claim"
+let test_action_alias_todo () = check_lenient "todo" "release"
+let test_action_alias_in_progress () = check_lenient "in_progress" "start"
+let test_action_alias_completed () = check_lenient "completed" "done"
+let test_action_alias_cancelled () = check_lenient "cancelled" "cancel"
+let test_action_canonical_still_works () = check_lenient "claim" "claim"
+let test_action_case_insensitive () = check_lenient "CLAIMED" "claim"
+
+let test_action_unknown_still_rejected () =
+  match task_action_of_string_lenient "definitely-not-an-action" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "lenient parser must reject genuine garbage"
+
+(* Strict parser must NOT have grown alias support — preserves SSOT
+   for places that document only canonical vocabulary. *)
+let test_strict_parser_unchanged () =
+  match task_action_of_string "claimed" with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "strict parser must reject aliases; lenient owns aliases"
+
 let () =
   Alcotest.run "Types" [
     "agent_status", [
@@ -72,5 +109,16 @@ let () =
     ];
     "timestamp", [
       Alcotest.test_case "parse utc epoch" `Quick test_parse_iso8601_epoch_utc;
+    ];
+    "task_action_lenient", [
+      Alcotest.test_case "alias claimed -> claim" `Quick test_action_alias_claimed;
+      Alcotest.test_case "alias todo -> release" `Quick test_action_alias_todo;
+      Alcotest.test_case "alias in_progress -> start" `Quick test_action_alias_in_progress;
+      Alcotest.test_case "alias completed -> done" `Quick test_action_alias_completed;
+      Alcotest.test_case "alias cancelled -> cancel" `Quick test_action_alias_cancelled;
+      Alcotest.test_case "canonical claim still works" `Quick test_action_canonical_still_works;
+      Alcotest.test_case "case insensitive" `Quick test_action_case_insensitive;
+      Alcotest.test_case "garbage still rejected" `Quick test_action_unknown_still_rejected;
+      Alcotest.test_case "strict parser ssot preserved" `Quick test_strict_parser_unchanged;
     ];
   ]


### PR DESCRIPTION
## Summary
Closes #8312.

`masc_transition` rejected target-state vocabulary that small LLM keepers and operator UIs naturally emit (`to=claimed`, `to=todo`, `note=...`, `action=in_progress`). Each rejection cost a keeper turn.

This PR introduces a **lenient parser** for incoming action strings and **arg-key normalization** in the transition dispatcher. The canonical `Types.task_action` Variant and its derived `valid_task_action_strings` are untouched — schema docs and strict validators still see only canonical actions. Aliases are an input-only concern.

## Changes

| File | Change |
|------|--------|
| `lib/types/types_core.ml` | Add `task_action_of_alias` + `task_action_of_string_lenient` (canonical-first, alias fallback). Strict `task_action_of_string` unchanged. |
| `lib/tool_task.ml` | `handle_transition` rewrites `note → notes` / `to → action` (only when canonical key absent), then parses via lenient. Existing canonical args win when both forms are sent. |
| `test/test_types.ml` | 9 unit tests covering each documented alias + regression that strict parser still rejects aliases (prevents future SSOT drift). |

## Variant SSOT preservation

> "Permissive input, strict output." Aliases live in a separate function so `valid_task_action_strings` (used in error messages and schema doc generation) stays canonical-only.

A regression test (`strict parser ssot preserved`) fails if anyone later merges aliases into the strict parser.

## release(todo) no-op
The issue's second requirement (`release` on already-`Todo` task = no-op) is **already implemented** in `lib/coord/coord_task.ml:797`. Verified the behavior survives the alias path (e.g. `to=todo` on a Todo task → action=Release → existing no-op branch).

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_types.exe` — 15/15 pass
- [ ] CI green
- [ ] Self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)