### PR TITLE
feat(auth): add local admin login bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,17 @@ Fast local auth bootstrap:
 dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin
 ```
 
-Typical use:
+Copy-paste example:
 
 ```bash
 LOGIN_JSON="$(dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin)"
 TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
 URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
 printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-MASC-Agent: codex-local-admin" \
+  | jq '.auth'
 ```
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ Schematically: `Offline → Running → {Failing | Overflowed | Compacting | Han
 
 Keeper definitions live in `config/keepers/*.toml`. When `MASC_KEEPER_BOOTSTRAP_ENABLED=true`, the server discovers and starts all keepers on boot with staggered warmup delays.
 
+Current experimental canary:
+
+- `config/keepers/watchdog.toml` + `config/personas/watchdog/profile.json`
+- role: chase stale `awaiting_verification` items and ask for re-validation
+- sandbox: `docker_hardened` + `network_mode=none`
+- quick operator guide: [docs/DOCKER-SANDBOX-QUICKSTART.md](docs/DOCKER-SANDBOX-QUICKSTART.md)
+
 ### Turn Budget
 
 Each keeper call to `Agent.run` is limited to `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` turns (default: 15). When exhausted, the keeper saves a checkpoint and resumes in the next heartbeat cycle. The keeper can call `extend_turns` to request more turns up to an absolute ceiling (200).

--- a/README.md
+++ b/README.md
@@ -311,13 +311,25 @@ cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run 
 Fast local auth bootstrap:
 
 ```bash
+~/me/scripts/masc dashboard-admin
+```
+
+Raw JSON path:
+
+```bash
+~/me/scripts/masc login --json --agent codex-local-admin
+```
+
+Repo-local fallback:
+
+```bash
 dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin
 ```
 
 Copy-paste example:
 
 ```bash
-LOGIN_JSON="$(dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin)"
+LOGIN_JSON="$(~/me/scripts/masc login --json --agent codex-local-admin)"
 TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
 URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
 printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
@@ -355,7 +367,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - Legacy `/sse` and `/messages` endpoints are deprecated.
 - Binding to `0.0.0.0` or `::` enables strict auth; local `/mcp` fails closed unless `require_token=true`.
 - `/mcp/operator` is bearer-token only with a remote-safe surface. Do not expose full `/mcp` externally.
-- Local dashboard/admin auth bootstrap: `dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin`
+- Local dashboard/admin auth bootstrap: `~/me/scripts/masc dashboard-admin` (or `~/me/scripts/masc login --json --agent codex-local-admin` for raw JSON)
 - Command-plane compatibility is retired from the supported product contract. Historical docs may still mention it, but new callers must not depend on it.
 - See [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) and [docs/spec/09-server-transport.md](docs/spec/09-server-transport.md).
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
   | jq '.auth'
 ```
 
+`--agent` is the persisted admin identity label for this local bootstrap flow. `local-admin` is only the default example: `ops-admin` works the same way, writes `<base_path>/.masc/auth/agents/<agent>.json` with mode `0600`, stores only the SHA256 token hash, survives server restarts, and invalidates the old raw token immediately when you rerun `login` for the same name.
+
 ## Verification
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -308,6 +308,21 @@ cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run 
 - For manual rebuilds, run `cd dashboard && pnpm run build`.
 - For local admin bearer bootstrap and dashboard keeper lifecycle control, see [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md).
 
+Fast local auth bootstrap:
+
+```bash
+dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin
+```
+
+Typical use:
+
+```bash
+LOGIN_JSON="$(dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin)"
+TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
+URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
+printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
+```
+
 ## Verification
 
 ```bash
@@ -336,6 +351,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - Legacy `/sse` and `/messages` endpoints are deprecated.
 - Binding to `0.0.0.0` or `::` enables strict auth; local `/mcp` fails closed unless `require_token=true`.
 - `/mcp/operator` is bearer-token only with a remote-safe surface. Do not expose full `/mcp` externally.
+- Local dashboard/admin auth bootstrap: `dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin`
 - Command-plane compatibility is retired from the supported product contract. Historical docs may still mention it, but new callers must not depend on it.
 - See [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) and [docs/spec/09-server-transport.md](docs/spec/09-server-transport.md).
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 | [docs/RELEASE-EVIDENCE.md](docs/RELEASE-EVIDENCE.md) | Release-grade smoke checks and proof bundle contract |
 | [docs/BENCHMARK-RUNBOOK.md](docs/BENCHMARK-RUNBOOK.md) | Benchmark and comparison harnesses |
 | [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | Keeper lifecycle and troubleshooting |
+| [docs/DOCKER-SANDBOX-QUICKSTART.md](docs/DOCKER-SANDBOX-QUICKSTART.md) | Keeper Docker sandbox presets and copy-paste recipes |
 | [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) | Supervised execution / operator workflow |
 | [docs/SWARM-DELIVERY-RUNBOOK.md](docs/SWARM-DELIVERY-RUNBOOK.md) | Single-agent vs swarm delivery |
 | [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md) | OAS/MASC ownership boundary |

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -607,6 +607,16 @@ let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in
   Arg.(value & flag & info ["force"] ~doc)
 
+let login_agent =
+  let doc =
+    "Admin agent name to mint a local bearer for. Defaults to `local-admin`."
+  in
+  Arg.(value & opt string "local-admin" & info ["agent"] ~docv:"NAME" ~doc)
+
+let login_json =
+  let doc = "Emit machine-readable JSON instead of text output" in
+  Arg.(value & flag & info ["json"] ~doc)
+
 type init_tally = { written : int; skipped : int; failed : int }
 
 let seed_one ~target_root ~force tally rel =
@@ -648,10 +658,68 @@ let init_cmd =
   let info = Cmd.info "init" ~doc in
   Cmd.v info Term.(const init_cmd_exit $ base_path $ init_force)
 
+let dashboard_login_host host =
+  match String.trim host with
+  | "" -> "127.0.0.1"
+  | "0.0.0.0" -> "127.0.0.1"
+  | "::" -> "localhost"
+  | value -> value
+
+let render_login_text
+    (bootstrap : Auth.local_admin_bootstrap) =
+  let room_secret_line =
+    match bootstrap.room_secret with
+    | Some secret -> secret
+    | None -> "(already configured; raw room secret unavailable)"
+  in
+  String.concat "\n"
+    [
+      Printf.sprintf "login: admin bearer ready for %s" bootstrap.agent_name;
+      Printf.sprintf "base_path=%s" bootstrap.base_path;
+      Printf.sprintf "auth_root=%s" bootstrap.auth_root;
+      Printf.sprintf "require_token=%b" bootstrap.require_token;
+      Printf.sprintf "reused_auth=%b" bootstrap.reused_auth;
+      Printf.sprintf "room_secret=%s" room_secret_line;
+      Printf.sprintf "bearer_token=%s" bootstrap.bearer_token;
+      Printf.sprintf "dashboard_url=%s" bootstrap.dashboard_url;
+      Printf.sprintf "authorization_header=Authorization: Bearer %s"
+        bootstrap.bearer_token;
+      Printf.sprintf "agent_header=X-MASC-Agent: %s" bootstrap.agent_name;
+    ]
+
+let login_cmd_exit host port base_path agent_name as_json =
+  let base_path = Env_config.normalize_masc_base_path_input base_path in
+  match
+    Auth.bootstrap_local_admin
+      ~host:(dashboard_login_host host)
+      ~port base_path ~agent_name
+  with
+  | Error err ->
+      Printf.eprintf "login: %s\n" (Types.masc_error_to_string err);
+      1
+  | Ok bootstrap ->
+      let output =
+        if as_json then
+          Auth.local_admin_bootstrap_to_yojson bootstrap
+          |> Yojson.Safe.pretty_to_string
+        else
+          render_login_text bootstrap
+      in
+      print_endline output;
+      0
+
+let login_cmd =
+  let doc =
+    "Enable local admin bearer auth (require_token=true) and print a dashboard login URL"
+  in
+  let info = Cmd.info "login" ~doc in
+  Cmd.v info
+    Term.(const login_cmd_exit $ host $ port $ base_path $ login_agent $ login_json)
+
 let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc-mcp" ~version:Masc_mcp.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ base_path)
-    info [ doctor_cmd; init_cmd ]
+    info [ doctor_cmd; init_cmd; login_cmd ]
 
 let () = exit (Cmd.eval' cmd)

--- a/config/keepers/watchdog.toml
+++ b/config/keepers/watchdog.toml
@@ -1,0 +1,8 @@
+[keeper]
+persona_name = "watchdog"
+execution_scope = "workspace"
+cascade_name = "cross_verifier"
+sandbox_profile = "docker_hardened"
+network_mode = "none"
+telemetry_feedback_enabled = true
+telemetry_feedback_window_hours = 24

--- a/config/personas/watchdog/profile.json
+++ b/config/personas/watchdog/profile.json
@@ -1,0 +1,81 @@
+{
+  "name": "감리관",
+  "role": "미검증 작업과 stale verification을 추적해 재검증을 다시 태우는 감시 keeper",
+  "background": "완료 선언이나 검증 대기 상태를 그대로 믿지 않고, 증거가 빠졌거나 재검증이 멈춘 항목을 찾아 assignee와 verifier를 다시 움직이게 만드는 집요한 감리자",
+  "trait": "정중하지만 반복 누락에는 집요하게 매달리는 감시자",
+  "tone": [
+    "짧고 직접적인 한국어",
+    "친절하지만 핑계는 받지 않는 톤",
+    "누락된 증거와 다음 행동을 바로 지시"
+  ],
+  "top_expressions": [
+    "이건 아직 검증 완료가 아닙니다.",
+    "빠진 증거부터 다시 붙여 주세요.",
+    "재검증 명령을 다시 돌리고 결과를 남겨 주세요.",
+    "같은 상태가 계속이면 이유와 다음 액션을 남기세요."
+  ],
+  "emoji_usage": "사용 안함",
+  "expertise": {
+    "stale verification sweep": [
+      "awaiting_verification 상태와 오래 멈춘 completion 추적",
+      "assignee, verifier, board post 사이의 증거 연결 확인",
+      "재검증 누락 항목을 짧은 액션 아이템으로 환원"
+    ],
+    "reminder routing": [
+      "기존 board thread가 있으면 comment 우선",
+      "없으면 새 board post로 독촉",
+      "누구에게 무엇을 다시 해야 하는지 명시"
+    ],
+    "anti-stall discipline": [
+      "증거 없는 done 선언을 그대로 흘리지 않기",
+      "같은 reminder를 상태 변화 없이 반복하지 않기",
+      "재현 명령, 로그, artifact 경로를 요구"
+    ]
+  },
+  "relationship": {
+    "position": "room 감리관 - 미검증 완료와 stale verification을 그냥 넘어가지 않게 만드는 운영 파트너",
+    "approach": [
+      "완료 주장보다 증거와 상태 전이를 먼저 본다",
+      "실패보다 방치와 누락을 더 빠르게 지적한다",
+      "한 번 재촉했으면 상태가 바뀔 때까지 같은 말만 반복하지 않는다"
+    ]
+  },
+  "integration": {
+    "trigger": [
+      "watchdog",
+      "감리관",
+      "독촉자",
+      "재검증",
+      "검증독촉"
+    ],
+    "modes": {
+      "text": "config/personas/watchdog/"
+    }
+  },
+  "keeper": {
+    "goal": "미검증 완료, stale verification, 증거 누락 completion을 찾아 재검증 루프를 다시 태운다.",
+    "short_goal": "awaiting_verification 상태와 recent board/task history를 확인하고, 멈춘 항목이 있으면 assignee와 verifier에게 정확한 재검증 액션을 남긴다.",
+    "mid_goal": "세션 전반에서 검증 없는 완료 선언과 방치된 verification queue가 오래 쌓이지 않게 만든다.",
+    "long_goal": "MASC room에서 완료와 검증이 분리되지 않고, 누락된 증거가 있으면 빠르게 다시 태워지는 운영 습관을 만든다.",
+    "will": "완료 선언을 바로 믿지 않고, 증거와 상태 전이를 먼저 확인한다.",
+    "needs": "masc_tasks, task history, board thread, assignee/verifier 정보, 재검증 명령 또는 artifact 경로",
+    "desires": "증거 없는 완료와 오래 멈춘 verification이 room에 그대로 방치되지 않게 만든다.",
+    "instructions": "너는 room 감리관이다. 우선 `keeper_tasks_list` 또는 `masc_tasks` 계열 읽기에서 awaiting_verification, stale completion, evidence 누락 징후를 찾는다. 관련 task history와 board thread를 읽고, 무엇이 빠졌는지 한 줄로 요약한 뒤 assignee와 verifier가 바로 다시 실행할 수 있는 다음 액션을 남긴다. 기존 thread가 있으면 comment를 우선하고, 없으면 새 board post를 쓴다. 독촉 메시지에는 빠진 artifact, 다시 돌릴 명령, 필요한 로그/경로를 명시한다. 같은 항목에 이미 reminder를 남겼다면 상태가 바뀌기 전까지 같은 말을 반복하지 말고, 변화가 없다는 사실과 escalation 필요성만 짧게 남긴다. 너의 1차 역할은 approve/reject가 아니라 재검증 루프를 다시 태우는 것이다.",
+    "mention_targets": [
+      "watchdog",
+      "감리관",
+      "독촉자",
+      "재검증",
+      "검증독촉"
+    ],
+    "tool_preset": "messaging",
+    "tool_also_allow": [
+      "masc_task_history",
+      "keeper_board_search"
+    ],
+    "proactive_enabled": true,
+    "telemetry_feedback_enabled": true,
+    "telemetry_feedback_window_hours": 24,
+    "cascade_name": "cross_verifier"
+  }
+}

--- a/docs/DOCKER-SANDBOX-QUICKSTART.md
+++ b/docs/DOCKER-SANDBOX-QUICKSTART.md
@@ -20,6 +20,22 @@ code_refs:
 이 문서에서 말하는 sandbox는 **keeper 실행용 Docker sandbox**다.
 `OAS_CODEX_SANDBOX` 같은 CLI sandbox와는 다른 레이어다.
 
+## 0.5 어디를 고치나
+
+```text
+config/personas/watchdog/profile.json   -> 누구인지 / 어떤 역할인지
+config/keepers/watchdog.toml            -> 여기서 어떻게 태울지
+<basepath>/.masc/keepers/watchdog.json  -> 지금 어떤 상태인지
+<basepath>/.masc/keepers/watchdog/      -> 로그, 메트릭, 흔적
+```
+
+짧은 암기:
+
+- `profile.json` = who
+- `keeper.toml` = where/how
+- `keeper.json` = current runtime state
+- `keeper/` directory = detailed history
+
 ## 1. 고르기
 
 | 상황 | 권장 설정 | 왜 |
@@ -89,6 +105,38 @@ tool_also_allow = [
   "masc_team_memory_write",
   "masc_team_memory_search",
 ]
+```
+
+### 실제 canary 예시: watchdog
+
+이 브랜치에는 Docker-born 감시 keeper 예시가 같이 들어 있다:
+
+```text
+config/personas/watchdog/profile.json
+config/keepers/watchdog.toml
+```
+
+역할:
+
+- awaiting_verification 상태를 훑는다
+- stale verification이나 빠진 evidence를 찾는다
+- assignee / verifier에게 다시 돌릴 명령과 필요한 artifact를 남긴다
+- 같은 reminder를 상태 변화 없이 반복하지 않는다
+
+재기동 확인:
+
+```bash
+# admin token + dashboard URL bootstrap
+~/me/scripts/masc dashboard-admin --no-open
+
+# restart only the watchdog keeper
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/watchdog/shutdown \
+  -H "Authorization: Bearer $MASC_OPERATOR_TOKEN" \
+  -H "X-MASC-Agent: ${MASC_OPERATOR_AGENT:-codex-local-admin}"
+
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/watchdog/boot \
+  -H "Authorization: Bearer $MASC_OPERATOR_TOKEN" \
+  -H "X-MASC-Agent: ${MASC_OPERATOR_AGENT:-codex-local-admin}"
 ```
 
 ## 3. 의미

--- a/docs/DOCKER-SANDBOX-QUICKSTART.md
+++ b/docs/DOCKER-SANDBOX-QUICKSTART.md
@@ -1,0 +1,128 @@
+---
+status: runbook
+last_verified: 2026-04-18
+code_refs:
+  - lib/keeper/
+  - docs/KEEPER-USER-MANUAL.md
+  - docs/KEEPER-FILE-MODEL.md
+---
+
+# Docker Sandbox Quickstart
+
+이 문서는 keeper Docker sandbox를 가장 짧게 켜는 경로만 남긴 문서다.
+
+처음에는 아래 세 줄만 기억하면 된다:
+
+- 기본값: `sandbox_profile="docker_hardened"` + `network_mode="none"`
+- 네트워크가 꼭 필요할 때만: `network_mode="inherit"`
+- Docker 자체가 문제일 때만: `sandbox_profile="legacy_local"`
+
+이 문서에서 말하는 sandbox는 **keeper 실행용 Docker sandbox**다.
+`OAS_CODEX_SANDBOX` 같은 CLI sandbox와는 다른 레이어다.
+
+## 1. 고르기
+
+| 상황 | 권장 설정 | 왜 |
+| --- | --- | --- |
+| 코드 읽기, 테스트, 패치, 로컬 빌드 | `docker_hardened` + `none` | 가장 보수적인 기본값 |
+| 패키지 설치, 원격 API 호출, git fetch 같은 네트워크 필요 작업 | `docker_hardened` + `inherit` | Docker 격리는 유지하고 네트워크만 연다 |
+| Docker가 아예 없거나, 지금 디버깅 대상이 Docker 자체 | `legacy_local` + `inherit` | escape hatch |
+
+피해야 하는 조합:
+
+- `legacy_local` + `none`
+- 처음부터 `legacy_local`로 시작하기
+- private playground 대신 arbitrary shared writable path를 열기
+
+## 2. 제일 많이 쓰는 복붙 예시
+
+### 안전한 기본값
+
+```json
+{
+  "name": "analyst",
+  "goal": "Review incoming issues and prepare safe changes",
+  "execution_scope": "workspace",
+  "sandbox_profile": "docker_hardened",
+  "network_mode": "none",
+  "shared_memory_scope": "room",
+  "tool_access": {
+    "kind": "preset",
+    "preset": "coding",
+    "also_allow": [
+      "masc_team_memory_read",
+      "masc_team_memory_write",
+      "masc_team_memory_search"
+    ]
+  }
+}
+```
+
+### 네트워크가 필요한 빌드/설치
+
+```json
+{
+  "name": "builder",
+  "goal": "Install dependencies and run the required build",
+  "execution_scope": "workspace",
+  "sandbox_profile": "docker_hardened",
+  "network_mode": "inherit",
+  "shared_memory_scope": "room",
+  "tool_access": {
+    "kind": "preset",
+    "preset": "coding"
+  }
+}
+```
+
+### keeper TOML overlay
+
+```toml
+[keeper]
+persona_name = "analyst"
+execution_scope = "workspace"
+sandbox_profile = "docker_hardened"
+network_mode = "none"
+shared_memory_scope = "room"
+tool_also_allow = [
+  "masc_team_memory_read",
+  "masc_team_memory_write",
+  "masc_team_memory_search",
+]
+```
+
+## 3. 의미
+
+`docker_hardened`는 keeper shell을 ephemeral Docker sandbox로 돌린다.
+운영자가 보통 기억해야 하는 건 이것뿐이다:
+
+- private playground만 writable
+- rootfs는 read-only
+- `/tmp`는 tmpfs
+- `cap-drop=ALL`
+- `no-new-privileges`
+- 기본 네트워크는 `none`
+
+즉, 처음엔 `docker_hardened`를 켜고, 정말 필요한 경우에만 `network_mode`를 올리면 된다.
+
+## 4. 자주 헷갈리는 것
+
+### `docker_hardened` vs `OAS_CODEX_SANDBOX`
+
+- `docker_hardened`: keeper shell 실행을 Docker로 격리
+- `OAS_CODEX_SANDBOX`: `codex exec -s ...`에 들어가는 Codex CLI 자체 sandbox
+
+둘은 독립적이다. 하나를 켰다고 다른 하나가 자동으로 바뀌지 않는다.
+
+### 왜 shared memory는 path가 아니라 tool인가
+
+keeper는 임의 shared writable directory를 여는 대신 typed lane만 쓴다.
+공유가 필요하면 `shared_memory_scope="room"`과 `masc_team_memory_*` 도구를 쓴다.
+
+## 5. 운영 규칙
+
+- 시작은 항상 `docker_hardened` + `none`
+- 실제 실패 원인이 네트워크 부족일 때만 `inherit`
+- Docker가 깨져 있거나, Docker 자체를 디버깅할 때만 `legacy_local`
+
+상세 필드 설명은 [KEEPER-USER-MANUAL.md](./KEEPER-USER-MANUAL.md)와 [KEEPER-FILE-MODEL.md](./KEEPER-FILE-MODEL.md)를 본다.

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -188,6 +188,14 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 
 ### Sandbox + Shared Memory Example
 
+If you want the shortest operator rule, start with:
+
+- `sandbox_profile = "docker_hardened"`
+- `network_mode = "none"`
+
+Only open network when the actual task needs it. Quick operator guide:
+[DOCKER-SANDBOX-QUICKSTART.md](./DOCKER-SANDBOX-QUICKSTART.md)
+
 ```toml
 [keeper]
 persona_name = "analyst"

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -21,6 +21,15 @@ basepath/.masc/keepers/sangsu.json
 basepath/.masc/keepers/sangsu/<many runtime artifacts>
 ```
 
+Operational picture:
+
+```text
+profile.json  ---> identity / intent / tone / default tool policy
+keeper.toml   ---> deployment override / sandbox / cascade / execution scope
+keeper.json   ---> durable current runtime state
+keepers/<name>/ ---> append-only runtime artifacts
+```
+
 ## Ownership Model
 
 | Path | Meaning | Truth class | Human edit surface |

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -69,6 +69,13 @@ OAS_CODEX_CONFIG = "sandbox_mode=read-only"
 
 키는 반드시 `^OAS_(CLAUDE|CODEX|GEMINI)_.+` 패턴에 맞아야 한다. 그 외 키(`PATH`, `LD_PRELOAD`, 임의 변수 등)는 silently 드롭되어 ambient env 주입을 차단한다. bool 값은 `true`→`"1"`, `false`→`"0"`으로 자동 변환된다.
 
+빠른 운영 규칙:
+- `OAS_CODEX_SANDBOX=read-only`: 읽기/진단 전용
+- `OAS_CODEX_SANDBOX=workspace-write`: 일반적인 로컬 코딩
+- `OAS_CODEX_SANDBOX=danger-full-access`: 마지막 수단
+
+주의: 이건 Codex CLI sandbox다. keeper Docker sandbox는 아래 3.1.1과 [DOCKER-SANDBOX-QUICKSTART.md](./DOCKER-SANDBOX-QUICKSTART.md)가 canonical이다.
+
 ### 1.2 MASC --- 조정 레이어
 
 MASC는 OAS 위에 멀티에이전트 협업 기능을 확장한다:
@@ -280,6 +287,14 @@ spawn 시 인자로 직접 설정하는 필드.
 | `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
 
 ### 3.1.1 Sandbox Core V1 사용법
+
+처음엔 이 규칙만 쓰면 된다:
+
+- 기본: `sandbox_profile="docker_hardened"` + `network_mode="none"`
+- 네트워크가 실제로 필요할 때만 `network_mode="inherit"`
+- Docker가 문제일 때만 `sandbox_profile="legacy_local"`
+
+짧은 복붙 문서는 [DOCKER-SANDBOX-QUICKSTART.md](./DOCKER-SANDBOX-QUICKSTART.md)다.
 
 가장 보수적인 기본 패턴:
 

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -74,11 +74,141 @@ MASC_BASE_PATH="$BASE_PATH" \
 
 Then run `./_build/default/bin/main_eio.exe doctor --base-path "$BASE_PATH"` and re-check `/health` to confirm the effective base path is the path you intended.
 
-## 4. Bootstrap an Admin Bearer
+## 4. Fast Path: Mint an Admin Bearer with `login`
 
 If you already have an admin bearer, skip to step 5.
 
-If you do not, the reliable local fallback is to seed the auth store directly.
+Preferred path:
+
+```bash
+~/me/scripts/masc login --json --agent codex-local-admin
+```
+
+If you are inside the repo and do not have the wrapper yet:
+
+```bash
+dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin
+```
+
+What this does:
+
+- enables room auth if it is still off
+- forces `require_token=true`
+- creates or rotates an admin bearer for the requested `agent_name`
+- prints a one-shot dashboard URL and the raw bearer token
+
+Typical JSON output:
+
+```json
+{
+  "base_path": "/Users/you/me",
+  "auth_root": "/Users/you/me/.masc/auth",
+  "auth_config_path": "/Users/you/me/.masc/auth/config.json",
+  "agents_root": "/Users/you/me/.masc/auth/agents",
+  "credential_path": "/Users/you/me/.masc/auth/agents/codex-local-admin.json",
+  "agent_name": "codex-local-admin",
+  "require_token": true,
+  "reused_auth": true,
+  "room_secret": null,
+  "bearer_token": "<raw-token>",
+  "dashboard_url": "http://127.0.0.1:8935/dashboard?agent=codex-local-admin&token=<raw-token>"
+}
+```
+
+Recommended shell flow:
+
+```bash
+LOGIN_JSON="$(~/me/scripts/masc login --json --agent codex-local-admin)"
+TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
+URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
+printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
+```
+
+Field meanings:
+
+- `reused_auth=true`: auth was already enabled; only the admin bearer was minted or rotated
+- `reused_auth=false`: auth was just bootstrapped now
+- `room_secret!=null`: a brand-new room secret was created during bootstrap
+- `room_secret=null`: auth already existed, so the raw room secret cannot be shown again
+
+Notes:
+
+- the server stores only the SHA256 hash, not the raw bearer
+- keep the raw bearer outside the repo
+- rerunning `login` is the supported local rotation path
+- this is for trusted local operator use, not a remote/public bootstrap path
+
+## 5. Open the Dashboard as Admin
+
+Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
+
+```text
+http://127.0.0.1:8935/dashboard?agent=codex-local-admin&token=<raw-token>
+```
+
+You can verify the session with:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-local-admin" \
+  | jq '.auth'
+```
+
+Expected:
+
+- `token_present=true`
+- `effective_agent="codex-local-admin"`
+- `effective_role="admin"`
+
+## 6. Verify Keeper Lifecycle Routes
+
+Use a low-risk keeper first.
+
+Boot:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/boot \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-local-admin"
+```
+
+Shutdown:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/shutdown \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-local-admin"
+```
+
+Then inspect the execution snapshot:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: codex-local-admin" \
+  | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
+```
+
+## 7. Rotate or Mint Another Admin Token
+
+Rotate the same admin identity:
+
+```bash
+~/me/scripts/masc login --json --agent codex-local-admin
+```
+
+Mint a second admin identity for a different operator:
+
+```bash
+~/me/scripts/masc login --json --agent ops-admin
+```
+
+Old raw tokens remain unusable once you rotate the same `agent_name`, because the stored hash in `.masc/auth/agents/<agent>.json` is replaced.
+
+## 8. Manual Fallback: Seed the Auth Store Directly
+
+Use this only if the `login` command is unavailable.
 
 1. Back up the auth config:
 
@@ -103,7 +233,7 @@ printf 'token=%s\nhash=%s\n' "$TOKEN" "$HASH"
 
 ```json
 {
-  "agent_name": "codex-tool-matrix",
+  "agent_name": "codex-local-admin",
   "token": "<sha256 hash>",
   "role": "admin",
   "created_at": "<created_at>",
@@ -114,7 +244,7 @@ printf 'token=%s\nhash=%s\n' "$TOKEN" "$HASH"
 Path:
 
 ```text
-<effective_base_path>/.masc/auth/agents/codex-tool-matrix.json
+<effective_base_path>/.masc/auth/agents/codex-local-admin.json
 ```
 
 4. Set `require_token=true` in the live auth config:
@@ -133,65 +263,7 @@ Path:
 <effective_base_path>/.masc/auth/config.json
 ```
 
-Notes:
-
-- the server stores only the SHA256 hash, not the raw bearer
-- keep the raw bearer outside the repo
-- this is for trusted local operator use, not a remote/public bootstrap path
-
-## 5. Open the Dashboard as Admin
-
-Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
-
-```text
-http://127.0.0.1:8935/dashboard?agent=codex-tool-matrix&token=<raw-token>
-```
-
-You can verify the session with:
-
-```bash
-curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
-  -H "Authorization: Bearer <raw-token>" \
-  -H "X-MASC-Agent: codex-tool-matrix" \
-  | jq '.auth'
-```
-
-Expected:
-
-- `token_present=true`
-- `effective_agent="codex-tool-matrix"`
-- `effective_role="admin"`
-
-## 6. Verify Keeper Lifecycle Routes
-
-Use a low-risk keeper first.
-
-Boot:
-
-```bash
-curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/boot \
-  -H "Authorization: Bearer <raw-token>" \
-  -H "X-MASC-Agent: codex-tool-matrix"
-```
-
-Shutdown:
-
-```bash
-curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/shutdown \
-  -H "Authorization: Bearer <raw-token>" \
-  -H "X-MASC-Agent: codex-tool-matrix"
-```
-
-Then inspect the execution snapshot:
-
-```bash
-curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
-  -H "Authorization: Bearer <raw-token>" \
-  -H "X-MASC-Agent: codex-tool-matrix" \
-  | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
-```
-
-## 7. Rollback
+## 9. Rollback
 
 If you need to go back to anonymous loopback behavior:
 
@@ -204,10 +276,10 @@ Example:
 ```bash
 BASE_PATH="${MASC_BASE_PATH:-$HOME}"
 mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
-rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
+rm -f "$BASE_PATH/.masc/auth/agents/codex-local-admin.json"
 ```
 
-## 8. Known Failure Modes
+## 10. Known Failure Modes
 
 - `effective_base_path` points somewhere else:
   you edited the wrong `.masc/auth` tree

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -202,6 +202,13 @@ Field meanings:
 
 Notes:
 
+- `credential_path` is the persistent on-disk credential file under `<base_path>/.masc/auth/agents/<agent>.json`
+- restarting the server does not require rerunning `login` as long as that credential file still exists
+- the credential file is written with mode `0600` and stores only the SHA256 token hash plus metadata, never the raw bearer
+- `--agent` is just the local operator identity label for this bootstrap flow; `local-admin` is a default example, not a magic suffix
+- the granted power comes from the stored `role="admin"` credential, not from the string `local-admin`
+- rerunning `login` with the same `agent_name` replaces the stored hash immediately, so old raw tokens fail on the next request and the dashboard must log in again
+- `login` is a local CLI bootstrap path, not a remote HTTP endpoint; use it only on a trusted loopback/dev machine
 - the server stores only the SHA256 hash, not the raw bearer
 - keep the raw bearer outside the repo
 - rerunning `login` is the supported local rotation path

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -28,28 +28,32 @@ MASC_BASE_PATH="$BASE_PATH" \
   --base-path "$BASE_PATH"
 ```
 
-In another shell, mint or rotate a local admin bearer and extract the values:
+In another shell, do the whole local admin flow in one command:
+
+```bash
+~/me/scripts/masc dashboard-admin
+```
+
+That command:
+
+- mints or rotates the admin bearer
+- prints `token=...` and `export MASC_OPERATOR_TOKEN=...`
+- opens the dashboard URL once
+- verifies `/api/v1/dashboard/shell`
+
+If you want the raw values without opening a browser:
+
+```bash
+~/me/scripts/masc dashboard-admin --no-open
+```
+
+If you need raw JSON for scripting:
 
 ```bash
 LOGIN_JSON="$(~/me/scripts/masc login --json --agent codex-local-admin)"
 TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
 URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
 printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
-```
-
-Open the dashboard as admin:
-
-```bash
-open "$URL"
-```
-
-Verify the admin session:
-
-```bash
-curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-MASC-Agent: codex-local-admin" \
-  | jq '.auth'
 ```
 
 Expected quick checks:
@@ -137,7 +141,13 @@ Then run `./_build/default/bin/main_eio.exe doctor --base-path "$BASE_PATH"` and
 
 If you already have an admin bearer, skip to step 5.
 
-Preferred path:
+Fastest path if you want the browser + verification too:
+
+```bash
+~/me/scripts/masc dashboard-admin
+```
+
+JSON path if you are scripting around the token:
 
 ```bash
 ~/me/scripts/masc login --json --agent codex-local-admin

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -14,6 +14,65 @@ Those routes are stricter than normal local `/mcp` calls:
 
 If the dashboard can read state but keeper boot/config/shutdown fails, use this runbook.
 
+## 0. Copy-Paste Example
+
+Start the server on loopback:
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc-mcp
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+MASC_BASE_PATH="$BASE_PATH" \
+  dune exec --root . ./bin/main_eio.exe -- \
+  --host 127.0.0.1 \
+  --port 8935 \
+  --base-path "$BASE_PATH"
+```
+
+In another shell, mint or rotate a local admin bearer and extract the values:
+
+```bash
+LOGIN_JSON="$(~/me/scripts/masc login --json --agent codex-local-admin)"
+TOKEN="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.bearer_token')"
+URL="$(printf '%s\n' "$LOGIN_JSON" | jq -r '.dashboard_url')"
+printf 'token=%s\nurl=%s\n' "$TOKEN" "$URL"
+```
+
+Open the dashboard as admin:
+
+```bash
+open "$URL"
+```
+
+Verify the admin session:
+
+```bash
+curl -sS http://127.0.0.1:8935/api/v1/dashboard/shell \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-MASC-Agent: codex-local-admin" \
+  | jq '.auth'
+```
+
+Expected quick checks:
+
+- `enabled=true`
+- `require_token=true`
+- `effective_role="admin"`
+
+Common next actions:
+
+```bash
+# boot a keeper
+curl -sS -X POST http://127.0.0.1:8935/api/v1/keepers/<keeper>/boot \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-MASC-Agent: codex-local-admin"
+
+# rotate the same admin token
+~/me/scripts/masc login --json --agent codex-local-admin
+
+# mint a separate admin identity
+~/me/scripts/masc login --json --agent ops-admin
+```
+
 ## 1. Confirm the Real Base Path
 
 Always check which `.masc` root the server is actually using before editing auth state.

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -296,16 +296,16 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
     let filtered = match capability with
       | None -> agents
       | Some cap ->
-        List.filter (fun (a : agent) ->
+        List.filter (fun (a : Types.agent) ->
           List.mem cap a.capabilities
         ) agents
     in
     (* Include local agent card *)
     let local_card = Agent_card.generate_default ~schemas () in
-    let agents_json = List.map (fun (a : agent) ->
+    let agents_json = List.map (fun (a : Types.agent) ->
       `Assoc [
         ("name", `String a.name);
-        ("status", `String (agent_status_to_string a.status));
+        ("status", `String (Types.agent_status_to_string a.status));
         ("capabilities", `List (List.map (fun s -> `String s) a.capabilities));
         ("current_task", match a.current_task with
           | None -> `Null
@@ -333,7 +333,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
 let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Coord.get_agents_raw config in
-  let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
+  let agent_opt = List.find_opt (fun (a : Types.agent) -> a.name = agent_name) agents in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
@@ -402,7 +402,7 @@ let delegate config ~agent_name ~target ~message
       ~initial_message:(Some full_message)
     in
     match portal_result with
-    | Error e -> Error (masc_error_to_string e)
+    | Error e -> Error (Types.masc_error_to_string e)
     | Ok msg ->
       let task_id = generate_uuid () in
       match task_type with

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -420,6 +420,88 @@ let enable_auth config ~require_token ~agent_name : string * string option =
   in
   (secret, bootstrap_token)
 
+type local_admin_bootstrap = {
+  base_path : string;
+  auth_root : string;
+  auth_config_path : string;
+  agents_root : string;
+  credential_path : string;
+  agent_name : string;
+  require_token : bool;
+  reused_auth : bool;
+  room_secret : string option;
+  bearer_token : string;
+  dashboard_url : string;
+}
+
+let dashboard_login_url ~host ~port ~agent_name ~token =
+  Printf.sprintf "http://%s:%d/dashboard?agent=%s&token=%s"
+    host port agent_name token
+
+let local_admin_bootstrap_to_yojson (bootstrap : local_admin_bootstrap) =
+  `Assoc [
+    ("base_path", `String bootstrap.base_path);
+    ("auth_root", `String bootstrap.auth_root);
+    ("auth_config_path", `String bootstrap.auth_config_path);
+    ("agents_root", `String bootstrap.agents_root);
+    ("credential_path", `String bootstrap.credential_path);
+    ("agent_name", `String bootstrap.agent_name);
+    ("require_token", `Bool bootstrap.require_token);
+    ("reused_auth", `Bool bootstrap.reused_auth);
+    ( "room_secret",
+      match bootstrap.room_secret with
+      | Some value -> `String value
+      | None -> `Null );
+    ("bearer_token", `String bootstrap.bearer_token);
+    ("dashboard_url", `String bootstrap.dashboard_url);
+  ]
+
+let bootstrap_local_admin ?(host = "127.0.0.1") ?(port = 8935) config
+    ~agent_name : (local_admin_bootstrap, masc_error) result =
+  let base_path = Env_config.normalize_masc_base_path_input config in
+  let existing_cfg = load_auth_config base_path in
+  let room_secret, reused_auth, bearer_token_result =
+    if existing_cfg.enabled then begin
+      if not existing_cfg.require_token then
+        save_auth_config base_path { existing_cfg with enabled = true; require_token = true };
+      (None, true, create_token base_path ~agent_name ~role:Admin)
+    end else begin
+      let secret, bootstrap_token =
+        enable_auth base_path ~require_token:true ~agent_name
+      in
+      let token_result =
+        match bootstrap_token with
+        | Some token ->
+            (match verify_token base_path ~agent_name ~token with
+             | Ok _ -> (
+                 match load_credential base_path agent_name with
+                 | Some cred -> Ok (token, cred)
+                 | None -> create_token base_path ~agent_name ~role:Admin)
+             | Error _ -> create_token base_path ~agent_name ~role:Admin)
+        | None -> create_token base_path ~agent_name ~role:Admin
+      in
+      (Some secret, false, token_result)
+    end
+  in
+  match bearer_token_result with
+  | Error _ as err -> err
+  | Ok (bearer_token, _cred) ->
+      Ok
+        {
+          base_path;
+          auth_root = auth_dir base_path;
+          auth_config_path = auth_config_file base_path;
+          agents_root = agents_dir base_path;
+          credential_path = credential_file base_path agent_name;
+          agent_name;
+          require_token = true;
+          reused_auth;
+          room_secret;
+          bearer_token;
+          dashboard_url =
+            dashboard_login_url ~host ~port ~agent_name ~token:bearer_token;
+        }
+
 (** Disable authentication *)
 let disable_auth config =
   let cfg = load_auth_config config in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -12,6 +12,25 @@ open Keeper_turn_up_args
 let preset_of_defaults defaults =
   Option.bind defaults.tool_preset tool_preset_of_string
 
+let resolve_creation_execution_policy (p : parsed_args) =
+  let sandbox_profile =
+    resolve_sandbox_profile
+      ~preferred:p.sandbox_profile_opt
+      ~fallback:p.profile_defaults.sandbox_profile
+  in
+  let network_mode =
+    resolve_network_mode
+      ~sandbox_profile
+      ~preferred:p.network_mode_opt
+      ~fallback:p.profile_defaults.network_mode
+  in
+  let shared_memory_scope =
+    resolve_shared_memory_scope
+      ~preferred:p.shared_memory_scope_opt
+      ~fallback:p.profile_defaults.shared_memory_scope
+  in
+  (sandbox_profile, network_mode, shared_memory_scope)
+
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;
   let task_id = Printf.sprintf "keeper_create_%s" p.name in
@@ -42,21 +61,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     |> first_some p.profile_defaults.execution_scope
     |> Option.value ~default:default_execution_scope
   in
-  let sandbox_profile =
-    resolve_sandbox_profile
-      ~preferred:p.sandbox_profile_opt
-      ~fallback:None
-  in
-  let network_mode =
-    resolve_network_mode
-      ~sandbox_profile
-      ~preferred:p.network_mode_opt
-      ~fallback:None
-  in
-  let shared_memory_scope =
-    resolve_shared_memory_scope
-      ~preferred:p.shared_memory_scope_opt
-      ~fallback:None
+  let sandbox_profile, network_mode, shared_memory_scope =
+    resolve_creation_execution_policy p
   in
   let voice_enabled =
     Option.value ~default:(default_voice_enabled_for p.name) p.voice_enabled_opt

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -44,6 +44,13 @@ include_bisect=false
 include_compact_protocol=false
 do_install=false
 agent_sdk_pin_source="${AGENT_SDK_PIN_URL:-${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}}"
+agent_sdk_pin_args=(-n -y)
+install_args=(--yes)
+
+if [[ -d "${agent_sdk_pin_source}" ]]; then
+  agent_sdk_pin_args=(--working-dir -n -y)
+  install_args=(--yes --working-dir)
+fi
 
 for arg in "$@"; do
   case "$arg" in
@@ -76,7 +83,7 @@ fi
 # as sub-libraries (mcp-protocol-sdk#60). Pin the released single-package line.
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0 -n -y
 pinned_pkgs+=("mcp_protocol")
-opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
+opam pin add agent_sdk "${agent_sdk_pin_source}" "${agent_sdk_pin_args[@]}"
 pinned_pkgs+=("agent_sdk")
 opam pin add ocaml-webrtc "https://github.com/jeong-sik/ocaml-webrtc.git#${WEBRTC_SHA}" -n -y
 pinned_pkgs+=("ocaml-webrtc")
@@ -102,7 +109,7 @@ fi
 if $do_install; then
   echo ""
   echo "[opam-pin] --install set; rebuilding ${#pinned_pkgs[@]} pinned packages..."
-  opam install --yes "${pinned_pkgs[@]}"
+  opam install "${install_args[@]}" "${pinned_pkgs[@]}"
   echo "[opam-pin] install complete. Installed binaries now match the pins above."
 else
   echo ""

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -30,6 +30,17 @@ let cleanup_test_room dir =
   in
   try rm_rf dir with _ -> ()
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 let permission_bits path =
   (Unix.stat path).Unix.st_perm land 0o777
 
@@ -292,6 +303,67 @@ let test_auth_enabled_with_valid_token () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
+let test_bootstrap_local_admin_enables_auth_and_returns_login_url () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      match
+        Auth.bootstrap_local_admin dir ~agent_name:"local-admin"
+          ~host:"127.0.0.1" ~port:8935
+      with
+      | Error e -> fail (Types.masc_error_to_string e)
+      | Ok bootstrap ->
+          let cfg = Auth.load_auth_config dir in
+          check bool "auth enabled" true cfg.enabled;
+          check bool "require_token enabled" true cfg.require_token;
+          check bool "fresh auth" false bootstrap.reused_auth;
+          check bool "room secret returned" true
+            (match bootstrap.room_secret with Some _ -> true | None -> false);
+          check bool "dashboard url contains agent" true
+            (contains_substring ~needle:"agent=local-admin"
+               bootstrap.dashboard_url);
+          check bool "dashboard url contains token" true
+            (contains_substring ~needle:bootstrap.bearer_token
+               bootstrap.dashboard_url);
+          match
+            Auth.verify_token dir ~agent_name:"local-admin"
+              ~token:bootstrap.bearer_token
+          with
+          | Ok cred ->
+              check string "admin role"
+                (Types.show_agent_role Types.Admin)
+                (Types.show_agent_role cred.role)
+          | Error e -> fail (Types.masc_error_to_string e))
+
+let test_bootstrap_local_admin_reuses_existing_auth_and_escalates_require_token
+    () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let _ = Auth.enable_auth dir ~require_token:false ~agent_name:"bootstrap-admin" in
+      match
+        Auth.bootstrap_local_admin dir ~agent_name:"local-admin"
+          ~host:"127.0.0.1" ~port:8935
+      with
+      | Error e -> fail (Types.masc_error_to_string e)
+      | Ok bootstrap ->
+          let cfg = Auth.load_auth_config dir in
+          check bool "reused auth" true bootstrap.reused_auth;
+          check bool "raw room secret omitted on reuse" true
+            (bootstrap.room_secret = None);
+          check bool "require_token escalated" true cfg.require_token;
+          match
+            Auth.verify_token dir ~agent_name:"local-admin"
+              ~token:bootstrap.bearer_token
+          with
+          | Ok cred ->
+              check string "admin role on reuse"
+                (Types.show_agent_role Types.Admin)
+                (Types.show_agent_role cred.role)
+          | Error e -> fail (Types.masc_error_to_string e))
+
 let test_permission_denied_for_reader () =
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
@@ -490,6 +562,10 @@ let () =
       test_case "auth disabled allows all" `Quick test_auth_disabled_allows_all;
       test_case "auth enabled requires token" `Quick test_auth_enabled_requires_token;
       test_case "auth enabled with valid token" `Quick test_auth_enabled_with_valid_token;
+      test_case "bootstrap local admin enables auth" `Quick
+        test_bootstrap_local_admin_enables_auth_and_returns_login_url;
+      test_case "bootstrap local admin reuses existing auth" `Quick
+        test_bootstrap_local_admin_reuses_existing_auth_and_escalates_require_token;
       test_case "permission denied for reader" `Quick test_permission_denied_for_reader;
       test_case "optional token overrides reader default role"
         `Quick test_optional_token_overrides_reader_default_role;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -364,6 +364,75 @@ let test_bootstrap_local_admin_reuses_existing_auth_and_escalates_require_token
                 (Types.show_agent_role cred.role)
           | Error e -> fail (Types.masc_error_to_string e))
 
+let test_bootstrap_local_admin_rotation_invalidates_previous_token () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let first =
+        match
+          Auth.bootstrap_local_admin dir ~agent_name:"local-admin"
+            ~host:"127.0.0.1" ~port:8935
+        with
+        | Ok bootstrap -> bootstrap
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let second =
+        match
+          Auth.bootstrap_local_admin dir ~agent_name:"local-admin"
+            ~host:"127.0.0.1" ~port:8935
+        with
+        | Ok bootstrap -> bootstrap
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      check bool "second bootstrap reuses auth" true second.reused_auth;
+      check bool "rotation changes raw token" true
+        (first.bearer_token <> second.bearer_token);
+      (match
+         Auth.verify_token dir ~agent_name:"local-admin"
+           ~token:first.bearer_token
+       with
+       | Error (Types.InvalidToken _) -> ()
+       | Ok _ -> fail "old token should be invalid after rotation"
+       | Error e -> fail (Types.masc_error_to_string e));
+      match
+        Auth.verify_token dir ~agent_name:"local-admin"
+          ~token:second.bearer_token
+      with
+      | Ok cred ->
+          check string "rotated token stays admin"
+            (Types.show_agent_role Types.Admin)
+            (Types.show_agent_role cred.role)
+      | Error e -> fail (Types.masc_error_to_string e))
+
+let test_bootstrap_local_admin_uses_requested_agent_identity () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      match
+        Auth.bootstrap_local_admin dir ~agent_name:"ops-admin"
+          ~host:"127.0.0.1" ~port:8935
+      with
+      | Error e -> fail (Types.masc_error_to_string e)
+      | Ok bootstrap ->
+          check string "agent name echoed" "ops-admin" bootstrap.agent_name;
+          check string "credential path keyed by agent"
+            (Auth.credential_file dir "ops-admin")
+            bootstrap.credential_path;
+          check bool "dashboard url contains requested agent" true
+            (contains_substring ~needle:"agent=ops-admin"
+               bootstrap.dashboard_url);
+          match
+            Auth.verify_token dir ~agent_name:"ops-admin"
+              ~token:bootstrap.bearer_token
+          with
+          | Ok cred ->
+              check string "requested agent is admin"
+                (Types.show_agent_role Types.Admin)
+                (Types.show_agent_role cred.role)
+          | Error e -> fail (Types.masc_error_to_string e))
+
 let test_permission_denied_for_reader () =
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
@@ -566,6 +635,10 @@ let () =
         test_bootstrap_local_admin_enables_auth_and_returns_login_url;
       test_case "bootstrap local admin reuses existing auth" `Quick
         test_bootstrap_local_admin_reuses_existing_auth_and_escalates_require_token;
+      test_case "bootstrap local admin rotation invalidates previous token"
+        `Quick test_bootstrap_local_admin_rotation_invalidates_previous_token;
+      test_case "bootstrap local admin uses requested agent identity"
+        `Quick test_bootstrap_local_admin_uses_requested_agent_identity;
       test_case "permission denied for reader" `Quick test_permission_denied_for_reader;
       test_case "optional token overrides reader default role"
         `Quick test_optional_token_overrides_reader_default_role;


### PR DESCRIPTION
## Summary
- add a `login` CLI command that bootstraps or rotates a local admin bearer for the dashboard/operator surface
- document the fast-path dashboard auth flow with copy-paste examples, persistence location, rotation semantics, and the `--agent` identity model
- add a Docker sandbox quickstart plus a `watchdog` canary keeper, and fix declarative keeper boot so `sandbox_profile` / `network_mode` defaults from `config/keepers/*.toml` are honored at runtime
- make local `AGENT_SDK_PIN_URL=/path/to/oas` installs use `--working-dir` so dirty local OAS worktrees actually flow into the opam switch

## Product impact
- local operators can get an admin dashboard session with one command instead of manually editing `.masc/auth`
- keeper Docker sandbox setup is now followable from docs instead of reverse-engineering multiple files
- declarative keeper bootstrap no longer silently falls back to legacy execution defaults when the TOML requested Docker isolation

## Evidence
- `login --json` now returns `credential_path`, `agent_name`, `bearer_token`, and `dashboard_url`, and the runbook explains that the credential persists across restarts, stores only the SHA256 token hash, and rotates immediately when the same `agent_name` is reused
- the `watchdog` canary is declared in `config/keepers/watchdog.toml` with `sandbox_profile = "docker_hardened"` and `network_mode = "none"`
- `keeper_turn_up_create.ml` now resolves missing runtime policy fields from the declarative keeper profile defaults before calling `create_keeper`

## Verification
- `git diff --check`
- `dune exec --root . ./test/test_auth.exe`
- `dune exec --root . ./bin/main_eio.exe -- login --json --agent codex-local-admin`
- `bash -n scripts/opam-pin-external-deps.sh`
- `dune build --root . bin/main_eio.exe test/test_oas_worker.exe`
- `env AGENT_SDK_PIN_URL=/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/task-995-default-mcp-off bash scripts/check-oas-pin.sh --local-only`
- local smoke: booted declarative `watchdog`, confirmed `.masc/keepers/watchdog.json` recorded `sandbox_profile="docker_hardened"` and `network_mode="none"`

## Review evidence
- reviewer gaps around token persistence, rotation semantics, and the `--agent` permission model are now addressed in `docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md` and `README.md`
- added auth tests that prove reusing the same `agent_name` invalidates the previous raw token immediately and that non-`local-admin` names such as `ops-admin` receive the same admin bootstrap behavior
- PR hygiene follow-up completed by linking an issue and expanding the body to reflect the full diff scope

## Linked issue
Closes #8404
