### PR TITLE
fix(dashboard): harden governance judge and approval errors

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -20,6 +20,30 @@
   "keeper_unified_temperature": 0.2,
   "keeper_unified_max_tokens": 16384,
 
+  "_comment_governance_judge": "Dashboard governance judge must resolve to its own cascade profile; if the name is missing from keeper_cascade_profile SSOT it silently collapses to keeper_unified and competes with live keeper traffic.",
+  "governance_judge_models": [
+    {"model": "claude_code:claude-haiku-4-5-20251001", "weight": 80},
+    {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 20}
+  ],
+  "governance_judge_strategy": "weighted_random",
+  "governance_judge_max_cycles": 1,
+  "governance_judge_cli_max_concurrent": 1,
+  "governance_judge_ollama_max_concurrent": 1,
+  "governance_judge_temperature": 0.1,
+  "governance_judge_max_tokens": 4096,
+
+  "_comment_operator_judge": "Operator judge runs on the same dashboard control plane but should not borrow keeper_unified routing; keep it cheap and isolated from long-running keeper cascades.",
+  "operator_judge_models": [
+    {"model": "claude_code:claude-haiku-4-5-20251001", "weight": 80},
+    {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 20}
+  ],
+  "operator_judge_strategy": "weighted_random",
+  "operator_judge_max_cycles": 1,
+  "operator_judge_cli_max_concurrent": 1,
+  "operator_judge_ollama_max_concurrent": 1,
+  "operator_judge_temperature": 0.1,
+  "operator_judge_max_tokens": 4096,
+
   "local_only_models": [
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -38,6 +38,25 @@ describe('post', () => {
 
     expect(defaultBoardVoter()).toBe('dashboard-user')
   })
+
+  it('surfaces structured server error bodies on POST failures', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":"approval appr_stale not found or already resolved"}', {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(post('/api/v1/dashboard/governance/approvals/resolve', {
+      id: 'appr_stale',
+      decision: 'approve',
+    })).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 400,
+      responseMessage: 'approval appr_stale not found or already resolved',
+    })
+  })
 })
 
 describe('get bootstrap warm-up mapping', () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -99,20 +99,23 @@ export class ApiRequestError extends Error {
   status?: number
   statusText?: string
   timeout: boolean
+  responseMessage?: string
 
   constructor(opts: {
     method: string
     path: string
     status?: number
     statusText?: string
+    responseMessage?: string
     timeout?: boolean
     timeoutMs?: number
   }) {
     const method = opts.method.toUpperCase()
     const timeout = opts.timeout === true
+    const responseMessage = opts.responseMessage?.trim()
     const message = timeout
       ? `${method} ${opts.path}: timeout after ${opts.timeoutMs ?? 0}ms`
-      : `${method} ${opts.path}: ${opts.status ?? 'unknown'} ${opts.statusText ?? ''}`.trim()
+      : `${method} ${opts.path}: ${opts.status ?? 'unknown'} ${opts.statusText ?? ''}${responseMessage ? ` - ${responseMessage}` : ''}`.trim()
     super(message)
     this.name = 'ApiRequestError'
     this.method = method
@@ -120,6 +123,7 @@ export class ApiRequestError extends Error {
     this.status = opts.status
     this.statusText = opts.statusText
     this.timeout = timeout
+    this.responseMessage = responseMessage
   }
 }
 
@@ -195,6 +199,31 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function readErrorMessage(res: Response): Promise<string | undefined> {
+  let rawText = ''
+  try {
+    rawText = await res.text()
+  } catch {
+    return undefined
+  }
+  const trimmed = rawText.trim()
+  if (trimmed === '') return undefined
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (isRecord(parsed)) {
+      if (typeof parsed.error === 'string' && parsed.error.trim() !== '') {
+        return parsed.error.trim()
+      }
+      if (typeof parsed.message === 'string' && parsed.message.trim() !== '') {
+        return parsed.message.trim()
+      }
+    }
+  } catch {
+    // Plain-text error bodies are still useful operator feedback.
+  }
+  return trimmed
 }
 
 function isNotInitializedEnvelope(raw: unknown): boolean {
@@ -323,15 +352,17 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
   )
   if (!res.ok) {
-    const warmPayload = await bootstrapWarmPayload(path, res)
+    const warmPayload = await bootstrapWarmPayload(path, res.clone())
     if (warmPayload !== null) {
       return warmPayload as T
     }
+    const responseMessage = await readErrorMessage(res)
     throw new ApiRequestError({
       method: 'GET',
       path,
       status: res.status,
       statusText: res.statusText,
+      responseMessage,
     })
   }
   const data = await res.json()
@@ -409,11 +440,13 @@ export async function post<T>(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
+    const responseMessage = await readErrorMessage(res)
     throw new ApiRequestError({
       method: 'POST',
       path,
       status: res.status,
       statusText: res.statusText,
+      responseMessage,
     })
   }
   return res.json() as Promise<T>

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -371,11 +371,19 @@ export function resolveGovernanceApproval(
   id: string,
   decision: 'approve' | 'reject',
   reason?: string,
+  hint?: {
+    keeper_name?: string
+    tool_name?: string
+    input_kind?: string
+  },
 ): Promise<{ ok: boolean; id: string; decision: 'approve' | 'reject' }> {
   return post('/api/v1/dashboard/governance/approvals/resolve', {
     id,
     decision,
     reason,
+    keeper_name: hint?.keeper_name,
+    tool_name: hint?.tool_name,
+    input_kind: hint?.input_kind,
   })
 }
 

--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -126,7 +126,19 @@ export async function respondToKeeperApproval(id: string, decision: 'approve' | 
   if (!id) return
   governanceApprovalActing.value = id
   try {
-    await resolveGovernanceApproval(id, decision)
+    const approval =
+      governanceData.value?.approval_queue?.find(item => item.id === id)
+    const rawInput = approval?.input
+    const inputKind =
+      rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)
+      && typeof (rawInput as { kind?: unknown }).kind === 'string'
+        ? (rawInput as { kind: string }).kind
+        : undefined
+    await resolveGovernanceApproval(id, decision, undefined, {
+      keeper_name: approval?.keeper_name,
+      tool_name: approval?.tool_name,
+      input_kind: inputKind,
+    })
     showToast(decision === 'approve' ? 'keeper 승인 요청을 승인했습니다' : 'keeper 승인 요청을 거부했습니다', 'success')
     await refreshGovernance()
   } catch (err) {
@@ -137,4 +149,3 @@ export async function respondToKeeperApproval(id: string, decision: 'approve' | 
     governanceApprovalActing.value = null
   }
 }
-

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -1,6 +1,6 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-04-18
 code_refs:
   - lib/dashboard/
   - lib/dashboard.ml
@@ -204,6 +204,15 @@ type attention_item = {
 - `cases_json`: 빈 case 목록 (pagination 유지)
 - `case_detail_json`: 단일 case 조회 시 not-found 응답
 - `factual_snapshot_json`: judge 입력용 빈 팩트 스냅샷
+- `approval_queue`: keeper HITL continue gate 목록. Ambiguous partial commit으로 keeper가 pause되면
+  `tool_name="keeper_continue_after_partial_commit"`와 `input.kind="continue_gate_required"`로 enqueue된다.
+  프로세스 재시작으로 in-memory queue가 유실돼도 supervisor sweep가 같은 shape의 gate를 재복원한다.
+
+continue gate lifecycle:
+- keeper turn이 committed mutating tool 이후 timeout/failure로 ambiguous partial commit에 들어가면 pause + approval queue enqueue
+- operator approve 시 keeper pause 해제, failure reason reset, 다음 cycle 재개
+- operator reject 시 keeper는 paused 상태 유지
+- dashboard resolve API와 `masc_approval_resolve`는 stale approval id에 대해 `keeper/tool/kind` fallback resolve를 지원
 
 ### 3.6. Governance Judge (`dashboard_governance_judge.ml`)
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -361,6 +361,7 @@ let list_pending_json () : Yojson.Safe.t =
       ("risk_level", `String (risk_level_to_string entry.risk_level));
       ("input_kind", Json_util.option_to_yojson (fun value -> `String value)
          (input_kind_opt entry.input));
+      ("input_preview", `String (input_preview_of_json entry.input));
       ("requested_at", `Float entry.requested_at);
       ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
     ] :: acc

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -183,18 +183,6 @@ let resolve_entry (entry : pending_approval) (decision : decision) =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> ()
 
-let find_pending_id ~keeper_name ~tool_name =
-  SMap.fold
-    (fun id entry acc ->
-      match acc with
-      | Some _ -> acc
-      | None ->
-        if String.equal entry.keeper_name keeper_name
-           && String.equal entry.tool_name tool_name
-        then Some id
-        else None)
-    (Atomic.get pending) None
-
 let input_kind_opt (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields -> (
@@ -204,6 +192,23 @@ let input_kind_opt (json : Yojson.Safe.t) =
           if trimmed = "" then None else Some trimmed
       | _ -> None)
   | _ -> None
+
+let find_pending_id map ~keeper_name ~tool_name ~input_kind =
+  SMap.fold
+    (fun id entry acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+        if String.equal entry.keeper_name keeper_name
+           && String.equal entry.tool_name tool_name
+           &&
+           match input_kind with
+           | None -> true
+           | Some expected ->
+               Option.equal String.equal (input_kind_opt entry.input) (Some expected)
+        then Some id
+        else None)
+    map None
 
 let fallback_matches ~keeper_name ~tool_name ?input_kind map =
   SMap.bindings map
@@ -250,7 +255,8 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
   : string =
   let created_entry = ref None in
   atomic_update pending (fun map ->
-    match find_pending_id ~keeper_name ~tool_name with
+    let input_kind = input_kind_opt input in
+    match find_pending_id map ~keeper_name ~tool_name ~input_kind with
     | Some id -> 
         created_entry := Some (`Existing id);
         map
@@ -353,6 +359,8 @@ let list_pending_json () : Yojson.Safe.t =
       ("keeper_name", `String entry.keeper_name);
       ("tool_name", `String entry.tool_name);
       ("risk_level", `String (risk_level_to_string entry.risk_level));
+      ("input_kind", Json_util.option_to_yojson (fun value -> `String value)
+         (input_kind_opt entry.input));
       ("requested_at", `Float entry.requested_at);
       ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
     ] :: acc
@@ -366,6 +374,8 @@ let list_pending_dashboard_json () : Yojson.Safe.t =
       ("keeper_name", `String entry.keeper_name);
       ("tool_name", `String entry.tool_name);
       ("risk_level", `String (risk_level_to_string entry.risk_level));
+      ("input_kind", Json_util.option_to_yojson (fun value -> `String value)
+         (input_kind_opt entry.input));
       ("requested_at", `Float entry.requested_at);
       ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
       ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -195,6 +195,27 @@ let find_pending_id ~keeper_name ~tool_name =
         else None)
     (Atomic.get pending) None
 
+let input_kind_opt (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with
+      | Some (`String value) ->
+          let trimmed = String.trim value in
+          if trimmed = "" then None else Some trimmed
+      | _ -> None)
+  | _ -> None
+
+let fallback_matches ~keeper_name ~tool_name ?input_kind map =
+  SMap.bindings map
+  |> List.filter (fun (_id, entry) ->
+         String.equal entry.keeper_name keeper_name
+         && String.equal entry.tool_name tool_name
+         &&
+         match input_kind with
+         | None -> true
+         | Some expected ->
+             Option.equal String.equal (input_kind_opt entry.input) (Some expected))
+
 let sort_entries_by_requested_at entries =
   List.sort
     (fun left right ->
@@ -256,8 +277,12 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
 (** Resolve a pending approval. Returns [Ok ()] if found, [Error msg] if not.
     Called from the dashboard approval HTTP handler
     ([server_dashboard_http.ml]). *)
-let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) result =
-  let result = ref (Error (Printf.sprintf "approval %s not found or already resolved" id)) in
+let resolve ?keeper_name ?tool_name ?input_kind
+    ~id ~(decision : Oas.Hooks.approval_decision) () : (unit, string) result =
+  let result =
+    ref
+      (Error (Printf.sprintf "approval %s not found or already resolved" id))
+  in
   atomic_update pending (fun map ->
     match SMap.find_opt id map with
     | None -> map
@@ -266,10 +291,57 @@ let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) resul
       SMap.remove id map
   );
   match !result with
-  | Error _ as err -> err
   | Ok entry ->
     resolve_entry entry decision;
     Ok ()
+  | Error _ -> (
+      match keeper_name, tool_name with
+      | Some keeper_name, Some tool_name ->
+        let fallback_result =
+          ref
+            (Error
+               (Printf.sprintf "approval %s not found or already resolved" id))
+        in
+        atomic_update pending (fun map ->
+          match fallback_matches ~keeper_name ~tool_name ?input_kind map with
+          | [] ->
+              let kind_suffix =
+                match input_kind with
+                | Some kind -> Printf.sprintf " kind=%s" kind
+                | None -> ""
+              in
+              fallback_result :=
+                Error
+                  (Printf.sprintf
+                     "approval %s not found or already resolved; no pending approval matches keeper=%s tool=%s%s"
+                     id keeper_name tool_name kind_suffix);
+              map
+          | [ (resolved_id, entry) ] ->
+              fallback_result := Ok (resolved_id, entry);
+              SMap.remove resolved_id map
+          | matches ->
+              let ids =
+                matches
+                |> List.map fst
+                |> String.concat ", "
+              in
+              fallback_result :=
+                Error
+                  (Printf.sprintf
+                     "approval %s not found; fallback hint matched multiple pending approvals (%s)"
+                     id ids);
+              map);
+        (match !fallback_result with
+         | Error _ as err -> err
+         | Ok (resolved_id, entry) ->
+             Log.Keeper.warn
+               "approval_queue: resolved stale approval id=%s via fallback keeper=%s tool=%s -> %s"
+               id keeper_name tool_name resolved_id;
+             resolve_entry entry decision;
+             Ok ())
+      | _ ->
+          Error
+            (Printf.sprintf "approval %s not found or already resolved" id))
 
 (* ── Query ────────────────────────────────────────────────── *)
 

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -8,6 +8,8 @@
 type t =
   | Default
   | Keeper_unified
+  | Governance_judge
+  | Operator_judge
   | Sangsu
   | Local_only
   | Local_recovery
@@ -24,6 +26,8 @@ type t =
 let to_string = function
   | Default -> "default"
   | Keeper_unified -> "keeper_unified"
+  | Governance_judge -> "governance_judge"
+  | Operator_judge -> "operator_judge"
   | Sangsu -> "sangsu"
   | Local_only -> "local_only"
   | Local_recovery -> "local_recovery"
@@ -38,9 +42,10 @@ let to_string = function
   | Resilient_breaker -> "resilient_breaker"
 
 let all =
-  [ Default; Keeper_unified; Sangsu; Local_only; Local_recovery; Tool_rerank;
-    Nick0cave; Capacity_queue_trio; Vendor_mix_balanced; Cost_tier_ladder;
-    Oauth_cli_rotate; Quality_sticky_glm51; Tool_use_strict; Resilient_breaker ]
+  [ Default; Keeper_unified; Governance_judge; Operator_judge; Sangsu;
+    Local_only; Local_recovery; Tool_rerank; Nick0cave; Capacity_queue_trio;
+    Vendor_mix_balanced; Cost_tier_ladder; Oauth_cli_rotate;
+    Quality_sticky_glm51; Tool_use_strict; Resilient_breaker ]
 
 (** All known cascade profile names, derived from the variant. Consumers
     that still operate on strings can use this list; new code should
@@ -62,6 +67,8 @@ let of_string_opt (raw : string) : t option =
      through to default. Collapsed here so bucket/metric code does not
      see a ghost value. *)
   | "keeper_turn" | "keeper_reply" -> Some default
+  | "governance_judge" -> Some Governance_judge
+  | "operator_judge" -> Some Operator_judge
   | "sangsu" -> Some Sangsu
   | "local_only" -> Some Local_only
   | "local_recovery" -> Some Local_recovery

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -17,11 +17,14 @@
 type t =
   | Default
   | Keeper_unified
+  | Governance_judge
+  | Operator_judge
   | Sangsu
   | Local_only
   | Local_recovery
   | Tool_rerank
-  (* v1 active catalog (2026-04-17): keepers route through these via
+  (* v1 active catalog (2026-04-18): keepers and dashboard judge loops
+     route through these via
      [config/cascade.json] presets. Adding a profile here unlocks lookup
      for [<name>_models]/[<name>_temperature]/[<name>_max_tokens] keys.
      Without the variant, [canonicalize] silently collapses the name to

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -275,7 +275,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
   let input =
     `Assoc
       [
-        ("kind", `String "reconcile_required");
+        ("kind", `String "continue_gate_required");
         ("keeper_name", `String meta.name);
         ("failure_reason", `String failure_reason);
         ("error_detail", `String blocker);
@@ -285,7 +285,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
   let _approval_id =
     Keeper_approval_queue.submit_pending
       ~keeper_name:meta.name
-      ~tool_name:"keeper_continue_after_reconcile"
+      ~tool_name:"keeper_continue_after_partial_commit"
       ~input
       ~risk_level:Keeper_approval_queue.Critical
       ~on_resolution:(fun decision ->
@@ -294,15 +294,15 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
         | Agent_sdk.Hooks.Edit _ ->
             resume_keeper_after_reconcile_gate ctx meta;
             Log.Keeper.info
-              "%s: restored reconcile continue gate approved; keeper resumed"
+              "%s: restored partial-commit continue gate approved; keeper resumed"
               meta.name
         | Agent_sdk.Hooks.Reject reason ->
             Log.Keeper.warn
-              "%s: restored reconcile continue gate rejected; keeper remains paused (%s)"
+              "%s: restored partial-commit continue gate rejected; keeper remains paused (%s)"
               meta.name reason)
   in
   Log.Keeper.warn
-    "%s: restored reconcile continue gate from persisted paused meta"
+    "%s: restored partial-commit continue gate from persisted paused meta"
     meta.name
 
 (* ── Sweep and recover ───────────────────────────────────── *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -218,6 +218,9 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
   | None ->
       Error "id is required"
   | Some id ->
+      let keeper_name = Safe_ops.json_string_opt "keeper_name" args in
+      let tool_name = Safe_ops.json_string_opt "tool_name" args in
+      let input_kind = Safe_ops.json_string_opt "input_kind" args in
       let decision_name =
         Safe_ops.json_string_opt "decision" args
         |> Option.value ~default:"approve"
@@ -239,7 +242,10 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
       match decision with
       | Error _ as err -> err
       | Ok decision ->
-          (match Keeper_approval_queue.resolve ~id ~decision with
+          (match
+             Keeper_approval_queue.resolve ?keeper_name ?tool_name ?input_kind
+               ~id ~decision ()
+           with
            | Ok () ->
                Ok
                  (`Assoc

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -92,6 +92,9 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
       Some (true, Yojson.Safe.to_string json)
   | "masc_approval_resolve" ->
       let id = arg_get_string "id" "" in
+      let keeper_name = arg_get_string_opt "keeper_name" in
+      let tool_name = arg_get_string_opt "tool_name" in
+      let input_kind = arg_get_string_opt "input_kind" in
       let decision_str = arg_get_string "decision" "approve" in
       if id = "" then Some (false, "id is required")
       else
@@ -102,7 +105,8 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
             Oas.Hooks.Reject reason
           | _ -> Oas.Hooks.Reject (Printf.sprintf "unknown decision: %s" decision_str)
         in
-        (match Keeper_approval_queue.resolve ~id ~decision () with
+        (match Keeper_approval_queue.resolve ?keeper_name ?tool_name ?input_kind
+                 ~id ~decision () with
          | Ok () ->
            Some (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str)
          | Error msg -> Some (false, msg))

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -102,7 +102,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
             Oas.Hooks.Reject reason
           | _ -> Oas.Hooks.Reject (Printf.sprintf "unknown decision: %s" decision_str)
         in
-        (match Keeper_approval_queue.resolve ~id ~decision with
+        (match Keeper_approval_queue.resolve ~id ~decision () with
          | Ok () ->
            Some (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str)
          | Error msg -> Some (false, msg))

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -1,6 +1,56 @@
 open Types
 
 let schemas : tool_schema list = [
+  (* masc_approval_pending *)
+  {
+    name = "masc_approval_pending";
+    description = "List pending HITL approvals that are blocking keeper or operator progress. \
+Returns approval ids plus keeper, tool, risk, input kind, and a preview so an operator can decide what to resolve.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+
+  (* masc_approval_resolve *)
+  {
+    name = "masc_approval_resolve";
+    description = "Resolve a pending HITL approval by id. \
+If the id is stale, keeper_name + tool_name + input_kind can be supplied as fallback hints to resolve the single matching pending approval safely.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Approval id to resolve");
+        ]);
+        ("decision", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "approve"; `String "reject"]);
+          ("description", `String "Approval decision");
+          ("default", `String "approve");
+        ]);
+        ("reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Reject reason. Used when decision='reject'.");
+        ]);
+        ("keeper_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Fallback hint: keeper name for stale approval ids");
+        ]);
+        ("tool_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Fallback hint: tool name for stale approval ids");
+        ]);
+        ("input_kind", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Fallback hint: approval input.kind for stale approval ids");
+        ]);
+      ]);
+      ("required", `List [`String "id"]);
+    ];
+  };
+
   (* masc_mcp_session *)
   {
     name = "masc_mcp_session";

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -630,6 +630,12 @@ let test_oas_capacity_restore_contracts () =
   check bool "governance judge selection is explicit" true
     (file_contains_pattern "lib/dashboard/dashboard_governance_judge.ml"
        {|[ "governance_judge" ]|});
+  check bool "governance judge has dedicated cascade config" true
+    (file_contains_pattern "config/cascade.json"
+       {|"governance_judge_models"|});
+  check bool "operator judge has dedicated cascade config" true
+    (file_contains_pattern "config/cascade.json"
+       {|"operator_judge_models"|});
   check bool "autoresearch background gating restores OAS capacity query" true
     (file_contains_pattern "lib/autoresearch_codegen.ml"
        "local_capacity_for_selections ~sw ~net");

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -354,7 +354,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
         {|{"path":"/tmp/danger"}|}
         (approval |> member "input_preview" |> to_string);
       let id = approval |> member "id" |> to_string in
-      (match Lib.Keeper_approval_queue.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+      (match Lib.Keeper_approval_queue.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
        | Ok () -> ()
        | Error msg -> fail ("resolve failed: " ^ msg));
       Eio.Fiber.yield ();

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -309,6 +309,67 @@ let test_background_pending_resolves_stale_id_via_hint () =
   | Some _ -> Alcotest.fail "expected approve callback via stale-id fallback"
   | None -> Alcotest.fail "expected callback to fire via stale-id fallback"
 
+let test_background_pending_keeps_distinct_input_kinds_separate () =
+  Eio_main.run @@ fun _env ->
+  let initial_count = AQ.pending_count () in
+  let first_callback = ref None in
+  let second_callback = ref None in
+  let id1 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper-kind"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> first_callback := Some decision)
+  in
+  let id2 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper-kind"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "manual_review_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> second_callback := Some decision)
+  in
+  Alcotest.(check bool) "different input kinds do not dedupe" true (id1 <> id2);
+  Alcotest.(check int) "both background entries kept"
+    (initial_count + 2) (AQ.pending_count ());
+  let pending_kinds =
+    match AQ.list_pending_json () with
+    | `List rows ->
+        rows
+        |> List.filter_map (function
+             | `Assoc fields ->
+                 let row = `Assoc fields in
+                 if Yojson.Safe.Util.(row |> member "keeper_name" |> to_string_option)
+                    = Some "gate-keeper-kind"
+                 then Yojson.Safe.Util.(row |> member "input_kind" |> to_string_option)
+                 else None
+             | _ -> None)
+        |> List.sort String.compare
+    | _ -> []
+  in
+  Alcotest.(check (list string)) "pending json includes both input kinds"
+    [ "continue_gate_required"; "manual_review_required" ]
+    pending_kinds;
+  (match AQ.resolve ~id:id1 ~decision:Agent_sdk.Hooks.Approve () with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve first distinct kind failed: " ^ msg));
+  Alcotest.(check bool) "second distinct kind remains pending" true
+    (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper-kind");
+  (match AQ.resolve ~id:id2 ~decision:(Agent_sdk.Hooks.Reject "keep paused") () with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve second distinct kind failed: " ^ msg));
+  Alcotest.(check int) "all distinct-kind entries removed"
+    initial_count (AQ.pending_count ());
+  (match !first_callback with
+   | Some Agent_sdk.Hooks.Approve -> ()
+   | Some _ -> Alcotest.fail "expected first distinct-kind callback approve"
+   | None -> Alcotest.fail "expected first distinct-kind callback");
+  (match !second_callback with
+   | Some (Agent_sdk.Hooks.Reject "keep paused") -> ()
+   | Some _ -> Alcotest.fail "expected second distinct-kind callback reject"
+   | None -> Alcotest.fail "expected second distinct-kind callback")
+
 (* ── 4. Approval callback integration ────────────────────── *)
 
 let test_callback_approves_low_risk () =
@@ -405,6 +466,8 @@ let () =
         test_background_pending_callback_and_keeper_lookup;
       Alcotest.test_case "background pending stale-id fallback" `Quick
         test_background_pending_resolves_stale_id_via_hint;
+      Alcotest.test_case "background pending keeps distinct input kinds separate" `Quick
+        test_background_pending_keeps_distinct_input_kinds_separate;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -151,7 +151,7 @@ let test_approval_queue_submit_and_resolve () =
     | _ -> Alcotest.fail "bad entry"
   in
   (* Operator resolves: approve *)
-  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
    | Ok () -> ()
    | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
   (* Agent fiber should resume *)
@@ -187,7 +187,7 @@ let test_approval_queue_reject () =
        | _ -> "")
     | _ -> ""
   in
-  (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "too dangerous") with
+  (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "too dangerous") () with
    | Ok () -> ()
    | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
   Eio.Fiber.yield ();
@@ -223,7 +223,7 @@ let test_approval_queue_expire_stale () =
 
 let test_approval_resolve_nonexistent () =
   Eio_main.run @@ fun _env ->
-  match AQ.resolve ~id:"nonexistent_id" ~decision:Agent_sdk.Hooks.Approve with
+  match AQ.resolve ~id:"nonexistent_id" ~decision:Agent_sdk.Hooks.Approve () with
   | Error msg ->
     Alcotest.(check bool) "error message" true
       (String.length msg > 0)
@@ -269,7 +269,7 @@ let test_background_pending_callback_and_keeper_lookup () =
     (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper");
   Alcotest.(check int) "background entry added"
     (initial_count + 1) (AQ.pending_count ());
-  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
    | Ok () -> ()
    | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
   Alcotest.(check bool) "keeper pending cleared" false
@@ -280,6 +280,34 @@ let test_background_pending_callback_and_keeper_lookup () =
   | Some Agent_sdk.Hooks.Approve -> ()
   | Some _ -> Alcotest.fail "expected approve callback"
   | None -> Alcotest.fail "expected callback to fire"
+
+let test_background_pending_resolves_stale_id_via_hint () =
+  Eio_main.run @@ fun _env ->
+  let callback_result = ref None in
+  let _actual_id =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> callback_result := Some decision)
+  in
+  (match
+     AQ.resolve
+       ~id:"appr_stale"
+       ~keeper_name:"gate-keeper"
+       ~tool_name:"keeper_continue_after_partial_commit"
+       ~input_kind:"continue_gate_required"
+       ~decision:Agent_sdk.Hooks.Approve ()
+   with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("stale-id fallback resolve failed: " ^ msg));
+  Alcotest.(check bool) "keeper pending cleared via fallback" false
+    (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper");
+  match !callback_result with
+  | Some Agent_sdk.Hooks.Approve -> ()
+  | Some _ -> Alcotest.fail "expected approve callback via stale-id fallback"
+  | None -> Alcotest.fail "expected callback to fire via stale-id fallback"
 
 (* ── 4. Approval callback integration ────────────────────── *)
 
@@ -325,7 +353,7 @@ let test_callback_production_keeper_write_requires_approval () =
        | _ -> Alcotest.fail "missing approval id")
     | _ -> Alcotest.fail "expected pending approval entry"
   in
-  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
    | Ok () -> ()
    | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
   Eio.Fiber.yield ();
@@ -375,6 +403,8 @@ let () =
       Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
       Alcotest.test_case "background pending callback" `Quick
         test_background_pending_callback_and_keeper_lookup;
+      Alcotest.test_case "background pending stale-id fallback" `Quick
+        test_background_pending_resolves_stale_id_via_hint;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -269,6 +269,16 @@ let test_background_pending_callback_and_keeper_lookup () =
     (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper");
   Alcotest.(check int) "background entry added"
     (initial_count + 1) (AQ.pending_count ());
+  let pending_preview =
+    match AQ.list_pending_json () with
+    | `List (`Assoc kvs :: _) ->
+        (match List.assoc_opt "input_preview" kvs with
+         | Some (`String value) -> value
+         | _ -> "")
+    | _ -> ""
+  in
+  Alcotest.(check bool) "pending json includes input preview" true
+    (String.length pending_preview > 0);
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
    | Ok () -> ()
    | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -9,6 +9,8 @@ module Profile = Masc_mcp.Keeper_cascade_profile
 let active_names =
   [ "default";
     "keeper_unified";
+    "governance_judge";
+    "operator_judge";
     "sangsu";
     "local_only";
     "local_recovery";

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -272,8 +272,8 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
         (AQ.has_pending_for_keeper ~keeper_name:meta.name);
       check int "approval count incremented"
         (pending_before + 1) (AQ.pending_count ());
-      let approval_id =
-        match AQ.list_pending_json () with
+      let approval_row =
+        match AQ.list_pending_dashboard_json () with
         | `List entries ->
             entries
             |> List.find_map (function
@@ -281,13 +281,23 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
                      let row = `Assoc fields in
                      if Yojson.Safe.Util.(row |> member "keeper_name" |> to_string_option)
                         = Some meta.name
-                     then Yojson.Safe.Util.(row |> member "id" |> to_string_option)
+                     then Some row
                      else None
                  | _ -> None)
-            |> Option.value ~default:""
-        | _ -> ""
+            |> Option.value ~default:`Null
+        | _ -> `Null
+      in
+      let approval_id =
+        Yojson.Safe.Util.(approval_row |> member "id" |> to_string_option)
+        |> Option.value ~default:""
       in
       check bool "approval id present" true (approval_id <> "");
+      check string "restored gate uses stable tool name"
+        "keeper_continue_after_partial_commit"
+        Yojson.Safe.Util.(approval_row |> member "tool_name" |> to_string);
+      check string "restored gate keeps stable input kind"
+        "continue_gate_required"
+        Yojson.Safe.Util.(approval_row |> member "input" |> member "kind" |> to_string);
       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve () with
        | Ok () -> ()
        | Error msg -> fail ("resolve failed: " ^ msg));

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -288,7 +288,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
         | _ -> ""
       in
       check bool "approval id present" true (approval_id <> "");
-      (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+      (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve () with
        | Ok () -> ()
        | Error msg -> fail ("resolve failed: " ^ msg));
       let resumed_meta =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -629,7 +629,7 @@ let test_pending_approval_blocks_turns_until_resolved () =
   check (list string) "approval pending reason is surfaced"
     [ "approval_pending" ]
     (WO.verdict_reasons_to_strings decision.verdict);
-  match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+  match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve () with
   | Ok () ->
     let resumed = WO.unified_turn_decision ~meta:minimal_meta reactive_obs in
     check bool "approval resolve re-opens reactive scheduling" true resumed.should_run;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -388,6 +388,31 @@ let test_masc_spawn_schema () =
           Alcotest.(check bool) "has prompt" true (List.mem_assoc "prompt" props)
       | None -> Alcotest.fail "masc_spawn missing properties"
 
+let test_masc_approval_pending_schema () =
+  match find_tool "masc_approval_pending" with
+  | None -> Alcotest.fail "masc_approval_pending not found"
+  | Some schema ->
+      Alcotest.(check string) "approval_pending schema type" "object"
+        (Option.value ~default:""
+           (get_json_string "type" schema.input_schema))
+
+let test_masc_approval_resolve_schema () =
+  match find_tool "masc_approval_resolve" with
+  | None -> Alcotest.fail "masc_approval_resolve not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has id" true (List.mem_assoc "id" props);
+          Alcotest.(check bool) "has decision" true (List.mem_assoc "decision" props);
+          Alcotest.(check bool) "has reason" true (List.mem_assoc "reason" props);
+          Alcotest.(check bool) "has keeper_name fallback" true
+            (List.mem_assoc "keeper_name" props);
+          Alcotest.(check bool) "has tool_name fallback" true
+            (List.mem_assoc "tool_name" props);
+          Alcotest.(check bool) "has input_kind fallback" true
+            (List.mem_assoc "input_kind" props)
+      | None -> Alcotest.fail "masc_approval_resolve missing properties"
+
 (* test_masc_runtime_verify_schema removed: tool pruned *)
 
 (* test_masc_persona_list_schema removed: persona list coverage is trivial. *)
@@ -735,6 +760,8 @@ let () =
     (* auth_tools, a2a_tools (poll_events/heartbeat_result), handover_tools,
        bounded_run removed: pruned from registry *)
     "spawn_runtime_tools", [
+      Alcotest.test_case "approval-pending" `Quick test_masc_approval_pending_schema;
+      Alcotest.test_case "approval-resolve" `Quick test_masc_approval_resolve_schema;
       Alcotest.test_case "spawn" `Quick test_masc_spawn_schema;
     ];
     "keeper_runtime_tools", [


### PR DESCRIPTION
## Summary

- fix dashboard judge cascade wiring so `governance_judge` and `operator_judge` no longer silently collapse to `keeper_unified`
- harden governance approval resolution with a stale-id fallback when the queue still has a unique matching pending entry
- surface structured POST error bodies in the dashboard so operator-facing 400s stop looking like silent failures

## Product impact

- governance/operator judge traffic no longer competes with live keeper traffic through the wrong cascade profile
- dashboard approval failures now show the actual server reason instead of a generic `400 Bad Request`
- stale approval IDs from a briefly outdated dashboard view can still resolve safely when the pending queue has exactly one matching keeper/tool/kind entry

## Evidence

- `dune build --root . test/test_hitl_approval.exe test/test_keeper_cascade_profile.exe test/test_ci_hardening_source.exe test/test_dashboard_governance.exe test/test_keeper_unified.exe test/test_keeper_supervisor.exe`
- `./_build/default/test/test_hitl_approval.exe`
- `./_build/default/test/test_keeper_cascade_profile.exe`
- `./_build/default/test/test_dashboard_governance.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `dashboard/node_modules/.bin/tsc --noEmit --pretty`
- `dashboard/node_modules/.bin/vitest run src/api/core.test.ts`

## Review evidence

- live runtime on `2026-04-18` showed governance judge timeout loops and misrouting; the server logs recorded `compute_judgments failed` while the internal cascade name resolved to `keeper_unified`
- `/api/v1/dashboard/governance` returned `judge_online=false` with `Timeout: Execution timed out after 30.0s`, confirming the operator surface was degraded while the real cause was hidden behind generic dashboard errors
- live `.masc/config/cascade.json` was also updated locally to match the new dedicated judge cascades; that runtime-only config change is intentionally not part of this PR

## Linked issue

- None. Runtime regression fix discovered during live dashboard investigation.
