### PR TITLE
[codex] harden dashboard delete auth and public-read CORS

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -1,4 +1,4 @@
-import { get, post, fetchWithTimeout } from './core'
+import { get, post } from './core'
 import { ACTIVITY_TIMEOUT_MS } from '../config/constants'
 import { callMcpTool } from './mcp'
 import {
@@ -46,11 +46,11 @@ export function fetchTaskEvents(taskId: string, limit = 50): Promise<unknown[]> 
 export async function fetchActivityGraph(since?: string): Promise<ActivityGraphResponse | null> {
   const params = since ? `?since=${since}` : ''
   try {
-    const resp = await fetchWithTimeout(`/api/v1/activity/graph${params}`, {}, ACTIVITY_TIMEOUT_MS)
-    if (!resp.ok) {
-      throw new Error(`GET /api/v1/activity/graph failed: ${resp.status} ${resp.statusText}`)
-    }
-    return parseActivityGraphResponse(await resp.json())
+    const raw = await get<unknown>(`/api/v1/activity/graph${params}`, {
+      timeoutMs: ACTIVITY_TIMEOUT_MS,
+      includeActorHeader: false,
+    })
+    return parseActivityGraphResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err
     console.debug('[activity] graph fetch failed', err instanceof Error ? err.message : err)
@@ -61,11 +61,11 @@ export async function fetchActivityGraph(since?: string): Promise<ActivityGraphR
 export async function fetchSwimlane(since?: string): Promise<SwimlaneResponse | null> {
   const params = since ? `?since=${since}` : ''
   try {
-    const resp = await fetchWithTimeout(`/api/v1/activity/swimlane${params}`, {}, ACTIVITY_TIMEOUT_MS)
-    if (!resp.ok) {
-      throw new Error(`GET /api/v1/activity/swimlane failed: ${resp.status} ${resp.statusText}`)
-    }
-    return parseSwimlaneResponse(await resp.json())
+    const raw = await get<unknown>(`/api/v1/activity/swimlane${params}`, {
+      timeoutMs: ACTIVITY_TIMEOUT_MS,
+      includeActorHeader: false,
+    })
+    return parseSwimlaneResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err
     console.debug('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiRequestError, defaultBoardVoter, extractApiError, get, post } from './core'
+import {
+  ApiRequestError,
+  confirmOperatorAction,
+  defaultBoardVoter,
+  extractApiError,
+  get,
+  post,
+  runOperatorAction,
+} from './core'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -37,6 +45,66 @@ describe('post', () => {
     window.history.replaceState({}, '', '/')
 
     expect(defaultBoardVoter()).toBe('dashboard-user')
+  })
+
+  it('surfaces JSON error messages from failed POST responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"status":"error","message":"actor mismatch: payload actor must match authenticated actor"}', {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(post('/api/v1/operator/action', { actor: 'ops-user' })).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 400,
+      detail: 'actor mismatch: payload actor must match authenticated actor',
+      message: 'POST /api/v1/operator/action: actor mismatch: payload actor must match authenticated actor',
+    })
+  })
+
+  it('uses the request actor for operator action headers when query agent differs', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-url-actor')
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"status":"ok","result":{}}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await runOperatorAction({
+      actor: 'dashboard-manual-actor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'keeper-one',
+      payload: {},
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-MASC-Agent'] ?? headers['x-masc-agent']).toBe('dashboard-manual-actor')
+  })
+
+  it('uses the confirmation actor for operator confirm headers when query agent differs', async () => {
+    window.history.replaceState({}, '', '/?agent=dashboard-url-actor')
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"status":"ok","result":{}}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await confirmOperatorAction('dashboard-manual-actor', 'opc_test_token')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-MASC-Agent'] ?? headers['x-masc-agent']).toBe('dashboard-manual-actor')
   })
 })
 
@@ -107,6 +175,24 @@ describe('get bootstrap warm-up mapping', () => {
       name: 'ApiRequestError',
       status: 500,
       path: '/api/v1/board',
+    })
+  })
+
+  it('surfaces JSON error messages from failed GET responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":"computation_timeout","message":"Dashboard governance timed out after 30s"}', {
+        status: 504,
+        statusText: 'Gateway Timeout',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(get('/api/v1/dashboard/governance')).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 504,
+      detail: 'Dashboard governance timed out after 30s',
+      message: 'GET /api/v1/dashboard/governance: Dashboard governance timed out after 30s',
     })
   })
 

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -61,6 +61,7 @@ describe('post', () => {
       name: 'ApiRequestError',
       status: 400,
       detail: 'actor mismatch: payload actor must match authenticated actor',
+      errorCode: 'error',
       message: 'POST /api/v1/operator/action: actor mismatch: payload actor must match authenticated actor',
     })
   })
@@ -192,6 +193,7 @@ describe('get bootstrap warm-up mapping', () => {
       name: 'ApiRequestError',
       status: 504,
       detail: 'Dashboard governance timed out after 30s',
+      errorCode: 'computation_timeout',
       message: 'GET /api/v1/dashboard/governance: Dashboard governance timed out after 30s',
     })
   })
@@ -340,6 +342,18 @@ describe('extractApiError', () => {
     expect(summary.timeout).toBe(true)
     expect(summary.status).toBeNull()
     expect(summary.path).toBe('/api/v1/operator/action')
+  })
+
+  it('stores structured error codes on ApiRequestError', () => {
+    const err = new ApiRequestError({
+      method: 'GET',
+      path: '/api/v1/dashboard/governance',
+      status: 504,
+      statusText: 'Gateway Timeout',
+      detail: 'Dashboard governance timed out after 30s',
+      errorCode: 'computation_timeout',
+    })
+    expect(err.errorCode).toBe('computation_timeout')
   })
 
   it('returns null status + path for plain Error', () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -206,7 +206,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
+export async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
   let rawText = ''
   try {
     rawText = (await res.text()).trim()
@@ -226,6 +226,21 @@ async function errorDetailFromResponse(res: Response): Promise<string | undefine
     // Fall through to plain-text body.
   }
   return rawText
+}
+
+export async function apiRequestErrorFromResponse(
+  method: string,
+  path: string,
+  res: Response,
+): Promise<ApiRequestError> {
+  const detail = await errorDetailFromResponse(res)
+  return new ApiRequestError({
+    method,
+    path,
+    status: res.status,
+    statusText: res.statusText,
+    detail,
+  })
 }
 
 function isNotInitializedEnvelope(raw: unknown): boolean {
@@ -358,14 +373,7 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     if (warmPayload !== null) {
       return warmPayload as T
     }
-    const detail = await errorDetailFromResponse(res)
-    throw new ApiRequestError({
-      method: 'GET',
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail,
-    })
+    throw await apiRequestErrorFromResponse('GET', path, res)
   }
   const data = await res.json()
   // Server may return 200 OK with {"error":"not initialized"} during startup
@@ -442,14 +450,7 @@ export async function post<T>(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
-    const detail = await errorDetailFromResponse(res)
-    throw new ApiRequestError({
-      method: 'POST',
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail,
-    })
+    throw await apiRequestErrorFromResponse('POST', path, res)
   }
   return res.json() as Promise<T>
 }
@@ -470,14 +471,7 @@ export async function patch<T>(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
-    const detail = await errorDetailFromResponse(res)
-    throw new ApiRequestError({
-      method: 'PATCH',
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail,
-    })
+    throw await apiRequestErrorFromResponse('PATCH', path, res)
   }
   return res.json() as Promise<T>
 }
@@ -497,14 +491,7 @@ export async function postRaw(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
-    const detail = await errorDetailFromResponse(res)
-    throw new ApiRequestError({
-      method: 'POST',
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail,
-    })
+    throw await apiRequestErrorFromResponse('POST', path, res)
   }
   return res.text()
 }

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -57,12 +57,15 @@ export function currentDashboardActor(): string {
 
 type HeaderOptions = {
   includeActor?: boolean
+  actorName?: string | null
 }
 
 export function authHeaders(options: HeaderOptions = {}): Record<string, string> {
   const headers: Record<string, string> = {}
   const token = getStoredToken()
-  const agent = resolveDashboardActorName(window.location.search)
+  const agent = options.actorName !== undefined
+    ? sanitizeDashboardActorName(options.actorName)
+    : resolveDashboardActorName(window.location.search)
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {
     headers['X-MASC-Agent'] = agent
@@ -99,6 +102,7 @@ export class ApiRequestError extends Error {
   status?: number
   statusText?: string
   timeout: boolean
+  detail?: string
 
   constructor(opts: {
     method: string
@@ -107,12 +111,16 @@ export class ApiRequestError extends Error {
     statusText?: string
     timeout?: boolean
     timeoutMs?: number
+    detail?: string
   }) {
     const method = opts.method.toUpperCase()
     const timeout = opts.timeout === true
+    const detail = opts.detail?.trim()
     const message = timeout
       ? `${method} ${opts.path}: timeout after ${opts.timeoutMs ?? 0}ms`
-      : `${method} ${opts.path}: ${opts.status ?? 'unknown'} ${opts.statusText ?? ''}`.trim()
+      : detail
+        ? `${method} ${opts.path}: ${detail}`
+        : `${method} ${opts.path}: ${opts.status ?? 'unknown'} ${opts.statusText ?? ''}`.trim()
     super(message)
     this.name = 'ApiRequestError'
     this.method = method
@@ -120,6 +128,7 @@ export class ApiRequestError extends Error {
     this.status = opts.status
     this.statusText = opts.statusText
     this.timeout = timeout
+    this.detail = detail
   }
 }
 
@@ -195,6 +204,28 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
+  let rawText = ''
+  try {
+    rawText = (await res.text()).trim()
+  } catch {
+    return undefined
+  }
+  if (!rawText) return undefined
+  try {
+    const parsed = JSON.parse(rawText) as unknown
+    if (isRecord(parsed)) {
+      const message = typeof parsed.message === 'string' ? parsed.message.trim() : ''
+      if (message) return message
+      const error = typeof parsed.error === 'string' ? parsed.error.trim() : ''
+      if (error) return error
+    }
+  } catch {
+    // Fall through to plain-text body.
+  }
+  return rawText
 }
 
 function isNotInitializedEnvelope(raw: unknown): boolean {
@@ -323,15 +354,17 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
   )
   if (!res.ok) {
-    const warmPayload = await bootstrapWarmPayload(path, res)
+    const warmPayload = await bootstrapWarmPayload(path, res.clone())
     if (warmPayload !== null) {
       return warmPayload as T
     }
+    const detail = await errorDetailFromResponse(res)
     throw new ApiRequestError({
       method: 'GET',
       path,
       status: res.status,
       statusText: res.statusText,
+      detail,
     })
   }
   const data = await res.json()
@@ -409,11 +442,13 @@ export async function post<T>(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
+    const detail = await errorDetailFromResponse(res)
     throw new ApiRequestError({
       method: 'POST',
       path,
       status: res.status,
       statusText: res.statusText,
+      detail,
     })
   }
   return res.json() as Promise<T>
@@ -435,11 +470,13 @@ export async function patch<T>(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
+    const detail = await errorDetailFromResponse(res)
     throw new ApiRequestError({
       method: 'PATCH',
       path,
       status: res.status,
       statusText: res.statusText,
+      detail,
     })
   }
   return res.json() as Promise<T>
@@ -460,11 +497,13 @@ export async function postRaw(
     body: JSON.stringify(body),
   }, timeoutMs)
   if (!res.ok) {
+    const detail = await errorDetailFromResponse(res)
     throw new ApiRequestError({
       method: 'POST',
       path,
       status: res.status,
       statusText: res.statusText,
+      detail,
     })
   }
   return res.text()
@@ -488,7 +527,7 @@ export async function runOperatorAction(body: OperatorActionRequest): Promise<Op
   const raw = await post<unknown>(
     '/api/v1/operator/action',
     body,
-    undefined,
+    authHeaders({ actorName: body.actor }),
     operatorActionTimeoutMs(body),
   )
   return parseOperatorActionResult(raw)
@@ -499,11 +538,15 @@ export async function confirmOperatorAction(
   confirmToken: string,
   decision: 'confirm' | 'deny' = 'confirm',
 ): Promise<OperatorActionResult> {
-  const raw = await post<unknown>('/api/v1/operator/confirm', {
-    actor,
-    confirm_token: confirmToken,
-    decision,
-  })
+  const raw = await post<unknown>(
+    '/api/v1/operator/confirm',
+    {
+      actor,
+      confirm_token: confirmToken,
+      decision,
+    },
+    authHeaders({ actorName: actor }),
+  )
   return parseOperatorActionResult(raw)
 }
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -103,6 +103,7 @@ export class ApiRequestError extends Error {
   statusText?: string
   timeout: boolean
   detail?: string
+  errorCode?: string
 
   constructor(opts: {
     method: string
@@ -112,6 +113,7 @@ export class ApiRequestError extends Error {
     timeout?: boolean
     timeoutMs?: number
     detail?: string
+    errorCode?: string
   }) {
     const method = opts.method.toUpperCase()
     const timeout = opts.timeout === true
@@ -129,6 +131,7 @@ export class ApiRequestError extends Error {
     this.statusText = opts.statusText
     this.timeout = timeout
     this.detail = detail
+    this.errorCode = opts.errorCode?.trim() || undefined
   }
 }
 
@@ -206,26 +209,42 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-export async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
+interface ErrorResponseInfo {
+  detail?: string
+  errorCode?: string
+}
+
+async function errorResponseInfoFromResponse(res: Response): Promise<ErrorResponseInfo> {
   let rawText = ''
   try {
     rawText = (await res.text()).trim()
   } catch {
-    return undefined
+    return {}
   }
-  if (!rawText) return undefined
+  if (!rawText) return {}
   try {
     const parsed = JSON.parse(rawText) as unknown
     if (isRecord(parsed)) {
+      const errorCode =
+        (typeof parsed.error === 'string' ? parsed.error.trim() : '')
+        || (typeof parsed.status === 'string' ? parsed.status.trim() : '')
       const message = typeof parsed.message === 'string' ? parsed.message.trim() : ''
-      if (message) return message
-      const error = typeof parsed.error === 'string' ? parsed.error.trim() : ''
-      if (error) return error
+      if (message || errorCode) {
+        return {
+          detail: message || errorCode || undefined,
+          errorCode: errorCode || undefined,
+        }
+      }
     }
   } catch {
     // Fall through to plain-text body.
   }
-  return rawText
+  return { detail: rawText }
+}
+
+export async function errorDetailFromResponse(res: Response): Promise<string | undefined> {
+  const info = await errorResponseInfoFromResponse(res)
+  return info.detail
 }
 
 export async function apiRequestErrorFromResponse(
@@ -233,13 +252,14 @@ export async function apiRequestErrorFromResponse(
   path: string,
   res: Response,
 ): Promise<ApiRequestError> {
-  const detail = await errorDetailFromResponse(res)
+  const info = await errorResponseInfoFromResponse(res)
   return new ApiRequestError({
     method,
     path,
     status: res.status,
     statusText: res.statusText,
-    detail,
+    detail: info.detail,
+    errorCode: info.errorCode,
   })
 }
 
@@ -399,6 +419,9 @@ function parseStatusFromMessage(message: string): number | null {
 
 function isRetryableError(err: unknown): boolean {
   if (err instanceof ApiRequestError) {
+    if (err.errorCode === 'computation_timeout' || err.errorCode === 'timeout') {
+      return false
+    }
     return err.timeout || (typeof err.status === 'number' && RETRYABLE_STATUS_CODES.has(err.status))
   }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchDashboardTools, fetchKeeperConfig, fetchToolQuality } from './dashboard'
+import {
+  fetchDashboardGovernance,
+  fetchDashboardTools,
+  fetchKeeperConfig,
+  fetchToolQuality,
+} from './dashboard'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -137,6 +142,29 @@ describe('fetchToolQuality', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?window_hours=24')
     expect(result.window_hours).toBe(24)
     expect(result.sampling_mode).toBe('window_hours')
+  })
+})
+
+describe('fetchDashboardGovernance', () => {
+  it('does not retry structured computation timeouts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        error: 'computation_timeout',
+        message: 'Dashboard governance timed out after 30s',
+      }), {
+        status: 504,
+        statusText: 'Gateway Timeout',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchDashboardGovernance()).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 504,
+      errorCode: 'computation_timeout',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  apiRequestErrorFromResponse,
   fetchWithTimeout,
   reportToolHostFailure,
   authHeaders,
@@ -8,6 +9,8 @@ const {
   getStoredToken,
   setStoredToken,
 } = vi.hoisted(() => ({
+  apiRequestErrorFromResponse: vi.fn(async (method: string, path: string, res: Response) =>
+    new Error(`${method} ${path}: ${res.status} ${res.statusText}`.trim())),
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
   authHeaders: vi.fn().mockReturnValue({}),
@@ -20,6 +23,7 @@ const {
 }))
 
 vi.mock('./core', () => ({
+  apiRequestErrorFromResponse,
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
   authHeaders,
@@ -177,6 +181,9 @@ describe('callMcpTool', () => {
   }, 60_000)
 
   it('preserves an explicit agent_name field when the caller already set one', async () => {
+    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
+      opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
+    ))
     setupMcpSessionMocks('sess-explicit')
 
     const { callMcpTool } = await import('./mcp')
@@ -188,6 +195,8 @@ describe('callMcpTool', () => {
     expect(body.params.arguments).toEqual({
       agent_name: 'codex-tool-matrix',
     })
+    const headers = toolCall![1].headers as Record<string, string>
+    expect(headers['X-MASC-Agent']).toBe('codex-tool-matrix')
   }, 60_000)
 
   it('reports tool-host failures after the MCP session is established', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,6 +1,7 @@
 // MASC Dashboard — MCP-over-HTTP client with session lifecycle
 
 import {
+  apiRequestErrorFromResponse,
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS,
   authHeaders,
@@ -103,10 +104,37 @@ function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
   return headers
 }
 
-async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promise<string> {
+function explicitToolActor(args: Record<string, unknown>): string | null {
+  const raw =
+    (typeof args._agent_name === 'string' && args._agent_name.trim() !== '' ? args._agent_name : null)
+    ?? (typeof args.agent_name === 'string' && args.agent_name.trim() !== '' ? args.agent_name : null)
+  return raw?.trim() ?? null
+}
+
+function mcpHeadersForActor(
+  actorName?: string | null,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    ...authHeaders({ actorName }),
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    ...(extra ?? {}),
+  }
+  if (mcpSessionId) {
+    headers['Mcp-Session-Id'] = mcpSessionId
+  }
+  return headers
+}
+
+async function mcpPost(
+  body: unknown,
+  timeoutMs = DEFAULT_MCP_TIMEOUT_MS,
+  actorName?: string | null,
+): Promise<string> {
   const res = await fetchWithTimeout('/mcp', {
     method: 'POST',
-    headers: mcpHeaders(),
+    headers: mcpHeadersForActor(actorName),
     body: JSON.stringify(body),
   }, timeoutMs)
   // Capture session ID from response
@@ -117,7 +145,7 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
       mcpSessionId = MCP_SESSION_BLOCKED
       throw new Error(MCP_BLOCKED_MESSAGE)
     }
-    throw new Error(`POST /mcp: ${res.status} ${res.statusText}`)
+    throw await apiRequestErrorFromResponse('POST', '/mcp', res)
   }
   return res.text()
 }
@@ -161,7 +189,7 @@ async function ensureSession(): Promise<void> {
           mcpSessionId = MCP_SESSION_BLOCKED
           throw new Error(MCP_BLOCKED_MESSAGE)
         }
-        throw new Error(`POST /mcp initialize: ${res.status} ${res.statusText}`)
+        throw await apiRequestErrorFromResponse('POST', '/mcp initialize', res)
       }
       const sid = res.headers.get('Mcp-Session-Id')
       if (sid) mcpSessionId = sid
@@ -233,9 +261,10 @@ export async function callMcpTool(toolName: string, args: Record<string, unknown
   try {
     await ensureSession()
     phase = 'tools/call'
-    const actor = currentDashboardActor()
+    const explicitActor = explicitToolActor(args)
+    const actor = explicitActor ?? currentDashboardActor()
     const toolArgs =
-      args._agent_name == null && args.agent_name == null && actor
+      explicitActor == null && actor
         ? { ...args, _agent_name: actor }
         : args
     const text = await mcpPost({
@@ -246,7 +275,7 @@ export async function callMcpTool(toolName: string, args: Record<string, unknown
         arguments: toolArgs,
       },
       id: Number.parseInt(requestId, 10),
-    })
+    }, DEFAULT_MCP_TIMEOUT_MS, actor)
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
@@ -335,4 +364,3 @@ function parseMcpJsonText(text: string): Record<string, unknown> {
   if (!trimmed) return {}
   return JSON.parse(trimmed) as Record<string, unknown>
 }
-

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -23,6 +23,7 @@ type state = {
   mutable expires_at : string option;
   mutable model_used : string option;
   mutable last_error : string option;
+  mutable last_disk_load_unix : float option;
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
 
@@ -70,6 +71,8 @@ let interval_sec () = Env_config.Dashboard_config.governance_judge_interval_sec
 let cache_ttl_sec () =
   float_of_int (max (interval_sec () * 4) 600)
 
+let empty_judgment_reload_cooldown_sec = 30.0
+
 let enabled () = Env_config.Dashboard_config.governance_judge_enabled
 
 let keeper_name = "governance-judge"
@@ -92,6 +95,7 @@ let get_state base_path =
             expires_at = None;
             model_used = None;
             last_error = None;
+            last_disk_load_unix = None;
           judgments = Hashtbl.create 32;
         }
       in
@@ -151,7 +155,18 @@ let load_latest_from_disk base_path =
 let latest_judgments base_path =
   let st = get_state base_path in
   with_lock st (fun () ->
-      if Hashtbl.length st.judgments = 0 then st.judgments <- load_latest_from_disk base_path;
+      if Hashtbl.length st.judgments = 0 then begin
+        let should_reload =
+          match st.last_disk_load_unix with
+          | None -> true
+          | Some last_load ->
+              Unix.gettimeofday () -. last_load >= empty_judgment_reload_cooldown_sec
+        in
+        if should_reload then begin
+          st.judgments <- load_latest_from_disk base_path;
+          st.last_disk_load_unix <- Some (Unix.gettimeofday ())
+        end
+      end;
       Hashtbl.to_seq_values st.judgments |> List.of_seq)
 
 let fresh_judgments_json ~base_path ~limit =
@@ -404,6 +419,7 @@ let refresh_once ~sw ~net
             st.expires_at_unix <- Some (Types.parse_iso8601 expires_at);
             st.model_used <- Some model_used;
             st.last_error <- None;
+            st.last_disk_load_unix <- Some (Unix.gettimeofday ());
             List.iter
               (fun json -> Hashtbl.replace st.judgments (judgment_key json) json)
               judgments)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -275,6 +275,30 @@ let get_origin (request : Httpun.Request.t) =
   Httpun.Headers.get request.headers "origin"
   |> Option.value ~default:"*"
 
+let public_read_cors_origin_opt (request : Httpun.Request.t) =
+  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
+  | None -> None
+  | Some origin -> (
+      match host_port_scheme_of_origin origin, host_port_of_request request with
+      | Some (origin_host, origin_port, scheme),
+        Some (request_host, request_port)
+        when String.equal
+               (normalize_loopback_host origin_host)
+               (normalize_loopback_host request_host) ->
+          let default = default_port_of_scheme scheme in
+          let norm p = match p with Some _ -> p | None -> default in
+          if norm origin_port = norm request_port then
+            Some origin
+          else if
+            is_loopback_host (normalize_loopback_host origin_host)
+            && is_allowlisted_loopback_dev_origin origin
+          then
+            Some origin
+          else
+            None
+      | _ when is_allowlisted_loopback_dev_origin origin -> Some origin
+      | _ -> None)
+
 (** CORS headers *)
 let cors_allow_headers_value =
   "Content-Type, Accept, Origin, Authorization, Idempotency-Key, Mcp-Session-Id, \
@@ -298,6 +322,15 @@ let cors_headers origin =
 let respond_json_with_cors ?(status = `OK) request reqd body =
   let origin = get_origin request in
   Http_server_eio.Response.json ~status ~extra_headers:(cors_headers origin) body reqd
+
+let public_read_cors_headers request =
+  match public_read_cors_origin_opt request with
+  | Some origin -> cors_headers origin
+  | None -> [ ("vary", "Origin") ]
+
+let respond_public_read_json ?(status = `OK) request reqd body =
+  Http_server_eio.Response.json ~status
+    ~extra_headers:(public_read_cors_headers request) body reqd
 
 let auth_error_json err =
   Yojson.Safe.to_string

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -12,7 +12,8 @@ open Server_auth
 let add_delete_action_routes router =
   router
   |> Http.Router.post "/api/v1/dashboard/board/delete" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun _state _agent_name req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -35,7 +36,8 @@ let add_delete_action_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/dashboard/tasks/delete" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -59,7 +61,8 @@ let add_delete_action_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/dashboard/goals/delete" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -84,7 +87,8 @@ let add_delete_action_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/dashboard/goals/sweep" (fun request reqd ->
-       with_public_read (fun state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name _req reqd ->
          let config = state.Mcp_server.room_config in
          let result = Goal_janitor.run config in
          Http.Response.json ~compress:true ~request

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -121,8 +121,20 @@ let inject_agent_name_into_body ~agent_name body_str =
     | Some "tools/call" ->
         let params = member "params" json in
         let args = member "arguments" params in
-        let existing = member "_agent_name" args |> to_string_option in
-        if Option.is_some existing then body_str
+        let existing_agent =
+          (member "_agent_name" args |> to_string_option)
+          |> Option.bind (fun value ->
+               let trimmed = String.trim value in
+               if String.equal trimmed "" then None else Some trimmed)
+        in
+        let existing_legacy_agent =
+          (member "agent_name" args |> to_string_option)
+          |> Option.bind (fun value ->
+               let trimmed = String.trim value in
+               if String.equal trimmed "" then None else Some trimmed)
+        in
+        if Option.is_some existing_agent || Option.is_some existing_legacy_agent
+        then body_str
         else
           let new_args = match args with
             | `Assoc fields ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -122,14 +122,16 @@ let inject_agent_name_into_body ~agent_name body_str =
         let params = member "params" json in
         let args = member "arguments" params in
         let existing_agent =
-          (member "_agent_name" args |> to_string_option)
-          |> Option.bind (fun value ->
+          Option.bind
+            (member "_agent_name" args |> to_string_option)
+            (fun value ->
                let trimmed = String.trim value in
                if String.equal trimmed "" then None else Some trimmed)
         in
         let existing_legacy_agent =
-          (member "agent_name" args |> to_string_option)
-          |> Option.bind (fun value ->
+          Option.bind
+            (member "agent_name" args |> to_string_option)
+            (fun value ->
                let trimmed = String.trim value in
                if String.equal trimmed "" then None else Some trimmed)
         in

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -67,11 +67,11 @@ let add_routes router =
            let path = Http.Request.path request in
            match extract_path_param ~prefix:"/api/v1/artifacts/" path with
            | None ->
-               respond_json_with_cors ~status:`Bad_request request reqd
+               respond_public_read_json ~status:`Bad_request request reqd
                  (Yojson.Safe.to_string
                     (`Assoc [ ("error", `String "sha256 path parameter required") ]))
            | Some raw when not (is_valid_sha256 raw) ->
-               respond_json_with_cors ~status:`Bad_request request reqd
+               respond_public_read_json ~status:`Bad_request request reqd
                  (Yojson.Safe.to_string
                     (`Assoc
                       [
@@ -81,6 +81,6 @@ let add_routes router =
                       ]))
            | Some sha256 ->
                let json, status = blob_response ~sha256 in
-               respond_json_with_cors ~status request reqd
+               respond_public_read_json ~status request reqd
                  (Yojson.Safe.to_string json))
          request reqd)

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -3,8 +3,10 @@
     Provides [/api/v1/gate/*] endpoints for external channel consumers
     (Discord bots, Telegram bots, etc.) to interact with keepers.
 
-    All Channel Gate API endpoints use Bearer token auth via [with_tool_auth],
-    except [/api/v1/gate/health], which is public and uses [with_public_read].
+    Mutation endpoints use Bearer token auth via [with_tool_auth]. Public
+    monitoring surfaces stay on [with_public_read], but their JSON responses
+    only emit CORS headers for same-origin or explicitly allowlisted local
+    dev origins.
 
     @since 2.217.0 *)
 
@@ -183,14 +185,14 @@ let handle_gate_events _state request reqd =
       ?room_id:(trim_filter "room_id")
       ~limit ()
   in
-  respond_json_with_cors ~status:`OK request reqd
+  respond_public_read_json ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
 (** GET /api/v1/gate/health
 
     Simple health check for the gate layer. *)
 let handle_gate_health _state request reqd =
-  respond_json_with_cors ~status:`OK request reqd
+  respond_public_read_json ~status:`OK request reqd
     {|{"ok":true,"service":"channel_gate"}|}
 
 (** GET /api/v1/gate/status
@@ -199,7 +201,7 @@ let handle_gate_health _state request reqd =
     average latency, error counts.  Public read. *)
 let handle_gate_status _state request reqd =
   let json = Channel_gate_metrics.snapshot_json () in
-  respond_json_with_cors ~status:`OK request reqd
+  respond_public_read_json ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
 (** GET /api/v1/gate/connectors
@@ -218,7 +220,7 @@ let handle_gate_connectors _state request reqd =
     Channel_gate_connector.connectors_json ~gate_status_json:gate_status
       ~audit_limit ()
   in
-  respond_json_with_cors ~status:`OK request reqd
+  respond_public_read_json ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
 (** GET /api/v1/gate/connector/status?name=<connector>&audit_limit=<n>
@@ -243,13 +245,13 @@ let handle_gate_connector_status _state request reqd =
   in
   match connector_name with
   | None | Some "" ->
-      respond_json_with_cors ~status:`Bad_request request reqd
+      respond_public_read_json ~status:`Bad_request request reqd
         (Yojson.Safe.to_string
            (Channel_gate.error_json "name or channel is required"))
   | Some name -> (
       match Channel_gate_connector.find name with
       | None ->
-          respond_json_with_cors ~status:`Not_found request reqd
+          respond_public_read_json ~status:`Not_found request reqd
             (Yojson.Safe.to_string
                (Channel_gate.error_json ("unknown connector: " ^ name)))
       | Some (module C) ->
@@ -257,7 +259,7 @@ let handle_gate_connector_status _state request reqd =
             int_query_param request "audit_limit" ~default:10
             |> fun value -> max 1 (min 50 value)
           in
-          respond_json_with_cors ~status:`OK request reqd
+          respond_public_read_json ~status:`OK request reqd
             (Yojson.Safe.to_string (C.status_json ~audit_limit ())))
 
 let gate_keeper_ctx ~sw ~clock state =

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -611,6 +611,52 @@ let test_custom_dev_origin_allows_loopback_cross_port () =
     | Ok () -> ()
     | Error e -> fail (Types.masc_error_to_string e))
 
+let test_public_read_cors_allows_matching_origin () =
+  let module SA = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "localhost:9000");
+        ("origin", "http://localhost:9000");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/api/v1/gate/events" in
+  match SA.public_read_cors_origin_opt request with
+  | Some origin ->
+      Alcotest.(check string) "matching origin reflected" "http://localhost:9000" origin
+  | None -> fail "expected public-read cors origin"
+
+let test_public_read_cors_rejects_cross_origin () =
+  let module SA = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "localhost:9000");
+        ("origin", "https://evil.example");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `GET "/api/v1/gate/events" in
+  match SA.public_read_cors_origin_opt request with
+  | None -> ()
+  | Some origin -> fail ("unexpected reflected origin: " ^ origin)
+
+let test_public_read_cors_allows_allowlisted_loopback_origin () =
+  let module SA = Masc_mcp.Server_auth in
+  with_env "MASC_HTTP_DEV_MUTATION_ORIGINS" "http://localhost:4317" (fun () ->
+    let headers =
+      Httpun.Headers.of_list
+        [
+          ("host", "localhost:9000");
+          ("origin", "http://localhost:4317");
+        ]
+    in
+    let request = Httpun.Request.create ~headers `GET "/api/v1/gate/events" in
+    match SA.public_read_cors_origin_opt request with
+    | Some origin ->
+        Alcotest.(check string) "allowlisted loopback origin reflected"
+          "http://localhost:4317" origin
+    | None -> fail "expected allowlisted public-read cors origin")
+
 let test_public_read_path_allows_generic_connector_status () =
   let module SA = Masc_mcp.Server_auth in
   check bool "generic connector status is public read" true
@@ -818,6 +864,12 @@ let () =
         test_env_flag_overrides_all;
       test_case "custom dev origin allows loopback cross-port" `Quick
         test_custom_dev_origin_allows_loopback_cross_port;
+      test_case "public-read cors allows matching origin" `Quick
+        test_public_read_cors_allows_matching_origin;
+      test_case "public-read cors rejects cross origin" `Quick
+        test_public_read_cors_rejects_cross_origin;
+      test_case "public-read cors allows allowlisted loopback origin" `Quick
+        test_public_read_cors_allows_allowlisted_loopback_origin;
       test_case "generic connector status is public read" `Quick
         test_public_read_path_allows_generic_connector_status;
       test_case "generic connector bind is not public read" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -559,6 +559,9 @@ let test_transport_route_contracts () =
   check bool "frontend exposes ws discovery route" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
        {|Http.Router.get "/ws" websocket_discovery_handler|});
+  check bool "mcp http agent injection preserves explicit legacy agent_name" true
+    (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+       {|Option.is_some existing_agent || Option.is_some existing_legacy_agent|});
   check bool "common http deps prefer runtime captured in server_state" true
     (file_contains_pattern "lib/server/server_routes_http_common.ml"
        "state.Mcp_server.sw");

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -247,6 +247,21 @@ let test_http_write_auth_contracts () =
   check bool "provider runs post requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        {|with_token_permission_auth ~permission:Types.CanAdmin|});
+  check bool "dashboard delete actions require token-bound admin permission" true
+    (file_contains_pattern "lib/server/server_dashboard_http_delete_actions.ml"
+       {|with_token_permission_auth ~permission:Types.CanAdmin|});
+  check bool "server auth defines public-read cors origin helper" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "let public_read_cors_origin_opt");
+  check bool "server auth exposes public-read json responder" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "let respond_public_read_json");
+  check bool "channel gate public reads use constrained cors responder" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_channel_gate.ml"
+       "respond_public_read_json");
+  check bool "artifacts endpoint uses constrained cors responder" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_artifacts.ml"
+       "respond_public_read_json");
   check bool "provider runs route threads state net into dashboard single-run" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        "~net:state.Mcp_server.net");

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -167,6 +167,52 @@ let test_runtime_status_and_judgments_are_live () =
       check string "judgment tool" "masc_operator_confirm"
         (first |> member "recommended_action" |> member "resolved_tool" |> to_string))
 
+let test_empty_judgment_disk_scan_uses_cooldown () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let json0 =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      check int "initially empty" 0
+        (json0 |> member "judgments" |> to_list |> List.length);
+      let now = Unix.gettimeofday () in
+      let generated_at = iso8601_of_unix now in
+      let expires_at = iso8601_of_unix (now +. 3600.0) in
+      write_legacy_judgment ~base_path:dir
+        (`Assoc
+          [
+            ("target_kind", `String "agent_health");
+            ("target_id", `String "cooldown-check");
+            ("status", `String "active");
+            ("summary", `String "disk cooldown regression guard");
+            ("confidence", `Float 0.75);
+            ("generated_at", `String generated_at);
+            ("expires_at", `String expires_at);
+            ("model_used", `String "llama:test");
+            ("keeper_name", `String Lib.Dashboard_governance_judge.keeper_name);
+          ]);
+      let json1 =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      check int "cooldown suppresses immediate reload" 0
+        (json1 |> member "judgments" |> to_list |> List.length);
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.last_disk_load_unix <- Some (Unix.gettimeofday () -. 31.0));
+      let json2 =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      check int "reload resumes after cooldown" 1
+        (json2 |> member "judgments" |> to_list |> List.length))
+
 let test_runtime_timestamps_fallback_to_unix_values () =
   let dir = test_dir () in
   Fun.protect
@@ -375,6 +421,8 @@ let () =
             test_empty_governance_structure;
           test_case "runtime status and judgments are live" `Quick
             test_runtime_status_and_judgments_are_live;
+          test_case "empty judgment disk scan uses cooldown" `Quick
+            test_empty_judgment_disk_scan_uses_cooldown;
           test_case "runtime timestamps fallback to unix values" `Quick
             test_runtime_timestamps_fallback_to_unix_values;
           test_case "monitoring uses live runtime" `Quick


### PR DESCRIPTION
## What changed
- require token-bound `CanAdmin` auth for dashboard delete and sweep endpoints
- add a dedicated public-read JSON responder that only reflects CORS for same-origin or explicitly allowlisted local dev origins
- switch public channel-gate monitoring routes and the artifacts endpoint to that constrained public-read CORS path
- add regression coverage for the tightened auth and CORS boundaries

## Why
These routes were mixing read-oriented/public access patterns with state mutation or sensitive runtime metadata exposure.
The delete/sweep endpoints were reachable through a read gate, and several public-read JSON endpoints reflected arbitrary `Origin` values.

## Impact
- destructive dashboard actions now require bearer-token admin permission
- public monitoring/artifact reads still work, but cross-origin browser reads are limited to same-origin or explicit local dev allowlists
- existing auth and source-guard tests cover the new boundary behavior

## Validation
- `test_auth_coverage`
- `test_ci_hardening_source`
- `test_artifacts_endpoint`