### PR TITLE
[codex] fix runtime keeper path/search recovery

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -419,9 +419,13 @@ module FileSystem = struct
     ])
 
   let lock_info_of_json json =
+    let trimmed = String.trim json in
+    if trimmed = "" then
+      None
+    else
     try
       let module U = Yojson.Safe.Util in
-      let j = Yojson.Safe.from_string json in
+      let j = Yojson.Safe.from_string trimmed in
       let parse_float = function
         | `Float f -> Some f
         | `Int i -> Some (float_of_int i)

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -153,7 +153,10 @@ let playground_relative_unless_allowed_root ~(config : Coord.config)
           "/base/.masc/playground/X/repos" *)
   let trimmed =
     if not (Filename.is_relative trimmed) then
-      let pg_root = keeper_playground_root ~config ~meta in
+      let pg_root =
+        keeper_playground_root ~config ~meta
+        |> Keeper_alerting_path.strip_trailing_slashes
+      in
       let doubled_prefix = pg_root ^ "/" ^ pg_bundle in
       if String.starts_with ~prefix:doubled_prefix trimmed then
         let rest = String.sub trimmed

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -267,7 +267,7 @@ let handle_code_search ctx args =
       @ (if case_insensitive then [ "-i" ] else [])
       @ (if not is_regex then [ "--fixed-strings" ] else [])
       @ (if file_pattern <> "" then [ "-g"; file_pattern ] else [])
-      @ [ "-C"; "2"; "--max-count"; string_of_int max_results; query; search_path ]
+      @ [ "-C"; "2"; "--max-count"; string_of_int max_results; "--"; query; search_path ]
     in
     let cmd = "rg" :: rg_args in
 

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -401,6 +401,11 @@ let test_lock_info_invalid_json () =
   | None -> ()
   | Some _ -> fail "invalid json should return None"
 
+let test_lock_info_blank_json () =
+  match Backend.FileSystem.lock_info_of_json "   \n\t  " with
+  | None -> ()
+  | Some _ -> fail "blank json should return None"
+
 let test_lock_info_missing_field () =
   match Backend.FileSystem.lock_info_of_json {|{"owner": "test"}|} with
   | None -> ()
@@ -510,6 +515,7 @@ let () =
     "eio_lock_info", [
       test_case "json roundtrip" `Quick test_lock_info_json_roundtrip;
       test_case "invalid json" `Quick test_lock_info_invalid_json;
+      test_case "blank json" `Quick test_lock_info_blank_json;
       test_case "missing field" `Quick test_lock_info_missing_field;
     ];
     "eio_fs_edge", [

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -416,6 +416,35 @@ let parse_category raw =
   |> Json.member "category"
   |> Json.to_string_option
 
+let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "masc-improver" in
+  let playground =
+    Filename.concat base_path (playground_path_of meta.name)
+  in
+  let repos = Filename.concat playground "repos" in
+  ensure_dir repos;
+  ignore (Fs_compat.save_file_atomic (Filename.concat repos "demo.txt") "ok");
+  let doubled_path =
+    Filename.concat playground ((playground_path_of meta.name) ^ "repos")
+  in
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~config ~meta
+      ~args:(`Assoc [
+        ("op", `String "ls");
+        ("path", `String doubled_path);
+      ])
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "ls succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check string) "path normalized to repos root" repos
+    (json |> Json.member "path" |> Json.to_string)
+
 (* task-238: terse "X blocked" error caused model retry loops. Hint must
    redirect the model to either separate calls or a specific sub-op. *)
 let test_readonly_chaining_hint_lists_subops () =
@@ -520,6 +549,8 @@ let () =
         test_docker_hardened_missing_seccomp_profile_fails_closed;
     ]);
     ("readonly_hints", [
+      Alcotest.test_case "doubled playground prefix auto-recovers" `Quick
+        test_keeper_shell_ls_recovers_doubled_playground_prefix;
       Alcotest.test_case "chaining hint lists sub-ops (task-238)" `Quick
         test_readonly_chaining_hint_lists_subops;
       Alcotest.test_case "redirect hint points at keeper_fs_edit" `Quick

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -154,6 +154,30 @@ let test_code_search_with_file_pattern_finds_matches () =
       Alcotest.(check string) "matched file basename" "match.ml"
         (Filename.basename matched_path))
 
+let test_code_search_treats_dash_prefixed_query_as_literal () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      run_shell_ok ~cwd:base_dir "git init -q -b main";
+      run_shell_ok ~cwd:base_dir "git config user.email test@example.com";
+      run_shell_ok ~cwd:base_dir "git config user.name test";
+      write_text_file (Filename.concat base_dir "sample.txt")
+        "--help should be searched literally\n";
+      let ctx = make_ctx_in_dir base_dir in
+      let args = `Assoc [
+        ("query", `String "--help");
+        ("path", `String ".");
+        ("case_insensitive", `Bool true);
+        ("max_results", `Int 10);
+      ] in
+      let (ok, msg) = dispatch_exn ctx ~name:"masc_code_search" ~args in
+      Alcotest.(check bool) "search succeeds" true ok;
+      let result = Yojson.Safe.from_string msg in
+      let module U = Yojson.Safe.Util in
+      let count = U.(result |> member "count" |> to_int) in
+      Alcotest.(check int) "finds dash-prefixed literal" 1 count)
+
 let test_code_search_schema_requires_path () =
   let schema =
     List.find_opt (fun (schema : Types.tool_schema) ->
@@ -276,6 +300,8 @@ let () =
       Alcotest.test_case "with options" `Quick test_code_search_with_options;
       Alcotest.test_case "file pattern matches files" `Quick
         test_code_search_with_file_pattern_finds_matches;
+      Alcotest.test_case "dash-prefixed query stays literal" `Quick
+        test_code_search_treats_dash_prefixed_query_as_literal;
       Alcotest.test_case "schema requires path" `Quick
         test_code_search_schema_requires_path;
     ]);


### PR DESCRIPTION
## Summary

This PR hardens three runtime failure paths seen in keeper execution logs:

- normalize doubled keeper playground absolute paths before read resolution
- pass `--` to `rg` so dash-prefixed literal queries are not parsed as flags
- treat blank lock metadata payloads as empty instead of logging parse failures
- add regression tests for all three cases

## Why

Recent runtime evidence showed the keeper pipeline breaking in a few low-level places before the larger `ambiguous partial commit` issue even came into play:

- doubled playground paths could fall through read resolution and produce `path_not_found_under_allowed_roots`
- `masc_code_search` could mis-handle literal queries that begin with `-`
- blank lock payloads emitted noisy `parse_lock_info failed: Blank input data` errors

## Product impact

- keeper path recovery is more resilient when the model repeats the playground prefix
- code search behaves correctly for literal dash-prefixed queries
- backend lock parsing emits less false-error noise on empty payloads

## Evidence

Runtime evidence:
- `logs/masc-server-20260413-v5.log`

Validation:
- `dune build --root .`
- `opam exec -- dune exec --root . test/test_tool_code_coverage.exe`
- `./_build/default/test/test_backend_coverage.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`

## Review evidence

The new regression coverage exercises:
- doubled playground path recovery in `keeper_shell op=ls`
- dash-prefixed literal search in `masc_code_search`
- blank JSON payload handling in backend lock parsing

## Linked issue

Refs #8358