### PR TITLE
fix(coord_task): fold duplicate task_status_to_string to Types alias (#8354)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -180,13 +180,11 @@ let emit_task_activity ?correlation_id ?run_id
       Log.Misc.warn "task activity emit failed (%s %s): %s" kind task_id
         (Printexc.to_string exn)
 
-let task_status_to_string = function
-  | Types.Todo -> "todo"
-  | Types.Claimed _ -> "claimed"
-  | Types.InProgress _ -> "in_progress"
-  | Types.AwaitingVerification _ -> "awaiting_verification"
-  | Types.Done _ -> "done"
-  | Types.Cancelled _ -> "cancelled"
+(* Issue #8354: was a verbatim duplicate of [Types.task_status_to_string].
+   Folded to a single-line alias so adding a 7th task_status constructor
+   only requires updating [Types]. The local name is kept so caller
+   sites (224, 269, 863, 870, 1019, 1020) need no churn. *)
+let task_status_to_string = Types.task_status_to_string
 
 (** Current assignee from the task status, for error messages.
 


### PR DESCRIPTION
## Summary
Follow-up to #8357 (acknowledged as out of scope there).

`lib/coord/coord_task.ml:183` held a verbatim copy of `Types.task_status_to_string`. Two definitions of the same Variant `match` are a known drift hotspot — adding a 7th `task_status` constructor would silently miss one of the sites.

## Change
Replace the 7-line duplicate with a 1-line alias:
\`\`\`ocaml
let task_status_to_string = Types.task_status_to_string
\`\`\`

Signature-preserving:
- The local name survives so all 6 call sites (lines 224, 269, 863, 870, 1019, 1020 in the original file) need no churn.
- `lib/coord/coord_task.mli:42` declares `val task_status_to_string : Types.task_status -> string`, which the alias matches exactly.

## Test plan
- [x] `dune build @check` clean
- [x] `test_tool_coord_coverage` 15/15 pass
- [x] `test_tool_task_coverage` 46/46 pass
- [ ] CI green

## Related
- #8354 issue
- #8357 parent PR (still in CI, this PR independent of it — both can land in either order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)