### PR TITLE
fix(response): task_claimed must report status="claimed" not "in_progress" (#8364)

### DIFF
--- a/lib/response/response.ml
+++ b/lib/response/response.ml
@@ -271,14 +271,24 @@ let handoff_verified ~similarity : t =
    Task-Specific Responses
    ======================================== *)
 
-(** Task claimed *)
+(** Task claimed.
+
+    Issue #8364: previously emitted [status="in_progress"], which is the
+    state AFTER the [Start] action. The [Claim] FSM transition is
+    [Todo -> Claimed] (see [lib/coord/coord_task.ml:752]); a separate
+    [Start] is required to reach [InProgress]. Routing through the
+    Variant SSOT prevents this from drifting again. *)
 let task_claimed ~task_id ~agent : t =
+  let claimed_status =
+    Types.task_status_to_string
+      (Types.Claimed { assignee = agent; claimed_at = Types.now_iso () })
+  in
   ok
     ~message:(Printf.sprintf "Task '%s' claimed by '%s'" task_id agent)
     (`Assoc [
       ("task_id", `String task_id);
       ("claimed_by", `String agent);
-      ("status", `String "in_progress");
+      ("status", `String claimed_status);
     ])
 
 (** Task already claimed *)

--- a/test/test_response.ml
+++ b/test/test_response.ml
@@ -332,7 +332,9 @@ let test_task_claimed () =
   (* Verify ACTUAL values *)
   assert_equal_string "task_id value" "task-001" (json_get_string resp.data "task_id");
   assert_equal_string "claimed_by value" "claude" (json_get_string resp.data "claimed_by");
-  assert_equal_string "status value" "in_progress" (json_get_string resp.data "status");
+  (* Issue #8364: status after Claim is "claimed" (Variant: Types.Claimed),
+     not "in_progress" (which requires a separate Start action). *)
+  assert_equal_string "status value" "claimed" (json_get_string resp.data "status");
   (* Verify message mentions task and agent *)
   assert_true "message mentions task-001" (
     try Str.search_forward (Str.regexp "task-001") resp.message 0 >= 0


### PR DESCRIPTION
## Summary
Closes #8364.

`Response.task_claimed` emitted `status="in_progress"`, which is the state **after** the `Start` action — not `Claim`. The FSM in `lib/coord/coord_task.ml:752-758`:

| Action | From | To | Status string |
|--------|------|-----|---------------|
| Claim | Todo | Claimed | `"claimed"` |
| Start | Claimed | InProgress | `"in_progress"` |

So `task_claimed` should report `"claimed"`. The existing test encoded the wrong expectation, so any future caller would silently inherit the bug.

## Change

1. `lib/response/response.ml:281` — route through `Types.task_status_to_string (Types.Claimed { ... })` so the string cannot drift from the Variant SSOT again. The literal `"in_progress"` is gone.
2. `test/test_response.ml:335` — assert `"claimed"` (with comment explaining the FSM transition).

## Variant SSOT

Same class as #8354. The pattern: any place that emits a status string should derive it from the Variant via `Types.task_status_to_string`, not hand-roll a literal.

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_response.exe` — 39/39 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)