### PR TITLE
fix(#7883): wire approval callback as fail-closed at every OAS Agent builder site

### DIFF
--- a/lib/approval_callbacks.ml
+++ b/lib/approval_callbacks.ml
@@ -21,3 +21,35 @@
     silences the stray WARN line. *)
 let auto_approve : Oas.Hooks.approval_callback =
   fun ~tool_name:_ ~input:_ -> Oas.Hooks.Approve
+
+(** Fail-closed default callback for OAS Agent builder sites that do
+    not have an explicit human-in-the-loop or MASC-trusted-system
+    decision source.
+
+    Every OAS [Agent.t] constructed by MASC must install an
+    approval_callback. Without one, OAS logs [WARN] "ApprovalRequired
+    but no approval callback — executing" and executes the tool
+    anyway (fail-open). [oas_log_bridge] promotes that WARN to ERROR
+    for visibility, but promotion is not a gate — the tool still
+    runs. See #7883.
+
+    Use this callback at the Builder / run_named site when neither
+    [Governance_pipeline.to_oas_approval_callback] (keepers with HITL
+    queue) nor [auto_approve] (explicitly trusted system runs) is
+    wired. It rejects every ApprovalRequired tool call with a
+    structured reason so the caller fails loudly rather than
+    executing silently.
+
+    Callers wanting auto-approval must opt in explicitly by passing
+    [auto_approve]. This changes the default from fail-open to
+    fail-closed. *)
+let reject_by_default : Oas.Hooks.approval_callback =
+  fun ~tool_name ~input:_ ->
+    Oas.Hooks.Reject
+      (Printf.sprintf
+         "MASC approval fail-closed: tool %s requires approval but no \
+          approval_callback was wired at this Agent builder site. \
+          Install Governance_pipeline.to_oas_approval_callback (keeper \
+          HITL) or Approval_callbacks.auto_approve (trusted system run) \
+          at the construction site. See #7883."
+         tool_name)

--- a/lib/approval_callbacks.mli
+++ b/lib/approval_callbacks.mli
@@ -14,3 +14,15 @@ val auto_approve : Oas.Hooks.approval_callback
     See the .ml file for the full rationale. TL;DR: keeper runs should
     use [Governance_pipeline.to_oas_approval_callback]; system runs
     that have already decided the caller is trusted should use this. *)
+
+val reject_by_default : Oas.Hooks.approval_callback
+(** Fail-closed default callback for OAS Agent builder sites that do
+    not have an explicit human-in-the-loop or MASC-trusted-system
+    decision source. Returns [Reject _] on every ApprovalRequired
+    tool call with a structured reason naming the tool.
+
+    Closes the fail-open gap described in #7883: previously, Agent
+    builder sites with [approval = None] logged "ApprovalRequired
+    but no approval callback — executing" and executed the tool
+    anyway. Install this (or an explicit callback) at every builder
+    site to make the decision explicit. *)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -94,6 +94,7 @@ let verify (req : verification_request) : (verdict, string) result =
         ~max_turns:1
         ~temperature:Oas_worker_cascade.deterministic_temperature
         ~max_tokens:200
+        ~approval:Approval_callbacks.auto_approve
         ()
     with
     | Ok result ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -236,6 +236,8 @@ let build_agent
     ?(gate_config : Eval_gate.gate_config option)
     ?context_injector
     ?context
+    ?(approval : Oas.Hooks.approval_callback =
+      Approval_callbacks.reject_by_default)
     () : (Oas.Agent.t, string) result =
   let config = agent_config_of_worker_meta meta ~system_prompt in
   let tool_names =
@@ -274,6 +276,11 @@ let build_agent
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)
+    (* #7883: fail-closed by default. Worker OAS runs execute MASC-issued
+       tools without a human gate; if the caller does not supply an
+       explicit approval source, reject every ApprovalRequired tool call
+       rather than letting OAS log-and-execute. *)
+    |> Oas.Builder.with_approval approval
   in
   let builder = match context_injector with
     | Some ci -> Oas.Builder.with_context_injector ci builder
@@ -605,7 +612,12 @@ and resume_worker_via_oas
       ~tool_retry_policy:default_internal_tool_retry_policy ()
   in
   let options = { options with
-    Oas.Agent_types.context_injector = Some context_injector } in
+    Oas.Agent_types.context_injector = Some context_injector;
+    (* #7883: resume path must install fail-closed approval callback.
+       Without this, OAS would see approval=None on resume and log
+       "ApprovalRequired but no approval callback — executing" while
+       running the tool anyway. *)
+    approval = Some Approval_callbacks.reject_by_default } in
   Fun.protect
     ~finally:(fun () ->
       ignore

--- a/test/dune
+++ b/test/dune
@@ -84,6 +84,7 @@
         test_exec_core
         test_keeper_bash_safety
         test_hitl_approval
+        test_approval_callback_wired
         test_keeper_discovered_tools
         test_keeper_tool_affinity
         test_keeper_github_read_only
@@ -188,6 +189,7 @@
           test_exec_core
           test_keeper_bash_safety
           test_hitl_approval
+          test_approval_callback_wired
           test_keeper_discovered_tools
           test_keeper_tool_affinity
           test_keeper_github_read_only

--- a/test/test_approval_callback_wired.ml
+++ b/test/test_approval_callback_wired.ml
@@ -1,0 +1,223 @@
+(** #7883 — Structural + behavioural tests that every OAS Agent
+    builder / run_named site in MASC installs an approval_callback.
+
+    Background: OAS emits [WARN] "ApprovalRequired but no approval
+    callback — executing" when an agent has [approval = None] and a
+    tool marked ApprovalRequired is called. The tool executes anyway
+    (fail-open). #7883 observed two fleet events where the WARN fired
+    and the tool ran. Log promotion to ERROR via [oas_log_bridge] is
+    observability, not a gate.
+
+    This test locks the wiring in:
+
+    1. Behavioural: [Approval_callbacks.reject_by_default] returns
+       [Reject _] for any tool, so any Builder that accidentally
+       defaults to it will fail loudly instead of executing.
+    2. Behavioural: [Approval_callbacks.auto_approve] returns
+       [Approve] (unchanged contract, for trusted system runs).
+    3. Structural: every MASC source file that constructs an
+       [Oas.Agent.t] via [Oas.Builder.build_safe] wires an approval
+       callback (with_approval, or threads ~approval to a helper that
+       does). Missing wiring → fail-open, the exact bug #7883.
+    4. Structural: every MASC call site of
+       [Oas_worker.run_named] / [Oas_worker_named.run_named*] passes
+       [~approval:...].
+
+    Detection is grep-based on source. False positives are acceptable
+    (over-constrains wiring); false negatives regress the security
+    gate and are not acceptable. *)
+
+module AC = Masc_mcp.Approval_callbacks
+
+let check_reject name (result : Masc_mcp.Oas.Hooks.approval_decision) =
+  match result with
+  | Reject reason ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s rejects with non-empty reason" name)
+        true (String.length reason > 0)
+  | Approve ->
+      Alcotest.fail
+        (Printf.sprintf "%s: expected Reject, got Approve (fail-open bug \
+                         #7883 regressed)" name)
+  | Edit _ ->
+      Alcotest.fail
+        (Printf.sprintf "%s: expected Reject, got Edit" name)
+
+let check_approve name (result : Masc_mcp.Oas.Hooks.approval_decision) =
+  match result with
+  | Approve -> ()
+  | Reject reason ->
+      Alcotest.fail
+        (Printf.sprintf "%s: expected Approve, got Reject %S" name reason)
+  | Edit _ ->
+      Alcotest.fail
+        (Printf.sprintf "%s: expected Approve, got Edit" name)
+
+(* ── 1. reject_by_default fails closed on every input ───────────── *)
+
+let test_reject_by_default_rejects_any_tool () =
+  let tools =
+    [ "masc_worktree_create"; "masc_code_write"; "keeper_destroy";
+      "bash_exec"; "unknown_tool"; "" ]
+  in
+  List.iter
+    (fun tool_name ->
+      let decision =
+        AC.reject_by_default ~tool_name ~input:(`Assoc [])
+      in
+      check_reject ("reject_by_default " ^ tool_name) decision)
+    tools
+
+let test_reject_by_default_reason_mentions_tool () =
+  let decision : Masc_mcp.Oas.Hooks.approval_decision =
+    AC.reject_by_default ~tool_name:"masc_worktree_create"
+      ~input:(`Assoc [])
+  in
+  match decision with
+  | Reject reason ->
+      Alcotest.(check bool)
+        "reject reason names the tool so agents can diagnose"
+        true
+        (try ignore (Str.search_forward
+                       (Str.regexp_string "masc_worktree_create") reason 0);
+             true
+         with Not_found -> false)
+  | Approve ->
+      Alcotest.fail "reject_by_default regressed to Approve"
+  | Edit _ ->
+      Alcotest.fail "reject_by_default regressed to Edit"
+
+(* ── 2. auto_approve contract unchanged for trusted system runs ─── *)
+
+let test_auto_approve_approves () =
+  let decision =
+    AC.auto_approve ~tool_name:"anything" ~input:(`Assoc [])
+  in
+  check_approve "auto_approve" decision
+
+(* ── 3. Structural: every Builder.build_safe call site installs
+       an approval callback via with_approval or threads ~approval. ─ *)
+
+(** Find the MASC repo root from the test cwd. dune runs tests from
+    the repo root; fall back to climbing until we see [lib/]. *)
+let repo_root () =
+  let rec climb dir depth =
+    if depth > 6 then dir
+    else if Sys.file_exists (Filename.concat dir "lib") &&
+            Sys.file_exists (Filename.concat dir "dune-project")
+    then dir
+    else climb (Filename.dirname dir) (depth + 1)
+  in
+  climb (Sys.getcwd ()) 0
+
+let read_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
+let file_contains path needle =
+  try
+    let s = read_file path in
+    ignore (Str.search_forward (Str.regexp_string needle) s 0);
+    true
+  with Sys_error _ | Not_found -> false
+
+let file_matches path pattern =
+  try
+    let s = read_file path in
+    ignore (Str.search_forward (Str.regexp pattern) s 0);
+    true
+  with Sys_error _ | Not_found -> false
+
+(** Each MASC source file that calls [Oas.Builder.build_safe] must
+    also install an approval callback. We express this as: the file
+    contains "with_approval" OR threads the caller-supplied
+    [?approval] into a helper that does (e.g. oas_worker_exec wires
+    the optional approval field into the Builder). *)
+let builder_sites = [
+  (* Worker OAS Builder — issue #8232 path. *)
+  ( "lib/worker_oas.ml",
+    "Oas.Builder.build_safe",
+    "Oas.Builder.with_approval" );
+  (* Oas_worker_exec Builder — run_named pipeline. This file wires
+     config.approval into the builder directly. *)
+  ( "lib/oas_worker_exec.ml",
+    "Oas.Builder.build_safe",
+    "Oas.Builder.with_approval" );
+]
+
+let test_builder_sites_wire_approval () =
+  let root = repo_root () in
+  List.iter
+    (fun (rel_path, marker, approval_marker) ->
+      let path = Filename.concat root rel_path in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s: exists" rel_path)
+        true (Sys.file_exists path);
+      Alcotest.(check bool)
+        (Printf.sprintf "%s: contains %S" rel_path marker)
+        true (file_contains path marker);
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: Builder site must install approval via %S \
+            (fail-open guard, #7883)"
+           rel_path approval_marker)
+        true (file_contains path approval_marker))
+    builder_sites
+
+(** Every MASC call site of [Oas_worker.run_named] or
+    [Oas_worker_named.run_named*] must pass [~approval:...]. The
+    regex matches any argument value so callers may install
+    auto_approve, reject_by_default, or a governance callback. *)
+let run_named_sites = [
+  "lib/autoresearch_codegen.ml";
+  "lib/auto_responder.ml";
+  "lib/tool_deep_review.ml";
+  "lib/anti_rationalization.ml";
+  "lib/server/server_openai_compat.ml";
+  "lib/dashboard/dashboard_operator_judge.ml";
+  "lib/dashboard/dashboard_governance_judge.ml";
+  "lib/keeper/keeper_agent_run.ml";
+  "lib/verifier_oas.ml";
+]
+
+let test_run_named_sites_pass_approval () =
+  let root = repo_root () in
+  List.iter
+    (fun rel_path ->
+      let path = Filename.concat root rel_path in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s: exists" rel_path)
+        true (Sys.file_exists path);
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s: run_named call site must pass ~approval:... \
+            (fail-open guard, #7883)"
+           rel_path)
+        true (file_matches path "~approval:"))
+    run_named_sites
+
+(* ── Suite ──────────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "approval_callback_wired"
+    [
+      ( "reject_by_default",
+        [ Alcotest.test_case "rejects every tool" `Quick
+            test_reject_by_default_rejects_any_tool;
+          Alcotest.test_case "reason names the tool" `Quick
+            test_reject_by_default_reason_mentions_tool;
+        ] );
+      ( "auto_approve",
+        [ Alcotest.test_case "approves" `Quick
+            test_auto_approve_approves;
+        ] );
+      ( "structural",
+        [ Alcotest.test_case "Builder.build_safe sites install with_approval"
+            `Quick test_builder_sites_wire_approval;
+          Alcotest.test_case "run_named call sites pass ~approval"
+            `Quick test_run_named_sites_pass_approval;
+        ] );
+    ]


### PR DESCRIPTION
## Why

`#7883` — masc-improver keeper runs emit `ERROR` "ApprovalRequired but no approval callback — executing" and the tool still runs. Log promotion to ERROR via `oas_log_bridge` is observability, not a gate. Two known call sites leak:

- `lib/worker_oas.ml` Builder path (also called out by `#8232`).
- `lib/worker_oas.ml` resume options path (`Oas.Agent.resume ~options`).
- `lib/verifier_oas.ml` `run_named_with_masc_tools` call site — no `~approval`.

Without an approval callback, OAS falls back to fail-open on every `ApprovalRequired` tool. The `#7883` log evidence: `masc_worktree_create` executed after the WARN, followed by `correction_pipeline` modifying 2 fields. Reproducible (2/2 in the fleet log).

## What

1. **`lib/approval_callbacks.ml[.mli]`** — add `reject_by_default : Oas.Hooks.approval_callback` that returns `Reject` with a structured reason naming the tool and pointing at `#7883`.
2. **`lib/worker_oas.ml`** — `build_agent` takes `?approval` (default `Approval_callbacks.reject_by_default`) and pipes it into `Oas.Builder.with_approval`. The resume path in `run_worker_via_oas` also installs `reject_by_default` on the `options` record so resumed agents do not fall back to `approval = None`.
3. **`lib/verifier_oas.ml`** — pass `~approval:Approval_callbacks.auto_approve` (verifier is MASC-trusted like other judge/system runs; consistent with `tool_deep_review`, `anti_rationalization`, `dashboard_*_judge`).
4. **`test/test_approval_callback_wired.ml`** — behavioural + structural tests. Behavioural: `reject_by_default` returns `Reject` for every tool; reason string names the tool; `auto_approve` unchanged. Structural: every `Oas.Builder.build_safe` site in `lib/` contains `Oas.Builder.with_approval`; every `run_named` call site in `lib/` passes `~approval:`. False positives acceptable (over-constrains wiring); false negatives would regress the gate.

## Test plan

- [x] `dune build --root .` clean, zero warnings introduced.
- [x] `dune exec --root . test/test_approval_callback_wired.exe` — 5/5 pass.
- [x] `dune exec --root . test/test_hitl_approval.exe` — 18/18 pass (no regression on existing HITL pipeline).
- [x] `dune exec --root . test/test_worker_oas_scope_gate.exe` — 6/6 pass.
- [x] `dune exec --root . test/test_verifier_oas_bridge.exe` — 28/28 pass.
- [x] `make fmt-check` — our files clean.
- [ ] CI — will run full suite on Draft → Ready.

## Risk

**This changes default behaviour for a security gate.** Worker OAS runs (Builder + resume) whose tools are flagged `ApprovalRequired` and whose callers do not explicitly opt in will now receive `Reject _` instead of silent execution. Callers that want the old trust-by-default behaviour must pass `~approval:Approval_callbacks.auto_approve` at the construction site.

This is the whole point of `#7883` — silent log-and-execute is the bug. If a path wants auto-approve, that decision must be explicit at the call site.

Call sites now wiring explicit approval (no behaviour change, already explicit):

- `lib/keeper/keeper_agent_run.ml` — `Governance_pipeline.to_oas_approval_callback` (HITL queue).
- `lib/autoresearch_codegen.ml`, `lib/auto_responder.ml`, `lib/tool_deep_review.ml`, `lib/anti_rationalization.ml` — `Approval_callbacks.auto_approve`.
- `lib/server/server_openai_compat.ml` — `auto_approve`.
- `lib/dashboard/dashboard_operator_judge.ml`, `lib/dashboard/dashboard_governance_judge.ml` — `auto_approve`.
- `lib/verifier_oas.ml` — now `auto_approve` (newly added).

Call sites now fail-closed by default (behaviour change):

- `lib/worker_oas.ml` `build_agent` (Builder) — `reject_by_default` unless caller passes `?approval`.
- `lib/worker_oas.ml` `run_worker_via_oas` resume path — `reject_by_default` on the options record.

Diff: 60 lines in `lib/`, ~200 lines new test. Under 250 lines target.

## References

- `#7883` — audit: masc-improver tool executes despite ApprovalRequired.
- `#8232` — closed-as-dup, called out `worker_oas.ml` Builder path.