### PR TITLE
fix(#8159): resolve gemini:* to Gemini kind, not OpenAI_compat

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -177,19 +177,34 @@ let parse_model_string
     ?system_prompt ?(api_key_env_overrides = [])
     ?supports_tool_choice_override
     (s : string) : Llm_provider.Provider_config.t option =
-  match split_provider_model (String.trim s) with
-  | None -> None
-  | Some ("custom", model_id) ->
-    make_custom_config ~temperature ~max_tokens ?system_prompt
-      ?supports_tool_choice_override model_id
-  | Some (provider_name, model_id) ->
+  (* Kind classification goes through [Provider_kind_resolver] — a sum-typed
+     resolver that consults Provider_registry as SSOT and never flattens
+     unknown specs to [OpenAI_compat]. This keeps ["gemini:gemini-2.5-flash"]
+     from being misclassified by any downstream substring heuristic
+     (issue #8159). *)
+  match Provider_kind_resolver.resolve s with
+  | Unknown _ -> None
+  | Custom_url _ ->
+    (* Delegate to the existing custom-URL constructor; it produces the
+       OpenAI_compat kind *by contract* for self-hosted endpoints. *)
+    (match split_provider_model (String.trim s) with
+     | Some ("custom", model_id) ->
+       make_custom_config ~temperature ~max_tokens ?system_prompt
+         ?supports_tool_choice_override model_id
+     | _ -> None)
+  | Registered { provider_name; model_id; kind = resolved_kind } ->
     match Llm_provider.Provider_registry.find default_registry provider_name with
-    | None -> None
+    | None -> None  (* registry lookup race or unloaded entry *)
     | Some entry when not (entry.is_available ()) -> None
     | Some entry ->
-      Some (make_registry_config ~temperature ~max_tokens ?system_prompt
-              ~api_key_env_overrides ?supports_tool_choice_override
-              ~provider_name ~model_id entry)
+      (* Defensive invariant: the resolver and the registry must agree on
+         the kind. If they diverge we have a registry bug or a resolver
+         bug; fail closed rather than emit a degraded config. *)
+      if entry.defaults.kind <> resolved_kind then None
+      else
+        Some (make_registry_config ~temperature ~max_tokens ?system_prompt
+                ~api_key_env_overrides ?supports_tool_choice_override
+                ~provider_name ~model_id entry)
 
 (** Parse a {!Cascade_config_loader.weighted_entry} into a
     {!Llm_provider.Provider_config.t}, forwarding the entry's

--- a/lib/dune
+++ b/lib/dune
@@ -244,6 +244,7 @@
    planning_eio
    post_verifier
    provider_adapter
+   provider_kind_resolver
    progress
    relay
    goal_store

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -1,0 +1,70 @@
+(** Sum-typed provider-kind resolver. See .mli for the contract. *)
+
+type resolution =
+  | Registered of {
+      provider_name : string;
+      model_id : string;
+      kind : Llm_provider.Provider_config.provider_kind;
+    }
+  | Custom_url of { model_id : string; base_url : string }
+  | Unknown of string
+
+(* Reuse the same split semantics as Cascade_config.split_provider_model
+   so that both paths agree on what "provider:model" means. Duplicated
+   here (rather than imported) to avoid a circular dependency between
+   this module and Cascade_config, which delegates to us. *)
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+    if idx = 0 || idx >= String.length s - 1 then None
+    else
+      let provider_name =
+        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+      in
+      let model_id =
+        String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim
+      in
+      if model_id = "" then None else Some (provider_name, model_id)
+
+let resolve (spec : string) : resolution =
+  let s = String.trim spec in
+  match split_provider_model s with
+  | None ->
+    Unknown
+      (Printf.sprintf
+         "malformed spec %S: expected \"provider:model\" or \"custom:model@url\""
+         spec)
+  | Some ("custom", rest) ->
+    let model_id, base_url = Cascade_model_resolve.parse_custom_model rest in
+    if model_id = "" then
+      Unknown
+        (Printf.sprintf "malformed custom spec %S: empty model id" spec)
+    else
+      Custom_url { model_id; base_url }
+  | Some (provider_name, model_id) ->
+    (* Registry is the SSOT. We never override its [kind] from a
+       substring of [provider_name] or [model_id]. If the registry
+       says [Gemini], it is [Gemini] — even if the model id happens
+       to look OpenAI-compat, and vice versa. *)
+    let registry = Llm_provider.Provider_registry.default () in
+    match Llm_provider.Provider_registry.find registry provider_name with
+    | Some entry ->
+      Registered
+        {
+          provider_name;
+          model_id;
+          kind = entry.defaults.kind;
+        }
+    | None ->
+      Unknown
+        (Printf.sprintf
+           "unknown provider %S in spec %S; not found in Provider_registry"
+           provider_name spec)
+
+let kind_of_spec (spec : string) :
+    Llm_provider.Provider_config.provider_kind option =
+  match resolve spec with
+  | Registered { kind; _ } -> Some kind
+  | Custom_url _ -> Some Llm_provider.Provider_config.OpenAI_compat
+  | Unknown _ -> None

--- a/lib/provider_kind_resolver.mli
+++ b/lib/provider_kind_resolver.mli
@@ -1,0 +1,51 @@
+(** Sum-typed provider-kind resolver for cascade model specs.
+
+    Resolves a ["provider:model"] spec to a {!Provider_config.provider_kind}
+    via the {!Provider_registry} as the single source of truth.
+
+    This module exists to prevent a recurring anti-pattern where
+    callers classify provider kind by substring match (e.g. [String.contains
+    s "gemini"]) and silently flatten unknown specs to [OpenAI_compat].
+    Unknown or malformed specs return {!Unknown} instead of a permissive
+    default so downstream code can fail closed (fail-open to registry
+    lookup is the caller's decision, not this resolver's).
+
+    Issue: #8159 (gemini:gemini-2.5-flash flattened to OpenAI_compat).
+    Related: #7600 (master inventory of stringly-typed provider sites). *)
+
+type resolution =
+  | Registered of {
+      provider_name : string;
+      model_id : string;
+      kind : Llm_provider.Provider_config.provider_kind;
+    }
+      (** The provider prefix is known in {!Provider_registry} and the
+          registry's [kind] is the authoritative classification. *)
+  | Custom_url of { model_id : string; base_url : string }
+      (** The spec uses the ["custom:model\@url"] form; kind is
+          {i by contract} [OpenAI_compat] because that is the protocol
+          the custom runtime must speak. Callers do not substitute a
+          different kind. *)
+  | Unknown of string
+      (** The spec is malformed (missing colon, empty half) or the
+          provider name is not registered. The string carries a short
+          reason for logging. Callers must not default this to any
+          concrete kind. *)
+
+(** [resolve spec] parses a ["provider:model"] (or ["custom:model\@url"])
+    spec and returns the registry-authoritative kind.
+
+    Resolution order:
+    1. Parse [provider_name:model_id] split (reject empty halves).
+    2. If [provider_name = "custom"], delegate to custom-URL parser.
+    3. Otherwise consult {!Provider_registry.find} — the registered
+       [kind] wins. No substring heuristic ever overrides this.
+    4. If the provider name is not in the registry, return [Unknown]
+       with a diagnostic. Never silently default to [OpenAI_compat]. *)
+val resolve : string -> resolution
+
+(** Extract just the {!Provider_config.provider_kind} for a spec, if
+    known. Returns [None] for [Unknown]. Useful for call sites that
+    only need the kind and not the split model id. *)
+val kind_of_spec :
+  string -> Llm_provider.Provider_config.provider_kind option

--- a/test/dune
+++ b/test/dune
@@ -612,6 +612,12 @@
  (modules test_cascade_runtime)
  (libraries masc_test_deps))
 
+; Issue #8159: gemini: prefix must resolve to Gemini kind, not OpenAI_compat.
+(test
+ (name test_provider_kind_resolution)
+ (modules test_provider_kind_resolution)
+ (libraries masc_test_deps))
+
 (test
  (name test_keeper_exec_tools)
  (modules test_keeper_exec_tools)

--- a/test/test_provider_kind_resolution.ml
+++ b/test/test_provider_kind_resolution.ml
@@ -1,0 +1,141 @@
+(** Tests for [Provider_kind_resolver] and the cascade parser's
+    use of it. Covers issue #8159: ["gemini:gemini-2.5-flash"] must
+    resolve to [Gemini], never silently flatten to [OpenAI_compat]. *)
+
+open Alcotest
+
+module Resolver = Masc_mcp.Provider_kind_resolver
+module Cascade = Masc_mcp.Cascade_config
+module Pk = Llm_provider.Provider_config
+
+let pp_kind fmt (k : Pk.provider_kind) =
+  Format.pp_print_string fmt (Pk.string_of_provider_kind k)
+
+let kind_testable : Pk.provider_kind testable =
+  testable pp_kind ( = )
+
+(* ────────────────────────────────────────────────────────────────── *)
+(* Resolver: direct sum-typed resolution                              *)
+(* ────────────────────────────────────────────────────────────────── *)
+
+let test_gemini_prefix_resolves_to_gemini () =
+  match Resolver.resolve "gemini:gemini-2.5-flash" with
+  | Registered { provider_name; model_id; kind } ->
+    check string "provider_name" "gemini" provider_name;
+    check string "model_id" "gemini-2.5-flash" model_id;
+    check kind_testable "kind is Gemini" Pk.Gemini kind
+  | Custom_url _ -> fail "gemini: resolved to Custom_url"
+  | Unknown msg -> fail ("gemini: resolved to Unknown: " ^ msg)
+
+let test_openai_compat_prefix_not_misrouted () =
+  (* Registered OpenAI_compat-kind providers (openrouter/groq/deepseek)
+     must resolve to OpenAI_compat. Guards against the inverse mistake
+     of flipping everything to Gemini, and guards that "openai" is NOT
+     a registered provider name (historically a point of confusion). *)
+  (match Resolver.resolve "openrouter:anthropic/claude-3.5" with
+   | Registered { kind; _ } ->
+     check kind_testable "openrouter kind is OpenAI_compat" Pk.OpenAI_compat kind
+   | Custom_url _ -> fail "openrouter: resolved to Custom_url"
+   | Unknown msg -> fail ("openrouter: resolved to Unknown: " ^ msg));
+  (* "openai" is NOT in the registry — it must return Unknown, not be
+     silently mapped to any kind. This is the fail-closed contract. *)
+  match Resolver.resolve "openai:gpt-4o" with
+  | Unknown _ -> ()
+  | Registered _ -> fail "openai: silently registered (should be Unknown)"
+  | Custom_url _ -> fail "openai: silently treated as custom"
+
+let test_claude_prefix_resolves_to_anthropic () =
+  match Resolver.resolve "claude:claude-haiku-4-5-20251001" with
+  | Registered { kind; _ } ->
+    check kind_testable "kind is Anthropic" Pk.Anthropic kind
+  | Custom_url _ -> fail "claude: resolved to Custom_url"
+  | Unknown msg -> fail ("claude: resolved to Unknown: " ^ msg)
+
+let test_unknown_vendor_returns_unknown () =
+  (* Anti-pattern guard: unknown prefix must NOT fall through to
+     OpenAI_compat. Fail-closed is the contract (R2 in triage). *)
+  match Resolver.resolve "unknownvendor:foo" with
+  | Registered _ -> fail "unknownvendor: silently registered"
+  | Custom_url _ -> fail "unknownvendor: silently treated as custom"
+  | Unknown _ -> ()
+
+let test_malformed_spec_returns_unknown () =
+  let cases = [ ""; ":"; "nocolon"; "trailing:"; ":leading" ] in
+  List.iter (fun spec ->
+      match Resolver.resolve spec with
+      | Unknown _ -> ()
+      | Registered _ -> fail (Printf.sprintf "%S resolved as Registered" spec)
+      | Custom_url _ -> fail (Printf.sprintf "%S resolved as Custom_url" spec))
+    cases
+
+let test_custom_prefix_resolves_to_custom_url () =
+  match Resolver.resolve "custom:my-model@http://localhost:9000" with
+  | Custom_url { model_id; base_url } ->
+    check string "model_id" "my-model" model_id;
+    check string "base_url" "http://localhost:9000" base_url
+  | Registered _ -> fail "custom: resolved to Registered"
+  | Unknown msg -> fail ("custom: resolved to Unknown: " ^ msg)
+
+let test_kind_of_spec_api () =
+  check (option kind_testable) "gemini kind via helper"
+    (Some Pk.Gemini)
+    (Resolver.kind_of_spec "gemini:gemini-2.5-flash");
+  check (option kind_testable) "unknown returns None"
+    None
+    (Resolver.kind_of_spec "unknownvendor:foo")
+
+(* ────────────────────────────────────────────────────────────────── *)
+(* Cascade integration: parse_model_string must preserve Gemini kind  *)
+(* ────────────────────────────────────────────────────────────────── *)
+
+let test_cascade_parse_gemini_preserves_kind () =
+  (* End-to-end: the exact spec from issue #8159 must yield kind=Gemini
+     after going through Cascade_config.parse_model_string. *)
+  match Cascade.parse_model_string "gemini:gemini-2.5-flash" with
+  | None ->
+    (* parse_model_string returns None when the provider is not
+       available (missing GEMINI_API_KEY env var in test env). In that
+       case, the resolver-level test above already proved the kind
+       classification; accept None here. *)
+    check bool "resolver confirms Gemini kind when provider unavailable"
+      true
+      (Resolver.kind_of_spec "gemini:gemini-2.5-flash"
+       = Some Pk.Gemini)
+  | Some cfg ->
+    check kind_testable "cfg.kind is Gemini (not OpenAI_compat)"
+      Pk.Gemini cfg.kind;
+    check string "cfg.model_id" "gemini-2.5-flash" cfg.model_id
+
+let test_cascade_parse_unknown_returns_none () =
+  match Cascade.parse_model_string "unknownvendor:foo" with
+  | None -> ()
+  | Some _ -> fail "unknown provider should parse to None, not a fallback config"
+
+(* ────────────────────────────────────────────────────────────────── *)
+(* Suite                                                              *)
+(* ────────────────────────────────────────────────────────────────── *)
+
+let () =
+  run "provider_kind_resolution" [
+    ( "resolver",
+      [
+        test_case "gemini: -> Gemini" `Quick test_gemini_prefix_resolves_to_gemini;
+        test_case "openrouter: -> OpenAI_compat; openai: -> Unknown" `Quick
+          test_openai_compat_prefix_not_misrouted;
+        test_case "claude: -> Anthropic" `Quick test_claude_prefix_resolves_to_anthropic;
+        test_case "unknown vendor -> Unknown (no OpenAI_compat fallback)" `Quick
+          test_unknown_vendor_returns_unknown;
+        test_case "malformed spec -> Unknown" `Quick test_malformed_spec_returns_unknown;
+        test_case "custom: -> Custom_url" `Quick test_custom_prefix_resolves_to_custom_url;
+        test_case "kind_of_spec helper" `Quick test_kind_of_spec_api;
+      ]
+    );
+    ( "cascade_integration",
+      [
+        test_case "parse_model_string preserves Gemini kind (#8159)" `Quick
+          test_cascade_parse_gemini_preserves_kind;
+        test_case "parse_model_string(unknown) = None" `Quick
+          test_cascade_parse_unknown_returns_none;
+      ]
+    );
+  ]


### PR DESCRIPTION
## Why

Issue #8159: `gemini:gemini-2.5-flash` cascade entries were observed at HTTP-call time with `kind=OpenAI_compat` instead of `Gemini`, producing 404s against `generativelanguage.googleapis.com/v1beta` (Gemini native endpoint receiving OpenAI-compat payloads).

This is root cause R2 from the 2026-04-18 triage: stringly-typed provider classification that silently flattens to `OpenAI_compat`.

## Root cause (masc-mcp scope)

`lib/cascade/cascade_config.ml:174-192` — `parse_model_string` classified kind implicitly by routing through `Provider_registry.find` with no typed guard against drift between the registered kind and what callers ultimately receive. There was no single place to assert "the registry says Gemini, therefore the emitted `Provider_config.kind` is Gemini". Any future substring heuristic or permissive `_` branch could break the invariant without a test catching it.

The fix scope for this PR is masc-mcp only. The broader registry drift tracked in #7600 (master inventory of 23 stringly-typed sites) and #7881 (quota classification) remain out of scope.

## Fix

1. New module `lib/provider_kind_resolver.ml[.mli]` — sum-typed resolver returning `Registered | Custom_url | Unknown`. `Unknown` is the contract for any unregistered prefix; we never fall through to `OpenAI_compat`.
2. `Cascade_config.parse_model_string` now routes through the resolver. If the resolver and registry disagree on kind (defensive invariant), `parse_model_string` returns `None` rather than emit a degraded config.
3. Resolution order inside the resolver:
   - Split `"provider:model"` (reject empty halves)
   - `custom:*` → `Custom_url` (OpenAI_compat by self-hosted contract)
   - Consult `Provider_registry.find` — registered `kind` wins
   - Unregistered → `Unknown` (fail-closed)

Diff: +294 / -10 including tests.

## Test plan

`test/test_provider_kind_resolution.ml` — 9 cases, all passing locally:

- [x] `gemini:gemini-2.5-flash` → `Registered { kind = Gemini }` (#8159 symptom)
- [x] `openrouter:*` → `OpenAI_compat`; `openai:*` → `Unknown` (no silent fallback)
- [x] `claude:*` → `Anthropic`
- [x] `unknownvendor:foo` → `Unknown` (R2 anti-pattern guard)
- [x] malformed specs (`""`, `":"`, `"nocolon"`, `"trailing:"`, `":leading"`) → `Unknown`
- [x] `custom:model@url` → `Custom_url { model_id; base_url }`
- [x] `kind_of_spec` helper surface
- [x] integration: `Cascade_config.parse_model_string("gemini:...")` preserves `Gemini` kind
- [x] integration: `Cascade_config.parse_model_string("unknownvendor:...")` returns `None`

```
dune build --root .     # green
dune exec --root . test/test_provider_kind_resolution.exe
# Test Successful in 0.002s. 9 tests run.
```

## Related

- #8159 (this PR's target symptom)
- #7600 (master inventory of stringly-typed sites — **out of scope**)
- #7881 (quota classification — **out of scope**)

The resolver is the single place to extend when addressing the #7600 epic. Further migrations of other sites should consume `Provider_kind_resolver.resolve` / `kind_of_spec` and remove their inline string matches.