### PR TITLE
feat(dashboard): typography axis — text-[Xpx] → named utilities

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -114,7 +114,7 @@ export function App() {
               >
                 ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
-              <div class="flex size-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[13px] text-[var(--text-strong)]">
+              <div class="flex size-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-sm text-[var(--text-strong)]">
                 ${currentView?.icon ?? 'M'}
               </div>
             </div>
@@ -122,7 +122,7 @@ export function App() {
             <div class="min-w-0 flex flex-col justify-center">
               ${currentSection && currentSection.label !== currentView?.label
                 ? html`
-                    <div class="mb-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                    <div class="mb-0.5 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
                       <span>${currentView?.label ?? '홈'}</span>
                       <span>/</span>
                     </div>

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -252,7 +252,7 @@ export function GraphView({ data }: GraphViewProps) {
         { label: '작전', color: 'var(--ok)' },
         { label: '게시글', color: '#f472b6' },
       ].map(({ label, color }) => html`
-        <div class="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]" key=${label}>
+        <div class="flex items-center gap-1.5 text-2xs text-[var(--text-muted)]" key=${label}>
           <span class="w-2.5 h-2.5 rounded-full inline-block" style="background:${color}"></span>
           ${label}
         </div>
@@ -263,32 +263,32 @@ export function GraphView({ data }: GraphViewProps) {
       <div class="rounded border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">
         <div class="flex items-center gap-3 mb-3">
           <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
-          <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-[11px] text-[var(--text-slate)] rounded">${kindLabel(selectedNode.kind)}</span>
-          <span class="py-0.5 px-2 rounded text-[11px] ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
+          <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-2xs text-[var(--text-slate)] rounded">${kindLabel(selectedNode.kind)}</span>
+          <span class="py-0.5 px-2 rounded text-2xs ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
           <button type="button" class="ml-auto text-[var(--text-muted)] hover:text-[var(--text-slate-light)] text-sm cursor-pointer bg-transparent border-none" onClick=${() => { selectedNodeId.value = null }}>닫기</button>
         </div>
         <div class="grid grid-cols-3 gap-3 mb-3">
           <div class="text-center">
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">중요도</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">중요도</div>
             <div class="text-xl font-bold text-[var(--text-near-white)] tabular-nums">${(selectedNode.semantic_weight ?? selectedNode.weight).toFixed(1)}</div>
           </div>
           <div class="text-center">
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">빈도</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">빈도</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${selectedNode.weight}</div>
           </div>
           <div class="text-center">
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">연결</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">연결</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${connectedEdges.length}</div>
           </div>
         </div>
         ${connectedEdges.length > 0 ? html`
           <div class="border-t border-[var(--slate-gray-10)] pt-3">
-            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em] mb-2">연결된 관계</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em] mb-2">연결된 관계</div>
             <div class="flex flex-col gap-1.5 max-h-[160px] overflow-y-auto">
               ${connectedEdges.slice(0, 20).map(({ edge, otherLabel }) => html`
-                <div class="flex items-center gap-2 text-[13px] py-1 px-2 rounded bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>
+                <div class="flex items-center gap-2 text-sm py-1 px-2 rounded bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>
                   <span class="text-[var(--text-slate-light)]">${otherLabel}</span>
-                  <span class="text-[11px] text-[var(--text-muted)]">${edgeKindLabel(edge.kind)}</span>
+                  <span class="text-2xs text-[var(--text-muted)]">${edgeKindLabel(edge.kind)}</span>
                   ${edge.active ? html`<span class="w-1.5 h-1.5 rounded-full bg-[var(--ok)]"></span>` : null}
                 </div>
               `)}

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -95,7 +95,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
     return html`
       <div class="rounded border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
+        <div class="text-3xs text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
         <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
       </div>
@@ -174,8 +174,8 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
     <div class="flex flex-col gap-3">
       <div class="flex flex-col gap-3 rounded border border-[var(--card-border)] bg-[var(--card)]/50 p-4">
         <div class="flex flex-col gap-1">
-          <div class="text-[14px] font-semibold text-[var(--text-strong)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
-          <div class="text-[12px] text-[var(--text-muted)]">
+          <div class="text-base font-semibold text-[var(--text-strong)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
+          <div class="text-xs text-[var(--text-muted)]">
             액션 ${isFiltering ? `${filteredGroups.length}/${categoryFilteredGroups.length}` : filteredGroups.length}개 · 원본 타임라인 ${data.timeline.length}건 · 분석 범위 ${data.stats.event_count ?? data.timeline.length}건
             ${lifecycleHiddenCount > 0 ? ` · 생명주기 ${lifecycleHiddenCount}건 숨김` : ''}
           </div>
@@ -188,24 +188,24 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
             placeholder="액션 필터 (title, actor, subject...)"
             aria-label="액션 타임라인 필터"
             onInput=${(e: Event) => { actionQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
           <button
             type="button"
-            class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-[11px] transition-all duration-150 ${showLifecycle.value
+            class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-2xs transition-all duration-150 ${showLifecycle.value
               ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
               : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'}"
             onClick=${() => { showLifecycle.value = !showLifecycle.value }}
           >
             생명주기 ${showLifecycle.value ? '표시 중' : '숨김'}
-            <span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[10px]">${rawCounts.lifecycle}</span>
+            <span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-3xs">${rawCounts.lifecycle}</span>
           </button>
         </div>
       </div>
 
       ${filteredGroups.length === 0
         ? (isFiltering && categoryFilteredGroups.length > 0
-          ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${categoryFilteredGroups.length} items)</div>`
+          ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${categoryFilteredGroups.length} items)</div>`
           : html`<${EmptyState} message="선택한 필터에 맞는 액션 그룹이 없습니다." compact />`)
         : filteredGroups.map(group => {
             const expanded = expandedActionGroups.value.has(group.id)
@@ -214,39 +214,39 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
-                      <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${actionCategoryClass(group)}">
+                      <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${actionCategoryClass(group)}">
                         ${categoryLabel(group.category)}
                       </span>
-                      ${group.actor ? html`<span class="text-[11px] font-medium text-[var(--text-body)]">${group.actor}</span>` : null}
-                      ${group.subjectId ? html`<span class="text-[11px] text-[var(--text-muted)] font-mono">${group.subjectId}</span>` : null}
+                      ${group.actor ? html`<span class="text-2xs font-medium text-[var(--text-body)]">${group.actor}</span>` : null}
+                      ${group.subjectId ? html`<span class="text-2xs text-[var(--text-muted)] font-mono">${group.subjectId}</span>` : null}
                     </div>
-                    <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">${group.title}</div>
-                    <div class="mt-1 text-[13px] leading-[1.6] text-[var(--text-body)]">${group.summary}</div>
+                    <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">${group.title}</div>
+                    <div class="mt-1 text-sm leading-[1.6] text-[var(--text-body)]">${group.summary}</div>
                   </div>
-                  <div class="flex shrink-0 flex-col items-end gap-2 text-[11px] text-[var(--text-muted)]">
+                  <div class="flex shrink-0 flex-col items-end gap-2 text-2xs text-[var(--text-muted)]">
                     <span>${group.rawCount}건</span>
                     <${TimeAgo} timestamp=${group.latestTs} />
                   </div>
                 </div>
                 <div class="mt-3 flex flex-wrap gap-1.5">
                   ${group.kinds.slice(0, 4).map(kind => html`
-                    <span class="inline-flex items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]" key=${kind}>
+                    <span class="inline-flex items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]" key=${kind}>
                       ${activityEventKindLabel(kind)}
                     </span>
                   `)}
                 </div>
                 <div class="mt-3 flex items-center justify-between gap-3 border-t border-[var(--white-6)] pt-3">
-                  <span class="text-[11px] text-[var(--text-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
+                  <span class="text-2xs text-[var(--text-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
                   <div class="flex items-center gap-2">
                     ${group.actor ? html`
                       <a
-                        class="rounded border border-[var(--accent-20)] bg-[var(--accent-soft)] px-3 py-1.5 text-[11px] text-[var(--accent)] no-underline transition-all duration-150 hover:bg-[var(--accent-10)]"
+                        class="rounded border border-[var(--accent-20)] bg-[var(--accent-soft)] px-3 py-1.5 text-2xs text-[var(--accent)] no-underline transition-all duration-150 hover:bg-[var(--accent-10)]"
                         href=${hashForRoute('monitoring', { section: 'observatory', keeper: group.actor, range: activityRange() })}
                       >이 keeper로 보기</a>
                     ` : null}
                     <button
                       type="button"
-                      class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
+                      class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-2xs text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
                       onClick=${() => toggleExpandedGroup(group.id)}
                     >
                       ${expanded ? '원본 접기' : '원본 보기'}
@@ -257,16 +257,16 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                   <div class="mt-3 flex flex-col gap-2 rounded border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
                     ${group.rawEvents.map(event => html`
                       <div class="flex items-start gap-3 rounded border border-[var(--white-6)] bg-[var(--white-3)] px-3 py-2" key=${event.seq}>
-                        <span class="inline-flex min-w-[72px] items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                        <span class="inline-flex min-w-[72px] items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
                           ${activityEventKindLabel(event.kind)}
                         </span>
                         <div class="min-w-0 flex-1">
-                          <div class="text-[12px] text-[var(--text-body)]">${eventDetail(event, 160)}</div>
+                          <div class="text-xs text-[var(--text-body)]">${eventDetail(event, 160)}</div>
                            ${(() => { const ns = visibleNamespaceLabel(event.room_id); return ns
-                             ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">namespace: ${ns}</div>`
+                             ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">namespace: ${ns}</div>`
                              : null; })()}
                         </div>
-                        <span class="shrink-0 text-[11px] text-[var(--text-muted)]">
+                        <span class="shrink-0 text-2xs text-[var(--text-muted)]">
                           <${TimeAgo} timestamp=${event.ts_iso} />
                         </span>
                       </div>
@@ -307,14 +307,14 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
             <div class="flex-1 flex flex-col gap-1 min-w-0">
               <div class="flex items-center gap-2">
                 <span class="text-base font-semibold text-[var(--text-near-white)] whitespace-nowrap overflow-hidden text-ellipsis">${node.label}</span>
-                <span class="text-[11px] text-[var(--text-muted)]">${node.weight}회</span>
+                <span class="text-2xs text-[var(--text-muted)]">${node.weight}회</span>
               </div>
               <div class="h-1 rounded-sm bg-[var(--slate-gray-10)] overflow-hidden">
                 <div class="h-full rounded-sm bg-[var(--cyan)] transition-[width] duration-300 ease-in-out" style="width:${pct}%"></div>
               </div>
             </div>
             <span class="text-sm font-semibold text-text-slate-light min-w-[32px] text-right">${score.toFixed(1)}</span>
-            <span class="text-[11px] py-0.5 px-[7px] rounded ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--ok)] bg-[var(--ok-10)]'}">${node.status}</span>
+            <span class="text-2xs py-0.5 px-[7px] rounded ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--ok)] bg-[var(--ok-10)]'}">${node.status}</span>
           </div>
         `
       })}
@@ -371,7 +371,7 @@ function DerivedActivityPanels({ data }: { data: ActivityGraphResponse }) {
         </div>
         <${StatsRow} data=${data} />
         <${GraphView} data=${data} />
-        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[13px]">
+        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-sm">
           <span>생성 시각: ${data.generated_at}</span>
           <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
           <span>필터: ${timeRangeLabel(activityRange())}</span>
@@ -417,7 +417,7 @@ export function ObservatoryActivityPanels() {
             : html`
                 <${CollapsibleSection}
                   title="활동 분석"
-                  badge=${html`<span class="ml-1 text-[10px] font-normal text-[var(--text-dim)]">액션 ${actionCount}</span>`}
+                  badge=${html`<span class="ml-1 text-3xs font-normal text-[var(--text-dim)]">액션 ${actionCount}</span>`}
                 >
                   <${ActivityTimelinePanel} data=${data} />
                 <//>

--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -255,7 +255,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
   return html`
     <${Card} title="활동 히트맵" testId="activity_heatmap">
       <div class="mb-2">
-        <p class="text-[13px] text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
+        <p class="text-sm text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
       <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3">
         <canvas ref=${canvasRef} class="block" />

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -116,7 +116,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
       id: agent,
       content: agent.length > 16 ? agent.slice(0, 15) + '..' : agent,
       title: agent,
-      className: 'agent-swimlane-group text-[11px] font-system text-[var(--slate-400)]',
+      className: 'agent-swimlane-group text-2xs font-system text-[var(--slate-400)]',
       order: i
     })))
 
@@ -232,12 +232,12 @@ export function ActivitySwimlane({ since }: { since?: string }) {
   return html`
     <${Card} title="활동 타임라인" testId="activity_swimlane">
       <div class="mb-2">
-        <p class="text-[13px] text-[var(--text-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
+        <p class="text-sm text-[var(--text-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다. 마우스 휠로 줌인/아웃, 드래그로 이동이 가능합니다.</p>
       </div>
       <div class="w-full bg-[#0f1117] rounded border border-[var(--card-border)] overflow-hidden swimlane-vis-container">
         <div ref=${containerRef} class="w-full"></div>
       </div>
-      <div class="flex flex-wrap gap-3 mt-3 text-[11px] text-[var(--text-muted)]">
+      <div class="flex flex-wrap gap-3 mt-3 text-2xs text-[var(--text-muted)]">
         <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--warn)] inline-block"></span>작업</span>
         <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--ok)] inline-block"></span>운영</span>
         <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[var(--cyan)] inline-block"></span>자율</span>

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -18,7 +18,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
         : html`
             <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`
-                <div class="agent-journal-entry flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
+                <div class="agent-journal-entry flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                   <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
                   <span class="agent-journal-type">${entry.eventType}</span>
                   <span class="agent-journal-text">${trimText(entry.text, 120) ?? ''}</span>

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -131,7 +131,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     ${outgoing.length > 0
                       ? html`
                           <div>
-                            <div class="text-[11px] text-[var(--text-muted)] mb-1">
+                            <div class="text-2xs text-[var(--text-muted)] mb-1">
                               내가 강화한 파트너 (out, ${outgoing.length})
                             </div>
                             <div class="space-y-1">
@@ -156,7 +156,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     ${incoming.length > 0
                       ? html`
                           <div>
-                            <div class="text-[11px] text-[var(--text-muted)] mb-1">
+                            <div class="text-2xs text-[var(--text-muted)] mb-1">
                               나를 강화한 파트너 (in, ${incoming.length})
                             </div>
                             <div class="space-y-1">
@@ -202,7 +202,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                   onInput=${(e: Event) => {
                     episodeQuery.value = (e.target as HTMLInputElement).value
                   }}
-                  class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                 />`
               : null}
           </div>
@@ -212,7 +212,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                   이 키퍼의 에피소드 기록이 없습니다.
                 </div>`
               : visibleEpisodes.length === 0
-                ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">
+                ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">
                     필터 결과 없음 (${episodes.length}개 중 0)
                   </div>`
                 : html`
@@ -240,10 +240,10 @@ export function AgentDetailMemory({ agentName }: Props) {
                                 <span class="${outcomeColor}">${outcomeIcon}</span>
                                 <span class="truncate text-[var(--text-muted)]">${highlightMatch(ep.summary, episodeQuery.value)}</span>
                               </div>
-                              <span class="text-[10px] text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+                              <span class="text-3xs text-[var(--text-muted)]0 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
                             </div>
                             ${ep.learnings.length > 0
-                              ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
+                              ? html`<div class="mt-1 text-2xs text-[var(--text-muted)] pl-3 border-l border-[var(--white-10)]">${highlightMatch(ep.learnings[0]!, episodeQuery.value)}</div>`
                               : null}
                           </div>
                         `

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -169,9 +169,9 @@ function SessionMeta({ agentName }: { agentName: string }) {
   return html`
     <div class="flex flex-wrap gap-2 mb-4">
       ${meta.map(m => html`
-        <span key=${m.label} class="inline-flex items-center gap-1.5 text-[11px] font-medium py-1 px-2.5 bg-white/5 border border-white/10 rounded text-text-muted">
+        <span key=${m.label} class="inline-flex items-center gap-1.5 text-2xs font-medium py-1 px-2.5 bg-white/5 border border-white/10 rounded text-text-muted">
           <span class="text-text-dim">${m.label}</span>
-          <span class="text-text-strong font-mono text-[10px]">${m.value}</span>
+          <span class="text-text-strong font-mono text-3xs">${m.value}</span>
         </span>
       `)}
     </div>
@@ -183,7 +183,7 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
 
   return html`
     <div class="mt-4">
-      <div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-2">태스크 이력</div>
+      <div class="text-2xs font-semibold uppercase tracking-wider text-text-muted mb-2">태스크 이력</div>
       <div class="flex flex-col gap-1">
         ${events.map((evt, idx) => {
           const title = detailStr(evt.detail, 'title') || detailStr(evt.detail, 'task_id')
@@ -191,8 +191,8 @@ function TaskEventTimeline({ events }: { events: AgentTimelineEvent[] }) {
           const color = taskEventColor(evt.type)
           return html`
             <div key=${idx} class="flex items-center gap-2 py-1.5 px-3 rounded hover:bg-white/3 transition-colors">
-              <span class="text-[10px] font-bold uppercase tracking-wider ${color} bg-white/5 px-2 py-0.5 rounded">${icon}</span>
-              <span class="text-[12px] text-text-body flex-1 truncate">${title}</span>
+              <span class="text-3xs font-bold uppercase tracking-wider ${color} bg-white/5 px-2 py-0.5 rounded">${icon}</span>
+              <span class="text-xs text-text-body flex-1 truncate">${title}</span>
               ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
             </div>
           `
@@ -224,12 +224,12 @@ function BroadcastReport({ report, index }: { report: { ts: string; content: str
           <${TimeAgo} timestamp=${report.ts} />
         </div>
         ${isLong ? html`
-          <span class="text-[10px] text-text-dim font-medium">
+          <span class="text-3xs text-text-dim font-medium">
             ${expanded ? '접기' : '펼치기'}
           </span>
         ` : null}
       </button>
-      <div class="px-4 py-3 text-[13px] leading-relaxed">
+      <div class="px-4 py-3 text-sm leading-relaxed">
         <${Markdown} text=${expanded || !isLong ? report.content : preview} />
       </div>
     </div>
@@ -267,17 +267,17 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
       ${summary ? html`
         <div class="flex gap-3 flex-wrap mb-4">
           ${summary.tasks_completed > 0 ? html`
-            <div class="flex items-center gap-1.5 text-[12px] font-medium text-ok bg-ok/10 border border-ok/20 px-3 py-1.5 rounded">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-ok bg-ok/10 border border-ok/20 px-3 py-1.5 rounded">
               <span class="font-bold">${summary.tasks_completed}</span> 완료
             </div>
           ` : null}
           ${summary.tasks_claimed > 0 ? html`
-            <div class="flex items-center gap-1.5 text-[12px] font-medium text-accent bg-[var(--accent-10)] border border-accent/20 px-3 py-1.5 rounded">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-accent bg-[var(--accent-10)] border border-accent/20 px-3 py-1.5 rounded">
               <span class="font-bold">${summary.tasks_claimed}</span> 수임
             </div>
           ` : null}
           ${summary.messages_sent > 0 ? html`
-            <div class="flex items-center gap-1.5 text-[12px] font-medium text-text-muted bg-white/5 border border-white/10 px-3 py-1.5 rounded">
+            <div class="flex items-center gap-1.5 text-xs font-medium text-text-muted bg-white/5 border border-white/10 px-3 py-1.5 rounded">
               <span class="font-bold">${summary.messages_sent}</span> 메시지
             </div>
           ` : null}
@@ -294,7 +294,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
             onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
           />
           ${hasQuery ? html`
-            <span class="text-[11px] text-text-muted whitespace-nowrap">
+            <span class="text-2xs text-text-muted whitespace-nowrap">
               ${filteredItems} / ${totalItems}
             </span>
           ` : null}
@@ -308,13 +308,13 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
           `)}
         </div>
       ` : hasQuery && reports.length > 0 ? html`
-        <div class="text-[12px] text-text-muted py-3">검색 결과 없음 (리포트)</div>
+        <div class="text-xs text-text-muted py-3">검색 결과 없음 (리포트)</div>
       ` : null}
 
       <${TaskEventTimeline} events=${filteredTaskEvents} />
 
       ${hasQuery && filteredTaskEvents.length === 0 && taskEvents.length > 0 ? html`
-        <div class="text-[12px] text-text-muted py-2">검색 결과 없음 (태스크)</div>
+        <div class="text-xs text-text-muted py-2">검색 결과 없음 (태스크)</div>
       ` : null}
     <//>
   `

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -97,28 +97,28 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
 
   return html`
     <div class="flex flex-col py-1.5 px-2 rounded hover:bg-[var(--white-4)] transition-colors" key=${idx} style=${{ animation: 'activityFadeIn 0.25s ease-out' }}>
-      <div class="flex items-center gap-2 text-[13px]">
-        <div class="flex-shrink-0 size-6 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[10px] font-mono font-bold ${cat.color}">
+      <div class="flex items-center gap-2 text-sm">
+        <div class="flex-shrink-0 size-6 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-3xs font-mono font-bold ${cat.color}">
           ${cat.icon}
         </div>
         <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[200px]" title=${toolName}>${toolName}</span>
-        <span class="text-[10px] px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
+        <span class="text-3xs px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
         ${durationMs != null
-          ? html`<span class="text-[11px] font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
+          ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
           : null}
         ${success
-          ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">ok</span>`
-          : html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">err</span>`}
+          ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">ok</span>`
+          : html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">err</span>`}
         <span class="flex-1"></span>
         ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
       </div>
       ${args ? html`
-        <div class="ml-8 mt-0.5 text-[10px] text-[var(--text-dim)] font-mono truncate">
+        <div class="ml-8 mt-0.5 text-3xs text-[var(--text-dim)] font-mono truncate">
           ${typeof args === 'string' ? trimText(args, 60) : formatArgs(args)}
         </div>
       ` : null}
       ${errorMsg ? html`
-        <div class="ml-8 mt-0.5 text-[10px] text-[var(--bad)] font-mono truncate" title=${errorMsg}>
+        <div class="ml-8 mt-0.5 text-3xs text-[var(--bad)] font-mono truncate" title=${errorMsg}>
           ${trimText(errorMsg, 60)}
         </div>
       ` : null}
@@ -142,11 +142,11 @@ export function AgentTimelineSection() {
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
-          ${summary.tasks_completed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
-          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+          ${summary.tasks_completed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">메시지 ${summary.messages_sent}</span>` : null}
+          ${(summary.tool_calls ?? 0) > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">도구 ${summary.tool_calls}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
         </div>
       ` : null}
       ${events.length === 0
@@ -176,7 +176,7 @@ export function AgentTimelineSection() {
                 onInput=${(e: Event) => { timelineSearchQuery.value = (e.target as HTMLInputElement).value }}
               />
               ${filterActive
-                ? html`<span class="text-[10px] text-[var(--text-dim)] tabular-nums">${filtered.length} / ${events.length}</span>`
+                ? html`<span class="text-3xs text-[var(--text-dim)] tabular-nums">${filtered.length} / ${events.length}</span>`
                 : null}
             </div>
             ${filtered.length === 0
@@ -190,7 +190,7 @@ export function AgentTimelineSection() {
                       const detail = evt.detail as Record<string, string | undefined>
                       const title = detail.title ?? detail.content ?? ''
                       return html`
-                        <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
+                        <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                           <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
                           <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
                           ${title ? html`<span class="agent-timeline-detail">${trimText(title, 80)}</span>` : null}

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -15,34 +15,34 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="워커 상태">
       <div class="flex flex-col gap-1.5">
-        <div class="flex items-baseline gap-2 text-[13px]">
-          <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">상태</span>
+        <div class="flex items-baseline gap-2 text-sm">
+          <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">상태</span>
           <${StatusBadge} status=${worker.state} />
         </div>
         ${worker.focus ? html`
-          <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">포커스</span>
+          <div class="flex items-baseline gap-2 text-sm">
+            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">포커스</span>
             <span>${worker.focus}</span>
           </div>
         ` : null}
         ${worker.recent_output_preview ? html`
-          <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">출력</span>
+          <div class="flex items-baseline gap-2 text-sm">
+            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">출력</span>
             <span class="agent-worker-brief__preview">${trimText(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`
-          <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">세션</span>
+          <div class="flex items-baseline gap-2 text-sm">
+            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">세션</span>
             <span class="font-mono truncate" style="font-size: 11px" title=${worker.related_session_id}>${worker.related_session_id}</span>
             <${CopyIdButton} value=${worker.related_session_id} label="session_id" size=${10} />
           </div>
         ` : null}
         ${worker.last_signal_at ? html`
-          <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
+          <div class="flex items-baseline gap-2 text-sm">
+            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
+            ${worker.signal_truth ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -116,7 +116,7 @@ function TaskSummary({ task }: { task: Task }) {
   return html`
     <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded shadow-sm">
       <${IdPill}>${task.id}<//>
-      <span class="flex-1 text-[13px] text-text-strong font-medium truncate">${task.title}</span>
+      <span class="flex-1 text-sm text-text-strong font-medium truncate">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
   `
@@ -128,7 +128,7 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
       <div class="mb-3">
         <${IdPill} class="group-hover:bg-accent/20 transition-colors">${row.taskId}<//>
       </div>
-      <pre class="m-0 whitespace-pre-wrap text-[12px] leading-relaxed text-text-body font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
+      <pre class="m-0 whitespace-pre-wrap text-xs leading-relaxed text-text-body font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
     </div>
   `
 }
@@ -142,7 +142,7 @@ function renderOwnedTasks(
     return html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
   }
   if (isFiltering && visibleTasks.length === 0) {
-    return html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${allTasks.length} tasks)</div>`
+    return html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allTasks.length} tasks)</div>`
   }
   return html`<div class="flex flex-col gap-3">${visibleTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`
 }
@@ -156,7 +156,7 @@ function renderTaskHistories(
     return html`<${EmptyState} message="작업 이력이 없습니다" compact />`
   }
   if (isFiltering && visibleRows.length === 0) {
-    return html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${allRows.length} rows)</div>`
+    return html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allRows.length} rows)</div>`
   }
   return html`<div class="flex flex-col gap-3">${visibleRows.map(row => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`
 }
@@ -226,16 +226,16 @@ export function AgentDetailOverlay() {
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
-                  ${unified.description !== unified.label ? html`<span class="text-[10px] font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
+                  ${unified.description !== unified.label ? html`<span class="text-3xs font-medium py-1 px-2 border border-white/10 bg-white/5 text-text-muted whitespace-nowrap rounded" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
-                  ${agent?.model ? html`<span class="font-mono text-[10px] font-medium bg-white/10 border border-white/5 px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
+                  ${agent?.model ? html`<span class="font-mono text-3xs font-medium bg-white/10 border border-white/5 px-2 py-1 rounded text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
                     : null}
                 </div>
               </div>
             </div>
-            <div class="mt-2 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
+            <div class="mt-2 flex gap-3 flex-wrap text-text-muted text-sm font-medium">
               ${agent?.current_task || missionBrief?.current_work
                 ? html`<span class="bg-card/40 px-3 py-1.5 rounded border border-card-border shadow-sm">태스크: <span class="text-text-strong">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
                 : null}
@@ -243,7 +243,7 @@ export function AgentDetailOverlay() {
             </div>
             ${keeper || continuitySummary || missionBrief?.related_session_id
               ? html`
-                  <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
+                  <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-sm font-medium">
                     ${keeper
                       ? html`<span class="flex items-center gap-1.5">연결된 키퍼:
                           <button
@@ -266,7 +266,7 @@ export function AgentDetailOverlay() {
             <${ActionButton}
               variant="ghost"
               size="lg"
-              class="px-4 py-2 text-[13px] rounded bg-card/60 shadow-sm"
+              class="px-4 py-2 text-sm rounded bg-card/60 shadow-sm"
               onClick=${() => { void refreshAgentDetail() }}
               disabled=${loading.value}
             >
@@ -275,7 +275,7 @@ export function AgentDetailOverlay() {
             <button
               ref=${closeButtonRef}
               type="button"
-              class="px-4 py-2 text-[13px] font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+              class="px-4 py-2 text-sm font-semibold rounded border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-colors duration-200 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
               onClick=${closeAgentDetail}
             >
               닫기
@@ -287,12 +287,12 @@ export function AgentDetailOverlay() {
 
         <${AgentSessionReport} agentName=${agentName} />
 
-        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-[10px] text-[var(--text-dim)] font-normal ml-1">통합 타임라인</span>`}>
+        <${CollapsibleSection} title="활동 추적" badge=${html`<span class="text-3xs text-[var(--text-dim)] font-normal ml-1">통합 타임라인</span>`}>
           <${SessionTraceView} agentName=${agentName} isKeeper=${!!keeper} />
         <//>
 
         <div class="flex items-center justify-between gap-2">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">
             작업 필터
             ${isFilteringTasks
               ? html`<span class="ml-2 normal-case tracking-normal text-text-muted">할당 ${visibleOwnedTasks.length}/${ownedTasks.length} · 이력 ${visibleHistories.length}/${historyRows.length}</span>`
@@ -304,7 +304,7 @@ export function AgentDetailOverlay() {
             placeholder="id / title / status 필터"
             aria-label="작업 필터"
             onInput=${(e: Event) => { taskQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
 
@@ -316,7 +316,7 @@ export function AgentDetailOverlay() {
           <${Card} title="최근 활동">
             ${lines.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
+              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 
@@ -335,7 +335,7 @@ export function AgentDetailOverlay() {
                   ['종합', agentFitness.value.overall_fitness],
                 ].map(([label, val]) => html`
                   <div class="rounded border border-card-border/50 bg-card/30 p-3 text-center">
-                    <div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
+                    <div class="text-3xs font-semibold uppercase tracking-wider text-text-muted mb-1">${label}</div>
                     <div class="text-lg font-bold ${(val as number) >= 0.7 ? 'text-ok' : (val as number) >= 0.4 ? 'text-[var(--warn)]' : 'text-bad'}">${val != null ? ((val as number) * 100).toFixed(0) + '%' : '-'}</div>
                   </div>
                 `)}
@@ -350,7 +350,7 @@ export function AgentDetailOverlay() {
           <${Card} title="직접 멘션">
             <div class="grid grid-cols-[1fr_auto] gap-3">
               <${TextInput}
-                class="px-4 py-2.5 rounded bg-card/60 text-text-strong text-[13px] placeholder:text-text-dim shadow-inner"
+                class="px-4 py-2.5 rounded bg-card/60 text-text-strong text-sm placeholder:text-text-dim shadow-inner"
                 value=${mentionText.value}
                 name="agent_direct_mention"
                 ariaLabel="직접 멘션 메시지"
@@ -363,7 +363,7 @@ export function AgentDetailOverlay() {
               <${ActionButton}
                 variant="primary"
                 size="lg"
-                class="px-5 py-2.5 text-[13px] shadow-sm shadow-accent/20"
+                class="px-5 py-2.5 text-sm shadow-sm shadow-accent/20"
                 onClick=${() => { void submitMention() }}
                 disabled=${sendingMention.value || mentionText.value.trim() === ''}
               >

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -150,11 +150,11 @@ export function AgentLiveTimeline({ name }: { name: string }) {
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2 flex-wrap">
         <${FilterChips} chips=${FILTER_CHIPS} active=${activeFilter} />
-        <div class="flex items-center gap-2 text-[11px]">
-          <span class="px-2 py-0.5 rounded bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)] text-[10px]">${eventsPerMin}/min</span>
+        <div class="flex items-center gap-2 text-2xs">
+          <span class="px-2 py-0.5 rounded bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)] text-3xs">${eventsPerMin}/min</span>
           <span class="text-[var(--text-muted)]">${filtered.length} events</span>
           <button type="button"
-            class="px-2 py-0.5 rounded text-[10px] border cursor-pointer transition-all duration-150 ${autoScroll.value
+            class="px-2 py-0.5 rounded text-3xs border cursor-pointer transition-all duration-150 ${autoScroll.value
               ? 'border-[rgba(34,197,94,0.4)] text-[var(--ok)] bg-[var(--white-4)]'
               : 'border-[var(--white-10)] text-[var(--text-dim)] bg-[var(--white-4)]'}"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
@@ -169,13 +169,13 @@ export function AgentLiveTimeline({ name }: { name: string }) {
         ${filtered.length === 0
           ? html`<${EmptyState} message="필터에 맞는 이벤트 없음" compact />`
           : filtered.map((entry: JournalEntry, idx: number) => html`
-              <div class="flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
+              <div class="flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                 <span class="agent-event-badge ${eventKindBadgeClass(entry)}">
                   ${eventKindLabel(entry.eventType)}
                 </span>
                 <span class="flex-1 text-[var(--text-body)] truncate">${compactText(entry.text)}</span>
                 ${entry.timestamp ? html`
-                  <span class="text-[var(--text-dim)] text-[11px] whitespace-nowrap"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                  <span class="text-[var(--text-dim)] text-2xs whitespace-nowrap"><${TimeAgo} timestamp=${entry.timestamp} /></span>
                 ` : null}
               </div>
             `)}

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -31,41 +31,41 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
 
   return html`
     <div class="agent-runtime-strip">
-      <div class="flex items-center gap-1.5 text-[13px]">
+      <div class="flex items-center gap-1.5 text-sm">
         <${PipelineStageBadge} stage=${stage} />
       </div>
 
       ${ctxPct != null ? html`
-        <div class="flex items-center gap-1.5 text-[13px]">
-          <span class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">CTX</span>
+        <div class="flex items-center gap-1.5 text-sm">
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">CTX</span>
           <div class="w-16 h-1.5 bg-[#1a1a2e] rounded-sm overflow-hidden">
             <div
               class="agent-runtime-ctx-fill rounded-sm ${ctxBarClass(ctxRatio)}"
               style=${{ width: `${ctxPct}%` }}
             ></div>
           </div>
-          <span class="text-[13px] text-[var(--text-body)] tabular-nums">${ctxPct}%</span>
+          <span class="text-sm text-[var(--text-body)] tabular-nums">${ctxPct}%</span>
         </div>
       ` : null}
 
       ${generation != null ? html`
-        <div class="flex items-center gap-1.5 text-[13px]">
-          <span class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">GEN</span>
-          <span class="text-[13px] text-[var(--text-body)] tabular-nums">${generation}</span>
+        <div class="flex items-center gap-1.5 text-sm">
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">GEN</span>
+          <span class="text-sm text-[var(--text-body)] tabular-nums">${generation}</span>
         </div>
       ` : null}
 
       ${model ? html`
-        <div class="flex items-center gap-1.5 text-[13px]">
-          <span class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">MODEL</span>
-          <span class="text-[13px] text-[var(--text-body)] font-mono truncate max-w-[200px]">${model}</span>
+        <div class="flex items-center gap-1.5 text-sm">
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">MODEL</span>
+          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-[200px]">${model}</span>
         </div>
       ` : null}
 
       ${lastTurnAge != null ? html`
-        <div class="flex items-center gap-1.5 text-[13px]">
-          <span class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">TURN</span>
-          <span class="text-[13px] text-[var(--text-body)] tabular-nums">${formatDuration(lastTurnAge)} ago</span>
+        <div class="flex items-center gap-1.5 text-sm">
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">TURN</span>
+          <span class="text-sm text-[var(--text-body)] tabular-nums">${formatDuration(lastTurnAge)} ago</span>
         </div>
       ` : null}
     </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -243,7 +243,7 @@ function CharacterPlate({ name }: { name: string }) {
           activityAge=${lastActivity}
           signalTruth=${signalTruth}
         />
-        ${isKeeper ? html`<div class="text-[10px] font-bold tracking-[1.5px] text-[var(--ff-gold)] uppercase text-center">KEEPER</div>` : null}
+        ${isKeeper ? html`<div class="text-3xs font-bold tracking-[1.5px] text-[var(--ff-gold)] uppercase text-center">KEEPER</div>` : null}
       </div>
 
       <div class="flex flex-col gap-1.5 min-w-0">
@@ -258,18 +258,18 @@ function CharacterPlate({ name }: { name: string }) {
 
         <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
-          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-[11px] text-[var(--text-muted)] bg-[var(--accent-8)] border border-[var(--accent-10)] px-[5px] py-px rounded">${model}</span>` : null}
+          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-2xs text-[var(--text-muted)] bg-[var(--accent-8)] border border-[var(--accent-10)] px-[5px] py-px rounded">${model}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
           <div class="flex items-center gap-2 mt-0.5">
-            <span class="text-[11px] font-bold text-[var(--ff-gold)] tracking-[1px] w-7">CTX</span>
+            <span class="text-2xs font-bold text-[var(--ff-gold)] tracking-[1px] w-7">CTX</span>
             <div class="h-1.5 mt-1.5 rounded-sm overflow-hidden bg-[var(--white-10)]" style="flex:1">
               <div class="h-full rounded-sm transition-[width] duration-[250ms] ease-[ease] motion-reduce:transition-none ${ctxBarClass(ctxRatio) === 'warn' ? 'bg-linear-to-r from-[var(--warn)] to-[var(--warn-bright)]' : ctxBarClass(ctxRatio) === 'bad' ? 'bg-linear-to-r from-[var(--bad)] to-[var(--warn-bright)]' : 'bg-linear-to-r from-[var(--accent)] to-[var(--ok)]'}" style=${{ width: `${ctxPct}%` }}></div>
             </div>
-            <span class="text-[13px] tabular-nums text-[var(--text-strong)] min-w-9 text-right">${ctxPct}%</span>
+            <span class="text-sm tabular-nums text-[var(--text-strong)] min-w-9 text-right">${ctxPct}%</span>
             ${keeper?.context_tokens != null && keeper?.context_max != null
-              ? html`<span class="text-[11px] tabular-nums text-[var(--text-muted)] font-mono ml-1">${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}</span>`
+              ? html`<span class="text-2xs tabular-nums text-[var(--text-muted)] font-mono ml-1">${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}</span>`
               : null}
           </div>
         ` : null}
@@ -279,19 +279,19 @@ function CharacterPlate({ name }: { name: string }) {
             ? html`<span class="text-base text-[var(--text-body)]">${currentWork}</span>`
             : html`<span class="text-base text-[var(--text-dim)] italic">대기 중</span>`
           }
-          ${workerState ? html`<span class="text-[11px] text-[var(--accent)] bg-[var(--accent-8)] px-[5px] py-px rounded-xs">${workerState}</span>` : null}
-          ${workerFocus ? html`<span class="text-[11px] text-[var(--text-muted)]">${workerFocus}</span>` : null}
+          ${workerState ? html`<span class="text-2xs text-[var(--accent)] bg-[var(--accent-8)] px-[5px] py-px rounded-xs">${workerState}</span>` : null}
+          ${workerFocus ? html`<span class="text-2xs text-[var(--text-muted)]">${workerFocus}</span>` : null}
         </div>
 
         ${lastSeenAt || lastActivity != null ? html`
-          <div class="flex gap-3 flex-wrap text-[13px] text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-sm text-[var(--text-muted)]">
             ${lastSeenAt ? html`<span>마지막 확인: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
             ${lastActivity != null ? html`<span>${formatDuration(lastActivity)} 전 활동</span>` : null}
           </div>
         ` : null}
 
         ${keeperIdent || continuitySummary || brief?.related_session_id ? html`
-          <div class="flex gap-3 flex-wrap text-[13px] text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-sm text-[var(--text-muted)]">
             ${keeperIdent ? html`<span>${keeperIdent}</span>` : null}
             ${brief?.related_session_id ? html`<span>세션 ${brief.related_session_id}</span>` : null}
             ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}
@@ -365,7 +365,7 @@ export function AgentProfile({ name }: { name: string }) {
             ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
                 <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded" key=${t.id}>
-                  <span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${t.id}</span>
+                  <span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${t.id}</span>
                   <span class="flex-1 text-[var(--text-strong)]">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
@@ -389,7 +389,7 @@ export function AgentProfile({ name }: { name: string }) {
                       onClick=${() => navigate('monitoring', { section: 'agents', agent: c.name })}
                     >
                       <span class="text-[var(--ff-gold)] font-semibold text-base flex-1">${c.name}</span>
-                      <span class="text-[var(--white-50)] text-[13px] tabular-nums">${c.collaborations}회</span>
+                      <span class="text-[var(--white-50)] text-sm tabular-nums">${c.collaborations}회</span>
                       ${c.last_collab ? html`<span class="ff-relation-time"><${TimeAgo} timestamp=${c.last_collab} /></span>` : null}
                     </button>
                   `)}
@@ -399,8 +399,8 @@ export function AgentProfile({ name }: { name: string }) {
                 <div class="border-t border-[var(--white-6)] pt-2 mt-2">
                   <span class="ff-interests-label">관심사</span>
                   <div class="flex flex-wrap gap-1 mt-1.5">
-                    ${interests.slice(0, 12).map(t => html`<span class="bg-[var(--gold-10)] text-[var(--white-70)] px-2 py-0.5 rounded-xs text-[11px] border border-[var(--gold-15)]" key=${t}>${t}</span>`)}
-                    ${interests.length > 12 ? html`<span class="bg-[var(--gold-10)] text-[var(--white-70)] px-2 py-0.5 rounded-xs text-[11px] border border-[var(--gold-15)]">+${interests.length - 12}</span>` : null}
+                    ${interests.slice(0, 12).map(t => html`<span class="bg-[var(--gold-10)] text-[var(--white-70)] px-2 py-0.5 rounded-xs text-2xs border border-[var(--gold-15)]" key=${t}>${t}</span>`)}
+                    ${interests.length > 12 ? html`<span class="bg-[var(--gold-10)] text-[var(--white-70)] px-2 py-0.5 rounded-xs text-2xs border border-[var(--gold-15)]">+${interests.length - 12}</span>` : null}
                   </div>
                 </div>
               ` : null}
@@ -415,9 +415,9 @@ export function AgentProfile({ name }: { name: string }) {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
                 return html`
-                  <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
-                    <span class="text-[11px] font-semibold text-[var(--ff-gold)] min-w-8">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="flex-1 text-[13px] text-[var(--text-body)]">${trimText(title, 80)}</span>` : null}
+                  <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
+                    <span class="text-2xs font-semibold text-[var(--ff-gold)] min-w-8">${timelineEventLabel(evt.type)}</span>
+                    ${title ? html`<span class="flex-1 text-sm text-[var(--text-body)]">${trimText(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
                   </div>
                 `
@@ -442,12 +442,12 @@ export function AgentProfile({ name }: { name: string }) {
                       placeholder="활동 필터 (메시지 본문)"
                       aria-label="프로젝트 활동 필터"
                       onInput=${(e: Event) => { activityQuery.value = (e.target as HTMLInputElement).value }}
-                      class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                      class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                     />
                     ${isFiltering && visible.length === 0
-                      ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${lines.length} items)</div>`
+                      ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${lines.length} items)</div>`
                       : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${visible.map((line: string, idx: number) =>
-                          html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[13px] text-[var(--text-body)] leading-[1.4] rounded">${line}</div>`)}</div>`}
+                          html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-sm text-[var(--text-body)] leading-[1.4] rounded">${line}</div>`)}</div>`}
                   </div>
                 `
               })()}
@@ -457,8 +457,8 @@ export function AgentProfile({ name }: { name: string }) {
           <${Card} title="태스크 이력" class="ff-card rounded col-span-full">
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
-                <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
-                <pre class="m-0 whitespace-pre-wrap text-[13px] leading-[1.5] text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
+                <div class="mb-2"><span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
+                <pre class="m-0 whitespace-pre-wrap text-sm leading-[1.5] text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>
           <//>
@@ -469,7 +469,7 @@ export function AgentProfile({ name }: { name: string }) {
         <${KeeperChatPanel} name=${keeperChatName} />
       ` : html`
         <div class="flex gap-2 items-center px-3.5 py-2.5 bg-[rgba(10,22,40,0.8)] border border-[var(--ff-gold-15)] rounded">
-          <span class="text-[13px] font-semibold text-[var(--ff-gold)] whitespace-nowrap">@${name}</span>
+          <span class="text-sm font-semibold text-[var(--ff-gold)] whitespace-nowrap">@${name}</span>
           <${TextInput}
             placeholder="메시지 입력..."
             value=${mentionText.value}

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -524,16 +524,16 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
             <div class="flex min-w-0 flex-col gap-2">
               <div class="flex flex-wrap items-center gap-3">
-                <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">디렉터리 필터</span>
-                <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
+                <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">디렉터리 필터</span>
+                <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
               </div>
-              <p class="m-0 max-w-[720px] text-[13px] leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
+              <p class="m-0 max-w-[720px] text-sm leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
             </div>
 
-            <label class="flex w-full flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
+            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
               <span>이름 / model / 작업</span>
               <${TextInput}
-                class="rounded bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+                class="rounded bg-[var(--white-3)] px-4 py-3 text-base text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
                 ariaLabel="에이전트 이름 · 모델 · 작업 검색"
                 autoComplete="off"
@@ -547,8 +547,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
-                <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
+                <div class="text-2xs font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
+                <p class="m-0 text-xs leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -565,11 +565,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 <div class="rounded border ${executionError.value ? 'border-[rgba(251,191,36,0.28)] bg-[var(--warn-10)]' : 'border-[var(--accent-20)] bg-[var(--accent-10)]'} px-4 py-3 shadow-[0_10px_28px_rgba(0,0,0,0.12)]">
                   <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap items-center gap-2">
-                      <strong class="text-[12px] font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>
-                      <span class="inline-flex items-center rounded-sm border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">${countSourceLabel}</span>
+                      <strong class="text-xs font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>
+                      <span class="inline-flex items-center rounded-sm border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5 text-3xs font-medium text-[var(--text-muted)]">${countSourceLabel}</span>
                     </div>
-                    <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-body)]">${fallbackStateMessage}</p>
-                    <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                    <p class="m-0 text-xs leading-[1.55] text-[var(--text-body)]">${fallbackStateMessage}</p>
+                    <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
                       <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
                       ${configuredKeeperHint ? html`<span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${configuredKeeperHint}</span>` : null}
                     </div>
@@ -686,45 +686,45 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <div class="flex flex-wrap items-center gap-2">
                       <strong class="min-w-0 overflow-hidden text-[17px] font-semibold leading-[1.3] text-[var(--text-strong)] transition-colors group-hover:text-[var(--accent)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
                       ${agent.synthetic ? html`
-                        <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] italic text-[var(--text-muted)]" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">
+                        <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-3xs italic text-[var(--text-muted)]" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">
                           파생
                         </span>
                       ` : null}
                     </div>
 
-                    <div class="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                    <div class="mt-1 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
                       <span class="uppercase tracking-[0.08em]">${identityLabel}</span>
                       ${runtimeName ? html`
                         <span class="text-[var(--text-dim)]">/</span>
-                        <span class="font-mono text-[10px]" translate="no">${runtimeName}</span>
+                        <span class="font-mono text-3xs" translate="no">${runtimeName}</span>
                       ` : null}
                     </div>
                   </div>
                 </div>
 
                 <div class="flex shrink-0 items-start">
-                  <span class="inline-flex items-center rounded-sm border px-2.5 py-1 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
+                  <span class="inline-flex items-center rounded-sm border px-2.5 py-1 text-2xs font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
                 </div>
               </div>
 
-              <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
+              <p class="m-0 text-sm leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${isKeeper ? html`
                 <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
-                    <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
+                    <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
                     ${fsmPhaseKey
                       ? html`<${KeeperPhaseBadge} phase=${fsmPhaseKey} compact />`
                       : html`
-                        <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">
+                        <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium text-[var(--text-muted)]">
                           생명주기 확인 필요
                         </span>
                       `}
-                    <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-[10px] font-medium ${stageBadgeClass(fsmStageKey)}" title=${keeperMonitoring?.stage.description ?? '활동 단계 정보가 없습니다.'}>
+                    <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-medium ${stageBadgeClass(fsmStageKey)}" title=${keeperMonitoring?.stage.description ?? '활동 단계 정보가 없습니다.'}>
                       ${fsmStageText}
                     </span>
                     ${generation != null && generation > 0 ? html`
-                      <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                      <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
                         세대 ${generation}
                       </span>
                     ` : null}
@@ -732,7 +732,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
               ` : null}
 
-              <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
                 <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                   최근 활동
                   <span class="ml-1 text-[var(--text-body)]">
@@ -755,36 +755,36 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 ${compactModel ? html`
                   <span class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                     <span>model</span>
-                    <span class="font-mono text-[10px] text-[var(--text-body)]" translate="no" title=${model ?? undefined}>${compactModel}</span>
+                    <span class="font-mono text-3xs text-[var(--text-body)]" translate="no" title=${model ?? undefined}>${compactModel}</span>
                   </span>
                 ` : null}
               </div>
 
               ${(primaryTool || toolCallCount != null || toolAuditAt) ? html`
-                <div class="flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                <div class="flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
                   <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">최근 도구</span>
                   ${primaryTool ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-body)]" translate="no">
+                    <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-3xs text-[var(--text-body)]" translate="no">
                       ${primaryTool}
                     </span>
                   ` : null}
                   ${extraToolCount > 0 ? html`
-                    <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                    <span class="inline-flex items-center rounded-sm border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
                       +${extraToolCount}
                     </span>
                   ` : null}
                   ${!primaryTool && toolCallCount === 0 ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
                       최근 도구 없음
                     </span>
                   ` : null}
                   ${!primaryTool && toolCallCount != null && toolCallCount > 0 ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
                       ${toolCallCount}회 관찰됨
                     </span>
                   ` : null}
                   ${toolAuditAt ? html`
-                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                    <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
                       감사 <${TimeAgo} timestamp=${toolAuditAt} />
                     </span>
                   ` : null}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -87,13 +87,13 @@ export function AgentsUnified() {
       />
 
       ${currentView !== 'fsm' ? html`
-        <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-[12px] text-[var(--text-muted)]">
-          <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">이 화면 밖</span>
+        <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--text-muted)]">
+          <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">이 화면 밖</span>
           <span>이벤트 로그, 도구 품질, 거버넌스</span>
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'fleet-health' }}
-            class="inline-flex shrink-0 items-center justify-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--accent-20)]"
+            class="inline-flex shrink-0 items-center justify-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--accent-20)]"
           >
             플릿 텔레메트리 열기
           <//>

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -139,10 +139,10 @@ function GateCard({
       <${SurfaceCard} variant="compact">
         <div class="flex flex-col gap-2">
           <div class="flex items-baseline justify-between">
-            <span class="text-[12px] font-semibold tracking-tight">${gate}</span>
-            <span class="text-[10px] text-[var(--text-muted)]">${total}건</span>
+            <span class="text-xs font-semibold tracking-tight">${gate}</span>
+            <span class="text-3xs text-[var(--text-muted)]">${total}건</span>
           </div>
-          <div class="grid grid-cols-2 gap-1 text-[11px]">
+          <div class="grid grid-cols-2 gap-1 text-2xs">
             <span class="text-[var(--ok)]">✓ ${passed}</span>
             <span class="text-[var(--warn)]">◐ ${partial}</span>
             <span class="text-[var(--bad-light)]">✗ ${policyFailed}</span>
@@ -170,16 +170,16 @@ function EventRow({
   return html`
     <button
       type="button"
-      class="w-full text-left px-3 py-2 border-b border-[var(--card-border)] flex items-center gap-3 text-[12px] ${rowBg}"
+      class="w-full text-left px-3 py-2 border-b border-[var(--card-border)] flex items-center gap-3 text-xs ${rowBg}"
       onClick=${onSelect}
     >
-      <span class="text-[11px] font-mono text-[var(--text-muted)] w-20 shrink-0">
+      <span class="text-2xs font-mono text-[var(--text-muted)] w-20 shrink-0">
         ${formatTs(event.recorded_at)}
       </span>
-      <span class="text-[10px] px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)} shrink-0">
+      <span class="text-3xs px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)} shrink-0">
         ${highlightMatch(a.origin, query)}
       </span>
-      <span class="font-mono text-[11px] w-36 shrink-0">${highlightMatch(a.gate, query)}</span>
+      <span class="font-mono text-2xs w-36 shrink-0">${highlightMatch(a.gate, query)}</span>
       <span class="${outcomeToneClass(a.outcome.kind)} shrink-0 w-20">
         ${outcomeLabel(a)}
       </span>
@@ -204,19 +204,19 @@ function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
     <${SurfaceCard} variant="compact">
       <div class="flex flex-col gap-3">
         <div class="flex items-baseline gap-3 flex-wrap">
-          <span class="text-[11px] text-[var(--text-muted)]">${formatTs(event.recorded_at)}</span>
-          <span class="font-mono text-[13px] font-semibold">${a.gate}</span>
-          <span class="text-[10px] px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)}">
+          <span class="text-2xs text-[var(--text-muted)]">${formatTs(event.recorded_at)}</span>
+          <span class="font-mono text-sm font-semibold">${a.gate}</span>
+          <span class="text-3xs px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)}">
             ${a.origin}
           </span>
-          <span class="${outcomeToneClass(a.outcome.kind)} text-[12px]">
+          <span class="${outcomeToneClass(a.outcome.kind)} text-xs">
             ${outcomeLabel(a)}
           </span>
         </div>
         ${reasonOf(a)
-          ? html`<div class="text-[12px] text-[var(--text-muted)]">${reasonOf(a)}</div>`
+          ? html`<div class="text-xs text-[var(--text-muted)]">${reasonOf(a)}</div>`
           : null}
-        <pre class="text-[11px] font-mono bg-[var(--white-5)]/30 rounded p-3 overflow-x-auto max-h-64 whitespace-pre-wrap">${evidenceJson}</pre>
+        <pre class="text-2xs font-mono bg-[var(--white-5)]/30 rounded p-3 overflow-x-auto max-h-64 whitespace-pre-wrap">${evidenceJson}</pre>
       </div>
     </${SurfaceCard}>
   `
@@ -294,10 +294,10 @@ export function AttributionPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-1">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Attribution — gate chain 관찰
         </div>
-        <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-muted)]">
+        <p class="m-0 text-xs leading-[1.55] text-[var(--text-muted)]">
           각 gate의 결과 카운트 + 최근 ${RECENT_LIMIT}건 이벤트. 5초마다 자동 갱신.
         </p>
       </div>
@@ -318,7 +318,7 @@ export function AttributionPanel() {
       <div class="flex items-center justify-between gap-2 flex-wrap">
         ${filterGate.value
           ? html`
-            <div class="text-[11px] text-[var(--text-muted)]">
+            <div class="text-2xs text-[var(--text-muted)]">
               필터: <span class="font-mono text-[var(--text-primary)]">${filterGate.value}</span>
               <button
                 class="ml-2 underline"
@@ -337,14 +337,14 @@ export function AttributionPanel() {
             query.value = (e.target as HTMLInputElement).value
             selectedEventIdx.value = null
           }}
-          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-5)]/20 px-2 py-1 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
+          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
         />
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <${SurfaceCard} variant="light">
           <div class="flex flex-col">
-            <div class="px-3 py-2 border-b border-[var(--card-border)] text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            <div class="px-3 py-2 border-b border-[var(--card-border)] text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
               최근 이벤트 (${isFiltering
                 ? `${visibleEvents.length}/${gateFiltered.length}`
                 : gateFiltered.length})

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -31,7 +31,7 @@ export function AuthStatus() {
   return html`
     <div class="relative">
       <button type="button"
-        class="flex items-center gap-1.5 text-[11px] py-1 px-2 rounded border border-solid border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--text-muted)]"
+        class="flex items-center gap-1.5 text-2xs py-1 px-2 rounded border border-solid border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--text-muted)]"
         onClick=${() => { popoverOpen.value = !popoverOpen.value }}
         title="인증 상태"
       >
@@ -65,26 +65,26 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
     <div class="absolute right-0 top-full mt-1.5 w-[280px] rounded border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
       ${authenticated ? html`
         <div class="flex flex-col gap-2">
-          <div class="text-[11px] text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>
+          <div class="text-2xs text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>
           <button type="button"
-            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded text-2xs border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer transition-colors"
             onClick=${handleClearToken}
           >토큰 제거</button>
         </div>
       ` : html`
         <div class="flex flex-col gap-2">
-          <div class="text-[11px] text-[var(--text-muted)]">Bearer token을 입력하면 원격 환경에서 mutation 작업이 가능합니다.</div>
+          <div class="text-2xs text-[var(--text-muted)]">Bearer token을 입력하면 원격 환경에서 mutation 작업이 가능합니다.</div>
           <input
             type="password"
             placeholder="Bearer token"
             aria-label="Bearer token"
-            class="w-full py-1.5 px-2 rounded text-[11px] border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] placeholder-[var(--text-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
+            class="w-full py-1.5 px-2 rounded text-2xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] placeholder-[var(--text-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
             value=${tokenInput.value}
             onInput=${(e: Event) => { tokenInput.value = (e.target as HTMLInputElement).value }}
             onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') handleSetToken() }}
           />
           <button type="button"
-            class="w-full py-1.5 px-3 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
+            class="w-full py-1.5 px-3 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
             onClick=${handleSetToken}
           >토큰 설정</button>
         </div>
@@ -97,15 +97,15 @@ export function RemoteWarningBanner() {
   if (bannerDismissed.value || !isRemoteAccess() || getStoredToken()) return null
 
   return html`
-    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-[12px] text-[var(--warn)]">
+    <div class="shrink-0 flex items-center justify-between gap-3 px-4 py-2 bg-[var(--warn-10)] border-b border-[var(--warn-20)] text-xs text-[var(--warn)]">
       <span>원격 접속이 감지되었습니다. Mutation 작업을 위해 Bearer token을 설정하세요.</span>
       <div class="flex items-center gap-2 shrink-0">
         <button type="button"
-          class="px-2 py-0.5 rounded text-[11px] border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
+          class="px-2 py-0.5 rounded text-2xs border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-15)] cursor-pointer transition-colors"
           onClick=${() => { popoverOpen.value = true }}
         >토큰 입력</button>
         <button type="button"
-          class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] transition-colors"
+          class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-2xs transition-colors"
           onClick=${() => { bannerDismissed.value = true }}
         >\u2715</button>
       </div>

--- a/dashboard/src/components/autoresearch-form.ts
+++ b/dashboard/src/components/autoresearch-form.ts
@@ -130,7 +130,7 @@ export function StartAutoresearchForm() {
 
       <div class="flex flex-col gap-3">
         <label class="flex flex-col gap-1">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">목표 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">목표 *</span>
           <${TextArea}
             value=${formGoal.value}
             placeholder="최적화 목표 (예: Reduce inference latency by optimizing hot path)"
@@ -140,7 +140,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <label class="flex flex-col gap-1">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">메트릭 명령어 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">메트릭 명령어 *</span>
           <${TextInput}
             value=${formMetricFn.value}
             placeholder="마지막 줄에 float를 출력하는 명령어 (예: python eval.py --metric accuracy)"
@@ -149,7 +149,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <label class="flex flex-col gap-1">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">대상 파일 *</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">대상 파일 *</span>
           <${TextInput}
             value=${formTargetFile.value}
             placeholder="수정할 파일 경로 (예: lib/optimizer.ml)"
@@ -158,7 +158,7 @@ export function StartAutoresearchForm() {
         </label>
 
         <button type="button"
-          class="self-start text-[11px] text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
+          class="self-start text-2xs text-[var(--text-muted)] hover:text-[var(--text-body)] transition-colors"
           onClick=${() => { formShowAdvanced.value = !formShowAdvanced.value }}
         >
           ${formShowAdvanced.value ? '고급 설정 접기 \u25B2' : '고급 설정 \u25BC'}
@@ -167,7 +167,7 @@ export function StartAutoresearchForm() {
         ${formShowAdvanced.value ? html`
           <div class="grid grid-cols-2 gap-3 border-t border-card-border pt-3">
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">작업 디렉토리</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">작업 디렉토리</span>
               <${TextInput}
                 value=${formWorkdir.value}
                 placeholder="기본: 프로젝트 루트"
@@ -175,7 +175,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">모델</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">모델</span>
               <${TextInput}
                 value=${formModelModel.value}
                 placeholder="glm"
@@ -183,7 +183,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">최대 사이클</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">최대 사이클</span>
               <${TextInput}
                 type="number"
                 value=${formMaxCycles.value}
@@ -192,7 +192,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">사이클 타임아웃 (초)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">사이클 타임아웃 (초)</span>
               <${TextInput}
                 type="number"
                 value=${formCycleTimeoutS.value}
@@ -201,7 +201,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">기준선 (baseline)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">기준선 (baseline)</span>
               <${TextInput}
                 type="number"
                 value=${formBaseline.value}
@@ -210,7 +210,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">인내 (patience)</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">인내 (patience)</span>
               <${TextInput}
                 type="number"
                 value=${formPatience.value}
@@ -219,7 +219,7 @@ export function StartAutoresearchForm() {
               />
             </label>
             <label class="col-span-2 flex flex-col gap-1">
-              <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">빌드 검증 명령어</span>
+              <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">빌드 검증 명령어</span>
               <${TextInput}
                 value=${formBuildVerifyFn.value}
                 placeholder="선택 (예: dune build)"

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -111,7 +111,7 @@ function LoopSelector() {
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
-        <label class="text-[11px] text-[var(--text-muted)] font-medium">실행자 필터</label>
+        <label class="text-2xs text-[var(--text-muted)] font-medium">실행자 필터</label>
         <select
           class="bg-card border border-card-border text-[var(--text-body)] text-xs rounded px-2 py-1 outline-none focus:border-accent"
           value=${authorFilter.value}
@@ -161,36 +161,36 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1">목표</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">목표</div>
           <div class="text-[var(--text-body)] text-sm leading-relaxed">${loop.goal}</div>
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">상태</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">상태</div>
             <div class="text-sm font-medium ${statusColor(loop.status)}">${statusLabel(loop.status)}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">사이클</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">사이클</div>
             <div class="text-[var(--text-strong)] text-sm font-mono">${loop.current_cycle} / ${loop.max_cycles}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">경과 시간</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">경과 시간</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">실행자</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">실행자</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.author ?? '알 수 없음'}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.model_model}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">소스</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">소스</div>
             <div class="text-[var(--text-body)] text-sm">${liveLabel(loop)}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최근 갱신</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최근 갱신</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.updated_at != null ? formatTimestampKo(loop.updated_at) : '알 수 없음'}</div>
           </div>
         </div>
@@ -199,16 +199,16 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
       <div class="flex flex-col gap-3">
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">기준선</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">기준선</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.baseline.toFixed(4)}</div>
           </div>
           <div>
-            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최고 점수</div>
+            <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최고 점수</div>
             <div class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.best_score.toFixed(4)}</div>
           </div>
         </div>
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1">유지 / 삭제</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1">유지 / 삭제</div>
           <div class="flex items-center gap-2">
             <span class="text-[var(--ok)] text-sm font-mono font-semibold">${loop.total_keeps}</span>
             <span class="text-[var(--text-muted)] text-xs">/</span>
@@ -229,11 +229,11 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           ` : null}
         </div>
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">대상 파일</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">대상 파일</div>
           <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.target_file}>${loop.target_file}</div>
         </div>
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">메트릭</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-0.5">메트릭</div>
           <div class="text-[var(--text-body)] text-xs font-mono truncate" title=${loop.metric_fn}>${loop.metric_fn}</div>
         </div>
       </div>
@@ -268,16 +268,16 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
           placeholder="가설 / 판정 / # 필터"
           aria-label="사이클 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleCycles.length === 0
-        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
         : html`
           <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
             <table class="w-full text-xs">
               <thead>
-                <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
+                <tr class="text-[var(--text-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">#</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-left py-2.5 px-3 font-medium">가설</th>
                   <th scope="col" class="sticky top-0 z-10 bg-[var(--backdrop-modal)] backdrop-blur-sm text-right py-2.5 px-3 font-medium">이전</th>
@@ -296,7 +296,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
                     <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
                     <td class="py-2 px-3 text-center">
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                      <span class="px-1.5 py-0.5 rounded text-3xs font-semibold ${
                         c.decision === 'keep'
                           ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
                           : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
@@ -351,8 +351,8 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
     <${SurfaceCard} variant="compact">
       <div class="flex flex-col gap-3">
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">Research Brief</div>
-          <div class="text-[13px] leading-[1.55] text-[var(--text-body)]">
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">Research Brief</div>
+          <div class="text-sm leading-[1.55] text-[var(--text-body)]">
             이 루프는 <span class="font-semibold text-[var(--text-strong)]">${loop.goal}</span> 를 목표로
             <span class="font-mono text-[var(--text-strong)]"> ${loop.target_file} </span>
             변경을 시도하고,
@@ -363,16 +363,16 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">무엇을 연구하나</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇을 연구하나</div>
             <div class="leading-relaxed text-[var(--text-body)]">${loop.goal}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">무엇으로 성공을 보나</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">무엇으로 성공을 보나</div>
             <div class="font-mono text-[var(--text-body)]">${loop.metric_fn}</div>
             <div class="mt-1 text-[var(--text-dim)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">연결된 실행 컨텍스트</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">연결된 실행 컨텍스트</div>
             <div class="flex flex-col gap-1 text-[var(--text-body)]">
               <span>session ${loop.session_id ?? '없음'}</span>
               <span>operation ${loop.operation_id ?? '없음'}</span>
@@ -380,7 +380,7 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
             </div>
           </div>
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">현재 가설 / 메모</div>
+            <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-muted)]">현재 가설 / 메모</div>
             <div class="flex flex-col gap-1 text-[var(--text-body)] leading-relaxed">
               <span>${loop.queued_hypothesis ?? '대기 가설 없음'}</span>
               <span class="text-[var(--text-dim)]">${loop.program_note ?? 'program note 없음'}</span>
@@ -388,7 +388,7 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[12px] leading-[1.5] text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-[1.5] text-[var(--text-muted)]">
           이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
           각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
         </div>
@@ -402,7 +402,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
     <${SurfaceCard} variant="compact">
       <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.3fr_1fr]">
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Experiment Outcomes</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Experiment Outcomes</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">이 화면은 keep/discard 루프를 봅니다.</div>
           <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
             어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
@@ -410,14 +410,14 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
         </div>
 
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Safety Harness</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Safety Harness</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
           <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
             평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
           </div>
           <button
             type="button"
-            class="mt-3 rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+            class="mt-3 rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
             onClick=${() => navigate('lab', { section: 'harness' })}
           >하네스 열기</button>
         </div>
@@ -459,12 +459,12 @@ function LoopDetailView() {
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-start justify-between gap-3 mb-3">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">루프 개요</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">루프 개요</div>
           ${canRepairErrorLoop ? html`
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="px-2.5 py-1 rounded text-[11px] text-[var(--text-body)] border border-card-border hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="px-2.5 py-1 rounded text-2xs text-[var(--text-body)] border border-card-border hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled=${loopActionBusy.value}
                 onClick=${() => { void retrySelectedLoop() }}
               >
@@ -472,7 +472,7 @@ function LoopDetailView() {
               </button>
               <button
                 type="button"
-                class="px-2.5 py-1 rounded text-[11px] text-[var(--bad)] border border-[var(--bad-30)] hover:border-[var(--bad)] opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="px-2.5 py-1 rounded text-2xs text-[var(--bad)] border border-[var(--bad-30)] hover:border-[var(--bad)] opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled=${loopActionBusy.value}
                 onClick=${() => { void deleteSelectedLoop() }}
               >
@@ -491,14 +491,14 @@ function LoopDetailView() {
 
       ${warnings.length > 0 ? html`
         <${SurfaceCard} variant="compact">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--warn)]/80 mb-3 font-medium">경고</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--warn)]/80 mb-3 font-medium">경고</div>
           <${WarningsList} warnings=${warnings} />
         <//>
       ` : null}
 
       <${SurfaceCard} variant="compact">
         <div class="flex items-center justify-between mb-3">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
             사이클 이력 ${detail ? `(${detail.history_count}건)` : ''}
           </div>
         </div>
@@ -506,7 +506,7 @@ function LoopDetailView() {
       <//>
 
       <${SurfaceCard} variant="compact">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">인사이트</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">인사이트</div>
         <${InsightsList} insights=${insights} />
       <//>
     </div>
@@ -563,20 +563,20 @@ export function Autoresearch() {
       <${OutcomeVsHarnessCallout} loopCount=${loops.length} />
 
       <div class="flex items-center justify-between">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] font-medium">
           전체 ${loops.length}개 루프
         </div>
         <div class="flex items-center gap-2">
           <${StartFormButton}
-            class="px-2.5 py-1 rounded text-[11px] text-accent border border-accent/40 hover:bg-[var(--accent-10)] transition-colors"
+            class="px-2.5 py-1 rounded text-2xs text-accent border border-accent/40 hover:bg-[var(--accent-10)] transition-colors"
           />
           <a href="/api/v1/autoresearch/loops/csv" download="autoresearch_loops.csv"
-            class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
+            class="px-2.5 py-1 rounded text-2xs text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors no-underline"
           >
             CSV 다운로드
           </a>
           <button type="button"
-            class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
+            class="px-2.5 py-1 rounded text-2xs text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
             onClick=${() => { void refreshAutoresearchSurface() }}
           >
             새로고침

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -167,7 +167,7 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
     >
       <span class="font-semibold">${row.keeper}</span>
       ${row.drift
-        ? html`<code class="text-[10px] text-[var(--text-muted)]">${row.raw_cascade_name}</code>`
+        ? html`<code class="text-3xs text-[var(--text-muted)]">${row.raw_cascade_name}</code>`
         : null}
     </span>
   `
@@ -308,7 +308,7 @@ function HealthTable({
         : null}
     </div>
     ${isFiltering && filtered.length === 0
-      ? html`<div class="py-4 text-center text-[11px] text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
+      ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
       : html`
         <table class="w-full text-xs">
           <thead>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -138,7 +138,7 @@ function ChatMessageBubble({
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
           <div
-            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-[11px] font-semibold uppercase tracking-[0.08em] ${
+            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-2xs font-semibold uppercase tracking-[0.08em] ${
               isMessenger ? 'size-8 rounded-card' : 'size-10 rounded'
             }`}
           >
@@ -148,16 +148,16 @@ function ChatMessageBubble({
             ${isMessenger
               ? html`
                   <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span class="truncate text-[12px] font-semibold text-[var(--text-strong)]">
+                    <span class="truncate text-xs font-semibold text-[var(--text-strong)]">
                       ${avatarLabel(entry)}
                     </span>
                     ${timestamp
-                      ? html`<span class="text-[11px] tabular-nums text-[var(--text-muted)]">${timestamp}</span>`
+                      ? html`<span class="text-2xs tabular-nums text-[var(--text-muted)]">${timestamp}</span>`
                       : null}
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -169,14 +169,14 @@ function ChatMessageBubble({
               : html`
                   <div class="flex flex-wrap items-center gap-1.5">
                     <span
-                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-sm border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]`}
+                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-semibold uppercase tracking-[0.12em]`}
                     >
                       ${entry.label}
                     </span>
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-3xs font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -185,13 +185,13 @@ function ChatMessageBubble({
                       : null}
                     ${timestamp
                       ? html`
-                          <span class="inline-flex items-center rounded-sm border border-[var(--slate-gray-16)] bg-[var(--slate-gray-8)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
+                          <span class="inline-flex items-center rounded-sm border border-[var(--slate-gray-16)] bg-[var(--slate-gray-8)] px-2.5 py-1 text-3xs font-medium tabular-nums text-[var(--text-muted)]">
                             ${timestamp}
                           </span>
                         `
                       : null}
                   </div>
-                  <div class="mt-2 truncate text-[13px] font-semibold text-[var(--text-strong)]">
+                  <div class="mt-2 truncate text-sm font-semibold text-[var(--text-strong)]">
                     ${avatarLabel(entry)}
                   </div>
                 `}
@@ -201,7 +201,7 @@ function ChatMessageBubble({
           ? html`
               <button
                 type="button"
-                class=${`border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
+                class=${`border border-[var(--card-border)] bg-[var(--white-3)] text-2xs font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)] ${
                   isMessenger ? 'rounded px-2.5 py-1' : 'rounded-sm px-3 py-1'
                 }`}
                 onClick=${() => { setExpandedRaw(!expandedRaw) }}
@@ -215,19 +215,19 @@ function ChatMessageBubble({
       ${showMetadata && detailItems.length > 0
         ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
-              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-strong)]">
+              <span class="inline-flex items-center rounded-sm border border-[var(--accent-soft)] bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-medium text-[var(--text-strong)]">
                 ${item}
               </span>
             `)}
           </div>`
         : null}
 
-      <div class="whitespace-pre-wrap break-words text-[14px] leading-[1.7] text-[var(--text-body)]">
+      <div class="whitespace-pre-wrap break-words text-base leading-[1.7] text-[var(--text-body)]">
         ${entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')}
       </div>
       ${entry.error
         ? html`
-            <div class="rounded border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-[12px] leading-[1.55] text-[var(--bad-light)]">
+            <div class="rounded border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-xs leading-[1.55] text-[var(--bad-light)]">
               ${entry.error}
             </div>
           `
@@ -241,8 +241,8 @@ function ChatMessageBubble({
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
                         <div class="rounded border border-[var(--slate-gray-12)] bg-[var(--white-3)] px-3 py-2.5">
-                          <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
-                          <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">${item.value}</div>
+                          <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
+                          <div class="mt-1 text-sm font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
                       `)}
                     </div>
@@ -251,10 +251,10 @@ function ChatMessageBubble({
               ${entry.details.skillPrimary
                 ? html`
                     <div class="chat-detail-callout rounded border border-[rgba(76,181,137,0.18)] px-3 py-3">
-                      <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#8fdcb3]">스킬 경로</div>
-                      <div class="mt-1 text-[13px] font-semibold text-[#d8f7e6]">${entry.details.skillPrimary}</div>
+                      <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[#8fdcb3]">스킬 경로</div>
+                      <div class="mt-1 text-sm font-semibold text-[#d8f7e6]">${entry.details.skillPrimary}</div>
                       ${entry.details.skillReason
-                        ? html`<div class="mt-1 text-[12px] leading-[1.6] text-[#bfe8cf]">${entry.details.skillReason}</div>`
+                        ? html`<div class="mt-1 text-xs leading-[1.6] text-[#bfe8cf]">${entry.details.skillReason}</div>`
                         : null}
                     </div>
                   `
@@ -262,12 +262,12 @@ function ChatMessageBubble({
               ${state.length > 0
                 ? html`
                     <div class="flex flex-col gap-2">
-                      <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
+                      <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
                           <div class="rounded border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
-                            <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--accent)]">${item.label}</div>
-                            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-body)]">${item.value}</div>
+                            <div class="text-3xs font-semibold uppercase tracking-[0.1em] text-[var(--accent)]">${item.label}</div>
+                            <div class="mt-1 text-xs leading-[1.55] text-[var(--text-body)]">${item.value}</div>
                           </div>
                         `)}
                       </div>
@@ -279,7 +279,7 @@ function ChatMessageBubble({
                     <div class="flex flex-col gap-2">
                       <button
                         type="button"
-                        class="self-start rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
+                        class="self-start rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1 text-2xs font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--white-10)] hover:text-[var(--text-body)]"
                         onClick=${() => { setRawExpandedRaw(!rawExpandedRaw) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
@@ -333,8 +333,8 @@ export function ChatTranscript({
       ${entries.length === 0
         ? html`
             <div class="flex min-h-[220px] flex-col items-center justify-center rounded-card border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
-              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
-              <div class="mt-3 max-w-[34rem] text-[13px] leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
+              <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
+              <div class="mt-3 max-w-[34rem] text-sm leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
             </div>
           `
         : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`)}
@@ -382,11 +382,11 @@ export function ChatComposer({
   return html`
     <div class="chat-composer flex flex-col gap-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">메시지</div>
-        <div class="text-[11px] text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
+        <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">메시지</div>
+        <div class="text-2xs text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
-        class="control-textarea min-h-[96px] rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-[14px] leading-[1.6]"
+        class="control-textarea min-h-[96px] rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-[1.6]"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}
@@ -401,7 +401,7 @@ export function ChatComposer({
         disabled=${disabled}
       ></textarea>
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-[11px] leading-[1.55] text-[var(--text-muted)]">
+        <div class="text-2xs leading-[1.55] text-[var(--text-muted)]">
           ${streaming
             ? '키퍼 응답 스트림이 활성 상태입니다. 멈춘 것 같으면 중지할 수 있습니다.'
             : '직접 메시지만 이 레인에 표시됩니다. 내부 키퍼 프롬프트는 숨겨집니다.'}

--- a/dashboard/src/components/common/badge.ts
+++ b/dashboard/src/components/common/badge.ts
@@ -1,5 +1,5 @@
 // CountBadge / StatusBadge — small pill indicators
-// Replaces 20+ inline badge patterns (text-[10px] px-1.5 py-px rounded)
+// Replaces 20+ inline badge patterns (text-3xs px-1.5 py-px rounded)
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -14,7 +14,7 @@ const TONE_CLASSES: Record<BadgeTone, string> = {
   accent: 'bg-[var(--accent-12)] text-[var(--accent)]',
 }
 
-const BASE = 'inline-flex items-center text-[10px] px-1.5 py-px rounded tabular-nums font-medium'
+const BASE = 'inline-flex items-center text-3xs px-1.5 py-px rounded tabular-nums font-medium'
 
 interface CountBadgeProps {
   tone?: BadgeTone

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -17,8 +17,8 @@ type ButtonSize = 'sm' | 'md' | 'lg'
 type ButtonType = 'button' | 'submit' | 'reset'
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
-  sm: 'py-1 px-2 text-[10px]',
-  md: 'py-1.5 px-2.5 text-[11px]',
+  sm: 'py-1 px-2 text-3xs',
+  md: 'py-1.5 px-2.5 text-2xs',
   lg: 'py-2 px-4 text-sm',
 }
 

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -94,17 +94,17 @@ export function ConfirmDialogOverlay() {
               <${IconComponent} size=${20} />
             </div>
             <div class="flex-1 min-w-0 pt-0.5">
-              <h2 id="confirm-dialog-title" class="text-[16px] font-semibold text-text-strong mb-1 leading-snug">${state.title}</h2>
-              <p class="text-[13px] text-text-body leading-relaxed opacity-90 whitespace-pre-wrap">${state.message}</p>
+              <h2 id="confirm-dialog-title" class="text-lg font-semibold text-text-strong mb-1 leading-snug">${state.title}</h2>
+              <p class="text-sm text-text-body leading-relaxed opacity-90 whitespace-pre-wrap">${state.message}</p>
             </div>
           </div>
           <div class="mt-6 flex items-center justify-end gap-2">
             <button type="button"
-              class="px-4 py-2 rounded text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
+              class="px-4 py-2 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-text-body hover:bg-[var(--white-8)] transition-colors cursor-pointer"
               onClick=${state.onCancel}
             >${state.cancelText}</button>
             <button type="button"
-              class="px-4 py-2 rounded text-[13px] font-medium border border-transparent transition-colors cursor-pointer ${confirmBtnClass}"
+              class="px-4 py-2 rounded text-sm font-medium border border-transparent transition-colors cursor-pointer ${confirmBtnClass}"
               onClick=${state.onConfirm}
             >${state.confirmText}</button>
           </div>

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -69,8 +69,8 @@ export function copyableWrapperClasses(variant: CopyableVariant): string {
     at the left edge and starts leading the reader's eye into the command. */
 export function copyableLabelClasses(variant: CopyableVariant): string {
   return variant === 'primary'
-    ? 'shrink-0 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--accent)]'
-    : 'shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]'
+    ? 'shrink-0 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--accent)]'
+    : 'shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]'
 }
 
 export function CopyableCode({
@@ -108,9 +108,9 @@ export function CopyableCode({
       ${label
         ? html`<span class=${labelTone}>${label}</span>`
         : null}
-      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-[11px] text-[var(--text-body)]">${command}</code>
+      <code class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-2xs text-[var(--text-body)]">${command}</code>
       ${justCopied
-        ? html`<span class="shrink-0 text-[10px] font-semibold text-[var(--ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
+        ? html`<span class="shrink-0 text-3xs font-semibold text-[var(--ok)]" data-copied-badge aria-live="polite">✓ Copied</span>`
         : null}
       <button
         type="button"

--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -283,13 +283,13 @@ export function CytoscapeFsm({ spec, height = '280px', class: className = '' }: 
   }, [spec, loading])
 
   if (error) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">${error}</div>`
+    return html`<div class="text-2xs text-[var(--text-dim)]">${error}</div>`
   }
 
   return html`
     <div class=${`relative rounded border border-[var(--white-8)] bg-[rgba(9,12,20,0.7)] overflow-hidden ${className}`.trim()}>
       ${loading ? html`
-        <div class="absolute inset-0 flex items-center justify-center text-[11px] text-[var(--text-dim)]">
+        <div class="absolute inset-0 flex items-center justify-center text-2xs text-[var(--text-dim)]">
           <${InlineSpinner} class="mr-2" />
           그래프 로딩중
         </div>

--- a/dashboard/src/components/common/dashed-notice.test.ts
+++ b/dashboard/src/components/common/dashed-notice.test.ts
@@ -21,7 +21,7 @@ describe('dashedNoticeClasses (pure)', () => {
 
   it('sm size: 10px text + rounded + tight padding (matches fsm-hub timeline panels)', () => {
     const cls = dashedNoticeClasses('sm')
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('rounded')
     expect(cls).toContain('px-4')
     expect(cls).toContain('py-2')
@@ -29,7 +29,7 @@ describe('dashedNoticeClasses (pure)', () => {
 
   it('md size: 12px text + rounded + generous padding', () => {
     const cls = dashedNoticeClasses('md')
-    expect(cls).toContain('text-[12px]')
+    expect(cls).toContain('text-xs')
     expect(cls).toContain('rounded')
     expect(cls).toContain('px-4')
     expect(cls).toContain('py-6')

--- a/dashboard/src/components/common/dashed-notice.ts
+++ b/dashboard/src/components/common/dashed-notice.ts
@@ -31,8 +31,8 @@ export function dashedNoticeClasses(
     ? 'border-[var(--white-8)]'
     : 'border-[var(--card-border)]'
   const sized = size === 'md'
-    ? 'rounded px-4 py-6 text-[12px]'
-    : 'rounded px-4 py-2 text-[10px]'
+    ? 'rounded px-4 py-6 text-xs'
+    : 'rounded px-4 py-2 text-3xs'
   const parts = [
     'border border-dashed text-center text-[var(--text-dim)]',
     sized,

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -77,12 +77,12 @@ export function DistributionBars({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
-            ${subtitle ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${subtitle}</div>` : null}
+            <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
+            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
           `
         : null}
       ${visibleItems.length === 0
-        ? html`<div class="${title ? 'mt-3 ' : ''}text-[11px] italic text-[var(--text-muted)]">${emptyLabel}</div>`
+        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--text-muted)]">${emptyLabel}</div>`
         : html`
             <div class="${title ? 'mt-3 ' : ''}flex flex-col gap-2.5">
               ${visibleItems.map(item => {
@@ -92,11 +92,11 @@ export function DistributionBars({
                   <div class="flex flex-col gap-1">
                     <div class="flex items-center justify-between gap-2">
                       <div class="min-w-0">
-                        <div class="truncate text-[12px] font-semibold text-[var(--text-strong)]">${item.label}</div>
-                        ${item.detail ? html`<div class="truncate text-[10px] text-[var(--text-muted)]">${item.detail}</div>` : null}
+                        <div class="truncate text-xs font-semibold text-[var(--text-strong)]">${item.label}</div>
+                        ${item.detail ? html`<div class="truncate text-3xs text-[var(--text-muted)]">${item.detail}</div>` : null}
                       </div>
                       <span
-                        class="shrink-0 rounded-sm border px-2 py-0.5 text-[10px] font-semibold"
+                        class="shrink-0 rounded-sm border px-2 py-0.5 text-3xs font-semibold"
                         style=${`color:${palette.text};background:${palette.chipBg};border-color:${palette.chipBorder};`}
                       >
                         ${valueFormatter(item.value)}
@@ -135,12 +135,12 @@ export function SegmentedBar({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
-            ${subtitle ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${subtitle}</div>` : null}
+            <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
+            ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
           `
         : null}
       ${total === 0
-        ? html`<div class="${title ? 'mt-3 ' : ''}text-[11px] italic text-[var(--text-muted)]">표시할 데이터가 없습니다.</div>`
+        ? html`<div class="${title ? 'mt-3 ' : ''}text-2xs italic text-[var(--text-muted)]">표시할 데이터가 없습니다.</div>`
         : html`
             <div class="${title ? 'mt-3 ' : ''}flex flex-col gap-2.5">
               <div class="flex h-3 overflow-hidden rounded-sm bg-[var(--white-5)]">
@@ -165,7 +165,7 @@ export function SegmentedBar({
                     <span
                       aria-label=${`${item.label}: ${formattedValue}`}
                       title=${`${item.label}: ${formattedValue}`}
-                      class="inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-[10px] font-medium"
+                      class="inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-3xs font-medium"
                       style=${`color:${palette.text};background:${palette.chipBg};border-color:${palette.chipBorder};`}
                     >
                       <span class="inline-block h-1.5 w-1.5 rounded-full" style=${`background:${palette.fill};`}></span>

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -45,9 +45,9 @@ export class ErrorBoundary extends Component<Props, State> {
           </div>
           <div class="flex-1 min-w-0">
             <h3 class="text-base font-semibold text-[var(--bad)] tracking-tight mb-1">${this.props.label ?? 'Component'} 렌더링 오류</h3>
-            <pre class="text-[13px] whitespace-pre-wrap opacity-80 text-[var(--text-body)] overflow-x-auto bg-[var(--black-20)] p-2 rounded">${this.state.error.message}</pre>
+            <pre class="text-sm whitespace-pre-wrap opacity-80 text-[var(--text-body)] overflow-x-auto bg-[var(--black-20)] p-2 rounded">${this.state.error.message}</pre>
             <button type="button"
-              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--text-strong)] text-[13px] hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bad)]"
+              class="mt-3 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 cursor-pointer rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--text-strong)] text-sm hover:bg-[var(--white-10)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--bad)]"
               onClick=${this.reset}
             >
               <${RefreshCcw} size=${14} />

--- a/dashboard/src/components/common/feedback-state.ts
+++ b/dashboard/src/components/common/feedback-state.ts
@@ -24,7 +24,7 @@ export function EmptyState({
   const content = children ?? message
 
   return html`
-    <div class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-[13px] text-[var(--text-muted)] ${cx ?? ''}">
+    <div class="flex flex-col items-center justify-center gap-2 text-center ${compact ? 'py-4' : 'py-8'} text-sm text-[var(--text-muted)] ${cx ?? ''}">
       ${icon ? html`<span class="text-2xl opacity-40">${icon}</span>` : null}
       ${content ? html`<span class="leading-relaxed">${content}</span>` : null}
       ${action ?? null}
@@ -40,7 +40,7 @@ interface LoadingStateProps {
 /** Loading indicator with spin animation */
 export function LoadingState({ class: cx, children }: LoadingStateProps) {
   return html`
-    <div class="loading-state flex flex-col items-center py-8 text-[13px] ${cx ?? ''}">
+    <div class="loading-state flex flex-col items-center py-8 text-sm ${cx ?? ''}">
       <${Loader2} size=${24} class="animate-spin mb-3 opacity-60 text-accent" />
       <span>${children ?? '불러오는 중...'}</span>
     </div>
@@ -54,7 +54,7 @@ interface ErrorStateProps {
 
 export function ErrorState({ message, class: cx }: ErrorStateProps) {
   return html`
-    <div class="flex items-start gap-2 rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-4 py-3 text-[13px] text-[var(--bad-light)] ${cx ?? ''}">
+    <div class="flex items-start gap-2 rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-4 py-3 text-sm text-[var(--bad-light)] ${cx ?? ''}">
       <${AlertTriangle} size=${16} class="mt-0.5 shrink-0" />
       <span>${message}</span>
     </div>

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -33,7 +33,7 @@ export function FilterChips<T extends string>({
 }: FilterChipsProps<T>) {
   const activeKey = active?.value ?? value
   const chipClass = size === 'md'
-    ? 'inline-flex min-h-9 items-center gap-1.5 rounded border px-3 py-2 text-[11px] font-medium'
+    ? 'inline-flex min-h-9 items-center gap-1.5 rounded border px-3 py-2 text-2xs font-medium'
     : 'inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[length:var(--fs-xs)]'
   const activeToneClass = tone === 'accent'
     ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -63,7 +63,7 @@ export function HeartbeatStreakChip({
   const label = formatStreakLabel(streak)
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
     title=${label}
     aria-label=${label}
     data-heartbeat-streak-chip

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -61,7 +61,7 @@ export function HeartbeatUptimeChip({
   const title = `${view.label}% uptime · ${summary.up}/${summary.up + summary.down} observed`
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-0.5 rounded-sm border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-0.5 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
     title=${title}
     aria-label=${title}
     data-heartbeat-uptime-chip

--- a/dashboard/src/components/common/id-pill.test.ts
+++ b/dashboard/src/components/common/id-pill.test.ts
@@ -10,7 +10,7 @@ describe('idPillClasses (pure)', () => {
     for (const token of [
       'inline-flex',
       'items-center',
-      'text-[10px]',
+      'text-3xs',
       'font-medium',
       'py-1',
       'px-2.5',
@@ -50,7 +50,7 @@ describe('idPillClasses (pure)', () => {
   it('shape tokens present regardless of mono flag (regression guard)', () => {
     for (const mono of [true, false]) {
       const cls = idPillClasses(mono)
-      for (const token of ['rounded', 'text-[10px]', 'px-2.5', 'py-1', 'text-accent']) {
+      for (const token of ['rounded', 'text-3xs', 'px-2.5', 'py-1', 'text-accent']) {
         expect(cls).toContain(token)
       }
     }

--- a/dashboard/src/components/common/id-pill.ts
+++ b/dashboard/src/components/common/id-pill.ts
@@ -41,7 +41,7 @@ import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
 const BASE =
-  'inline-flex items-center text-[10px] font-medium py-1 px-2.5 rounded whitespace-nowrap shadow-sm border'
+  'inline-flex items-center text-3xs font-medium py-1 px-2.5 rounded whitespace-nowrap shadow-sm border'
 const TONE_ACCENT =
   'border-accent/20 bg-[var(--accent-10)] text-accent'
 const MONO_CLASS = 'font-mono'

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -43,7 +43,7 @@ export function TextInput({
     <input
       id=${id}
       type=${type}
-      class="${INPUT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
+      class="${INPUT_BASE} px-3 py-2 text-sm ${cx ?? ''}"
       value=${value}
       placeholder=${placeholder}
       disabled=${disabled}
@@ -82,7 +82,7 @@ export function TextArea({
   return html`
     <textarea
       id=${id}
-      class="${INPUT_BASE} px-3 py-2 text-[13px] min-h-[80px] resize-y ${cx ?? ''}"
+      class="${INPUT_BASE} px-3 py-2 text-sm min-h-[80px] resize-y ${cx ?? ''}"
       placeholder=${placeholder}
       rows=${rows}
       name=${name}

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -20,7 +20,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
   if (isObject && ancestors.includes(data as object)) {
     return html`
-      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+      <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
         ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
         <span class="text-[var(--text-muted)] italic">[Circular]</span>
       </div>
@@ -42,7 +42,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
     }
 
     return html`
-      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
+      <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5 min-w-0 max-w-full">
         ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
         <div class="min-w-0 break-words">${valueNode}</div>
       </div>
@@ -56,7 +56,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
   if (isEmpty) {
     return html`
-      <div class="font-mono text-[13px] leading-relaxed flex items-start gap-1.5 py-0.5">
+      <div class="font-mono text-sm leading-relaxed flex items-start gap-1.5 py-0.5">
         ${label ? html`<span class="text-[var(--text-body)] shrink-0 font-medium whitespace-nowrap">${label}:</span>` : null}
         <span class="text-[var(--text-muted)]">${isArray ? '[]' : '{}'}</span>
       </div>
@@ -64,7 +64,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
   }
 
   return html`
-    <div class="font-mono text-[13px] leading-relaxed flex flex-col py-0.5 w-full min-w-0">
+    <div class="font-mono text-sm leading-relaxed flex flex-col py-0.5 w-full min-w-0">
       <button
         type="button"
         class="flex items-center gap-1.5 cursor-pointer hover:bg-[var(--white-4)] rounded px-1 -mx-1 select-none w-max max-w-full text-left bg-transparent border-0"
@@ -74,7 +74,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
       >
         <span aria-hidden="true" class="text-[var(--text-muted)] shrink-0 w-4 inline-flex justify-center transition-transform duration-150 ${collapsed ? '-rotate-90' : ''}">▼</span>
         ${label ? html`<span class="text-[var(--text-body)] font-medium truncate">${label}</span>` : null}
-        <span class="text-[var(--text-muted)] text-[11px] ml-1 shrink-0">
+        <span class="text-[var(--text-muted)] text-2xs ml-1 shrink-0">
           ${isArray ? `[${(data as unknown[]).length}]` : `{${entries.length}}`}
         </span>
       </button>
@@ -94,7 +94,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
   return html`
     <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded overflow-hidden flex flex-col max-h-[400px]" data-testid="json-viewer-card" data-title=${title ?? ''}>
-      ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-[11px] uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
+      ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-2xs uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
       <div class="p-3 overflow-y-auto min-h-0 w-full">
         <${JsonViewer} data=${data} />
       </div>

--- a/dashboard/src/components/common/kbd.test.ts
+++ b/dashboard/src/components/common/kbd.test.ts
@@ -11,14 +11,14 @@ describe('kbdClasses (pure)', () => {
 
   it('md variant: 10px text + 1.5 horizontal padding + body-text color', () => {
     const cls = kbdClasses('md')
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('px-1.5')
     expect(cls).toContain('text-[var(--text-body)]')
   })
 
   it('sm variant: 10px text + tight padding (px-1 py-0) + dimmed color', () => {
     const cls = kbdClasses('sm')
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('px-1')
     expect(cls).toContain('text-[var(--text-dim)]')
   })

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -29,8 +29,8 @@ const BASE = 'inline-flex items-center justify-center rounded border font-mono t
 export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
   const sized =
     size === 'sm'
-      ? 'text-[10px] px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
-      : 'text-[10px] px-1.5 py-[1px] border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
+      ? 'text-3xs px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
+      : 'text-3xs px-1.5 py-[1px] border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
   return extra === undefined || extra === ''
     ? `${BASE} ${sized}`
     : `${BASE} ${sized} ${extra}`

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -260,7 +260,7 @@ function MarkdownContent({ text, class: className }: { text: string; class?: str
 
           if (shikiPre && shikiPre.tagName === 'PRE') {
             // Apply dashboard specific classes to match existing UI
-            shikiPre.classList.add('shiki-rendered', 'rounded', 'my-3', 'text-[13px]', 'leading-relaxed')
+            shikiPre.classList.add('shiki-rendered', 'rounded', 'my-3', 'text-sm', 'leading-relaxed')
 
             pre.replaceWith(shikiPre)
           }

--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -72,7 +72,7 @@ export function NumberInput({
       type="number"
       id=${id}
       name=${name}
-      class="${INPUT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
+      class="${INPUT_BASE} px-3 py-2 text-sm ${cx ?? ''}"
       value=${value}
       placeholder=${placeholder}
       disabled=${disabled}

--- a/dashboard/src/components/common/observatory-filter-bar.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.ts
@@ -28,7 +28,7 @@ function Chip({
   onClear: () => void
 }) {
   return html`
-    <span class="inline-flex items-center gap-1.5 rounded-sm border border-card-border bg-card/50 px-2.5 py-1 text-[11px]">
+    <span class="inline-flex items-center gap-1.5 rounded-sm border border-card-border bg-card/50 px-2.5 py-1 text-2xs">
       <span class="text-text-dim font-medium">${label}:</span>
       <span class="font-mono text-text-strong">${value}</span>
       <button
@@ -57,7 +57,7 @@ export function ObservatoryFilterBar() {
       role="region"
       aria-label="활성 관찰 필터"
     >
-      <span class="text-[10px] uppercase tracking-wider text-text-dim font-semibold">필터</span>
+      <span class="text-3xs uppercase tracking-wider text-text-dim font-semibold">필터</span>
       ${keeper ? html`
         <${Chip}
           label="Keeper"
@@ -88,7 +88,7 @@ export function ObservatoryFilterBar() {
       ` : null}
       <button
         type="button"
-        class="ml-auto rounded text-[11px] font-medium text-text-muted underline decoration-dotted underline-offset-2 hover:text-text-strong transition-colors"
+        class="ml-auto rounded text-2xs font-medium text-text-muted underline decoration-dotted underline-offset-2 hover:text-text-strong transition-colors"
         onClick=${() => clearObservatoryFilters()}
       >
         모두 해제

--- a/dashboard/src/components/common/rich-composer.ts
+++ b/dashboard/src/components/common/rich-composer.ts
@@ -32,7 +32,7 @@ export function RichComposer({
             <button
               key=${tab}
               type="button"
-              class=${`rounded border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+              class=${`rounded border px-2.5 py-1 text-2xs font-medium transition-colors ${
                 mode === tab
                   ? 'border-[rgba(71,184,255,0.35)] bg-[var(--accent-12)] text-[var(--accent)]'
                   : 'border-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'
@@ -44,7 +44,7 @@ export function RichComposer({
             </button>
           `)}
         </div>
-        <div class="text-[10px] text-[var(--text-muted)]">
+        <div class="text-3xs text-[var(--text-muted)]">
           Markdown, code fence, URL, image link
         </div>
       </div>
@@ -68,12 +68,12 @@ export function RichComposer({
                 </div>
               `
             : html`
-                <div class="rounded border border-dashed border-[var(--card-border)] bg-[var(--white-3)] px-3 py-6 text-center text-[12px] text-[var(--text-muted)]">
+                <div class="rounded border border-dashed border-[var(--card-border)] bg-[var(--white-3)] px-3 py-6 text-center text-xs text-[var(--text-muted)]">
                   미리볼 내용이 아직 없습니다.
                 </div>
               `}
         ${helpText
-          ? html`<div class="mt-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${helpText}</div>`
+          ? html`<div class="mt-2 text-2xs leading-relaxed text-[var(--text-muted)]">${helpText}</div>`
           : null}
       </div>
     </div>

--- a/dashboard/src/components/common/rich-content.ts
+++ b/dashboard/src/components/common/rich-content.ts
@@ -34,15 +34,15 @@ function previewCard(preview: LinkPreview) {
           `
         : null}
       <div class="min-w-0 flex-1 px-3 py-2.5">
-        <div class="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+        <div class="flex items-center gap-2 text-2xs text-[var(--text-muted)]">
           ${faviconUrl ? html`<img src=${faviconUrl} alt="" class="h-3.5 w-3.5 rounded-sm" loading="lazy" />` : null}
           <span class="truncate">${preview.site_name || hostLabel}</span>
         </div>
-        <div class="mt-1 text-[12px] font-semibold leading-snug text-[var(--text-strong)] group-hover:text-[var(--accent)]">
+        <div class="mt-1 text-xs font-semibold leading-snug text-[var(--text-strong)] group-hover:text-[var(--accent)]">
           ${title}
         </div>
         ${description
-          ? html`<div class="mt-1 line-clamp-3 text-[11px] leading-relaxed text-[var(--text-muted)]">${description}</div>`
+          ? html`<div class="mt-1 line-clamp-3 text-2xs leading-relaxed text-[var(--text-muted)]">${description}</div>`
           : null}
       </div>
     </a>

--- a/dashboard/src/components/common/section-cap.test.ts
+++ b/dashboard/src/components/common/section-cap.test.ts
@@ -7,7 +7,7 @@ import { SectionCap, sectionCapClasses } from './section-cap'
 describe('sectionCapClasses (pure)', () => {
   it('default (muted, normal) includes base tokens + muted tone + no weight', () => {
     const cls = sectionCapClasses()
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('uppercase')
     expect(cls).toContain('tracking-wider')
     expect(cls).toContain('text-text-muted')
@@ -39,7 +39,7 @@ describe('sectionCapClasses (pure)', () => {
     for (const tone of ['muted', 'dim'] as const) {
       for (const weight of ['normal', 'semibold'] as const) {
         const cls = sectionCapClasses(tone, weight)
-        for (const token of ['text-[10px]', 'uppercase', 'tracking-wider']) {
+        for (const token of ['text-3xs', 'uppercase', 'tracking-wider']) {
           expect(cls).toContain(token)
         }
       }
@@ -87,7 +87,7 @@ describe('SectionCap component', () => {
     render(html`<${SectionCap} class="mb-1 flex items-center gap-2">tag<//>`, container)
     const el = container.querySelector('[data-section-cap]')!
     const cls = el.getAttribute('class') ?? ''
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('mb-1')
     expect(cls).toContain('flex')
   })

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -39,7 +39,7 @@ import type { ComponentChildren } from 'preact'
 type SectionCapTone = 'muted' | 'dim'
 type SectionCapWeight = 'normal' | 'semibold'
 
-const BASE = 'text-[10px] uppercase tracking-wider'
+const BASE = 'text-3xs uppercase tracking-wider'
 
 const TONE: Record<SectionCapTone, string> = {
   muted: 'text-text-muted',

--- a/dashboard/src/components/common/section-header.ts
+++ b/dashboard/src/components/common/section-header.ts
@@ -1,5 +1,5 @@
 // SectionHeader — consistent section labels across dashboard
-// Replaces 34+ inline patterns: `text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)] font-medium`
+// Replaces 34+ inline patterns: `text-3xs uppercase tracking-[0.08em] text-[var(--text-muted)] font-medium`
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -7,9 +7,9 @@ import type { ComponentChildren } from 'preact'
 type HeaderSize = 'xs' | 'sm' | 'md'
 
 const SIZE_CLASSES: Record<HeaderSize, string> = {
-  xs: 'text-[10px]',
-  sm: 'text-[11px]',
-  md: 'text-[13px]',
+  xs: 'text-3xs',
+  sm: 'text-2xs',
+  md: 'text-sm',
 }
 
 interface SectionHeaderProps {

--- a/dashboard/src/components/common/select.ts
+++ b/dashboard/src/components/common/select.ts
@@ -61,7 +61,7 @@ export function Select({
     <select
       id=${id}
       name=${name}
-      class="${SELECT_BASE} px-3 py-2 text-[13px] ${cx ?? ''}"
+      class="${SELECT_BASE} px-3 py-2 text-sm ${cx ?? ''}"
       value=${currentValue}
       disabled=${disabled}
       aria-label=${ariaLabel}

--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -27,9 +27,9 @@ const VALUE_SIZE = {
 export function StatCell({ label, value, detail, tone, size = 'md', bg = 'white-4', class: className }: StatCellProps) {
   return html`
     <div class="p-4 rounded ${BG[bg]} border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
-      <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
+      <span class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
       <strong class="text-[var(--text-strong)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
-      ${detail != null ? html`<small class="text-[var(--text-muted)] text-[10px] leading-relaxed">${detail}</small>` : null}
+      ${detail != null ? html`<small class="text-[var(--text-muted)] text-3xs leading-relaxed">${detail}</small>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/stat-row.ts
+++ b/dashboard/src/components/common/stat-row.ts
@@ -15,9 +15,9 @@ interface KpiCardProps {
 export function KpiCard({ label, value, hint, tone, class: cx }: KpiCardProps) {
   return html`
     <div class="flex flex-col gap-1 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] ${cx ?? ''}">
-      <span class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium">${label}</span>
+      <span class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium">${label}</span>
       <span class="text-[20px] font-semibold tabular-nums leading-none ${tone ?? 'text-[var(--text-strong)]'}">${value}</span>
-      ${hint ? html`<span class="text-[11px] text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
+      ${hint ? html`<span class="text-2xs text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
     </div>
   `
 }
@@ -32,7 +32,7 @@ interface StatGridProps {
 export function StatGrid({ cols = 2, class: cx, children }: StatGridProps) {
   const colClass = cols === 2 ? 'grid-cols-2' : cols === 3 ? 'grid-cols-3' : 'grid-cols-4'
   return html`
-    <div class="grid ${colClass} gap-x-4 gap-y-1 text-[11px] ${cx ?? ''}">${children}</div>
+    <div class="grid ${colClass} gap-x-4 gap-y-1 text-2xs ${cx ?? ''}">${children}</div>
   `
 }
 

--- a/dashboard/src/components/common/status-chip.test.ts
+++ b/dashboard/src/components/common/status-chip.test.ts
@@ -60,7 +60,7 @@ describe('statusChipClasses (pure)', () => {
     expect(cls).toContain('border')
     expect(cls).toContain('px-2')
     expect(cls).toContain('py-0.5')
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('uppercase')
     expect(cls).toContain('tracking-wider')
     // neutral fallback
@@ -97,7 +97,7 @@ describe('statusChipClasses (pure)', () => {
   it('base shape tokens present for every tone (regression guard, uppercase=true default)', () => {
     for (const tone of ['ok', 'warn', 'bad', 'info', 'neutral', '', 'bg-[var(--ok)]']) {
       const cls = statusChipClasses(tone)
-      for (const token of ['rounded-sm', 'text-[10px]', 'uppercase', 'tracking-wider']) {
+      for (const token of ['rounded-sm', 'text-3xs', 'uppercase', 'tracking-wider']) {
         expect(cls).toContain(token)
       }
     }
@@ -111,7 +111,7 @@ describe('statusChipClasses uppercase flag', () => {
     expect(cls).not.toContain('tracking-wider')
     // shape + tone still present
     expect(cls).toContain('rounded-sm')
-    expect(cls).toContain('text-[10px]')
+    expect(cls).toContain('text-3xs')
     expect(cls).toContain('text-[var(--text-muted)]')
   })
 
@@ -122,7 +122,7 @@ describe('statusChipClasses uppercase flag', () => {
   it('shape tokens always present regardless of uppercase flag', () => {
     for (const uppercase of [true, false]) {
       const cls = statusChipClasses('warn', undefined, uppercase)
-      for (const token of ['inline-flex', 'rounded-sm', 'border', 'px-2', 'py-0.5', 'text-[10px]']) {
+      for (const token of ['inline-flex', 'rounded-sm', 'border', 'px-2', 'py-0.5', 'text-3xs']) {
         expect(cls).toContain(token)
       }
     }

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -26,7 +26,7 @@
 // every existing usage compiling while the caller mix converges.
 //
 // P3 update — `uppercase` prop (default true) splits the shape
-// tokens (rounded-sm + border + px-2 py-0.5 + text-[10px]) from
+// tokens (rounded-sm + border + px-2 py-0.5 + text-3xs) from
 // the uppercase/tracking-wider pair. `uppercase={false}` renders
 // a plain (non-uppercase, non-tracked) neutral pill — the shape
 // used by config-resolution-panel's 4 "inline tag" call sites
@@ -50,7 +50,7 @@ type StatusChipTone =
   | ''
 
 const BASE_SHAPE =
-  'inline-flex items-center rounded-sm border px-2 py-0.5 text-[10px]'
+  'inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs'
 const UPPERCASE_CLASS = 'uppercase tracking-wider'
 
 const SEMANTIC_TONE: Record<StatusChipTone, string> = {
@@ -134,7 +134,7 @@ export function isSemanticTone(tone: string): tone is StatusChipTone {
     uppercase flag (default true). Handles the semantic/raw tone
     dichotomy so callers never have to.
 
-    Shape tokens (rounded-sm + border + px-2 py-0.5 + text-[10px])
+    Shape tokens (rounded-sm + border + px-2 py-0.5 + text-3xs)
     are always present. `uppercase + tracking-wider` is conditional
     on the `uppercase` flag — callers rendering plain tag pills
     (no all-caps) pass `uppercase={false}` to drop both together. */

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -181,11 +181,11 @@ export function ToastContainer() {
           data-toast-id=${t.id}
         >
           <span class="shrink-0 flex items-center ${ICON_COLOR[t.type]}">${ICON[t.type]()}</span>
-          <span class="flex-1 text-[13px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+          <span class="flex-1 text-sm text-[var(--text-body)] leading-[1.4]">${t.message}</span>
           ${t.action ? html`
             <button
               type="button"
-              class="shrink-0 text-[11px] px-2 py-1 rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
+              class="shrink-0 text-2xs px-2 py-1 rounded border border-[var(--card-border)] bg-[var(--white-5)] text-[var(--accent)] hover:bg-[var(--white-10)] cursor-pointer transition-colors duration-150"
               onClick=${(e: Event) => {
                 e.stopPropagation()
                 t.action!.onClick()

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -316,7 +316,7 @@ export function ConnectorConfigToggle({ connectorId }: { connectorId: string }) 
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
       aria-expanded=${entry.open}
       aria-controls=${`connector-config-${connectorId}`}
       onClick=${onClick}
@@ -342,12 +342,12 @@ function FieldWidget({ id, field, value, revealed }: {
     setEntry(id, { reveal: { ...getEntry(id).reveal, [field.name]: !revealed } })
   }
 
-  const baseInput = 'w-full rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-1 font-mono text-[11px] text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none'
+  const baseInput = 'w-full rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none'
 
   switch (field.type) {
     case 'boolean':
       return html`
-        <label class="flex items-center gap-2 text-[11px] text-[var(--text-body)]">
+        <label class="flex items-center gap-2 text-2xs text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${value === 'true'}
@@ -402,7 +402,7 @@ function FieldWidget({ id, field, value, revealed }: {
       `
     default:
       return html`
-        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-[10px] text-[var(--warn)]">
+        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs text-[var(--warn)]">
           unsupported type — refactor BotConfig?
         </div>
       `
@@ -429,12 +429,12 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.error !== null) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] p-3 text-[11px] text-[var(--bad-light)]">
+      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] p-3 text-2xs text-[var(--bad-light)]">
         <div class="font-semibold">schema 가져오기 실패</div>
-        <div class="mt-1 text-[10px] opacity-80">${entry.error}</div>
+        <div class="mt-1 text-3xs opacity-80">${entry.error}</div>
         <button
           type="button"
-          class="mt-2 cursor-pointer rounded border border-[var(--bad-20)] px-2 py-1 text-[10px] hover:bg-[var(--bad-10)]"
+          class="mt-2 cursor-pointer rounded border border-[var(--bad-20)] px-2 py-1 text-3xs hover:bg-[var(--bad-10)]"
           onClick=${() => fetchSchema(connectorId)}
         >다시 시도</button>
       </div>
@@ -443,7 +443,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
 
   if (entry.fields.length === 0) {
     return html`
-      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3 text-[11px] text-[var(--text-dim)]">
+      <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3 text-2xs text-[var(--text-dim)]">
         schema가 비어있습니다. backend가 sidecar venv를 못 찾았을 수 있어요.
       </div>
     `
@@ -454,14 +454,14 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   return html`
     <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3">
       <div class="mb-2 flex items-center justify-between">
-        <div class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
+        <div class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required
           ${entry.lastSavedAt
             ? html`
                 <span class="ml-2 text-[var(--ok)]">· 저장됨 ${new Date(entry.lastSavedAt).toLocaleTimeString()}</span>
                 <button
                   type="button"
-                  class="ml-2 cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-50"
+                  class="ml-2 cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-50"
                   disabled=${entry.restarting}
                   title="POST /sidecar/stop → 800ms → POST /sidecar/start"
                   onClick=${() => { void restartSidecar(connectorId) }}
@@ -473,7 +473,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
         </div>
         <div class="flex items-center gap-2">
           <label
-            class="flex cursor-pointer items-center gap-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
             title="저장 직후 자동으로 sidecar 재시작 (stop → 800ms → start)"
           >
             <input
@@ -512,10 +512,10 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
       <div class="space-y-2.5">
         ${entry.fields.map(field => html`
           <div class="flex flex-col gap-1">
-            <label class="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
+            <label class="flex items-center gap-1.5 text-2xs font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
               <span>${field.name}</span>
               ${field.required ? html`<span class="text-[var(--bad-light)]" aria-label="required">*</span>` : null}
-              <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
+              <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
             </label>
             <${FieldWidget}
               id=${connectorId}
@@ -524,13 +524,13 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
               revealed=${entry.reveal[field.name] === true}
             />
             ${field.description
-              ? html`<div class="text-[10px] text-[var(--text-dim)]">${field.description}</div>`
+              ? html`<div class="text-3xs text-[var(--text-dim)]">${field.description}</div>`
               : null}
             ${(() => {
               const hint = getFieldHint(field.name)
               if (hint === null) return null
               return html`
-                <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-10)]0/5 px-2 py-1 text-[10px] text-[var(--accent)]" data-field-hint=${field.name}>
+                <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-10)]0/5 px-2 py-1 text-3xs text-[var(--accent)]" data-field-hint=${field.name}>
                   <span class="mr-1" aria-hidden="true">📍</span>
                   <span>${hint.where}</span>
                   ${hint.url
@@ -551,11 +551,11 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
       </div>
 
       <div class="mt-3 border-t border-[var(--white-8)] pt-2.5">
-        <div class="mb-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
+        <div class="mb-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
           .env 블록 (현재 입력값)
         </div>
         ${envBlock === ''
-          ? html`<div class="text-[10px] text-[var(--text-dim)]">(필수 필드를 채우면 여기에 표시됩니다)</div>`
+          ? html`<div class="text-3xs text-[var(--text-dim)]">(필수 필드를 채우면 여기에 표시됩니다)</div>`
           : html`<${CopyableCode} command=${envBlock} ariaLabel=${`Copy ${connectorId} .env block`} />`}
       </div>
     </div>

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -203,7 +203,7 @@ function MatrixCellButton({ cell }: { cell: MatrixCell }) {
   return html`
     <button
       type="button"
-      class=${`flex h-full w-full cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[11px] transition-colors ${tone.bg} ${tone.text} hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-40`}
+      class=${`flex h-full w-full cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-2xs transition-colors ${tone.bg} ${tone.text} hover:brightness-125 disabled:cursor-not-allowed disabled:opacity-40`}
       onClick=${onClick}
       disabled=${disabled}
       title=${title}
@@ -229,10 +229,10 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
     <section class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
       <header class="mb-2 flex items-baseline justify-between gap-3">
         <div>
-          <h4 class="text-[12px] font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">
+          <h4 class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">
             Keeper × Connector Matrix
           </h4>
-          <p class="mt-0.5 text-[10px] text-[var(--text-dim)]">
+          <p class="mt-0.5 text-3xs text-[var(--text-dim)]">
             ${matrix.totals.knownKeepers} keeper${matrix.totals.knownKeepers === 1 ? '' : 's'}
             · ${matrix.totals.liveConnectors}/${matrix.columns.length} connector
             · ${matrix.totals.totalBindings} binding${matrix.totals.totalBindings === 1 ? '' : 's'}
@@ -241,7 +241,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
               : null}
           </p>
         </div>
-        <div class="text-[10px] text-[var(--text-dim)]">
+        <div class="text-3xs text-[var(--text-dim)]">
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--ok-10)]"></span>bound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-8)]"></span>unbound</span>
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--white-4)]"></span>n/a</span>
@@ -251,18 +251,18 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
 
       ${!hasKeepers
         ? html`
-            <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-center text-[11px] text-[var(--text-dim)]">
+            <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-4 text-center text-2xs text-[var(--text-dim)]">
               No keepers yet — add one under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart.
             </div>
           `
         : html`
             <div class="overflow-x-auto">
-              <div class="grid gap-1 text-[11px]" style=${gridCols} data-matrix-grid>
-                <div class="px-1 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
+              <div class="grid gap-1 text-2xs" style=${gridCols} data-matrix-grid>
+                <div class="px-1 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
                 ${matrix.columns.map(colId => html`
                   <button
                     type="button"
-                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-[10px] uppercase tracking-[0.12em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-3xs uppercase tracking-[0.12em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
                     onClick=${() => scrollToConnectorRow(colId)}
                     title=${`${CONNECTOR_DISPLAY_NAMES[colId] ?? colId} — 행으로 이동`}
                   >
@@ -271,7 +271,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
                   </button>
                 `)}
                 <div
-                  class="px-1 py-1 text-center text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+                  class="px-1 py-1 text-center text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
                   title="Per-keeper coverage totals (bound / unbound / n·a)"
                   data-matrix-coverage-header
                 >Coverage</div>
@@ -304,14 +304,14 @@ function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
       data-matrix-column-totals-divider
     ></div>
     <div
-      class="flex items-center gap-1 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+      class="flex items-center gap-1 px-2 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
       data-matrix-column-totals-label
     >Totals →</div>
     ${matrix.columns.map((_, idx) => html`
       <${ColumnTotalsCell} counts=${summarizeMatrixColumn(matrix, idx)} />
     `)}
     <div
-      class=${`flex items-center justify-end gap-1 px-1 py-1 text-[10px] tabular-nums ${totalBound > 0 ? 'text-[var(--ok)]' : 'text-[var(--text-dim)]'}`}
+      class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${totalBound > 0 ? 'text-[var(--ok)]' : 'text-[var(--text-dim)]'}`}
       title=${`Grand total: ${totalBound} bound cells across all keepers × connectors`}
       data-matrix-grand-total
       data-matrix-grand-total-bound=${totalBound}
@@ -335,7 +335,7 @@ function ColumnTotalsCell({ counts }: { counts: MatrixStateCounts }) {
   const title = `${bound} bound · ${unbound} unbound · ${unknown} unknown · ${counts.na} n/a`
   return html`
     <div
-      class=${`flex items-center justify-center gap-1 px-1 py-1 text-[10px] tabular-nums ${tone}`}
+      class=${`flex items-center justify-center gap-1 px-1 py-1 text-3xs tabular-nums ${tone}`}
       title=${title}
       data-matrix-column-total-bound=${bound}
       data-matrix-column-total-unknown=${unknown}
@@ -351,7 +351,7 @@ function MatrixRowRender({ row }: { row: MatrixRow }) {
   return html`
     <button
       type="button"
-      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-[12px] hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-[var(--warn)]'}`}
+      class=${`flex cursor-pointer items-center gap-2 truncate rounded px-2 py-1 text-left text-xs hover:bg-[var(--white-4)] ${row.known ? 'text-[var(--text-body)]' : 'text-[var(--warn)]'}`}
       onClick=${() => scrollToKeeper(row.keeperName)}
       title=${row.known ? row.keeperName : `${row.keeperName} — directory 밖 keeper`}
     >
@@ -382,7 +382,7 @@ function RowCoverageChip({
     'text-[var(--text-dim)]'
   return html`
     <div
-      class=${`flex items-center justify-end gap-1 px-1 py-1 text-[10px] tabular-nums ${tone}`}
+      class=${`flex items-center justify-end gap-1 px-1 py-1 text-3xs tabular-nums ${tone}`}
       title=${title}
       data-matrix-row-coverage=${keeperName}
       data-matrix-row-bound=${bound}

--- a/dashboard/src/components/connector-keyboard-shortcuts.ts
+++ b/dashboard/src/components/connector-keyboard-shortcuts.ts
@@ -87,12 +87,12 @@ export function ConnectorKeyboardShortcuts() {
   if (!cheatsheetOpen.value) return null
   return html`
     <div
-      class="fixed bottom-4 right-4 z-50 rounded border border-[var(--white-10)] bg-[var(--bg-1)] p-3 text-[11px] text-[var(--text-body)] shadow-sm"
+      class="fixed bottom-4 right-4 z-50 rounded border border-[var(--white-10)] bg-[var(--bg-1)] p-3 text-2xs text-[var(--text-body)] shadow-sm"
       data-connector-shortcut-cheatsheet
       role="dialog"
       aria-label="커넥터 단축키"
     >
-      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">Shortcuts</div>
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">Shortcuts</div>
       ${KNOWN_CONNECTOR_IDS.map((id, i) => html`
         <div class="flex items-center justify-between gap-4">
           <${Kbd}>${i + 1}<//>

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -52,14 +52,14 @@ function OnboardingCard({ connectorId }: { connectorId: KnownConnectorId }) {
         </div>
         <button
           type="button"
-          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-[10px] ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
+          class=${`rounded cursor-pointer transition-all duration-200 font-medium border border-solid border-[var(--accent-30)] bg-[var(--accent-12)] text-[var(--text-strong)] hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)] py-1 px-2 text-3xs ${starting ? 'opacity-50 pointer-events-none' : 'active:scale-[0.97]'}`}
           disabled=${starting}
           aria-busy=${starting ? 'true' : 'false'}
           data-onboarding-start=${connectorId}
           onClick=${() => { void onStart() }}
         >${onboardingStartLabel(starting)}</button>
       </div>
-      <div class="text-[11px] text-[var(--text-dim)]">
+      <div class="text-2xs text-[var(--text-dim)]">
         <strong>Start</strong>를 누르면 backend가 sidecar를 spawn합니다. 또는 명령을 복사해 새 터미널에서 직접 실행하세요.
       </div>
       <div class="mt-2 grid grid-cols-1 gap-1.5">
@@ -76,7 +76,7 @@ export function ConnectorOnboardingGrid() {
     <div>
       <div class="mb-3">
         <h3 class="text-sm font-semibold text-[var(--text-body)]">아직 연결된 sidecar가 없습니다</h3>
-        <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+        <div class="mt-1 text-2xs text-[var(--text-dim)]">
           4개의 채널 sidecar를 켤 수 있습니다. 카드의 시작 명령을 복사해 새 터미널에서 실행하거나, 아래
           <strong>Start All</strong>로 한 번에 spawn하세요. spawn 후 이 화면이 라이브 상태로 갱신됩니다.
         </div>

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -249,29 +249,29 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         aria-pressed=${selected ? 'true' : 'false'}
       >
         <span
-          class="flex h-7 w-7 shrink-0 items-center justify-center rounded text-[14px]"
+          class="flex h-7 w-7 shrink-0 items-center justify-center rounded text-base"
           style=${accent}
         >${channelIcon(id)}</span>
         <span class="min-w-0 flex-1">
           <span class="flex items-center gap-2">
-            <span class="block truncate text-[13px] font-semibold text-[var(--text-body)]">${displayName}</span>
-            <span class=${`rounded-sm border px-2 py-0.5 text-[10px] font-medium ${summary.badgeClass}`}>${summary.badge}</span>
+            <span class="block truncate text-sm font-semibold text-[var(--text-body)]">${displayName}</span>
+            <span class=${`rounded-sm border px-2 py-0.5 text-3xs font-medium ${summary.badgeClass}`}>${summary.badge}</span>
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-[1px] text-[10px] font-normal text-[var(--ok)]/80"
+                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-[1px] text-3xs font-normal text-[var(--ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
                 `
               : null}
           </span>
-          <span class="mt-1 block text-[11px] leading-5 text-[var(--text-dim)]" data-overview-summary>${summary.detail}</span>
+          <span class="mt-1 block text-2xs leading-5 text-[var(--text-dim)]" data-overview-summary>${summary.detail}</span>
           ${(() => {
             const identity = formatTileIdentityLine(connector)
             return identity !== null
               ? html`<span
-                  class="mt-1 block truncate text-[10px] text-[var(--text-dim)]"
+                  class="mt-1 block truncate text-3xs text-[var(--text-dim)]"
                   data-tile-identity=${id}
                   title=${identity}
                 >${identity}</span>`
@@ -280,7 +280,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
-      <span class=${`text-[10px] uppercase tracking-[0.14em] ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--text-dim)]'}`}>
+      <span class=${`text-3xs uppercase tracking-[0.14em] ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--text-dim)]'}`}>
         ${selected ? 'Selected' : 'View Details'}
       </span>
       <${TilePrimaryAction} id=${id} sidecarUp=${sidecarUp} />
@@ -342,7 +342,7 @@ export function tilePrimaryActionView(
 const TILE_ACTION_TONE_CLASS: Record<'start' | 'stop', string> = {
   // Emerald tokens match BulkActions "Start All" — one color vocabulary
   // across per-tile + bulk controls. The per-tile button is deliberately
-  // block-width and text-[12px] so it reads as the primary action of the
+  // block-width and text-xs so it reads as the primary action of the
   // tile, distinct from the smaller pill row above.
   start: 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)] hover:bg-[var(--ok-10)]',
   stop: 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-10)]',
@@ -362,7 +362,7 @@ function TilePrimaryAction({ id, sidecarUp }: { id: KnownConnectorId; sidecarUp:
   return html`
     <button
       type="button"
-      class=${`w-full cursor-pointer rounded border px-2 py-1.5 text-[12px] font-semibold tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${tone}`}
+      class=${`w-full cursor-pointer rounded border px-2 py-1.5 text-xs font-semibold tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${tone}`}
       disabled=${view.busy}
       aria-busy=${view.busy ? 'true' : 'false'}
       aria-label=${sidecarUp ? `${id} sidecar 정지` : `${id} sidecar 시작`}
@@ -435,7 +435,7 @@ function TileErrorNotice({ connector }: { connector: GateConnectorInfo | null })
   const glyph = TILE_NOTICE_GLYPH[notice.tone]
   return html`
     <div
-      class=${`flex min-w-0 items-center gap-1.5 rounded border px-2 py-1 text-[10px] ${tone}`}
+      class=${`flex min-w-0 items-center gap-1.5 rounded border px-2 py-1 text-3xs ${tone}`}
       role="alert"
       aria-label=${`${notice.label}: ${notice.detail}`}
       title=${notice.detail}
@@ -522,10 +522,10 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   const startBusy = bulkInflight.value.start
   const stopBusy = bulkInflight.value.stop
   return html`
-    <div class="flex items-center gap-2 text-[11px] text-[var(--text-dim)]">
+    <div class="flex items-center gap-2 text-2xs text-[var(--text-dim)]">
       <button
         type="button"
-        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-[11px] text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-[var(--ok-20)] bg-[var(--ok-10)] px-2 py-1 text-2xs text-[var(--ok)] hover:bg-[var(--ok-10)] disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${startBusy || downCount === 0}
         title=${downCount === 0 ? '모두 이미 실행 중' : `${downCount} 개 sidecar 시작`}
         onClick=${() => { void runBulk('start', c => c?.available !== true, connectors) }}
@@ -535,7 +535,7 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
       </button>
       <button
         type="button"
-        class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[11px] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:cursor-not-allowed disabled:opacity-40"
+        class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-2xs text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:cursor-not-allowed disabled:opacity-40"
         disabled=${stopBusy || upCount === 0}
         title=${upCount === 0 ? '실행 중인 sidecar 없음' : `${upCount} 개 sidecar 정지`}
         onClick=${() => { void runBulk('stop', c => c?.available === true, connectors) }}
@@ -635,7 +635,7 @@ function StatusSummaryLine({ summary, connectors }: { summary: ConnectorStripSum
   const offlineLabel = formatOfflineConnectorLabel(offlineConnectorNames(connectors))
   return html`
     <div
-      class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-[var(--text-dim)]"
+      class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-2xs text-[var(--text-dim)]"
       data-strip-summary
     >
       <${LivePulseDot}
@@ -676,13 +676,13 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
     .join(', ')
   return html`
     <div
-      class="mb-2 flex items-center gap-2 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[var(--bad-light)]"
+      class="mb-2 flex items-center gap-2 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-1.5 text-2xs font-semibold text-[var(--bad-light)]"
       data-incident-banner
       role="alert"
     >
       <span aria-hidden="true">⚠</span>
       <span>최근 5분 내 연결 끊김 — ${names}</span>
-      <span class="ml-auto text-[10px] font-normal text-[var(--bad-light)]/80">아래 Start 버튼으로 복구</span>
+      <span class="ml-auto text-3xs font-normal text-[var(--bad-light)]/80">아래 Start 버튼으로 복구</span>
     </div>
   `
 }

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -67,7 +67,7 @@ function PathRow({ label, value, hint }: { label: string; value: string; hint: s
   return html`
     <div class="flex items-center gap-2" data-paths-row=${label}>
       <span
-        class="w-[100px] shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]"
+        class="w-[100px] shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
         title=${hint}
       >${label}</span>
       <div class="min-w-0 flex-1">
@@ -87,13 +87,13 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
     >
       <button
         type="button"
-        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+        class="flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
         onClick=${() => { pathsExpanded.value = !open }}
         aria-expanded=${open}
         aria-controls="connector-paths-body"
       >
         <span>
-          <span class="mr-2 text-[10px] uppercase tracking-[0.14em]">Paths</span>
+          <span class="mr-2 text-3xs uppercase tracking-[0.14em]">Paths</span>
           <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
           <span class="ml-2 text-[var(--text-dim)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
         </span>

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -103,7 +103,7 @@ export function QuickBindForm({ connectorId, keepers }: {
       data-quick-bind=${connectorId}
     >
       <div class="min-w-0 flex-1 basis-[160px]">
-        <label class="mb-1 block text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-channel-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-channel-${connectorId}`}>
           채널 ID
         </label>
         <${TextInput}
@@ -125,12 +125,12 @@ export function QuickBindForm({ connectorId, keepers }: {
         />
       </div>
       <div class="min-w-0 basis-[140px]">
-        <label class="mb-1 block text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-keeper-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-keeper-${connectorId}`}>
           Keeper
         </label>
         <select
           id=${`qb-keeper-${connectorId}`}
-          class="w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 font-mono text-[11px] text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
+          class="w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 font-mono text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
           onChange=${(ev: Event) => {
             const target = ev.currentTarget as HTMLSelectElement
             setEntry(connectorId, { keeperName: target.value })

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -152,13 +152,13 @@ function Pill({ pill }: { pill: RailPill }) {
     >
       <span
         aria-hidden="true"
-        class=${`flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-[12px] font-bold ${inflight ? 'bg-[var(--white-10)]' : tone.dot} text-[var(--bg-0)]`}
+        class=${`flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-xs font-bold ${inflight ? 'bg-[var(--white-10)]' : tone.dot} text-[var(--bg-0)]`}
       >
         ${inflight ? '…' : tone.icon}
       </span>
       <span
         aria-hidden="true"
-        class=${`block text-[10px] uppercase tracking-[0.14em] ${tone.text}`}
+        class=${`block text-3xs uppercase tracking-[0.14em] ${tone.text}`}
       >${pill.label}</span>
     </button>
   `

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -320,7 +320,7 @@ export function HeaderMiniStat({
       data-testid=${testId}
     >
       <span class=${`text-sm font-semibold tabular-nums leading-tight ${valueTone}`}>${value}</span>
-      <span class="mt-0.5 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
+      <span class="mt-0.5 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
     </div>
   `
 }
@@ -827,14 +827,14 @@ function ConnectorLivePanel({
 
   return html`
     <div id=${`connector-card-${connectorId}`} class=${`mb-4 scroll-mt-4 rounded border border-[var(--card-border)] ${connectorCardBorderClass(directLabel)} p-4`} data-connector-card-state=${directLabel} style=${connectorAccentStyle(connectorId)}>
-      <div class="flex flex-wrap items-center gap-2 text-[12px]">
+      <div class="flex flex-wrap items-center gap-2 text-xs">
         <span class="text-base leading-none" aria-hidden="true">${headerIcon}</span>
         <span class="text-sm font-semibold text-[var(--text-body)]">${connectorName}</span>
         ${connector?.bot_user_name
           ? html`<span class="text-[var(--text-dim)]">· ${connector.bot_user_name}</span>`
           : null}
         <span class="text-[var(--text-dim)]">·</span>
-        <span class=${`inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${directTone}`}>
+        <span class=${`inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-[0.14em] ${directTone}`}>
           <span class=${`inline-block h-2 w-2 rounded-full ${dotClassForLabel(directLabel)}`}></span>
           <span>${directLabel}</span>
         </span>
@@ -850,7 +850,7 @@ function ConnectorLivePanel({
             ? html`
                 <button
                   type="button"
-                  class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
+                  class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
                   disabled=${isActionLoading}
                   aria-label=${`stop ${connectorName} sidecar`}
                   onClick=${() => { void stopSidecar(connectorId) }}
@@ -860,11 +860,11 @@ function ConnectorLivePanel({
           <${SidecarLogToggle} connectorId=${connectorId} />
           <${ConnectorConfigToggle} connectorId=${connectorId} />
           ${sidecarLogPath
-            ? html`<span class="cursor-help text-[10px] text-[var(--text-dim)]" title=${sidecarLogPath}>↗</span>`
+            ? html`<span class="cursor-help text-3xs text-[var(--text-dim)]" title=${sidecarLogPath}>↗</span>`
             : null}
           <button
             type="button"
-            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            class="cursor-pointer rounded border border-[var(--card-border)] px-1.5 text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
             aria-label="toggle header details"
             onClick=${() => { patchConnectorUiState(connectorId, { headerExpanded: !ui.headerExpanded }) }}
           >${ui.headerExpanded ? '▴' : '▾'}</button>
@@ -905,7 +905,7 @@ function ConnectorLivePanel({
 
       ${ui.headerExpanded
         ? html`
-            <div class="mt-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] p-3 text-[11px]">
+            <div class="mt-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] p-3 text-2xs">
               <div class="space-y-1.5">
                 ${livenessDots.map(dot => html`
                   <div class="flex min-w-0 flex-wrap items-center gap-2">
@@ -918,7 +918,7 @@ function ConnectorLivePanel({
                   </div>
                 `)}
               </div>
-              <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
+              <div class="mt-3 flex flex-wrap gap-3 text-3xs text-[var(--text-dim)]">
                 <span>guilds ${connector?.guild_count ?? 0}</span>
                 <span>gate ${gateHealthLabel}</span>
                 <span>source ${connector?.binding_source || 'unknown'}</span>
@@ -933,7 +933,7 @@ function ConnectorLivePanel({
         : null}
 
       ${connectorError || connector?.error
-        ? html`<div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
+        ? html`<div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
         : null}
 
       <${SidecarLogViewer} connectorId=${connectorId} />
@@ -942,11 +942,11 @@ function ConnectorLivePanel({
       ${keeperDirectoryError && keepers.length === 0
         ? html`
             <div
-              class="mt-3 rounded border border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]"
+              class="mt-3 rounded border border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]"
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
@@ -960,12 +960,12 @@ function ConnectorLivePanel({
       ${showNoKeeperEmpty
         ? html`
             <div
-              class="mt-3 rounded border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-[12px]"
+              class="mt-3 rounded border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-xs"
               data-no-keepers-empty-panel
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
@@ -974,7 +974,7 @@ function ConnectorLivePanel({
                 </span>
                 <span class="font-medium text-[var(--text-body)]">No keepers configured</span>
               </div>
-              <div class="text-[10px] text-[var(--warn)]/80">
+              <div class="text-3xs text-[var(--warn)]/80">
                 Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
               </div>
             </div>
@@ -994,13 +994,13 @@ function ConnectorLivePanel({
             // on the outer card for vertical scannability.
             return html`
               <div
-                class="mt-3 rounded border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-[12px]"
+                class="mt-3 rounded border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-xs"
                 data-sidecar-not-started-panel
               >
                 <div class="mb-1 flex items-center justify-between gap-2">
                   <div class="flex items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
@@ -1016,17 +1016,17 @@ function ConnectorLivePanel({
                       disabled=${isActionLoading}
                       onClick=${() => { void startSidecar(connectorId) }}
                     >${isActionLoading ? '...' : 'Start'}<//>
-                    <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">${connectorName}</span>
+                    <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">${connectorName}</span>
                   </div>
                 </div>
-                <div class="text-[11px] text-[var(--warn)]/80">
+                <div class="text-2xs text-[var(--warn)]/80">
                   Click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal.
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
                   <${CopyableCode} label="start" command=${cmds.start} variant="primary" />
                 </div>
                 <div class="mt-2">
-                  <div class="mb-1 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">
+                  <div class="mb-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
                     Or for diagnostics
                   </div>
                   <div class="grid grid-cols-1 gap-1.5" data-sidecar-secondary-cmds>
@@ -1052,11 +1052,11 @@ function ConnectorLivePanel({
                   aria-label="Keeper 필터"
                   data-testid=${`keeper-filter-${connectorId}`}
                   onInput=${(e: Event) => { patchConnectorUiState(connectorId, { keeperGroupQuery: (e.target as HTMLInputElement).value }) }}
-                  class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                 />
               </div>
               ${isFilteringKeepers && visibleKnownGroups.length === 0
-                ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${knownGroups.length} keepers)</div>`
+                ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${knownGroups.length} keepers)</div>`
                 : null}
               ${visibleKnownGroups.map(group => {
                 const keeper = group.keeper
@@ -1077,7 +1077,7 @@ function ConnectorLivePanel({
                       <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
                       ${keeper
                         ? html`
-                            <div class="text-[10px] text-[var(--text-dim)]">
+                            <div class="text-3xs text-[var(--text-dim)]">
                               status ${keeper.status || 'unknown'}
                               ${modelLabelForKeeper(keeper) ? ` · model ${modelLabelForKeeper(keeper)}` : ''}
                               ${runtimeLabelForKeeper(keeper) ? ` · runtime ${runtimeLabelForKeeper(keeper)}` : ''}
@@ -1087,19 +1087,19 @@ function ConnectorLivePanel({
                     </div>
 
                     ${group.bindings.length === 0
-                      ? html`<div class="mt-1 text-[11px] text-[var(--text-dim)]">(no channels)</div>`
+                      ? html`<div class="mt-1 text-2xs text-[var(--text-dim)]">(no channels)</div>`
                       : html`
                           <div class="mt-2 space-y-1">
                             ${group.bindings.map(binding => {
                               const humanized = humanizeChannel(names, binding.channel_id)
                               return html`
-                                <div class="flex items-center justify-between gap-3 text-[12px]" data-channel-id=${binding.channel_id}>
+                                <div class="flex items-center justify-between gap-3 text-xs" data-channel-id=${binding.channel_id}>
                                   <div class="min-w-0 text-[var(--text-body)]">
                                     <span class="mr-1 text-[var(--text-dim)]">·</span>
                                     ${humanized
                                       ? html`<span>${humanized}</span>`
                                       : html`<span class="text-[var(--text-dim)]" title="sidecar has not sent names yet">names pending</span>`}
-                                    <span class="ml-2 text-[10px] text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
+                                    <span class="ml-2 text-3xs text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
                                   </div>
                                   ${bindingActionsEnabled
                                     ? html`
@@ -1123,7 +1123,7 @@ function ConnectorLivePanel({
                           <div class="mt-2">
                             <button
                               type="button"
-                              class="cursor-pointer text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                              class="cursor-pointer text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)]"
                               aria-label=${`add channel to ${group.name}`}
                               onClick=${toggleExpand}
                             >${expanded ? '− close' : '+ add channel'}</button>
@@ -1138,7 +1138,7 @@ function ConnectorLivePanel({
                                     onInput=${(e: Event) => { patchConnectorUiState(connectorId, { channelDraft: (e.target as HTMLInputElement).value }) }}
                                   />
                                   ${ui.channelDraft.trim() && humanizeChannel(names, ui.channelDraft.trim())
-                                    ? html`<div class="mt-1 text-[10px] text-[var(--text-dim)]">resolves to ${humanizeChannel(names, ui.channelDraft.trim())}</div>`
+                                    ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">resolves to ${humanizeChannel(names, ui.channelDraft.trim())}</div>`
                                     : null}
                                   ${observedRooms.length > 0
                                     ? html`
@@ -1148,7 +1148,7 @@ function ConnectorLivePanel({
                                             return html`
                                               <button
                                                 type="button"
-                                                class="cursor-pointer rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-body)] hover:bg-[var(--white-8)]"
+                                                class="cursor-pointer rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] hover:bg-[var(--white-8)]"
                                                 title=${roomId}
                                                 onClick=${() => { patchConnectorUiState(connectorId, { channelDraft: roomId }) }}
                                               >${humanized
@@ -1188,20 +1188,20 @@ function ConnectorLivePanel({
                     <span class="text-[var(--warn)]">⚠</span>
                     <div class="min-w-0">
                       <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
-                      <div class="text-[10px] text-[var(--warn)]/90">binding references undefined keeper</div>
+                      <div class="text-3xs text-[var(--warn)]/90">binding references undefined keeper</div>
                     </div>
                   </div>
                   <div class="mt-2 space-y-1">
                     ${group.bindings.map(binding => {
                       const humanized = humanizeChannel(names, binding.channel_id)
                       return html`
-                        <div class="flex items-center justify-between gap-3 text-[12px]" data-channel-id=${binding.channel_id}>
+                        <div class="flex items-center justify-between gap-3 text-xs" data-channel-id=${binding.channel_id}>
                           <div class="min-w-0 text-[var(--text-body)]">
                             <span class="mr-1 text-[var(--text-dim)]">·</span>
                             ${humanized
                               ? html`<span>${humanized}</span>`
                               : html`<span class="text-[var(--text-dim)]">names pending</span>`}
-                            <span class="ml-2 text-[10px] text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
+                            <span class="ml-2 text-3xs text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
                           </div>
                           ${bindingActionsEnabled
                             ? html`
@@ -1226,7 +1226,7 @@ function ConnectorLivePanel({
 
       ${connector
         ? html`
-            <div class="mt-4 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
+            <div class="mt-4 flex flex-wrap gap-3 text-3xs text-[var(--text-dim)]">
               ${connector.status_path
                 ? html`<span title=${connector.status_path}>runtime ${truncateMiddle(connector.status_path, 50)}</span>`
                 : null}
@@ -1251,14 +1251,14 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
           <span class="text-lg">${channelIcon(ch.channel)}</span>
           <div>
             <div class="text-sm font-medium text-[var(--text-body)]">${ch.channel}</div>
-            <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-dim)]">
+            <div class="text-3xs uppercase tracking-[0.18em] text-[var(--text-dim)]">
               ${ch.last_keeper ? `keeper ${ch.last_keeper}` : 'no keeper yet'}
             </div>
           </div>
         </div>
         <div class="flex items-center gap-2">
           <div class="h-2 w-2 rounded-full" style="background: ${tone.dot}"></div>
-          <span class=${`rounded-sm px-2 py-1 text-[10px] uppercase tracking-[0.16em] ${tone.badge}`}>
+          <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${tone.badge}`}>
             ${tone.label}
           </span>
         </div>
@@ -1291,7 +1291,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
         </div>
       </div>
 
-      <div class="mt-3 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)]">
+      <div class="mt-3 grid grid-cols-2 gap-2 text-2xs text-[var(--text-dim)]">
         <div>
           avg ${(ch.avg_duration_ms / 1000).toFixed(1)}s
           <span class="text-[var(--text-dim)]"> / max ${(ch.max_duration_ms / 1000).toFixed(1)}s</span>
@@ -1312,7 +1312,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
 
       ${lastError
         ? html`
-            <div class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-[11px] text-[var(--bad-light)]">
+            <div class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-2xs text-[var(--bad-light)]">
               <div class="mb-1 uppercase tracking-[0.16em] text-[var(--bad-light)]/80">
                 ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
               </div>
@@ -1335,15 +1335,15 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
           <div class="text-xs font-medium text-[var(--text-body)]">
             ${binding.channel} · room ${truncateMiddle(binding.room_id)}
           </div>
-          <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+          <div class="text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
             ${binding.keeper ? `keeper ${binding.keeper}` : 'keeper pending'}
           </div>
         </div>
-        <span class=${`rounded-sm px-2 py-1 text-[10px] uppercase tracking-[0.16em] ${tone.badge}`}>
+        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${tone.badge}`}>
           ${tone.label}
         </span>
       </div>
-      <div class="mt-2 grid grid-cols-3 gap-2 text-[11px] text-[var(--text-dim)]">
+      <div class="mt-2 grid grid-cols-3 gap-2 text-2xs text-[var(--text-dim)]">
         <div>
           msgs <span class="font-mono text-[var(--text-body)]">${binding.message_count}</span>
         </div>
@@ -1354,12 +1354,12 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
           last <span class="font-mono text-[var(--text-body)]">${binding.last_outcome}</span>
         </div>
       </div>
-      <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+      <div class="mt-1 text-2xs text-[var(--text-dim)]">
         recent activity <span class="font-mono text-[var(--text-body)]">${timeAgo(binding.last_activity)}</span>
       </div>
       ${lastError
         ? html`
-            <div class="mt-2 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[10px] text-[var(--bad-light)]">
+            <div class="mt-2 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-3xs text-[var(--bad-light)]">
               ${binding.last_error_kind || 'error'} · ${lastError}
             </div>
           `
@@ -1377,7 +1377,7 @@ function EventRow({ event }: { event: GateEventInfo }) {
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
       <div class="flex items-start justify-between gap-3">
-        <div class="min-w-0 text-[11px] text-[var(--text-dim)]">
+        <div class="min-w-0 text-2xs text-[var(--text-dim)]">
           <div class="font-medium text-[var(--text-body)]">
             ${event.channel} · ${event.keeper || 'unassigned'} · room ${truncateMiddle(event.room_id)}
           </div>
@@ -1388,13 +1388,13 @@ function EventRow({ event }: { event: GateEventInfo }) {
               : null}
           </div>
         </div>
-        <span class=${`rounded-sm px-2 py-1 text-[10px] uppercase tracking-[0.16em] ${badgeClass}`}>
+        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${badgeClass}`}>
           ${event.outcome}
         </span>
       </div>
       ${event.error
         ? html`
-            <div class="mt-2 text-[10px] text-[var(--bad-light)]">
+            <div class="mt-2 text-3xs text-[var(--bad-light)]">
               ${event.error_kind || 'error'} · ${shortText(event.error, 96)}
             </div>
           `
@@ -1419,10 +1419,10 @@ function DisclosurePanel({
       <summary class="cursor-pointer list-none px-3 py-2.5">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">${title}</div>
-            <div class="mt-1 text-[11px] text-[var(--text-dim)]">${subtitle}</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">${title}</div>
+            <div class="mt-1 text-2xs text-[var(--text-dim)]">${subtitle}</div>
           </div>
-          <span class="text-[11px] text-[var(--text-dim)]">펴기</span>
+          <span class="text-2xs text-[var(--text-dim)]">펴기</span>
         </div>
       </summary>
       <div class="border-t border-[var(--card-border)] px-3 py-3">
@@ -1467,7 +1467,7 @@ function GateAnalyticsSection({
                 <${StatCard} label="Dedup Keys" value=${gate.dedup_table_size} />
               </div>
 
-              <div class="mb-4 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)] max-[720px]:grid-cols-1">
+              <div class="mb-4 grid grid-cols-2 gap-2 text-2xs text-[var(--text-dim)] max-[720px]:grid-cols-1">
                 <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-2">
                   duplicate suppressions
                   <span class="ml-2 font-mono text-[var(--text-body)]">${gate.total_duplicates}</span>
@@ -1480,7 +1480,7 @@ function GateAnalyticsSection({
 
               <div class="mb-4 grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
                 <div>
-                  <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
                     Observed room bindings
                   </div>
                   ${gate.bindings.length === 0
@@ -1493,7 +1493,7 @@ function GateAnalyticsSection({
                 </div>
 
                 <div>
-                  <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
                     Recent gate events
                   </div>
                   ${gate.recent_events.length === 0
@@ -1588,7 +1588,7 @@ export function ConnectorStatusPanel() {
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
           <h3 class="text-sm font-semibold text-[var(--text-body)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
-          <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+          <div class="mt-1 text-2xs text-[var(--text-dim)]">
             ${filterId
               ? `${CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? filterId} sidecar의 라이브 상태와 keeper 바인딩.`
               : '4종 채널 sidecar overview 카드에서 커넥터를 고르면 아래 상세 패널이 교체됩니다.'}
@@ -1596,7 +1596,7 @@ export function ConnectorStatusPanel() {
         </div>
         ${filterId
           ? html`
-              <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+              <div class="text-right text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
                 <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
                 <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
               </div>
@@ -1623,7 +1623,7 @@ export function ConnectorStatusPanel() {
               class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-0)]/40 p-3"
               data-testid="connector-detail-panel"
             >
-              <div class="mb-3 flex items-center justify-between gap-3 text-[11px]">
+              <div class="mb-3 flex items-center justify-between gap-3 text-2xs">
                 <div>
                   <span class="font-semibold text-[var(--text-body)]">${CONNECTOR_DISPLAY_NAMES[focusedConnectorId]}</span>
                   <span class="ml-2 text-[var(--text-dim)]">선택한 커넥터의 상세와 액션만 보여줍니다.</span>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -99,7 +99,7 @@ export function ConnectionStatus() {
 
   return html`
     <div
-      class="flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
+      class="flex items-center gap-1.5 whitespace-nowrap text-xs ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
       title=${titleAttr || undefined}
     >
       <span class="inline-block size-[8px] rounded-sm ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--bad)]'}"></span>
@@ -197,7 +197,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-3xs text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -336,7 +336,7 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
   return html`
     <div class="flex items-center gap-2 px-1" role="status" aria-label=${label} title=${titleText}>
       ${dot}
-      <span class="text-[11px] text-[var(--text-muted)] truncate">${label}</span>
+      <span class="text-2xs text-[var(--text-muted)] truncate">${label}</span>
     </div>
   `
 }
@@ -351,8 +351,8 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
-            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">내비게이션</div>
-            <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
+            <div class="text-3xs font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">내비게이션</div>
+            <div class="mt-0.5 text-sm font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
           </div>
         ` : null}
         <button type="button"
@@ -394,11 +394,11 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   class="flex items-center gap-2 w-full rounded border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[var(--white-5)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[14px]" aria-hidden="true">
+                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-3)] text-base" aria-hidden="true">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--accent)]' : ''}">${surface.label}</div>
+                    <div class="text-base font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--accent)]' : ''}">${surface.label}</div>
                   </div>
                 <//>
 
@@ -411,7 +411,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           role="listitem"
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-sm transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)] hover:text-[var(--text-body)]'}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>
@@ -577,7 +577,7 @@ function SurfaceLead() {
     <div class="mb-3 flex flex-col gap-1.5">
       ${trail.length > 0
         ? html`<nav
-            class="flex items-center gap-1 text-[11px] text-[var(--text-dim)]"
+            class="flex items-center gap-1 text-2xs text-[var(--text-dim)]"
             aria-label="페이지 경로"
             data-surface-breadcrumb
           >
@@ -612,7 +612,7 @@ function SurfaceLead() {
             />`
           : null}
       </div>
-      ${description ? html`<p class="m-0 text-[13px] leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
+      ${description ? html`<p class="m-0 text-sm leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -133,7 +133,7 @@ function statusChipClass(status: FeatureStatus): string {
 
 function StatusPill({ status }: { status: FeatureStatus }) {
   return html`
-    <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusChipClass(status)}`}>
+    <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wide ${statusChipClass(status)}`}>
       ${statusLabel(status)}
     </span>
   `
@@ -148,11 +148,11 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
             <code class="text-xs font-medium text-[var(--text-strong)]">${item.env_name}</code>
             <${StatusPill} status=${item.status} />
             ${item.is_enabled ? html`
-              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--ok)]">
+              <span class="inline-flex items-center rounded border border-[var(--ok-30)] bg-[var(--ok-12)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--ok)]">
                 ON
               </span>
             ` : html`
-              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--text-muted)]">
+              <span class="inline-flex items-center rounded border border-[var(--white-12)] bg-[var(--white-4)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--text-muted)]">
                 OFF
               </span>
             `}
@@ -222,7 +222,7 @@ export function FeatureHealth() {
                     </div>
                     <button
                       type="button"
-                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                      class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
                       onClick=${() => { void loadFeatureHealth() }}
                     >새로고침</button>
                   </div>

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -63,8 +63,8 @@ export function FleetHealthPanel() {
   return html`
     <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-1">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">운영 신호 묶음</div>
-          <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">운영 신호 묶음</div>
+          <p class="m-0 text-xs leading-[1.55] text-[var(--text-muted)]">
             이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.
           </p>
         </div>

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -125,9 +125,9 @@ function SummaryCard({
 
   return html`
     <div class="rounded border ${toneClass} p-3">
-      <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">${title}</div>
+      <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">${title}</div>
       <div class="mt-1 text-xl font-semibold text-[var(--text)]">${value}</div>
-      <div class="mt-1 text-[11px] leading-relaxed text-[var(--text-dim)]">${detail}</div>
+      <div class="mt-1 text-2xs leading-relaxed text-[var(--text-dim)]">${detail}</div>
     </div>
   `
 }
@@ -135,7 +135,7 @@ function SummaryCard({
 function WarningBanner({ warnings }: { warnings: string[] }) {
   if (warnings.length === 0) return null
   return html`
-    <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">
+    <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">
       <div class="font-medium text-[var(--warn)]">Partial telemetry</div>
       <div class="mt-1 flex flex-col gap-1">
         ${warnings.map(warning => html`<div>${warning}</div>`)}
@@ -157,7 +157,7 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
 
   if (watchlist.length === 0) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-[11px] text-[var(--text-dim)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
         No keepers are near context pressure or stale activity thresholds.
       </div>
     `
@@ -166,7 +166,7 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)]">
       ${watchlist.map(row => html`
-        <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2 text-[11px] last:border-b-0">
+        <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2 text-2xs last:border-b-0">
           <div class="min-w-0">
             <div class="font-mono text-[var(--text)]">${row.name}</div>
             <div class="text-[var(--text-dim)]">
@@ -200,7 +200,7 @@ function TrendCell({ name, metric, value, valueClass }: {
     <td class="py-1.5 text-right">
       <div class="flex items-center justify-end gap-1">
         <span class="font-mono ${valueClass}">${value}</span>
-        ${arrow ? html`<span class="text-[10px] ${colorClass}">${arrow}</span>` : null}
+        ${arrow ? html`<span class="text-3xs ${colorClass}">${arrow}</span>` : null}
       </div>
       ${trend && trend.values.length >= 2
         ? html`<div class="mt-0.5 flex justify-end"><${Sparkline} values=${trend.values} width=${48} height=${14} color=${sColor} /></div>`
@@ -211,12 +211,12 @@ function TrendCell({ name, metric, value, valueClass }: {
 
 function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (name: string) => void }) {
   if (rows.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">Keeper 데이터 없음.</div>`
+    return html`<div class="text-2xs text-[var(--text-dim)]">Keeper 데이터 없음.</div>`
   }
 
   return html`
     <div class="overflow-x-auto">
-      <table class="w-full text-[11px]">
+      <table class="w-full text-2xs">
         <thead>
           <tr class="border-b border-[var(--card-border)] text-[var(--text-dim)]">
             <th class="py-1 text-left font-normal">Keeper</th>
@@ -241,18 +241,18 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
                 ${row.runtime_blocker_summary
                   ? html`
-                    <div class="max-w-[240px] truncate text-[10px] text-[var(--warn)]" title=${row.runtime_blocker_summary}>
+                    <div class="max-w-[240px] truncate text-3xs text-[var(--warn)]" title=${row.runtime_blocker_summary}>
                       ${row.runtime_blocker_summary}
                     </div>
                   `
                   : null}
-                <div class="max-w-[240px] truncate text-[10px] text-[var(--text-dim)]" title=${toolInfo.title}>
+                <div class="max-w-[240px] truncate text-3xs text-[var(--text-dim)]" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
               <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</td>
-              <td class="py-1.5 text-right text-[10px] ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
+              <td class="py-1.5 text-right text-3xs ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
                 ${row.tool_audit_at ? formatTimeAgo(row.tool_audit_at) : '-'}
               </td>
               <${TrendCell}
@@ -275,13 +275,13 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 value=${formatLatency(row.last_latency_ms)}
                 valueClass="text-[var(--text-dim)]"
               />
-              <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
+              <td class="py-1.5 text-right text-3xs text-[var(--text-dim)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
+                  ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--bad-light)]" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
-                    : html`<span class="text-[10px] text-[var(--text-dim)]">\u2014</span>`}
+                    ? html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold text-[var(--warn)]" title="TOML override 적용됨">OVR</span>`
+                    : html`<span class="text-3xs text-[var(--text-dim)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button
@@ -303,7 +303,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
 
 function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] }) {
   if (sources.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">Telemetry store summary is unavailable.</div>`
+    return html`<div class="text-2xs text-[var(--text-dim)]">Telemetry store summary is unavailable.</div>`
   }
 
   const sorted = [...sources].sort((a, b) => b.entry_count - a.entry_count)
@@ -312,12 +312,12 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
       ${sorted.map(source => html`
         <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-[11px] font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
-            <div class="font-mono text-[11px] ${sourceCountClass(source)}">
+            <div class="text-2xs font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
+            <div class="font-mono text-2xs ${sourceCountClass(source)}">
               ${source.entry_count.toLocaleString()}
             </div>
           </div>
-          <div class="mt-1 text-[10px] text-[var(--text-dim)]">${sourceDetail(source)}</div>
+          <div class="mt-1 text-3xs text-[var(--text-dim)]">${sourceDetail(source)}</div>
         </div>
       `)}
     </div>
@@ -326,7 +326,7 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
 
 function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityResponse }) {
   if (toolQuality.failure_categories.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">최근 실패 카테고리 없음.</div>`
+    return html`<div class="text-2xs text-[var(--text-dim)]">최근 실패 카테고리 없음.</div>`
   }
 
   const top = toolQuality.failure_categories.slice(0, 8)
@@ -335,7 +335,7 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
   return html`
     <div class="flex flex-col gap-1.5">
       ${top.map(category => html`
-        <div class="flex items-center gap-2 text-[11px]">
+        <div class="flex items-center gap-2 text-2xs">
           <div class="flex min-w-0 flex-1 items-center gap-1.5">
             <div
               class="h-1.5 rounded-sm bg-[var(--bad-10)]"
@@ -466,7 +466,7 @@ export function FleetTelemetryPanel() {
   }
 
   if (value.error) {
-    return html`<div class="p-4 text-[11px] text-[var(--bad-light)]">${value.error}</div>`
+    return html`<div class="p-4 text-2xs text-[var(--bad-light)]">${value.error}</div>`
   }
 
   const handleReset = async (name: string) => {
@@ -498,7 +498,7 @@ export function FleetTelemetryPanel() {
       <div class="flex items-start justify-between gap-3">
         <div class="flex items-center gap-3">
           <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
-          <div class="flex items-center gap-2 text-[10px]">
+          <div class="flex items-center gap-2 text-3xs">
             ${activeCount > 0 ? html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-[var(--ok)]">${activeCount} 가동</span>` : null}
             ${attentionCount > 0 ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[var(--warn)]">${attentionCount} 주의</span>` : null}
             ${offlineCount > 0 ? html`<span class="rounded-sm bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
@@ -506,15 +506,15 @@ export function FleetTelemetryPanel() {
           </div>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-[10px] text-[var(--text-dim)]">
+          <span class="text-3xs text-[var(--text-dim)]">
             ${value.updated_at ? `${formatTimeAgo(value.updated_at)} 갱신` : ''}
           </span>
           <button
-            class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
+            class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-3xs text-[var(--text-dim)] hover:text-[var(--text)]"
             onClick=${() => { void loadFleetTelemetry() }}
             aria-label="Keeper 텔레메트리 새로고침"
           >새로고침</button>
-          <span class="text-[10px] text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+          <span class="text-3xs text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         </div>
       </div>
 
@@ -552,34 +552,34 @@ export function FleetTelemetryPanel() {
       </div>
 
       <div>
-        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Pressure Watchlist</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Pressure Watchlist</div>
         <${PressureWatchlist} rows=${value.rows} />
       </div>
 
       <div>
         <div class="mb-1 flex items-center justify-between gap-2">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
           <input
             type="search"
             value=${query.value}
             placeholder="name / model / blocker 필터"
             aria-label="Keeper 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
         ${isFiltering && visibleRows.length === 0 && value.rows.length > 0
-          ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
+          ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
           : html`<${FleetComparisonTable} rows=${visibleRows} onReset=${handleReset} />`}
       </div>
 
       <div>
-        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Telemetry Sources</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Telemetry Sources</div>
         <${TelemetrySourcesPanel} sources=${value.telemetry_sources} />
       </div>
 
       <div>
-        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Failure Categories</div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Failure Categories</div>
         <${FailureCategoryPanel} toolQuality=${value.tool_quality} />
       </div>
     </div>

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -33,7 +33,7 @@ export function FlowControlPanel() {
   return html`
     <${SurfaceCard} variant="compact" class="mb-4">
       <div class="flex items-center gap-3 mb-3">
-        <h3 class="text-[13px] text-[var(--text-strong)] font-medium">흐름 제어</h3>
+        <h3 class="text-sm text-[var(--text-strong)] font-medium">흐름 제어</h3>
         <${CountBadge} tone=${stateTone(state)}>${stateLabel(state)}<//>
       </div>
       <div class="flex flex-wrap gap-2">
@@ -47,7 +47,7 @@ export function FlowControlPanel() {
     ${'' /* ── Maintenance ── */}
     <${SurfaceCard} variant="compact">
       <details>
-        <summary class="cursor-pointer text-[13px] text-[var(--text-strong)] font-medium select-none py-1">유지보수</summary>
+        <summary class="cursor-pointer text-sm text-[var(--text-strong)] font-medium select-none py-1">유지보수</summary>
         <div class="mt-3 flex flex-wrap gap-2">
           <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value}
             onClick=${async () => {
@@ -63,7 +63,7 @@ export function FlowControlPanel() {
             ${maintenanceLoading.value ? '...' : '좀비 정리'}<//>
         </div>
         ${maintenanceResult.value ? html`
-          <pre class="mt-3 p-3 rounded border border-card-border/50 bg-card/30 text-[11px] text-text-body font-mono max-h-[160px] overflow-auto custom-scrollbar whitespace-pre-wrap">${maintenanceResult.value}</pre>
+          <pre class="mt-3 p-3 rounded border border-card-border/50 bg-card/30 text-2xs text-text-body font-mono max-h-[160px] overflow-auto custom-scrollbar whitespace-pre-wrap">${maintenanceResult.value}</pre>
         ` : null}
       </details>
     <//>

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -35,11 +35,11 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
   const m = snapshot.measurement
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
+      <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
         Measurement
       </div>
       ${m.captured && m.auto_rules ? html`
-        <div class="flex flex-col gap-1.5 text-[11px] text-[var(--text-body)]">
+        <div class="flex flex-col gap-1.5 text-2xs text-[var(--text-body)]">
           <div class="flex flex-wrap gap-1.5 font-mono">
             <${Flag} label="reflect" on=${m.auto_rules.reflect} />
             <${Flag} label="plan" on=${m.auto_rules.plan} />
@@ -49,16 +49,16 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
           <div class="flex items-center gap-2 font-mono">
             <${Flag} label="guardrail" on=${m.auto_rules.guardrail_stop} tone="warn" />
             <span
-              class="text-[10px] text-[var(--text-dim)] cursor-help"
+              class="text-3xs text-[var(--text-dim)] cursor-help"
               title="Goal drift: 0 = keeper is on-target; higher = keeper output is diverging from its declared goal. Values above ~0.5 typically trigger the guardrail."
             >drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
           </div>
           ${m.auto_rules.guardrail_reason ? html`
-            <div class="text-[10px] text-[var(--amber-bright)] mt-0.5">사유: ${m.auto_rules.guardrail_reason}</div>
+            <div class="text-3xs text-[var(--amber-bright)] mt-0.5">사유: ${m.auto_rules.guardrail_reason}</div>
           ` : null}
         </div>
       ` : html`
-        <div class="text-[10px] text-[var(--text-dim)]">키퍼가 첫 턴을 완료하면 auto-rules가 여기 표시됩니다</div>
+        <div class="text-3xs text-[var(--text-dim)]">키퍼가 첫 턴을 완료하면 auto-rules가 여기 표시됩니다</div>
       `}
     </div>
   `
@@ -78,7 +78,7 @@ function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: '
       : 'text-[var(--emerald)] border-[var(--emerald-30)] bg-[var(--emerald-8)]'
   return html`
     <span
-      class=${`rounded-sm border px-2 py-0.5 text-[10px] cursor-help ${on ? onCls : offCls}`}
+      class=${`rounded-sm border px-2 py-0.5 text-3xs cursor-help ${on ? onCls : offCls}`}
       title=${flagTooltip(label, on)}
     >
       ${label}
@@ -119,11 +119,11 @@ export function InvariantsPanel({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Safety
         </div>
         <span
-          class=${`rounded-sm border px-2 py-0.5 text-[10px] font-mono tabular-nums ${
+          class=${`rounded-sm border px-2 py-0.5 text-3xs font-mono tabular-nums ${
             allOk
               ? 'text-[var(--emerald)] border-[var(--emerald-30)] bg-[var(--emerald-8)]'
               : 'text-[var(--bad)] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
@@ -144,7 +144,7 @@ export function InvariantsPanel({
             : ''
           const tooltip = `${entry.label} — ${entry.ok ? 'holds' : 'BROKEN'}\n${desc}${rate ? `\n누적: ${rate}` : ''}`
           return html`
-            <li class="flex gap-2 text-[10px] cursor-help" title=${tooltip}>
+            <li class="flex gap-2 text-3xs cursor-help" title=${tooltip}>
               <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[var(--emerald)]' : 'bg-[var(--bad)]'}`}></span>
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-1.5">
@@ -152,12 +152,12 @@ export function InvariantsPanel({
                     ${entry.label}
                   </span>
                   ${vCount > 0 ? html`
-                    <span class="ml-auto text-[8px] font-mono tabular-nums text-[var(--bad-light)]">
+                    <span class="ml-auto text-4xs font-mono tabular-nums text-[var(--bad-light)]">
                       ${vCount}/${sampleCount}
                     </span>
                   ` : null}
                 </div>
-                <div class="text-[8px] leading-relaxed text-[var(--text-dim)]">
+                <div class="text-4xs leading-relaxed text-[var(--text-dim)]">
                   ${entry.detail}
                 </div>
               </div>

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -93,29 +93,29 @@ export function OperationalMeaningPanel({
     >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>
           <div class="mt-1 text-[18px] font-semibold text-[var(--text-strong)]">${insight.headline}</div>
-          <div class="mt-1 text-[11px] text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
+          <div class="mt-1 text-2xs text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
         </div>
-        <span class=${`rounded-sm border px-2.5 py-0.5 text-[10px] font-mono ${INSIGHT_BADGE_CLS[insight.tone]}`}>
+        <span class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono ${INSIGHT_BADGE_CLS[insight.tone]}`}>
           ${insight.tone}
         </span>
       </div>
 
-      <div class="mt-2 text-[10px] text-[var(--text-body)]">
+      <div class="mt-2 text-3xs text-[var(--text-body)]">
         <span class="font-semibold text-[var(--text-muted)]">Next:</span> ${insight.nextStep}
       </div>
 
       <div class="mt-2 flex flex-wrap gap-1.5">
         ${insight.evidence.map(item => html`
-          <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-[10px] font-mono text-[var(--text-dim)]">
+          <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs font-mono text-[var(--text-dim)]">
             ${item}
           </span>
         `)}
       </div>
 
       <div class="mt-4 flex items-center justify-between gap-2">
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           관찰 레인
         </div>
         <input
@@ -124,26 +124,26 @@ export function OperationalMeaningPanel({
           placeholder="field / label / state / meaning 필터"
           aria-label="관찰 레인 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
 
       ${isFiltering && visibleLanes.length === 0 && lanes.length > 0
-        ? html`<div class="mt-2 py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${lanes.length} lanes)</div>`
+        ? html`<div class="mt-2 py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${lanes.length} lanes)</div>`
         : html`
           <div class="mt-2 grid gap-2 md:grid-cols-2 xl:grid-cols-5">
             ${visibleLanes.map(lane => html`
               <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
                 <div class="flex items-center justify-between gap-2">
-                  <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
-                  <span class=${`rounded-sm border px-1.5 py-0.5 text-[8px] font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
+                  <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
+                  <span class=${`rounded-sm border px-1.5 py-0.5 text-4xs font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
                     ${fmtDuration(lane.observedForSec)}
                   </span>
                 </div>
-                <div class="mt-1 font-mono text-[13px] font-semibold text-[var(--text-strong)]">${lane.value}</div>
-                <div class="mt-0.5 text-[10px] text-[var(--text-dim)]">${lane.label}</div>
-                <div class="mt-1.5 text-[10px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
-                <div class="mt-1 text-[8px] font-mono text-[var(--text-dim)]">
+                <div class="mt-1 font-mono text-sm font-semibold text-[var(--text-strong)]">${lane.value}</div>
+                <div class="mt-0.5 text-3xs text-[var(--text-dim)]">${lane.label}</div>
+                <div class="mt-1.5 text-3xs leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
+                <div class="mt-1 text-4xs font-mono text-[var(--text-dim)]">
                   ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
                 </div>
               </div>
@@ -196,7 +196,7 @@ function PhaseSparkline({
 
   return html`
     <div class="mt-2 flex items-center gap-2">
-      <span class="text-[8px] text-[var(--text-dim)]">phase</span>
+      <span class="text-4xs text-[var(--text-dim)]">phase</span>
       <svg
         width=${W} height=${H}
         viewBox=${`0 0 ${W} ${H}`}
@@ -292,18 +292,18 @@ export function HeroPhase({
     >
       <div class="flex items-baseline justify-between">
         <div>
-          <div class="text-[10px] font-semibold tracking-[0.06em] text-[var(--text-muted)]" id="ksm-label">Keeper 생명주기 <span class="font-mono text-[8px] text-[var(--text-dim)]">KSM</span></div>
+          <div class="text-3xs font-semibold tracking-[0.06em] text-[var(--text-muted)]" id="ksm-label">Keeper 생명주기 <span class="font-mono text-4xs text-[var(--text-dim)]">KSM</span></div>
           <div class=${`mt-1 font-mono text-[32px] font-bold tracking-tight ${color}`} aria-labelledby="ksm-label">
             ${displayState(snapshot.phase)}
           </div>
-          <div class="mt-0.5 text-[10px] font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
+          <div class="mt-0.5 text-3xs font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
           ${heldFor ? html`
-            <div class="mt-1 text-[10px] font-mono text-[var(--text-dim)]" aria-hidden="true">
+            <div class="mt-1 text-3xs font-mono text-[var(--text-dim)]" aria-hidden="true">
               유지 <span class="text-[var(--text-body)]">${heldFor}</span>
             </div>
           ` : null}
         </div>
-        ${flash ? html`<span class="text-[10px] text-[var(--accent)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
+        ${flash ? html`<span class="text-3xs text-[var(--accent)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
       </div>
       <${PhaseSparkline} observations=${observations} now=${now} />
     </div>
@@ -378,17 +378,17 @@ export function PipelineStep({
         <div class="flex items-center justify-between gap-1.5">
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[var(--indigo)] ${activePulse} shrink-0"></span>` : null}
-            <span class="text-[10px] font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
+            <span class="text-3xs font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
             ${limited ? html`<span class="text-[7px] font-mono text-[var(--text-dim)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
           </div>
           ${heldFor ? html`
-            <span class=${`text-[10px] font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
+            <span class=${`text-3xs font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
           ` : null}
         </div>
-        <div class=${`mt-0.5 font-mono text-[13px] font-semibold ${isActive ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'} ${flash ? 'animate-pulse' : ''}`}>
+        <div class=${`mt-0.5 font-mono text-sm font-semibold ${isActive ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'} ${flash ? 'animate-pulse' : ''}`}>
           ${displayState(value)}
         </div>
-        <div class="text-[8px] font-mono text-[var(--text-dim)] mt-0.5">${shortLabel} · ${value}</div>
+        <div class="text-4xs font-mono text-[var(--text-dim)] mt-0.5">${shortLabel} · ${value}</div>
       </div>
       ${!isLast ? html`<div class=${`hidden md:block w-5 shrink-0 ${connectorCls}`}></div>` : null}
     </div>
@@ -406,7 +406,7 @@ export function TurnPipelineStrip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-2 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         턴 파이프라인
       </div>
       <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -163,7 +163,7 @@ export function SwimlaneTimeline({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
       <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           상태 타임라인
         </div>
         <div class="flex items-center gap-1 flex-wrap">
@@ -172,7 +172,7 @@ export function SwimlaneTimeline({
             const isBusiest = busiestLane === lane.short && count > 0
             return html`
               <span
-                class=${`rounded-sm border px-1.5 py-0.5 text-[10px] font-mono tabular-nums ${
+                class=${`rounded-sm border px-1.5 py-0.5 text-3xs font-mono tabular-nums ${
                   count === 0
                     ? 'text-[var(--text-dim)] border-[var(--white-8)]'
                     : isBusiest
@@ -184,7 +184,7 @@ export function SwimlaneTimeline({
             `
           })}
         </div>
-        <div class="text-[10px] font-mono text-[var(--text-dim)]">
+        <div class="text-3xs font-mono text-[var(--text-dim)]">
           <span>${fmtAbs(spanStart)}</span>
           <span class="mx-1 text-[var(--text-muted)]">→</span>
           <span>${fmtAbs(spanEnd)}</span>
@@ -197,7 +197,7 @@ export function SwimlaneTimeline({
           const segments = deriveSwimlaneSegments(observations, lane.key, spanEnd)
           return html`
             <div class="flex items-center gap-2">
-              <div class="w-[44px] shrink-0 text-[10px] font-mono font-semibold text-[var(--text-muted)]">
+              <div class="w-[44px] shrink-0 text-3xs font-mono font-semibold text-[var(--text-muted)]">
                 ${lane.short}
               </div>
               <div class="flex h-4 flex-1 overflow-hidden rounded border border-[var(--white-8)]" role="group" aria-label=${`${lane.label} swimlane with ${segments.length} segments`}>
@@ -247,7 +247,7 @@ export function SwimlaneTimeline({
                   style=${`left: ${leftPct.toFixed(2)}%; transform: translateX(-50%)`}
                 >
                   <div class="h-1 w-px bg-[var(--white-10)]"></div>
-                  <div class="text-[8px] font-mono leading-none mt-0.5">${tick.label}</div>
+                  <div class="text-4xs font-mono leading-none mt-0.5">${tick.label}</div>
                 </div>
               `
             })}
@@ -256,7 +256,7 @@ export function SwimlaneTimeline({
       ` : null}
       ${observations.length > 1 ? html`
         <div class="mt-0.5 flex items-center gap-2" aria-hidden="true">
-          <div class="w-[44px] shrink-0 text-[8px] text-[var(--text-dim)] text-right">obs</div>
+          <div class="w-[44px] shrink-0 text-4xs text-[var(--text-dim)] text-right">obs</div>
           <div class="relative flex-1 h-2.5">
             ${observations.map((obs, obsIndex) => {
               const leftPct = ((obs.ts - spanStart) / spanWidth) * 100
@@ -290,7 +290,7 @@ export function SwimlaneTimeline({
           </div>
         </div>
       ` : null}
-      <div class="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--indigo-45)]"></span>active</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--amber-bright-45)]"></span>compact</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[var(--purple-50)]"></span>handoff</span>
@@ -386,7 +386,7 @@ export function TransitionTrail({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 flex items-center justify-between gap-2">
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Transition History (${isFiltering ? `${visibleHistory.length}/${history.length}` : history.length})
         </div>
         <input
@@ -395,11 +395,11 @@ export function TransitionTrail({
           placeholder="field / from / to 필터"
           aria-label="전이 이력 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[120px] max-w-[200px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[120px] max-w-[200px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleHistory.length === 0
-        ? html`<div class="py-3 text-center text-[10px] text-[var(--text-dim)]">필터 결과 없음 (${history.length} items)</div>`
+        ? html`<div class="py-3 text-center text-3xs text-[var(--text-dim)]">필터 결과 없음 (${history.length} items)</div>`
         : html`
       <div ref=${scrollRef} class="flex flex-col gap-0.5 max-h-[120px] overflow-y-auto">
         ${visibleHistory.map((entry, trailIndex) => {
@@ -418,14 +418,14 @@ export function TransitionTrail({
             <div
               data-trail-index=${trailIndex}
               title=${tooltip}
-              class=${`flex items-center gap-2 text-[10px] font-mono leading-tight transition-opacity duration-150 cursor-help ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
+              class=${`flex items-center gap-2 text-3xs font-mono leading-tight transition-opacity duration-150 cursor-help ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
             >
               <span class="w-[52px] shrink-0 text-right text-[var(--text-dim)]">${ago} ago</span>
               <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
               <span class="text-[var(--text-dim)]">${entry.from}</span>
               <span class="text-[var(--text-muted)]">→</span>
               <span class="text-[var(--text-strong)]">${entry.to}</span>
-              ${reason ? html`<span class="ml-1 text-[8px] text-[var(--text-dim)] opacity-50">ⓘ</span>` : null}
+              ${reason ? html`<span class="ml-1 text-4xs text-[var(--text-dim)] opacity-50">ⓘ</span>` : null}
             </div>
           `
         })}
@@ -458,7 +458,7 @@ export function TopTransitionsPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         Top Transitions (${transitions.length})
       </div>
       <div class="flex flex-col gap-0.5">
@@ -473,7 +473,7 @@ export function TopTransitionsPanel({
             : ''
           return html`
             <div
-              class=${`flex items-center gap-2 text-[10px] font-mono leading-tight transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
+              class=${`flex items-center gap-2 text-3xs font-mono leading-tight transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
               title=${`${entry.field}: ${entry.from} → ${entry.to} (관측 ${entry.count}회)`}
             >
               <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
@@ -522,7 +522,7 @@ export function DwellHistogramPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
         State Dwell Time
       </div>
       <div class="flex flex-col gap-2">
@@ -534,8 +534,8 @@ export function DwellHistogramPanel({
           return html`
             <div class=${`transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''}`}>
               <div class="flex items-center gap-1.5 mb-0.5">
-                <span class=${`text-[10px] font-semibold ${color}`}>${lane.field}</span>
-                <span class="text-[10px] text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
+                <span class=${`text-3xs font-semibold ${color}`}>${lane.field}</span>
+                <span class="text-3xs text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
               </div>
               <div class="flex flex-col gap-px">
                 ${lane.entries.map((entry) => {
@@ -547,7 +547,7 @@ export function DwellHistogramPanel({
                     : ''
                   return html`
                     <div
-                      class=${`flex items-center gap-1.5 text-[10px] font-mono leading-tight ${rowCls}`}
+                      class=${`flex items-center gap-1.5 text-3xs font-mono leading-tight ${rowCls}`}
                       title=${`${displayState(entry.value)}: ${fmtDuration(entry.seconds)} (${entry.pct.toFixed(1)}%)`}
                     >
                       <span class="w-[60px] shrink-0 text-[var(--text-body)] truncate">${displayState(entry.value)}</span>
@@ -557,7 +557,7 @@ export function DwellHistogramPanel({
                           style=${`width: ${Math.max(2, entry.pct)}%`}
                         ></span>
                       </span>
-                      <span class="w-[36px] shrink-0 text-right text-[10px] text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
+                      <span class="w-[36px] shrink-0 text-right text-3xs text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
                     </div>
                   `
                 })}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -531,7 +531,7 @@ export function FsmHub(props: FsmHubProps = {}) {
           open=${graphOpen}
           onToggle=${(e: Event) => setGraphOpen((e.target as HTMLDetailsElement).open)}
         >
-          <summary class="cursor-pointer select-none px-4 py-2.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] hover:text-[var(--text-body)]">
+          <summary class="cursor-pointer select-none px-4 py-2.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] hover:text-[var(--text-body)]">
             Compound Graph — 5 sub-FSMs (Cytoscape)
           </summary>
           <div class="px-3 pb-3">
@@ -575,18 +575,18 @@ function ShortcutsOverlay({
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
             키보드 단축키
           </div>
           <button
-            class="text-[10px] text-[var(--text-dim)] hover:text-[var(--text-body)] cursor-pointer"
+            class="text-3xs text-[var(--text-dim)] hover:text-[var(--text-body)] cursor-pointer"
             onClick=${onClose}
             aria-label="닫기"
           >Esc</button>
         </div>
         <div class="flex flex-col gap-1.5">
           ${rows.map(r => html`
-            <div class="flex items-center gap-3 text-[11px]">
+            <div class="flex items-center gap-3 text-2xs">
               <kbd class="font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-body)] min-w-[64px] text-center">
                 ${r.keys}
               </kbd>
@@ -648,8 +648,8 @@ function StatusBar({
     && (now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)) > 300
   const liveBadge = snapshot
     ? snapshot.is_live
-      ? html`<span class="px-2 py-0.5 rounded-sm border text-[10px] font-mono text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
-      : html`<span class="px-2 py-0.5 rounded-sm border text-[10px] font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-[var(--warn-20)]' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-[8px] opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
+      ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
+      : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-[var(--warn-20)]' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-4xs opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
 
   const staleSec = lastFetchAt > 0 ? Math.max(0, now - lastFetchAt) : 0
@@ -671,10 +671,10 @@ function StatusBar({
     <div class=${`sticky top-0 z-20 rounded border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-sm shadow-[0_4px_12px_rgba(0,0,0,0.25)] ${containerPadding}`}>
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <div class="flex items-center gap-3">
-          <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>
+          <span class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>
           <${Kbd} size="sm" class="hidden md:inline-flex" title="단축키 목록 (?)">?<//>
           <button
-            class=${`text-[10px] font-mono px-1.5 py-0.5 rounded border cursor-pointer transition-all ${
+            class=${`text-3xs font-mono px-1.5 py-0.5 rounded border cursor-pointer transition-all ${
               refreshFlash
                 ? 'border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)]'
                 : 'border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)]'
@@ -686,7 +686,7 @@ function StatusBar({
             ${refreshFlash ? '✓' : '↻'}
           </button>
           <button
-            class="text-[10px] font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)] cursor-pointer"
+            class="text-3xs font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)] hover:text-[var(--text-body)] hover:border-[var(--accent-30)] cursor-pointer"
             onClick=${onDensityToggle}
             title=${`현재 밀도: ${density === 'compact' ? '조밀' : '여유'} (단축키 d)`}
             aria-label=${`밀도 토글: 현재 ${density === 'compact' ? '조밀' : '여유'}`}
@@ -697,18 +697,18 @@ function StatusBar({
           ${loading ? html`<${InlineSpinner} size="xs" />` : null}
           ${paused ? html`
             <span
-              class="px-1.5 py-0.5 rounded border text-[10px] font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
+              class="px-1.5 py-0.5 rounded border text-3xs font-mono text-[var(--text-muted)] border-[var(--white-10)] bg-[var(--white-3)]"
               title="탭이 백그라운드 상태 — 폴링 중지됨. 탭으로 돌아오면 즉시 갱신됩니다."
             >
               ⏸ 일시 중지
             </span>
           ` : null}
           ${staleSec > 120 ? html`
-            <span class="text-[10px] font-mono text-[var(--bad-light)] animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
+            <span class="text-3xs font-mono text-[var(--bad-light)] animate-pulse" title="마지막 관측이 2분 이상 경과 — 대시보드 데이터가 현재 상태를 반영하지 않을 수 있습니다">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : staleSec > 60 ? html`
-            <span class="text-[10px] font-mono text-[var(--warn)]" title="마지막 관측이 1분 이상 경과">
+            <span class="text-3xs font-mono text-[var(--warn)]" title="마지막 관측이 1분 이상 경과">
               ${fmtDuration(staleSec)} 전 갱신
             </span>
           ` : null}
@@ -721,11 +721,11 @@ function StatusBar({
               placeholder="keeper 이름 필터"
               aria-label="Keeper 이름 필터"
               onInput=${(e: Event) => onKeeperFilterChange((e.target as HTMLInputElement).value)}
-              class="min-w-[120px] max-w-[180px] rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-[10px] font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
+              class="min-w-[120px] max-w-[180px] rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
             />
           ` : null}
           ${keeperFilterHasNoMatch ? html`
-            <span class="text-[10px] font-mono text-[var(--text-dim)]">
+            <span class="text-3xs font-mono text-[var(--text-dim)]">
               필터 결과 없음 (${keeperNames.length} keepers)
             </span>
           ` : visibleKeeperNames.map((name, i) => {
@@ -738,7 +738,7 @@ function StatusBar({
                 role="tab"
                 aria-selected=${active}
                 tabindex=${active ? 0 : -1}
-                class=${`rounded-sm border px-2.5 py-0.5 text-[10px] font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-0)] ${cls}`}
+                class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-0)] ${cls}`}
                 onClick=${() => onSelect(name)}
                 title=${i < 9 ? `${name} — 단축키 ${i + 1}` : name}
                 onKeyDown=${(e: KeyboardEvent) => {
@@ -766,7 +766,7 @@ function StatusBar({
         </div>
       </div>
       ${snapshot ? html`
-        <div class="mt-1.5 flex items-center gap-2 text-[10px] font-mono flex-wrap">
+        <div class="mt-1.5 flex items-center gap-2 text-3xs font-mono flex-wrap">
           ${/* KPI micro-metrics */ ''}
           <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-body)]">
             턴 ${snapshot.last_outcome ? `#${snapshot.last_outcome.turn_id}` : '—'}
@@ -932,8 +932,8 @@ function CollapsibleZone({
         aria-expanded=${!collapsed}
         aria-controls=${`zone-${id}`}
       >
-        <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${zoneTitle}</span>
-        <span class=${`text-[10px] text-[var(--text-dim)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`}>▾</span>
+        <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${zoneTitle}</span>
+        <span class=${`text-3xs text-[var(--text-dim)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`}>▾</span>
       </button>
       ${!collapsed ? html`<div id=${`zone-${id}`} class="px-4 pb-3">${children}</div>` : null}
     </div>

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -139,7 +139,7 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
       <div class="flex-1 ${h} rounded-sm bg-white/10 overflow-hidden">
         <div class="${h} rounded-sm transition-all duration-500" style="width:${clamped}%;background:${barColor}"></div>
       </div>
-      <span class="text-[11px] font-semibold tabular-nums text-text-muted w-[36px] text-right">${clamped}%</span>
+      <span class="text-2xs font-semibold tabular-nums text-text-muted w-[36px] text-right">${clamped}%</span>
     </div>
   `
 }
@@ -151,22 +151,22 @@ function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_goals}</div>
-        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">전체 목표</div>
+        <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mt-1">전체 목표</div>
       </div>
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.active_goals}</div>
-        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">진행 중</div>
+        <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mt-1">진행 중</div>
       </div>
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-text-strong tabular-nums">${summary.total_tasks}</div>
-        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">연결 태스크</div>
+        <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mt-1">연결 태스크</div>
       </div>
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.done_tasks}</div>
-        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
+        <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
       </div>
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3">
-        <div class="text-[10px] font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
+        <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
         <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
       </div>
     </div>
@@ -177,11 +177,11 @@ function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
 
 function TreeTask({ task }: { task: GoalTreeTask }) {
   return html`
-    <div class="flex items-center gap-2 py-1.5 px-2 rounded bg-white/3 text-[12px]">
+    <div class="flex items-center gap-2 py-1.5 px-2 rounded bg-white/3 text-xs">
       <span class="size-2 rounded-sm shrink-0" style="background:${task.status_color}"></span>
       <span class="flex-1 min-w-0 truncate text-text-body">${task.title}</span>
       ${task.assignee ? html`
-        <span class="shrink-0 rounded border border-accent/20 bg-[var(--accent-10)] px-1.5 py-0.5 text-[10px] font-medium text-accent">${task.assignee}</span>
+        <span class="shrink-0 rounded border border-accent/20 bg-[var(--accent-10)] px-1.5 py-0.5 text-3xs font-medium text-accent">${task.assignee}</span>
       ` : null}
       <${StatusBadge} status=${task.status} />
     </div>
@@ -198,21 +198,21 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
   const headerContent = html`
     ${hasContent ? html`
-      <span class="shrink-0 mt-0.5 text-[12px] text-text-dim transition-transform ${isExpanded ? 'rotate-90' : ''}">\u25B6</span>
+      <span class="shrink-0 mt-0.5 text-xs text-text-dim transition-transform ${isExpanded ? 'rotate-90' : ''}">\u25B6</span>
     ` : html`
-      <span class="shrink-0 mt-0.5 text-[12px] text-text-dim/30">\u25CB</span>
+      <span class="shrink-0 mt-0.5 text-xs text-text-dim/30">\u25CB</span>
     `}
 
     <div class="flex-1 min-w-0">
       <div class="flex flex-wrap items-center gap-2 mb-1">
-        <span class="shrink-0 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest" style="color:${horizonColor(node.horizon)}">
+        <span class="shrink-0 rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-3xs font-bold uppercase tracking-widest" style="color:${horizonColor(node.horizon)}">
           ${horizonLabel(node.horizon)}
         </span>
-        <span class="text-[14px] font-semibold text-text-strong break-words line-clamp-2">${node.title}</span>
-        <span class="text-[11px] text-text-dim">${priorityStars(node.priority)}</span>
+        <span class="text-base font-semibold text-text-strong break-words line-clamp-2">${node.title}</span>
+        <span class="text-2xs text-text-dim">${priorityStars(node.priority)}</span>
       </div>
 
-      <div class="flex flex-wrap items-center gap-3 text-[11px] text-text-muted">
+      <div class="flex flex-wrap items-center gap-3 text-2xs text-text-muted">
         ${node.metric ? html`
           <span class="rounded-md border border-accent/20 bg-[var(--accent-10)] px-2 py-0.5 text-accent">
             ${node.metric}${node.target_value ? ` \u2192 ${node.target_value}` : ''}
@@ -238,7 +238,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
     <div class="flex flex-col items-end gap-1 shrink-0">
       <${StatusBadge} status=${node.status} />
-      <span class="text-[10px] text-text-dim">
+      <span class="text-3xs text-text-dim">
         <${TimeAgo} timestamp=${node.updated_at} />
       </span>
     </div>
@@ -265,7 +265,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
         <div class="mt-1.5 flex flex-col gap-1.5">
           ${node.tasks.length > 0 ? html`
             <div class="ml-6 flex flex-col gap-1 rounded border border-card-border/40 bg-[rgba(5,9,16,0.6)] p-2">
-              <div class="text-[10px] font-semibold uppercase tracking-widest text-text-dim mb-1">연결된 태스크</div>
+              <div class="text-3xs font-semibold uppercase tracking-widest text-text-dim mb-1">연결된 태스크</div>
               ${node.tasks.map(t => html`<${TreeTask} key=${t.id} task=${t} />`)}
             </div>
           ` : null}
@@ -301,9 +301,9 @@ export function GoalTree() {
       <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
           <div class="max-w-[760px]">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>
             <h3 class="mt-1 text-[20px] font-semibold tracking-[-0.02em] text-text-strong">목표 계층 구조</h3>
-            <p class="mt-1.5 text-[13px] leading-relaxed text-text-muted">
+            <p class="mt-1.5 text-sm leading-relaxed text-text-muted">
               목표의 부모-자식 관계와 연결된 태스크를 트리 형태로 보여줍니다. 수렴도는 하위 태스크 완료율 기반입니다.
             </p>
           </div>
@@ -315,7 +315,7 @@ export function GoalTree() {
                 placeholder="목표 / 태스크 제목 필터"
                 aria-label="목표 트리 필터"
                 onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
-                class="min-w-[180px] max-w-[260px] rounded border border-white/10 bg-white/5 px-2 py-1 text-[12px] text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
+                class="min-w-[180px] max-w-[260px] rounded border border-white/10 bg-white/5 px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
               />
               <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기
@@ -345,7 +345,7 @@ export function GoalTree() {
       ` : data && data.tree.length === 0 ? html`
         <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert 도구로 목표를 등록하세요." />
       ` : data && isFiltering && visibleTree.length === 0 ? html`
-        <section class="py-4 text-center text-[12px] text-text-dim">
+        <section class="py-4 text-center text-xs text-text-dim">
           필터 결과 없음 (${data.tree.length} 목표)
         </section>
       ` : data ? html`

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -105,12 +105,12 @@ function KanbanCard({ task }: { task: Task }) {
     <article class="flex flex-col gap-3 rounded border border-card-border/60 border-l-4 bg-[rgba(7,12,20,0.92)] p-4 ${priorityToneClass(p)}">
       <div class="flex items-start justify-between gap-3">
         <div class="flex flex-wrap items-center gap-2">
-          <span class="rounded border border-current/20 px-2 py-0.5 text-[11px] font-semibold">${priorityLabel(p)}</span>
-          ${scope ? html`<span class="rounded border border-card-border/70 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-body">${scope}</span>` : null}
+          <span class="rounded border border-current/20 px-2 py-0.5 text-2xs font-semibold">${priorityLabel(p)}</span>
+          ${scope ? html`<span class="rounded border border-card-border/70 bg-white/5 px-2 py-0.5 text-2xs font-medium text-text-body">${scope}</span>` : null}
         </div>
         <button
           type="button"
-          class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[10px] font-semibold text-[var(--bad-light)] transition-colors hover:bg-[rgba(239,68,68,0.16)] disabled:opacity-50 disabled:cursor-not-allowed"
+          class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-3xs font-semibold text-[var(--bad-light)] transition-colors hover:bg-[rgba(239,68,68,0.16)] disabled:opacity-50 disabled:cursor-not-allowed"
           onClick=${handleDelete}
           disabled=${isDeleting}
         >
@@ -120,19 +120,19 @@ function KanbanCard({ task }: { task: Task }) {
 
       <button
         type="button"
-        class="text-left text-[14px] font-semibold leading-snug text-text-strong whitespace-pre-wrap break-words cursor-pointer bg-transparent border-none p-0 font-[inherit] transition-colors hover:text-accent"
+        class="text-left text-base font-semibold leading-snug text-text-strong whitespace-pre-wrap break-words cursor-pointer bg-transparent border-none p-0 font-[inherit] transition-colors hover:text-accent"
         onClick=${() => openTaskDetail(task)}
       >${task.title}</button>
 
       ${hasDescription ? html`
         <div class="flex flex-col gap-2">
-          <div class=${`overflow-hidden text-[13px] leading-relaxed text-text-body ${isExpanded || !canExpand ? '' : 'max-h-[9rem]'}`}>
+          <div class=${`overflow-hidden text-sm leading-relaxed text-text-body ${isExpanded || !canExpand ? '' : 'max-h-[9rem]'}`}>
             <${RichContent} text=${description} previewLimit=${1} />
           </div>
           ${canExpand ? html`
             <button
               type="button"
-              class="w-fit rounded border border-card-border/70 bg-white/4 px-2 py-1 text-[11px] text-text-muted transition-colors hover:text-text-strong"
+              class="w-fit rounded border border-card-border/70 bg-white/4 px-2 py-1 text-2xs text-text-muted transition-colors hover:text-text-strong"
               onClick=${() => toggleTaskExpand(task.id)}
             >
               ${isExpanded ? '설명 접기' : '설명 더 보기'}
@@ -140,10 +140,10 @@ function KanbanCard({ task }: { task: Task }) {
           ` : null}
         </div>
       ` : html`
-        <div class="text-[12px] text-text-dim">설명 없음</div>
+        <div class="text-xs text-text-dim">설명 없음</div>
       `}
 
-      <div class="flex flex-wrap items-center gap-2 text-[11px] text-text-muted">
+      <div class="flex flex-wrap items-center gap-2 text-2xs text-text-muted">
         ${task.completed_at && task.status === 'done'
           ? html`<span class="rounded border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완�� <${TimeAgo} timestamp=${task.completed_at} /></span>`
           : task.completed_at && task.status === 'cancelled'
@@ -191,10 +191,10 @@ function TaskColumn({
     <section class="flex min-h-[240px] flex-col gap-4 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="flex items-start justify-between gap-3 border-b border-card-border/50 pb-3">
         <div>
-          <h3 class="text-[15px] font-semibold text-text-strong">${title}</h3>
-          <p class="mt-1 text-[12px] leading-relaxed text-text-muted">${description}</p>
+          <h3 class="text-md font-semibold text-text-strong">${title}</h3>
+          <p class="mt-1 text-xs leading-relaxed text-text-muted">${description}</p>
         </div>
-        <span class="rounded px-2.5 py-1 text-[12px] font-semibold ${badgeClass}">${count}</span>
+        <span class="rounded px-2.5 py-1 text-xs font-semibold ${badgeClass}">${count}</span>
       </div>
       <div ref=${listRef} class="flex max-h-[680px] flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
         ${children}
@@ -266,7 +266,7 @@ export function TaskBacklog() {
   return html`
     <${Card} title="태스크 백로그" class="section">
       ${hasError && hasData ? html`
-        <div class="mb-3 rounded border border-warn/25 bg-warn/10 px-3 py-2 text-[12px] text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
+        <div class="mb-3 rounded border border-warn/25 bg-warn/10 px-3 py-2 text-xs text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
       ` : null}
       <div class="mb-4 flex flex-wrap items-center gap-2">
         <div class="min-w-[220px] flex-1">
@@ -280,13 +280,13 @@ export function TaskBacklog() {
         ${hasSearch ? html`
           <button
             type="button"
-            class="rounded border border-card-border/70 bg-white/4 px-3 py-2 text-[12px] text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+            class="rounded border border-card-border/70 bg-white/4 px-3 py-2 text-xs text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
             onClick=${() => {
               resetTaskSearch()
               searchDoneVisibleCount.value = DONE_PAGE_SIZE
             }}
           >검색 초기화</button>
-          <span class="text-[12px] text-text-muted">${filteredTotal}/${totalTasks}</span>
+          <span class="text-xs text-text-muted">${filteredTotal}/${totalTasks}</span>
         ` : null}
       </div>
       <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-4 items-start">
@@ -322,7 +322,7 @@ export function TaskBacklog() {
           ${hasMoreDone ? html`
             <button
               type="button"
-              class="w-full rounded border border-card-border/60 bg-white/3 px-3 py-2 text-[12px] font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+              class="w-full rounded border border-card-border/60 bg-white/3 px-3 py-2 text-xs font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
               onClick=${() => {
                 if (hasSearch) searchDoneVisibleCount.value += DONE_PAGE_SIZE
                 else doneVisibleCount.value += DONE_PAGE_SIZE

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -41,7 +41,7 @@ function PlanningStat({
 
   return html`
     <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
-      <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
+      <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
       <div class="mt-2 text-[30px] font-bold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
   `
@@ -53,7 +53,7 @@ function ExternalDocLink({ href, label }: { href: string; label: string }) {
       href=${href}
       target="_blank"
       rel="noreferrer"
-      class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-white/3 px-2.5 py-1.5 text-[11px] font-medium text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+      class="inline-flex items-center gap-1 rounded border border-card-border/70 bg-white/3 px-2.5 py-1.5 text-2xs font-medium text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
     >
       ${label}
       <span aria-hidden="true">\u2197</span>
@@ -84,17 +84,17 @@ function GuideCard({
     <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="flex items-start justify-between gap-3">
         <div>
-          <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">${eyebrow}</div>
-          <h3 class="mt-1 text-[15px] font-semibold text-text-strong">${title}</h3>
+          <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">${eyebrow}</div>
+          <h3 class="mt-1 text-md font-semibold text-text-strong">${title}</h3>
         </div>
-        <span class="rounded border border-card-border/70 bg-white/4 px-2.5 py-1 text-[11px] font-semibold text-text-body">
+        <span class="rounded border border-card-border/70 bg-white/4 px-2.5 py-1 text-2xs font-semibold text-text-body">
           ${count}
         </span>
       </div>
-      <p class="text-[13px] leading-relaxed text-text-muted whitespace-pre-wrap">${summary}</p>
+      <p class="text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${summary}</p>
       ${command ? html`
-        <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-[12px] leading-relaxed text-text-body">
-          <code class="text-[11px] text-text-strong">${command}</code>
+        <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-xs leading-relaxed text-text-body">
+          <code class="text-2xs text-text-strong">${command}</code>
         </div>
       ` : null}
       ${children}
@@ -139,31 +139,31 @@ function KeeperToolActivity() {
 
   return html`
     <details class="overview-section-collapsible group overflow-hidden rounded border border-card-border/60 bg-[var(--backdrop-deep)]" open=${true}>
-      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-white/3">
+      <summary class="flex items-center gap-3 border-b border-card-border/60 px-4 py-3.5 cursor-pointer text-base font-bold text-text-strong transition-colors hover:bg-white/3">
         <div class="min-w-0">
           <div>도구 활동 요약</div>
-          <div class="mt-1 text-[12px] font-normal text-text-muted">
+          <div class="mt-1 text-xs font-normal text-text-muted">
             keeper가 최근 사용한 도구와 활동 현황. 상세는 keeper 클릭.
           </div>
         </div>
-        <span class="ml-auto inline-flex items-center rounded border border-card-border/70 bg-white/4 px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-body font-semibold">
+        <span class="ml-auto inline-flex items-center rounded border border-card-border/70 bg-white/4 px-2.5 py-1 text-3xs uppercase tracking-wider text-text-body font-semibold">
           ${totalToolTurns} calls
         </span>
       </summary>
       <div class="p-5">
         ${activeKeepers.length > 0 ? html`
           <div class="mb-4">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">활성 keeper</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">활성 keeper</div>
             <div class="flex flex-wrap gap-2">
               ${activeKeepers.map(k => html`
                 <button
                   key=${k.name}
                   type="button"
-                  class="inline-flex items-center gap-1.5 rounded border border-card-border/60 bg-white/4 px-3 py-1.5 text-[12px] text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
+                  class="inline-flex items-center gap-1.5 rounded border border-card-border/60 bg-white/4 px-3 py-1.5 text-xs text-text-body transition-colors hover:border-accent/35 hover:text-text-strong"
                   onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
                 >
                   ${k.emoji ?? ''} ${k.koreanName ?? k.name}
-                  <span class="text-[10px] font-mono text-text-dim">${k.turn_count ?? 0}t</span>
+                  <span class="text-3xs font-mono text-text-dim">${k.turn_count ?? 0}t</span>
                 </button>
               `)}
             </div>
@@ -172,10 +172,10 @@ function KeeperToolActivity() {
 
         ${topTools.length > 0 ? html`
           <div>
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">최근 자주 사용된 도구</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">최근 자주 사용된 도구</div>
             <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1.5">
               ${topTools.map(([name, count]) => html`
-                <div key=${name} class="flex items-center justify-between rounded bg-white/3 px-3 py-1.5 text-[12px]">
+                <div key=${name} class="flex items-center justify-between rounded bg-white/3 px-3 py-1.5 text-xs">
                   <span class="font-mono text-text-body truncate">${name.replace(/^(keeper_|masc_)/, '')}</span>
                   <span class="ml-2 flex-shrink-0 font-mono text-text-dim">${count}</span>
                 </div>
@@ -214,9 +214,9 @@ export function Planning() {
       <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div class="max-w-[760px]">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Planning Status</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Planning Status</div>
             <h3 class="mt-2 text-[22px] font-semibold tracking-[-0.02em] text-text-strong">${planStatusHeadline}</h3>
-            <p class="mt-2 text-[13px] leading-relaxed text-text-muted whitespace-pre-wrap">${planStatusBody}</p>
+            <p class="mt-2 text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${planStatusBody}</p>
           </div>
           <${ActionButton}
             variant="ghost"
@@ -239,8 +239,8 @@ export function Planning() {
         <div class="mt-5 grid gap-4 xl:grid-cols-2">
           <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
             <div class="mb-3">
-              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Backlog Entry</div>
-              <h3 class="mt-1 text-[15px] font-semibold text-text-strong">태스크 추가</h3>
+              <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">Backlog Entry</div>
+              <h3 class="mt-1 text-md font-semibold text-text-strong">태스크 추가</h3>
             </div>
             <${TaskCreateForm} />
             <div class="mt-3 flex items-center gap-2">
@@ -268,14 +268,14 @@ export function Planning() {
       <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">Goal Pipeline</div>
-            <h3 class="mt-1 text-[15px] font-semibold text-text-strong">
+            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">Goal Pipeline</div>
+            <h3 class="mt-1 text-md font-semibold text-text-strong">
               장기 목표 ${hasGoals ? `(${goals.value.length})` : ''}
             </h3>
           </div>
           <button
             type="button"
-            class="inline-flex items-center gap-1.5 rounded border border-accent/25 bg-[var(--accent-12)] px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:border-accent/40 hover:bg-[var(--accent-15)]"
+            class="inline-flex items-center gap-1.5 rounded border border-accent/25 bg-[var(--accent-12)] px-3 py-1.5 text-xs font-medium text-accent transition-colors hover:border-accent/40 hover:bg-[var(--accent-15)]"
             onClick=${() => navigate('workspace', { section: 'planning', view: 'goal-tree' })}
           >
             목표 트리에서 보기
@@ -285,23 +285,23 @@ export function Planning() {
         ${hasGoals ? html`
           <div class="mt-3 flex flex-wrap gap-2">
             ${(grouped.short ?? []).length > 0 ? html`
-              <span class="rounded border border-ok/25 bg-ok/10 px-2 py-0.5 text-[11px] text-ok">
+              <span class="rounded border border-ok/25 bg-ok/10 px-2 py-0.5 text-2xs text-ok">
                 단기 ${(grouped.short ?? []).length}
               </span>
             ` : null}
             ${(grouped.mid ?? []).length > 0 ? html`
-              <span class="rounded border border-warn/25 bg-warn/10 px-2 py-0.5 text-[11px] text-warn">
+              <span class="rounded border border-warn/25 bg-warn/10 px-2 py-0.5 text-2xs text-warn">
                 중기 ${(grouped.mid ?? []).length}
               </span>
             ` : null}
             ${(grouped.long ?? []).length > 0 ? html`
-              <span class="rounded border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-[11px] text-accent">
+              <span class="rounded border border-accent/25 bg-[var(--accent-10)] px-2 py-0.5 text-2xs text-accent">
                 장기 ${(grouped.long ?? []).length}
               </span>
             ` : null}
           </div>
         ` : html`
-          <p class="mt-2 text-[13px] text-text-muted">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>
+          <p class="mt-2 text-sm text-text-muted">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>
         `}
       </section>
     </div>

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -72,10 +72,10 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
   if (!hasDetail) {
     return html`
       <div class="flex items-center gap-3 py-1.5 px-3 rounded hover:bg-[var(--white-3)] transition-colors">
-        <span class="text-[13px] ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
-        <span class="flex-1 text-[12px] text-text-body truncate">${event.summary}</span>
-        ${event.duration_ms != null ? html`<span class="text-[10px] tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
-        ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-text-dim shrink-0" />` : null}
+        <span class="text-sm ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
+        <span class="flex-1 text-xs text-text-body truncate">${event.summary}</span>
+        ${event.duration_ms != null ? html`<span class="text-3xs tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
+        ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-text-dim shrink-0" />` : null}
       </div>
     `
   }
@@ -88,11 +88,11 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
       }}
     >
       <summary class="flex items-center gap-3 py-1.5 px-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-        <span class="text-[13px] ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
-        <span class="flex-1 text-[12px] text-text-body truncate">${event.summary}</span>
-        ${event.duration_ms != null ? html`<span class="text-[10px] tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
-        ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-text-dim shrink-0" />` : null}
-        <span class="text-[10px] text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} aria-hidden="true" focusable="false" /></span>
+        <span class="text-sm ${kindColor(event.kind)}">${kindIcon(event.kind)}</span>
+        <span class="flex-1 text-xs text-text-body truncate">${event.summary}</span>
+        ${event.duration_ms != null ? html`<span class="text-3xs tabular-nums ${durationColor(event.duration_ms)}">${event.duration_ms}ms</span>` : null}
+        ${event.ts_iso ? html`<${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-text-dim shrink-0" />` : null}
+        <span class="text-3xs text-text-dim flex items-center justify-center"><${ChevronRight} size=${14} aria-hidden="true" focusable="false" /></span>
       </summary>
       ${isOpen ? html`
         <div class="px-3 pb-2 pt-1 ml-7">
@@ -111,8 +111,8 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
               <${JsonViewerCard} data=${event.detail} title="Detail" />
             </div>
           ` : null}
-          ${event.error ? html`<div class="text-[11px] text-[var(--bad-light)] mt-1">${event.error}</div>` : null}
-          ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
+          ${event.error ? html`<div class="text-2xs text-[var(--bad-light)] mt-1">${event.error}</div>` : null}
+          ${event.cost_usd != null ? html`<div class="text-3xs text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
         </div>
       ` : null}
     </details>
@@ -161,7 +161,7 @@ export function TaskActivityList({
           <button
             key=${chip.key}
             type="button"
-            class="px-2 py-1 rounded text-[11px] font-medium border cursor-pointer transition-colors ${
+            class="px-2 py-1 rounded text-2xs font-medium border cursor-pointer transition-colors ${
               filter === chip.key
                 ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
                 : 'border-[var(--white-10)] bg-[var(--white-4)] text-text-muted hover:bg-[var(--white-8)]'
@@ -169,7 +169,7 @@ export function TaskActivityList({
             onClick=${() => { activeFilter.value = chip.key }}
           >${chip.label}</button>
         `)}
-        <span class="ml-auto text-[10px] text-text-dim tabular-nums">${filtered.length}건</span>
+        <span class="ml-auto text-3xs text-text-dim tabular-nums">${filtered.length}건</span>
       </div>
       <div class="flex flex-col gap-0.5 max-h-[400px] overflow-y-auto">
         ${filtered.map((evt, i) => {

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -79,9 +79,9 @@ function TaskEventsSection() {
           placeholder="이벤트 검색 (label/agent/notes)"
           ariaLabel="이벤트 검색"
           onInput=${(e: Event) => { taskEventsSearchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[180px] flex-1 !py-1 !text-[11px]"
+          class="min-w-[180px] flex-1 !py-1 !text-2xs"
         />
-        <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+        <span class="text-3xs text-[var(--text-muted)] tabular-nums">
           ${trimmed
             ? `${visible.length} / ${events.length}`
             : `${events.length}개`}
@@ -96,17 +96,17 @@ function TaskEventsSection() {
         const key = evt.ts ? `${evt.ts}-${i}` : `${evt.label}-${i}`
         return html`
           <div key=${key} class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--white-3)] transition-colors">
-            <div class="size-7 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[11px] font-mono font-bold ${color}">
+            <div class="size-7 shrink-0 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xs font-mono font-bold ${color}">
               ${icon}
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
-                <span class="text-[12px] font-medium text-text-strong">${evt.label}</span>
-                ${evt.agent ? html`<span class="text-[10px] text-accent">@${evt.agent}${evt.actorKind ? ` · ${evt.actorKind}` : ''}</span>` : null}
+                <span class="text-xs font-medium text-text-strong">${evt.label}</span>
+                ${evt.agent ? html`<span class="text-3xs text-accent">@${evt.agent}${evt.actorKind ? ` · ${evt.actorKind}` : ''}</span>` : null}
               </div>
-              ${evt.notes ? html`<div class="mt-1 text-[11px] text-text-muted"><${RichContent} text=${evt.notes} previewLimit=${1} /></div>` : null}
+              ${evt.notes ? html`<div class="mt-1 text-2xs text-text-muted"><${RichContent} text=${evt.notes} previewLimit=${1} /></div>` : null}
             </div>
-            ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} class="text-[10px] text-text-dim shrink-0" />` : null}
+            ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} class="text-3xs text-text-dim shrink-0" />` : null}
           </div>
         `
       })}
@@ -137,13 +137,13 @@ function GateSection({
   return html`
     <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
       <div class="flex items-center justify-between gap-3">
-        <div class="text-[12px] font-medium text-text-strong">${title}</div>
-        <span class=${`rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${gateTone(gate.status)}`}>${gate.status}</span>
+        <div class="text-xs font-medium text-text-strong">${title}</div>
+        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${gateTone(gate.status)}`}>${gate.status}</span>
       </div>
       ${gate.reasons && gate.reasons.length > 0 ? html`
         <div class="mt-2 flex flex-col gap-1">
           ${gate.reasons.slice(0, 4).map(reason => html`
-            <div key=${reason} class="text-[11px] leading-relaxed text-text-muted">${reason}</div>
+            <div key=${reason} class="text-2xs leading-relaxed text-text-muted">${reason}</div>
           `)}
         </div>
       ` : null}
@@ -165,10 +165,10 @@ function ContractSection({ task }: { task: Task }) {
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">계약 게이트</div>
-        <span class=${`rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${contract?.strict ? 'text-accent border-accent/25 bg-[var(--accent-10)]' : 'text-text-muted border-[var(--white-10)] bg-[var(--white-5)]'}`}>${contract?.strict ? 'strict' : 'advisory'}</span>
+        <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted">계약 게이트</div>
+        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${contract?.strict ? 'text-accent border-accent/25 bg-[var(--accent-10)]' : 'text-text-muted border-[var(--white-10)] bg-[var(--white-5)]'}`}>${contract?.strict ? 'strict' : 'advisory'}</span>
         ${isAwaitingVerification ? html`
-          <span class="rounded border border-accent/40 bg-[var(--accent-10)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-accent">
+          <span class="rounded border border-accent/40 bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] text-accent">
             검증 대기
           </span>
         ` : null}
@@ -176,11 +176,11 @@ function ContractSection({ task }: { task: Task }) {
 
       ${isAwaitingVerification ? html`
         <div class="rounded border border-accent/30 bg-[var(--accent-5)] px-4 py-3">
-          <div class="text-[12px] font-medium text-accent">Verifier Keeper 검증 중</div>
-          <div class="mt-1 text-[11px] text-text-body">
+          <div class="text-xs font-medium text-accent">Verifier Keeper 검증 중</div>
+          <div class="mt-1 text-2xs text-text-body">
             Submitter: <span class="font-mono">${verifierAssignee ?? '(unknown)'}</span>
           </div>
-          <div class="mt-0.5 text-[11px] text-text-muted">
+          <div class="mt-0.5 text-2xs text-text-muted">
             다른 keeper가 completion_contract의 정량 기준을 독립 실측 중입니다.
             통과 시 approve_verification → done, 미충족 시 reject_verification → in_progress로 복귀.
           </div>
@@ -193,10 +193,10 @@ function ContractSection({ task }: { task: Task }) {
 
       ${completionItems.length > 0 ? html`
         <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-          <div class="text-[12px] font-medium text-text-strong">Completion Contract</div>
+          <div class="text-xs font-medium text-text-strong">Completion Contract</div>
           <div class="mt-2 flex flex-col gap-1">
             ${completionItems.map((item: string) => html`
-              <div key=${item} class=${`text-[11px] ${unmetItems.includes(item) ? 'text-bad' : 'text-text-body'}`}>${item}</div>
+              <div key=${item} class=${`text-2xs ${unmetItems.includes(item) ? 'text-bad' : 'text-text-body'}`}>${item}</div>
             `)}
           </div>
         </div>
@@ -204,10 +204,10 @@ function ContractSection({ task }: { task: Task }) {
 
       ${requiredEvidence.length > 0 ? html`
         <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-          <div class="text-[12px] font-medium text-text-strong">Required Evidence</div>
+          <div class="text-xs font-medium text-text-strong">Required Evidence</div>
           <div class="mt-2 flex flex-wrap gap-1.5">
             ${requiredEvidence.map((item: string) => html`
-              <span key=${item} class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-[10px] font-mono text-text-body">${item}</span>
+              <span key=${item} class="rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-3xs font-mono text-text-body">${item}</span>
             `)}
           </div>
         </div>
@@ -228,12 +228,12 @@ function ExecutionLinksSection({ task }: { task: Task }) {
 
   return html`
     <div>
-      <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">연결된 실행</div>
+      <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">연결된 실행</div>
       <div class="flex flex-col gap-2">
         ${items.map(([label, value]) => html`
           <div key=${label} class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-            <div class="text-[10px] uppercase tracking-[0.12em] text-text-dim">${label}</div>
-            <div class="mt-1 text-[12px] font-mono text-text-body break-all">${value}</div>
+            <div class="text-3xs uppercase tracking-[0.12em] text-text-dim">${label}</div>
+            <div class="mt-1 text-xs font-mono text-text-body break-all">${value}</div>
           </div>
         `)}
       </div>
@@ -247,16 +247,16 @@ function HandoffSection({ task }: { task: Task }) {
 
   return html`
     <div>
-      <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 Handoff</div>
+      <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 Handoff</div>
       <div class="rounded border border-warn/20 bg-warn/8 px-4 py-3">
-        <div class="text-[13px] leading-relaxed text-text-body"><${RichContent} text=${handoff.summary} previewLimit=${2} /></div>
-        ${handoff.reason ? html`<div class="mt-2 text-[11px] text-text-muted">reason: ${handoff.reason}</div>` : null}
-        ${handoff.next_step ? html`<div class="mt-1 text-[11px] text-text-muted">next: ${handoff.next_step}</div>` : null}
-        ${handoff.failure_mode ? html`<div class="mt-1 text-[11px] text-text-muted">failure: ${handoff.failure_mode}</div>` : null}
+        <div class="text-sm leading-relaxed text-text-body"><${RichContent} text=${handoff.summary} previewLimit=${2} /></div>
+        ${handoff.reason ? html`<div class="mt-2 text-2xs text-text-muted">reason: ${handoff.reason}</div>` : null}
+        ${handoff.next_step ? html`<div class="mt-1 text-2xs text-text-muted">next: ${handoff.next_step}</div>` : null}
+        ${handoff.failure_mode ? html`<div class="mt-1 text-2xs text-text-muted">failure: ${handoff.failure_mode}</div>` : null}
         ${handoff.evidence_refs && handoff.evidence_refs.length > 0 ? html`
           <div class="mt-2 flex flex-wrap gap-1.5">
             ${handoff.evidence_refs.map((item: string) => html`
-              <span key=${item} class="rounded border border-warn/20 bg-[var(--white-5)] px-2 py-0.5 text-[10px] font-mono text-text-body">${item}</span>
+              <span key=${item} class="rounded border border-warn/20 bg-[var(--white-5)] px-2 py-0.5 text-3xs font-mono text-text-body">${item}</span>
             `)}
           </div>
         ` : null}
@@ -278,7 +278,7 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex flex-wrap items-center gap-2">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">담당 키퍼의 활성 목표</div>
+        <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted">담당 키퍼의 활성 목표</div>
         ${goalIds.length > 1 ? html`
           <input
             type="search"
@@ -286,9 +286,9 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
             placeholder="목표 검색 (title/status/metric)"
             aria-label="목표 검색"
             onInput=${(e: Event) => { goalRelationSearchQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
-          <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+          <span class="text-3xs text-[var(--text-muted)] tabular-nums">
             ${isFiltering
               ? `${visibleIds.length} / ${goalIds.length}`
               : `${goalIds.length}개`}
@@ -296,14 +296,14 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
         ` : null}
       </div>
       ${isFiltering && visibleIds.length === 0
-        ? html`<div class="py-3 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${goalIds.length} goals)</div>`
+        ? html`<div class="py-3 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${goalIds.length} goals)</div>`
         : html`
       <div class="flex flex-col gap-1">
         ${visibleIds.map(id => {
           const goal = goalById(id)
           return html`
             <div key=${id} class="flex items-center gap-2 rounded border border-card-border/50 bg-[var(--white-3)] px-3 py-2">
-              <span class="text-[12px] text-text-body">${goal?.title ?? id}</span>
+              <span class="text-xs text-text-body">${goal?.title ?? id}</span>
               ${goal?.status ? html`<${StatusBadge} status=${goal.status} />` : null}
             </div>
           `
@@ -338,11 +338,11 @@ export function TaskDetailOverlay() {
       ${'' /* Sticky Header */}
       <div class="sticky top-0 z-10 flex items-center justify-between gap-4 px-6 py-4 border-b border-[var(--card-border)] bg-[rgba(13,21,38,0.97)] backdrop-blur-sm rounded-t-2xl">
         <div class="flex-1 min-w-0">
-          <h2 id=${titleId} class="text-[16px] font-semibold text-text-strong break-words">${task.title}</h2>
+          <h2 id=${titleId} class="text-lg font-semibold text-text-strong break-words">${task.title}</h2>
           <div class="mt-1.5 flex flex-wrap items-center gap-2">
             <${StatusBadge} status=${task.status ?? 'todo'} />
-            <span class="rounded border border-current/20 bg-[var(--white-5)] px-2 py-0.5 text-[11px] font-semibold text-text-body">${priorityLabel(p)}</span>
-            ${task.assignee ? html`<span class="text-[11px] text-accent">@${task.assignee}${assigneeKind ? ` (${assigneeKind})` : ''}</span>` : null}
+            <span class="rounded border border-current/20 bg-[var(--white-5)] px-2 py-0.5 text-2xs font-semibold text-text-body">${priorityLabel(p)}</span>
+            ${task.assignee ? html`<span class="text-2xs text-accent">@${task.assignee}${assigneeKind ? ` (${assigneeKind})` : ''}</span>` : null}
           </div>
         </div>
         <button
@@ -361,7 +361,7 @@ export function TaskDetailOverlay() {
             <button
               key=${tab}
               type="button"
-              class="px-3 py-1.5 rounded text-[12px] font-medium border cursor-pointer transition-colors ${
+              class="px-3 py-1.5 rounded text-xs font-medium border cursor-pointer transition-colors ${
                 activeTab.value === tab
                   ? 'border-accent/40 bg-accent/12 text-[var(--accent)]'
                   : 'border-transparent text-text-muted hover:bg-[var(--white-8)]'
@@ -378,8 +378,8 @@ export function TaskDetailOverlay() {
           ${'' /* Description */}
           ${task.description ? html`
             <div>
-              <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">설명</div>
-              <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-[13px] leading-relaxed text-text-body">
+              <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">설명</div>
+              <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-sm leading-relaxed text-text-body">
                 <${RichContent} text=${task.description} previewLimit=${2} />
               </div>
             </div>
@@ -394,12 +394,12 @@ export function TaskDetailOverlay() {
 
           ${'' /* Recent task events */}
           <div>
-            <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 태스크 이벤트</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 태스크 이벤트</div>
             <${TaskEventsSection} />
           </div>
 
           ${'' /* Metadata */}
-          <div class="flex flex-wrap items-center gap-3 text-[11px] text-text-dim border-t border-[var(--card-border)] pt-4">
+          <div class="flex flex-wrap items-center gap-3 text-2xs text-text-dim border-t border-[var(--card-border)] pt-4">
             ${task.created_at ? html`<span>생성: <${TimeAgo} timestamp=${task.created_at} /></span>` : null}
             <span class="font-mono">${task.id}</span>
           </div>

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -195,10 +195,10 @@ export function GovernanceMonitor() {
           ${allRejections.length === 0
             ? html`<${EmptyState} message="선택한 시간 범위에 tool rejection이 없습니다." compact />`
             : isFiltering && visibleRejections.length === 0
-              ? html`<div class="py-4 text-center text-[11px] text-[var(--text-muted)]">필터 결과 없음 (${allRejections.length} items)</div>`
+              ? html`<div class="py-4 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${allRejections.length} items)</div>`
               : html`
                 <div class="overflow-x-auto">
-                  <table class="w-full text-[12px]">
+                  <table class="w-full text-xs">
                     <thead>
                       <tr class="text-left text-[var(--text-muted)] border-b border-[var(--card-border)]">
                         <th class="py-1.5 pr-4 font-medium">Tool</th>
@@ -209,9 +209,9 @@ export function GovernanceMonitor() {
                     <tbody>
                       ${visibleRejections.map(r => html`
                         <tr class="border-b border-[var(--card-border)]/30 text-[var(--text-body)]">
-                          <td class="py-1.5 pr-4 font-mono text-[11px]">${r.tool}</td>
+                          <td class="py-1.5 pr-4 font-mono text-2xs">${r.tool}</td>
                           <td class="py-1.5 pr-4">
-                            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-[var(--bg-panel-hover)]">${r.reason}</span>
+                            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--bg-panel-hover)]">${r.reason}</span>
                           </td>
                           <td class="py-1.5 text-right font-medium text-[var(--text-strong)]">${r.count}</td>
                         </tr>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -46,7 +46,7 @@ function GovernanceSummaryStrip() {
 
   return html`
     ${isStale ? html`
-      <div class="mb-3.5 flex items-center gap-3 rounded border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
+      <div class="mb-3.5 flex items-center gap-3 rounded border border-warn/30 bg-warn/10 p-3.5 text-sm font-medium text-warn shadow-sm">
         <div class="shrink-0"><${AlertTriangle} size=${18} aria-hidden="true" /></div>
         <div>
           모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
@@ -58,16 +58,16 @@ function GovernanceSummaryStrip() {
     <div class="mb-2.5 flex items-center justify-between gap-3 px-0.5">
       <div class="flex items-center gap-3 min-w-0">
         <h2 class="text-lg font-bold text-text-strong tracking-wide">Live Judge</h2>
-        <span class="rounded border border-white/5 bg-[var(--white-3)] px-2 py-0.5 text-[11px] font-medium text-text-muted">
+        <span class="rounded border border-white/5 bg-[var(--white-3)] px-2 py-0.5 text-2xs font-medium text-text-muted">
           ${judgeOnlyLabel}
         </span>
       </div>
       <div class="flex items-center gap-3 shrink-0">
-        ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}
+        ${data?.generated_at ? html`<span class="text-2xs text-text-dim font-mono">${data.generated_at}</span>` : null}
         <${ActionButton}
           variant="ghost"
           size="sm"
-          class="rounded border-transparent bg-[var(--white-3)] px-2.5 py-1 text-[12px] font-semibold text-text-muted hover:bg-white/10 hover:text-text-strong"
+          class="rounded border-transparent bg-[var(--white-3)] px-2.5 py-1 text-xs font-semibold text-text-muted hover:bg-white/10 hover:text-text-strong"
           onClick=${refreshGovernance}
           disabled=${governanceLoading.value}
         >
@@ -94,7 +94,7 @@ function GovernanceSummaryStrip() {
       />
     </div>
     <${JudgeStatusBar} />
-    ${governanceError.value ? html`<div class="mb-5 rounded border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
+    ${governanceError.value ? html`<div class="mb-5 rounded border border-[var(--bad-30)] bg-[var(--bad-8)] p-2.5 text-xs text-[#f7b6b6]">${governanceError.value}</div>` : null}
   `
 }
 
@@ -107,7 +107,7 @@ function JudgeStatusBar() {
     ? (judge.refreshing ? '갱신 중' : '온라인')
     : (judge.last_error ? '오류' : '오프라인')
   return html`
-    <div class="mb-4 flex items-center gap-3 rounded border border-white/5 bg-white/3 px-3.5 py-2 text-[12px]" data-testid="judge-status">
+    <div class="mb-4 flex items-center gap-3 rounded border border-white/5 bg-white/3 px-3.5 py-2 text-xs" data-testid="judge-status">
       <span class="flex items-center gap-1.5">
         <${StatusDot} size="sm" class=${dotClass} />
         <span class="font-medium text-text-muted">평가 모델 ${label}</span>
@@ -164,7 +164,7 @@ function JudgmentsSection() {
         <${Card} title=${title} class="section mb-5" variant="compact">
           <${EmptyState} message=${message} compact />
           ${lastSeen || meta ? html`
-            <div class="mt-1 flex flex-wrap items-center justify-center gap-2 text-[11px] ${tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
+            <div class="mt-1 flex flex-wrap items-center justify-center gap-2 text-2xs ${tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
               ${lastSeen ? html`<span class="inline-flex items-center rounded border ${chipClass} px-2 py-0.5 font-medium">
                 마지막 판단 <${TimeAgo} timestamp=${lastSeen} />
               </span>` : null}
@@ -180,24 +180,24 @@ function JudgmentsSection() {
     <${Card} title=${title} class="section mb-5" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
-          <div class="rounded border border-card-border bg-card/34 p-3.5 text-[13px]" data-testid="judgment-item">
+          <div class="rounded border border-card-border bg-card/34 p-3.5 text-sm" data-testid="judgment-item">
             <div class="flex items-center gap-2 mb-1.5">
-              <span class="inline-flex items-center rounded border border-accent/20 bg-[var(--accent-10)] px-1.5 py-0.5 text-[10px] font-bold text-accent">${j.target_kind ?? 'unknown'}</span>
+              <span class="inline-flex items-center rounded border border-accent/20 bg-[var(--accent-10)] px-1.5 py-0.5 text-3xs font-bold text-accent">${j.target_kind ?? 'unknown'}</span>
               <span class="font-medium text-text-strong">${j.target_id ?? ''}</span>
-              ${j.confidence != null ? html`<span class="ml-auto text-[11px] text-text-muted">신뢰도 ${Math.round(j.confidence * 100)}%</span>` : null}
+              ${j.confidence != null ? html`<span class="ml-auto text-2xs text-text-muted">신뢰도 ${Math.round(j.confidence * 100)}%</span>` : null}
             </div>
             <div class="text-text-muted/90 leading-relaxed">${j.summary ?? ''}</div>
             ${j.recommended_action ? html`
-              <div class="mt-2 flex items-center gap-1.5 text-[11px]">
+              <div class="mt-2 flex items-center gap-1.5 text-2xs">
                 <span class="rounded border border-accent/20 bg-accent/8 px-1.5 py-0.5 font-medium text-accent">${j.recommended_action.action_kind ?? 'action'}</span>
                 ${j.recommended_action.resolved_tool ? html`<span class="text-text-dim font-mono">${j.recommended_action.resolved_tool}</span>` : null}
                 ${j.recommended_action.reason ? html`<span class="text-text-muted/80 truncate max-w-[250px]">${j.recommended_action.reason}</span>` : null}
               </div>
             ` : null}
             ${j.guardrail_state?.requires_human_gate ? html`
-              <div class="mt-1.5 inline-flex items-center rounded border border-warn/30 bg-warn/10 px-2 py-0.5 text-[10px] font-bold text-warn">승인 필요</div>
+              <div class="mt-1.5 inline-flex items-center rounded border border-warn/30 bg-warn/10 px-2 py-0.5 text-3xs font-bold text-warn">승인 필요</div>
             ` : null}
-            ${j.generated_at ? html`<div class="mt-1.5 text-[11px] text-text-dim"><${TimeAgo} timestamp=${j.generated_at} /></div>` : null}
+            ${j.generated_at ? html`<div class="mt-1.5 text-2xs text-text-dim"><${TimeAgo} timestamp=${j.generated_at} /></div>` : null}
           </div>
         `)}
       </div>
@@ -291,10 +291,10 @@ function KeeperApprovalAlertBanner() {
       <div class="flex-1 min-w-0">
         <div class="flex items-baseline gap-2 flex-wrap">
           <span class="text-[20px] font-extrabold leading-none">${items.length}건</span>
-          <span class="text-[13px] font-semibold">Keeper HITL 승인 대기</span>
-          ${maxRisk ? html`<span class="text-[11px] font-bold uppercase tracking-wider opacity-80">최고 ${maxRisk}</span>` : null}
+          <span class="text-sm font-semibold">Keeper HITL 승인 대기</span>
+          ${maxRisk ? html`<span class="text-2xs font-bold uppercase tracking-wider opacity-80">최고 ${maxRisk}</span>` : null}
         </div>
-        <div class="mt-1 text-[12px] opacity-85">
+        <div class="mt-1 text-xs opacity-85">
           위험도 threshold를 넘은 keeper tool call이 사용자 판단을 기다리고 있습니다.
         </div>
       </div>
@@ -324,9 +324,9 @@ function KeeperApprovalEmptyState() {
   return html`
     <div data-testid="keeper-hitl-empty">
       <${EmptyState} message=${ctx.primary} compact />
-      ${ctx.secondary ? html`<div class="mt-0.5 text-center text-[11px] text-text-dim">${ctx.secondary}</div>` : null}
+      ${ctx.secondary ? html`<div class="mt-0.5 text-center text-2xs text-text-dim">${ctx.secondary}</div>` : null}
       ${ctx.lastActivity || meta ? html`
-        <div class="mt-1.5 flex flex-wrap items-center justify-center gap-2 text-[11px] ${ctx.tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
+        <div class="mt-1.5 flex flex-wrap items-center justify-center gap-2 text-2xs ${ctx.tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
           ${ctx.lastActivity ? html`<span class="inline-flex items-center rounded border ${chipClass} px-2 py-0.5 font-medium">
             마지막 judge 활동 <${TimeAgo} timestamp=${ctx.lastActivity} />
           </span>` : null}
@@ -393,14 +393,14 @@ function KeeperApprovalQueueSection() {
   const isFiltering = query.value.trim() !== ''
   const countBadgeClass = hasItems
     ? (maxRisk === 'critical' || maxRisk === 'high'
-        ? 'border-bad/40 bg-bad/15 text-bad text-[13px] px-3 py-1 font-extrabold'
-        : 'border-warn/40 bg-warn/15 text-warn text-[13px] px-3 py-1 font-extrabold')
-    : 'border-white/10 bg-[var(--white-3)] text-text-muted text-[11px] px-2 py-0.5 font-bold'
+        ? 'border-bad/40 bg-bad/15 text-bad text-sm px-3 py-1 font-extrabold'
+        : 'border-warn/40 bg-warn/15 text-warn text-sm px-3 py-1 font-extrabold')
+    : 'border-white/10 bg-[var(--white-3)] text-text-muted text-2xs px-2 py-0.5 font-bold'
   return html`
     <div id="keeper-hitl-approval" data-testid="keeper-hitl-approval">
     <${Card} title="Keeper HITL 승인 대기" class="section mb-5" variant="compact">
       <div class="mb-3 flex items-center justify-between gap-3">
-        <div class="text-[12px] text-text-muted">
+        <div class="text-xs text-text-muted">
           위험도가 threshold를 넘은 keeper tool call이 여기서 대기합니다.
         </div>
         <span class="rounded border ${countBadgeClass}">
@@ -416,7 +416,7 @@ function KeeperApprovalQueueSection() {
             aria-label="Keeper HITL 승인 필터"
             data-testid="keeper-hitl-approval-filter"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
       ` : null}
@@ -424,7 +424,7 @@ function KeeperApprovalQueueSection() {
         ? html`<${KeeperApprovalEmptyState} />`
         : isFiltering && visibleItems.length === 0
           ? html`
-              <div class="py-4 text-center text-[11px] text-[var(--text-dim)]" data-testid="keeper-hitl-approval-empty-filter">
+              <div class="py-4 text-center text-2xs text-[var(--text-dim)]" data-testid="keeper-hitl-approval-empty-filter">
                 필터 결과 없음 (${items.length} items)
               </div>
             `
@@ -435,22 +435,22 @@ function KeeperApprovalQueueSection() {
                 return html`
                   <div class="rounded border border-card-border bg-card/34 p-4 shadow-sm" data-testid="governance-approval-item">
                     <div class="flex flex-wrap items-start gap-2.5">
-                      <span class="inline-flex items-center rounded border border-white/10 bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-bold text-text-muted">
+                      <span class="inline-flex items-center rounded border border-white/10 bg-[var(--white-3)] px-2 py-0.5 text-3xs font-bold text-text-muted">
                         keeper ${item.keeper_name}
                       </span>
-                      <span class="inline-flex items-center rounded border border-accent/20 bg-[var(--accent-10)] px-2 py-0.5 text-[10px] font-bold text-accent">
+                      <span class="inline-flex items-center rounded border border-accent/20 bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-bold text-accent">
                         ${item.tool_name}
                       </span>
-                      <span class="inline-flex items-center rounded border px-2 py-0.5 text-[10px] font-bold ${approvalRiskToneClass(item.risk_level)}">
+                      <span class="inline-flex items-center rounded border px-2 py-0.5 text-3xs font-bold ${approvalRiskToneClass(item.risk_level)}">
                         ${item.risk_level}
                       </span>
-                      <span class="ml-auto text-[11px] text-text-dim">
+                      <span class="ml-auto text-2xs text-text-dim">
                         ${item.requested_at ? html`요청 <${TimeAgo} timestamp=${item.requested_at} />` : null}
                         ${item.waiting_s != null ? ` · 대기 ${Math.max(0, Math.round(item.waiting_s))}s` : ''}
                       </span>
                     </div>
                     ${item.input_preview
-                      ? html`<div class="mt-2 text-[12px] leading-relaxed text-text-muted break-words">${item.input_preview}</div>`
+                      ? html`<div class="mt-2 text-xs leading-relaxed text-text-muted break-words">${item.input_preview}</div>`
                       : null}
                     <div class="mt-3 grid gap-3 min-[1100px]:grid-cols-[minmax(0,1fr)_auto]">
                       <${JsonViewerCard} data=${item.input ?? {}} title="Approval Input" />

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -285,11 +285,11 @@ export function HandoffTimeline({
       <header class="flex items-baseline justify-between">
         <div>
           <h3 class="text-sm font-semibold text-text">A2A Event Timeline</h3>
-          <p class="text-[11px] text-text-muted">
+          <p class="text-2xs text-text-muted">
             OAS event_bus → SSE relay. 최근 ${Math.round(windowMs / 1000 / 60)}분, keeper당 row.
           </p>
         </div>
-        <div class="flex gap-2 text-[10px] text-text-muted">
+        <div class="flex gap-2 text-3xs text-text-muted">
           <span class="flex items-center gap-1">
             <span class="w-2 h-2 rounded-full bg-[var(--ok-10)]"></span>lifecycle
           </span>
@@ -314,15 +314,15 @@ export function HandoffTimeline({
           placeholder="keeper / event / task / peer 필터"
           aria-label="Handoff timeline 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-card-border bg-bg-1/40 px-2 py-1 text-[11px] text-text placeholder:text-text-dim focus:outline-none focus:border-accent"
+          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-card-border bg-bg-1/40 px-2 py-1 text-2xs text-text placeholder:text-text-dim focus:outline-none focus:border-accent"
         />
       </div>
       ${error !== null
-        ? html`<p class="text-[11px] text-[var(--bad-light)]">오류: ${error}</p>`
+        ? html`<p class="text-2xs text-[var(--bad-light)]">오류: ${error}</p>`
         : rows.length === 0
-          ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
+          ? html`<p class="text-2xs text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
           : isFiltering && visibleRows.length === 0
-            ? html`<p class="text-[11px] text-text-dim">필터 결과 없음 (${rows.length} handoffs)</p>`
+            ? html`<p class="text-2xs text-text-dim">필터 결과 없음 (${rows.length} handoffs)</p>`
             : html`
               <div class="flex flex-col gap-1 relative">
                 ${(() => {
@@ -354,7 +354,7 @@ export function HandoffTimeline({
                     : 'text-text-muted hover:text-text hover:bg-bg-1/60'
                   const clickable = typeof onSelectKeeper === 'function'
                   const rowLabelCls =
-                    `w-32 shrink-0 truncate text-[11px] font-mono rounded px-1 text-left ${labelCls}` +
+                    `w-32 shrink-0 truncate text-2xs font-mono rounded px-1 text-left ${labelCls}` +
                     (clickable
                       ? ' cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent'
                       : '')

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -300,7 +300,7 @@ export function ScopePairing() {
             </div>
             <button
               type="button"
-              class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+              class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
               onClick=${() => navigate('lab', { section: 'autoresearch' })}
             >오토리서치 열기</button>
           </div>
@@ -371,11 +371,11 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
           placeholder="task / agent / gate / cascade 필터"
           aria-label="판정 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${items.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${items.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">
@@ -418,11 +418,11 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
           placeholder="keeper / trigger / model / strategy 필터"
           aria-label="압축 이벤트 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">
@@ -439,7 +439,7 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
             ${item.strategies.length > 0 ? html`
               <div class="mt-2 flex flex-wrap gap-1">
                 ${item.strategies.map(strategy => html`
-                  <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${strategy}</span>
+                  <span class="rounded-sm border border-[var(--white-8)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${strategy}</span>
                 `)}
               </div>
             ` : null}
@@ -470,11 +470,11 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
           placeholder="keeper / model / trace_id 필터"
           aria-label="세대 교체 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
-        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
+        ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${section.recent_events.length} items)</div>`
         : visibleItems.map(item => html`
           <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
             <div class="flex items-start justify-between gap-3">

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -189,7 +189,7 @@ function HarnessFlowCard({ data }: { data: HarnessHealthData }) {
         </div>
       </div>
 
-      <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-dim)]">
+      <div class="flex flex-wrap gap-2 text-2xs text-[var(--text-dim)]">
         <span class="rounded-sm border border-[var(--white-8)] px-2 py-1">실선: 실시간 신호</span>
         <span class="rounded-sm border border-[var(--white-8)] px-2 py-1">점선: 스냅샷 갱신</span>
         <span class="rounded-sm border border-[var(--accent)] px-2 py-1 text-[var(--text-body)]">강조: 가장 최근 채널</span>
@@ -252,12 +252,12 @@ export function HarnessHealth() {
             <div class="flex items-center gap-2">
               <button
                 type="button"
-                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
                 onClick=${() => { void loadHarnessHealth() }}
               >새로고침</button>
               <button
                 type="button"
-                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+                class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
                 onClick=${() => navigate('lab', { section: 'autoresearch' })}
               >오토리서치 보기</button>
             </div>

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -449,8 +449,8 @@ function MetricChip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-[10px] uppercase tracking-[0.12em] text-[var(--text-dim)]">${label}</div>
-      <div class="mt-1 flex items-center gap-2 text-[13px] font-semibold text-[var(--text-strong)]">
+      <div class="text-3xs uppercase tracking-[0.12em] text-[var(--text-dim)]">${label}</div>
+      <div class="mt-1 flex items-center gap-2 text-sm font-semibold text-[var(--text-strong)]">
         <${StatusChip} tone=${tone} uppercase=${false}>${value}<//>
       </div>
     </div>
@@ -466,8 +466,8 @@ function JourneyTile({
 }) {
   return html`
     <section class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-4 flex flex-col gap-3 min-h-[150px]">
-      <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">${label}</div>
-      <div class="flex flex-col gap-2 text-[13px] text-[var(--text-body)]">
+      <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">${label}</div>
+      <div class="flex flex-col gap-2 text-sm text-[var(--text-body)]">
         ${children}
       </div>
     </section>
@@ -475,7 +475,7 @@ function JourneyTile({
 }
 
 function TileHint({ text }: { text: string }) {
-  return html`<div class="text-[12px] leading-relaxed text-[var(--text-muted)]">${text}</div>`
+  return html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${text}</div>`
 }
 
 function JourneyCard({ record }: { record: JourneyRecord }) {
@@ -506,7 +506,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
             <//>
           </div>
           ${record.subtitle
-            ? html`<div class="mt-1 text-[13px] leading-relaxed text-[var(--text-muted)]">${record.subtitle}</div>`
+            ? html`<div class="mt-1 text-sm leading-relaxed text-[var(--text-muted)]">${record.subtitle}</div>`
             : null}
         </div>
 
@@ -514,7 +514,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
           <${RouteLink}
             tab="workspace"
             params=${{ section: 'planning' }}
-            class="inline-flex items-center rounded-full border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-1.5 text-[12px] text-[var(--text-body)] hover:bg-[var(--white-8)]"
+            class="inline-flex items-center rounded-full border border-[var(--white-10)] bg-[var(--white-5)] px-3 py-1.5 text-xs text-[var(--text-body)] hover:bg-[var(--white-8)]"
           >
             작업 보기
           <//>
@@ -528,7 +528,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                     ...(record.sessionId ? { session_id: record.sessionId } : {}),
                     ...(record.operationId ? { operation_id: record.operationId } : {}),
                   }}
-                  class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-[12px] text-[var(--accent)] hover:bg-[var(--accent-20)]"
+                  class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-xs text-[var(--accent)] hover:bg-[var(--accent-20)]"
                 >
                   실행 로그
                 <//>
@@ -539,7 +539,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                 <${RouteLink}
                   tab="monitoring"
                   params=${{ section: 'agents', agent: searchKeeperName }}
-                  class="inline-flex items-center rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-3 py-1.5 text-[12px] text-[var(--ok)] hover:bg-[var(--ok-20)]"
+                  class="inline-flex items-center rounded-full border border-[var(--ok-20)] bg-[var(--ok-10)] px-3 py-1.5 text-xs text-[var(--ok)] hover:bg-[var(--ok-20)]"
                 >
                   키퍼 보기
                 <//>
@@ -552,12 +552,12 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
         <${JourneyTile} label="Task">
           ${task
             ? html`
-                <div class="font-mono text-[12px] text-[var(--text-strong)]">${task.id}</div>
+                <div class="font-mono text-xs text-[var(--text-strong)]">${task.id}</div>
                 ${task.assignee
                   ? html`<div>담당: <strong class="text-[var(--text-strong)]">${task.assignee}</strong></div>`
                   : html`<${TileHint} text="아직 assignee가 없습니다." />`}
                 ${task.updated_at
-                  ? html`<div class="text-[12px] text-[var(--text-muted)]">최근 갱신 <${TimeAgo} timestamp=${task.updated_at} /></div>`
+                  ? html`<div class="text-xs text-[var(--text-muted)]">최근 갱신 <${TimeAgo} timestamp=${task.updated_at} /></div>`
                   : null}
               `
             : html`<${TileHint} text="현재 연결된 task 없이 keeper 연속성만 추적 중입니다." />`}
@@ -565,16 +565,16 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
 
         <${JourneyTile} label="Run">
           ${record.sessionId
-            ? html`<div><span class="text-[var(--text-dim)]">session</span><div class="mt-1 font-mono text-[12px] text-[var(--text-strong)]">${truncate(record.sessionId, 24)}</div></div>`
+            ? html`<div><span class="text-[var(--text-dim)]">session</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.sessionId, 24)}</div></div>`
             : html`<${TileHint} text="아직 session_id가 연결되지 않았습니다." />`}
           ${record.operationId
-            ? html`<div><span class="text-[var(--text-dim)]">operation</span><div class="mt-1 font-mono text-[12px] text-[var(--text-strong)]">${truncate(record.operationId, 24)}</div></div>`
+            ? html`<div><span class="text-[var(--text-dim)]">operation</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.operationId, 24)}</div></div>`
             : null}
           ${record.workerRunId
-            ? html`<div><span class="text-[var(--text-dim)]">worker run</span><div class="mt-1 font-mono text-[12px] text-[var(--text-strong)]">${truncate(record.workerRunId, 24)}</div></div>`
+            ? html`<div><span class="text-[var(--text-dim)]">worker run</span><div class="mt-1 font-mono text-xs text-[var(--text-strong)]">${truncate(record.workerRunId, 24)}</div></div>`
             : null}
           ${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)
-            ? html`<div class="text-[12px] leading-relaxed text-[var(--text-muted)]">${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)}</div>`
+            ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(record.executionSession?.goal ?? record.missionSession?.goal, 90)}</div>`
             : null}
         <//>
 
@@ -595,11 +595,11 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                   <${MetricChip} label="evidence" value=${requiredEvidence.length} />
                 </div>
                 ${unmetItems.length > 0
-                  ? html`<div class="text-[12px] leading-relaxed text-[var(--warn)]">${unmetItems.slice(0, 2).join(' · ')}</div>`
+                  ? html`<div class="text-xs leading-relaxed text-[var(--warn)]">${unmetItems.slice(0, 2).join(' · ')}</div>`
                   : null}
               `
             : keeper?.runtime_blocker_class === 'completion_contract_violation'
-              ? html`<div class="text-[12px] leading-relaxed text-[var(--bad-light)]">최근 runtime blocker가 completion contract violation으로 관측됐습니다.</div>`
+              ? html`<div class="text-xs leading-relaxed text-[var(--bad-light)]">최근 runtime blocker가 completion contract violation으로 관측됐습니다.</div>`
               : html`<${TileHint} text="현재 contract gate가 연결된 task가 없습니다." />`}
         <//>
 
@@ -611,13 +611,13 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                   ${keeper.phase ? html`<${StatusChip} tone=${keeperStateTone(keeper.phase)}>${keeper.phase}<//>` : null}
                   <${StatusChip} tone=${keeperStateTone(keeper.status)}>${keeper.status}<//>
                 </div>
-                <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)]">
+                <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)]">
                   <span>ctx ${formatPct(keeper.context_ratio)}</span>
                   ${contextSummary ? html`<span>${contextSummary}</span>` : null}
                   ${keeper.last_activity_ago_s != null ? html`<span>활동 ${formatAgeSeconds(keeper.last_activity_ago_s)}</span>` : null}
                 </div>
                 ${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)
-                  ? html`<div class="text-[12px] leading-relaxed text-[var(--text-muted)]">${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)}</div>`
+                  ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)}</div>`
                   : null}
               `
             : html`<${TileHint} text="현재 task에 연결된 keeper가 없습니다." />`}
@@ -631,13 +631,13 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
             ? html`<div><span class="text-[var(--text-dim)]">skill</span><div class="mt-1 font-semibold text-[var(--text-strong)]">${keeper.skill_primary}</div></div>`
             : null}
           ${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)
-            ? html`<div class="text-[12px] leading-relaxed text-[var(--text-muted)]">${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)}</div>`
+            ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(keeper?.skill_reason ?? keeper?.recent_input_preview ?? record.worker?.focus, 100)}</div>`
             : null}
         <//>
 
         <${JourneyTile} label="Memory">
           ${trimText(keeper?.memory_recent_note, 100)
-            ? html`<div class="text-[12px] leading-relaxed text-[var(--text-body)]">${trimText(keeper?.memory_recent_note, 100)}</div>`
+            ? html`<div class="text-xs leading-relaxed text-[var(--text-body)]">${trimText(keeper?.memory_recent_note, 100)}</div>`
             : html`<${TileHint} text="최근 memory note가 아직 없습니다." />`}
           ${keeper?.metrics_window
             ? html`
@@ -659,7 +659,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                   <${MetricChip} label="auto" value=${keeper.autonomous_turn_count ?? 0} />
                 </div>
                 ${keeper.runtime_blocker_summary
-                  ? html`<div class="text-[12px] leading-relaxed text-[var(--warn)]">${trimText(keeper.runtime_blocker_summary, 100)}</div>`
+                  ? html`<div class="text-xs leading-relaxed text-[var(--warn)]">${trimText(keeper.runtime_blocker_summary, 100)}</div>`
                   : null}
               `
             : html`<${TileHint} text="연결된 keeper turn 정보가 없습니다." />`}
@@ -674,9 +674,9 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                       <${StatusChip} tone=${entry.source === 'journal' ? 'info' : entry.source === 'handoff' ? 'warn' : 'neutral'} uppercase=${false}>
                         ${entry.source}
                       <//>
-                      ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} class="text-[11px] text-[var(--text-dim)]" />` : null}
+                      ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} class="text-2xs text-[var(--text-dim)]" />` : null}
                     </div>
-                    <div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${entry.text}</div>
+                    <div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${entry.text}</div>
                   </div>
                 `)}
               `
@@ -690,14 +690,14 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                   ${keeper.cascade_name ? html`<${StatusChip} tone="info">${keeper.cascade_name}<//>` : null}
                   ${keeper.active_model ? html`<${StatusChip} tone="neutral" uppercase=${false}>${keeper.active_model}<//>` : null}
                 </div>
-                <div class="text-[12px] text-[var(--text-muted)]">
+                <div class="text-xs text-[var(--text-muted)]">
                   ${keeper.last_model_used || keeper.model ? html`last ${keeper.last_model_used ?? keeper.model}` : 'model 기록 없음'}
                 </div>
                 ${keeper.next_model_hint
-                  ? html`<div class="text-[12px] text-[var(--text-muted)]">next ${keeper.next_model_hint}</div>`
+                  ? html`<div class="text-xs text-[var(--text-muted)]">next ${keeper.next_model_hint}</div>`
                   : null}
                 ${keeper.metrics_window?.fallback_rate != null
-                  ? html`<div class="text-[12px] text-[var(--text-muted)]">fallback ${formatPct(keeper.metrics_window.fallback_rate)}</div>`
+                  ? html`<div class="text-xs text-[var(--text-muted)]">fallback ${formatPct(keeper.metrics_window.fallback_rate)}</div>`
                   : null}
               `
             : html`<${TileHint} text="cascade 선택 정보는 keeper runtime에서만 노출됩니다." />`}
@@ -742,7 +742,7 @@ export function JourneyPanel() {
             <h2 class="m-0 text-[20px] font-semibold text-[var(--text-strong)]">Task → Run → Contract → Keeper → Thinking → Memory → Turn → Life → Cascade</h2>
             <${StatusChip} tone="info">journey beta<//>
           </div>
-          <div class="text-[13px] leading-relaxed text-[var(--text-muted)]">
+          <div class="text-sm leading-relaxed text-[var(--text-muted)]">
             task 중심 흐름과 task에 안 묶인 keeper 연속성을 같은 카드 문법으로 읽습니다. 실행 링크, contract gate, keeper stage, memory note, recent life signal, cascade 선택을 한 번에 붙여 봅니다.
           </div>
         </div>
@@ -766,7 +766,7 @@ export function JourneyPanel() {
               query.value = (event.target as HTMLInputElement).value
             }}
           />
-          <div class="text-[12px] text-[var(--text-muted)]">
+          <div class="text-xs text-[var(--text-muted)]">
             ${query.value.trim() !== '' ? `${visible.length} / ${records.length}개 표시` : `${records.length}개 흐름`}
           </div>
         </div>
@@ -778,7 +778,7 @@ export function JourneyPanel() {
             ${taskRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Task Journeys</div>
+                    <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Task Journeys</div>
                     ${taskRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `
@@ -787,7 +787,7 @@ export function JourneyPanel() {
             ${keeperRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Standalone Keeper Journeys</div>
+                    <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Standalone Keeper Journeys</div>
                     ${keeperRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -197,9 +197,9 @@ export function KeeperChatPanel({ name }: { name: string }) {
     <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
       <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
         <div class="min-w-[220px] flex-1">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
-          <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${name}</div>
-          <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
+          <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
+          <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">@${name}</div>
+          <div class="mt-1 text-sm leading-[1.65] text-[var(--text-secondary)]">
             이 키퍼와의 실시간 직접 대화입니다. 스트리밍 응답은 동일한 대화 레인에 표시됩니다.
           </div>
         </div>
@@ -213,7 +213,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
             value=${query}
             onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
           />
-          <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">
+          <span class="inline-flex items-center rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">
             ${hasQuery ? `${filteredMessages.length} / ${messages.length}개 메시지` : `${messages.length}개 메시지`}
           </span>
         </div>
@@ -221,7 +221,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
 
       <div class="px-4 py-4">
         ${chatAccess.message
-          ? html`<div class="mb-4 rounded-card border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-[12px] leading-[1.6] text-[var(--warn-bright)]">${chatAccess.message}</div>`
+          ? html`<div class="mb-4 rounded-card border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--warn-bright)]">${chatAccess.message}</div>`
           : null}
         <${ChatTranscript}
           entries=${transcriptEntries}
@@ -233,7 +233,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
       </div>
 
       ${chatError.value
-        ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-[12px] leading-[1.6] text-[var(--bad-light)]">${chatError.value}</div>`
+        ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--bad-light)]">${chatError.value}</div>`
         : null}
 
       <div class="border-t border-[var(--slate-gray-12)] bg-[var(--white-3)] px-4 py-4">

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -116,22 +116,22 @@ export function KeeperConditionsDivergent({ keeper }: { keeper: Keeper }) {
   return html`
     <section class="rounded border border-[var(--warn-24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--warn)]">
+        <h3 class="text-2xs font-semibold tracking-[0.08em] uppercase text-[var(--warn)]">
           ⚠️ 조건-Phase 불일치
         </h3>
-        <span class="text-[10px] text-[var(--text-dim)]">phase가 아직 반응하지 않은 관측 신호</span>
+        <span class="text-3xs text-[var(--text-dim)]">phase가 아직 반응하지 않은 관측 신호</span>
       </header>
       <div class="flex flex-wrap gap-1.5">
         ${divs.map(d => html`
           <span
-            class="px-2 py-0.5 rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-8)] text-[var(--warn)] text-[11px] font-mono tabular-nums"
+            class="px-2 py-0.5 rounded-sm border border-[rgba(251,191,36,0.3)] bg-[var(--warn-8)] text-[var(--warn)] text-2xs font-mono tabular-nums"
             title=${d.reason}
           >
             ${d.field}=${String(d.value)}
           </span>
         `)}
       </div>
-      <div class="mt-2 text-[10px] text-[var(--text-dim)] leading-snug">
+      <div class="mt-2 text-3xs text-[var(--text-dim)] leading-snug">
         ${first.reason}${rest.length > 0 ? ` (외 ${rest.length}건, 칩 hover로 확인)` : ''}
       </div>
     </section>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -234,15 +234,15 @@ export function peekKeeperConfigLoadStatus(
 function ConfigRow({ label, value }: { label: string; value: string }) {
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
-      <span class="text-[12px] font-medium text-text-muted">${label}</span>
-      <span class="text-[12px] font-semibold text-text-strong">${value}</span>
+      <span class="text-xs font-medium text-text-muted">${label}</span>
+      <span class="text-xs font-semibold text-text-strong">${value}</span>
     </div>
   `
 }
 
 function SectionHeader({ title }: { title: string }) {
   return html`
-    <div class="text-[11px] font-bold uppercase tracking-widest text-accent mt-6 mb-3 pb-1.5 border-b border-accent/20 flex items-center gap-2">
+    <div class="text-2xs font-bold uppercase tracking-widest text-accent mt-6 mb-3 pb-1.5 border-b border-accent/20 flex items-center gap-2">
       <span class="w-1.5 h-1.5 rounded-full bg-accent/50 shadow-[0_0_8px_rgba(71,184,255,0.6)]"></span>
       ${title}
     </div>
@@ -264,16 +264,16 @@ function Callout({
       : 'border-card-border/60 bg-card/35 text-text-body'
   return html`
     <div class="rounded border px-3 py-3 shadow-sm ${toneClass}">
-      <div class="text-[11px] font-bold uppercase tracking-widest text-text-muted mb-1">${title}</div>
-      <div class="text-[12px] leading-relaxed">${body}</div>
+      <div class="text-2xs font-bold uppercase tracking-widest text-text-muted mb-1">${title}</div>
+      <div class="text-xs leading-relaxed">${body}</div>
     </div>
   `
 }
 
 function BoolBadge({ value }: { value: boolean }) {
   return value
-    ? html`<span class="text-[11px] font-bold px-2 py-0.5 rounded bg-ok/10 text-ok border border-ok/20 shadow-sm shadow-ok/5">ON</span>`
-    : html`<span class="text-[11px] font-bold px-2 py-0.5 rounded bg-white/5 text-text-dim border border-white/10 shadow-sm">OFF</span>`
+    ? html`<span class="text-2xs font-bold px-2 py-0.5 rounded bg-ok/10 text-ok border border-ok/20 shadow-sm shadow-ok/5">ON</span>`
+    : html`<span class="text-2xs font-bold px-2 py-0.5 rounded bg-white/5 text-text-dim border border-white/10 shadow-sm">OFF</span>`
 }
 
 function formatHookDestructiveTools(value: string[] | string): string {
@@ -285,21 +285,21 @@ function formatHookDestructiveTools(value: string[] | string): string {
 }
 
 function ModelList({ models }: { models: string[] }) {
-  if (models.length === 0) return html`<span class="text-[11px] text-text-muted italic">none</span>`
+  if (models.length === 0) return html`<span class="text-2xs text-text-muted italic">none</span>`
   return html`
     <div class="flex flex-wrap gap-1.5">
-      ${models.map(m => html`<span class="inline-flex items-center py-1 px-2.5 rounded text-[11px] font-semibold bg-[var(--accent-10)] text-accent border border-accent/20 shadow-sm hover:bg-accent/20 transition-colors cursor-default">${m}</span>`)}
+      ${models.map(m => html`<span class="inline-flex items-center py-1 px-2.5 rounded text-2xs font-semibold bg-[var(--accent-10)] text-accent border border-accent/20 shadow-sm hover:bg-accent/20 transition-colors cursor-default">${m}</span>`)}
     </div>
   `
 }
 
 function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: number | null }) {
-  if (!text || text.trim() === '') return html`<span class="text-[11px] text-text-muted italic">--</span>`
+  if (!text || text.trim() === '') return html`<span class="text-2xs text-text-muted italic">--</span>`
   const truncated =
     truncateAt !== null && truncateAt >= 0 && text.length > truncateAt
       ? text.slice(0, truncateAt) + '...'
       : text
-  return html`<div class="text-[12px] text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-sm p-3 rounded mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
+  return html`<div class="text-xs text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-sm p-3 rounded mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
 }
 
 
@@ -310,7 +310,7 @@ function PromptSourceBadge({ source }: { source: string }) {
       : source === 'file'
         ? 'bg-[var(--ok-10)] text-[var(--ok)] border-[var(--ok-20)]'
         : 'bg-white/5 text-text-dim border-white/10'
-  return html`<span class="text-[10px] font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
+  return html`<span class="text-3xs font-bold px-2 py-0.5 rounded border ${tone} shadow-sm">${source.toUpperCase()}</span>`
 }
 
 function PromptBlock({
@@ -323,9 +323,9 @@ function PromptBlock({
   return html`
     <div class="mt-2">
       <div class="flex items-center justify-between gap-2 mb-1">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</div>
         <div class="flex items-center gap-2">
-          <span class="text-[10px] text-text-dim">${block.key}</span>
+          <span class="text-3xs text-text-dim">${block.key}</span>
           <${PromptSourceBadge} source=${block.source} />
         </div>
       </div>
@@ -334,14 +334,14 @@ function PromptBlock({
   `
 }
 
-const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-[13px] border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
+const fieldStyle = 'w-full bg-card/60 backdrop-blur-sm text-text-strong text-sm border border-card-border rounded py-2 px-3 font-sans focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner'
 
 // ── Inline editing components for runtime config ────────
 
 function InlineToggleRow({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
-      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <span class="text-xs font-medium text-text-muted">${label}</span>
       <button type="button"
         class="relative inline-flex h-5 w-9 items-center rounded-sm transition-colors cursor-pointer ${value ? 'bg-ok/60' : 'bg-white/10'}"
         onClick=${() => onChange(!value)}
@@ -358,10 +358,10 @@ function InlineNumberRow({ label, value, onChange, min, max, step, suffix }: {
 }) {
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5">
-      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <span class="text-xs font-medium text-text-muted">${label}</span>
       <div class="flex items-center gap-1.5">
         <input type="number"
-          class="w-20 text-right bg-card/60 text-text-strong text-[12px] font-semibold border border-card-border rounded py-1 px-2 focus:outline-none focus:border-accent/50 transition-colors"
+          class="w-20 text-right bg-card/60 text-text-strong text-xs font-semibold border border-card-border rounded py-1 px-2 focus:outline-none focus:border-accent/50 transition-colors"
           value=${value}
           min=${min}
           max=${max}
@@ -371,7 +371,7 @@ function InlineNumberRow({ label, value, onChange, min, max, step, suffix }: {
             if (!isNaN(v)) onChange(v)
           }}
         />
-        ${suffix ? html`<span class="text-[10px] text-text-dim w-4">${suffix}</span>` : null}
+        ${suffix ? html`<span class="text-3xs text-text-dim w-4">${suffix}</span>` : null}
       </div>
     </div>
   `
@@ -390,7 +390,7 @@ function InlineSelectRow({
 }) {
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 backdrop-blur-sm hover:bg-card/40 transition-colors shadow-sm mb-1.5 gap-3">
-      <span class="text-[12px] font-medium text-text-muted">${label}</span>
+      <span class="text-xs font-medium text-text-muted">${label}</span>
       <select
         aria-label=${label}
         class="text-xs bg-card/60 border border-card-border rounded px-2 py-1 text-text-strong"
@@ -417,7 +417,7 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
   const val = d[field] as string
   return html`
     <div class="mt-3">
-      <div class="text-[11px] font-semibold uppercase tracking-wider text-text-muted mb-1.5">${label}</div>
+      <div class="text-2xs font-semibold uppercase tracking-wider text-text-muted mb-1.5">${label}</div>
       <textarea
         class="${fieldStyle} resize-y custom-scrollbar"
         rows=${rows}
@@ -568,30 +568,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <${EditTextarea} field="instructions" label="지시사항" rows=${4} />
   ` : html`
     <${SectionHeader} title="프롬프트" />
-    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">목표</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">목표</div>
     <${LongText} text=${c.prompt.goal} />
     ${c.prompt.short_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">단기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">단기 목표</div>
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">중기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">중기 목표</div>
       <${LongText} text=${c.prompt.mid_goal} />
     ` : null}
     ${c.prompt.long_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">장기 목표</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">장기 목표</div>
       <${LongText} text=${c.prompt.long_goal} />
     ` : null}
     ${c.prompt.instructions ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">지시사항</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">지시사항</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
+    <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
     <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
     <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
     <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
     <details class="mt-3">
-      <summary class="cursor-pointer py-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
+      <summary class="cursor-pointer py-2 px-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
       <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
     </details>
   `
@@ -620,18 +620,18 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">라이브 오버라이드</span>
         <${BoolBadge} value=${c.sources.has_live_override} />
       </div>
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
+      <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
       <${LongText} text=${c.sources.live_meta_path} />
       ${c.sources.default_manifest_path ? html`
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
         <${LongText} text=${c.sources.default_manifest_path} />
       ` : null}
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">우선순위</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">우선순위</div>
         <${ModelList} models=${c.sources.precedence} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">오버라이드 필드</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">오버라이드 필드</div>
         <${ModelList} models=${c.sources.override_fields} />
       </div>
 
@@ -642,7 +642,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${BoolBadge} value=${c.execution.verify} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
         <${ModelList} models=${c.execution.models} />
       </div>
 
@@ -695,7 +695,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <div class="py-2 px-3 rounded bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs text-[var(--text-body)]">allowed_paths</span>
-            <span class="text-[10px] text-[var(--text-muted)]">한 줄에 하나씩. * = 전체 허용</span>
+            <span class="text-3xs text-[var(--text-muted)]">한 줄에 하나씩. * = 전체 허용</span>
           </div>
           <textarea class="w-full text-xs font-mono bg-[var(--white-6)] border border-[var(--card-border)] rounded px-2 py-1.5 text-[var(--text-body)] resize-y"
             rows=${3}
@@ -705,7 +705,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           ></textarea>
         </div>
         ${(c.effective_allowed_paths ?? []).length > 0 ? html`
-          <div class="py-1.5 px-3 text-[10px] text-[var(--text-muted)]">
+          <div class="py-1.5 px-3 text-3xs text-[var(--text-muted)]">
             effective: ${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'}
           </div>
         ` : null}
@@ -807,12 +807,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="프로젝트 범위" value=${c.coordination.room_scope || '--'} />
       ${c.coordination.mention_targets.length > 0 ? html`
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       ` : null}
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 네임스페이스</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 네임스페이스</div>
         <${ModelList} models=${c.coordination.joined_room_ids} />
       </div>
 
@@ -846,7 +846,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
             class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
             onClick=${resetRuntimeDraft}
           >초기화</button>
-          <span class="text-[10px] text-accent">변경된 설정이 있습니다</span>
+          <span class="text-3xs text-accent">변경된 설정이 있습니다</span>
         </div>
       ` : null}
 
@@ -857,30 +857,30 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         return html`
           <${SectionHeader} title="훅 슬롯" />
           <div class="flex items-center justify-between gap-2 mb-2">
-            <span class="text-[10px] text-text-muted">${allEntries.length} slots</span>
+            <span class="text-3xs text-text-muted">${allEntries.length} slots</span>
             <input
               type="search"
               value=${hookFilterQuery.value}
               placeholder="슬롯 이름 / source / gate 필터"
               aria-label="훅 슬롯 필터"
               onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
             />
           </div>
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
-            ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
+            ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
             : visibleEntries.map(([name, slot]) => html`
                 <div class="flex items-start gap-2 py-2 px-3 rounded border border-card-border/50 bg-card/20 mb-1.5">
                   <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
                   <div class="flex-1 min-w-0">
                     <div class="flex justify-between">
-                      <span class="text-[12px] font-semibold text-text-strong">${name}</span>
-                      <span class="text-[10px] text-text-muted">${slot.source}</span>
+                      <span class="text-xs font-semibold text-text-strong">${name}</span>
+                      <span class="text-3xs text-text-muted">${slot.source}</span>
                     </div>
                     ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
                       <div class="flex flex-wrap gap-1 mt-1">
                         ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                          <span class="text-[10px] px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
+                          <span class="text-3xs px-1.5 py-0.5 rounded ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
                         `)}
                       </div>
                     ` : null}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -130,8 +130,8 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
   return html`
     <div class="p-3.5 rounded border ${KPI_TONE[tone]} flex flex-col gap-1.5 transition-colors">
       <div class="flex items-center justify-between">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
-        ${icon ? html`<span class="text-[11px] opacity-60">${icon}</span>` : null}
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
+        ${icon ? html`<span class="text-2xs opacity-60">${icon}</span>` : null}
       </div>
       <div class="text-2xl font-bold ${KPI_VALUE_TONE[tone]} tabular-nums leading-none">${value}</div>
       ${progress != null ? html`
@@ -139,7 +139,7 @@ function KpiCard({ label, value, hint, tone = 'default', progress }: {
           <div class="h-full rounded-sm transition-all duration-500" style="width:${Math.min(progress, 100)}%;background:${ctxColor(progress)}"></div>
         </div>
       ` : null}
-      ${hint ? html`<div class="text-[10px] text-[var(--text-dim)] leading-snug">${hint}</div>` : null}
+      ${hint ? html`<div class="text-3xs text-[var(--text-dim)] leading-snug">${hint}</div>` : null}
     </div>
   `
 }
@@ -165,30 +165,30 @@ function OperationalHealth({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">운영 건강도</div>
+      <div class="mb-2 text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">운영 건강도</div>
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
         ${hb ? html`
           <div class="p-2 rounded border ${KPI_TONE[hbTone]} flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Heartbeat</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Heartbeat</span>
             <span class="text-xs font-mono ${KPI_VALUE_TONE[hbTone]}">${hb.replace('T', ' ').slice(0, 19)}</span>
           </div>
         ` : null}
         ${compSavedRatio != null ? html`
           <div class="p-2 rounded border ${KPI_TONE[compTone]} flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">압축 절감률</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">압축 절감률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[compTone]}">${(compSavedRatio * 100).toFixed(1)}%</span>
-            ${avgSaved != null ? html`<span class="text-[10px] text-[var(--text-dim)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
+            ${avgSaved != null ? html`<span class="text-3xs text-[var(--text-dim)]">avg ${formatTokens(avgSaved)} saved</span>` : null}
           </div>
         ` : null}
         ${dropRatio != null ? html`
           <div class="p-2 rounded border ${KPI_TONE[dropTone]} flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">메모리 손실률</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">메모리 손실률</span>
             <span class="text-sm font-mono tabular-nums ${KPI_VALUE_TONE[dropTone]}">${(dropRatio * 100).toFixed(1)}%</span>
           </div>
         ` : null}
         ${lastCompAgo != null ? html`
           <div class="p-2 rounded border ${KPI_TONE['default']} flex flex-col gap-0.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">마지막 압축</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">마지막 압축</span>
             <span class="text-xs font-mono text-[var(--text-strong)]">${formatDuration(lastCompAgo)} 전</span>
           </div>
         ` : null}
@@ -245,8 +245,8 @@ function OutcomesLedger({ keeper, outcomes }: {
       ${'' /* Row 1 — Success / Failure Ledger */}
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">성공/실패 (최근 ${observed_turns}턴)</span>
-          <span class="text-[10px] text-[var(--text-dim)]">${ledgerTotal > 0 ? `합계 ${ledgerTotal}` : '관측 없음'}</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">성공/실패 (최근 ${observed_turns}턴)</span>
+          <span class="text-3xs text-[var(--text-dim)]">${ledgerTotal > 0 ? `합계 ${ledgerTotal}` : '관측 없음'}</span>
         </div>
         <div class="flex items-center gap-3 text-xs">
           <span class="tabular-nums"><span class="text-[var(--ok)]">✅</span> ${successes.substantive_turns} 성공</span>
@@ -259,7 +259,7 @@ function OutcomesLedger({ keeper, outcomes }: {
           <div class="h-full bg-[var(--bad)]" style="width:${pctReject}%" title=${`거절 ${pctReject.toFixed(0)}%`}></div>
         </div>
         ${(successes.compactions_ok > 0 || successes.handoffs_ok > 0 || failures.compaction_failed > 0 || failures.handoff_failed > 0) ? html`
-          <div class="mt-2 flex flex-wrap gap-1.5 text-[10px]">
+          <div class="mt-2 flex flex-wrap gap-1.5 text-3xs">
             ${successes.compactions_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--ok)]">압축 ${successes.compactions_ok}</span>` : null}
             ${failures.compaction_failed > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--bad)]">압축 실패 ${failures.compaction_failed}</span>` : null}
             ${successes.handoffs_ok > 0 ? html`<span class="px-2 py-0.5 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-6)] text-[var(--ok)]">인계 ${successes.handoffs_ok}</span>` : null}
@@ -271,8 +271,8 @@ function OutcomesLedger({ keeper, outcomes }: {
       ${'' /* Row 2 — Validator Pass Rate */}
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">검증자 (OAS verdict)</span>
-          <span class="text-[10px] text-[var(--text-dim)]">
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">검증자 (OAS verdict)</span>
+          <span class="text-3xs text-[var(--text-dim)]">
             ${verdictTotal > 0 ? `${verdicts.pass}/${verdictTotal} pass` : 'verdict 없음'}
           </span>
         </div>
@@ -284,7 +284,7 @@ function OutcomesLedger({ keeper, outcomes }: {
             <span class="shrink-0 text-sm font-semibold tabular-nums" style="color:${passBarColor}">${passRatePct}%</span>
           </div>
           ${verdicts.top_failure_reasons.length > 0 ? html`
-            <div class="mt-2 flex flex-wrap gap-1.5 text-[10px]">
+            <div class="mt-2 flex flex-wrap gap-1.5 text-3xs">
               <span class="text-[var(--text-dim)]">주요 실패 원인:</span>
               ${verdicts.top_failure_reasons.map(reason => html`
                 <span class="px-2 py-0.5 rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] font-mono text-[var(--text-body)]">${reason}</span>
@@ -292,7 +292,7 @@ function OutcomesLedger({ keeper, outcomes }: {
             </div>
           ` : null}
           ${validation.cdal_gate ? html`
-            <div class="mt-2 flex flex-wrap gap-3 text-[11px] text-[var(--text-body)]">
+            <div class="mt-2 flex flex-wrap gap-3 text-2xs text-[var(--text-body)]">
               <span class="tabular-nums">CDAL pass <span class="font-semibold text-[var(--ok)]">${validation.cdal_gate.pass}</span></span>
               <span class="tabular-nums">reject <span class="font-semibold text-[var(--bad)]">${validation.cdal_gate.reject}</span></span>
               ${validation.cdal_gate.pending_verification > 0 ? html`
@@ -301,7 +301,7 @@ function OutcomesLedger({ keeper, outcomes }: {
             </div>
           ` : null}
         ` : html`
-          <div class="text-[11px] text-[var(--text-dim)] leading-snug">
+          <div class="text-2xs text-[var(--text-dim)] leading-snug">
             이 키퍼에 대해 기록된 OAS verdict가 아직 없습니다.
           </div>
         `}
@@ -310,10 +310,10 @@ function OutcomesLedger({ keeper, outcomes }: {
       ${'' /* Row 3 — Resilience Profile */}
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
         <div class="flex items-baseline justify-between gap-2 mb-1.5">
-          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">회복력</span>
-          <span class="text-[10px] text-[var(--text-dim)]">supervisor 이력</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">회복력</span>
+          <span class="text-3xs text-[var(--text-dim)]">supervisor 이력</span>
         </div>
-        <div class="flex flex-wrap gap-1.5 text-[11px]">
+        <div class="flex flex-wrap gap-1.5 text-2xs">
           <span class="px-2 py-0.5 rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] tabular-nums">세대 ${keeper.generation ?? '-'}</span>
           <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.crashes > 0 ? 'border border-[var(--bad-20)] bg-[var(--bad-6)] text-[var(--bad)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>크래시 ${failures.crashes}회</span>
           <span class=${`px-2 py-0.5 rounded-sm tabular-nums ${failures.restarts > 0 ? 'border border-[var(--warn-20)] bg-[var(--warn-8)] text-[var(--warn)]' : 'border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)]'}`}>재시작 ${failures.restarts}회</span>
@@ -348,8 +348,8 @@ function KpiSection({ title, question, children }: {
   return html`
     <section class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-[11px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">${title}</h3>
-        <span class="text-[10px] text-[var(--text-dim)] truncate">${question}</span>
+        <h3 class="text-2xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">${title}</h3>
+        <span class="text-3xs text-[var(--text-dim)] truncate">${question}</span>
       </header>
       ${children}
     </section>
@@ -429,13 +429,13 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           <${OperationalHealth} keeper=${keeper} />
           ${totalCalls > 0 ? html`
             <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
-              <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">모델 호출 분포</div>
+              <div class="mb-2 text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">모델 호출 분포</div>
               <div class="flex flex-col gap-1.5">
                 ${modelEntries.slice(0, 4).map(([model, count]) => {
                   const pct = Math.round((count / totalCalls) * 100)
                   return html`
                     <div class="flex items-center gap-2 text-xs">
-                      <span class="shrink-0 w-[140px] truncate font-mono text-[11px] text-[var(--accent)]" title=${model}>${model}</span>
+                      <span class="shrink-0 w-[140px] truncate font-mono text-2xs text-[var(--accent)]" title=${model}>${model}</span>
                       <${ProgressBar}
                         pct=${pct}
                         size="sm"
@@ -449,7 +449,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
                 })}
               </div>
               ${modelEntries.length > 4 ? html`
-                <div class="mt-1 text-[10px] text-[var(--text-muted)]">외 ${modelEntries.length - 4}개 모델</div>
+                <div class="mt-1 text-3xs text-[var(--text-muted)]">외 ${modelEntries.length - 4}개 모델</div>
               ` : null}
             </div>
           ` : null}
@@ -485,7 +485,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
 
       <${KpiSection} title="결과" question="무엇을 해냈고 실패했고 검증을 통과했나?">
         ${outcomes ? html`<${OutcomesLedger} keeper=${keeper} outcomes=${outcomes} />` : html`
-          <div class="text-[11px] text-[var(--text-dim)] leading-snug">
+          <div class="text-2xs text-[var(--text-dim)] leading-snug">
             outcomes 집계를 불러오는 중이거나, 이 키퍼는 아직 관찰된 전이가 없습니다.
           </div>
         `}
@@ -595,18 +595,18 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Turn Token Trend</span>
-        <span class="text-[10px] text-[var(--text-dim)]">${points.length} turns</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Turn Token Trend</span>
+        <span class="text-3xs text-[var(--text-dim)]">${points.length} turns</span>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
         ${'' /* Dual-line chart: input (cyan) + output (green) */}
         <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center gap-4 mb-1.5">
-            <span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+            <span class="flex items-center gap-1 text-3xs text-[var(--text-muted)]">
               <span class="inline-block w-2.5 h-0.5 rounded bg-[#67e8f9]"></span> input
               <span class="font-mono text-[var(--cyan)]">${formatTokens(lastInput)}</span>
             </span>
-            <span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+            <span class="flex items-center gap-1 text-3xs text-[var(--text-muted)]">
               <span class="inline-block w-2.5 h-0.5 rounded bg-[var(--ok)]"></span> output
               <span class="font-mono text-[var(--good)]">${formatTokens(lastOutput)}</span>
             </span>
@@ -619,9 +619,9 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
 
         ${'' /* Input/Output ratio */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">In/Out 비율</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">In/Out 비율</span>
           <span class="text-lg font-mono tabular-nums text-[var(--accent)]">${avgRatio.toFixed(1)}x</span>
-          <span class="text-[10px] text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
+          <span class="text-3xs text-[var(--text-dim)]">${avgRatio > 10 ? '프롬프트 비대 주의' : avgRatio > 5 ? '프롬프트 무거움' : '정상 범위'}</span>
         </div>
       </div>
     </div>
@@ -675,11 +675,11 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Prompt Fingerprint</span>
-        <span class="text-[10px] text-[var(--text-dim)]">${promptPoints.length} snapshots</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Prompt Fingerprint</span>
+        <span class="text-3xs text-[var(--text-dim)]">${promptPoints.length} snapshots</span>
         ${latest?.prompt_fingerprint
           ? html`<span class="inline-flex items-center gap-1">
-              <span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
+              <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>
               <${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${10} />
             </span>`
           : null}
@@ -687,13 +687,13 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
         <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">estimated prompt tokens</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">estimated prompt tokens</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="var(--amber-bright)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="mt-1 flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)]">
+          <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--text-dim)]">
             <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
             <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
@@ -701,18 +701,18 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${fingerprintTransitions}</span>
-          <span class="text-[10px] text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
+          <span class="text-3xs text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
         </div>
 
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest fingerprint</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest fingerprint</span>
           <div class="flex items-center gap-1.5">
             <span class="text-sm font-mono break-all text-[var(--text-strong)]" title=${latest?.prompt_fingerprint ?? ''}>${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
             ${latest?.prompt_fingerprint ? html`<${CopyIdButton} value=${latest.prompt_fingerprint} label="fingerprint" size=${12} />` : null}
           </div>
-          <span class="text-[10px] text-[var(--text-dim)]">${latestSegments.length} segments</span>
+          <span class="text-3xs text-[var(--text-dim)]">${latestSegments.length} segments</span>
         </div>
       </div>
 
@@ -721,19 +721,19 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
           ${latestSegments.map(([segmentKey, segment]) => html`
             <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
               <div class="flex items-center justify-between gap-2 mb-2">
-                <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
+                <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
                 <span class="inline-flex items-center gap-1">
-                  <span class="text-[10px] font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
+                  <span class="text-3xs font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
               <div class="grid grid-cols-2 gap-2 text-xs">
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
+                  <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
                   <div class="mt-1 font-mono tabular-nums text-[var(--accent)]">${formatTokens(segment.estimated_tokens)}</div>
                 </div>
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
-                  <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
+                  <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
                   <div class="mt-1 font-mono tabular-nums text-[var(--text-strong)]">${segment.bytes.toLocaleString()}</div>
                 </div>
               </div>
@@ -791,13 +791,13 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">CTX Composition</span>
-        <span class="text-[10px] text-[var(--text-dim)]">${points.length} snapshots</span>
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">CTX Composition</span>
+        <span class="text-3xs text-[var(--text-dim)]">${points.length} snapshots</span>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
         <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest turn input</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest turn input</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${formatTokens(latestTotal)}</span>
           </div>
           <div class="h-3 rounded-sm overflow-hidden border border-[var(--white-8)] bg-[var(--white-2)] flex">
@@ -809,7 +809,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
               ></div>`
             })}
           </div>
-          <div class="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)]">
+          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--text-dim)]">
             ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
             <span>known ${formatTokens(latestKnown)}</span>
             <span>${Math.round(knownRatio * 100)}% attributed</span>
@@ -818,25 +818,25 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">largest bucket</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">largest bucket</span>
           <span class="text-sm font-medium text-[var(--text-strong)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
-          <span class="text-[10px] font-mono text-[var(--text-dim)]">
+          <span class="text-3xs font-mono text-[var(--text-dim)]">
             ${latestEntries[0] ? `${formatTokens(latestEntries[0][1].estimated_tokens)} · ${((latestEntries[0][1].estimated_tokens / latestTotal) * 100).toFixed(1)}%` : '-'}
           </span>
         </div>
 
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">residual</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">residual</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${formatTokens(unattributedTokens)}</span>
-          <span class="text-[10px] text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
+          <span class="text-3xs text-[var(--text-dim)]">tool schema / provider overhead / estimator gap</span>
         </div>
       </div>
 
       <div class="mt-3 grid grid-cols-1 md:grid-cols-3 gap-3">
         <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">stacked history</span>
-            <span class="text-[10px] text-[var(--text-dim)]">${points.length} turns</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">stacked history</span>
+            <span class="text-3xs text-[var(--text-dim)]">${points.length} turns</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
@@ -864,8 +864,8 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
 
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between gap-2 mb-2">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
-            <span class="text-[10px] font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
+            <span class="text-3xs font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
           </div>
           <input
             type="search"
@@ -873,10 +873,10 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
             placeholder="세그먼트 필터 (예: history, memory)"
             aria-label="context composition 세그먼트 필터"
             onInput=${(e: Event) => { ctxCompositionSearch.value = (e.target as HTMLInputElement).value }}
-            class="mb-2 w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="mb-2 w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
           ${visibleCtxEntries.length === 0 ? html`
-            <div class="py-4 text-center text-[11px] text-[var(--text-dim)]">
+            <div class="py-4 text-center text-2xs text-[var(--text-dim)]">
               필터 결과 없음 (${latestEntries.length} items)
             </div>
           ` : null}
@@ -884,7 +884,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
             ${visibleCtxEntries.map(([key, segment]) => {
               const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
               return html`
-                <div class="flex items-center justify-between gap-2 text-[11px]">
+                <div class="flex items-center justify-between gap-2 text-2xs">
                   <span class="inline-flex items-center gap-2 min-w-0">
                     <span class="inline-block w-2.5 h-2.5 rounded-full shrink-0" style=${`background:${ctxSegmentColor(key)};`}></span>
                     <span class="truncate text-[var(--text-body)]">${ctxSegmentLabel(key)}</span>
@@ -959,27 +959,27 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="mb-5">
       <div class="flex items-center gap-2 mb-2">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Inference Telemetry</span>
-        <span class="text-[10px] text-[var(--text-dim)]">${telemetryPoints.length} points</span>
-        ${lastFp ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
+        <span class="text-2xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Inference Telemetry</span>
+        <span class="text-3xs text-[var(--text-dim)]">${telemetryPoints.length} points</span>
+        ${lastFp ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
       </div>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         ${'' /* tok/s sparkline */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">tok/s</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">tok/s</span>
             <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastTps.toFixed(1)}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
             ${tpsLine ? html`<polyline points="${tpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="text-[10px] text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
+          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
         </div>
 
         ${'' /* request latency */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">API latency</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">API latency</span>
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
@@ -989,16 +989,16 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
 
         ${'' /* cache hits */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">KV Cache</span>
           <span class="text-lg font-mono tabular-nums text-[var(--purple)]">${totalCacheN > 0 ? totalCacheN.toLocaleString() : '-'}</span>
-          <span class="text-[10px] text-[var(--text-dim)]">cumulative tokens</span>
+          <span class="text-3xs text-[var(--text-dim)]">cumulative tokens</span>
         </div>
 
         ${'' /* reasoning tokens */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Reasoning</span>
           <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${totalReasoning > 0 ? totalReasoning.toLocaleString() : '-'}</span>
-          <span class="text-[10px] text-[var(--text-dim)]">total tokens</span>
+          <span class="text-3xs text-[var(--text-dim)]">total tokens</span>
         </div>
       </div>
     </div>
@@ -1038,9 +1038,9 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${'' /* Latency + fallback markers */}
       <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">지연 시간</span>
           <span class="flex items-center gap-2">
-            ${fallbackCount > 0 ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-soft)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
+            ${fallbackCount > 0 ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-soft)] text-[var(--bad)] font-mono">FB ${fallbackCount}</span>` : null}
             <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${lastLatency > 0 ? `${(lastLatency / 1000).toFixed(1)}s` : '-'}</span>
           </span>
         </div>
@@ -1056,7 +1056,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${'' /* Cost */}
       <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
         <div class="flex items-center justify-between mb-1.5">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">비용</span>
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">비용</span>
           <span class="text-xs font-mono tabular-nums text-[var(--purple)]">$${totalCost.toFixed(4)}</span>
         </div>
         <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
@@ -1068,12 +1068,12 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${modelSwitches.length > 0 ? html`
         <div class="md:col-span-2 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">모델 전환</span>
-            <span class="text-[10px] text-[var(--text-dim)]">${modelSwitches.length}회</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">모델 전환</span>
+            <span class="text-3xs text-[var(--text-dim)]">${modelSwitches.length}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${modelSwitches.map(s => html`
-              <span class="text-[10px] px-2 py-0.5 rounded-sm bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)] font-mono">
+              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)] font-mono">
                 T${s.index} -> ${s.model.length > MODEL_NAME_MAX_LEN ? s.model.slice(0, MODEL_NAME_MAX_LEN) + '...' : s.model}
               </span>
             `)}
@@ -1085,12 +1085,12 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
       ${fallbackCount > 0 ? html`
         <div class="md:col-span-2 p-3 rounded border border-[var(--bad-20)] bg-[var(--bad-6)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Cascade Fallback</span>
-            <span class="text-[10px] text-[var(--bad)]">${fallbackCount}회</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Cascade Fallback</span>
+            <span class="text-3xs text-[var(--bad)]">${fallbackCount}회</span>
           </div>
           <div class="flex flex-wrap gap-1.5">
             ${series.filter((p: KeeperMetricPoint) => p.fallback_applied).slice(-10).map((p: KeeperMetricPoint) => html`
-              <span class="text-[10px] px-2 py-0.5 rounded-sm bg-[var(--bad-10)] text-[var(--bad)] border border-[var(--bad-20)] font-mono">
+              <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--bad-10)] text-[var(--bad)] border border-[var(--bad-20)] font-mono">
                 ${p.fallback_from ?? '?'} -> ${p.fallback_to ?? p.model_used}${p.fallback_reason ? ` (${p.fallback_reason.length > 20 ? p.fallback_reason.slice(0, 20) + '...' : p.fallback_reason})` : ''}
               </span>
             `)}
@@ -1163,7 +1163,7 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
         ${filtered.map((f, i) => html`
           <div class="grid grid-cols-[100px_80px_1fr] gap-2 py-2 px-2 text-xs rounded ${i % 2 === 0 ? 'bg-[var(--white-2)]' : ''}">
             <span class="font-semibold text-[var(--text-body)] truncate">${f.title}</span>
-            <span class="font-mono text-[var(--cyan)] text-[11px] truncate">${f.key}</span>
+            <span class="font-mono text-[var(--cyan)] text-2xs truncate">${f.key}</span>
             <span class="text-right text-[var(--text-body)] truncate">${f.value}</span>
           </div>
         `)}
@@ -1188,7 +1188,7 @@ export function EquipmentList({ items }: { items: string[] }) {
       ${items.map((item, i) => html`
         <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
           <span class="text-xs text-[var(--text-body)]">${item}</span>
-          <span class="text-[10px] text-[var(--cyan)] font-mono">#${i + 1}</span>
+          <span class="text-3xs text-[var(--cyan)] font-mono">#${i + 1}</span>
         </div>
       `)}
     </div>
@@ -1203,8 +1203,8 @@ export function RelationshipList({ rels }: { rels: Record<string, string> }) {
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
         <div class="flex items-center gap-2 py-2 px-3 bg-[var(--white-3)] rounded">
-          <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-[11px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${name}</span>
-          <span class="text-[11px] text-[var(--text-muted)] font-mono">${relation}</span>
+          <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${name}</span>
+          <span class="text-2xs text-[var(--text-muted)] font-mono">${relation}</span>
         </div>
       `)}
     </div>
@@ -1216,9 +1216,9 @@ export function TraitsList({ traits, label }: { traits: string[]; label: string 
 
   return html`
     <div class="mb-3">
-      <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
+      <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
       <div class="flex flex-wrap gap-1.5">
-        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-sm text-[11px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${t}</span>`)}
+        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${t}</span>`)}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -67,7 +67,7 @@ function ToolChip({ name }: { name: string }) {
   const cat = toolCategory(name)
   return html`
     <button type="button"
-      class="inline-flex items-center gap-1 py-0.5 px-2 rounded-sm text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
+      class="inline-flex items-center gap-1 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)] hover:bg-[var(--accent-20)] cursor-pointer transition-colors"
       title=${`${cat.label}: ${name}`}
       onClick=${() => openToolsInventory(name)}
     >
@@ -107,7 +107,7 @@ export function AllowlistPreview({
   }, [tools.length, firstTool, lastTool, previewLimit])
 
   if (tools.length === 0) {
-    return html`<span class="text-[11px] text-[var(--text-muted)] italic">${emptyLabel}</span>`
+    return html`<span class="text-2xs text-[var(--text-muted)] italic">${emptyLabel}</span>`
   }
 
   const { visibleTools, hiddenCount } = expanded
@@ -120,7 +120,7 @@ export function AllowlistPreview({
         ${visibleTools.map(tool => html`<${ToolChip} name=${tool} />`)}
         ${!expanded && hiddenCount > 0
           ? html`
-              <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+              <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
                 +${hiddenCount}
               </span>
             `
@@ -129,7 +129,7 @@ export function AllowlistPreview({
       ${tools.length > previewLimit
         ? html`
             <button type="button"
-              class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+              class="self-start text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
               aria-expanded=${expanded}
               aria-label=${expanded ? '허용된 도구 접기' : `허용된 도구 나머지 ${hiddenCount}개 보기`}
               onClick=${() => setExpanded(value => !value)}
@@ -147,12 +147,12 @@ export function AllowlistPreview({
 function ToolSection({ title, description, tools, fallback }: { title: string; description?: string; tools: string[]; fallback: string }) {
   return html`
     <div class="flex flex-col gap-1.5 mt-3">
-      <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</span>
-      ${description ? html`<span class="text-[11px] text-[var(--text-muted)] leading-snug">${description}</span>` : null}
+      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</span>
+      ${description ? html`<span class="text-2xs text-[var(--text-muted)] leading-snug">${description}</span>` : null}
       <div class="flex flex-wrap gap-1.5">
         ${tools.length > 0
           ? tools.map(tool => html`<${ToolChip} name=${tool} />`)
-          : html`<span class="text-[11px] text-[var(--text-muted)] italic">${fallback}</span>`}
+          : html`<span class="text-2xs text-[var(--text-muted)] italic">${fallback}</span>`}
       </div>
     </div>
   `
@@ -220,13 +220,13 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   let pill
   if (isInvalid) {
     valueClass = 'text-[var(--bad-light)] underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
+    pill = html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid</span>`
   } else if (isOverride) {
     valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
+    pill = html`<span class="rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
   } else {
     valueClass = 'text-[var(--text-muted)] cursor-help'
-    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
+    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
   }
 
   return html`
@@ -234,7 +234,7 @@ function BudgetRow({ label, slot, manifest, clamp }: {
       <span class="text-xs text-[var(--text-muted)]">${label}</span>
       <div class="flex items-center gap-2">
         ${isOverride && deltaText
-          ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">${deltaText}</span>`
+          ? html`<span class="text-3xs text-[var(--text-muted)] tabular-nums">${deltaText}</span>`
           : null}
         <span
           class="text-xs font-medium tabular-nums ${valueClass}"
@@ -250,7 +250,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   const budget = keeper.turn_budget
   if (!budget) {
     return html`
-      <div class="text-[11px] text-[var(--text-muted)] italic">
+      <div class="text-2xs text-[var(--text-muted)] italic">
         턴 예산 정보를 아직 수신하지 못했습니다. 서버 재시작 후 확인해주세요.
       </div>
     `
@@ -267,14 +267,14 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="flex flex-col gap-1.5">
       <div class="flex items-center gap-2 mb-1">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
-          ? html`<span class="rounded-sm bg-[var(--bad-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
+          ? html`<span class="rounded-sm bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--bad-light)]">invalid override</span>`
           : hasOverride
-            ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
-            : html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
+            ? html`<span class="rounded-sm bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider text-[var(--warn)]">override</span>`
+            : html`<span class="rounded-sm bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wider text-[var(--ok)]">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형"
@@ -288,7 +288,7 @@ function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
         manifest=${budget.manifest_path}
         clamp=${clamp}
       />
-      <span class="text-[11px] text-[var(--text-muted)] leading-snug mt-1">
+      <span class="text-2xs text-[var(--text-muted)] leading-snug mt-1">
         반응형 = 보드/멘션 반응 턴 예산, 예약 자율 = 자율 주기 턴 예산.
         값에 마우스를 올리면 설정 출처와 기본값 비교를 확인할 수 있습니다.
       </span>
@@ -300,10 +300,10 @@ export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
   const diverges = hasTurnBudgetDivergence(keeper)
   return html`
     <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm" open=${diverges}>
-      <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+      <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-[var(--warn-10)]' : 'bg-accent/50'}"></span>
         턴 예산
-        ${diverges ? html`<span class="text-[10px] text-[var(--warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
+        ${diverges ? html`<span class="text-3xs text-[var(--warn)] font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
       </summary>
       <div class="mt-3">
         <${TurnBudgetPanel} keeper=${keeper} />
@@ -453,7 +453,7 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
             <div class="flex items-center gap-2">
               <input
                 type="search"
-                class="flex-1 min-w-0 py-1.5 px-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-30)]"
+                class="flex-1 min-w-0 py-1.5 px-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-30)]"
                 placeholder="신호 지표 필터 (예: 폴백, 메모리, 컴팩션)"
                 aria-label="런타임 신호 지표 필터"
                 value=${signalQuery}
@@ -463,21 +463,21 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
                 }}
               />
               ${isFiltering
-                ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap">${matchedRows}/${totalRows}</span>`
+                ? html`<span class="text-3xs text-[var(--text-muted)] tabular-nums whitespace-nowrap">${matchedRows}/${totalRows}</span>`
                 : null}
             </div>
           `
         : null}
       ${showEmptyState
         ? html`
-            <div class="py-3 px-3 rounded border border-dashed border-[var(--card-border)] text-[11px] text-[var(--text-muted)] italic">
+            <div class="py-3 px-3 rounded border border-dashed border-[var(--card-border)] text-2xs text-[var(--text-muted)] italic">
               필터 결과 없음 (${totalRows} items)
             </div>
           `
         : null}
       ${filteredGroups.map(g => html`
         <div class="flex flex-col gap-1">
-          <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] px-1">${g.title}</span>
+          <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] px-1">${g.title}</span>
           <div class="flex flex-col gap-1">
             ${g.rows.map(r => html`<${SignalRow} label=${r.label} value=${r.value} />`)}
           </div>
@@ -606,7 +606,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
       <div class="flex justify-end mt-1">
         <button type="button"
-          class="py-1.5 px-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
+          class="py-1.5 px-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default"
           disabled=${!openToolsQuery}
           onClick=${() => { openToolsInventory(openToolsQuery) }}
         >
@@ -615,9 +615,9 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       </div>
 
       <div class="flex items-center justify-between mt-3">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">허용된 도구</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">허용된 도구</span>
         <button type="button"
-          class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
+          class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-default"
           disabled=${!policyEditable}
           onClick=${() => {
             showAllowlistEditor.value = !showAllowlistEditor.value
@@ -642,7 +642,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
             }}
           />`
         : html`
-          <span class="text-[11px] text-[var(--text-muted)] leading-snug">
+          <span class="text-2xs text-[var(--text-muted)] leading-snug">
             ${policyLoading
               ? '정적 도구 정책을 불러오는 중입니다.'
               : policyEditable

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -173,16 +173,16 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="px-6 pt-4">
-      <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[12px] text-[var(--text-body)]">
+      <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--text-body)]">
         ${keeper.paused
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[11px] font-semibold bg-[var(--warn-14)] text-[var(--warn)]">일시정지</span>
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">일시정지</span>
             <button
-              class="inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('resume')}
             >재개</button>`
           : html`<button
-              class="inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
             >일시정지</button>`}
@@ -192,24 +192,24 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
             ? html`<span>하트비트는 유지되지만 자율 행동은 멈춰 있습니다.</span>`
           : null}
         ${hbStale
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[11px] font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">Heartbeat stale</span>
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">Heartbeat stale</span>
             <span>마지막 하트비트: <${TimeAgo} timestamp=${keeper.last_heartbeat} /></span>`
           : null}
         ${continueGate
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[11px] font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 계속 진행 승인 대기
               </span>
             `
           : socialFallbackActive
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[11px] font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 Social fallback
               </span>
             `
           : runtimeBlockerClass
           ? html`
-              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[11px] font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">
+              <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">
                 ${runtimeBlockerLabel ?? 'Runtime blocker'}
               </span>
             `
@@ -239,7 +239,7 @@ function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; e
 
   if (isOffline) return html`
     <button type="button"
-      class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[var(--emerald-8)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
+      class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[rgba(34,197,94,0.4)] bg-[var(--emerald-8)] text-[var(--ok)] hover:bg-[rgba(34,197,94,0.15)] transition-colors"
       onClick=${() => {
         void (async () => {
           try {
@@ -259,7 +259,7 @@ function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; e
 
   if (isRunning) return html`
     <button type="button"
-      class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
+      class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
       onClick=${() => {
         void (async () => {
           const confirmed = await requestConfirm({
@@ -325,16 +325,16 @@ function KeeperClearContextDialog({
       <div class="p-5 flex flex-col gap-4">
         <div class="flex flex-col gap-1">
           <h3 id=${titleId} class="m-0 text-[17px] font-semibold text-[var(--text-strong)]">키퍼 컨텍스트 비우기</h3>
-          <p id=${descId} class="m-0 text-[13px] leading-relaxed text-[var(--text-muted)]">
+          <p id=${descId} class="m-0 text-sm leading-relaxed text-[var(--text-muted)]">
             ${keeperName}의 checkpoint 대화와 continuity summary를 비웁니다. 사유는 감사 로그에 남습니다.
           </p>
         </div>
 
         <label class="flex flex-col gap-2">
-          <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
+          <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
           <textarea
             ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
+            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-sm leading-[1.55] text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
             placeholder="예: stale continuity replay 제거"
             disabled=${pending}
             value=${reason}
@@ -342,7 +342,7 @@ function KeeperClearContextDialog({
           ></textarea>
         </label>
 
-        <label class="flex items-start gap-3 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-body)]">
+        <label class="flex items-start gap-3 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-body)]">
           <input
             type="checkbox"
             class="mt-0.5"
@@ -356,20 +356,20 @@ function KeeperClearContextDialog({
           </span>
         </label>
 
-        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">
           마지막 수단용 액션입니다. 잘못된 continuity가 재주입될 때만 쓰고, 실행 후 즉시 상태를 다시 확인하세요.
         </div>
 
         <div class="flex items-center justify-end gap-2">
           <button
             type="button"
-            class="px-4 py-2 rounded text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="px-4 py-2 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${pending}
             onClick=${onClose}
           >취소</button>
           <button
             type="button"
-            class="px-4 py-2 rounded text-[13px] font-medium border border-transparent bg-[var(--bad)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="px-4 py-2 rounded text-sm font-medium border border-transparent bg-[var(--bad)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${pending || reason.trim() === ''}
             onClick=${onSubmit}
           >${pending ? '비우는 중...' : '비우기'}</button>
@@ -423,7 +423,7 @@ function CheckpointSummaryCard({
 }) {
   if (!summary) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-muted)]">
         ${title}: 저장된 checkpoint 없음
       </div>
     `
@@ -432,26 +432,26 @@ function CheckpointSummaryCard({
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
       <div class="flex flex-wrap items-center gap-2">
-        <span class="text-[12px] font-semibold text-[var(--text-strong)]">${title}</span>
-        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
+        <span class="text-xs font-semibold text-[var(--text-strong)]">${title}</span>
+        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
           gen ${summary.generation}
         </span>
-        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
           ${summary.message_count} msgs
         </span>
         ${summary.system_prompt_present
-          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
+          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
           : null}
       </div>
-      <div class="mt-2 text-[11px] text-[var(--text-muted)]">
+      <div class="mt-2 text-2xs text-[var(--text-muted)]">
         ${formatCheckpointTime(summary.created_at)}
       </div>
       ${summary.latest_preview
-        ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${summary.latest_preview}</div>`
+        ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${summary.latest_preview}</div>`
         : null}
       ${summary.continuity_summary
-        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
-        : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
+        : html`<div class="mt-2 text-2xs text-[var(--text-dim)]">continuity snapshot 없음</div>`}
     </div>
   `
 }
@@ -529,7 +529,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
   if (loading) {
     return html`
-      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-xs text-[var(--text-muted)]">
         checkpoint inventory 로딩 중...
       </div>
     `
@@ -537,11 +537,11 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
   if (error) {
     return html`
-      <div class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-[12px] text-[#fda4af]">
+      <div class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-xs text-[#fda4af]">
         ${error}
         <button
           type="button"
-          class="ml-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+          class="ml-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
           onClick=${loadInventory}
         >다시 로드</button>
       </div>
@@ -551,7 +551,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center justify-between gap-3">
-        <div class="text-[11px] text-[var(--text-muted)]">
+        <div class="text-2xs text-[var(--text-muted)]">
           current OAS checkpoint와 OAS snapshot history만 노출합니다.
           ${inventory && inventory.legacy_shadow_count > 0
             ? html`<span class="block mt-1 text-[var(--warn)]">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
@@ -560,12 +560,12 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
         <div class="flex items-center gap-2">
           <button
             type="button"
-            class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] font-semibold text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+            class="rounded border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-1.5 text-2xs font-semibold text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
             onClick=${loadInventory}
           >새로고침</button>
           <button
             type="button"
-            class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-2xs font-semibold text-[var(--rose-light)] hover:bg-[var(--bad-soft)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
             disabled=${deleting || selectedIds.length === 0}
             onClick=${deleteSelected}
           >${deleting ? '삭제 중...' : `선택 삭제 (${selectedIds.length})`}</button>
@@ -579,10 +579,10 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] px-3 py-2">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
             OAS Snapshot History
             ${inventory && inventory.history.length > 0 && historyQuery.trim() !== ''
-              ? html`<span class="ml-2 text-[10px] font-normal normal-case tracking-normal text-[var(--text-dim)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`
+              ? html`<span class="ml-2 text-3xs font-normal normal-case tracking-normal text-[var(--text-dim)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`
               : null}
           </div>
           <input
@@ -591,21 +591,21 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
             placeholder="snapshot id / preview / 요약 필터"
             aria-label="OAS snapshot history 필터"
             onInput=${(e: Event) => { setHistoryQuery((e.target as HTMLInputElement).value) }}
-            class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
         ${!inventory || inventory.history.length === 0
-          ? html`<div class="px-3 py-3 text-[12px] text-[var(--text-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
+          ? html`<div class="px-3 py-3 text-xs text-[var(--text-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
           : (() => {
               const visibleHistory = filterCheckpointHistory(inventory.history, historyQuery)
               const isFiltering = historyQuery.trim() !== ''
               if (isFiltering && visibleHistory.length === 0) {
-                return html`<div class="px-3 py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${inventory.history.length} items)</div>`
+                return html`<div class="px-3 py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${inventory.history.length} items)</div>`
               }
               return html`
               <div class="flex flex-col">
                 ${visibleHistory.map(item => html`
-                  <label class="flex gap-3 border-b border-[var(--card-border)] px-3 py-3 text-[12px] last:border-b-0">
+                  <label class="flex gap-3 border-b border-[var(--card-border)] px-3 py-3 text-xs last:border-b-0">
                     <input
                       type="checkbox"
                       class="mt-1"
@@ -615,26 +615,26 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                     <div class="min-w-0 flex-1">
                       <div class="flex flex-wrap items-center gap-2">
                         <span class="font-mono text-[var(--text-strong)]">${item.snapshot_id}</span>
-                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
+                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-18)]">
                           gen ${item.generation}
                         </span>
-                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+                        <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
                           ${item.message_count} msgs
                         </span>
                         ${item.system_prompt_present
-                          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-[10px] font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
+                          ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-3xs font-semibold border border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]">system kept</span>`
                           : null}
                       </div>
-                      <div class="mt-1 text-[11px] text-[var(--text-muted)]">
+                      <div class="mt-1 text-2xs text-[var(--text-muted)]">
                         ${formatCheckpointTime(item.created_at)}
                         ${item.file_stat?.size_bytes ? html` · ${(item.file_stat.size_bytes / 1024).toFixed(1)} KB` : null}
                       </div>
                       ${item.latest_preview
-                        ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${item.latest_preview}</div>`
+                        ? html`<div class="mt-2 text-xs leading-relaxed text-[var(--text-body)]">${item.latest_preview}</div>`
                         : null}
                       ${item.continuity_summary
-                        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
-                        : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+                        ? html`<pre class="mt-2 whitespace-pre-wrap rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
+                        : html`<div class="mt-2 text-2xs text-[var(--text-dim)]">continuity snapshot 없음</div>`}
                     </div>
                   </label>
                 `)}
@@ -653,10 +653,10 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="border-t border-[var(--border-slate-12)] pt-5">
-      <h3 class="m-0 mb-3 text-[13px] font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
+      <h3 class="m-0 mb-3 text-sm font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
 
       ${isOffline ? html`
-        <div class="px-4 py-3 rounded border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-[13px] text-[var(--text-muted)]">
+        <div class="px-4 py-3 rounded border border-[var(--card-border)] bg-[rgba(90,100,120,0.08)] text-sm text-[var(--text-muted)]">
           이 키퍼는 현재 비활동 상태입니다. 기동 후 메시지를 보낼 수 있습니다.
         </div>
       ` : html`
@@ -676,7 +676,7 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
     <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
-      <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
+      <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}
       </div>
@@ -760,19 +760,19 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
       <div class="flex flex-col gap-3">
         ${repos.length > 0 ? html`
           <div>
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Repos (${repos.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Repos (${repos.length})</div>
             <div class="flex flex-col gap-1.5">
               ${repos.map(r => html`
                 <div class="flex items-center gap-3 px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
                       <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
-                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${r.branch}</span>
-                      ${r.shallow ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">shallow</span>` : null}
+                      <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${r.branch}</span>
+                      ${r.shallow ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">shallow</span>` : null}
                     </div>
-                    <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
+                    <div class="text-3xs text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
                   </div>
-                  <span class="text-[10px] text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
+                  <span class="text-3xs text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
                 </div>
               `)}
             </div>
@@ -781,14 +781,14 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
         ${prs.length > 0 ? html`
           <div>
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">PRs (${prs.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">PRs (${prs.length})</div>
             <div class="flex flex-col gap-1.5">
               ${prs.map(pr => html`
                 <div class="flex items-center gap-2 px-3 py-1.5 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                   <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
-                  <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${pr.branch}</span>
-                  ${pr.draft ? html`<span class="text-[10px] px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">draft</span>` : null}
-                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
+                  <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">${pr.branch}</span>
+                  ${pr.draft ? html`<span class="text-3xs px-1 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)] border border-[var(--warn-20)]">draft</span>` : null}
+                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-3xs text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
                 </div>
               `)}
             </div>
@@ -797,10 +797,10 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
         ${worktrees.length > 0 ? html`
           <div>
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
             <div class="flex flex-wrap gap-1.5">
               ${worktrees.map(w => html`
-                <span class="text-[10px] font-mono px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]" title=${w.path}>${w.name}</span>
+                <span class="text-3xs font-mono px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]" title=${w.path}>${w.name}</span>
               `)}
             </div>
           </div>
@@ -977,7 +977,7 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
   return html`
     <div class="md:col-span-2">
       <${SectionCard} title="Generation Lineage">
-        <div class="text-[11px] text-[var(--text-muted)] mb-3">
+        <div class="text-2xs text-[var(--text-muted)] mb-3">
           Track keeper state transfer across successful handoffs. Lineage telemetry is append-only, shows the latest rollover first, and helps explain whether the same keeper identity carried into the new trace.
         </div>
 
@@ -985,21 +985,21 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
           ? html`
             <div class="rounded border border-[var(--accent-20)] bg-[var(--accent-8)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-1">
-                <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]">Latest Handoff</span>
-                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">
+                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--accent)]">Latest Handoff</span>
+                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">
                   ${lineageTransitionLabel(latestEntry.parent_generation, latestEntry.generation)}
                 </span>
-                <span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(latestEntry.continuity_verdict)}">
+                <span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(latestEntry.continuity_verdict)}">
                   ${latestEntryMeta?.badgeLabel}
                 </span>
                 ${latestEntry.created_at
-                  ? html`<span class="text-[10px] text-[var(--text-dim)]">recorded <${TimeAgo} timestamp=${latestEntry.created_at} /></span>`
+                  ? html`<span class="text-3xs text-[var(--text-dim)]">recorded <${TimeAgo} timestamp=${latestEntry.created_at} /></span>`
                   : null}
               </div>
-              <div class="text-[11px] text-[var(--text-body)]">
+              <div class="text-2xs text-[var(--text-body)]">
                 ${latestEntry.trigger_reason ? `trigger ${latestEntry.trigger_reason} · ` : ''}context ratio ${formatLineageRatio(latestEntry.context_ratio)}
               </div>
-              <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+              <div class="mt-1 text-2xs text-[var(--text-dim)]">
                 ${latestEntryMeta?.detail}
               </div>
             </div>
@@ -1008,19 +1008,19 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
 
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-3">
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Gen</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Gen</div>
             <div class="mt-1 text-lg font-semibold text-[var(--text-strong)]">${currentGeneration ?? '-'}</div>
-            ${generationId ? html`<div class="text-[10px] text-[var(--text-dim)] font-mono truncate" title=${generationId}>${generationId}</div>` : null}
+            ${generationId ? html`<div class="text-3xs text-[var(--text-dim)] font-mono truncate" title=${generationId}>${generationId}</div>` : null}
           </div>
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Trace Lineage</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Trace Lineage</div>
             <div class="mt-1 text-lg font-semibold text-[var(--text-strong)]">${traceHistoryCount}</div>
-            <div class="text-[10px] text-[var(--text-dim)]">historical traces retained in meta.trace_history</div>
+            <div class="text-3xs text-[var(--text-dim)]">historical traces retained in meta.trace_history</div>
           </div>
           <div class="px-3 py-2 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Trace</div>
+            <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Trace</div>
             <div class="mt-1 text-sm font-mono text-[var(--text-strong)] truncate" title=${currentTraceId ?? ''}>${currentTraceId ? compactTraceId(currentTraceId) : '-'}</div>
-            <div class="text-[10px] text-[var(--text-dim)]">artifact appears after the first successful handoff</div>
+            <div class="text-3xs text-[var(--text-dim)]">artifact appears after the first successful handoff</div>
           </div>
         </div>
 
@@ -1028,25 +1028,25 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
           ? html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3">
               <div class="flex flex-wrap items-center gap-2 mb-2">
-                <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Manifest</span>
-                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${manifest.generation}</span>
+                <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Current Manifest</span>
+                <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${manifest.generation}</span>
                 ${continuity?.verdict
-                  ? html`<span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(continuity.verdict)}">${continuityMeta.badgeLabel}</span>`
+                  ? html`<span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(continuity.verdict)}">${continuityMeta.badgeLabel}</span>`
                   : null}
                 ${manifest.created_at
-                  ? html`<span class="text-[10px] text-[var(--text-dim)]">created <${TimeAgo} timestamp=${manifest.created_at} /></span>`
+                  ? html`<span class="text-3xs text-[var(--text-dim)]">created <${TimeAgo} timestamp=${manifest.created_at} /></span>`
                   : null}
               </div>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-[11px]">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-2xs">
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-                  <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Parent</div>
+                  <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Parent</div>
                   <div class="text-[var(--text-strong)]">${manifest.parent_generation != null ? `gen ${manifest.parent_generation}` : 'root generation'}</div>
                   ${manifest.parent_trace_id
                     ? html`<div class="font-mono text-[var(--text-dim)] truncate" title=${manifest.parent_trace_id}>${compactTraceId(manifest.parent_trace_id)}</div>`
                     : null}
                 </div>
                 <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-                  <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">Trigger</div>
+                  <div class="text-3xs text-[var(--text-muted)] uppercase tracking-wider mb-1">Trigger</div>
                   <div class="text-[var(--text-strong)]">${manifest.trigger_reason ?? '-'}</div>
                   <div class="text-[var(--text-dim)]">context ratio ${formatLineageRatio(manifest.context_ratio)}</div>
                 </div>
@@ -1054,38 +1054,38 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
               <div class="mt-3 flex flex-wrap gap-2">
                 ${delta
                   ? html`
-                    <span class="text-[10px] px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
                       inherited ${delta.inherited_fields.length}
                     </span>
-                    <span class="text-[10px] px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
                       changed ${delta.changed_fields.length}
                     </span>
-                    <span class="text-[10px] px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
+                    <span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">
                       dropped ${delta.dropped_fields.length}
                     </span>
                   `
                   : null}
                 ${continuity?.similarity != null
-                  ? html`<span class="text-[10px] px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">similarity ${(continuity.similarity * 100).toFixed(1)}%</span>`
+                  ? html`<span class="text-3xs px-2 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]">similarity ${(continuity.similarity * 100).toFixed(1)}%</span>`
                   : null}
               </div>
               ${continuity?.verdict
-                ? html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">${continuityMeta.detail}</div>`
+                ? html`<div class="mt-2 text-2xs text-[var(--text-dim)]">${continuityMeta.detail}</div>`
                 : null}
               ${delta && delta.changed_fields.length === 0 && delta.dropped_fields.length === 0
-                ? html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">identity-only inheritance stayed intact across the rollover.</div>`
+                ? html`<div class="mt-2 text-2xs text-[var(--text-dim)]">identity-only inheritance stayed intact across the rollover.</div>`
                 : null}
             </div>
           `
           : html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3 text-[11px] text-[var(--text-muted)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3 mb-3 text-2xs text-[var(--text-muted)]">
               아직 handoff lineage manifest가 없습니다. generation 0에서는 현재 trace만 유지되고, 첫 successful handoff 이후부터 manifest/index가 생깁니다.
             </div>
           `}
 
         <div>
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Recent Handoffs</div>
-          <div class="text-[11px] text-[var(--text-dim)] mb-2">Latest recorded rollover appears first so operators can compare the current trace against recent history.</div>
+          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Recent Handoffs</div>
+          <div class="text-2xs text-[var(--text-dim)] mb-2">Latest recorded rollover appears first so operators can compare the current trace against recent history.</div>
           ${recent.length > 0
             ? html`
               <div class="flex flex-col gap-2">
@@ -1095,31 +1095,31 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                   return html`
                   <div class=${`px-3 py-2 rounded border ${isLatest ? 'border-[var(--accent-22)] bg-[var(--accent-8)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}>
                     <div class="flex flex-wrap items-center gap-2">
-                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${entry.generation}</span>
+                      <span class="text-3xs font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-15)]">gen ${entry.generation}</span>
                       ${isLatest
-                        ? html`<span class="text-[10px] px-1.5 py-0.5 rounded border border-[var(--accent-18)] bg-[var(--accent-12)] text-[var(--accent)]">latest</span>`
+                        ? html`<span class="text-3xs px-1.5 py-0.5 rounded border border-[var(--accent-18)] bg-[var(--accent-12)] text-[var(--accent)]">latest</span>`
                         : null}
                       ${entry.continuity_verdict
-                        ? html`<span class="text-[10px] px-1.5 py-0.5 rounded ${verdictBadgeClass(entry.continuity_verdict)}">${entryMeta.badgeLabel}</span>`
+                        ? html`<span class="text-3xs px-1.5 py-0.5 rounded ${verdictBadgeClass(entry.continuity_verdict)}">${entryMeta.badgeLabel}</span>`
                         : null}
                       ${entry.created_at
-                        ? html`<span class="text-[10px] text-[var(--text-dim)]"><${TimeAgo} timestamp=${entry.created_at} /></span>`
+                        ? html`<span class="text-3xs text-[var(--text-dim)]"><${TimeAgo} timestamp=${entry.created_at} /></span>`
                         : null}
                     </div>
-                    <div class="mt-1 text-[11px] text-[var(--text-body)]">
+                    <div class="mt-1 text-2xs text-[var(--text-body)]">
                       ${lineageTransitionLabel(entry.parent_generation, entry.generation)}
                       ${entry.trigger_reason ? ` · ${entry.trigger_reason}` : ''}
                       ${entry.context_ratio != null ? ` · ratio ${formatLineageRatio(entry.context_ratio)}` : ''}
                     </div>
-                    <div class="mt-1 text-[10px] font-mono text-[var(--text-dim)] truncate" title=${entry.trace_id}>
+                    <div class="mt-1 text-3xs font-mono text-[var(--text-dim)] truncate" title=${entry.trace_id}>
                       ${compactTraceId(entry.trace_id)}
                     </div>
                     ${entry.continuity_verdict
-                      ? html`<div class="mt-1 text-[10px] text-[var(--text-dim)]">${entryMeta.detail}</div>`
+                      ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">${entryMeta.detail}</div>`
                       : null}
                     ${(entry.identity_changed_fields?.length ?? 0) > 0 || (entry.identity_dropped_fields?.length ?? 0) > 0
                       ? html`
-                        <div class="mt-1 text-[10px] text-[var(--text-dim)]">
+                        <div class="mt-1 text-3xs text-[var(--text-dim)]">
                           ${entry.identity_changed_fields && entry.identity_changed_fields.length > 0 ? `changed: ${entry.identity_changed_fields.join(', ')}` : ''}
                           ${entry.identity_changed_fields && entry.identity_changed_fields.length > 0 && entry.identity_dropped_fields && entry.identity_dropped_fields.length > 0 ? ' · ' : ''}
                           ${entry.identity_dropped_fields && entry.identity_dropped_fields.length > 0 ? `dropped: ${entry.identity_dropped_fields.join(', ')}` : ''}
@@ -1130,12 +1130,12 @@ function GenerationLineagePanel({ keeperName }: { keeperName: string }) {
                 `})}
               </div>
             `
-            : html`<div class="text-[11px] text-[var(--text-muted)]">No recorded handoff entries yet.</div>`}
+            : html`<div class="text-2xs text-[var(--text-muted)]">No recorded handoff entries yet.</div>`}
         </div>
 
         ${manifestPath || indexPath
           ? html`
-            <div class="mt-3 flex flex-col gap-1 text-[10px] text-[var(--text-dim)]">
+            <div class="mt-3 flex flex-col gap-1 text-3xs text-[var(--text-dim)]">
               ${manifestPath ? html`<div class="font-mono truncate" title=${manifestPath}>manifest ${manifestPath}</div>` : null}
               ${indexPath ? html`<div class="font-mono truncate" title=${indexPath}>index ${indexPath}</div>` : null}
             </div>
@@ -1249,7 +1249,7 @@ export function KeeperDetailOverlay() {
                   const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
                   const display = lastUsed || keeper.active_model || keeper.model
                   return display ? html`
-                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
+                    <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
                       title=${lastUsed && keeper.model ? `마지막 호출: ${lastUsed}\n설정: ${keeper.model}` : ''}
                     >${display}</span>
                   ` : null
@@ -1260,7 +1260,7 @@ export function KeeperDetailOverlay() {
                   // SSOT: config/tool_policy.toml [git_clone.workflow_presets]
                   const canPR = ['coding', 'delivery', 'full'].includes(preset)
                   return html`
-                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold uppercase tracking-wide
+                    <span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold uppercase tracking-wide
                       ${canPR
                         ? 'bg-[var(--ok-10)] text-[var(--ok)] border border-[var(--ok-20)]'
                         : 'bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)]'
@@ -1278,7 +1278,7 @@ export function KeeperDetailOverlay() {
                   if (profiles.length <= 1) return null
                   return html`
                     <select
-                      class="py-0.5 px-1 rounded text-[10px] font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
+                      class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
                       title="Cascade profile"
                       value=${currentCascade}
                       onChange=${(e: Event) => {
@@ -1305,7 +1305,7 @@ export function KeeperDetailOverlay() {
           <div class="flex items-center gap-2">
             <button
               type="button"
-              class="py-1 px-3 rounded text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
+              class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
               onClick=${() => setClearDialogOpen(true)}
             >비우기</button>
             <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
@@ -1329,7 +1329,7 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Pipeline stage + Phase state diagram ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
         <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-          <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(71,184,255,0.5)]"></span>
             Phase State Machine
           </summary>
@@ -1339,7 +1339,7 @@ export function KeeperDetailOverlay() {
         </details>
 
         <details class="rounded border border-[var(--white-8)] bg-[var(--white-2)]">
-          <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+          <summary class="cursor-pointer py-2 px-4 text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[rgba(99,102,241,0.5)]"></span>
             Memory Tier & Compaction
           </summary>
@@ -1365,17 +1365,17 @@ export function KeeperDetailOverlay() {
           ? html`
             <div class="flex flex-wrap items-start gap-3 px-1">
               ${keeper.last_heartbeat
-                ? html`<span class="inline-flex items-center gap-1.5 text-[11px] text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                     하트비트 <${TimeAgo} timestamp=${keeper.last_heartbeat} />
                   </span>`
                 : null}
               ${keeper.last_speech_act
-                ? html`<span class="inline-flex items-center gap-1.5 text-[11px] text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)]">
                     최근 <span class="font-mono text-[var(--text-body)]">${keeper.last_speech_act}</span>
                   </span>`
                 : null}
               ${keeper.social_model_recognized === false
-                ? html`<span class="inline-flex items-center gap-1.5 text-[11px] text-[var(--warn)] px-2.5 py-1 rounded border border-[var(--warn-24)] bg-[var(--warn-8)]">
+                ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--warn)] px-2.5 py-1 rounded border border-[var(--warn-24)] bg-[var(--warn-8)]">
                     소셜 모델
                     ${keeper.configured_social_model
                       ? html`<span class="font-mono text-[var(--text-body)]">${keeper.configured_social_model}</span>`
@@ -1389,12 +1389,12 @@ export function KeeperDetailOverlay() {
                   </span>`
                 : null}
               ${(keeper.k2k_count ?? 0) > 0
-                ? html`<span class="inline-flex items-center gap-1 text-[11px] px-2.5 py-1 rounded bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
+                ? html`<span class="inline-flex items-center gap-1 text-2xs px-2.5 py-1 rounded bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] text-[var(--text-muted)]">
                     K2K <span class="font-mono font-medium text-[var(--purple)]">${keeper.k2k_count}</span>
                   </span>`
                 : null}
               ${keeper.memory_recent_note
-                ? html`<span class="text-[11px] text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-[360px]" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
+                ? html`<span class="text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-[360px]" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
                 : null}
             </div>
             ${keeper.recent_output_preview
@@ -1431,7 +1431,7 @@ export function KeeperDetailOverlay() {
           open=${diagOpen}
           onToggle=${(e: Event) => setDiagOpen((e.currentTarget as HTMLDetailsElement).open)}
         >
-          <summary class="cursor-pointer py-3 px-5 text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+          <summary class="cursor-pointer py-3 px-5 text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
             런타임 진단
           </summary>
@@ -1444,7 +1444,7 @@ export function KeeperDetailOverlay() {
               onSocialSweep=${() => { void runSocialSweep() }}
             />
             <div class="pt-3 border-t border-[var(--border-slate-12)]">
-              <h4 class="m-0 mb-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">호출 검사기</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">호출 검사기</h4>
               ${diagOpen ? html`<${KeeperToolCallInspector} keeperName=${keeper.name} />` : null}
             </div>
           </div>
@@ -1469,7 +1469,7 @@ export function KeeperDetailOverlay() {
                 </div>`
               : null}
             ${keeper.skill_reason
-              ? html`<div class="text-[11px] text-[var(--text-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
+              ? html`<div class="text-2xs text-[var(--text-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
 
             ${'' /* ── Identity: will / needs / desires ── */}
@@ -1507,24 +1507,24 @@ export function KeeperDetailOverlay() {
           ${'' /* ── Activity Trace (promoted to main view) ── */}
           <div class="md:col-span-2">
             <${SectionCard} title="세션 활동 로그">
-              <div class="text-[11px] text-[var(--text-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
+              <div class="text-2xs text-[var(--text-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
               <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
           </div>
 
           <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm">
-            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+            <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               품질 시그널 (고급 지표)
             </summary>
-            <div class="mt-3 text-[11px] text-[var(--text-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
+            <div class="mt-3 text-2xs text-[var(--text-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
             <${RuntimeSignals} keeper=${keeper} />
           </details>
 
           <${TurnBudgetSection} keeper=${keeper} />
 
           <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm">
-            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+            <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               도구 정책
             </summary>
@@ -1536,7 +1536,7 @@ export function KeeperDetailOverlay() {
           <${PlaygroundReposPanel} keeperName=${keeper.name} />
 
           <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm">
-            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+            <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               설정
             </summary>
@@ -1546,7 +1546,7 @@ export function KeeperDetailOverlay() {
           </details>
 
           <details class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm">
-            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+            <summary class="cursor-pointer text-2xs font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
               <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
               Checkpoint & Snapshots
             </summary>
@@ -1561,17 +1561,17 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Debug (journal + raw data) ── */}
         <details class="mt-4">
-          <summary class="cursor-pointer py-3 px-4 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
+          <summary class="cursor-pointer py-3 px-4 text-2xs font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
             <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
             디버그
           </summary>
           <div class="mt-2 flex flex-col gap-4">
             <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm">
-              <h4 class="m-0 mb-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">저널</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">저널</h4>
               <${AgentJournalStream} agentName=${keeper.name} />
             </div>
             <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm">
-              <h4 class="m-0 mb-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">원시 데이터</h4>
+              <h4 class="m-0 mb-3 text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">원시 데이터</h4>
               <${RawDataDebug} keeper=${keeper} />
             </div>
           </div>

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -89,9 +89,9 @@ function LayerResultRow({ layer }: { layer: EvalLayerResult }) {
   return html`
     <div class="flex items-center gap-3 py-1.5 px-2 rounded hover:bg-[var(--white-3)] transition-colors">
       <span class="flex-shrink-0 w-4 text-center font-bold text-sm ${iconCls}">${icon}</span>
-      <span class="flex-shrink-0 w-[120px] text-[11px] font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
-      <span class="flex-shrink-0 w-10 text-right text-[11px] font-mono tabular-nums text-[var(--text-strong)]">${scoreText}</span>
-      <span class="flex-1 text-[10px] text-[var(--text-muted)] truncate" title=${detail}>${detail}</span>
+      <span class="flex-shrink-0 w-[120px] text-2xs font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
+      <span class="flex-shrink-0 w-10 text-right text-2xs font-mono tabular-nums text-[var(--text-strong)]">${scoreText}</span>
+      <span class="flex-1 text-3xs text-[var(--text-muted)] truncate" title=${detail}>${detail}</span>
     </div>
   `
 }
@@ -134,8 +134,8 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (loading && !data) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
-        <div class="text-[11px] text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
+        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-2xs text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
       </div>
     `
   }
@@ -143,8 +143,8 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (error && !data) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
-        <div class="text-[11px] text-[var(--text-dim)]">eval 데이터 없음</div>
+        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-2xs text-[var(--text-dim)]">eval 데이터 없음</div>
       </div>
     `
   }
@@ -152,8 +152,8 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (!data || data.count === 0) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
-        <div class="text-[11px] text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
+        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-2xs text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
       </div>
     `
   }
@@ -173,16 +173,16 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Header */}
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">
-          <span class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Eval Quality</span>
+          <span class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Eval Quality</span>
           ${allPassed
-            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[10px] font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
-            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[10px] font-semibold bg-[var(--bad-12)] text-[var(--bad)]">FAIL</span>`
+            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
+            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-12)] text-[var(--bad)]">FAIL</span>`
           }
-          ${baseline ? html`<span class="text-[10px] font-medium ${baseline.cls}">${baseline.text}</span>` : null}
+          ${baseline ? html`<span class="text-3xs font-medium ${baseline.cls}">${baseline.text}</span>` : null}
         </div>
         <button
           type="button"
-          class="text-[10px] text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
+          class="text-3xs text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
           onClick=${() => void loadEvalData(keeperName)}
           title="새로고침"
         >${loading ? '...' : '\u21bb'}</button>
@@ -190,7 +190,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* Coverage bar */}
       <div class="flex items-center gap-3 mb-3">
-        <span class="text-[10px] text-[var(--text-muted)] flex-shrink-0 w-16">Coverage</span>
+        <span class="text-3xs text-[var(--text-muted)] flex-shrink-0 w-16">Coverage</span>
         <div class="flex-1 h-2 bg-[var(--white-6)] rounded-sm overflow-hidden">
           <div
             class="h-full rounded-sm transition-all duration-500"
@@ -203,7 +203,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Layer Results */}
       ${layers.length > 0 ? html`
         <div class="mb-3">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)] mb-1.5">Layer Results</div>
+          <div class="text-3xs uppercase tracking-wider text-[var(--text-dim)] mb-1.5">Layer Results</div>
           <div class="flex flex-col gap-0.5">
             ${layers.map((layer: EvalLayerResult) => html`<${LayerResultRow} layer=${layer} />`)}
           </div>
@@ -213,18 +213,18 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* 24h Trend */}
       ${trend ? html`
         <div class="flex items-center gap-2 pt-2 border-t border-[var(--white-8)]">
-          <span class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
-          <span class="text-[11px] font-mono tabular-nums text-[var(--text-muted)]">
+          <span class="text-3xs uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
+          <span class="text-2xs font-mono tabular-nums text-[var(--text-muted)]">
             ${trend.oldCoverage.toFixed(2)} \u2192 ${trend.newCoverage.toFixed(2)}
           </span>
-          <span class="text-[11px] font-mono tabular-nums font-semibold ${trend.deltaPercent >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">
+          <span class="text-2xs font-mono tabular-nums font-semibold ${trend.deltaPercent >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">
             (${trend.deltaPercent >= 0 ? '+' : ''}${trend.deltaPercent.toFixed(1)}%)
           </span>
         </div>
       ` : null}
 
       ${'' /* Snapshot count */}
-      <div class="mt-2 text-[10px] text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
+      <div class="mt-2 text-3xs text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -104,7 +104,7 @@ export function KeeperMemoryTierPanel({
 
   if (loading) {
     return html`
-      <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
+      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--text-dim)]">
         <${InlineSpinner} />
         메모리 티어 로딩중
       </div>
@@ -132,7 +132,7 @@ export function KeeperMemoryTierPanel({
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
+      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
         <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
           total ${totalUsed} / ${totalCap}
         </span>
@@ -156,7 +156,7 @@ export function KeeperMemoryTierPanel({
           placeholder="kind 필터"
           aria-label="memory kind 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[120px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[120px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
         <${FilterChips}
           chips=${[
@@ -169,7 +169,7 @@ export function KeeperMemoryTierPanel({
       </div>
 
       ${visible.length === 0 ? html`
-        <div class="py-4 text-center text-[11px] text-[var(--text-dim)]">
+        <div class="py-4 text-center text-2xs text-[var(--text-dim)]">
           필터 결과 없음
         </div>
       ` : null}
@@ -184,7 +184,7 @@ export function KeeperMemoryTierPanel({
               ? 'bg-[rgba(34,197,94,0.7)]'
               : 'bg-[rgba(99,102,241,0.6)]'
           return html`
-            <div class="flex items-center gap-2 text-[11px]">
+            <div class="flex items-center gap-2 text-2xs">
               <div class="w-24 truncate text-[var(--text-body)] font-mono" title=${row.kind}>
                 ${row.kind}
               </div>
@@ -194,7 +194,7 @@ export function KeeperMemoryTierPanel({
               <div class="w-16 text-right text-[var(--text-muted)] tabular-nums">
                 ${row.used}/${row.cap}
               </div>
-              <div class="w-10 text-right text-[10px] text-[var(--text-dim)] tabular-nums">
+              <div class="w-10 text-right text-3xs text-[var(--text-dim)] tabular-nums">
                 p${row.priority}
               </div>
             </div>
@@ -203,7 +203,7 @@ export function KeeperMemoryTierPanel({
       </div>
 
       <div class="mt-2">
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
           Compaction sub-FSM (KeeperCompactionLifecycle.tla)
         </div>
         <${CytoscapeFsm} spec=${compactionSpec} height="200px" />

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -71,7 +71,7 @@ function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseSty
 export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | string | null; compact?: boolean }) {
   const style = getPhaseStyle(phase)
   const isBuffer = BUFFER_PHASES.has(phase ?? '')
-  const size = compact ? 'px-1.5 py-px text-[10px]' : 'px-2 py-0.5 text-[11px]'
+  const size = compact ? 'px-1.5 py-px text-3xs' : 'px-2 py-0.5 text-2xs'
 
   return html`
     <span
@@ -81,7 +81,7 @@ export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | str
       role="status"
       aria-label="${style.label}"
     >
-      <span class="text-[8px] leading-none" aria-hidden="true">${style.icon}</span>
+      <span class="text-4xs leading-none" aria-hidden="true">${style.icon}</span>
       ${style.label}
     </span>
   `
@@ -117,10 +117,10 @@ export function KeeperPhaseAndStage({
     <div class="flex items-center gap-2">
       <${KeeperPhaseBadge} phase=${phase} />
       ${dwellText ? html`
-        <span class="text-[10px] text-[var(--text-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간">· ${dwellText}</span>
+        <span class="text-3xs text-[var(--text-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간">· ${dwellText}</span>
       ` : null}
       ${stageLabel ? html`
-        <span class="text-[10px] text-[var(--text-dim)] font-mono tracking-tight opacity-80">${stageLabel}</span>
+        <span class="text-3xs text-[var(--text-dim)] font-mono tracking-tight opacity-80">${stageLabel}</span>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -66,7 +66,7 @@ function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
         style="border-color: ${color}; background: ${color}33"
       />
       <div class="absolute bottom-full mb-2 hidden group-hover:flex flex-col items-center z-10">
-        <div class="rounded border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-sm text-[11px] whitespace-nowrap">
+        <div class="rounded border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
           <div class="font-semibold">${t.prev_phase} → ${t.new_phase}</div>
           <div class="text-[var(--text-muted)] mt-0.5">${eventLabel(t.selected_event)}</div>
           <div class="text-[var(--text-muted)]"><${TimeAgo} timestamp=${t.wall_clock_at_decision * 1000} /></div>
@@ -83,9 +83,9 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
   return html`
     <div class="flex items-center gap-3 py-2 px-3 rounded border border-[var(--white-6)] bg-[var(--white-3)]">
       <div class="w-24 shrink-0">
-        <div class="text-[13px] font-semibold text-[var(--text-strong)] truncate">${name}</div>
+        <div class="text-sm font-semibold text-[var(--text-strong)] truncate">${name}</div>
         <div
-          class="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-semibold tracking-wide mt-1"
+          class="inline-flex items-center rounded px-2 py-0.5 text-3xs font-semibold tracking-wide mt-1"
           style="${phaseInlineStyle(phase)}"
         >
           ${getPhaseStyle(toPascalPhase(phase)).icon} ${getPhaseStyle(toPascalPhase(phase)).label}
@@ -93,14 +93,14 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
       </div>
       <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-[24px]">
         ${transitions.length === 0
-          ? html`<span class="text-[11px] text-[var(--text-muted)]">전환 없음</span>`
+          ? html`<span class="text-2xs text-[var(--text-muted)]">전환 없음</span>`
           : transitions.map((t, i) => html`
               <${TransitionDot} t=${t} idx=${i} />
               ${i < transitions.length - 1 ? html`<div class="w-3 h-px bg-[var(--white-10)]" />` : null}
             `)
         }
       </div>
-      <div class="shrink-0 text-[11px] text-[var(--text-muted)] tabular-nums">
+      <div class="shrink-0 text-2xs text-[var(--text-muted)] tabular-nums">
         ${transitions.length}건
       </div>
     </div>
@@ -119,16 +119,16 @@ export function KeeperPhaseTimeline() {
   }
 
   if (keeperList.length === 0) {
-    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">등록된 키퍼 없음</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">등록된 키퍼 없음</div>`
   }
 
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between mb-1">
-        <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">페이즈 전환 (최근 30건)</div>
+        <div class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">페이즈 전환 (최근 30건)</div>
         <button
           type="button"
-          class="text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)] transition-colors"
+          class="text-2xs text-[var(--text-dim)] hover:text-[var(--text-body)] transition-colors"
           onClick=${() => { void loadAll() }}
         >새로고침</button>
       </div>
@@ -138,8 +138,8 @@ export function KeeperPhaseTimeline() {
           ? html`<${KeeperStrip} name=${k.name} data=${d} key=${k.name} />`
           : html`
             <div class="flex items-center gap-3 py-2 px-3 rounded border border-[var(--white-6)] bg-[var(--white-3)]" key=${k.name}>
-              <div class="w-24 text-[13px] font-semibold text-[var(--text-strong)] truncate">${k.name}</div>
-              <span class="text-[11px] text-[var(--text-muted)]">데이터 없음</span>
+              <div class="w-24 text-sm font-semibold text-[var(--text-strong)] truncate">${k.name}</div>
+              <span class="text-2xs text-[var(--text-muted)]">데이터 없음</span>
             </div>
           `
       })}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -151,7 +151,7 @@ function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnosti
 
 function DiagChip({ label }: { label: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${label}</span>
+    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${label}</span>
   `
 }
 
@@ -183,10 +183,10 @@ export function KeeperDiagnosticSummary({
   return html`
     <div class="py-3 px-4 rounded border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
       <div class="mb-3 flex items-center justify-between gap-3">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">명시적 상태 조회</div>
+        <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">명시적 상태 조회</div>
         <button
           type="button"
-          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+          class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
           disabled=${busy}
           onClick=${() => { void refreshStatus() }}
         >
@@ -293,28 +293,28 @@ export function KeeperConversationPanel({
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
           <div class="min-w-[220px] flex-1">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
+            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
-              <div class="text-[15px] font-semibold text-[var(--text-strong)]">@${keeperName}</div>
-              <span class=${`inline-flex items-center rounded-sm border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
+              <div class="text-md font-semibold text-[var(--text-strong)]">@${keeperName}</div>
+              <span class=${`inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
                 ${conversationStateLabel(sending, hydrating)}
               </span>
             </div>
-            <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
+            <div class="mt-1 text-sm leading-[1.65] text-[var(--text-secondary)]">
               Keeper 상세 안에서 직접 대화와 내부 메시지를 함께 봅니다. 필요하면 토글로 내부 프롬프트와 tool chatter를 숨길 수 있습니다.
             </div>
           </div>
           <div class="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
               onClick=${toggleMetadata}
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
             <button
               type="button"
-              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
+              class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)] ${showInternal ? 'border-[rgba(167,139,250,0.3)] text-[var(--purple)]' : ''}"
               onClick=${toggleInternal}
             >
               ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
@@ -323,7 +323,7 @@ export function KeeperConversationPanel({
               ? html`
                   <button
                     type="button"
-                    class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+                    class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
                     disabled=${hydrating}
                     onClick=${() => { void expandHistory() }}
                   >
@@ -341,7 +341,7 @@ export function KeeperConversationPanel({
         <div class="px-4 py-4">
           ${chatAccess.message
             ? html`
-                <div class="mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-[12px] leading-[1.6] text-[var(--warn-bright)]">
+                <div class="mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--warn-bright)]">
                   ${chatAccess.message}
                 </div>
               `
@@ -356,7 +356,7 @@ export function KeeperConversationPanel({
 
         ${!showInternal && hiddenCount > 0
           ? html`
-              <div class="mx-4 mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] leading-[1.55] text-[var(--warn-bright)]">
+              <div class="mx-4 mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-[1.55] text-[var(--warn-bright)]">
                 ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
               </div>
             `

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -16,7 +16,7 @@ export function KeeperSpawnPanel() {
   return html`
     <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-4">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-[13px] text-[var(--text-strong)] font-medium">키퍼 생성</h3>
+        <h3 class="text-sm text-[var(--text-strong)] font-medium">키퍼 생성</h3>
         <${ActionButton} variant="subtle" size="sm" onClick=${() => { showSpawnPanel.value = false }}>닫기<//>
       </div>
       <div class="flex gap-2 mb-3">
@@ -27,7 +27,7 @@ export function KeeperSpawnPanel() {
       </div>
       ${spawnMode.value === 'persona'
         ? html`<${PersonaBrowser} />`
-        : html`<p class="text-[12px] text-[var(--text-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--accent)]">masc_keeper_up</code>을 사용하세요.</p>`}
+        : html`<p class="text-xs text-[var(--text-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--accent)]">masc_keeper_up</code>을 사용하세요.</p>`}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -39,14 +39,14 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
   const title = persona.displayName ?? persona.name
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-[180px]">
-      <div class="text-[14px] text-[var(--text-strong)] font-medium">${title}</div>
-      ${persona.role ? html`<div class="text-[11px] text-[var(--text-muted)]">${persona.role}</div>` : null}
-      ${persona.mode ? html`<div class="text-[10px] text-[var(--text-muted)]">모드: ${persona.mode}</div>` : null}
-      ${persona.description ? html`<div class="text-[11px] text-[var(--text-body)] mt-1 line-clamp-2">${persona.description}</div>` : null}
+      <div class="text-base text-[var(--text-strong)] font-medium">${title}</div>
+      ${persona.role ? html`<div class="text-2xs text-[var(--text-muted)]">${persona.role}</div>` : null}
+      ${persona.mode ? html`<div class="text-3xs text-[var(--text-muted)]">모드: ${persona.mode}</div>` : null}
+      ${persona.description ? html`<div class="text-2xs text-[var(--text-body)] mt-1 line-clamp-2">${persona.description}</div>` : null}
       <div class="mt-auto pt-2">
         ${isConfirming ? html`
           <div class="flex flex-col gap-1.5">
-            <p class="text-[10px] text-[var(--warn)]">키퍼를 시작합니까?</p>
+            <p class="text-3xs text-[var(--warn)]">키퍼를 시작합니까?</p>
             <div class="flex gap-1.5">
               <${ActionButton} variant="primary" size="sm" disabled=${isSpawning}
                 onClick=${() => { void spawnKeeperFromPersona(persona.name).then(() => { confirmTarget.value = null }) }}>
@@ -64,13 +64,13 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
 
 export function PersonaBrowser() {
   useEffect(() => { if (personas.value.length === 0 && !personasLoading.value) void loadPersonas() }, [])
-  if (personasLoading.value) return html`<p class="text-[12px] text-[var(--text-muted)] py-4">페르소나 로딩 중...</p>`
+  if (personasLoading.value) return html`<p class="text-xs text-[var(--text-muted)] py-4">페르소나 로딩 중...</p>`
   if (personasError.value) return html`
     <div class="py-4">
-      <p class="text-[12px] text-[var(--bad)] mb-2">${personasError.value}</p>
+      <p class="text-xs text-[var(--bad)] mb-2">${personasError.value}</p>
       <${ActionButton} variant="ghost" size="sm" onClick=${() => void loadPersonas()}>재시도<//>
     </div>`
-  if (personas.value.length === 0) return html`<p class="text-[12px] text-[var(--text-muted)] py-4">등록된 페르소나가 없습니다.</p>`
+  if (personas.value.length === 0) return html`<p class="text-xs text-[var(--text-muted)] py-4">등록된 페르소나가 없습니다.</p>`
   const visible = filterPersonas(personas.value, searchQuery.value)
   return html`
     <div>
@@ -81,16 +81,16 @@ export function PersonaBrowser() {
           placeholder="페르소나 검색 (이름/역할/모드/설명)"
           aria-label="페르소나 검색"
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[180px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[180px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
-        <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+        <span class="text-3xs text-[var(--text-muted)] tabular-nums">
           ${searchQuery.value.trim()
             ? `${visible.length} / ${personas.value.length}`
             : `${personas.value.length}개`}
         </span>
       </div>
       ${visible.length === 0
-        ? html`<p class="text-[12px] text-[var(--text-muted)] py-4">검색 조건에 맞는 페르소나가 없습니다.</p>`
+        ? html`<p class="text-xs text-[var(--text-muted)] py-4">검색 조건에 맞는 페르소나가 없습니다.</p>`
         : html`
           <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3">
             ${visible.map(p => html`<${PersonaCard} key=${p.name} persona=${p} />`)}
@@ -98,7 +98,7 @@ export function PersonaBrowser() {
         `}
       ${spawnResult.value ? html`
         <${SurfaceCard} class="mt-3" variant="compact">
-          <pre class="text-[11px] font-mono overflow-x-auto max-h-[200px] overflow-y-auto
+          <pre class="text-2xs font-mono overflow-x-auto max-h-[200px] overflow-y-auto
             ${spawnResult.value.success ? 'text-[var(--text-body)]' : 'text-[var(--bad)]'}">${spawnResult.value.message}</pre>
         <//>` : null}
     </div>

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -134,7 +134,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
   if (loading) {
     return html`
-      <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
+      <div class="flex items-center justify-center gap-2 py-6 text-2xs text-[var(--text-dim)]">
         <${InlineSpinner} />
         composite lifecycle 로딩중
       </div>
@@ -147,7 +147,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
+      <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--text-dim)]">
         <span class="inline-flex items-center rounded-sm border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-0.5 text-[var(--accent)]">
           composite ${snapshot.phase}
         </span>
@@ -176,13 +176,13 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       </div>
 
       ${phaseMismatch ? html`
-        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-[1.5] text-[var(--text-body)]">
           keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다.
         </div>
       ` : null}
 
       <div>
-        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
+        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
         <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
       </div>
 
@@ -190,7 +190,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         ${INVARIANT_LABELS.map(([key, label]) => {
           const ok = snapshot.invariants[key]
           return html`
-            <div class=${`rounded border px-3 py-2 text-[11px] leading-[1.5] ${badgeTone(ok)}`}>
+            <div class=${`rounded border px-3 py-2 text-2xs leading-[1.5] ${badgeTone(ok)}`}>
               <div class="font-semibold">${label}</div>
               <div class="mt-1 font-mono">${ok ? 'ok' : 'violated'}</div>
             </div>
@@ -200,14 +200,14 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
       ${transitions.length > 0 ? html`
         <div class="grid gap-2">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Observed transitions</div>
+          <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Observed transitions</div>
           ${transitions.map(transition => html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-[1.5] text-[var(--text-body)]">
               <div class="flex flex-wrap items-center gap-2">
                 <span class="font-mono text-[var(--text-strong)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
                 <span class="text-[var(--text-dim)]">→</span>
                 <span class="font-mono text-[var(--accent)]">${normalizePhase(transition.new_phase) ?? transition.new_phase}</span>
-                <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
                   ${transitionType(transition.selected_event)}
                 </span>
               </div>

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -25,7 +25,7 @@ const crashShowAll = signal<boolean>(false)
 function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
   return html`
     <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
-      <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
+      <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         ${title}
       </div>
@@ -44,7 +44,7 @@ function registryStateBadge(state: string | null) {
     Paused: { bg: 'bg-[var(--white-10)]', text: 'text-[var(--purple)]' },
   }
   const c = colors[state] ?? { bg: 'bg-[rgba(138,163,211,0.1)]', text: 'text-[#86a0cf]' }
-  return html`<span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold ${c.bg} ${c.text}">${state}</span>`
+  return html`<span class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-semibold ${c.bg} ${c.text}">${state}</span>`
 }
 
 const COHORT_COLORS: Record<CrashCategory, string> = {
@@ -64,7 +64,7 @@ function CrashCohortBar({ crash_log }: { crash_log: KeeperSupervisorCrashLogEntr
     .filter(([, count]) => count > 0)
   return html`
     <div>
-      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 유형 분포</div>
+      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 유형 분포</div>
       <div class="flex w-full h-3 rounded-sm overflow-hidden bg-[var(--white-5)]">
         ${entries.map(([key, count]) => html`
           <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${COHORT_COLORS[key]}"
@@ -74,7 +74,7 @@ function CrashCohortBar({ crash_log }: { crash_log: KeeperSupervisorCrashLogEntr
       </div>
       <div class="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
         ${entries.map(([key, count]) => html`
-          <span class="text-[10px] text-[var(--text-muted)] flex items-center gap-1">
+          <span class="text-3xs text-[var(--text-muted)] flex items-center gap-1">
             <span class="inline-block w-2 h-2 rounded-full" style="background: ${COHORT_COLORS[key]}"></span>
             ${key} ${count}
           </span>
@@ -96,10 +96,10 @@ function SpEventsPanel({ sp_events }: { sp_events?: unknown[] }) {
   const entries = sp_events.slice(0, 10) as SpEventLike[]
   return html`
     <div>
-      <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">자기 보호 발동 이력</div>
+      <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">자기 보호 발동 이력</div>
       <div class="space-y-1 max-h-28 overflow-y-auto">
         ${entries.map((e) => html`
-          <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[rgba(139,92,246,0.06)]">
+          <div class="flex items-center justify-between py-1 px-2 rounded text-2xs bg-[rgba(139,92,246,0.06)]">
             <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
             <span class="text-[#8b5cf6]">${e.suppressed_count ?? 0}/${e.total ?? 0} 억제 (${e.dominant_cohort ?? '--'})</span>
           </div>
@@ -151,13 +151,13 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         ${typeof dead_eta_sec === 'number' && dead_eta_sec > 0 && dead_since == null ? html`
           <div class="flex items-center justify-between">
             <span class="text-xs text-[var(--text-muted)]">종료 예상</span>
-            <span class="text-[11px] font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--text-body)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
+            <span class="text-2xs font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--text-body)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
           </div>
         ` : null}
         ${last_failure_reason ? html`
           <div class="flex items-center justify-between">
             <span class="text-xs text-[var(--text-muted)]">마지막 실패 원인</span>
-            <span class="text-[11px] font-mono text-[var(--rose-light)]">${last_failure_reason}</span>
+            <span class="text-2xs font-mono text-[var(--rose-light)]">${last_failure_reason}</span>
           </div>
         ` : null}
         ${dead_since ? html`
@@ -179,10 +179,10 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
           return html`
             <div>
               <div class="flex items-center justify-between mb-2">
-                <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">장애 이력</div>
+                <div class="text-3xs font-semibold uppercase tracking-widest text-[var(--text-muted)]">장애 이력</div>
                 ${filtered.length > 10 ? html`
                   <button type="button"
-                    class="text-[10px] font-medium px-2 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)] transition-colors"
+                    class="text-3xs font-medium px-2 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)] transition-colors"
                     onClick=${() => { crashShowAll.value = !crashShowAll.value }}
                     aria-pressed=${crashShowAll.value}>
                     ${crashShowAll.value ? `최근 10건 보기` : `전체 ${filtered.length}건 보기`}
@@ -200,9 +200,9 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
               ` : null}
               <div class="space-y-1 ${crashShowAll.value ? 'max-h-64' : 'max-h-32'} overflow-y-auto">
                 ${visible.length === 0 ? html`
-                  <div class="py-2 px-2 text-[11px] text-[var(--text-muted)] italic">선택된 카테고리에 해당하는 장애가 없습니다.</div>
+                  <div class="py-2 px-2 text-2xs text-[var(--text-muted)] italic">선택된 카테고리에 해당하는 장애가 없습니다.</div>
                 ` : visible.map((e) => html`
-                  <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
+                  <div class="flex items-center justify-between py-1 px-2 rounded text-2xs bg-[var(--white-3)]">
                     <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
                     <span class="text-[var(--rose-light)]">${e.reason ?? 'unknown'}</span>
                   </div>

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -58,7 +58,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
       ${expanded.value ? html`
         <div class="px-3 pb-3 space-y-2">
           ${entry.model ? html`
-            <div class="text-[10px] text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
+            <div class="text-3xs text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
           ` : null}
           <div>
             <${SectionCap} class="mb-1">Input<//>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -110,7 +110,7 @@ function SuccessRateBar({ stat }: { stat: ToolStat }) {
       <div class="flex-1 h-1.5 rounded-sm bg-[var(--white-5)] overflow-hidden">
         <div class="h-full rounded-sm transition-all duration-300" style="width: ${successPct}%; background: ${barColor}"></div>
       </div>
-      <span class="text-[10px] font-mono w-10 text-right" style="color: ${barColor}">
+      <span class="text-3xs font-mono w-10 text-right" style="color: ${barColor}">
         ${successPct === 100 ? '100%' : `${successPct.toFixed(0)}%`}
       </span>
     </div>
@@ -179,14 +179,14 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
 
   return html`
     <div class="p-5 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-sm">
-      <div class="text-[11px] font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
+      <div class="text-2xs font-semibold uppercase tracking-widest text-text-muted mb-4 flex items-center gap-2">
         <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
         도구 텔레메트리
       </div>
       <div class="flex flex-col gap-4">
 
       ${'' /* Summary row */}
-      <div class="flex gap-3 flex-wrap text-[11px]">
+      <div class="flex gap-3 flex-wrap text-2xs">
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-[var(--white-4)] border border-[var(--white-6)] text-[var(--text-muted)]">
           <span class="font-mono font-medium text-[var(--text-strong)]">${s.tools.length}</span> 도구
         </span>
@@ -224,9 +224,9 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
               placeholder="도구 검색 (이름/카테고리)"
               aria-label="도구 텔레메트리 검색"
               onInput=${(e: Event) => { setQuery((e.target as HTMLInputElement).value) }}
-              class="min-w-[160px] rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-[160px] rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
             />
-            <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+            <span class="text-3xs text-[var(--text-muted)] tabular-nums">
               ${trimmedQuery
                 ? `${visibleTools.length} / ${s.tools.length}`
                 : `${s.tools.length}개`}
@@ -234,7 +234,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           </div>
         </div>
         ${visibleTools.length === 0 ? html`
-          <div class="text-[11px] text-[var(--text-muted)] py-2 px-2">
+          <div class="text-2xs text-[var(--text-muted)] py-2 px-2">
             필터 결과 없음 (${s.tools.length} items)
           </div>
         ` : visibleTools.slice(0, 15).map(stat => {
@@ -242,10 +242,10 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           const barWidth = (stat.call_count / maxCount) * 100
           return html`
             <div class="flex items-center gap-2 py-1 group">
-              <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-[10px] font-mono font-bold ${cat.color}">
+              <div class="size-5 rounded flex-shrink-0 bg-[var(--white-5)] flex items-center justify-center text-3xs font-mono font-bold ${cat.color}">
                 ${cat.icon}
               </div>
-              <div class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate" title=${stat.name}>
+              <div class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--text-muted)] truncate" title=${stat.name}>
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </div>
               <div class="flex-1 h-3 rounded bg-[var(--white-5)] overflow-hidden">
@@ -253,8 +253,8 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
                   style="width: ${barWidth}%; background: ${stat.failure_count > 0 ? 'var(--warn)' : 'var(--accent)'}; opacity: 0.7">
                 </div>
               </div>
-              <span class="w-8 text-right text-[11px] font-mono text-[var(--text-muted)]">${stat.call_count}</span>
-              <span class="w-14 text-right text-[10px] font-mono ${durationColor(stat.avg_duration_ms)}">
+              <span class="w-8 text-right text-2xs font-mono text-[var(--text-muted)]">${stat.call_count}</span>
+              <span class="w-14 text-right text-3xs font-mono ${durationColor(stat.avg_duration_ms)}">
                 ${formatDuration(stat.avg_duration_ms)}
               </span>
             </div>
@@ -268,11 +268,11 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           <${SectionCap} tone="dim" weight="semibold" class="mb-1">성공률<//>
           ${s.tools.filter(st => st.failure_count > 0).map(stat => html`
             <div class="flex items-center gap-2">
-              <span class="w-28 flex-shrink-0 text-[11px] font-mono text-[var(--text-muted)] truncate">
+              <span class="w-28 flex-shrink-0 text-2xs font-mono text-[var(--text-muted)] truncate">
                 ${stat.name.replace(/^(keeper_|masc_)/, '')}
               </span>
               <${SuccessRateBar} stat=${stat} />
-              <span class="text-[10px] text-[var(--bad)] w-10 text-right">${stat.failure_count}err</span>
+              <span class="text-3xs text-[var(--bad)] w-10 text-right">${stat.failure_count}err</span>
             </div>
           `)}
         </div>
@@ -284,10 +284,10 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
           <${SectionCap} tone="dim" weight="semibold" class="mb-1">P95 지연 시간<//>
           ${slowest.map(stat => html`
             <div class="flex items-center justify-between py-1 px-2 rounded bg-[var(--white-3)]">
-              <span class="text-[11px] font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
+              <span class="text-2xs font-mono text-[var(--text-muted)]">${stat.name.replace(/^(keeper_|masc_)/, '')}</span>
               <div class="flex items-center gap-3">
-                <span class="text-[10px] text-[var(--text-dim)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
-                <span class="text-[11px] font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatDuration(stat.p95_duration_ms)}</span>
+                <span class="text-3xs text-[var(--text-dim)]">avg ${formatDuration(stat.avg_duration_ms)}</span>
+                <span class="text-2xs font-mono font-medium ${durationColor(stat.p95_duration_ms)}">p95 ${formatDuration(stat.p95_duration_ms)}</span>
               </div>
             </div>
           `)}

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -61,7 +61,7 @@ function InspectorTabButton({
     <button
       type="button"
       class=${[
-        'rounded-sm border px-3 py-1.5 text-[11px] font-semibold transition-colors',
+        'rounded-sm border px-3 py-1.5 text-2xs font-semibold transition-colors',
         active
           ? 'border-accent/30 bg-[var(--accent-10)] text-[var(--accent)]'
           : 'border-card-border bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-body)] hover:bg-[var(--white-6)]',
@@ -80,18 +80,18 @@ function InspectorOverview() {
     <div class="grid gap-4">
       <${Card} title="Dashboard Focus" class="section">
         <div class="grid gap-3">
-          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-[13px] leading-[1.7] text-[var(--text-body)]">
+          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-sm leading-[1.7] text-[var(--text-body)]">
             이제 대시보드는 <strong class="text-[var(--text-strong)]">핵심 운영 화면</strong>에 더 집중합니다.
             낮은 활용도의 화면은 줄이고, 진짜 자주 보는 상태/개입/근거 화면으로 빠르게 이동할 수 있게 정리했습니다.
           </div>
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
             ${FOCUS_SURFACES.map(surface => html`
               <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3">
-                <div class="text-[12px] font-semibold text-[var(--text-strong)]">${surface.title}</div>
-                <div class="mt-2 text-[11px] leading-[1.6] text-[var(--text-muted)]">${surface.description}</div>
+                <div class="text-xs font-semibold text-[var(--text-strong)]">${surface.title}</div>
+                <div class="mt-2 text-2xs leading-[1.6] text-[var(--text-muted)]">${surface.description}</div>
                 <button
                   type="button"
-                  class="mt-3 rounded border border-accent/25 bg-[var(--accent-10)] px-2.5 py-1.5 text-[11px] font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent-20)]"
+                  class="mt-3 rounded border border-accent/25 bg-[var(--accent-10)] px-2.5 py-1.5 text-2xs font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent-20)]"
                   onClick=${() => navigate(surface.tab, surface.params)}
                 >
                   ${surface.action}
@@ -112,7 +112,7 @@ export function LabInspector() {
     <div class="flex flex-col gap-4">
       <${Card} title="운영 인스펙터" class="section">
         <div class="flex flex-col gap-3">
-          <div class="text-[13px] leading-[1.7] text-[var(--text-body)]">
+          <div class="text-sm leading-[1.7] text-[var(--text-body)]">
             피처 플래그와 서버 설정을 한 곳에서 보고, 대시보드에서 실제 자주 쓰는 운영 화면으로 빠르게 이동합니다.
           </div>
           <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -22,7 +22,7 @@ export function Live({ variant = 'full' }: LiveProps) {
           <div class="flex flex-col gap-2">
             <div class="flex flex-col gap-2">
               <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
-              <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+              <p class="m-0 text-sm leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
             </div>
           </div>
         </section>

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -28,7 +28,7 @@ function FilterBar() {
       ${FILTER_OPTIONS.map(opt => html`
         <button type="button"
           key=${opt.kind}
-          class="px-3 py-1.5 text-[11px] rounded-sm border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
+          class="px-3 py-1.5 text-2xs rounded-sm border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
             ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
             : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--text-body)]'}"
           onClick=${() => toggleLiveFilter(opt.kind)}
@@ -63,11 +63,11 @@ export function ActivityStream() {
               class="activity-item rounded border border-[var(--border-slate-12)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
               <div class="activity-item-head flex items-center gap-2">
-                <span class="activity-kind-chip rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
+                <span class="activity-kind-chip rounded px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
                 <span class="text-[0.75rem] text-[var(--text-body)] font-medium">${entry.agent}</span>
                 <span class="text-[0.7rem] text-[var(--text-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="text-[13px] text-[var(--text-body)] leading-[1.5] break-words">${entry.text}</div>
+              <div class="text-sm text-[var(--text-body)] leading-[1.5] break-words">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -41,7 +41,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
           `}
       <div class="grid content-start gap-1.5 overflow-y-auto pr-1 ${compact ? 'max-h-[32vh]' : 'max-h-[560px]'}">
         ${list.length === 0
-          ? html`<div class="py-6 text-center text-[var(--text-muted)] text-[13px]">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
+          ? html`<div class="py-6 text-center text-[var(--text-muted)] text-sm">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
           : list.map(agent => html`
             <button
               type="button"
@@ -64,8 +64,8 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
                 : null}
               <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText
-                  ? html`<span class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
-                  : html`<span class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic">최근 활동 없음</span>`}
+                  ? html`<span class="text-2xs text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
+                  : html`<span class="text-2xs text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic">최근 활동 없음</span>`}
                 ${agent.lastActivityAt
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}

--- a/dashboard/src/components/live/keeper-health-strip.ts
+++ b/dashboard/src/components/live/keeper-health-strip.ts
@@ -36,10 +36,10 @@ export function KeeperHealthStrip() {
   return html`
     <div class="flex items-center gap-4 rounded border border-[var(--border-slate-12)] bg-[var(--white-3)] px-4 py-2.5">
       <div class="flex items-center gap-2 min-w-0">
-        <span class="text-[13px] font-medium text-[var(--text-strong)] whitespace-nowrap">
+        <span class="text-sm font-medium text-[var(--text-strong)] whitespace-nowrap">
           Keeper
         </span>
-        <span class="text-[13px] text-[var(--text-body)] whitespace-nowrap">
+        <span class="text-sm text-[var(--text-body)] whitespace-nowrap">
           ${summary.activeCount} 활성
           <span class="text-[var(--text-muted)]">/ ${summary.totalCount}</span>
         </span>
@@ -53,11 +53,11 @@ export function KeeperHealthStrip() {
 
       <div class="flex items-center gap-2 ml-auto whitespace-nowrap">
         ${alertCount > 0
-          ? html`<span class="text-[12px] font-medium text-[var(--warn)]">${alertCount} 주의</span>`
-          : html`<span class="text-[12px] text-[var(--text-muted)]">정상</span>`
+          ? html`<span class="text-xs font-medium text-[var(--warn)]">${alertCount} 주의</span>`
+          : html`<span class="text-xs text-[var(--text-muted)]">정상</span>`
         }
         ${summary.criticalCount > 0 && html`
-          <span class="text-[12px] font-medium text-[var(--bad)]">${summary.criticalCount} 위험</span>
+          <span class="text-xs font-medium text-[var(--bad)]">${summary.criticalCount} 위험</span>
         `}
       </div>
     </div>

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -19,7 +19,7 @@ export function PulseStrip() {
   if (pulses.length === 0) {
     return html`
       <div class="pulse-strip rounded">
-        <span class="text-[var(--text-dim)] text-[13px]">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
+        <span class="text-[var(--text-dim)] text-sm">연결된 에이전트 없음. masc_join으로 에이전트가 접속하면 여기에 표시됩니다.</span>
       </div>
     `
   }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -247,55 +247,55 @@ function renderLogRow(entry: LogEntry) {
       key=${entry.seq}
       class="logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-card border border-[rgba(255,255,255,0.05)] px-3 py-3 ${backgroundClass}"
     >
-      <div class="font-mono text-[11px] whitespace-nowrap text-[color:var(--text-muted)]">
+      <div class="font-mono text-2xs whitespace-nowrap text-[color:var(--text-muted)]">
         ${entry.ts.replace('T', ' ').replace('Z', '')}
       </div>
-      <div class="font-mono text-[11px] font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[level] ?? 'inherit'}">
+      <div class="font-mono text-2xs font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[level] ?? 'inherit'}">
         ${level}
       </div>
-      <div class="min-w-0 font-mono text-[11px] text-[color:var(--accent)] truncate" title=${entry.module || '(root)'}>
+      <div class="min-w-0 font-mono text-2xs text-[color:var(--accent)] truncate" title=${entry.module || '(root)'}>
         ${entry.module || '(root)'}
       </div>
       <div class="flex flex-wrap items-start gap-1">
-        <span class="rounded-sm border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceClass}">
+        <span class="rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-[0.08em] ${sourceClass}">
           ${sourceLabel(source)}
         </span>
         ${entry.legacy_classified
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">classified</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">classified</span>`
           : null}
         ${rawLevelChanged
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${entry.raw_level}</span>`
           : null}
         ${clientName
-          ? html`<span class="rounded-sm border border-[var(--accent-soft)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
+          ? html`<span class="rounded-sm border border-[var(--accent-soft)] px-2 py-0.5 text-3xs text-[#dff3ff]">${clientName}</span>`
           : null}
         ${toolName
-          ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px]"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
+          ? html`<span class="inline-flex items-center gap-1 rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
           : null}
         ${fixes
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">fixes ${fixes}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">fixes ${fixes}</span>`
           : null}
         ${phase
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${phase}</span>`
           : null}
         ${requestId
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">req ${requestId}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">req ${requestId}</span>`
           : null}
         ${sessionId
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">session ${sessionId}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">session ${sessionId}</span>`
           : null}
         ${failure
-          ? html`<span class="rounded-sm border border-[rgba(224,80,80,0.24)] bg-[var(--brick-soft)] px-2 py-0.5 text-[10px] text-[var(--bad-light)]">${failure.cause_code}</span>`
+          ? html`<span class="rounded-sm border border-[rgba(224,80,80,0.24)] bg-[var(--brick-soft)] px-2 py-0.5 text-3xs text-[var(--bad-light)]">${failure.cause_code}</span>`
           : null}
         ${failure
-          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${failure.recoverability}</span>`
+          ? html`<span class="rounded-sm border border-[var(--white-10)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">${failure.recoverability}</span>`
           : null}
         ${failure?.operator_action
-          ? html`<span class="rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-[10px] text-[#dff3ff]">next ${failure.operator_action}</span>`
+          ? html`<span class="rounded-sm border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-3xs text-[#dff3ff]">next ${failure.operator_action}</span>`
           : null}
       </div>
       <div
-        class="text-[12px] leading-relaxed text-[var(--text-body)]"
+        class="text-xs leading-relaxed text-[var(--text-body)]"
         title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}
         style=${{
           display: '-webkit-box',
@@ -368,7 +368,7 @@ export function LogViewer() {
             <select
               name="log-level"
               aria-label="로그 레벨"
-              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)]"
               value=${levelFilter.value}
               onChange=${(e: Event) => {
                 levelFilter.value = (e.target as HTMLSelectElement).value
@@ -405,7 +405,7 @@ export function LogViewer() {
             <select
               name="log-limit"
               aria-label="로그 개수"
-              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              class="logs-select rounded border border-[var(--white-10)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)]"
               value=${String(logLimit.value)}
               onChange=${(e: Event) => {
                 logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -419,7 +419,7 @@ export function LogViewer() {
             </select>
           </div>
 
-          <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
+          <div class="logs-actions flex flex-wrap gap-3 items-center text-2xs text-[color:var(--text-muted)]">
             <span class="rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-1 tabular-nums">${logEntries.length.toLocaleString()} / ${logTotal.toLocaleString()}</span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
@@ -433,7 +433,7 @@ export function LogViewer() {
             </label>
             <button
               type="button"
-              class="logs-refresh-btn rounded border border-[var(--accent-22)] bg-[var(--accent-10)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]"
+              class="logs-refresh-btn rounded border border-[var(--accent-22)] bg-[var(--accent-10)] px-3 py-2 text-2xs font-medium text-[#dff3ff]"
               onClick=${() => {
                 latestSeq.value = null
                 logResource.reset()
@@ -447,11 +447,11 @@ export function LogViewer() {
         </div>
 
         ${logError ? html`
-          <div class="mx-4 mt-4 rounded border border-solid border-[#e05050] bg-[var(--brick-soft)] px-4 py-3 text-[12px] text-[#ffb3b3]">${logError}</div>
+          <div class="mx-4 mt-4 rounded border border-solid border-[#e05050] bg-[var(--brick-soft)] px-4 py-3 text-xs text-[#ffb3b3]">${logError}</div>
         ` : null}
 
         <div class="px-3 pt-3">
-          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
             <div>timestamp</div>
             <div>level</div>
             <div>module</div>
@@ -462,7 +462,7 @@ export function LogViewer() {
 
         ${logEntries.length === 0
           ? html`
-              <div class="flex flex-1 items-center justify-center px-6 text-[13px] text-[var(--text-muted)]">
+              <div class="flex flex-1 items-center justify-center px-6 text-sm text-[var(--text-muted)]">
                 ${logLoading ? '로그를 불러오는 중...' : '조건에 맞는 로그가 없습니다.'}
               </div>
             `

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -36,8 +36,8 @@ function expiryChip(post: BoardPost) {
   if (!post.expires_at) return null
   const expiresAtMs = Date.parse(post.expires_at)
   if (!Number.isFinite(expiresAtMs)) return null
-  if (expiresAtMs <= Date.now()) return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] tracking-wide uppercase bg-[var(--bad-15)] text-[var(--bad-light)] border border-[var(--bad-30)]">만료됨</span>`
-  return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] tracking-wide uppercase bg-[var(--warn-15)] text-[var(--warn)] border border-[var(--warn-30)]">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
+  if (expiresAtMs <= Date.now()) return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs tracking-wide uppercase bg-[var(--bad-15)] text-[var(--bad-light)] border border-[var(--bad-30)]">만료됨</span>`
+  return html`<span class="inline-flex items-center px-2 py-0.5 rounded-sm text-3xs tracking-wide uppercase bg-[var(--warn-15)] text-[var(--warn)] border border-[var(--warn-30)]">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
 }
 
 // ── Comment tree building ──────────────────────────────────────────
@@ -134,18 +134,18 @@ function CommentItem({
     <div class="${indent}">
       <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
-          <span class="text-[12px]">${authorAvatar(comment.author)}</span>
-          <button type="button" class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</button>
-          <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
+          <span class="text-xs">${authorAvatar(comment.author)}</span>
+          <button type="button" class="text-xs font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</button>
+          <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <button type="button"
-            class="text-[11px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
+            class="text-2xs text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}</button>
         </div>
-        <div class="text-[13px] text-[var(--text-body)] leading-[1.55]"><${RichContent} text=${displayText} previewLimit=${1} /></div>
+        <div class="text-sm text-[var(--text-body)] leading-[1.55]"><${RichContent} text=${displayText} previewLimit=${1} /></div>
         ${needsTruncation ? html`
           <button type="button"
-            class="mt-1 text-[11px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
+            class="mt-1 text-2xs text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
             onClick=${() => setExpanded(!expanded)}
           >${expanded ? '접기' : '더 보기...'}</button>
         ` : null}
@@ -162,7 +162,7 @@ function CommentItem({
             />
             <div class="mt-2 flex justify-end">
               <button type="button"
-                class="py-1.5 px-3 rounded text-[12px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
+                class="py-1.5 px-3 rounded text-xs font-medium font-[inherit] cursor-pointer transition-all duration-150 border
                   ${commentSubmitting.value || commentText.value.trim() === ''
                     ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
                     : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
@@ -208,14 +208,14 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2 mb-1">
-        <div class="text-[11px] text-[var(--text-muted)]">댓글 ${comments.length}개${isFiltering ? ` · 일치 ${filteredRoots.length}` : ''}</div>
+        <div class="text-2xs text-[var(--text-muted)]">댓글 ${comments.length}개${isFiltering ? ` · 일치 ${filteredRoots.length}` : ''}</div>
         <input
           type="search"
           value=${query.value}
           placeholder="댓글 내용 검색"
           aria-label="댓글 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="ml-auto min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="ml-auto min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && filteredRoots.length === 0 ? html`
@@ -223,14 +223,14 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
       ` : null}
       ${!expanded && hiddenCount > 0 ? html`
         <button type="button"
-          class="text-[12px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
+          class="text-xs text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기</button>
       ` : null}
       ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} postId=${postId} depth=${0} childrenMap=${filteredChildrenMap} />`)}
       ${expanded && hiddenCount > 0 ? html`
         <button type="button"
-          class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"
+          class="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(false)}
         >접기</button>
       ` : null}
@@ -253,7 +253,7 @@ function CommentForm({ postId }: { postId: string }) {
       />
       <div class="mt-2 flex justify-end">
         <button type="button"
-          class="py-2 px-4 rounded text-[13px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
+          class="py-2 px-4 rounded text-sm font-medium font-[inherit] cursor-pointer transition-all duration-150 border
             ${commentSubmitting.value || commentText.value.trim() === ''
               ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
               : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
@@ -289,7 +289,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
   return html`
     <div>
       <button type="button"
-        class="mb-4 px-3 py-1.5 rounded text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
+        class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
         onClick=${() => navigate('workspace', { section: 'board' })}
       >← 게시판으로 돌아가기</button>
 
@@ -299,16 +299,16 @@ export function PostDetail({ post }: { post: BoardPost }) {
             <h1 class="m-0 text-[20px] font-semibold leading-tight text-[var(--text-strong)]">${post.title}</h1>
           </div>
 
-          <div class="text-[13px] text-[var(--text-body)] leading-[1.65]">
+          <div class="text-sm text-[var(--text-body)] leading-[1.65]">
             <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
           </div>
 
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
-            <span class="text-[13px]">${authorAvatar(post.author)}</span>
-            <button type="button" class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(post.author)}>${post.author}</button>
-            <span class="text-[11px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
-            <span class="text-[11px] text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
+            <span class="text-sm">${authorAvatar(post.author)}</span>
+            <button type="button" class="text-xs text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(post.author)}>${post.author}</button>
+            <span class="text-2xs text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
+            <span class="text-2xs text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
           </div>
 
           <!-- Badges -->
@@ -316,13 +316,13 @@ export function PostDetail({ post }: { post: BoardPost }) {
             ? html`
                 <div class="flex flex-col gap-2">
                   <div class="flex gap-1.5 flex-wrap">
-                    ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
-                    ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
-                    <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
+                    ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
+                    ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-3xs font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
                     ${expiryChip(post)}
                   </div>
                   ${post.classification_reason
-                    ? html`<div class="text-[11px] text-[var(--text-muted)]">분류 근거: ${post.classification_reason}</div>`
+                    ? html`<div class="text-2xs text-[var(--text-muted)]">분류 근거: ${post.classification_reason}</div>`
                     : null}
                 </div>
               `
@@ -332,11 +332,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           ${post.meta
             ? html`
                 <details class="mt-1">
-                  <summary class="cursor-pointer text-[12px] text-[var(--text-muted)] py-1.5 hover:text-[var(--text-body)] transition-colors">운영 메타</summary>
+                  <summary class="cursor-pointer text-xs text-[var(--text-muted)] py-1.5 hover:text-[var(--text-body)] transition-colors">운영 메타</summary>
                   <div class="mt-2 p-3 rounded bg-[var(--white-3)] border border-[var(--border-slate-12)]">
-                    ${post.meta.source ? html`<div class="text-[12px] text-[var(--text-body)]"><span class="text-[var(--text-muted)]">출처:</span> ${post.meta.source}</div>` : null}
+                    ${post.meta.source ? html`<div class="text-xs text-[var(--text-body)]"><span class="text-[var(--text-muted)]">출처:</span> ${post.meta.source}</div>` : null}
                     ${post.meta.state_block
-                      ? html`<pre class="whitespace-pre-wrap mt-2 text-[11px] text-[var(--text-muted)] leading-relaxed">${post.meta.state_block}</pre>`
+                      ? html`<pre class="whitespace-pre-wrap mt-2 text-2xs text-[var(--text-muted)] leading-relaxed">${post.meta.state_block}</pre>`
                       : null}
                   </div>
                 </details>
@@ -346,11 +346,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <!-- Vote buttons -->
           <div class="flex gap-2">
             <button type="button"
-              class="vote-btn upvote px-3 py-1.5 rounded text-[12px] font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] transition-all cursor-pointer"
+              class="vote-btn upvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:border-[var(--warn-30)] hover:bg-[var(--warn-10)] transition-all cursor-pointer"
               onClick=${() => handleVote('up')}
             >▲ 추천</button>
             <button type="button"
-              class="vote-btn downvote px-3 py-1.5 rounded text-[12px] font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] transition-all cursor-pointer"
+              class="vote-btn downvote px-3 py-1.5 rounded text-xs font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent-30)] hover:bg-[var(--accent-10)] transition-all cursor-pointer"
               onClick=${() => handleVote('down')}
             >▼ 비추천</button>
           </div>

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -297,7 +297,7 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
 // the backend; reverse for chronological left-to-right rendering.
 function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
   if (!history || history.length < 2) {
-    return html`<span class="text-[var(--text-muted)] text-[10px] w-20 text-center">—</span>`
+    return html`<span class="text-[var(--text-muted)] text-3xs w-20 text-center">—</span>`
   }
   const chronological = [...history].reverse()
   const { width: sw, height: sh, strokeWidth } = SPARKLINE
@@ -426,7 +426,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
         ${ep.participants.map(
           (p: string) => html`<span class="font-mono">${p}</span>`,
         )}
-        <span class="text-[var(--text-muted)] font-mono text-[10px]">${ep.id}</span>
+        <span class="text-[var(--text-muted)] font-mono text-3xs">${ep.id}</span>
       </div>
       ${
         ep.learnings.length > 0

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -148,7 +148,7 @@ function renderCategorySection(
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
     return html`
-      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-[12px] text-[var(--text-muted)]">
+      <div class="mb-3 px-3 py-2 rounded border border-dashed border-[var(--border-slate-16)] text-xs text-[var(--text-muted)]">
         ${label} — ${hidden}건 숨김
       </div>
     `
@@ -166,7 +166,7 @@ function renderCategorySection(
         }} />
         <div class="text-center py-3">
           <button type="button"
-            class="px-4 py-2 rounded text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer disabled:opacity-50"
+            class="px-4 py-2 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer disabled:opacity-50"
             disabled=${loadingMore}
             onClick=${() => {
               expandCategory(category, limits, limit, posts.length)
@@ -189,7 +189,7 @@ function NewPostForm() {
   if (!showNewPostForm.value) {
     return html`
       <button type="button"
-        class="w-full py-2.5 rounded border border-dashed border-[var(--card-border)] text-[13px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--text-body)] transition-colors bg-transparent"
+        class="w-full py-2.5 rounded border border-dashed border-[var(--card-border)] text-sm text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--text-body)] transition-colors bg-transparent"
         onClick=${() => { showNewPostForm.value = true }}
       >+ 새 글 작성</button>
     `
@@ -215,11 +215,11 @@ function NewPostForm() {
       />
       <div class="flex gap-2 justify-end">
         <button type="button"
-          class="px-3 py-1.5 rounded text-[13px] border border-[var(--card-border)] bg-transparent text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]"
+          class="px-3 py-1.5 rounded text-sm border border-[var(--card-border)] bg-transparent text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]"
           onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
         >취소</button>
         <button type="button"
-          class="px-4 py-1.5 rounded text-[13px] font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
+          class="px-4 py-1.5 rounded text-sm font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[var(--accent-20)] disabled:opacity-50"
           disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
           onClick=${() => { void submitNewPost() }}
         >${newPostSubmitting.value ? '등록 중...' : '등록'}</button>
@@ -237,7 +237,7 @@ function SortBar() {
       <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
           <button type="button"
-            class="px-3 py-1.5 rounded text-[12px] font-medium transition-all duration-150 border cursor-pointer
+            class="px-3 py-1.5 rounded text-xs font-medium transition-all duration-150 border cursor-pointer
               ${current === mode.id
                 ? 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
                 : 'bg-transparent text-[var(--text-muted)] border-transparent hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
@@ -260,7 +260,7 @@ function SortBar() {
           const isHidden = boardHiddenCategories.value.has(g.category)
           return html`
             <button type="button"
-              class="px-2.5 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer
+              class="px-2.5 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer
                 ${isHidden
                   ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)] line-through opacity-60'
                   : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
@@ -281,7 +281,7 @@ function SortBar() {
           placeholder="작성자"
           aria-label="작성자 필터"
           value=${boardAuthorFilter.value}
-          class="px-2.5 py-1 rounded text-[11px] font-medium border bg-transparent text-[var(--text)] border-[var(--border-slate-16)] placeholder:text-[var(--text-muted)] w-28 focus:outline-none focus:border-[var(--accent)]"
+          class="px-2.5 py-1 rounded text-2xs font-medium border bg-transparent text-[var(--text)] border-[var(--border-slate-16)] placeholder:text-[var(--text-muted)] w-28 focus:outline-none focus:border-[var(--accent)]"
           onKeyDown=${(e: KeyboardEvent) => {
             if (e.key === 'Enter') {
               boardAuthorFilter.value = (e.target as HTMLInputElement).value.trim()
@@ -299,19 +299,19 @@ function SortBar() {
         <div class="ml-auto flex items-center gap-2">
           ${selectedPostIds.value.size > 0 ? html`
             <button type="button"
-              class="px-3 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[var(--bad-20)] disabled:opacity-50 disabled:cursor-not-allowed"
+              class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-30)] hover:bg-[var(--bad-20)] disabled:opacity-50 disabled:cursor-not-allowed"
               onClick=${bulkDeleteSelected}
               disabled=${bulkDeleting.value}
             >
               ${bulkDeleting.value ? '삭제 중...' : `선택 삭제 (${selectedPostIds.value.size})`}
             </button>
             <button type="button"
-              class="px-2 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
+              class="px-2 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]"
               onClick=${() => { selectedPostIds.value = new Set() }}
             >선택 해제</button>
           ` : null}
           <button type="button"
-            class="px-3 py-1 rounded text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] disabled:opacity-50 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded text-2xs font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshBoard}
             disabled=${boardLoading.value}
           >
@@ -328,8 +328,8 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   return html`
-    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--card-border)] bg-[var(--card)] text-[12px] text-[var(--text-muted)]">
-      <span class="font-semibold text-[var(--text-strong)] tabular-nums text-[15px]">${visibleCount}</span>
+    <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded border border-[var(--card-border)] bg-[var(--card)] text-xs text-[var(--text-muted)]">
+      <span class="font-semibold text-[var(--text-strong)] tabular-nums text-md">${visibleCount}</span>
       <span>개 표시 중</span>
       ${grouped.groups.map(g => {
         const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
@@ -339,7 +339,7 @@ function MemorySummary() {
         `
       })}
       ${lastBoardRefreshAt.value ? html`
-        <span class="ml-auto text-[11px]">갱신 <${TimeAgo} timestamp=${lastBoardRefreshAt.value} /></span>
+        <span class="ml-auto text-2xs">갱신 <${TimeAgo} timestamp=${lastBoardRefreshAt.value} /></span>
       ` : null}
     </div>
   `
@@ -403,12 +403,12 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Vote column -->
       <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-[36px]">
         <button type="button"
-          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('up', event)}
         >▲</button>
-        <span class="text-[13px] font-semibold tabular-nums text-[var(--text-strong)]">${post.votes ?? 0}</span>
+        <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${post.votes ?? 0}</span>
         <button type="button"
-          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--accent-10)] transition-colors cursor-pointer border-0 bg-transparent"
+          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--accent-10)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('down', event)}
         >▼</button>
       </div>
@@ -416,10 +416,10 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Post body -->
       <div class="flex-1 min-w-0">
         <!-- Title -->
-        <div class="text-[15px] font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${stripInlineMarkdown(post.title)}</div>
+        <div class="text-md font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${stripInlineMarkdown(post.title)}</div>
 
         <!-- Content preview: rendered markdown, height-capped -->
-        <div class="board-post-preview text-[13px] text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
+        <div class="board-post-preview text-sm text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
           <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
           <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--card)] to-transparent pointer-events-none" />
         </div>
@@ -427,28 +427,28 @@ function PostCard({ post }: { post: BoardPost }) {
         <!-- Footer: author + meta + badges -->
         <div class="flex items-center gap-2 flex-wrap">
           <!-- Author line -->
-          <span class="text-[12px] text-[var(--text-muted)]">${authorAvatar(post.author)}</span>
+          <span class="text-xs text-[var(--text-muted)]">${authorAvatar(post.author)}</span>
           <a
-            class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+            class="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
             onClick=${(e: Event) => navigateToAuthor(post.author, e)}
           >${post.author}</a>
-          <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
-          ${isUpdated(post) ? html`<span class="text-[10px] text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}
+          <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
+          ${isUpdated(post) ? html`<span class="text-3xs text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}
 
           <!-- Separator -->
           <span class="text-[var(--text-muted)] opacity-30">|</span>
 
           <!-- Counts -->
-          <span class="text-[11px] text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
+          <span class="text-2xs text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
-          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
-          ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
-          ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
+          ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
+          ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
 
           <!-- Delete button -->
           <button type="button"
-            class="ml-auto px-2 py-0.5 rounded text-[10px] font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="ml-auto px-2 py-0.5 rounded text-3xs font-semibold border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad-light)] hover:bg-[var(--bad-20)] transition-all cursor-pointer opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${handleDelete}
             disabled=${isDeleting}
           >
@@ -492,7 +492,7 @@ export function Memory() {
           <div>
             <${MemorySummary} />
             <button type="button"
-              class="mb-4 px-3 py-1.5 rounded text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
+              class="mb-4 px-3 py-1.5 rounded text-xs font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
               onClick=${() => navigate('workspace', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
@@ -507,7 +507,7 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${hint ? html`
-        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-[12px] text-[var(--text-muted)]">
+        <div class="mb-4 px-3 py-2 rounded border border-[var(--border-slate-16)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
           ${hint}
         </div>
       ` : null}
@@ -521,17 +521,17 @@ export function Memory() {
           placeholder="제목/본문에서 검색"
           aria-label="게시글 본문 필터"
           onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[180px] max-w-[320px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[12px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[180px] max-w-[320px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && posts.length === 0 && rawPosts.length > 0
-        ? html`<div class="py-4 text-center text-[12px] text-[var(--text-dim)]">필터 결과 없음 (${rawPosts.length} items)</div>`
+        ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">필터 결과 없음 (${rawPosts.length} items)</div>`
         : posts.length === 0 && boardLoading.value
           ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
           : posts.length === 0
             ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
             : html`
-                ${boardLoading.value ? html`<div class="mb-2 text-[11px] text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
+                ${boardLoading.value ? html`<div class="mb-2 text-2xs text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
                 ${grouped.groups.map(g => html`
                   <${CategorySection} key=${g.category} group=${g} />
                 `)}

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -130,12 +130,12 @@ export function OasHealthChip() {
         <div class="mt-3 pt-3 border-t border-[var(--white-6)] grid md:grid-cols-2 gap-4">
           ${recentEvents.value.length > 0 ? html`
             <div>
-              <div class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
+              <div class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
                 최근 자율성 이벤트
               </div>
               <ul class="space-y-1">
                 ${recentEvents.value.map(evt => html`
-                  <li class="flex items-baseline justify-between gap-2 text-[11px]">
+                  <li class="flex items-baseline justify-between gap-2 text-2xs">
                     <span class="text-[var(--text-body)] truncate">
                       <span class="font-mono text-[var(--text-dim)]">${evt.agent_name}</span>
                       <span class="text-[var(--text-muted)]"> · </span>
@@ -151,12 +151,12 @@ export function OasHealthChip() {
           ` : null}
           ${recentKeepers.value.length > 0 ? html`
             <div>
-              <div class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
+              <div class="text-3xs text-[var(--text-muted)] tracking-wider uppercase font-medium mb-2">
                 활성 Keeper
               </div>
               <ul class="space-y-1">
                 ${recentKeepers.value.map(snap => html`
-                  <li class="flex items-baseline justify-between gap-2 text-[11px]">
+                  <li class="flex items-baseline justify-between gap-2 text-2xs">
                     <span class="text-[var(--text-body)] truncate">
                       <span class="font-mono text-[var(--text-dim)]">${snap.keeper_name}</span>
                       <span class="text-[var(--text-muted)]"> · gen ${snap.generation} · ${Math.round(snap.context_ratio * 100)}%</span>

--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -59,7 +59,7 @@ function Row({
       : tone === 'bad' ? 'text-[var(--bad-light)]'
       : 'text-text-strong'
   return html`
-    <div class="flex items-center justify-between gap-4 text-[11px]">
+    <div class="flex items-center justify-between gap-4 text-2xs">
       <span class="text-text-dim">${label}</span>
       <span class="font-mono font-semibold ${toneClass}">${value}</span>
     </div>
@@ -93,8 +93,8 @@ export function CrossSignalReadout({ events, hourlyTrend, eventWindowMs }: Props
   return html`
     <div class="rounded border border-accent/20 bg-accent/5 px-3 py-2 shadow-sm">
       <div class="mb-1.5 flex items-center justify-between">
-        <span class="text-[10px] uppercase tracking-widest text-accent font-semibold">cursor</span>
-        <span class="text-[11px] font-mono text-text-strong">
+        <span class="text-3xs uppercase tracking-widest text-accent font-semibold">cursor</span>
+        <span class="text-2xs font-mono text-text-strong">
           ${new Date(cursor.ts).toLocaleTimeString()}
         </span>
       </div>

--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -42,7 +42,7 @@ function keeperOf(entry: TelemetryEntry): string | null {
 
 function MetaRow({ label, value }: { label: string; value: string }) {
   return html`
-    <div class="flex items-baseline gap-2 text-[11px]">
+    <div class="flex items-baseline gap-2 text-2xs">
       <span class="w-20 shrink-0 text-text-dim">${label}</span>
       <span class="font-mono text-text-strong break-all">${value}</span>
     </div>
@@ -69,17 +69,17 @@ export function DetailPane() {
     <div class="rounded border border-accent/30 bg-bg-0/60 shadow-sm">
       <div class="flex items-center justify-between border-b border-card-border px-3 py-2">
         <div class="flex items-center gap-2">
-          <span class="text-[10px] uppercase tracking-widest text-accent font-semibold">상세</span>
-          <span class="text-[12px] font-semibold text-text-strong">${selectionTitle(selection)}</span>
+          <span class="text-3xs uppercase tracking-widest text-accent font-semibold">상세</span>
+          <span class="text-xs font-semibold text-text-strong">${selectionTitle(selection)}</span>
           ${outcome ? html`
-            <span class="rounded-sm border px-2 py-0.5 text-[10px] font-mono ${toneClass(outcome.tone)}">
+            <span class="rounded-sm border px-2 py-0.5 text-3xs font-mono ${toneClass(outcome.tone)}">
               ${outcome.label}
             </span>
           ` : null}
         </div>
         <button
           type="button"
-          class="rounded px-2 py-0.5 text-[11px] text-text-dim hover:text-text-strong hover:bg-white/5"
+          class="rounded px-2 py-0.5 text-2xs text-text-dim hover:text-text-strong hover:bg-white/5"
           onClick=${clearSelection}
           aria-label="상세 패널 닫기"
         >
@@ -101,10 +101,10 @@ export function DetailPane() {
         ` : null}
       </div>
       <details class="border-t border-card-border">
-        <summary class="cursor-pointer px-3 py-1.5 text-[11px] text-text-dim hover:text-text-strong">
+        <summary class="cursor-pointer px-3 py-1.5 text-2xs text-text-dim hover:text-text-strong">
           raw entry (JSON)
         </summary>
-        <pre class="max-h-64 overflow-auto px-3 py-2 text-[10px] font-mono text-text-strong bg-[var(--white-5)]/30">${formatJson(selection.entry)}</pre>
+        <pre class="max-h-64 overflow-auto px-3 py-2 text-3xs font-mono text-text-strong bg-[var(--white-5)]/30">${formatJson(selection.entry)}</pre>
       </details>
     </div>
   `

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -49,7 +49,7 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
 
   return html`
     <div class="flex items-center gap-3">
-      <div class="w-24 shrink-0 text-[11px] font-semibold text-text-muted">
+      <div class="w-24 shrink-0 text-2xs font-semibold text-text-muted">
         이벤트 (${windowedEvents.length})
       </div>
       <div
@@ -61,7 +61,7 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
         onMouseLeave=${clearCursor}
       >
         ${markers.length === 0
-          ? html`<div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">이 시간 범위에 이벤트 없음</div>`
+          ? html`<div class="absolute inset-0 flex items-center justify-center text-3xs text-text-dim">이 시간 범위에 이벤트 없음</div>`
           : markers.map(({ entry, ts, count }) => {
               const pct = ((ts - windowStart) / span) * 100
               const color = sourceColor(typeof entry.source === 'string' ? entry.source : undefined)
@@ -81,7 +81,7 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
                     selectEntity({ kind: 'event', entry, ts, bucketCount: count })
                   }}
                 >${count > 1 ? html`
-                  <span class="absolute -top-4 left-1/2 -translate-x-1/2 rounded bg-bg-0/90 px-1 py-0.5 text-[8px] font-mono text-text-dim">
+                  <span class="absolute -top-4 left-1/2 -translate-x-1/2 rounded bg-bg-0/90 px-1 py-0.5 text-4xs font-mono text-text-dim">
                     ${count}
                   </span>
                 ` : null}</span>

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -53,14 +53,14 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
   return html`
     <div class="flex items-center gap-3">
       <div class="w-24 shrink-0">
-        <div class="text-[11px] font-semibold text-text-muted">도구 성공률</div>
+        <div class="text-2xs font-semibold text-text-muted">도구 성공률</div>
         ${lastRate != null ? html`
-          <div class="text-[13px] font-mono font-semibold ${lastRateColor}">
+          <div class="text-sm font-mono font-semibold ${lastRateColor}">
             ${lastRate.toFixed(1)}%
           </div>
-        ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
+        ` : html`<div class="text-3xs text-text-dim">데이터 없음</div>`}
         ${anomalyCount > 0 ? html`
-          <div class="text-[10px] font-mono text-[var(--bad-light)]">${anomalyCount} anomaly</div>
+          <div class="text-3xs font-mono text-[var(--bad-light)]">${anomalyCount} anomaly</div>
         ` : null}
       </div>
       <div
@@ -72,7 +72,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
         onMouseLeave=${clearCursor}
       >
         ${windowed.length === 0 ? html`
-          <div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">
+          <div class="absolute inset-0 flex items-center justify-center text-3xs text-text-dim">
             hourly_trend 데이터 부족
           </div>
         ` : html`

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -95,7 +95,7 @@ function TimeAxis({ windowStart, windowEnd }: { windowStart: number; windowEnd: 
   }
 
   return html`
-    <div class="relative h-6 border-b border-card-border text-[10px] text-text-dim font-mono">
+    <div class="relative h-6 border-b border-card-border text-3xs text-text-dim font-mono">
       ${ticks.map(tick => html`
         <span
           class="absolute top-0 -translate-x-1/2 whitespace-nowrap"
@@ -113,7 +113,7 @@ function TimeAxis({ windowStart, windowEnd }: { windowStart: number; windowEnd: 
 function RangeSelector() {
   const current = currentTimeRangeFilter() ?? DEFAULT_RANGE
   return html`
-    <div class="inline-flex items-center gap-0.5 rounded border border-card-border p-0.5 text-[11px]">
+    <div class="inline-flex items-center gap-0.5 rounded border border-card-border p-0.5 text-2xs">
       ${TIME_RANGE_PRESETS.map((preset: TimeRangePreset) => html`
         <button
           type="button"
@@ -140,7 +140,7 @@ function ViewSelector({
   onSelect: (view: ObservatoryView) => void
 }) {
   return html`
-    <div class="inline-flex items-center gap-0.5 rounded border border-card-border p-0.5 text-[11px]">
+    <div class="inline-flex items-center gap-0.5 rounded border border-card-border p-0.5 text-2xs">
       ${([
         { key: 'timeline', label: '타임라인' },
         { key: 'live', label: '라이브' },
@@ -259,8 +259,8 @@ export function Observatory() {
     <div class="flex flex-col gap-5">
       <div class="flex items-center justify-between">
         <div class="flex flex-col gap-0.5">
-          <h3 class="text-[13px] font-semibold text-text-strong">관찰소 (Observatory)</h3>
-          <p class="text-[11px] text-text-dim">
+          <h3 class="text-sm font-semibold text-text-strong">관찰소 (Observatory)</h3>
+          <p class="text-2xs text-text-dim">
             ${activeView.value === 'timeline'
               ? html`
                   ${currentKeeperFilter() ? `keeper=${currentKeeperFilter()}` : '전체 keeper'}
@@ -281,7 +281,7 @@ export function Observatory() {
             <${RangeSelector} />
             <button
               type="button"
-              class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+              class="inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-2xs font-medium transition-colors ${
                 liveMode.value
                   ? 'border-[var(--ok-20)] bg-[var(--ok-10)] text-[var(--ok)]'
                   : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
@@ -305,7 +305,7 @@ export function Observatory() {
       </div>
 
       ${activeView.value === 'timeline' && data.error ? html`
-        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]">
+        <div class="rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">
           일부 데이터 불러오기 실패: ${data.error}
         </div>
       ` : null}
@@ -333,7 +333,7 @@ export function Observatory() {
                 windowEnd=${data.windowEnd}
               />
               ${cursorPosition.value === null ? html`
-                <div class="mt-1 text-[10px] text-text-dim italic">
+                <div class="mt-1 text-3xs text-text-dim italic">
                   hover any track for cross-signal readout
                 </div>
               ` : null}
@@ -351,7 +351,7 @@ export function Observatory() {
       ${activeView.value === 'timeline' ? html`<${ObservatoryActivityPanels} />` : null}
 
       ${activeView.value === 'timeline' ? html`
-        <p class="text-[10px] text-text-dim italic">
+        <p class="text-3xs text-text-dim italic">
         Phase 3a — anomaly highlight. 추가 track(메모리, autoresearch)과 compare mode는 이후 단계에서.
         </p>
       ` : null}

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -92,8 +92,8 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
   return html`
     <div class="flex items-center gap-3">
       <div class="w-24 shrink-0">
-        <div class="text-[11px] font-semibold text-text-muted">도구 호출</div>
-        <div class="text-[10px] text-text-dim">
+        <div class="text-2xs font-semibold text-text-muted">도구 호출</div>
+        <div class="text-3xs text-text-dim">
           <span class="text-[var(--ok)]">${successCount}</span>
           <span class="text-text-dim/60 mx-0.5">·</span>
           <span class="text-[var(--bad-light)]">${failureCount}</span>
@@ -108,7 +108,7 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
         onMouseLeave=${clearCursor}
       >
         ${markers.length === 0
-          ? html`<div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">이 시간 범위에 도구 호출 없음</div>`
+          ? html`<div class="absolute inset-0 flex items-center justify-center text-3xs text-text-dim">이 시간 범위에 도구 호출 없음</div>`
           : markers.map(({ entry, ts, count, failureCount: bucketFailures }) => {
               const pct = ((ts - windowStart) / span) * 100
               const outcome = bucketFailures > 0 ? 'failure' : toolCallOutcome(entry)
@@ -129,7 +129,7 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
                     selectEntity({ kind: 'tool_call', entry, ts, bucketCount: count })
                   }}
                 >${count > 1 ? html`
-                  <span class="absolute -top-4 left-1/2 -translate-x-1/2 rounded bg-bg-0/90 px-1 py-0.5 text-[8px] font-mono text-text-dim">
+                  <span class="absolute -top-4 left-1/2 -translate-x-1/2 rounded bg-bg-0/90 px-1 py-0.5 text-4xs font-mono text-text-dim">
                     ${count}
                   </span>
                 ` : null}</span>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -153,7 +153,7 @@ function renderActivityTimeline() {
     return html`
       <div data-testid="ops-activity-timeline-empty">
         <${EmptyState} message=${message} compact />
-        ${hint ? html`<div class="mt-0.5 text-center text-[11px] text-text-dim">${hint}</div>` : null}
+        ${hint ? html`<div class="mt-0.5 text-center text-2xs text-text-dim">${hint}</div>` : null}
       </div>
     `
   }
@@ -167,13 +167,13 @@ function renderActivityTimeline() {
           data-activity-kind=${entry.kind}
           class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3"
         >
-          <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+          <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
             <${CountBadge} tone=${entry.tone}>${entry.label}<//>
             <span>${entry.target}</span>
             <span>${entry.actor}</span>
             <span><${TimeAgo} timestamp=${entry.at} /></span>
           </div>
-          <div class="mt-2 text-[13px] leading-[1.55] text-[var(--text-body)]">${entry.detail}</div>
+          <div class="mt-2 text-sm leading-[1.55] text-[var(--text-body)]">${entry.detail}</div>
         </article>
       `)}
     </div>
@@ -220,8 +220,8 @@ export function Ops() {
             <span>${workflowTargetLabel(workflowContext)}</span>
           </div>
           <div class="text-[var(--text-strong)] leading-relaxed">${workflowContext.summary}</div>
-          ${workflowContext.payload_preview ? html`<div class="mt-1 p-2 rounded bg-[var(--white-3)] text-[12px] font-mono">${workflowContext.payload_preview}</div>` : null}
-          <div class="text-[var(--text-muted)] text-[12px]">
+          ${workflowContext.payload_preview ? html`<div class="mt-1 p-2 rounded bg-[var(--white-3)] text-xs font-mono">${workflowContext.payload_preview}</div>` : null}
+          <div class="text-[var(--text-muted)] text-xs">
             ${workflowReady
               ? '추천 액션 기준으로 대상 선택과 입력값을 미리 맞춰 두었습니다.'
               : '대상이 현재 snapshot에 없습니다. 일반 개입 화면으로 열렸고, 실제 대상 선택은 수동으로 해야 합니다.'}
@@ -238,7 +238,7 @@ export function Ops() {
         <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1">
           <div>
             <h2 class="text-sm font-semibold text-[var(--text-strong)]">최근 운영 활동</h2>
-            <p class="mt-1 text-[12px] text-[var(--text-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다. 검토 큐와 Live Judge 판단은 거버넌스 페이지에서 처리합니다.</p>
+            <p class="mt-1 text-xs text-[var(--text-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다. 검토 큐와 Live Judge 판단은 거버넌스 페이지에서 처리합니다.</p>
           </div>
           <${renderActivityTimeline} />
         </section>

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -54,7 +54,7 @@ export function QuickIntervene() {
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0">
           <h3 class="text-sm font-semibold text-[var(--text-strong)]">빠른 개입</h3>
-          <p class="mt-1 text-[12px] leading-[1.45] text-[var(--text-muted)]">메시지나 메모를 방 또는 키퍼에 바로 보냅니다.</p>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">메시지나 메모를 방 또는 키퍼에 바로 보냅니다.</p>
         </div>
         <${ActionButton}
           variant="subtle"
@@ -68,7 +68,7 @@ export function QuickIntervene() {
 
       <div class="flex gap-2 items-stretch flex-wrap">
         <select
-          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[13px] text-[var(--text-body)] transition-colors cursor-pointer min-w-[120px] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-body)] transition-colors cursor-pointer min-w-[120px] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
           value=${quickTarget.value}
           aria-label="개입 대상"
           onChange=${(e: Event) => { quickTarget.value = (e.target as HTMLSelectElement).value }}
@@ -100,10 +100,10 @@ export function QuickIntervene() {
       ${showAdvanced
         ? html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-              <label class="block text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]" for="quick-intervene-actor">
+              <label class="block text-2xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]" for="quick-intervene-actor">
                 기록 주체
               </label>
-              <p class="mt-1 text-[12px] leading-[1.45] text-[var(--text-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>
+              <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>
               <${TextInput}
                 class="mt-3 max-w-[260px] border-[var(--white-8)] bg-[var(--white-3)]"
                 value=${actorName.value.trim() || 'dashboard'}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -94,7 +94,7 @@ function FunnelCell({
 }) {
   return html`
     <div class="flex flex-col gap-1 min-w-0" data-testid=${testId}>
-      <span class="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
+      <span class="text-2xs uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
       <span class=${`text-2xl font-semibold tabular-nums ${toneClass ?? 'text-[var(--text-strong)]'}`}>${value}</span>
     </div>
   `
@@ -112,7 +112,7 @@ function FunnelCard({ counts }: { counts: FunnelCounts }) {
     <section class=${CARD} aria-label="오늘 상황" data-testid="overview-funnel">
       <header class="flex items-center justify-between mb-3">
         <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)]">오늘 상황</h2>
-        <span class="text-[11px] text-[var(--text-muted)]">task 기준</span>
+        <span class="text-2xs text-[var(--text-muted)]">task 기준</span>
       </header>
       <div class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4">
         <${FunnelCell} label="신규" value=${String(counts.created)} testId="funnel-created" />
@@ -152,7 +152,7 @@ function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
   return html`
     <section class=${CARD} aria-label="오늘의 하이라이트" data-testid="overview-highlight">
       <div class="flex items-center gap-2 min-w-0">
-        <span class=${`text-[11px] font-semibold uppercase tracking-wider shrink-0 ${severityToneClass(severity)}`}>
+        <span class=${`text-2xs font-semibold uppercase tracking-wider shrink-0 ${severityToneClass(severity)}`}>
           ${severity.toUpperCase()}
         </span>
         <span class="truncate text-sm text-[var(--text-strong)]">${attention.summary}</span>
@@ -202,7 +202,7 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
       <header class="flex items-center justify-between gap-3 mb-3">
         <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)]">진행 중 파티</h2>
         ${startedAt !== null && startedAt !== undefined && startedAt !== ''
-          ? html`<${TimeAgo} timestamp=${startedAt} class="text-[11px] text-[var(--text-muted)]" />`
+          ? html`<${TimeAgo} timestamp=${startedAt} class="text-2xs text-[var(--text-muted)]" />`
           : null}
       </header>
       <p class="text-sm text-[var(--text-strong)] mb-3 line-clamp-2" data-testid="overview-party-goal">
@@ -215,7 +215,7 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
                 name => html`<${AgentAvatar} name=${name} status=${active.health ?? 'idle'} size="sm" />`,
               )}
               ${extra > 0
-                ? html`<span class="text-[11px] text-[var(--text-muted)]">+${extra}</span>`
+                ? html`<span class="text-2xs text-[var(--text-muted)]">+${extra}</span>`
                 : null}
             </div>
           `
@@ -226,14 +226,14 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
               <div class="flex-1 h-2 rounded bg-card-border/40 overflow-hidden">
                 <div class="h-full bg-[var(--ok)]" style=${`width: ${pct}%`}></div>
               </div>
-              <span class="text-[11px] tabular-nums text-[var(--text-muted)]">${pct}%</span>
+              <span class="text-2xs tabular-nums text-[var(--text-muted)]">${pct}%</span>
             </div>
           `
         : null}
       ${blocker !== null && blocker !== undefined && blocker !== ''
         ? html`
             <div
-              class="mt-3 rounded border border-[var(--warn)]/40 bg-[var(--warn)]/10 px-2 py-1 text-[11px] text-[var(--warn)]"
+              class="mt-3 rounded border border-[var(--warn)]/40 bg-[var(--warn)]/10 px-2 py-1 text-2xs text-[var(--warn)]"
               data-testid="overview-party-blocker"
             >
               blocker: ${blocker}
@@ -301,7 +301,7 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
                 ? html`
                     <${TimeAgo}
                       timestamp=${k.last_heartbeat}
-                      class="text-[11px] text-[var(--text-muted)] ml-auto shrink-0"
+                      class="text-2xs text-[var(--text-muted)] ml-auto shrink-0"
                     />
                   `
                 : null}

--- a/dashboard/src/components/perf-snapshot.ts
+++ b/dashboard/src/components/perf-snapshot.ts
@@ -57,9 +57,9 @@ function PerfStat({
 }) {
   return html`
     <div class="rounded border border-card-border/45 bg-[var(--white-5)]/10 px-3 py-3">
-      <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${label}</div>
+      <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${label}</div>
       <div class="mt-1 text-[20px] font-bold text-[var(--text-strong)]">${value}</div>
-      ${detail ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${detail}</div>` : null}
+      ${detail ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${detail}</div>` : null}
     </div>
   `
 }
@@ -70,10 +70,10 @@ function DiffRow({ row }: { row: DashboardPerfComparisonRow }) {
   return html`
     <div class="flex items-center justify-between gap-3 rounded border border-card-border/35 bg-[var(--white-5)]/8 px-3 py-2">
       <div class="min-w-0">
-        <div class="truncate text-[12px] font-semibold text-[var(--text-strong)]">${row.benchmark}</div>
-        <div class="text-[11px] text-[var(--text-muted)]">avg ${avgDelta}ms · p95 ${p95Delta}ms</div>
+        <div class="truncate text-xs font-semibold text-[var(--text-strong)]">${row.benchmark}</div>
+        <div class="text-2xs text-[var(--text-muted)]">avg ${avgDelta}ms · p95 ${p95Delta}ms</div>
       </div>
-      <div class="shrink-0 text-[11px] font-semibold uppercase tracking-[0.14em] ${verdictTone(row.verdict)}">${row.verdict}</div>
+      <div class="shrink-0 text-2xs font-semibold uppercase tracking-[0.14em] ${verdictTone(row.verdict)}">${row.verdict}</div>
     </div>
   `
 }
@@ -173,14 +173,14 @@ export function PerfSnapshotPanel() {
     <div class="flex flex-col gap-4">
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Perf Snapshot</div>
-          <div class="mt-1 text-[13px] text-[var(--text-body)]">
+          <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Perf Snapshot</div>
+          <div class="mt-1 text-sm text-[var(--text-body)]">
             ${generatedAt
               ? html`최근 run <strong class="text-[var(--text-strong)]"><${TimeAgo} timestamp=${generatedAt} /></strong>`
               : '최근 run 없음'}
           </div>
           ${data?.source?.result_file
-            ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${shortPath(data.source.result_file)}</div>`
+            ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${shortPath(data.source.result_file)}</div>`
             : null}
         </div>
         <${ActionButton}
@@ -196,11 +196,11 @@ export function PerfSnapshotPanel() {
       </div>
 
       ${error.value
-        ? html`<div class="rounded border border-bad/35 bg-bad/10 px-3 py-3 text-[12px] text-[var(--bad)]">${error.value}</div>`
+        ? html`<div class="rounded border border-bad/35 bg-bad/10 px-3 py-3 text-xs text-[var(--bad)]">${error.value}</div>`
         : null}
 
       ${data?.status === 'empty'
-        ? html`<div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3 text-[12px] text-[var(--text-muted)]">
+        ? html`<div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3 text-xs text-[var(--text-muted)]">
             benchmark artifact가 아직 없습니다. <code>benchmark.sh</code>를 한 번 돌리면 latest summary와 baseline diff가 여기에 나타납니다.
           </div>`
         : null}
@@ -255,7 +255,7 @@ export function PerfSnapshotPanel() {
               ? html`
                   <div class="grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] gap-3 max-[960px]:grid-cols-1">
                     <div class="flex flex-col gap-2">
-                      <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Top Changes</div>
+                      <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Top Changes</div>
                       ${topChanges.slice(0, 4).map(row => html`<${DiffRow} row=${row} />`)}
                     </div>
                     <${DistributionBars}

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -156,7 +156,7 @@ function typeBadge(type: string): ReturnType<typeof html> {
     gauge: 'bg-[var(--ok-10)] text-[var(--ok)]',
     summary: 'bg-[var(--warn-10)] text-[var(--warn)]',
   }
-  return html`<span class="inline-block rounded px-1.5 py-0.5 text-[10px] font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--text-muted)]'}">${type}</span>`
+  return html`<span class="inline-block rounded px-1.5 py-0.5 text-3xs font-mono ${colors[type] ?? 'bg-[var(--white-5)] text-[var(--text-muted)]'}">${type}</span>`
 }
 
 function labelPills(labels: Record<string, string>): ReturnType<typeof html> | null {
@@ -165,7 +165,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
   return html`<span class="ml-2 inline-flex gap-1 flex-wrap">${entries.map(([k, v]) => {
     if (k === 'keeper') {
       return html`<button
-        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-[10px] text-[var(--accent)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--accent-10)] px-1 py-0.5 text-3xs text-[var(--accent)] font-mono hover:bg-[var(--accent-10)] hover:text-[var(--accent)] transition-colors cursor-pointer"
         title="View keeper detail"
         onClick=${(e: Event) => {
           e.stopPropagation()
@@ -175,7 +175,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
     }
     if (k === 'tool_name' || k === 'tool') {
       return html`<button
-        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-[10px] text-[var(--warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--warn)] transition-colors cursor-pointer"
+        class="rounded bg-[var(--warn-10)] px-1 py-0.5 text-3xs text-[var(--warn)] font-mono hover:bg-[var(--warn-10)] hover:text-[var(--warn)] transition-colors cursor-pointer"
         title="View tool quality"
         onClick=${(e: Event) => {
           e.stopPropagation()
@@ -183,7 +183,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
         }}
       >${k}=${v}</button>`
     }
-    return html`<span class="rounded bg-[var(--white-5)] px-1 py-0.5 text-[10px] text-[var(--text-muted)] font-mono">${k}=${v}</span>`
+    return html`<span class="rounded bg-[var(--white-5)] px-1 py-0.5 text-3xs text-[var(--text-muted)] font-mono">${k}=${v}</span>`
   })}</span>`
 }
 
@@ -353,11 +353,11 @@ export function PrometheusMetrics() {
                 <span class="text-xs text-[var(--text-muted)]">${meta.description}</span>
               </div>
               <div class="flex items-center gap-2">
-                <span class="rounded-sm bg-[var(--bg-2)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                <span class="rounded-sm bg-[var(--bg-2)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
                   ${catMetrics.length} metrics
                 </span>
                 ${activeSamples > 0 && html`
-                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-[10px] text-[var(--ok)]">
+                  <span class="rounded-sm bg-[var(--ok-10)] px-2 py-0.5 text-3xs text-[var(--ok)]">
                     ${activeSamples} active
                   </span>
                 `}
@@ -381,7 +381,7 @@ export function PrometheusMetrics() {
                             <tr key="${m.name}" class="border-b border-[var(--card-border)]/30 hover:bg-[var(--bg-1)]">
                               <td class="py-1.5 font-mono text-[var(--text-body)]">
                                 ${m.name}
-                                <div class="text-[10px] text-[var(--text-muted)] font-sans">${m.help}</div>
+                                <div class="text-3xs text-[var(--text-muted)] font-sans">${m.help}</div>
                               </td>
                               <td class="py-1.5">${typeBadge(m.type)}</td>
                               <td class="py-1.5 text-right text-[var(--text-muted)]">--</td>
@@ -391,7 +391,7 @@ export function PrometheusMetrics() {
                             <tr key="${s.name}-${i}" class="border-b border-[var(--card-border)]/30 hover:bg-[var(--bg-1)]">
                               <td class="py-1.5 font-mono ${s.value !== 0 ? 'text-[var(--text-body)]' : 'text-[var(--text-muted)]'}">
                                 ${s.name}${labelPills(s.labels)}
-                                ${i === 0 && html`<div class="text-[10px] text-[var(--text-muted)] font-sans">${m.help}</div>`}
+                                ${i === 0 && html`<div class="text-3xs text-[var(--text-muted)] font-sans">${m.help}</div>`}
                               </td>
                               <td class="py-1.5">${i === 0 ? typeBadge(m.type) : null}</td>
                               <td class="py-1.5 text-right font-mono tabular-nums ${s.value !== 0 ? 'text-[var(--ok)]' : 'text-[var(--text-muted)]'}">

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -220,29 +220,29 @@ export function RuntimeMonitor() {
                 <article class="p-4 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
-                      <strong class="text-[13px] text-text-strong">${provider.provider}</strong>
-                      <span class="text-[12px] text-text-muted">${provider.runtime_kind ?? 'runtime'} · ${provider.auth_kind ?? 'auth'} · ${provider.source ?? 'source unknown'}</span>
+                      <strong class="text-sm text-text-strong">${provider.provider}</strong>
+                      <span class="text-xs text-text-muted">${provider.runtime_kind ?? 'runtime'} · ${provider.auth_kind ?? 'auth'} · ${provider.source ?? 'source unknown'}</span>
                     </div>
                     <${StatusChip}
                       label=${provider.status ?? (provider.available ? 'available' : 'unknown')}
                       tone=${runtimeProviderTone(provider)}
                     />
                   </div>
-                  <div class="grid grid-cols-2 gap-3 text-[12px] text-text-body">
+                  <div class="grid grid-cols-2 gap-3 text-xs text-text-body">
                     <div>default model · ${provider.default_model ?? '없음'}</div>
                     <div>catalog · ${provider.models.join(', ') || '없음'}</div>
                     <div>single-run · ${provider.supports_single_agent_run ? 'yes' : 'no'}</div>
                     <div>endpoint · ${provider.endpoint_url ?? '없음'}</div>
                   </div>
                   ${provider.discovery
-                    ? html`<div class="grid grid-cols-2 gap-3 text-[12px] text-text-body pt-2 border-t border-card-border/50">
+                    ? html`<div class="grid grid-cols-2 gap-3 text-xs text-text-body pt-2 border-t border-card-border/50">
                         <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
                         <div>ctx · ${fmtNumber(provider.discovery.ctx_size)}</div>
                         <div>slots · ${fmtNumber(provider.discovery.busy_slots)}/${fmtNumber(provider.discovery.total_slots)}</div>
                         <div>model · ${provider.discovery.discovered_model ?? '없음'}</div>
                       </div>`
                     : null}
-                  ${provider.note ? html`<div class="text-[12px] text-text-muted">${provider.note}</div>` : null}
+                  ${provider.note ? html`<div class="text-xs text-text-muted">${provider.note}</div>` : null}
                 </article>
               `)
             : html`<${EmptyState} message="provider runtime snapshot이 없습니다." compact />`}
@@ -272,13 +272,13 @@ export function RuntimeMonitor() {
             type="search"
             ariaLabel="모델 ID 검색"
             placeholder="model_id 또는 도구 이름"
-            class="min-w-[220px] flex-1 !py-1 !text-[11px]"
+            class="min-w-[220px] flex-1 !py-1 !text-2xs"
             value=${modelSearch.value}
             onInput=${(e: Event) => { modelSearch.value = (e.target as HTMLInputElement).value }}
           />
         </div>
         ${(metrics?.models ?? []).length > 0 && filterModelMetrics(metrics?.models ?? [], modelSearch.value).length === 0
-          ? html`<div class="text-[11px] text-[var(--text-muted)] mb-2">검색 결과 없음 (${metrics?.models.length ?? 0}개 중)</div>`
+          ? html`<div class="text-2xs text-[var(--text-muted)] mb-2">검색 결과 없음 (${metrics?.models.length ?? 0}개 중)</div>`
           : null}
         <div class="flex flex-col gap-3">
           ${(metrics?.models ?? []).length > 0
@@ -299,8 +299,8 @@ export function RuntimeMonitor() {
                 >
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
-                      <strong class="text-[13px] text-text-strong">${metric.model_id}</strong>
-                      <span class="text-[12px] text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
+                      <strong class="text-sm text-text-strong">${metric.model_id}</strong>
+                      <span class="text-xs text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
                     </div>
                     <div class="flex gap-2 items-center">
                       <${StatusChip}
@@ -325,7 +325,7 @@ export function RuntimeMonitor() {
                         : null}
                     </div>
                   </div>
-                  <div class="grid grid-cols-3 gap-3 text-[12px] text-text-body">
+                  <div class="grid grid-cols-3 gap-3 text-xs text-text-body">
                     <div>latency avg/p95 · ${fmtNumber(metric.avg_latency_ms, 1)} / ${fmtNumber(metric.p95_latency_ms, 1)} ms</div>
                     <div>wall tok/s p50/p95 · ${fmtNumber(metric.p50_tok_per_sec, 1)} / ${fmtNumber(metric.p95_tok_per_sec, 1)}</div>
                     <div>cost · ${fmtCost(metric.total_cost_usd)}</div>
@@ -337,7 +337,7 @@ export function RuntimeMonitor() {
                       : null}
                   </div>
                   ${(metric.buckets ?? []).length >= 2
-                    ? html`<div class="flex items-center gap-4 mt-1 text-[11px] text-[var(--text-muted)]">
+                    ? html`<div class="flex items-center gap-4 mt-1 text-2xs text-[var(--text-muted)]">
                         <span>p95 latency</span>
                         <span dangerouslySetInnerHTML=${{ __html: sparklineSvg((metric.buckets as BucketMetric[]).map(b => b.p95_latency_ms), 'var(--status-warn)', 80, 18) }}></span>
                         <span>error rate</span>
@@ -348,17 +348,17 @@ export function RuntimeMonitor() {
                     const cacheRead = metric.total_cache_read_tokens ?? 0
                     const totalIn = cacheRead + (metric.total_input_tokens ?? 0)
                     const cacheRatio = totalIn > 0 ? cacheRead / totalIn : 0
-                    return html`<div class="text-[11px] text-[var(--text-muted)] mt-1">
+                    return html`<div class="text-2xs text-[var(--text-muted)] mt-1">
                       cost ${fmtCost(metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtNumber(cacheRead)} / ${fmtNumber(totalIn)} tokens)
                     </div>`
                   })()}
                   ${(metric.error_count ?? 0) > 0
-                    ? html`<div class="text-[11px] text-[var(--status-bad)] mt-1">errors ${fmtNumber(metric.error_count)} / success ${fmtNumber(metric.success_count)}</div>`
+                    ? html`<div class="text-2xs text-[var(--status-bad)] mt-1">errors ${fmtNumber(metric.error_count)} / success ${fmtNumber(metric.success_count)}</div>`
                     : null}
                   ${(metric.top_tools ?? []).length > 0
                     ? html`<div class="flex flex-wrap gap-1 mt-1">
                         ${metric.top_tools?.slice(0, 5).map(t => html`
-                          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] bg-[var(--bg-panel-hover)] text-[var(--text-muted)]">
+                          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-3xs bg-[var(--bg-panel-hover)] text-[var(--text-muted)]">
                             ${t.tool} <span class="ml-0.5 text-[var(--text-strong)]">${t.count}</span>
                           </span>
                         `)}
@@ -367,18 +367,18 @@ export function RuntimeMonitor() {
                   ${(metric.recent_entries ?? []).length > 0
                     ? html`
                       <button
-                        class="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-strong)] mt-1 text-left"
+                        class="text-2xs text-[var(--text-muted)] hover:text-[var(--text-strong)] mt-1 text-left"
                         onClick=${() => { expandedModel.value = expandedModel.value === metric.model_id ? null : metric.model_id }}
                       >
                         ${expandedModel.value === metric.model_id ? '▾' : '▸'} recent ${metric.recent_entries?.length ?? 0} turns
                       </button>
                       ${expandedModel.value === metric.model_id
                         ? html`<div class="mt-1 border-t border-card-border/50 pt-2">
-                            <div class="grid grid-cols-6 gap-1 text-[10px] text-[var(--text-muted)] font-medium mb-1">
+                            <div class="grid grid-cols-6 gap-1 text-3xs text-[var(--text-muted)] font-medium mb-1">
                               <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>cost</div><div>tools</div>
                             </div>
                             ${metric.recent_entries?.map(re => html`
-                              <div class="grid grid-cols-6 gap-1 text-[11px] text-[var(--text-body)]">
+                              <div class="grid grid-cols-6 gap-1 text-2xs text-[var(--text-body)]">
                                 <div>${fmtTime(re.ts_unix)}</div>
                                 <div>${fmtNumber(re.input_tokens)}</div>
                                 <div>${fmtNumber(re.output_tokens)}</div>

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -61,10 +61,10 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
           ${!isDefault ? html`
-            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
           ` : null}
           ${entry.sensitive ? html`
-            <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)]">sensitive</span>
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)]">sensitive</span>
           ` : null}
         </div>
         <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>
@@ -74,7 +74,7 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
           ${entry.value ?? entry.default}
         </div>
         ${!isDefault && entry.default ? html`
-          <div class="text-[10px] text-[var(--text-muted)] mt-0.5">
+          <div class="text-3xs text-[var(--text-muted)] mt-0.5">
             default: ${entry.default}
           </div>
         ` : null}
@@ -103,7 +103,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
           <span class="text-xs text-[var(--text-muted)]">(${filtered.length})</span>
         </div>
         ${customCount > 0 ? html`
-          <span class="text-[10px] px-2 py-0.5 rounded-sm bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">
+          <span class="text-3xs px-2 py-0.5 rounded-sm bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">
             ${customCount} custom
           </span>
         ` : null}
@@ -126,19 +126,19 @@ function ServerMeta() {
   return html`
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Version</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Version</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.version}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Uptime</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Uptime</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${formatUptime(server.uptime_seconds)}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">OCaml</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">OCaml</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.ocaml_version}</div>
       </div>
       <div class="px-3 py-2 rounded bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">PID</div>
+        <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">PID</div>
         <div class="text-sm font-mono text-[var(--text-primary)]">${server.pid}</div>
       </div>
     </div>

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -164,7 +164,7 @@ function DiffBlock({ text }: { text: string }) {
   const truncatedCount = allLines.length - lines.length
 
   return html`
-    <div class="font-mono text-[11px] leading-[1.6] overflow-x-auto">
+    <div class="font-mono text-2xs leading-[1.6] overflow-x-auto">
       ${lines.map((line: string) => {
         const cls =
           line.startsWith('+') && !line.startsWith('+++') ? 'text-[var(--ok)] bg-[var(--ok-6)]'
@@ -201,9 +201,9 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
   return html`
     <div>
       <div class="flex items-center justify-between mb-1">
-        <span class="text-[10px] font-semibold uppercase tracking-wider ${titleColor}">${titleLabel}</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider ${titleColor}">${titleLabel}</span>
         ${hint !== 'plain' ? html`
-          <span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
+          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase">${hint}</span>
         ` : null}
       </div>
       <div class="rounded border ${borderColor} ${bgColor} overflow-hidden">
@@ -211,7 +211,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
              style=${shouldCollapse ? `max-height: ${RESULT_COLLAPSED_MAX_HEIGHT}px` : ''}>
           ${hint === 'diff' ? html`<${DiffBlock} text=${text} />`
             : hint === 'json' ? html`<${JsonViewerCard} title=${titleLabel} data=${parseJsonLikeData(text)} />`
-            : html`<pre class="m-0 text-[11px] font-mono ${isErr ? 'text-[var(--bad)]' : 'text-[var(--text-body)]'} p-3 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">${displayText}</pre>`}
+            : html`<pre class="m-0 text-2xs font-mono ${isErr ? 'text-[var(--bad)]' : 'text-[var(--text-body)]'} p-3 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">${displayText}</pre>`}
           ${shouldCollapse ? html`
             <div class="absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t ${isErr ? 'from-[rgba(239,68,68,0.08)]' : 'from-[var(--white-3)]'} to-transparent pointer-events-none"></div>
           ` : null}
@@ -219,7 +219,7 @@ function ResultViewer({ text, hint, isError: isErr }: { text: string; hint: Cont
         ${needsCollapse ? html`
           <button
             type="button"
-            class="w-full py-1.5 text-[10px] font-medium text-[var(--accent)] hover:text-[var(--text-strong)] hover:bg-[var(--white-5)] transition-colors cursor-pointer border-t border-[var(--white-6)] bg-transparent"
+            class="w-full py-1.5 text-3xs font-medium text-[var(--accent)] hover:text-[var(--text-strong)] hover:bg-[var(--white-5)] transition-colors cursor-pointer border-t border-[var(--white-6)] bg-transparent"
             onClick=${() => { expanded.value = !expanded.value }}
           >
             ${expanded.value ? '접기' : `전체 보기 (${text.split('\n').length}줄)`}
@@ -241,7 +241,7 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
     <div class="mt-2 space-y-2">
       ${event.toolArgs ? html`
         <div>
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Args</div>
+          <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Args</div>
           <${JsonViewerCard} title="Args" data=${parseJsonLikeData(event.toolArgs)} />
         </div>
       ` : null}
@@ -249,13 +249,13 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
         <${ResultViewer} text=${resultText} hint=${hint} isError=${Boolean(event.error)} />
       ` : null}
       ${gateRejected ? html`
-        <div class="text-[10px] px-2 py-1 rounded bg-[var(--bad-10)] text-[var(--bad)] inline-block">
+        <div class="text-3xs px-2 py-1 rounded bg-[var(--bad-10)] text-[var(--bad)] inline-block">
           거부: ${event.gate?.reason ?? ''}
         </div>
       ` : null}
       ${'' /* Metadata row */}
       ${event.cost_usd != null && event.cost_usd > 0 ? html`
-        <div class="flex gap-3 text-[10px] text-[var(--text-dim)]">
+        <div class="flex gap-3 text-3xs text-[var(--text-dim)]">
           <span>비용: <span class="font-mono text-[var(--accent)]">$${event.cost_usd.toFixed(4)}</span></span>
           ${event.duration_ms != null ? html`<span>소요: <span class="font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span></span>` : null}
         </div>
@@ -268,7 +268,7 @@ function BroadcastDetail({ event }: { event: UnifiedTraceEvent }) {
   const content = typeof event.detail.content === 'string' ? event.detail.content : ''
   if (!content) return null
   return html`
-    <div class="mt-2 text-[13px] leading-relaxed px-3 py-2 bg-[var(--white-3)] rounded border border-[var(--white-6)]">
+    <div class="mt-2 text-sm leading-relaxed px-3 py-2 bg-[var(--white-3)] rounded border border-[var(--white-6)]">
       <${Markdown} text=${content} />
     </div>
   `
@@ -280,7 +280,7 @@ function TaskDetail({ event }: { event: UnifiedTraceEvent }) {
   const title = typeof d.title === 'string' ? d.title : null
   const notes = typeof d.completion_notes === 'string' ? d.completion_notes : null
   return html`
-    <div class="mt-2 text-[12px] text-[var(--text-body)] space-y-1 px-3 py-2 bg-[var(--white-3)] rounded">
+    <div class="mt-2 text-xs text-[var(--text-body)] space-y-1 px-3 py-2 bg-[var(--white-3)] rounded">
       ${taskId ? html`<div><span class="text-[var(--text-dim)]">ID:</span> <span class="font-mono">${taskId}</span></div>` : null}
       ${title ? html`<div><span class="text-[var(--text-dim)]">제목:</span> ${title}</div>` : null}
       ${notes ? html`<div><span class="text-[var(--text-dim)]">노트:</span> ${notes}</div>` : null}
@@ -300,7 +300,7 @@ function ThinkingDetail({ event }: { event: UnifiedTraceEvent }) {
   if (!content) return null
   return html`
     <div class="mt-2 px-3 py-2 rounded bg-[rgba(192,132,252,0.04)] border border-[rgba(192,132,252,0.12)]">
-      <div class="text-[13px] leading-relaxed text-[var(--text-body)]">
+      <div class="text-sm leading-relaxed text-[var(--text-body)]">
         <${Markdown} text=${content} />
       </div>
     </div>
@@ -318,11 +318,11 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const phaseColor = phase === 'called' ? 'text-[var(--accent)]' : 'text-[var(--ok)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)] space-y-1">
-        <div class="flex items-center gap-2 text-[12px]">
+        <div class="flex items-center gap-2 text-xs">
           <span class="text-[var(--text-dim)]">단계:</span>
           <span class="font-mono font-semibold ${phaseColor}">${phaseLabel}</span>
         </div>
-        <div class="flex items-center gap-2 text-[12px]">
+        <div class="flex items-center gap-2 text-xs">
           <span class="text-[var(--text-dim)]">도구:</span>
           <span class="font-mono text-[var(--text-body)]">${toolName}</span>
         </div>
@@ -337,7 +337,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const phaseLabel = phase === 'started' ? '시작' : phase === 'completed' ? '완료' : phase
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)]">
-        <div class="flex items-center gap-2 text-[12px]">
+        <div class="flex items-center gap-2 text-xs">
           <span class="text-[var(--text-dim)]">턴 ${turn != null ? String(turn) : '-'}:</span>
           <span class="font-mono font-semibold text-[var(--text-body)]">${phaseLabel}</span>
         </div>
@@ -354,7 +354,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const compactPhase = typeof d.phase === 'string' ? d.phase : ''
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--sky-4)] border border-[rgba(56,189,248,0.15)] space-y-2">
-        <div class="flex items-center gap-3 text-[12px]">
+        <div class="flex items-center gap-3 text-xs">
           ${before != null ? html`<span><span class="text-[var(--text-dim)]">Before:</span> <span class="font-mono">${before.toLocaleString()}</span></span>` : null}
           <span class="text-[var(--text-dim)]">→</span>
           ${after != null ? html`<span><span class="text-[var(--text-dim)]">After:</span> <span class="font-mono">${after.toLocaleString()}</span></span>` : null}
@@ -368,10 +368,10 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
               trackClass="flex-1"
               class="bg-[var(--sky-400)]"
             />
-            <span class="text-[10px] font-mono text-[var(--sky-400)]">-${saved.toLocaleString()}tok (${(ratio ?? 0).toFixed(0)}%)</span>
+            <span class="text-3xs font-mono text-[var(--sky-400)]">-${saved.toLocaleString()}tok (${(ratio ?? 0).toFixed(0)}%)</span>
           </div>
         ` : null}
-        ${compactPhase ? html`<div class="text-[10px] text-[var(--text-dim)]">단계: ${compactPhase}</div>` : null}
+        ${compactPhase ? html`<div class="text-3xs text-[var(--text-dim)]">단계: ${compactPhase}</div>` : null}
       </div>
     `
   }
@@ -385,7 +385,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const turn = d.turn
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--sky-4)] border border-[rgba(56,189,248,0.12)] space-y-1">
-        <div class="flex items-center gap-3 text-[12px]">
+        <div class="flex items-center gap-3 text-xs">
           <span><span class="text-[var(--text-dim)]">모델:</span> <span class="font-mono">${model}</span></span>
           <span><span class="text-[var(--text-dim)]">입력:</span> <span class="font-mono">${inputTokens.toLocaleString()}tok</span></span>
           ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
@@ -403,7 +403,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--ok)]' : 'text-[var(--warn)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[rgba(34,211,238,0.04)] border border-[var(--cyan-12)] space-y-1">
-        <div class="flex items-center gap-3 text-[12px] flex-wrap">
+        <div class="flex items-center gap-3 text-xs flex-wrap">
           <span><span class="text-[var(--text-dim)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
           <span><span class="text-[var(--text-dim)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
           ${durationMs != null ? html`<span><span class="text-[var(--text-dim)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
@@ -411,8 +411,8 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
         </div>
         ${responseText ? html`
           <details class="mt-1">
-            <summary class="text-[10px] text-[var(--text-dim)] cursor-pointer hover:text-[var(--text-body)]">응답 텍스트</summary>
-            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-[11px] font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-[300px] overflow-auto">${responseText}</pre>
+            <summary class="text-3xs text-[var(--text-dim)] cursor-pointer hover:text-[var(--text-body)]">응답 텍스트</summary>
+            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-2xs font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-[300px] overflow-auto">${responseText}</pre>
           </details>
         ` : null}
       </div>
@@ -424,8 +424,8 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const errorDetail = typeof d.detail === 'string' ? d.detail : ''
     return html`
       <div class="mt-2 px-3 py-2 rounded bg-[var(--bad-6)] border border-[var(--bad-soft)] space-y-1">
-        <div class="text-[12px]"><span class="text-[var(--text-dim)]">도메인:</span> <span class="font-mono text-[var(--bad)]">${domain}</span></div>
-        ${errorDetail ? html`<div class="text-[11px] font-mono text-[var(--text-body)] break-all">${errorDetail}</div>` : null}
+        <div class="text-xs"><span class="text-[var(--text-dim)]">도메인:</span> <span class="font-mono text-[var(--bad)]">${domain}</span></div>
+        ${errorDetail ? html`<div class="text-2xs font-mono text-[var(--text-body)] break-all">${errorDetail}</div>` : null}
       </div>
     `
   }
@@ -438,7 +438,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
   return html`
     <div class="mt-2 grid gap-1.5 px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--white-6)]">
       ${detailRows.map(row => html`
-        <div class="flex items-start gap-2 text-[12px] leading-relaxed">
+        <div class="flex items-start gap-2 text-xs leading-relaxed">
           <span class="min-w-[92px] text-[var(--text-dim)] font-mono">${row.label}</span>
           <span class="text-[var(--text-body)] font-mono break-all">${row.value}</span>
         </div>
@@ -482,7 +482,7 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
   const row = html`
     <div class="flex items-start gap-3 py-2 px-3 rounded ${gateRejected ? 'opacity-50' : ''}">
       ${'' /* Icon */}
-      <div class="flex-shrink-0 mt-0.5 size-7 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[11px] font-mono font-bold ${style.color}">
+      <div class="flex-shrink-0 mt-0.5 size-7 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-2xs font-mono font-bold ${style.color}">
         ${style.icon}
       </div>
 
@@ -491,32 +491,32 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
         <div class="flex items-center gap-2 flex-wrap">
           ${event.kind === 'tool_call' && event.toolName
             ? html`<span class="text-xs font-mono font-medium ${style.color}">${event.toolName}</span>`
-            : html`<span class="text-[10px] font-medium uppercase tracking-wider ${kindStyle.color}">${kindStyle.label}</span>`}
-          <span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase tracking-wider">
+            : html`<span class="text-3xs font-medium uppercase tracking-wider ${kindStyle.color}">${kindStyle.label}</span>`}
+          <span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] uppercase tracking-wider">
             ${event.sourceLane === 'oas' ? 'OAS' : 'MASC'}
           </span>
           ${event.turn != null ? html`
-            <span class="text-[10px] text-[var(--text-dim)]">
+            <span class="text-3xs text-[var(--text-dim)]">
               T${event.turn}${event.round != null ? `R${event.round}` : ''}
             </span>
           ` : null}
-          ${event.sessionId ? html`<span class="text-[10px] text-[var(--text-dim)] font-mono">S ${event.sessionId}</span>` : null}
-          ${event.operationId ? html`<span class="text-[10px] text-[var(--text-dim)] font-mono">OP ${event.operationId}</span>` : null}
-          ${event.workerRunId ? html`<span class="text-[10px] text-[var(--text-dim)] font-mono">WR ${event.workerRunId}</span>` : null}
+          ${event.sessionId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">S ${event.sessionId}</span>` : null}
+          ${event.operationId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">OP ${event.operationId}</span>` : null}
+          ${event.workerRunId ? html`<span class="text-3xs text-[var(--text-dim)] font-mono">WR ${event.workerRunId}</span>` : null}
           ${event.kind === 'task' ? html`
-            <span class="text-[10px] font-bold uppercase tracking-wider ${taskColor(String(event.detail.type))} bg-[var(--white-5)] px-1.5 py-0.5 rounded">
+            <span class="text-3xs font-bold uppercase tracking-wider ${taskColor(String(event.detail.type))} bg-[var(--white-5)] px-1.5 py-0.5 rounded">
               ${taskIcon(String(event.detail.type))}
             </span>
           ` : null}
           ${event.error
-            ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>`
+            ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">오류</span>`
             : gateRejected
-              ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">거부</span>`
+              ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--bad-10)] text-[var(--bad)]">거부</span>`
               : event.kind === 'tool_call'
-                ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">완료</span>`
+                ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[rgba(52,211,153,0.1)] text-[var(--ok)]">완료</span>`
                 : null}
         </div>
-        <div class="mt-0.5 text-[11px] text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
+        <div class="mt-0.5 text-2xs text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
           <${HighlightedText} text=${summaryText} query=${searchQuery ?? ''} />
         </div>
       </div>
@@ -524,9 +524,9 @@ export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceE
       ${'' /* Right side: duration + time */}
       <div class="flex-shrink-0 flex flex-col items-end gap-0.5">
         ${event.duration_ms != null ? html`
-          <span class="text-[11px] font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span>
+          <span class="text-2xs font-mono ${durationColor(event.duration_ms)}">${formatDuration(event.duration_ms)}</span>
         ` : null}
-        <${TimeAgo} timestamp=${event.ts_iso} class="text-[10px] text-[var(--text-dim)]" />
+        <${TimeAgo} timestamp=${event.ts_iso} class="text-3xs text-[var(--text-dim)]" />
       </div>
     </div>
   `

--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -66,12 +66,12 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
             const v = (e.target as HTMLInputElement).value
             setTraceSearchQuery(agentName, v)
           }}
-          class="w-full px-3 py-1.5 text-[12px] rounded bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--text-body)] placeholder:text-[var(--text-dim)] outline-none focus:border-[var(--accent)]"
+          class="w-full px-3 py-1.5 text-xs rounded bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--text-body)] placeholder:text-[var(--text-dim)] outline-none focus:border-[var(--accent)]"
         />
         ${searchQuery ? html`
           <button
             onClick=${() => setTraceSearchQuery(agentName, '')}
-            class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)] hover:text-[var(--text-body)] text-[14px] leading-none"
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)] hover:text-[var(--text-body)] text-base leading-none"
           >\u00d7</button>
         ` : null}
       </div>
@@ -88,7 +88,7 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
       <!-- Status chips -->
       ${statusCounts.all > 0 ? html`
         <div>
-          <div class="text-[10px] text-[var(--text-dim)] mb-1">상태</div>
+          <div class="text-3xs text-[var(--text-dim)] mb-1">상태</div>
           <${FilterChips}
             chips=${statusChips}
             value=${currentStatus}

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -54,7 +54,7 @@ function TraceSummaryBar({ summary }: { summary: TraceSummary }) {
   if (s.total_cost_usd > 0) items.push(`$${s.total_cost_usd.toFixed(3)}`)
 
   return html`
-    <div class="flex flex-wrap gap-2 text-[10px] text-[var(--text-muted)]">
+    <div class="flex flex-wrap gap-2 text-3xs text-[var(--text-muted)]">
       ${items.map(item => html`
         <span class="inline-flex items-center bg-[var(--white-4)] border border-[var(--white-6)] px-2 py-1 rounded font-medium">
           ${item}
@@ -75,7 +75,7 @@ function LiveIndicator({ events }: { events: readonly { ts: number }[] }) {
   if (!isRecent) return null
 
   return html`
-    <div class="flex items-center gap-2 px-3 py-2 text-[11px] text-[var(--text-muted)]">
+    <div class="flex items-center gap-2 px-3 py-2 text-2xs text-[var(--text-muted)]">
       <span class="relative flex size-2">
         <span class="animate-ping absolute inline-flex h-full w-full rounded-sm bg-[var(--ok)] opacity-75"></span>
         <span class="relative inline-flex size-2 rounded-sm bg-[var(--ok)]"></span>
@@ -190,7 +190,7 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
       </div>
 
       ${'' /* Footer: event count */}
-      <div class="text-[10px] text-[var(--text-dim)] text-right">
+      <div class="text-3xs text-[var(--text-dim)] text-right">
         ${events.length}건 표시
       </div>
     </div>

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -75,7 +75,7 @@ function ExternalLinkChip({ href, label }: { href: string; label: string }) {
       href=${href}
       target="_blank"
       rel="noopener noreferrer"
-      class="inline-flex items-center gap-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] px-1.5 py-0.5 text-[10px] text-[var(--text-body)] transition-colors hover:bg-[var(--white-8)]"
+      class="inline-flex items-center gap-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] px-1.5 py-0.5 text-3xs text-[var(--text-body)] transition-colors hover:bg-[var(--white-8)]"
     >
       ${label}
       <${ExternalLink} size=${10} />
@@ -115,7 +115,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
     >
       <button
         type="button"
-        class="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-[12px] text-[var(--text-body)] hover:bg-[var(--white-4)]"
+        class="flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-xs text-[var(--text-body)] hover:bg-[var(--white-4)]"
         aria-expanded=${isOpen}
         aria-controls=${`setup-guide-${connectorId}`}
         onClick=${toggle}
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >
@@ -139,7 +139,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
             : null}
         </div>
         <span
-          class=${`text-[10px] uppercase tracking-[0.14em] tabular-nums ${countToneClass}`}
+          class=${`text-3xs uppercase tracking-[0.14em] tabular-nums ${countToneClass}`}
           data-setup-progress=${connectorId}
           data-setup-progress-pct=${pct}
         >${stepCompletionSummary(doneCount, guide.steps.length)}</span>
@@ -166,7 +166,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
 
       ${isOpen
         ? html`
-            <div id=${`setup-guide-${connectorId}`} class="border-t border-[var(--white-8)] px-3 py-2.5 text-[11px] text-[var(--text-body)]">
+            <div id=${`setup-guide-${connectorId}`} class="border-t border-[var(--white-8)] px-3 py-2.5 text-2xs text-[var(--text-body)]">
               <p class="mb-2 text-[var(--text-dim)]">${guide.intro}</p>
               <ol class="list-none space-y-2" data-setup-step-list>
                 ${guide.steps.map((step, idx) => {
@@ -182,7 +182,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                   return html`
                     <li class="flex items-start gap-2.5" data-setup-step-item=${idx}>
                       <span
-                        class=${`mt-[2px] inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border text-[10px] font-semibold tabular-nums transition-colors ${circleToneClass}`}
+                        class=${`mt-[2px] inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border text-3xs font-semibold tabular-nums transition-colors ${circleToneClass}`}
                         aria-hidden="true"
                         data-setup-step-circle=${`${connectorId}:${idx}`}
                       >${done ? '✓' : idx + 1}</span>
@@ -214,7 +214,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
               ${guide.references.length > 0
                 ? html`
                     <div class="mt-3 flex flex-wrap items-center gap-1.5 border-t border-[var(--white-8)] pt-2">
-                      <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]">refs</span>
+                      <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">refs</span>
                       ${guide.references.map(ref => html`<${ExternalLinkChip} href=${ref.href} label=${ref.label} />`)}
                     </div>
                   `

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -124,7 +124,7 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
       aria-expanded=${entry.open}
       aria-controls=${`sidecar-log-${connectorId}`}
       onClick=${onClick}
@@ -146,7 +146,7 @@ function LevelPills({ connectorId, active }: { connectorId: string; active: LogL
     <div class="flex items-center gap-1" role="radiogroup" aria-label="log level filter">
       ${LEVELS.map(level => {
         const isActive = level === active
-        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]'
+        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em]'
         const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--text-body)]'
         const idleCls = 'border-[var(--white-8)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
         return html`
@@ -191,11 +191,11 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
       class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-2"
     >
       <div class="mb-2 flex items-center justify-between gap-2">
-        <div class="min-w-0 truncate text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" title=${entry.logPath}>
+        <div class="min-w-0 truncate text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" title=${entry.logPath}>
           ${entry.logPath || '(log path unknown)'}
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)]" data-log-count>
+          <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" data-log-count>
             ${entry.available
               ? hasFilter
                 ? `${filtered.length} / ${entry.lines.length} lines`
@@ -218,7 +218,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                 type="search"
                 value=${entry.keyword}
                 placeholder="keyword 필터 (case-insensitive)"
-                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-0.5 text-[11px] text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
+                class="min-w-0 flex-1 rounded border border-[var(--white-8)] bg-[var(--bg-0)] px-2 py-0.5 text-2xs text-[var(--text-body)] focus:border-[var(--accent-1)] focus:outline-none"
                 data-log-keyword
                 onInput=${(ev: Event) => {
                   const v = (ev.target as HTMLInputElement).value
@@ -229,7 +229,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                 ? html`
                     <button
                       type="button"
-                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
                       data-log-filter-clear
                       onClick=${() => setEntry(connectorId, { level: 'all', keyword: '' })}
                     >clear</button>
@@ -239,7 +239,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           `
         : null}
       ${entry.error
-        ? html`<div class="rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-[11px] text-[var(--bad-light)]">${entry.error}</div>`
+        ? html`<div class="rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-1 text-2xs text-[var(--bad-light)]">${entry.error}</div>`
         : entry.loading && entry.lines.length === 0
           ? html`
               <div class="rounded bg-[var(--bg-0)] p-2">
@@ -249,7 +249,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
           : entry.available
             ? filtered.length === 0 && hasFilter
               ? html`
-                  <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-[11px] text-[var(--text-dim)]">
+                  <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--text-dim)]">
                     필터 조건에 맞는 라인이 없습니다.
                     ${entry.lines.length > MAX_FILTER_WINDOW
                       ? ` (최근 ${MAX_FILTER_WINDOW}줄만 검색)`
@@ -257,10 +257,10 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                   </div>
                 `
               : html`
-                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-[10px] leading-[1.4] text-[var(--text-body)]">${filtered.join('\n')}</pre>
+                  <pre class="max-h-[40vh] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-0)] p-2 font-mono text-3xs leading-[1.4] text-[var(--text-body)]">${filtered.join('\n')}</pre>
                 `
             : html`
-                <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-[11px] text-[var(--text-dim)]">
+                <div class="rounded border border-dashed border-[var(--white-8)] px-3 py-3 text-center text-2xs text-[var(--text-dim)]">
                   오늘 날짜 로그 파일이 아직 없습니다. sidecar를 시작하면 자동 생성됩니다.
                 </div>
               `}

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -95,20 +95,20 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
 
   return html`
     <div
-      class="mt-2 flex items-center gap-2 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-[11px] text-[var(--warn)]"
+      class="mt-2 flex items-center gap-2 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]"
       data-startup-warning=${connectorId}
     >
       <span class="text-base leading-none" aria-hidden="true">⚠</span>
       <div class="min-w-0 flex-1">
         <div class="font-semibold" data-startup-warning-elapsed=${String(elapsedSec)}>기동 응답 없음 (${elapsedSec}s 경과)</div>
-        <div class="text-[10px] opacity-90">
+        <div class="text-3xs opacity-90">
           Start 요청은 보냈지만 sidecar가 online으로 올라오지 않았습니다.
           토큰 검증 실패 / 의존성 누락이 가장 흔한 원인 — 로그를 확인하세요.
         </div>
       </div>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-[var(--warn-10)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-[var(--warn-10)]"
         onClick=${() => {
           openSidecarLogs(connectorId)
           // Don't clear startAt yet — operator might toggle logs back closed
@@ -118,7 +118,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       >📋 로그 열기</button>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] px-1.5 py-0.5 text-[14px] leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] px-1.5 py-0.5 text-base leading-none text-[var(--warn)]/70 hover:text-[var(--warn)]"
         aria-label="dismiss startup warning"
         onClick=${() => clearStartAttempt(connectorId)}
       >×</button>

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -22,8 +22,8 @@ export function TaskCreateForm() {
   if (!showTaskCreate.value) {
     return html`
       <div class="flex flex-col gap-3">
-        <div class="text-[12px] leading-relaxed text-text-muted">
-          이 프로젝트의 백로그에 바로 추가됩니다. 우선순위는 <code class="rounded bg-white/5 px-1 py-0.5 text-[11px] text-text-strong">P1</code>이 가장 높습니다.
+        <div class="text-xs leading-relaxed text-text-muted">
+          이 프로젝트의 백로그에 바로 추가됩니다. 우선순위는 <code class="rounded bg-white/5 px-1 py-0.5 text-2xs text-text-strong">P1</code>이 가장 높습니다.
         </div>
         <${ActionButton}
           variant="primary"
@@ -39,8 +39,8 @@ export function TaskCreateForm() {
     <div class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.88)] p-4">
       <div class="mb-3 flex items-start justify-between gap-3">
         <div>
-          <h3 class="text-[14px] font-semibold text-text-strong">새 태스크</h3>
-          <p class="mt-1 text-[12px] leading-relaxed text-text-muted">
+          <h3 class="text-base font-semibold text-text-strong">새 태스크</h3>
+          <p class="mt-1 text-xs leading-relaxed text-text-muted">
             간단한 제목만 있어도 backlog에 등록됩니다. 설명은 나중에 보강해도 됩니다.
           </p>
         </div>
@@ -48,7 +48,7 @@ export function TaskCreateForm() {
 
       <div class="flex flex-col gap-3">
         <div class="flex flex-col gap-1.5">
-          <label class="text-[11px] font-medium text-text-muted">
+          <label class="text-2xs font-medium text-text-muted">
             제목<span class="ml-0.5 text-[var(--bad)]">*</span>
           </label>
           <${TextInput}
@@ -60,7 +60,7 @@ export function TaskCreateForm() {
 
         <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
           <div class="flex flex-col gap-1.5">
-            <label class="text-[11px] font-medium text-text-muted">설명</label>
+            <label class="text-2xs font-medium text-text-muted">설명</label>
             <${RichComposer}
               value=${description.value}
               placeholder="배경, 재현 조건, 원하는 결과를 적으면 backlog 카드와 Task 상세에서 그대로 렌더링됩니다."
@@ -72,13 +72,13 @@ export function TaskCreateForm() {
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label class="text-[11px] font-medium text-text-muted">우선순위</label>
+            <label class="text-2xs font-medium text-text-muted">우선순위</label>
             <${Select}
               value=${String(priority.value)}
               options=${PRIORITY_OPTIONS}
               onInput=${(v: string) => { priority.value = Number(v) }}
             />
-            <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-[11px] leading-relaxed text-text-muted">
+            <div class="rounded border border-card-border/60 bg-white/3 px-3 py-2 text-2xs leading-relaxed text-text-muted">
               backlog 카드와 동일하게 <strong class="text-text-strong">P1 → P4</strong> 순으로 표시됩니다.
             </div>
           </div>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -425,7 +425,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
         <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
       </div>
-      ${meta.sublabel ? html`<div class="text-[10px] text-[var(--text-dim)] mb-1">${meta.sublabel}</div>` : null}
+      ${meta.sublabel ? html`<div class="text-3xs text-[var(--text-dim)] mb-1">${meta.sublabel}</div>` : null}
       <div class="text-2xl font-bold ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
         ${src.entry_count.toLocaleString()}
       </div>
@@ -445,7 +445,7 @@ function DiagnosisCard({ title, value, detail, tone }: { title: string; value: s
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
       <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
       <div class="text-2xl font-bold ${toneColor}">${value}</div>
-      <div class="text-[10px] text-[var(--text-dim)]">${detail}</div>
+      <div class="text-3xs text-[var(--text-dim)]">${detail}</div>
     </div>
   `
 }
@@ -479,7 +479,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         </span>
         ${scopeBadges.length > 0 ? html`
           <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-            ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-[10px] text-[var(--text-dim)] font-mono">${badge}</span>`)}
+            ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
           </span>
         ` : null}
         <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
@@ -488,10 +488,10 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
         <div class="px-3 pb-3 flex flex-col gap-2">
           ${scopeBadges.length > 0 ? html`
             <div class="flex flex-wrap gap-1.5">
-              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-dim)] font-mono">${badge}</span>`)}
+              ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </div>
           ` : null}
-          <pre class="text-[10px] font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
+          <pre class="text-3xs font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
 ${JSON.stringify(entry, null, 2)}</pre>
         </div>
       ` : null}
@@ -524,27 +524,27 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
           ${meta.label} · ${item.label} · ${item.count} events
         </span>
         ${sourceIcons.length > 0 ? html`
-          <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-[10px] text-[var(--text-dim)] font-mono">
+          <span class="hidden lg:flex items-center gap-1 flex-shrink-0 text-3xs text-[var(--text-dim)] font-mono">
             ${sourceIcons.join('/')}
           </span>
         ` : null}
         ${item.scopeBadges.length > 0 ? html`
           <span class="hidden xl:flex items-center gap-1 flex-shrink-0">
-            ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-[10px] text-[var(--text-dim)] font-mono">${badge}</span>`)}
+            ${item.scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
           </span>
         ` : null}
         <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
       </button>
       <div id=${contentId} class=${expanded.value ? 'px-3 pb-3 flex flex-col gap-2' : 'hidden'} role="region">
         ${expanded.value ? html`
-          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-[11px] text-[var(--text-dim)]">
+          <div class="rounded bg-[var(--white-3)] px-2 py-1.5 text-2xs text-[var(--text-dim)]">
             Latest: <span class="font-mono text-[var(--text-strong)]">${latestPreview}</span>
           </div>
           ${item.entries.map((entry, index) => {
             const entryMeta = sourceMeta(entry.source)
             const ts = entryTimestamp(entry)
             return html`
-              <div class="flex items-center gap-2 rounded bg-[var(--black-20)] px-2 py-1.5 text-[10px]" key=${`${item.key}:${index}`}>
+              <div class="flex items-center gap-2 rounded bg-[var(--black-20)] px-2 py-1.5 text-3xs" key=${`${item.key}:${index}`}>
                 <span class="font-mono font-bold ${entryMeta.color} w-4 text-center flex-shrink-0">${entryMeta.icon}</span>
                 <span class="font-mono text-[var(--text-dim)] w-24 flex-shrink-0" title=${formatTs(ts)}>${timeAgoSafe(ts)}</span>
                 <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>${entryPreview(entry)}</span>
@@ -552,8 +552,8 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
             `
           })}
           <details class="rounded bg-[var(--black-20)] px-2 py-1.5">
-            <summary class="cursor-pointer text-[10px] text-[var(--text-dim)]">Raw JSON</summary>
-            <pre class="mt-2 text-[10px] font-mono text-[var(--text-muted)] overflow-x-auto max-h-[280px] overflow-y-auto whitespace-pre-wrap break-all">
+            <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">Raw JSON</summary>
+            <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-[280px] overflow-y-auto whitespace-pre-wrap break-all">
 ${JSON.stringify(item.entries, null, 2)}</pre>
           </details>
         ` : null}
@@ -708,15 +708,15 @@ export function TelemetryUnified() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-4">
-        <div class="text-[12px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Runtime Diagnosis</div>
-        <div class="mt-1 text-[14px] leading-relaxed text-[var(--text-body)]">
+        <div class="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">Runtime Diagnosis</div>
+        <div class="mt-1 text-base leading-relaxed text-[var(--text-body)]">
           MASC telemetry store (keeper/tool/agent) 진단 뷰.
         </div>
         <div class="mt-3 flex flex-wrap gap-2">
-          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-dim)]">MASC: keeper/tool/agent store</span>
-          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-[11px] font-mono text-[var(--text-dim)]">session ${sessionFilter.value}</span>` : null}
-          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-[11px] font-mono text-[var(--text-dim)]">operation ${operationFilter.value}</span>` : null}
-          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-[11px] font-mono text-[var(--text-dim)]">worker_run ${workerRunFilter.value}</span>` : null}
+          <span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-dim)]">MASC: keeper/tool/agent store</span>
+          ${sessionFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">session ${sessionFilter.value}</span>` : null}
+          ${operationFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">operation ${operationFilter.value}</span>` : null}
+          ${workerRunFilter.value ? html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-2xs font-mono text-[var(--text-dim)]">worker_run ${workerRunFilter.value}</span>` : null}
         </div>
       </div>
 
@@ -844,7 +844,7 @@ export function TelemetryUnified() {
             : ''}
         </div>
         ${condensed.groups > 0 ? html`
-          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-1)] flex flex-wrap gap-2 text-[11px]">
+          <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-1)] flex flex-wrap gap-2 text-2xs">
             ${Array.from(condensed.byCategory.entries()).map(([category, count]) => {
               const meta = CONDENSED_CATEGORY_META[category]
               return html`

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-3xs font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/components/tool-executor/schema-field.ts
+++ b/dashboard/src/components/tool-executor/schema-field.ts
@@ -21,13 +21,13 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     : null
 
   const hint = schema.description
-    ? html`<span class="text-[10px] text-[var(--text-muted)] mt-0.5">${schema.description}</span>`
+    ? html`<span class="text-3xs text-[var(--text-muted)] mt-0.5">${schema.description}</span>`
     : null
 
   if (schema.type === 'string' && schema.enum) {
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${Select} value=${(value as string) ?? ''} options=${schema.enum} placeholder="-- 선택 --"
           onInput=${(v: string) => onChange(name, v)} />
@@ -40,7 +40,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     if (isLong) {
       return html`
         <div class="flex flex-col gap-1">
-          <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+          <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
           ${hint}
           <${TextArea} value=${(value as string) ?? (schema.default as string) ?? ''} placeholder=${name} rows=${3}
             onInput=${(e: Event) => onChange(name, (e.target as HTMLTextAreaElement).value)} />
@@ -49,7 +49,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     }
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${TextInput} value=${(value as string) ?? (schema.default as string) ?? ''} placeholder=${name}
           onInput=${(e: Event) => onChange(name, (e.target as HTMLInputElement).value)} />
@@ -60,7 +60,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
   if (schema.type === 'integer' || schema.type === 'number') {
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
+        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${NumberInput} value=${(value as number) ?? (schema.default as number) ?? ''} placeholder=${name}
           step=${schema.type === 'integer' ? 1 : 'any'} onInput=${(v: number | undefined) => onChange(name, v)} />
@@ -73,8 +73,8 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
       <div class="flex items-center gap-2 py-1">
         <${Checkbox} checked=${(value as boolean) ?? (schema.default as boolean) ?? false}
           onChange=${(v: boolean) => onChange(name, v)} />
-        <label class="text-[12px] text-[var(--text-body)]">${name}${requiredMark}</label>
-        ${schema.description ? html`<span class="text-[10px] text-[var(--text-muted)]">- ${schema.description}</span>` : null}
+        <label class="text-xs text-[var(--text-body)]">${name}${requiredMark}</label>
+        ${schema.description ? html`<span class="text-3xs text-[var(--text-muted)]">- ${schema.description}</span>` : null}
       </div>
     `
   }
@@ -83,7 +83,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     const strValue = Array.isArray(value) ? (value as string[]).join('\n') : ''
     return html`
       <div class="flex flex-col gap-1">
-        <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}
+        <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}
           <span class="font-normal"> (줄바꿈으로 구분)</span></label>
         ${hint}
         <${TextArea} value=${strValue} placeholder=${name} rows=${3}
@@ -99,10 +99,10 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
     : typeof value === 'string' ? value : JSON.stringify(value, null, 2)
   return html`
     <div class="flex flex-col gap-1">
-      <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}
+      <label class="text-2xs text-[var(--text-muted)] font-medium">${name}${requiredMark}
         <span class="font-normal"> (JSON)</span></label>
       ${hint}
-      <${TextArea} value=${rawValue} placeholder=${'{ ... }'} rows=${4} class="font-mono text-[12px]"
+      <${TextArea} value=${rawValue} placeholder=${'{ ... }'} rows=${4} class="font-mono text-xs"
         onInput=${(e: Event) => {
           const raw = (e.target as HTMLTextAreaElement).value
           try { onChange(name, JSON.parse(raw)) } catch { /* typing */ }

--- a/dashboard/src/components/tool-executor/schema-form.ts
+++ b/dashboard/src/components/tool-executor/schema-form.ts
@@ -10,7 +10,7 @@ interface SchemaFormProps {
 
 export function SchemaForm({ schema, values, onChange }: SchemaFormProps) {
   if (!schema.properties || Object.keys(schema.properties).length === 0) {
-    return html`<p class="text-[var(--text-muted)] text-[12px] py-2">이 도구는 파라미터가 없습니다.</p>`
+    return html`<p class="text-[var(--text-muted)] text-xs py-2">이 도구는 파라미터가 없습니다.</p>`
   }
 
   const required = new Set(schema.required ?? [])

--- a/dashboard/src/components/tool-executor/tool-executor.ts
+++ b/dashboard/src/components/tool-executor/tool-executor.ts
@@ -14,7 +14,7 @@ import {
 function ConfirmDialog({ toolName, onConfirm, onCancel }: { toolName: string; onConfirm: () => void; onCancel: () => void }) {
   return html`
     <div class="rounded border border-[rgba(251,113,133,0.4)] bg-[var(--bad-10)] p-3">
-      <p class="text-[12px] text-[var(--bad-light)] mb-2"><strong>${toolName}</strong> 은 파괴적(destructive) 도구입니다. 실행하시겠습니까?</p>
+      <p class="text-xs text-[var(--bad-light)] mb-2"><strong>${toolName}</strong> 은 파괴적(destructive) 도구입니다. 실행하시겠습니까?</p>
       <div class="flex gap-2">
         <${ActionButton} variant="danger" size="sm" onClick=${onConfirm}>실행<//>
         <${ActionButton} variant="ghost" size="sm" onClick=${onCancel}>취소<//>
@@ -26,7 +26,7 @@ function ConfirmDialog({ toolName, onConfirm, onCancel }: { toolName: string; on
 function ToolDetail() {
   const showConfirm = useSignal(false)
   const tool = selectedTool.value
-  if (!tool) return html`<div class="flex items-center justify-center h-full text-[var(--text-muted)] text-[13px]">좌측에서 도구를 선택하세요.</div>`
+  if (!tool) return html`<div class="flex items-center justify-center h-full text-[var(--text-muted)] text-sm">좌측에서 도구를 선택하세요.</div>`
 
   const isDestructive = tool.annotations?.destructiveHint === true
   const missing = validationErrors.value
@@ -36,15 +36,15 @@ function ToolDetail() {
   return html`
     <div class="flex flex-col gap-3 h-full overflow-y-auto">
       <div>
-        <h3 class="text-[14px] text-[var(--text-strong)] font-mono font-medium">${tool.name}</h3>
-        <p class="text-[12px] text-[var(--text-muted)] mt-1">${tool.description}</p>
-        ${tool.annotations?.readOnlyHint === true ? html`<span class="text-[10px] text-[var(--ok)] mt-1">읽기 전용</span>` : null}
-        ${isDestructive ? html`<span class="text-[10px] text-[var(--bad)] mt-1 ml-2">파괴적</span>` : null}
+        <h3 class="text-base text-[var(--text-strong)] font-mono font-medium">${tool.name}</h3>
+        <p class="text-xs text-[var(--text-muted)] mt-1">${tool.description}</p>
+        ${tool.annotations?.readOnlyHint === true ? html`<span class="text-3xs text-[var(--ok)] mt-1">읽기 전용</span>` : null}
+        ${isDestructive ? html`<span class="text-3xs text-[var(--bad)] mt-1 ml-2">파괴적</span>` : null}
       </div>
       <div class="border-t border-[var(--card-border)] pt-3">
         <${SchemaForm} schema=${tool.inputSchema} values=${formValues.value} onChange=${updateFormValues} />
       </div>
-      ${missing.length > 0 ? html`<p class="text-[11px] text-[var(--bad)]">필수 필드 누락: ${missing.join(', ')}</p>` : null}
+      ${missing.length > 0 ? html`<p class="text-2xs text-[var(--bad)]">필수 필드 누락: ${missing.join(', ')}</p>` : null}
       ${showConfirm.value
         ? html`<${ConfirmDialog} toolName=${tool.name} onConfirm=${handleConfirmedExecute} onCancel=${() => { showConfirm.value = false }} />`
         : html`
@@ -61,11 +61,11 @@ function ToolDetail() {
 export function ToolExecutor() {
   useEffect(() => { void loadToolSchemas() }, [])
   if (schemasLoading.value && !selectedTool.value) {
-    return html`<${SurfaceCard}><p class="text-[12px] text-[var(--text-muted)] py-8 text-center">도구 스키마 로딩 중...</p><//>`
+    return html`<${SurfaceCard}><p class="text-xs text-[var(--text-muted)] py-8 text-center">도구 스키마 로딩 중...</p><//>`
   }
   if (schemasError.value) {
     return html`<${SurfaceCard}><div class="py-4 text-center">
-      <p class="text-[12px] text-[var(--bad)] mb-2">${schemasError.value}</p>
+      <p class="text-xs text-[var(--bad)] mb-2">${schemasError.value}</p>
       <${ActionButton} variant="ghost" size="sm" onClick=${() => void loadToolSchemas(true)}>재시도<//>
     </div><//>`
   }

--- a/dashboard/src/components/tool-executor/tool-picker.ts
+++ b/dashboard/src/components/tool-executor/tool-picker.ts
@@ -20,11 +20,11 @@ function ToolRow({ tool, isSelected }: { tool: McpToolSchema; isSelected: boolea
       ${isSelected ? 'bg-[var(--accent-12)] border border-[var(--accent-30)]' : 'hover:bg-[var(--white-6)] border border-transparent'}
       ${isDeprecated ? 'opacity-50' : ''}" onClick=${() => selectTool(tool)}>
       <div class="flex items-center gap-1.5">
-        <span class="text-[12px] text-[var(--text-strong)] font-mono truncate flex-1">${tool.name}</span>
+        <span class="text-xs text-[var(--text-strong)] font-mono truncate flex-1">${tool.name}</span>
         ${isDestructive ? html`<${CountBadge} tone="bad">D<//>` : null}
         ${isReadOnly ? html`<${CountBadge} tone="ok">R<//>` : null}
       </div>
-      <div class="text-[10px] text-[var(--text-muted)] mt-0.5 line-clamp-1">${tool.description}</div>
+      <div class="text-3xs text-[var(--text-muted)] mt-0.5 line-clamp-1">${tool.description}</div>
     </button>
   `
 }
@@ -38,17 +38,17 @@ export function ToolPicker() {
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }} />
       <div class="flex gap-1">
         ${TIER_OPTIONS.map(opt => html`
-          <button type="button" class="text-[10px] px-2 py-0.5 rounded transition-colors cursor-pointer
+          <button type="button" class="text-3xs px-2 py-0.5 rounded transition-colors cursor-pointer
             ${tierFilter.value === opt.value
               ? 'bg-[var(--accent-12)] text-[var(--text-strong)] border border-[var(--accent-30)]'
               : 'text-[var(--text-muted)] hover:text-[var(--text-body)] border border-transparent hover:bg-[var(--white-6)]'}"
             onClick=${() => { tierFilter.value = opt.value }}>${opt.label}</button>
         `)}
-        <span class="text-[10px] text-[var(--text-muted)] ml-auto self-center">${tools.length}개</span>
+        <span class="text-3xs text-[var(--text-muted)] ml-auto self-center">${tools.length}개</span>
       </div>
       <div class="flex flex-col gap-0.5 overflow-y-auto flex-1 min-h-0 pr-1">
         ${tools.length === 0
-          ? html`<p class="text-[12px] text-[var(--text-muted)] py-4 text-center">결과 없음</p>`
+          ? html`<p class="text-xs text-[var(--text-muted)] py-4 text-center">결과 없음</p>`
           : tools.map(tool => html`<${ToolRow} key=${tool.name} tool=${tool} isSelected=${selected?.name === tool.name} />`)}
       </div>
     </div>

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -70,12 +70,12 @@ function StoredBlobView({
       <div class="flex flex-col gap-2 mt-3">
         <div class="flex items-center gap-2">
           <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-          <span class="text-[11px] text-[var(--text-muted)]">${toolName}</span>
-          <span class="text-[10px] text-[var(--text-muted)] ml-auto">${timeStr}</span>
+          <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
+          <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
         </div>
         <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
           <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-            <button type="button" class="text-[10px] text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
+            <button type="button" class="text-3xs text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
               onClick=${() => { expanded.value = false }}>
               접기 (${marker.bytes.toLocaleString()}B)
             </button>
@@ -87,7 +87,7 @@ function StoredBlobView({
               const { isJson, parsed } = tryParseJson(fullText.value ?? '')
               return isJson
                 ? html`<${JsonViewer} data=${parsed} />`
-                : html`<pre class="text-[12px] font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${fullText.value}</pre>`
+                : html`<pre class="text-xs font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${fullText.value}</pre>`
             })()}
           </div>
         </div>
@@ -100,12 +100,12 @@ function StoredBlobView({
     <div class="flex flex-col gap-2 mt-3" data-testid="tool-blob-marker">
       <div class="flex items-center gap-2">
         <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-        <span class="text-[11px] text-[var(--text-muted)]">${toolName}</span>
-        <span class="text-[10px] text-[var(--text-muted)] ml-auto">${timeStr}</span>
+        <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
+        <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
       </div>
       <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
         <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-          <span class="text-[10px] text-[var(--text-muted)]">
+          <span class="text-3xs text-[var(--text-muted)]">
             저장된 출력 · ${marker.bytes.toLocaleString()}B · sha ${marker.sha256.slice(0, 12)}\u2026
           </span>
           <${ActionButton}
@@ -116,10 +116,10 @@ function StoredBlobView({
           <//>
         </div>
         <div class="px-3 py-2 overflow-x-auto max-h-[200px] overflow-y-auto">
-          <pre class="text-[12px] font-mono text-[var(--text-muted)] whitespace-pre-wrap">${marker.preview}</pre>
+          <pre class="text-xs font-mono text-[var(--text-muted)] whitespace-pre-wrap">${marker.preview}</pre>
         </div>
         ${error.value ? html`
-          <div class="px-3 py-1.5 border-t border-[var(--card-border)] text-[11px] text-[var(--bad-light)]">
+          <div class="px-3 py-1.5 border-t border-[var(--card-border)] text-2xs text-[var(--bad-light)]">
             ${error.value}
           </div>
         ` : null}
@@ -149,12 +149,12 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
     <div class="flex flex-col gap-2 mt-3">
       <div class="flex items-center gap-2">
         <${CountBadge} tone=${success ? 'ok' : 'bad'}>${success ? 'OK' : 'ERR'}<//>
-        <span class="text-[11px] text-[var(--text-muted)]">${toolName}</span>
-        <span class="text-[10px] text-[var(--text-muted)] ml-auto">${timeStr}</span>
+        <span class="text-2xs text-[var(--text-muted)]">${toolName}</span>
+        <span class="text-3xs text-[var(--text-muted)] ml-auto">${timeStr}</span>
       </div>
       <div class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] overflow-hidden">
         <div class="flex items-center justify-between px-3 py-1.5 border-b border-[var(--card-border)]">
-          <button type="button" class="text-[10px] text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
+          <button type="button" class="text-3xs text-[var(--text-muted)] cursor-pointer hover:text-[var(--text-body)]"
             onClick=${() => { expanded.value = !expanded.value }}>
             ${expanded.value ? '접기' : '펼치기'} (${lines}줄)
           </button>
@@ -164,7 +164,7 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <div class="px-3 py-2 overflow-x-auto max-h-[400px] overflow-y-auto">
             ${isJson
               ? html`<${JsonViewer} data=${parsed} />`
-              : html`<pre class="text-[12px] font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${text}</pre>`
+              : html`<pre class="text-xs font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${text}</pre>`
             }
           </div>
         ` : null}

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -74,14 +74,14 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
         return html`
           <div class="tool-bar-row" key=${item.name}>
             <div class="flex items-center gap-1.5 overflow-hidden">
-              <span class="flex-shrink-0 size-4 rounded text-[10px] font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
-              <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px]" title=${item.name}>${item.name}</span>
+              <span class="flex-shrink-0 size-4 rounded text-3xs font-mono font-bold flex items-center justify-center bg-[var(--white-5)] ${cat.color}">${cat.icon}</span>
+              <span class="text-[var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-2xs" title=${item.name}>${item.name}</span>
             </div>
-            <span class="px-1.5 py-px rounded-xs text-[10px] font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>
+            <span class="px-1.5 py-px rounded-xs text-3xs font-medium text-center text-[var(--text-dim)] bg-[var(--white-4)]">${cat.label}</span>
             <div class="h-3.5 rounded-xs bg-[var(--white-6)] overflow-hidden">
               <div class="h-full rounded-xs min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%`, backgroundColor: barBg }} />
             </div>
-            <span class="text-[var(--text-muted)] text-[11px] text-right font-mono">${item.call_count}</span>
+            <span class="text-[var(--text-muted)] text-2xs text-right font-mono">${item.call_count}</span>
           </div>
         `
       })}
@@ -90,28 +90,28 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
 }
 
 function ToolDistribution({ dist }: { dist: { total: number; public: number; visible: number; hidden: number } | null | undefined }) {
-  if (!dist) return html`<div class="text-[11px] text-[var(--text-muted)] italic">도구 분포 데이터가 없습니다.</div>`
+  if (!dist) return html`<div class="text-2xs text-[var(--text-muted)] italic">도구 분포 데이터가 없습니다.</div>`
   // Mutually exclusive segments: public ⊂ visible, hidden = total - visible
   const visibleExclusive = Math.max(0, dist.visible - dist.public)
   const pct = (n: number) => dist.total > 0 ? ((n / dist.total) * 100).toFixed(1) : '0'
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-essential">공개 MCP</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-essential">공개 MCP</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(dist.public)}%</span>
+        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.public)}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-standard">내부 전용</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-standard">내부 전용</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${visibleExclusive}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(visibleExclusive)}%</span>
+        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(visibleExclusive)}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[11px] font-semibold text-center rounded badge-full">숨김</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-full">숨김</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
-        <span class="text-[var(--text-muted)] text-[13px] min-w-12 text-right">${pct(dist.hidden)}%</span>
+        <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.hidden)}%</span>
       </div>
-      <div class="text-[10px] text-[var(--text-dim)] mt-1">전체 ${dist.total}개 (공개 ${dist.public} + 내부 ${visibleExclusive} + 숨김 ${dist.hidden})</div>
+      <div class="text-3xs text-[var(--text-dim)] mt-1">전체 ${dist.total}개 (공개 ${dist.public} + 내부 ${visibleExclusive} + 숨김 ${dist.hidden})</div>
     </div>
   `
 }
@@ -144,39 +144,39 @@ export function ToolMetrics() {
       ${error ? html`<${ErrorState} message=${error} />` : null}
 
       ${data ? html`
-        <div class="text-[11px] text-[var(--text-muted)] mb-3">
+        <div class="text-2xs text-[var(--text-muted)] mb-3">
           서버 시작 이후 메모리 기반 집계. 재시작 시 초기화됩니다.
         </div>
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>
-            <span class="text-[11px] text-[var(--text-muted)] font-medium">총 호출 수</span>
+            <span class="text-2xs text-[var(--text-muted)] font-medium">총 호출 수</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
-            <span class="text-[11px] text-[var(--text-muted)] font-medium">사용된 도구</span>
+            <span class="text-2xs text-[var(--text-muted)] font-medium">사용된 도구</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.never_called_count}</span>
-            <span class="text-[11px] text-[var(--text-muted)] font-medium">미사용 도구</span>
+            <span class="text-2xs text-[var(--text-muted)] font-medium">미사용 도구</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.registered_count}</span>
-            <span class="text-[11px] text-[var(--text-muted)] font-medium">등록됨 (v2)</span>
+            <span class="text-2xs text-[var(--text-muted)] font-medium">등록됨 (v2)</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
-            <span class="text-[11px] text-[var(--text-muted)] font-medium">Dispatch v2</span>
+            <span class="text-2xs text-[var(--text-muted)] font-medium">Dispatch v2</span>
           </div>
         </div>
 
         <div class="tool-metrics-sections">
           <div>
-            <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">도구 분포</h4>
+            <h4 class="text-[var(--text-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">도구 분포</h4>
             <${ToolDistribution} dist=${data.tool_distribution} />
           </div>
           <div>
-            <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
+            <h4 class="text-[var(--text-muted)] text-2xs uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
             ${(() => {
               // Build category chips from labels actually present in top_20.
               const labelCounts = new Map<string, number>()
@@ -211,7 +211,7 @@ export function ToolMetrics() {
                   />
                 </div>
                 ${(categoryFilter.value !== 'all' || searchQuery.value.trim() !== '') ? html`
-                  <div class="mb-2 text-[11px] text-[var(--text-muted)]">
+                  <div class="mb-2 text-2xs text-[var(--text-muted)]">
                     ${filtered.length} / ${data.top_20.length}개 도구
                   </div>
                 ` : null}

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -120,7 +120,7 @@ function RateGauge({ rate, label }: { rate: number; label: string }) {
   const color = rate >= 95 ? 'bg-[var(--ok-10)]' : rate >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
   return html`
     <div class="flex flex-col gap-1">
-      <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider">${label}</div>
+      <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider">${label}</div>
       <div class="flex items-center gap-2">
         <div class="flex-1 h-1.5 bg-[var(--bg-subtle)] rounded-sm overflow-hidden">
           <div class="${color} h-full rounded-sm transition-all" style="width: ${Math.min(rate, 100)}%" />
@@ -150,12 +150,12 @@ function ToolTable({
   const hasQuery = query.trim() !== ''
   if (hasQuery && filtered.length === 0) {
     return html`
-      <div class="text-[11px] text-[var(--text-dim)] py-2">조건에 맞는 도구가 없습니다.</div>
+      <div class="text-2xs text-[var(--text-dim)] py-2">조건에 맞는 도구가 없습니다.</div>
     `
   }
   return html`
     <div class="overflow-x-auto">
-      <table class="w-full text-[11px]">
+      <table class="w-full text-2xs">
         <thead>
           <tr class="text-[var(--text-dim)] border-b border-[var(--card-border)]">
             <th class="text-left py-1 font-normal">Tool</th>
@@ -175,7 +175,7 @@ function ToolTable({
               : 'border-b border-[var(--card-border)] border-opacity-30'
             return html`
               <tr class=${rowClass} ref=${isHighlighted ? ((el: HTMLElement | null) => el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })) : undefined}>
-                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-[10px] text-[var(--warn)]">◀ selected</span>` : null}</td>
+                <td class="py-0.5 font-mono">${t.name.replace('keeper_', '').replace('masc_', 'm:')}${isHighlighted ? html`<span class="ml-1 text-3xs text-[var(--warn)]">◀ selected</span>` : null}</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.calls}</td>
                 <td class="text-right py-0.5 font-mono ${color}">${t.success_pct.toFixed(0)}%</td>
                 <td class="text-right py-0.5 text-[var(--text-dim)]">${t.avg_ms.toFixed(0)}</td>
@@ -220,7 +220,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
       <div class="flex items-center justify-between mb-1.5">
-        <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">성공률 추이</span>
+        <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">성공률 추이</span>
         <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
       </div>
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
@@ -229,7 +229,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
         `)}
         <polyline points="${rateLine}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
       </svg>
-      <div class="flex justify-between mt-1 text-[8px] text-[var(--text-dim)] font-mono">
+      <div class="flex justify-between mt-1 text-4xs text-[var(--text-dim)] font-mono">
         <span>${points[0]?.hour?.slice(5) ?? ''}</span>
         <span>${points[points.length - 1]?.hour?.slice(5) ?? ''}</span>
       </div>
@@ -245,7 +245,7 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
         const color = k.success_pct >= 95 ? 'bg-[var(--ok-10)]' : k.success_pct >= 90 ? 'bg-[var(--warn-10)]' : 'bg-[var(--bad-10)]'
         const textColor = k.success_pct >= 95 ? 'text-[var(--ok)]' : k.success_pct >= 90 ? 'text-[var(--warn)]' : 'text-[var(--bad-light)]'
         return html`
-          <div class="flex items-center gap-2 text-[11px]">
+          <div class="flex items-center gap-2 text-2xs">
             <span class="w-24 truncate text-[var(--text-dim)] font-mono" title=${k.name}>${k.name}</span>
             <div class="flex-1 h-1.5 bg-[var(--bg-subtle)] rounded-sm overflow-hidden">
               <div class="${color} h-full rounded-sm transition-all" style="width:${Math.min(k.success_pct, 100)}%" />
@@ -261,11 +261,11 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
 
 function FailureList({ categories }: { categories: FailureCategory[] }) {
   const top = categories.slice(0, 8)
-  if (top.length === 0) return html`<div class="text-[11px] text-[var(--text-dim)]">실패 없음</div>`
+  if (top.length === 0) return html`<div class="text-2xs text-[var(--text-dim)]">실패 없음</div>`
   return html`
     <div class="flex flex-col gap-1">
       ${top.map(c => html`
-        <div class="flex items-center justify-between text-[11px]">
+        <div class="flex items-center justify-between text-2xs">
           <span class="font-mono text-[var(--bad-light)]/80 truncate flex-1 mr-2">${c.category}</span>
           <span class="text-[var(--text-dim)] shrink-0">${c.count}x</span>
         </div>
@@ -299,41 +299,41 @@ export function ToolQualityPanel() {
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
   if (error.value) return html`<${ErrorState} message=${error.value} class="m-4" />`
-  if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
+  if (!d || d.total === 0) return html`<div class="p-4 text-2xs text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
 
   return html`
     <div class="flex flex-col gap-4 p-4">
       <div class="flex items-center justify-between">
         <div>
           <h2 class="text-sm font-medium">도구 호출 품질</h2>
-          <div class="text-[10px] text-[var(--text-dim)]">
+          <div class="text-3xs text-[var(--text-dim)]">
             ${d.sampling_mode === 'recent_n'
               ? `최근 ${d.sample_limit.toLocaleString()}건 기준 집계`
               : `최근 ${(d.window_hours ?? TOOL_QUALITY_WINDOW_HOURS).toLocaleString()}시간 기준 집계`}
           </div>
         </div>
         <button
-          class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
+          class="text-3xs px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
           onClick=${handleRefreshToolQualityClick}
           aria-label="도구 품질 새로고침"
         >새로고침</button>
-        <span class="text-[10px] text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        <span class="text-3xs text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div class="text-center">
           <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
-          <div class="text-[10px] text-[var(--text-dim)] uppercase">성공률</div>
+          <div class="text-3xs text-[var(--text-dim)] uppercase">성공률</div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
-          <div class="text-[10px] text-[var(--text-dim)] uppercase">
+          <div class="text-3xs text-[var(--text-dim)] uppercase">
             ${d.sampling_mode === 'recent_n' ? 'Sampled Calls' : 'Window Calls'}
           </div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--bad-light)]/80">${d.failure}</div>
-          <div class="text-[10px] text-[var(--text-dim)] uppercase">Failures</div>
+          <div class="text-3xs text-[var(--text-dim)] uppercase">Failures</div>
         </div>
       </div>
 
@@ -344,13 +344,13 @@ export function ToolQualityPanel() {
       ` : null}
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Per Keeper</div>
+        <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider mb-1">Per Keeper</div>
         <${KeeperRateBars} keepers=${d.by_keeper} />
       </div>
 
       <div>
         <div class="flex items-center justify-between mb-1 gap-2">
-          <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider">도구별 성공률</div>
+          <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider">도구별 성공률</div>
           <${TextInput}
             class="max-w-[180px]"
             name="tool_quality_search"
@@ -369,7 +369,7 @@ export function ToolQualityPanel() {
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Failure Categories</div>
+        <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider mb-1">Failure Categories</div>
         <${FailureList} categories=${d.failure_categories} />
       </div>
     </div>

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -157,7 +157,7 @@ function ConfigRow({
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3" title=${item.path}>
       <div class="mb-2 flex flex-wrap items-center gap-2">
-        <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+        <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
         <${StatusChip} tone=${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}>${item.exists ? 'present' : 'missing'}<//>
         ${showSourceBadge
           ? html`
@@ -171,14 +171,14 @@ function ConfigRow({
           : null}
       </div>
       <div class="flex items-start gap-1.5">
-        <div class="min-w-0 flex-1 break-all font-mono text-[12px] leading-relaxed text-[var(--text-body)]">${pathInfo.primary}</div>
+        <div class="min-w-0 flex-1 break-all font-mono text-xs leading-relaxed text-[var(--text-body)]">${pathInfo.primary}</div>
         ${item.path
           ? html`<${CopyIdButton} value=${copyablePath(item)} label=${label} ariaLabel=${`${label} 경로 복사`} />`
           : null}
       </div>
       ${pathInfo.context
         ? html`
-            <div class="mt-2 text-[11px] text-[var(--text-muted)]">${pathInfo.context}</div>
+            <div class="mt-2 text-2xs text-[var(--text-muted)]">${pathInfo.context}</div>
           `
         : null}
     </div>
@@ -196,10 +196,10 @@ function WarningBlock({
 
   return html`
     <div class="rounded border border-[var(--yellow-bright-28)] bg-[var(--warn-10)] px-3 py-3">
-      <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--yellow-100)]">${title}</div>
+      <div class="mb-2 text-2xs uppercase tracking-[0.08em] text-[var(--yellow-100)]">${title}</div>
       <div class="flex flex-col gap-2">
         ${warnings.map(warning => html`
-          <div class="text-[12px] leading-relaxed text-[var(--text-body)]">${warning}</div>
+          <div class="text-xs leading-relaxed text-[var(--text-body)]">${warning}</div>
         `)}
       </div>
     </div>
@@ -215,8 +215,8 @@ function RuntimeMetaRow({
 }) {
   return html`
     <div class="flex items-center justify-between gap-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
-      <div class="break-all text-right font-mono text-[12px] text-[var(--text-body)]">${value}</div>
+      <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+      <div class="break-all text-right font-mono text-xs text-[var(--text-body)]">${value}</div>
     </div>
   `
 }
@@ -231,9 +231,9 @@ function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
               <${StatusChip} tone="warn">${item.signal}<//>
             `
           : null}
-        <span class="text-[11px] text-[var(--text-muted)]">${item.ts}</span>
+        <span class="text-2xs text-[var(--text-muted)]">${item.ts}</span>
       </div>
-      <div class="text-[12px] leading-relaxed text-[var(--text-body)]">${item.message}</div>
+      <div class="text-xs leading-relaxed text-[var(--text-body)]">${item.message}</div>
     </div>
   `
 }
@@ -318,7 +318,7 @@ function RuntimeProbePanel() {
   return html`
     <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">ollama warm / kv probe</div>
+        <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">ollama warm / kv probe</div>
         <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
@@ -326,7 +326,7 @@ function RuntimeProbePanel() {
             `
           : null}
         <button
-          class="ml-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-[11px] text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          class="ml-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-2xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void load(true)}
         >
           ${state.value.loading ? 'probing...' : 'refresh probe'}
@@ -335,7 +335,7 @@ function RuntimeProbePanel() {
 
       ${state.value.error
         ? html`
-            <div class="rounded border border-[var(--rose-28)] bg-[var(--rose-10)] px-3 py-3 text-[12px] text-[#fecdd3]">
+            <div class="rounded border border-[var(--rose-28)] bg-[var(--rose-10)] px-3 py-3 text-xs text-[#fecdd3]">
               ${state.value.error}
             </div>
           `
@@ -343,7 +343,7 @@ function RuntimeProbePanel() {
 
       ${!state.value.error && !probe
         ? html`
-            <div class="text-[12px] text-[var(--text-muted)]">
+            <div class="text-xs text-[var(--text-muted)]">
               ${state.value.loading ? 'runtime probe를 불러오는 중입니다.' : 'probe result가 아직 없습니다.'}
             </div>
           `
@@ -381,7 +381,7 @@ function RuntimeProbePanel() {
 
             ${assessment?.note
               ? html`
-                  <div class="mt-3 text-[12px] leading-relaxed text-[var(--text-muted)]">
+                  <div class="mt-3 text-xs leading-relaxed text-[var(--text-muted)]">
                     ${assessment.note}
                   </div>
                 `
@@ -391,7 +391,7 @@ function RuntimeProbePanel() {
               ? html`
                   <div class="mt-3 flex flex-col gap-2">
                     ${probe.observations?.map(item => html`
-                      <div class="rounded border border-[var(--card-border)] bg-[var(--white-6)] px-3 py-2 text-[12px] text-[var(--text-body)]">
+                      <div class="rounded border border-[var(--card-border)] bg-[var(--white-6)] px-3 py-2 text-xs text-[var(--text-body)]">
                         ${item}
                       </div>
                     `)}
@@ -403,7 +403,7 @@ function RuntimeProbePanel() {
               ? html`
                   <div class="mt-3 flex flex-col gap-2">
                     ${probe.errors?.map(item => html`
-                      <div class="rounded border border-[var(--rose-28)] bg-[var(--rose-10)] px-3 py-2 text-[12px] text-[#fecdd3]">
+                      <div class="rounded border border-[var(--rose-28)] bg-[var(--rose-10)] px-3 py-2 text-xs text-[#fecdd3]">
                         ${item}
                       </div>
                     `)}
@@ -438,7 +438,7 @@ export function ConfigResolutionPanel({
 
   return html`
     <${Card} title="설정 경로" class="section mb-4">
-      <div class="mb-4 text-[12px] leading-relaxed text-[var(--text-muted)]">
+      <div class="mb-4 text-xs leading-relaxed text-[var(--text-muted)]">
         서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. 체크인된 repo config는 fallback/default source일 뿐이며, 현재 실행이 바라보는 경로와는 다를 수 있습니다.
       </div>
 
@@ -448,7 +448,7 @@ export function ConfigResolutionPanel({
               <div class="mb-3 flex flex-wrap items-center gap-2">
                 <${StatusChip} tone=${toneClass(resolution.status)}>${resolution.status}<//>
                 <${StatusChip} tone="neutral" uppercase=${false}>${sourceLabel(resolution.config_root.source)}<//>
-                <span class="text-[12px] text-[var(--text-muted)]">resolved config root</span>
+                <span class="text-xs text-[var(--text-muted)]">resolved config root</span>
               </div>
 
               <div class="mb-4">
@@ -497,7 +497,7 @@ export function ConfigResolutionPanel({
             <div>
               <div class="mb-3 flex flex-wrap items-center gap-2">
                 <${StatusChip} tone=${toneClass(runtimeResolution.status)}>${runtimeResolution.status}<//>
-                <span class="text-[12px] text-[var(--text-muted)]">runtime path resolution</span>
+                <span class="text-xs text-[var(--text-muted)]">runtime path resolution</span>
                 ${runtimeResolution.source_mismatch
                   ? html`
                       <${StatusChip} tone="bad">source mismatch<//>
@@ -526,7 +526,7 @@ export function ConfigResolutionPanel({
 
               <div class="mt-4">
                 <div class="mb-2 flex items-center justify-between gap-2">
-                  <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                  <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
                     recent diagnostics
                   </div>
                   ${runtimeResolution.diagnostics.length > 0
@@ -537,7 +537,7 @@ export function ConfigResolutionPanel({
                           placeholder="kind / signal / message 필터"
                           aria-label="Diagnostics 필터"
                           onInput=${(e: Event) => { diagnosticsQuery.value = (e.target as HTMLInputElement).value }}
-                          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                         />
                       `
                     : null}
@@ -545,13 +545,13 @@ export function ConfigResolutionPanel({
                 <div class="flex flex-col gap-3">
                   ${runtimeResolution.diagnostics.length === 0
                     ? html`
-                        <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+                        <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-xs text-[var(--text-muted)]">
                           최근 runtime warning이 없습니다.
                         </div>
                       `
                     : isFilteringDiagnostics && visibleDiagnostics.length === 0
                       ? html`
-                          <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-center text-[12px] text-[var(--text-muted)]">
+                          <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-center text-xs text-[var(--text-muted)]">
                             필터 결과 없음 (${runtimeResolution.diagnostics.length} diagnostics)
                           </div>
                         `

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -166,18 +166,18 @@ export function PromptRegistryPanel() {
 
   return html`
     <${Card} title="프롬프트 레지스트리" class="section mb-4">
-      <div class="mb-4 text-[12px] text-[var(--text-muted)] leading-relaxed">
+      <div class="mb-4 text-xs text-[var(--text-muted)] leading-relaxed">
         <div>기준 원문은 resolved config root의 <code>prompts/*.md</code>입니다. 경로는 설정 경로 상세 패널에서 확인할 수 있습니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
       </div>
 
       ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
-      ${status ? html`<div class="mb-4 rounded border border-[var(--sky-28)] bg-[var(--sky-8)] px-3 py-2 text-[12px] text-[#bae6fd]">${status}</div>` : null}
+      ${status ? html`<div class="mb-4 rounded border border-[var(--sky-28)] bg-[var(--sky-8)] px-3 py-2 text-xs text-[#bae6fd]">${status}</div>` : null}
 
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <div class="min-h-[260px] rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
-            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
               등록된 프롬프트
               ${sourceFilter.value !== 'all' || searchQuery.value
                 ? html`<span class="ml-1 normal-case tracking-normal text-[var(--text-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
@@ -207,7 +207,7 @@ export function PromptRegistryPanel() {
           </div>
           <div class="flex max-h-[520px] flex-col gap-2 overflow-y-auto pr-1">
             ${visiblePrompts.length === 0 ? html`
-              <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-6 text-center text-[11px] text-[var(--text-muted)]">
+              <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-6 text-center text-2xs text-[var(--text-muted)]">
                 조건에 맞는 프롬프트가 없습니다.
               </div>
             ` : null}
@@ -224,11 +224,11 @@ export function PromptRegistryPanel() {
                 }}
               >
                 <div class="mb-1 flex items-start justify-between gap-2">
-                  <div class="font-mono text-[12px] text-[var(--text-strong)]">${prompt.key}</div>
+                  <div class="font-mono text-xs text-[var(--text-strong)]">${prompt.key}</div>
                   <${StatusChip} tone=${sourceBadgeClass(prompt.source)}>${prompt.source}<//>
                 </div>
-                <div class="mb-1 text-[11px] text-[var(--text-muted)]">${prompt.category}</div>
-                <div class="text-[12px] text-[var(--text-body)] leading-relaxed">${prompt.description}</div>
+                <div class="mb-1 text-2xs text-[var(--text-muted)]">${prompt.category}</div>
+                <div class="text-xs text-[var(--text-body)] leading-relaxed">${prompt.description}</div>
               </button>
             `)}
           </div>
@@ -237,7 +237,7 @@ export function PromptRegistryPanel() {
         <div class="min-w-0 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-4">
           ${selectedPrompt ? html`
             <div class="mb-4 flex flex-wrap items-center gap-2">
-              <div class="font-mono text-[13px] text-[var(--text-strong)]">${selectedPrompt.key}</div>
+              <div class="font-mono text-sm text-[var(--text-strong)]">${selectedPrompt.key}</div>
               <${StatusChip} tone=${sourceBadgeClass(selectedPrompt.source)}>${selectedPrompt.source}<//>
               ${selectedPrompt.has_override
                 ? html`<${StatusChip} tone="warn">오버라이드 활성<//>`
@@ -246,39 +246,39 @@ export function PromptRegistryPanel() {
 
             <div class="mb-4 grid gap-3 md:grid-cols-2">
               <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">마크다운 파일</div>
-                <div class="mt-1 break-all font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.file_path ?? '미설정'}</div>
+                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">마크다운 파일</div>
+                <div class="mt-1 break-all font-mono text-xs text-[var(--text-body)]">${selectedPrompt.file_path ?? '미설정'}</div>
               </div>
               <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">문자 수</div>
-                <div class="mt-1 font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.char_count}</div>
+                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">문자 수</div>
+                <div class="mt-1 font-mono text-xs text-[var(--text-body)]">${selectedPrompt.char_count}</div>
               </div>
             </div>
 
             ${selectedPrompt.template_variables.length > 0 ? html`
               <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">허용된 플레이스홀더</div>
+                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">허용된 플레이스홀더</div>
                 <div class="mt-2 flex flex-wrap gap-2">
                   ${selectedPrompt.template_variables.map(variable => html`
-                    <span class="rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-body)]">${`{{${variable}}}`}</span>
+                    <span class="rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-2xs text-[var(--text-body)]">${`{{${variable}}}`}</span>
                   `)}
                 </div>
               </div>
             ` : null}
 
             <div class="mb-4">
-              <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
+              <div class="mb-2 text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
               <div class="max-h-[220px] overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
-              <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">런타임 오버라이드</div>
-              <div class="text-[11px] text-[var(--text-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
+              <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">런타임 오버라이드</div>
+              <div class="text-2xs text-[var(--text-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
             </div>
             <${TextArea}
               rows=${18}
               value=${draft}
-              class="min-h-[320px] font-mono text-[12px]"
+              class="min-h-[320px] font-mono text-xs"
               onInput=${(event: Event) => {
                 setDraft((event.target as HTMLTextAreaElement).value)
                 setStatus(null)
@@ -300,7 +300,7 @@ export function PromptRegistryPanel() {
               <//>
             </div>
           ` : html`
-            <div class="rounded border border-dashed border-[var(--card-border)] px-4 py-10 text-center text-[12px] text-[var(--text-muted)]">
+            <div class="rounded border border-dashed border-[var(--card-border)] px-4 py-10 text-center text-xs text-[var(--text-muted)]">
               ${loading ? '프롬프트 목록을 불러오는 중입니다.' : '표시할 프롬프트가 없습니다.'}
             </div>
           `}

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -104,10 +104,10 @@ function removeFromList(listSig: typeof alsoAllowItems, name: string) {
 
 function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void }) {
   return html`
-    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-sm text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
+    <span class="inline-flex items-center gap-0.5 py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
       ${name}
       <button type="button"
-        class="text-[var(--accent)]/50 hover:text-[#ff6b6b] cursor-pointer text-[11px] leading-none transition-colors"
+        class="text-[var(--accent)]/50 hover:text-[#ff6b6b] cursor-pointer text-2xs leading-none transition-colors"
         onClick=${onRemove}
         title="제거"
       >\u00d7</button>
@@ -117,7 +117,7 @@ function RemovableChip({ name, onRemove }: { name: string; onRemove: () => void 
 
 function ReadOnlyChip({ name }: { name: string }) {
   return html`
-    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-[10px] font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
+    <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">
       ${name}
     </span>
   `
@@ -194,8 +194,8 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
   if (tools.length === 0) {
     return html`
       <div class="flex flex-col gap-1">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">resolved allowlist (0)</span>
-        <span class="text-[11px] text-[var(--text-muted)] italic">resolved allowlist 없음</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">resolved allowlist (0)</span>
+        <span class="text-2xs text-[var(--text-muted)] italic">resolved allowlist 없음</span>
       </div>
     `
   }
@@ -209,7 +209,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
   return html`
     <div class="flex flex-col gap-1">
       <div class="flex items-center justify-between gap-2">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           resolved allowlist (${tools.length}개, ${groups.length} 카테고리)
         </span>
         <input
@@ -218,11 +218,11 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
           placeholder="도구/카테고리 필터"
           aria-label="resolved allowlist 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleTools.length === 0
-        ? html`<div class="py-3 text-center text-[11px] text-[var(--text-muted)]">필터 결과 없음 (${tools.length}개 도구)</div>`
+        ? html`<div class="py-3 text-center text-2xs text-[var(--text-muted)]">필터 결과 없음 (${tools.length}개 도구)</div>`
         : html`
           <div class="flex flex-col gap-2">
             ${visibleGroups.map(group => {
@@ -230,12 +230,12 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
               const hiddenToolCount = Math.max(0, group.names.length - visibleNames.length)
               return html`
               <div class="flex flex-col gap-1">
-                <span class="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
+                <span class="text-3xs font-bold uppercase tracking-widest text-[var(--text-muted)]">${group.category} (${group.names.length})</span>
                 <div class="flex flex-wrap gap-1">
                   ${visibleNames.map(name => html`<${ReadOnlyChip} name=${name} />`)}
                   ${!expanded && hiddenToolCount > 0
                     ? html`
-                        <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-[10px] font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
+                        <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-3xs font-medium border border-dashed border-[var(--card-border)] text-[var(--text-muted)]">
                           +${hiddenToolCount}
                         </span>
                       `
@@ -248,7 +248,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
           ${hasHiddenContent
             ? html`
                 <button type="button"
-                  class="self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+                  class="self-start text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
                   aria-expanded=${expanded}
                   aria-label=${expanded ? 'resolved allowlist 접기' : `resolved allowlist 전체 ${tools.length}개 보기`}
                   onClick=${() => setExpanded(value => !value)}
@@ -349,7 +349,7 @@ function ToolSearchPicker({
         <input
           ...${getInputProps({
             placeholder,
-            class: 'w-full px-3 py-1.5 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]',
+            class: 'w-full px-3 py-1.5 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]',
           })}
         />
 
@@ -361,7 +361,7 @@ function ToolSearchPicker({
           ${showMenu && filtered.length > 0
             ? Array.from(groupedFiltered.entries()).map(([cat, names]) => html`
               ${groupedFiltered.size > 1
-                ? html`<li class="px-3 pt-2 pb-0.5 text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)] select-none" aria-hidden="true">${cat}</li>`
+                ? html`<li class="px-3 pt-2 pb-0.5 text-3xs font-bold uppercase tracking-widest text-[var(--text-muted)] select-none" aria-hidden="true">${cat}</li>`
                 : null}
               ${names.map(name => {
                 const idx = filtered.indexOf(name)
@@ -375,10 +375,10 @@ function ToolSearchPicker({
                         : 'hover:bg-[var(--accent-10)]'
                     }`}
                   >
-                    <span class="text-[11px] text-[var(--text-body)] font-medium shrink-0">${name}</span>
-                    ${usage ? html`<span class="text-[10px] text-[var(--text-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
+                    <span class="text-2xs text-[var(--text-body)] font-medium shrink-0">${name}</span>
+                    ${usage ? html`<span class="text-3xs text-[var(--text-muted)] shrink-0 tabular-nums">${usage}x</span>` : null}
                     ${descMap.has(name)
-                      ? html`<span class="text-[10px] text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
+                      ? html`<span class="text-3xs text-[var(--text-muted)] truncate">${descMap.get(name)}</span>`
                       : null}
                   </li>
                 `
@@ -388,7 +388,7 @@ function ToolSearchPicker({
         </ul>
         ${showMenu && filtered.length === 0
           ? html`
-            <div class="absolute z-10 top-full left-0 right-0 mt-1 px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] text-[11px] text-[var(--text-muted)]">
+            <div class="absolute z-10 top-full left-0 right-0 mt-1 px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] text-2xs text-[var(--text-muted)]">
               ${allNames.length === 0
                 ? '도구 목록 로딩 중... Enter로 직접 추가 가능'
                 : '일치하는 도구 없음. Enter로 직접 추가 가능'}
@@ -412,7 +412,7 @@ function TextModeToggle({
   if (!isText) {
     return html`
       <button type="button"
-        class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
         onClick=${() => {
           textInputBuffer.value = listSig.value.join(', ')
           textInputSection.value = section
@@ -424,14 +424,14 @@ function TextModeToggle({
   return html`
     <div class="flex gap-2">
       <button type="button"
-        class="text-[10px] text-[var(--ok)] hover:text-[var(--ok)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--ok)] hover:text-[var(--ok)] cursor-pointer transition-colors"
         onClick=${() => {
           listSig.value = parseToolList(textInputBuffer.value)
           textInputSection.value = null
         }}
       >적용</button>
       <button type="button"
-        class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
+        class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer transition-colors"
         onClick=${() => { textInputSection.value = null }}
       >취소</button>
     </div>
@@ -451,7 +451,7 @@ function SectionHeader({
 }) {
   return html`
     <div class="flex items-center justify-between">
-      <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+      <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
         ${label}${listSig.value.length > 0 ? html` <span class="text-[var(--text-body)]">(${listSig.value.length})</span>` : ''}
       </span>
       <${TextModeToggle} section=${section} listSig=${listSig} />
@@ -528,9 +528,9 @@ export function ToolAllowlistEditor({
   return html`
     <div class="flex flex-col gap-3 mt-2 p-3 rounded border border-[var(--card-border)] bg-[var(--panel-dark-60)]">
       <div class="flex items-center justify-between">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">도구 정책 편집</span>
+        <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">도구 정책 편집</span>
         <button type="button"
-          class="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer"
+          class="text-3xs text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer"
           onClick=${() => resetEditorState({
             mode: currentMode,
             preset: currentPreset,
@@ -545,7 +545,7 @@ export function ToolAllowlistEditor({
       <div class="flex gap-2">
         ${(['preset', 'custom'] as const).map(mode => html`
           <button type="button"
-            class=${`py-1 px-3 rounded text-[10px] font-medium border transition-colors cursor-pointer ${
+            class=${`py-1 px-3 rounded text-3xs font-medium border transition-colors cursor-pointer ${
               policyMode.value === mode
                 ? 'border-[var(--accent-30)] bg-[var(--accent-soft)] text-[var(--accent)]'
                 : 'border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)]'
@@ -559,9 +559,9 @@ export function ToolAllowlistEditor({
       ${policyMode.value === 'preset'
         ? html`
           <label class="flex flex-col gap-1">
-            <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">preset</span>
+            <span class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">preset</span>
             <select
-              class="w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)]"
+              class="w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)]"
               value=${preset.value}
               onChange=${(e: Event) => { preset.value = (e.target as HTMLSelectElement).value as typeof preset.value }}
             >
@@ -576,7 +576,7 @@ export function ToolAllowlistEditor({
             ${textInputSection.value === 'also_allow'
               ? html`
                 <textarea
-                  class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+                  class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
                   placeholder="쉼표 또는 줄바꿈으로 구분"
                   value=${textInputBuffer.value}
                   onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -600,15 +600,15 @@ export function ToolAllowlistEditor({
               ? html`
                 <div class="flex flex-col gap-2 px-3 py-2 rounded bg-[var(--bad-12)] border border-[var(--bad-30)]">
                   <div class="flex items-start gap-2">
-                    <span class="text-[var(--bad)] text-[13px] shrink-0 font-bold">0</span>
-                    <span class="text-[11px] text-[var(--bad)] leading-snug">
+                    <span class="text-[var(--bad)] text-sm shrink-0 font-bold">0</span>
+                    <span class="text-2xs text-[var(--bad)] leading-snug">
                       allowlist가 비어 있으면 이 키퍼는 <strong>도구를 하나도 사용할 수 없습니다</strong>.
                     </span>
                   </div>
                   ${resolvedAllowlist.length > 0
                     ? html`
                       <button type="button"
-                        class="self-start py-1 px-3 rounded text-[10px] font-medium border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-22)] cursor-pointer transition-colors"
+                        class="self-start py-1 px-3 rounded text-3xs font-medium border border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--accent)] hover:bg-[var(--accent-22)] cursor-pointer transition-colors"
                         onClick=${() => { customAllowItems.value = [...resolvedAllowlist] }}
                       >현재 resolved list에서 복사 (${resolvedAllowlist.length}개)</button>
                     `
@@ -619,7 +619,7 @@ export function ToolAllowlistEditor({
             ${textInputSection.value === 'custom'
               ? html`
                 <textarea
-                  class="min-h-[88px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+                  class="min-h-[88px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
                   placeholder="쉼표 또는 줄바꿈으로 구분"
                   value=${textInputBuffer.value}
                   onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -642,7 +642,7 @@ export function ToolAllowlistEditor({
         ${textInputSection.value === 'deny'
           ? html`
             <textarea
-              class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+              class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
               placeholder="쉼표 또는 줄바꿈으로 구분"
               value=${textInputBuffer.value}
               onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -663,7 +663,7 @@ export function ToolAllowlistEditor({
       <!-- Apply -->
       <div class="flex items-center gap-3">
         <button type="button"
-          class=${`py-1.5 px-4 rounded text-[10px] font-medium transition-colors cursor-pointer disabled:opacity-50 ${
+          class=${`py-1.5 px-4 rounded text-3xs font-medium transition-colors cursor-pointer disabled:opacity-50 ${
             isCustomEmpty
               ? 'bg-[var(--bad-light)] text-white hover:bg-[var(--bad)]'
               : 'bg-[var(--ok)] text-[#000] hover:bg-[var(--emerald)]'
@@ -677,7 +677,7 @@ export function ToolAllowlistEditor({
               ? '도구 0개로 적용'
               : '정책 적용'}
         </button>
-        <span class="text-[10px] text-[var(--text-muted)]">
+        <span class="text-3xs text-[var(--text-muted)]">
           ${policyMode.value === 'custom'
             ? `${customAllowItems.value.length}개 허용${denyItems.value.length > 0 ? `, ${denyItems.value.length}개 차단` : ''}`
             : `preset: ${preset.value}${alsoAllowItems.value.length > 0 ? ` + ${alsoAllowItems.value.length}개 추가` : ''}${denyItems.value.length > 0 ? `, ${denyItems.value.length}개 차단` : ''}`}
@@ -685,10 +685,10 @@ export function ToolAllowlistEditor({
       </div>
 
       ${lastError.value
-        ? html`<span class="text-[10px] text-[var(--bad)]">${lastError.value}</span>`
+        ? html`<span class="text-3xs text-[var(--bad)]">${lastError.value}</span>`
         : null}
       ${lastSuccess.value
-        ? html`<span class="text-[10px] text-[var(--ok)]">${lastSuccess.value}</span>`
+        ? html`<span class="text-3xs text-[var(--ok)]">${lastSuccess.value}</span>`
         : null}
     </div>
   `

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -86,42 +86,42 @@ export function FullInventoryView({
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${publicCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
+          <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
       </div>
 
-      <div class="text-[12px] text-[var(--text-muted)] mb-4">
+      <div class="text-xs text-[var(--text-muted)] mb-4">
         카드 숫자는 서로 다른 축이다. MCP 공개는 surface, 숨김은 visibility, 직접 호출은 hidden direct-call policy 기준이다.
       </div>
 
       <div class="flex flex-wrap gap-2 mb-4">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
           <button type="button"
-            class=${`px-3 py-1.5 rounded text-[13px] font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
+            class=${`px-3 py-1.5 rounded text-sm font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[10px] font-semibold bg-[var(--white-8)] text-[var(--text-muted)] rounded-sm ml-1">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-3xs font-semibold bg-[var(--white-8)] text-[var(--text-muted)] rounded-sm ml-1">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
@@ -139,7 +139,7 @@ export function FullInventoryView({
           }}
         />
         <select
-          class="px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none"
+          class="px-3 py-2 rounded bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-sm focus:border-[var(--accent)]/50 outline-none"
           name="tool_inventory_category"
           aria-label="도구 카테고리 필터"
           value=${categoryFilter.value}
@@ -152,7 +152,7 @@ export function FullInventoryView({
             <option value=${category}>${category === 'uncategorized' ? '미분류' : category}</option>
           `)}
         </select>
-        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${directOnly.value}
@@ -162,7 +162,7 @@ export function FullInventoryView({
           />
           <span>직접 호출만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showHidden.value}
@@ -172,7 +172,7 @@ export function FullInventoryView({
           />
           <span>숨김 표시</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
+        <label class="inline-flex items-center gap-2 text-xs text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showDeprecated.value}
@@ -183,7 +183,7 @@ export function FullInventoryView({
           <span>지원 중단 표시</span>
         </label>
         <button type="button"
-          class="px-3 py-1.5 rounded text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
+          class="px-3 py-1.5 rounded text-sm font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
           onClick=${() => { void loadTools() }}
           disabled=${loading}
         >

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -12,8 +12,8 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
     <article class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
         <div>
-          <div class="text-[15px] font-bold text-[var(--text-strong)]">${item.name}</div>
-          <div class="tool-inventory-desc text-[12px] text-[var(--text-muted)] mt-0.5">${item.description}</div>
+          <div class="text-md font-bold text-[var(--text-strong)]">${item.name}</div>
+          <div class="tool-inventory-desc text-xs text-[var(--text-muted)] mt-0.5">${item.description}</div>
         </div>
         <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -22,15 +22,15 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
-      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-2">
+      <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)] mt-2">
         <span>카테고리: <strong class="text-[var(--text-body)]">${categoryLabel}${categoryHint}</strong></span>
         <span>직접 호출: <strong class="text-[var(--text-body)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
         <span>권한: <strong class="text-[var(--text-body)]">${item.required_permission ?? '없음'}</strong></span>
       </div>
       ${item.reason
-        ? html`<div class="tool-inventory-reason text-[12px] text-[var(--text-muted)] mt-1.5">${item.reason}</div>`
+        ? html`<div class="tool-inventory-reason text-xs text-[var(--text-muted)] mt-1.5">${item.reason}</div>`
         : null}
-      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-1.5">
+      <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)] mt-1.5">
         ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[var(--text-body)]">${item.canonicalName}</strong></span>` : null}
         ${item.replacement ? html`<span>대체 도구: <strong class="text-[var(--text-body)]">${item.replacement}</strong></span>` : null}
         ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[var(--text-body)]">${item.doc_refs.join(', ')}</strong></span>` : null}

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -76,7 +76,7 @@ export function toolBadge(label: string, tone: 'default' | 'ok' | 'warn' | 'surf
       : tone === 'surface' ? 'text-[#c4b5fd] bg-[rgba(139,92,246,0.18)]'
       : 'text-[var(--text-muted)] bg-[var(--white-8)]'
   return html`
-    <span class="text-[11px] rounded-sm px-2 py-0.5 ${toneClass}">
+    <span class="text-2xs rounded-sm px-2 py-0.5 ${toneClass}">
       ${label}
     </span>
   `

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -58,7 +58,7 @@ export function Tools() {
       <${Card} title="도구 사용 현황" class="section mb-4">
         ${usage
           ? html`
-              <div class="text-[12px] text-[var(--text-muted)] mb-2">
+              <div class="text-xs text-[var(--text-muted)] mb-2">
                 등록됨 ${usage.registered_count} (모든 MCP 서버 합산) · 사용된 ${usage.distinct_tools_called} · 미사용 ${usage.never_called_count}
               </div>
             `
@@ -66,7 +66,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[12px]">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-xs">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -249,7 +249,7 @@ function MetricRow({ label, value, sub }: { label: string; value: string | numbe
       <span class="text-xs text-text-muted">${label}</span>
       <div class="flex items-center gap-2 min-w-0">
         <span class="text-sm font-mono font-medium text-text-strong truncate">${value}</span>
-        ${sub ? html`<span class="text-[10px] text-text-muted truncate">${sub}</span>` : null}
+        ${sub ? html`<span class="text-3xs text-text-muted truncate">${sub}</span>` : null}
       </div>
     </div>
   `
@@ -285,7 +285,7 @@ function SectionCard({
           <${StatusDot} size="sm" class=${statusDot(status)} />
           <span class="text-xs font-semibold text-text-strong uppercase tracking-wider truncate">${title}</span>
         </div>
-        ${eyebrow ? html`<span class=${`text-[10px] uppercase tracking-wider ${toneClass(status)}`}>${eyebrow}</span>` : null}
+        ${eyebrow ? html`<span class=${`text-3xs uppercase tracking-wider ${toneClass(status)}`}>${eyebrow}</span>` : null}
       </div>
       <div class="divide-y divide-card-border/50">
         ${children}
@@ -299,11 +299,11 @@ function CaseCard({ item, data }: { item: PracticalCase; data: TransportHealthDa
     <div class="rounded border border-card-border/70 bg-card/40 p-4">
       <div class="flex items-center justify-between gap-3 mb-2">
         <div class="text-sm font-semibold text-text-strong">${item.title}</div>
-        <div class="text-[10px] uppercase tracking-wider text-text-muted">${item.transport}</div>
+        <div class="text-3xs uppercase tracking-wider text-text-muted">${item.transport}</div>
       </div>
-      <div class="text-[11px] text-text-muted mb-2 font-mono break-all">${item.endpoint(data)}</div>
-      <div class="text-[12px] text-text-body leading-relaxed">${item.description}</div>
-      <div class="mt-3 text-[11px] text-[var(--accent)]">${item.live(data)}</div>
+      <div class="text-2xs text-text-muted mb-2 font-mono break-all">${item.endpoint(data)}</div>
+      <div class="text-xs text-text-body leading-relaxed">${item.description}</div>
+      <div class="mt-3 text-2xs text-[var(--accent)]">${item.live(data)}</div>
     </div>
   `
 }
@@ -372,26 +372,26 @@ export function TransportHealthPanel() {
         <div>
           <div class="flex items-center gap-2">
             <span class="text-base text-text-strong">트랜스포트</span>
-            <span class="text-[10px] uppercase tracking-wider text-text-muted">${namespaceChip}</span>
+            <span class="text-3xs uppercase tracking-wider text-text-muted">${namespaceChip}</span>
           </div>
           <div class="mt-1 text-sm text-text-body">
             primary path: <span class="font-mono text-text-strong">${data.summary.primary_path}</span>
-            <span class=${`ml-2 text-[11px] uppercase tracking-wider ${toneClass(sseStatus)}`}>${data.summary.queue_pressure}</span>
+            <span class=${`ml-2 text-2xs uppercase tracking-wider ${toneClass(sseStatus)}`}>${data.summary.queue_pressure}</span>
           </div>
           ${truthLine
-            ? html`<div class="mt-1 text-[11px] text-text-muted">${truthLine}</div>`
+            ? html`<div class="mt-1 text-2xs text-text-muted">${truthLine}</div>`
             : null}
         </div>
         <button
-          class="text-[10px] text-text-muted hover:text-text-body transition-colors"
+          class="text-3xs text-text-muted hover:text-text-body transition-colors"
           onClick=${() => void refreshTransportHealth()}
         >새로고침</button>
       </div>
 
       <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden" open=${hasAnyBadTransport}>
-        <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
+        <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-sm font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
           <span>트랜스포트 상세</span>
-          <span class="ml-auto flex items-center gap-2 text-[11px] font-normal text-text-muted">
+          <span class="ml-auto flex items-center gap-2 text-2xs font-normal text-text-muted">
             <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(sseStatus)} />SSE</span>
             <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(grpcStatus)} />gRPC</span>
             <span class="inline-flex items-center gap-1"><${StatusDot} size="xs" class=${statusDot(wsStatus)} />WS</span>
@@ -440,7 +440,7 @@ export function TransportHealthPanel() {
             <//>
 
             <${SectionCard} title="에이전트 풀" status=${clusterStatus} eyebrow=${clusterEyebrow}>
-              <div class="text-[10px] text-text-muted mb-2">클러스터 내 관리 유닛 풀. 부실(stale) = 하트비트가 끊긴 에이전트.</div>
+              <div class="text-3xs text-text-muted mb-2">클러스터 내 관리 유닛 풀. 부실(stale) = 하트비트가 끊긴 에이전트.</div>
               <${MetricRow} label="관리 유닛" value=${formatMetricValue(data.cluster.managed_units)} sub=${managedUnitsSub} />
               <${MetricRow} label="활성 작업" value=${formatMetricValue(data.cluster.active_operations)} />
               <${MetricRow} label="부실 유닛" value=${formatMetricValue(data.cluster.stale_units)} />
@@ -457,16 +457,16 @@ export function TransportHealthPanel() {
             const isFiltered = query.trim() !== ''
             return html`
             <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden" open=${data.sse.hot_sessions.length >= 3}>
-              <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
+              <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-sm font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
                 <span>핫 큐</span>
-                <span class="ml-auto text-[11px] font-normal text-text-muted">${data.sse.hot_sessions.length}개 세션 -- SSE 백프레셔 위험</span>
+                <span class="ml-auto text-2xs font-normal text-text-muted">${data.sse.hot_sessions.length}개 세션 -- SSE 백프레셔 위험</span>
               </summary>
               <div class="p-4">
                 <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
-                  <div class="text-[11px] text-text-muted">SSE 세션 중 메시지 큐가 쌓여 있는 세션입니다. 큐 depth가 높으면 해당 클라이언트가 이벤트 처리를 따라가지 못하고 있습니다.</div>
+                  <div class="text-2xs text-text-muted">SSE 세션 중 메시지 큐가 쌓여 있는 세션입니다. 큐 depth가 높으면 해당 클라이언트가 이벤트 처리를 따라가지 못하고 있습니다.</div>
                   <${TextInput}
                     type="search"
-                    class="min-w-[180px] flex-1 !py-1 !text-[11px]"
+                    class="min-w-[180px] flex-1 !py-1 !text-2xs"
                     name="hot_sessions_search"
                     ariaLabel="핫 세션 검색 (session id, kind, last event id)"
                     autoComplete="off"
@@ -478,23 +478,23 @@ export function TransportHealthPanel() {
                   />
                 </div>
                 ${isFiltered ? html`
-                  <div class="mb-2 text-[11px] text-text-muted">${filtered.length} / ${data.sse.hot_sessions.length}개 세션</div>
+                  <div class="mb-2 text-2xs text-text-muted">${filtered.length} / ${data.sse.hot_sessions.length}개 세션</div>
                 ` : null}
                 ${filtered.length === 0 ? html`
-                  <div class="text-[11px] text-text-muted py-3">검색 결과 없음</div>
+                  <div class="text-2xs text-text-muted py-3">검색 결과 없음</div>
                 ` : html`
                   <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3">
                     ${filtered.map((session) => html`
                       <div key=${session.session_id} class="rounded border border-card-border/60 bg-bg-1/60 p-3">
                         <div class="flex items-center justify-between gap-2 mb-1">
                           <div class="flex min-w-0 items-center gap-1">
-                            <span class="truncate text-[11px] font-mono text-text-strong">${compactId(session.session_id)}</span>
+                            <span class="truncate text-2xs font-mono text-text-strong">${compactId(session.session_id)}</span>
                             <${CopyIdButton} value=${session.session_id} label="session_id" />
                           </div>
-                          <span class="text-[10px] uppercase tracking-wider text-text-muted">${session.kind}</span>
+                          <span class="text-3xs uppercase tracking-wider text-text-muted">${session.kind}</span>
                         </div>
-                        <div class="text-[11px] text-text-body">queue ${session.queue_depth}</div>
-                        <div class="text-[10px] text-text-muted mt-1">idle ${formatIdle(session.idle_seconds)} · last ${session.last_event_id}</div>
+                        <div class="text-2xs text-text-body">queue ${session.queue_depth}</div>
+                        <div class="text-3xs text-text-muted mt-1">idle ${formatIdle(session.idle_seconds)} · last ${session.last_event_id}</div>
                       </div>
                     `)}
                   </div>
@@ -506,12 +506,12 @@ export function TransportHealthPanel() {
         : null}
 
       <details class="group rounded border border-card-border/50 bg-card/18 overflow-hidden">
-        <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-[13px] font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
+        <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer text-sm font-semibold text-text-strong bg-card/28 hover:bg-card/44 transition-colors">
           <span>실용 경로</span>
-          <span class="ml-auto text-[11px] font-normal text-text-muted">각 트랜스포트의 실제 연결 방법 레퍼런스</span>
+          <span class="ml-auto text-2xs font-normal text-text-muted">각 트랜스포트의 실제 연결 방법 레퍼런스</span>
         </summary>
         <div class="p-4">
-          <div class="text-[11px] text-text-muted mb-3">5가지 트랜스포트(SSE, gRPC, WebSocket, WebRTC, HTTP)를 실제로 어떻게 연결하는지 보여주는 가이드입니다. 운영 데이터가 아닌 참조용 정보입니다.</div>
+          <div class="text-2xs text-text-muted mb-3">5가지 트랜스포트(SSE, gRPC, WebSocket, WebRTC, HTTP)를 실제로 어떻게 연결하는지 보여주는 가이드입니다. 운영 데이터가 아닌 참조용 정보입니다.</div>
           <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
             ${PRACTICAL_CASES.map((item) => html`<${CaseCard} item=${item} data=${data} />`)}
           </div>

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -201,10 +201,10 @@ async function submitResolve(
 // ── Row actions (approve/reject UI) ───────────────────
 
 const BTN_PRIMARY =
-  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
 
 const BTN_SECONDARY =
-  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-body)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
+  'rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50 disabled:cursor-not-allowed'
 
 function RowActions({
   row,
@@ -219,7 +219,7 @@ function RowActions({
 
   if (state.kind === 'pending') {
     return html`
-      <span class="text-[11px] text-[var(--text-muted)]">
+      <span class="text-2xs text-[var(--text-muted)]">
         ${state.decision === 'approve' ? '승인 중…' : '반려 중…'}
       </span>
     `
@@ -228,7 +228,7 @@ function RowActions({
   if (state.kind === 'confirm-approve') {
     return html`
       <div class="flex items-center gap-1 flex-wrap">
-        <span class="text-[11px] text-[var(--text-strong)]">승인 확정?</span>
+        <span class="text-2xs text-[var(--text-strong)]">승인 확정?</span>
         <button
           class=${BTN_PRIMARY}
           onClick=${() => void submitResolve(row, 'approve', '', refresh)}
@@ -248,7 +248,7 @@ function RowActions({
       <div class="flex items-center gap-1 flex-wrap">
         <input
           type="text"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-[11px] text-[var(--text-body)] w-[200px]"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] w-[200px]"
           placeholder="반려 사유 (필수)"
           value=${reason}
           autofocus
@@ -289,7 +289,7 @@ function RowActions({
         onClick=${() => setRowAction(requestId, { kind: 'compose-reject', reason: '' })}
       >반려</button>
       ${state.kind === 'error'
-        ? html`<span class="text-[10px] text-[var(--text-bad)]" title=${state.message}>
+        ? html`<span class="text-3xs text-[var(--text-bad)]" title=${state.message}>
             실패 · 다시 시도
           </span>`
         : null}
@@ -352,7 +352,7 @@ function VerificationRow({
       <td class="py-2">
         ${hasDetails
           ? html`
-              <details class="text-[11px]">
+              <details class="text-2xs">
                 <summary class="cursor-pointer text-[var(--text-muted)] hover:text-[var(--text-body)]">
                   자세히
                 </summary>
@@ -360,7 +360,7 @@ function VerificationRow({
                   ${hasTaskTitle
                     ? html`
                         <div>
-                          <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
                             Task Title
                           </div>
                           <div class="text-[var(--text-body)]">${row.task_title}</div>
@@ -370,7 +370,7 @@ function VerificationRow({
                   ${hasContract
                     ? html`
                         <div>
-                          <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
                             Completion Contract
                           </div>
                           <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
@@ -382,7 +382,7 @@ function VerificationRow({
                   ${hasEvidence
                     ? html`
                         <div>
-                          <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
                             Required Evidence
                           </div>
                           <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
@@ -394,7 +394,7 @@ function VerificationRow({
                   ${row.verdict_reason !== ''
                     ? html`
                         <div>
-                          <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
                             Verdict Reason
                           </div>
                           <div class="text-[var(--text-body)]">${row.verdict_reason}</div>
@@ -561,7 +561,7 @@ export function VerificationRequestsPanel() {
         ? html`
             <div
               role="note"
-              class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2 text-[11px] text-[var(--text-muted)]"
+              class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2 text-2xs text-[var(--text-muted)]"
             >
               검증 대기(pending) 요청이 없어 액션 컬럼이 비어 있습니다. 승인/반려 버튼은
               <code class="text-[var(--text-strong)]">pending</code> 상태에서만 표시됩니다.

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -48,6 +48,8 @@
   --radius-xs: 3px;
   --radius-card: 18px;
 
+  --font-size-4xs: 8px;
+  --font-size-3xs: 10px;
   --font-size-2xs: 11px;
   --font-size-xs: 12px;
   --font-size-sm: 13px;


### PR DESCRIPTION
## Why
Color axis 8 phase 마무리 후 다음 axis 진입. Anyang Sleepers Design System은 typography scale도 명명 utility로 통일 요구.

이전 dashboard에 1700+ `text-[Xpx]` arbitrary value가 산포 → 의미적 명명으로 전환.

## What
### 신규 Tailwind utility (자동 생성)
Tailwind v4 `@theme` 블록 (tokens.css)에 두 token 추가:
- `--font-size-3xs: 10px` → `text-3xs` 자동 생성
- `--font-size-4xs: 8px` → `text-4xs` 자동 생성

기존 `--font-size-{2xs,xs,sm,base,md,lg}`는 그대로 활용.

### Sweep
| Before | After | Count |
|--------|-------|-------|
| `text-[8px]` | `text-4xs` | 15 |
| `text-[10px]` | `text-3xs` | 702 |
| `text-[11px]` | `text-2xs` | 584 |
| `text-[12px]` | `text-xs` | 230 |
| `text-[13px]` | `text-sm` | 145 |
| `text-[14px]` | `text-base` | 16 |
| `text-[15px]` | `text-md` | 10 |
| `text-[16px]` | `text-lg` | 2 |
| **Total** | | **1704 / 150 files** |

## Verification
- `pnpm typecheck` ✅
- `pnpm test` — 232 files / **3793 tests** all pass

## 누적 디자인 시스템 마이그레이션
| Axis | PR(s) | Status |
|------|-------|--------|
| Color | 12 phase chain | ✅ |
| Radii | 3 PR | ✅ |
| Pills | #8315 | ✅ |
| Shadows | #8299 | ✅ |
| Blur | #8304 | ✅ |
| **Typography** | (this) | 🔄 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)