### PR TITLE
chore(governance): use String_util.contains_substring_ci in stale-approval check

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -359,18 +359,8 @@ let rec add_routes ~sw ~clock router =
                     refresh the queue rather than treating it as a malformed
                     request. Validation errors stay as 400. *)
                  let is_stale =
-                   let s = String.lowercase_ascii message in
-                   let contains sub =
-                     let len_s = String.length s in
-                     let len_sub = String.length sub in
-                     let rec loop i =
-                       if i + len_sub > len_s then false
-                       else if String.sub s i len_sub = sub then true
-                       else loop (i + 1)
-                     in
-                     loop 0
-                   in
-                   contains "not found" || contains "already resolved"
+                   String_util.contains_substring_ci message "not found"
+                   || String_util.contains_substring_ci message "already resolved"
                  in
                  let status = if is_stale then `Not_found else `Bad_request in
                  respond_json_with_cors ~status request reqd


### PR DESCRIPTION
## Summary
Follow-up to #8349 (Simplify review).

#8349 의 inline 9줄 lowercase-then-scan substring 헬퍼는 \`String_util.contains_substring_ci\` (lib/core/string_util.ml:14) 를 그대로 재구현한 것. 같은 알고리즘이 codebase 15+ 곳에서 이미 사용되어 있음.

## Change
- \`lib/server/server_routes_http_routes_dashboard.ml\`: 9줄 inline scanner 제거, \`String_util.contains_substring_ci\` 호출로 교체. 함께 redundant \`String.lowercase_ascii\` 1회 할당 제거 (helper 가 내부에서 처리).
- Net: -12 / +2

## Test plan
- [x] dune build @check 통과
- [ ] 기존 #8349 의 stale-id → 404 동작 보존 확인 (리그레션 없음)

## Out of scope (review에서 나온 다른 finding, 별도 PR)
- typed Result variant for Keeper_approval_queue.resolve (3 call sites refactor)
- 404 path test 추가 (test_dashboard_governance.ml)
- PR #8353 의 default 60 SSOT / Feature_flag_registry 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)