### PR TITLE
[codex] harden backlog recovery on primary JSON corruption

### DIFF
--- a/lib/coord/coord_backlog.ml
+++ b/lib/coord/coord_backlog.ml
@@ -5,18 +5,46 @@
 open Types
 open Coord_utils
 
+let backlog_recovery_path config =
+  backlog_path config ^ ".last-good"
+
+let decode_backlog ~path json =
+  match backlog_of_yojson json with
+  | Ok backlog -> Ok backlog
+  | Error msg ->
+      Error
+        (Printf.sprintf
+           "[read_backlog] backlog decode failed for %s: %s"
+           path
+           msg)
+
 let read_backlog_r config =
   match read_json_result config (backlog_path config) with
-  | Error msg -> Error msg
-  | Ok json ->
-      (match backlog_of_yojson json with
-       | Ok backlog -> Ok backlog
-       | Error msg ->
+  | Ok json -> decode_backlog ~path:(backlog_path config) json
+  | Error primary_msg ->
+      let recovery_path = backlog_recovery_path config in
+      (match read_json_result config recovery_path with
+       | Ok json ->
+           (match decode_backlog ~path:recovery_path json with
+            | Ok backlog ->
+                Log.Misc.warn
+                  "read_backlog: primary backlog unreadable, recovered from %s (%s)"
+                  recovery_path
+                  primary_msg;
+                Ok backlog
+            | Error recovery_msg ->
+                Error
+                  (Printf.sprintf
+                     "%s; recovery failed: %s"
+                     primary_msg
+                     recovery_msg))
+       | Error recovery_msg ->
            Error
              (Printf.sprintf
-                "[read_backlog] backlog decode failed for %s: %s"
-                (backlog_path config)
-                msg))
+                "%s; recovery read failed for %s: %s"
+                primary_msg
+                recovery_path
+                recovery_msg))
 
 let read_backlog config =
   match read_backlog_r config with
@@ -26,4 +54,6 @@ let read_backlog config =
       { tasks = []; last_updated = now_iso (); version = 1 }
 
 let write_backlog config backlog =
-  write_json config (backlog_path config) (backlog_to_yojson backlog)
+  let json = backlog_to_yojson backlog in
+  write_json config (backlog_path config) json;
+  write_json config (backlog_recovery_path config) json

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -21,6 +21,9 @@ let contains_check result = String.sub result 0 3 = "\xE2\x9C\x85"  (* ✅ *)
 let contains_warning result = String.sub result 0 3 = "\xE2\x9A\xA0"  (* ⚠ *)
 let contains_portal result = String.sub result 0 4 = "\xF0\x9F\x8C\x80"  (* 🌀 *)
 
+let backlog_recovery_path config =
+  Coord.backlog_path config ^ ".last-good"
+
 let room_config tmp_dir =
   Unix.putenv "MASC_BASE_PATH" tmp_dir;
   Coord.default_config tmp_dir
@@ -724,15 +727,37 @@ let test_room_bootstrap_ignores_invalid_room_id_in_flat_mode () =
       (Coord.is_initialized config)
   )
 
-let test_read_backlog_r_reports_parse_error () =
+let test_read_backlog_r_recovers_from_last_good_snapshot () =
+  with_test_env (fun config ->
+    let expected =
+      {
+        Types.tasks = [];
+        last_updated = Types.now_iso ();
+        version = 7;
+      }
+    in
+    Coord.write_backlog config expected;
+    Out_channel.with_open_text (Coord.backlog_path config) (fun oc ->
+      output_string oc "{\n  \"tasks\": [\n");
+    match Coord.read_backlog_r config with
+    | Ok backlog ->
+        Alcotest.(check int) "recovered backlog version" expected.version backlog.version
+    | Error msg -> Alcotest.failf "expected recovery, got error: %s" msg
+  )
+
+let test_read_backlog_r_reports_parse_error_when_recovery_is_also_invalid () =
   with_test_env (fun config ->
     Out_channel.with_open_text (Coord.backlog_path config) (fun oc ->
+      output_string oc "{\n  \"tasks\": [\n");
+    Out_channel.with_open_text (backlog_recovery_path config) (fun oc ->
       output_string oc "{\n  \"tasks\": [\n");
     match Coord.read_backlog_r config with
     | Ok _ -> Alcotest.fail "expected backlog parse error"
     | Error msg ->
-        Alcotest.(check bool) "mentions backlog decode/read failure" true
-          (str_contains msg "read_backlog" || str_contains msg "JSON parse error")
+        Alcotest.(check bool) "mentions primary backlog failure" true
+          (str_contains msg "read_backlog" || str_contains msg "JSON parse error");
+        Alcotest.(check bool) "mentions recovery failure" true
+          (str_contains msg "recovery")
   )
 
 let test_release_stale_claims_skips_invalid_backlog () =
@@ -1610,8 +1635,10 @@ let () =
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "backend bootstrap preserves room state" `Quick test_room_bootstrap_preserves_backend_state;
       Alcotest.test_case "bootstrap ignores invalid room id in flat mode" `Quick test_room_bootstrap_ignores_invalid_room_id_in_flat_mode;
-      Alcotest.test_case "read_backlog_r reports parse error" `Quick
-        test_read_backlog_r_reports_parse_error;
+      Alcotest.test_case "read_backlog_r recovers from last good snapshot" `Quick
+        test_read_backlog_r_recovers_from_last_good_snapshot;
+      Alcotest.test_case "read_backlog_r reports parse error when recovery also invalid" `Quick
+        test_read_backlog_r_reports_parse_error_when_recovery_is_also_invalid;
       Alcotest.test_case "release stale claims skips invalid backlog" `Quick
         test_release_stale_claims_skips_invalid_backlog;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;


### PR DESCRIPTION
## Summary

Harden `Coord_backlog` so primary `backlog.json` corruption does not immediately collapse into an empty backlog view.

## What changed

- `write_backlog` now writes a second atomic recovery snapshot alongside the primary backlog file.
- `read_backlog_r` now falls back to that last-good snapshot when the primary backlog read/decode fails.
- if both the primary and recovery snapshot are invalid, the old error path is preserved.
- regression tests now cover:
  - corrupted primary + valid recovery => successful read
  - corrupted primary + corrupted recovery => explicit error

## Product impact

This reduces the damage from the runtime failure pattern seen in `~/.masc/tasks/backlog.json`:
- blank reads
- truncated JSON reads
- downstream empty-backlog downgrade after parse failure

This PR does **not** claim to fix the root cause of backlog corruption. It narrows the blast radius by preserving a last-known-good snapshot instead of silently dropping to an empty backlog as soon as the primary file is unreadable.

## Evidence

Runtime evidence that motivated this change:
- repeated `Blank input data` and `Unexpected end of input` on `~/.masc/tasks/backlog.json`
- current issue: #8367

Code path addressed here:
- `lib/coord/coord_backlog.ml`
- `test/test_room.ml`

## Review evidence

Validated locally in the worktree with:

```bash
dune build --root . --build-dir _build_codex_backlog test/test_room.exe
./_build_codex_backlog/default/test/test_room.exe
```

`test_room.exe` passed: 89/89.

## Linked issue

Relates #8367