### PR TITLE
chore: harden keeper and transport failure boundaries

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -14,6 +14,14 @@ let service_name = "masc.coordination.v1.MascCoordination"
 (** Current timestamp in milliseconds. *)
 let now_ms () = Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
+let decode_request_or_raise ~rpc decode bytes =
+  match decode bytes with
+  | Ok req -> req
+  | Error msg ->
+    Log.Transport.warn "gRPC %s decode failed: %s" rpc msg;
+    Grpc_core.Status.raise_error Grpc_core.Status.Invalid_argument
+      (Printf.sprintf "%s request decode failed: %s" rpc msg)
+
 (** Read a file to string. Returns [""] on non-cancellation errors.
     Propagates [Eio.Cancel.Cancelled] so cooperative cancellation is preserved. *)
 let read_file_safe path =
@@ -51,7 +59,9 @@ let task_info_of_task (task : Types.task) : T.task_info =
 
 (** Join handler: agent joins the coordination room. *)
 let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.JoinRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Join" T.JoinRequest.of_bytes_result bytes
+  in
   let result =
     try
       let msg =
@@ -108,7 +118,9 @@ let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string
 
 (** Leave handler: agent leaves the coordination room. *)
 let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.LeaveRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Leave" T.LeaveRequest.of_bytes_result bytes
+  in
   let result =
     try
       let msg = Coord.leave room_config ~agent_name:req.agent_name in
@@ -123,7 +135,9 @@ let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : strin
 
 (** Broadcast handler: send a message to all agents. *)
 let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.BroadcastRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Broadcast" T.BroadcastRequest.of_bytes_result bytes
+  in
   let result =
     try
       let content =
@@ -190,7 +204,9 @@ let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes :
 let handle_tool_call
     (tool_dispatcher : string -> string -> (string, string) result)
     (bytes : string) : string =
-  let req = T.ToolCallRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"ToolCall" T.ToolCallRequest.of_bytes_result bytes
+  in
   let result =
     match tool_dispatcher req.tool_name req.arguments_json with
     | Ok result_json ->
@@ -377,7 +393,9 @@ let handle_subscribe
     (room_config : Coord_utils_backend_setup.config)
     (bytes : string)
   : string Grpc_eio.Stream.t =
-  let req = T.SubscribeRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Subscribe" T.SubscribeRequest.of_bytes_result bytes
+  in
   let stream = Grpc_eio.Stream.create 64 in
   Atomic.incr active_subscribe_streams;
   Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -16,15 +16,22 @@ module P = Masc_proto.Masc_coordination.Masc.Coordination.V1
 let encode to_proto msg =
   Ocaml_protoc_plugin.Writer.contents (to_proto msg)
 
+(** Deserialize a protobuf message from a binary string. *)
+let decode_result from_proto bytes =
+  let reader = Ocaml_protoc_plugin.Reader.create bytes in
+  match from_proto reader with
+  | Ok v -> Ok v
+  | Error e ->
+    Error
+      (Printf.sprintf "protobuf decode error: %s"
+         (Ocaml_protoc_plugin.Result.show_error e))
+
 (** Deserialize a protobuf message from a binary string.
     Raises [Invalid_argument] on parse error. *)
 let decode from_proto bytes =
-  let reader = Ocaml_protoc_plugin.Reader.create bytes in
-  match from_proto reader with
+  match decode_result from_proto bytes with
   | Ok v -> v
-  | Error e ->
-    invalid_arg (Printf.sprintf "protobuf decode error: %s"
-      (Ocaml_protoc_plugin.Result.show_error e))
+  | Error msg -> invalid_arg msg
 
 (** {1 Shared Types} *)
 
@@ -90,12 +97,20 @@ module JoinRequest = struct
     metadata : (string * string) list;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.JoinRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             capabilities = p.capabilities;
+             metadata = p.metadata;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.JoinRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      capabilities = p.capabilities;
-      metadata = p.metadata;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.JoinRequest.to_proto
@@ -136,11 +151,19 @@ module LeaveRequest = struct
     session_id : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.LeaveRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.LeaveRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.LeaveRequest.to_proto
@@ -178,13 +201,21 @@ module HeartbeatPing = struct
     current_task_id : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.HeartbeatPing.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             timestamp_ms = p.timestamp_ms;
+             current_task_id = p.current_task_id;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.HeartbeatPing.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      timestamp_ms = p.timestamp_ms;
-      current_task_id = p.current_task_id;
-    }
+    match of_bytes_result bytes with
+    | Ok ping -> ping
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.HeartbeatPing.to_proto
@@ -230,13 +261,21 @@ module SubscribeRequest = struct
     since_seq : int64;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.SubscribeRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             event_types = p.event_types;
+             since_seq = p.since_seq;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.SubscribeRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      event_types = p.event_types;
-      since_seq = p.since_seq;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 end
 
 module SubscribeRequest_serde = struct
@@ -287,13 +326,21 @@ module ToolCallRequest = struct
     arguments_json : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.ToolCallRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             tool_name = p.tool_name;
+             arguments_json = p.arguments_json;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.ToolCallRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      tool_name = p.tool_name;
-      arguments_json = p.arguments_json;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.ToolCallRequest.to_proto
@@ -338,12 +385,20 @@ module BroadcastRequest = struct
     mentions : string list;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.BroadcastRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             message = p.message;
+             mentions = p.mentions;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.BroadcastRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      message = p.message;
-      mentions = p.mentions;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.BroadcastRequest.to_proto

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -34,6 +34,7 @@ module JoinRequest : sig
     capabilities : string list;
     metadata : (string * string) list;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -54,6 +55,7 @@ module LeaveRequest : sig
     agent_name : string;
     session_id : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -76,6 +78,7 @@ module HeartbeatPing : sig
     timestamp_ms : int64;
     current_task_id : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -100,6 +103,7 @@ module SubscribeRequest : sig
     event_types : string list;
     since_seq : int64;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
 end
 
@@ -129,6 +133,7 @@ module ToolCallRequest : sig
     tool_name : string;
     arguments_json : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -152,6 +157,7 @@ module BroadcastRequest : sig
     message : string;
     mentions : string list;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -331,36 +331,28 @@ module Request = struct
 
   (** Read request body synchronously - uses Condition for proper synchronization *)
   let read_body_sync reqd =
-    let result = ref None in
-    let mutex = Eio.Mutex.create () in
-    let cond = Eio.Condition.create () in
+    let result_promise, resolve_result = Eio.Promise.create () in
+    let resolved = Atomic.make false in
+
+    let resolve_once outcome =
+      if Atomic.compare_and_set resolved false true then
+        Eio.Promise.resolve resolve_result outcome
+    in
 
     read_body_async_with_limit reqd
       ~on_body:(fun body_str ->
-        Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          result := Some (Ok body_str);
-          Eio.Condition.broadcast cond))
+        resolve_once (Ok body_str))
       ~on_error:(function
         | `Too_large max_bytes ->
             respond_too_large reqd max_bytes;
-            Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-              result := Some (Error (Printf.sprintf "Request too large (max %d bytes)" max_bytes));
-              Eio.Condition.broadcast cond)
+            resolve_once
+              (Error
+                 (Printf.sprintf "Request too large (max %d bytes)" max_bytes))
         | `Internal exn ->
             respond_internal_error reqd exn;
-            Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-              result := Some (Error (Printexc.to_string exn));
-              Eio.Condition.broadcast cond));
+            resolve_once (Error (Printexc.to_string exn)));
 
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      while !result = None do
-        Eio.Condition.await_no_mutex cond
-      done);
-
-    match !result with
-    | Some (Ok s) -> Ok s
-    | Some (Error msg) -> Error msg
-    | None -> Error "read_body_sync: impossible state"
+    Eio.Promise.await result_promise
 
   (** Get path from request target *)
   let path (request : Httpun.Request.t) =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -195,6 +195,18 @@ let find_pending_id ~keeper_name ~tool_name =
         else None)
     (Atomic.get pending) None
 
+let find_pending_id_in_map map ~keeper_name ~tool_name =
+  SMap.fold
+    (fun id entry acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+        if String.equal entry.keeper_name keeper_name
+           && String.equal entry.tool_name tool_name
+        then Some id
+        else None)
+    map None
+
 let sort_entries_by_requested_at entries =
   List.sort
     (fun left right ->
@@ -227,29 +239,24 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
 
 let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
   : string =
-  let created_entry = ref None in
-  atomic_update pending (fun map ->
-    match find_pending_id ~keeper_name ~tool_name with
-    | Some id -> 
-        created_entry := Some (`Existing id);
-        map
+  let rec submit () =
+    let map = Atomic.get pending in
+    match find_pending_id_in_map map ~keeper_name ~tool_name with
+    | Some id -> id
     | None ->
-        let id = generate_id () in
-        let entry =
-          create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
-            ~resolver:None ~on_resolution:(Some on_resolution)
-        in
-        created_entry := Some (`Created entry);
-        SMap.add id entry map
-  );
-  (* The ref is always set inside the CAS body above (both branches assign),
-     so None is unreachable. *)
-  match !created_entry with
-  | None -> assert false
-  | Some (`Existing id) -> id
-  | Some (`Created entry) ->
-    record_pending entry;
-    entry.id
+      let id = generate_id () in
+      let entry =
+        create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
+          ~resolver:None ~on_resolution:(Some on_resolution)
+      in
+      let updated = SMap.add id entry map in
+      if Atomic.compare_and_set pending map updated then (
+        record_pending entry;
+        id
+      ) else
+        submit ()
+  in
+  submit ()
 
 (* ── Resolve (operator action) ────────────────────────────── *)
 

--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -74,14 +74,22 @@ let parse_decision_line (line : string) : parsed_decision option =
 let tail_limit_for ~window_hours =
   max 500 (min 10_000 (window_hours * 180 + 200))
 
+let load_decision_lines ~decision_log_path ~window_hours =
+  try
+    Dated_jsonl.load_tail_lines decision_log_path
+      ~max_lines:(tail_limit_for ~window_hours)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "telemetry_feedback: failed to load decision log %s: %s"
+      decision_log_path (Printexc.to_string exn);
+    []
+
 let compute_stats ~decision_log_path ~window_hours =
   let now_ts = Unix.gettimeofday () in
   let window_start = now_ts -. (float_of_int window_hours *. 3600.0) in
-  let lines =
-    try Dated_jsonl.load_tail_lines decision_log_path
-          ~max_lines:(tail_limit_for ~window_hours)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
-  in
+  let lines = load_decision_lines ~decision_log_path ~window_hours in
   let decisions =
     lines
     |> List.filter_map parse_decision_line

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -41,14 +41,26 @@ let externalization_disabled () =
   | Some ("0" | "false" | "no" | "off") -> true
   | _ -> false
 
-(* Lazy singleton. Resolved once per process from [base_path_opt]; if no
-   base path is configured (typical in tests with [MASC_BASE_PATH ""]),
-   externalization is silently disabled. *)
-let blob_store_lazy : Tool_blob_store.t option Lazy.t =
-  lazy
-    (match Env_config_core.base_path_opt () with
-     | None -> None
-     | Some base_path -> Some (Tool_blob_store.create ~base_path))
+(* This path is exercised both under Eio and from tests/module-init code, so a
+   cross-context Atomic+Stdlib.Mutex memo is safer than Stdlib.Lazy.force. *)
+let blob_store_cache : Tool_blob_store.t option option Atomic.t = Atomic.make None
+let blob_store_cache_mu = Mutex.create ()
+
+let resolve_blob_store () =
+  match Atomic.get blob_store_cache with
+  | Some store -> store
+  | None ->
+      Mutex.protect blob_store_cache_mu (fun () ->
+        match Atomic.get blob_store_cache with
+        | Some store -> store
+        | None ->
+            let store =
+              match Env_config_core.base_path_opt () with
+              | None -> None
+              | Some base_path -> Some (Tool_blob_store.create ~base_path)
+            in
+            Atomic.set blob_store_cache (Some store);
+            store)
 
 (** Externalize [msg] when it exceeds the threshold AND a blob store is
     available; otherwise pass through unchanged. Best-effort — any
@@ -60,7 +72,7 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
     let threshold = externalize_threshold_bytes () in
     if String.length msg <= threshold then msg
     else
-      match Lazy.force blob_store_lazy with
+      match resolve_blob_store () with
       | None -> msg
       | Some store ->
           (try

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -29,13 +29,25 @@ type persisted_record = {
   duration_ms : float;
 }
 
-let parse_record (json : Yojson.Safe.t) : persisted_record option =
+let parse_record (json : Yojson.Safe.t)
+  : (persisted_record, string) result =
   let tool_name = Safe_ops.json_string_opt "tool_name" json in
   let success = Safe_ops.json_bool_opt "success" json in
   let duration_ms = Safe_ops.json_float_opt "duration_ms" json in
   match tool_name, success, duration_ms with
-  | Some tn, Some s, Some d -> Some { tool_name = tn; success = s; duration_ms = d }
-  | _ -> None
+  | Some tn, Some s, Some d -> Ok { tool_name = tn; success = s; duration_ms = d }
+  | _ ->
+    let missing =
+      [ ("tool_name", Option.is_none tool_name)
+      ; ("success", Option.is_none success)
+      ; ("duration_ms", Option.is_none duration_ms)
+      ]
+      |> List.filter_map (fun (field, is_missing) ->
+        if is_missing then Some field else None)
+    in
+    Error
+      (Printf.sprintf "missing required field(s): %s"
+         (String.concat ", " missing))
 
 (* ── Write queue ────────────────────────────────────── *)
 
@@ -132,12 +144,14 @@ let start_flush_fiber ~sw ~clock ~base_path =
 let restore ~base_path : int =
   let store = get_or_create_store ~base_path in
   let count = ref 0 in
+  let skipped = ref 0 in
+  let first_skip_reason = ref None in
   (try
      (* Read all available records (cap at 1M to avoid OOM on huge histories) *)
      let jsons = Dated_jsonl.read_recent store 1_000_000 in
      List.iter (fun json ->
        match parse_record json with
-       | Some r ->
+       | Ok r ->
          let result : Tool_result.t = {
            tool_name = r.tool_name;
            success = r.success;
@@ -146,8 +160,18 @@ let restore ~base_path : int =
          } in
          Tool_metrics.record result;
          incr count
-       | None -> ()
-     ) jsons
+       | Error reason ->
+         incr skipped;
+         if Option.is_none !first_skip_reason then
+           first_skip_reason := Some reason
+     ) jsons;
+     if !skipped > 0 then
+       Log.Metrics.warn
+         "tool_metrics_persist: skipped %d malformed restore record(s)%s"
+         !skipped
+         (match !first_skip_reason with
+          | Some reason -> Printf.sprintf " (first error: %s)" reason
+          | None -> "")
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -7,6 +7,7 @@
     serialization/deserialization via of_bytes/to_bytes. *)
 
 module T = Masc_mcp.Masc_grpc_types
+let malformed_protobuf = "\x0a\x05ab"
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -328,6 +329,60 @@ let test_protobuf_binary_format () =
     true
     (String.length bytes = 0 || bytes.[0] <> '{')
 
+let test_join_request_invalid_bytes_result () =
+  match T.JoinRequest.of_bytes_result malformed_protobuf with
+  | Ok _ -> Alcotest.fail "expected decode failure"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions decode" true
+        (String.starts_with ~prefix:"protobuf decode error:" msg)
+
+let test_tool_call_request_invalid_bytes_result () =
+  match T.ToolCallRequest.of_bytes_result malformed_protobuf with
+  | Ok _ -> Alcotest.fail "expected decode failure"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions decode" true
+        (String.starts_with ~prefix:"protobuf decode error:" msg)
+
+let test_join_handler_invalid_bytes_raise_grpc_status () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_temp_dir "masc-grpc-invalid-join" (fun dir ->
+      let room_config = Coord_utils.default_config dir in
+      let service =
+        Masc_mcp.Masc_grpc_service.create_service
+          ~room_config
+          ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+      in
+      match Grpc_eio.Service.get_method service "Join" with
+      | Some { handler = `Unary handler; _ } ->
+          (match handler malformed_protobuf with
+           | _ -> Alcotest.fail "expected typed gRPC decode error"
+           | exception exn ->
+               Alcotest.(check bool) "invalid_argument grpc error" true
+                 (String.starts_with
+                    ~prefix:"Grpc_error(INVALID_ARGUMENT:"
+                    (Printexc.to_string exn)))
+      | _ -> Alcotest.fail "Join unary handler missing")
+
+let test_subscribe_handler_invalid_bytes_raise_grpc_status () =
+  with_temp_dir "masc-grpc-invalid-subscribe" (fun dir ->
+      let room_config = Coord_utils.default_config dir in
+      let service =
+        Masc_mcp.Masc_grpc_service.create_service
+          ~room_config
+          ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+      in
+      match Grpc_eio.Service.get_method service "Subscribe" with
+      | Some { handler = `ServerStreaming handler; _ } ->
+          (match handler malformed_protobuf with
+           | _ -> Alcotest.fail "expected typed gRPC decode error"
+           | exception exn ->
+               Alcotest.(check bool) "invalid_argument grpc error" true
+                 (String.starts_with
+                    ~prefix:"Grpc_error(INVALID_ARGUMENT:"
+                    (Printexc.to_string exn)))
+      | _ -> Alcotest.fail "Subscribe server-streaming handler missing")
+
 (* ====== Test suite ====== *)
 
 let () =
@@ -349,12 +404,20 @@ let () =
           Alcotest.test_case "StatusResponse" `Quick test_status_response_roundtrip;
           Alcotest.test_case "empty_request" `Quick test_empty_request_handling;
           Alcotest.test_case "protobuf_binary" `Quick test_protobuf_binary_format;
+          Alcotest.test_case "JoinRequest invalid bytes result" `Quick
+            test_join_request_invalid_bytes_result;
+          Alcotest.test_case "ToolCallRequest invalid bytes result" `Quick
+            test_tool_call_request_invalid_bytes_result;
         ] );
       ( "service",
         [
           Alcotest.test_case "service_name" `Quick test_service_name;
           Alcotest.test_case "get_status_projects_backlog_tasks" `Quick
             test_get_status_projects_backlog_tasks;
+          Alcotest.test_case "join invalid bytes raise grpc status" `Quick
+            test_join_handler_invalid_bytes_raise_grpc_status;
+          Alcotest.test_case "subscribe invalid bytes raise grpc status" `Quick
+            test_subscribe_handler_invalid_bytes_raise_grpc_status;
         ] );
       ( "server_config",
         [

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -281,6 +281,41 @@ let test_background_pending_callback_and_keeper_lookup () =
   | Some _ -> Alcotest.fail "expected approve callback"
   | None -> Alcotest.fail "expected callback to fire"
 
+let test_background_pending_reuses_existing_entry () =
+  Eio_main.run @@ fun _env ->
+  let initial_count = AQ.pending_count () in
+  let first_callback = ref None in
+  let second_callback = ref None in
+  let id1 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> first_callback := Some decision)
+  in
+  let after_first = AQ.pending_count () in
+  let id2 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> second_callback := Some decision)
+  in
+  Alcotest.(check string) "existing pending id reused" id1 id2;
+  Alcotest.(check int) "only one entry created"
+    (initial_count + 1) after_first;
+  Alcotest.(check int) "second submit does not grow queue"
+    after_first (AQ.pending_count ());
+  (match AQ.resolve ~id:id1 ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  Alcotest.(check bool) "first callback fired" true
+    (match !first_callback with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
+  Alcotest.(check bool) "second callback not attached to duplicate submit" true
+    (Option.is_none !second_callback)
+
 (* ── 4. Approval callback integration ────────────────────── *)
 
 let test_callback_approves_low_risk () =
@@ -375,6 +410,8 @@ let () =
       Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
       Alcotest.test_case "background pending callback" `Quick
         test_background_pending_callback_and_keeper_lookup;
+      Alcotest.test_case "background pending reuses existing entry" `Quick
+        test_background_pending_reuses_existing_entry;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;


### PR DESCRIPTION
## Summary
- harden keeper approval/telemetry persistence paths so malformed or failed restore/load cases stop disappearing silently
- replace the unsafe `tool_bridge` blob-store lazy singleton with an OCaml 5-safe `Atomic + Mutex` memo
- turn gRPC request decode failures into typed `INVALID_ARGUMENT` gRPC errors and remove the `http_server_eio` POST body read deadlock

## Details
- `keeper_approval_queue`: remove the non-total `submit_pending` path and avoid the `assert false` branch
- `tool_metrics_persist`: warn on malformed restore records instead of silently dropping them
- `keeper_telemetry_feedback`: warn when decision-log loading fails
- `tool_bridge`: replace process-global `Stdlib.Lazy.force` on a shared path
- `masc_grpc_types` / `masc_grpc_service`: add `of_bytes_result` helpers and raise typed gRPC decode errors at handler boundaries
- `http_server_eio`: replace the `Eio.Mutex + Eio.Condition` body-read handshake with `Eio.Promise`

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/chore-ocaml-hardening-batch1-20260418 ./test/test_hitl_approval.exe ./test/test_tool_metrics_persist.exe ./test/test_keeper_telemetry_feedback.exe ./test/test_http_server_eio.exe ./test/test_http_server_eio_coverage.exe ./test/test_grpc_coordination.exe ./test/test_tool_bridge_externalize.exe`
- direct execution of built test binaries for the same suites with `DUNE_SOURCEROOT` set to the worktree root

## Follow-up
- Leaves larger SSOT / runtime drift follow-ups in `#8376` and `#8377`
- Fixes `#8378`