### PR TITLE
refactor(keeper_tool_affinity): DRY env readers + List.take (simplify pass)

### DIFF
--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -20,33 +20,31 @@ let default_lookback_days = 7
 let min_success_rate = 0.3
 let recency_lambda = 0.01
 
-(* [Safe_ops.int_of_string_with_default] is built on the
-   exception-free [int_of_string_opt], so these readers no longer need
-   a hand-rolled [try ... with Eio.Cancel.Cancelled -> raise | _ ->
-   default] block.  The clamp runs after parsing, so a malformed env
-   value returns [default] unmodified.
-
-   An empty or whitespace-only value is treated as "unset" because
-   OCaml's stdlib lacks a portable [Unix.unsetenv] prior to 4.12 and
-   the codebase convention is [Unix.putenv name ""] to clear an env
-   var.  Without this guard, [Some ""] would be distinguishable from
-   [None] at the reader level even though the intent is identical. *)
-let configured_max_k ?(getenv = Sys.getenv_opt) () =
-  match getenv "MASC_KEEPER_TOOL_AFFINITY_K" with
+(* Empty/whitespace-only env values count as unset: OCaml stdlib has no
+   portable [Unix.unsetenv] before 4.12, and the codebase convention is
+   [Unix.putenv name ""] to clear a var. Without the trim guard,
+   [Some ""] would be distinguishable from [None] at the reader level
+   even though the intent is identical. *)
+let clamped_env_int ?(getenv = Sys.getenv_opt) ~name ~min_val ~max_val ~default () =
+  match getenv name with
   | Some s when String.trim s <> "" ->
-    max 0
-      (min 20
-         (Safe_ops.int_of_string_with_default ~default:default_max_k s))
-  | Some _ | None -> default_max_k
+    max min_val
+      (min max_val
+         (Safe_ops.int_of_string_with_default ~default s))
+  | Some _ | None -> default
+
+(* Clamp bounds: max_k cap of 20 keeps the discovered-tools window
+   bounded for small-context models; lookback cap of 30 days matches
+   the trajectory retention window. *)
+let configured_max_k ?(getenv = Sys.getenv_opt) () =
+  clamped_env_int ~getenv
+    ~name:"MASC_KEEPER_TOOL_AFFINITY_K"
+    ~min_val:0 ~max_val:20 ~default:default_max_k ()
 
 let configured_lookback_days ?(getenv = Sys.getenv_opt) () =
-  match getenv "MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS" with
-  | Some s when String.trim s <> "" ->
-    max 1
-      (min 30
-         (Safe_ops.int_of_string_with_default
-            ~default:default_lookback_days s))
-  | Some _ | None -> default_lookback_days
+  clamped_env_int ~getenv
+    ~name:"MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS"
+    ~min_val:1 ~max_val:30 ~default:default_lookback_days ()
 
 (* ================================================================ *)
 (* Types                                                             *)
@@ -118,7 +116,7 @@ let compute_affinity ~(tool_stats : Trajectory.tool_stat list)
         Some { tool_name = s.name; score; call_count = s.call_count;
                success_rate })
     |> List.sort (fun a b -> Float.compare b.score a.score)
-    |> List.filteri (fun i _ -> i < max_k)
+    |> List.take max_k
 
 (* ================================================================ *)
 (* Main entry point                                                  *)


### PR DESCRIPTION
## 동기

`/simplify` 자가 검토 (3개 review agent 병렬 — reuse / quality / efficiency)에서 `lib/keeper/keeper_tool_affinity.ml`의 env reader + top-K 패턴에 세 가지 simplify 기회를 발견. 동작 변경 0, refactor only.

## 변경

### 1) `clamped_env_int` 헬퍼 추출 (DRY)

`configured_max_k`/`configured_lookback_days`가 env name + clamp 범위 + default만 다르고 본문은 동일. 공유 parser로 추출:

```ocaml
let clamped_env_int ?(getenv = Sys.getenv_opt) ~name ~min_val ~max_val ~default () =
  match getenv name with
  | Some s when String.trim s <> "" -> max min_val (min max_val (Safe_ops.int_of_string_with_default ~default s))
  | Some _ | None -> default

let configured_max_k ?(getenv = Sys.getenv_opt) () =
  clamped_env_int ~getenv ~name:"MASC_KEEPER_TOOL_AFFINITY_K"
    ~min_val:0 ~max_val:20 ~default:default_max_k ()
```

### 2) `List.filteri` → `List.take`

`compute_affinity`의 top-K 추출:
```ocaml
- |> List.filteri (fun i _ -> i < max_k)
+ |> List.take max_k
```
Stdlib `List.take`는 `max_k` 도달 시 short-circuit. 기존 `filteri`는 정렬 이후 전체 traversal하면서 매 요소에 인덱스 계산. 동일 shape, lower constant.

### 3) Comment 축소

11-line comment block → 5 lines. `.mli` docstring에 이미 명시된 부분(clamp-after-parse 동작) 제거. WHY (empty-string treatment의 stdlib 한계 근거)만 남김.

### 4) Magic number rationale

clamp 범위 `20`/`30`에 한 줄 설명 추가:
- `max_k=20`: small-context model의 discovered-tools window 한계
- `lookback=30 days`: trajectory retention window와 일치

## 검증

- 17/17 `keeper_tool_affinity` unit tests pass
- `?getenv` DI seam 유지 (autocoder가 추가한 test injection 패턴)
- `lib/keeper/` build pass

## 보류한 finding

다음은 별도 follow-up 권고 (scope 초과):

- `Env_config_core.get_int`에 trim guard 통합 → `lib/orchestrator.ml` 등의 anti-pattern 동시 fix (multi-module 영향)
- env name `lib/config/env_config_keeper.ml` 중앙화 (stringly-typed 제거)
- `unix_of_iso8601`의 N×Unix.mktime 캐시 (typical <50 stats 기준 negligible)
