### PR TITLE
fix(cascade): loud load-time diagnostics for unresolvable provider schemes

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -206,17 +206,99 @@ let parse_weighted_entry
     ?supports_tool_choice_override:entry.supports_tool_choice
     entry.model
 
-(** Parse a list of weighted entries, discarding unavailable providers. *)
+(** Categorised diagnostic for a failed weighted-entry parse. *)
+type weighted_entry_drop =
+  | Drop_unregistered_scheme of { model : string; scheme : string }
+  | Drop_unavailable_scheme of { model : string; scheme : string }
+  | Drop_invalid_syntax of string
+
+(** Parse a weighted entry, distinguishing why it was rejected (unregistered
+    scheme, unavailable scheme, invalid syntax). Used by
+    {!parse_weighted_entries} to produce actionable load-time diagnostics
+    instead of silently discarding entries via [List.filter_map]. *)
+let parse_weighted_entry_diag
+    ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
+    ?system_prompt ?(api_key_env_overrides = [])
+    (entry : Cascade_config_loader.weighted_entry)
+  : (Llm_provider.Provider_config.t, weighted_entry_drop) result =
+  let raw = String.trim entry.model in
+  match split_provider_model raw with
+  | None -> Error (Drop_invalid_syntax raw)
+  | Some ("custom", model_id) ->
+    (match make_custom_config ~temperature ~max_tokens ?system_prompt
+             ?supports_tool_choice_override:entry.supports_tool_choice model_id with
+     | Some c -> Ok c
+     | None -> Error (Drop_invalid_syntax raw))
+  | Some (provider_name, model_id) ->
+    match Llm_provider.Provider_registry.find default_registry provider_name with
+    | None ->
+      Error (Drop_unregistered_scheme { model = raw; scheme = provider_name })
+    | Some reg_entry when not (reg_entry.is_available ()) ->
+      Error (Drop_unavailable_scheme { model = raw; scheme = provider_name })
+    | Some reg_entry ->
+      Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
+            ~api_key_env_overrides
+            ?supports_tool_choice_override:entry.supports_tool_choice
+            ~provider_name ~model_id reg_entry)
+
+(** Parse a list of weighted entries, dropping ones that cannot produce a
+    provider config. Load-time drops are logged once per call with
+    categorised reasons so upstream drift (e.g. a cascade.json entry
+    referencing an unregistered provider scheme due to library/binary
+    version skew) surfaces as ERROR rather than silently filtering away.
+
+    If [cascade_name] is supplied it appears in the log message. *)
 let parse_weighted_entries
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)
     ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
     ?system_prompt ?(api_key_env_overrides = [])
+    ?(cascade_name = "")
     (entries : Cascade_config_loader.weighted_entry list)
   : Llm_provider.Provider_config.t list =
-  List.filter_map
-    (parse_weighted_entry ~temperature ~max_tokens ?system_prompt
-       ~api_key_env_overrides)
-    entries
+  let parsed, unregistered, unavailable, invalid =
+    List.fold_left
+      (fun (acc, unr, unv, inv) entry ->
+         match parse_weighted_entry_diag ~temperature ~max_tokens
+                 ?system_prompt ~api_key_env_overrides entry with
+         | Ok c -> (c :: acc, unr, unv, inv)
+         | Error (Drop_unregistered_scheme { model; scheme }) ->
+           (acc, (model, scheme) :: unr, unv, inv)
+         | Error (Drop_unavailable_scheme { model; scheme }) ->
+           (acc, unr, (model, scheme) :: unv, inv)
+         | Error (Drop_invalid_syntax s) -> (acc, unr, unv, s :: inv))
+      ([], [], [], [])
+      entries
+  in
+  let label =
+    if cascade_name = "" then "cascade" else Printf.sprintf "cascade %S" cascade_name
+  in
+  let render_drops drops =
+    String.concat ", "
+      (List.map (fun (model, scheme) ->
+         Printf.sprintf "%s (scheme=%s)" model scheme) drops)
+  in
+  (if unregistered <> [] then
+     Log.Misc.error
+       "%s: dropped %d entry/entries referencing unregistered provider \
+        scheme(s): [%s]. Likely library/binary drift or cascade.json typo \
+        — rebuild or fix the config entry."
+       label (List.length unregistered) (render_drops unregistered));
+  (if invalid <> [] then
+     Log.Misc.error
+       "%s: dropped %d invalid-syntax entry/entries: [%s]"
+       label (List.length invalid) (String.concat ", " invalid));
+  (if unavailable <> [] then
+     Log.Misc.warn
+       "%s: skipped %d unavailable entry/entries (missing credential or \
+        CLI binary): [%s]"
+       label (List.length unavailable) (render_drops unavailable));
+  (if parsed = [] && entries <> [] then
+     Log.Misc.error
+       "%s: all %d configured entries filtered out — cascade will \
+        produce no responses until at least one entry resolves"
+       label (List.length entries));
+  List.rev parsed
 
 let parse_model_string_exn
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -72,9 +72,20 @@ val parse_weighted_entry :
   Cascade_config_loader.weighted_entry ->
   Llm_provider.Provider_config.t option
 
-(** Parse a list of weighted entries, discarding unavailable providers.
-    Preserves input order. Equivalent to
-    [List.filter_map parse_weighted_entry].
+(** Parse a list of weighted entries, dropping ones that cannot produce a
+    provider config. Preserves input order.
+
+    Drops are categorised (unregistered provider scheme, unavailable
+    provider, invalid syntax) and logged once per call through
+    {!Log.Misc}: unregistered schemes and invalid syntax are promoted to
+    ERROR because they usually indicate cascade.json drift or a stale
+    binary linked against an older provider registry. Unavailable
+    schemes (missing API key, missing CLI binary) log at WARN. If every
+    entry is filtered out the call escalates to an additional ERROR so
+    zero-provider cascades surface at load time rather than silently
+    producing no responses.
+
+    [cascade_name] is included in diagnostics when supplied.
 
     @since 0.150.0 *)
 val parse_weighted_entries :
@@ -82,6 +93,7 @@ val parse_weighted_entries :
   ?max_tokens:int ->
   ?system_prompt:string ->
   ?api_key_env_overrides:(string * string) list ->
+  ?cascade_name:string ->
   Cascade_config_loader.weighted_entry list ->
   Llm_provider.Provider_config.t list
 

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -293,7 +293,7 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
   in
   let specs =
     (if weighted <> [] then
-       Cascade_config.parse_weighted_entries weighted
+       Cascade_config.parse_weighted_entries ~cascade_name weighted
      else
        Cascade_config.parse_model_strings
          (models_of_cascade_name cascade_name))


### PR DESCRIPTION
## Context

2026-04-18 morning telemetry on the live `main_eio` server (basepath `~/me`, port 8935) showed ~6,195 WARN+ERROR log entries across the day. The top three clusters were:

| count | message |
|------|---------|
| 351 | `Network error: invalid URL "": missing host` |
| 300 | `cascade quality_sticky_glm51: claude-haiku-4-5-20251001 failed (missing host), trying next` |
| 134 | `sangsu: keeper cycle FAILED cascade=resilient_breaker` |

Root cause was a library/binary skew on opam switch `5.4.1`: `agent_sdk` had been reinstalled at 18:04 with the new `Provider_registry.default ()` registering `claude_code`, `glm-coding`, `ollama`, `codex_cli`, `gemini_cli`, but the live `main_eio.exe` binary was built at 17:55 and linked against the previous registry snapshot (which only had `claude/gemini/glm/openrouter/cc`). Every `claude_code:<model>` entry in `cascade.json` resolved to `Provider_registry.find ... = None` at runtime and was silently discarded by `List.filter_map` inside `Cascade_config.parse_weighted_entries`, leaving several cascades (`resilient_breaker`, `quality_sticky_glm51`, `tool_use_strict`, `governance_judge`) with zero resolvable providers. The keepers bound to those cascades (`sangsu`, `oracle`, `cheolsu`) ran 250 failed cycles over a day without producing any output — which explained the complete absence of git commits from those agents.

A `dune build bin/main_eio.exe` + restart against the already-current opam lib eliminated all 351 `missing host` lines immediately. That is the correct remediation for the incident. This PR is the structural follow-up so the **next** drift of this class gets caught at load time instead of in production.

## Change

`Cascade_config.parse_weighted_entries` is reworked to categorise drops and log them:

| category | log level | meaning |
|----------|-----------|---------|
| `Drop_unregistered_scheme` | ERROR | `cascade.json` references a provider name not in the registry. Almost always a typo or stale binary. |
| `Drop_unavailable_scheme`  | WARN  | Registered but `is_available ()` returned false (missing API key / CLI binary). Operational. |
| `Drop_invalid_syntax`      | ERROR | Malformed `provider:model`. |
| All entries dropped, non-empty input | ERROR | Zero-provider cascade surfaces as a load-time error rather than as N per-request HTTP failures. |

Logs are emitted once per call (aggregated by category), so hot-reload of `cascade.json` does not produce log spam. `?cascade_name` is threaded through from `cascade_runtime.ml` so the diagnostic labels are actionable (`cascade "resilient_breaker": dropped 1 entry referencing unregistered provider scheme(s): [claude_code:claude-haiku-4-5-20251001 (scheme=claude_code)]. Likely library/binary drift or cascade.json typo.`).

## What this does NOT do

- No `cascade.json` edits. Config remains the single source of truth.
- No change to parsing outcome for healthy cascades — the returned `Provider_config.t list` is identical in content and order. Only the side-effect logging is new.
- No new Log submodule. Reuses `Log.Misc` to match the existing cascade runtime convention.

## Backward compatibility

`?cascade_name` is optional. Existing callers compile unchanged. The new diagnostics still fire for unnamed calls, just without the cascade name in the message.

## Test plan

- [x] `dune build bin/main_eio.exe` clean
- [x] `dune runtest` — `Cascade config validity` and `Cascade_runtime` suites pass
- [ ] Intentional live verification: restart server with a synthetic unregistered entry in a scratch cascade, confirm a single ERROR appears and cycle OK count remains stable for the other cascades

## Follow-ups (not in this PR)

- Keeper checkpoint migration's `dropped_blocks=N dropped_messages=1` silent context truncation warrants the same loud-or-fix treatment. Separate PR.
- Consider a `cascade_health_tracker` degraded-state transition when a cascade's parsed list is empty on load, so operators can dashboard it independently of request-path health.