### PR TITLE
fix(types): derive agent_role schema enum from Variant SSOT (#8386)

### DIFF
--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -205,8 +205,12 @@ After masc_tool_admin_snapshot to review current state before making changes.";
         ]);
         ("default_role", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "reader"; `String "worker"; `String "admin"]);
-          ("description", `String "Default role for unauthenticated agents");
+          (* Issue #8386: derived from Types.agent_role Variant SSOT.
+             Hand-rolled enum risks dropping a constructor on extension. *)
+          ("enum", `List (List.map (fun s -> `String s) Types.valid_agent_role_strings));
+          ("description", `String
+            (Printf.sprintf "Default role for unauthenticated agents (%s)"
+               (String.concat " | " Types.valid_agent_role_strings)));
         ]);
         ("token_expiry_hours", `Assoc [
           ("type", `String "integer");

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -202,6 +202,15 @@ let agent_role_of_string = function
   | "admin" -> Ok Admin
   | s -> Error ("Unknown agent role: " ^ s)
 
+(** Issue #8386: schema enums for [agent_role] used to be hand-rolled
+    in [tool_schemas_misc.ml:208], matching the same drift class as
+    #8354 (task_status) and #8372 (agent_status). [agent_role] is
+    nullary across all constructors so the simple [List.map] trick
+    works. Adding a 4th constructor will fail compilation in
+    [agent_role_to_string] and in the test asserts. *)
+let all_agent_roles = [ Reader; Worker; Admin ]
+let valid_agent_role_strings = List.map agent_role_to_string all_agent_roles
+
 let agent_role_to_yojson r = `String (agent_role_to_string r)
 
 let agent_role_of_yojson = function

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -182,4 +182,21 @@ let () =
       Alcotest.test_case "awaiting_verification in enum" `Quick test_awaiting_verification_in_enum;
       Alcotest.test_case "actions enum has verification actions" `Quick test_actions_enum_has_verification_actions;
     ];
+    "agent_role_ssot", [
+      Alcotest.test_case "witness covers all variants" `Quick (fun () ->
+        let open Types_auth in
+        let witness s =
+          let actual = agent_role_to_string s in
+          if not (List.mem actual valid_agent_role_strings) then
+            Alcotest.failf "agent_role_to_string %S not in valid_agent_role_strings" actual
+        in
+        witness Reader; witness Worker; witness Admin;
+        Alcotest.(check int) "count" 3 (List.length valid_agent_role_strings));
+      Alcotest.test_case "all 3 strings present" `Quick (fun () ->
+        let open Types_auth in
+        List.iter (fun expected ->
+          Alcotest.(check bool) (Printf.sprintf "%s present" expected) true
+            (List.mem expected valid_agent_role_strings)
+        ) ["reader"; "worker"; "admin"]);
+    ];
   ]


### PR DESCRIPTION
## Summary
Closes #8386. Carbon-copy of #8372 (agent_status) for the auth-side `agent_role` Variant.

`lib/tool_schemas/tool_schemas_misc.ml:208` hand-rolled the `agent_role` enum. All 3 constructors happened to be present today, but it's the same drift class as #8354.

## Changes

| File | Change |
|------|--------|
| `lib/types/types_auth.ml` | Add `all_agent_roles` + `valid_agent_role_strings` next to `agent_role_to_string`. |
| `lib/tool_schemas/tool_schemas_misc.ml:208` | Replace literal enum with `List.map (fun s -> ` ` `String s) Types.valid_agent_role_strings`. Description string also reuses helper. |
| `test/test_types.ml` | New `agent_role_ssot` section: witness + name-presence asserts. |

## Pattern catalog (now 6)
| PR | Variant | Sites |
|----|---------|-------|
| #8350 | task_action lenient parser | dispatcher |
| #8357 | task_status | tool_shard.ml + mcp_server.ml |
| #8362 | task_status duplicate | coord_task.ml fold |
| #8368 | task_status post-action | Response.task_claimed |
| #8380 | agent_status | tool_schemas_agent.ml |
| **THIS** | **agent_role** | **tool_schemas_misc.ml** |

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_types.exe` — 17/17 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)