### PR TITLE
fix(board): derive visibility schema enum from Variant SSOT (#8392)

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -20,6 +20,16 @@ let visibility_of_string = function
   | "direct" -> Some Direct
   | _ -> None
 
+(** Issue #8392: schema enums for [visibility] used to be hand-rolled
+    in [tool_board.ml:699], matching the same drift class as #8354
+    (task_status), #8372 (agent_status), #8386 (agent_role). All
+    constructors are nullary so the simple [List.map] trick works.
+    Adding a 5th constructor will fail compilation in
+    [visibility_to_string] and in the test asserts. *)
+let all_visibilities = [ Public; Unlisted; Internal; Direct ]
+let valid_visibility_strings =
+  List.map visibility_to_string all_visibilities
+
 let post_kind_to_string = function
   | Human_post -> "direct"
   | Automation_post -> "automation"

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -696,7 +696,15 @@ let tool_post_list : Types.tool_schema = {
     ("type", `String "object");
     ("properties", `Assoc [
       ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max posts to return"); ("default", `Int 20); ("minimum", `Int 1); ("maximum", `Int 100)]);
-      ("visibility", `Assoc [("type", `String "string"); ("enum", `List [`String "public"; `String "unlisted"; `String "internal"; `String "direct"]); ("description", `String "Filter by visibility")]);
+      ("visibility", `Assoc [
+        ("type", `String "string");
+        (* Issue #8392: derived from Board_types.visibility Variant SSOT.
+           Hand-rolled enum risks dropping a constructor on extension. *)
+        ("enum", `List (List.map (fun s -> `String s) Board_core_classify.valid_visibility_strings));
+        ("description", `String
+          (Printf.sprintf "Filter by visibility (%s)"
+             (String.concat " | " Board_core_classify.valid_visibility_strings)));
+      ]);
       ("hearth", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter by hearth topic (e.g. webrtc, code-review)")]);
       ("random", `Assoc [("type", `String "boolean"); ("description", `String "Shuffle posts randomly (default: false)")]);
       ("offset", `Assoc [("type", `String "integer"); ("description", `String "Skip first N posts (default: 0)"); ("minimum", `Int 0); ("maximum", `Int 1000)]);

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -12,6 +12,32 @@ let with_eio f () =
 let test_default_ttl () =
   Alcotest.(check int) "default_ttl_hours is 0" 0 Limits.default_ttl_hours
 
+(* Issue #8392: schema enums for [visibility] must stay in sync with the
+   Variant SSOT. The witness function uses an exhaustive [match]: adding
+   a 5th constructor to [visibility] forces [visibility_to_string] to
+   fail compilation, and the count assertion below catches list/Variant
+   drift in [all_visibilities]. *)
+let test_visibility_witness_in_enum () =
+  let module C = Masc_mcp.Board_core_classify in
+  let witness s =
+    let actual = C.visibility_to_string s in
+    if not (List.mem actual C.valid_visibility_strings) then
+      Alcotest.failf "visibility_to_string %S not in valid_visibility_strings" actual
+  in
+  witness Public;
+  witness Unlisted;
+  witness Internal;
+  witness Direct;
+  Alcotest.(check int) "count" 4
+    (List.length C.valid_visibility_strings)
+
+let test_visibility_strings_complete () =
+  let strs = Masc_mcp.Board_core_classify.valid_visibility_strings in
+  List.iter (fun expected ->
+    Alcotest.(check bool) (Printf.sprintf "%s present" expected) true
+      (List.mem expected strs)
+  ) ["public"; "unlisted"; "internal"; "direct"]
+
 let test_permanent_post () =
   let store = create_store () in
   match
@@ -150,6 +176,13 @@ let () =
             (with_eio test_expiring_post);
           Alcotest.test_case "sweeper skips permanent" `Quick
             (with_eio test_sweeper_skips_permanent);
+        ] );
+      ( "visibility_ssot",
+        [
+          Alcotest.test_case "witness covers all 4 variants" `Quick
+            test_visibility_witness_in_enum;
+          Alcotest.test_case "all 4 strings present" `Quick
+            test_visibility_strings_complete;
         ] );
       ( "post_kind",
         [


### PR DESCRIPTION
## Summary
Closes #8392. Carbon copy of #8389 (agent_role) — 7th PR in the Variant SSOT helper pattern.

`lib/tool_board.ml:699` hand-rolled the `visibility` enum. All 4 constructors present today, no live correctness bug, but same drift class as #8354.

## Changes

| File | Change |
|------|--------|
| `lib/board_core_classify.ml` | Add `all_visibilities` + `valid_visibility_strings` next to `visibility_to_string`. All constructors nullary so `List.map` works. |
| `lib/tool_board.ml:699` | Replace literal enum + description with derivations from the helper. |
| `test/test_board_ttl.ml` | New `visibility_ssot` section: witness covers all 4 variants + asserts each canonical name present. |

## Pattern catalog (now 7)
| PR | Variant | Sites |
|----|---------|-------|
| #8350 | task_action lenient parser | dispatcher |
| #8357 | task_status | tool_shard.ml + mcp_server.ml |
| #8362 | task_status duplicate | coord_task.ml fold |
| #8368 | task_status post-action | Response.task_claimed |
| #8380 | agent_status | tool_schemas_agent.ml |
| #8389 | agent_role | tool_schemas_misc.ml |
| **THIS** | **visibility** | **tool_board.ml** |

## Future direction
At 7 PRs of the same pattern, a generic `derive valid_strings` ppx (or convention enforcement) would amortize the cost. Out of scope for this PR but worth a separate thread once this batch lands.

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_board_ttl.exe` — 11/11 pass (4 existing TTL + 2 new SSOT + 5 post_kind)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)