### PR TITLE
feat(dashboard): typography axis follow-up — extend scale + drift gate

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -128,7 +128,7 @@ export function App() {
                     </div>
                   `
                 : null}
-              <h1 class="min-w-0 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none [overflow-wrap:anywhere]">
+              <h1 class="min-w-0 text-xl font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none [overflow-wrap:anywhere]">
                 ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
               </h1>
             </div>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -96,7 +96,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
     return html`
       <div class="rounded border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="text-3xs text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
+        <div class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
       </div>
     `

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -248,7 +248,7 @@ function CharacterPlate({ name }: { name: string }) {
 
       <div class="flex flex-col gap-1.5 min-w-0">
         <div class="flex items-baseline gap-2 flex-wrap">
-          <h2 class="m-0 text-[20px] text-[var(--ff-gold)] flex items-center gap-1.5">
+          <h2 class="m-0 text-2xl text-[var(--ff-gold)] flex items-center gap-1.5">
             ${agentEmoji ? html`<span class="text-[1.4em]">${agentEmoji}</span>` : ''}
             ${displayName}
           </h2>

--- a/dashboard/src/components/common/stat-row.ts
+++ b/dashboard/src/components/common/stat-row.ts
@@ -16,7 +16,7 @@ export function KpiCard({ label, value, hint, tone, class: cx }: KpiCardProps) {
   return html`
     <div class="flex flex-col gap-1 p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] ${cx ?? ''}">
       <span class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium">${label}</span>
-      <span class="text-[20px] font-semibold tabular-nums leading-none ${tone ?? 'text-[var(--text-strong)]'}">${value}</span>
+      <span class="text-2xl font-semibold tabular-nums leading-none ${tone ?? 'text-[var(--text-strong)]'}">${value}</span>
       ${hint ? html`<span class="text-2xs text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
     </div>
   `

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -381,7 +381,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span class="text-[18px] drop-shadow-sm" aria-hidden="true">${surface.icon}</span>
+                  <span class="text-xl drop-shadow-sm" aria-hidden="true">${surface.icon}</span>
                 <//>
               `
             }

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -94,7 +94,7 @@ export function OperationalMeaningPanel({
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
           <div class="text-3xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>
-          <div class="mt-1 text-[18px] font-semibold text-[var(--text-strong)]">${insight.headline}</div>
+          <div class="mt-1 text-xl font-semibold text-[var(--text-strong)]">${insight.headline}</div>
           <div class="mt-1 text-2xs text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
         </div>
         <span class=${`rounded-sm border px-2.5 py-0.5 text-3xs font-mono ${INSIGHT_BADGE_CLS[insight.tone]}`}>

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -302,7 +302,7 @@ export function GoalTree() {
         <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
           <div class="max-w-[760px]">
             <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>
-            <h3 class="mt-1 text-[20px] font-semibold tracking-[-0.02em] text-text-strong">목표 계층 구조</h3>
+            <h3 class="mt-1 text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 계층 구조</h3>
             <p class="mt-1.5 text-sm leading-relaxed text-text-muted">
               목표의 부모-자식 관계와 연결된 태스크를 트리 형태로 보여줍니다. 수렴도는 하위 태스크 완료율 기반입니다.
             </p>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -42,7 +42,7 @@ function PlanningStat({
   return html`
     <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
-      <div class="mt-2 text-[30px] font-bold leading-none tabular-nums ${toneClass}">${value}</div>
+      <div class="mt-2 text-3xl font-bold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
   `
 }

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -290,7 +290,7 @@ function KeeperApprovalAlertBanner() {
       </div>
       <div class="flex-1 min-w-0">
         <div class="flex items-baseline gap-2 flex-wrap">
-          <span class="text-[20px] font-extrabold leading-none">${items.length}건</span>
+          <span class="text-2xl font-extrabold leading-none">${items.length}건</span>
           <span class="text-sm font-semibold">Keeper HITL 승인 대기</span>
           ${maxRisk ? html`<span class="text-2xs font-bold uppercase tracking-wider opacity-80">최고 ${maxRisk}</span>` : null}
         </div>

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -495,7 +495,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
       <div class="flex flex-wrap items-start justify-between gap-4">
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
-            <h3 class="m-0 text-[18px] font-semibold text-[var(--text-strong)]">${record.title}</h3>
+            <h3 class="m-0 text-xl font-semibold text-[var(--text-strong)]">${record.title}</h3>
             ${task?.status
               ? html`<${StatusBadge} status=${task.status} />`
               : keeper?.status
@@ -739,7 +739,7 @@ export function JourneyPanel() {
       <${Card} class="flex flex-col gap-4">
         <div class="flex flex-col gap-2">
           <div class="flex flex-wrap items-center gap-2">
-            <h2 class="m-0 text-[20px] font-semibold text-[var(--text-strong)]">Task → Run → Contract → Keeper → Thinking → Memory → Turn → Life → Cascade</h2>
+            <h2 class="m-0 text-2xl font-semibold text-[var(--text-strong)]">Task → Run → Contract → Keeper → Thinking → Memory → Turn → Life → Cascade</h2>
             <${StatusChip} tone="info">journey beta<//>
           </div>
           <div class="text-sm leading-relaxed text-[var(--text-muted)]">

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -296,7 +296,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
       <${Card}>
         <div class="flex flex-col gap-4">
           <div>
-            <h1 class="m-0 text-[20px] font-semibold leading-tight text-[var(--text-strong)]">${post.title}</h1>
+            <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--text-strong)]">${post.title}</h1>
           </div>
 
           <div class="text-sm text-[var(--text-body)] leading-[1.65]">

--- a/dashboard/src/components/perf-snapshot.ts
+++ b/dashboard/src/components/perf-snapshot.ts
@@ -58,7 +58,7 @@ function PerfStat({
   return html`
     <div class="rounded border border-card-border/45 bg-[var(--white-5)]/10 px-3 py-3">
       <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${label}</div>
-      <div class="mt-1 text-[20px] font-bold text-[var(--text-strong)]">${value}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-strong)]">${value}</div>
       ${detail ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${detail}</div>` : null}
     </div>
   `

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -149,23 +149,23 @@ export function ToolMetrics() {
         </div>
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>
+            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.total_calls}</span>
             <span class="text-2xs text-[var(--text-muted)] font-medium">총 호출 수</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
+            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
             <span class="text-2xs text-[var(--text-muted)] font-medium">사용된 도구</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.never_called_count}</span>
+            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.never_called_count}</span>
             <span class="text-2xs text-[var(--text-muted)] font-medium">미사용 도구</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.registered_count}</span>
+            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.registered_count}</span>
             <span class="text-2xs text-[var(--text-muted)] font-medium">등록됨 (v2)</span>
           </div>
           <div class="flex flex-col items-center gap-1 rounded border border-[var(--card-border)] bg-[var(--card)] p-3">
-            <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
+            <span class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
             <span class="text-2xs text-[var(--text-muted)] font-medium">Dispatch v2</span>
           </div>
         </div>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -85,27 +85,27 @@ export function FullInventoryView({
     <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[var(--backdrop-modal)] backdrop-blur-[8px] py-3 border-b border-[var(--card-border)]">
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${publicCount}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${publicCount}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${hiddenCount}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${directCallCount}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
         <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
+          <span class="text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums">${filtered.length}</span>
           <span class="text-2xs text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
       </div>

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -48,6 +48,12 @@
   --radius-xs: 3px;
   --radius-card: 18px;
 
+  /* Font-size scale.
+     INTENTIONAL OVERRIDE: --font-size-sm = 13px (Tailwind v4 default is 14px)
+     and --font-size-md = 15px (Tailwind v4 has no built-in md; we add one).
+     The dashboard's dense operational UI runs one notch tighter than the
+     stock Tailwind scale — keep this in mind when copying components from
+     external Tailwind v4 docs/examples. */
   --font-size-4xs: 8px;
   --font-size-3xs: 10px;
   --font-size-2xs: 11px;
@@ -56,6 +62,9 @@
   --font-size-base: 14px;
   --font-size-md: 15px;
   --font-size-lg: 16px;
+  --font-size-xl: 18px;
+  --font-size-2xl: 20px;
+  --font-size-3xl: 30px;
 
   --color-text-dim: #a0a8b4;
   --color-text-slate: #b0bfd4;

--- a/scripts/dashboard-drift-check.sh
+++ b/scripts/dashboard-drift-check.sh
@@ -31,7 +31,8 @@ PATTERNS=(
   "bg-zinc|bg-zinc-[0-9]+|zero|Use bg-[var(--white-N)]"
   "border-zinc|border-zinc-[0-9]+|zero|Use border-[var(--border-*)]"
   "rounded-px-literal|rounded-\\[[0-9]+px\\]|ratchet|Use rounded-{xs,sm,md,lg,xl,card} (tokens.css)"
-  "text-9px|text-\\[9px\\]|zero|Use text-[10px] (kbd sm) or text-[11px]"
+  "text-9px|text-\\[9px\\]|zero|Use text-3xs (10px) or text-2xs (11px)"
+  "text-px-literal|text-\\[[0-9]+px\\]|ratchet|Use text-{4xs,3xs,2xs,xs,sm,base,md,lg} (tokens.css)"
 )
 
 count_pattern() {


### PR DESCRIPTION
## Why
`/simplify` review of #8373 (typography axis sweep) surfaced 4 actionable findings. This PR addresses 3 of them — the 4th (parallel `--fs-*` system in `variables.css` colliding with `--font-size-*` in `tokens.css`, with `responsive.css` mobile scaling applying only to `--fs-*`) is a deeper cleanup filed for a separate PR.

## What
### 1) Extend font-size scale (3 new tokens, 24 sweep)
Tailwind v4 `@theme` block in `tokens.css`:
- `--font-size-xl: 18px` (4 callsites)
- `--font-size-2xl: 20px` (7 callsites)
- `--font-size-3xl: 30px` (also covers 28px → ~13 callsites)

Sweep:
- `text-[18px]` → `text-xl`
- `text-[20px]` → `text-2xl`
- `text-[28px]` → `text-3xl`
- `text-[30px]` → `text-3xl`

24 replacements / 14 files.

### 2) Document Tailwind v4 shadow (no code change)
Added comment to `tokens.css` explaining that `--font-size-sm: 13px` and `--font-size-md: 15px` **intentionally** differ from Tailwind v4 defaults (sm=14px, no built-in md). Dashboard's dense operational UI runs one notch tighter — future contributors won't be surprised when copying components from external Tailwind v4 examples.

### 3) Drift-check ratchet
`scripts/dashboard-drift-check.sh`:
- Updated `text-9px` zero-policy hint to reference new utility names (`text-3xs (10px) or text-2xs (11px)`)
- Added new ratchet rule `text-px-literal` matching `text-[Npx]` to prevent any future regression to inline pixel values

## Verification
- `pnpm typecheck` ✅
- `pnpm test`: slow host run (800s+) hit `telemetry-unified.test.ts` 5000ms timeout flake (unrelated to typography — file not in this diff)

## Remaining drift (optional Phase)
Long-tail `text-[Xpx]` not converted (singletons): `text-[7px]` (1), `text-[17px]` (2), `text-[22px]` (2), `text-[32px]` (1). 6 sites total — not worth dedicated tokens.

## /simplify finding 4 (deferred)
`variables.css --fs-*` runs parallel to `tokens.css --font-size-*` with identical values. `responsive.css` applies mobile-viewport scaling only to `--fs-*` set. Tailwind utilities (built from `--font-size-*`) bypass that scaling. → separate consolidation PR needed (port responsive.css rules to `--font-size-*` variables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)