### PR TITLE
test: follow up keeper regressions and CI retry

### DIFF
--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -141,6 +141,15 @@ isolated_build_dir_cmd() {
   printf 'export DUNE_BUILD_DIR=%q; %s' "${ACTIVE_TEST_BUILD_DIR}" "${cmd}"
 }
 
+cache_disabled_cmd() {
+  local cmd="${1}"
+  if [[ "${cmd}" == *"DUNE_CACHE=disabled"* ]]; then
+    printf '%s' "${cmd}"
+  else
+    printf 'export DUNE_CACHE=disabled; %s' "${cmd}"
+  fi
+}
+
 agent_sdk_interface_mismatch_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
   grep -Eq \
@@ -163,6 +172,19 @@ clean_current_build_dir() {
       > >(tee -a "${TEST_LOG_FILE}") \
       2> >(tee -a "${TEST_LOG_FILE}" >&2)
   fi
+}
+
+run_agent_sdk_clean_retry() {
+  CI_TEST_CLEAN_RETRY_DONE=1
+  run_cmd="$(cache_disabled_cmd "${run_cmd}")"
+  log_line "[ci-run] WARN: detected Agent_sdk interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled"
+  log_line "[ci-run] retry_command: ${run_cmd}"
+  clean_current_build_dir
+  log_line "[ci-run] retry_started_at=$(iso_now)"
+  set +e
+  run_with_timeout "${run_cmd}"
+  status=$?
+  set -e
 }
 
 run_with_timeout() {
@@ -243,14 +265,7 @@ if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && agent_sdk_interface_mismatch_detected; then
-  CI_TEST_CLEAN_RETRY_DONE=1
-  log_line "[ci-run] WARN: detected Agent_sdk interface mismatch; running dune clean and retrying once"
-  clean_current_build_dir
-  log_line "[ci-run] retry_started_at=$(iso_now)"
-  set +e
-  run_with_timeout "${run_cmd}"
-  status=$?
-  set -e
+  run_agent_sdk_clean_retry
 fi
 
 if [[ "${status}" -eq 124 ]]; then
@@ -280,6 +295,14 @@ if [[ "${status}" -ne 0 ]] \
   run_with_timeout "${run_cmd}"
   status=$?
   set -e
+fi
+
+if [[ "${status}" -ne 0 ]] \
+  && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
+  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && test_cmd_needs_dune_sanitization \
+  && agent_sdk_interface_mismatch_detected; then
+  run_agent_sdk_clean_retry
 fi
 
 if [[ "${status}" -ne 0 ]]; then

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -98,6 +98,41 @@ exit 0
   Unix.chmod dune_path 0o755;
   bin_dir
 
+let make_fake_dune_flaky_then_interface_mismatch dir =
+  let bin_dir = Filename.concat dir "bin-interface" in
+  Unix.mkdir bin_dir 0o755;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+printf '%s|%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "${DUNE_CACHE:-}" "$(pwd)" >>"$log_file"
+if [ "${1:-}" = "--version" ]; then
+  printf '3.21.0\n'
+  exit 0
+fi
+if [ "${1:-}" = "clean" ]; then
+  exit 0
+fi
+if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
+  printf 'plain failure\n' >&2
+  exit 1
+fi
+if [ "${DUNE_BUILD_DIR}" = ".ci_build_flaky" ] && [ "${DUNE_CACHE:-}" != "disabled" ]; then
+  printf 'Error: Files lib/autoresearch/masc_autoresearch.cmxa\n' >&2
+  printf '       and /tmp/agent_sdk.cmxa\n' >&2
+  printf '       make inconsistent assumptions over interface Agent_sdk__Event_bus\n' >&2
+  exit 1
+fi
+mkdir -p "${DUNE_BUILD_DIR}/default/test/_build/_tests"
+printf 'fake ok\n' > "${DUNE_BUILD_DIR}/default/test/_build/_tests/fake.output"
+printf 'Testing `fake`.\n'
+exit 0
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  bin_dir
+
 let test_rpc_retry_uses_isolated_build_dir () =
   with_temp_dir "ci-run-tests-retry" (fun dir ->
       let repo_dir = Filename.concat dir "repo" in
@@ -158,6 +193,73 @@ let test_rpc_retry_uses_isolated_build_dir () =
           failf "expected exactly two dune invocations, got:\n%s"
             (String.concat "\n" log_lines))
 
+let test_interface_mismatch_after_flaky_retry_disables_cache () =
+  with_temp_dir "ci-run-tests-interface" (fun dir ->
+      let repo_dir = Filename.concat dir "repo" in
+      Unix.mkdir repo_dir 0o755;
+      let fake_log = Filename.concat dir "fake-dune.log" in
+      let ci_log = Filename.concat dir "ci-run-tests.log" in
+      let fake_bin = make_fake_dune_flaky_then_interface_mismatch dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("DUNE_BUILD_DIR", "");
+          ("FAKE_DUNE_LOG", fake_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_TEST_LOG_FILE", ci_log);
+          ("CI_CONTRACT_HARNESS_ENABLED", "0");
+        ]
+      in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env
+          (Printf.sprintf "%s %s" (quote (script_path ()))
+             (quote
+                (Printf.sprintf "cd %s && dune test --root ." (quote repo_dir))))
+      in
+      if code <> 0 then
+        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let ci_log_contents = read_file ci_log in
+      let observed_output =
+        String.concat "\n" [ ci_log_contents; stdout; stderr ]
+      in
+      check bool "flaky retry warning present" true
+        (contains_substring observed_output
+           "test failed (exit=1); retrying once with isolated build dir .ci_build_flaky");
+      check bool "interface mismatch warning present" true
+        (contains_substring observed_output
+           "detected Agent_sdk interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled");
+      check bool "retry command disables cache" true
+        (contains_substring observed_output
+           "retry_command: export DUNE_CACHE=disabled; export DUNE_BUILD_DIR=.ci_build_flaky; unset DUNE_RPC;");
+      let log_lines =
+        read_file fake_log
+        |> String.split_on_char '\n'
+        |> List.filter (fun line -> String.trim line <> "")
+      in
+      match log_lines with
+      | [ first; second; third; fourth ] ->
+          check string "first attempt uses default build dir"
+            (Printf.sprintf "test|||%s" repo_dir)
+            first;
+          check string "flaky retry uses isolated build dir without cache override"
+            (Printf.sprintf "test|.ci_build_flaky||%s" repo_dir)
+            second;
+          check string "clean uses isolated build dir"
+            (Printf.sprintf "clean|.ci_build_flaky||%s" dir)
+            third;
+          check string "clean retry disables dune cache"
+            (Printf.sprintf "test|.ci_build_flaky|disabled|%s" repo_dir)
+            fourth
+      | _ ->
+          failf "expected exactly four dune invocations, got:\n%s"
+            (String.concat "\n" log_lines))
+
 let () =
   run "ci_run_tests_script"
     [
@@ -165,5 +267,8 @@ let () =
         [
           test_case "rpc retry uses isolated build dir" `Quick
             test_rpc_retry_uses_isolated_build_dir;
+          test_case "interface mismatch after flaky retry disables cache"
+            `Quick
+            test_interface_mismatch_after_flaky_retry_disables_cache;
         ] );
     ]

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -466,11 +466,16 @@ let test_keeper_bash_still_opens_boundary () =
    blocked.  Lock the [masc_] and [keeper_] families to the same
    exemption semantics so the next rename does not silently drift. *)
 let test_masc_coordination_aliases_bypass_boundary () =
-  let check name =
+  let check_pair name =
+    let expected_ro = Tool_dispatch.is_read_only name in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s read-only classification" name)
+      expected_ro
+      (is_ro ~tool_name:name ~input:(`Assoc []));
     Alcotest.(check bool) (name ^ " bypasses boundary") true
       (is_boundary_exempt ~tool_name:name ~input:(`Assoc []))
   in
-  List.iter check
+  List.iter check_pair
     [ "masc_tasks"; "masc_add_task"; "masc_claim_next";
       "masc_batch_add_tasks"; "masc_plan_init"; "masc_plan_set_task";
       "masc_plan_update"; "masc_plan_get"; "masc_transition";

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -158,8 +158,6 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
    | Fresh | Init_only -> ());
   { generic; config; meta; ctx_snapshot; tools }
 
-let keeper_agent_name fixture = "keeper-" ^ fixture.meta.name
-
 let find_tool fixture name =
   List.find_opt
     (fun (tool : Agent_sdk.Tool.t) -> String.equal tool.schema.name name)
@@ -175,7 +173,7 @@ let ensure_keeper_claim fixture =
   ignore (Generic.ensure_task fixture.generic);
   ignore
     (Masc_mcp.Coord.claim_next fixture.config
-       ~agent_name:(keeper_agent_name fixture))
+       ~agent_name:fixture.meta.agent_name)
 
 let ensure_voice_session fixture =
   let mgr = Masc_mcp.Keeper_voice_local.get_session_manager () in
@@ -293,7 +291,9 @@ let keeper_arguments fixture (schema : Types.tool_schema) =
       `Assoc
         [
           ("task_id", `String (Generic.ensure_task fixture.generic));
-          ("result", `String "tool matrix result");
+          ( "result",
+            `String
+              "Validated the keeper tool matrix case, confirmed the task fixture was claimed, and recorded the successful completion path." );
         ]
   | "keeper_board_cleanup" | "keeper_board_delete" ->
       `Assoc [ ("post_id", `String (Generic.ensure_board_post fixture.generic)) ]
@@ -342,6 +342,13 @@ let keeper_expectation_for_name name =
   | "keeper_pr_review_reply"
   | "keeper_preflight_check" ->
       Expect_success_or_guard github_guard_fragments
+  | "keeper_task_done" ->
+      Expect_success_or_guard
+        [
+          "Completion rejected by anti-rationalization gate";
+          "review format unrecognized";
+          "Revise your completion notes";
+        ]
   | "keeper_fs_read" ->
       (* Playground resolves paths under .masc/playground/<agent>/ but
          the sample file is written at base_path. File-not-found in


### PR DESCRIPTION
## Summary
- fix post-merge keeper test regressions exposed after the task-done FSM changes
- align keeper tool matrix fixtures with the keeper task-done ownership and anti-rationalization gate behavior
- teach `scripts/ci-run-tests.sh` to recover when an `Agent_sdk` interface mismatch appears after the flaky isolated-build retry path

## Why
- `#8317` and `#8327` are already merged
- this branch is a follow-up PR for regressions that only showed up in later quick-suite / CI runs on `main`

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-postmerge-ci ./test/test_keeper_github_read_only.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-postmerge-ci ./test/test_ci_run_tests_script.exe`
- `KEEPER_TOOL_MATRIX_ONLY=keeper_task_done dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-postmerge-ci ./test/test_keeper_tool_matrix.exe`
- `scripts/ci-run-tests.sh "opam exec -- dune test --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-postmerge-ci"`

## Notes
- the rebased branch quick-suite rerun is still finishing the long `keeper_tool_matrix` tail as this PR is opened