### PR TITLE
feat(cdal-gate): record attribution for advisory (strict=false) contracts

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -233,11 +233,25 @@ let persisted_contract_rejection ~(ctx : context)
     end else
       match task.contract with
       | None -> None
-      | Some contract when not contract.strict -> None
-      | Some _contract ->
-        Log.Task.info "[cdal-gate] checking verdict for task=%s agent=%s"
-          task.id ctx.agent_name;
-        Cdal_verdict_gate.gate_check ~task_id:task.id ()
+      | Some contract ->
+        (* Always run the verdict lookup so Dashboard_attribution records the
+           outcome (pass / policy_failed / missing). strict=false stays
+           advisory — we drop the rejection but keep the audit trail so the
+           dashboard shows a verification trace instead of nothing. *)
+        Log.Task.info
+          "[cdal-gate] checking verdict for task=%s agent=%s strict=%b"
+          task.id ctx.agent_name contract.strict;
+        let rejection = Cdal_verdict_gate.gate_check ~task_id:task.id () in
+        if contract.strict then rejection
+        else begin
+          (match rejection with
+           | Some msg ->
+             Log.Task.info
+               "[cdal-gate] advisory (strict=false) for task=%s: %s"
+               task.id msg
+           | None -> ());
+          None
+        end
 
 (* Handlers *)
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -348,6 +348,46 @@ let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
       (Printf.sprintf "expected CDAL gate rejection message, got: %s" result_done)
 )
 
+(* Advisory contract (strict=false): CDAL gate must still record an attribution
+   event so the dashboard has a verification trace, but must NOT block the
+   transition. Regression guard for the user-reported gap "검증 흔적이 UI에서
+   안 보인다" — strict=false tasks used to bypass the gate entirely, leaving
+   no audit trail. *)
+let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
+  Dashboard_attribution.reset ();
+  let ctx = make_test_ctx_with_agent "advisory-agent" in
+  let _ =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Advisory deliverable task");
+          ( "contract",
+            `Assoc
+              [
+                ("strict", `Bool false);
+                ( "completion_contract",
+                  `List [ `String "deliverable-ready" ] );
+              ] );
+        ])
+  in
+  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let success_done, _result_done =
+    Tool_task.handle_done ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("notes", `String "deliverable-ready");
+        ])
+  in
+  if not success_done then
+    failwith "advisory contract (strict=false) must not block handle_done";
+  let recent = Dashboard_attribution.recent ~gate:"cdal_verdict" ~limit:20 () in
+  if recent = [] then
+    failwith
+      "expected Dashboard_attribution to record a cdal_verdict entry for \
+       advisory contract (audit trail regression)"
+)
+
 let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =


### PR DESCRIPTION
## Summary

- `persisted_contract_rejection` used to skip the CDAL verdict lookup entirely when `contract.strict = false`, so no `Dashboard_attribution` entry was recorded and the dashboard had no verification trace for the advisory case.
- Always invoke `Cdal_verdict_gate.gate_check` (which records the attribution envelope on both present/missing verdicts). Only enforce the rejection when `strict = true`; `strict = false` keeps the audit trail but drops the rejection, making advisory contracts a real advisory instead of a silent skip.
- Regression test `handle_done_advisory_contract_records_attribution` asserts the attribution ring now receives an entry for the strict=false path.

## Context

User feedback: "CDAL이 Task/Goal/Board/Keeper 어디에도 이런걸 확인하거나 검증하고나 검증됐거나 한 흔적이 없다." This PR is the first incremental step toward making verification activity visible. The audit surface was already wired (`Dashboard_attribution` ring buffer, `cdal_verdict` gate label) — strict=false was the only code path bypassing it.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 1 of 5).

## Scope guard

- Gate 4 (FSM redirect) / Gate 5 (CDAL) ordering is **not** changed — empirical read of `tool_task.ml` showed CDAL already runs before the FSM redirect.
- `Env_config_runtime.Cdal.gate_enabled` and `Verification.fsm_enabled` defaults are unchanged.
- Public interfaces (`Tool_task.handle_*`, `Cdal_verdict_gate.*`) are untouched.

## Test plan

- [x] `dune exec test/test_tool_task_coverage.exe` — 47 tests pass (includes new advisory test).
- [x] `dune exec test/test_cdal_verdict_gate.exe` — 19 tests pass (no regression in attribution helpers).
- [ ] CI green (deferred to auto-run).
- [ ] Manual smoke: create task with `contract.strict=false`, call `masc_done`, observe entry on `/attribution` dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)