### PR TITLE
[codex] reject foreign tool surfaces in keeper turns

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1860,52 +1860,66 @@ let run_turn
        let tool_names =
          Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
-       let usage = Keeper_exec_context.usage_of_response result.response in
-       let ctx_composition =
-         build_ctx_composition_metrics
-           ~system_prompt:turn_system_prompt
-           ~dynamic_context
-           ~memory_context
-           ~temporal_context
-           ~user_message
-           ~history_messages
-           ~actual_input_tokens:usage.input_tokens
+       let unexpected_tool_names =
+         Keeper_tool_disclosure.unexpected_tool_names
+           ~allowed_tool_names:all_tool_names
+           ~tool_names
        in
-       (* Text-response trap tolerance: when tool_choice=Any is set but
-          the provider ignores it (e.g. Ollama #14493), the model returns
-          text-only on non-last turns. Instead of hard-failing the turn
-          (which wastes the entire OAS run), log a warning and treat the
-          text response as valid. The turn is counted as text_response
-          in telemetry via keeper_unified_turn. See #5566. *)
-       let text =
-         match
-           Keeper_tool_disclosure.validate_completion_contract
-             ~contract:!completion_contract_ref
-             ~tool_names
-             ()
-         with
-         | Ok () -> text
-         | Error reason ->
-           let contract_str =
-             match !completion_contract_ref with
-             | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
-             | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
-           in
-           Log.Keeper.warn
-             "keeper:%s text_response trap: tool contract violated \
-              (turn=%d, tools=0, contract=%s). \
-              Provider likely ignored tool_choice=Any. Tolerating text-only \
-              response to avoid wasting OAS run. Reason: %s"
-             meta.name result.turns contract_str reason;
-           (* When both text and tool_names are empty, normalize_response_text
-              would hard-fail. Synthesize minimal text so the turn survives. *)
-           if String.trim text = "" && tool_names = []
-           then "[no output]"
-           else text
-       in
-       (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
-        | Error e -> Error (Oas.Error.Internal e)
-        | Ok response_text ->
+       if unexpected_tool_names <> [] then
+         let reason =
+           Printf.sprintf
+             "keeper turn reported unexpected tool names outside keeper surface: %s"
+             (String.concat ", " unexpected_tool_names)
+         in
+         Log.Keeper.error "keeper:%s %s" meta.name reason;
+         Error (Oas.Error.Internal reason)
+       else (
+         let usage = Keeper_exec_context.usage_of_response result.response in
+         let ctx_composition =
+           build_ctx_composition_metrics
+             ~system_prompt:turn_system_prompt
+             ~dynamic_context
+             ~memory_context
+             ~temporal_context
+             ~user_message
+             ~history_messages
+             ~actual_input_tokens:usage.input_tokens
+         in
+         (* Text-response trap tolerance: when tool_choice=Any is set but
+            the provider ignores it (e.g. Ollama #14493), the model returns
+            text-only on non-last turns. Instead of hard-failing the turn
+            (which wastes the entire OAS run), log a warning and treat the
+            text response as valid. The turn is counted as text_response
+            in telemetry via keeper_unified_turn. See #5566. *)
+         let text =
+           match
+             Keeper_tool_disclosure.validate_completion_contract
+               ~contract:!completion_contract_ref
+               ~tool_names
+               ()
+           with
+           | Ok () -> text
+           | Error reason ->
+             let contract_str =
+               match !completion_contract_ref with
+               | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
+               | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
+             in
+             Log.Keeper.warn
+               "keeper:%s text_response trap: tool contract violated \
+                (turn=%d, tools=0, contract=%s). \
+                Provider likely ignored tool_choice=Any. Tolerating text-only \
+                response to avoid wasting OAS run. Reason: %s"
+               meta.name result.turns contract_str reason;
+             (* When both text and tool_names are empty, normalize_response_text
+                would hard-fail. Synthesize minimal text so the turn survives. *)
+             if String.trim text = "" && tool_names = []
+             then "[no output]"
+             else text
+         in
+         match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
+         | Error e -> Error (Oas.Error.Internal e)
+         | Ok response_text ->
           (* Ensure every generation has a [STATE] block for continuity.
              If the model omitted it, synthesize one deterministically
              from tool usage and stop reason. *)
@@ -2213,10 +2227,11 @@ let run_turn
                ; usage
                ; tools_used = tool_names
                ; checkpoint = saved_checkpoint
-               ; proof = result.proof
-               ; trace_ref = result.trace_ref
-               ; run_validation = result.run_validation
-               ; stop_reason = result.stop_reason
-               ; inference_telemetry = result.response.telemetry
-               }))
+	               ; proof = result.proof
+	               ; trace_ref = result.trace_ref
+	               ; run_validation = result.run_validation
+	               ; stop_reason = result.stop_reason
+	               ; inference_telemetry = result.response.telemetry
+	               })
+	       )
 ;;

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -41,6 +41,23 @@ let merge_reported_and_observed_tool_names
         reported_tool_names
 ;;
 
+let unexpected_tool_names
+      ~(allowed_tool_names : string list)
+      ~(tool_names : string list)
+  : string list
+  =
+  let allowed = Hashtbl.create (List.length allowed_tool_names) in
+  let seen = Hashtbl.create (List.length tool_names) in
+  List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;
+  tool_names
+  |> List.filter (fun tool_name ->
+       if Hashtbl.mem allowed tool_name || Hashtbl.mem seen tool_name
+       then false
+       else (
+         Hashtbl.replace seen tool_name ();
+         true))
+;;
+
 type completion_contract =
   | Allow_text_or_tool
   | Require_tool_use

--- a/test/dune
+++ b/test/dune
@@ -60,6 +60,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_tool_surface_guard
         test_keeper_pr_review
         test_keeper_execution_scope
         test_playground_paths
@@ -165,6 +166,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_tool_surface_guard
           test_keeper_pr_review
           test_keeper_execution_scope
           test_playground_paths

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -1,0 +1,31 @@
+open Alcotest
+
+module KTD = Masc_mcp.Keeper_tool_disclosure
+
+let test_unexpected_tool_names_accepts_keeper_surface () =
+  check (list string) "no unexpected tools" []
+    (KTD.unexpected_tool_names
+       ~allowed_tool_names:
+         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:[ "keeper_task_claim"; "extend_turns" ])
+
+let test_unexpected_tool_names_reports_foreign_surface () =
+  check (list string) "foreign tools flagged"
+    [ "Skill"; "Bash"; "Agent" ]
+    (KTD.unexpected_tool_names
+       ~allowed_tool_names:
+         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:
+         [ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+
+let () =
+  run "keeper_tool_surface_guard"
+    [
+      ( "surface_guard",
+        [
+          test_case "accepts keeper surface" `Quick
+            test_unexpected_tool_names_accepts_keeper_surface;
+          test_case "reports foreign surface" `Quick
+            test_unexpected_tool_names_reports_foreign_surface;
+        ] );
+    ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2602,6 +2602,22 @@ let test_validate_completion_contract_accepts_stay_silent () =
   | Ok () -> ()
   | Error e -> fail ("unexpected error: " ^ e)
 
+let test_unexpected_tool_names_accepts_keeper_surface () =
+  check (list string) "no unexpected tools" []
+    (KTD.unexpected_tool_names
+       ~allowed_tool_names:
+         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:[ "keeper_task_claim"; "extend_turns" ])
+
+let test_unexpected_tool_names_reports_foreign_surface () =
+  check (list string) "foreign tools flagged"
+    [ "Skill"; "Bash"; "Agent" ]
+    (KTD.unexpected_tool_names
+       ~allowed_tool_names:
+         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:
+         [ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+
 let test_completion_contract_of_tool_choice_allows_auto () =
   check bool "auto allows text" true
     (match KTD.completion_contract_of_tool_choice None with
@@ -3460,6 +3476,10 @@ let () =
             test_validate_completion_contract_requires_tool_use;
           test_case "completion contract accepts stay silent" `Quick
             test_validate_completion_contract_accepts_stay_silent;
+          test_case "unexpected tool names accepts keeper surface" `Quick
+            test_unexpected_tool_names_accepts_keeper_surface;
+          test_case "unexpected tool names reports foreign surface" `Quick
+            test_unexpected_tool_names_reports_foreign_surface;
           test_case "completion contract mapping allows auto" `Quick
             test_completion_contract_of_tool_choice_allows_auto;
           test_case "completion contract mapping requires any" `Quick


### PR DESCRIPTION
## Summary

Add a hard guard so keeper turns cannot be recorded as successful when they report tool names outside the keeper runtime surface.

## What changed

- `Keeper_tool_disclosure` now exposes `unexpected_tool_names` to diff actual tool names against the keeper tool universe.
- `keeper_agent_run` now fails the turn with `Oas.Error.Internal` when the reported/observed tool list includes names outside the current keeper surface.
- added a small dedicated regression test file for foreign-tool detection.
- mirrored helper assertions in `test_keeper_unified.ml` so the main keeper suite also covers the helper when CI runs the full binary.

## Product impact

This directly targets the runtime pattern tracked in #8366:
- keeper world state advertises `keeper_task_claim`
- decision logs still show `Skill`, `Bash`, `Grep`, `Read`, `Glob`, `Agent`, or text like `Claude Code session`
- those turns were landing as `outcome=success`

After this patch, that mismatch becomes an explicit keeper-turn failure instead of silently looking like a valid successful turn.

This does **not** fully fix the underlying root cause of the mixed execution surface. It hardens detection and prevents the runtime from treating those turns as legitimate keeper work.

## Evidence

Issue #8366 contains the motivating live evidence from `~/.masc/keepers/*.decisions.jsonl`, including:
- `cheolsu`, `qa-king`, `ani1999`, `adversary`, `oracle`, `masc-improver`
- foreign tool names such as `Skill`, `Bash`, `Grep`, `Read`, `Glob`, `Agent`
- text responses claiming `[CALLING keeper_task_claim({})]` without `claim_executed=true`

## Review evidence

Validated locally with compile-focused checks:

```bash
dune build --root . --build-dir _build_codex_surface_lib lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_agent_run.ml
dune build --root . --build-dir _build_codex_surface_unified_src test/test_keeper_unified.ml
dune build --root . --build-dir _build_codex_surface test/test_keeper_tool_surface_guard.ml
```

The dedicated test executable link was started but not completed locally before opening this PR, so CI should be treated as the first full binary execution for the new test.

## Linked issue

Relates #8366