### PR TITLE
fix(dashboard): harden sse contracts and refresh shell

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -97,16 +97,18 @@ export function App() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
+  const activeSurfaceLabel = currentSection && currentSection.label !== currentView?.label
+    ? `${currentView?.label ?? '홈'} / ${currentSection.label}`
+    : (currentSection?.label ?? currentView?.label ?? '홈')
 
   return html`
-    <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
-      <header class="relative z-10 shrink-0 border-b border-[var(--white-5)] bg-[rgba(8,14,26,0.36)] px-4 py-1.5 backdrop-blur-xl">
-        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
+    <div class="dashboard-shell-app flex min-h-screen h-screen flex-col overflow-hidden text-[var(--text-body)]">
+      <header class="dashboard-topbar relative z-10 shrink-0 px-4 py-2">
         <div class="flex w-full items-center justify-between gap-3 max-[900px]:flex-col max-[900px]:items-stretch">
           <div class="min-w-0 flex items-center gap-3">
-            <div class="flex shrink-0 items-center gap-2">
+            <div class="flex shrink-0 items-center gap-2.5">
               <button type="button"
-                class="hidden max-[768px]:flex size-9 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+                class="dashboard-chip dashboard-chip--control hidden max-[768px]:flex size-9 items-center justify-center p-0 cursor-pointer text-[var(--text-body)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 aria-controls="dashboard-side-rail"
@@ -114,27 +116,21 @@ export function App() {
               >
                 ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
-              <div class="flex size-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[13px] text-[var(--text-strong)]">
+              <div class="dashboard-surface-code shrink-0">
                 ${currentView?.icon ?? 'M'}
               </div>
             </div>
 
             <div class="min-w-0 flex flex-col justify-center">
-              ${currentSection && currentSection.label !== currentView?.label
-                ? html`
-                    <div class="mb-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
-                      <span>${currentView?.label ?? '홈'}</span>
-                      <span>/</span>
-                    </div>
-                  `
-                : null}
-              <h1 class="min-w-0 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none [overflow-wrap:anywhere]">
-                ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
+              <div class="dashboard-topbar__eyebrow">Multi-Agent Namespace Console</div>
+              <h1 class="dashboard-topbar__title min-w-0 [overflow-wrap:anywhere]">
+                MASC Control Deck
               </h1>
+              <div class="dashboard-topbar__summary">${activeSurfaceLabel}</div>
             </div>
           </div>
 
-          <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <div class="flex shrink-0 flex-wrap items-center justify-end gap-2.5">
             <${AuthStatus} />
             <${ConnectionStatus} />
             <${ThemeSwitch} />
@@ -145,12 +141,12 @@ export function App() {
 
       <${RemoteWarningBanner} />
 
-      <div class="flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col">
-        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+      <div class="dashboard-shell-grid flex flex-1 gap-3 overflow-hidden p-3 max-[1100px]:flex-col">
+        <aside id="dashboard-side-rail" class="dashboard-rail ${sidebarCollapsed.value ? 'w-14' : 'w-[248px]'} shrink-0 overflow-y-auto overflow-x-hidden transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[320px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 
-        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(10,15,26,0.68)] backdrop-blur-lg max-[1100px]:min-h-0">
+        <main class="dashboard-main-panel min-w-0 flex-1 overflow-hidden max-[1100px]:min-h-0">
           <div class="h-full overflow-y-auto p-4">
             <${DashboardMain} />
           </div>

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -31,7 +31,7 @@ export function AuthStatus() {
   return html`
     <div class="relative">
       <button type="button"
-        class="flex items-center gap-1.5 text-[11px] py-1 px-2 rounded border border-solid border-[var(--card-border)] bg-[var(--white-4)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--white-8)] text-[var(--text-muted)]"
+        class="dashboard-chip dashboard-chip--meta flex items-center gap-1.5 text-[11px] py-1 px-2 cursor-pointer font-[inherit] text-[var(--text-muted)]"
         onClick=${() => { popoverOpen.value = !popoverOpen.value }}
         title="인증 상태"
       >

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -99,7 +99,7 @@ export function ConnectionStatus() {
 
   return html`
     <div
-      class="flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
+      class="dashboard-chip dashboard-chip--live flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}"
       title=${titleAttr || undefined}
     >
       <span class="inline-block size-[8px] rounded-sm ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--bad)]'}"></span>
@@ -107,7 +107,7 @@ export function ConnectionStatus() {
       ${attentionCount > 0 ? html`
         <${RouteLink}
           tab="overview"
-          class="inline-flex items-center justify-center rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 tabular-nums attention-badge"
+          class="dashboard-chip dashboard-chip--quiet inline-flex items-center justify-center tabular-nums attention-badge"
         >주의 ${attentionCount}건<//>
       ` : null}
     </div>
@@ -197,7 +197,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="dashboard-chip dashboard-chip--meta cursor-pointer px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -350,13 +350,13 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
     <nav class="flex flex-col h-full" aria-label="Dashboard navigation">
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2 pt-2 pb-1">
         ${!collapsed ? html`
-          <div class="px-1">
-            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--text-muted)]">내비게이션</div>
-            <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
+          <div class="dashboard-rail__title px-1">
+            <div class="dashboard-rail__eyebrow">Field Map</div>
+            <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Surfaces</div>
           </div>
         ` : null}
         <button type="button"
-          class="flex size-7 items-center justify-center rounded text-[var(--text-muted)] cursor-pointer transition-colors duration-200 hover:bg-[var(--white-10)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
+          class="dashboard-chip dashboard-chip--control flex size-7 items-center justify-center p-0 cursor-pointer text-[var(--text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-1)]"
           aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
@@ -376,12 +376,12 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center justify-center w-full rounded border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
+                  class="dashboard-rail__surface dashboard-rail__surface--collapsed ${isSurfaceActive ? 'is-active' : ''}"
                   title=${surface.label}
                   aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span class="text-[18px] drop-shadow-sm" aria-hidden="true">${surface.icon}</span>
+                  <span class="dashboard-surface-code dashboard-surface-code--small" aria-hidden="true">${surface.icon}</span>
                 <//>
               `
             }
@@ -391,13 +391,14 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                 <${RouteLink}
                   tab=${surface.defaultTab}
                   params=${surface.defaultParams}
-                  class="flex items-center gap-2 w-full rounded border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[var(--white-5)]'}"
+                  class="dashboard-rail__surface ${isSurfaceActive && sections.length === 0 ? 'is-active' : ''}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[14px]" aria-hidden="true">
+                  <span class="dashboard-surface-code dashboard-surface-code--small" aria-hidden="true">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
+                    <div class="text-[11px] uppercase tracking-[0.18em] text-[var(--text-dim)]">Surface</div>
                     <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[var(--accent)]' : ''}">${surface.label}</div>
                   </div>
                 <//>
@@ -411,7 +412,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                           role="listitem"
                           tab=${surface.id}
                           params=${item.params}
-                          class="w-full rounded border px-2 py-1 text-left cursor-pointer text-[13px] transition-[background-color,border-color,color,box-shadow] duration-200 ${isSectionActive ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-soft)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)] hover:text-[var(--text-body)]'}"
+                          class="dashboard-rail__section ${isSectionActive ? 'is-active' : ''}"
                           ariaCurrent=${isSectionActive ? 'page' : undefined}
                         >
                           <div class="truncate">${item.label}</div>
@@ -558,6 +559,7 @@ function SurfaceLead() {
 
   const description = currentSection?.description ?? currentView?.description ?? null
   const title = currentSection?.label ?? currentView?.label ?? '홈'
+  const surfaceCode = currentView?.icon ?? 'MC'
   const shareUrl = currentSectionShareUrl()
   // Only surface a trail when the operator has drilled into a section —
   // otherwise the crumb would be \"Connectors\" right above a \"Connectors\"
@@ -574,10 +576,14 @@ function SurfaceLead() {
   }, [currentView?.label, currentSection?.label])
 
   return html`
-    <div class="mb-3 flex flex-col gap-1.5">
+    <div class="dashboard-surface-lead mb-4 flex flex-col gap-2">
+      <div class="dashboard-surface-lead__eyebrow">
+        <span class="dashboard-surface-code dashboard-surface-code--pill">${surfaceCode}</span>
+        <span>${currentView?.label ?? 'MASC'}</span>
+      </div>
       ${trail.length > 0
         ? html`<nav
-            class="flex items-center gap-1 text-[11px] text-[var(--text-dim)]"
+            class="dashboard-surface-lead__breadcrumb flex items-center gap-1 text-[11px] text-[var(--text-dim)]"
             aria-label="페이지 경로"
             data-surface-breadcrumb
           >
@@ -600,7 +606,7 @@ function SurfaceLead() {
           </nav>`
         : null}
       <div class="flex items-center gap-2">
-        <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
+        <h2 class="text-[24px] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">
           ${title}
         </h2>
         ${shareUrl !== ''
@@ -612,7 +618,7 @@ function SurfaceLead() {
             />`
           : null}
       </div>
-      ${description ? html`<p class="m-0 text-[13px] leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
+      ${description ? html`<p class="m-0 max-w-[72ch] text-[13px] leading-[1.6] text-[var(--text-dim)]">${description}</p>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -10,16 +10,10 @@ import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
 import { selectEntity, detailSelection } from './detail-selection-store'
 import { bucketTelemetryEntries, entryTimestampMs, useTrackBucketCount } from './observatory-utils'
+import { telemetrySourceMeta } from '../../config/telemetry-sources'
 
 function sourceColor(source: string | undefined): string {
-  switch (source) {
-    case 'oas_event': return 'bg-accent'
-    case 'agent_event': return 'bg-[var(--ok-10)]'
-    case 'tool_call_io': return 'bg-[var(--accent-10)]'
-    case 'tool_usage': return 'bg-[var(--accent-10)]'
-    case 'keeper_metrics': return 'bg-[var(--accent-10)]'
-    default: return 'bg-text-dim'
-  }
+  return telemetrySourceMeta(source ?? '').trackClass
 }
 
 function eventLabel(entry: TelemetryEntry): string {

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="dashboard-chip dashboard-chip--control cursor-pointer px-[10px] py-[5px] text-[10px] font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -60,7 +60,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'overview',
     label: '오버뷰',
-    icon: '🏠',
+    icon: 'OV',
     description: '빠른 신호 및 브리핑 통합 화면',
     defaultTab: 'overview',
     tabs: ['overview'],
@@ -68,7 +68,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'monitoring',
     label: '모니터링',
-    icon: '📡',
+    icon: 'MN',
     description: '에이전트 디렉터리와 플릿 신호 관찰',
     defaultTab: 'monitoring',
     defaultParams: { section: 'agents' },
@@ -77,7 +77,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'command',
     label: '운영',
-    icon: '🎛️',
+    icon: 'OP',
     description: '실시간 개입과 거버넌스 판단/승인 운영 화면',
     defaultTab: 'command',
     defaultParams: { section: 'operations' },
@@ -86,7 +86,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'connectors',
     label: '커넥터',
-    icon: '🔌',
+    icon: 'IO',
     description: 'Discord, iMessage, Slack, Telegram 등 채널 sidecar 상태와 keeper 바인딩',
     defaultTab: 'connectors',
     defaultParams: { section: 'connector-status' },
@@ -95,7 +95,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'workspace',
     label: '작업',
-    icon: '📋',
+    icon: 'WK',
     description: '작업 게시판, 증명/판정, 계획 이력 탐색',
     defaultTab: 'workspace',
     defaultParams: { section: 'board' },
@@ -104,7 +104,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'lab',
     label: '실험실',
-    icon: '🧪',
+    icon: 'LB',
     description: '도구 진단과 실험 제어',
     defaultTab: 'lab',
     defaultParams: { section: 'tools' },
@@ -113,7 +113,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'logs',
     label: '로그',
-    icon: '📜',
+    icon: 'LG',
     description: '시스템 실행 로그',
     defaultTab: 'logs',
     tabs: ['logs'],

--- a/dashboard/src/config/telemetry-sources.ts
+++ b/dashboard/src/config/telemetry-sources.ts
@@ -15,15 +15,16 @@ interface TelemetrySourceMeta {
   sublabel: string
   color: string
   icon: string
+  trackClass: string
 }
 
 export const TELEMETRY_SOURCE_META: Record<TelemetrySourceKey, TelemetrySourceMeta> = {
-  keeper_metric: { label: 'Keeper 턴 로그', sublabel: 'heartbeat ~80%, 실제 추론 턴 ~20%', color: 'text-blue-400', icon: 'K' },
-  agent_event: { label: 'Agent 이벤트', sublabel: 'tool_called 다수, join/leave/task 포함', color: 'text-emerald-400', icon: 'A' },
-  tool_call_io: { label: 'Keeper Tool I/O', sublabel: 'keeper->tool 입출력 전체 기록', color: 'text-amber-400', icon: 'T' },
-  tool_usage: { label: 'Keeper 내부 호출', sublabel: 'keeper_internal caller 기록', color: 'text-purple-400', icon: 'U' },
-  oas_event: { label: 'OAS 이벤트', sublabel: 'native/custom event bus durable relay', color: 'text-rose-400', icon: 'O' },
-  tool_metric: { label: 'Tool 성능', sublabel: 'duration/success 측정', color: 'text-cyan-400', icon: 'M' },
+  keeper_metric: { label: 'Keeper 턴 로그', sublabel: 'heartbeat ~80%, 실제 추론 턴 ~20%', color: 'text-blue-400', icon: 'K', trackClass: 'bg-[var(--blue-400)]' },
+  agent_event: { label: 'Agent 이벤트', sublabel: 'tool_called 다수, join/leave/task 포함', color: 'text-emerald-400', icon: 'A', trackClass: 'bg-[var(--emerald)]' },
+  tool_call_io: { label: 'Keeper Tool I/O', sublabel: 'keeper->tool 입출력 전체 기록', color: 'text-amber-400', icon: 'T', trackClass: 'bg-[var(--amber-bright)]' },
+  tool_usage: { label: 'Keeper 내부 호출', sublabel: 'keeper_internal caller 기록', color: 'text-purple-400', icon: 'U', trackClass: 'bg-[var(--purple)]' },
+  oas_event: { label: 'OAS 이벤트', sublabel: 'native/custom event bus durable relay', color: 'text-rose-400', icon: 'O', trackClass: 'bg-[var(--rose)]' },
+  tool_metric: { label: 'Tool 성능', sublabel: 'duration/success 측정', color: 'text-cyan-400', icon: 'M', trackClass: 'bg-[var(--cyan)]' },
 }
 
 /** Get source label — returns Korean label, falls back to raw key. */
@@ -34,5 +35,5 @@ export function telemetrySourceLabel(source: string): string {
 /** Get full source meta — returns defaults for unknown sources. */
 export function telemetrySourceMeta(source: string): TelemetrySourceMeta {
   return TELEMETRY_SOURCE_META[source as TelemetrySourceKey]
-    ?? { label: source, sublabel: '', color: 'text-gray-400', icon: '?' }
+    ?? { label: source, sublabel: '', color: 'text-gray-400', icon: '?', trackClass: 'bg-[var(--text-dim)]' }
 }

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -11,8 +11,28 @@ describe('SSEEventTypeSchema', () => {
     expect(SSEEventTypeSchema.parse('keeper_heartbeat')).toBe('keeper_heartbeat')
   })
 
+  it('accepts live masc/ compatibility variants before switch normalization', () => {
+    expect(SSEEventTypeSchema.parse('masc/agent_joined')).toBe('masc/agent_joined')
+    expect(SSEEventTypeSchema.parse('masc/broadcast')).toBe('masc/broadcast')
+  })
+
+  it('accepts native OAS events emitted by the bridge', () => {
+    expect(SSEEventTypeSchema.parse('oas:agent_failed')).toBe('oas:agent_failed')
+    expect(SSEEventTypeSchema.parse('oas:context_compact_started')).toBe('oas:context_compact_started')
+  })
+
+  it('accepts open OAS families for custom and durable relays', () => {
+    expect(SSEEventTypeSchema.parse('oas:masc:keeper_gate')).toBe('oas:masc:keeper_gate')
+    expect(SSEEventTypeSchema.parse('oas:durable:llm_request')).toBe('oas:durable:llm_request')
+  })
+
   it('rejects an unknown event type', () => {
     const r = SSEEventTypeSchema.safeParse('this_is_not_a_real_event')
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects malformed oas prefixes outside the supported families', () => {
+    const r = SSEEventTypeSchema.safeParse('oas:unknown_family:event')
     expect(r.success).toBe(false)
   })
 })
@@ -108,6 +128,17 @@ describe('SSEMessageSchema', () => {
         gate: 'oas_completion',
         evidence: { reason: 'ok' },
         outcome: { kind: 'passed' },
+      },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts open-family OAS events without dropping the payload', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'oas:masc:keeper_gate',
+      payload: {
+        keeper_name: 'keeper-a',
+        decision: 'allow',
       },
     })
     expect(r.success).toBe(true)

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -1,10 +1,12 @@
 // Zod schema-at-boundary for SSE events from the MCP server.
 //
-// Parse gate: the top-level `type` discriminator is validated against a
-// closed enum so unknown event names surface as drift instead of becoming
-// silent no-ops. All other fields are declared as optional (mirrors the
-// existing `SSEEvent` interface) so new backend payload shapes don't hard-
-// fail the dashboard — but the field types are still checked when present.
+// Parse gate: the top-level `type` discriminator is validated against the
+// shared runtime contract in `types/sse.ts`. Exact event names stay closed,
+// while the intentionally open `oas:masc:*` / `oas:durable:*` families pass
+// through so relay namespaces do not silently disappear at the boundary. All
+// other fields are declared as optional (mirrors the existing `SSEEvent`
+// interface) so new backend payload shapes don't hard-fail the dashboard —
+// but the field types are still checked when present.
 //
 // TypeScript SSOT: src/types/sse.ts (SSEEvent interface).
 // Phase 1 goal: eliminate the `as SSEEvent` cast in src/sse.ts by giving
@@ -12,74 +14,22 @@
 // per-variant z.discriminatedUnion so handlers can switch exhaustively.
 
 import { z } from 'zod'
+import {
+  isKnownSSEEventType,
+  isOpenSSEEventType,
+  type SSEEventType,
+} from '../types/sse'
 
-// --- Type discriminator (closed enum) -------------------------------------
-// Mirror of `SSEEventType` in ../types/sse.ts. Keep in sync on add/remove.
-// Strict: an unknown `type` value causes safeParse to fail and the event
-// is dropped with a console.warn.
-export const SSEEventTypeSchema = z.enum([
-  'agent_joined',
-  'agent_left',
-  'broadcast',
-  'task_update',
-  'board_post',
-  'masc/board_post',
-  'board_comment',
-  'masc/board_comment',
-  'board_delete',
-  'masc/board_delete',
-  'post_created',
-  'comment_added',
-  'post_voted',
-  'comment_voted',
-  'heartbeat',
-  'keeper_heartbeat',
-  'keeper_handoff',
-  'masc/keeper_handoff',
-  'keeper_compaction',
-  'masc/keeper_compaction',
-  'keeper_guardrail',
-  'masc/keeper_guardrail',
-  'keeper_phase_changed',
-  'keeper_composite_changed',
-  'keeper_tool_call',
-  'masc/keeper_tool_call',
-  'keeper_tool_skipped',
-  'keeper_turn_complete',
-  'masc/keeper_turn_complete',
-  'client_input_approved',
-  'client_input_rejected',
-  'client_input_updated',
-  'governance_param_changed',
-  'approval:pending',
-  'approval:resolved',
-  'oas:masc:autonomy:agent_selected',
-  'oas:masc:autonomy:agent_decision',
-  'oas:masc:autonomy:agent_action_executed',
-  'oas:masc:keeper:snapshot',
-  'oas:masc:keeper:lifecycle',
-  'oas:masc:trust_updated',
-  'oas:masc:reputation_changed',
-  'oas:agent_started',
-  'oas:agent_completed',
-  'oas:tool_called',
-  'oas:tool_completed',
-  'oas:turn_started',
-  'oas:turn_completed',
-  'oas:context_compacted',
-  'oas:task_state_changed',
-  'oas:masc:harness:verdict_recorded',
-  'oas:masc:harness:pre_compact',
-  'oas:masc:harness:handoff',
-  'room_truth_snapshot',
-  'namespace_truth_snapshot',
-  'execution_snapshot',
-  'operator_snapshot',
-  'operator_digest',
-  'transport_health_snapshot',
-])
-
-export type SSEEventType = z.infer<typeof SSEEventTypeSchema>
+// --- Type discriminator ----------------------------------------------------
+// Exact names stay in ../types/sse.ts. `oas:masc:*` and `oas:durable:*`
+// remain open because the backend intentionally relays those namespaces
+// without a closed list at compile time.
+export const SSEEventTypeSchema = z.custom<SSEEventType>(
+  (value) =>
+    typeof value === 'string'
+    && (isKnownSSEEventType(value) || isOpenSSEEventType(value)),
+  { message: 'unknown SSE event type' },
+)
 
 // --- Attribution envelope (nested discriminated union) --------------------
 // OCaml SSOT: lib/attribution.mli. Structurally mirrors AttributionOutcome

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -790,7 +790,8 @@ function handleEvent(event: SSEEvent): void {
       )
       break
     }
-    case 'oas:task_state_changed': {
+    case 'oas:task_state_changed':
+    case 'oas:masc:task_transition': {
       const p = (event.payload ?? {}) as Record<string, unknown>
       const taskId = asString(p.task_id) ?? event.task_id ?? 'unknown'
       const fromState = asString(p.from_state)

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -4,6 +4,260 @@
 
 /* ═══ Dashboard ═══ */
 
+/* ── Shell ─────────────────────────────────────────────────────────────── */
+
+.dashboard-shell-app {
+  position: relative;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 14% 0%, rgba(251, 191, 36, 0.10), transparent 24%),
+    radial-gradient(circle at 88% 12%, rgba(71, 184, 255, 0.14), transparent 28%),
+    linear-gradient(180deg, #08111d 0%, #0d1729 48%, #09111d 100%);
+}
+
+.dashboard-shell-app::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.35;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(180deg, rgba(255, 255, 255, 0.4), transparent 82%);
+}
+
+.dashboard-topbar {
+  border-bottom: 1px solid rgba(138, 163, 211, 0.14);
+  background:
+    linear-gradient(135deg, rgba(9, 15, 25, 0.90), rgba(16, 24, 40, 0.88));
+  box-shadow:
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04),
+    0 12px 28px rgba(0, 0, 0, 0.20);
+}
+
+.dashboard-topbar::after {
+  content: "";
+  position: absolute;
+  inset: auto 20px 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(251, 191, 36, 0.45), rgba(71, 184, 255, 0.45), transparent);
+}
+
+.dashboard-topbar__eyebrow,
+.dashboard-rail__eyebrow,
+.dashboard-surface-lead__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.dashboard-topbar__title {
+  margin: 2px 0 0;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--text-strong);
+}
+
+.dashboard-topbar__summary {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.dashboard-shell-grid {
+  position: relative;
+}
+
+.dashboard-rail {
+  border: 1px solid rgba(138, 163, 211, 0.16);
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(10, 17, 29, 0.94), rgba(16, 24, 39, 0.96));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 18px 44px rgba(0, 0, 0, 0.24);
+}
+
+.dashboard-main-panel {
+  position: relative;
+  border-radius: 28px;
+  border: 1px solid rgba(138, 163, 211, 0.16);
+  background:
+    linear-gradient(180deg, rgba(9, 15, 25, 0.88), rgba(12, 19, 32, 0.98));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 24px 56px rgba(0, 0, 0, 0.26);
+}
+
+.dashboard-main-panel::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 20px;
+  right: 20px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.24), transparent);
+}
+
+.dashboard-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(138, 163, 211, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.dashboard-chip:hover {
+  border-color: rgba(71, 184, 255, 0.24);
+  background: rgba(255, 255, 255, 0.08);
+  text-decoration: none;
+}
+
+.dashboard-chip--meta,
+.dashboard-chip--control,
+.dashboard-chip--quiet {
+  padding: 5px 10px;
+}
+
+.dashboard-chip--live {
+  padding: 5px 10px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.03));
+}
+
+.dashboard-chip--control {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.dashboard-chip--quiet {
+  border-color: rgba(251, 191, 36, 0.18);
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.dashboard-surface-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 54px;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(71, 184, 255, 0.24);
+  background: linear-gradient(135deg, rgba(71, 184, 255, 0.16), rgba(71, 184, 255, 0.05));
+  color: var(--text-strong);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.dashboard-surface-code--small {
+  min-width: 44px;
+  height: 28px;
+  font-size: 10px;
+}
+
+.dashboard-surface-code--pill {
+  min-width: auto;
+  height: auto;
+  padding: 4px 10px;
+  font-size: 10px;
+}
+
+.dashboard-rail__surface {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  padding: 10px;
+  color: var(--text-strong);
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+
+.dashboard-rail__surface:hover {
+  border-color: rgba(138, 163, 211, 0.18);
+  background: rgba(255, 255, 255, 0.05);
+  text-decoration: none;
+}
+
+.dashboard-rail__surface.is-active {
+  border-color: rgba(71, 184, 255, 0.22);
+  background: linear-gradient(135deg, rgba(71, 184, 255, 0.14), rgba(251, 191, 36, 0.05));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.dashboard-rail__surface--collapsed {
+  justify-content: center;
+  padding: 8px 6px;
+}
+
+.dashboard-rail__section {
+  display: block;
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+  transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+
+.dashboard-rail__section:hover {
+  border-color: rgba(138, 163, 211, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-body);
+  text-decoration: none;
+}
+
+.dashboard-rail__section.is-active {
+  border-color: rgba(71, 184, 255, 0.16);
+  background: rgba(71, 184, 255, 0.10);
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.dashboard-surface-lead {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(138, 163, 211, 0.18);
+  border-radius: 24px;
+  padding: 20px 22px;
+  background:
+    linear-gradient(145deg, rgba(12, 19, 32, 0.92), rgba(18, 28, 45, 0.98));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 18px 44px rgba(0, 0, 0, 0.20);
+}
+
+.dashboard-surface-lead::after {
+  content: "";
+  position: absolute;
+  right: -40px;
+  bottom: -90px;
+  width: 240px;
+  height: 240px;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(71, 184, 255, 0.18), transparent 66%);
+}
+
+.dashboard-surface-lead__breadcrumb {
+  position: relative;
+  z-index: 1;
+}
+
 /* ── Collapsible Sections ── */
 .overview-section-collapsible > summary {
   transition: background 0.15s;

--- a/dashboard/src/styles/responsive.css
+++ b/dashboard/src/styles/responsive.css
@@ -1,23 +1,12 @@
 /* MASC Dashboard — Responsive Overrides (Task 292) */
 
 @media (max-width: 1024px) {
-  .app-shell {
-    width: calc(100% - 16px);
-    margin: 8px auto 16px;
+  .dashboard-shell-grid {
+    padding: 12px;
   }
 
-  .dashboard-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 16px;
-    padding: 16px;
-    min-height: auto;
-  }
-
-  .header-right {
-    width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
+  .dashboard-topbar {
+    padding: 12px 16px;
   }
 }
 
@@ -29,8 +18,16 @@
     --fs-2xs: 10px;
   }
 
-  .header-title-wrap h1 {
+  .dashboard-topbar__title {
     font-size: 22px;
+  }
+
+  .dashboard-topbar__summary {
+    font-size: 11px;
+  }
+
+  .dashboard-surface-lead {
+    padding: 16px 18px;
   }
 
   /* Stack all common grids */
@@ -55,22 +52,16 @@
 }
 
 @media (max-width: 480px) {
-  .dashboard-header {
-    padding: 12px;
+  .dashboard-topbar {
+    padding: 12px 14px;
   }
 
-  .header-title-wrap h1 {
+  .dashboard-topbar__title {
     font-size: 18px;
   }
 
-  .header-subtitle {
+  .dashboard-topbar__eyebrow,
+  .dashboard-surface-lead__eyebrow {
     font-size: 11px;
-  }
-
-  .tab-pill-bar {
-    overflow-x: auto;
-    justify-content: flex-start !important;
-    padding-bottom: 4px;
-    &::-webkit-scrollbar { display: none; }
   }
 }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -1,72 +1,98 @@
 // --- SSE Events ---
 
-export type SSEEventType =
-  | 'agent_joined'
-  | 'agent_left'
-  | 'broadcast'
-  | 'task_update'
-  | 'board_post'
-  | 'masc/board_post'
-  | 'board_comment'
-  | 'masc/board_comment'
-  | 'board_delete'
-  | 'masc/board_delete'
+// Runtime SSOT for exact non-pattern event names accepted from the server.
+// Keep the open OAS families below for relayed custom/durable namespaces.
+export const SSE_EVENT_TYPES = [
+  'agent_joined',
+  'agent_left',
+  'broadcast',
+  // Legacy/live namespaced compatibility variants still emitted by inline dispatch.
+  'masc/agent_joined',
+  'masc/agent_left',
+  'masc/broadcast',
+  'task_update',
+  'board_post',
+  'masc/board_post',
+  'board_comment',
+  'masc/board_comment',
+  'board_delete',
+  'masc/board_delete',
   // Path A board events (notifications/board envelope, unwrapped to params.type)
-  | 'post_created'
-  | 'comment_added'
-  | 'post_voted'
-  | 'comment_voted'
-  | 'heartbeat'
-  | 'keeper_heartbeat'
-  | 'keeper_handoff'
-  | 'masc/keeper_handoff'
-  | 'keeper_compaction'
-  | 'masc/keeper_compaction'
-  | 'keeper_guardrail'
-  | 'masc/keeper_guardrail'
-  | 'keeper_phase_changed'
-  | 'keeper_composite_changed'
-  | 'keeper_tool_call'
-  | 'masc/keeper_tool_call'
-  | 'keeper_tool_skipped'
-  | 'keeper_turn_complete'
-  | 'masc/keeper_turn_complete'
-  | 'client_input_approved'
-  | 'client_input_rejected'
-  | 'client_input_updated'
-  | 'governance_param_changed'
-  | 'approval:pending'
-  | 'approval:resolved'
+  'post_created',
+  'comment_added',
+  'post_voted',
+  'comment_voted',
+  'heartbeat',
+  'keeper_heartbeat',
+  'keeper_handoff',
+  'masc/keeper_handoff',
+  'keeper_compaction',
+  'masc/keeper_compaction',
+  'keeper_guardrail',
+  'masc/keeper_guardrail',
+  'keeper_phase_changed',
+  'keeper_composite_changed',
+  'keeper_tool_call',
+  'masc/keeper_tool_call',
+  'keeper_tool_skipped',
+  'keeper_turn_complete',
+  'masc/keeper_turn_complete',
+  'client_input_approved',
+  'client_input_rejected',
+  'client_input_updated',
+  'governance_param_changed',
+  'approval:pending',
+  'approval:resolved',
   // OAS bridge events (relayed from Event_bus via oas_sse_bridge)
-  | 'oas:masc:autonomy:agent_selected'
-  | 'oas:masc:autonomy:agent_decision'
-  | 'oas:masc:autonomy:agent_action_executed'
-  | 'oas:masc:keeper:snapshot'
-  | 'oas:masc:keeper:lifecycle'
-  | 'oas:masc:trust_updated'
-  | 'oas:masc:reputation_changed'
-  | 'oas:agent_started'
-  | 'oas:agent_completed'
-  | 'oas:agent_failed'
-  | 'oas:tool_called'
-  | 'oas:tool_completed'
-  | 'oas:turn_started'
-  | 'oas:turn_completed'
-  | 'oas:handoff_requested'
-  | 'oas:handoff_completed'
-  | 'oas:context_compacted'
-  | 'oas:task_state_changed'
+  'oas:agent_started',
+  'oas:agent_completed',
+  'oas:agent_failed',
+  'oas:tool_called',
+  'oas:tool_completed',
+  'oas:turn_started',
+  'oas:turn_completed',
+  'oas:handoff_requested',
+  'oas:handoff_completed',
+  'oas:context_compacted',
+  'oas:context_overflow_imminent',
+  'oas:context_compact_started',
+  'oas:content_replacement_replaced',
+  'oas:content_replacement_kept',
+  'oas:slot_scheduler_observed',
+  'oas:task_state_changed',
   // Harness observability events (#3165)
-  | 'oas:masc:harness:verdict_recorded'
-  | 'oas:masc:harness:pre_compact'
-  | 'oas:masc:harness:handoff'
+  'oas:masc:harness:verdict_recorded',
+  'oas:masc:harness:pre_compact',
+  'oas:masc:harness:handoff',
+  // Known MASC custom events currently projected in the dashboard.
+  'oas:masc:autonomy:agent_selected',
+  'oas:masc:autonomy:agent_decision',
+  'oas:masc:autonomy:agent_action_executed',
+  'oas:masc:keeper:snapshot',
+  'oas:masc:keeper:lifecycle',
+  'oas:masc:trust_updated',
+  'oas:masc:reputation_changed',
   // Server-push snapshot events (proactive cache broadcasts)
-  | 'room_truth_snapshot'
-  | 'namespace_truth_snapshot'
-  | 'execution_snapshot'
-  | 'operator_snapshot'
-  | 'operator_digest'
-  | 'transport_health_snapshot'
+  'room_truth_snapshot',
+  'namespace_truth_snapshot',
+  'execution_snapshot',
+  'operator_snapshot',
+  'operator_digest',
+  'transport_health_snapshot',
+] as const
+
+type StaticSSEEventType = typeof SSE_EVENT_TYPES[number]
+type OpenSSEEventType = `oas:masc:${string}` | `oas:durable:${string}`
+
+export type SSEEventType = StaticSSEEventType | OpenSSEEventType
+
+export function isKnownSSEEventType(value: string): value is StaticSSEEventType {
+  return (SSE_EVENT_TYPES as readonly string[]).includes(value)
+}
+
+export function isOpenSSEEventType(value: string): value is OpenSSEEventType {
+  return value.startsWith('oas:masc:') || value.startsWith('oas:durable:')
+}
 
 export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
 export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse'

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -14,6 +14,14 @@ let service_name = "masc.coordination.v1.MascCoordination"
 (** Current timestamp in milliseconds. *)
 let now_ms () = Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
+let decode_request_or_raise ~rpc decode bytes =
+  match decode bytes with
+  | Ok req -> req
+  | Error msg ->
+    Log.Transport.warn "gRPC %s decode failed: %s" rpc msg;
+    Grpc_core.Status.raise_error Grpc_core.Status.Invalid_argument
+      (Printf.sprintf "%s request decode failed: %s" rpc msg)
+
 (** Read a file to string. Returns [""] on non-cancellation errors.
     Propagates [Eio.Cancel.Cancelled] so cooperative cancellation is preserved. *)
 let read_file_safe path =
@@ -51,7 +59,9 @@ let task_info_of_task (task : Types.task) : T.task_info =
 
 (** Join handler: agent joins the coordination room. *)
 let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.JoinRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Join" T.JoinRequest.of_bytes_result bytes
+  in
   let result =
     try
       let msg =
@@ -108,7 +118,9 @@ let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string
 
 (** Leave handler: agent leaves the coordination room. *)
 let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.LeaveRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Leave" T.LeaveRequest.of_bytes_result bytes
+  in
   let result =
     try
       let msg = Coord.leave room_config ~agent_name:req.agent_name in
@@ -123,7 +135,9 @@ let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : strin
 
 (** Broadcast handler: send a message to all agents. *)
 let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req = T.BroadcastRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Broadcast" T.BroadcastRequest.of_bytes_result bytes
+  in
   let result =
     try
       let content =
@@ -190,7 +204,9 @@ let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes :
 let handle_tool_call
     (tool_dispatcher : string -> string -> (string, string) result)
     (bytes : string) : string =
-  let req = T.ToolCallRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"ToolCall" T.ToolCallRequest.of_bytes_result bytes
+  in
   let result =
     match tool_dispatcher req.tool_name req.arguments_json with
     | Ok result_json ->
@@ -377,7 +393,9 @@ let handle_subscribe
     (room_config : Coord_utils_backend_setup.config)
     (bytes : string)
   : string Grpc_eio.Stream.t =
-  let req = T.SubscribeRequest.of_bytes bytes in
+  let req =
+    decode_request_or_raise ~rpc:"Subscribe" T.SubscribeRequest.of_bytes_result bytes
+  in
   let stream = Grpc_eio.Stream.create 64 in
   Atomic.incr active_subscribe_streams;
   Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -16,15 +16,22 @@ module P = Masc_proto.Masc_coordination.Masc.Coordination.V1
 let encode to_proto msg =
   Ocaml_protoc_plugin.Writer.contents (to_proto msg)
 
+(** Deserialize a protobuf message from a binary string. *)
+let decode_result from_proto bytes =
+  let reader = Ocaml_protoc_plugin.Reader.create bytes in
+  match from_proto reader with
+  | Ok v -> Ok v
+  | Error e ->
+    Error
+      (Printf.sprintf "protobuf decode error: %s"
+         (Ocaml_protoc_plugin.Result.show_error e))
+
 (** Deserialize a protobuf message from a binary string.
     Raises [Invalid_argument] on parse error. *)
 let decode from_proto bytes =
-  let reader = Ocaml_protoc_plugin.Reader.create bytes in
-  match from_proto reader with
+  match decode_result from_proto bytes with
   | Ok v -> v
-  | Error e ->
-    invalid_arg (Printf.sprintf "protobuf decode error: %s"
-      (Ocaml_protoc_plugin.Result.show_error e))
+  | Error msg -> invalid_arg msg
 
 (** {1 Shared Types} *)
 
@@ -90,12 +97,20 @@ module JoinRequest = struct
     metadata : (string * string) list;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.JoinRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             capabilities = p.capabilities;
+             metadata = p.metadata;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.JoinRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      capabilities = p.capabilities;
-      metadata = p.metadata;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.JoinRequest.to_proto
@@ -136,11 +151,19 @@ module LeaveRequest = struct
     session_id : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.LeaveRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.LeaveRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.LeaveRequest.to_proto
@@ -178,13 +201,21 @@ module HeartbeatPing = struct
     current_task_id : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.HeartbeatPing.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             timestamp_ms = p.timestamp_ms;
+             current_task_id = p.current_task_id;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.HeartbeatPing.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      timestamp_ms = p.timestamp_ms;
-      current_task_id = p.current_task_id;
-    }
+    match of_bytes_result bytes with
+    | Ok ping -> ping
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.HeartbeatPing.to_proto
@@ -230,13 +261,21 @@ module SubscribeRequest = struct
     since_seq : int64;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.SubscribeRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             event_types = p.event_types;
+             since_seq = p.since_seq;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.SubscribeRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      event_types = p.event_types;
-      since_seq = p.since_seq;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 end
 
 module SubscribeRequest_serde = struct
@@ -287,13 +326,21 @@ module ToolCallRequest = struct
     arguments_json : string;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.ToolCallRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             session_id = p.session_id;
+             tool_name = p.tool_name;
+             arguments_json = p.arguments_json;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.ToolCallRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      session_id = p.session_id;
-      tool_name = p.tool_name;
-      arguments_json = p.arguments_json;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.ToolCallRequest.to_proto
@@ -338,12 +385,20 @@ module BroadcastRequest = struct
     mentions : string list;
   }
 
+  let of_bytes_result bytes =
+    match decode_result P.BroadcastRequest.from_proto bytes with
+    | Ok p ->
+        Ok
+          ({ agent_name = p.agent_name;
+             message = p.message;
+             mentions = p.mentions;
+           } : t)
+    | Error _ as err -> err
+
   let of_bytes bytes =
-    let p = decode P.BroadcastRequest.from_proto bytes in
-    { agent_name = p.agent_name;
-      message = p.message;
-      mentions = p.mentions;
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
 
   let to_bytes (t : t) =
     encode P.BroadcastRequest.to_proto

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -34,6 +34,7 @@ module JoinRequest : sig
     capabilities : string list;
     metadata : (string * string) list;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -54,6 +55,7 @@ module LeaveRequest : sig
     agent_name : string;
     session_id : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -76,6 +78,7 @@ module HeartbeatPing : sig
     timestamp_ms : int64;
     current_task_id : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -100,6 +103,7 @@ module SubscribeRequest : sig
     event_types : string list;
     since_seq : int64;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
 end
 
@@ -129,6 +133,7 @@ module ToolCallRequest : sig
     tool_name : string;
     arguments_json : string;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -152,6 +157,7 @@ module BroadcastRequest : sig
     message : string;
     mentions : string list;
   }
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -331,36 +331,28 @@ module Request = struct
 
   (** Read request body synchronously - uses Condition for proper synchronization *)
   let read_body_sync reqd =
-    let result = ref None in
-    let mutex = Eio.Mutex.create () in
-    let cond = Eio.Condition.create () in
+    let result_promise, resolve_result = Eio.Promise.create () in
+    let resolved = Atomic.make false in
+
+    let resolve_once outcome =
+      if Atomic.compare_and_set resolved false true then
+        Eio.Promise.resolve resolve_result outcome
+    in
 
     read_body_async_with_limit reqd
       ~on_body:(fun body_str ->
-        Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          result := Some (Ok body_str);
-          Eio.Condition.broadcast cond))
+        resolve_once (Ok body_str))
       ~on_error:(function
         | `Too_large max_bytes ->
             respond_too_large reqd max_bytes;
-            Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-              result := Some (Error (Printf.sprintf "Request too large (max %d bytes)" max_bytes));
-              Eio.Condition.broadcast cond)
+            resolve_once
+              (Error
+                 (Printf.sprintf "Request too large (max %d bytes)" max_bytes))
         | `Internal exn ->
             respond_internal_error reqd exn;
-            Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-              result := Some (Error (Printexc.to_string exn));
-              Eio.Condition.broadcast cond));
+            resolve_once (Error (Printexc.to_string exn)));
 
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      while !result = None do
-        Eio.Condition.await_no_mutex cond
-      done);
-
-    match !result with
-    | Some (Ok s) -> Ok s
-    | Some (Error msg) -> Error msg
-    | None -> Error "read_body_sync: impossible state"
+    Eio.Promise.await result_promise
 
   (** Get path from request target *)
   let path (request : Httpun.Request.t) =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -195,6 +195,18 @@ let find_pending_id ~keeper_name ~tool_name =
         else None)
     (Atomic.get pending) None
 
+let find_pending_id_in_map map ~keeper_name ~tool_name =
+  SMap.fold
+    (fun id entry acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+        if String.equal entry.keeper_name keeper_name
+           && String.equal entry.tool_name tool_name
+        then Some id
+        else None)
+    map None
+
 let sort_entries_by_requested_at entries =
   List.sort
     (fun left right ->
@@ -227,29 +239,24 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
 
 let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
   : string =
-  let created_entry = ref None in
-  atomic_update pending (fun map ->
-    match find_pending_id ~keeper_name ~tool_name with
-    | Some id -> 
-        created_entry := Some (`Existing id);
-        map
+  let rec submit () =
+    let map = Atomic.get pending in
+    match find_pending_id_in_map map ~keeper_name ~tool_name with
+    | Some id -> id
     | None ->
-        let id = generate_id () in
-        let entry =
-          create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
-            ~resolver:None ~on_resolution:(Some on_resolution)
-        in
-        created_entry := Some (`Created entry);
-        SMap.add id entry map
-  );
-  (* The ref is always set inside the CAS body above (both branches assign),
-     so None is unreachable. *)
-  match !created_entry with
-  | None -> assert false
-  | Some (`Existing id) -> id
-  | Some (`Created entry) ->
-    record_pending entry;
-    entry.id
+      let id = generate_id () in
+      let entry =
+        create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
+          ~resolver:None ~on_resolution:(Some on_resolution)
+      in
+      let updated = SMap.add id entry map in
+      if Atomic.compare_and_set pending map updated then (
+        record_pending entry;
+        id
+      ) else
+        submit ()
+  in
+  submit ()
 
 (* ── Resolve (operator action) ────────────────────────────── *)
 

--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -74,14 +74,22 @@ let parse_decision_line (line : string) : parsed_decision option =
 let tail_limit_for ~window_hours =
   max 500 (min 10_000 (window_hours * 180 + 200))
 
+let load_decision_lines ~decision_log_path ~window_hours =
+  try
+    Dated_jsonl.load_tail_lines decision_log_path
+      ~max_lines:(tail_limit_for ~window_hours)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "telemetry_feedback: failed to load decision log %s: %s"
+      decision_log_path (Printexc.to_string exn);
+    []
+
 let compute_stats ~decision_log_path ~window_hours =
   let now_ts = Unix.gettimeofday () in
   let window_start = now_ts -. (float_of_int window_hours *. 3600.0) in
-  let lines =
-    try Dated_jsonl.load_tail_lines decision_log_path
-          ~max_lines:(tail_limit_for ~window_hours)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
-  in
+  let lines = load_decision_lines ~decision_log_path ~window_hours in
   let decisions =
     lines
     |> List.filter_map parse_decision_line

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -41,14 +41,26 @@ let externalization_disabled () =
   | Some ("0" | "false" | "no" | "off") -> true
   | _ -> false
 
-(* Lazy singleton. Resolved once per process from [base_path_opt]; if no
-   base path is configured (typical in tests with [MASC_BASE_PATH ""]),
-   externalization is silently disabled. *)
-let blob_store_lazy : Tool_blob_store.t option Lazy.t =
-  lazy
-    (match Env_config_core.base_path_opt () with
-     | None -> None
-     | Some base_path -> Some (Tool_blob_store.create ~base_path))
+(* This path is exercised both under Eio and from tests/module-init code, so a
+   cross-context Atomic+Stdlib.Mutex memo is safer than Stdlib.Lazy.force. *)
+let blob_store_cache : Tool_blob_store.t option option Atomic.t = Atomic.make None
+let blob_store_cache_mu = Mutex.create ()
+
+let resolve_blob_store () =
+  match Atomic.get blob_store_cache with
+  | Some store -> store
+  | None ->
+      Mutex.protect blob_store_cache_mu (fun () ->
+        match Atomic.get blob_store_cache with
+        | Some store -> store
+        | None ->
+            let store =
+              match Env_config_core.base_path_opt () with
+              | None -> None
+              | Some base_path -> Some (Tool_blob_store.create ~base_path)
+            in
+            Atomic.set blob_store_cache (Some store);
+            store)
 
 (** Externalize [msg] when it exceeds the threshold AND a blob store is
     available; otherwise pass through unchanged. Best-effort — any
@@ -60,7 +72,7 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
     let threshold = externalize_threshold_bytes () in
     if String.length msg <= threshold then msg
     else
-      match Lazy.force blob_store_lazy with
+      match resolve_blob_store () with
       | None -> msg
       | Some store ->
           (try

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -29,13 +29,25 @@ type persisted_record = {
   duration_ms : float;
 }
 
-let parse_record (json : Yojson.Safe.t) : persisted_record option =
+let parse_record (json : Yojson.Safe.t)
+  : (persisted_record, string) result =
   let tool_name = Safe_ops.json_string_opt "tool_name" json in
   let success = Safe_ops.json_bool_opt "success" json in
   let duration_ms = Safe_ops.json_float_opt "duration_ms" json in
   match tool_name, success, duration_ms with
-  | Some tn, Some s, Some d -> Some { tool_name = tn; success = s; duration_ms = d }
-  | _ -> None
+  | Some tn, Some s, Some d -> Ok { tool_name = tn; success = s; duration_ms = d }
+  | _ ->
+    let missing =
+      [ ("tool_name", Option.is_none tool_name)
+      ; ("success", Option.is_none success)
+      ; ("duration_ms", Option.is_none duration_ms)
+      ]
+      |> List.filter_map (fun (field, is_missing) ->
+        if is_missing then Some field else None)
+    in
+    Error
+      (Printf.sprintf "missing required field(s): %s"
+         (String.concat ", " missing))
 
 (* ── Write queue ────────────────────────────────────── *)
 
@@ -132,12 +144,14 @@ let start_flush_fiber ~sw ~clock ~base_path =
 let restore ~base_path : int =
   let store = get_or_create_store ~base_path in
   let count = ref 0 in
+  let skipped = ref 0 in
+  let first_skip_reason = ref None in
   (try
      (* Read all available records (cap at 1M to avoid OOM on huge histories) *)
      let jsons = Dated_jsonl.read_recent store 1_000_000 in
      List.iter (fun json ->
        match parse_record json with
-       | Some r ->
+       | Ok r ->
          let result : Tool_result.t = {
            tool_name = r.tool_name;
            success = r.success;
@@ -146,8 +160,18 @@ let restore ~base_path : int =
          } in
          Tool_metrics.record result;
          incr count
-       | None -> ()
-     ) jsons
+       | Error reason ->
+         incr skipped;
+         if Option.is_none !first_skip_reason then
+           first_skip_reason := Some reason
+     ) jsons;
+     if !skipped > 0 then
+       Log.Metrics.warn
+         "tool_metrics_persist: skipped %d malformed restore record(s)%s"
+         !skipped
+         (match !first_skip_reason with
+          | Some reason -> Printf.sprintf " (first error: %s)" reason
+          | None -> "")
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -7,6 +7,7 @@
     serialization/deserialization via of_bytes/to_bytes. *)
 
 module T = Masc_mcp.Masc_grpc_types
+let malformed_protobuf = "\x0a\x05ab"
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -328,6 +329,60 @@ let test_protobuf_binary_format () =
     true
     (String.length bytes = 0 || bytes.[0] <> '{')
 
+let test_join_request_invalid_bytes_result () =
+  match T.JoinRequest.of_bytes_result malformed_protobuf with
+  | Ok _ -> Alcotest.fail "expected decode failure"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions decode" true
+        (String.starts_with ~prefix:"protobuf decode error:" msg)
+
+let test_tool_call_request_invalid_bytes_result () =
+  match T.ToolCallRequest.of_bytes_result malformed_protobuf with
+  | Ok _ -> Alcotest.fail "expected decode failure"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions decode" true
+        (String.starts_with ~prefix:"protobuf decode error:" msg)
+
+let test_join_handler_invalid_bytes_raise_grpc_status () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_temp_dir "masc-grpc-invalid-join" (fun dir ->
+      let room_config = Coord_utils.default_config dir in
+      let service =
+        Masc_mcp.Masc_grpc_service.create_service
+          ~room_config
+          ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+      in
+      match Grpc_eio.Service.get_method service "Join" with
+      | Some { handler = `Unary handler; _ } ->
+          (match handler malformed_protobuf with
+           | _ -> Alcotest.fail "expected typed gRPC decode error"
+           | exception exn ->
+               Alcotest.(check bool) "invalid_argument grpc error" true
+                 (String.starts_with
+                    ~prefix:"Grpc_error(INVALID_ARGUMENT:"
+                    (Printexc.to_string exn)))
+      | _ -> Alcotest.fail "Join unary handler missing")
+
+let test_subscribe_handler_invalid_bytes_raise_grpc_status () =
+  with_temp_dir "masc-grpc-invalid-subscribe" (fun dir ->
+      let room_config = Coord_utils.default_config dir in
+      let service =
+        Masc_mcp.Masc_grpc_service.create_service
+          ~room_config
+          ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+      in
+      match Grpc_eio.Service.get_method service "Subscribe" with
+      | Some { handler = `ServerStreaming handler; _ } ->
+          (match handler malformed_protobuf with
+           | _ -> Alcotest.fail "expected typed gRPC decode error"
+           | exception exn ->
+               Alcotest.(check bool) "invalid_argument grpc error" true
+                 (String.starts_with
+                    ~prefix:"Grpc_error(INVALID_ARGUMENT:"
+                    (Printexc.to_string exn)))
+      | _ -> Alcotest.fail "Subscribe server-streaming handler missing")
+
 (* ====== Test suite ====== *)
 
 let () =
@@ -349,12 +404,20 @@ let () =
           Alcotest.test_case "StatusResponse" `Quick test_status_response_roundtrip;
           Alcotest.test_case "empty_request" `Quick test_empty_request_handling;
           Alcotest.test_case "protobuf_binary" `Quick test_protobuf_binary_format;
+          Alcotest.test_case "JoinRequest invalid bytes result" `Quick
+            test_join_request_invalid_bytes_result;
+          Alcotest.test_case "ToolCallRequest invalid bytes result" `Quick
+            test_tool_call_request_invalid_bytes_result;
         ] );
       ( "service",
         [
           Alcotest.test_case "service_name" `Quick test_service_name;
           Alcotest.test_case "get_status_projects_backlog_tasks" `Quick
             test_get_status_projects_backlog_tasks;
+          Alcotest.test_case "join invalid bytes raise grpc status" `Quick
+            test_join_handler_invalid_bytes_raise_grpc_status;
+          Alcotest.test_case "subscribe invalid bytes raise grpc status" `Quick
+            test_subscribe_handler_invalid_bytes_raise_grpc_status;
         ] );
       ( "server_config",
         [

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -281,6 +281,41 @@ let test_background_pending_callback_and_keeper_lookup () =
   | Some _ -> Alcotest.fail "expected approve callback"
   | None -> Alcotest.fail "expected callback to fire"
 
+let test_background_pending_reuses_existing_entry () =
+  Eio_main.run @@ fun _env ->
+  let initial_count = AQ.pending_count () in
+  let first_callback = ref None in
+  let second_callback = ref None in
+  let id1 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> first_callback := Some decision)
+  in
+  let after_first = AQ.pending_count () in
+  let id2 =
+    AQ.submit_pending
+      ~keeper_name:"gate-keeper"
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [("kind", `String "continue_gate_required")])
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> second_callback := Some decision)
+  in
+  Alcotest.(check string) "existing pending id reused" id1 id2;
+  Alcotest.(check int) "only one entry created"
+    (initial_count + 1) after_first;
+  Alcotest.(check int) "second submit does not grow queue"
+    after_first (AQ.pending_count ());
+  (match AQ.resolve ~id:id1 ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  Alcotest.(check bool) "first callback fired" true
+    (match !first_callback with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
+  Alcotest.(check bool) "second callback not attached to duplicate submit" true
+    (Option.is_none !second_callback)
+
 (* ── 4. Approval callback integration ────────────────────── *)
 
 let test_callback_approves_low_risk () =
@@ -375,6 +410,8 @@ let () =
       Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
       Alcotest.test_case "background pending callback" `Quick
         test_background_pending_callback_and_keeper_lookup;
+      Alcotest.test_case "background pending reuses existing entry" `Quick
+        test_background_pending_reuses_existing_entry;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;


### PR DESCRIPTION
## Summary
- harden dashboard SSE parsing so live bridge/custom events stop getting dropped at the schema boundary
- move observatory marker colors onto the telemetry-source SSOT instead of a stale local switch
- refresh the dashboard shell hierarchy so the header, rail, and main stage read as distinct surfaces instead of one repeated glass treatment

## Details
- `dashboard/src/types/sse.ts`: centralize exact event names in `SSE_EVENT_TYPES`, add live `masc/*` compatibility variants, and allow open `oas:masc:*` / `oas:durable:*` families
- `dashboard/src/schemas/sse.ts`: validate event types against the shared runtime contract instead of a duplicated closed enum
- `dashboard/src/schemas/sse.test.ts`: add coverage for live `masc/*`, native OAS events, and open relay families
- `dashboard/src/sse.ts`: accept both legacy `oas:task_state_changed` and live `oas:masc:task_transition`
- `dashboard/src/config/telemetry-sources.ts` + `dashboard/src/components/observatory/event-track.ts`: derive event-track marker colors from telemetry SSOT
- `dashboard/src/app.ts`, `dashboard/src/components/dashboard-shell.ts`, `dashboard/src/styles/dashboard.css`, `dashboard/src/styles/responsive.css`, `dashboard/src/config/navigation.ts`: rebuild the shell chrome, introduce coded surface badges, and sharpen the rail/main hierarchy
- `dashboard/src/components/auth-status.ts` + `dashboard/src/components/theme-switch.ts`: move header controls onto the shared shell chip styling

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run src/schemas/sse.test.ts src/config/telemetry-sources.test.ts`
- `pnpm build`

## Notes
- `pnpm test` still fails in this environment outside the touched surface area, including `src/components/telemetry-unified.test.ts`, `src/lib/saved-signal.test.ts`, and `src/lib/persistent-signal.test.ts`, with `--localstorage-file` / localStorage-related failures. I did not fold that unrelated test-harness repair into this PR.
- Fixes #8376