### PR TITLE
fix(keeper): bind keeper_exec_board post_kind literal to Variant constructor

### DIFF
--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -35,7 +35,11 @@ let ensure_keeper_board_post_args ~author ~source = function
     in
     `Assoc
       ([ "author", `String author
-       ; "post_kind", `String "automation"
+       (* Variant SSOT: bind the literal to the Variant constructor so a
+          rename of [Automation_post] forces this site to update too.
+          Same pattern family as #8354 / #8392. *)
+       ; "post_kind", `String
+           (Board_core_classify.post_kind_to_string Board_types.Automation_post)
        ; "meta", keeper_board_meta ~source raw_meta
        ]
        @ fields)


### PR DESCRIPTION
## Summary
Smaller-scale follow-up to the Variant SSOT pattern series (#8354, #8392 etc).

`lib/keeper/keeper_exec_board.ml:38` emitted `("post_kind", ` ` `String "automation")` as a fixed literal. Intent: "this is an automation post" — i.e. the emission represents `Board_types.Automation_post`.

Hand-rolled fixed values are smaller risk than hand-rolled enums (no constructor-set drift), but a future rename of `Automation_post` would silently leave this site out of date. Binding the literal to the Variant constructor closes that gap.

## Change
\`\`\`diff
- ; "post_kind", `String "automation"
+ ; "post_kind", `String
+     (Board_core_classify.post_kind_to_string Board_types.Automation_post)
\`\`\`

## Pattern series
| PR | Scope | Variant |
|----|-------|---------|
| #8350 | dispatcher | task_action |
| #8357 | enum sites | task_status |
| #8362 | duplicate fold | task_status |
| #8368 | post-action emission | task_status |
| #8380 | enum sites | agent_status |
| #8389 | enum sites | agent_role |
| #8398 | enum sites | visibility |
| **THIS** | **fixed-value emission** | **post_kind** |

## Test plan
- [x] `dune build @check` clean
- [ ] CI green (only behavioral change is "automation" remains "automation"; behavior preserved by definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)