### PR TITLE
feat(doctor): add top-level sidecar and all commands

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -29,6 +29,7 @@ module Dashboard_mission = Masc_mcp.Dashboard_mission
 module Dashboard_mission_briefing = Masc_mcp.Dashboard_mission_briefing
 module Build_identity = Masc_mcp.Build_identity
 module Config_doctor = Masc_mcp.Config_doctor
+module Doctor_cli = Masc_mcp.Doctor_cli
 module Graphql_api = Masc_mcp.Graphql_api
 module Types = Types
 module Tempo = Masc_mcp.Tempo
@@ -300,6 +301,10 @@ let base_path =
 let doctor_json =
   let doc = "Emit machine-readable JSON instead of text output" in
   Arg.(value & flag & info ["json"] ~doc)
+
+let doctor_fix =
+  let doc = "Run available auto-fixes before re-checking sidecar doctors" in
+  Arg.(value & flag & info ["fix"] ~doc)
 
 (** Graceful shutdown exception *)
 (* Shutdown exception removed: graceful shutdown returns normally from
@@ -580,28 +585,226 @@ let run_cmd_exit host port base_path =
   run_cmd host port base_path;
   Cmd.Exit.ok
 
-let doctor_cmd_exit base_path as_json =
+let doctor_config_report base_path =
   let report =
     Config_doctor.analyze
       ~base_path_input:base_path
       ~default_base_path:(default_base_path ())
       ()
   in
+  let exit_code = Config_doctor.exit_code report in
+  let text = Config_doctor.render_text report in
+  let json = Config_doctor.to_yojson report in
+  (exit_code, text, json)
+
+let doctor_config_cmd_exit base_path as_json =
+  let exit_code, text, json = doctor_config_report base_path in
   let output =
     if as_json then
-      Config_doctor.to_yojson report |> Yojson.Safe.pretty_to_string
+      Yojson.Safe.pretty_to_string json
     else
-      Config_doctor.render_text report
+      text
   in
   print_endline output;
-  Config_doctor.exit_code report
+  exit_code
 
-let doctor_cmd =
+type doctor_block = {
+  title : string;
+  exit_code : int;
+  text : string;
+  json : Yojson.Safe.t;
+}
+
+let process_status_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 2
+
+let merge_env_binding key value =
+  let prefix = key ^ "=" in
+  Unix.environment ()
+  |> Array.to_list
+  |> List.filter (fun entry ->
+         let entry_len = String.length entry in
+         let prefix_len = String.length prefix in
+         entry_len < prefix_len
+         || not (String.equal (String.sub entry 0 prefix_len) prefix))
+  |> fun entries -> Array.of_list ((prefix ^ value) :: entries)
+
+let doctor_block_error ~title message =
+  {
+    title;
+    exit_code = 2;
+    text = message;
+    json =
+      `Assoc
+        [
+          ("title", `String title);
+          ("error", `String message);
+          ("summary", `Assoc [ ("ok", `Int 0); ("info", `Int 0); ("warn", `Int 0); ("error", `Int 1); ("skip", `Int 0) ]);
+        ];
+  }
+
+let render_doctor_blocks_text blocks =
+  blocks
+  |> List.map (fun block ->
+         let body = String.trim block.text in
+         if body = ""
+         then Printf.sprintf "## %s" block.title
+         else Printf.sprintf "## %s\n%s" block.title body)
+  |> String.concat "\n\n"
+
+let doctor_blocks_exit_code blocks =
+  List.fold_left (fun acc block -> max acc block.exit_code) 0 blocks
+
+let parse_json_output ~title raw =
+  try Ok (Yojson.Safe.from_string raw)
+  with Yojson.Json_error err ->
+    Error (doctor_block_error ~title
+             (Printf.sprintf "doctor JSON parse failed: %s\nraw output:\n%s" err raw))
+
+let run_sidecar_doctor_blocks ~base_path ~as_json ~fix request =
+  let title_of_sidecar sidecar =
+    Printf.sprintf "%s Sidecar Doctor" (Doctor_cli.sidecar_display_name sidecar)
+  in
+  match
+    Doctor_cli.find_repo_root ~cwd:(Sys.getcwd ()) ~exe_path:Sys.executable_name ()
+  with
+  | Error message ->
+      [ doctor_block_error ~title:"Sidecar Doctor" message ]
+  | Ok repo_root ->
+      let env =
+        merge_env_binding "MASC_BASE_PATH"
+          (Env_config.normalize_masc_base_path_input base_path)
+      in
+      Doctor_cli.sidecars_of_request request
+      |> List.map (fun sidecar ->
+             let title = title_of_sidecar sidecar in
+             let spec =
+               Doctor_cli.sidecar_run_spec ~repo_root ~sidecar ~json:as_json ~fix
+             in
+             let status, output =
+               Process_eio.run_argv_with_status ~timeout_sec:60.0 ~env spec.argv
+             in
+             let exit_code = process_status_exit_code status in
+             if as_json then
+               match parse_json_output ~title output with
+               | Ok json -> { title; exit_code; text = output; json }
+               | Error block -> block
+             else
+               {
+                 title;
+                 exit_code;
+                 text = output;
+                 json =
+                   `Assoc
+                     [
+                       ("title", `String title);
+                       ("raw_output", `String output);
+                       ("exit_code", `Int exit_code);
+                     ];
+               })
+
+let doctor_sidecar_request =
+  let doc =
+    Printf.sprintf
+      "Sidecar target (%s or all). Defaults to all."
+      (String.concat ", " (Doctor_cli.sidecar_names ()))
+  in
+  Arg.(value & pos 0 (some string) None & info [] ~docv:"TARGET" ~doc)
+
+let doctor_sidecar_cmd_exit base_path as_json fix request =
+  let parsed_request =
+    match request with
+    | None -> Ok None
+    | Some raw ->
+        (match Doctor_cli.sidecar_request_of_string raw with
+         | Ok parsed -> Ok (Some parsed)
+         | Error msg -> Error msg)
+  in
+  let blocks =
+    match parsed_request with
+    | Ok parsed ->
+        run_sidecar_doctor_blocks ~base_path ~as_json ~fix parsed
+    | Error message ->
+        [ doctor_block_error ~title:"Sidecar Doctor" message ]
+  in
+  let output =
+    if as_json then
+      `Assoc
+        [
+          ("kind", `String "sidecar");
+          ("sidecars", `List (List.map (fun block -> block.json) blocks));
+          ("exit_code", `Int (doctor_blocks_exit_code blocks));
+        ]
+      |> Yojson.Safe.pretty_to_string
+    else
+      render_doctor_blocks_text blocks
+  in
+  print_endline output;
+  doctor_blocks_exit_code blocks
+
+let doctor_all_cmd_exit base_path as_json fix =
+  let config_exit, config_text, config_json = doctor_config_report base_path in
+  let sidecar_blocks =
+    run_sidecar_doctor_blocks ~base_path ~as_json ~fix None
+  in
+  let blocks =
+    { title = "Config Doctor"; exit_code = config_exit; text = config_text; json = config_json }
+    :: sidecar_blocks
+  in
+  let output =
+    if as_json then
+      `Assoc
+        [
+          ("kind", `String "all");
+          ("config", config_json);
+          ("sidecars", `List (List.map (fun block -> block.json) sidecar_blocks));
+          ("exit_code", `Int (doctor_blocks_exit_code blocks));
+        ]
+      |> Yojson.Safe.pretty_to_string
+    else
+      render_doctor_blocks_text blocks
+  in
+  print_endline output;
+  doctor_blocks_exit_code blocks
+
+let doctor_config_cmd =
   let doc =
     "Diagnose config initialization, active config roots, and base-path shadowing"
   in
+  let info = Cmd.info "config" ~doc in
+  Cmd.v info Term.(const doctor_config_cmd_exit $ base_path $ doctor_json)
+
+let doctor_sidecar_cmd =
+  let doc =
+    "Run sidecar doctor checks (defaults to all registered sidecars)"
+  in
+  let info = Cmd.info "sidecar" ~doc in
+  Cmd.v info
+    Term.(
+      const doctor_sidecar_cmd_exit
+      $ base_path
+      $ doctor_json
+      $ doctor_fix
+      $ doctor_sidecar_request)
+
+let doctor_all_cmd =
+  let doc =
+    "Run config doctor plus all registered sidecar doctors"
+  in
+  let info = Cmd.info "all" ~doc in
+  Cmd.v info
+    Term.(const doctor_all_cmd_exit $ base_path $ doctor_json $ doctor_fix)
+
+let doctor_cmd =
+  let doc =
+    "Diagnostics front door: config, sidecar, or all"
+  in
   let info = Cmd.info "doctor" ~doc in
-  Cmd.v info Term.(const doctor_cmd_exit $ base_path $ doctor_json)
+  Cmd.group
+    ~default:Term.(const doctor_config_cmd_exit $ base_path $ doctor_json)
+    info
+    [ doctor_config_cmd; doctor_sidecar_cmd; doctor_all_cmd ]
 
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -45,6 +45,16 @@ $ ./run.sh doctor
 summary: 3 ok, 1 warn, 1 error
 ```
 
+현재 front door 는 top-level `doctor` 계층으로 정리한다:
+
+```bash
+./_build/default/bin/main_eio.exe doctor                # config doctor (기본)
+./_build/default/bin/main_eio.exe doctor config
+./_build/default/bin/main_eio.exe doctor sidecar        # 등록된 sidecar 전부
+./_build/default/bin/main_eio.exe doctor sidecar discord
+./_build/default/bin/main_eio.exe doctor all            # config + sidecar 전부
+```
+
 ## 계약
 
 ### Severity 5단계
@@ -123,8 +133,9 @@ class AutoFix:
 
 | 계층 | Doctor | 구현 상태 |
 |------|--------|-----------|
-| OCaml 서버 | `main_eio.exe doctor` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
-| Discord sidecar | `python -m src doctor` | 이 PR |
+| OCaml front door | `main_eio.exe doctor [config|sidecar|all]` | 이 PR에서 top-level entry 정리 |
+| OCaml config doctor | `main_eio.exe doctor` / `main_eio.exe doctor config` | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
+| Discord sidecar | `python -m src doctor` / `main_eio.exe doctor sidecar discord` | 이 PR |
 | Slack sidecar | `python -m src doctor` | 후속 |
 | Telegram sidecar | `python -m src doctor` | 후속 |
 | iMessage sidecar | `python -m src doctor` | 후속 |

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -1,0 +1,174 @@
+---
+status: design
+last_verified: 2026-04-18
+code_refs:
+  - sidecars/shared/gate_shared/doctor.py
+  - sidecars/discord-bot/src/doctor.py
+  - bin/main_eio.ml
+---
+
+# Doctor 아키텍처
+
+MASC 의 각 런타임 계층(OCaml 서버 / Python sidecar / 대시보드)이
+**동일한 진단 계약** 을 공유하도록 하는 설계 문서.
+
+`flutter doctor`, `brew doctor`, `rustup check`, `npm doctor` 의 공통 패턴을
+분해·일반화한 결과물이다.
+
+## 왜 필요한가
+
+운영 중 가장 자주 반복되는 질문은 언제나 같다:
+
+- "왜 바인딩이 안 돼요?"
+- "이 커넥터, 지금 살아있나요?"
+- "이 설정 파일이 진짜 반영된 게 맞나요?"
+
+현재는 각 질문마다 서로 다른 엔드포인트·로그·스크립트를 엮어서 설명해야 한다.
+Doctor 아키텍처는 이 질문을 **정해진 형식의 하나의 명령**으로 압축한다:
+
+```
+$ ./run.sh doctor
+# Discord Sidecar Doctor
+
+[✓] python >= 3.11  (3.12.4)
+[✓] discord.py installed  (2.4.0)
+[!] DISCORD_ADMIN_ROLE_ID
+    ↳ admin role 이 비어 있어 바인딩 명령 권한이 누구에게나 열립니다.
+      hint: 서버에서 역할을 만들고 ID 를 복사해 env 에 기록
+[✓] gate reachable  (http://localhost:8935/api/v1/gate/health → 200)
+[✗] binding paths writable
+    ↳ binding store: /var/gate (permission denied)
+      hint: 상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정
+      fix: 접근 권한이 없는 상위 디렉터리에 0755 시도
+        auto-fix 가능: doctor --fix
+
+summary: 3 ok, 1 warn, 1 error
+```
+
+## 계약
+
+### Severity 5단계
+
+| 단계 | 의미 | exit code 기여 |
+|------|------|----------------|
+| `ok` | 정상 | 0 |
+| `info` | 참고 정보 | 0 |
+| `warn` | 일부 기능 비활성 / 권장사항 누락 | 1 |
+| `error` | 실행 불가 | 2 |
+| `skip` | 전제가 부족해 검사를 건너뜀 | 0 |
+
+우선순위: `error > warn > (ok, info, skip)`. 하나라도 `error` 가 있으면 exit 2.
+
+### Check 데이터 모델
+
+```python
+@dataclass(frozen=True, slots=True)
+class Check:
+    name: str            # 화면에 표시할 짧은 이름
+    severity: Severity
+    message: str         # 사람이 읽는 설명 (warn/error 에서만 렌더됨)
+    detail: str = ""     # 수치·경로·버전 같은 보조 정보
+    hint: str | None = None        # 운영자가 직접 해야 할 조치
+    auto_fix: AutoFix | None = None
+    tags: tuple[str, ...] = ()
+```
+
+- `hint` = "이거 해라" (운영자가 직접).
+- `auto_fix` = "내가 해주겠다" (doctor --fix 로 실행).
+
+### AutoFix
+
+```python
+@dataclass(frozen=True, slots=True)
+class AutoFix:
+    description: str
+    command: str | None = None      # 복붙용 쉘 예시
+    callback: Callable[[], Awaitable[None]] | None = None
+```
+
+두 축 중 하나만 채워도 된다. `callback` 이 있으면 `doctor --fix` 에서
+실제 실행되고, 동일한 doctor 가 다시 한 바퀴 돌면서 결과를 재검증한다.
+
+## 출력 포맷
+
+### pretty (default)
+
+- `[✓]` / `[!]` / `[✗]` / `[i]` / `[·]` (skip)
+- TTY 일 때만 ANSI 색. 파이프/리다이렉트면 plain.
+- warn/error 만 세부 라인을 출력해서 정상 체크는 한 줄로 끝난다.
+
+### json
+
+```json
+{
+  "title": "Discord Sidecar Doctor",
+  "checks": [
+    {
+      "name": "gate reachable",
+      "severity": "ok",
+      "detail": "http://localhost:8935/api/v1/gate/health → 200",
+      "message": "",
+      "hint": null,
+      "auto_fix": null,
+      "tags": []
+    }
+  ],
+  "summary": {"ok": 4, "info": 0, "warn": 1, "error": 0, "skip": 0}
+}
+```
+
+대시보드 패널과 CI 스모크 테스트가 이 포맷을 파싱한다.
+
+## 현재 커버리지
+
+| 계층 | Doctor | 구현 상태 |
+|------|--------|-----------|
+| OCaml 서버 | `main_eio.exe doctor` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
+| Discord sidecar | `python -m src doctor` | 이 PR |
+| Slack sidecar | `python -m src doctor` | 후속 |
+| Telegram sidecar | `python -m src doctor` | 후속 |
+| iMessage sidecar | `python -m src doctor` | 후속 |
+| CLI connector | `python -m src doctor` | 후속 |
+| 대시보드 | `/api/v1/dashboard/doctor` 취합 패널 | 후속 |
+
+## Discord Sidecar Doctor 체크 목록
+
+| 이름 | 심각도 결정 기준 |
+|------|------------------|
+| `python >= 3.11` | 3.11 미만이면 error |
+| `discord.py installed` | 미설치 error, 2.4 미만 warn |
+| `DISCORD_BOT_TOKEN` | 미설정 error, 40자 미만 warn |
+| `GATE_BASE_URL` | 정보 표시 (항상 ok) |
+| `GATE_API_TOKEN policy` | 비-loopback 인데 토큰 없으면 error |
+| `DISCORD_ADMIN_ROLE_ID` | 빈 값이면 warn (권한 가드 없음) |
+| `DISCORD_KEEPER_MAP parses` | JSON 오류 error, 빈 맵 warn |
+| `gate reachable` | 연결 실패 error, 4xx warn |
+| `keeper names exist` | gate keepers 목록에 없는 이름이면 error |
+| `binding paths writable` | 쓰기 불가 error (`--fix` 로 chmod 시도) |
+| `legacy runtime paths` | `.masc/connectors/discord/*` 잔존 시 warn (자동 이관 안내) |
+
+## 확장 규칙
+
+새 Doctor 를 추가할 때 지켜야 하는 원칙:
+
+1. **독립성**: 각 체크는 다른 체크의 성공을 가정하지 않는다.
+   전제가 부족하면 `Severity.skip` 을 돌려준다.
+2. **읽기 전용이 기본**: `--fix` 가 오기 전까지 어떤 체크도
+   파일을 쓰거나 env 를 변경하지 않는다.
+3. **민감정보는 마스크**: 토큰·비밀번호는 앞뒤 4자만 노출한다.
+4. **네트워크 타임아웃은 3초**: 체크 하나가 run 전체를 막지 않도록.
+5. **한국어 설명 우선**: hint/message 는 운영자가 바로 따라할 수 있는
+   구체적인 행동으로 쓴다 ("설정 확인" 같은 모호한 문장은 금지).
+
+## 대시보드 패널 (후속)
+
+계획: `/api/v1/dashboard/doctor` 가 등록된 모든 Doctor 를 병렬 실행하고
+SSE 로 결과를 흘려보낸다. 대시보드 쪽은 각 커넥터별로 세부 섹션을 접어두고,
+red/yellow 가 있을 때만 자동으로 펼친다. `--fix` 버튼은 `callback_available`
+이 `true` 인 체크에만 노출한다.
+
+## 참고
+
+- `docs/CONFIG-DOCTOR.md` — OCaml 쪽 doctor SSOT
+- `docs/CONNECTOR-CONFIG-SCHEMA.md` — env 필드 레퍼런스
+- `docs/CONNECTOR-UI-DESIGN.md` — 대시보드 UX 가이드

--- a/lib/doctor_cli.ml
+++ b/lib/doctor_cli.ml
@@ -1,0 +1,118 @@
+(** Doctor_cli — pure helpers for top-level doctor command routing.
+
+    Keeps target parsing, repo-root discovery, and sidecar subprocess
+    spec assembly out of [bin/main_eio.ml] so the command shape is
+    testable without booting the server. *)
+
+type sidecar =
+  | Discord
+
+type sidecar_request =
+  | All
+  | Named of sidecar
+
+type sidecar_run_spec = {
+  sidecar : sidecar;
+  script_path : string;
+  argv : string list;
+}
+
+let sidecar_name = function
+  | Discord -> "discord"
+
+let sidecar_display_name = function
+  | Discord -> "Discord"
+
+let known_sidecars = [ Discord ]
+
+let sidecar_names () =
+  List.map sidecar_name known_sidecars
+
+let sidecar_request_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "all" -> Ok All
+  | "discord" -> Ok (Named Discord)
+  | other ->
+      Error
+        (Printf.sprintf
+           "unknown sidecar '%s' (expected one of: %s, all)"
+           other
+           (String.concat ", " (sidecar_names ())))
+
+let sidecar_request_to_string = function
+  | All -> "all"
+  | Named sidecar -> sidecar_name sidecar
+
+let sidecars_of_request = function
+  | None | Some All -> known_sidecars
+  | Some (Named sidecar) -> [ sidecar ]
+
+let sidecar_rel_dir = function
+  | Discord -> "sidecars/discord-bot"
+
+let sidecar_rel_script sidecar =
+  Filename.concat (sidecar_rel_dir sidecar) "run.sh"
+
+let ancestor_paths start =
+  let normalized =
+    Env_config.strip_path_trailing_slashes
+      (Env_config.normalize_masc_base_path_input start)
+  in
+  let rec loop path acc =
+    let next = Filename.dirname path in
+    if String.equal next path then
+      List.rev (path :: acc)
+    else
+      loop next (path :: acc)
+  in
+  if normalized = "" then [] else loop normalized []
+
+let uniq_keep_order paths =
+  let seen = Hashtbl.create 8 in
+  List.filter
+    (fun path ->
+      if path = "" || Hashtbl.mem seen path then
+        false
+      else (
+        Hashtbl.add seen path ();
+        true))
+    paths
+
+let absolute_path ~cwd path =
+  if Filename.is_relative path then Filename.concat cwd path else path
+
+let find_repo_root_with ~cwd ~exe_path ~file_exists () =
+  let exe_abs = absolute_path ~cwd exe_path in
+  let starts =
+    uniq_keep_order
+      [ cwd; Filename.dirname exe_abs ]
+  in
+  let has_sidecar_marker root =
+    file_exists (Filename.concat root (sidecar_rel_script Discord))
+  in
+  let rec find = function
+    | [] -> None
+    | root :: rest ->
+        if has_sidecar_marker root then Some root else find rest
+  in
+  starts
+  |> List.concat_map ancestor_paths
+  |> uniq_keep_order
+  |> find
+  |> function
+  | Some root -> Ok root
+  | None ->
+      Error
+        "doctor sidecar/all requires a repo checkout with sidecars/<name>/run.sh available"
+
+let find_repo_root ~cwd ~exe_path () =
+  find_repo_root_with ~cwd ~exe_path ~file_exists:Sys.file_exists ()
+
+let sidecar_run_spec ~repo_root ~sidecar ~json ~fix =
+  let script_path = Filename.concat repo_root (sidecar_rel_script sidecar) in
+  let argv =
+    [ "/bin/bash"; script_path; "doctor" ]
+    @ (if json then [ "--json" ] else [])
+    @ (if fix then [ "--fix" ] else [])
+  in
+  { sidecar; script_path; argv }

--- a/lib/dune
+++ b/lib/dune
@@ -77,6 +77,7 @@
    briefing_sections
    dashboard_mission_briefing
    drift_guard
+   doctor_cli
    server_utils
    server_auth
    server_voice_config

--- a/sidecars/discord-bot/run.sh
+++ b/sidecars/discord-bot/run.sh
@@ -9,6 +9,9 @@
 #   ./run.sh              start the bot (foreground, tees to today's log)
 #   ./run.sh tail         tail -F today's log file
 #   ./run.sh status       pretty-print the current status.json
+#   ./run.sh doctor       run health checks without starting the bot
+#   ./run.sh doctor --json   machine-readable check output
+#   ./run.sh doctor --fix    run available auto-fixes then recheck
 #
 # Designed to be safe to copy-paste: no background launches, no pid files.
 
@@ -64,6 +67,11 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  doctor)
+    cd "$(script_dir)"
+    shift || true
+    python -m src doctor "$@"
+    ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.
     if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
@@ -74,7 +82,7 @@ case "$cmd" in
     fi
     ;;
   *)
-    echo "Usage: $0 [start|stop|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status|doctor]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/discord-bot/src/__main__.py
+++ b/sidecars/discord-bot/src/__main__.py
@@ -1,4 +1,49 @@
-"""Entry point: python -m src"""
-from .bot import main
+"""Entry point: python -m src
+
+기본은 봇 기동. ``doctor`` subcommand 로 건강 점검만 실행한다.
+
+    python -m src                # 봇 기동
+    python -m src doctor         # 점검
+    python -m src doctor --json  # 점검 결과 JSON
+    python -m src doctor --fix   # 가능한 부분 자동 치유 후 재점검
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+from gate_shared import exit_code_for, render_json, render_pretty  # noqa: E402
+
+from .bot import main  # noqa: E402
+from .doctor import run_doctor  # noqa: E402
+
+
+def _run_doctor(argv: list[str]) -> int:
+    as_json = "--json" in argv
+    auto_fix = "--fix" in argv
+
+    async def run() -> int:
+        doctor = await run_doctor()
+        checks = await doctor.run()
+        if auto_fix:
+            checks = await doctor.run_auto_fixes(checks)
+        if as_json:
+            sys.stdout.write(render_json(doctor.title, checks))
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(render_pretty(doctor.title, checks))
+            sys.stdout.write("\n")
+        return exit_code_for(checks)
+
+    return asyncio.run(run())
+
+
+if len(sys.argv) > 1 and sys.argv[1] == "doctor":
+    raise SystemExit(_run_doctor(sys.argv[2:]))
 
 main()

--- a/sidecars/discord-bot/src/doctor.py
+++ b/sidecars/discord-bot/src/doctor.py
@@ -1,0 +1,454 @@
+"""Discord Sidecar Doctor — 실행 전 건강 점검.
+
+사용법::
+
+    python -m src doctor           # 사람용 출력
+    python -m src doctor --json    # 자동화용 JSON
+    python -m src doctor --fix     # 가능한 부분은 자동 치유
+
+각 체크는 ``gate_shared.doctor`` 의 ``Check`` 를 반환한다.
+
+다음을 확인한다:
+
+1. 필수 env (DISCORD_BOT_TOKEN, GATE_BASE_URL) 존재 여부
+2. GATE_API_TOKEN 규칙 (loopback 이 아니면 필수)
+3. DISCORD_KEEPER_MAP JSON 파싱 + 값이 비어있지 않은지
+4. Channel Gate (/api/v1/gate/health) 도달 가능 여부
+5. Gate 가 알고 있는 keeper 목록에 DISCORD_KEEPER_MAP 의 대상이 모두 존재하는지
+6. binding/audit/status/names 저장 경로의 상위 디렉터리 생성 가능 여부
+7. Legacy 경로 (`.masc/connectors/discord/*`) 잔존 여부 (있으면 자동 이관 힌트)
+8. DISCORD_ADMIN_ROLE_ID 가 비어 있는지 (비어 있으면 서버 권한 가드 없음 → warn)
+
+각 체크는 독립적이고, 이전 실패에 관계없이 모두 실행된다.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import sys
+from pathlib import Path
+
+_shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+import httpx  # noqa: E402
+
+from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
+
+from .config import BotConfig, get_config  # noqa: E402
+
+
+async def run_doctor() -> Doctor:
+    """체크들을 등록한 Doctor 인스턴스를 돌려준다."""
+
+    doc = Doctor("Discord Sidecar Doctor")
+    doc.register(check_python_version)
+    doc.register(check_discord_py_version)
+    doc.register(check_env_token)
+    doc.register(check_env_gate_url)
+    doc.register(check_env_api_token)
+    doc.register(check_admin_role_id)
+    doc.register(check_keeper_map_parses)
+    doc.register(check_gate_reachable)
+    doc.register(check_keeper_map_alignment)
+    doc.register(check_binding_paths_writable)
+    doc.register(check_legacy_runtime_paths)
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+async def check_python_version() -> Check:
+    major, minor = sys.version_info[:2]
+    ver = f"{major}.{minor}.{sys.version_info[2]}"
+    if (major, minor) < (3, 11):
+        return Check(
+            name="python >= 3.11",
+            severity=Severity.error,
+            message=f"Python {ver} is too old; discord.py 2.4 requires 3.11+",
+            detail=ver,
+            hint="uv venv --python 3.11 하거나 pyenv 로 3.11 활성화",
+        )
+    return Check(name="python >= 3.11", severity=Severity.ok, detail=ver, message="")
+
+
+async def check_discord_py_version() -> Check:
+    try:
+        ver = importlib.metadata.version("discord.py")
+    except importlib.metadata.PackageNotFoundError:
+        return Check(
+            name="discord.py installed",
+            severity=Severity.error,
+            message="discord.py 가 설치되어 있지 않습니다.",
+            hint="uv sync 또는 pip install -e .",
+        )
+    parts = ver.split(".")
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return Check(
+            name="discord.py installed",
+            severity=Severity.info,
+            detail=ver,
+            message="버전 문자열을 파싱할 수 없어 호환성 판단을 건너뜀",
+        )
+    if (major, minor) < (2, 4):
+        return Check(
+            name="discord.py installed",
+            severity=Severity.warn,
+            detail=ver,
+            message="discord.py 2.4 이상을 권장합니다.",
+            hint="uv sync --upgrade",
+        )
+    return Check(
+        name="discord.py installed",
+        severity=Severity.ok,
+        detail=ver,
+        message="",
+    )
+
+
+def _config_or_none() -> BotConfig | None:
+    try:
+        return get_config()
+    except Exception:  # pydantic ValidationError 포함
+        return None
+
+
+async def check_env_token() -> Check:
+    raw = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if not raw:
+        return Check(
+            name="DISCORD_BOT_TOKEN",
+            severity=Severity.error,
+            message="Discord 봇 토큰이 설정되지 않았습니다.",
+            hint="Discord Developer Portal → Bot → Reset Token 으로 발급 후 env 에 기록",
+            auto_fix=AutoFix(
+                description="`.env` 에 DISCORD_BOT_TOKEN=... 추가",
+                command='echo "DISCORD_BOT_TOKEN=<token>" >> .env',
+            ),
+        )
+    # Discord 토큰은 보통 59+ 문자. 노출은 피함.
+    masked = raw[:4] + "…" + raw[-4:] if len(raw) > 10 else "(too short)"
+    if len(raw) < 40:
+        return Check(
+            name="DISCORD_BOT_TOKEN",
+            severity=Severity.warn,
+            detail=masked,
+            message="토큰 길이가 예상보다 짧습니다. 만료 또는 오타를 의심하세요.",
+        )
+    return Check(name="DISCORD_BOT_TOKEN", severity=Severity.ok, detail=masked, message="")
+
+
+async def check_env_gate_url() -> Check:
+    raw = os.getenv("GATE_BASE_URL", "").strip() or "http://localhost:8935"
+    return Check(
+        name="GATE_BASE_URL",
+        severity=Severity.ok,
+        detail=raw,
+        message="",
+    )
+
+
+async def check_env_api_token() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="GATE_API_TOKEN policy",
+            severity=Severity.skip,
+            message="config 로드 실패로 규칙 검증을 건너뜀",
+        )
+    if cfg.gate_api_token:
+        return Check(
+            name="GATE_API_TOKEN policy",
+            severity=Severity.ok,
+            detail="token set",
+            message="",
+        )
+    if cfg.gate_base_url_is_loopback():
+        return Check(
+            name="GATE_API_TOKEN policy",
+            severity=Severity.info,
+            detail="loopback gate",
+            message="loopback 대상이므로 토큰 없이 통신이 허용됩니다.",
+        )
+    return Check(
+        name="GATE_API_TOKEN policy",
+        severity=Severity.error,
+        message="비-loopback gate 에 접근하려면 GATE_API_TOKEN 이 필요합니다.",
+        hint="MASC 서버 측 gate_api_token 과 동일한 값을 설정",
+    )
+
+
+async def check_admin_role_id() -> Check:
+    raw = os.getenv("DISCORD_ADMIN_ROLE_ID", "").strip()
+    if raw:
+        return Check(
+            name="DISCORD_ADMIN_ROLE_ID",
+            severity=Severity.ok,
+            detail=raw,
+            message="",
+        )
+    return Check(
+        name="DISCORD_ADMIN_ROLE_ID",
+        severity=Severity.warn,
+        message="admin role 이 비어 있어 Discord 쪽 바인딩 명령 권한이 누구에게나 열립니다.",
+        hint="서버에서 역할을 만들고 ID 를 복사해 env 에 기록",
+    )
+
+
+async def check_keeper_map_parses() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="DISCORD_KEEPER_MAP parses",
+            severity=Severity.skip,
+            message="config 로드 실패로 검증 건너뜀",
+        )
+    try:
+        parsed = cfg.keeper_map()
+    except json.JSONDecodeError as exc:
+        return Check(
+            name="DISCORD_KEEPER_MAP parses",
+            severity=Severity.error,
+            message=f"JSON 파싱 실패: {exc}",
+            hint='형식 예: {"123456789012345678":"keeper_name"}',
+        )
+    if not parsed:
+        return Check(
+            name="DISCORD_KEEPER_MAP parses",
+            severity=Severity.warn,
+            detail="empty map",
+            message="채널↔키퍼 바인딩이 비어 있습니다. 대시보드 또는 API 로 추가하세요.",
+            hint="POST /api/v1/gate/connector/bind?name=discord",
+        )
+    return Check(
+        name="DISCORD_KEEPER_MAP parses",
+        severity=Severity.ok,
+        detail=f"{len(parsed)} binding(s)",
+        message="",
+    )
+
+
+async def check_gate_reachable() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="gate reachable",
+            severity=Severity.skip,
+            message="config 로드 실패로 검증 건너뜀",
+        )
+    url = cfg.gate_health_url()
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(url)
+    except httpx.ConnectError as exc:
+        return Check(
+            name="gate reachable",
+            severity=Severity.error,
+            detail=url,
+            message=f"연결 실패: {exc}",
+            hint="MASC 서버가 기동되어 있는지 확인 (./start-masc-mcp.sh)",
+        )
+    except httpx.HTTPError as exc:
+        return Check(
+            name="gate reachable",
+            severity=Severity.warn,
+            detail=url,
+            message=f"HTTP 오류: {exc}",
+        )
+    if resp.status_code >= 500:
+        return Check(
+            name="gate reachable",
+            severity=Severity.error,
+            detail=f"{url} → {resp.status_code}",
+            message="서버가 응답하지만 내부 오류 상태입니다.",
+        )
+    if resp.status_code >= 400:
+        return Check(
+            name="gate reachable",
+            severity=Severity.warn,
+            detail=f"{url} → {resp.status_code}",
+            message="인증 또는 경로 문제일 수 있습니다.",
+        )
+    return Check(
+        name="gate reachable",
+        severity=Severity.ok,
+        detail=f"{url} → {resp.status_code}",
+        message="",
+    )
+
+
+async def check_keeper_map_alignment() -> Check:
+    """DISCORD_KEEPER_MAP 에 적힌 키퍼 이름이 실제 gate 의 keepers 목록에 있는지."""
+
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="keeper names exist",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    keepers_expected = set(cfg.keeper_map().values())
+    if not keepers_expected:
+        return Check(
+            name="keeper names exist",
+            severity=Severity.skip,
+            message="바인딩이 비어 있어 정렬 확인을 건너뜀",
+        )
+    base = cfg.gate_base_url.rstrip("/")
+    url = f"{base}/api/v1/gate/keepers"
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {cfg.gate_api_token}"}
+                if cfg.gate_api_token
+                else {},
+            )
+    except httpx.HTTPError as exc:
+        return Check(
+            name="keeper names exist",
+            severity=Severity.warn,
+            detail=url,
+            message=f"keepers 목록을 가져오지 못했습니다: {exc}",
+        )
+    if resp.status_code >= 400:
+        return Check(
+            name="keeper names exist",
+            severity=Severity.warn,
+            detail=f"{resp.status_code}",
+            message="keepers 엔드포인트가 오류 응답. 토큰/권한 확인 필요.",
+        )
+    try:
+        body = resp.json()
+        known = {str(k) for k in _extract_keeper_names(body)}
+    except (json.JSONDecodeError, ValueError):
+        return Check(
+            name="keeper names exist",
+            severity=Severity.warn,
+            message="keepers 응답을 파싱하지 못했습니다.",
+        )
+    missing = sorted(keepers_expected - known)
+    if missing:
+        return Check(
+            name="keeper names exist",
+            severity=Severity.error,
+            detail=", ".join(missing),
+            message="KEEPER_MAP 에 적힌 대상이 서버에 등록돼 있지 않습니다.",
+            hint="config/keepers/*.toml 또는 runtime 등록을 확인",
+        )
+    return Check(
+        name="keeper names exist",
+        severity=Severity.ok,
+        detail=f"{len(keepers_expected)} bound / {len(known)} registered",
+        message="",
+    )
+
+
+def _extract_keeper_names(body: object) -> list[str]:
+    """gate /keepers 응답에서 이름 필드를 보수적으로 추출한다."""
+
+    if isinstance(body, list):
+        names: list[str] = []
+        for item in body:  # type: ignore[assignment]
+            if isinstance(item, dict) and "name" in item:
+                name = item.get("name")  # type: ignore[assignment]
+                if isinstance(name, str):
+                    names.append(name)
+            elif isinstance(item, str):
+                names.append(item)
+        return names
+    if isinstance(body, dict):
+        items = body.get("keepers")  # type: ignore[assignment]
+        if isinstance(items, list):
+            return _extract_keeper_names(items)
+    return []
+
+
+async def check_binding_paths_writable() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="binding paths writable",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    candidates: list[tuple[str, Path]] = [
+        ("binding store", cfg.binding_store_path()),
+        ("binding audit", cfg.binding_audit_path()),
+        ("status", cfg.status_path()),
+        ("names", cfg.names_path()),
+    ]
+    unwritable: list[str] = []
+    auto_fix_targets: list[Path] = []
+    for label, path in candidates:
+        parent = path.parent
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            unwritable.append(f"{label}: {parent} ({exc.strerror or exc})")
+            continue
+        if not os.access(parent, os.W_OK):
+            unwritable.append(f"{label}: {parent} (permission denied)")
+            auto_fix_targets.append(parent)
+    if not unwritable:
+        return Check(
+            name="binding paths writable",
+            severity=Severity.ok,
+            detail=f"{len(candidates)} paths",
+            message="",
+        )
+
+    async def _attempt_chmod() -> None:
+        for p in auto_fix_targets:
+            try:
+                p.chmod(0o755)
+            except OSError:
+                pass
+
+    return Check(
+        name="binding paths writable",
+        severity=Severity.error,
+        message="; ".join(unwritable),
+        hint="상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정",
+        auto_fix=AutoFix(
+            description="접근 권한이 없는 상위 디렉터리에 0755 시도",
+            callback=_attempt_chmod if auto_fix_targets else None,
+        ),
+    )
+
+
+async def check_legacy_runtime_paths() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="legacy runtime paths",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    migrations = cfg.legacy_runtime_migrations()
+    present: list[tuple[str, Path, Path]] = [
+        m for m in migrations if m[1].exists()
+    ]
+    if not present:
+        return Check(
+            name="legacy runtime paths",
+            severity=Severity.ok,
+            detail="none",
+            message="",
+        )
+    describe = ", ".join(f"{label}: {src} → {dst}" for label, src, dst in present)
+    return Check(
+        name="legacy runtime paths",
+        severity=Severity.warn,
+        detail=f"{len(present)} legacy file(s)",
+        message=f"구 레이아웃 잔존: {describe}",
+        hint="봇을 한 번 기동하면 자동 이관됩니다 (storage_migration.py)",
+    )

--- a/sidecars/discord-bot/src/doctor.py
+++ b/sidecars/discord-bot/src/doctor.py
@@ -6,20 +6,7 @@
     python -m src doctor --json    # 자동화용 JSON
     python -m src doctor --fix     # 가능한 부분은 자동 치유
 
-각 체크는 ``gate_shared.doctor`` 의 ``Check`` 를 반환한다.
-
-다음을 확인한다:
-
-1. 필수 env (DISCORD_BOT_TOKEN, GATE_BASE_URL) 존재 여부
-2. GATE_API_TOKEN 규칙 (loopback 이 아니면 필수)
-3. DISCORD_KEEPER_MAP JSON 파싱 + 값이 비어있지 않은지
-4. Channel Gate (/api/v1/gate/health) 도달 가능 여부
-5. Gate 가 알고 있는 keeper 목록에 DISCORD_KEEPER_MAP 의 대상이 모두 존재하는지
-6. binding/audit/status/names 저장 경로의 상위 디렉터리 생성 가능 여부
-7. Legacy 경로 (`.masc/connectors/discord/*`) 잔존 여부 (있으면 자동 이관 힌트)
-8. DISCORD_ADMIN_ROLE_ID 가 비어 있는지 (비어 있으면 서버 권한 가드 없음 → warn)
-
-각 체크는 독립적이고, 이전 실패에 관계없이 모두 실행된다.
+등록된 체크 목록은 ``run_doctor`` 의 ``register`` 호출이 SSOT.
 """
 
 from __future__ import annotations
@@ -35,8 +22,10 @@ if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
 import httpx  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
 from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
+from gate_shared.doctor import NETWORK_TIMEOUT_SEC  # noqa: E402
 
 from .config import BotConfig, get_config  # noqa: E402
 
@@ -117,7 +106,7 @@ async def check_discord_py_version() -> Check:
 def _config_or_none() -> BotConfig | None:
     try:
         return get_config()
-    except Exception:  # pydantic ValidationError 포함
+    except (ValidationError, OSError):
         return None
 
 
@@ -246,7 +235,7 @@ async def check_gate_reachable() -> Check:
         )
     url = cfg.gate_health_url()
     try:
-        async with httpx.AsyncClient(timeout=3.0) as client:
+        async with httpx.AsyncClient(timeout=NETWORK_TIMEOUT_SEC) as client:
             resp = await client.get(url)
     except httpx.ConnectError as exc:
         return Check(
@@ -305,7 +294,7 @@ async def check_keeper_map_alignment() -> Check:
     base = cfg.gate_base_url.rstrip("/")
     url = f"{base}/api/v1/gate/keepers"
     try:
-        async with httpx.AsyncClient(timeout=3.0) as client:
+        async with httpx.AsyncClient(timeout=NETWORK_TIMEOUT_SEC) as client:
             resp = await client.get(
                 url,
                 headers={"Authorization": f"Bearer {cfg.gate_api_token}"}
@@ -407,11 +396,16 @@ async def check_binding_paths_writable() -> Check:
         )
 
     async def _attempt_chmod() -> None:
+        # Auto-fix failure must be observable: silent pass makes the follow-up
+        # rerun look identical to "fix didn't run" from the operator's side.
         for p in auto_fix_targets:
             try:
                 p.chmod(0o755)
-            except OSError:
-                pass
+            except OSError as exc:
+                print(
+                    f"[doctor] chmod 0755 {p} failed: {exc.strerror or exc}",
+                    file=sys.stderr,
+                )
 
     return Check(
         name="binding paths writable",

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -1,6 +1,28 @@
 """Shared connector components for MASC Channel Gate sidecars."""
 
-from .gate_response import GateResponse
+from .doctor import (
+    AutoFix,
+    Check,
+    CheckFn,
+    Doctor,
+    Severity,
+    exit_code_for,
+    render_json,
+    render_pretty,
+)
 from .gate_client_base import BreakerSnapshot, GateClientBase
+from .gate_response import GateResponse
 
-__all__ = ["BreakerSnapshot", "GateClientBase", "GateResponse"]
+__all__ = [
+    "AutoFix",
+    "BreakerSnapshot",
+    "Check",
+    "CheckFn",
+    "Doctor",
+    "GateClientBase",
+    "GateResponse",
+    "Severity",
+    "exit_code_for",
+    "render_json",
+    "render_pretty",
+]

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -1,6 +1,7 @@
 """Shared connector components for MASC Channel Gate sidecars."""
 
 from .doctor import (
+    NETWORK_TIMEOUT_SEC,
     AutoFix,
     Check,
     CheckFn,
@@ -21,6 +22,7 @@ __all__ = [
     "Doctor",
     "GateClientBase",
     "GateResponse",
+    "NETWORK_TIMEOUT_SEC",
     "Severity",
     "exit_code_for",
     "render_json",

--- a/sidecars/shared/gate_shared/doctor.py
+++ b/sidecars/shared/gate_shared/doctor.py
@@ -1,0 +1,264 @@
+"""Doctor framework for MASC connector sidecars.
+
+진단(Diagnose) → 보고(Report) → 힌트(Hint) → 자가치유(Fix) 의 네 단계를 표준화한다.
+각 커넥터는 ``Check`` 들을 등록하고 ``Doctor.run()`` 으로 실행한다.
+
+외모는 ``flutter doctor`` / ``brew doctor`` / ``rustup check`` 를 참고한다:
+
+    [✓] gate reachable (http://localhost:8935)
+    [!] DISCORD_ADMIN_ROLE_ID not set
+        ↳ 서버 권한 가드가 열려 있습니다. 역할 ID 를 설정하세요.
+          fix: export DISCORD_ADMIN_ROLE_ID=<role_id>
+    [✗] binding store path not writable
+        ↳ .gate/runtime/discord/bindings.json 을 만들 수 없습니다.
+          auto-fix 가능: doctor --fix
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Final
+
+__all__ = [
+    "AutoFix",
+    "Check",
+    "CheckFn",
+    "Doctor",
+    "Severity",
+    "render_pretty",
+    "render_json",
+]
+
+
+class Severity(str, Enum):
+    """체크 심각도.
+
+    - ``ok``: 정상. 추가 조치 불필요.
+    - ``info``: 참고용 정보. 동작에는 영향 없음.
+    - ``warn``: 일부 기능이 비활성화되거나 권장 설정이 빠짐.
+    - ``error``: 실행 자체가 불가능. 반드시 조치 필요.
+    - ``skip``: 사전 조건이 충족되지 않아 검사를 건너뜀.
+    """
+
+    ok = "ok"
+    info = "info"
+    warn = "warn"
+    error = "error"
+    skip = "skip"
+
+
+@dataclass(frozen=True, slots=True)
+class AutoFix:
+    """자동 치유 힌트.
+
+    ``command`` 는 복사해서 실행할 수 있는 쉘 예시.
+    ``callback`` 는 ``doctor --fix`` 시 실제로 호출되는 함수.
+    둘 중 하나만 채우면 되며, 양쪽 모두 제공 시 ``callback`` 가 우선한다.
+    """
+
+    description: str
+    command: str | None = None
+    callback: Callable[[], Awaitable[None]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Check:
+    """단일 진단 결과.
+
+    ``detail`` 에는 사용자가 바로 참고할 수 있는 수치/경로를 담는다.
+    예: 파일 크기, URL, PID, 버전.
+    """
+
+    name: str
+    severity: Severity
+    message: str
+    detail: str = ""
+    hint: str | None = None
+    auto_fix: AutoFix | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+CheckFn = Callable[[], Awaitable[Check]]
+
+
+_SYMBOL: Final[dict[Severity, str]] = {
+    Severity.ok: "[✓]",
+    Severity.info: "[i]",
+    Severity.warn: "[!]",
+    Severity.error: "[✗]",
+    Severity.skip: "[·]",
+}
+
+# ANSI 는 TTY 일 때만 켠다. json / CI 로그에는 plain text.
+_COLOR: Final[dict[Severity, str]] = {
+    Severity.ok: "\x1b[32m",
+    Severity.info: "\x1b[36m",
+    Severity.warn: "\x1b[33m",
+    Severity.error: "\x1b[31m",
+    Severity.skip: "\x1b[90m",
+}
+_RESET: Final[str] = "\x1b[0m"
+
+
+def _colorize(text: str, sev: Severity, *, use_color: bool) -> str:
+    if not use_color:
+        return text
+    return f"{_COLOR[sev]}{text}{_RESET}"
+
+
+def render_pretty(
+    title: str,
+    checks: Sequence[Check],
+    *,
+    use_color: bool | None = None,
+) -> str:
+    """사람이 읽기 좋은 출력 ( ``flutter doctor`` 풍)."""
+
+    if use_color is None:
+        use_color = sys.stdout.isatty()
+
+    lines: list[str] = []
+    lines.append(f"# {title}")
+    lines.append("")
+    for c in checks:
+        sym = _colorize(_SYMBOL[c.severity], c.severity, use_color=use_color)
+        head = f"{sym} {c.name}"
+        if c.detail:
+            head += f"  ({c.detail})"
+        lines.append(head)
+        if c.severity == Severity.ok:
+            continue
+        if c.message:
+            lines.append(f"    ↳ {c.message}")
+        if c.hint:
+            lines.append(f"      hint: {c.hint}")
+        if c.auto_fix is not None:
+            lines.append(f"      fix: {c.auto_fix.description}")
+            if c.auto_fix.command:
+                lines.append(f"        $ {c.auto_fix.command}")
+            if c.auto_fix.callback is not None:
+                lines.append("        auto-fix 가능: doctor --fix")
+    lines.append("")
+    counts = _tally(checks)
+    summary = ", ".join(
+        f"{counts[s]} {s.value}" for s in Severity if counts[s] > 0
+    )
+    lines.append(f"summary: {summary or '0 checks'}")
+    return "\n".join(lines)
+
+
+def render_json(title: str, checks: Sequence[Check]) -> str:
+    payload = {
+        "title": title,
+        "checks": [
+            {
+                "name": c.name,
+                "severity": c.severity.value,
+                "message": c.message,
+                "detail": c.detail,
+                "hint": c.hint,
+                "auto_fix": None
+                if c.auto_fix is None
+                else {
+                    "description": c.auto_fix.description,
+                    "command": c.auto_fix.command,
+                    "callback_available": c.auto_fix.callback is not None,
+                },
+                "tags": list(c.tags),
+            }
+            for c in checks
+        ],
+        "summary": {s.value: _tally(checks)[s] for s in Severity},
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _tally(checks: Sequence[Check]) -> dict[Severity, int]:
+    out: dict[Severity, int] = {s: 0 for s in Severity}
+    for c in checks:
+        out[c.severity] += 1
+    return out
+
+
+def exit_code_for(checks: Sequence[Check]) -> int:
+    """관례: 0 = 건강, 1 = 조치 필요, 2 = 실행 불가.
+
+    - error 가 하나라도 있으면 2
+    - warn 이 있고 error 는 없으면 1
+    - 나머지는 0
+    """
+
+    counts = _tally(checks)
+    if counts[Severity.error] > 0:
+        return 2
+    if counts[Severity.warn] > 0:
+        return 1
+    return 0
+
+
+class Doctor:
+    """체크 등록 → 실행 → 렌더링 오케스트레이터.
+
+    사용 예::
+
+        doctor = Doctor("Discord Sidecar Doctor")
+        doctor.register(check_env)
+        doctor.register(check_gate_reachable)
+        checks = await doctor.run()
+        print(render_pretty(doctor.title, checks))
+    """
+
+    def __init__(self, title: str) -> None:
+        self._title = title
+        self._checks: list[CheckFn] = []
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    def register(self, check: CheckFn) -> None:
+        self._checks.append(check)
+
+    def register_many(self, checks: Iterable[CheckFn]) -> None:
+        for c in checks:
+            self.register(c)
+
+    async def run(self) -> list[Check]:
+        """모든 체크를 순차 실행한다.
+
+        체크 내부 예외는 ``Severity.error`` 로 승격된다.
+        하나의 체크가 실패해도 나머지는 계속 실행된다.
+        """
+
+        results: list[Check] = []
+        for fn in self._checks:
+            try:
+                results.append(await fn())
+            except Exception as exc:  # 진단 도구 자체는 멈추면 안 된다.
+                results.append(
+                    Check(
+                        name=getattr(fn, "__name__", "unknown_check"),
+                        severity=Severity.error,
+                        message=f"check raised: {exc.__class__.__name__}: {exc}",
+                    )
+                )
+        return results
+
+    async def run_auto_fixes(self, checks: Sequence[Check]) -> list[Check]:
+        """auto_fix callback 이 있는 체크만 재실행용으로 처리한다.
+
+        실제 호출 결과는 '후속 체크 1회 더 돌리기' 로 검증해야 정확하다.
+        여기서는 callback 만 실행하고, 다시 ``run()`` 한 결과를 돌려준다.
+        """
+
+        for c in checks:
+            if c.auto_fix is None or c.auto_fix.callback is None:
+                continue
+            if c.severity not in (Severity.warn, Severity.error):
+                continue
+            await c.auto_fix.callback()
+        return await self.run()

--- a/sidecars/shared/gate_shared/doctor.py
+++ b/sidecars/shared/gate_shared/doctor.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -23,11 +24,15 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Final
 
+NETWORK_TIMEOUT_SEC: Final[float] = 3.0
+"""체크 하나의 HTTP 타임아웃 상한. 체크 1개가 run 전체를 막지 않도록 짧게 둔다."""
+
 __all__ = [
     "AutoFix",
     "Check",
     "CheckFn",
     "Doctor",
+    "NETWORK_TIMEOUT_SEC",
     "Severity",
     "render_pretty",
     "render_json",
@@ -35,31 +40,18 @@ __all__ = [
 
 
 class Severity(str, Enum):
-    """체크 심각도.
-
-    - ``ok``: 정상. 추가 조치 불필요.
-    - ``info``: 참고용 정보. 동작에는 영향 없음.
-    - ``warn``: 일부 기능이 비활성화되거나 권장 설정이 빠짐.
-    - ``error``: 실행 자체가 불가능. 반드시 조치 필요.
-    - ``skip``: 사전 조건이 충족되지 않아 검사를 건너뜀.
-    """
-
     ok = "ok"
     info = "info"
     warn = "warn"
     error = "error"
     skip = "skip"
 
+    def needs_action(self) -> bool:
+        return self in (Severity.warn, Severity.error)
+
 
 @dataclass(frozen=True, slots=True)
 class AutoFix:
-    """자동 치유 힌트.
-
-    ``command`` 는 복사해서 실행할 수 있는 쉘 예시.
-    ``callback`` 는 ``doctor --fix`` 시 실제로 호출되는 함수.
-    둘 중 하나만 채우면 되며, 양쪽 모두 제공 시 ``callback`` 가 우선한다.
-    """
-
     description: str
     command: str | None = None
     callback: Callable[[], Awaitable[None]] | None = None
@@ -67,12 +59,6 @@ class AutoFix:
 
 @dataclass(frozen=True, slots=True)
 class Check:
-    """단일 진단 결과.
-
-    ``detail`` 에는 사용자가 바로 참고할 수 있는 수치/경로를 담는다.
-    예: 파일 크기, URL, PID, 버전.
-    """
-
     name: str
     severity: Severity
     message: str
@@ -185,13 +171,6 @@ def _tally(checks: Sequence[Check]) -> dict[Severity, int]:
 
 
 def exit_code_for(checks: Sequence[Check]) -> int:
-    """관례: 0 = 건강, 1 = 조치 필요, 2 = 실행 불가.
-
-    - error 가 하나라도 있으면 2
-    - warn 이 있고 error 는 없으면 1
-    - 나머지는 0
-    """
-
     counts = _tally(checks)
     if counts[Severity.error] > 0:
         return 2
@@ -201,17 +180,6 @@ def exit_code_for(checks: Sequence[Check]) -> int:
 
 
 class Doctor:
-    """체크 등록 → 실행 → 렌더링 오케스트레이터.
-
-    사용 예::
-
-        doctor = Doctor("Discord Sidecar Doctor")
-        doctor.register(check_env)
-        doctor.register(check_gate_reachable)
-        checks = await doctor.run()
-        print(render_pretty(doctor.title, checks))
-    """
-
     def __init__(self, title: str) -> None:
         self._title = title
         self._checks: list[CheckFn] = []
@@ -228,37 +196,27 @@ class Doctor:
             self.register(c)
 
     async def run(self) -> list[Check]:
-        """모든 체크를 순차 실행한다.
+        # Checks are independent (env reads, disk stat, HTTP to different
+        # endpoints). Sequential execution makes a slow gate timeout block
+        # every later check; gather collapses the worst case to one timeout.
+        return list(await asyncio.gather(*(self._safe_call(fn) for fn in self._checks)))
 
-        체크 내부 예외는 ``Severity.error`` 로 승격된다.
-        하나의 체크가 실패해도 나머지는 계속 실행된다.
-        """
-
-        results: list[Check] = []
-        for fn in self._checks:
-            try:
-                results.append(await fn())
-            except Exception as exc:  # 진단 도구 자체는 멈추면 안 된다.
-                results.append(
-                    Check(
-                        name=getattr(fn, "__name__", "unknown_check"),
-                        severity=Severity.error,
-                        message=f"check raised: {exc.__class__.__name__}: {exc}",
-                    )
-                )
-        return results
+    @staticmethod
+    async def _safe_call(fn: CheckFn) -> Check:
+        try:
+            return await fn()
+        except Exception as exc:  # 진단 도구 자체는 멈추면 안 된다.
+            return Check(
+                name=getattr(fn, "__name__", "unknown_check"),
+                severity=Severity.error,
+                message=f"check raised: {exc.__class__.__name__}: {exc}",
+            )
 
     async def run_auto_fixes(self, checks: Sequence[Check]) -> list[Check]:
-        """auto_fix callback 이 있는 체크만 재실행용으로 처리한다.
-
-        실제 호출 결과는 '후속 체크 1회 더 돌리기' 로 검증해야 정확하다.
-        여기서는 callback 만 실행하고, 다시 ``run()`` 한 결과를 돌려준다.
-        """
-
         for c in checks:
             if c.auto_fix is None or c.auto_fix.callback is None:
                 continue
-            if c.severity not in (Severity.warn, Severity.error):
+            if not c.severity.needs_action():
                 continue
             await c.auto_fix.callback()
         return await self.run()

--- a/sidecars/shared/tests/test_doctor.py
+++ b/sidecars/shared/tests/test_doctor.py
@@ -1,0 +1,114 @@
+"""Doctor framework 단위 테스트.
+
+실제 네트워크/파일시스템 의존 없이 Check 조립 / 렌더링 / exit code / auto-fix
+콜백 동작만 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gate_shared.doctor import (
+    AutoFix,
+    Check,
+    Doctor,
+    Severity,
+    exit_code_for,
+    render_json,
+    render_pretty,
+)
+
+
+def test_severity_symbols_render_prefix() -> None:
+    checks = [
+        Check(name="alpha", severity=Severity.ok, message=""),
+        Check(name="beta", severity=Severity.warn, message="missing"),
+        Check(name="gamma", severity=Severity.error, message="broken"),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "[✓] alpha" in text
+    assert "[!] beta" in text
+    assert "[✗] gamma" in text
+    # ok 는 상세 줄이 없어야 한다
+    assert "↳ " in text  # warn/error 는 ↳ 로 설명
+    assert "missing" in text and "broken" in text
+
+
+def test_render_json_shape() -> None:
+    checks = [Check(name="x", severity=Severity.ok, message="", detail="v1")]
+    payload = json.loads(render_json("T", checks))
+    assert payload["title"] == "T"
+    assert payload["checks"][0]["severity"] == "ok"
+    assert payload["summary"]["ok"] == 1
+    assert payload["summary"]["error"] == 0
+
+
+def test_exit_code_priority() -> None:
+    ok = [Check(name="a", severity=Severity.ok, message="")]
+    warn = [Check(name="a", severity=Severity.warn, message="m")]
+    err = [
+        Check(name="a", severity=Severity.warn, message="m"),
+        Check(name="b", severity=Severity.error, message="boom"),
+    ]
+    assert exit_code_for(ok) == 0
+    assert exit_code_for(warn) == 1
+    assert exit_code_for(err) == 2
+
+
+@pytest.mark.asyncio
+async def test_doctor_runs_all_checks_even_when_one_raises() -> None:
+    async def good() -> Check:
+        return Check(name="good", severity=Severity.ok, message="")
+
+    async def bad() -> Check:
+        raise RuntimeError("boom")
+
+    async def other() -> Check:
+        return Check(name="other", severity=Severity.warn, message="skip-me")
+
+    d = Doctor("unit")
+    d.register_many([good, bad, other])
+    results = await d.run()
+    names = [c.name for c in results]
+    assert names == ["good", "bad", "other"]
+    bad_check = results[1]
+    assert bad_check.severity == Severity.error
+    assert "RuntimeError" in bad_check.message
+
+
+@pytest.mark.asyncio
+async def test_auto_fix_callback_invoked_only_for_warn_or_error() -> None:
+    calls: list[str] = []
+
+    async def fix_ok() -> None:
+        calls.append("ok-fix")
+
+    async def fix_bad() -> None:
+        calls.append("bad-fix")
+
+    ok_check = Check(
+        name="ok",
+        severity=Severity.ok,
+        message="",
+        auto_fix=AutoFix(description="noop", callback=fix_ok),
+    )
+    bad_check = Check(
+        name="bad",
+        severity=Severity.error,
+        message="x",
+        auto_fix=AutoFix(description="retry", callback=fix_bad),
+    )
+
+    async def emit_ok() -> Check:
+        return ok_check
+
+    async def emit_bad() -> Check:
+        return bad_check
+
+    d = Doctor("unit")
+    d.register_many([emit_ok, emit_bad])
+    initial = await d.run()
+    await d.run_auto_fixes(initial)
+    assert calls == ["bad-fix"]

--- a/sidecars/shared/tests/test_doctor.py
+++ b/sidecars/shared/tests/test_doctor.py
@@ -57,6 +57,14 @@ def test_exit_code_priority() -> None:
     assert exit_code_for(err) == 2
 
 
+def test_severity_needs_action() -> None:
+    assert Severity.warn.needs_action()
+    assert Severity.error.needs_action()
+    assert not Severity.ok.needs_action()
+    assert not Severity.info.needs_action()
+    assert not Severity.skip.needs_action()
+
+
 @pytest.mark.asyncio
 async def test_doctor_runs_all_checks_even_when_one_raises() -> None:
     async def good() -> Check:

--- a/test/dune
+++ b/test/dune
@@ -118,6 +118,7 @@
         test_observability_provider_contracts
         test_worker_oas_scope_gate
         test_config_doctor
+        test_doctor_cli
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
@@ -222,6 +223,7 @@
           test_observability_provider_contracts
           test_worker_oas_scope_gate
           test_config_doctor
+          test_doctor_cli
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine

--- a/test/test_doctor_cli.ml
+++ b/test/test_doctor_cli.ml
@@ -1,0 +1,132 @@
+open Alcotest
+
+module DC = Masc_mcp.Doctor_cli
+
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rec mkdir_p path =
+  if path = "" || path = Filename.dirname path then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let test_sidecar_request_parse () =
+  (match DC.sidecar_request_of_string "discord" with
+   | Ok (DC.Named DC.Discord) -> ()
+   | Ok _ -> fail "expected discord request"
+   | Error msg -> fail msg);
+  (match DC.sidecar_request_of_string "all" with
+   | Ok DC.All -> ()
+   | Ok _ -> fail "expected all request"
+   | Error msg -> fail msg);
+  (match DC.sidecar_request_of_string "unknown" with
+   | Ok _ -> fail "expected parse error for unknown sidecar"
+   | Error _ -> ())
+
+let test_known_sidecars_covers_all () =
+  let names = DC.sidecar_names () in
+  check (list string) "known sidecars" [ "discord" ] names
+
+let test_find_repo_root_from_cwd_ancestor () =
+  let root = temp_dir "doctor_cli_repo_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir root)
+    (fun () ->
+      let marker =
+        Filename.concat root "sidecars/discord-bot/run.sh"
+      in
+      write_file marker "#!/usr/bin/env bash\n";
+      let cwd = Filename.concat root "nested/deeper" in
+      mkdir_p cwd;
+      match
+        DC.find_repo_root_with
+          ~cwd
+          ~exe_path:"/tmp/main_eio.exe"
+          ~file_exists:Sys.file_exists
+          ()
+      with
+      | Ok actual -> check string "repo root resolved from cwd" root actual
+      | Error msg -> fail msg)
+
+let test_find_repo_root_from_exe_path_fallback () =
+  let root = temp_dir "doctor_cli_exe_repo_" in
+  let unrelated = temp_dir "doctor_cli_unrelated_" in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir root;
+      cleanup_dir unrelated)
+    (fun () ->
+      let marker =
+        Filename.concat root "sidecars/discord-bot/run.sh"
+      in
+      write_file marker "#!/usr/bin/env bash\n";
+      let exe =
+        Filename.concat root "_build/default/bin/main_eio.exe"
+      in
+      write_file exe "";
+      match
+        DC.find_repo_root_with
+          ~cwd:unrelated
+          ~exe_path:exe
+          ~file_exists:Sys.file_exists
+          ()
+      with
+      | Ok actual -> check string "repo root resolved from executable path" root actual
+      | Error msg -> fail msg)
+
+let test_sidecar_run_spec () =
+  let spec =
+    DC.sidecar_run_spec
+      ~repo_root:"/repo"
+      ~sidecar:DC.Discord
+      ~json:true
+      ~fix:true
+  in
+  check string "script path" "/repo/sidecars/discord-bot/run.sh"
+    spec.script_path;
+  check (list string) "argv"
+    [ "/bin/bash"; "/repo/sidecars/discord-bot/run.sh"; "doctor"; "--json"; "--fix" ]
+    spec.argv;
+  check string "display sidecar" "discord" (DC.sidecar_name spec.sidecar)
+
+let () =
+  run "doctor_cli"
+    [
+      ("parse", [ test_case "sidecar request parse" `Quick test_sidecar_request_parse ]);
+      ("coverage", [ test_case "known sidecars covers all" `Quick test_known_sidecars_covers_all ]);
+      ( "repo_root",
+        [
+          test_case "find from cwd ancestor" `Quick
+            test_find_repo_root_from_cwd_ancestor;
+          test_case "find from executable fallback" `Quick
+            test_find_repo_root_from_exe_path_fallback;
+        ] );
+      ("spec", [ test_case "sidecar run spec" `Quick test_sidecar_run_spec ]);
+    ]


### PR DESCRIPTION
## Summary

- turn `main_eio.exe doctor` into a top-level doctor front door with `config`, `sidecar`, and `all` entrypoints while keeping bare `doctor` as the existing config-doctor default
- add a small `Doctor_cli` helper module so sidecar target parsing, repo-root discovery, and sidecar subprocess specs are testable outside `bin/main_eio.ml`
- update the Doctor architecture doc to reflect the intended top-level UX instead of treating OCaml doctor and sidecar doctor as two unrelated entrypoints

## User-facing shape

```bash
./_build/default/bin/main_eio.exe doctor                # config doctor (backward compatible)
./_build/default/bin/main_eio.exe doctor config
./_build/default/bin/main_eio.exe doctor sidecar        # all registered sidecars in this follow-up (Discord)
./_build/default/bin/main_eio.exe doctor sidecar discord
./_build/default/bin/main_eio.exe doctor all            # config + sidecar doctors
```

`doctor sidecar` and `doctor all` bridge to the sidecar `run.sh doctor` surface and pass through `MASC_BASE_PATH`, so the same runtime root is checked across layers.

## Why

PR #8375 established the shared Doctor framework and the first sidecar-local consumer, but the operator UX still split into:

- `main_eio.exe doctor` for config
- `./run.sh doctor` for Discord sidecar

That leaves the top-level story unfinished. This follow-up makes `doctor` an actual front door instead of two separate commands that happen to share a name.

## Scope

- deliberately scoped to the already-merged Discord doctor path
- does **not** pull in the concurrent Slack-sidecar WIP still present in the worktree
- does **not** add dashboard aggregation yet

## Verification

- `dune build --root . --build-dir _build_doctor4 ./lib/doctor_cli.ml`
- `dune build --root . --build-dir _build_doctor5 ./bin/main_eio.ml`
- `dune build --root . --build-dir _build_doctor6 ./test/test_doctor_cli.ml`
- `git diff --check`

## Follow-up

- extend the sidecar registry once Slack / Telegram / iMessage doctor surfaces land cleanly
- add dashboard/API aggregation after the command-line front door shape stabilizes

## Context

- follow-up to merged PR #8375
