### PR TITLE
refactor(#7883): apply simplify-review feedback (post-merge follow-up to #8369)

### DIFF
--- a/lib/approval_callbacks.ml
+++ b/lib/approval_callbacks.ml
@@ -5,51 +5,29 @@
     it without forming a dependency cycle through
     [Operator_pending_confirm] and the governance approval queue. *)
 
-(** Always-approve callback for system-level OAS runs that are
-    explicitly trusted by MASC: judges (operator/governance),
-    auto_responder, autoresearch codegen, deep_review,
-    anti_rationalization, and the /v1/chat/completions OpenAI-compat
-    bridge.
+(* #7883 *)
 
-    OAS emits [WARN] "ApprovalRequired but no approval callback —
-    executing" when a run has [approval=None] and a tool is flagged as
-    ApprovalRequired. For keeper runs the correct callback is
-    [Governance_pipeline.to_oas_approval_callback] (HITL queue +
-    trifecta risk). For system runs there is no human on the other
-    side, so the correct semantics is "always Approve" — passing this
-    callback makes the trust decision explicit at the call site and
-    silences the stray WARN line. *)
+(** Always-approve callback for system-level OAS runs that MASC has
+    already decided to trust (judges, auto_responder, autoresearch
+    codegen, deep_review, anti_rationalization, OpenAI-compat bridge).
+    Unreachable-by-policy tool calls will be accepted here — install only
+    where the trust decision is made at the call site. *)
 let auto_approve : Oas.Hooks.approval_callback =
-  fun ~tool_name:_ ~input:_ -> Oas.Hooks.Approve
+  Oas.Approval.(create [ always_approve ] |> as_callback)
 
-(** Fail-closed default callback for OAS Agent builder sites that do
-    not have an explicit human-in-the-loop or MASC-trusted-system
-    decision source.
-
-    Every OAS [Agent.t] constructed by MASC must install an
-    approval_callback. Without one, OAS logs [WARN] "ApprovalRequired
-    but no approval callback — executing" and executes the tool
-    anyway (fail-open). [oas_log_bridge] promotes that WARN to ERROR
-    for visibility, but promotion is not a gate — the tool still
-    runs. See #7883.
-
-    Use this callback at the Builder / run_named site when neither
-    [Governance_pipeline.to_oas_approval_callback] (keepers with HITL
-    queue) nor [auto_approve] (explicitly trusted system runs) is
-    wired. It rejects every ApprovalRequired tool call with a
-    structured reason so the caller fails loudly rather than
-    executing silently.
-
-    Callers wanting auto-approval must opt in explicitly by passing
-    [auto_approve]. This changes the default from fail-open to
-    fail-closed. *)
+(** Fail-closed default for OAS Agent builder sites without an explicit
+    HITL or trusted-system decision source. Rejects every
+    ApprovalRequired tool call with a reason that names the tool.
+    Unreachable-by-policy cases will now be rejected rather than silently
+    executed (OAS's fail-open default). Hand-rolled instead of
+    [Oas.Approval.always_reject] to preserve per-call tool-name
+    templating. *)
 let reject_by_default : Oas.Hooks.approval_callback =
   fun ~tool_name ~input:_ ->
     Oas.Hooks.Reject
       (Printf.sprintf
          "MASC approval fail-closed: tool %s requires approval but no \
-          approval_callback was wired at this Agent builder site. \
-          Install Governance_pipeline.to_oas_approval_callback (keeper \
-          HITL) or Approval_callbacks.auto_approve (trusted system run) \
-          at the construction site. See #7883."
+          approval_callback was wired at this Agent builder site. Install \
+          Governance_pipeline.to_oas_approval_callback (keeper HITL) or \
+          Approval_callbacks.auto_approve (trusted system run). See #7883."
          tool_name)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -276,10 +276,7 @@ let build_agent
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)
-    (* #7883: fail-closed by default. Worker OAS runs execute MASC-issued
-       tools without a human gate; if the caller does not supply an
-       explicit approval source, reject every ApprovalRequired tool call
-       rather than letting OAS log-and-execute. *)
+    (* #7883 *)
     |> Oas.Builder.with_approval approval
   in
   let builder = match context_injector with
@@ -575,6 +572,8 @@ and resume_worker_via_oas
     ~(raw_trace : Oas.Raw_trace.t)
     ?contract
     ?worker_run_id
+    ?(approval : Oas.Hooks.approval_callback =
+      Approval_callbacks.reject_by_default)
     () : (Worker_container_types.run_result, string) result =
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in
@@ -613,11 +612,8 @@ and resume_worker_via_oas
   in
   let options = { options with
     Oas.Agent_types.context_injector = Some context_injector;
-    (* #7883: resume path must install fail-closed approval callback.
-       Without this, OAS would see approval=None on resume and log
-       "ApprovalRequired but no approval callback — executing" while
-       running the tool anyway. *)
-    approval = Some Approval_callbacks.reject_by_default } in
+    (* #7883 *)
+    approval = Some approval } in
   Fun.protect
     ~finally:(fun () ->
       ignore


### PR DESCRIPTION
## Why

Follow-up to merged PR #8369. /simplify 3-axis review (Reuse/Quality/Efficiency) identified 3 fixes. A fixup commit was pushed to the original branch ~15min AFTER the PR was merged — per `feedback_no-push-after-squash-merge.md`, post-merge pushes do not reach main. This PR applies the fixups cleanly on top of current main.

## Reproducer of the problem

- PR #8369 mergeCommit: `7999d883` at 2026-04-18 18:46 KST
- Fixup commit `a1a3bb5a0` pushed to `fix/7883-approval-callback` at 2026-04-18 19:01 KST — **NOT reflected in main**
- `git log origin/main --oneline | grep 7883` confirms only the original fix is on main

## What (cherry-picked as 8aea9b6f1)

1. **`?approval` param on `resume_worker_via_oas`** — mirrors `build_agent`'s shape; default = `reject_by_default`.
2. **`auto_approve` uses OAS `Approval` helpers** — thin wrapper `Oas.Approval.(create [always_approve] |> as_callback)`.
3. **Comment trim** — deleted change narration ("previously logged WARN", "promotion is not a gate"), kept one-line `(* #7883 *)` refs, risk acknowledgement docstrings intact.

**Intentionally partial**: `reject_by_default` kept hand-rolled `Hooks.Reject`. OAS `Approval.always_reject` takes a fixed reason; existing test `test_reject_by_default_reason_mentions_tool` asserts per-call tool_name templating, so hand-rolled version stays.

## Test plan

- [x] `dune build --root .` clean
- [x] `test_approval_callback_wired` 5/5 OK
- [x] `test_hitl_approval` 19/19 OK
- [ ] CI green

## Risk

Very low — net simplification (+22 / -48) with zero behaviour change. The fail-closed contract (#7883) remains intact.

## References

- Parent: #8369 (merged)
- Issue: #7883
- /simplify review findings recorded in session memory
- Memory: `feedback_no-push-after-squash-merge.md`, `feedback_verify-premise-before-spawning-pr-agent.md`