### PR TITLE
fix(fs_compat): fsync tmp + parent dir in save_file_atomic

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -97,12 +97,29 @@ let save_file (path : string) (content : string) : unit =
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
 
+(* Durable atomic write: tmp → fsync(tmp) → rename → fsync(parent dir).
+   Without the fsync pair, a crash between the rename and the kernel's
+   dirty-page flush can leave the target truncated or zero-length — exactly
+   what we observed on backlog.json after an abrupt shutdown (2026-04-18). *)
+let fsync_path path =
+  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () -> try Unix.close fd with _ -> ())
+    (fun () ->
+      try Unix.fsync fd
+      with Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
+        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
+           is still durable to the extent the underlying FS offers. *)
+        ())
+
 let save_file_atomic (path : string) (content : string) : (unit, string) result =
   let dir = Filename.dirname path in
   let tmp = Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp" in
   try
     save_file tmp content;
+    fsync_path tmp;
     Sys.rename tmp path;
+    (try fsync_path dir with Unix.Unix_error _ -> ());
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -40,6 +40,33 @@ let test_mkdir_p_does_not_shell_inject () =
   check bool "no shell side-effect file created" false (Sys.file_exists pwned);
   check bool "dangerous path exists" true (Sys.file_exists dangerous && Sys.is_directory dangerous)
 
+let test_save_file_atomic_leaves_no_tmp_on_success () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let target = Filename.concat base "out.json" in
+  (match Fs_compat.save_file_atomic target {|{"ok":true}|} with
+   | Ok () -> ()
+   | Error msg -> fail msg);
+  check bool "target exists" true (Sys.file_exists target);
+  check string "content matches" {|{"ok":true}|} (Fs_compat.load_file target);
+  let leftover_tmps =
+    Sys.readdir base
+    |> Array.to_list
+    |> List.filter (fun n ->
+        String.length n >= 8 && String.sub n 0 8 = ".atomic_")
+  in
+  check (list string) "no leftover .atomic_ tmp files" [] leftover_tmps
+
+let test_save_file_atomic_overwrites_existing () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let target = Filename.concat base "out.json" in
+  Fs_compat.save_file target "old";
+  (match Fs_compat.save_file_atomic target "new" with
+   | Ok () -> ()
+   | Error msg -> fail msg);
+  check string "overwrite succeeded" "new" (Fs_compat.load_file target)
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -49,6 +76,14 @@ let () =
     , [
         test_case "creates nested dirs" `Quick test_mkdir_p_creates_nested_dirs;
         test_case "no shell injection" `Quick test_mkdir_p_does_not_shell_inject;
+      ]
+    );
+    ( "save_file_atomic"
+    , [
+        test_case "leaves no .atomic_ tmp on success" `Quick
+          test_save_file_atomic_leaves_no_tmp_on_success;
+        test_case "overwrites existing target" `Quick
+          test_save_file_atomic_overwrites_existing;
       ]
     );
   ]


### PR DESCRIPTION
## 요약

라이브 인시던트 (2026-04-18) 의 **근본 원인** 수정.

`save_file_atomic` 은 tmp→rename 은 하고 있었지만 **fsync 가 누락**돼 있어, 프로세스가 rename 직후 죽으면 커널이 rename 메타데이터는 저널에 커밋해도 **데이터 블록이 dirty 상태**로 남아 recovery 시 target 파일이 truncated/zero-length 로 보임.

바로 이 증상이 오늘 `backlog.json` 에서 발생: 2731 라인에서 notes 문자열 중간이 잘려 Orchestrator / Dashboard / Keeper 전부 read 실패.

## 변경 내용

`lib/fs_compat/fs_compat.ml` — `save_file_atomic` 의 순서:

```
1. write tmp
2. fsync tmp            ← 추가
3. rename tmp → target
4. fsync parent dir     ← 추가
```

`EINVAL` / `EOPNOTSUPP` 는 삼킴 (tmpfs 등 일부 FS 는 fsync 를 거절 — 해당 FS 의 기본 내구성 수준을 따른다는 약속).

## 파급

Fs_compat.save_file_atomic 를 거치는 모든 writer 가 자동 수혜:
- `coord_utils_ops.write_json_local` → backlog.json / state.json / roomlist 등
- `tool_team_memory` → team memory shards
- `procedural_memory` → procedural_memory snapshots
- `board_core` → task board writes

호출 사이트 변경 **없음**.

## 왜 지금까지 안 터졌나

- `save_file_atomic` 은 `save_file` 성공 후 바로 `Sys.rename` — 정상 shutdown 에서는 OS 가 언젠가 fsync 를 해줌 (보통 30s 이내 dirty page flush).
- 비정상 종료 (OOM kill, 강제 kill, 커널 panic, 순간 정전) + 직전 write 가 겹칠 때만 증상 발현.
- 오늘 발생 — 2731 라인 mid-string 에서 truncated 파일 관찰.

## 테스트

- 기존: `test_fs_compat` 2 cases
- 추가: 2 cases (`leaves no .atomic_ tmp on success`, `overwrites existing target`)
- 크래시-윈도우는 결정적으로 재현 불가 — fsync 호출 자체는 기존 disk-backed path 가 암묵적으로 실행해 검증.

```
$ dune exec test/test_fs_compat.exe
Testing `fs_compat'.
  [OK]  mkdir_p               0   creates nested dirs.
  [OK]  mkdir_p               1   no shell injection.
  [OK]  save_file_atomic      0   leaves no .atomic_ tmp on success.
  [OK]  save_file_atomic      1   overwrites existing target.
Test Successful in 0.013s. 4 tests run.
```

## 후속 고려 (별 이슈)

- `write_backlog` 은 primary + `.last-good` 을 **순차로** 쓴다. 오늘 incident 에서는 `.last-good` 이 존재조차 안 했음 — 즉 recovery layer 가 의도대로 안 깔림. 원인 추가 조사 필요.
- Config Doctor 에 "task backlog parses / .last-good present" 체크 추가 후보.

## 체크리스트

- [x] 단일 파일 수정, API 동일
- [x] fsync 실패 경로(EINVAL/EOPNOTSUPP) 처리
- [x] 기존 atomic rename 계약 유지, 추가 guarantee 만 보강
- [x] Unit test 4 pass
- [ ] 크래시-윈도우 e2e (kill -9 under load) — 별 작업으로 분리
