### PR TITLE
fix(response): task_completed must report status="done" via Variant SSOT (#8412)

### DIFF
--- a/lib/response/response.ml
+++ b/lib/response/response.ml
@@ -307,13 +307,27 @@ let task_already_claimed ~task_id ~claimed_by : t =
     ]
     ()
 
-(** Task completed *)
+(** Task completed.
+
+    Issue #8412: previously emitted [status="completed"], but
+    [Types.task_status_to_string Done = "done"] — the string "completed"
+    is never produced by the Variant SSOT. Sister bug to #8364
+    (task_claimed). Routing through the Variant guarantees the string
+    matches what every other emitter and parser sees. *)
 let task_completed ~task_id ~agent ~notes : t =
+  let done_status =
+    Types.task_status_to_string
+      (Types.Done {
+        assignee = agent;
+        completed_at = Types.now_iso ();
+        notes = if notes = "" then None else Some notes;
+      })
+  in
   ok
     ~message:(Printf.sprintf "Task '%s' completed" task_id)
     (`Assoc [
       ("task_id", `String task_id);
       ("completed_by", `String agent);
       ("notes", `String notes);
-      ("status", `String "completed");
+      ("status", `String done_status);
     ])

--- a/test/test_response.ml
+++ b/test/test_response.ml
@@ -372,7 +372,9 @@ let test_task_completed () =
   assert_equal_string "task_id" "task-001" (json_get_string resp.data "task_id");
   assert_equal_string "completed_by" "claude" (json_get_string resp.data "completed_by");
   assert_equal_string "notes" "All tests pass" (json_get_string resp.data "notes");
-  assert_equal_string "status" "completed" (json_get_string resp.data "status");
+  (* Issue #8412: status string comes from Types.task_status_to_string Done = "done",
+     not the cosmetic "completed" hand-rolled previously. *)
+  assert_equal_string "status" "done" (json_get_string resp.data "status");
   Printf.printf "  test_task_completed passed\n"
 
 (* ========================================


### PR DESCRIPTION
## Summary
Closes #8412. Sister fix to #8368 (task_claimed) — same Variant SSOT pattern.

`Response.task_completed` emitted `status="completed"` but `Types.task_status_to_string Done = "done"`. Any downstream consumer comparing the response status to results from `task_status_to_string` would silently mismatch.

## Change
1. `lib/response/response.ml:318` — route through `Types.task_status_to_string (Types.Done { ... })`. Inherits assignee + completed_at + notes from the function args, so the Variant constructor is fully populated.
2. `test/test_response.ml:375` — assert `"done"` (with comment explaining the FSM/Variant SSOT).

## Status
Currently dead code (no callers of `Response.task_completed`), but the test encoded the wrong expectation, so any future caller would have inherited the bug.

## Pattern series
| PR | Function | Bug |
|----|----------|-----|
| #8368 | task_claimed | "in_progress" → "claimed" |
| **THIS** | **task_completed** | **"completed" → "done"** |

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_response.exe` — 39/39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)