### PR TITLE
refactor(dashboard): consolidate parallel font-size systems → single SSOT

### DIFF
--- a/dashboard/src/styles/responsive.css
+++ b/dashboard/src/styles/responsive.css
@@ -22,11 +22,16 @@
 }
 
 @media (max-width: 768px) {
+  /* Mobile font-size scale-down — overrides the canonical @theme tokens
+     so BOTH Tailwind utilities (text-sm, text-base, ...) AND legacy CSS
+     `var(--fs-*)` consumers (which now alias to --font-size-* in
+     variables.css) shrink. Pre-consolidation only --fs-* shrank;
+     Tailwind utilities bypassed the override. */
   :root {
-    --fs-base: 13px;
-    --fs-sm: 12px;
-    --fs-xs: 11px;
-    --fs-2xs: 10px;
+    --font-size-base: 13px;
+    --font-size-sm: 12px;
+    --font-size-xs: 11px;
+    --font-size-2xs: 10px;
   }
 
   .header-title-wrap h1 {

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -235,13 +235,17 @@
   --radius-sm: 6px;
   --header-h: 94px;
 
-  /* Font-size scale */
-  --fs-2xs: 11px;
-  --fs-xs: 12px;
-  --fs-sm: 13px;
-  --fs-base: 14px;
-  --fs-md: 15px;
-  --fs-lg: 16px;
+  /* Font-size scale — aliases to the canonical Tailwind v4 @theme tokens
+     in tokens.css. Single SSOT: change values there, both Tailwind utilities
+     (text-sm, text-base, ...) and direct CSS consumers (var(--fs-sm)) stay
+     in lockstep. Mobile responsive scaling now overrides --font-size-* at
+     :root (see responsive.css), reaching both code paths. */
+  --fs-2xs: var(--font-size-2xs);
+  --fs-xs: var(--font-size-xs);
+  --fs-sm: var(--font-size-sm);
+  --fs-base: var(--font-size-base);
+  --fs-md: var(--font-size-md);
+  --fs-lg: var(--font-size-lg);
 
   /* Extended palette */
   --cyan: #22d3ee;


### PR DESCRIPTION
## Why
`/simplify` review of #8373 deferred Finding 4: `variables.css --fs-*` and `tokens.css --font-size-*` maintained identical values in parallel. `responsive.css` scaled `--fs-*` on mobile (≤768px) but Tailwind utilities (generated from `--font-size-*`) bypassed it.

→ `text-sm` rendered 13px on mobile while `var(--fs-sm)` was 12px below 768px. Same intent, different code paths, divergent visual.

## Fix
1. **`variables.css`**: alias `--fs-*` to `var(--font-size-*)`. No more value duplication.
2. **`responsive.css`**: mobile override sets `--font-size-*` directly. Both Tailwind utilities AND legacy `var(--fs-*)` consumers now shrink together.
3. SSOT: `tokens.css @theme` block.

## Diff
- `variables.css` 6 lines (literal → var alias)
- `responsive.css` 4 lines (--fs-* → --font-size-* in `:root` override)
- 0 TS changes

## Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅ (CSS bundle compiled cleanly)
- `pnpm test`: pre-existing `telemetry-unified.test.ts` 5000ms timeout flake on slow 800s+ host runs (CSS-only diff cannot affect it)

## Result
| Path | Before | After |
|------|--------|-------|
| `text-sm` (Tailwind utility) | 13px always | 13px (≥768px), 12px (<768px) |
| `var(--fs-sm)` (CSS) | 13px (≥768px), 12px (<768px) | 13px (≥768px), 12px (<768px) |
| `var(--font-size-sm)` (Tailwind theme) | 13px always | 13px (≥768px), 12px (<768px) |

Mobile font-size scaling now applies uniformly across Tailwind utilities and direct CSS — divergence eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)