### PR TITLE
feat(keeper): surface verifier_role_keeper signal on decision records

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -753,6 +753,17 @@ let work_kind_of_selected_mode (selected_mode : string) : string =
   | "noop" -> "noop"
   | _ -> "text_turn"
 
+(* A keeper acts as a verification authority when its persona wires the
+   "verifier"/"검증자" mention targets. The dashboard and prompt builder
+   need a cheap predicate to pick verifier keepers out of the fleet
+   without reloading the persona profile. *)
+let verifier_role_mention_tokens = [ "verifier"; "검증자" ]
+
+let is_verifier_role_keeper (meta : Keeper_types.keeper_meta) : bool =
+  List.exists
+    (fun token -> List.mem token meta.mention_targets)
+    verifier_role_mention_tokens
+
 let observed_triggers_of_observation
     (observation : Keeper_world_observation.world_observation) : string list =
   let triggers = ref [] in
@@ -895,6 +906,7 @@ let append_decision_record
               ("pending_verification_count", `Int observation.pending_verification_count);
               ("active_agent_count", `Int observation.active_agent_count);
               ("worktree_change_detected", `Bool (Option.is_some observation.worktree_change_summary));
+              ("verifier_role_keeper", `Bool (is_verifier_role_keeper meta));
             ] );
         ("tool_call_count", `Int tool_call_count);
         ("tools_used", `List (List.map (fun s -> `String s) tools_used));

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -21,6 +21,13 @@
     No action classification — metrics are derived from the run result.
 
     Exposed for testing. *)
+(** Cheap persona-derived predicate: returns [true] when the keeper's
+    [mention_targets] include one of the verifier role tokens
+    (["verifier"; "검증자"]). Used by the dashboard decision-record JSON and
+    prompt builder to distinguish verification-authority keepers from the
+    rest of the fleet. Pure — does not re-read the persona profile. *)
+val is_verifier_role_keeper : Keeper_types.keeper_meta -> bool
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3660,4 +3660,36 @@ let () =
           test_case "keeper allowed tools exclude heartbeat" `Quick
             test_keeper_allowed_tools_exclude_heartbeat;
         ] );
+      ( "verifier_role",
+        [
+          test_case "is_verifier_role_keeper detects english token" `Quick
+            (fun () ->
+              let meta =
+                { minimal_meta with mention_targets = [ "verifier" ] }
+              in
+              check bool "verifier token matches" true
+                (UT.is_verifier_role_keeper meta));
+          test_case "is_verifier_role_keeper detects korean token" `Quick
+            (fun () ->
+              let meta =
+                { minimal_meta with mention_targets = [ "검증자" ] }
+              in
+              check bool "korean token matches" true
+                (UT.is_verifier_role_keeper meta));
+          test_case "is_verifier_role_keeper rejects non-verifier persona"
+            `Quick (fun () ->
+              let meta =
+                {
+                  minimal_meta with
+                  mention_targets = [ "analyst"; "scholar" ];
+                }
+              in
+              check bool "non-verifier mention targets" false
+                (UT.is_verifier_role_keeper meta));
+          test_case "is_verifier_role_keeper empty mention targets" `Quick
+            (fun () ->
+              check bool "empty mention_targets" false
+                (UT.is_verifier_role_keeper
+                   { minimal_meta with mention_targets = [] }));
+        ] );
     ]


### PR DESCRIPTION
## Summary

- Adds `Keeper_unified_turn.is_verifier_role_keeper` — a pure predicate that returns `true` when the keeper's `mention_targets` include `"verifier"` or `"검증자"`. The existing verifier persona wires both tokens.
- Emits `observation.verifier_role_keeper : bool` on every keeper decision record so the dashboard can pick verification-authority keepers out of the fleet without reloading the persona profile.
- 4 new unit tests under the `verifier_role` Alcotest group cover English token, Korean token, non-verifier rejection, and empty mention_targets.

## Context

User feedback: "검증자 keeper 자체도 흔적이 없다." The verifier persona already exists (`config/personas/verifier/profile.json`) with a detailed goal / instructions block, but the runtime surface carries no marker that an LLM consumer or dashboard renderer can use to distinguish verifier keepers. This PR adds the cheapest possible marker — downstream UI work (PR 3 of the plan) consumes it.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 2 of 5).

## Scope guard

- No schema change on `keeper_meta` — predicate reads existing `mention_targets`.
- No persona profile rewrites.
- No prompt builder changes; only the decision record JSON gains one field.
- `verifier_role_keeper` is advisory: string matching on mention_targets, not an authoritative persona role. A stronger guarantee can land later by propagating `Keeper_types_profile.persona_name` to `keeper_meta`.

## Test plan

- [x] `dune exec test/test_keeper_unified.exe` — 175 tests pass including 4 new `verifier_role` cases.
- [ ] CI green (deferred to auto-run).
- [ ] Dashboard consumption (next PR in the series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)