### PR TITLE
feat(dashboard): add 검증 대기 Kanban column for awaiting_verification tasks

### DIFF
--- a/dashboard/src/components/goals/kanban-components.test.ts
+++ b/dashboard/src/components/goals/kanban-components.test.ts
@@ -74,4 +74,29 @@ describe('TaskBacklog', () => {
       expect(screen.queryByRole('button', { name: /완료 태스크 .*더 보기/ })).not.toBeInTheDocument()
     })
   })
+
+  it('renders awaiting_verification column with task card and pill', async () => {
+    const awaitingTask: Task = {
+      id: 'task-awaiting-001',
+      title: 'Awaiting verification task',
+      status: 'awaiting_verification',
+      priority: 2,
+      description: 'Verifier keeper is measuring completion contract.',
+      created_at: '2026-04-18T00:00:00Z',
+      updated_at: '2026-04-18T00:05:00Z',
+    }
+    tasks.value = [awaitingTask]
+
+    render(h(TaskBacklog, {}))
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: '검증 대기' })).toBeInTheDocument()
+      expect(screen.getByText('Awaiting verification task')).toBeInTheDocument()
+    })
+
+    // Both the column header and the card pill include "검증 대기"; assert two
+    // occurrences so a regression that drops either surface fails loudly.
+    const matches = screen.getAllByText(/검증 대기/)
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -144,13 +144,15 @@ function KanbanCard({ task }: { task: Task }) {
       `}
 
       <div class="flex flex-wrap items-center gap-2 text-2xs text-text-muted">
-        ${task.completed_at && task.status === 'done'
-          ? html`<span class="rounded border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완�� <${TimeAgo} timestamp=${task.completed_at} /></span>`
-          : task.completed_at && task.status === 'cancelled'
-            ? html`<span class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[var(--bad-light)]">취소 <${TimeAgo} timestamp=${task.completed_at} /></span>`
-            : task.created_at
-              ? html`<span class="rounded border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>`
-              : null}
+        ${task.status === 'awaiting_verification'
+          ? html`<span class="rounded border border-accent/30 bg-[var(--accent-10)] px-2 py-1 text-accent" title="verifier keeper의 독립 실측을 기다리는 중">검증 대기${task.updated_at ? html` <${TimeAgo} timestamp=${task.updated_at} />` : null}</span>`
+          : task.completed_at && task.status === 'done'
+            ? html`<span class="rounded border border-ok/25 bg-ok/10 px-2 py-1 text-ok">완�� <${TimeAgo} timestamp=${task.completed_at} /></span>`
+            : task.completed_at && task.status === 'cancelled'
+              ? html`<span class="rounded border border-[var(--bad-30)] bg-[var(--bad-10)] px-2 py-1 text-[var(--bad-light)]">취소 <${TimeAgo} timestamp=${task.completed_at} /></span>`
+              : task.created_at
+                ? html`<span class="rounded border border-card-border/70 bg-white/4 px-2 py-1"><${TimeAgo} timestamp=${task.created_at} /></span>`
+                : null}
         ${task.assignee ? html`<span class="rounded border border-accent/20 bg-[var(--accent-10)] px-2 py-1 text-accent">@${task.assignee}</span>` : null}
         <a
           href=${link.href}
@@ -204,16 +206,22 @@ function TaskColumn({
 }
 
 export function TaskBacklog() {
-  const { todo, inProgress, done } = tasksByStatus.value
-  const totalTasks = todo.length + inProgress.length + done.length
+  const { todo, inProgress, awaitingVerification, done } = tasksByStatus.value
+  const totalTasks = todo.length + inProgress.length + awaitingVerification.length + done.length
   const query = taskSearchQuery.value
   const hasSearch = query.trim().length > 0
   const filteredTodo = filterTasksByQuery(todo, query)
   const filteredInProgress = filterTasksByQuery(inProgress, query)
+  const filteredAwaitingVerification = filterTasksByQuery(awaitingVerification, query)
   const filteredDone = filterTasksByQuery(done, query)
-  const filteredTotal = filteredTodo.length + filteredInProgress.length + filteredDone.length
+  const filteredTotal =
+    filteredTodo.length +
+    filteredInProgress.length +
+    filteredAwaitingVerification.length +
+    filteredDone.length
   const sortedTodo = [...filteredTodo].sort(sortByPriority)
   const sortedInProgress = [...filteredInProgress].sort(sortByPriority)
+  const sortedAwaitingVerification = [...filteredAwaitingVerification].sort(sortByPriority)
   const sortedDone = [...filteredDone].sort(sortByTimeDesc)
   const activeDoneVisibleCount = hasSearch ? searchDoneVisibleCount.value : doneVisibleCount.value
   const effectiveDoneVisibleCount = Math.min(activeDoneVisibleCount, sortedDone.length)
@@ -309,6 +317,16 @@ export function TaskBacklog() {
           ${sortedInProgress.length === 0
             ? html`<${EmptyState} message=${emptyColumnMessage ?? '진행 중인 태스크가 없습니다'} compact />`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
+        <//>
+        <${TaskColumn}
+          title="검증 대기"
+          count=${sortedAwaitingVerification.length}
+          description="verifier keeper가 completion_contract 정량 기준을 독립 실측 중인 태스크입니다."
+          badgeClass="border border-accent/30 bg-[var(--accent-10)] text-accent"
+        >
+          ${sortedAwaitingVerification.length === 0
+            ? html`<${EmptyState} message=${emptyColumnMessage ?? '검증 대기 중인 태스크가 없습니다'} compact />`
+            : sortedAwaitingVerification.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         <//>
         <${TaskColumn}
           title="완료"

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -275,6 +275,7 @@ export const tasksByStatus = computed(() => {
   return {
     todo: all.filter(t => t.status === 'todo'),
     inProgress: all.filter(t => t.status === 'in_progress' || t.status === 'claimed'),
+    awaitingVerification: all.filter(t => t.status === 'awaiting_verification'),
     done: all.filter(t => t.status === 'done'),
   }
 })


### PR DESCRIPTION
## Summary

- `tasksByStatus` now buckets `awaiting_verification` tasks separately (they used to disappear from the Kanban view entirely — the FSM state existed on the `Task` model but the selector dropped it).
- `TaskBacklog` renders a new fourth column "검증 대기" between 진행 중 and 완료, wired through the existing search / filter / sort pipeline.
- `KanbanCard` shows a cyan "검증 대기" pill (with last-update timestamp) in place of the completed-at/created-at pill for awaiting_verification tasks, so the FSM state is visible on the card face, not only in the detail overlay.
- 2 test cases in `kanban-components.test.ts` pass, including a new one asserting both the column heading and the card pill render.

## Context

User feedback: "Task 완료가 왜 완료인지 UI에서 전혀 안 보인다." The verification FSM has been producing `awaiting_verification` states for a while, but the Kanban — the primary Board surface — never rendered them. This PR is the first UI-visible step of the verification surfacing series. The verdict lineage block on `task-detail-overlay` and the `verifier_role_keeper` wiring (PR #8422) are follow-up PRs.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 3a of 5).

## Scope guard

- No change to `dashboard_verification.ml` projection or task types.
- No change to verification request panel (the dedicated "검증" tab stays as is).
- No column reorder or existing-column styling change.

## Test plan

- [x] `pnpm vitest run src/components/goals/kanban-components.test.ts` — 2 tests pass.
- [x] `pnpm tsc --noEmit` — clean.
- [ ] Manual verification (please): run dev server, create a task with `completion_contract`, call `masc_done` to push it into `awaiting_verification`, confirm the new column + card pill render as expected.

⚠️ **do-not-merge** label — please keep draft until a human adds the before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)