### PR TITLE
feat(dashboard): spacing axis — w/h/spacing literals → Tailwind native scale

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -146,7 +146,7 @@ export function App() {
       <${RemoteWarningBanner} />
 
       <div class="flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col">
-        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--white-5)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -242,7 +242,7 @@ export function GraphView({ data }: GraphViewProps) {
 
   return html`
     <div class="relative w-full my-3 rounded border border-[var(--card-border)] bg-[#0f1117]">
-      <div ref=${containerRef} class="w-full h-[360px]"></div>
+      <div ref=${containerRef} class="w-full h-90"></div>
     </div>
     <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 px-1">
       ${[
@@ -284,7 +284,7 @@ export function GraphView({ data }: GraphViewProps) {
         ${connectedEdges.length > 0 ? html`
           <div class="border-t border-[var(--slate-gray-10)] pt-3">
             <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em] mb-2">연결된 관계</div>
-            <div class="flex flex-col gap-1.5 max-h-[160px] overflow-y-auto">
+            <div class="flex flex-col gap-1.5 max-h-40 overflow-y-auto">
               ${connectedEdges.slice(0, 20).map(({ edge, otherLabel }) => html`
                 <div class="flex items-center gap-2 text-sm py-1 px-2 rounded bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>
                   <span class="text-[var(--text-slate-light)]">${otherLabel}</span>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -188,7 +188,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
             placeholder="액션 필터 (title, actor, subject...)"
             aria-label="액션 타임라인 필터"
             onInput=${(e: Event) => { actionQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
           <button
             type="button"
@@ -257,7 +257,7 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                   <div class="mt-3 flex flex-col gap-2 rounded border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">
                     ${group.rawEvents.map(event => html`
                       <div class="flex items-start gap-3 rounded border border-[var(--white-6)] bg-[var(--white-3)] px-3 py-2" key=${event.seq}>
-                        <span class="inline-flex min-w-[72px] items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
+                        <span class="inline-flex min-w-18 items-center rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
                           ${activityEventKindLabel(event.kind)}
                         </span>
                         <div class="min-w-0 flex-1">
@@ -302,7 +302,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
         const score = nodeScore(node)
         const pct = maxScore > 0 ? (score / maxScore) * 100 : 0
         return html`
-          <div class="flex items-center gap-[10px] py-2 px-3 rounded-[10px] bg-[rgba(15,23,42,0.5)] border border-solid border-[var(--slate-gray-8)]" key=${node.id}>
+          <div class="flex items-center gap-2.5 py-2 px-3 rounded-[10px] bg-[rgba(15,23,42,0.5)] border border-solid border-[var(--slate-gray-8)]" key=${node.id}>
             <span class="w-[22px] text-center text-sm font-bold text-text-slate">${i + 1}</span>
             <div class="flex-1 flex flex-col gap-1 min-w-0">
               <div class="flex items-center gap-2">
@@ -313,7 +313,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
                 <div class="h-full rounded-sm bg-[var(--cyan)] transition-[width] duration-300 ease-in-out" style="width:${pct}%"></div>
               </div>
             </div>
-            <span class="text-sm font-semibold text-text-slate-light min-w-[32px] text-right">${score.toFixed(1)}</span>
+            <span class="text-sm font-semibold text-text-slate-light min-w-8 text-right">${score.toFixed(1)}</span>
             <span class="text-2xs py-0.5 px-[7px] rounded ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--ok)] bg-[var(--ok-10)]'}">${node.status}</span>
           </div>
         `
@@ -355,7 +355,7 @@ function useActivityGraphState() {
 function ActivityTimelinePanel({ data }: { data: ActivityGraphResponse }) {
   return html`
     <${Card} title="액션 타임라인" class="section" testId="activity_graph.timeline">
-      <div class="max-h-[360px] overflow-y-auto">
+      <div class="max-h-90 overflow-y-auto">
         <${ActionTimeline} data=${data} />
       </div>
     <//>

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -16,7 +16,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
       ${entries.length === 0
         ? html`<${EmptyState} message="아직 활동 기록이 없습니다" compact />`
         : html`
-            <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
+            <div class="flex flex-col gap-0.5 max-h-70 overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`
                 <div class="agent-journal-entry flex items-baseline gap-1.5 py-1 px-2 text-sm transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                   <span class="agent-journal-kind">${journalKindIcon(entry)}</span>

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -202,7 +202,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                   onInput=${(e: Event) => {
                     episodeQuery.value = (e.target as HTMLInputElement).value
                   }}
-                  class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                 />`
               : null}
           </div>
@@ -216,7 +216,7 @@ export function AgentDetailMemory({ agentName }: Props) {
                     필터 결과 없음 (${episodes.length}개 중 0)
                   </div>`
                 : html`
-                  <div class="space-y-1.5 max-h-[240px] overflow-y-auto pr-1 custom-scrollbar">
+                  <div class="space-y-1.5 max-h-60 overflow-y-auto pr-1 custom-scrollbar">
                     ${visibleEpisodes
                       .slice()
                       .reverse()

--- a/dashboard/src/components/agent-detail-session-report.ts
+++ b/dashboard/src/components/agent-detail-session-report.ts
@@ -290,7 +290,7 @@ export function AgentSessionReport({ agentName }: { agentName: string }) {
             value=${query}
             placeholder="리포트/태스크 검색..."
             ariaLabel="세션 리포트 검색"
-            class="max-w-[360px]"
+            class="max-w-90"
             onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
           />
           ${hasQuery ? html`

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -101,7 +101,7 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
         <div class="flex-shrink-0 size-6 rounded bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-3xs font-mono font-bold ${cat.color}">
           ${cat.icon}
         </div>
-        <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-[200px]" title=${toolName}>${toolName}</span>
+        <span class="text-xs font-mono font-medium ${cat.color} truncate max-w-50" title=${toolName}>${toolName}</span>
         <span class="text-3xs px-1 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)]">${cat.label}</span>
         ${durationMs != null
           ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span>`
@@ -167,7 +167,7 @@ export function AgentTimelineSection() {
                 tone="accent"
               />
               <${TextInput}
-                class="max-w-[220px]"
+                class="max-w-55"
                 name="agent_timeline_search"
                 ariaLabel="타임라인 검색"
                 autoComplete="off"
@@ -182,7 +182,7 @@ export function AgentTimelineSection() {
             ${filtered.length === 0
               ? html`<${EmptyState} message="조건에 맞는 이벤트가 없습니다" compact />`
               : html`
-                  <div class="flex flex-col gap-0.5 max-h-[400px] overflow-y-auto">
+                  <div class="flex flex-col gap-0.5 max-h-100 overflow-y-auto">
                     ${filtered.map((evt: AgentTimelineEvent, idx: number) => {
                       if (evt.type === 'tool_call') {
                         return html`<${ToolCallEventRow} evt=${evt} idx=${idx} />`

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -16,31 +16,31 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
     <${Card} title="워커 상태">
       <div class="flex flex-col gap-1.5">
         <div class="flex items-baseline gap-2 text-sm">
-          <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">상태</span>
+          <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">상태</span>
           <${StatusBadge} status=${worker.state} />
         </div>
         ${worker.focus ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">포커스</span>
+            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">포커스</span>
             <span>${worker.focus}</span>
           </div>
         ` : null}
         ${worker.recent_output_preview ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">출력</span>
+            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">출력</span>
             <span class="agent-worker-brief__preview">${trimText(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">세션</span>
+            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">세션</span>
             <span class="font-mono truncate" style="font-size: 11px" title=${worker.related_session_id}>${worker.related_session_id}</span>
             <${CopyIdButton} value=${worker.related_session_id} label="session_id" size=${10} />
           </div>
         ` : null}
         ${worker.last_signal_at ? html`
           <div class="flex items-baseline gap-2 text-sm">
-            <span class="text-2xs text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
+            <span class="text-2xs text-[var(--text-muted)] min-w-15 shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
             ${worker.signal_truth ? html`<span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${worker.signal_truth}</span>` : null}
           </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -139,7 +139,7 @@ function renderOwnedTasks(
   isFiltering: boolean,
 ) {
   if (allTasks.length === 0) {
-    return html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
+    return html`<div class="h-full min-h-30"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
   }
   if (isFiltering && visibleTasks.length === 0) {
     return html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${allTasks.length} tasks)</div>`
@@ -304,7 +304,7 @@ export function AgentDetailOverlay() {
             placeholder="id / title / status 필터"
             aria-label="작업 필터"
             onInput=${(e: Event) => { taskQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
 
@@ -315,8 +315,8 @@ export function AgentDetailOverlay() {
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
+              ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
+              : html`<div class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-xs text-text-body leading-relaxed rounded shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -165,7 +165,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
         </div>
       </div>
 
-      <div class="flex flex-col gap-0.5 max-h-[320px] overflow-y-auto" ref=${scrollRef}>
+      <div class="flex flex-col gap-0.5 max-h-80 overflow-y-auto" ref=${scrollRef}>
         ${filtered.length === 0
           ? html`<${EmptyState} message="필터에 맞는 이벤트 없음" compact />`
           : filtered.map((entry: JournalEntry, idx: number) => html`

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -58,7 +58,7 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
       ${model ? html`
         <div class="flex items-center gap-1.5 text-sm">
           <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">MODEL</span>
-          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-[200px]">${model}</span>
+          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-50">${model}</span>
         </div>
       ` : null}
 

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -411,7 +411,7 @@ export function AgentProfile({ name }: { name: string }) {
         <${Card} title="타임라인" class="ff-card rounded">
           ${!timeline || (timeline.events ?? []).length === 0
             ? html`<${EmptyState} message="이벤트 없음" compact />`
-            : html`<div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
+            : html`<div class="flex flex-col gap-0.5 max-h-75 overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
                 return html`

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -527,7 +527,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">디렉터리 필터</span>
                 <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
               </div>
-              <p class="m-0 max-w-[720px] text-sm leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
+              <p class="m-0 max-w-180 text-sm leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
             </div>
 
             <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -337,7 +337,7 @@ export function AttributionPanel() {
             query.value = (e.target as HTMLInputElement).value
             selectedEventIdx.value = null
           }}
-          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--card-border)] bg-[var(--white-5)]/20 px-2 py-1 text-2xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-20)]0/50"
         />
       </div>
 

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -62,7 +62,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
   }
 
   return html`
-    <div class="absolute right-0 top-full mt-1.5 w-[280px] rounded border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
+    <div class="absolute right-0 top-full mt-1.5 w-70 rounded border border-[var(--card-border)] bg-[rgba(10,18,34,0.97)] shadow-sm backdrop-blur-sm p-3 z-50">
       ${authenticated ? html`
         <div class="flex flex-col gap-2">
           <div class="text-2xs text-[var(--text-muted)]">Bearer token이 설정되어 있습니다.</div>

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -268,13 +268,13 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
           placeholder="가설 / 판정 / # 필터"
           aria-label="사이클 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleCycles.length === 0
         ? html`<div class="py-4 text-center text-2xs text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
         : html`
-          <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
+          <div class="overflow-x-auto overflow-y-auto max-h-100 custom-scrollbar rounded border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
             <table class="w-full text-xs">
               <thead>
                 <tr class="text-[var(--text-muted)] text-3xs uppercase tracking-wider border-b border-[var(--white-10)]">
@@ -291,7 +291,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
                 ${visibleCycles.map(c => html`
                   <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
                     <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
-                    <td class="py-2 px-3 text-[var(--text-body)] max-w-[200px] truncate" title=${c.hypothesis}>${c.hypothesis}</td>
+                    <td class="py-2 px-3 text-[var(--text-body)] max-w-50 truncate" title=${c.hypothesis}>${c.hypothesis}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
                     <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
                     <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -297,7 +297,7 @@ function HealthTable({
     <div class="flex items-center gap-3 mb-2">
       <${TextInput}
         type="search"
-        class="max-w-[280px]"
+        class="max-w-70"
         placeholder="provider 필터 (key, cooldown...)"
         ariaLabel="health provider 검색"
         value=${searchQuery.value}
@@ -719,7 +719,7 @@ export function CascadeConfigPanel() {
           ? html`
             <div class="flex items-center gap-3 mb-3">
               <${TextInput}
-                class="max-w-[280px]"
+                class="max-w-70"
                 placeholder="검색 (cascade, strategy, 결과...)"
                 ariaLabel="strategy trace 검색"
                 value=${traceSearch.value}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -322,7 +322,7 @@ export function ChatTranscript({
 
   return html`
     <div
-      class=${`chat-transcript flex min-h-[300px] max-h-[520px] flex-col overflow-y-auto border border-[var(--slate-gray-14)] shadow-[inset_0_1px_0_var(--white-3)] ${
+      class=${`chat-transcript flex min-h-75 max-h-130 flex-col overflow-y-auto border border-[var(--slate-gray-14)] shadow-[inset_0_1px_0_var(--white-3)] ${
         variant === 'messenger'
           ? 'gap-4 rounded-[26px] px-4 py-5 sm:px-5'
           : 'gap-3 rounded-[var(--radius-xl)] px-3 py-4'
@@ -332,7 +332,7 @@ export function ChatTranscript({
     >
       ${entries.length === 0
         ? html`
-            <div class="flex min-h-[220px] flex-col items-center justify-center rounded-card border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
+            <div class="flex min-h-55 flex-col items-center justify-center rounded-card border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
               <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
               <div class="mt-3 max-w-[34rem] text-sm leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
             </div>
@@ -386,7 +386,7 @@ export function ChatComposer({
         <div class="text-2xs text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
-        class="control-textarea min-h-[96px] rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-[1.6]"
+        class="control-textarea min-h-24 rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-[1.6]"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}

--- a/dashboard/src/components/common/confirm-dialog.ts
+++ b/dashboard/src/components/common/confirm-dialog.ts
@@ -87,7 +87,7 @@ export function ConfirmDialogOverlay() {
 
   return html`
     <div class="fixed inset-0 z-[100] bg-[var(--white-5)]/60 backdrop-blur-sm isolate flex items-center justify-center p-4 animate-in fade-in duration-200" onClick=${handleClose}>
-      <div class="w-full max-w-[400px] bg-[rgba(13,21,38,0.98)] rounded-md border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+      <div class="w-full max-w-100 bg-[rgba(13,21,38,0.98)] rounded-md border border-[var(--card-border)] shadow-[0_24px_64px_rgba(0,0,0,0.6)] overflow-hidden" onClick=${stopPropagation} role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
         <div class="p-5">
           <div class="flex items-start gap-4">
             <div class="shrink-0 size-10 rounded-sm border flex items-center justify-center ${iconBg} ${iconColor}">

--- a/dashboard/src/components/common/heartbeat-strip.ts
+++ b/dashboard/src/components/common/heartbeat-strip.ts
@@ -15,7 +15,7 @@ const COLOR: Record<HeartbeatState, string> = {
   unknown: 'bg-[var(--white-8)]',
 }
 
-const BAR_W = 'w-[4px]'
+const BAR_W = 'w-1'
 const BAR_H = 'h-3'
 const BAR_RADIUS = 'rounded-[1px]'
 
@@ -92,7 +92,7 @@ export function HeartbeatStrip({
   const bars = padHistory(history, slots)
   const summary = summarizeHistory(history)
   const label = ariaLabel ?? formatHeartbeatLabel(summary)
-  const cls = cx ? `inline-flex items-end gap-[2px] ${cx}` : 'inline-flex items-end gap-[2px]'
+  const cls = cx ? `inline-flex items-end gap-0.5 ${cx}` : 'inline-flex items-end gap-0.5'
   return html`<span
     class=${cls}
     role="img"

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -82,7 +82,7 @@ export function TextArea({
   return html`
     <textarea
       id=${id}
-      class="${INPUT_BASE} px-3 py-2 text-sm min-h-[80px] resize-y ${cx ?? ''}"
+      class="${INPUT_BASE} px-3 py-2 text-sm min-h-20 resize-y ${cx ?? ''}"
       placeholder=${placeholder}
       rows=${rows}
       name=${name}

--- a/dashboard/src/components/common/json-viewer.ts
+++ b/dashboard/src/components/common/json-viewer.ts
@@ -93,7 +93,7 @@ export function JsonViewer({ data, label, initialCollapsed = false, level = 0, a
 
 export function JsonViewerCard({ data, title }: { data: unknown; title?: string }) {
   return html`
-    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded overflow-hidden flex flex-col max-h-[400px]" data-testid="json-viewer-card" data-title=${title ?? ''}>
+    <div class="bg-[var(--bg-0)] border border-[var(--card-border)] rounded overflow-hidden flex flex-col max-h-100" data-testid="json-viewer-card" data-title=${title ?? ''}>
       ${title ? html`<div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-2xs uppercase tracking-wider font-semibold text-[var(--text-muted)]">${title}</div>` : null}
       <div class="p-3 overflow-y-auto min-h-0 w-full">
         <${JsonViewer} data=${data} />

--- a/dashboard/src/components/common/kbd.ts
+++ b/dashboard/src/components/common/kbd.ts
@@ -14,7 +14,7 @@
 //  - `sm`           — dense inline hints (\"press ?\" micro-badge, status
 //                     bar). Same 10px text as `md` (P5 density sweep
 //                     upgraded `sm` from 9px → 10px for legibility),
-//                     but tighter padding (px-1 py-0 vs px-1.5 py-[1px]).
+//                     but tighter padding (px-1 py-0 vs px-1.5 py-px).
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -30,7 +30,7 @@ export function kbdClasses(size: KbdSize = 'md', extra?: string): string {
   const sized =
     size === 'sm'
       ? 'text-3xs px-1 py-0 border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-dim)]'
-      : 'text-3xs px-1.5 py-[1px] border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
+      : 'text-3xs px-1.5 py-px border-[var(--white-10)] bg-[var(--bg-0)] text-[var(--text-body)]'
   return extra === undefined || extra === ''
     ? `${BASE} ${sized}`
     : `${BASE} ${sized} ${extra}`

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -62,7 +62,7 @@ export function MermaidGraph({
   prefix = 'mermaid-graph',
   class: className = '',
   diagramClass = '',
-  minHeightClass = 'min-h-[160px]',
+  minHeightClass = 'min-h-40',
   fallbackText,
 }: MermaidGraphProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)

--- a/dashboard/src/components/common/rich-composer.ts
+++ b/dashboard/src/components/common/rich-composer.ts
@@ -57,13 +57,13 @@ export function RichComposer({
                 placeholder=${placeholder}
                 rows=${rows}
                 disabled=${disabled}
-                class="min-h-[140px]"
+                class="min-h-35"
                 onInput=${(event: Event) => onValueChange((event.target as HTMLTextAreaElement).value)}
               />
             `
           : value.trim()
             ? html`
-                <div class="max-h-[320px] overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3 custom-scrollbar">
+                <div class="max-h-80 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3 custom-scrollbar">
                   <${RichContent} text=${value} previewLimit=${previewLimit} />
                 </div>
               `

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -173,7 +173,7 @@ export function ToastContainer() {
         <div
           key=${t.id}
           role=${t.type === 'error' ? 'alert' : 'status'}
-          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
+          class="pointer-events-auto flex items-center gap-2.5 py-2 px-3 min-w-55 max-w-90 rounded border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-sm animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
           onMouseEnter=${() => pauseToastTimer(t.id)}
           onMouseLeave=${() => resumeToastTimer(t.id)}
           onFocusIn=${() => pauseToastTimer(t.id)}

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -154,7 +154,7 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
         <${MermaidGraph}
           source=${MERMAID_COMPOSITE}
           prefix="composite-fsm"
-          minHeightClass="min-h-[320px]"
+          minHeightClass="min-h-80"
           fallbackText="Flowchart render failed — see browser console."
         />
       </div>

--- a/dashboard/src/components/connector-overview-skeleton.ts
+++ b/dashboard/src/components/connector-overview-skeleton.ts
@@ -33,7 +33,7 @@ export function overviewSkeletonTileCount(): number {
   return KNOWN_CONNECTOR_IDS.length
 }
 
-const BAR = 'h-3 w-[4px] rounded-[1px] bg-[var(--white-4)] animate-pulse'
+const BAR = 'h-3 w-1 rounded-[1px] bg-[var(--white-4)] animate-pulse'
 const PILL = 'h-4 flex-1 rounded-sm bg-[var(--white-4)] animate-pulse'
 const LINE = 'h-3 rounded bg-[var(--white-4)] animate-pulse'
 
@@ -56,10 +56,10 @@ function TileSkeleton() {
         <div class=${PILL}></div>
       </div>
       <div class="flex items-center gap-1">
-        <div class="h-4 w-[64px] rounded-sm bg-[var(--white-4)] animate-pulse"></div>
-        <div class="h-4 w-[44px] rounded-sm bg-[var(--white-4)] animate-pulse"></div>
+        <div class="h-4 w-16 rounded-sm bg-[var(--white-4)] animate-pulse"></div>
+        <div class="h-4 w-11 rounded-sm bg-[var(--white-4)] animate-pulse"></div>
       </div>
-      <div class="flex items-end gap-[2px]" aria-hidden="true">
+      <div class="flex items-end gap-0.5" aria-hidden="true">
         ${Array.from({ length: 45 }, (_, i) => html`<span class=${BAR} data-skeleton-bar-index=${i}></span>`)}
       </div>
     </div>

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -259,7 +259,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
             ${uptimeLabel !== null
               ? html`
                   <span
-                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-[1px] text-3xs font-normal text-[var(--ok)]/80"
+                    class="rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-px text-3xs font-normal text-[var(--ok)]/80"
                     data-uptime-chip
                     title="last_ready_at 기준 경과 시간"
                   >${uptimeLabel}</span>
@@ -486,7 +486,7 @@ function TileHeartbeatStrip({ id }: { id: KnownConnectorId }) {
       <${HeartbeatStrip}
         history=${history}
         slots=${45}
-        class="-ml-[1px]"
+        class="-ml-px"
         testId=${`heartbeat-strip-${id}`}
       />
     </div>

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -67,7 +67,7 @@ function PathRow({ label, value, hint }: { label: string; value: string; hint: s
   return html`
     <div class="flex items-center gap-2" data-paths-row=${label}>
       <span
-        class="w-[100px] shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
+        class="w-25 shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
         title=${hint}
       >${label}</span>
       <div class="min-w-0 flex-1">

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -314,7 +314,7 @@ export function HeaderMiniStat({
   const valueTone = headerStatToneClass(tone)
   return html`
     <div
-      class="flex min-w-[60px] flex-col items-end justify-center rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-1 text-right"
+      class="flex min-w-15 flex-col items-end justify-center rounded border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-1 text-right"
       data-header-mini-stat=${label}
       data-header-mini-stat-tone=${tone}
       data-testid=${testId}
@@ -1052,7 +1052,7 @@ function ConnectorLivePanel({
                   aria-label="Keeper 필터"
                   data-testid=${`keeper-filter-${connectorId}`}
                   onInput=${(e: Event) => { patchConnectorUiState(connectorId, { keeperGroupQuery: (e.target as HTMLInputElement).value }) }}
-                  class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                  class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                 />
               </div>
               ${isFilteringKeepers && visibleKnownGroups.length === 0

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -197,7 +197,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-3xs text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
         aria-label=${`서버 빌드 정보 ${label}`}
         title=${hoverTitle}
@@ -209,7 +209,7 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+8px)] right-0 min-w-[280px] rounded border border-solid border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
+            <div class="absolute top-[calc(100%+8px)] right-0 min-w-70 rounded border border-solid border-[var(--card-border)] bg-[var(--bg-panel)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
                 <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -254,7 +254,7 @@ export function FeatureHealth() {
                     active=${statusFilter}
                   />
                   <${TextInput}
-                    class="sm:max-w-[260px]"
+                    class="sm:max-w-65"
                     name="feature_health_search"
                     ariaLabel="기능 플래그 검색"
                     autoComplete="off"

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -341,7 +341,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
           aria-label="Keeper 필터"
           data-testid="fleet-fsm-matrix-filter"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[160px] max-w-[260px] rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--text-muted)] placeholder:text-[var(--text-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
+          class="min-w-40 max-w-65 rounded border border-[var(--white-10)] bg-[var(--white-5)] px-2 py-0.5 text-xs text-[var(--text-muted)] placeholder:text-[var(--text-muted)]0 focus:border-[var(--white-10)]0 focus:outline-none"
         />
         ${tallies
           ? html`

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -241,12 +241,12 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
                 ${row.runtime_blocker_summary
                   ? html`
-                    <div class="max-w-[240px] truncate text-3xs text-[var(--warn)]" title=${row.runtime_blocker_summary}>
+                    <div class="max-w-60 truncate text-3xs text-[var(--warn)]" title=${row.runtime_blocker_summary}>
                       ${row.runtime_blocker_summary}
                     </div>
                   `
                   : null}
-                <div class="max-w-[240px] truncate text-3xs text-[var(--text-dim)]" title=${toolInfo.title}>
+                <div class="max-w-60 truncate text-3xs text-[var(--text-dim)]" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
               </td>
@@ -565,7 +565,7 @@ export function FleetTelemetryPanel() {
             placeholder="name / model / blocker 필터"
             aria-label="Keeper 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
         ${isFiltering && visibleRows.length === 0 && value.rows.length > 0

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -63,7 +63,7 @@ export function FlowControlPanel() {
             ${maintenanceLoading.value ? '...' : '좀비 정리'}<//>
         </div>
         ${maintenanceResult.value ? html`
-          <pre class="mt-3 p-3 rounded border border-card-border/50 bg-card/30 text-2xs text-text-body font-mono max-h-[160px] overflow-auto custom-scrollbar whitespace-pre-wrap">${maintenanceResult.value}</pre>
+          <pre class="mt-3 p-3 rounded border border-card-border/50 bg-card/30 text-2xs text-text-body font-mono max-h-40 overflow-auto custom-scrollbar whitespace-pre-wrap">${maintenanceResult.value}</pre>
         ` : null}
       </details>
     <//>

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -124,7 +124,7 @@ export function OperationalMeaningPanel({
           placeholder="field / label / state / meaning 필터"
           aria-label="관찰 레인 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
 

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -197,7 +197,7 @@ export function SwimlaneTimeline({
           const segments = deriveSwimlaneSegments(observations, lane.key, spanEnd)
           return html`
             <div class="flex items-center gap-2">
-              <div class="w-[44px] shrink-0 text-3xs font-mono font-semibold text-[var(--text-muted)]">
+              <div class="w-11 shrink-0 text-3xs font-mono font-semibold text-[var(--text-muted)]">
                 ${lane.short}
               </div>
               <div class="flex h-4 flex-1 overflow-hidden rounded border border-[var(--white-8)]" role="group" aria-label=${`${lane.label} swimlane with ${segments.length} segments`}>
@@ -237,7 +237,7 @@ export function SwimlaneTimeline({
       </div>
       ${ticks.length > 0 ? html`
         <div class="mt-1 flex items-center gap-2" aria-hidden="true">
-          <div class="w-[44px] shrink-0"></div>
+          <div class="w-11 shrink-0"></div>
           <div class="relative flex-1 h-3">
             ${ticks.map(tick => {
               const leftPct = ((tick.ts - spanStart) / spanWidth) * 100
@@ -256,7 +256,7 @@ export function SwimlaneTimeline({
       ` : null}
       ${observations.length > 1 ? html`
         <div class="mt-0.5 flex items-center gap-2" aria-hidden="true">
-          <div class="w-[44px] shrink-0 text-4xs text-[var(--text-dim)] text-right">obs</div>
+          <div class="w-11 shrink-0 text-4xs text-[var(--text-dim)] text-right">obs</div>
           <div class="relative flex-1 h-2.5">
             ${observations.map((obs, obsIndex) => {
               const leftPct = ((obs.ts - spanStart) / spanWidth) * 100
@@ -395,13 +395,13 @@ export function TransitionTrail({
           placeholder="field / from / to 필터"
           aria-label="전이 이력 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[120px] max-w-[200px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-30 max-w-50 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleHistory.length === 0
         ? html`<div class="py-3 text-center text-3xs text-[var(--text-dim)]">필터 결과 없음 (${history.length} items)</div>`
         : html`
-      <div ref=${scrollRef} class="flex flex-col gap-0.5 max-h-[120px] overflow-y-auto">
+      <div ref=${scrollRef} class="flex flex-col gap-0.5 max-h-30 overflow-y-auto">
         ${visibleHistory.map((entry, trailIndex) => {
           const ago = fmtDuration(Math.max(0, now - entry.ts))
           const color = FIELD_COLOR[entry.field] ?? 'text-[var(--text-body)]'
@@ -550,14 +550,14 @@ export function DwellHistogramPanel({
                       class=${`flex items-center gap-1.5 text-3xs font-mono leading-tight ${rowCls}`}
                       title=${`${displayState(entry.value)}: ${fmtDuration(entry.seconds)} (${entry.pct.toFixed(1)}%)`}
                     >
-                      <span class="w-[60px] shrink-0 text-[var(--text-body)] truncate">${displayState(entry.value)}</span>
+                      <span class="w-15 shrink-0 text-[var(--text-body)] truncate">${displayState(entry.value)}</span>
                       <span class="flex-1 h-1.5 rounded-sm bg-[var(--white-8)] overflow-hidden">
                         <span
                           class=${`block h-full ${barColor}`}
                           style=${`width: ${Math.max(2, entry.pct)}%`}
                         ></span>
                       </span>
-                      <span class="w-[36px] shrink-0 text-right text-3xs text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
+                      <span class="w-9 shrink-0 text-right text-3xs text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
                     </div>
                   `
                 })}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -571,7 +571,7 @@ function ShortcutsOverlay({
       aria-label="키보드 단축키"
     >
       <div
-        class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-[280px] shadow-sm"
+        class="rounded border border-[var(--white-10)] bg-[var(--bg-0)] p-5 min-w-70 shadow-sm"
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">
@@ -587,7 +587,7 @@ function ShortcutsOverlay({
         <div class="flex flex-col gap-1.5">
           ${rows.map(r => html`
             <div class="flex items-center gap-3 text-2xs">
-              <kbd class="font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-body)] min-w-[64px] text-center">
+              <kbd class="font-mono px-1.5 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-3)] text-[var(--text-body)] min-w-16 text-center">
                 ${r.keys}
               </kbd>
               <span class="text-[var(--text-body)]">${r.desc}</span>
@@ -721,7 +721,7 @@ function StatusBar({
               placeholder="keeper 이름 필터"
               aria-label="Keeper 이름 필터"
               onInput=${(e: Event) => onKeeperFilterChange((e.target as HTMLInputElement).value)}
-              class="min-w-[120px] max-w-[180px] rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
+              class="min-w-30 max-w-45 rounded-sm border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-3xs font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
             />
           ` : null}
           ${keeperFilterHasNoMatch ? html`

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -139,7 +139,7 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
       <div class="flex-1 ${h} rounded-sm bg-white/10 overflow-hidden">
         <div class="${h} rounded-sm transition-all duration-500" style="width:${clamped}%;background:${barColor}"></div>
       </div>
-      <span class="text-2xs font-semibold tabular-nums text-text-muted w-[36px] text-right">${clamped}%</span>
+      <span class="text-2xs font-semibold tabular-nums text-text-muted w-9 text-right">${clamped}%</span>
     </div>
   `
 }
@@ -231,7 +231,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
         ` : null}
       </div>
 
-      <div class="mt-2 max-w-[400px]">
+      <div class="mt-2 max-w-100">
         <${ConvergenceBar} pct=${node.convergence_pct} size="sm" />
       </div>
     </div>
@@ -300,7 +300,7 @@ export function GoalTree() {
     <div class="flex flex-col gap-5">
       <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
-          <div class="max-w-[760px]">
+          <div class="max-w-190">
             <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Tree</div>
             <h3 class="mt-1 text-2xl font-semibold tracking-[-0.02em] text-text-strong">목표 계층 구조</h3>
             <p class="mt-1.5 text-sm leading-relaxed text-text-muted">
@@ -315,7 +315,7 @@ export function GoalTree() {
                 placeholder="목표 / 태스크 제목 필터"
                 aria-label="목표 트리 필터"
                 onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
-                class="min-w-[180px] max-w-[260px] rounded border border-white/10 bg-white/5 px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
+                class="min-w-45 max-w-65 rounded border border-white/10 bg-white/5 px-2 py-1 text-xs text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
               />
               <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -188,7 +188,7 @@ function TaskColumn({
   }, [listRef])
 
   return html`
-    <section class="flex min-h-[240px] flex-col gap-4 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
+    <section class="flex min-h-60 flex-col gap-4 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="flex items-start justify-between gap-3 border-b border-card-border/50 pb-3">
         <div>
           <h3 class="text-md font-semibold text-text-strong">${title}</h3>
@@ -196,7 +196,7 @@ function TaskColumn({
         </div>
         <span class="rounded px-2.5 py-1 text-xs font-semibold ${badgeClass}">${count}</span>
       </div>
-      <div ref=${listRef} class="flex max-h-[680px] flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
+      <div ref=${listRef} class="flex max-h-170 flex-col gap-3 overflow-y-auto pr-1 custom-scrollbar">
         ${children}
       </div>
     </section>
@@ -269,7 +269,7 @@ export function TaskBacklog() {
         <div class="mb-3 rounded border border-warn/25 bg-warn/10 px-3 py-2 text-xs text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
       ` : null}
       <div class="mb-4 flex flex-wrap items-center gap-2">
-        <div class="min-w-[220px] flex-1">
+        <div class="min-w-55 flex-1">
           <${TextInput}
             value=${query}
             placeholder="태스크 제목/설명/담당자 검색..."

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -213,7 +213,7 @@ export function Planning() {
     <div class="flex flex-col gap-6">
       <section class="rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
         <div class="flex flex-wrap items-start justify-between gap-4">
-          <div class="max-w-[760px]">
+          <div class="max-w-190">
             <div class="text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">Planning Status</div>
             <h3 class="mt-2 text-[22px] font-semibold tracking-[-0.02em] text-text-strong">${planStatusHeadline}</h3>
             <p class="mt-2 text-sm leading-relaxed text-text-muted whitespace-pre-wrap">${planStatusBody}</p>

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -171,7 +171,7 @@ export function TaskActivityList({
         `)}
         <span class="ml-auto text-3xs text-text-dim tabular-nums">${filtered.length}건</span>
       </div>
-      <div class="flex flex-col gap-0.5 max-h-[400px] overflow-y-auto">
+      <div class="flex flex-col gap-0.5 max-h-100 overflow-y-auto">
         ${filtered.map((evt, i) => {
           const stable = evt.id ?? evt.ts_iso ?? evt.summary
           return html`<${ActivityEntry} key=${`${stable}-${i}`} event=${evt} />`

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -79,7 +79,7 @@ function TaskEventsSection() {
           placeholder="이벤트 검색 (label/agent/notes)"
           ariaLabel="이벤트 검색"
           onInput=${(e: Event) => { taskEventsSearchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[180px] flex-1 !py-1 !text-2xs"
+          class="min-w-45 flex-1 !py-1 !text-2xs"
         />
         <span class="text-3xs text-[var(--text-muted)] tabular-nums">
           ${trimmed
@@ -286,7 +286,7 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
             placeholder="목표 검색 (title/status/metric)"
             aria-label="목표 검색"
             onInput=${(e: Event) => { goalRelationSearchQuery.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
           <span class="text-3xs text-[var(--text-muted)] tabular-nums">
             ${isFiltering

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -190,7 +190,7 @@ export function GovernanceMonitor() {
             placeholder="tool / reason 필터"
             aria-label="Tool rejection 필터"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[240px] rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-60 rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
           />
           ${allRejections.length === 0
             ? html`<${EmptyState} message="선택한 시간 범위에 tool rejection이 없습니다." compact />`

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -120,7 +120,7 @@ function JudgeStatusBar() {
                 ? html`<span class="text-text-dim"><${TimeAgo} timestamp=${judge.generated_at} /></span>`
                 : null}
               ${judge.last_error
-                ? html`<span class="text-bad/80 truncate max-w-[300px]">${judge.last_error}</span>`
+                ? html`<span class="text-bad/80 truncate max-w-75">${judge.last_error}</span>`
                 : null}
             </span>
           `
@@ -416,7 +416,7 @@ function KeeperApprovalQueueSection() {
             aria-label="Keeper HITL 승인 필터"
             data-testid="keeper-hitl-approval-filter"
             onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-            class="min-w-[160px] max-w-[280px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-70 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
       ` : null}

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -314,7 +314,7 @@ export function HandoffTimeline({
           placeholder="keeper / event / task / peer 필터"
           aria-label="Handoff timeline 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-card-border bg-bg-1/40 px-2 py-1 text-2xs text-text placeholder:text-text-dim focus:outline-none focus:border-accent"
+          class="min-w-40 max-w-65 flex-1 rounded border border-card-border bg-bg-1/40 px-2 py-1 text-2xs text-text placeholder:text-text-dim focus:outline-none focus:border-accent"
         />
       </div>
       ${error !== null

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -371,7 +371,7 @@ export function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
           placeholder="task / agent / gate / cascade 필터"
           aria-label="판정 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
@@ -418,7 +418,7 @@ export function PreCompactList({ section }: { section: HarnessSignalSection<PreC
           placeholder="keeper / trigger / model / strategy 필터"
           aria-label="압축 이벤트 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0
@@ -470,7 +470,7 @@ export function HandoffList({ section }: { section: HarnessSignalSection<Handoff
           placeholder="keeper / model / trace_id 필터"
           aria-label="세대 교체 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleItems.length === 0

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -199,7 +199,7 @@ function HarnessFlowCard({ data }: { data: HarnessHealthData }) {
         source=${source}
         prefix="harness-flow"
         fallbackText=${fallbackText}
-        minHeightClass="min-h-[260px]"
+        minHeightClass="min-h-65"
         diagramClass="border border-[var(--white-8)]"
       />
     </div>

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -196,7 +196,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
   return html`
     <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
       <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
-        <div class="min-w-[220px] flex-1">
+        <div class="min-w-55 flex-1">
           <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
           <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">@${name}</div>
           <div class="mt-1 text-sm leading-[1.65] text-[var(--text-secondary)]">
@@ -205,7 +205,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
         </div>
         <div class="flex items-center gap-2">
           <${TextInput}
-            class="max-w-[220px]"
+            class="max-w-55"
             name="keeper_chat_search"
             ariaLabel="대화 내용 검색"
             autoComplete="off"

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -299,7 +299,7 @@ function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: numbe
     truncateAt !== null && truncateAt >= 0 && text.length > truncateAt
       ? text.slice(0, truncateAt) + '...'
       : text
-  return html`<div class="text-xs text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-sm p-3 rounded mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
+  return html`<div class="text-xs text-text-body whitespace-pre-wrap max-h-35 overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-sm p-3 rounded mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
 }
 
 
@@ -864,7 +864,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
               placeholder="슬롯 이름 / source / gate 필터"
               aria-label="훅 슬롯 필터"
               onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
-              class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
             />
           </div>
           ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -435,7 +435,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
                   const pct = Math.round((count / totalCalls) * 100)
                   return html`
                     <div class="flex items-center gap-2 text-xs">
-                      <span class="shrink-0 w-[140px] truncate font-mono text-2xs text-[var(--accent)]" title=${model}>${model}</span>
+                      <span class="shrink-0 w-35 truncate font-mono text-2xs text-[var(--accent)]" title=${model}>${model}</span>
                       <${ProgressBar}
                         pct=${pct}
                         size="sm"
@@ -1200,7 +1200,7 @@ export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">관계 없음</div>`
 
   return html`
-    <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">
+    <div class="max-h-55 overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
         <div class="flex items-center gap-2 py-2 px-3 bg-[var(--white-3)] rounded">
           <span class="inline-flex items-center py-0.5 px-2 rounded-sm text-2xs font-medium bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-30)]">${name}</span>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -320,7 +320,7 @@ function KeeperClearContextDialog({
       onClose=${pending ? () => {} : onClose}
       initialFocusRef=${reasonRef}
       overlayClass="fixed inset-0 z-[80] bg-[var(--white-5)]/70 backdrop-blur-sm isolate flex items-center justify-center p-4"
-      panelClass="w-full max-w-[520px] rounded border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
+      panelClass="w-full max-w-130 rounded border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
     >
       <div class="p-5 flex flex-col gap-4">
         <div class="flex flex-col gap-1">
@@ -591,7 +591,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
             placeholder="snapshot id / preview / 요약 필터"
             aria-label="OAS snapshot history 필터"
             onInput=${(e: Event) => { setHistoryQuery((e.target as HTMLInputElement).value) }}
-            class="min-w-[160px] max-w-[260px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            class="min-w-40 max-w-65 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
           />
         </div>
         ${!inventory || inventory.history.length === 0
@@ -1394,7 +1394,7 @@ export function KeeperDetailOverlay() {
                   </span>`
                 : null}
               ${keeper.memory_recent_note
-                ? html`<span class="text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-[360px]" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
+                ? html`<span class="text-2xs text-[var(--text-muted)] px-2.5 py-1 rounded border border-[var(--white-8)] bg-[var(--white-2)] truncate max-w-90" title=${keeper.memory_recent_note}>${keeper.memory_recent_note}</span>`
                 : null}
             </div>
             ${keeper.recent_output_preview

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -89,7 +89,7 @@ function LayerResultRow({ layer }: { layer: EvalLayerResult }) {
   return html`
     <div class="flex items-center gap-3 py-1.5 px-2 rounded hover:bg-[var(--white-3)] transition-colors">
       <span class="flex-shrink-0 w-4 text-center font-bold text-sm ${iconCls}">${icon}</span>
-      <span class="flex-shrink-0 w-[120px] text-2xs font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
+      <span class="flex-shrink-0 w-30 text-2xs font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
       <span class="flex-shrink-0 w-10 text-right text-2xs font-mono tabular-nums text-[var(--text-strong)]">${scoreText}</span>
       <span class="flex-1 text-3xs text-[var(--text-muted)] truncate" title=${detail}>${detail}</span>
     </div>

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -156,7 +156,7 @@ export function KeeperMemoryTierPanel({
           placeholder="kind 필터"
           aria-label="memory kind 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[120px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-30 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
         <${FilterChips}
           chips=${[

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -91,7 +91,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
           ${getPhaseStyle(toPascalPhase(phase)).icon} ${getPhaseStyle(toPascalPhase(phase)).label}
         </div>
       </div>
-      <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-[24px]">
+      <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-6">
         ${transitions.length === 0
           ? html`<span class="text-2xs text-[var(--text-muted)]">전환 없음</span>`
           : transitions.map((t, i) => html`

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -222,7 +222,7 @@ export function KeeperDiagnosticSummary({
         ? html`<div class="text-xs text-[var(--bad-light)] leading-relaxed mt-1">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<div class="mt-3 max-h-[240px] overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`
+        ? html`<div class="mt-3 max-h-60 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```text\n' + (detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.') + '\n```'} /></div>`
         : null}
     </div>
   `
@@ -292,7 +292,7 @@ export function KeeperConversationPanel({
     <div class="flex flex-col gap-3">
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
-          <div class="min-w-[220px] flex-1">
+          <div class="min-w-55 flex-1">
             <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
               <div class="text-md font-semibold text-[var(--text-strong)]">@${keeperName}</div>

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -38,7 +38,7 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
   const isSpawning = spawning.value && isConfirming
   const title = persona.displayName ?? persona.name
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-[180px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-4)] p-4 flex flex-col gap-2 min-w-45">
       <div class="text-base text-[var(--text-strong)] font-medium">${title}</div>
       ${persona.role ? html`<div class="text-2xs text-[var(--text-muted)]">${persona.role}</div>` : null}
       ${persona.mode ? html`<div class="text-3xs text-[var(--text-muted)]">모드: ${persona.mode}</div>` : null}
@@ -81,7 +81,7 @@ export function PersonaBrowser() {
           placeholder="페르소나 검색 (이름/역할/모드/설명)"
           aria-label="페르소나 검색"
           onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[180px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-45 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
         <span class="text-3xs text-[var(--text-muted)] tabular-nums">
           ${searchQuery.value.trim()
@@ -98,7 +98,7 @@ export function PersonaBrowser() {
         `}
       ${spawnResult.value ? html`
         <${SurfaceCard} class="mt-3" variant="compact">
-          <pre class="text-2xs font-mono overflow-x-auto max-h-[200px] overflow-y-auto
+          <pre class="text-2xs font-mono overflow-x-auto max-h-50 overflow-y-auto
             ${spawnResult.value.success ? 'text-[var(--text-body)]' : 'text-[var(--bad)]'}">${spawnResult.value.message}</pre>
         <//>` : null}
     </div>

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -224,7 +224,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
               placeholder="도구 검색 (이름/카테고리)"
               aria-label="도구 텔레메트리 검색"
               onInput=${(e: Event) => { setQuery((e.target as HTMLInputElement).value) }}
-              class="min-w-[160px] rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+              class="min-w-40 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
             />
             <span class="text-3xs text-[var(--text-muted)] tabular-nums">
               ${trimmedQuery

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -46,10 +46,10 @@ export function Live({ variant = 'full' }: LiveProps) {
         <//>
       ` : html`
         <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-          <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
+          <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4">
             <${ActivityStream} />
           </section>
-          <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
+          <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-130 p-4">
             <${FocusSidebar} />
           </section>
         </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -39,7 +39,7 @@ function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
               <span class="text-xs text-[var(--text-muted)]">${list.length}명 활성</span>
             </div>
           `}
-      <div class="grid content-start gap-1.5 overflow-y-auto pr-1 ${compact ? 'max-h-[32vh]' : 'max-h-[560px]'}">
+      <div class="grid content-start gap-1.5 overflow-y-auto pr-1 ${compact ? 'max-h-[32vh]' : 'max-h-140'}">
         ${list.length === 0
           ? html`<div class="py-6 text-center text-[var(--text-muted)] text-sm">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
           : list.map(agent => html`

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -34,7 +34,7 @@ export function PulseStrip() {
           title="${p.koreanName ? `${p.name} (${p.koreanName})` : p.name}${p.currentTask ? ` — ${p.currentTask}` : ''}"
         >
           <span class="text-[1.15rem] leading-none">${p.emoji || p.name.charAt(0).toUpperCase()}</span>
-          <span class="text-[0.65rem] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[64px]">${p.koreanName ?? p.name}</span>
+          <span class="text-[0.65rem] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis max-w-16">${p.koreanName ?? p.name}</span>
         </button>
       `)}
     </div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -381,7 +381,7 @@ export function LogViewer() {
             </select>
 
             <${TextInput}
-              class="min-w-[220px]"
+              class="min-w-55"
               name="log-module-filter"
               ariaLabel="모듈 필터"
               placeholder="모듈 필터"

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -215,7 +215,7 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
           placeholder="댓글 내용 검색"
           aria-label="댓글 필터"
           onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
-          class="ml-auto min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="ml-auto min-w-35 max-w-55 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && filteredRoots.length === 0 ? html`

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -356,7 +356,7 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
                 class="text-[var(--text-muted)] hover:text-[var(--accent)] truncate w-32 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
                 onClick=${() => openAgentDetail(s.to_agent)}
               >${shortAgentLabel(s.to_agent)}</button>
-              <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-[60px]">
+              <div class="flex-1 bg-[var(--white-5)] rounded h-1.5 min-w-15">
                 <div class="${weightBarClass(s.weight)} rounded h-1.5" style="width:${pct}%"></div>
               </div>
               <span class="text-[var(--text-muted)] w-10 text-right">${pct}%</span>
@@ -581,7 +581,7 @@ export function MemorySubsystems() {
                   <${MermaidGraph}
                     source=${ARCHITECTURE_FLOW}
                     prefix="memory-arch"
-                    minHeightClass="min-h-[320px]"
+                    minHeightClass="min-h-80"
                   />
                 </div>
               `
@@ -625,7 +625,7 @@ export function MemorySubsystems() {
                     onInput=${(e: Event) => {
                       synapseQuery.value = (e.target as HTMLInputElement).value
                     }}
-                    class="flex-1 min-w-[200px] bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+                    class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
                   />
                   ${
                     isSynapseFiltering
@@ -693,7 +693,7 @@ export function MemorySubsystems() {
             placeholder="검색 (summary, learnings, event_type...)"
             value=${searchQuery.value}
             onInput=${onSearchInput}
-            class="flex-1 min-w-[200px] bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
+            class="flex-1 min-w-50 bg-[var(--white-5)] border border-[var(--white-10)] rounded px-2 py-1 text-sm text-[var(--text-muted)] placeholder:text-[var(--text-muted)] focus:border-[var(--white-10)]0 focus:outline-none"
           />
           <select
             value=${keeperFilter.value}

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -401,7 +401,7 @@ function PostCard({ post }: { post: BoardPost }) {
       </div>
 
       <!-- Vote column -->
-      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-[36px]">
+      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-9">
         <button type="button"
           class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-2xs text-[var(--text-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('up', event)}
@@ -521,7 +521,7 @@ export function Memory() {
           placeholder="제목/본문에서 검색"
           aria-label="게시글 본문 필터"
           onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[180px] max-w-[320px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-45 max-w-80 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && posts.length === 0 && rawPosts.length > 0

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -68,7 +68,7 @@ export function QuickIntervene() {
 
       <div class="flex gap-2 items-stretch flex-wrap">
         <select
-          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-body)] transition-colors cursor-pointer min-w-[120px] focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-body)] transition-colors cursor-pointer min-w-30 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
           value=${quickTarget.value}
           aria-label="개입 대상"
           onChange=${(e: Event) => { quickTarget.value = (e.target as HTMLSelectElement).value }}
@@ -82,7 +82,7 @@ export function QuickIntervene() {
           `)}
         </select>
         <${TextInput}
-          class="min-w-[200px] flex-1 border-[var(--white-8)] bg-[var(--white-3)]"
+          class="min-w-50 flex-1 border-[var(--white-8)] bg-[var(--white-3)]"
           placeholder="메시지"
           value=${quickMessage.value}
           name="quick_intervene_message"
@@ -105,7 +105,7 @@ export function QuickIntervene() {
               </label>
               <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>
               <${TextInput}
-                class="mt-3 max-w-[260px] border-[var(--white-8)] bg-[var(--white-3)]"
+                class="mt-3 max-w-65 border-[var(--white-8)] bg-[var(--white-3)]"
                 value=${actorName.value.trim() || 'dashboard'}
                 name="quick_intervene_actor"
                 ariaLabel="개입 기록 주체"

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -315,7 +315,7 @@ export function PrometheusMetrics() {
       `}
 
       <${TextInput}
-        class="max-w-[300px]"
+        class="max-w-75"
         placeholder="검색 (메트릭 이름, 라벨...)"
         ariaLabel="메트릭 검색"
         value=${searchQuery.value}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -279,7 +279,7 @@ export function RuntimeMonitor() {
             type="search"
             ariaLabel="모델 ID 검색"
             placeholder="model_id 또는 도구 이름"
-            class="min-w-[220px] flex-1 !py-1 !text-2xs"
+            class="min-w-55 flex-1 !py-1 !text-2xs"
             value=${modelSearch.value}
             onInput=${(e: Event) => { modelSearch.value = (e.target as HTMLInputElement).value }}
           />

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -412,7 +412,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
         ${responseText ? html`
           <details class="mt-1">
             <summary class="text-3xs text-[var(--text-dim)] cursor-pointer hover:text-[var(--text-body)]">응답 텍스트</summary>
-            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-2xs font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-[300px] overflow-auto">${responseText}</pre>
+            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-2xs font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-75 overflow-auto">${responseText}</pre>
           </details>
         ` : null}
       </div>

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -182,7 +182,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
                   return html`
                     <li class="flex items-start gap-2.5" data-setup-step-item=${idx}>
                       <span
-                        class=${`mt-[2px] inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border text-3xs font-semibold tabular-nums transition-colors ${circleToneClass}`}
+                        class=${`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border text-3xs font-semibold tabular-nums transition-colors ${circleToneClass}`}
                         aria-hidden="true"
                         data-setup-step-circle=${`${connectorId}:${idx}`}
                       >${done ? '✓' : idx + 1}</span>

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -420,7 +420,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const hasData = src.entry_count > 0
 
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
       <div class="flex items-center gap-2 mb-1">
         <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
         <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
@@ -442,7 +442,7 @@ function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
 function DiagnosisCard({ title, value, detail, tone }: { title: string; value: string; detail: string; tone: 'ok' | 'warn' | 'neutral' }) {
   const toneColor = tone === 'ok' ? 'text-[var(--ok)]' : tone === 'warn' ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'
   return html`
-    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
       <div class="text-xs font-medium text-[var(--text-muted)] mb-1">${title}</div>
       <div class="text-2xl font-bold ${toneColor}">${value}</div>
       <div class="text-3xs text-[var(--text-dim)]">${detail}</div>
@@ -491,7 +491,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
               ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </div>
           ` : null}
-          <pre class="text-3xs font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
+          <pre class="text-3xs font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
 ${JSON.stringify(entry, null, 2)}</pre>
         </div>
       ` : null}
@@ -553,7 +553,7 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
           })}
           <details class="rounded bg-[var(--black-20)] px-2 py-1.5">
             <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">Raw JSON</summary>
-            <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-[280px] overflow-y-auto whitespace-pre-wrap break-all">
+            <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
 ${JSON.stringify(item.entries, null, 2)}</pre>
           </details>
         ` : null}
@@ -724,7 +724,7 @@ export function TelemetryUnified() {
 
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-[140px]">
+        <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 min-w-35">
           <div class="text-xs font-medium text-[var(--text-muted)] mb-1">전체</div>
           <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
         </div>
@@ -857,7 +857,7 @@ export function TelemetryUnified() {
             })}
           </div>
         ` : null}
-        <div class="max-h-[600px] overflow-y-auto">
+        <div class="max-h-150 overflow-y-auto">
           ${displayItems.length > 0
             ? displayItems.map(item => item.kind === 'group'
               ? html`<${GroupRow} key=${item.key} item=${item} />`

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-3xs font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/components/tool-executor/tool-executor.ts
+++ b/dashboard/src/components/tool-executor/tool-executor.ts
@@ -70,9 +70,9 @@ export function ToolExecutor() {
     </div><//>`
   }
   return html`
-    <${SurfaceCard} class="h-[calc(100vh-240px)] min-h-[400px]">
+    <${SurfaceCard} class="h-[calc(100vh-240px)] min-h-100">
       <div class="flex gap-4 h-full">
-        <div class="w-[280px] flex-shrink-0 border-r border-[var(--card-border)] pr-4"><${ToolPicker} /></div>
+        <div class="w-70 flex-shrink-0 border-r border-[var(--card-border)] pr-4"><${ToolPicker} /></div>
         <div class="flex-1 min-w-0"><${ToolDetail} /></div>
       </div>
     <//>

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -82,7 +82,7 @@ function StoredBlobView({
             <${ActionButton} variant="subtle" size="sm"
               onClick=${() => void navigator.clipboard.writeText(fullText.value ?? '')}>복사<//>
           </div>
-          <div class="px-3 py-2 overflow-x-auto max-h-[400px] overflow-y-auto">
+          <div class="px-3 py-2 overflow-x-auto max-h-100 overflow-y-auto">
             ${(() => {
               const { isJson, parsed } = tryParseJson(fullText.value ?? '')
               return isJson
@@ -115,7 +115,7 @@ function StoredBlobView({
             ${loading.value ? '\uad6c\uac00\uc624\ub294 \uc911\u2026' : '\uc804\uccb4 \ucd9c\ub825 \uc5f4\uae30'}
           <//>
         </div>
-        <div class="px-3 py-2 overflow-x-auto max-h-[200px] overflow-y-auto">
+        <div class="px-3 py-2 overflow-x-auto max-h-50 overflow-y-auto">
           <pre class="text-xs font-mono text-[var(--text-muted)] whitespace-pre-wrap">${marker.preview}</pre>
         </div>
         ${error.value ? html`
@@ -161,7 +161,7 @@ export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolRe
           <${ActionButton} variant="subtle" size="sm" onClick=${() => void navigator.clipboard.writeText(text)}>복사<//>
         </div>
         ${expanded.value ? html`
-          <div class="px-3 py-2 overflow-x-auto max-h-[400px] overflow-y-auto">
+          <div class="px-3 py-2 overflow-x-auto max-h-100 overflow-y-auto">
             ${isJson
               ? html`<${JsonViewer} data=${parsed} />`
               : html`<pre class="text-xs font-mono ${success ? 'text-[var(--text-body)]' : 'text-[var(--bad-light)]'}">${text}</pre>`

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -97,17 +97,17 @@ function ToolDistribution({ dist }: { dist: { total: number; public: number; vis
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-essential">공개 MCP</span>
+        <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-essential">공개 MCP</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.public}</span>
         <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.public)}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-standard">내부 전용</span>
+        <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-standard">내부 전용</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${visibleExclusive}</span>
         <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(visibleExclusive)}%</span>
       </div>
       <div class="flex items-center gap-3">
-        <span class="inline-block min-w-[72px] px-2 py-0.5 text-2xs font-semibold text-center rounded badge-full">숨김</span>
+        <span class="inline-block min-w-18 px-2 py-0.5 text-2xs font-semibold text-center rounded badge-full">숨김</span>
         <span class="text-[var(--text-strong)] text-sm font-semibold min-w-9 text-right">${dist.hidden}</span>
         <span class="text-[var(--text-muted)] text-sm min-w-12 text-right">${pct(dist.hidden)}%</span>
       </div>
@@ -199,7 +199,7 @@ export function ToolMetrics() {
                     active=${categoryFilter}
                   />
                   <${TextInput}
-                    class="sm:max-w-[240px]"
+                    class="sm:max-w-60"
                     name="tool_metrics_search"
                     ariaLabel="도구 이름 검색"
                     autoComplete="off"

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -352,7 +352,7 @@ export function ToolQualityPanel() {
         <div class="flex items-center justify-between mb-1 gap-2">
           <div class="text-3xs text-[var(--text-dim)] uppercase tracking-wider">도구별 성공률</div>
           <${TextInput}
-            class="max-w-[180px]"
+            class="max-w-45"
             name="tool_quality_search"
             ariaLabel="도구 이름 검색"
             autoComplete="off"

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -537,7 +537,7 @@ export function ConfigResolutionPanel({
                           placeholder="kind / signal / message 필터"
                           aria-label="Diagnostics 필터"
                           onInput=${(e: Event) => { diagnosticsQuery.value = (e.target as HTMLInputElement).value }}
-                          class="min-w-[160px] max-w-[240px] flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                          class="min-w-40 max-w-60 flex-1 rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
                         />
                       `
                     : null}

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -175,7 +175,7 @@ export function PromptRegistryPanel() {
       ${status ? html`<div class="mb-4 rounded border border-[var(--sky-28)] bg-[var(--sky-8)] px-3 py-2 text-xs text-[#bae6fd]">${status}</div>` : null}
 
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
-        <div class="min-h-[260px] rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
+        <div class="min-h-65 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
             <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
               등록된 프롬프트
@@ -205,7 +205,7 @@ export function PromptRegistryPanel() {
               onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
             />
           </div>
-          <div class="flex max-h-[520px] flex-col gap-2 overflow-y-auto pr-1">
+          <div class="flex max-h-130 flex-col gap-2 overflow-y-auto pr-1">
             ${visiblePrompts.length === 0 ? html`
               <div class="rounded border border-dashed border-[var(--card-border)] px-3 py-6 text-center text-2xs text-[var(--text-muted)]">
                 조건에 맞는 프롬프트가 없습니다.
@@ -268,7 +268,7 @@ export function PromptRegistryPanel() {
 
             <div class="mb-4">
               <div class="mb-2 text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
-              <div class="max-h-[220px] overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
+              <div class="max-h-55 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
@@ -278,7 +278,7 @@ export function PromptRegistryPanel() {
             <${TextArea}
               rows=${18}
               value=${draft}
-              class="min-h-[320px] font-mono text-xs"
+              class="min-h-80 font-mono text-xs"
               onInput=${(event: Event) => {
                 setDraft((event.target as HTMLTextAreaElement).value)
                 setStatus(null)

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -218,7 +218,7 @@ export function ResolvedPreview({ tools, catMap }: { tools: string[]; catMap: Ma
           placeholder="도구/카테고리 필터"
           aria-label="resolved allowlist 필터"
           onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-          class="min-w-[140px] max-w-[220px] flex-1 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-35 max-w-55 flex-1 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-1 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]"
         />
       </div>
       ${isFiltering && visibleTools.length === 0
@@ -355,7 +355,7 @@ function ToolSearchPicker({
 
         <ul ...${getMenuProps({
           class: showMenu && filtered.length > 0
-            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-[220px] overflow-y-auto rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] shadow-sm backdrop-blur-sm list-none m-0 p-0'
+            ? 'absolute z-10 top-full left-0 right-0 mt-1 max-h-55 overflow-y-auto rounded border border-[var(--card-border)] bg-[var(--backdrop-modal)] shadow-sm backdrop-blur-sm list-none m-0 p-0'
             : 'hidden',
         })}>
           ${showMenu && filtered.length > 0
@@ -576,7 +576,7 @@ export function ToolAllowlistEditor({
             ${textInputSection.value === 'also_allow'
               ? html`
                 <textarea
-                  class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+                  class="min-h-18 w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
                   placeholder="쉼표 또는 줄바꿈으로 구분"
                   value=${textInputBuffer.value}
                   onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}
@@ -642,7 +642,7 @@ export function ToolAllowlistEditor({
         ${textInputSection.value === 'deny'
           ? html`
             <textarea
-              class="min-h-[72px] w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
+              class="min-h-18 w-full px-3 py-2 rounded border border-[var(--card-border)] bg-[var(--white-3)] text-2xs text-[var(--text-body)] placeholder:text-[var(--text-muted)]"
               placeholder="쉼표 또는 줄바꿈으로 구분"
               value=${textInputBuffer.value}
               onInput=${(e: Event) => { textInputBuffer.value = (e.target as HTMLTextAreaElement).value }}

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -128,7 +128,7 @@ export function FullInventoryView({
 
       <div class="flex flex-wrap gap-3 items-center">
         <${TextInput}
-          class="max-w-[320px]"
+          class="max-w-80"
           name="tool_inventory_query"
           ariaLabel="도구 인벤토리 검색"
           autoComplete="off"
@@ -194,7 +194,7 @@ export function FullInventoryView({
 
     ${error ? html`<${ErrorState} message=${error} class="mt-2" />` : null}
 
-    <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-[300px]">
+    <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-75">
       ${filtered.length > 0
         ? html`<${VirtualList}
             items=${filtered}

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -482,7 +482,7 @@ export function TransportHealthPanel() {
                   <div class="text-2xs text-text-muted">SSE 세션 중 메시지 큐가 쌓여 있는 세션입니다. 큐 depth가 높으면 해당 클라이언트가 이벤트 처리를 따라가지 못하고 있습니다.</div>
                   <${TextInput}
                     type="search"
-                    class="min-w-[180px] flex-1 !py-1 !text-2xs"
+                    class="min-w-45 flex-1 !py-1 !text-2xs"
                     name="hot_sessions_search"
                     ariaLabel="핫 세션 검색 (session id, kind, last event id)"
                     autoComplete="off"

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -248,7 +248,7 @@ function RowActions({
       <div class="flex items-center gap-1 flex-wrap">
         <input
           type="text"
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] w-[200px]"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-2xs text-[var(--text-body)] w-50"
           placeholder="반려 사유 (필수)"
           value=${reason}
           autofocus
@@ -544,7 +544,7 @@ export function VerificationRequestsPanel() {
 
       <${TextInput}
         type="search"
-        class="max-w-[260px]"
+        class="max-w-65"
         placeholder="request / task / 제출자 / 승인자 필터"
         ariaLabel="검증 요청 필터"
         value=${searchQuery.value}

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -174,7 +174,7 @@ export function VerificationSpecsPanel() {
           tone="accent"
         />
         <${TextInput}
-          class="max-w-[200px]"
+          class="max-w-50"
           name="spec_search"
           ariaLabel="스펙 검색"
           autoComplete="off"


### PR DESCRIPTION
## Why
Spacing axis migration. Tailwind v4 default `--spacing: 0.25rem` (= 4px) covers all clean 4px-multiple panel sizes natively — no new tokens needed.

## What
**Sweep:** 195 replacements / 84 files

### Width/height (4px multiples → wN/hN)
- `w-[60px]` → `w-15` (8 sites)
- `w-[120px]` → `w-30` (5)
- `w-[140px]` → `w-35` (6)
- `w-[160px]` → `w-40` (20)
- `w-[180px]` → `w-45` (8)
- `w-[200px]` → `w-50` (9)
- `w-[220px]` → `w-55` (11)
- `w-[240px]` → `w-60` (11)
- `w-[260px]` → `w-65` (13)
- `w-[280px]` → `w-70` (8)
- `w-[300/320/360/400/520/760px]` → respective wN
- Same scheme for `h-[Xpx]` (h-[400px] → h-100, etc.)

### Spacing (Tailwind native)
- `py-[1px]` → `py-px` (3)
- `mt-[1px]` → `mt-px` (1), `ml-[1px]` → `ml-px` (1)
- `gap-[2px]` → `gap-0.5` (3)
- `mt-[2px]` → `mt-0.5` (1)
- `px-[10px]` → `px-2.5` (2)
- `gap-[10px]` → `gap-2.5` (1)

### Skipped (non-4px-multiple)
`3px/5px/7px/15px` literals (~10 sites) stay inline — Tailwind scale has no native exact match. Custom tokens for 1-3 sites each wouldn't pay off.

## Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` — 232 files / **3808 tests** all pass

## 누적 axis 진행
| Axis | 상태 |
|------|------|
| Color | ✅ |
| Radii | ✅ |
| Pills | ✅ |
| Shadows/Blur | ✅ |
| Typography | ✅ |
| Mobile responsive SSOT | ✅ |
| **Spacing** | ✅ (this) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)