### PR TITLE
fix(coord_task): teach LLM keepers what's legal via valid_next_actions hint (#7646)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -202,6 +202,37 @@ let task_assignee_of_status = function
   | Types.AwaitingVerification { assignee; _ } -> Some assignee
   | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
 
+(** Issue #7646: symmetric to [task_assignee_of_status]. When a transition
+    fails for a reason other than ownership mismatch, surface what
+    actions ARE legal from the current state so the LLM stops
+    guess-retrying.
+
+    Exhaustive [match] over [Types.task_status]: adding a 7th constructor
+    will fail to compile. Each branch lists actions that
+    [transition_task_r]'s match-arms accept for that status — keep this
+    in sync if you add new transitions there. Verifier-FSM transitions
+    require [MASC_VERIFICATION_FSM_ENABLED=true] but are listed
+    unconditionally so the hint stays accurate when the flag is on; the
+    flag-off case still rejects them and produces a more specific error. *)
+let valid_next_actions_for_status : Types.task_status -> Types.task_action list = function
+  | Types.Todo                   -> [Types.Claim; Types.Cancel]
+  | Types.Claimed _              -> [Types.Start; Types.Done_action;
+                                     Types.Submit_for_verification;
+                                     Types.Release; Types.Cancel]
+  | Types.InProgress _           -> [Types.Done_action;
+                                     Types.Submit_for_verification;
+                                     Types.Release; Types.Cancel]
+  | Types.AwaitingVerification _ -> [Types.Approve_verification;
+                                     Types.Reject_verification]
+  | Types.Done _ | Types.Cancelled _ -> []  (* terminal *)
+
+let next_actions_hint status =
+  match valid_next_actions_for_status status with
+  | [] -> ""
+  | xs ->
+    Printf.sprintf ", valid_next_actions=[%s]"
+      (String.concat ";" (List.map Types.task_action_to_string xs))
+
 let task_started_at_unix status =
   let default_time = Time_compat.now () in
   match status with
@@ -856,10 +887,19 @@ let transition_task_r config ~agent_name ~task_id ~action
                 Printf.sprintf ", current_assignee=%s" a
               | _ -> ""
             in
+            (* Issue #7646: ownership-mismatch dominates; only show
+               valid_next_actions when the failure isn't an ownership
+               problem. Otherwise the hint risks misdirecting the LLM
+               toward retrying actions it cannot perform on someone
+               else's task. *)
+            let actions_hint =
+              if assignee_hint <> "" then ""
+              else next_actions_hint task.task_status
+            in
             Error (Types.TaskInvalidState
-              (Printf.sprintf "Invalid transition: %s -> %s (%s, agent=%s%s)"
+              (Printf.sprintf "Invalid transition: %s -> %s (%s, agent=%s%s%s)"
                 (task_status_to_string task.task_status) action_s task_id agent_name
-                assignee_hint))
+                assignee_hint actions_hint))
       in
       if new_status = task.task_status && set_current = None then
         (* Idempotent no-op: status unchanged, skip write/events.

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -41,6 +41,17 @@ val task_actor_kind : string -> string
 
 val task_status_to_string : Types.task_status -> string
 
+val valid_next_actions_for_status : Types.task_status -> Types.task_action list
+(** Issue #7646: actions that [transition_task_r] accepts from the given
+    [task_status]. Used to enrich "Invalid transition" error messages so
+    LLM keepers see what they SHOULD have called, not just what failed.
+    Empty list for terminal states ([Done], [Cancelled]). *)
+
+val next_actions_hint : Types.task_status -> string
+(** Issue #7646: rendered hint string suitable for embedding in error
+    messages, e.g. [", valid_next_actions=[claim;cancel]"]. Returns the
+    empty string for terminal states. *)
+
 val task_started_at_unix : Types.task_status -> float
 
 val task_transition_details :

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -238,6 +238,51 @@ let () = test "get_bool_missing" (fun () ->
   assert (Tool_args.get_bool args "key" true = true)
 )
 
+(* Issue #7646: valid_next_actions_for_status hint tests. One per
+   [Types.task_status] variant. The witness ensures every variant has a
+   defined hint AND the ones with content list each action canonically. *)
+let next_hint = Coord_task.next_actions_hint
+
+let () = test "next_hint_todo lists claim and cancel" (fun () ->
+  let h = next_hint Types.Todo in
+  assert (str_contains h "claim");
+  assert (str_contains h "cancel");
+  assert (str_contains h "valid_next_actions=")
+)
+
+let () = test "next_hint_claimed lists start, done, release, cancel" (fun () ->
+  let h = next_hint (Types.Claimed { assignee = "a"; claimed_at = "t" }) in
+  assert (str_contains h "start");
+  assert (str_contains h "done");
+  assert (str_contains h "release");
+  assert (str_contains h "cancel")
+)
+
+let () = test "next_hint_in_progress lists done and release" (fun () ->
+  let h = next_hint (Types.InProgress { assignee = "a"; started_at = "t" }) in
+  assert (str_contains h "done");
+  assert (str_contains h "release");
+  assert (not (str_contains h "claim"))  (* Claim is not legal from InProgress *)
+)
+
+let () = test "next_hint_awaiting_verification lists approve and reject" (fun () ->
+  let h = next_hint (Types.AwaitingVerification {
+    assignee = "a"; submitted_at = "t"; verification_id = "v";
+    required_verifier_role = Types.Reviewer; deadline = None }) in
+  assert (str_contains h "approve");
+  assert (str_contains h "reject")
+)
+
+let () = test "next_hint_done is empty (terminal)" (fun () ->
+  let h = next_hint (Types.Done { assignee = "a"; completed_at = "t"; notes = None }) in
+  assert (h = "")
+)
+
+let () = test "next_hint_cancelled is empty (terminal)" (fun () ->
+  let h = next_hint (Types.Cancelled { cancelled_by = "a"; cancelled_at = "t"; reason = None }) in
+  assert (h = "")
+)
+
 let () =
   Alcotest.run "Tool_coord"
     [


### PR DESCRIPTION
## Summary
Closes #7646. Issue body included a complete patch suggestion; this PR implements it with one tweak (Submit_for_verification listed alongside Done from Claimed/InProgress).

## Before vs After

**Before**
\`\`\`
❌ Invalid task state: Invalid transition: todo -> start
   (task-193, agent=gemini-hale-shark)
\`\`\`

**After**
\`\`\`
❌ Invalid task state: Invalid transition: todo -> start
   (task-193, agent=gemini-hale-shark, valid_next_actions=[claim;cancel])
\`\`\`

For an LLM keeper, the second form is strictly more informative — it sees the prerequisite it skipped (`claim`) instead of having to guess.

## Suppression rule
The hint is **suppressed** when `current_assignee` is already shown — ownership mismatch dominates, and listing actions the caller cannot perform on someone else's task would misdirect retries. This matches the issue body's recommendation.

## Variant SSOT enforcement
`valid_next_actions_for_status` is an exhaustive `match` over `Types.task_status` — adding a 7th constructor will fail to compile. Same pattern family as #8354 / #8357 / #8392.

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_tool_coord_coverage.exe` — 21/21 pass (15 existing + 6 new variant-witness cases)
- [ ] CI green

## Related
- #7464 (MERGED) — covered ownership-mismatch subclass
- #7459, #7466 (MERGED) — same `tool-error-messages-teach-llm` class on other tool surfaces
- Memory: `feedback_tool-error-messages-teach-llm`, `feedback_gate-response-llm-readable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)