### PR TITLE
fix(#8391 HIGH #1): keeper pause/resume non-silent on read_meta failure

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -203,6 +203,8 @@ let metric_keeper_write_meta_failures =
   "masc_keeper_write_meta_failures_total"
 let metric_keeper_lifecycle_dispatch_rejections =
   "masc_keeper_lifecycle_dispatch_rejections_total"
+let metric_keeper_paused_state_persist_errors =
+  "masc_keeper_paused_state_persist_errors_total"
 
 (* OAS SSE relay (oas_sse_bridge.ml). *)
 let metric_oas_sse_relay_retries =
@@ -302,6 +304,10 @@ let init () =
     Counter;
   add metric_keeper_lifecycle_dispatch_rejections
     "Total post-turn lifecycle dispatch rejections, labeled by event"
+    Counter;
+  add metric_keeper_paused_state_persist_errors
+    "Total keeper paused-state persistence failures, labeled by phase \
+     (boot_resume_check|boot_resume_persist) and reason (read_meta_error|meta_missing)"
     Counter;
   add metric_oas_sse_relay_retries
     "Total OAS SSE relay retry attempts, labeled by failed stage"

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -696,7 +696,31 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                  name
                  (if paused then "pause" else "resume")
                  err)
-      | Ok None | Error _ -> ()
+      (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from
+         [Error _] (IO/parse failure) so silent failures become visible.
+         The boot HTTP contract is unchanged — auto-resume cleanup is a
+         best-effort side effect of [boot], not the primary action. *)
+      | Ok None ->
+          Log.Keeper.warn
+            "keeper %s %s: meta missing — skipping paused-state persist"
+            name
+            (if paused then "pause" else "resume");
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_paused_state_persist_errors
+            ~labels:[("phase", "boot_resume_persist");
+                     ("reason", "meta_missing")]
+            ()
+      | Error err ->
+          Log.Keeper.error
+            "keeper %s %s: read_meta failed: %s"
+            name
+            (if paused then "pause" else "resume")
+            err;
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_paused_state_persist_errors
+            ~labels:[("phase", "boot_resume_persist");
+                     ("reason", "read_meta_error")]
+            ()
     in
     let resume_booted_keeper_if_needed () =
       match Keeper_types.read_meta config name with
@@ -711,9 +735,29 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                Log.Keeper.warn
                  "keeper boot: agent_name not found for paused keeper %s"
                  name)
-      | Ok (Some _)
-      | Ok None
-      | Error _ -> ()
+      | Ok (Some _) -> ()
+      (* Issue #8391 HIGH #1: split [Ok None] from [Error _] — boot itself
+         already succeeded via Tool_keeper.dispatch, so we don't change the
+         HTTP status. We make the failure observable instead. *)
+      | Ok None ->
+          Log.Keeper.warn
+            "keeper %s boot: meta missing — skipping auto-resume check"
+            name;
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_paused_state_persist_errors
+            ~labels:[("phase", "boot_resume_check");
+                     ("reason", "meta_missing")]
+            ()
+      | Error err ->
+          Log.Keeper.error
+            "keeper %s boot: read_meta failed during auto-resume check: %s"
+            name
+            err;
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_paused_state_persist_errors
+            ~labels:[("phase", "boot_resume_check");
+                     ("reason", "read_meta_error")]
+            ()
     in
     let keeper_ctx : _ Tool_keeper.context =
       {
@@ -815,8 +859,13 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           reqd
     | Ok action_str ->
         let config = state.Mcp_server.room_config in
+        (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from [Error _]
+           (IO/parse failure). For pause/resume the operator expects state to
+           change; silent 200 hides the failure. For wakeup we preserve the
+           prior best-effort semantics (wakeup does not require meta). *)
+        let read_result = Keeper_types.read_meta config name in
         let meta_opt =
-          match Keeper_types.read_meta config name with
+          match read_result with
           | Ok (Some meta) -> Some meta
           | Ok None | Error _ -> None
         in
@@ -840,29 +889,83 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                      err)
           | Some _ | None -> ()
         in
-        (match action_str with
-         | "pause" -> persist_paused_state true
-         | "resume" -> persist_paused_state false
-         | "wakeup"
-         | _ -> ());
-        let resolved_agent_name =
-          match Keeper_registry.find_by_name name with
-          | Some entry -> entry.meta.agent_name
-          | None -> (
-              match meta_opt with
-              | Some meta -> meta.agent_name
-              | None -> Keeper_types.keeper_agent_name name)
+        let proceed () =
+          (match action_str with
+           | "pause" -> persist_paused_state true
+           | "resume" -> persist_paused_state false
+           | "wakeup"
+           | _ -> ());
+          let resolved_agent_name =
+            match Keeper_registry.find_by_name name with
+            | Some entry -> entry.meta.agent_name
+            | None -> (
+                match meta_opt with
+                | Some meta -> meta.agent_name
+                | None -> Keeper_types.keeper_agent_name name)
+          in
+          Keeper_keepalive.process_directive
+            ~agent_name:resolved_agent_name action_str;
+          (match action_str with
+           | "pause" -> refresh_keeper_execution_surfaces ~name "paused"
+           | "resume" -> refresh_keeper_execution_surfaces ~name "resumed"
+           | "wakeup" -> invalidate_keeper_execution_surfaces ()
+           | _ -> invalidate_keeper_execution_surfaces ());
+          Http.Response.json ~compress:true ~request:req
+            (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
+               (String.escaped action_str) (String.escaped name))
+            reqd
         in
-        Keeper_keepalive.process_directive ~agent_name:resolved_agent_name action_str;
-        (match action_str with
-         | "pause" -> refresh_keeper_execution_surfaces ~name "paused"
-         | "resume" -> refresh_keeper_execution_surfaces ~name "resumed"
-         | "wakeup" -> invalidate_keeper_execution_surfaces ()
-         | _ -> invalidate_keeper_execution_surfaces ());
-        Http.Response.json ~compress:true ~request:req
-          (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
-             (String.escaped action_str) (String.escaped name))
-          reqd
+        let needs_meta_for_state_transition =
+          match action_str with
+          | "pause" | "resume" -> true
+          | _ -> false
+        in
+        (match read_result, needs_meta_for_state_transition with
+         | Error err, true ->
+             Log.Keeper.error
+               "directive %s: read_meta failed for %s: %s"
+               action_str
+               name
+               err;
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_paused_state_persist_errors
+               ~labels:[("phase", "directive");
+                        ("reason", "read_meta_error")]
+               ();
+             Http.Response.json ~status:`Internal_server_error ~request:req
+               (Printf.sprintf
+                  {|{"ok":false,"action":"%s","name":"%s","error":"read_meta failed: %s"}|}
+                  (String.escaped action_str)
+                  (String.escaped name)
+                  (String.escaped err))
+               reqd
+         | Ok None, true ->
+             Log.Keeper.warn
+               "directive %s: keeper meta missing for %s — refusing silent no-op"
+               action_str
+               name;
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_paused_state_persist_errors
+               ~labels:[("phase", "directive");
+                        ("reason", "meta_missing")]
+               ();
+             Http.Response.json ~status:`Not_found ~request:req
+               (Printf.sprintf
+                  {|{"ok":false,"action":"%s","name":"%s","error":"keeper meta not found"}|}
+                  (String.escaped action_str)
+                  (String.escaped name))
+               reqd
+         | Error err, false ->
+             (* Wakeup does not require meta; log but proceed. *)
+             Log.Keeper.warn
+               "directive %s: read_meta failed for %s (best-effort proceed): %s"
+               action_str
+               name
+               err;
+             proceed ()
+         | Ok None, false
+         | Ok (Some _), _ ->
+             proceed ())
 
 (** Keeper GET sub-routes handler: /config, /chat/history, /trajectory.
     Called from prefix_get "/api/v1/keepers/" in the main routing file. *)

--- a/test/dune
+++ b/test/dune
@@ -935,6 +935,11 @@
  (libraries alcotest unix str))
 
 (test
+ (name test_keeper_pause_silent_failure_source)
+ (modules test_keeper_pause_silent_failure_source)
+ (libraries alcotest unix str))
+
+(test
  (name test_channel_gate)
  (modules test_channel_gate)
  (libraries masc_test_deps))

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -1,0 +1,167 @@
+(** Structural guard for issue #8391 HIGH #1.
+
+    The keeper pause/resume HTTP handlers in
+    [lib/server/server_dashboard_http_keeper_api.ml] used to fold
+    [Ok None] (keeper meta vanished) and [Error _] (IO/parse failure)
+    into a single silent no-op arm. The dashboard endpoint then
+    returned HTTP 200 OK and the operator believed the keeper was
+    paused, while it kept running.
+
+    These tests are intentionally structural (read the source file and
+    assert patterns) rather than integration. Mocking [read_meta] would
+    require spinning up the full server and a fake meta file.
+
+    Cases covered:
+
+    - (a) happy [Ok (Some meta)] arm exists in both closures
+    - (b) [Ok None] arm exists separately and is observable (logs +
+          counter or non-200 response)
+    - (c) [Error _] arm exists separately and is observable (logs +
+          counter or 500 response)
+    - (d) the silent fold ["Ok None | Error _"] does not return at the
+          known offending sites in [persist_keeper_paused_state] /
+          [resume_booted_keeper_if_needed] / directive [meta_opt]
+*)
+
+open Alcotest
+
+let target_file = "lib/server/server_dashboard_http_keeper_api.ml"
+
+let metric_name = "metric_keeper_paused_state_persist_errors"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path)
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic)
+
+let count_occurrences ~needle haystack =
+  let nlen = String.length needle in
+  if nlen = 0 then 0
+  else
+    let re = Str.regexp_string needle in
+    let rec loop pos acc =
+      match Str.search_forward re haystack pos with
+      | exception Not_found -> acc
+      | _ ->
+          let m = Str.match_end () in
+          loop m (acc + 1)
+    in
+    loop 0 0
+
+let test_metric_registered () =
+  let prom = load_source "lib/prometheus.ml" in
+  check bool "paused-state persist-errors metric declared" true
+    (count_occurrences
+       ~needle:"masc_keeper_paused_state_persist_errors_total"
+       prom
+     >= 1);
+  check bool "paused-state persist-errors metric registered with HELP"
+    true
+    (count_occurrences ~needle:metric_name prom >= 2)
+
+let test_happy_path_preserved () =
+  let src = load_source target_file in
+  (* (a) The happy [Ok (Some meta)] arms must still be present in both
+     closures so successful pause/resume keeps returning 200. *)
+  check bool "persist_keeper_paused_state happy arm present" true
+    (count_occurrences
+       ~needle:"Ok (Some meta) when Bool.equal meta.paused paused -> ()"
+       src
+     >= 1);
+  check bool "resume_booted_keeper_if_needed happy arm present" true
+    (count_occurrences
+       ~needle:"Ok (Some meta) when meta.paused"
+       src
+     >= 1)
+
+let test_silent_fold_removed () =
+  let src = load_source target_file in
+  (* (d) The exact silent fold ["Ok None | Error _ -> ()"] must not
+     reappear inside [persist_keeper_paused_state] or
+     [resume_booted_keeper_if_needed]. We allow it elsewhere because
+     [resolve_keeper_agent_name] (line ~678) legitimately collapses
+     both into [None] for a name lookup. *)
+  let needle = "Ok None | Error _ -> ()" in
+  check int "silent fold returning unit removed" 0
+    (count_occurrences ~needle src)
+
+let test_ok_none_branch_observable () =
+  let src = load_source target_file in
+  (* (b) The [Ok None] case must be observable: either logged + counter,
+     or a distinct HTTP response. We assert the log marker. *)
+  check bool "Ok None warn log: persist phase" true
+    (count_occurrences
+       ~needle:"meta missing — skipping paused-state persist"
+       src
+     >= 1);
+  check bool "Ok None warn log: boot resume check phase" true
+    (count_occurrences
+       ~needle:"meta missing — skipping auto-resume check"
+       src
+     >= 1);
+  check bool "Ok None directive 404 response" true
+    (count_occurrences
+       ~needle:"keeper meta not found"
+       src
+     >= 1);
+  check bool "Ok None observability counter labelled meta_missing" true
+    (count_occurrences ~needle:"meta_missing" src >= 3)
+
+let test_error_branch_observable () =
+  let src = load_source target_file in
+  (* (c) The [Error err] case must surface the underlying reason. *)
+  check bool "Error err: persist phase logs reason" true
+    (count_occurrences
+       ~needle:": read_meta failed: %s"
+       src
+     >= 1);
+  check bool "Error err: boot check phase logs reason" true
+    (count_occurrences
+       ~needle:"read_meta failed during auto-resume check"
+       src
+     >= 1);
+  check bool "Error err: directive 500 response" true
+    (count_occurrences
+       ~needle:"\"read_meta failed: %s\"" src
+     >= 1);
+  check bool "Error err observability counter labelled read_meta_error"
+    true
+    (count_occurrences ~needle:"read_meta_error" src >= 3)
+
+let test_counter_inc_calls () =
+  let src = load_source target_file in
+  (* The metric must actually be incremented at least 4 times: 2 in
+     [persist_keeper_paused_state] (Ok None / Error), 2 in
+     [resume_booted_keeper_if_needed] (Ok None / Error), 2 in the
+     directive endpoint (Ok None / Error) — total 6. *)
+  check bool "Prometheus.inc_counter called for new metric >= 6 times"
+    true
+    (count_occurrences
+       ~needle:"Prometheus.metric_keeper_paused_state_persist_errors"
+       src
+     >= 6)
+
+let () =
+  run "keeper_pause_silent_failure_source"
+    [ ( "issue-8391-high-1"
+      , [ test_case "metric registered" `Quick test_metric_registered
+        ; test_case "happy path preserved" `Quick test_happy_path_preserved
+        ; test_case "silent fold removed" `Quick test_silent_fold_removed
+        ; test_case "Ok None branch observable" `Quick
+            test_ok_none_branch_observable
+        ; test_case "Error _ branch observable" `Quick
+            test_error_branch_observable
+        ; test_case "counter inc calls present" `Quick
+            test_counter_inc_calls
+        ] )
+    ]


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE — manual review required**
> This PR changes a public HTTP API contract (404/500 on the keeper directive endpoint). Operator-facing governance change. Hold for human review even when CI is green. Auto-merge label has been disabled via \`do-not-merge\`.

## Why

Issue #8391 HIGH #1 in the silent-failure rollup. Operator clicks "pause" in the dashboard → handler returns HTTP 200 → operator believes the keeper is paused → it keeps running because \`Keeper_types.read_meta\` failed (or the meta vanished) and the handler folded both into a no-op. Highest-leverage governance gap in the sweep.

## Root cause

\`lib/server/server_dashboard_http_keeper_api.ml\` had three sites where \`Ok None\` (keeper meta vanished) and \`Error _\` (IO/parse failure) were folded into a single \`-> ()\` arm:

| Closure / site | File:line (pre-fix) | HTTP impact |
|---|---|---|
| \`persist_keeper_paused_state\` | \`:699\` | Boot returned 200 even when paused-state cleanup failed silently |
| \`resume_booted_keeper_if_needed\` | \`:716\` | Boot returned 200 even when auto-resume check could not run |
| Directive endpoint \`meta_opt\` | \`:821\` | **pause/resume returned 200 with no state change** — the operator-visible silent failure |

The third site is the actual operator-visible silent failure described in the audit. Lines 699 / 716 are inside the \`boot\` action's auto-resume cleanup; \`Tool_keeper.dispatch\` already succeeded by then so the boot itself is fine, but cleanup failures stayed invisible.

## Fix

Each arm split into \`Ok None\` and \`Error err\`, with observability and (for the directive endpoint only) a contract change.

**Boot path — no HTTP contract change.** Boot's primary action already succeeded, so we keep returning 200, but emit \`Log.Keeper.warn\` / \`Log.Keeper.error\` and increment \`masc_keeper_paused_state_persist_errors_total{phase, reason}\` for the two sites:
- \`persist_keeper_paused_state\`: \`{phase=boot_resume_persist, reason=meta_missing|read_meta_error}\`
- \`resume_booted_keeper_if_needed\`: \`{phase=boot_resume_check, reason=meta_missing|read_meta_error}\`

**Directive endpoint — HTTP contract change.** The handler now reads \`read_meta\` once and routes by action:
- \`pause\` / \`resume\` + \`Error err\`  → **500** \`{ok:false,error:"read_meta failed: <err>"}\`
- \`pause\` / \`resume\` + \`Ok None\`    → **404** \`{ok:false,error:"keeper meta not found"}\`
- \`wakeup\` + \`Error err\`              → 200 (preserves prior best-effort: wakeup does not require meta), with warn log
- \`wakeup\` + \`Ok None\`                → 200 (unchanged)
- \`Ok (Some _)\` (any action)           → 200 (unchanged happy path)

New metric \`masc_keeper_paused_state_persist_errors_total\` registered in \`lib/prometheus.ml\` with HELP and zero baseline.

### Before / after of the two boot-path arms

\`persist_keeper_paused_state\` (line 699 pre-fix):

\`\`\`ocaml
           | Error err ->
               Log.Keeper.warn
                 "keeper %s %s: write_meta failed: %s"
                 name
                 (if paused then "pause" else "resume")
                 err)
      | Ok None | Error _ -> ()
    in
\`\`\`

after:

\`\`\`ocaml
      | Ok None ->
          Log.Keeper.warn "keeper %s %s: meta missing — skipping paused-state persist" ...;
          Prometheus.inc_counter Prometheus.metric_keeper_paused_state_persist_errors
            ~labels:[("phase","boot_resume_persist");("reason","meta_missing")] ()
      | Error err ->
          Log.Keeper.error "keeper %s %s: read_meta failed: %s" name ... err;
          Prometheus.inc_counter Prometheus.metric_keeper_paused_state_persist_errors
            ~labels:[("phase","boot_resume_persist");("reason","read_meta_error")] ()
\`\`\`

\`resume_booted_keeper_if_needed\` (line 716 pre-fix):

\`\`\`ocaml
      | Ok (Some _)
      | Ok None
      | Error _ -> ()
    in
\`\`\`

after:

\`\`\`ocaml
      | Ok (Some _) -> ()
      | Ok None ->
          Log.Keeper.warn "keeper %s boot: meta missing — skipping auto-resume check" name;
          Prometheus.inc_counter Prometheus.metric_keeper_paused_state_persist_errors
            ~labels:[("phase","boot_resume_check");("reason","meta_missing")] ()
      | Error err ->
          Log.Keeper.error "keeper %s boot: read_meta failed during auto-resume check: %s" name err;
          Prometheus.inc_counter Prometheus.metric_keeper_paused_state_persist_errors
            ~labels:[("phase","boot_resume_check");("reason","read_meta_error")] ()
    in
\`\`\`

The directive endpoint (line 821 pre-fix) is restructured around a \`proceed ()\` continuation that runs the original 200-path; the new branches build the 404 / 500 responses for the \`needs_meta_for_state_transition = true\` case (pause / resume only).

## Test plan

- [x] \`dune build --root <worktree>\` clean
- [x] New \`test/test_keeper_pause_silent_failure_source.ml\` (structural guard, 6 cases): all pass
  - metric registered in prometheus.ml
  - happy \`Ok (Some meta)\` arms preserved
  - silent fold \`Ok None | Error _ -> ()\` does not appear in target file
  - \`Ok None\` branch observable (warn log + 404 + meta_missing label appears ≥3x)
  - \`Error _\` branch observable (error log + 500 + read_meta_error label appears ≥3x)
  - \`Prometheus.metric_keeper_paused_state_persist_errors\` referenced ≥6 times (2 per site × 3 sites)
- [x] Existing \`test_dashboard_keeper_routes.exe\` and \`test_keeper_lifecycle.exe\` build clean
- [ ] Manual smoke: pause endpoint with a non-existent keeper name → expect 404 (currently 200) — recommended pre-merge

Mocking \`Keeper_types.read_meta\` would require spinning up the full server with a fake meta file; the existing keeper-routes harness does exactly that and is too heavy for a targeted regression test. Per the issue body's guidance ("If mocking \`read_meta\` is too heavy, structural-grep") we use structural assertions.

## Risk

- **API contract change on the directive endpoint.** Any client that today swallows the 200 response and re-polls keeper state will now see 404 (vanished keeper) or 500 (read_meta failure). This is the intended fix; clients depending on the silent-200 behavior were already broken. The dashboard UI handles non-2xx with toast errors, so the operator-facing impact is "the failure becomes visible."
- **Wakeup semantics intentionally preserved.** \`wakeup\` does not need meta; we still proceed on \`Ok None\` / \`Error _\` (with a log on errors) so we don't break the wake-stuck-keeper recovery path.
- **Boot path semantics unchanged.** Boot still returns 200 on success even if the auto-resume cleanup fails. Cleanup failures are now visible via logs and the new counter; if the team wants boot to fail-loud on cleanup failure, that's a separate decision.
- **No version bump.** Bug-fix only, no public Caqti/RPC/CLI surface added; doc-truth and version-truth gates should be unaffected.

## References

- #8391 (silent-failure sweep, HIGH #1)
- #7772 (silent-failure sweep family)
- Feedback memory: \`feedback_structural-bug-class-rg-sweep.md\` — full-repo grep informed fixing all three sites in the same file
- Feedback memory: \`feedback_no-arbitrary-max-tokens-lowering.md\` — the directive 404/500 split is a contract change made deliberately, not silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)