### PR TITLE
fix(dashboard): preserve keeper diagnostic truth in execution views

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -62,6 +62,14 @@ const SseOuterSchema = object({
   broadcast_count: fallback(number(), 0),
   queue_avg_depth: fallback(number(), 0),
   queue_max_depth: fallback(number(), 0),
+  relay_queue_depth: fallback(number(), 0),
+  relay_retry_total: fallback(number(), 0),
+  relay_retry_append: fallback(number(), 0),
+  relay_retry_broadcast: fallback(number(), 0),
+  relay_drop_total: fallback(number(), 0),
+  relay_drop_queue: fallback(number(), 0),
+  relay_drop_append: fallback(number(), 0),
+  relay_drop_broadcast: fallback(number(), 0),
   // Lenient per-entry on hot_sessions handled in parseSse below.
   hot_sessions: optional(unknown()),
 })
@@ -75,6 +83,14 @@ interface SseSection {
   broadcast_count: number
   queue_avg_depth: number
   queue_max_depth: number
+  relay_queue_depth: number
+  relay_retry_total: number
+  relay_retry_append: number
+  relay_retry_broadcast: number
+  relay_drop_total: number
+  relay_drop_queue: number
+  relay_drop_append: number
+  relay_drop_broadcast: number
   hot_sessions: HotSession[]
 }
 
@@ -146,6 +162,7 @@ const ClusterSchema = object({
 
 const AgentHealthSchema = object({
   stale_total: fallback(number(), 0),
+  lifecycle_dispatch_rejections_total: fallback(number(), 0),
 })
 
 // `projection_diagnostics` is only present when the backend explicitly
@@ -230,6 +247,14 @@ export function parseTransportHealthData(data: unknown): TransportHealthData {
       broadcast_count: outer.sse.broadcast_count,
       queue_avg_depth: outer.sse.queue_avg_depth,
       queue_max_depth: outer.sse.queue_max_depth,
+      relay_queue_depth: outer.sse.relay_queue_depth,
+      relay_retry_total: outer.sse.relay_retry_total,
+      relay_retry_append: outer.sse.relay_retry_append,
+      relay_retry_broadcast: outer.sse.relay_retry_broadcast,
+      relay_drop_total: outer.sse.relay_drop_total,
+      relay_drop_queue: outer.sse.relay_drop_queue,
+      relay_drop_append: outer.sse.relay_drop_append,
+      relay_drop_broadcast: outer.sse.relay_drop_broadcast,
       hot_sessions: parseSseHotSessions(outer.sse.hot_sessions),
     },
     grpc: outer.grpc,

--- a/dashboard/src/api/transport-health.test.ts
+++ b/dashboard/src/api/transport-health.test.ts
@@ -83,6 +83,9 @@ describe('decodeTransportHealthData', () => {
     expect(result!.summary.external_fanout_targets).toBe(0)
     // sse defaults
     expect(result!.sse.sessions_total).toBe(0)
+    expect(result!.sse.relay_queue_depth).toBe(0)
+    expect(result!.sse.relay_retry_total).toBe(0)
+    expect(result!.sse.relay_drop_total).toBe(0)
     expect(result!.sse.hot_sessions).toEqual([])
     // grpc defaults
     expect(result!.grpc.enabled).toBe(false)
@@ -100,6 +103,7 @@ describe('decodeTransportHealthData', () => {
     expect(result!.cluster.total_units).toBeNull()
     // agent_health defaults
     expect(result!.agent_health.stale_total).toBe(0)
+    expect(result!.agent_health.lifecycle_dispatch_rejections_total).toBe(0)
     // projection_diagnostics not present
     expect(result!.projection_diagnostics).toBeUndefined()
   })
@@ -123,6 +127,14 @@ describe('decodeTransportHealthData', () => {
         broadcast_count: 100,
         queue_avg_depth: 2,
         queue_max_depth: 10,
+        relay_queue_depth: 4,
+        relay_retry_total: 6,
+        relay_retry_append: 2,
+        relay_retry_broadcast: 4,
+        relay_drop_total: 3,
+        relay_drop_queue: 1,
+        relay_drop_append: 1,
+        relay_drop_broadcast: 1,
         hot_sessions: [
           { session_id: 'sess-1', kind: 'observer', queue_depth: 5, last_event_id: 99, idle_seconds: 3 },
           { session_id: 'sess-2', kind: 'coordinator', queue_depth: 0, last_event_id: 50, idle_seconds: 30 },
@@ -187,12 +199,15 @@ describe('decodeTransportHealthData', () => {
         active_operations: 1,
         stale_units: 0,
       },
-      agent_health: { stale_total: 2 },
+      agent_health: { stale_total: 2, lifecycle_dispatch_rejections_total: 5 },
     })
     const result = decodeTransportHealthData(raw)
     expect(result!.summary.primary_path).toBe('grpc')
     expect(result!.summary.recent_messages).toBe(42)
     expect(result!.sse.sessions_total).toBe(3)
+    expect(result!.sse.relay_queue_depth).toBe(4)
+    expect(result!.sse.relay_retry_total).toBe(6)
+    expect(result!.sse.relay_drop_total).toBe(3)
     expect(result!.sse.hot_sessions).toHaveLength(2)
     expect(result!.sse.hot_sessions[0]!.session_id).toBe('sess-1')
     expect(result!.sse.hot_sessions[0]!.kind).toBe('observer')
@@ -205,6 +220,7 @@ describe('decodeTransportHealthData', () => {
     expect(result!.cluster.total_units).toBe(5)
     expect(result!.cluster.live_agents).toBe(3)
     expect(result!.agent_health.stale_total).toBe(2)
+    expect(result!.agent_health.lifecycle_dispatch_rejections_total).toBe(5)
   })
 
   it('decodes hot_sessions with defaults', () => {

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -13,6 +13,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     name: 'keeper-x',
     status: 'active',
     keepalive_running: true,
+    diagnostic_health_state: null,
+    diagnostic_summary: null,
     context_ratio: 0.3,
     turn_count: 0,
     last_latency_ms: 0,
@@ -287,6 +289,47 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Partial telemetry')
     expect(container.textContent).toContain('keepers are blocked in the admission queue')
     expect(container.textContent).toContain('Admission queue wait timeout after 45.0s.')
+  }, 30_000)
+
+  it('surfaces snapshot diagnostic summaries for inactive keepers', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue({
+      ...executionResponse,
+      keepers: [
+        {
+          name: 'keeper-stale',
+          status: 'inactive',
+          keepalive_running: true,
+          context_ratio: 0.22,
+          total_turns: 11,
+          last_latency_ms: 1200,
+          last_activity_ago_s: 640,
+          last_model_used: 'gpt-5.4',
+          diagnostic: {
+            health_state: 'stale',
+            next_action_path: 'recover',
+            last_reply_status: 'stale',
+            summary: 'Keepalive heartbeat is stale; probe or recover before the next turn.',
+          },
+        },
+      ],
+    } satisfies DashboardExecutionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue({ ...toolQualityResponse, by_keeper: [] })
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('keeper-stale')
+    expect(container.textContent).toContain('Keepalive heartbeat is stale; probe or recover before the next turn.')
+    expect(container.textContent).toContain('1 주의')
   }, 30_000)
 
   it('falls back to runtime model and tool audit data when quality rows are sparse', async () => {

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -29,6 +29,7 @@ import {
   buildTelemetryWarnings,
   emptyState,
   errorMessage,
+  fleetBand,
   formatActivity,
   formatLatency,
   formatPercent,
@@ -235,14 +236,28 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
         <tbody>
           ${rows.map(row => {
             const toolInfo = toolSummary(row)
+            const diagnosticState = row.diagnostic_health_state?.trim().toLowerCase() ?? null
+            const rowHint =
+              row.runtime_blocker_summary
+              ?? (
+                diagnosticState
+                && diagnosticState !== 'healthy'
+                && diagnosticState !== 'idle'
+                  ? row.diagnostic_summary ?? null
+                  : null
+              )
+            const rowHintClass =
+              diagnosticState === 'offline' || diagnosticState === 'dead'
+                ? 'text-[var(--bad-light)]'
+                : 'text-[var(--warn)]'
             return html`
             <tr class="border-b border-[var(--card-border)] border-opacity-30 align-top">
               <td class="py-1.5">
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
-                ${row.runtime_blocker_summary
+                ${rowHint
                   ? html`
-                    <div class="max-w-[240px] truncate text-3xs text-[var(--warn)]" title=${row.runtime_blocker_summary}>
-                      ${row.runtime_blocker_summary}
+                    <div class="max-w-[240px] truncate text-3xs ${rowHintClass}" title=${rowHint}>
+                      ${rowHint}
                     </div>
                   `
                   : null}
@@ -485,12 +500,7 @@ export function FleetTelemetryPanel() {
   }
 
   const activeCount = counts.live
-  const attentionCount = value.rows.filter(row => row.keepalive_running && (
-    row.runtime_blocker_class != null
-    || row.context_ratio >= PRESSURE_WARN_RATIO
-    || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
-    || (row.tool_success_pct != null && row.tool_success_pct < 90)
-  )).length
+  const attentionCount = value.rows.filter(row => fleetBand(row) === 'attention').length
   const offlineCount = value.rows.length - activeCount
 
   return html`

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -37,6 +37,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     name: 'test-keeper',
     status: 'active',
     keepalive_running: true,
+    diagnostic_health_state: null,
+    diagnostic_summary: null,
     context_ratio: 0.3,
     turn_count: 10,
     last_latency_ms: 500,
@@ -161,6 +163,14 @@ describe('fleetBand', () => {
     expect(fleetBand(makeRow({ status: 'paused' }))).toBe('paused')
   })
 
+  it('classifies inactive keepalive rows as attention, not offline', () => {
+    expect(fleetBand(makeRow({ status: 'inactive', keepalive_running: true }))).toBe('attention')
+  })
+
+  it('classifies attention for stale diagnostic health state', () => {
+    expect(fleetBand(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toBe('attention')
+  })
+
   it('classifies attention for runtime blocker', () => {
     expect(fleetBand(makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' }))).toBe('attention')
   })
@@ -249,6 +259,14 @@ describe('statusClass', () => {
 
   it('returns warn for runtime blocker', () => {
     expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--warn)')
+  })
+
+  it('returns warn for stale diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toContain('var(--warn)')
+  })
+
+  it('returns bad-light for offline diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'offline' }))).toContain('var(--bad-light)')
   })
 
   it('returns ok for healthy', () => {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -14,6 +14,8 @@ export interface FleetRow {
   name: string
   status: string
   keepalive_running: boolean
+  diagnostic_health_state?: string | null
+  diagnostic_summary?: string | null
   context_ratio: number
   turn_count: number
   last_latency_ms: number
@@ -208,12 +210,25 @@ export function buildToolQualityMap(toolQuality: ToolQualityResponse): Map<strin
 
 type FleetBand = 'attention' | 'active' | 'paused' | 'offline'
 
+function normalizedDiagnosticHealthState(row: FleetRow): string | null {
+  return normalizeText(row.diagnostic_health_state)?.toLowerCase() ?? null
+}
+
+function isOfflineDiagnosticHealthState(state: string | null): boolean {
+  return state === 'offline' || state === 'dead'
+}
+
+function isAttentionDiagnosticHealthState(state: string | null): boolean {
+  return state === 'stale' || state === 'degraded' || state === 'zombie'
+}
+
 export function fleetBand(row: FleetRow): FleetBand {
   const normalizedStatus = normalizeText(row.status)?.toLowerCase() ?? 'unknown'
+  const diagnosticHealthState = normalizedDiagnosticHealthState(row)
   if (
     !row.keepalive_running
+    || isOfflineDiagnosticHealthState(diagnosticHealthState)
     || normalizedStatus === 'offline'
-    || normalizedStatus === 'inactive'
     || normalizedStatus === 'unbooted'
     || normalizedStatus === 'stopped'
     || normalizedStatus === 'dead'
@@ -223,7 +238,9 @@ export function fleetBand(row: FleetRow): FleetBand {
   }
   if (normalizedStatus === 'paused') return 'paused'
   if (
-    row.runtime_blocker_class != null
+    isAttentionDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'inactive'
+    || row.runtime_blocker_class != null
     || row.context_ratio >= PRESSURE_WARN_RATIO
     || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
     || (row.tool_success_pct != null && row.tool_success_pct < 90)
@@ -298,6 +315,9 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             name: keeper.name,
             status: keeper.status ?? (keeper.keepalive_running ? 'active' : 'offline'),
             keepalive_running: keeper.keepalive_running === true,
+            diagnostic_health_state: keeper.diagnostic?.health_state ?? null,
+            diagnostic_summary:
+              firstNonEmptyString(keeper.diagnostic?.continuity_summary, keeper.diagnostic?.summary) ?? null,
             context_ratio: keeper.context_ratio ?? 0,
             turn_count: keeper.total_turns ?? keeper.turn_count ?? 0,
             last_latency_ms: keeperLastLatencyMs(keeper),
@@ -327,6 +347,8 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           name: keeper.name,
           status: 'unknown',
           keepalive_running: false,
+          diagnostic_health_state: null,
+          diagnostic_summary: null,
           context_ratio: 0,
           turn_count: 0,
           last_latency_ms: 0,
@@ -364,8 +386,26 @@ export function pressureClass(ratio: number): string {
 }
 
 export function statusClass(row: FleetRow): string {
-  if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-[var(--bad-light)]'
-  if (row.runtime_blocker_class != null) return 'text-[var(--warn)]'
+  const normalizedStatus = normalizeText(row.status)?.toLowerCase() ?? 'unknown'
+  const diagnosticHealthState = normalizedDiagnosticHealthState(row)
+  if (
+    !row.keepalive_running
+    || isOfflineDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'offline'
+    || normalizedStatus === 'stopped'
+    || normalizedStatus === 'unbooted'
+    || normalizedStatus === 'dead'
+    || normalizedStatus === 'crashed'
+  ) {
+    return 'text-[var(--bad-light)]'
+  }
+  if (
+    isAttentionDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'inactive'
+    || row.runtime_blocker_class != null
+  ) {
+    return 'text-[var(--warn)]'
+  }
   if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--warn)]'
   return 'text-[var(--ok)]'
 }

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -51,9 +51,10 @@ vi.mock('./common/toast', () => ({
 }))
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
+import { keeperStatusDetails } from '../keeper-runtime'
 import { hydrateKeeperStatus } from '../keeper-runtime'
 import { shellAuthSummary } from '../store'
-import { KeeperConversationPanel, KeeperRuntimeActions } from './keeper-shared'
+import { KeeperConversationPanel, KeeperDiagnosticSummary, KeeperRuntimeActions } from './keeper-shared'
 
 describe('KeeperConversationPanel', () => {
   let container: HTMLDivElement
@@ -70,6 +71,7 @@ describe('KeeperConversationPanel', () => {
     keeperThreads.value = {}
     keeperSending.value = {}
     keeperHydrating.value = {}
+    keeperStatusDetails.value = {}
     keeperActionErrors.value = {}
     keeperStreamStartedAt.value = {}
     shellAuthSummary.value = null
@@ -164,5 +166,27 @@ describe('KeeperConversationPanel', () => {
     expect(buttons).toContain('Social sweep')
     expect(buttons).not.toContain('기동')
     expect(buttons).not.toContain('종료')
+  })
+
+  it('falls back to snapshot diagnostic when hydrated detail is absent', async () => {
+    const keeper = {
+      name: 'sangsu',
+      status: 'inactive',
+      diagnostic: {
+        health_state: 'stale',
+        next_action_path: 'recover',
+        last_reply_status: 'stale',
+        summary: 'Snapshot says the keeper heartbeat is stale.',
+      },
+    } as any
+
+    render(
+      html`<${KeeperDiagnosticSummary} keeper=${keeper} />`,
+      container,
+    )
+    await Promise.resolve()
+
+    expect(container.textContent).toContain('stale')
+    expect(container.textContent).toContain('Snapshot says the keeper heartbeat is stale.')
   })
 })

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -144,7 +144,7 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
   if (!keeper) return null
   const detail = keeperStatusDetails.value[keeper.name]
-  return detail?.diagnostic ?? null
+  return detail?.diagnostic ?? keeper.diagnostic ?? null
 }
 
 // ── Diagnostic chip ──────────────────────────────────────

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -20,6 +20,34 @@ function makeMetric(overrides: Partial<DashboardRuntimeModelMetric> = {}): Dashb
 // ── runtimeProviderTone ──
 
 describe('runtimeProviderTone', () => {
+  it('prefers backend-advertised missing_auth over optimistic booleans', () => {
+    expect(
+      runtimeProviderTone(
+        makeProvider({
+          status: 'missing_auth',
+          available: true,
+          discovery: { healthy: true },
+        }),
+      ),
+    ).toBe('bad')
+  })
+
+  it('treats vertex_adc as warn because inventory is visible but run is disabled', () => {
+    expect(
+      runtimeProviderTone(
+        makeProvider({
+          status: 'vertex_adc',
+          available: true,
+          discovery: { healthy: true },
+        }),
+      ),
+    ).toBe('warn')
+  })
+
+  it('treats unsupported backend status as bad', () => {
+    expect(runtimeProviderTone(makeProvider({ status: 'unsupported' }))).toBe('bad')
+  })
+
   it('returns bad when available is false', () => {
     expect(runtimeProviderTone(makeProvider({ available: false }))).toBe('bad')
   })
@@ -40,7 +68,7 @@ describe('runtimeProviderTone', () => {
     expect(runtimeProviderTone(makeProvider())).toBe('warn')
   })
 
-  it('returns warn when available is true but discovery is null', () => {
+  it('returns ok when available is true but discovery is null', () => {
     expect(runtimeProviderTone(makeProvider({ available: true, discovery: null }))).toBe('ok')
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -80,6 +80,13 @@ async function loadRuntimeData(resource: ManagedAsyncResource<RuntimeData>, wind
 // performance (success_rate, cooldown). Both signals can be shown together
 // without being duplicates.
 export function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string {
+  const advertised = provider.status?.trim().toLowerCase()
+  if (advertised === 'missing_auth' || advertised === 'unsupported' || advertised === 'offline') {
+    return 'bad'
+  }
+  if (advertised === 'vertex_adc') {
+    return 'warn'
+  }
   if (provider.available === false) return 'bad'
   if (provider.discovery?.healthy === false) return 'warn'
   if (provider.available === true) return 'ok'

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -242,7 +242,7 @@ describe('TransportHealthPanel', () => {
       sampleResponse({
         summary: {
           primary_path: 'streamable_http',
-          queue_pressure: 'watch',
+          queue_pressure: 'high',
           recent_messages: null,
           recent_messages_available: false,
           recent_messages_source: 'metrics_only',
@@ -282,6 +282,7 @@ describe('TransportHealthPanel', () => {
     render(html`<${TransportHealthPanel} />`, container)
     await flushUi()
 
+    expect(container.textContent).toContain('high')
     expect(container.textContent).toContain('Relay Queue')
     expect(container.textContent).toContain('Relay Retries')
     expect(container.textContent).toContain('Relay Drops')

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -24,6 +24,14 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
       broadcast_count: 2,
       queue_avg_depth: 0,
       queue_max_depth: 1,
+      relay_queue_depth: 0,
+      relay_retry_total: 0,
+      relay_retry_append: 0,
+      relay_retry_broadcast: 0,
+      relay_drop_total: 0,
+      relay_drop_queue: 0,
+      relay_drop_append: 0,
+      relay_drop_broadcast: 0,
       hot_sessions: [],
     },
     grpc: {
@@ -87,6 +95,7 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
     },
     agent_health: {
       stale_total: 0,
+      lifecycle_dispatch_rejections_total: 0,
     },
     generated_at: '2026-04-02T00:00:00Z',
     ...overrides,
@@ -226,6 +235,59 @@ describe('TransportHealthPanel', () => {
     expect(container.textContent).toContain('live_metrics')
     expect(container.textContent).toContain('cache fresh')
     expect(container.textContent).toContain('last ok 2026-04-15T10:00:00Z')
+  })
+
+  it('renders relay health rows and lifecycle rejects when boundary failures are present', async () => {
+    const fetchTransportHealth = vi.fn<() => Promise<unknown>>().mockResolvedValue(
+      sampleResponse({
+        summary: {
+          primary_path: 'streamable_http',
+          queue_pressure: 'watch',
+          recent_messages: null,
+          recent_messages_available: false,
+          recent_messages_source: 'metrics_only',
+          external_fanout_targets: 0,
+        },
+        sse: {
+          sessions_observer: 1,
+          sessions_coordinator: 0,
+          sessions_total: 1,
+          external_subscribers: 0,
+          broadcast_avg_seconds: 0.01,
+          broadcast_count: 2,
+          queue_avg_depth: 0,
+          queue_max_depth: 1,
+          relay_queue_depth: 3,
+          relay_retry_total: 4,
+          relay_retry_append: 1,
+          relay_retry_broadcast: 3,
+          relay_drop_total: 2,
+          relay_drop_queue: 1,
+          relay_drop_append: 1,
+          relay_drop_broadcast: 0,
+          hot_sessions: [],
+        },
+        agent_health: {
+          stale_total: 0,
+          lifecycle_dispatch_rejections_total: 5,
+        },
+      }),
+    )
+
+    const { TransportHealthPanel } = await loadComponentWithApi({
+      fetchTransportHealth,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${TransportHealthPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Relay Queue')
+    expect(container.textContent).toContain('Relay Retries')
+    expect(container.textContent).toContain('Relay Drops')
+    expect(container.textContent).toContain('Lifecycle Rejects')
+    expect(container.textContent).toContain('append 1 · broadcast 3')
+    expect(container.textContent).toContain('queue 1 · append 1 · broadcast 0')
   })
 
   it('debounces SSE-driven transport refreshes through FetchScheduler', async () => {

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -178,6 +178,12 @@ function queuePressureTone(pressure: string): StatusTone {
   return 'ok'
 }
 
+function sseTone(data: TransportHealthData): StatusTone {
+  if (data.sse.relay_drop_total > 0) return 'bad'
+  if (data.sse.relay_retry_total > 0 || data.sse.relay_queue_depth > 0) return 'warn'
+  return queuePressureTone(data.summary.queue_pressure)
+}
+
 function transportTone(configured: boolean, listening: boolean, active: boolean): StatusTone {
   if (!configured) return 'warn'
   if (!listening) return 'bad'
@@ -222,6 +228,12 @@ function staleTone(staleTotal: number): StatusTone {
   if (staleTotal === 0) return 'ok'
   if (staleTotal < 3) return 'warn'
   return 'bad'
+}
+
+function agentPoolTone(data: TransportHealthData): StatusTone {
+  const staleStatus = staleTone(data.agent_health.stale_total)
+  if (staleStatus !== 'ok') return staleStatus
+  return data.agent_health.lifecycle_dispatch_rejections_total > 0 ? 'warn' : 'ok'
 }
 
 function formatMetricValue(value: number | null): string | number {
@@ -347,12 +359,12 @@ export function TransportHealthPanel() {
     return html`<div class="p-6 text-center text-text-muted text-sm">트랜스포트 데이터 불완전. <button class="underline" onClick=${() => void refreshTransportHealth()}>재시도</button></div>`
   }
 
-  const sseStatus = queuePressureTone(data.summary.queue_pressure)
+  const sseStatus = sseTone(data)
   const grpcStatus = grpcTone(data)
   const wsStatus = websocketTone(data)
   const webrtcStatus = webrtcTone(data)
   const h2Status = http2Tone(data)
-  const clusterStatus = data.cluster.topology_available ? staleTone(data.agent_health.stale_total) : 'warn'
+  const clusterStatus = data.cluster.topology_available ? agentPoolTone(data) : 'warn'
   const hasAnyBadTransport = [sseStatus, grpcStatus, wsStatus, webrtcStatus, h2Status, clusterStatus].includes('bad')
   const clusterEyebrow = data.cluster.topology_available
     ? `${formatMetricValue(data.cluster.live_agents)} live`
@@ -406,6 +418,9 @@ export function TransportHealthPanel() {
               <${MetricRow} label="Coordinator" value=${data.sse.sessions_coordinator} />
               <${MetricRow} label="External Fanout" value=${data.sse.external_subscribers} />
               <${MetricRow} label="Queue" value=${data.sse.queue_max_depth} sub=${`max / avg ${formatFloat(data.sse.queue_avg_depth)}`} />
+              <${MetricRow} label="Relay Queue" value=${data.sse.relay_queue_depth} />
+              <${MetricRow} label="Relay Retries" value=${data.sse.relay_retry_total} sub=${`append ${data.sse.relay_retry_append} · broadcast ${data.sse.relay_retry_broadcast}`} />
+              <${MetricRow} label="Relay Drops" value=${data.sse.relay_drop_total} sub=${`queue ${data.sse.relay_drop_queue} · append ${data.sse.relay_drop_append} · broadcast ${data.sse.relay_drop_broadcast}`} />
               <${MetricRow} label="Broadcast Avg" value=${formatLatency(data.sse.broadcast_avg_seconds)} sub=${`${data.sse.broadcast_count} events`} />
             <//>
 
@@ -445,6 +460,7 @@ export function TransportHealthPanel() {
               <${MetricRow} label="활성 작업" value=${formatMetricValue(data.cluster.active_operations)} />
               <${MetricRow} label="부실 유닛" value=${formatMetricValue(data.cluster.stale_units)} />
               <${MetricRow} label="부실 에이전트" value=${data.agent_health.stale_total} />
+              <${MetricRow} label="Lifecycle Rejects" value=${data.agent_health.lifecycle_dispatch_rejections_total} />
             <//>
           </div>
         </div>

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -11,6 +11,7 @@ import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp 
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
+import { normalizeKeeperDiagnostic } from './keeper-state'
 
 /** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
  *  Backend (keeper_state_machine.ml) emits lowercase: "offline", "running", "handing_off", etc.
@@ -442,6 +443,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         tool_audit_source: asString(row.tool_audit_source) ?? null,
         tool_audit_at: toIsoTimestamp(row.tool_audit_at) ?? asString(row.tool_audit_at) ?? null,
         turn_budget: normalizeTurnBudget(row.turn_budget),
+        diagnostic: normalizeKeeperDiagnostic(row.diagnostic),
         conversation_tail_count: asNumber(row.conversation_tail_count),
         k2k_count: asNumber(row.k2k_count),
         handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -522,6 +522,7 @@ export interface Keeper {
   presence_keepalive?: boolean
   presence_keepalive_sec?: number
   keepalive_running?: boolean
+  diagnostic?: KeeperDiagnostic | null
   registry_state?: string | null
   proactive_enabled?: boolean
   proactive_idle_sec?: number

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -45,6 +45,39 @@ let messages_safe config =
 let assoc_upsert fields key value =
   (key, value) :: List.remove_assoc key fields
 
+let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson.Safe.t) =
+  let open Yojson.Safe.Util in
+  match keeper_json with
+  | `Assoc fields -> (
+      match member "name" keeper_json with
+      | `String name -> (
+          match Keeper_types.read_meta_resolved config name with
+          | Ok (Some (_resolved_name, meta)) ->
+              let keepalive_running =
+                match member "keepalive_running" keeper_json with
+                | `Bool value -> value
+                | _ -> Keeper_status_bridge.runtime_keepalive_running config meta
+              in
+              let now_ts = Time_compat.now () in
+              let diagnostic =
+                Keeper_exec_status.keeper_diagnostic_json
+                  ~meta
+                  ~agent_status:(member "agent" keeper_json)
+                  ~keepalive_running
+                  ~history_items:[]
+                  ~now_ts
+                |> Keeper_exec_status.augment_keeper_diagnostic_json
+                     ~meta
+                     ~keepalive_running
+                     ~keepalive_started_at:
+                       (Keeper_status_bridge.runtime_keepalive_started_at config meta)
+                     ~now_ts
+              in
+              `Assoc (assoc_upsert fields "diagnostic" diagnostic)
+          | Ok None | Error _ -> keeper_json)
+      | _ -> keeper_json)
+  | _ -> keeper_json
+
 let model_map_of_keeper_rows keepers =
   let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
   let open Yojson.Safe.Util in
@@ -184,7 +217,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let keepers =
         member_assoc "keepers" snapshot_json |> member_assoc "items"
         |> function
-        | `List items -> items
+        | `List items -> List.map (enrich_keeper_with_diagnostic ~config) items
         | _ -> []
       in
       Eio.Fiber.yield ();

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -328,14 +328,15 @@ type relay_stage =
   | Append
   | Broadcast
 
-type relay_result =
-  | Delivered
-  | Retryable_failure of relay_stage * exn
-
 type pending_relay = {
   json : Yojson.Safe.t;
   attempts : int;
+  appended : bool;
 }
+
+type relay_result =
+  | Delivered
+  | Retryable_failure of pending_relay * relay_stage * exn
 
 let relay_stage_to_string = function
   | Append -> "append"
@@ -433,33 +434,50 @@ let prepare_pending_event evt =
          retry queue so every retry uses the same sanitized payload. *)
       let json = Inference_utils.sanitize_json_utf8 json in
       emit_native_event_log evt json;
-      Some { json; attempts = 0; }
+      Some { json; attempts = 0; appended = false; }
+
+let deliver_pending_with
+    ~(append_json : Yojson.Safe.t -> unit)
+    ~(broadcast_json : Yojson.Safe.t -> unit)
+    (pending : pending_relay) =
+  let pending =
+    if pending.appended then pending
+    else begin
+      append_json pending.json;
+      { pending with appended = true; }
+    end
+  in
+  try
+    broadcast_json pending.json;
+    Delivered
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Retryable_failure (pending, Broadcast, exn)
 
 let deliver_pending ?store_ref (pending : pending_relay) =
-  let append_result =
+  let append_json =
     match store_ref with
+    | None -> (fun _json -> ())
     | Some store_ref ->
-        let store = !store_ref in
-        (try
-           Dated_jsonl.append store pending.json;
-           Delivered
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-             store_ref :=
-               Dated_jsonl.create ~base_dir:(Dated_jsonl.base_dir store) ();
-             Retryable_failure (Append, exn))
-    | None -> Delivered
+        (fun json ->
+           let store = !store_ref in
+           try
+             Dated_jsonl.append store json
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               store_ref :=
+                 Dated_jsonl.create ~base_dir:(Dated_jsonl.base_dir store) ();
+               raise exn)
   in
-  match append_result with
-  | Retryable_failure _ as retry -> retry
-  | Delivered ->
-      (try
-         Sse.broadcast_to All pending.json;
-         Delivered
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn -> Retryable_failure (Broadcast, exn))
+  try
+    deliver_pending_with
+      ~append_json
+      ~broadcast_json:(Sse.broadcast_to All)
+      pending
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Retryable_failure (pending, Append, exn)
 
 let enqueue_pending pending item =
   if List.length pending < relay_max_queue_depth then
@@ -475,7 +493,7 @@ let rec process_pending ?store_ref acc = function
       match deliver_pending ?store_ref pending with
       | Delivered ->
           process_pending ?store_ref acc rest
-      | Retryable_failure (stage, exn) ->
+      | Retryable_failure (pending, stage, exn) ->
           let attempt = pending.attempts + 1 in
           if attempt >= relay_max_attempts then begin
             Prometheus.inc_counter Prometheus.metric_oas_sse_relay_drops
@@ -495,6 +513,59 @@ let rec process_pending ?store_ref acc = function
               ({ pending with attempts = attempt; } :: acc)
               rest
           end)
+
+type bridge_pending_relay = pending_relay
+type bridge_relay_stage = relay_stage
+type bridge_relay_result = relay_result
+
+let deliver_pending_with_impl = deliver_pending_with
+
+module For_testing = struct
+  type pending_relay = {
+    json : Yojson.Safe.t;
+    attempts : int;
+    appended : bool;
+  }
+
+  type relay_stage =
+    | Append
+    | Broadcast
+
+  type relay_result =
+    | Delivered
+    | Retryable_failure of pending_relay * relay_stage * exn
+
+  let make_pending json = { json; attempts = 0; appended = false; }
+
+  let to_pending (pending : pending_relay) : bridge_pending_relay =
+    { json = pending.json;
+      attempts = pending.attempts;
+      appended = pending.appended; }
+
+  let of_pending (pending : bridge_pending_relay) : pending_relay =
+    { json = pending.json;
+      attempts = pending.attempts;
+      appended = pending.appended; }
+
+  let of_stage (stage : bridge_relay_stage) =
+    match relay_stage_to_string stage with
+    | "append" -> Append
+    | "broadcast" -> Broadcast
+    | _ -> Broadcast
+
+  let of_result (result : bridge_relay_result) =
+    match result with
+    | Delivered -> Delivered
+    | Retryable_failure (pending, stage, exn) ->
+        Retryable_failure (of_pending pending, of_stage stage, exn)
+
+  let deliver_pending_with ~append_json ~broadcast_json pending =
+    deliver_pending_with_impl
+      ~append_json
+      ~broadcast_json
+      (to_pending pending)
+    |> of_result
+end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
   let store =

--- a/lib/oas_sse_bridge.mli
+++ b/lib/oas_sse_bridge.mli
@@ -33,3 +33,27 @@ val start_with_interval :
 (** Serialize a single OAS event to SSE JSON.
     Exposed for unit testing. *)
 val native_event_to_json : Agent_sdk.Event_bus.event -> Yojson.Safe.t option
+
+module For_testing : sig
+  type pending_relay = private {
+    json : Yojson.Safe.t;
+    attempts : int;
+    appended : bool;
+  }
+
+  type relay_stage = private
+    | Append
+    | Broadcast
+
+  type relay_result = private
+    | Delivered
+    | Retryable_failure of pending_relay * relay_stage * exn
+
+  val make_pending : Yojson.Safe.t -> pending_relay
+
+  val deliver_pending_with :
+    append_json:(Yojson.Safe.t -> unit) ->
+    broadcast_json:(Yojson.Safe.t -> unit) ->
+    pending_relay ->
+    relay_result
+end

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -135,6 +135,13 @@ let get_metric_value name ?(labels=[]) () =
 let metric_value_or_zero name ?(labels=[]) () =
   get_metric_value name ~labels () |> Option.value ~default:0.0
 
+let metric_total name =
+  with_lock (fun () ->
+    Hashtbl.fold
+      (fun _ (m : metric) acc ->
+        if String.equal m.name name then acc +. m.value else acc)
+      metrics 0.0)
+
 (** Observe a histogram value.
     Tracks cumulative sum in the metric value; a matching _count counter
     is auto-created for computing averages. *)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -184,9 +184,10 @@ let primary_path ~webrtc_channels ~grpc_subscribers ~ws_sessions ~sse_sessions =
   else if sse_sessions > 0 then "sse"
   else "streamable_http"
 
-let queue_pressure max_queue_depth =
+let queue_pressure ~sse_queue_max ~relay_queue_depth =
+  let max_queue_depth = max sse_queue_max relay_queue_depth in
   if max_queue_depth >= 32 then "high"
-  else if max_queue_depth >= 8 then "watch"
+  else if max_queue_depth >= 8 || relay_queue_depth > 0 then "watch"
   else "steady"
 
 let ws_enabled () = Env_config.Transport.ws_enabled ()
@@ -218,6 +219,40 @@ let transport_health_json ~config =
   in
   let sse_queue_avg = v "masc_sse_queue_depth_avg" () in
   let sse_queue_max = int_of_float (v "masc_sse_queue_depth_max" ()) in
+  let relay_queue_depth =
+    int_of_float (v Prometheus.metric_oas_sse_relay_queue_depth ())
+  in
+  let relay_retry_append =
+    int_of_float
+      (v Prometheus.metric_oas_sse_relay_retries
+         ~labels:[ ("stage", "append") ] ())
+  in
+  let relay_retry_broadcast =
+    int_of_float
+      (v Prometheus.metric_oas_sse_relay_retries
+         ~labels:[ ("stage", "broadcast") ] ())
+  in
+  let relay_retry_total =
+    int_of_float (Prometheus.metric_total Prometheus.metric_oas_sse_relay_retries)
+  in
+  let relay_drop_queue =
+    int_of_float
+      (v Prometheus.metric_oas_sse_relay_drops
+         ~labels:[ ("stage", "queue") ] ())
+  in
+  let relay_drop_append =
+    int_of_float
+      (v Prometheus.metric_oas_sse_relay_drops
+         ~labels:[ ("stage", "append") ] ())
+  in
+  let relay_drop_broadcast =
+    int_of_float
+      (v Prometheus.metric_oas_sse_relay_drops
+         ~labels:[ ("stage", "broadcast") ] ())
+  in
+  let relay_drop_total =
+    int_of_float (Prometheus.metric_total Prometheus.metric_oas_sse_relay_drops)
+  in
   let broadcast_sum = v "masc_sse_broadcast_duration_seconds" () in
   let broadcast_count = v "masc_sse_broadcast_duration_seconds_count" () in
   let broadcast_avg =
@@ -233,6 +268,11 @@ let transport_health_json ~config =
   in
   let grpc_events = v "masc_grpc_events_delivered_total" () in
   let stale_agents = v "masc_agent_stale_total" () in
+  let lifecycle_dispatch_rejections =
+    int_of_float
+      (Prometheus.metric_total
+         Prometheus.metric_keeper_lifecycle_dispatch_rejections)
+  in
   let ws_sessions = int_of_float (v "masc_ws_sessions_total" ()) in
   let grpc_configured = grpc_enabled () in
   let grpc_live = grpc_listening () in
@@ -263,7 +303,9 @@ let transport_health_json ~config =
   `Assoc [
     ("summary", `Assoc [
       ("primary_path", `String primary_path);
-      ("queue_pressure", `String (queue_pressure sse_queue_max));
+      ("queue_pressure",
+       `String
+         (queue_pressure ~sse_queue_max ~relay_queue_depth));
       ("recent_messages", int_option_json recent_messages);
       ("recent_messages_available", `Bool recent_messages_available);
       ("recent_messages_source", `String degraded_source);
@@ -278,6 +320,14 @@ let transport_health_json ~config =
       ("broadcast_count", `Int (int_of_float broadcast_count));
       ("queue_avg_depth", `Float sse_queue_avg);
       ("queue_max_depth", `Int sse_queue_max);
+      ("relay_queue_depth", `Int relay_queue_depth);
+      ("relay_retry_total", `Int relay_retry_total);
+      ("relay_retry_append", `Int relay_retry_append);
+      ("relay_retry_broadcast", `Int relay_retry_broadcast);
+      ("relay_drop_total", `Int relay_drop_total);
+      ("relay_drop_queue", `Int relay_drop_queue);
+      ("relay_drop_append", `Int relay_drop_append);
+      ("relay_drop_broadcast", `Int relay_drop_broadcast);
       ("hot_sessions", `List (List.map hot_session_json (Atomic.get sse_hot_sessions)));
     ]);
     ("grpc", `Assoc [
@@ -344,6 +394,8 @@ let transport_health_json ~config =
     ]);
     ("agent_health", `Assoc [
       ("stale_total", `Int (int_of_float stale_agents));
+      ("lifecycle_dispatch_rejections_total",
+       `Int lifecycle_dispatch_rejections);
     ]);
     ("generated_at", `String (Types.now_iso ()));
   ]

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -184,10 +184,15 @@ let primary_path ~webrtc_channels ~grpc_subscribers ~ws_sessions ~sse_sessions =
   else if sse_sessions > 0 then "sse"
   else "streamable_http"
 
-let queue_pressure ~sse_queue_max ~relay_queue_depth =
+let queue_pressure
+    ~sse_queue_max
+    ~relay_queue_depth
+    ~relay_retry_total
+    ~relay_drop_total =
   let max_queue_depth = max sse_queue_max relay_queue_depth in
-  if max_queue_depth >= 32 then "high"
-  else if max_queue_depth >= 8 || relay_queue_depth > 0 then "watch"
+  if max_queue_depth >= 32 || relay_drop_total > 0 then "high"
+  else if max_queue_depth >= 8 || relay_queue_depth > 0 || relay_retry_total > 0
+  then "watch"
   else "steady"
 
 let ws_enabled () = Env_config.Transport.ws_enabled ()
@@ -305,7 +310,11 @@ let transport_health_json ~config =
       ("primary_path", `String primary_path);
       ("queue_pressure",
        `String
-         (queue_pressure ~sse_queue_max ~relay_queue_depth));
+         (queue_pressure
+            ~sse_queue_max
+            ~relay_queue_depth
+            ~relay_retry_total
+            ~relay_drop_total));
       ("recent_messages", int_option_json recent_messages);
       ("recent_messages_available", `Bool recent_messages_available);
       ("recent_messages_source", `String degraded_source);

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -499,6 +499,41 @@ let test_dashboard_execution_fresh_join_not_marked_stale () =
           false has_test_agent
       ))
 
+let test_dashboard_execution_surfaces_keeper_diagnostic () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:None);
+      Eio.Switch.run (fun sw ->
+        Fun.protect
+          ~finally:(fun () ->
+            Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu")
+          (fun () ->
+            create_keeper env sw config "sangsu";
+            let json =
+              Lib.Dashboard_execution.json
+                ~config
+                ~sw
+                ~clock:(Eio.Stdenv.clock env)
+                ~proc_mgr:None
+                ()
+            in
+            let open Yojson.Safe.Util in
+            let row =
+              json |> member "keepers" |> to_list
+              |> List.find (fun keeper -> keeper |> member "name" |> to_string = "sangsu")
+            in
+            check bool "diagnostic surfaced on execution keeper row" true
+              (row |> member "diagnostic" <> `Null);
+            check bool "diagnostic health state surfaced" true
+              (row |> member "diagnostic" |> member "health_state" <> `Null);
+            check bool "diagnostic next action surfaced" true
+              (row |> member "diagnostic" |> member "next_action_path" <> `Null))))
+
 let test_patch_keeper_dependent_caches_tolerates_null_agent () =
   let execution_json =
     `Assoc
@@ -622,6 +657,8 @@ let () =
             test_dashboard_shell_excludes_keeper_agents_from_general_count;
           Alcotest.test_case "fresh join is not stale" `Quick
             test_dashboard_execution_fresh_join_not_marked_stale;
+          Alcotest.test_case "execution surfaces keeper diagnostic" `Quick
+            test_dashboard_execution_surfaces_keeper_diagnostic;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick
             test_patch_keeper_dependent_caches_tolerates_null_agent;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -373,6 +373,53 @@ let test_oas_sse_bridge_drop_marker_on_exhausted_append_failure () =
                 raise Exit)
       with Exit -> ())
 
+let test_oas_sse_bridge_broadcast_retry_does_not_duplicate_append () =
+  let append_count = ref 0 in
+  let broadcast_count = ref 0 in
+  let pending =
+    Oas_sse_bridge.For_testing.make_pending
+      (`Assoc
+         [
+           ("type", `String "oas:tool_called");
+           ("event_type", `String "tool_called");
+           ("correlation_id", `String "sess-broadcast");
+           ("run_id", `String "run-broadcast");
+         ])
+  in
+  let first =
+    Oas_sse_bridge.For_testing.deliver_pending_with
+      ~append_json:(fun _json -> incr append_count)
+      ~broadcast_json:(fun _json ->
+        incr broadcast_count;
+        if !broadcast_count = 1 then failwith "synthetic broadcast failure")
+      pending
+  in
+  let pending_after_failure =
+    match first with
+    | Oas_sse_bridge.For_testing.Retryable_failure
+        (pending, Oas_sse_bridge.For_testing.Broadcast, _) ->
+        pending
+    | Oas_sse_bridge.For_testing.Retryable_failure _ ->
+        Alcotest.fail "expected broadcast-stage retryable failure"
+    | Oas_sse_bridge.For_testing.Delivered ->
+        Alcotest.fail "expected first delivery to fail on broadcast"
+  in
+  Alcotest.(check int) "append happens exactly once before retry" 1 !append_count;
+  Alcotest.(check bool) "pending remembers durable append" true
+    pending_after_failure.appended;
+  let second =
+    Oas_sse_bridge.For_testing.deliver_pending_with
+      ~append_json:(fun _json -> incr append_count)
+      ~broadcast_json:(fun _json -> incr broadcast_count)
+      pending_after_failure
+  in
+  (match second with
+   | Oas_sse_bridge.For_testing.Delivered -> ()
+   | Oas_sse_bridge.For_testing.Retryable_failure _ ->
+       Alcotest.fail "expected retry to deliver after broadcast recovery");
+  Alcotest.(check int) "retry does not duplicate durable append" 1 !append_count;
+  Alcotest.(check int) "broadcast retried once" 2 !broadcast_count
+
 (* ================================================================ *)
 (* Message conversion tests (formerly oas_checkpoint_bridge)         *)
 (* ================================================================ *)
@@ -714,6 +761,8 @@ let () =
         test_oas_sse_bridge_retries_append_failure_then_recovers;
       Alcotest.test_case "sse bridge emits drop marker on exhausted append failure" `Quick
         test_oas_sse_bridge_drop_marker_on_exhausted_append_failure;
+      Alcotest.test_case "sse bridge retry avoids duplicate append after broadcast failure" `Quick
+        test_oas_sse_bridge_broadcast_retry_does_not_duplicate_append;
       Alcotest.test_case "agent_completed includes usage" `Quick
         test_agent_completed_includes_usage;
       Alcotest.test_case "agent_completed no usage on error" `Quick

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -271,7 +271,7 @@ let test_transport_health_json () =
     (cluster_json |> U.member "room_id" |> U.to_string);
   check bool "summary primary path exists" true
     (String.length (summary_json |> U.member "primary_path" |> U.to_string) > 0);
-  check string "summary queue pressure reflects relay queue" "watch"
+  check string "summary queue pressure reflects relay drops" "high"
     (summary_json |> U.member "queue_pressure" |> U.to_string);
   check int "agent lifecycle dispatch rejections surfaced" 2
     (agent_health_json

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -211,6 +211,17 @@ let test_transport_health_json () =
        ~push:(fun _ -> ()) ~last_event_id:0);
   TM.set_grpc_active_streams 1;
   TM.set_grpc_subscribers 2;
+  Prometheus.set_gauge Prometheus.metric_oas_sse_relay_queue_depth 4.0;
+  Prometheus.inc_counter Prometheus.metric_oas_sse_relay_retries
+    ~labels:[ ("stage", "append") ] ~delta:2.0 ();
+  Prometheus.inc_counter Prometheus.metric_oas_sse_relay_retries
+    ~labels:[ ("stage", "broadcast") ] ~delta:1.0 ();
+  Prometheus.inc_counter Prometheus.metric_oas_sse_relay_drops
+    ~labels:[ ("stage", "queue") ] ~delta:3.0 ();
+  Prometheus.inc_counter Prometheus.metric_oas_sse_relay_drops
+    ~labels:[ ("stage", "append") ] ~delta:1.0 ();
+  Prometheus.inc_counter Prometheus.metric_keeper_lifecycle_dispatch_rejections
+    ~labels:[ ("event", "compaction_started") ] ~delta:2.0 ();
   Masc_mcp.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   let json = TM.transport_health_json ~config in
   let sse_json = json |> U.member "sse" in
@@ -219,6 +230,7 @@ let test_transport_health_json () =
   let webrtc_json = json |> U.member "webrtc" in
   let cluster_json = json |> U.member "cluster" in
   let summary_json = json |> U.member "summary" in
+  let agent_health_json = json |> U.member "agent_health" in
   check int "observer sessions" 1
     (sse_json |> U.member "sessions_observer" |> U.to_int);
   check int "coordinator sessions" 1
@@ -227,6 +239,12 @@ let test_transport_health_json () =
     ((sse_json |> U.member "queue_max_depth" |> U.to_int) > 0);
   check bool "hot sessions are reported" true
     ((sse_json |> U.member "hot_sessions" |> U.to_list |> List.length) > 0);
+  check int "relay queue depth" 4
+    (sse_json |> U.member "relay_queue_depth" |> U.to_int);
+  check int "relay retries total" 3
+    (sse_json |> U.member "relay_retry_total" |> U.to_int);
+  check int "relay drops total" 4
+    (sse_json |> U.member "relay_drop_total" |> U.to_int);
   check int "grpc active streams" 1
     (grpc_json |> U.member "active_streams" |> U.to_int);
   check int "grpc subscribers" 2
@@ -253,6 +271,12 @@ let test_transport_health_json () =
     (cluster_json |> U.member "room_id" |> U.to_string);
   check bool "summary primary path exists" true
     (String.length (summary_json |> U.member "primary_path" |> U.to_string) > 0);
+  check string "summary queue pressure reflects relay queue" "watch"
+    (summary_json |> U.member "queue_pressure" |> U.to_string);
+  check int "agent lifecycle dispatch rejections surfaced" 2
+    (agent_health_json
+     |> U.member "lifecycle_dispatch_rejections_total"
+     |> U.to_int);
   ignore (Masc_mcp.Sse.close_all_clients ());
   cleanup_dir base_dir
 


### PR DESCRIPTION
Superseded by a clean-branch follow-up. This branch accidentally reused the pre-squash `#8379` commit chain, so the diff was larger than intended. Closing in favor of a `main`-based PR that contains only `c64dd301d` (`fix(dashboard): preserve keeper diagnostic truth in execution views`).