### PR TITLE
fix(dashboard): preserve keeper diagnostic truth in execution views

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -13,6 +13,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     name: 'keeper-x',
     status: 'active',
     keepalive_running: true,
+    diagnostic_health_state: null,
+    diagnostic_summary: null,
     context_ratio: 0.3,
     turn_count: 0,
     last_latency_ms: 0,
@@ -287,6 +289,47 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Partial telemetry')
     expect(container.textContent).toContain('keepers are blocked in the admission queue')
     expect(container.textContent).toContain('Admission queue wait timeout after 45.0s.')
+  }, 30_000)
+
+  it('surfaces snapshot diagnostic summaries for inactive keepers', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue({
+      ...executionResponse,
+      keepers: [
+        {
+          name: 'keeper-stale',
+          status: 'inactive',
+          keepalive_running: true,
+          context_ratio: 0.22,
+          total_turns: 11,
+          last_latency_ms: 1200,
+          last_activity_ago_s: 640,
+          last_model_used: 'gpt-5.4',
+          diagnostic: {
+            health_state: 'stale',
+            next_action_path: 'recover',
+            last_reply_status: 'stale',
+            summary: 'Keepalive heartbeat is stale; probe or recover before the next turn.',
+          },
+        },
+      ],
+    } satisfies DashboardExecutionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue({ ...toolQualityResponse, by_keeper: [] })
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('keeper-stale')
+    expect(container.textContent).toContain('Keepalive heartbeat is stale; probe or recover before the next turn.')
+    expect(container.textContent).toContain('1 주의')
   }, 30_000)
 
   it('falls back to runtime model and tool audit data when quality rows are sparse', async () => {

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -29,6 +29,7 @@ import {
   buildTelemetryWarnings,
   emptyState,
   errorMessage,
+  fleetBand,
   formatActivity,
   formatLatency,
   formatPercent,
@@ -235,14 +236,28 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
         <tbody>
           ${rows.map(row => {
             const toolInfo = toolSummary(row)
+            const diagnosticState = row.diagnostic_health_state?.trim().toLowerCase() ?? null
+            const rowHint =
+              row.runtime_blocker_summary
+              ?? (
+                diagnosticState
+                && diagnosticState !== 'healthy'
+                && diagnosticState !== 'idle'
+                  ? row.diagnostic_summary ?? null
+                  : null
+              )
+            const rowHintClass =
+              diagnosticState === 'offline' || diagnosticState === 'dead'
+                ? 'text-[var(--bad-light)]'
+                : 'text-[var(--warn)]'
             return html`
             <tr class="border-b border-[var(--card-border)] border-opacity-30 align-top">
               <td class="py-1.5">
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
-                ${row.runtime_blocker_summary
+                ${rowHint
                   ? html`
-                    <div class="max-w-60 truncate text-3xs text-[var(--warn)]" title=${row.runtime_blocker_summary}>
-                      ${row.runtime_blocker_summary}
+                    <div class="max-w-60 truncate text-3xs ${rowHintClass}" title=${rowHint}>
+                      ${rowHint}
                     </div>
                   `
                   : null}
@@ -485,12 +500,7 @@ export function FleetTelemetryPanel() {
   }
 
   const activeCount = counts.live
-  const attentionCount = value.rows.filter(row => row.keepalive_running && (
-    row.runtime_blocker_class != null
-    || row.context_ratio >= PRESSURE_WARN_RATIO
-    || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
-    || (row.tool_success_pct != null && row.tool_success_pct < 90)
-  )).length
+  const attentionCount = value.rows.filter(row => fleetBand(row) === 'attention').length
   const offlineCount = value.rows.length - activeCount
 
   return html`

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -37,6 +37,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     name: 'test-keeper',
     status: 'active',
     keepalive_running: true,
+    diagnostic_health_state: null,
+    diagnostic_summary: null,
     context_ratio: 0.3,
     turn_count: 10,
     last_latency_ms: 500,
@@ -161,6 +163,14 @@ describe('fleetBand', () => {
     expect(fleetBand(makeRow({ status: 'paused' }))).toBe('paused')
   })
 
+  it('classifies inactive keepalive rows as attention, not offline', () => {
+    expect(fleetBand(makeRow({ status: 'inactive', keepalive_running: true }))).toBe('attention')
+  })
+
+  it('classifies attention for stale diagnostic health state', () => {
+    expect(fleetBand(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toBe('attention')
+  })
+
   it('classifies attention for runtime blocker', () => {
     expect(fleetBand(makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' }))).toBe('attention')
   })
@@ -249,6 +259,14 @@ describe('statusClass', () => {
 
   it('returns warn for runtime blocker', () => {
     expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--warn)')
+  })
+
+  it('returns warn for stale diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'stale' }))).toContain('var(--warn)')
+  })
+
+  it('returns bad-light for offline diagnostic health state', () => {
+    expect(statusClass(makeRow({ status: 'inactive', diagnostic_health_state: 'offline' }))).toContain('var(--bad-light)')
   })
 
   it('returns ok for healthy', () => {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -14,6 +14,8 @@ export interface FleetRow {
   name: string
   status: string
   keepalive_running: boolean
+  diagnostic_health_state?: string | null
+  diagnostic_summary?: string | null
   context_ratio: number
   turn_count: number
   last_latency_ms: number
@@ -208,12 +210,25 @@ export function buildToolQualityMap(toolQuality: ToolQualityResponse): Map<strin
 
 type FleetBand = 'attention' | 'active' | 'paused' | 'offline'
 
+function normalizedDiagnosticHealthState(row: FleetRow): string | null {
+  return normalizeText(row.diagnostic_health_state)?.toLowerCase() ?? null
+}
+
+function isOfflineDiagnosticHealthState(state: string | null): boolean {
+  return state === 'offline' || state === 'dead'
+}
+
+function isAttentionDiagnosticHealthState(state: string | null): boolean {
+  return state === 'stale' || state === 'degraded' || state === 'zombie'
+}
+
 export function fleetBand(row: FleetRow): FleetBand {
   const normalizedStatus = normalizeText(row.status)?.toLowerCase() ?? 'unknown'
+  const diagnosticHealthState = normalizedDiagnosticHealthState(row)
   if (
     !row.keepalive_running
+    || isOfflineDiagnosticHealthState(diagnosticHealthState)
     || normalizedStatus === 'offline'
-    || normalizedStatus === 'inactive'
     || normalizedStatus === 'unbooted'
     || normalizedStatus === 'stopped'
     || normalizedStatus === 'dead'
@@ -223,7 +238,9 @@ export function fleetBand(row: FleetRow): FleetBand {
   }
   if (normalizedStatus === 'paused') return 'paused'
   if (
-    row.runtime_blocker_class != null
+    isAttentionDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'inactive'
+    || row.runtime_blocker_class != null
     || row.context_ratio >= PRESSURE_WARN_RATIO
     || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
     || (row.tool_success_pct != null && row.tool_success_pct < 90)
@@ -298,6 +315,9 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             name: keeper.name,
             status: keeper.status ?? (keeper.keepalive_running ? 'active' : 'offline'),
             keepalive_running: keeper.keepalive_running === true,
+            diagnostic_health_state: keeper.diagnostic?.health_state ?? null,
+            diagnostic_summary:
+              firstNonEmptyString(keeper.diagnostic?.continuity_summary, keeper.diagnostic?.summary) ?? null,
             context_ratio: keeper.context_ratio ?? 0,
             turn_count: keeper.total_turns ?? keeper.turn_count ?? 0,
             last_latency_ms: keeperLastLatencyMs(keeper),
@@ -327,6 +347,8 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           name: keeper.name,
           status: 'unknown',
           keepalive_running: false,
+          diagnostic_health_state: null,
+          diagnostic_summary: null,
           context_ratio: 0,
           turn_count: 0,
           last_latency_ms: 0,
@@ -364,8 +386,26 @@ export function pressureClass(ratio: number): string {
 }
 
 export function statusClass(row: FleetRow): string {
-  if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-[var(--bad-light)]'
-  if (row.runtime_blocker_class != null) return 'text-[var(--warn)]'
+  const normalizedStatus = normalizeText(row.status)?.toLowerCase() ?? 'unknown'
+  const diagnosticHealthState = normalizedDiagnosticHealthState(row)
+  if (
+    !row.keepalive_running
+    || isOfflineDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'offline'
+    || normalizedStatus === 'stopped'
+    || normalizedStatus === 'unbooted'
+    || normalizedStatus === 'dead'
+    || normalizedStatus === 'crashed'
+  ) {
+    return 'text-[var(--bad-light)]'
+  }
+  if (
+    isAttentionDiagnosticHealthState(diagnosticHealthState)
+    || normalizedStatus === 'inactive'
+    || row.runtime_blocker_class != null
+  ) {
+    return 'text-[var(--warn)]'
+  }
   if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-[var(--warn)]'
   return 'text-[var(--ok)]'
 }

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -51,9 +51,10 @@ vi.mock('./common/toast', () => ({
 }))
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
+import { keeperStatusDetails } from '../keeper-runtime'
 import { hydrateKeeperStatus } from '../keeper-runtime'
 import { shellAuthSummary } from '../store'
-import { KeeperConversationPanel, KeeperRuntimeActions } from './keeper-shared'
+import { KeeperConversationPanel, KeeperDiagnosticSummary, KeeperRuntimeActions } from './keeper-shared'
 
 describe('KeeperConversationPanel', () => {
   let container: HTMLDivElement
@@ -70,6 +71,7 @@ describe('KeeperConversationPanel', () => {
     keeperThreads.value = {}
     keeperSending.value = {}
     keeperHydrating.value = {}
+    keeperStatusDetails.value = {}
     keeperActionErrors.value = {}
     keeperStreamStartedAt.value = {}
     shellAuthSummary.value = null
@@ -164,5 +166,27 @@ describe('KeeperConversationPanel', () => {
     expect(buttons).toContain('Social sweep')
     expect(buttons).not.toContain('기동')
     expect(buttons).not.toContain('종료')
+  })
+
+  it('falls back to snapshot diagnostic when hydrated detail is absent', async () => {
+    const keeper = {
+      name: 'sangsu',
+      status: 'inactive',
+      diagnostic: {
+        health_state: 'stale',
+        next_action_path: 'recover',
+        last_reply_status: 'stale',
+        summary: 'Snapshot says the keeper heartbeat is stale.',
+      },
+    } as any
+
+    render(
+      html`<${KeeperDiagnosticSummary} keeper=${keeper} />`,
+      container,
+    )
+    await Promise.resolve()
+
+    expect(container.textContent).toContain('stale')
+    expect(container.textContent).toContain('Snapshot says the keeper heartbeat is stale.')
   })
 })

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -144,7 +144,7 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
   if (!keeper) return null
   const detail = keeperStatusDetails.value[keeper.name]
-  return detail?.diagnostic ?? null
+  return detail?.diagnostic ?? keeper.diagnostic ?? null
 }
 
 // ── Diagnostic chip ──────────────────────────────────────

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -11,6 +11,7 @@ import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp 
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
+import { normalizeKeeperDiagnostic } from './keeper-state'
 
 /** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
  *  Backend (keeper_state_machine.ml) emits lowercase: "offline", "running", "handing_off", etc.
@@ -444,6 +445,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         tool_audit_source: asString(row.tool_audit_source) ?? null,
         tool_audit_at: toIsoTimestamp(row.tool_audit_at) ?? asString(row.tool_audit_at) ?? null,
         turn_budget: normalizeTurnBudget(row.turn_budget),
+        diagnostic: normalizeKeeperDiagnostic(row.diagnostic),
         conversation_tail_count: asNumber(row.conversation_tail_count),
         k2k_count: asNumber(row.k2k_count),
         handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -522,6 +522,7 @@ export interface Keeper {
   presence_keepalive?: boolean
   presence_keepalive_sec?: number
   keepalive_running?: boolean
+  diagnostic?: KeeperDiagnostic | null
   registry_state?: string | null
   proactive_enabled?: boolean
   proactive_idle_sec?: number

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -45,6 +45,39 @@ let messages_safe config =
 let assoc_upsert fields key value =
   (key, value) :: List.remove_assoc key fields
 
+let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson.Safe.t) =
+  let open Yojson.Safe.Util in
+  match keeper_json with
+  | `Assoc fields -> (
+      match member "name" keeper_json with
+      | `String name -> (
+          match Keeper_types.read_meta_resolved config name with
+          | Ok (Some (_resolved_name, meta)) ->
+              let keepalive_running =
+                match member "keepalive_running" keeper_json with
+                | `Bool value -> value
+                | _ -> Keeper_status_bridge.runtime_keepalive_running config meta
+              in
+              let now_ts = Time_compat.now () in
+              let diagnostic =
+                Keeper_exec_status.keeper_diagnostic_json
+                  ~meta
+                  ~agent_status:(member "agent" keeper_json)
+                  ~keepalive_running
+                  ~history_items:[]
+                  ~now_ts
+                |> Keeper_exec_status.augment_keeper_diagnostic_json
+                     ~meta
+                     ~keepalive_running
+                     ~keepalive_started_at:
+                       (Keeper_status_bridge.runtime_keepalive_started_at config meta)
+                     ~now_ts
+              in
+              `Assoc (assoc_upsert fields "diagnostic" diagnostic)
+          | Ok None | Error _ -> keeper_json)
+      | _ -> keeper_json)
+  | _ -> keeper_json
+
 let model_map_of_keeper_rows keepers =
   let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
   let open Yojson.Safe.Util in
@@ -184,7 +217,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let keepers =
         member_assoc "keepers" snapshot_json |> member_assoc "items"
         |> function
-        | `List items -> items
+        | `List items -> List.map (enrich_keeper_with_diagnostic ~config) items
         | _ -> []
       in
       Eio.Fiber.yield ();

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -499,6 +499,41 @@ let test_dashboard_execution_fresh_join_not_marked_stale () =
           false has_test_agent
       ))
 
+let test_dashboard_execution_surfaces_keeper_diagnostic () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:None);
+      Eio.Switch.run (fun sw ->
+        Fun.protect
+          ~finally:(fun () ->
+            Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu")
+          (fun () ->
+            create_keeper env sw config "sangsu";
+            let json =
+              Lib.Dashboard_execution.json
+                ~config
+                ~sw
+                ~clock:(Eio.Stdenv.clock env)
+                ~proc_mgr:None
+                ()
+            in
+            let open Yojson.Safe.Util in
+            let row =
+              json |> member "keepers" |> to_list
+              |> List.find (fun keeper -> keeper |> member "name" |> to_string = "sangsu")
+            in
+            check bool "diagnostic surfaced on execution keeper row" true
+              (row |> member "diagnostic" <> `Null);
+            check bool "diagnostic health state surfaced" true
+              (row |> member "diagnostic" |> member "health_state" <> `Null);
+            check bool "diagnostic next action surfaced" true
+              (row |> member "diagnostic" |> member "next_action_path" <> `Null))))
+
 let test_patch_keeper_dependent_caches_tolerates_null_agent () =
   let execution_json =
     `Assoc
@@ -622,6 +657,8 @@ let () =
             test_dashboard_shell_excludes_keeper_agents_from_general_count;
           Alcotest.test_case "fresh join is not stale" `Quick
             test_dashboard_execution_fresh_join_not_marked_stale;
+          Alcotest.test_case "execution surfaces keeper diagnostic" `Quick
+            test_dashboard_execution_surfaces_keeper_diagnostic;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick
             test_patch_keeper_dependent_caches_tolerates_null_agent;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick


### PR DESCRIPTION
## Summary
- surface keeper `diagnostic` on dashboard execution keeper rows instead of dropping it at the execution projection boundary
- make fleet telemetry prefer backend `diagnostic.health_state` and diagnostic summary when classifying attention/offline tone and row hints
- let keeper diagnostic UI fall back to snapshot diagnostic truth when hydrated detail payload has not been loaded yet

## Why
A second SSOT drift remained after `#8379`:
- the execution surface already had enough information to compute keeper diagnostics, but the execution projection did not expose that payload to the dashboard row model
- fleet telemetry therefore re-derived status only from `status` / `keepalive_running` / blocker heuristics, which could misclassify `inactive` keepers and lose backend continuity/recovery hints
- keeper detail chips only trusted hydrated detail responses, so the initial dashboard snapshot could stay silent even when the execution snapshot already knew the keeper was `stale` / `degraded`

## Product impact
- execution/fleet views now keep backend diagnostic truth attached to each keeper row
- fleet status tone no longer collapses `inactive` keepalive rows into an implicit offline heuristic when backend health says `stale` / `degraded`
- row-level hint text can show diagnostic continuity/recovery summaries even without a runtime blocker
- keeper diagnostic chips render immediately from snapshot truth before an explicit hydrate round-trip

## Evidence
- `pnpm exec vitest run src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts src/components/keeper-shared.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`

## Review evidence
- added fleet telemetry regression coverage for `inactive` + diagnostic-health-state combinations
- added a panel-level regression proving snapshot diagnostic summaries surface in the fleet table
- added a keeper-shared regression proving snapshot diagnostic fallback works before hydrated detail exists
- added dashboard execution regression coverage asserting execution keeper rows expose `diagnostic`

## Notes
- `#8428` was closed because it accidentally reused the pre-squash `#8379` branch history and produced an oversized diff; this PR is the clean `main`-based follow-up containing only `2a62b792b`
- local native relink for `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-fleet-diagnostic-truth test/test_dashboard_execution.exe` was unusually slow in this environment, so the OCaml executable build/test could not be cleanly closed in-turn; the frontend/type checks above passed and the dashboard execution sources were updated with matching regression coverage

## Linked issue
- Relates #8365
- Follow-up to #8379