### PR TITLE
fix(types): tolerate missing last_updated/version in backlog_of_yojson

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -902,8 +902,23 @@ let backlog_of_yojson json =
     let tasks = List.filter_map (fun j ->
       match task_of_yojson j with Ok t -> Some t | Error _ -> None
     ) tasks_json in
-    let last_updated = json |> member "last_updated" |> to_string in
-    let version = json |> member "version" |> to_int in
+    (* [last_updated] and [version] are display metadata; writers may
+       omit them (observed in live basepath [~/me/.masc/tasks/backlog.json]
+       where the top-level is just [{"tasks": [...]}]).  Strict
+       [to_string]/[to_int] decoders rejected such payloads as
+       [Type_error("Expected string, got null")], forcing every reader
+       onto the [read_backlog] empty fallback and wiping every claim
+       from the reader's view (hundreds of [read_backlog backlog decode
+       failed] entries/day driven [stale-claims] GC to skip mutation,
+       so claims never transitioned).  Tolerate missing/null fields. *)
+    let last_updated =
+      json |> member "last_updated" |> to_string_option
+      |> Option.value ~default:""
+    in
+    let version =
+      json |> member "version" |> to_int_option
+      |> Option.value ~default:1
+    in
     Ok { tasks; last_updated; version }
   with e -> Error (Printexc.to_string e)
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -146,6 +146,49 @@ let test_actions_enum_has_verification_actions () =
       (List.mem s valid_task_action_strings)
   ) must
 
+(* Regression for live-basepath decode spike (2026-04-18): backlog.json
+   written without the [last_updated]/[version] metadata fields used to
+   fail parsing with [Type_error("Expected string, got null")], forcing
+   every reader onto the empty fallback and blocking the stale-claims
+   GC for hours. *)
+let test_backlog_parse_missing_metadata_fields () =
+  let json =
+    `Assoc [
+      ("tasks", `List [
+         `Assoc [
+           ("id", `String "t-1");
+           ("title", `String "demo");
+           ("description", `String "");
+           ("files", `List []);
+           ("created_at", `String "2026-04-18T10:00:00Z");
+           ("status", `String "todo");
+         ];
+      ]);
+    ]
+  in
+  match backlog_of_yojson json with
+  | Ok b ->
+    Alcotest.(check int) "one task parsed" 1 (List.length b.tasks);
+    Alcotest.(check string) "last_updated defaulted to empty" "" b.last_updated;
+    Alcotest.(check int) "version defaulted to 1" 1 b.version
+  | Error msg ->
+    Alcotest.fail ("expected Ok, got Error: " ^ msg)
+
+let test_backlog_parse_null_metadata_fields () =
+  let json =
+    `Assoc [
+      ("tasks", `List []);
+      ("last_updated", `Null);
+      ("version", `Null);
+    ]
+  in
+  match backlog_of_yojson json with
+  | Ok b ->
+    Alcotest.(check string) "null last_updated -> empty" "" b.last_updated;
+    Alcotest.(check int) "null version -> 1" 1 b.version
+  | Error msg ->
+    Alcotest.fail ("expected Ok with null metadata, got Error: " ^ msg)
+
 let () =
   Alcotest.run "Types" [
     "agent_status", [
@@ -161,6 +204,12 @@ let () =
     ];
     "timestamp", [
       Alcotest.test_case "parse utc epoch" `Quick test_parse_iso8601_epoch_utc;
+    ];
+    "backlog_lenient_parse", [
+      Alcotest.test_case "missing last_updated/version -> defaults" `Quick
+        test_backlog_parse_missing_metadata_fields;
+      Alcotest.test_case "null last_updated/version -> defaults" `Quick
+        test_backlog_parse_null_metadata_fields;
     ];
     "task_action_lenient", [
       Alcotest.test_case "alias claimed -> claim" `Quick test_action_alias_claimed;


### PR DESCRIPTION
## Context

Live basepath \`~/me\` at 2026-04-18 ~19:24–19:59 KST produced **457 occurrences in 35 minutes** of:

\`\`\`
[read_backlog] backlog decode failed for /Users/dancer/me/.masc/tasks/backlog.json:
Yojson__Safe.Util.Type_error(\"Expected string, got null\", 870828711)
\`\`\`

And a parallel cluster of \`[stale-claims] skipping backlog mutation due to read failure\`. Stale-claims GC could not read the backlog, so it never retired stale claims — the user-visible symptom was keeper cycles running (post-#8388 cascade fix) but claims like task-170/172/… not progressing.

Root cause is schema strictness here, not IO: \`backlog_of_yojson\` demanded \`last_updated: string\` and \`version: int\` via \`Yojson.Safe.Util.to_string\` / \`to_int\`. The live \`backlog.json\` on disk is only \`{\"tasks\": [...]}\` — no metadata fields — so every read failed with \`Type_error(\"Expected string, got null\")\` (\`member\` returns \`\\\`Null\` for absent keys, and \`to_string\`/\`to_int\` reject null). \`read_backlog\` then returned its empty fallback, so every reader saw zero tasks.

\`backlog_to_yojson\` still writes both fields, so existing payloads continue to round-trip.

## Change

Make \`last_updated\` and \`version\` optional in the decoder, defaulting to \`\"\"\` and \`1\` respectively. Missing-key and explicit-\`null\` both parse successfully.

No behavior change for healthy backlogs; the returned \`backlog\` record still contains the strict value when the writer emitted one.

## Tests

\`test/test_types.ml\` grows two cases under a new \`backlog_lenient_parse\` suite:

- missing \`last_updated\`/\`version\` keys → defaults applied, tasks parsed
- explicit \`\\\`Null\` values → same result

All 24 \`test_types\` cases pass locally.

## Why this matters now

Follow-up to #8388 (cascade load-time loudness merged earlier today). #8388 fixed the \"keepers can't talk to cascades\" layer; this fixes the adjacent \"backlog reader sees empty tasks\" layer. Together they restore the claim-update pipeline end-to-end.

Related investigation: Issue #8393 (path resolver anchor) — separate layer, not blocked by this PR.