### PR TITLE
feat(doctor): iMessage sidecar doctor (macOS-only)

### DIFF
--- a/sidecars/imessage-bot/run.sh
+++ b/sidecars/imessage-bot/run.sh
@@ -12,6 +12,9 @@
 #   ./run.sh              start the bot (foreground, tees to today's log)
 #   ./run.sh tail         tail -F today's log file
 #   ./run.sh status       pretty-print the current status.json
+#   ./run.sh doctor       run health checks without starting the bot
+#   ./run.sh doctor --json   machine-readable check output
+#   ./run.sh doctor --fix    run available auto-fixes then recheck
 
 set -euo pipefail
 
@@ -70,6 +73,11 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  doctor)
+    cd "$(script_dir)"
+    shift || true
+    python -m src doctor "$@"
+    ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.
     if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
@@ -80,7 +88,7 @@ case "$cmd" in
     fi
     ;;
   *)
-    echo "Usage: $0 [start|stop|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status|doctor]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/imessage-bot/src/__main__.py
+++ b/sidecars/imessage-bot/src/__main__.py
@@ -1,6 +1,48 @@
-"""Entry point: python -m src.bot"""
-from .bot import main
+"""Entry point: python -m src.
+
+기본은 봇 기동. ``doctor`` subcommand 로 건강 점검만 실행.
+
+    python -m src                # 봇 기동
+    python -m src doctor         # 점검
+    python -m src doctor --json  # 점검 결과 JSON
+    python -m src doctor --fix   # 가능한 auto-fix 후 재점검
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+from gate_shared import exit_code_for, render_json, render_pretty  # noqa: E402
+
+from .bot import main  # noqa: E402
+from .doctor import run_doctor  # noqa: E402
+
+
+def _run_doctor(argv: list[str]) -> int:
+    as_json = "--json" in argv
+    auto_fix = "--fix" in argv
+
+    async def run() -> int:
+        doctor = await run_doctor()
+        checks = await doctor.run()
+        if auto_fix:
+            checks = await doctor.run_auto_fixes(checks)
+        if as_json:
+            sys.stdout.write(render_json(doctor.title, checks))
+        else:
+            sys.stdout.write(render_pretty(doctor.title, checks))
+        sys.stdout.write("\n")
+        return exit_code_for(checks)
+
+    return asyncio.run(run())
+
 
 if __name__ == "__main__":
-    import asyncio
+    if len(sys.argv) > 1 and sys.argv[1] == "doctor":
+        raise SystemExit(_run_doctor(sys.argv[2:]))
     asyncio.run(main())

--- a/sidecars/imessage-bot/src/doctor.py
+++ b/sidecars/imessage-bot/src/doctor.py
@@ -1,0 +1,416 @@
+"""iMessage Sidecar Doctor — 기동 전 건강 점검 (macOS 전용).
+
+iMessage 커넥터는 토큰을 쓰지 않는다. 대신 macOS 의 두 가지 권한에 의존한다:
+
+1. **Full Disk Access (FDA)** — `~/Library/Messages/chat.db` 읽기
+2. **Automation (Messages.app)** — `osascript` 로 메시지 전송
+
+Doctor 는 이 두 권한이 실제로 살아있는지까지 한 번에 검증한다.
+단순 존재 확인이 아니라 SQLite 열기 시도 / osascript 실행 시도로
+"설정돼 있는 것처럼 보이지만 실제로 안 되는" 케이스를 잡아낸다.
+
+사용법::
+
+    python -m src doctor           # 사람용 출력
+    python -m src doctor --json    # 자동화용 JSON
+    python -m src doctor --fix     # 가능한 auto-fix 후 재점검
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+_shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+import httpx  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
+from gate_shared.doctor import NETWORK_TIMEOUT_SEC  # noqa: E402
+
+from .config import BotConfig, get_config  # noqa: E402
+
+
+async def run_doctor() -> Doctor:
+    doc = Doctor("iMessage Sidecar Doctor")
+    doc.register(check_python_version)
+    doc.register(check_macos_platform)
+    doc.register(check_sqlite3_module)
+    doc.register(check_chat_db_readable)
+    doc.register(check_osascript_available)
+    doc.register(check_env_gate_url)
+    doc.register(check_env_api_token)
+    doc.register(check_reply_mode_consistency)
+    doc.register(check_gate_reachable)
+    doc.register(check_binding_paths_writable)
+    doc.register(check_legacy_binding_path)
+    return doc
+
+
+# --- runtime -----------------------------------------------------------------
+
+
+async def check_python_version() -> Check:
+    major, minor = sys.version_info[:2]
+    ver = f"{major}.{minor}.{sys.version_info[2]}"
+    if (major, minor) < (3, 11):
+        return Check(
+            name="python >= 3.11",
+            severity=Severity.error,
+            detail=ver,
+            message="Python 3.11 이상을 요구합니다.",
+            hint="uv venv --python 3.11 또는 pyenv 로 3.11 활성화",
+        )
+    return Check(name="python >= 3.11", severity=Severity.ok, detail=ver, message="")
+
+
+async def check_macos_platform() -> Check:
+    system = platform.system()
+    if system != "Darwin":
+        return Check(
+            name="macOS host",
+            severity=Severity.error,
+            detail=system,
+            message="iMessage 커넥터는 macOS (Darwin) 에서만 동작합니다.",
+            hint="macOS 호스트에서만 이 sidecar 를 기동하세요.",
+        )
+    release = platform.mac_ver()[0] or "unknown"
+    return Check(
+        name="macOS host",
+        severity=Severity.ok,
+        detail=f"Darwin {release}",
+        message="",
+    )
+
+
+async def check_sqlite3_module() -> Check:
+    ver = sqlite3.sqlite_version
+    return Check(
+        name="sqlite3 module",
+        severity=Severity.ok,
+        detail=ver,
+        message="",
+    )
+
+
+def _config_or_none() -> BotConfig | None:
+    try:
+        return get_config()
+    except (ValidationError, OSError):
+        return None
+
+
+# --- FDA & chat.db -----------------------------------------------------------
+
+
+async def check_chat_db_readable() -> Check:
+    """FDA 권한이 실제로 살아있는지 SQLite open + SELECT 1 로 검증."""
+
+    cfg = _config_or_none()
+    path = Path(cfg.chat_db_path if cfg else "~/Library/Messages/chat.db").expanduser()
+    if not path.exists():
+        return Check(
+            name="chat.db readable (FDA)",
+            severity=Severity.error,
+            detail=str(path),
+            message="chat.db 를 찾을 수 없습니다.",
+            hint="Messages.app 을 한 번 실행해서 chat.db 가 생성되게 하세요.",
+        )
+    if not os.access(path, os.R_OK):
+        return Check(
+            name="chat.db readable (FDA)",
+            severity=Severity.error,
+            detail=str(path),
+            message="파일은 있지만 읽기 권한이 없습니다.",
+            hint=_fda_hint(),
+        )
+    # 진짜 FDA 가 통과했는지는 open + query 로만 확실하게 알 수 있다.
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=1.0)
+        try:
+            conn.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as exc:
+        return Check(
+            name="chat.db readable (FDA)",
+            severity=Severity.error,
+            detail=str(path),
+            message=f"SQLite open 실패: {exc}",
+            hint=_fda_hint(),
+        )
+    size = path.stat().st_size
+    size_mb = size / (1024 * 1024)
+    return Check(
+        name="chat.db readable (FDA)",
+        severity=Severity.ok,
+        detail=f"{path.name} ({size_mb:.1f} MiB)",
+        message="",
+    )
+
+
+def _fda_hint() -> str:
+    return (
+        "System Settings → Privacy & Security → Full Disk Access → "
+        "현재 터미널(또는 sidecar 를 실행하는 프로세스) 에 권한 부여"
+    )
+
+
+# --- osascript (Messages.app Automation) -------------------------------------
+
+
+async def check_osascript_available() -> Check:
+    """osascript 가 설치돼 있고 Messages.app Automation 권한이 있는지."""
+
+    path = shutil.which("osascript")
+    if not path:
+        return Check(
+            name="osascript available",
+            severity=Severity.error,
+            message="osascript 바이너리가 없습니다 (macOS 필수 도구).",
+        )
+    # Messages Automation 실제 권한은 send 시도가 있어야 확인 가능하지만,
+    # 소극적으로 Messages.app 번들 존재 + osascript 로 tell application 호출이
+    # Automation 권한 프롬프트를 띄우는지 문법만 체크.
+    try:
+        result = subprocess.run(
+            [path, "-e", 'tell application "Messages" to name'],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return Check(
+            name="osascript available",
+            severity=Severity.warn,
+            detail=path,
+            message="osascript 호출이 5초 안에 끝나지 않았습니다 (권한 프롬프트 대기 가능).",
+            hint="시스템 설정에서 Messages Automation 권한을 승인한 뒤 다시 실행.",
+        )
+    except OSError as exc:
+        return Check(
+            name="osascript available",
+            severity=Severity.warn,
+            detail=path,
+            message=f"osascript 실행 실패: {exc}",
+        )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "not allowed" in stderr.lower() or "1743" in stderr:
+            return Check(
+                name="osascript available",
+                severity=Severity.error,
+                detail=path,
+                message="Messages.app Automation 권한이 거부됐습니다.",
+                hint=(
+                    "System Settings → Privacy & Security → Automation → "
+                    "현재 터미널이 Messages 를 제어할 수 있도록 체크"
+                ),
+            )
+        return Check(
+            name="osascript available",
+            severity=Severity.warn,
+            detail=path,
+            message=f"osascript 가 비정상 종료 (rc={result.returncode}): {stderr}",
+        )
+    return Check(
+        name="osascript available",
+        severity=Severity.ok,
+        detail=path,
+        message="",
+    )
+
+
+# --- gate + env --------------------------------------------------------------
+
+
+async def check_env_gate_url() -> Check:
+    raw = os.getenv("MASC_GATE_URL", "").strip() or os.getenv("GATE_BASE_URL", "").strip() or "http://127.0.0.1:8935"
+    return Check(name="MASC_GATE_URL", severity=Severity.ok, detail=raw, message="")
+
+
+async def check_env_api_token() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="MASC_GATE_API_TOKEN policy",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    if cfg.gate_api_token:
+        return Check(
+            name="MASC_GATE_API_TOKEN policy",
+            severity=Severity.ok,
+            detail="token set",
+            message="",
+        )
+    if cfg.is_loopback():
+        return Check(
+            name="MASC_GATE_API_TOKEN policy",
+            severity=Severity.info,
+            detail="loopback gate",
+            message="loopback 대상이므로 토큰 없이 통신이 허용됩니다.",
+        )
+    return Check(
+        name="MASC_GATE_API_TOKEN policy",
+        severity=Severity.error,
+        message="비-loopback gate 에 접근하려면 MASC_GATE_API_TOKEN 이 필요합니다.",
+        hint="MASC 서버의 gate_api_token 과 동일한 값을 설정",
+    )
+
+
+async def check_reply_mode_consistency() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="reply_mode consistency",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    if cfg.reply_mode == "self-chat" and not cfg.self_chat_guid:
+        return Check(
+            name="reply_mode consistency",
+            severity=Severity.warn,
+            detail="reply_mode=self-chat, self_chat_guid=''",
+            message="self-chat 모드지만 IMESSAGE_SELF_CHAT_GUID 가 비어 있습니다.",
+            hint="Messages.app 의 자기 자신 대화방 guid 를 지정하면 대화방 자동 탐색 없이 안정적으로 동작합니다.",
+        )
+    return Check(
+        name="reply_mode consistency",
+        severity=Severity.ok,
+        detail=cfg.reply_mode,
+        message="",
+    )
+
+
+async def check_gate_reachable() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="gate reachable",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    url = cfg.gate_health_url()
+    headers = {"Authorization": f"Bearer {cfg.gate_api_token}"} if cfg.gate_api_token else {}
+    try:
+        async with httpx.AsyncClient(timeout=NETWORK_TIMEOUT_SEC) as client:
+            res = await client.get(url, headers=headers)
+    except httpx.ConnectError as exc:
+        return Check(
+            name="gate reachable",
+            severity=Severity.error,
+            detail=url,
+            message=f"연결 실패: {exc}",
+            hint="MASC 서버 기동 여부 확인 (./start-masc-mcp.sh)",
+        )
+    except httpx.HTTPError as exc:
+        return Check(
+            name="gate reachable",
+            severity=Severity.warn,
+            detail=url,
+            message=f"HTTP 오류: {exc}",
+        )
+    if res.status_code >= 500:
+        return Check(
+            name="gate reachable",
+            severity=Severity.error,
+            detail=f"{url} → {res.status_code}",
+            message="서버는 응답하지만 내부 오류 상태.",
+        )
+    if res.status_code >= 400:
+        return Check(
+            name="gate reachable",
+            severity=Severity.warn,
+            detail=f"{url} → {res.status_code}",
+            message="인증 또는 경로 문제일 수 있음.",
+        )
+    return Check(name="gate reachable", severity=Severity.ok, detail=f"{url} → {res.status_code}", message="")
+
+
+# --- filesystem --------------------------------------------------------------
+
+
+def _resolve_state_path(raw: str) -> Path:
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p
+    base = os.getenv("MASC_BASE_PATH", "").strip()
+    return Path(base).expanduser() / p if base else Path.cwd() / p
+
+
+async def check_binding_paths_writable() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="binding paths writable",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    candidates = [
+        ("binding store", _resolve_state_path(cfg.binding_store_path)),
+        ("binding audit", _resolve_state_path(cfg.binding_audit_path)),
+        ("status", _resolve_state_path(cfg.status_path)),
+        ("cursor", _resolve_state_path(cfg.cursor_path)),
+    ]
+    unwritable: list[str] = []
+    auto_fix_targets: list[Path] = []
+    for label, path in candidates:
+        parent = path.parent
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            unwritable.append(f"{label}: {parent} ({exc.strerror or exc})")
+            continue
+        if not os.access(parent, os.W_OK):
+            unwritable.append(f"{label}: {parent} (permission denied)")
+            auto_fix_targets.append(parent)
+    if not unwritable:
+        return Check(
+            name="binding paths writable",
+            severity=Severity.ok,
+            detail=f"{len(candidates)} paths",
+            message="",
+        )
+
+    async def _attempt_chmod() -> None:
+        for p in auto_fix_targets:
+            try:
+                p.chmod(0o755)
+            except OSError as exc:
+                print(f"[doctor] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
+
+    return Check(
+        name="binding paths writable",
+        severity=Severity.error,
+        message="; ".join(unwritable),
+        hint="상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정",
+        auto_fix=AutoFix(
+            description="접근 권한이 없는 상위 디렉터리에 0755 시도",
+            callback=_attempt_chmod if auto_fix_targets else None,
+        ),
+    )
+
+
+async def check_legacy_binding_path() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(name="legacy binding path", severity=Severity.skip, message="config 로드 실패로 건너뜀")
+    legacy = _resolve_state_path(cfg.legacy_binding_store_path)
+    if legacy.exists():
+        return Check(
+            name="legacy binding path",
+            severity=Severity.warn,
+            detail=str(legacy),
+            message="pre-v0.9.0 binding store 가 남아 있습니다.",
+            hint="봇을 기동하면 다음 save 시 신 포맷으로 이관됩니다.",
+        )
+    return Check(name="legacy binding path", severity=Severity.ok, detail="none", message="")


### PR DESCRIPTION
## 요약

Per-connector doctor 롤아웃 완료 (Discord #8375, Slack #8406, Telegram #8410 에 이어).

iMessage 는 다른 커넥터와 본질이 다름 — 봇 토큰이 없고, 대신 **macOS 권한 2종** 에 의존:

1. **Full Disk Access (FDA)** — `~/Library/Messages/chat.db` 읽기
2. **Messages.app Automation** — `osascript` 로 메시지 전송

이 권한들은 "시스템 설정에 허용된 것처럼 보이는데 실제로는 안 됨" 상태가 흔해서(TCC 캐시 등), doctor 는 존재 확인 대신 **실제 동작 확인** 까지 간다.

## 체크 11개 요약

| 이름 | 특징 |
|------|------|
| `python >= 3.11` | 기본 |
| **`macOS host`** | Darwin 이 아니면 error — Linux 등에서 실행 차단 |
| `sqlite3 module` | chat.db 읽기용 |
| **`chat.db readable (FDA)`** | 존재 → 권한 → **실제 sqlite3 open + SELECT** 3단 검증 |
| **`osascript available`** | `osascript -e 'tell application "Messages" to name'` 5초 타임아웃으로 실행. 오류 1743 → Automation 거부로 분류 |
| `MASC_GATE_URL` | 정보 |
| `MASC_GATE_API_TOKEN policy` | loopback 예외 |
| **`reply_mode consistency`** | `self-chat` 이면서 `self_chat_guid` 비어있으면 warn |
| `gate reachable` | 공통 |
| `binding paths writable` | 4경로 (binding/audit/status/cursor), chmod auto-fix |
| `legacy binding path` | `.masc/connectors/imessage/bindings.json` 잔존 감지 |

## 실제 예시 (macOS 권한 거부 시)

```
[✗] chat.db readable (FDA)  (/Users/dancer/Library/Messages/chat.db)
    ↳ SQLite open 실패: unable to open database file
      hint: System Settings → Privacy & Security → Full Disk Access → 현재 터미널(또는 sidecar 를 실행하는 프로세스) 에 권한 부여

[✗] osascript available  (/usr/bin/osascript)
    ↳ Messages.app Automation 권한이 거부됐습니다.
      hint: System Settings → Privacy & Security → Automation → 현재 터미널이 Messages 를 제어할 수 있도록 체크

summary: 9 ok, 2 error
```

## 왜 "존재 확인" 이 아니라 "실제 호출" 인가

macOS TCC (권한 관리 서비스) 는 **stale 상태가 자주 발생**. 시스템 설정 창에서 체크가 보여도 실제 실행 시 거부되는 경우가 많다. 특히:
- 터미널 바이너리 경로 변경 (Homebrew update, pyenv 재설치)
- TCC 캐시 리셋 없이 앱 이동/이름 변경
- 코드사이닝 서명 변경

따라서 FDA 는 `sqlite3.connect() + SELECT`, Automation 은 `osascript` 실제 호출로만 확실히 판단 가능.

## 체크리스트

- [x] Python-only, framework 수정 없음
- [x] `python -m src doctor [--json] [--fix]` 규약 일관
- [x] macOS 전용 — 다른 플랫폼에서는 `macOS host` error 로 조기 차단
- [x] 실제 권한 검증 (존재 확인 금지)
- [x] 한국어 hint — 시스템 설정 경로 정확히 명시
- [ ] 실기기 macOS 에서 권한 거부/승인 시나리오 e2e (후속)

## 후속

이 PR 로 Python sidecar 쪽 per-connector doctor 롤아웃 완료. 남은 것:

1. **CLI connector doctor** — 대화형/파이프 모드 분기 체크
2. **OCaml 쪽 `Doctor_cli`** 에 Slack/Telegram/iMessage/CLI variant 통합 (진행 중인 top-level doctor front door PR 와 합류)
3. `/api/v1/dashboard/doctor` 엔드포인트 + 대시보드 Doctor 패널
