### PR TITLE
feat(dashboard): typography detail axis — tracking & leading tokens

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -269,21 +269,21 @@ export function GraphView({ data }: GraphViewProps) {
         </div>
         <div class="grid grid-cols-3 gap-3 mb-3">
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">중요도</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">중요도</div>
             <div class="text-xl font-bold text-[var(--text-near-white)] tabular-nums">${(selectedNode.semantic_weight ?? selectedNode.weight).toFixed(1)}</div>
           </div>
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">빈도</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">빈도</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${selectedNode.weight}</div>
           </div>
           <div class="text-center">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em]">연결</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1">연결</div>
             <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${connectedEdges.length}</div>
           </div>
         </div>
         ${connectedEdges.length > 0 ? html`
           <div class="border-t border-[var(--slate-gray-10)] pt-3">
-            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-[0.08em] mb-2">연결된 관계</div>
+            <div class="text-3xs text-[var(--text-muted)] uppercase tracking-1 mb-2">연결된 관계</div>
             <div class="flex flex-col gap-1.5 max-h-40 overflow-y-auto">
               ${connectedEdges.slice(0, 20).map(({ edge, otherLabel }) => html`
                 <div class="flex items-center gap-2 text-sm py-1 px-2 rounded bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -95,7 +95,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
     return html`
       <div class="rounded border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-3xs text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
+        <div class="text-3xs text-[var(--text-muted)] tracking-1 uppercase font-medium">${label}</div>
         <div class="mt-1.5 text-[var(--text-strong)] text-3xl font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
         ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
       </div>
@@ -214,14 +214,14 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                 <div class="flex flex-wrap items-start justify-between gap-3">
                   <div class="min-w-0 flex-1">
                     <div class="flex flex-wrap items-center gap-2">
-                      <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${actionCategoryClass(group)}">
+                      <span class="inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 ${actionCategoryClass(group)}">
                         ${categoryLabel(group.category)}
                       </span>
                       ${group.actor ? html`<span class="text-2xs font-medium text-[var(--text-body)]">${group.actor}</span>` : null}
                       ${group.subjectId ? html`<span class="text-2xs text-[var(--text-muted)] font-mono">${group.subjectId}</span>` : null}
                     </div>
                     <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">${group.title}</div>
-                    <div class="mt-1 text-sm leading-[1.6] text-[var(--text-body)]">${group.summary}</div>
+                    <div class="mt-1 text-sm leading-loose text-[var(--text-body)]">${group.summary}</div>
                   </div>
                   <div class="flex shrink-0 flex-col items-end gap-2 text-2xs text-[var(--text-muted)]">
                     <span>${group.rawCount}건</span>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -458,7 +458,7 @@ export function AgentProfile({ name }: { name: string }) {
             <div class="agent-history-list">${(profileData?.taskHistories ?? []).map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
                 <div class="mb-2"><span class="text-3xs py-0.5 px-2 border border-solid border-[var(--accent-36)] bg-[var(--accent-12)] text-[var(--accent)] whitespace-nowrap rounded-sm">${row.taskId}</span></div>
-                <pre class="m-0 whitespace-pre-wrap text-sm leading-[1.5] text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
+                <pre class="m-0 whitespace-pre-wrap text-sm leading-normal text-[var(--text-strong)] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>
           <//>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -524,13 +524,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
             <div class="flex min-w-0 flex-col gap-2">
               <div class="flex flex-wrap items-center gap-3">
-                <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">디렉터리 필터</span>
+                <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">디렉터리 필터</span>
                 <span class="inline-flex items-center rounded-sm border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
               </div>
-              <p class="m-0 max-w-180 text-sm leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
+              <p class="m-0 max-w-180 text-sm leading-loose text-[var(--text-body)]">${pageDescription}</p>
             </div>
 
-            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
+            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-1 text-[var(--text-muted)] uppercase">
               <span>이름 / model / 작업</span>
               <${TextInput}
                 class="rounded bg-[var(--white-3)] px-4 py-3 text-base text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
@@ -547,8 +547,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
-                <div class="text-2xs font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-xs leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
+                <div class="text-2xs font-semibold tracking-1 text-[var(--text-strong)] uppercase">운영 상태</div>
+                <p class="m-0 text-xs leading-normal text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -568,7 +568,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                       <strong class="text-xs font-semibold text-[var(--text-strong)]">${fallbackStateTitle}</strong>
                       <span class="inline-flex items-center rounded-sm border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5 text-3xs font-medium text-[var(--text-muted)]">${countSourceLabel}</span>
                     </div>
-                    <p class="m-0 text-xs leading-[1.55] text-[var(--text-body)]">${fallbackStateMessage}</p>
+                    <p class="m-0 text-xs leading-paragraph text-[var(--text-body)]">${fallbackStateMessage}</p>
                     <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
                       <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
                       ${configuredKeeperHint ? html`<span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${configuredKeeperHint}</span>` : null}
@@ -693,7 +693,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     </div>
 
                     <div class="mt-1 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
-                      <span class="uppercase tracking-[0.08em]">${identityLabel}</span>
+                      <span class="uppercase tracking-1">${identityLabel}</span>
                       ${runtimeName ? html`
                         <span class="text-[var(--text-dim)]">/</span>
                         <span class="font-mono text-3xs" translate="no">${runtimeName}</span>
@@ -707,12 +707,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
               </div>
 
-              <p class="m-0 text-sm leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
+              <p class="m-0 text-sm leading-paragraph text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${isKeeper ? html`
                 <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,var(--white-3),var(--white-1))] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
-                    <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
+                    <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">FSM</span>
                     ${fsmPhaseKey
                       ? html`<${KeeperPhaseBadge} phase=${fsmPhaseKey} compact />`
                       : html`

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -88,7 +88,7 @@ export function AgentsUnified() {
 
       ${currentView !== 'fsm' ? html`
         <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--text-muted)]">
-          <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">이 화면 밖</span>
+          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">이 화면 밖</span>
           <span>이벤트 로그, 도구 품질, 거버넌스</span>
           <${RouteLink}
             tab="monitoring"

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -294,10 +294,10 @@ export function AttributionPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-1">
-        <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
           Attribution — gate chain 관찰
         </div>
-        <p class="m-0 text-xs leading-[1.55] text-[var(--text-muted)]">
+        <p class="m-0 text-xs leading-paragraph text-[var(--text-muted)]">
           각 gate의 결과 카운트 + 최근 ${RECENT_LIMIT}건 이벤트. 5초마다 자동 갱신.
         </p>
       </div>
@@ -344,7 +344,7 @@ export function AttributionPanel() {
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <${SurfaceCard} variant="light">
           <div class="flex flex-col">
-            <div class="px-3 py-2 border-b border-[var(--card-border)] text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            <div class="px-3 py-2 border-b border-[var(--card-border)] text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
               최근 이벤트 (${isFiltering
                 ? `${visibleEvents.length}/${gateFiltered.length}`
                 : gateFiltered.length})

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -352,7 +352,7 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
       <div class="flex flex-col gap-3">
         <div>
           <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">Research Brief</div>
-          <div class="text-sm leading-[1.55] text-[var(--text-body)]">
+          <div class="text-sm leading-paragraph text-[var(--text-body)]">
             이 루프는 <span class="font-semibold text-[var(--text-strong)]">${loop.goal}</span> 를 목표로
             <span class="font-mono text-[var(--text-strong)]"> ${loop.target_file} </span>
             변경을 시도하고,
@@ -388,7 +388,7 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-[1.5] text-[var(--text-muted)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs leading-normal text-[var(--text-muted)]">
           이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
           각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
         </div>
@@ -404,7 +404,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
           <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Experiment Outcomes</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">이 화면은 keep/discard 루프를 봅니다.</div>
-          <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
+          <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
             어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
           </div>
         </div>
@@ -412,7 +412,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
         <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3">
           <div class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">Safety Harness</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
-          <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
+          <div class="mt-2 text-sm leading-loose text-[var(--text-body)]">
             평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
           </div>
           <button

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -138,7 +138,7 @@ function ChatMessageBubble({
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
           <div
-            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-2xs font-semibold uppercase tracking-[0.08em] ${
+            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-2xs font-semibold uppercase tracking-1 ${
               isMessenger ? 'size-8 rounded-card' : 'size-10 rounded'
             }`}
           >
@@ -157,7 +157,7 @@ function ChatMessageBubble({
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2 py-0.5 text-3xs font-medium uppercase tracking-1 text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -169,14 +169,14 @@ function ChatMessageBubble({
               : html`
                   <div class="flex flex-wrap items-center gap-1.5">
                     <span
-                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-semibold uppercase tracking-[0.12em]`}
+                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-semibold uppercase tracking-3`}
                     >
                       ${entry.label}
                     </span>
                     ${showDeliveryBadge(entry, variant)
                       ? html`
                           <span
-                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-3xs font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+                            class="inline-flex items-center rounded-sm border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-1 text-3xs font-medium uppercase tracking-2 text-[var(--text-muted)]"
                             data-chat-delivery=${delivery}
                           >
                             ${delivery}
@@ -222,12 +222,12 @@ function ChatMessageBubble({
           </div>`
         : null}
 
-      <div class="whitespace-pre-wrap break-words text-base leading-[1.7] text-[var(--text-body)]">
+      <div class="whitespace-pre-wrap break-words text-base leading-airy text-[var(--text-body)]">
         ${entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')}
       </div>
       ${entry.error
         ? html`
-            <div class="rounded border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-xs leading-[1.55] text-[var(--bad-light)]">
+            <div class="rounded border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-xs leading-paragraph text-[var(--bad-light)]">
               ${entry.error}
             </div>
           `
@@ -241,7 +241,7 @@ function ChatMessageBubble({
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
                         <div class="rounded border border-[var(--slate-gray-12)] bg-[var(--white-3)] px-3 py-2.5">
-                          <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
+                          <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">${item.label}</div>
                           <div class="mt-1 text-sm font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
                       `)}
@@ -251,10 +251,10 @@ function ChatMessageBubble({
               ${entry.details.skillPrimary
                 ? html`
                     <div class="chat-detail-callout rounded border border-[rgba(76,181,137,0.18)] px-3 py-3">
-                      <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[#8fdcb3]">스킬 경로</div>
+                      <div class="text-3xs font-semibold uppercase tracking-3 text-[#8fdcb3]">스킬 경로</div>
                       <div class="mt-1 text-sm font-semibold text-[#d8f7e6]">${entry.details.skillPrimary}</div>
                       ${entry.details.skillReason
-                        ? html`<div class="mt-1 text-xs leading-[1.6] text-[#bfe8cf]">${entry.details.skillReason}</div>`
+                        ? html`<div class="mt-1 text-xs leading-loose text-[#bfe8cf]">${entry.details.skillReason}</div>`
                         : null}
                     </div>
                   `
@@ -262,12 +262,12 @@ function ChatMessageBubble({
               ${state.length > 0
                 ? html`
                     <div class="flex flex-col gap-2">
-                      <div class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
+                      <div class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
                           <div class="rounded border border-[var(--accent-soft)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
-                            <div class="text-3xs font-semibold uppercase tracking-[0.1em] text-[var(--accent)]">${item.label}</div>
-                            <div class="mt-1 text-xs leading-[1.55] text-[var(--text-body)]">${item.value}</div>
+                            <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--accent)]">${item.label}</div>
+                            <div class="mt-1 text-xs leading-paragraph text-[var(--text-body)]">${item.value}</div>
                           </div>
                         `)}
                       </div>
@@ -333,8 +333,8 @@ export function ChatTranscript({
       ${entries.length === 0
         ? html`
             <div class="flex min-h-55 flex-col items-center justify-center rounded-card border border-dashed border-[rgba(148,163,184,0.18)] bg-[var(--white-3)] px-6 text-center">
-              <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
-              <div class="mt-3 max-w-[34rem] text-sm leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
+              <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 메시지 없음</div>
+              <div class="mt-3 max-w-[34rem] text-sm leading-airy text-[var(--text-secondary)]">${emptyText}</div>
             </div>
           `
         : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`)}
@@ -382,11 +382,11 @@ export function ChatComposer({
   return html`
     <div class="chat-composer flex flex-col gap-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">메시지</div>
+        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">메시지</div>
         <div class="text-2xs text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
-        class="control-textarea min-h-24 rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-[1.6]"
+        class="control-textarea min-h-24 rounded-card border border-[var(--slate-gray-16)] bg-[var(--white-3)] px-3 py-3 text-base leading-loose"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}
@@ -401,7 +401,7 @@ export function ChatComposer({
         disabled=${disabled}
       ></textarea>
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs leading-[1.55] text-[var(--text-muted)]">
+        <div class="text-2xs leading-paragraph text-[var(--text-muted)]">
           ${streaming
             ? '키퍼 응답 스트림이 활성 상태입니다. 멈춘 것 같으면 중지할 수 있습니다.'
             : '직접 메시지만 이 레인에 표시됩니다. 내부 키퍼 프롬프트는 숨겨집니다.'}

--- a/dashboard/src/components/common/copyable-code.ts
+++ b/dashboard/src/components/common/copyable-code.ts
@@ -69,8 +69,8 @@ export function copyableWrapperClasses(variant: CopyableVariant): string {
     at the left edge and starts leading the reader's eye into the command. */
 export function copyableLabelClasses(variant: CopyableVariant): string {
   return variant === 'primary'
-    ? 'shrink-0 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--accent)]'
-    : 'shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]'
+    ? 'shrink-0 text-3xs font-semibold uppercase tracking-4 text-[var(--accent)]'
+    : 'shrink-0 text-3xs uppercase tracking-4 text-[var(--text-dim)]'
 }
 
 export function CopyableCode({

--- a/dashboard/src/components/common/distribution-bars.ts
+++ b/dashboard/src/components/common/distribution-bars.ts
@@ -77,7 +77,7 @@ export function DistributionBars({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
+            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">${title}</div>
             ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
           `
         : null}
@@ -135,7 +135,7 @@ export function SegmentedBar({
     <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-3 py-3">
       ${title
         ? html`
-            <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${title}</div>
+            <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">${title}</div>
             ${subtitle ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${subtitle}</div>` : null}
           `
         : null}

--- a/dashboard/src/components/common/heartbeat-streak-chip.ts
+++ b/dashboard/src/components/common/heartbeat-streak-chip.ts
@@ -63,7 +63,7 @@ export function HeartbeatStreakChip({
   const label = formatStreakLabel(streak)
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 tabular-nums ${tone} ${chipClass}`}
     title=${label}
     aria-label=${label}
     data-heartbeat-streak-chip

--- a/dashboard/src/components/common/heartbeat-uptime-chip.ts
+++ b/dashboard/src/components/common/heartbeat-uptime-chip.ts
@@ -61,7 +61,7 @@ export function HeartbeatUptimeChip({
   const title = `${view.label}% uptime · ${summary.up}/${summary.up + summary.down} observed`
   const chipClass = cx ?? ''
   return html`<span
-    class=${`inline-flex items-center gap-0.5 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] tabular-nums ${tone} ${chipClass}`}
+    class=${`inline-flex items-center gap-0.5 rounded-sm border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 tabular-nums ${tone} ${chipClass}`}
     title=${title}
     aria-label=${title}
     data-heartbeat-uptime-chip

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -120,7 +120,7 @@ export function MermaidGraph({
         <div class="space-y-2">
           <${EmptyState} message=${error} compact />
           ${fallbackText ? html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm leading-[1.6] text-[var(--text-dim)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm leading-loose text-[var(--text-dim)]">
               ${fallbackText}
             </div>
           ` : null}

--- a/dashboard/src/components/common/section-cap.ts
+++ b/dashboard/src/components/common/section-cap.ts
@@ -6,7 +6,7 @@
 // small section" marker. Recognizing it instantly gives the reader
 // a grid: subhead above, content below, more whitespace before the
 // next one. Inline Tailwind strings scattered across ~20 files
-// always drift within weeks (tracking-[0.08em] vs tracking-[0.14em]
+// always drift within weeks (tracking-1 vs tracking-4
 // vs tracking-[0.18em] — pixel-noise differences that break the
 // grid silently).
 //

--- a/dashboard/src/components/common/section-header.ts
+++ b/dashboard/src/components/common/section-header.ts
@@ -1,5 +1,5 @@
 // SectionHeader — consistent section labels across dashboard
-// Replaces 34+ inline patterns: `text-3xs uppercase tracking-[0.08em] text-[var(--text-muted)] font-medium`
+// Replaces 34+ inline patterns: `text-3xs uppercase tracking-1 text-[var(--text-muted)] font-medium`
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -316,7 +316,7 @@ export function ConnectorConfigToggle({ connectorId }: { connectorId: string }) 
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
       aria-expanded=${entry.open}
       aria-controls=${`connector-config-${connectorId}`}
       onClick=${onClick}
@@ -454,7 +454,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   return html`
     <div id=${`connector-config-${connectorId}`} class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-3">
       <div class="mb-2 flex items-center justify-between">
-        <div class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
+        <div class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">
           ${entry.fields.length} fields · ${entry.fields.filter(f => f.required).length} required
           ${entry.lastSavedAt
             ? html`
@@ -473,7 +473,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
         </div>
         <div class="flex items-center gap-2">
           <label
-            class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            class="flex cursor-pointer items-center gap-1 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:text-[var(--text-body)]"
             title="저장 직후 자동으로 sidecar 재시작 (stop → 800ms → start)"
           >
             <input
@@ -515,7 +515,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
             <label class="flex items-center gap-1.5 text-2xs font-medium text-[var(--text-body)]" for=${`field-${connectorId}-${field.name}`}>
               <span>${field.name}</span>
               ${field.required ? html`<span class="text-[var(--bad-light)]" aria-label="required">*</span>` : null}
-              <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">${field.type}</span>
+              <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">${field.type}</span>
             </label>
             <${FieldWidget}
               id=${connectorId}
@@ -551,7 +551,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
       </div>
 
       <div class="mt-3 border-t border-[var(--white-8)] pt-2.5">
-        <div class="mb-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
+        <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">
           .env 블록 (현재 입력값)
         </div>
         ${envBlock === ''

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -229,7 +229,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
     <section class="mb-4 rounded border border-[var(--card-border)] bg-[var(--bg-1)] p-3" data-panel="connector-keeper-matrix">
       <header class="mb-2 flex items-baseline justify-between gap-3">
         <div>
-          <h4 class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">
+          <h4 class="text-xs font-semibold uppercase tracking-4 text-[var(--text-body)]">
             Keeper × Connector Matrix
           </h4>
           <p class="mt-0.5 text-3xs text-[var(--text-dim)]">
@@ -258,11 +258,11 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
         : html`
             <div class="overflow-x-auto">
               <div class="grid gap-1 text-2xs" style=${gridCols} data-matrix-grid>
-                <div class="px-1 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
+                <div class="px-1 py-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">Keeper ↓ / Connector →</div>
                 ${matrix.columns.map(colId => html`
                   <button
                     type="button"
-                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-3xs uppercase tracking-[0.12em] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                    class="flex cursor-pointer items-center justify-center gap-1 rounded px-1 py-1 text-3xs uppercase tracking-3 text-[var(--text-dim)] hover:text-[var(--text-body)]"
                     onClick=${() => scrollToConnectorRow(colId)}
                     title=${`${CONNECTOR_DISPLAY_NAMES[colId] ?? colId} — 행으로 이동`}
                   >
@@ -271,7 +271,7 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
                   </button>
                 `)}
                 <div
-                  class="px-1 py-1 text-center text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
+                  class="px-1 py-1 text-center text-3xs uppercase tracking-4 text-[var(--text-dim)]"
                   title="Per-keeper coverage totals (bound / unbound / n·a)"
                   data-matrix-coverage-header
                 >Coverage</div>
@@ -304,7 +304,7 @@ function MatrixColumnTotalsRow({ matrix }: { matrix: MatrixData }) {
       data-matrix-column-totals-divider
     ></div>
     <div
-      class="flex items-center gap-1 px-2 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
+      class="flex items-center gap-1 px-2 py-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]"
       data-matrix-column-totals-label
     >Totals →</div>
     ${matrix.columns.map((_, idx) => html`

--- a/dashboard/src/components/connector-keyboard-shortcuts.ts
+++ b/dashboard/src/components/connector-keyboard-shortcuts.ts
@@ -92,7 +92,7 @@ export function ConnectorKeyboardShortcuts() {
       role="dialog"
       aria-label="커넥터 단축키"
     >
-      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">Shortcuts</div>
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-4 text-[var(--text-dim)]">Shortcuts</div>
       ${KNOWN_CONNECTOR_IDS.map((id, i) => html`
         <div class="flex items-center justify-between gap-4">
           <${Kbd}>${i + 1}<//>

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -280,7 +280,7 @@ function OverviewTile({ id, connector, keeperCount, selected, onSelectConnector,
         </span>
       </button>
       <${ConnectorReadinessRail} pills=${pills} />
-      <span class=${`text-3xs uppercase tracking-[0.14em] ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--text-dim)]'}`}>
+      <span class=${`text-3xs uppercase tracking-4 ${selected ? 'text-[var(--accent-1)]' : 'text-[var(--text-dim)]'}`}>
         ${selected ? 'Selected' : 'View Details'}
       </span>
       <${TilePrimaryAction} id=${id} sidecarUp=${sidecarUp} />
@@ -442,7 +442,7 @@ function TileErrorNotice({ connector }: { connector: GateConnectorInfo | null })
       data-tile-notice=${notice.tone}
     >
       <span aria-hidden="true" class="shrink-0">${glyph}</span>
-      <span class="shrink-0 font-semibold uppercase tracking-[0.1em]">${notice.label}</span>
+      <span class="shrink-0 font-semibold uppercase tracking-2">${notice.label}</span>
       <span class="min-w-0 truncate font-normal normal-case tracking-normal opacity-80">${notice.detail}</span>
     </div>
   `

--- a/dashboard/src/components/connector-paths-strip.ts
+++ b/dashboard/src/components/connector-paths-strip.ts
@@ -67,7 +67,7 @@ function PathRow({ label, value, hint }: { label: string; value: string; hint: s
   return html`
     <div class="flex items-center gap-2" data-paths-row=${label}>
       <span
-        class="w-25 shrink-0 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]"
+        class="w-25 shrink-0 text-3xs uppercase tracking-4 text-[var(--text-dim)]"
         title=${hint}
       >${label}</span>
       <div class="min-w-0 flex-1">
@@ -93,7 +93,7 @@ export function ConnectorPathsStrip({ connectors }: { connectors: GateConnectorI
         aria-controls="connector-paths-body"
       >
         <span>
-          <span class="mr-2 text-3xs uppercase tracking-[0.14em]">Paths</span>
+          <span class="mr-2 text-3xs uppercase tracking-4">Paths</span>
           <span class="font-mono">${paths.connectorsDir ?? paths.sidecarsDir}</span>
           <span class="ml-2 text-[var(--text-dim)]">${paths.connectorsDir ? '' : '(런타임 미관찰 · sidecar 경로만 표시)'}</span>
         </span>

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -103,7 +103,7 @@ export function QuickBindForm({ connectorId, keepers }: {
       data-quick-bind=${connectorId}
     >
       <div class="min-w-0 flex-1 basis-[160px]">
-        <label class="mb-1 block text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-channel-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--text-dim)]" for=${`qb-channel-${connectorId}`}>
           채널 ID
         </label>
         <${TextInput}
@@ -125,7 +125,7 @@ export function QuickBindForm({ connectorId, keepers }: {
         />
       </div>
       <div class="min-w-0 basis-[140px]">
-        <label class="mb-1 block text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" for=${`qb-keeper-${connectorId}`}>
+        <label class="mb-1 block text-3xs uppercase tracking-4 text-[var(--text-dim)]" for=${`qb-keeper-${connectorId}`}>
           Keeper
         </label>
         <select

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -158,7 +158,7 @@ function Pill({ pill }: { pill: RailPill }) {
       </span>
       <span
         aria-hidden="true"
-        class=${`block text-3xs uppercase tracking-[0.14em] ${tone.text}`}
+        class=${`block text-3xs uppercase tracking-4 ${tone.text}`}
       >${pill.label}</span>
     </button>
   `

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -320,7 +320,7 @@ export function HeaderMiniStat({
       data-testid=${testId}
     >
       <span class=${`text-sm font-semibold tabular-nums leading-tight ${valueTone}`}>${value}</span>
-      <span class="mt-0.5 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">${label}</span>
+      <span class="mt-0.5 text-3xs uppercase tracking-5 text-[var(--text-dim)]">${label}</span>
     </div>
   `
 }
@@ -834,7 +834,7 @@ function ConnectorLivePanel({
           ? html`<span class="text-[var(--text-dim)]">· ${connector.bot_user_name}</span>`
           : null}
         <span class="text-[var(--text-dim)]">·</span>
-        <span class=${`inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-[0.14em] ${directTone}`}>
+        <span class=${`inline-flex items-center gap-1.5 rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-4 ${directTone}`}>
           <span class=${`inline-block h-2 w-2 rounded-full ${dotClassForLabel(directLabel)}`}></span>
           <span>${directLabel}</span>
         </span>
@@ -850,7 +850,7 @@ function ConnectorLivePanel({
             ? html`
                 <button
                   type="button"
-                  class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
+                  class="cursor-pointer rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--bad-light)] hover:bg-[var(--bad-10)] disabled:opacity-50"
                   disabled=${isActionLoading}
                   aria-label=${`stop ${connectorName} sidecar`}
                   onClick=${() => { void stopSidecar(connectorId) }}
@@ -946,7 +946,7 @@ function ConnectorLivePanel({
               data-keeper-directory-error-panel
             >
               <span
-                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                class="mr-2 inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
@@ -965,7 +965,7 @@ function ConnectorLivePanel({
             >
               <div class="mb-1 flex items-center gap-2">
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
                   aria-label="Keeper configuration status: none configured"
                   data-no-keepers-status-chip
                 >
@@ -1000,7 +1000,7 @@ function ConnectorLivePanel({
                 <div class="mb-1 flex items-center justify-between gap-2">
                   <div class="flex items-center gap-2">
                     <span
-                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--warn)]"
+                      class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
                       aria-label="Sidecar process status: not running"
                       data-sidecar-status-chip
                     >
@@ -1016,7 +1016,7 @@ function ConnectorLivePanel({
                       disabled=${isActionLoading}
                       onClick=${() => { void startSidecar(connectorId) }}
                     >${isActionLoading ? '...' : 'Start'}<//>
-                    <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">${connectorName}</span>
+                    <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">${connectorName}</span>
                   </div>
                 </div>
                 <div class="text-2xs text-[var(--warn)]/80">
@@ -1026,7 +1026,7 @@ function ConnectorLivePanel({
                   <${CopyableCode} label="start" command=${cmds.start} variant="primary" />
                 </div>
                 <div class="mt-2">
-                  <div class="mb-1 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">
+                  <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">
                     Or for diagnostics
                   </div>
                   <div class="grid grid-cols-1 gap-1.5" data-sidecar-secondary-cmds>
@@ -1258,7 +1258,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
         </div>
         <div class="flex items-center gap-2">
           <div class="h-2 w-2 rounded-full" style="background: ${tone.dot}"></div>
-          <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${tone.badge}`}>
+          <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-5 ${tone.badge}`}>
             ${tone.label}
           </span>
         </div>
@@ -1313,7 +1313,7 @@ function ChannelCard({ ch }: { ch: ChannelInfo }) {
       ${lastError
         ? html`
             <div class="mt-3 rounded border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-2xs text-[var(--bad-light)]">
-              <div class="mb-1 uppercase tracking-[0.16em] text-[var(--bad-light)]/80">
+              <div class="mb-1 uppercase tracking-5 text-[var(--bad-light)]/80">
                 ${ch.last_error_kind || 'error'} · ${timeAgo(ch.last_error_at)}
               </div>
               <div>${lastError}</div>
@@ -1335,11 +1335,11 @@ function BindingRow({ binding }: { binding: BindingInfo }) {
           <div class="text-xs font-medium text-[var(--text-body)]">
             ${binding.channel} · room ${truncateMiddle(binding.room_id)}
           </div>
-          <div class="text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
+          <div class="text-3xs uppercase tracking-5 text-[var(--text-dim)]">
             ${binding.keeper ? `keeper ${binding.keeper}` : 'keeper pending'}
           </div>
         </div>
-        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${tone.badge}`}>
+        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-5 ${tone.badge}`}>
           ${tone.label}
         </span>
       </div>
@@ -1388,7 +1388,7 @@ function EventRow({ event }: { event: GateEventInfo }) {
               : null}
           </div>
         </div>
-        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-[0.16em] ${badgeClass}`}>
+        <span class=${`rounded-sm px-2 py-1 text-3xs uppercase tracking-5 ${badgeClass}`}>
           ${event.outcome}
         </span>
       </div>
@@ -1419,7 +1419,7 @@ function DisclosurePanel({
       <summary class="cursor-pointer list-none px-3 py-2.5">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-body)]">${title}</div>
+            <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-body)]">${title}</div>
             <div class="mt-1 text-2xs text-[var(--text-dim)]">${subtitle}</div>
           </div>
           <span class="text-2xs text-[var(--text-dim)]">펴기</span>
@@ -1480,7 +1480,7 @@ function GateAnalyticsSection({
 
               <div class="mb-4 grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
                 <div>
-                  <div class="mb-2 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--text-dim)]">
                     Observed room bindings
                   </div>
                   ${gate.bindings.length === 0
@@ -1493,7 +1493,7 @@ function GateAnalyticsSection({
                 </div>
 
                 <div>
-                  <div class="mb-2 text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                  <div class="mb-2 text-3xs uppercase tracking-5 text-[var(--text-dim)]">
                     Recent gate events
                   </div>
                   ${gate.recent_events.length === 0
@@ -1596,7 +1596,7 @@ export function ConnectorStatusPanel() {
         </div>
         ${filterId
           ? html`
-              <div class="text-right text-3xs uppercase tracking-[0.16em] text-[var(--text-dim)]">
+              <div class="text-right text-3xs uppercase tracking-5 text-[var(--text-dim)]">
                 <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
                 <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
               </div>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -612,7 +612,7 @@ function SurfaceLead() {
             />`
           : null}
       </div>
-      ${description ? html`<p class="m-0 text-sm leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
+      ${description ? html`<p class="m-0 text-sm leading-normal text-[var(--text-dim)]">${description}</p>` : null}
     </div>
   `
 }

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -215,7 +215,7 @@ export function FeatureHealth() {
                       <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
                         ${overview.enabled_count} / ${overview.total_features} 기능 활성화
                       </div>
-                      <div class="mt-2 text-sm leading-[1.7] text-[var(--text-body)]">
+                      <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">
                         시스템 기능 플래그 상태를 실시간으로 모니터링합니다.
                         ${overview.overridden_count ? `${overview.overridden_count}개 플래그가 환경변수로 오버라이드되었습니다.` : ''}
                       </div>

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -63,8 +63,8 @@ export function FleetHealthPanel() {
   return html`
     <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-1">
-          <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">운영 신호 묶음</div>
-          <p class="m-0 text-xs leading-[1.55] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">운영 신호 묶음</div>
+          <p class="m-0 text-xs leading-paragraph text-[var(--text-muted)]">
             이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.
           </p>
         </div>

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -35,7 +35,7 @@ export function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapsho
   const m = snapshot.measurement
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
+      <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">
         Measurement
       </div>
       ${m.captured && m.auto_rules ? html`
@@ -119,7 +119,7 @@ export function InvariantsPanel({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
           Safety
         </div>
         <span

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -93,7 +93,7 @@ export function OperationalMeaningPanel({
     >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
-          <div class="text-3xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>
+          <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--text-muted)]">Operator Meaning</div>
           <div class="mt-1 text-xl font-semibold text-[var(--text-strong)]">${insight.headline}</div>
           <div class="mt-1 text-2xs text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
         </div>
@@ -115,7 +115,7 @@ export function OperationalMeaningPanel({
       </div>
 
       <div class="mt-4 flex items-center justify-between gap-2">
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
           관찰 레인
         </div>
         <input
@@ -135,7 +135,7 @@ export function OperationalMeaningPanel({
             ${visibleLanes.map(lane => html`
               <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
                 <div class="flex items-center justify-between gap-2">
-                  <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
+                  <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">${lane.field}</span>
                   <span class=${`rounded-sm border px-1.5 py-0.5 text-4xs font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
                     ${fmtDuration(lane.observedForSec)}
                   </span>
@@ -406,7 +406,7 @@ export function TurnPipelineStrip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-2 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
         턴 파이프라인
       </div>
       <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -163,7 +163,7 @@ export function SwimlaneTimeline({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
       <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
           상태 타임라인
         </div>
         <div class="flex items-center gap-1 flex-wrap">
@@ -386,7 +386,7 @@ export function TransitionTrail({
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
       <div class="mb-1.5 flex items-center justify-between gap-2">
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
           Transition History (${isFiltering ? `${visibleHistory.length}/${history.length}` : history.length})
         </div>
         <input
@@ -458,7 +458,7 @@ export function TopTransitionsPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
         Top Transitions (${transitions.length})
       </div>
       <div class="flex flex-col gap-0.5">
@@ -522,7 +522,7 @@ export function DwellHistogramPanel({
 
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
-      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
         State Dwell Time
       </div>
       <div class="flex flex-col gap-2">

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -531,7 +531,7 @@ export function FsmHub(props: FsmHubProps = {}) {
           open=${graphOpen}
           onToggle=${(e: Event) => setGraphOpen((e.target as HTMLDetailsElement).open)}
         >
-          <summary class="cursor-pointer select-none px-4 py-2.5 text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] hover:text-[var(--text-body)]">
+          <summary class="cursor-pointer select-none px-4 py-2.5 text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] hover:text-[var(--text-body)]">
             Compound Graph — 5 sub-FSMs (Cytoscape)
           </summary>
           <div class="px-3 pb-3">
@@ -575,7 +575,7 @@ function ShortcutsOverlay({
         onClick=${(e: MouseEvent) => e.stopPropagation()}
       >
         <div class="flex items-center justify-between mb-3">
-          <div class="text-2xs font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-2 text-[var(--text-muted)]">
             키보드 단축키
           </div>
           <button
@@ -671,7 +671,7 @@ function StatusBar({
     <div class=${`sticky top-0 z-20 rounded border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-sm shadow-[0_4px_12px_rgba(0,0,0,0.25)] ${containerPadding}`}>
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <div class="flex items-center gap-3">
-          <span class="text-3xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>
+          <span class="text-3xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">FSM Hub</span>
           <${Kbd} size="sm" class="hidden md:inline-flex" title="단축키 목록 (?)">?<//>
           <button
             class=${`text-3xs font-mono px-1.5 py-0.5 rounded border cursor-pointer transition-all ${
@@ -932,7 +932,7 @@ function CollapsibleZone({
         aria-expanded=${!collapsed}
         aria-controls=${`zone-${id}`}
       >
-        <span class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${zoneTitle}</span>
+        <span class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">${zoneTitle}</span>
         <span class=${`text-3xs text-[var(--text-dim)] transition-transform duration-200 ${collapsed ? '' : 'rotate-180'}`}>▾</span>
       </button>
       ${!collapsed ? html`<div id=${`zone-${id}`} class="px-4 pb-3">${children}</div>` : null}

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -41,7 +41,7 @@ function PlanningStat({
 
   return html`
     <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
-      <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">${label}</div>
+      <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">${label}</div>
       <div class="mt-2 text-3xl font-bold leading-none tabular-nums ${toneClass}">${value}</div>
     </div>
   `
@@ -84,7 +84,7 @@ function GuideCard({
     <section class="flex flex-col gap-3 rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
       <div class="flex items-start justify-between gap-3">
         <div>
-          <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">${eyebrow}</div>
+          <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">${eyebrow}</div>
           <h3 class="mt-1 text-md font-semibold text-text-strong">${title}</h3>
         </div>
         <span class="rounded border border-card-border/70 bg-white/4 px-2.5 py-1 text-2xs font-semibold text-text-body">
@@ -153,7 +153,7 @@ function KeeperToolActivity() {
       <div class="p-5">
         ${activeKeepers.length > 0 ? html`
           <div class="mb-4">
-            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">활성 keeper</div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">활성 keeper</div>
             <div class="flex flex-wrap gap-2">
               ${activeKeepers.map(k => html`
                 <button
@@ -172,7 +172,7 @@ function KeeperToolActivity() {
 
         ${topTools.length > 0 ? html`
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted mb-2">최근 자주 사용된 도구</div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted mb-2">최근 자주 사용된 도구</div>
             <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1.5">
               ${topTools.map(([name, count]) => html`
                 <div key=${name} class="flex items-center justify-between rounded bg-white/3 px-3 py-1.5 text-xs">
@@ -239,7 +239,7 @@ export function Planning() {
         <div class="mt-5 grid gap-4 xl:grid-cols-2">
           <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
             <div class="mb-3">
-              <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">Backlog Entry</div>
+              <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">Backlog Entry</div>
               <h3 class="mt-1 text-md font-semibold text-text-strong">태스크 추가</h3>
             </div>
             <${TaskCreateForm} />
@@ -268,7 +268,7 @@ export function Planning() {
       <section class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
         <div class="flex items-center justify-between gap-3">
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-text-muted">Goal Pipeline</div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-text-muted">Goal Pipeline</div>
             <h3 class="mt-1 text-md font-semibold text-text-strong">
               장기 목표 ${hasGoals ? `(${goals.value.length})` : ''}
             </h3>

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -138,7 +138,7 @@ function GateSection({
     <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
       <div class="flex items-center justify-between gap-3">
         <div class="text-xs font-medium text-text-strong">${title}</div>
-        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${gateTone(gate.status)}`}>${gate.status}</span>
+        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 ${gateTone(gate.status)}`}>${gate.status}</span>
       </div>
       ${gate.reasons && gate.reasons.length > 0 ? html`
         <div class="mt-2 flex flex-col gap-1">
@@ -165,10 +165,10 @@ function ContractSection({ task }: { task: Task }) {
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted">계약 게이트</div>
-        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] ${contract?.strict ? 'text-accent border-accent/25 bg-[var(--accent-10)]' : 'text-text-muted border-[var(--white-10)] bg-[var(--white-5)]'}`}>${contract?.strict ? 'strict' : 'advisory'}</span>
+        <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted">계약 게이트</div>
+        <span class=${`rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 ${contract?.strict ? 'text-accent border-accent/25 bg-[var(--accent-10)]' : 'text-text-muted border-[var(--white-10)] bg-[var(--white-5)]'}`}>${contract?.strict ? 'strict' : 'advisory'}</span>
         ${isAwaitingVerification ? html`
-          <span class="rounded border border-accent/40 bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[0.08em] text-accent">
+          <span class="rounded border border-accent/40 bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 text-accent">
             검증 대기
           </span>
         ` : null}
@@ -228,11 +228,11 @@ function ExecutionLinksSection({ task }: { task: Task }) {
 
   return html`
     <div>
-      <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">연결된 실행</div>
+      <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted mb-2">연결된 실행</div>
       <div class="flex flex-col gap-2">
         ${items.map(([label, value]) => html`
           <div key=${label} class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
-            <div class="text-3xs uppercase tracking-[0.12em] text-text-dim">${label}</div>
+            <div class="text-3xs uppercase tracking-3 text-text-dim">${label}</div>
             <div class="mt-1 text-xs font-mono text-text-body break-all">${value}</div>
           </div>
         `)}
@@ -247,7 +247,7 @@ function HandoffSection({ task }: { task: Task }) {
 
   return html`
     <div>
-      <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 Handoff</div>
+      <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted mb-2">최근 Handoff</div>
       <div class="rounded border border-warn/20 bg-warn/8 px-4 py-3">
         <div class="text-sm leading-relaxed text-text-body"><${RichContent} text=${handoff.summary} previewLimit=${2} /></div>
         ${handoff.reason ? html`<div class="mt-2 text-2xs text-text-muted">reason: ${handoff.reason}</div>` : null}
@@ -278,7 +278,7 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex flex-wrap items-center gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted">담당 키퍼의 활성 목표</div>
+        <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted">담당 키퍼의 활성 목표</div>
         ${goalIds.length > 1 ? html`
           <input
             type="search"
@@ -378,7 +378,7 @@ export function TaskDetailOverlay() {
           ${'' /* Description */}
           ${task.description ? html`
             <div>
-              <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">설명</div>
+              <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted mb-2">설명</div>
               <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-sm leading-relaxed text-text-body">
                 <${RichContent} text=${task.description} previewLimit=${2} />
               </div>
@@ -394,7 +394,7 @@ export function TaskDetailOverlay() {
 
           ${'' /* Recent task events */}
           <div>
-            <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 태스크 이벤트</div>
+            <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted mb-2">최근 태스크 이벤트</div>
             <${TaskEventsSection} />
           </div>
 

--- a/dashboard/src/components/harness-health-sections.ts
+++ b/dashboard/src/components/harness-health-sections.ts
@@ -304,7 +304,7 @@ export function ScopePairing() {
               onClick=${() => navigate('lab', { section: 'autoresearch' })}
             >오토리서치 열기</button>
           </div>
-          <div class="text-sm leading-[1.6] text-[var(--text-body)]">
+          <div class="text-sm leading-loose text-[var(--text-body)]">
             어떤 파일을 어떻게 바꿔 어떤 metric을 밀어 올리려는지, 그리고 cycle별 keep/discard가 어땠는지 봅니다.
           </div>
         </div>
@@ -314,7 +314,7 @@ export function ScopePairing() {
         <div class="flex flex-col gap-2">
           <${SectionCap}>안전 감시<//>
           <div class="text-sm font-medium text-[var(--text-strong)]">하네스가 답하는 것</div>
-          <div class="text-sm leading-[1.6] text-[var(--text-body)]">
+          <div class="text-sm leading-loose text-[var(--text-body)]">
             평가 모델이 건강한지, 장기 실행 중 압축이 정상인지, 세대 교체가 안전한지 봅니다.
           </div>
         </div>
@@ -341,7 +341,7 @@ export function RailHeader({
           <div class="text-sm font-medium text-[var(--text-strong)]">${title}</div>
           <${StatusPill} status=${status} />
         </div>
-        <div class="mt-1 text-sm leading-[1.6] text-[var(--text-muted)]">${description}</div>
+        <div class="mt-1 text-sm leading-loose text-[var(--text-muted)]">${description}</div>
       </div>
       <div class="text-xs text-[var(--text-dim)]">최근 신호 ${freshnessLabel(lastEventAt)}</div>
     </div>

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -180,7 +180,7 @@ function HarnessFlowCard({ data }: { data: HarnessHealthData }) {
       <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
         <div>
           <div class="text-sm font-medium text-[var(--text-strong)]">실시간 상태 그래프</div>
-          <div class="mt-1 text-sm leading-[1.6] text-[var(--text-muted)]">
+          <div class="mt-1 text-sm leading-loose text-[var(--text-muted)]">
             작업 완료, 컨텍스트 압축, 세대 교체 신호가 하네스로 모이는 구조입니다.
           </div>
         </div>
@@ -247,7 +247,7 @@ export function HarnessHealth() {
             <div class="max-w-3xl">
               <${SectionCap}>keeper 장기 실행 중 평가/압축/교체가 정상인지 감시합니다<//>
               <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">${heroTitle(data)}</div>
-              <div class="mt-2 text-sm leading-[1.7] text-[var(--text-body)]">${heroBody(data)}</div>
+              <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">${heroBody(data)}</div>
             </div>
             <div class="flex items-center gap-2">
               <button
@@ -289,7 +289,7 @@ export function HarnessHealth() {
           </div>
         </div>
 
-        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-[1.7] text-[var(--text-body)]">
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-airy text-[var(--text-body)]">
           ${data.scope_note}
         </div>
 
@@ -355,7 +355,7 @@ export function HarnessHealth() {
               />
             </div>
 
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-[1.6] text-[var(--text-muted)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-loose text-[var(--text-muted)]">
               인간 라벨 ${cal.labeled_count}건이 calibration ground truth입니다. 값이 0이면 runtime health는 볼 수 있어도 evaluator accuracy는 아직 검증되지 않았습니다.
             </div>
 

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -449,7 +449,7 @@ function MetricChip({
 }) {
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-3xs uppercase tracking-[0.12em] text-[var(--text-dim)]">${label}</div>
+      <div class="text-3xs uppercase tracking-3 text-[var(--text-dim)]">${label}</div>
       <div class="mt-1 flex items-center gap-2 text-sm font-semibold text-[var(--text-strong)]">
         <${StatusChip} tone=${tone} uppercase=${false}>${value}<//>
       </div>
@@ -466,7 +466,7 @@ function JourneyTile({
 }) {
   return html`
     <section class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-4 flex flex-col gap-3 min-h-[150px]">
-      <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-dim)]">${label}</div>
+      <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-dim)]">${label}</div>
       <div class="flex flex-col gap-2 text-sm text-[var(--text-body)]">
         ${children}
       </div>
@@ -778,7 +778,7 @@ export function JourneyPanel() {
             ${taskRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Task Journeys</div>
+                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">Task Journeys</div>
                     ${taskRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `
@@ -787,7 +787,7 @@ export function JourneyPanel() {
             ${keeperRecords.length > 0
               ? html`
                   <div class="flex flex-col gap-3">
-                    <div class="text-2xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">Standalone Keeper Journeys</div>
+                    <div class="text-2xs font-semibold uppercase tracking-3 text-[var(--text-muted)]">Standalone Keeper Journeys</div>
                     ${keeperRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
                   </div>
                 `

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -197,9 +197,9 @@ export function KeeperChatPanel({ name }: { name: string }) {
     <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
       <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
         <div class="min-w-55 flex-1">
-          <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
+          <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 대화</div>
           <div class="mt-2 text-md font-semibold text-[var(--text-strong)]">@${name}</div>
-          <div class="mt-1 text-sm leading-[1.65] text-[var(--text-secondary)]">
+          <div class="mt-1 text-sm leading-loose text-[var(--text-secondary)]">
             이 키퍼와의 실시간 직접 대화입니다. 스트리밍 응답은 동일한 대화 레인에 표시됩니다.
           </div>
         </div>
@@ -221,7 +221,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
 
       <div class="px-4 py-4">
         ${chatAccess.message
-          ? html`<div class="mb-4 rounded-card border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--warn-bright)]">${chatAccess.message}</div>`
+          ? html`<div class="mb-4 rounded-card border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">${chatAccess.message}</div>`
           : null}
         <${ChatTranscript}
           entries=${transcriptEntries}
@@ -233,7 +233,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
       </div>
 
       ${chatError.value
-        ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--bad-light)]">${chatError.value}</div>`
+        ? html`<div class="mx-4 mb-4 rounded-card border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-xs leading-loose text-[var(--bad-light)]">${chatError.value}</div>`
         : null}
 
       <div class="border-t border-[var(--slate-gray-12)] bg-[var(--white-3)] px-4 py-4">

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -116,7 +116,7 @@ export function KeeperConditionsDivergent({ keeper }: { keeper: Keeper }) {
   return html`
     <section class="rounded border border-[var(--warn-24)] bg-[rgba(251,191,36,0.05)] p-3 mb-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-2xs font-semibold tracking-[0.08em] uppercase text-[var(--warn)]">
+        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--warn)]">
           ⚠️ 조건-Phase 불일치
         </h3>
         <span class="text-3xs text-[var(--text-dim)]">phase가 아직 반응하지 않은 관측 신호</span>

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -165,7 +165,7 @@ function OperationalHealth({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
-      <div class="mb-2 text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">운영 건강도</div>
+      <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">운영 건강도</div>
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
         ${hb ? html`
           <div class="p-2 rounded border ${KPI_TONE[hbTone]} flex flex-col gap-0.5">
@@ -348,7 +348,7 @@ function KpiSection({ title, question, children }: {
   return html`
     <section class="rounded border border-[var(--card-border)] bg-[var(--white-2)] p-3">
       <header class="mb-2 flex items-baseline justify-between gap-2">
-        <h3 class="text-2xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">${title}</h3>
+        <h3 class="text-2xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">${title}</h3>
         <span class="text-3xs text-[var(--text-dim)] truncate">${question}</span>
       </header>
       ${children}
@@ -429,7 +429,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           <${OperationalHealth} keeper=${keeper} />
           ${totalCalls > 0 ? html`
             <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] p-3">
-              <div class="mb-2 text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">모델 호출 분포</div>
+              <div class="mb-2 text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">모델 호출 분포</div>
               <div class="flex flex-col gap-1.5">
                 ${modelEntries.slice(0, 4).map(([model, count]) => {
                   const pct = Math.round((count / totalCalls) * 100)

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -331,10 +331,10 @@ function KeeperClearContextDialog({
         </div>
 
         <label class="flex flex-col gap-2">
-          <span class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
+          <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">사유</span>
           <textarea
             ref=${reasonRef}
-            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-sm leading-[1.55] text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
+            class="min-h-[112px] resize-y rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-sm leading-paragraph text-[var(--text-body)] outline-none focus:border-[var(--accent-45)] focus:ring-2 focus:ring-[var(--accent-18)]"
             placeholder="예: stale continuity replay 제거"
             disabled=${pending}
             value=${reason}
@@ -579,7 +579,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
 
       <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)]">
         <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] px-3 py-2">
-          <div class="text-2xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
             OAS Snapshot History
             ${inventory && inventory.history.length > 0 && historyQuery.trim() !== ''
               ? html`<span class="ml-2 text-3xs font-normal normal-case tracking-normal text-[var(--text-dim)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -134,7 +134,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (loading && !data) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-2xs text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
       </div>
     `
@@ -143,7 +143,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (error && !data) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-2xs text-[var(--text-dim)]">eval 데이터 없음</div>
       </div>
     `
@@ -152,7 +152,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
   if (!data || data.count === 0) {
     return html`
       <div class="p-4 rounded border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
         <div class="text-2xs text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
       </div>
     `
@@ -173,7 +173,7 @@ export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
       ${'' /* Header */}
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">
-          <span class="text-3xs font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Eval Quality</span>
+          <span class="text-3xs font-semibold tracking-1 uppercase text-[var(--text-muted)]">Eval Quality</span>
           ${allPassed
             ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
             : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-12)] text-[var(--bad)]">FAIL</span>`

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -203,7 +203,7 @@ export function KeeperMemoryTierPanel({
       </div>
 
       <div class="mt-2">
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">
           Compaction sub-FSM (KeeperCompactionLifecycle.tla)
         </div>
         <${CytoscapeFsm} spec=${compactionSpec} height="200px" />

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -183,7 +183,7 @@ export function KeeperDiagnosticSummary({
   return html`
     <div class="py-3 px-4 rounded border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
       <div class="mb-3 flex items-center justify-between gap-3">
-        <div class="text-2xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">명시적 상태 조회</div>
+        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">명시적 상태 조회</div>
         <button
           type="button"
           class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-2xs text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
@@ -293,14 +293,14 @@ export function KeeperConversationPanel({
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--slate-gray-12)] px-4 py-4">
           <div class="min-w-55 flex-1">
-            <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
+            <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
               <div class="text-md font-semibold text-[var(--text-strong)]">@${keeperName}</div>
-              <span class=${`inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
+              <span class=${`inline-flex items-center rounded-sm border px-2.5 py-1 text-3xs font-medium uppercase tracking-2 ${conversationStateClass(sending, hydrating)}`}>
                 ${conversationStateLabel(sending, hydrating)}
               </span>
             </div>
-            <div class="mt-1 text-sm leading-[1.65] text-[var(--text-secondary)]">
+            <div class="mt-1 text-sm leading-loose text-[var(--text-secondary)]">
               Keeper 상세 안에서 직접 대화와 내부 메시지를 함께 봅니다. 필요하면 토글로 내부 프롬프트와 tool chatter를 숨길 수 있습니다.
             </div>
           </div>
@@ -341,7 +341,7 @@ export function KeeperConversationPanel({
         <div class="px-4 py-4">
           ${chatAccess.message
             ? html`
-                <div class="mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-[1.6] text-[var(--warn-bright)]">
+                <div class="mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
                   ${chatAccess.message}
                 </div>
               `
@@ -356,7 +356,7 @@ export function KeeperConversationPanel({
 
         ${!showInternal && hiddenCount > 0
           ? html`
-              <div class="mx-4 mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-[1.55] text-[var(--warn-bright)]">
+              <div class="mx-4 mb-4 rounded-[16px] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
                 ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
               </div>
             `

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -176,13 +176,13 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
       </div>
 
       ${phaseMismatch ? html`
-        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-[1.5] text-[var(--text-body)]">
+        <div class="rounded border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-normal text-[var(--text-body)]">
           keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다.
         </div>
       ` : null}
 
       <div>
-        <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
+        <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)] mb-2">Composite Lifecycle (KSM · KTC · KDP · KCL · KMC)</div>
         <${CytoscapeFsm} spec=${compositeSpec} height="320px" />
       </div>
 
@@ -190,7 +190,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         ${INVARIANT_LABELS.map(([key, label]) => {
           const ok = snapshot.invariants[key]
           return html`
-            <div class=${`rounded border px-3 py-2 text-2xs leading-[1.5] ${badgeTone(ok)}`}>
+            <div class=${`rounded border px-3 py-2 text-2xs leading-normal ${badgeTone(ok)}`}>
               <div class="font-semibold">${label}</div>
               <div class="mt-1 font-mono">${ok ? 'ok' : 'violated'}</div>
             </div>
@@ -200,9 +200,9 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
       ${transitions.length > 0 ? html`
         <div class="grid gap-2">
-          <div class="text-3xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Observed transitions</div>
+          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">Observed transitions</div>
           ${transitions.map(transition => html`
-            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-[1.5] text-[var(--text-body)]">
+            <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-normal text-[var(--text-body)]">
               <div class="flex flex-wrap items-center gap-2">
                 <span class="font-mono text-[var(--text-strong)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
                 <span class="text-[var(--text-dim)]">→</span>

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -80,7 +80,7 @@ function InspectorOverview() {
     <div class="grid gap-4">
       <${Card} title="Dashboard Focus" class="section">
         <div class="grid gap-3">
-          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-sm leading-[1.7] text-[var(--text-body)]">
+          <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3 text-sm leading-airy text-[var(--text-body)]">
             이제 대시보드는 <strong class="text-[var(--text-strong)]">핵심 운영 화면</strong>에 더 집중합니다.
             낮은 활용도의 화면은 줄이고, 진짜 자주 보는 상태/개입/근거 화면으로 빠르게 이동할 수 있게 정리했습니다.
           </div>
@@ -88,7 +88,7 @@ function InspectorOverview() {
             ${FOCUS_SURFACES.map(surface => html`
               <div class="rounded border border-card-border/35 bg-[var(--white-5)]/10 px-4 py-3">
                 <div class="text-xs font-semibold text-[var(--text-strong)]">${surface.title}</div>
-                <div class="mt-2 text-2xs leading-[1.6] text-[var(--text-muted)]">${surface.description}</div>
+                <div class="mt-2 text-2xs leading-loose text-[var(--text-muted)]">${surface.description}</div>
                 <button
                   type="button"
                   class="mt-3 rounded border border-accent/25 bg-[var(--accent-10)] px-2.5 py-1.5 text-2xs font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent-20)]"
@@ -112,7 +112,7 @@ export function LabInspector() {
     <div class="flex flex-col gap-4">
       <${Card} title="운영 인스펙터" class="section">
         <div class="flex flex-col gap-3">
-          <div class="text-sm leading-[1.7] text-[var(--text-body)]">
+          <div class="text-sm leading-airy text-[var(--text-body)]">
             피처 플래그와 서버 설정을 한 곳에서 보고, 대시보드에서 실제 자주 쓰는 운영 화면으로 빠르게 이동합니다.
           </div>
           <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -22,7 +22,7 @@ export function Live({ variant = 'full' }: LiveProps) {
           <div class="flex flex-col gap-2">
             <div class="flex flex-col gap-2">
               <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
-              <p class="m-0 text-sm leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+              <p class="m-0 text-sm leading-paragraph text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
             </div>
           </div>
         </section>

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -67,7 +67,7 @@ export function ActivityStream() {
                 <span class="text-[0.75rem] text-[var(--text-body)] font-medium">${entry.agent}</span>
                 <span class="text-[0.7rem] text-[var(--text-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="text-sm text-[var(--text-body)] leading-[1.5] break-words">${entry.text}</div>
+              <div class="text-sm text-[var(--text-body)] leading-normal break-words">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -257,7 +257,7 @@ function renderLogRow(entry: LogEntry) {
         ${entry.module || '(root)'}
       </div>
       <div class="flex flex-wrap items-start gap-1">
-        <span class="rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-[0.08em] ${sourceClass}">
+        <span class="rounded-sm border px-2 py-0.5 text-3xs uppercase tracking-1 ${sourceClass}">
           ${sourceLabel(source)}
         </span>
         ${entry.legacy_classified
@@ -451,7 +451,7 @@ export function LogViewer() {
         ` : null}
 
         <div class="px-3 pt-3">
-          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)]">
             <div>timestamp</div>
             <div>level</div>
             <div>module</div>

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -142,7 +142,7 @@ function CommentItem({
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}</button>
         </div>
-        <div class="text-sm text-[var(--text-body)] leading-[1.55]"><${RichContent} text=${displayText} previewLimit=${1} /></div>
+        <div class="text-sm text-[var(--text-body)] leading-paragraph"><${RichContent} text=${displayText} previewLimit=${1} /></div>
         ${needsTruncation ? html`
           <button type="button"
             class="mt-1 text-2xs text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
@@ -299,7 +299,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
             <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--text-strong)]">${post.title}</h1>
           </div>
 
-          <div class="text-sm text-[var(--text-body)] leading-[1.65]">
+          <div class="text-sm text-[var(--text-body)] leading-loose">
             <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
           </div>
 

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -419,7 +419,7 @@ function PostCard({ post }: { post: BoardPost }) {
         <div class="text-md font-semibold text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${stripInlineMarkdown(post.title)}</div>
 
         <!-- Content preview: rendered markdown, height-capped -->
-        <div class="board-post-preview text-sm text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
+        <div class="board-post-preview text-sm text-[var(--text-body)] leading-paragraph mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
           <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
           <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--card)] to-transparent pointer-events-none" />
         </div>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -173,7 +173,7 @@ function renderActivityTimeline() {
             <span>${entry.actor}</span>
             <span><${TimeAgo} timestamp=${entry.at} /></span>
           </div>
-          <div class="mt-2 text-sm leading-[1.55] text-[var(--text-body)]">${entry.detail}</div>
+          <div class="mt-2 text-sm leading-paragraph text-[var(--text-body)]">${entry.detail}</div>
         </article>
       `)}
     </div>

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -100,7 +100,7 @@ export function QuickIntervene() {
       ${showAdvanced
         ? html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3">
-              <label class="block text-2xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]" for="quick-intervene-actor">
+              <label class="block text-2xs font-medium uppercase tracking-1 text-[var(--text-muted)]" for="quick-intervene-actor">
                 기록 주체
               </label>
               <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">개입과 승인 요청은 이 이름으로 기록됩니다.</p>

--- a/dashboard/src/components/perf-snapshot.ts
+++ b/dashboard/src/components/perf-snapshot.ts
@@ -57,7 +57,7 @@ function PerfStat({
 }) {
   return html`
     <div class="rounded border border-card-border/45 bg-[var(--white-5)]/10 px-3 py-3">
-      <div class="text-3xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">${label}</div>
+      <div class="text-3xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">${label}</div>
       <div class="mt-1 text-2xl font-bold text-[var(--text-strong)]">${value}</div>
       ${detail ? html`<div class="mt-1 text-2xs text-[var(--text-muted)]">${detail}</div>` : null}
     </div>
@@ -73,7 +73,7 @@ function DiffRow({ row }: { row: DashboardPerfComparisonRow }) {
         <div class="truncate text-xs font-semibold text-[var(--text-strong)]">${row.benchmark}</div>
         <div class="text-2xs text-[var(--text-muted)]">avg ${avgDelta}ms · p95 ${p95Delta}ms</div>
       </div>
-      <div class="shrink-0 text-2xs font-semibold uppercase tracking-[0.14em] ${verdictTone(row.verdict)}">${row.verdict}</div>
+      <div class="shrink-0 text-2xs font-semibold uppercase tracking-4 ${verdictTone(row.verdict)}">${row.verdict}</div>
     </div>
   `
 }
@@ -255,7 +255,7 @@ export function PerfSnapshotPanel() {
               ? html`
                   <div class="grid grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] gap-3 max-[960px]:grid-cols-1">
                     <div class="flex flex-col gap-2">
-                      <div class="text-2xs font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Top Changes</div>
+                      <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--text-muted)]">Top Changes</div>
                       ${topChanges.slice(0, 4).map(row => html`<${DiffRow} row=${row} />`)}
                     </div>
                     <${DistributionBars}

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -164,7 +164,7 @@ function DiffBlock({ text }: { text: string }) {
   const truncatedCount = allLines.length - lines.length
 
   return html`
-    <div class="font-mono text-2xs leading-[1.6] overflow-x-auto">
+    <div class="font-mono text-2xs leading-loose overflow-x-auto">
       ${lines.map((line: string) => {
         const cls =
           line.startsWith('+') && !line.startsWith('+++') ? 'text-[var(--ok)] bg-[var(--ok-6)]'

--- a/dashboard/src/components/setup-guide-card.ts
+++ b/dashboard/src/components/setup-guide-card.ts
@@ -128,7 +128,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
           ${tone === 'complete'
             ? html`
                 <span
-                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--ok)]"
+                  class="inline-flex items-center gap-1 rounded-sm border border-[var(--ok-20)] bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--ok)]"
                   aria-label="Setup guide complete"
                   data-setup-complete-badge
                 >
@@ -139,7 +139,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
             : null}
         </div>
         <span
-          class=${`text-3xs uppercase tracking-[0.14em] tabular-nums ${countToneClass}`}
+          class=${`text-3xs uppercase tracking-4 tabular-nums ${countToneClass}`}
           data-setup-progress=${connectorId}
           data-setup-progress-pct=${pct}
         >${stepCompletionSummary(doneCount, guide.steps.length)}</span>
@@ -214,7 +214,7 @@ export function SetupGuideCard({ connectorId }: { connectorId: string }) {
               ${guide.references.length > 0
                 ? html`
                     <div class="mt-3 flex flex-wrap items-center gap-1.5 border-t border-[var(--white-8)] pt-2">
-                      <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]">refs</span>
+                      <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]">refs</span>
                       ${guide.references.map(ref => html`<${ExternalLinkChip} href=${ref.href} label=${ref.label} />`)}
                     </div>
                   `

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -124,7 +124,7 @@ export function SidecarLogToggle({ connectorId }: { connectorId: string }) {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+      class="cursor-pointer rounded border border-[var(--white-8)] px-2 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
       aria-expanded=${entry.open}
       aria-controls=${`sidecar-log-${connectorId}`}
       onClick=${onClick}
@@ -146,7 +146,7 @@ function LevelPills({ connectorId, active }: { connectorId: string; active: LogL
     <div class="flex items-center gap-1" role="radiogroup" aria-label="log level filter">
       ${LEVELS.map(level => {
         const isActive = level === active
-        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-[0.14em]'
+        const base = 'cursor-pointer rounded border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4'
         const activeCls = 'border-[var(--accent-1)] bg-[var(--accent-1)]/15 text-[var(--text-body)]'
         const idleCls = 'border-[var(--white-8)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
         return html`
@@ -191,11 +191,11 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
       class="mt-3 rounded border border-[var(--white-8)] bg-[var(--bg-1)] p-2"
     >
       <div class="mb-2 flex items-center justify-between gap-2">
-        <div class="min-w-0 truncate text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" title=${entry.logPath}>
+        <div class="min-w-0 truncate text-3xs uppercase tracking-4 text-[var(--text-dim)]" title=${entry.logPath}>
           ${entry.logPath || '(log path unknown)'}
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)]" data-log-count>
+          <span class="text-3xs uppercase tracking-4 text-[var(--text-dim)]" data-log-count>
             ${entry.available
               ? hasFilter
                 ? `${filtered.length} / ${entry.lines.length} lines`
@@ -229,7 +229,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
                 ? html`
                     <button
                       type="button"
-                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-3xs uppercase tracking-[0.14em] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
+                      class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 py-0.5 text-3xs uppercase tracking-4 text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)]"
                       data-log-filter-clear
                       onClick=${() => setEntry(connectorId, { level: 'all', keyword: '' })}
                     >clear</button>

--- a/dashboard/src/components/sidecar-startup-watch.ts
+++ b/dashboard/src/components/sidecar-startup-watch.ts
@@ -108,7 +108,7 @@ export function StartupCheckBanner({ connectorId, sidecarUp }: {
       </div>
       <button
         type="button"
-        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs uppercase tracking-[0.14em] text-[var(--warn)] hover:bg-[var(--warn-10)]"
+        class="shrink-0 cursor-pointer rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-3xs uppercase tracking-4 text-[var(--warn)] hover:bg-[var(--warn-10)]"
         onClick=${() => {
           openSidecarLogs(connectorId)
           // Don't clear startAt yet — operator might toggle logs back closed

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -56,7 +56,7 @@ export function ThemeSwitch() {
   return html`
     <button
       type="button"
-      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-[0.14em] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+      class="cursor-pointer rounded-sm border border-[var(--white-10)] bg-[var(--white-4)] px-2.5 py-[5px] text-3xs font-mono uppercase tracking-4 text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
       aria-label=${TITLE[key]}
       title=${TITLE[key]}
       onClick=${toggleTheme}

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -157,7 +157,7 @@ function ConfigRow({
   return html`
     <div class="rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3" title=${item.path}>
       <div class="mb-2 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${label}</div>
         <${StatusChip} tone=${toneClass(item.exists ? 'ready' : item.source === 'invalid_env' ? 'invalid_env' : 'warn')}>${item.exists ? 'present' : 'missing'}<//>
         ${showSourceBadge
           ? html`
@@ -196,7 +196,7 @@ function WarningBlock({
 
   return html`
     <div class="rounded border border-[var(--yellow-bright-28)] bg-[var(--warn-10)] px-3 py-3">
-      <div class="mb-2 text-2xs uppercase tracking-[0.08em] text-[var(--yellow-100)]">${title}</div>
+      <div class="mb-2 text-2xs uppercase tracking-1 text-[var(--yellow-100)]">${title}</div>
       <div class="flex flex-col gap-2">
         ${warnings.map(warning => html`
           <div class="text-xs leading-relaxed text-[var(--text-body)]">${warning}</div>
@@ -215,7 +215,7 @@ function RuntimeMetaRow({
 }) {
   return html`
     <div class="flex items-center justify-between gap-3 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
-      <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+      <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${label}</div>
       <div class="break-all text-right font-mono text-xs text-[var(--text-body)]">${value}</div>
     </div>
   `
@@ -318,7 +318,7 @@ function RuntimeProbePanel() {
   return html`
     <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">ollama warm / kv probe</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">ollama warm / kv probe</div>
         <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
@@ -526,7 +526,7 @@ export function ConfigResolutionPanel({
 
               <div class="mt-4">
                 <div class="mb-2 flex items-center justify-between gap-2">
-                  <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                  <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">
                     recent diagnostics
                   </div>
                   ${runtimeResolution.diagnostics.length > 0

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -177,7 +177,7 @@ export function PromptRegistryPanel() {
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <div class="min-h-65 rounded border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
-            <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">
               등록된 프롬프트
               ${sourceFilter.value !== 'all' || searchQuery.value
                 ? html`<span class="ml-1 normal-case tracking-normal text-[var(--text-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
@@ -246,18 +246,18 @@ export function PromptRegistryPanel() {
 
             <div class="mb-4 grid gap-3 md:grid-cols-2">
               <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">마크다운 파일</div>
+                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">마크다운 파일</div>
                 <div class="mt-1 break-all font-mono text-xs text-[var(--text-body)]">${selectedPrompt.file_path ?? '미설정'}</div>
               </div>
               <div class="rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">문자 수</div>
+                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">문자 수</div>
                 <div class="mt-1 font-mono text-xs text-[var(--text-body)]">${selectedPrompt.char_count}</div>
               </div>
             </div>
 
             ${selectedPrompt.template_variables.length > 0 ? html`
               <div class="mb-4 rounded border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">허용된 플레이스홀더</div>
+                <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">허용된 플레이스홀더</div>
                 <div class="mt-2 flex flex-wrap gap-2">
                   ${selectedPrompt.template_variables.map(variable => html`
                     <span class="rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-2xs text-[var(--text-body)]">${`{{${variable}}}`}</span>
@@ -267,12 +267,12 @@ export function PromptRegistryPanel() {
             ` : null}
 
             <div class="mb-4">
-              <div class="mb-2 text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
+              <div class="mb-2 text-2xs uppercase tracking-1 text-[var(--text-muted)]">파일 기준값</div>
               <div class="max-h-55 overflow-auto rounded border border-[var(--card-border)] bg-[var(--bg-0)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
-              <div class="text-2xs uppercase tracking-[0.08em] text-[var(--text-muted)]">런타임 오버라이드</div>
+              <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">런타임 오버라이드</div>
               <div class="text-2xs text-[var(--text-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
             </div>
             <${TextArea}

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -360,7 +360,7 @@ function VerificationRow({
                   ${hasTaskTitle
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
                             Task Title
                           </div>
                           <div class="text-[var(--text-body)]">${row.task_title}</div>
@@ -370,7 +370,7 @@ function VerificationRow({
                   ${hasContract
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
                             Completion Contract
                           </div>
                           <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
@@ -382,7 +382,7 @@ function VerificationRow({
                   ${hasEvidence
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
                             Required Evidence
                           </div>
                           <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--text-body)]">
@@ -394,7 +394,7 @@ function VerificationRow({
                   ${row.verdict_reason !== ''
                     ? html`
                         <div>
-                          <div class="text-3xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1">
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
                             Verdict Reason
                           </div>
                           <div class="text-[var(--text-body)]">${row.verdict_reason}</div>

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -66,6 +66,24 @@
   --font-size-2xl: 20px;
   --font-size-3xl: 30px;
 
+  /* Letter-spacing for uppercase mono labels (sec-lbl, t-label, status pills).
+     Numbered scale 1..5 corresponds to widening uppercase tracking; the
+     dashboard's mono uppercase labels need wider tracking than body to read
+     as discrete tokens, not running text. tracking-1 is the default for
+     UI labels; 4/5 are reserved for dense tabular header rows. */
+  --tracking-1: 0.08em;
+  --tracking-2: 0.10em;
+  --tracking-3: 0.12em;
+  --tracking-4: 0.14em;
+  --tracking-5: 0.16em;
+
+  /* Line-height presets. Tailwind v4 `leading-normal` (1.5) covers compact
+     UI text. The other named tokens cover documentation-style copy where
+     longer line-length needs more breathing room. */
+  --leading-paragraph: 1.55;  /* article body inside cards */
+  --leading-loose: 1.6;       /* multi-line tooltip / hint text */
+  --leading-airy: 1.7;        /* large headings or onboarding flows */
+
   --color-text-dim: #a0a8b4;
   --color-text-slate: #b0bfd4;
   --color-text-slate-light: #cbd5e1;


### PR DESCRIPTION
## Why
Anyang Sleepers Design System extension. Previous typography PRs (#8373, #8399) covered font-size scale. This PR closes the typography axis with letter-spacing + line-height tokens.

## What
**8 new Tailwind v4 `@theme` tokens** (auto-generates utilities):

### Letter-spacing (`tracking-1..5`)
| Token | Value | Use |
|-------|-------|-----|
| `--tracking-1` | `0.08em` | UI labels (default) |
| `--tracking-2` | `0.10em` | (Tailwind widest = 0.1em) |
| `--tracking-3` | `0.12em` | section labels |
| `--tracking-4` | `0.14em` | dense tabular headers |
| `--tracking-5` | `0.16em` | dense tabular headers (variant) |

### Line-height
| Token | Value | Use |
|-------|-------|-----|
| `--leading-paragraph` | `1.55` | article body inside cards |
| `--leading-loose` | `1.6` | multi-line tooltip / hint |
| `--leading-airy` | `1.7` | large headings, onboarding |

### Sweep — 200 replacements / 60 files
- Tracking: 5 distinct values, 151 occurrences
- Leading: 5 distinct values, 49 occurrences (1.65 → 1.6 normalize 3% delta, imperceptible)
- `leading-[1.5]` → `leading-normal` (Tailwind native)

## Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` — 232 files / **3809 tests** all pass

## 누적 axis
| Axis | Status | Tokens added |
|------|--------|--------------|
| Color | ✅ | 55 |
| Radii | ✅ | 5 |
| Pills | ✅ | 0 |
| Shadows/Blur | ✅ | 0 |
| Typography (font-size) | ✅ | 5 |
| Mobile SSOT | ✅ | 0 (alias) |
| Spacing | ✅ | 0 |
| **Typography (tracking+leading)** | ✅ | **8** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)