### PR TITLE
spec(tla): add TaskLifecycle bug-model for AwaitingVerification gate

### DIFF
--- a/tla/TaskLifecycle-buggy.cfg
+++ b/tla/TaskLifecycle-buggy.cfg
@@ -1,0 +1,6 @@
+\* Buggy: BugSkipVerification MUST violate DoneRequiresApproval.
+\* If it passes the invariant is too weak and the spec is not checking
+\* the verification gate.
+SPECIFICATION SpecBuggy
+INVARIANT TypeOK
+INVARIANT DoneRequiresApproval

--- a/tla/TaskLifecycle.cfg
+++ b/tla/TaskLifecycle.cfg
@@ -1,0 +1,4 @@
+\* Clean: DoneRequiresApproval must pass.
+SPECIFICATION SpecClean
+INVARIANT TypeOK
+INVARIANT DoneRequiresApproval

--- a/tla/TaskLifecycle.tla
+++ b/tla/TaskLifecycle.tla
@@ -1,0 +1,104 @@
+------------------------------ MODULE TaskLifecycle ------------------------------
+(* TLA+ spec for the MASC task lifecycle and the AwaitingVerification gate.
+
+   Covers the Todo / InProgress / AwaitingVerification / Done / Cancelled
+   variants defined in Types_core.task_status. The central claim is that
+   state = "Done" is only reachable after an Approve_verification that flips
+   the "verified" ghost variable to TRUE.
+
+   Bug Model pattern (feedback_tla-spec-audit-outcome-trichotomy):
+     - Clean cfg: SpecClean + DoneRequiresApproval passes.
+     - Buggy cfg: SpecBuggy adds a direct InProgress -> Done skip which
+       MUST violate DoneRequiresApproval. If it passes the invariant is
+       too weak and the spec is not actually checking anything.
+*)
+
+EXTENDS Integers
+
+VARIABLES state, verified
+
+vars == <<state, verified>>
+
+States == { "Todo", "InProgress", "AwaitingVerification", "Done", "Cancelled" }
+
+TypeOK ==
+    /\ state \in States
+    /\ verified \in BOOLEAN
+
+\* ── Init ────────────────────────────────────
+
+Init ==
+    /\ state = "Todo"
+    /\ verified = FALSE
+
+\* ── Clean transitions ───────────────────────
+
+Claim ==
+    /\ state = "Todo"
+    /\ state' = "InProgress"
+    /\ UNCHANGED verified
+
+Submit ==
+    /\ state = "InProgress"
+    /\ state' = "AwaitingVerification"
+    /\ UNCHANGED verified
+
+Approve ==
+    /\ state = "AwaitingVerification"
+    /\ state' = "Done"
+    /\ verified' = TRUE
+
+Reject ==
+    /\ state = "AwaitingVerification"
+    /\ state' = "InProgress"
+    /\ UNCHANGED verified
+
+Cancel ==
+    /\ state \in { "Todo", "InProgress", "AwaitingVerification" }
+    /\ state' = "Cancelled"
+    /\ UNCHANGED verified
+
+\* Terminal states stutter so TLC can close the model.
+Terminal ==
+    /\ state \in { "Done", "Cancelled" }
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ Claim
+    \/ Submit
+    \/ Approve
+    \/ Reject
+    \/ Cancel
+    \/ Terminal
+
+\* ── Bug: skip verification ──────────────────
+\* Models the wrong_approach where a handler flips InProgress directly
+\* to Done without a verifier approval. DoneRequiresApproval must catch
+\* this.
+
+BugSkipVerification ==
+    /\ state = "InProgress"
+    /\ state' = "Done"
+    /\ UNCHANGED verified
+
+NextBuggy ==
+    \/ NextClean
+    \/ BugSkipVerification
+
+\* ── Specs ───────────────────────────────────
+
+SpecClean == Init /\ [][NextClean]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety ──────────────────────────────────
+
+\* Done is reachable only after the verifier flipped [verified] to TRUE.
+DoneRequiresApproval ==
+    state = "Done" => verified = TRUE
+
+\* Terminal states do not flip back. (Stability check — also catches a
+\* class of refactor bugs where Done mutates verified post-hoc.)
+VerifiedMonotone ==
+    state = "Done" => verified = TRUE
+
+================================================================================


### PR DESCRIPTION
## Summary

- Adds `tla/TaskLifecycle.tla` modelling the `Todo → InProgress → AwaitingVerification → Done` lifecycle with a `[verified]` ghost variable.
- Safety invariant `DoneRequiresApproval` pins down the central claim: a task can reach `Done` only after `Approve_verification` flips `verified` to `TRUE`.
- Clean cfg (`TaskLifecycle.cfg`) passes — 5 distinct states, exit 0.
- Buggy cfg (`TaskLifecycle-buggy.cfg`) adds `BugSkipVerification` (InProgress → Done directly) which MUST violate the invariant. Local run: TLC exits 12 with `Invariant DoneRequiresApproval is violated`, confirming the invariant actually catches the bug it claims to catch.

## Context

User feedback: "TLA+/FSM으로 닦였지만 검증 흔적이 없다." Inspection showed the keeper/cascade side has rich TLA+ coverage but the task lifecycle — specifically the AwaitingVerification bridge — had no spec. Without a bug-model the "verifier must approve before Done" contract was only enforced by OCaml pattern matching, not by an independently checked invariant.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 4 of 5).

## Scope guard

- No Makefile / workflow change: `scripts/tla-check.sh` already auto-discovers `tla/*.tla`, so the new spec runs on the next `tla-specs` CI job without further wiring.
- No OCaml side change.
- Spec is deliberately minimal (5 states, 6 actions, 1 ghost var) to keep check time under 15s and avoid state-space blowup.

## Test plan

- [x] `java -cp tla2tools.jar tlc2.TLC -config TaskLifecycle.cfg TaskLifecycle.tla` — 5 states, exit 0.
- [x] `java -cp tla2tools.jar tlc2.TLC -config TaskLifecycle-buggy.cfg TaskLifecycle.tla` — exit 12, `Invariant DoneRequiresApproval is violated`.
- [ ] CI `tla-specs` job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)