### PR TITLE
fix(backend): atomic set via tmp+rename to stop reader-race truncation

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -223,24 +223,45 @@ module FileSystem = struct
               Error (IOError (Printexc.to_string exn))
     )
 
-  (** Set value (auto-compresses with ZSTD if beneficial) *)
+  (** Set value (auto-compresses with ZSTD if beneficial).
+
+      Writes go through a sibling [.tmp-atomic] file and are then
+      [Eio.Path.rename]d into place. Without this indirection a reader
+      that opens the target file while [Eio.Path.save ~Or_truncate] is
+      still streaming bytes observes a truncated payload — that was the
+      source of the [JSON parse error: Unexpected end of input] storm
+      on [backlog.json] (62 occurrences in one hour, 2026-04-18) that
+      dropped the stale-claims GC into its read-failure skip branch
+      and blocked claim lifecycle transitions.
+
+      The mutex inside [t] already serialises writers against each
+      other; this change adds atomicity against concurrent readers. *)
   let set t key value =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-      match key_to_path t key with
+      match validate_key key with
       | Error e -> Error e
-      | Ok path ->
+      | Ok safe_key ->
+          let path_part =
+            String.map (function ':' -> '/' | c -> c) safe_key
+          in
+          let path = Eio.Path.(t.fs / path_part) in
+          let tmp_path =
+            Eio.Path.(t.fs / (path_part ^ ".tmp-atomic"))
+          in
           try
             _ensure_parent_dir ~log_errors:true path;
-            (* Compact Protocol v4: Compress before saving (if beneficial) *)
             let compressed = _compress value in
-            (* Write file *)
-            Eio.Path.save ~create:(`Or_truncate 0o644) path compressed;
+            Eio.Path.save ~create:(`Or_truncate 0o644) tmp_path compressed;
+            Eio.Path.rename tmp_path path;
             ki_replace t key ();
             Ok ()
           with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Eio.Cancel.Cancelled _ as exn ->
+              (try Eio.Path.unlink tmp_path with _ -> ());
+              raise exn
           | exn ->
-            Error (IOError (Printexc.to_string exn))
+              (try Eio.Path.unlink tmp_path with _ -> ());
+              Error (IOError (Printexc.to_string exn))
     )
 
   (** Delete key *)


### PR DESCRIPTION
## Context

On the live basepath \`~/me\` (2026-04-18 ~19:24–19:59 KST) backlog.json produced **62 \`[…/backlog.json] JSON parse error: Unexpected end of input\`** entries in one hour at varying byte offsets — the classic signature of read-during-write truncation. The stale-claims scan fell through to its read-failure branch and skipped every mutation, so task claims never transitioned.

This is an independent layer from the two companion fixes:

- PR #8388 (merged) — \`claude_code:\` provider scheme registry drift made keeper cycles fail cold.
- PR #8431 (draft) — \`backlog_of_yojson\` demanded metadata fields the writer omits, so parses succeeded textually but failed schema-wise.

This PR fixes the *physical* layer: writer atomicity against concurrent readers.

## Root

\`Backend.FileSystem.set\` called \`Eio.Path.save ~create:(\\\`Or_truncate 0o644)\`. The \`t.mutex\` serialises writers among themselves, but readers do not take the lock — they \`Fs_compat.load_file\` directly. Any read that starts between open+truncate and the final byte landing observes a partial payload.

## Change

Route writes through a sibling \`<path>.tmp-atomic\` and \`Eio.Path.rename\` into place. Since tmp sits in the same directory (same filesystem), \`rename\` is POSIX-atomic; a reader sees either the old inode contents or the new one, never a half-written tail. Tmp cleanup on exceptions mirrors \`Fs_compat.save_file_atomic\`.

Diff is 29 insertions / 8 deletions in a single file.

## Tests

- \`dune build bin/main_eio.exe\` clean
- \`test_backend\` (10 cases) pass
- \`test_server_runtime_bootstrap\` (38 cases) pass

No new unit test in this PR: writing a deterministic read-vs-write race test is timing-dependent and brittle; the existing backend suite exercises set/get round-tripping and the bootstrap suite exercises the integrated write/read path. The structural guarantee (tmp+rename is atomic) is the primary correctness argument.

## Interaction with #8431

Independent but complementary. #8431 keeps parse errors from propagating when metadata is missing; this PR prevents the parse errors from being produced in the first place. Either alone narrows the failure window; together the cluster closes out.