### PR TITLE
docs(changelog): summarize verification surface series (#8402/#8422/#8424/#8437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 ### Changed
 
+- **Verification surface — advisory CDAL attribution + verifier keeper
+  signal + Kanban visibility + TLA+ bug-model.** Responds to the
+  "검증 흔적이 UI에서 안 보인다" feedback by making every hop of the
+  verification pipeline observable.
+  - CDAL gate records an attribution entry for advisory (strict=false)
+    contracts instead of silently skipping the lookup (#8402).
+  - `Keeper_unified_turn.is_verifier_role_keeper` predicate plus
+    `observation.verifier_role_keeper` field on every decision record
+    let the dashboard pick verification-authority keepers out of the
+    fleet (#8422).
+  - Kanban adds a "검증 대기" column (store bucket +
+    `TaskBacklog` wiring + card pill) so `awaiting_verification`
+    tasks stop disappearing into the Done column (#8424).
+  - `tla/TaskLifecycle.tla` bug-model: `DoneRequiresApproval`
+    invariant is verified on the clean cfg (5 states, exit 0) and
+    violated on the buggy cfg (exit 12), confirming the contract
+    that Done is reachable only after Approve_verification (#8437,
+    draft).
+
 - **Dashboard design-system migration.** Multi-wave sweep of raw Tailwind
   color utilities to semantic CSS var tokens (`var(--ok)`, `var(--warn)`,
   `var(--bad-light)`, `var(--accent)`) across ~50 files.


### PR DESCRIPTION
## Summary

- Adds a single CHANGELOG bullet under `0.10.0` summarizing the four verification-surface PRs produced over the `/loop 20m` session.
- No version bump — all four land inside the existing `0.10.0` window, so the 5-SSOT truth check stays unchanged (`bash scripts/check-doc-truth.sh` exits 0).

## Context

Final (docs-only) PR of the verification-surface series prompted by the user feedback "CDAL이 Task/Goal/Board/Keeper 어디에도 이런걸 확인하거나 검증됐거나 한 흔적이 없다." The four upstream PRs covered:

- `#8402` Advisory CDAL attribution for `contract.strict=false`.
- `#8422` `verifier_role_keeper` predicate + decision-record signal.
- `#8424` "검증 대기" Kanban column + card pill.
- `#8437` `tla/TaskLifecycle.tla` bug-model for `DoneRequiresApproval`.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 5 of 5).

## Scope guard

- No `dune-project` / opam version bump. A dedicated `0.10.1` bump PR can land later once PR #8437 merges.
- No `SPEC-INDEX.md` / `PRODUCT-OPERATING-PLAN.md` changes — `tla/` specs are not indexed in SPEC-INDEX today (CheckpointTrim, SocialStateCap both unlisted), so this PR preserves that convention.

## Test plan

- [x] `bash scripts/check-doc-truth.sh` — Version truth OK, Doc truth OK, Doc code_refs OK.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)