### PR TITLE
feat(dashboard): verdict lineage timeline in task detail overlay

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -116,6 +116,80 @@ function TaskEventsSection() {
   `
 }
 
+// -- Verdict Lineage (compact timeline of the verification pipeline) ---
+
+const VERDICT_LINEAGE_LABELS = new Set([
+  'submit_for_verification',
+  'awaiting_verification',
+  'approve',
+  'approved',
+  'reject',
+  'rejected',
+])
+
+function verdictStageLabel(label: string): string {
+  switch (label) {
+    case 'submit_for_verification':
+    case 'awaiting_verification': return 'Submit'
+    case 'approve':
+    case 'approved': return 'Approve'
+    case 'reject':
+    case 'rejected': return 'Reject'
+    default: return label
+  }
+}
+
+function verdictToneClass(label: string): string {
+  switch (label) {
+    case 'approve':
+    case 'approved': return 'border-ok/30 bg-ok/10 text-ok'
+    case 'reject':
+    case 'rejected': return 'border-warn/30 bg-warn/10 text-warn'
+    default: return 'border-accent/30 bg-[var(--accent-10)] text-accent'
+  }
+}
+
+function VerdictLineageSection() {
+  const events = taskEvents.value
+  const verdictEvents = events
+    .filter((e: NormalizedTaskEvent) => VERDICT_LINEAGE_LABELS.has(e.label))
+    .sort((a: NormalizedTaskEvent, b: NormalizedTaskEvent) => {
+      if (!a.ts) return 1
+      if (!b.ts) return -1
+      return a.ts.localeCompare(b.ts)
+    })
+
+  if (verdictEvents.length === 0) return null
+
+  return html`
+    <div>
+      <div class="text-2xs font-semibold uppercase tracking-3 text-text-muted mb-2">검증 진행 이력</div>
+      <div class="rounded border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3">
+        <div class="flex flex-col gap-2">
+          ${verdictEvents.map((evt: NormalizedTaskEvent, i: number) => {
+            const tone = verdictToneClass(evt.label)
+            const stage = verdictStageLabel(evt.label)
+            const key = evt.ts ? `${evt.ts}-${i}` : `${evt.label}-${i}`
+            return html`
+              <div key=${key} class="flex items-start gap-3">
+                <span class=${`shrink-0 rounded border px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 ${tone}`}>${stage}</span>
+                <div class="flex-1 min-w-0 text-2xs">
+                  <div class="flex flex-wrap items-center gap-2 text-text-body">
+                    ${evt.agent ? html`<span class="font-mono text-accent">@${evt.agent}</span>` : html`<span class="text-text-muted">(unknown)</span>`}
+                    ${evt.actorKind ? html`<span class="text-text-muted">· ${evt.actorKind}</span>` : null}
+                    ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} class="text-3xs text-text-dim" />` : null}
+                  </div>
+                  ${evt.notes ? html`<div class="mt-1 text-3xs text-text-muted break-words"><${RichContent} text=${evt.notes} previewLimit=${1} /></div>` : null}
+                </div>
+              </div>
+            `
+          })}
+        </div>
+      </div>
+    </div>
+  `
+}
+
 function gateTone(status?: string | null): string {
   switch (status) {
     case 'ready': return 'text-ok border-ok/25 bg-ok/10'
@@ -386,6 +460,7 @@ export function TaskDetailOverlay() {
           ` : null}
 
           <${ContractSection} task=${task} />
+          <${VerdictLineageSection} />
           <${ExecutionLinksSection} task=${task} />
           <${HandoffSection} task=${task} />
 


### PR DESCRIPTION
## Summary

- New `VerdictLineageSection` component in `task-detail-overlay.ts` renders a compact Submit / Approve / Reject timeline sourced from `taskEvents` (no new API surface).
- Section auto-hides when no verdict events exist — unchanged UX for tasks without a verification history.
- Inserted between `ContractSection` and `ExecutionLinksSection` so the verdict chain follows the contract gate block immediately.

## Context

Closes the UI half of the verification-surface series (see PRs #8402 / #8422 / #8424 / #8437 / #8440). User feedback: "Task 완료가 왜 완료인지 뭐가 누구에게 단계적으로 검증 됐음을 확인 받았는지 인증이 UI에서 안 보인다." The Kanban column change (#8424) exposed the FSM state; this PR exposes the approval chain itself — who submitted, who approved / rejected, when, with what reason — inside the task detail context instead of forcing a trip to the dedicated 검증 tab.

Plan file: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-t-vectorized-hippo.md` (PR 6, follow-up to PR 3b deferred in the original plan).

## Scope guard

- No change to `dashboard_verification.ml` projection — lineage is derived from existing `taskEvents` on the client.
- No new API endpoint.
- No change to `ContractSection` or the existing event list — the lineage is a specialized view alongside them.
- Section is rendered only in the overview tab (task detail body), not in activity tab.

## Test plan

- [x] `pnpm tsc --noEmit` — clean.
- [ ] Manual: open a task that has been through verification (awaiting → approve or reject), confirm the timeline renders with verifier @agent / timestamp / reason.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)