### PR TITLE
fix(verdict): derive PASS/WARN/FAIL and APPROVE/REJECT enums from Variant SSOT (#8436)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -28,6 +28,17 @@ type verdict =
   | Approve
   | Reject of string
 
+(** Issue #8436: schema enum used to be hand-rolled as a 2-element
+    string list. Payload-bearing [Reject _] prevents the simple
+    [List.map] trick. Witness function below ensures every variant
+    maps to a name in [valid_verdict_strings]. Adding a 3rd
+    constructor will fail compilation in [verdict_constructor_name]. *)
+let verdict_constructor_name = function
+  | Approve -> "APPROVE"
+  | Reject _ -> "REJECT"
+
+let valid_verdict_strings = [ "APPROVE"; "REJECT" ]
+
 type gate =
   | Length
   | Excuse
@@ -216,7 +227,9 @@ let report_review_verdict_schema : Types.tool_schema =
       "properties", `Assoc [
         "verdict", `Assoc [
           "type", `String "string";
-          "enum", `List [`String "APPROVE"; `String "REJECT"];
+          (* Issue #8436: derived from Variant SSOT. Hand-rolled enum
+             risks dropping a constructor on extension. *)
+          "enum", `List (List.map (fun s -> `String s) valid_verdict_strings);
           "description", `String "APPROVE if notes describe real work, REJECT if vague or avoidant";
         ];
         "reason", `Assoc [

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -28,6 +28,15 @@ type verdict =
   | Approve
   | Reject of string
 
+val verdict_constructor_name : verdict -> string
+(** Issue #8436: canonical UPPERCASE name (without payload) for a
+    [verdict] — used as the witness function for schema enum SSOT. *)
+
+val valid_verdict_strings : string list
+(** Issue #8436: complete list of canonical [verdict] strings the
+    schema enum advertises. Adding a 3rd constructor will fail
+    compilation in [verdict_constructor_name]. *)
+
 (** Which gate produced the verdict. Variant type prevents typos that
     would silently compile with a stringly-typed field. *)
 type gate =

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -73,6 +73,21 @@ let verdict_to_string = function
   | Warn reason -> sprintf "WARN: %s" reason
   | Fail reason -> sprintf "FAIL: %s" reason
 
+(** Issue #8436: schema enum for [verdict] used to be hand-rolled as
+    a 3-element string list. Payload-bearing variants ([Warn _],
+    [Fail _]) prevent the simple [List.map verdict_to_string list]
+    trick (it would emit [WARN: <reason>] etc.). Instead we expose the
+    canonical constructor names directly + a witness function that
+    [test_types.ml] uses to assert every variant maps to a name in
+    [valid_verdict_strings]. Adding a 4th constructor will fail
+    compilation in [verdict_to_string] and in [verdict_constructor_name]. *)
+let verdict_constructor_name = function
+  | Pass -> "PASS"
+  | Warn _ -> "WARN"
+  | Fail _ -> "FAIL"
+
+let valid_verdict_strings = [ "PASS"; "WARN"; "FAIL" ]
+
 let has_keyword_boundary upper len =
   let tlen = String.length upper in
   len >= tlen || not (is_word_char upper.[len])
@@ -119,7 +134,9 @@ let report_verdict_schema : Types.tool_schema =
       "properties", `Assoc [
         "verdict", `Assoc [
           "type", `String "string";
-          "enum", `List [`String "PASS"; `String "WARN"; `String "FAIL"];
+          (* Issue #8436: derived from Variant SSOT. Hand-rolled enum
+             risks dropping a constructor on extension. *)
+          "enum", `List (List.map (fun s -> `String s) valid_verdict_strings);
           "description", `String "PASS if correct, WARN if acceptable with concerns, FAIL if wrong or harmful";
         ];
         "reason", `Assoc [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -277,4 +277,31 @@ let () =
         Alcotest.(check bool) "delivery present" true
           (List.mem "delivery" valid_tool_preset_strings));
     ];
+    "verdict_ssot", [
+      (* Issue #8436: payload-bearing variants need a witness function
+         (not List.map verdict_to_string list, which would emit "WARN: "
+         etc). Adding a new constructor will fail compilation in the
+         witness inside the impl. *)
+      Alcotest.test_case "verifier_core covers Pass/Warn/Fail" `Quick (fun () ->
+        let open Masc_mcp.Verifier_core in
+        let witness v =
+          let n = verdict_constructor_name v in
+          if not (List.mem n valid_verdict_strings) then
+            Alcotest.failf "verdict_constructor_name %S not in valid_verdict_strings" n
+        in
+        witness Pass;
+        witness (Warn "x");
+        witness (Fail "y");
+        Alcotest.(check int) "count" 3 (List.length valid_verdict_strings));
+      Alcotest.test_case "anti_rationalization covers Approve/Reject" `Quick (fun () ->
+        let open Masc_mcp.Anti_rationalization in
+        let witness v =
+          let n = verdict_constructor_name v in
+          if not (List.mem n valid_verdict_strings) then
+            Alcotest.failf "verdict_constructor_name %S not in valid_verdict_strings" n
+        in
+        witness Approve;
+        witness (Reject "x");
+        Alcotest.(check int) "count" 2 (List.length valid_verdict_strings));
+    ];
   ]


### PR DESCRIPTION
## Summary
Closes #8436. Two more verdict-style Variants brought into the SSOT helper pattern. Both happen to be in sync today (no missing-constructor bug like #8430), but same drift class as the rest of the series.

## Changes

| File | Variant | Sites |
|------|---------|-------|
| `lib/verifier_core.ml` | `Pass \| Warn _ \| Fail _` | adds `verdict_constructor_name` + `valid_verdict_strings`; replaces enum at line 122 |
| `lib/anti_rationalization.ml` (+ .mli) | `Approve \| Reject _` | same pattern; replaces enum at line 230 |
| `test/test_types.ml` | new `verdict_ssot` section | witness covers every variant in both modules |

## Witness pattern for payloaded Variants

`Verifier_core.verdict_to_string` returns `"WARN: <reason>"`, not `"WARN"` — so `List.map verdict_to_string [Pass; Warn ""; Fail ""]` would corrupt the schema enum. Instead each module exposes a `verdict_constructor_name` (Variant → canonical name without payload) plus a `valid_verdict_strings` list. The witness function in tests asserts every `verdict_constructor_name` result appears in the list — adding a new constructor fails compilation in `verdict_constructor_name`.

This is the same trick used for `task_status` in #8357 (which has record payloads).

## Pattern catalog (now 10 sites)
| PR | Variant | Real bug? |
|----|---------|-----------|
| #8350-#8398 | task_action / task_status / agent_status / agent_role / visibility | partial |
| #8430 | tool_preset | YES (Social, Delivery missing) |
| **THIS** | **verifier_core.verdict + anti_rationalization.verdict** | no (hygiene) |

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_types.exe` — 24/24 pass (2 new verdict_ssot tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)