### PR TITLE
chore(scripts): TLC artefact + merged-worktree cleanup (non-destructive)

### DIFF
--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Safely remove worktrees whose branch is already merged into main.
+# Never uses --force.  Respects uncommitted changes.
+#
+# Usage:
+#   ./scripts/cleanup-merged-worktrees.sh          # dry run, shows candidates
+#   ./scripts/cleanup-merged-worktrees.sh --apply  # actually remove
+
+set -euo pipefail
+
+APPLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=1 ;;
+    -h|--help)
+      sed -n '1,15p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git fetch origin main --quiet
+
+# Two merged sources:
+#  (1) `git branch --merged origin/main` — catches fast-forward / non-squash merges
+#  (2) `gh pr list --state merged` — catches squash-merges (common case on this repo)
+# Union both so squash-merged worktrees are actually cleaned.
+FF_MERGED="$(git branch --merged origin/main | sed 's/^[* ]*//' | grep -v '^main$' || true)"
+
+if command -v gh >/dev/null 2>&1; then
+  SQUASH_MERGED="$(gh pr list --state merged --limit 500 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
+else
+  SQUASH_MERGED=""
+fi
+
+MERGED_BRANCHES="$(printf '%s\n%s\n' "$FF_MERGED" "$SQUASH_MERGED" | awk 'NF' | sort -u)"
+if [ -z "$MERGED_BRANCHES" ]; then
+  echo "No merged branches to clean."
+  exit 0
+fi
+
+removed=0
+skipped=0
+dirty=0
+
+while read -r branch; do
+  [ -z "$branch" ] && continue
+  wt_path="$(git worktree list --porcelain | awk -v b="refs/heads/$branch" '/^worktree /{p=$2} /^branch /{if ($2==b) print p}')"
+  [ -z "$wt_path" ] && continue
+  [ "$wt_path" = "$REPO_ROOT" ] && continue
+
+  # Skip if worktree has uncommitted changes
+  if ! git -C "$wt_path" diff --quiet 2>/dev/null || ! git -C "$wt_path" diff --cached --quiet 2>/dev/null; then
+    echo "DIRTY  $wt_path (branch $branch) — skipped"
+    dirty=$((dirty+1))
+    continue
+  fi
+
+  if [ "$APPLY" -eq 1 ]; then
+    if git worktree remove "$wt_path" 2>/dev/null; then
+      echo "REMOVED $wt_path (branch $branch)"
+      removed=$((removed+1))
+      git branch -d "$branch" 2>/dev/null || true
+    else
+      echo "SKIP    $wt_path (remove failed — likely locked or submodule state)"
+      skipped=$((skipped+1))
+    fi
+  else
+    echo "CANDID  $wt_path (branch $branch)"
+    removed=$((removed+1))
+  fi
+done <<< "$MERGED_BRANCHES"
+
+if [ "$APPLY" -eq 1 ]; then
+  git worktree prune
+  echo ""
+  echo "Summary: removed=$removed skipped=$skipped dirty=$dirty"
+else
+  echo ""
+  echo "Summary: $removed candidates (dry run — pass --apply to remove)"
+fi

--- a/scripts/cleanup-tlc-artifacts.sh
+++ b/scripts/cleanup-tlc-artifacts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Clean up TLC model-checker disk artefacts that Makefile's -cleanup flag misses.
+# Safe: only touches paths matched by specs/.gitignore rules.
+# Idempotent: no-op if already clean.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SPECS_DIR="$REPO_ROOT/specs"
+
+if [ ! -d "$SPECS_DIR" ]; then
+  echo "cleanup-tlc-artifacts: no specs/ dir, skipping"
+  exit 0
+fi
+
+before_kb=$(du -sk "$SPECS_DIR" 2>/dev/null | awk '{print $1}')
+
+# specs/states/ (top-level MC export) — entirely gitignored
+rm -rf "$SPECS_DIR/states" 2>/dev/null || true
+
+# specs/**/states/ — per-spec MC state dir (gitignored)
+find "$SPECS_DIR" -type d -name states -prune -exec rm -rf {} + 2>/dev/null || true
+
+# specs/**/*_TTrace_*.bin|.tla and TraceData.tla — gitignored
+find "$SPECS_DIR" -type f \( \
+  -name '*_TTrace_*.bin' -o \
+  -name '*_TTrace_*.tla' -o \
+  -name 'TraceData.tla' \
+  \) -delete 2>/dev/null || true
+
+after_kb=$(du -sk "$SPECS_DIR" 2>/dev/null | awk '{print $1}')
+freed_mb=$(( (before_kb - after_kb) / 1024 ))
+
+if [ "$freed_mb" -gt 0 ]; then
+  echo "cleanup-tlc-artifacts: freed ${freed_mb} MB"
+else
+  echo "cleanup-tlc-artifacts: no artefacts to clean"
+fi

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -50,7 +50,12 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)
 BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure list
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure list clean clean-artefacts
+
+clean: clean-artefacts
+
+clean-artefacts:
+	@bash $(shell git rev-parse --show-toplevel)/scripts/cleanup-tlc-artifacts.sh
 
 check-all: check-clean check-buggy
 	@echo "=== All TLA+ specs passed ==="


### PR DESCRIPTION
## ⚠️ DO NOT MERGE without operator review

This PR only adds cleanup scripts and a Makefile target. It does NOT execute any cleanup. Operator must invoke the scripts manually.

## Why

Measured 2026-04-18 on masc-mcp root checkout (not a worktree):
- `specs/states/` 58 GB, `specs/masc-ecosystem/` 24 GB, `specs/bug-models/` 9.5 GB, `specs/keeper-state-machine/` 2 GB — TLA+ Model Checker export dirs, all matched by `specs/.gitignore` but the Makefile never cleans them.
- `.worktrees/` contains 335 worktrees, 272 of them on branches already merged into main (via fast-forward or squash). Each worktree is 60-650 MB. Rough total: 80 GB+.
- `_build_task215/` 97 MB stray dune alternate build-dir in repo root.

Neither of these is a dune bug. dune is behaving correctly per worktree.

## What

1. `scripts/cleanup-tlc-artifacts.sh`
   - Removes `specs/states/`, `specs/**/states/`, `*_TTrace_*.bin`, `*_TTrace_*.tla`, `TraceData.tla`.
   - All paths gitignored, so tracked `.tla`/`.cfg` files are NOT touched.
   - Idempotent. Reports MB freed.
2. `scripts/cleanup-merged-worktrees.sh`
   - Dry-run by default. `--apply` actually removes.
   - Detects merged branches via BOTH `git branch --merged origin/main` (ff) AND `gh pr list --state merged` (squash).
   - Skips worktrees with uncommitted/staged changes.
   - Never uses `--force`.
3. `specs/Makefile` — new `clean` / `clean-artefacts` targets.

## Test plan

- [x] `bash -n` syntax check both scripts
- [x] `make -C specs -n clean-artefacts` shows correct invocation
- [x] `scripts/cleanup-merged-worktrees.sh` dry-run shows 272 candidates without any action taken

## How operators use this

```bash
# reclaim TLC artefacts (safe)
make -C specs clean

# preview worktree cleanup
./scripts/cleanup-merged-worktrees.sh

# execute worktree cleanup
./scripts/cleanup-merged-worktrees.sh --apply
```

## Risk

Very low. PR only adds files, does not delete anything. Both scripts have safety guards (gitignore-matched paths, dirty-check, no --force).

## Follow-up (separate work)

- Wire `make clean` into CI post-run step so TLC artefacts don't accumulate.
- Consider a session-end hook that runs `cleanup-merged-worktrees.sh --apply` automatically.

## References
- Session 2026-04-18 tick 7 disk audit
- `feedback_no-push-after-squash-merge.md`
- `feedback_draft-banner-useless-against-masc-auto-merge.md`