### PR TITLE
fix(#8391 HIGH #3): observe write_meta failure in keeper_supervisor presence sync

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -208,7 +208,12 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     let live_meta =
       try
         let synced = ensure_keeper_room_presence ctx.config meta in
-        ignore (write_meta ctx.config synced);
+        (match write_meta ctx.config synced with
+         | Ok () -> ()
+         | Error msg ->
+           Log.Keeper.warn
+             "supervisor presence sync: write_meta failed for %s: %s"
+             meta.name msg);
         synced
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Keeper.error "supervisor presence sync failed: %s"

--- a/test/dune
+++ b/test/dune
@@ -940,6 +940,11 @@
  (libraries alcotest unix str))
 
 (test
+ (name test_keeper_supervisor_write_meta_source)
+ (modules test_keeper_supervisor_write_meta_source)
+ (libraries alcotest unix str))
+
+(test
  (name test_channel_gate)
  (modules test_channel_gate)
  (libraries masc_test_deps))

--- a/test/test_keeper_supervisor_write_meta_source.ml
+++ b/test/test_keeper_supervisor_write_meta_source.ml
@@ -1,0 +1,77 @@
+(** Structural guard for issue #8391 HIGH #3.
+
+    [lib/keeper/keeper_supervisor.ml] used [ignore (write_meta ...)] inside
+    [supervise_keepalive]'s presence sync. A write failure silently dropped
+    the error while the in-memory [Keeper_registry] entry still advertised
+    the synced meta → registry/disk divergence with no log line.
+
+    This test pins the fix:
+
+    - (a) the raw [ignore (write_meta ...)] pattern must not reappear in
+          [keeper_supervisor.ml]
+    - (b) the file must keep a [match write_meta ...] with an [Error]
+          arm (any observable handling), so the failure is not discarded
+          again by refactors.
+
+    Structural (source grep) rather than behavioural because the call
+    site is inside [supervise_keepalive], which requires a full Coord /
+    Keeper_registry fixture to exercise; the risk we guard against is
+    exactly that someone collapses the handler back to [ignore] during
+    cleanup.
+*)
+
+open Alcotest
+
+let target_file = "lib/keeper/keeper_supervisor.ml"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path)
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic)
+
+let contains_re haystack re =
+  try
+    let _ = Str.search_forward re haystack 0 in
+    true
+  with Not_found -> false
+
+let test_no_ignore_write_meta () =
+  let src = load_source target_file in
+  let re = Str.regexp "ignore[ \t]*([ \t]*write_meta" in
+  check bool
+    "keeper_supervisor.ml must not call `ignore (write_meta ...)` (silent failure — issue #8391 HIGH #3)"
+    false
+    (contains_re src re)
+
+let test_error_arm_present () =
+  let src = load_source target_file in
+  (* Fix must keep a match on write_meta with an Error arm, so a future
+     refactor cannot re-silence the failure. *)
+  let match_re = Str.regexp "match[ \t\n]+write_meta" in
+  let error_re = Str.regexp "|[ \t]*Error" in
+  check bool
+    "keeper_supervisor.ml must retain `match write_meta ...` handling"
+    true
+    (contains_re src match_re);
+  check bool
+    "keeper_supervisor.ml must retain an `Error` arm near write_meta"
+    true
+    (contains_re src error_re)
+
+let () =
+  run "keeper_supervisor_write_meta_source" [
+    "silent_failure_guard", [
+      test_case "no `ignore (write_meta ...)`" `Quick test_no_ignore_write_meta;
+      test_case "match write_meta + Error arm present" `Quick test_error_arm_present;
+    ];
+  ]


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

Draft — awaiting triage under the #8391 silent-failure sweep. Label
`do-not-merge` applied; review welcome, merge gated on the sweep owner.

## Why

`lib/keeper/keeper_supervisor.ml:211` used
`ignore (write_meta ctx.config synced)` inside `supervise_keepalive`'s
presence sync. A write failure was swallowed silently while
`Keeper_registry.update_meta` continued to publish the synced meta →
**in-memory registry diverges from the on-disk meta file with zero log
signal**. Operators have no way to notice the drift.

Tracked as HIGH #3 in silent-failure rollup #8391.

## Root cause

`lib/keeper/keeper_supervisor.ml:211` (pre-fix):

```ocaml
let synced = ensure_keeper_room_presence ctx.config meta in
ignore (write_meta ctx.config synced);   (* <— (unit, string) result discarded *)
synced
```

`Keeper_types.write_meta` returns `(unit, string) result`. The `ignore`
fold collapses `Error msg` into the same no-op as `Ok ()`.

## Fix

Replace `ignore` with a match. Log the stringified error at `warn` on the
`Error` arm. Keep the registry update path unchanged (no circuit break —
this PR is observability-only).

```ocaml
let synced = ensure_keeper_room_presence ctx.config meta in
(match write_meta ctx.config synced with
 | Ok () -> ()
 | Error msg ->
   Log.Keeper.warn
     "supervisor presence sync: write_meta failed for %s: %s"
     meta.name msg);
synced
```

No metrics counter added — no `Metrics.incr` convention exists in this
module; keeping scope minimal. If a keeper-level counter is desired later,
it can piggy-back on the new warn log site.

## Test plan

- New structural guard
  `test/test_keeper_supervisor_write_meta_source.ml` (pattern mirrors the
  existing `test_keeper_pause_silent_failure_source.ml` for HIGH #1):
  - asserts `lib/keeper/keeper_supervisor.ml` contains no
    `ignore[\s]*([\s]*write_meta` match
  - asserts the file retains a `match write_meta ...` with an `| Error`
    arm, so a future refactor cannot re-silence the failure
- Local runs (in worktree):
  - `dune build --root . @check` → clean
  - `dune exec --root . test/test_keeper_supervisor_write_meta_source.exe`
    → 2/2 pass
  - `dune exec --root . test/test_keeper_supervisor.exe` → 18/18 pass
    (baseline unchanged)

Behavioural test (stub `write_meta` returning `Error`) was considered
but rejected — `supervise_keepalive` requires a full Coord /
`Keeper_registry` fixture; the risk class is "someone collapses the
handler back to `ignore` during cleanup", which is exactly what the
structural guard catches.

## Risk

None in steady state. Strictly observability:

- Success path: identical to before (no log).
- Failure path: emits one `Log.Keeper.warn` line per sync cycle and
  returns `synced` as before. No new branches, no new state.

Diff: 7 LOC prod, 77 LOC test (structural guard), 5 LOC dune.

## References

- #8391 — silent-failure rollup (HIGH #3)
- #7036, #7772 — prior silent-failure fixes in the same area