### PR TITLE
fix(board): introduce sort_order SSOT helpers + derive schema enum (#8449 PR A)

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -8,6 +8,37 @@
 
 type sort_order = Hot | Trending | Recent | Updated | Discussed
 
+(** Issue #8449: SSOT helpers for [sort_order]. Three call sites used to
+    own private parsers and a separate Variant in [Tool_board]; this PR
+    A introduces the canonical helpers here so the schema enum can derive
+    from the Variant. PR B will collapse the duplicate Variant; PR C
+    will route [server_utils] through these parsers.
+
+    All constructors are nullary so [List.map] works. *)
+let all_sort_orders = [ Hot; Trending; Recent; Updated; Discussed ]
+
+let sort_order_to_string = function
+  | Hot -> "hot"
+  | Trending -> "trending"
+  | Recent -> "recent"
+  | Updated -> "updated"
+  | Discussed -> "discussed"
+
+let valid_sort_order_strings = List.map sort_order_to_string all_sort_orders
+
+(** Lenient parser: canonical names plus documented aliases that the
+    three pre-existing parsers (Tool_board.sort_order_of_string,
+    Tool_board.parse_sort_order, server_utils inline) all accept.
+    Aliases: new=Recent, active=Updated, comments=Discussed. *)
+let sort_order_of_string_opt s =
+  match String.lowercase_ascii (String.trim s) with
+  | "hot" -> Some Hot
+  | "trending" -> Some Trending
+  | "recent" | "new" -> Some Recent
+  | "updated" | "active" -> Some Updated
+  | "discussed" | "comments" -> Some Discussed
+  | _ -> None
+
 type board_backend =
   | Jsonl of Board.store
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -708,7 +708,14 @@ let tool_post_list : Types.tool_schema = {
       ("hearth", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter by hearth topic (e.g. webrtc, code-review)")]);
       ("random", `Assoc [("type", `String "boolean"); ("description", `String "Shuffle posts randomly (default: false)")]);
       ("offset", `Assoc [("type", `String "integer"); ("description", `String "Skip first N posts (default: 0)"); ("minimum", `Int 0); ("maximum", `Int 1000)]);
-      ("sort_by", `Assoc [("type", `String "string"); ("enum", `List [`String "hot"; `String "trending"; `String "recent"; `String "updated"; `String "discussed"]); ("description", `String "Sort order (default: hot)")]);
+      ("sort_by", `Assoc [
+        ("type", `String "string");
+        (* Issue #8449 PR A: derived from Board_dispatch.sort_order Variant SSOT.
+           Hand-rolled enum had 5 values that happened to be in sync; future
+           constructor would silently miss this site. *)
+        ("enum", `List (List.map (fun s -> `String s) Board_dispatch.valid_sort_order_strings));
+        ("description", `String "Sort order (default: hot)");
+      ]);
       ("exclude_system", `Assoc [("type", `String "boolean"); ("description", `String "Exclude system posts like Activity Reports (default: false)")]);
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -38,6 +38,36 @@ let test_visibility_strings_complete () =
       (List.mem expected strs)
   ) ["public"; "unlisted"; "internal"; "direct"]
 
+(* Issue #8449 PR A: Board_dispatch.sort_order schema enum SSOT.
+   Witness covers all 5 variants; adding a 6th constructor will fail
+   compilation in [sort_order_to_string]. *)
+let test_sort_order_witness_in_enum () =
+  let module D = Masc_mcp.Board_dispatch in
+  let witness s =
+    let actual = D.sort_order_to_string s in
+    if not (List.mem actual D.valid_sort_order_strings) then
+      Alcotest.failf "sort_order_to_string %S not in valid_sort_order_strings" actual
+  in
+  witness D.Hot;
+  witness D.Trending;
+  witness D.Recent;
+  witness D.Updated;
+  witness D.Discussed;
+  Alcotest.(check int) "count" 5
+    (List.length D.valid_sort_order_strings)
+
+let test_sort_order_aliases () =
+  let module D = Masc_mcp.Board_dispatch in
+  Alcotest.(check (option string)) "new -> Recent" (Some "recent")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "new"));
+  Alcotest.(check (option string)) "active -> Updated" (Some "updated")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "active"));
+  Alcotest.(check (option string)) "comments -> Discussed" (Some "discussed")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "comments"));
+  Alcotest.(check (option string)) "garbage rejected" None
+    (D.sort_order_of_string_opt "definitely-not-an-order"
+     |> Option.map D.sort_order_to_string)
+
 let test_permanent_post () =
   let store = create_store () in
   match
@@ -183,6 +213,13 @@ let () =
             test_visibility_witness_in_enum;
           Alcotest.test_case "all 4 strings present" `Quick
             test_visibility_strings_complete;
+        ] );
+      ( "sort_order_ssot",
+        [
+          Alcotest.test_case "witness covers all 5 variants" `Quick
+            test_sort_order_witness_in_enum;
+          Alcotest.test_case "aliases new/active/comments accepted" `Quick
+            test_sort_order_aliases;
         ] );
       ( "post_kind",
         [


### PR DESCRIPTION
## Summary
PR A of 3 for #8449. Introduces canonical `sort_order` SSOT helpers in `Board_dispatch` and derives the `tool_board` schema enum from them. Smallest, lowest-risk slice — does not touch the duplicate Variant in `tool_board.ml` (PR B) or the inline parser in `server_utils` (PR C).

## Changes

| File | Change |
|------|--------|
| `lib/board_dispatch.ml` | Add `all_sort_orders`, `sort_order_to_string`, `valid_sort_order_strings`, `sort_order_of_string_opt` (canonical + aliases). |
| `lib/tool_board.ml:711` | Replace literal enum with `List.map (fun s -> ` ` `String s) Board_dispatch.valid_sort_order_strings`. |
| `test/test_board_ttl.ml` | New `sort_order_ssot` section: witness covers all 5 variants + alias acceptance test. |

## Why split into 3 PRs
The full unification (one Variant, one parser, no bridge) touches 4+ files and changes the public Variant alias in `Tool_board`. Doing it in one PR risks merge-window blocking on review. PR A lands the helpers + ratchets schema drift; B and C are mechanical follow-ups that depend on A.

## Pattern catalog (now 11)
| PR | Variant | Real bug? |
|----|---------|-----------|
| #8430 | tool_preset | YES — Social, Delivery missing |
| #8445 | verifier_core.verdict + anti_rationalization.verdict | no |
| **THIS (PR A)** | **sort_order (helpers + enum derive)** | no (yet — 4-site drift surface) |

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_board_ttl.exe` — 13/13 pass (2 new sort_order_ssot tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)