### PR TITLE
feat(dashboard): surface Verifier role badge on keeper config panel

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -9,6 +9,7 @@ import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens } from '../lib/format-number'
+import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { createAsyncResource, loaded } from '../lib/async-state'
@@ -804,6 +805,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
 
       <${SectionHeader} title="네임스페이스 조율" />
+      ${isVerifierRoleKeeper(c.coordination.mention_targets) ? html`
+      <div class="mb-2 flex items-center gap-2 rounded border border-accent/30 bg-[var(--accent-10)] px-3 py-2">
+        <span class="rounded border border-accent/40 bg-[var(--accent-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 text-accent">Verifier</span>
+        <span class="text-2xs text-text-body">이 keeper는 task completion_contract를 독립 실측하는 검증자 역할입니다.</span>
+      </div>
+      ` : null}
       <${ConfigRow} label="프로젝트 범위" value=${c.coordination.room_scope || '--'} />
       ${c.coordination.mention_targets.length > 0 ? html`
       <div class="mt-1.5">

--- a/dashboard/src/lib/keeper-utils.test.ts
+++ b/dashboard/src/lib/keeper-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isVerifierRoleKeeper } from './keeper-utils'
+
+describe('isVerifierRoleKeeper', () => {
+  it('detects the english "verifier" token', () => {
+    expect(isVerifierRoleKeeper(['verifier'])).toBe(true)
+  })
+
+  it('detects the korean "검증자" token', () => {
+    expect(isVerifierRoleKeeper(['검증자'])).toBe(true)
+  })
+
+  it('rejects non-verifier mention targets', () => {
+    expect(isVerifierRoleKeeper(['analyst', 'scholar'])).toBe(false)
+  })
+
+  it('returns false for empty mention targets', () => {
+    expect(isVerifierRoleKeeper([])).toBe(false)
+  })
+
+  it('returns false for null / undefined', () => {
+    expect(isVerifierRoleKeeper(null)).toBe(false)
+    expect(isVerifierRoleKeeper(undefined)).toBe(false)
+  })
+
+  it('accepts mixed mention targets including the verifier token', () => {
+    expect(isVerifierRoleKeeper(['analyst', 'verifier', 'guard'])).toBe(true)
+  })
+})

--- a/dashboard/src/lib/keeper-utils.ts
+++ b/dashboard/src/lib/keeper-utils.ts
@@ -8,3 +8,18 @@ export function findKeeper(name?: string | null): Keeper | null {
   if (!name) return null
   return keepers.value.find(k => k.name === name || k.agent_name === name) ?? null
 }
+
+/**
+ * Client-side mirror of Keeper_unified_turn.is_verifier_role_keeper (OCaml).
+ * Returns true when mention_targets include one of the verifier role tokens
+ * ("verifier" / "검증자"). Used by dashboard surfaces that need to distinguish
+ * verification-authority keepers without reloading the persona profile.
+ */
+const VERIFIER_ROLE_MENTION_TOKENS: readonly string[] = ['verifier', '검증자']
+
+export function isVerifierRoleKeeper(
+  mentionTargets: readonly string[] | null | undefined,
+): boolean {
+  if (!mentionTargets || mentionTargets.length === 0) return false
+  return VERIFIER_ROLE_MENTION_TOKENS.some(token => mentionTargets.includes(token))
+}


### PR DESCRIPTION
## Summary

- Adds `isVerifierRoleKeeper()` in `dashboard/src/lib/keeper-utils.ts` — client-side mirror of the OCaml `Keeper_unified_turn.is_verifier_role_keeper` predicate, taking the `mention_targets` array and returning true when it includes `"verifier"` or `"검증자"`.
- `keeper-config-panel.ts` renders a cyan "Verifier" badge + short explanation at the top of the 네임스페이스 조율 section when the predicate matches, so verifier-authority keepers are visually distinct in the keeper detail view.
- 6 unit tests in `keeper-utils.test.ts` cover English token, Korean token, non-verifier rejection, empty, null/undefined, mixed targets.

## Context

Cashes in the `verifier_role_keeper` wiring from #8422 — the OCaml predicate was landed and emitted on every decision record, but no UI surface rendered it, so the user-reported gap "검증자 keeper 자체도 흔적이 없다" was only half-addressed. This PR closes that loop on the Keeper Config panel. The next natural consumer would be the Keeper list/grid (badge on the card face), which can follow in a separate PR once the helper is in place.

## Scope guard

- Client helper duplicates (not reuses) the OCaml predicate — intentional, to avoid a wire-format dependency. Both share the canonical constant `["verifier", "검증자"]` and must stay in sync; a cross-language test could be added later.
- No change to `KeeperConfigCoordination` type, API schema, or server projection.
- Only the keeper-config-panel surface gains the badge in this PR (keeper grid / detail header follow-ups are separate).

## Test plan

- [x] `pnpm vitest run src/lib/keeper-utils.test.ts` — 6/6 pass.
- [x] `pnpm tsc --noEmit` — clean.
- [ ] Manual: spawn a verifier persona keeper, open its config panel, confirm the badge appears at the top of 네임스페이스 조율. Spawn a non-verifier keeper, confirm the badge is absent.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)