### PR TITLE
test: lock dashboard runtime and MCP transport regressions

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -8,6 +8,7 @@ import {
   post,
   runOperatorAction,
 } from './core'
+import { OperatorActionSchemaDriftError } from './schemas/operator-action'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -106,6 +107,70 @@ describe('post', () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const headers = init.headers as Record<string, string>
     expect(headers['X-MASC-Agent'] ?? headers['x-masc-agent']).toBe('dashboard-manual-actor')
+  })
+  it('surfaces invalid JSON in 200 operator action responses as ApiRequestError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('not-json', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(runOperatorAction({
+      actor: 'dashboard-manual-actor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'keeper-one',
+      payload: {},
+    })).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 200,
+      detail: 'invalid JSON response',
+      message: 'POST /api/v1/operator/action: invalid JSON response',
+    })
+  })
+
+  it('surfaces empty JSON in 200 operator confirm responses as ApiRequestError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(confirmOperatorAction(
+      'dashboard-manual-actor',
+      'opc_test_token',
+      'deny',
+    )).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 200,
+      detail: 'empty JSON response',
+      message: 'POST /api/v1/operator/confirm: empty JSON response',
+    })
+  })
+
+  it('rejects 200 operator action payloads whose JSON body is still missing the status contract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"result":{"ok":true}}', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(runOperatorAction({
+      actor: 'dashboard-manual-actor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'keeper-one',
+      payload: {},
+    })).rejects.toBeInstanceOf(OperatorActionSchemaDriftError)
   })
 })
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -263,6 +263,47 @@ export async function apiRequestErrorFromResponse(
   })
 }
 
+async function parseJsonResponse<T>(
+  method: string,
+  path: string,
+  res: Response,
+): Promise<T> {
+  let rawText = ''
+  try {
+    rawText = await res.text()
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'failed to read response body',
+    })
+  }
+
+  if (rawText.trim() === '') {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'empty JSON response',
+    })
+  }
+
+  try {
+    return JSON.parse(rawText) as T
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'invalid JSON response',
+    })
+  }
+}
+
 function isNotInitializedEnvelope(raw: unknown): boolean {
   if (!isRecord(raw)) return false
   return typeof raw.error === 'string' && raw.error.trim().toLowerCase() === 'not initialized'
@@ -395,13 +436,13 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     }
     throw await apiRequestErrorFromResponse('GET', path, res)
   }
-  const data = await res.json()
+  const data = await parseJsonResponse<T>('GET', path, res)
   // Server may return 200 OK with {"error":"not initialized"} during startup
   if (DASHBOARD_BOOTSTRAP_WARM_PATHS.has(path) && isNotInitializedEnvelope(data)) {
     const payload = bootstrapInitializingPayload(path)
     if (payload !== null) return payload as T
   }
-  return data as T
+  return data
 }
 
 export function sleep(ms: number): Promise<void> {
@@ -475,7 +516,7 @@ export async function post<T>(
   if (!res.ok) {
     throw await apiRequestErrorFromResponse('POST', path, res)
   }
-  return res.json() as Promise<T>
+  return parseJsonResponse<T>('POST', path, res)
 }
 
 export async function patch<T>(
@@ -496,7 +537,7 @@ export async function patch<T>(
   if (!res.ok) {
     throw await apiRequestErrorFromResponse('PATCH', path, res)
   }
-  return res.json() as Promise<T>
+  return parseJsonResponse<T>('PATCH', path, res)
 }
 
 export async function postRaw(

--- a/dashboard/src/components/activity-swimlane-fetch.test.ts
+++ b/dashboard/src/components/activity-swimlane-fetch.test.ts
@@ -1,0 +1,137 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { signal } from '@preact/signals'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+function emptySwimlane() {
+  return {
+    agents: [],
+    spans: [],
+    time_range: {
+      min_ms: 0,
+      max_ms: 0,
+    },
+  }
+}
+
+async function loadSwimlane(options: {
+  fetchSwimlane: ReturnType<typeof vi.fn>
+  onRegisterRefresh?: (fn: () => void) => void
+}) {
+  vi.resetModules()
+  vi.doMock('../api', () => ({
+    fetchSwimlane: options.fetchSwimlane,
+  }))
+  vi.doMock('../sse-store', () => ({
+    registerActivityRefresh: vi.fn((fn: () => void) => {
+      options.onRegisterRefresh?.(fn)
+      return () => {}
+    }),
+  }))
+  vi.doMock('./common/card', () => ({
+    Card: ({ children, testId, title }: { children?: unknown; testId?: string; title?: string }) =>
+      html`<section data-testid=${testId ?? undefined}><h2>${title ?? ''}</h2>${children}</section>`,
+  }))
+  vi.doMock('./common/feedback-state', () => ({
+    EmptyState: ({ children }: { children?: unknown }) => html`<div>${children}</div>`,
+    LoadingState: ({ children }: { children?: unknown }) => html`<div>${children}</div>`,
+  }))
+  vi.doMock('./activity-graph-view', () => ({
+    selectedNodeId: signal<string | null>(null),
+    highlightedAgentId: signal<string | null>(null),
+  }))
+  vi.doMock('../lib/format-time', () => ({
+    formatDurationMs: (ms: number) => `${ms}ms`,
+  }))
+  vi.doMock('../lib/escape-html', () => ({
+    escapeHtml: (value: string) => value,
+    tooltipHtml: (lines: string[]) => lines.join(' | '),
+  }))
+  vi.doMock('vis-data', () => ({
+    DataSet: class MockDataSet<T> {
+      readonly items: T[]
+
+      constructor(items: T[]) {
+        this.items = items
+      }
+
+      get(): undefined {
+        return undefined
+      }
+    },
+  }))
+  vi.doMock('vis-timeline', () => ({
+    Timeline: class MockTimeline {
+      on(): void {}
+
+      setSelection(): void {}
+
+      focus(): void {}
+
+      destroy(): void {}
+    },
+  }))
+  return import('./activity-swimlane')
+}
+
+describe('ActivitySwimlane fetch wiring', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('fetches swimlane for the mounted range and the updated range', async () => {
+    const fetchSwimlane = vi.fn().mockResolvedValue(emptySwimlane())
+    const { ActivitySwimlane } = await loadSwimlane({ fetchSwimlane })
+
+    render(html`<${ActivitySwimlane} since="1h" />`, container)
+    await flushUi()
+
+    render(html`<${ActivitySwimlane} since="24h" />`, container)
+    await flushUi()
+
+    expect(fetchSwimlane).toHaveBeenCalledTimes(2)
+    expect(fetchSwimlane.mock.calls[0]?.[0]).toBe('1h')
+    expect(fetchSwimlane.mock.calls[1]?.[0]).toBe('24h')
+  })
+
+  it('re-fetches swimlane with the latest range when activity refresh fires', async () => {
+    let activityRefreshCallback: (() => void) | undefined
+    const fetchSwimlane = vi.fn().mockResolvedValue(emptySwimlane())
+    const { ActivitySwimlane } = await loadSwimlane({
+      fetchSwimlane,
+      onRegisterRefresh: (fn) => { activityRefreshCallback = fn },
+    })
+
+    render(html`<${ActivitySwimlane} since="1h" />`, container)
+    await flushUi()
+
+    render(html`<${ActivitySwimlane} since="24h" />`, container)
+    await flushUi()
+
+    expect(activityRefreshCallback).toBeTypeOf('function')
+    const callback = activityRefreshCallback
+    if (callback == null) throw new Error('missing activity refresh callback')
+    callback()
+    await flushUi()
+
+    expect(fetchSwimlane).toHaveBeenCalledTimes(3)
+    expect(fetchSwimlane.mock.calls[2]?.[0]).toBe('24h')
+  })
+})

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -44,7 +44,8 @@ let parse_status header_raw =
   in
   find_http lines
 
-let run_curl_post ?(max_time_sec = 8) ~port ~path ~session_id ~payload () =
+let run_curl_post ?(max_time_sec = 8) ?(extra_headers = []) ~port ~path
+    ~session_id ~payload () =
   let header_file = Filename.temp_file "mcp-post-sse-header-" ".txt" in
   let body_file = Filename.temp_file "mcp-post-sse-body-" ".txt" in
   let data_file = Filename.temp_file "mcp-post-sse-request-" ".json" in
@@ -53,32 +54,39 @@ let run_curl_post ?(max_time_sec = 8) ~port ~path ~session_id ~payload () =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc payload);
+  let extra_header_args =
+    List.concat_map (fun header -> [ "-H"; header ]) extra_headers
+  in
   let args =
-    [|
-      "curl";
-      "-sS";
-      "-N";
-      "--http1.1";
-      "--max-time";
-      string_of_int max_time_sec;
-      "-X";
-      "POST";
-      "-H";
-      "Content-Type: application/json";
-      "-H";
-      "Accept: application/json, text/event-stream";
-      "-H";
-      Printf.sprintf "Mcp-Session-Id: %s" session_id;
-      "-H";
-      "Mcp-Protocol-Version: 2025-11-25";
-      "-o";
-      body_file;
-      "-D";
-      header_file;
-      "--data-binary";
-      "@" ^ data_file;
-      url;
-    |]
+    Array.of_list
+      ([
+         "curl";
+         "-sS";
+         "-N";
+         "--http1.1";
+         "--max-time";
+         string_of_int max_time_sec;
+         "-X";
+         "POST";
+         "-H";
+         "Content-Type: application/json";
+         "-H";
+         "Accept: application/json, text/event-stream";
+         "-H";
+         Printf.sprintf "Mcp-Session-Id: %s" session_id;
+         "-H";
+         "Mcp-Protocol-Version: 2025-11-25";
+       ]
+      @ extra_header_args
+      @ [
+          "-o";
+          body_file;
+          "-D";
+          header_file;
+          "--data-binary";
+          "@" ^ data_file;
+          url;
+        ])
   in
   let (ic, oc2, ec) =
     Unix.open_process_args_full "curl" args (Unix.environment ())
@@ -375,6 +383,47 @@ let test_post_tools_call_streams_sse_framing () =
   in
   check bool "status text present" true (String.length text > 0)
 
+let rec join_until_ready ~port ~retries_left =
+  let result =
+    run_curl_post ~max_time_sec:8 ~port ~path:"/mcp"
+      ~session_id:"legacy-agent-name-preservation"
+      ~extra_headers:[ "X-MASC-Agent: dashboard-header-actor" ]
+      ~payload:
+        (tool_payload ~id:202 ~name:"masc_join"
+           ~arguments:(`Assoc [ ("agent_name", `String "gemini") ]))
+      ()
+  in
+  match (result.status, retries_left) with
+  | Some 500, retries
+    when retries > 0
+         && contains_substr "Server state not initialized" result.body ->
+      Unix.sleepf 0.5;
+      join_until_ready ~port ~retries_left:(retries - 1)
+  | Some 503, retries
+    when retries > 0
+         && contains_substr "Server is starting up, not ready yet" result.body ->
+      Unix.sleepf 0.5;
+      join_until_ready ~port ~retries_left:(retries - 1)
+  | _ -> result
+
+let test_post_tools_call_preserves_explicit_legacy_agent_name () =
+  with_server @@ fun ~port ->
+  let result = join_until_ready ~port ~retries_left:40 in
+  require_http_ok "legacy agent_name preservation tools/call" result;
+  check int "curl exits cleanly" 0 result.curl_exit;
+  let json = parse_json_body "legacy agent_name preservation tools/call" result in
+  check bool "json-rpc error absent" true (json |> U.member "error" = `Null);
+  check bool "tool succeeded" false
+    (json |> U.member "result" |> U.member "isError" |> U.to_bool);
+  let text =
+    json |> U.member "result" |> U.member "content" |> U.index 0
+    |> U.member "text" |> U.to_string
+  in
+  check bool "explicit legacy agent_name preserved" true
+    (contains_substr "Type: gemini" text);
+  check bool "header actor not injected over explicit legacy agent_name" false
+    (contains_substr "Type: dashboard-header-actor" text)
+
 let () =
   run "mcp_post_sse_e2e"
     [
@@ -382,5 +431,7 @@ let () =
         [
           test_case "post tools/call streams sse framing" `Slow
             test_post_tools_call_streams_sse_framing;
+          test_case "post tools/call preserves explicit legacy agent_name"
+            `Slow test_post_tools_call_preserves_explicit_legacy_agent_name;
         ] );
     ]


### PR DESCRIPTION
## Summary
- harden dashboard JSON decode boundaries so malformed 2xx JSON surfaces as `ApiRequestError` instead of leaking raw `SyntaxError`
- add regression coverage for malformed 200 operator action payloads and activity swimlane refresh/range wiring
- add `/mcp` HTTP e2e coverage that preserves an explicit legacy `agent_name` even when an actor header is present

## Verification
- `pnpm exec vitest run src/api/core.test.ts src/components/activity-swimlane-fetch.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `env MASC_E2E_TESTS=true dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/redteam-bughunt-20260418 --build-dir _build_contracts test/test_mcp_post_sse_e2e.exe`
- `env MASC_E2E_TESTS=true ./_build_contracts/default/test/test_mcp_post_sse_e2e.exe test '^mcp$' 1`

## Follow-up
- stale public keepalive e2e still targets removed `masc_listen`: #8446