### PR TITLE
[codex] restore explicit glm coding provider routing

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,19 +1,19 @@
 {
   "_comment": "Known cascade profiles (SSOT: lib/keeper/keeper_cascade_profile.ml). Every <name>_models key here must correspond to a known cascade in that module, and vice versa. Personal/playground-only cascades belong in $MASC_BASE_PATH/.masc/playground/<persona>/.../cascade.json, not in this repo config.",
   "default_models": [
-    {"model": "glm-coding:glm-5.1", "weight": 50},
+    {"model": "glm-coding-plan:glm-5.1", "weight": 50},
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30},
     {"model": "ollama:gemma4:26b", "weight": 20}
   ],
   "default_temperature": 0.3,
   "default_max_tokens": 4096,
   "default_api_key_env": {
-    "glm-coding": "ZAI_API_KEY_SB",
-    "glm": "ZAI_API_KEY_SB"
+    "glm-coding-plan": "ZAI_API_KEY_SB",
+    "glm-api": "ZAI_API_KEY_SB"
   },
 
   "keeper_unified_models": [
-    {"model": "glm-coding:glm-5.1", "weight": 50},
+    {"model": "glm-coding-plan:glm-5.1", "weight": 50},
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30},
     {"model": "ollama:gemma4:26b", "weight": 20}
   ],
@@ -36,10 +36,10 @@
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
 
-  "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls.  Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle.  Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04.  Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama).",
+  "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls.  Bias heavily toward local ollama to keep cost near zero, but include glm-coding-plan as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle.  Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04.  Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm-coding-plan), 10% put glm-coding-plan first (then ollama).",
   "sangsu_models": [
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 90, "supports_tool_choice": true},
-    {"model": "glm-coding:glm-5.1", "weight": 10}
+    {"model": "glm-coding-plan:glm-5.1", "weight": 10}
   ],
   "sangsu_temperature": 0.1,
   "sangsu_max_tokens": 16384

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -151,8 +151,8 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `MASC_INFERENCE_CACHE_MAX_TEMP` | float | 0.0 | 캐시 허용 최대 온도 |
 | `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | int | 512 | L1 인메모리 캐시 상한 |
 | `MASC_SPAWN_CACHE_POLICY` | string | `"safe_only"` | Spawn 캐시 정책 (`off`/`safe_only`) |
-| `ZAI_DEFAULT_MODEL` | string | `"glm-5.1"` | `glm` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:38) |
-| `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
+| `ZAI_DEFAULT_MODEL` | string | `"glm-5.1"` | `glm-api` provider `auto` 기본 모델 (legacy alias: `glm`) |
+| `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding-plan` provider `auto` 기본 모델 (legacy alias: `glm-coding`) |
 | `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
 | `ANTHROPIC_DEFAULT_MODEL` | string | `"claude-sonnet-4-6-20250514"` | `claude` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:70) |
 | `OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | `openai` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:73) |
@@ -341,8 +341,8 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 |----------|----------------|----------|
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
 | `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
-| `glm` | `Glm` | `ZAI_DEFAULT_MODEL` |
-| `glm-coding` | `Glm` | `ZAI_CODING_DEFAULT_MODEL` |
+| `glm-api` | `Glm` | `ZAI_DEFAULT_MODEL` |
+| `glm-coding-plan` | `Glm` | `ZAI_CODING_DEFAULT_MODEL` |
 | `gemini` | `Gemini` | `GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `ANTHROPIC_DEFAULT_MODEL` |
 | `openai` | `OpenAI` | `OPENAI_DEFAULT_MODEL` |
@@ -404,7 +404,7 @@ capacity 조회 순서: `Cascade_throttle` (llama-server /slots 기반) → `Cas
 ```json
 {
   "keeper_unified_models": [
-    "glm-coding:auto",
+    "glm-coding-plan:auto",
     "ollama:qwen3.5:35b-a3b-nvfp4",
     "gemini_cli:auto"
   ],

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -55,7 +55,9 @@ let split_provider_model (s : string) : (string * string) option =
     if idx = 0 || idx >= String.length s - 1 then None
     else
       let provider_name =
-        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+        String.sub s 0 idx
+        |> String.trim
+        |> Provider_adapter.registry_provider_name
       in
       let model_id =
         String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim
@@ -98,12 +100,34 @@ let resolve_effective_api_key_env
     | Some v when v <> "" -> Some v
     | _ -> None
   in
-  match find_non_empty provider_name with
+  match
+    Provider_adapter.provider_override_keys provider_name
+    |> List.find_map find_non_empty
+  with
   | Some env -> env
-  | None ->
+  | None -> (
     match find_non_empty "*" with
     | Some env -> env
-    | None -> registry_default
+    | None -> registry_default)
+
+let api_key_env_present env_name =
+  env_name = ""
+  ||
+  match Sys.getenv_opt env_name with
+  | Some value -> String.trim value <> ""
+  | None -> false
+
+let provider_entry_is_available
+    ~(api_key_env_overrides : (string * string) list)
+    ~(provider_name : string)
+    (entry : Llm_provider.Provider_registry.entry) =
+  let effective_api_key_env =
+    resolve_effective_api_key_env
+      ~api_key_env_overrides
+      ~provider_name
+      ~registry_default:entry.defaults.api_key_env
+  in
+  api_key_env_present effective_api_key_env
 
 (** Build a {!Llm_provider.Provider_config.t} from a registry entry. *)
 let make_registry_config ~temperature ~max_tokens ?system_prompt
@@ -195,7 +219,13 @@ let parse_model_string
   | Registered { provider_name; model_id; kind = resolved_kind } ->
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None -> None  (* registry lookup race or unloaded entry *)
-    | Some entry when not (entry.is_available ()) -> None
+    | Some entry
+      when not
+             (provider_entry_is_available
+                ~api_key_env_overrides
+                ~provider_name
+                entry) ->
+      None
     | Some entry ->
       (* Defensive invariant: the resolver and the registry must agree on
          the kind. If they diverge we have a registry bug or a resolver
@@ -249,7 +279,12 @@ let parse_weighted_entry_diag
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None ->
       Error (Drop_unregistered_scheme { model = raw; scheme = provider_name })
-    | Some reg_entry when not (reg_entry.is_available ()) ->
+    | Some reg_entry
+      when not
+             (provider_entry_is_available
+                ~api_key_env_overrides
+                ~provider_name
+                reg_entry) ->
       Error (Drop_unavailable_scheme { model = raw; scheme = provider_name })
     | Some reg_entry ->
       Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
@@ -318,7 +353,8 @@ let parse_weighted_entries
 let parse_model_string_exn
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)
     ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
-    ?system_prompt (s : string) : (Llm_provider.Provider_config.t, string) result =
+    ?system_prompt ?(api_key_env_overrides = [])
+    (s : string) : (Llm_provider.Provider_config.t, string) result =
   let s = String.trim s in
   match split_provider_model s with
   | None ->
@@ -332,12 +368,23 @@ let parse_model_string_exn
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None ->
       Error (Printf.sprintf "unknown provider %S in model spec %S" provider_name s)
-    | Some entry when not (entry.is_available ()) ->
+    | Some entry
+      when not
+             (provider_entry_is_available
+                ~api_key_env_overrides
+                ~provider_name
+                entry) ->
+      let effective_api_key_env =
+        resolve_effective_api_key_env
+          ~api_key_env_overrides
+          ~provider_name
+          ~registry_default:entry.defaults.api_key_env
+      in
       Error (Printf.sprintf "provider %S unavailable (missing env var %S)"
-               provider_name entry.defaults.api_key_env)
+               provider_name effective_api_key_env)
     | Some entry ->
       Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
-            ~provider_name ~model_id entry)
+            ~api_key_env_overrides ~provider_name ~model_id entry)
 
 (** Expand provider:auto specs that map to multiple models.
     "glm:auto" expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -107,6 +107,7 @@ val parse_model_string_exn :
   ?temperature:float ->
   ?max_tokens:int ->
   ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
   string -> (Llm_provider.Provider_config.t, string) result
 
 (** Expand provider:auto specs that map to multiple models.

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -52,7 +52,7 @@ let resolve_glm_coding_model_id model_id =
     resolve the model_id before invoking [Llm_provider.Discovery.endpoint_for_model]
     to avoid routing mismatches. *)
 let resolve_auto_model_id provider_name model_id =
-  match provider_name with
+  match Provider_adapter.registry_provider_name provider_name with
   | "llama" | "ollama" ->
     (* Local providers: "auto" resolved earlier via Discovery in
        cascade_config.ml.  If still "auto" here, try discovery then env var. *)

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -264,9 +264,14 @@ let default_model_strings_from_config () : string list =
   models_of_cascade_name "default"
 
 let resolve_providers_from_model_strings ?provider_filter
+    ?(api_key_env_overrides = [])
     (model_strings : string list)
     : Llm_provider.Provider_config.t list =
-  let specs = Cascade_config.parse_model_strings model_strings in
+  let specs =
+    Cascade_config.parse_model_strings
+      ~api_key_env_overrides
+      model_strings
+  in
   let filtered =
     Cascade_config.apply_provider_filter
       ~provider_filter
@@ -284,6 +289,11 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let defaults = default_model_strings ~cascade_name in
   let config_path = cascade_config_path () in
+  let api_key_env_overrides =
+    match config_path with
+    | Some path -> Cascade_config.resolve_api_key_env ~config_path:path ~name:cascade_name
+    | None -> []
+  in
   let weighted =
     match config_path with
     | Some path ->
@@ -293,9 +303,13 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
   in
   let specs =
     (if weighted <> [] then
-       Cascade_config.parse_weighted_entries ~cascade_name weighted
+       Cascade_config.parse_weighted_entries
+         ~api_key_env_overrides
+         ~cascade_name
+         weighted
      else
        Cascade_config.parse_model_strings
+         ~api_key_env_overrides
          (models_of_cascade_name cascade_name))
     |> Cascade_config.apply_provider_filter ~provider_filter ~label:cascade_name
   in
@@ -308,4 +322,7 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
     Log.Misc.warn
       "cascade %s: configured models unavailable — retrying built-in defaults"
       cascade_name;
-    resolve_providers_from_model_strings ?provider_filter defaults)
+    resolve_providers_from_model_strings
+      ?provider_filter
+      ~api_key_env_overrides
+      defaults)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -38,4 +38,5 @@ val resolve_named_providers :
   cascade_name:string -> unit -> Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
   ?provider_filter:string list ->
+  ?api_key_env_overrides:(string * string) list ->
   string list -> Llm_provider.Provider_config.t list

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -182,7 +182,17 @@ module Ollama = struct
 end
 
 module Glm = struct
-  let server_url = Env_config_core.get_string ~default:"https://api.z.ai" "ZAI_BASE_URL"
+  let api_server_url =
+    Env_config_core.get_string
+      ~default:"https://api.z.ai/api/paas/v4"
+      "ZAI_BASE_URL"
+
+  let coding_plan_server_url =
+    Env_config_core.get_string
+      ~default:"https://api.z.ai/api/coding/paas/v4"
+      "ZAI_CODING_BASE_URL"
+
+  let server_url = api_server_url
 end
 
 (** {1 Cancellation Token Configuration} *)

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -78,6 +78,8 @@ module Llama : sig
 end
 
 module Glm : sig
+  val api_server_url : string
+  val coding_plan_server_url : string
   val server_url : string
 end
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -42,7 +42,7 @@ let keeper_denied_tools =
     than guessing when no rule fits, so analysis queries can filter
     those rows out rather than miscount them. *)
 let known_providers = [
-  "glm-coding"; "glm"; "claude"; "claude_code";
+  "glm-coding-plan"; "glm-api"; "glm-coding"; "glm"; "claude"; "claude_code";
   "gemini"; "gemini_cli"; "codex_cli"; "ollama";
 ]
 
@@ -52,7 +52,7 @@ let provider_of_model (model : string) : string =
       String.length model >= String.length prefix
       && String.sub model 0 (String.length prefix) = prefix
     in
-    if starts_with "glm-" then "glm-coding"
+    if starts_with "glm-" then "glm-coding-plan"
     else if starts_with "claude-" then "claude"
     else if starts_with "gemini-" then "gemini"
     else if starts_with "gpt-" then "openai"
@@ -61,8 +61,12 @@ let provider_of_model (model : string) : string =
   in
   match String.index_opt model ':' with
   | Some i ->
-    let prefix = String.sub model 0 i in
-    if List.mem prefix known_providers then prefix
+    let prefix = String.sub model 0 i |> Provider_adapter.normalize_label in
+    if List.mem prefix known_providers then
+      (match prefix with
+       | "glm-coding" -> "glm-coding-plan"
+       | "glm" -> "glm-api"
+       | other -> other)
     else bare_heuristic ()
   | None -> bare_heuristic ()
 

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -151,13 +151,11 @@ let reset_cascade_counters_for_test () =
 (* ================================================================ *)
 
 (** Map provider_kind to cascade-label prefix (e.g. "claude", "gemini").
-    Delegates to Provider_adapter.cascade_prefix_of_provider_kind.
-    Note: reverse-mapping from provider_kind is inherently lossy —
-    OpenAI_compat conflates codex/openrouter/llama into one kind.
-    TODO: pass the provider name from cascade config parsing instead of
-    reverse-mapping from provider_kind to avoid this ambiguity. *)
+    Delegates to Provider_adapter.cascade_prefix_of_provider_config so
+    endpoint-sensitive families (glm-api vs glm-coding-plan, llama vs openai)
+    stay distinct in observability. *)
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  Provider_adapter.cascade_prefix_of_provider_kind cfg.kind
+  Provider_adapter.cascade_prefix_of_provider_config cfg
 
 let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
   Printf.sprintf "%s:%s" (provider_name_of_config cfg) cfg.model_id

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -93,7 +93,9 @@ let cn_gemini = "gemini"
 let cn_claude_api = "claude-api"
 let cn_codex_api = "codex-api"
 let cn_gemini_api = "gemini-api"
-let cn_glm = "glm"
+let cn_glm_api = "glm-api"
+let cn_glm_coding_plan = "glm-coding-plan"
+let cn_glm = cn_glm_api
 let cn_openrouter = "openrouter"
 
 (** Default API base URLs — overridable via env var for proxying/testing. *)
@@ -125,6 +127,20 @@ let local_cascade_prefix = cn_llama
 let make_local_label (model_id : string) : string =
   local_cascade_prefix ^ ":" ^ model_id
 
+let registry_provider_name label =
+  match normalize_label label with
+  | "glm" | "glm-api" -> "glm"
+  | "glm-coding" | "glm-coding-plan" | "glm-coding-plan-api" -> "glm-coding"
+  | other -> other
+
+let provider_override_keys provider_name =
+  let normalized = normalize_label provider_name in
+  match registry_provider_name normalized with
+  | "glm" -> [ normalized; cn_glm_api; "glm" ]
+  | "glm-coding" ->
+    [ normalized; cn_glm_coding_plan; "glm-coding"; "glm-coding-plan-api" ]
+  | _ -> [ normalized ]
+
 (** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
     Note: OpenAI_compat maps to codex-api (cloud); llama (local) uses the
     same provider_kind but is identified by endpoint, not by this function. *)
@@ -136,7 +152,7 @@ let string_of_provider_kind
   | Ollama -> cn_ollama
   | Gemini -> cn_gemini_api
   | Gemini_cli -> cn_gemini
-  | Glm -> cn_glm
+  | Glm -> cn_glm_api
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
@@ -243,14 +259,25 @@ let direct_adapters =
       default_model_id = Some "auto";
     };
     {
-      canonical_name = cn_glm;
+      canonical_name = cn_glm_coding_plan;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ZAI_API_KEY";
-      aliases = [ cn_glm; "glm_cloud"; "zai" ];
+      aliases = [ cn_glm_coding_plan; "glm-coding"; "glm-coding-plan-api" ];
       spawn_key = None;
-      cascade_prefix = "glm";
+      cascade_prefix = cn_glm_coding_plan;
       default_voice = None;
-      endpoint_url = Some Env_config_runtime.Glm.server_url;
+      endpoint_url = Some Env_config_runtime.Glm.coding_plan_server_url;
+      default_model_id = Some "auto";
+    };
+    {
+      canonical_name = cn_glm_api;
+      runtime_kind = Direct_api;
+      auth_mode = Api_key "ZAI_API_KEY";
+      aliases = [ cn_glm_api; "glm"; "glm_cloud"; "zai" ];
+      spawn_key = None;
+      cascade_prefix = cn_glm_api;
+      default_voice = None;
+      endpoint_url = Some Env_config_runtime.Glm.api_server_url;
       default_model_id = Some "auto";
     };
     {
@@ -960,6 +987,11 @@ let cascade_prefix_of_adapter (adapter : adapter) = adapter.cascade_prefix
 
 let endpoint_url_of_adapter (adapter : adapter) = adapter.endpoint_url
 
+let base_url_matches expected actual =
+  String.equal
+    (normalize_label expected)
+    (normalize_label actual)
+
 (** Best-effort mapping from Provider_registry/OAS [provider_kind] to a cascade prefix via the
     adapter registry.
 
@@ -977,6 +1009,23 @@ let cascade_prefix_of_provider_kind (kind : Llm_provider.Provider_config.provide
   match resolve_direct_adapter cn with
   | Some a -> a.cascade_prefix
   | None -> cn
+
+let cascade_prefix_of_provider_config
+    (cfg : Llm_provider.Provider_config.t) : string =
+  match cfg.kind with
+  | Llm_provider.Provider_config.Glm ->
+    if Llm_provider.Zai_catalog.is_coding_base_url cfg.base_url then
+      cn_glm_coding_plan
+    else
+      cn_glm_api
+  | Llm_provider.Provider_config.OpenAI_compat ->
+    if Llm_provider.Provider_config.is_local cfg then
+      cn_llama
+    else if base_url_matches (openrouter_api_url ()) cfg.base_url then
+      cn_openrouter
+    else
+      "openai"
+  | _ -> cascade_prefix_of_provider_kind cfg.kind
 
 (** Resolve auth detail for any provider by canonical name or alias.
     Gemini-specific Vertex ADC vs API Key logic is internal. *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -87,6 +87,8 @@ val cn_claude_api : string
 val cn_codex_api : string
 val cn_gemini_api : string
 val cn_glm : string
+val cn_glm_api : string
+val cn_glm_coding_plan : string
 val cn_openrouter : string
 val cn_custom : string
 
@@ -133,6 +135,12 @@ val all_auth_env_keys : unit -> string list
 
 (** Resolve an adapter by canonical name or alias. *)
 val resolve_direct_adapter : string -> adapter option
+
+(** Map a cascade/provider alias to the underlying Provider_registry name. *)
+val registry_provider_name : string -> string
+
+(** All acceptable override keys for a provider in api_key_env mappings. *)
+val provider_override_keys : string -> string list
 
 (** Resolve the canonical name for a provider label. *)
 val resolve_direct_canonical_name : string -> string option
@@ -272,6 +280,10 @@ val endpoint_url_of_adapter : adapter -> string option
     MASC cascade prefix. *)
 val cascade_prefix_of_provider_kind :
   Llm_provider.Provider_config.provider_kind -> string
+
+(** Endpoint-aware mapping from provider config to a disambiguated cascade prefix. *)
+val cascade_prefix_of_provider_config :
+  Llm_provider.Provider_config.t -> string
 
 (** {1 Gemini Auth} *)
 

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -20,7 +20,9 @@ let split_provider_model (s : string) : (string * string) option =
     if idx = 0 || idx >= String.length s - 1 then None
     else
       let provider_name =
-        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+        String.sub s 0 idx
+        |> String.trim
+        |> Provider_adapter.registry_provider_name
       in
       let model_id =
         String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim

--- a/test/test_keeper_hooks_oas_provider.ml
+++ b/test/test_keeper_hooks_oas_provider.ml
@@ -7,9 +7,10 @@ module Hooks = Masc_mcp.Keeper_hooks_oas
    transports, and truly unrecognised strings (should route to "unknown"
    rather than guess). *)
 let cases_prefix = [
-  "glm-coding:glm-5-turbo",                "glm-coding";
-  "glm-coding:glm-5.1",                    "glm-coding";
-  "glm:glm-5-turbo",                       "glm";
+  "glm-coding-plan:glm-5-turbo",           "glm-coding-plan";
+  "glm-coding:glm-5.1",                    "glm-coding-plan";
+  "glm-api:glm-5-turbo",                   "glm-api";
+  "glm:glm-5-turbo",                       "glm-api";
   "claude:claude-haiku-4-5-20251001",      "claude";
   "claude_code:haiku",                     "claude_code";
   "gemini:gemini-2.5-flash",               "gemini";
@@ -19,8 +20,8 @@ let cases_prefix = [
 ]
 
 let cases_bare = [
-  "glm-5-turbo",                           "glm-coding";
-  "glm-4.7",                               "glm-coding";
+  "glm-5-turbo",                           "glm-coding-plan";
+  "glm-4.7",                               "glm-coding-plan";
   "claude-haiku-4-5-20251001",             "claude";
   "gemini-2.5-flash",                      "gemini";
   "gpt-5.4",                               "openai";

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -347,10 +347,10 @@ let test_cascade_observation_json_includes_fallback_fields () =
   let observation : Oas_worker.cascade_observation =
     {
       cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
-      configured_labels = [ "glm:auto"; "llama:auto" ];
-      candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
-      primary_model = Some "glm:glm-5.1";
-      selected_model = Some "openai:qwen3.5-35b";
+      configured_labels = [ "glm-api:auto"; "llama:auto" ];
+      candidate_models = [ "glm-api:glm-5.1"; "llama:qwen3.5-35b" ];
+      primary_model = Some "glm-api:glm-5.1";
+      selected_model = Some "llama:qwen3.5-35b";
       selected_model_raw = Some "qwen3.5-35b";
       selected_index = Some 1;
       fallback_hops = Some 1;
@@ -360,14 +360,14 @@ let test_cascade_observation_json_includes_fallback_fields () =
           {
             attempt_index = 0;
             model_id = "glm-5.1";
-            model_label = Some "glm:glm-5.1";
+            model_label = Some "glm-api:glm-5.1";
             latency_ms = None;
             error = Some "HTTP 503";
           };
           {
             attempt_index = 1;
             model_id = "qwen3.5-35b";
-            model_label = Some "openai:qwen3.5-35b";
+            model_label = Some "llama:qwen3.5-35b";
             latency_ms = Some 212;
             error = None;
           };
@@ -376,9 +376,9 @@ let test_cascade_observation_json_includes_fallback_fields () =
         [
           {
             from_model_id = "glm-5.1";
-            from_model_label = Some "glm:glm-5.1";
+            from_model_label = Some "glm-api:glm-5.1";
             to_model_id = "qwen3.5-35b";
-            to_model_label = Some "openai:qwen3.5-35b";
+            to_model_label = Some "llama:qwen3.5-35b";
             reason = "HTTP 503";
           };
         ];
@@ -393,7 +393,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
     Yojson.Safe.Util.(json |> member "fallback_applied" |> to_bool);
   Alcotest.(check int) "fallback hops preserved" 1
     Yojson.Safe.Util.(json |> member "fallback_hops" |> to_int);
-  Alcotest.(check string) "selected model preserved" "openai:qwen3.5-35b"
+  Alcotest.(check string) "selected model preserved" "llama:qwen3.5-35b"
     Yojson.Safe.Util.(json |> member "selected_model" |> to_string);
   Alcotest.(check int) "attempt count preserved" 2
     Yojson.Safe.Util.(json |> member "attempts" |> to_list |> List.length);
@@ -502,10 +502,10 @@ let test_cascade_audit_persists_observation () =
       let observation : Masc_mcp.Oas_worker_cascade.cascade_observation =
         {
           cascade_name = "audit-cascade";
-          configured_labels = [ "glm:auto"; "openai:auto" ];
-          candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
-          primary_model = Some "glm:glm-5.1";
-          selected_model = Some "openai:qwen3.5-35b";
+          configured_labels = [ "glm-api:auto"; "llama:auto" ];
+          candidate_models = [ "glm-api:glm-5.1"; "llama:qwen3.5-35b" ];
+          primary_model = Some "glm-api:glm-5.1";
+          selected_model = Some "llama:qwen3.5-35b";
           selected_model_raw = Some "qwen3.5-35b";
           selected_index = Some 1;
           fallback_hops = Some 1;
@@ -515,14 +515,14 @@ let test_cascade_audit_persists_observation () =
               {
                 attempt_index = 0;
                 model_id = "glm-5.1";
-                model_label = Some "glm:glm-5.1";
+                model_label = Some "glm-api:glm-5.1";
                 latency_ms = Some 120;
                 error = Some "HTTP 503";
               };
               {
                 attempt_index = 1;
                 model_id = "qwen3.5-35b";
-                model_label = Some "openai:qwen3.5-35b";
+                model_label = Some "llama:qwen3.5-35b";
                 latency_ms = Some 90;
                 error = None;
               };
@@ -531,9 +531,9 @@ let test_cascade_audit_persists_observation () =
             [
               {
                 from_model_id = "glm-5.1";
-                from_model_label = Some "glm:glm-5.1";
+                from_model_label = Some "glm-api:glm-5.1";
                 to_model_id = "qwen3.5-35b";
-                to_model_label = Some "openai:qwen3.5-35b";
+                to_model_label = Some "llama:qwen3.5-35b";
                 reason = "HTTP 503";
               };
             ];
@@ -557,7 +557,7 @@ let test_cascade_audit_persists_observation () =
           Alcotest.(check string) "outcome persisted" "failure"
             Yojson.Safe.Util.(json |> member "outcome" |> to_string);
           Alcotest.(check string) "selected model persisted"
-            "openai:qwen3.5-35b"
+            "llama:qwen3.5-35b"
             Yojson.Safe.Util.(
               json |> member "observation" |> member "selected_model" |> to_string);
           Alcotest.(check bool) "fallback flag persisted" true

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -11,13 +11,48 @@ open Alcotest
 
 module Adapter = Masc_mcp.Provider_adapter
 
+let with_env name value_opt f =
+  let prior = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "")
+    (fun () ->
+      (match value_opt with
+       | Some value -> Unix.putenv name value
+       | None -> Unix.putenv name "");
+      f ())
+
+let with_temp_dir prefix f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists dir then (
+        Array.iter
+          (fun name ->
+            let path = Filename.concat dir name in
+            if Sys.file_exists path then Sys.remove path)
+          (Sys.readdir dir);
+        Unix.rmdir dir))
+    (fun () -> f dir)
+
 let test_alias_roundtrip () =
   let cases =
     [ ("anthropic", "claude-api"); ("Claude", "claude");
       ("google", "gemini-api"); ("Gemini", "gemini");
       ("openai", "codex-api"); ("OpenAI", "codex-api");
       ("llama", "llama"); ("llamacpp", "llama");
-      ("glm", "glm"); ("zai", "glm");
+      ("glm", "glm-api"); ("glm-api", "glm-api");
+      ("glm-coding", "glm-coding-plan");
+      ("glm-coding-plan", "glm-coding-plan");
+      ("zai", "glm-api");
       ("openrouter", "openrouter") ]
   in
   List.iter (fun (input, expected) ->
@@ -64,7 +99,10 @@ let test_runtime_kind_strings () =
 (* ── Section 2: OAS model resolve contracts ── *)
 
 let test_resolve_canonical_wraps_adapter () =
-  let labels = [ "claude"; "anthropic"; "gemini"; "google"; "openai"; "llama" ] in
+  let labels =
+    [ "claude"; "anthropic"; "gemini"; "google"; "openai"; "llama";
+      "glm"; "glm-api"; "glm-coding"; "glm-coding-plan" ]
+  in
   List.iter (fun label ->
     let via_fn = Adapter.resolve_direct_canonical_name label in
     let via_adapter =
@@ -154,6 +192,68 @@ let test_labels_require_local_discovery () =
   check bool "malformed labels skip refresh" false
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
        [ "default"; "glm:auto" ])
+
+let test_registry_provider_name_normalizes_glm_aliases () =
+  check string "glm-api -> glm registry key" "glm"
+    (Adapter.registry_provider_name "glm-api");
+  check string "glm-coding-plan -> glm-coding registry key" "glm-coding"
+    (Adapter.registry_provider_name "glm-coding-plan");
+  check string "legacy glm stays glm" "glm"
+    (Adapter.registry_provider_name "glm");
+  check string "legacy glm-coding stays glm-coding" "glm-coding"
+    (Adapter.registry_provider_name "glm-coding")
+
+let test_cascade_prefix_of_provider_config_disambiguates_glm_and_llama () =
+  let coding_cfg =
+    match Masc_mcp.Cascade_config.parse_model_string_exn "glm-coding-plan:glm-5.1" with
+    | Ok cfg -> cfg
+    | Error err -> fail err
+  in
+  let api_cfg =
+    match Masc_mcp.Cascade_config.parse_model_string_exn "glm-api:glm-5.1" with
+    | Ok cfg -> cfg
+    | Error err -> fail err
+  in
+  let llama_cfg =
+    match Masc_mcp.Cascade_config.parse_model_string_exn "llama:qwen3.5:27b-nvfp4" with
+    | Ok cfg -> cfg
+    | Error err -> fail err
+  in
+  check string "coding-plan prefix preserved" "glm-coding-plan"
+    (Adapter.cascade_prefix_of_provider_config coding_cfg);
+  check string "glm-api prefix preserved" "glm-api"
+    (Adapter.cascade_prefix_of_provider_config api_cfg);
+  check string "local openai-compat rendered as llama" "llama"
+    (Adapter.cascade_prefix_of_provider_config llama_cfg)
+
+let test_resolve_named_providers_honors_api_key_override_for_glm_coding_plan () =
+  with_temp_dir "glm-coding-provider" @@ fun config_dir ->
+  let cascade_path = Filename.concat config_dir "cascade.json" in
+  let oc = open_out cascade_path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        {|{
+  "default_models": [{"model":"glm-coding-plan:glm-5.1","weight":1}],
+  "default_api_key_env": {"glm-coding-plan":"ZAI_API_KEY_SB"}
+}|});
+  with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+  with_env "ZAI_API_KEY" None @@ fun () ->
+  with_env "ZAI_API_KEY_SB" (Some "sb-key") @@ fun () ->
+    let providers =
+      Masc_mcp.Oas_model_resolve.resolve_named_providers ~cascade_name:"default" ()
+    in
+    match providers with
+    | [ cfg ] ->
+      check string "coding-plan base url"
+        "https://api.z.ai/api/coding/paas/v4"
+        cfg.Llm_provider.Provider_config.base_url;
+      check string "resolved model"
+        "glm-5.1"
+        cfg.Llm_provider.Provider_config.model_id
+    | _ ->
+      fail (Printf.sprintf "expected one provider, got %d" (List.length providers))
 
 (* ── Section 3: Dashboard schema contracts ── *)
 
@@ -253,6 +353,12 @@ let () =
             test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
+          test_case "registry provider aliases normalize" `Quick
+            test_registry_provider_name_normalizes_glm_aliases;
+          test_case "provider config prefixes stay disambiguated" `Quick
+            test_cascade_prefix_of_provider_config_disambiguates_glm_and_llama;
+          test_case "named providers honor glm coding override" `Quick
+            test_resolve_named_providers_honors_api_key_override_for_glm_coding_plan;
           test_case "resolve max cascade context" `Quick
             test_resolve_max_cascade_context;
         ] );


### PR DESCRIPTION
## Summary
- restore `glm-coding-plan` / `glm-api` as explicit cascade provider labels while keeping legacy `glm-coding` / `glm` aliases working
- thread per-cascade `api_key_env` overrides through named cascade resolution so weighted GLM entries do not get filtered out before `make_registry_config`
- make cascade/audit/keeper observability endpoint-aware so local llama no longer shows up as `openai:qwen...` and GLM coding-plan vs general API stay distinct

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/runtime-glm-coding-provider-20260418 test/test_observability_provider_contracts.exe test/test_keeper_hooks_oas_provider.exe test/test_oas_worker.exe`
- `./_build/default/test/test_keeper_hooks_oas_provider.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_oas_worker.exe`
- `git diff --check`

## Notes
- a full `dune build --root ...` was started but took too long in this environment; compile coverage comes from the targeted build above plus the passing test executables.
- checked-in `config/cascade.json` and `docs/spec/14-configuration.md` now use the explicit canonical labels; runtime still accepts legacy aliases for live configs during migration.