### PR TITLE
fix(board): collapse Tool_board.sort_order into Board_dispatch.sort_order (#8449 PR B)

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -8,6 +8,37 @@
 
 type sort_order = Hot | Trending | Recent | Updated | Discussed
 
+(** Issue #8449: SSOT helpers for [sort_order]. Three call sites used to
+    own private parsers and a separate Variant in [Tool_board]; this PR
+    A introduces the canonical helpers here so the schema enum can derive
+    from the Variant. PR B will collapse the duplicate Variant; PR C
+    will route [server_utils] through these parsers.
+
+    All constructors are nullary so [List.map] works. *)
+let all_sort_orders = [ Hot; Trending; Recent; Updated; Discussed ]
+
+let sort_order_to_string = function
+  | Hot -> "hot"
+  | Trending -> "trending"
+  | Recent -> "recent"
+  | Updated -> "updated"
+  | Discussed -> "discussed"
+
+let valid_sort_order_strings = List.map sort_order_to_string all_sort_orders
+
+(** Lenient parser: canonical names plus documented aliases that the
+    three pre-existing parsers (Tool_board.sort_order_of_string,
+    Tool_board.parse_sort_order, server_utils inline) all accept.
+    Aliases: new=Recent, active=Updated, comments=Discussed. *)
+let sort_order_of_string_opt s =
+  match String.lowercase_ascii (String.trim s) with
+  | "hot" -> Some Hot
+  | "trending" -> Some Trending
+  | "recent" | "new" -> Some Recent
+  | "updated" | "active" -> Some Updated
+  | "discussed" | "comments" -> Some Discussed
+  | _ -> None
+
 type board_backend =
   | Jsonl of Board.store
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -708,7 +708,14 @@ let tool_post_list : Types.tool_schema = {
       ("hearth", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter by hearth topic (e.g. webrtc, code-review)")]);
       ("random", `Assoc [("type", `String "boolean"); ("description", `String "Shuffle posts randomly (default: false)")]);
       ("offset", `Assoc [("type", `String "integer"); ("description", `String "Skip first N posts (default: 0)"); ("minimum", `Int 0); ("maximum", `Int 1000)]);
-      ("sort_by", `Assoc [("type", `String "string"); ("enum", `List [`String "hot"; `String "trending"; `String "recent"; `String "updated"; `String "discussed"]); ("description", `String "Sort order (default: hot)")]);
+      ("sort_by", `Assoc [
+        ("type", `String "string");
+        (* Issue #8449 PR A: derived from Board_dispatch.sort_order Variant SSOT.
+           Hand-rolled enum had 5 values that happened to be in sync; future
+           constructor would silently miss this site. *)
+        ("enum", `List (List.map (fun s -> `String s) Board_dispatch.valid_sort_order_strings));
+        ("description", `String "Sort order (default: hot)");
+      ]);
       ("exclude_system", `Assoc [("type", `String "boolean"); ("description", `String "Exclude system posts like Activity Reports (default: false)")]);
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -367,33 +367,25 @@ let handle_post_create args =
       | Error e ->
           (false, Printf.sprintf "❌ %s" (board_error_to_string e))
 
-(** Sort posts by different criteria *)
-type sort_order = Hot | Trending | Recent | Updated | Discussed
+(** Issue #8449 PR B: [sort_order] is now a re-export of
+    [Board_dispatch.sort_order] (type-alias with definition equality),
+    eliminating the parallel Variant + bridge function. Constructors
+    [Hot]/[Trending]/[Recent]/[Updated]/[Discussed] are interchangeable
+    across both modules — no [dispatch_sort_of] conversion needed. *)
+type sort_order = Board_dispatch.sort_order =
+  | Hot | Trending | Recent | Updated | Discussed
 
-let sort_order_of_string = function
-  | "hot" -> Hot
-  | "trending" -> Trending
-  | "recent" | "new" -> Recent
-  | "updated" | "active" -> Updated
-  | "discussed" | "comments" -> Discussed
-  | _ -> Hot  (* default *)
-
+(** Issue #8449 PR B: parser delegates to [Board_dispatch.sort_order_of_string_opt]
+    (canonical + documented aliases new/active/comments). Error message
+    derives from [Board_dispatch.valid_sort_order_strings] so adding a
+    constructor automatically updates the user-facing list. *)
 let parse_sort_order value =
-  match String.lowercase_ascii (String.trim value) with
-  | "hot" -> Ok Hot
-  | "trending" -> Ok Trending
-  | "recent" | "new" -> Ok Recent
-  | "updated" | "active" -> Ok Updated
-  | "discussed" | "comments" -> Ok Discussed
-  | _ -> Error "invalid sort. Valid: hot, trending, recent, updated, discussed"
-
-let dispatch_sort_of sort_by =
-  match sort_by with
-  | Hot -> Board_dispatch.Hot
-  | Trending -> Board_dispatch.Trending
-  | Recent -> Board_dispatch.Recent
-  | Updated -> Board_dispatch.Updated
-  | Discussed -> Board_dispatch.Discussed
+  match Board_dispatch.sort_order_of_string_opt value with
+  | Some s -> Ok s
+  | None ->
+    Error (Printf.sprintf
+      "invalid sort. Valid: %s"
+      (String.concat ", " Board_dispatch.valid_sort_order_strings))
 
 (** Deterministic cache key from board_list args.  Serializes the
     normalized JSON so identical parameter sets hit the same entry. *)
@@ -441,7 +433,7 @@ let handle_post_list_uncached args =
       let sorted_posts =
         Board_dispatch.list_posts ~visibility_filter ?hearth ?author_filter
           ~exclude_system ~exclude_automation
-          ~sort_by:(dispatch_sort_of sort_by) ~limit:fetch_limit ()
+          ~sort_by ~limit:fetch_limit ()
       in
 
       let posts =

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -38,6 +38,36 @@ let test_visibility_strings_complete () =
       (List.mem expected strs)
   ) ["public"; "unlisted"; "internal"; "direct"]
 
+(* Issue #8449 PR A: Board_dispatch.sort_order schema enum SSOT.
+   Witness covers all 5 variants; adding a 6th constructor will fail
+   compilation in [sort_order_to_string]. *)
+let test_sort_order_witness_in_enum () =
+  let module D = Masc_mcp.Board_dispatch in
+  let witness s =
+    let actual = D.sort_order_to_string s in
+    if not (List.mem actual D.valid_sort_order_strings) then
+      Alcotest.failf "sort_order_to_string %S not in valid_sort_order_strings" actual
+  in
+  witness D.Hot;
+  witness D.Trending;
+  witness D.Recent;
+  witness D.Updated;
+  witness D.Discussed;
+  Alcotest.(check int) "count" 5
+    (List.length D.valid_sort_order_strings)
+
+let test_sort_order_aliases () =
+  let module D = Masc_mcp.Board_dispatch in
+  Alcotest.(check (option string)) "new -> Recent" (Some "recent")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "new"));
+  Alcotest.(check (option string)) "active -> Updated" (Some "updated")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "active"));
+  Alcotest.(check (option string)) "comments -> Discussed" (Some "discussed")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "comments"));
+  Alcotest.(check (option string)) "garbage rejected" None
+    (D.sort_order_of_string_opt "definitely-not-an-order"
+     |> Option.map D.sort_order_to_string)
+
 let test_permanent_post () =
   let store = create_store () in
   match
@@ -183,6 +213,13 @@ let () =
             test_visibility_witness_in_enum;
           Alcotest.test_case "all 4 strings present" `Quick
             test_visibility_strings_complete;
+        ] );
+      ( "sort_order_ssot",
+        [
+          Alcotest.test_case "witness covers all 5 variants" `Quick
+            test_sort_order_witness_in_enum;
+          Alcotest.test_case "aliases new/active/comments accepted" `Quick
+            test_sort_order_aliases;
         ] );
       ( "post_kind",
         [

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -84,28 +84,29 @@ let test_visibility_of_string () =
     (match Tool_board.visibility_of_string "garbage" with
      | None -> "none" | _ -> "other")
 
+(* Issue #8449 PR B: [Tool_board.sort_order_of_string] removed —
+   replaced by [parse_sort_order] (Result-returning) which delegates to
+   [Board_dispatch.sort_order_of_string_opt]. The previous silent
+   "unknown defaults to Hot" behavior is now an explicit Error so
+   garbage input is surfaced instead of swallowed. *)
 let test_sort_order_of_string () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check string) "hot" "hot"
-    (match Tool_board.sort_order_of_string "hot" with
-     | Tool_board.Hot -> "hot" | _ -> "x");
-  Alcotest.(check string) "trending" "trending"
-    (match Tool_board.sort_order_of_string "trending" with
-     | Tool_board.Trending -> "trending" | _ -> "x");
-  Alcotest.(check string) "recent" "recent"
-    (match Tool_board.sort_order_of_string "recent" with
-     | Tool_board.Recent -> "recent" | _ -> "x");
-  Alcotest.(check string) "updated" "updated"
-    (match Tool_board.sort_order_of_string "updated" with
-     | Tool_board.Updated -> "updated" | _ -> "x");
-  Alcotest.(check string) "discussed" "discussed"
-    (match Tool_board.sort_order_of_string "discussed" with
-     | Tool_board.Discussed -> "discussed" | _ -> "x");
-  Alcotest.(check string) "unknown defaults to hot" "hot"
-    (match Tool_board.sort_order_of_string "xyz" with
-     | Tool_board.Hot -> "hot" | _ -> "x")
+  let check name expected input =
+    match Tool_board.parse_sort_order input with
+    | Ok v when v = expected -> Alcotest.(check string) name name name
+    | Ok _ -> Alcotest.failf "%s: parsed wrong variant" name
+    | Error e -> Alcotest.failf "%s: expected Ok, got Error: %s" name e
+  in
+  check "hot" Tool_board.Hot "hot";
+  check "trending" Tool_board.Trending "trending";
+  check "recent" Tool_board.Recent "recent";
+  check "updated" Tool_board.Updated "updated";
+  check "discussed" Tool_board.Discussed "discussed";
+  (* Garbage input is now an explicit Error, not a silent Hot default. *)
+  Alcotest.(check bool) "garbage rejected" true
+    (match Tool_board.parse_sort_order "xyz" with Error _ -> true | Ok _ -> false)
 
 let test_board_error_to_string () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
PR B of 3 for #8449. Builds on PR A (#8453). Eliminates the duplicate `sort_order` Variant in `Tool_board` plus the `dispatch_sort_of` bridge function.

## Stack
- **PR A** (#8453, MERGED-PENDING): Helpers in `Board_dispatch` + schema enum derive
- **PR B** (this): Type-alias `Tool_board.sort_order = Board_dispatch.sort_order`, remove bridge
- **PR C** (next): Route `server_utils` inline parser through canonical helper

## Change

\`\`\`diff
- type sort_order = Hot | Trending | Recent | Updated | Discussed
+ type sort_order = Board_dispatch.sort_order =
+   | Hot | Trending | Recent | Updated | Discussed

- let sort_order_of_string = function ...      (* silent default to Hot *)
- let parse_sort_order value = match ... ...   (* duplicated alias logic *)
+ let parse_sort_order value =
+   match Board_dispatch.sort_order_of_string_opt value with
+   | Some s -> Ok s
+   | None -> Error (Printf.sprintf "invalid sort. Valid: %s"
+       (String.concat ", " Board_dispatch.valid_sort_order_strings))

- let dispatch_sort_of sort_by = match ... ... (* identity after type-alias *)

  ~sort_by:(dispatch_sort_of sort_by)  (* call site *)
+ ~sort_by                             (* now identity *)
\`\`\`

## Behavior change
The removed `sort_order_of_string` silently returned `Hot` for unknown input. The Result-returning `parse_sort_order` (already used by the only call site) returns an explicit `Error`. Garbage like `"xyz"` was already mapped to `Error` via `parse_sort_order` in production; only the silent fallback function used in one test is removed. No external callers depend on the silent-Hot semantics (verified via rg).

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_tool_board_coverage.exe` — 56/56 pass (test updated to assert Error rejection)
- [ ] CI green

## Pattern catalog (now 12)
| PR | Variant | Real bug? |
|----|---------|-----------|
| #8453 (PR A) | sort_order helpers + enum | no |
| **THIS (PR B)** | **sort_order type unified, bridge removed** | **silent Hot default fixed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)