### PR TITLE
feat(dashboard): surface awaiting_verification count on goal tree

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -10,6 +10,8 @@ import {
   filterTasksByQuery,
   resetTaskSearch,
   taskSearchQuery,
+  countAwaitingVerificationTasks,
+  countAwaitingVerificationInTree,
 } from './goal-helpers'
 import type { Task } from '../../types'
 
@@ -252,5 +254,55 @@ describe('resetTaskSearch', () => {
     taskSearchQuery.value = 'something'
     resetTaskSearch()
     expect(taskSearchQuery.value).toBe('')
+  })
+})
+
+// ================================================================
+// countAwaitingVerificationTasks / countAwaitingVerificationInTree
+// ================================================================
+
+describe('countAwaitingVerificationTasks', () => {
+  it('counts only awaiting_verification statuses', () => {
+    const tasks = [
+      { status: 'todo' },
+      { status: 'awaiting_verification' },
+      { status: 'done' },
+      { status: 'awaiting_verification' },
+    ]
+    expect(countAwaitingVerificationTasks(tasks)).toBe(2)
+  })
+
+  it('returns 0 for empty task list', () => {
+    expect(countAwaitingVerificationTasks([])).toBe(0)
+  })
+})
+
+describe('countAwaitingVerificationInTree', () => {
+  it('sums awaiting counts across nested children', () => {
+    const tree = [
+      {
+        tasks: [{ status: 'awaiting_verification' }, { status: 'done' }],
+        children: [
+          {
+            tasks: [{ status: 'awaiting_verification' }],
+            children: [
+              {
+                tasks: [{ status: 'awaiting_verification' }, { status: 'todo' }],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        tasks: [{ status: 'done' }],
+        children: [],
+      },
+    ]
+    expect(countAwaitingVerificationInTree(tree)).toBe(3)
+  })
+
+  it('returns 0 for empty tree', () => {
+    expect(countAwaitingVerificationInTree([])).toBe(0)
   })
 })

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -128,3 +128,29 @@ export function sortByTimeDesc(a: Task, b: Task): number {
   const tb = b.updated_at ?? b.created_at ?? ''
   return tb.localeCompare(ta)
 }
+
+// -- Goal tree verification helpers ----------------------------
+
+interface StatusBearer {
+  status: string
+}
+
+export function countAwaitingVerificationTasks(tasks: readonly StatusBearer[]): number {
+  let n = 0
+  for (const t of tasks) if (t.status === 'awaiting_verification') n++
+  return n
+}
+
+interface TreeNodeLike {
+  tasks: readonly StatusBearer[]
+  children: readonly TreeNodeLike[]
+}
+
+export function countAwaitingVerificationInTree(nodes: readonly TreeNodeLike[]): number {
+  let n = 0
+  for (const node of nodes) {
+    n += countAwaitingVerificationTasks(node.tasks)
+    if (node.children.length > 0) n += countAwaitingVerificationInTree(node.children)
+  }
+  return n
+}

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -14,7 +14,13 @@ import type {
   GoalTreeTask,
   GoalTreeSummary,
 } from '../../types'
-import { horizonLabel, horizonColor, priorityStars } from './goal-helpers'
+import {
+  horizonLabel,
+  horizonColor,
+  priorityStars,
+  countAwaitingVerificationTasks,
+  countAwaitingVerificationInTree,
+} from './goal-helpers'
 
 /**
  * Pure hierarchy filter for goal tree nodes.
@@ -146,7 +152,13 @@ function ConvergenceBar({ pct, size = 'md' }: { pct: number; size?: 'sm' | 'md' 
 
 // --- Summary stats ---
 
-function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
+function TreeSummary({
+  summary,
+  awaitingVerificationCount,
+}: {
+  summary: GoalTreeSummary
+  awaitingVerificationCount: number
+}) {
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3 text-center">
@@ -165,6 +177,12 @@ function TreeSummary({ summary }: { summary: GoalTreeSummary }) {
         <div class="text-2xl font-bold text-ok tabular-nums">${summary.done_tasks}</div>
         <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mt-1">완료</div>
       </div>
+      ${awaitingVerificationCount > 0 ? html`
+        <div class="rounded border border-accent/30 bg-[var(--accent-10)] p-3 text-center">
+          <div class="text-2xl font-bold text-accent tabular-nums">${awaitingVerificationCount}</div>
+          <div class="text-3xs font-semibold uppercase tracking-widest text-accent/80 mt-1">검증 대기</div>
+        </div>
+      ` : null}
       <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-3">
         <div class="text-3xs font-semibold uppercase tracking-widest text-text-muted mb-2">전체 수렴도</div>
         <${ConvergenceBar} pct=${summary.overall_convergence_pct} />
@@ -226,6 +244,14 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
         ${node.task_count > 0 ? html`
           <span class="font-medium">${node.task_done_count}/${node.task_count} 태스크</span>
         ` : null}
+        ${(() => {
+          const awaiting = countAwaitingVerificationTasks(node.tasks)
+          return awaiting > 0 ? html`
+            <span class="rounded border border-accent/30 bg-[var(--accent-10)] px-2 py-0.5 text-3xs font-medium text-accent" title="verifier keeper의 독립 실측을 기다리는 task">
+              검증 대기 ${awaiting}
+            </span>
+          ` : null
+        })()}
         ${node.child_count > 0 ? html`
           <span class="font-medium">${node.child_count} 하위 목표</span>
         ` : null}
@@ -337,7 +363,10 @@ export function GoalTree() {
 
         ${error ? html`<${ErrorState} message=${error} />` : null}
 
-        ${data ? html`<${TreeSummary} summary=${data.summary} />` : null}
+        ${data ? html`<${TreeSummary}
+          summary=${data.summary}
+          awaitingVerificationCount=${countAwaitingVerificationInTree(data.tree)}
+        />` : null}
       </section>
 
       ${loading && !data ? html`


### PR DESCRIPTION
## Summary

- Adds pure helpers `countAwaitingVerificationTasks` (per-goal) and `countAwaitingVerificationInTree` (recursive) in `goal-helpers.ts`.
- `goal-tree.ts` renders a cyan "검증 대기 N" chip next to the per-node task counter when any direct task is in the `awaiting_verification` state, and a summary tile when the tree-wide count is non-zero.
- 42 unit tests in `goal-helpers.test.ts` pass (includes new helpers).
- `pnpm tsc --noEmit` clean.

## Context

Closes the "목표 (goal)" axis of the verification-surfacing series. Prior PRs covered Task (#8402/#8424/#8444), Keeper (#8422/#8454), and TLA+ (#8437). The goal tree was the last place where verification state was invisible — a goal with 8 of 10 tasks waiting on a verifier looked identical to one with 2 actively-blocked tasks.

## Scope guard

- Client-side computation only — no `GoalTreeSummary` schema change, no OCaml projection change, no new API surface.
- Reuses the "검증 대기" wording from #8424 / #8444 for visual consistency.
- Does not recurse the per-node chip into descendants (only direct tasks); the summary tile does recurse the whole tree.

## Test plan

- [x] `pnpm vitest run src/components/goals/goal-helpers.test.ts` — 42/42 pass.
- [x] `pnpm tsc --noEmit` — clean.
- [ ] Manual: open the goals section, confirm a goal with an awaiting_verification task shows the chip; TreeSummary shows the tile when the tree aggregate is non-zero.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)