### PR TITLE
fix(dashboard): governance/operator judges accept markdown-fenced JSON

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -338,21 +338,30 @@ let compute_judgments
   | Ok result -> (
       let response = result.Oas_worker.response in
       try
-        let parsed = Yojson.Safe.from_string (Oas_response.text_of_response response) in
-        let generated_at = now_iso () in
-        let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
-        let items =
-          match parsed |> member "items" with
-          | `List rows -> rows
-          | _ -> []
-        in
-        let judgments =
-          items
-          |> List.filter_map
-               (parse_item_judgment ~generated_at ~expires_at
-                  ~model_used:response.model)
-        in
-        Ok (response.model, generated_at, expires_at, judgments)
+        (* LLMs frequently wrap JSON in ```json … ``` markdown fences despite
+           explicit prompt instructions. Lenient_json strips fences, repairs
+           trailing commas, unwraps double-stringified JSON, and falls back
+           to {raw: string} only after all recovery transforms fail. *)
+        let raw_text = Oas_response.text_of_response response in
+        let parsed = Llm_provider.Lenient_json.parse raw_text in
+        match parsed with
+        | `Assoc [("raw", `String _)] ->
+            Error "Governance judge returned unparseable response (Lenient_json fallback hit)"
+        | _ ->
+            let generated_at = now_iso () in
+            let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+            let items =
+              match parsed |> member "items" with
+              | `List rows -> rows
+              | _ -> []
+            in
+            let judgments =
+              items
+              |> List.filter_map
+                   (parse_item_judgment ~generated_at ~expires_at
+                      ~model_used:response.model)
+            in
+            Ok (response.model, generated_at, expires_at, judgments)
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -248,8 +248,15 @@ let compute_judgments
   | Error err -> Error (Oas.Error.to_string err)
   | Ok result -> (
       let response = result.Oas_worker.response in
-      try Ok (response.model,
-              Yojson.Safe.from_string (Oas_response.text_of_response response))
+      try
+        (* See dashboard_governance_judge.ml for rationale: LLMs frequently
+           wrap JSON in ```json … ``` markdown fences. Lenient_json strips
+           fences and applies other deterministic recovery transforms. *)
+        let raw_text = Oas_response.text_of_response response in
+        match Llm_provider.Lenient_json.parse raw_text with
+        | `Assoc [("raw", `String _)] ->
+            Error "Operator judge returned unparseable response (Lenient_json fallback hit)"
+        | parsed -> Ok (response.model, parsed)
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)


### PR DESCRIPTION
## Symptom
> Governance judge returned invalid JSON: Line 1, bytes 0-34: Invalid token '\`\`\`json { \"items\": [ { '

User-reported runtime failure during a live tick.

## Root Cause
LLM responses occasionally wrap JSON in markdown fences (\`\`\`json … \`\`\`) despite explicit prompt instructions to return raw JSON. `Yojson.Safe.from_string` rejects the leading backticks at byte 0.

Both `governance_judge` and `operator_judge` parse LLM output with raw `Yojson.Safe.from_string` — same hidden assumption, same fragility.

## Fix
Route both judges through `Llm_provider.Lenient_json.parse` — the existing utility already used by `autoresearch_codegen`. It applies deterministic recovery transforms:
- Strip markdown fences
- Repair trailing commas
- Unwrap double-stringified JSON
- Keyword completion + bracket closure
- Falls back to `{raw: string}` only when all transforms fail

Both call sites now also **detect the `{raw: string}` fallback explicitly** and surface a meaningful error instead of silently producing empty judgment lists (the previous code path on raw fallback would treat it as `parsed |> member \"items\"` → `null` → empty list).

## Files
- `lib/dashboard/dashboard_governance_judge.ml` (1 site)
- `lib/dashboard/dashboard_operator_judge.ml` (1 site)

`agent_sdk.llm_provider` is already a dependency in `lib/dune` — no dep change.

## Verification
- `dune build @check` ✅

## Why not strengthen the prompt?
Prompt-level instructions like "return raw JSON, no markdown" are widely ignored by smaller models. Lenient parsing at the consumer is the durable fix; structured outputs / tool calling would be the next step but require deeper plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)