### PR TITLE
refactor(dashboard): .css inline #hex → CSS variables (existing tokens)

### DIFF
--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -164,12 +164,12 @@
 }
 
 .swimlane-vis-container .vis-time-axis .vis-text {
-  color: #94a3b8;
+  color: var(--slate-400);
   font-size: 10px;
 }
 
 .swimlane-vis-container .vis-labelset .vis-label {
-  color: #cbd5e1;
+  color: var(--text-slate-light);
   font-size: 11px;
   border-bottom: 1px solid rgba(100, 116, 139, 0.12);
 }
@@ -180,7 +180,7 @@
 }
 
 .swimlane-vis-container .vis-labelset .vis-label.activity-swimlane-group-highlighted {
-  color: #fbbf24;
+  color: var(--warn);
 }
 
 .swimlane-vis-container .vis-panel.vis-center,
@@ -192,14 +192,14 @@
 }
 
 .swimlane-vis-container .vis-current-time {
-  background-color: #f43f5e;
+  background-color: var(--rose);
 }
 
 .swimlane-vis-container .vis-tooltip {
   background-color: rgba(15, 23, 42, 0.95);
   border: 1px solid rgba(100, 116, 139, 0.3);
   border-radius: 6px;
-  color: #e2e8f0;
+  color: var(--frost-100);
   font-size: 11px;
   padding: 8px 10px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
@@ -207,7 +207,7 @@
 }
 
 .swimlane-vis-container .vis-item.vis-selected {
-  border-color: #fbbf24;
+  border-color: var(--warn);
   border-width: 2px;
   box-shadow: 0 0 5px rgba(251, 191, 36, 0.5);
   z-index: 10;

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -122,16 +122,16 @@
   color: var(--text-muted);
   &.active { background: var(--ok-22); color: var(--ok); }
   &.busy { background: var(--warn-15); color: var(--warn); }
-  &.listening { background: rgba(56,189,248,0.15); color: #38bdf8; }
+  &.listening { background: rgba(56,189,248,0.15); color: var(--sky-400); }
   &.idle { background: rgba(136,136,136,0.22); color: #b8c0cc; }
   &.offline { background: rgba(85,85,85,0.22); color: #7a8494; }
   &.todo { background: rgba(136,136,136,0.22); color: #b8c0cc; }
   &.in-progress, &.in_progress { background: var(--warn-15); color: var(--warn); }
   &.done, &.completed { background: var(--ok-22); color: var(--ok); }
   &.running { background: var(--warn-15); color: var(--warn); }
-  &.interrupted { background: rgba(56,189,248,0.15); color: #38bdf8; }
+  &.interrupted { background: rgba(56,189,248,0.15); color: var(--sky-400); }
   &.stopped { background: var(--slate-gray-15); color: var(--text-slate); }
-  &.error { background: rgba(251,113,133,0.15); color: #fb7185; }
+  &.error { background: rgba(251,113,133,0.15); color: var(--rose-light); }
 }
 
 @utility control-textarea {

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -4,7 +4,7 @@
 
 @utility ops-banner {
   &.error { background: var(--bad-12); border-color: rgba(239, 68, 68, 0.34); color: #fecaca; }
-  &.warn { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.28); color: #fde68a; }
+  &.warn { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.28); color: var(--yellow-100); }
   &.info { background: var(--cyan-12); border-color: rgba(34, 211, 238, 0.26); color: #cffafe; }
 }
 


### PR DESCRIPTION
## Why
Companion to #8443 (CSS rgba sweep). Same pattern, hex literal form. No new tokens — exact matches to tokens already defined.

## What
| Hex | Token | Count |
|-----|-------|-------|
| `#38bdf8` | `--sky-400` | 2 |
| `#fbbf24` | `--warn` | 2 |
| `#fde68a` | `--yellow-100` | 1 |
| `#fb7185` | `--rose-light` | 1 |
| `#94a3b8` | `--slate-400` | 1 |
| `#cbd5e1` | `--text-slate-light` | 1 |
| `#e2e8f0` | `--frost-100` | 1 |
| `#f43f5e` | `--rose` | 1 |

**Skipped (singletons, no token ROI):** `#7193ff`, `#7a8494`, `#ff4500`, `#b8c0cc`, `#fecaca`, `#cffafe`, `#a855f7`.

## Sweep
10 replacements / 3 files (global.css, dashboard.css, ops.css)

## Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)