### PR TITLE
fix(server): route board sort_by HTTP parser through Board_dispatch SSOT (#8449 PR C)

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -8,6 +8,37 @@
 
 type sort_order = Hot | Trending | Recent | Updated | Discussed
 
+(** Issue #8449: SSOT helpers for [sort_order]. Three call sites used to
+    own private parsers and a separate Variant in [Tool_board]; this PR
+    A introduces the canonical helpers here so the schema enum can derive
+    from the Variant. PR B will collapse the duplicate Variant; PR C
+    will route [server_utils] through these parsers.
+
+    All constructors are nullary so [List.map] works. *)
+let all_sort_orders = [ Hot; Trending; Recent; Updated; Discussed ]
+
+let sort_order_to_string = function
+  | Hot -> "hot"
+  | Trending -> "trending"
+  | Recent -> "recent"
+  | Updated -> "updated"
+  | Discussed -> "discussed"
+
+let valid_sort_order_strings = List.map sort_order_to_string all_sort_orders
+
+(** Lenient parser: canonical names plus documented aliases that the
+    three pre-existing parsers (Tool_board.sort_order_of_string,
+    Tool_board.parse_sort_order, server_utils inline) all accept.
+    Aliases: new=Recent, active=Updated, comments=Discussed. *)
+let sort_order_of_string_opt s =
+  match String.lowercase_ascii (String.trim s) with
+  | "hot" -> Some Hot
+  | "trending" -> Some Trending
+  | "recent" | "new" -> Some Recent
+  | "updated" | "active" -> Some Updated
+  | "discussed" | "comments" -> Some Discussed
+  | _ -> None
+
 type board_backend =
   | Jsonl of Board.store
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -29,24 +29,22 @@ let iso8601_of_unix ts =
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
     tm.tm_hour tm.tm_min tm.tm_sec
 
+(** Issue #8449 PR C: HTTP query-param sort_by parser. Delegates to
+    [Board_dispatch.sort_order_of_string_opt] (canonical + documented
+    aliases new/active/comments) instead of duplicating the inline
+    match. HTTP semantics keep the "default to Hot" fallback for
+    missing or invalid query params — graceful UI degradation, not
+    silent data corruption. *)
 let board_sort_order_of_request request =
-  let to_sort = function
-    | "trending" -> Board_dispatch.Trending
-    | "recent" | "new" -> Board_dispatch.Recent
-    | "updated" | "active" -> Board_dispatch.Updated
-    | "discussed" | "comments" -> Board_dispatch.Discussed
-    | _ -> Board_dispatch.Hot
-  in
   match query_param request "sort_by" with
   | None -> Board_dispatch.Hot
-  | Some sort -> to_sort (String.lowercase_ascii (String.trim sort))
+  | Some sort ->
+    (match Board_dispatch.sort_order_of_string_opt sort with
+     | Some s -> s
+     | None -> Board_dispatch.Hot)
 
-let board_sort_label = function
-  | Board_dispatch.Hot -> "hot"
-  | Board_dispatch.Trending -> "trending"
-  | Board_dispatch.Recent -> "recent"
-  | Board_dispatch.Updated -> "updated"
-  | Board_dispatch.Discussed -> "discussed"
+(** Issue #8449 PR C: thin alias over the Variant SSOT helper. *)
+let board_sort_label = Board_dispatch.sort_order_to_string
 
 let filter_board_posts ~exclude_system ~exclude_automation posts =
   posts

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -708,7 +708,14 @@ let tool_post_list : Types.tool_schema = {
       ("hearth", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter by hearth topic (e.g. webrtc, code-review)")]);
       ("random", `Assoc [("type", `String "boolean"); ("description", `String "Shuffle posts randomly (default: false)")]);
       ("offset", `Assoc [("type", `String "integer"); ("description", `String "Skip first N posts (default: 0)"); ("minimum", `Int 0); ("maximum", `Int 1000)]);
-      ("sort_by", `Assoc [("type", `String "string"); ("enum", `List [`String "hot"; `String "trending"; `String "recent"; `String "updated"; `String "discussed"]); ("description", `String "Sort order (default: hot)")]);
+      ("sort_by", `Assoc [
+        ("type", `String "string");
+        (* Issue #8449 PR A: derived from Board_dispatch.sort_order Variant SSOT.
+           Hand-rolled enum had 5 values that happened to be in sync; future
+           constructor would silently miss this site. *)
+        ("enum", `List (List.map (fun s -> `String s) Board_dispatch.valid_sort_order_strings));
+        ("description", `String "Sort order (default: hot)");
+      ]);
       ("exclude_system", `Assoc [("type", `String "boolean"); ("description", `String "Exclude system posts like Activity Reports (default: false)")]);
       ("exclude_automation", `Assoc [("type", `String "boolean"); ("description", `String "Exclude automation posts (heartbeat, probes, etc.) (default: false)")]);
       ("author", `Assoc [("type", `String "string"); ("maxLength", `Int 100); ("description", `String "Filter posts by author name (case-insensitive substring match)")]);

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -367,33 +367,25 @@ let handle_post_create args =
       | Error e ->
           (false, Printf.sprintf "❌ %s" (board_error_to_string e))
 
-(** Sort posts by different criteria *)
-type sort_order = Hot | Trending | Recent | Updated | Discussed
+(** Issue #8449 PR B: [sort_order] is now a re-export of
+    [Board_dispatch.sort_order] (type-alias with definition equality),
+    eliminating the parallel Variant + bridge function. Constructors
+    [Hot]/[Trending]/[Recent]/[Updated]/[Discussed] are interchangeable
+    across both modules — no [dispatch_sort_of] conversion needed. *)
+type sort_order = Board_dispatch.sort_order =
+  | Hot | Trending | Recent | Updated | Discussed
 
-let sort_order_of_string = function
-  | "hot" -> Hot
-  | "trending" -> Trending
-  | "recent" | "new" -> Recent
-  | "updated" | "active" -> Updated
-  | "discussed" | "comments" -> Discussed
-  | _ -> Hot  (* default *)
-
+(** Issue #8449 PR B: parser delegates to [Board_dispatch.sort_order_of_string_opt]
+    (canonical + documented aliases new/active/comments). Error message
+    derives from [Board_dispatch.valid_sort_order_strings] so adding a
+    constructor automatically updates the user-facing list. *)
 let parse_sort_order value =
-  match String.lowercase_ascii (String.trim value) with
-  | "hot" -> Ok Hot
-  | "trending" -> Ok Trending
-  | "recent" | "new" -> Ok Recent
-  | "updated" | "active" -> Ok Updated
-  | "discussed" | "comments" -> Ok Discussed
-  | _ -> Error "invalid sort. Valid: hot, trending, recent, updated, discussed"
-
-let dispatch_sort_of sort_by =
-  match sort_by with
-  | Hot -> Board_dispatch.Hot
-  | Trending -> Board_dispatch.Trending
-  | Recent -> Board_dispatch.Recent
-  | Updated -> Board_dispatch.Updated
-  | Discussed -> Board_dispatch.Discussed
+  match Board_dispatch.sort_order_of_string_opt value with
+  | Some s -> Ok s
+  | None ->
+    Error (Printf.sprintf
+      "invalid sort. Valid: %s"
+      (String.concat ", " Board_dispatch.valid_sort_order_strings))
 
 (** Deterministic cache key from board_list args.  Serializes the
     normalized JSON so identical parameter sets hit the same entry. *)
@@ -441,7 +433,7 @@ let handle_post_list_uncached args =
       let sorted_posts =
         Board_dispatch.list_posts ~visibility_filter ?hearth ?author_filter
           ~exclude_system ~exclude_automation
-          ~sort_by:(dispatch_sort_of sort_by) ~limit:fetch_limit ()
+          ~sort_by ~limit:fetch_limit ()
       in
 
       let posts =

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -38,6 +38,36 @@ let test_visibility_strings_complete () =
       (List.mem expected strs)
   ) ["public"; "unlisted"; "internal"; "direct"]
 
+(* Issue #8449 PR A: Board_dispatch.sort_order schema enum SSOT.
+   Witness covers all 5 variants; adding a 6th constructor will fail
+   compilation in [sort_order_to_string]. *)
+let test_sort_order_witness_in_enum () =
+  let module D = Masc_mcp.Board_dispatch in
+  let witness s =
+    let actual = D.sort_order_to_string s in
+    if not (List.mem actual D.valid_sort_order_strings) then
+      Alcotest.failf "sort_order_to_string %S not in valid_sort_order_strings" actual
+  in
+  witness D.Hot;
+  witness D.Trending;
+  witness D.Recent;
+  witness D.Updated;
+  witness D.Discussed;
+  Alcotest.(check int) "count" 5
+    (List.length D.valid_sort_order_strings)
+
+let test_sort_order_aliases () =
+  let module D = Masc_mcp.Board_dispatch in
+  Alcotest.(check (option string)) "new -> Recent" (Some "recent")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "new"));
+  Alcotest.(check (option string)) "active -> Updated" (Some "updated")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "active"));
+  Alcotest.(check (option string)) "comments -> Discussed" (Some "discussed")
+    (Option.map D.sort_order_to_string (D.sort_order_of_string_opt "comments"));
+  Alcotest.(check (option string)) "garbage rejected" None
+    (D.sort_order_of_string_opt "definitely-not-an-order"
+     |> Option.map D.sort_order_to_string)
+
 let test_permanent_post () =
   let store = create_store () in
   match
@@ -183,6 +213,13 @@ let () =
             test_visibility_witness_in_enum;
           Alcotest.test_case "all 4 strings present" `Quick
             test_visibility_strings_complete;
+        ] );
+      ( "sort_order_ssot",
+        [
+          Alcotest.test_case "witness covers all 5 variants" `Quick
+            test_sort_order_witness_in_enum;
+          Alcotest.test_case "aliases new/active/comments accepted" `Quick
+            test_sort_order_aliases;
         ] );
       ( "post_kind",
         [

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -84,28 +84,29 @@ let test_visibility_of_string () =
     (match Tool_board.visibility_of_string "garbage" with
      | None -> "none" | _ -> "other")
 
+(* Issue #8449 PR B: [Tool_board.sort_order_of_string] removed —
+   replaced by [parse_sort_order] (Result-returning) which delegates to
+   [Board_dispatch.sort_order_of_string_opt]. The previous silent
+   "unknown defaults to Hot" behavior is now an explicit Error so
+   garbage input is surfaced instead of swallowed. *)
 let test_sort_order_of_string () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check string) "hot" "hot"
-    (match Tool_board.sort_order_of_string "hot" with
-     | Tool_board.Hot -> "hot" | _ -> "x");
-  Alcotest.(check string) "trending" "trending"
-    (match Tool_board.sort_order_of_string "trending" with
-     | Tool_board.Trending -> "trending" | _ -> "x");
-  Alcotest.(check string) "recent" "recent"
-    (match Tool_board.sort_order_of_string "recent" with
-     | Tool_board.Recent -> "recent" | _ -> "x");
-  Alcotest.(check string) "updated" "updated"
-    (match Tool_board.sort_order_of_string "updated" with
-     | Tool_board.Updated -> "updated" | _ -> "x");
-  Alcotest.(check string) "discussed" "discussed"
-    (match Tool_board.sort_order_of_string "discussed" with
-     | Tool_board.Discussed -> "discussed" | _ -> "x");
-  Alcotest.(check string) "unknown defaults to hot" "hot"
-    (match Tool_board.sort_order_of_string "xyz" with
-     | Tool_board.Hot -> "hot" | _ -> "x")
+  let check name expected input =
+    match Tool_board.parse_sort_order input with
+    | Ok v when v = expected -> Alcotest.(check string) name name name
+    | Ok _ -> Alcotest.failf "%s: parsed wrong variant" name
+    | Error e -> Alcotest.failf "%s: expected Ok, got Error: %s" name e
+  in
+  check "hot" Tool_board.Hot "hot";
+  check "trending" Tool_board.Trending "trending";
+  check "recent" Tool_board.Recent "recent";
+  check "updated" Tool_board.Updated "updated";
+  check "discussed" Tool_board.Discussed "discussed";
+  (* Garbage input is now an explicit Error, not a silent Hot default. *)
+  Alcotest.(check bool) "garbage rejected" true
+    (match Tool_board.parse_sort_order "xyz" with Error _ -> true | Ok _ -> false)
 
 let test_board_error_to_string () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
PR C of 3 for #8449. Closes the sort_order Variant SSOT triangle by routing `Server_utils` through the canonical helpers from PR A.

## Stack
- **PR A** (#8453): Helpers in `Board_dispatch` + schema enum derive
- **PR B** (#8459): Type-alias `Tool_board.sort_order = Board_dispatch.sort_order`
- **PR C** (this): `Server_utils` HTTP parser → canonical helpers

## Final state after A+B+C land
| Concern | Site | Sites before |
|---------|------|--------------|
| Variant definition | `Board_dispatch.sort_order` | 2 |
| to_string | `Board_dispatch.sort_order_to_string` | 3 (Tool_board + Server_utils + bridge) |
| of_string parser | `Board_dispatch.sort_order_of_string_opt` | 3 |
| Schema enum | derived from `valid_sort_order_strings` | hand-rolled |
| Bridge function | (removed) | `dispatch_sort_of` |

## HTTP "default to Hot" preserved
Unlike PR B's `sort_order_of_string` (silent fallback for unknown that I removed), the HTTP query-param fallback in `board_sort_order_of_request` is preserved — when a user sends `?sort_by=xyz` or omits `sort_by`, returning `Hot` is the right UI degradation. The fallback now only fires after `Board_dispatch.sort_order_of_string_opt` returns `None`, which is auditable and explicit.

## Test plan
- [x] `dune build @check` clean
- [x] `dune exec test/test_board_ttl.exe` — 13/13 pass
- [x] `dune exec test/test_tool_board_coverage.exe` — 56/56 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)