### PR TITLE
fix(redact): preserve [masc:blob ...] sentinel; pretty-print output in keeper inspector

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -11,6 +11,7 @@ import { LoadingState } from './common/feedback-state'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -23,6 +24,30 @@ export function formatInput(input: unknown): string {
   } catch {
     return String(input)
   }
+}
+
+function tryPrettyJson(s: string): string | null {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2)
+  } catch {
+    return null
+  }
+}
+
+// Tool output may be (a) a raw string, (b) a JSON blob we logged as a string,
+// or (c) a [masc:blob ...] sentinel produced by Tool_output.encode_for_oas
+// when the bytes exceeded the inline threshold. Render all three as
+// human-readable pretty JSON when possible so the inspector matches what
+// Input already does via [formatInput].
+export function formatOutput(output: string): string {
+  if (!output) return '(empty)'
+  const marker = parseToolBlobMarker(output)
+  if (marker !== null) {
+    const prettyPreview = tryPrettyJson(marker.preview) ?? marker.preview
+    const shaShort = marker.sha256.slice(0, 12)
+    return `[masc:blob sha256=${shaShort}\u2026 bytes=${marker.bytes} mime=${marker.mime}]\n${prettyPreview}`
+  }
+  return tryPrettyJson(output) ?? output
 }
 
 // ── Single tool call row (expandable) ───────────────────
@@ -66,7 +91,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
           </div>
           <div>
             <${SectionCap} class="mb-1">Output<//>
-            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--text-strong)]">${entry.output || '(empty)'}</pre>
+            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--text-strong)]">${formatOutput(entry.output)}</pre>
           </div>
         </div>
       ` : null}

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -99,8 +99,13 @@ let generate_id () =
   "appr_" ^ String.sub digest 0 12
 
 let input_preview_of_json (json : Yojson.Safe.t) =
+  (* Per-leaf sentinel-aware truncation: a naive [String.sub] on the
+     serialized form would chop a [masc:blob ...] marker mid-field and
+     leave sha256/bytes/mime malformed so the approval-queue viewer
+     cannot round-trip the preview. *)
+  let json = Observability_redact.preview_json_strings ~max_len:200 json in
   let raw = Yojson.Safe.to_string json in
-  String.sub raw 0 (min 200 (String.length raw))
+  Observability_redact.redact_preview ~max_len:200 raw
 
 let create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
     ~resolver ~on_resolution =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -102,13 +102,18 @@ let reset_for_testing () =
   Hashtbl.reset pending_truncation;
   Hashtbl.reset pending_turn_context
 
-let suffix = "...(truncated)"
-let suffix_len = String.length suffix
-
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
+  (* Per-leaf sentinel-aware truncation. Previously
+     [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
+     through a [masc:blob ...] marker embedded in a nested JSON string
+     value and stranded sha256/bytes/mime halfway, breaking the keeper
+     artifact hydrator on replay. *)
+  let input =
+    Observability_redact.preview_json_strings ~max_len:max_output_len input
+  in
   let s = Yojson.Safe.to_string input in
   if String.length s > max_output_len then
-    `String (String.sub s 0 (max_output_len - suffix_len) ^ suffix)
+    `String (Observability_redact.redact_preview ~max_len:max_output_len s)
   else input
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -55,8 +55,21 @@ let truncate ?(max_len = default_max_len) (s : string) : string =
   if String.length s <= max_len then s
   else String.sub s 0 max_len ^ "...(truncated)"
 
+(* Blob sentinels (see [Tool_output.encode_for_oas]) embed a 64-hex sha256
+   that the 24+ alnum pattern would otherwise overwrite with [REDACTED],
+   destroying the structural fields the dashboard needs to render the marker
+   as a "Stored blob" preview. Decode, redact only the user-visible preview
+   body, then re-encode so sha256/bytes/mime survive intact. *)
 let redact_preview ?(max_len = default_max_len) (s : string) : string =
-  s |> truncate ~max_len |> redact_patterns
+  if Tool_output.is_sentinel s then
+    match Tool_output.decode_from_oas s with
+    | Tool_output.Stored { sha256; bytes; preview; mime } ->
+        let preview = preview |> truncate ~max_len |> redact_patterns in
+        Tool_output.encode_for_oas
+          (Tool_output.Stored { sha256; bytes; preview; mime })
+    | Tool_output.Inline _ ->
+        s |> truncate ~max_len |> redact_patterns
+  else s |> truncate ~max_len |> redact_patterns
 
 let rec redact_json_value = function
   | `Assoc fields ->

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -71,6 +71,16 @@ let redact_preview ?(max_len = default_max_len) (s : string) : string =
         s |> truncate ~max_len |> redact_patterns
   else s |> truncate ~max_len |> redact_patterns
 
+let rec preview_json_strings ?(max_len = default_max_len) (json : Yojson.Safe.t)
+    : Yojson.Safe.t =
+  match json with
+  | `String s -> `String (redact_preview ~max_len s)
+  | `Assoc fields ->
+      `Assoc
+        (List.map (fun (k, v) -> (k, preview_json_strings ~max_len v)) fields)
+  | `List items -> `List (List.map (preview_json_strings ~max_len) items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as j -> j
+
 let rec redact_json_value = function
   | `Assoc fields ->
       `Assoc

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -17,7 +17,18 @@ val redact_json_value : Yojson.Safe.t -> Yojson.Safe.t
 
 val redact_preview : ?max_len:int -> string -> string
 (** Truncate to [max_len] (default 200) and strip known sensitive patterns.
-    Result is safe for storage in proof/dashboard/metrics. *)
+    Result is safe for storage in proof/dashboard/metrics.
+
+    Sentinel-aware: if the input is a [Tool_output] blob marker, decode
+    and redact only the user-visible preview body so sha256/bytes/mime
+    survive intact for downstream parsers. *)
+
+val preview_json_strings : ?max_len:int -> Yojson.Safe.t -> Yojson.Safe.t
+(** Recursively apply [redact_preview] to every string leaf, preserving
+    JSON structure. Use this instead of [Yojson.Safe.to_string |>
+    String.sub] when the JSON may contain a [masc:blob ...] sentinel in
+    a string field — blind byte truncation chops through sha256 and
+    strands the marker. *)
 
 val redact_tool_input : tool_name:string -> Yojson.Safe.t -> string option
 (** Produce a redacted preview of tool input JSON.

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -82,6 +82,34 @@ let test_blob_sentinel_redacts_preview_body () =
   Alcotest.(check bool) "sha256 still present as structural field" true
     (Observability_redact.contains_substring ~sub:("sha256=" ^ sha) redacted)
 
+(* Regression: a sentinel embedded inside a JSON string field used to be
+   corrupted by callers that did [Yojson.Safe.to_string |> String.sub]
+   because the top-level value looks like [{...}] not [\[masc:blob ...\]],
+   so [redact_preview] took the else-branch and the 24+ alnum scrubber
+   ate sha256. [preview_json_strings] walks leaves instead. *)
+let test_preview_json_strings_preserves_embedded_sentinel () =
+  let sha = String.make 64 'c' in
+  let marker =
+    Tool_output.encode_for_oas
+      (Tool_output.Stored
+         { sha256 = sha; bytes = 500; preview = "hi"; mime = "text/plain" })
+  in
+  let json = `Assoc [("content", `String marker); ("meta", `Int 1)] in
+  let out = Observability_redact.preview_json_strings json in
+  match out with
+  | `Assoc fields ->
+      (match List.assoc_opt "content" fields with
+       | Some (`String s) ->
+           (match Tool_output.decode_from_oas s with
+            | Tool_output.Stored { sha256; bytes; mime; _ } ->
+                Alcotest.(check string) "sha256 preserved in leaf" sha sha256;
+                Alcotest.(check int) "bytes preserved in leaf" 500 bytes;
+                Alcotest.(check string) "mime preserved in leaf" "text/plain" mime
+            | Tool_output.Inline _ ->
+                Alcotest.fail "sentinel in JSON leaf was corrupted")
+       | _ -> Alcotest.fail "content field missing or not a string")
+  | _ -> Alcotest.fail "expected Assoc root"
+
 let () =
   Alcotest.run "observability_redact"
     [
@@ -95,6 +123,8 @@ let () =
             test_blob_sentinel_preserves_structure;
           Alcotest.test_case "blob sentinel redacts preview body" `Quick
             test_blob_sentinel_redacts_preview_body;
+          Alcotest.test_case "preview_json_strings preserves embedded sentinel"
+            `Quick test_preview_json_strings_preserves_embedded_sentinel;
         ] );
       ( "deny_list",
         [

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -49,6 +49,39 @@ let test_normal_tool_output_returns_some () =
   Alcotest.(check bool) "normal tool returns Some" true
     (Option.is_some result)
 
+(* Regression: the 24+ alnum pattern used to eat the 64-hex sha256 in a blob
+   sentinel and produce "[masc:blob [REDACTED] bytes=... preview=..."
+   which [Tool_output.decode_from_oas] cannot parse back. *)
+let test_blob_sentinel_preserves_structure () =
+  let sha = String.make 64 'a' in
+  let marker =
+    Tool_output.encode_for_oas
+      (Tool_output.Stored
+         { sha256 = sha; bytes = 10523; preview = "hello"; mime = "text/plain" })
+  in
+  let redacted = Observability_redact.redact_preview marker in
+  match Tool_output.decode_from_oas redacted with
+  | Tool_output.Stored { sha256; bytes; mime; _ } ->
+      Alcotest.(check string) "sha256 preserved" sha sha256;
+      Alcotest.(check int) "bytes preserved" 10523 bytes;
+      Alcotest.(check string) "mime preserved" "text/plain" mime
+  | Tool_output.Inline _ ->
+      Alcotest.fail "marker structure destroyed by redaction"
+
+let test_blob_sentinel_redacts_preview_body () =
+  let sha = String.make 64 'b' in
+  let preview = {|{"api_key": "sk-proj-abc123xyz456def789ghi012jkl345"}|} in
+  let marker =
+    Tool_output.encode_for_oas
+      (Tool_output.Stored
+         { sha256 = sha; bytes = 999; preview; mime = "application/json" })
+  in
+  let redacted = Observability_redact.redact_preview marker in
+  Alcotest.(check bool) "raw key scrubbed from preview" true
+    (not (Observability_redact.contains_substring ~sub:"abc123xyz456" redacted));
+  Alcotest.(check bool) "sha256 still present as structural field" true
+    (Observability_redact.contains_substring ~sub:("sha256=" ^ sha) redacted)
+
 let () =
   Alcotest.run "observability_redact"
     [
@@ -58,6 +91,10 @@ let () =
           Alcotest.test_case "URL credential redacted" `Quick test_url_credential_redacted;
           Alcotest.test_case "max length enforced" `Quick test_max_length_enforced;
           Alcotest.test_case "short input unchanged" `Quick test_short_input_unchanged;
+          Alcotest.test_case "blob sentinel preserves structure" `Quick
+            test_blob_sentinel_preserves_structure;
+          Alcotest.test_case "blob sentinel redacts preview body" `Quick
+            test_blob_sentinel_redacts_preview_body;
         ] );
       ( "deny_list",
         [


### PR DESCRIPTION
## Summary
Dashboard keeper tool-call inspector rendered stored tool outputs as
one-line `[masc:blob [REDACTED] bytes=... preview="{...}"]` blobs (see
screenshot in the triggering thread). Root cause is server-side, not UI.

This PR fixes the corruption at three sites in the observability pipeline
that all shared the same bug class: **structural sentinel string passed
through an opaque-bytes transform that doesn't understand structure**.

## Bug class
`lib/tool_blob_store/tool_output.ml::encode_for_oas` produces
`[masc:blob sha256=<64hex> bytes=<int> mime=<s> preview=%S]` markers.
Three downstream sites treated the string (or its JSON-embedded form)
as opaque:

1. **`lib/observability_redact.ml::redact_preview`** — generic 24+ alnum
   scrubber ate the 64-hex sha256, producing `[masc:blob [REDACTED] ...]`
   that no downstream parser recognizes.
2. **`lib/keeper_tool_call_log.ml::input_to_json`** — serialized the JSON
   input value and did `String.sub s 0 (max - suffix_len)`. A sentinel
   embedded in a nested JSON string field straddling the cut lost its
   sha256/bytes/mime tail.
3. **`lib/keeper/keeper_approval_queue.ml::input_preview_of_json`** —
   same serialize-then-chop pattern at 200 chars.

Confirmed via `Explore` audit across the pipeline. `sanitize_text_utf8`
is safe (preserves ASCII unchanged).

## Fix
- `redact_preview` — detects `Tool_output.is_sentinel`, decodes, redacts
  only the user-visible preview body, re-encodes so sha256/bytes/mime
  survive.
- New `preview_json_strings` helper walks a Yojson tree and applies
  `redact_preview` to each string leaf, preserving structure *and* any
  embedded blob markers. Both truncator sites now use it before the
  serialize/fallback step.
- Dashboard `keeper-tool-call-inspector.ts::formatOutput` parses sentinel
  markers into a compact header + JSON-pretty preview body, falls back
  to JSON pretty-print on raw JSON, and leaves other text alone. Mirrors
  `formatInput` on the Input pane.

## Test plan
- [x] `dune exec test/test_observability_redact.exe` — 11/11 pass incl.
  3 new sentinel-regression cases
- [x] `dune exec test/test_keeper_tool_call_log.exe` — 13/13
- [x] `dune exec test/test_dashboard_governance.exe` — 8/8 (approval-queue)
- [x] `bun run typecheck` in `dashboard/` — clean
- [x] `bun run test src/lib/tool-blob-marker.test.ts` — 14/14
- [ ] Manual: trigger `keeper_pr_review_read` on a large PR, confirm
  dashboard shows sha256-preserved marker + pretty JSON preview

## Scope kept tight
Only the redact helper, two JSON truncator call sites, and the inspector
display path change. No touch to `Tool_output` itself, to `ToolResultDisplay`,
or to the server-side tool log schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)