### PR TITLE
feat(doctor): Korean banner + action list + summary (flutter/brew-style polish)

### DIFF
--- a/sidecars/shared/gate_shared/doctor.py
+++ b/sidecars/shared/gate_shared/doctor.py
@@ -98,19 +98,111 @@ def _colorize(text: str, sev: Severity, *, use_color: bool) -> str:
     return f"{_COLOR[sev]}{text}{_RESET}"
 
 
+def _banner(counts: dict[Severity, int], *, use_color: bool) -> str:
+    """검사 결과를 한 줄로 요약한 상단 배너. ``flutter doctor`` 헤드라인 풍.
+
+    error > warn > (모두 skip) > ok 순으로 우선 판정한다. skip 만 있을 때
+    "통과" 로 표시하면 전제가 깨진 상태를 정상처럼 오해하게 된다.
+    """
+
+    n_err = counts[Severity.error]
+    n_warn = counts[Severity.warn]
+    n_ok = counts[Severity.ok]
+    n_skip = counts[Severity.skip]
+    actionable = n_ok + n_warn + n_err  # skip 은 "전제 부족" — 통과도 실패도 아님
+    if n_err > 0:
+        return _colorize(
+            f"✗ 심각한 문제 {n_err}개 — 실행 전 점검이 필요합니다.",
+            Severity.error,
+            use_color=use_color,
+        )
+    if n_warn > 0:
+        return _colorize(
+            f"! 주의 항목 {n_warn}개 — 실행은 가능합니다.",
+            Severity.warn,
+            use_color=use_color,
+        )
+    if actionable == 0 and n_skip > 0:
+        return _colorize(
+            f"· 모든 검사를 건너뛰었습니다 ({n_skip}개, 전제 부족).",
+            Severity.skip,
+            use_color=use_color,
+        )
+    return _colorize(
+        "✓ 모든 검사가 통과했습니다.",
+        Severity.ok,
+        use_color=use_color,
+    )
+
+
+def _action_items(checks: Sequence[Check]) -> list[str]:
+    """warn/error 의 hint 와 auto-fix 를 모아 번호 매긴 조치 목록으로.
+
+    운영자가 위에서 아래로만 읽어도 다음 행동을 알 수 있도록 footer 로 재정리.
+    per-check 블록에 이미 같은 정보가 있지만, 검사가 많아지면 스크롤을 되돌려야
+    한다. 이 목록은 "지금 뭘 해야 하나?" 에 한눈에 답한다.
+    """
+
+    items: list[str] = []
+    n = 0
+    for c in checks:
+        if not c.severity.needs_action():
+            continue
+        if c.hint:
+            n += 1
+            items.append(f"  {n}. [설정] {c.name} — {c.hint}")
+        if c.auto_fix is not None:
+            n += 1
+            label = "자동 치유" if c.auto_fix.callback is not None else "수동 실행"
+            items.append(f"  {n}. [{label}] {c.auto_fix.description}")
+            if c.auto_fix.command:
+                items.append(f"       $ {c.auto_fix.command}")
+            if c.auto_fix.callback is not None:
+                items.append("       # doctor --fix 로 실행")
+    return items
+
+
+_SEVERITY_KR: Final[dict[Severity, str]] = {
+    Severity.ok: "정상",
+    Severity.warn: "경고",
+    Severity.error: "오류",
+    Severity.info: "참고",
+    Severity.skip: "건너뜀",
+}
+
+
+def _summary_kr(counts: dict[Severity, int]) -> str:
+    order = (Severity.ok, Severity.warn, Severity.error, Severity.info, Severity.skip)
+    parts = [f"{_SEVERITY_KR[s]} {counts[s]}" for s in order if counts[s] > 0]
+    return "합계: " + (" · ".join(parts) if parts else "검사 없음")
+
+
 def render_pretty(
     title: str,
     checks: Sequence[Check],
     *,
     use_color: bool | None = None,
 ) -> str:
-    """사람이 읽기 좋은 출력 ( ``flutter doctor`` 풍)."""
+    """사람이 읽기 좋은 출력.
+
+    레이아웃은 ``flutter doctor`` / ``brew doctor`` 외형을 참고:
+
+    1. 제목 (``# Discord Sidecar Doctor``)
+    2. 배너 — 전체 상태 한 줄 요약
+    3. 검사 목록 — 등록 순서 유지 (검진 흐름이 곧 읽는 순서)
+    4. 조치 항목 — warn/error 에서 나온 hint + auto-fix 를 번호 목록으로
+    5. 합계 — 한글 카운트
+    """
 
     if use_color is None:
         use_color = sys.stdout.isatty()
 
+    counts = _tally(checks)
+
     lines: list[str] = []
     lines.append(f"# {title}")
+    lines.append("")
+    lines.append(_banner(counts, use_color=use_color))
     lines.append("")
     for c in checks:
         sym = _colorize(_SYMBOL[c.severity], c.severity, use_color=use_color)
@@ -130,12 +222,13 @@ def render_pretty(
                 lines.append(f"        $ {c.auto_fix.command}")
             if c.auto_fix.callback is not None:
                 lines.append("        auto-fix 가능: doctor --fix")
+    actions = _action_items(checks)
+    if actions:
+        lines.append("")
+        lines.append("조치 항목:")
+        lines.extend(actions)
     lines.append("")
-    counts = _tally(checks)
-    summary = ", ".join(
-        f"{counts[s]} {s.value}" for s in Severity if counts[s] > 0
-    )
-    lines.append(f"summary: {summary or '0 checks'}")
+    lines.append(_summary_kr(counts))
     return "\n".join(lines)
 
 

--- a/sidecars/shared/tests/test_doctor.py
+++ b/sidecars/shared/tests/test_doctor.py
@@ -37,6 +37,99 @@ def test_severity_symbols_render_prefix() -> None:
     assert "missing" in text and "broken" in text
 
 
+def test_banner_all_ok() -> None:
+    checks = [
+        Check(name="a", severity=Severity.ok, message=""),
+        Check(name="b", severity=Severity.ok, message=""),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "모든 검사가 통과" in text
+    # all-ok 에서는 조치 항목 블록이 나오면 안 된다
+    assert "조치 항목:" not in text
+
+
+def test_banner_has_error_takes_priority_over_warn() -> None:
+    checks = [
+        Check(name="a", severity=Severity.ok, message=""),
+        Check(name="b", severity=Severity.warn, message="m"),
+        Check(name="c", severity=Severity.error, message="boom"),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "심각한 문제 1개" in text
+    assert "실행 전 점검" in text
+    # warn 배너 문구는 error 가 있을 때 배너 줄에 노출되지 않아야 한다
+    banner_section = text.split("조치 항목:")[0]
+    assert "주의 항목" not in banner_section.splitlines()[2]
+
+
+def test_banner_warn_only() -> None:
+    checks = [Check(name="a", severity=Severity.warn, message="m")]
+    text = render_pretty("T", checks, use_color=False)
+    assert "주의 항목 1개" in text
+    assert "실행은 가능" in text
+
+
+def test_banner_all_skipped_not_ok() -> None:
+    """전제 부족으로 전부 skip 될 때는 '통과' 로 오해되지 않도록."""
+
+    checks = [
+        Check(name="a", severity=Severity.skip, message=""),
+        Check(name="b", severity=Severity.skip, message=""),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "건너뛰었습니다" in text
+    assert "모든 검사가 통과" not in text
+
+
+def test_action_items_lists_hints_and_auto_fix() -> None:
+    checks = [
+        Check(
+            name="needs-cfg",
+            severity=Severity.warn,
+            message="m",
+            hint="SLACK_BOT_TOKEN 을 환경에 설정",
+        ),
+        Check(
+            name="needs-fix",
+            severity=Severity.error,
+            message="x",
+            auto_fix=AutoFix(description="권한 재설정", command="chmod 0755 /var/gate"),
+        ),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "조치 항목:" in text
+    assert "[설정] needs-cfg — SLACK_BOT_TOKEN 을 환경에 설정" in text
+    assert "[수동 실행] 권한 재설정" in text
+    assert "$ chmod 0755 /var/gate" in text
+
+
+def test_action_item_marks_auto_fix_callback_available() -> None:
+    async def _noop() -> None:
+        return None
+
+    checks = [
+        Check(
+            name="auto",
+            severity=Severity.error,
+            message="x",
+            auto_fix=AutoFix(description="재시작", callback=_noop),
+        )
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "[자동 치유] 재시작" in text
+    assert "# doctor --fix 로 실행" in text
+
+
+def test_summary_line_in_korean() -> None:
+    checks = [
+        Check(name="a", severity=Severity.ok, message=""),
+        Check(name="b", severity=Severity.warn, message="m"),
+        Check(name="c", severity=Severity.error, message="x"),
+    ]
+    text = render_pretty("T", checks, use_color=False)
+    assert "합계: 정상 1 · 경고 1 · 오류 1" in text
+
+
 def test_render_json_shape() -> None:
     checks = [Check(name="x", severity=Severity.ok, message="", detail="v1")]
     payload = json.loads(render_json("T", checks))


### PR DESCRIPTION
## 요약

Doctor pretty 렌더러 외모 개선. `flutter doctor` / `brew doctor` 레이아웃을 참고해 **배너 → 검사 → 조치 항목 → 한글 합계** 4블록으로 재구성. 5 sidecar 전체가 즉시 혜택 (shared `gate_shared.doctor` 단일 변경).

## Before / After

**Before** — summary 한 줄만, 운영자는 hint 를 찾아 스크롤해야 함:

```
# Discord Sidecar Doctor

[✓] python >= 3.11  (3.12.4)
[!] DISCORD_ADMIN_ROLE_ID
    ↳ admin role 이 비어 있어 바인딩 명령 권한이 누구에게나 열립니다.
      hint: 서버에서 역할을 만들고 ID 를 복사해 env 에 기록
[✗] binding paths writable
    ↳ /var/gate (permission denied)
      hint: 상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정
      fix: 접근 권한이 없는 상위 디렉터리에 0755 시도
        auto-fix 가능: doctor --fix

summary: 3 ok, 1 warn, 1 error
```

**After** — 상단 한 줄 판정 + 하단 조치 목록:

```
# Discord Sidecar Doctor

✗ 심각한 문제 1개 — 실행 전 점검이 필요합니다.

[✓] python >= 3.11  (3.12.4)
[!] DISCORD_ADMIN_ROLE_ID
    ↳ admin role 이 비어 있어 바인딩 명령 권한이 누구에게나 열립니다.
      hint: 서버에서 역할을 만들고 ID 를 복사해 env 에 기록
[✗] binding paths writable
    ↳ /var/gate (permission denied)
      hint: 상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정
      fix: 접근 권한이 없는 상위 디렉터리에 0755 시도
        auto-fix 가능: doctor --fix

조치 항목:
  1. [설정] DISCORD_ADMIN_ROLE_ID — 서버에서 역할을 만들고 ID 를 복사해 env 에 기록
  2. [설정] binding paths writable — 상위 디렉터리 권한을 확인하거나 경로를 명시적으로 설정
  3. [자동 치유] 접근 권한이 없는 상위 디렉터리에 0755 시도
       # doctor --fix 로 실행

합계: 정상 3 · 경고 1 · 오류 1
```

## 왜

Discord/Slack/Telegram/iMessage/CLI 5 커넥터가 모두 같은 renderer 를 공유. 각 sidecar 의 check 개수는 7~11 개로 늘었고, 운영자는 `↳` 로 들여쓰기된 hint 를 스크롤로 긁어 모아 읽어야 했다. **"지금 뭘 해야 하나?"** 에 한눈에 답하는 footer 가 없었다.

`flutter doctor` / `brew doctor` 외형 특징:
- **배너 1줄**: 전체 판정을 맨 위에
- **조치 목록**: warn/error 의 hint 를 번호 매겨 footer 에 재정리
- **한글 친화**: 운영자가 한국어 사용자라면 한글 문구

이 3축을 `render_pretty` 에만 적용. `render_json` 은 불변 — 대시보드 / CI 스모크 호환 유지.

## 추가된 블록

### ① 배너 (title 바로 아래)

| 조건 | 문구 | 색 |
|------|------|----|
| error ≥ 1 | `✗ 심각한 문제 N개 — 실행 전 점검이 필요합니다.` | 적색 |
| warn ≥ 1 (error 없음) | `! 주의 항목 N개 — 실행은 가능합니다.` | 황색 |
| 전부 skip | `· 모든 검사를 건너뛰었습니다 (N개, 전제 부족).` | 회색 |
| 그 외 | `✓ 모든 검사가 통과했습니다.` | 녹색 |

우선순위 판정으로 "skip 만" 케이스를 "통과" 로 오해하지 않는다.

### ② 조치 항목 footer

```
조치 항목:
  1. [설정] <name> — <hint>
  2. [자동 치유] <description>
       # doctor --fix 로 실행
  3. [수동 실행] <description>
       $ <command>
```

- `[설정]` — 운영자가 직접 (hint 만 있을 때)
- `[자동 치유]` — `callback` 있음 → `doctor --fix` 로 실행 가능
- `[수동 실행]` — `command` 만 있음 → 쉘에 복붙

all-ok 에서는 이 블록 전체가 숨어서 시각 소음 없음.

### ③ 한글 합계

```
합계: 정상 N · 경고 N · 오류 N [· 참고 N] [· 건너뜀 N]
```

카운트 0 인 항목은 자동으로 빠진다.

## 변경 없는 것

- per-check 라인 포맷 (`[✓] name (detail)` / `↳ message` / `hint:` / `fix:`)
- 기호 테이블 (`[✓]/[!]/[✗]/[i]/[·]`)
- ANSI 색 (TTY 에서만)
- 등록 순서대로 출력 (정렬 안 함 — 검진 흐름 = 읽기 순서)
- `render_json` — 대시보드·CI 스모크 호환 유지

## 테스트

8 신규, 15 total pass (기존 7 포함).

```
sidecars/shared/tests/test_doctor.py:
  test_severity_symbols_render_prefix (기존)
  test_banner_all_ok
  test_banner_has_error_takes_priority_over_warn
  test_banner_warn_only
  test_banner_all_skipped_not_ok   ← skip-only "통과" 오분류 regression guard
  test_action_items_lists_hints_and_auto_fix
  test_action_item_marks_auto_fix_callback_available
  test_summary_line_in_korean
  ... (기존 7개 그대로)
```

```
$ python -m pytest tests/test_doctor.py -q
...............  [100%]
15 passed in 0.07s
```

## 체크리스트

- [x] 기존 테스트 regression 0
- [x] render_json 불변 (대시보드 호환)
- [x] all-ok / has-error / warn-only / all-skipped 4 케이스 assertion
- [x] skip-only 를 "통과" 로 오해하지 않는 regression guard
- [x] 5 sidecar 자동 혜택 (shared 경로)
- [ ] 실사 — deps 미설치 환경에서 sidecar 돌려 육안 확인 (후속)

## Out of scope (후속 PR)

- OCaml `masc-mcp doctor` 최상위에 `sidecar|all` 서브커맨드 dispatch
- Dashboard `/api/v1/dashboard/doctor` 엔드포인트 + 패널
- 실제 `--fix` auto-fix callback 본격 구현 (`chmod 0755`, `mkdir -p`, env 재로드)
