### PR TITLE
fix(keeper_schema): mirror profile enums (sandbox/network/shared_memory) (#8467)

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -10,6 +10,22 @@ open Types
 let tool_preset_enum_strings =
   [ "minimal"; "social"; "messaging"; "coding"; "research"; "delivery"; "full" ]
 
+(** Issue #8467: canonical strings for [Keeper_types_profile.sandbox_profile],
+    [network_mode], and [shared_memory_scope]. Same cycle constraint as
+    [tool_preset_enum_strings] above — Keeper_schema cannot depend on
+    Keeper_types_profile directly because the latter [include]s
+    Keeper_config and is otherwise downstream. The test
+    [test_types.ml :: keeper_profile_enum_ssot] asserts these mirrors
+    stay in sync with [valid_*_strings] so adding a constructor in
+    Keeper_types_profile fails the test instead of silently dropping
+    from the JSON Schema. *)
+let sandbox_profile_enum_strings =
+  [ "legacy_local"; "docker_hardened" ]
+let network_mode_enum_strings =
+  [ "none"; "inherit" ]
+let shared_memory_scope_enum_strings =
+  [ "disabled"; "room" ]
+
 let string_array_schema =
   `Assoc [
     ("type", `String "array");
@@ -254,17 +270,17 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("sandbox_profile", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "legacy_local"; `String "docker_hardened"]);
+          ("enum", `List (List.map (fun s -> `String s) sandbox_profile_enum_strings));
           ("description", `String "Filesystem/process sandbox profile. 'legacy_local' keeps the current local execution model. 'docker_hardened' runs keeper_bash in an ephemeral hardened Docker container rooted at the keeper playground.");
         ]);
         ("network_mode", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "none"; `String "inherit"]);
+          ("enum", `List (List.map (fun s -> `String s) network_mode_enum_strings));
           ("description", `String "Network policy associated with the sandbox profile. 'none' is valid only with sandbox_profile='docker_hardened'.");
         ]);
         ("shared_memory_scope", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "disabled"; `String "room"]);
+          ("enum", `List (List.map (fun s -> `String s) shared_memory_scope_enum_strings));
           ("description", `String "Typed shared-memory lane policy. 'room' enables keeper-authorized masc_team_memory_* access on the flattened default namespace.");
         ]);
         ("allowed_paths", `Assoc [

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -29,6 +29,14 @@ let sandbox_profile_of_string raw =
   | "docker_hardened" -> Some Docker_hardened
   | _ -> None
 
+(* Issue #8467: Variant SSOT — adding a constructor to [sandbox_profile]
+   forces [sandbox_profile_to_string] exhaustiveness AND extends
+   [valid_sandbox_profile_strings] so [keeper_schema] picks it up via
+   the mirror declared there. *)
+let all_sandbox_profiles = [ Legacy_local; Docker_hardened ]
+let valid_sandbox_profile_strings =
+  List.map sandbox_profile_to_string all_sandbox_profiles
+
 let network_mode_to_string = function
   | Network_none -> "none"
   | Network_inherit -> "inherit"
@@ -39,6 +47,11 @@ let network_mode_of_string raw =
   | "inherit" -> Some Network_inherit
   | _ -> None
 
+(* Issue #8467: Variant SSOT for [network_mode]. *)
+let all_network_modes = [ Network_none; Network_inherit ]
+let valid_network_mode_strings =
+  List.map network_mode_to_string all_network_modes
+
 let shared_memory_scope_to_string = function
   | Shared_memory_disabled -> "disabled"
   | Shared_memory_room -> "room"
@@ -48,6 +61,11 @@ let shared_memory_scope_of_string raw =
   | "disabled" -> Some Shared_memory_disabled
   | "room" -> Some Shared_memory_room
   | _ -> None
+
+(* Issue #8467: Variant SSOT for [shared_memory_scope]. *)
+let all_shared_memory_scopes = [ Shared_memory_disabled; Shared_memory_room ]
+let valid_shared_memory_scope_strings =
+  List.map shared_memory_scope_to_string all_shared_memory_scopes
 
 let default_sandbox_profile = Legacy_local
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -305,6 +305,52 @@ let () =
           (Masc_mcp.Operator_control_snapshot.snapshot_view_of_string_opt
              "sessions" <> None));
     ];
+    "keeper_profile_enum_ssot", [
+      (* Issue #8467: witness exhaustiveness for [Keeper_types_profile]
+         nullary variants — adding a new constructor fails compilation
+         in the matching [*_to_string] function. *)
+      Alcotest.test_case "sandbox_profile witness covers both variants" `Quick (fun () ->
+        let open Masc_mcp.Keeper_types_profile in
+        let witness s =
+          let actual = sandbox_profile_to_string s in
+          if not (List.mem actual valid_sandbox_profile_strings) then
+            Alcotest.failf "sandbox_profile_to_string %S not in valid_sandbox_profile_strings" actual
+        in
+        witness Legacy_local; witness Docker_hardened;
+        Alcotest.(check int) "count" 2 (List.length valid_sandbox_profile_strings));
+      Alcotest.test_case "network_mode witness covers both variants" `Quick (fun () ->
+        let open Masc_mcp.Keeper_types_profile in
+        let witness s =
+          let actual = network_mode_to_string s in
+          if not (List.mem actual valid_network_mode_strings) then
+            Alcotest.failf "network_mode_to_string %S not in valid_network_mode_strings" actual
+        in
+        witness Network_none; witness Network_inherit;
+        Alcotest.(check int) "count" 2 (List.length valid_network_mode_strings));
+      Alcotest.test_case "shared_memory_scope witness covers both variants" `Quick (fun () ->
+        let open Masc_mcp.Keeper_types_profile in
+        let witness s =
+          let actual = shared_memory_scope_to_string s in
+          if not (List.mem actual valid_shared_memory_scope_strings) then
+            Alcotest.failf "shared_memory_scope_to_string %S not in valid_shared_memory_scope_strings" actual
+        in
+        witness Shared_memory_disabled; witness Shared_memory_room;
+        Alcotest.(check int) "count" 2 (List.length valid_shared_memory_scope_strings));
+      Alcotest.test_case "schema mirrors stay in sync" `Quick (fun () ->
+        (* Cycle-avoidance: Keeper_schema cannot depend on
+           Keeper_types_profile directly, so it hand-mirrors the SSOT.
+           This test catches drift before a new constructor silently
+           drops from the JSON Schema. *)
+        Alcotest.(check (list string)) "sandbox_profile mirror"
+          Masc_mcp.Keeper_types_profile.valid_sandbox_profile_strings
+          Masc_mcp.Keeper_schema.sandbox_profile_enum_strings;
+        Alcotest.(check (list string)) "network_mode mirror"
+          Masc_mcp.Keeper_types_profile.valid_network_mode_strings
+          Masc_mcp.Keeper_schema.network_mode_enum_strings;
+        Alcotest.(check (list string)) "shared_memory_scope mirror"
+          Masc_mcp.Keeper_types_profile.valid_shared_memory_scope_strings
+          Masc_mcp.Keeper_schema.shared_memory_scope_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8467.

`lib/keeper/keeper_schema.ml` lines 257/262/267 hardcoded JSON Schema `enum` arrays mirroring three Variants in `lib/keeper/keeper_types_profile.ml`:

| line | enum | Variant |
|---|---|---|
| 257 | `[legacy_local; docker_hardened]` | `sandbox_profile` |
| 262 | `[none; inherit]` | `network_mode` |
| 267 | `[disabled; room]` | `shared_memory_scope` |

Adding a constructor would silently drop from schema — same drift class as #8430 (`tool_preset` Social/Delivery).

## Approach

Same cycle-avoidance pattern as #8430:
- Add `all_*` + `valid_*_strings` to `keeper_types_profile.ml` (nullary -> simple `List.map`).
- Declare local mirror constants in `keeper_schema.ml` (cycle: Schema -> Types -> Types_profile -> Schema blocks direct dep).
- Sync regression test asserts mirror == `valid_*_strings`.
- Schema enums replaced with `List.map (fun s -> \`String s) <mirror>`.

## Verification

- `dune build` clean.
- `test_types.ml :: keeper_profile_enum_ssot` adds 4 cases (3 witness + 1 mirror sync).
- `test_types` 33/33 pass.

## Risk

Low — same shape as #8430 (merged). No behavior change today; structural prevention only.

## Drift catalog (cumulative)

After this PR the cycle-avoidance mirror pattern protects:
1. `tool_preset` (#8430)
2. `sandbox_profile` (#8467)
3. `network_mode` (#8467)
4. `shared_memory_scope` (#8467)
