### PR TITLE
observe(coord_task): warn on claimed->done FSM drift (pre-ratchet)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -786,7 +786,19 @@ let transition_task_r config ~agent_name ~task_id ~action
         | (Types.Claim | Types.Start), Types.Done _ ->
             (* Idempotent: already done, no-op *)
             Ok (task.task_status, None)
-        | Types.Done_action, Types.Claimed { assignee; _ }
+        | Types.Done_action, Types.Claimed { assignee; _ } when assignee = agent_name || force ->
+            (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress.
+               Log WARN so dashboards can surface keepers that skip Start. The
+               jump is still permitted for client compatibility; strictness
+               ratchet follows once keeper_task_start is exposed. *)
+            Log.RoomTask.warn
+              "fsm_drift claimed_to_done_skip task=%s agent=%s force=%b"
+              task_id agent_name force;
+            Ok (Types.Done {
+              assignee = agent_name;
+              completed_at = now;
+              notes = if notes = "" then None else Some notes;
+            }, None)
         | Types.Done_action, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
             Ok (Types.Done {
               assignee = agent_name;


### PR DESCRIPTION
## Summary

- **Drift**: TLA+ `KeeperTaskInterlock.DoneTask` (line 137) requires `status = in_progress`; OCaml `coord_task.ml:789-790` accepts `Done_action` from `Claimed` too, skipping `Start`.
- **Live evidence** (2026-04-18 backlog): 155 tasks, `in_progress=0`. Entire keeper fleet bypasses `Start` every time.
- **Root cause**: keeper tool surface exposes `keeper_task_claim` + `keeper_task_done` but **not** `keeper_task_start`. Keepers literally cannot emit the transition.
- This PR does not close the tool surface gap yet — it only adds a `Log.RoomTask.warn "fsm_drift claimed_to_done_skip ..."` on every direct jump so dashboards and telemetry can surface the drift per-agent/per-task while the follow-up lands.

## Why not strict rejection

8 test files + every running keeper rely on the shortcut. Strict ratchet requires:
1. Expose `keeper_task_start` in tool registry
2. Update `keeper_prompt.ml` lifecycle ("Claim → Start → Work → Done")
3. Migrate 8 tests
4. Flip the transition relation to reject `claimed → done`

That sequence is tracked as a follow-up PR; this observability patch is the ratchet's first rung.

## Test plan

- [x] `dune build --root .` — green
- [x] `dune build --root . @runtest` — full suite exits 0 (no test asserts on log silence)
- [ ] Post-merge: grep server logs for `fsm_drift claimed_to_done_skip` to quantify per-keeper drift frequency → inform follow-up priority
- [ ] Next PR: expose `keeper_task_start` tool + prompt update

## TLA+ spec reference

`specs/bug-models/KeeperTaskInterlock.tla:137`:
```tla
DoneTask(t) ==
    /\ task_status[t] = "in_progress"
    /\ task_status'  = [task_status  EXCEPT ![t] = "done"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)