### PR TITLE
fix(tool_operator): derive view enum from Variant SSOT — Sessions was missing (#8471)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -723,14 +723,42 @@ type snapshot_view =
   | Messages
   | Full
 
+(* Issue #8471: Variant SSOT for [snapshot_view]. Adding a constructor
+   forces [snapshot_view_to_string] exhaustiveness AND extends
+   [valid_snapshot_view_strings]; the schema in [tool_operator.ml]
+   derives its enum from this list, so a new constructor flows
+   through automatically instead of silently dropping (as [Sessions]
+   did before this fix). *)
+let snapshot_view_to_string = function
+  | Summary -> "summary"
+  | Sessions -> "sessions"
+  | Keepers -> "keepers"
+  | Messages -> "messages"
+  | Full -> "full"
+
+let all_snapshot_views = [ Summary; Sessions; Keepers; Messages; Full ]
+
+let valid_snapshot_view_strings =
+  List.map snapshot_view_to_string all_snapshot_views
+
+(* Sound partial parser — Some for canonical strings, None otherwise.
+   [parse_snapshot_view] below intentionally falls back to [Full] for
+   tool/HTTP back-compat; this opt variant exists for callers that
+   want to distinguish unknown input. *)
+let snapshot_view_of_string_opt raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "summary" -> Some Summary
+  | "sessions" -> Some Sessions
+  | "keepers" -> Some Keepers
+  | "messages" -> Some Messages
+  | "full" -> Some Full
+  | _ -> None
+
 let parse_snapshot_view = function
   | Some raw -> (
-      match String.trim raw |> String.lowercase_ascii with
-      | "summary" -> Summary
-      | "sessions" -> Sessions
-      | "keepers" -> Keepers
-      | "messages" -> Messages
-      | _ -> Full)
+      match snapshot_view_of_string_opt raw with
+      | Some v -> v
+      | None -> Full)
   | None -> Full
 
 (* Snapshot TTL cache with same-key deduplication (singleflight).

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -53,7 +53,12 @@ let snapshot_schema ~remote =
             schema_properties
               [
                 ("actor", `Assoc [ ("type", `String "string") ]);
-                ("view", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "summary"; `String "keepers"; `String "messages"; `String "full" ]) ]);
+                (* Issue #8471: derive enum from Variant SSOT
+                   ([Operator_control_snapshot.valid_snapshot_view_strings]).
+                   Sessions was missing from the hand-written list before
+                   this fix; the parser accepted "sessions" but the
+                   schema rejected it. *)
+                ("view", `Assoc [ ("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) Operator_control_snapshot.valid_snapshot_view_strings)) ]);
                 ("include_messages", `Assoc [ ("type", `String "boolean") ]);
                 ("include_keepers", `Assoc [ ("type", `String "boolean") ]);
               ] );

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -277,6 +277,34 @@ let () =
         Alcotest.(check bool) "delivery present" true
           (List.mem "delivery" valid_tool_preset_strings));
     ];
+    "operator_view_ssot", [
+      (* Issue #8471: tool_operator view enum was missing 'sessions'
+         while parser+impl supported all 5. This test catches schema
+         drift by deriving the asserted list from the Variant SSOT. *)
+      Alcotest.test_case "witness covers all 5 variants" `Quick (fun () ->
+        let open Masc_mcp.Operator_control_snapshot in
+        let witness v =
+          let actual = snapshot_view_to_string v in
+          if not (List.mem actual valid_snapshot_view_strings) then
+            Alcotest.failf "snapshot_view_to_string %S not in valid_snapshot_view_strings" actual
+        in
+        witness Summary; witness Sessions; witness Keepers;
+        witness Messages; witness Full;
+        Alcotest.(check int) "count" 5 (List.length valid_snapshot_view_strings));
+      Alcotest.test_case "all 5 strings present" `Quick (fun () ->
+        let strs = Masc_mcp.Operator_control_snapshot.valid_snapshot_view_strings in
+        List.iter (fun expected ->
+          Alcotest.(check bool) (Printf.sprintf "%s present" expected) true
+            (List.mem expected strs)
+        ) ["summary"; "sessions"; "keepers"; "messages"; "full"]);
+      Alcotest.test_case "of_string_opt rejects garbage" `Quick (fun () ->
+        Alcotest.(check bool) "garbage" true
+          (Masc_mcp.Operator_control_snapshot.snapshot_view_of_string_opt
+             "definitely-not-a-view" = None);
+        Alcotest.(check bool) "sessions accepted" true
+          (Masc_mcp.Operator_control_snapshot.snapshot_view_of_string_opt
+             "sessions" <> None));
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8471. **Real missing-constructor bug fix** (not prevention-only).

`lib/tool_operator.ml:56` JSON Schema enum was `[summary; keepers; messages; full]`. But `Operator_control_snapshot.snapshot_view` (lib/operator/operator_control_snapshot.ml:719) has 5 constructors:

```ocaml
type snapshot_view = Summary | Sessions | Keepers | Messages | Full
```

`Sessions` was missing from schema → tool callers sending `view=sessions` got JSON-Schema validation rejection while `parse_snapshot_view` could parse it. Same drift class as #8430.

## Approach

- Added Variant SSOT helpers next to the type def in `operator_control_snapshot.ml`:
  - `snapshot_view_to_string` (exhaustive match — adds new constructor → compile error)
  - `all_snapshot_views`
  - `valid_snapshot_view_strings`
  - `snapshot_view_of_string_opt` (sound partial: Some for canonical, None otherwise)
- `parse_snapshot_view` refactored to call `snapshot_view_of_string_opt` then fall back to `Full` (preserves HTTP/tool back-compat).
- `tool_operator.ml:56` schema enum now `List.map (fun s -> \`String s) Operator_control_snapshot.valid_snapshot_view_strings`.

## Verification

- `dune build` clean.
- `test_types.ml :: operator_view_ssot` — 3 cases (witness + presence + opt rejection).
- Total `test_types` 32/32 pass.

## Risk

- Schema enum gains "sessions" — existing callers see no change (they were already using subset). New callers can now send "sessions" without rejection.
- `parse_snapshot_view` semantic preserved (back-compat with `_ -> Full` fallback), so internal call sites unchanged.

## Drift catalog (cumulative — Variant SSOT pattern)

1. `tool_preset` (#8430) — REAL bug
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL bug
