### PR TITLE
[H1-j] keeper-memory-tier-panel: add tick subscription

### DIFF
--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -12,6 +12,9 @@ import { InlineSpinner } from './common/inline-spinner'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { FilterChips } from './common/filter-chips'
 import { buildCompactionSpec } from './keeper-fsm-specs'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+
+const REFRESH_MS = 30_000
 
 interface KeeperMemoryTierPanelProps {
   keeperName: string
@@ -66,40 +69,48 @@ export function KeeperMemoryTierPanel({
     setLoading(true)
     setError(null)
 
-    Promise.allSettled([
-      fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
-      fetchKeeperComposite(keeperName, { signal: controller.signal }),
-    ])
-      .then(([usageResult, compositeResult]) => {
-        if (controller.signal.aborted) return
-        let nextError: string | null = null
+    const refresh = async () => {
+      Promise.allSettled([
+        fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
+        fetchKeeperComposite(keeperName, { signal: controller.signal }),
+      ])
+        .then(([usageResult, compositeResult]) => {
+          if (controller.signal.aborted) return
+          let nextError: string | null = null
 
-        if (usageResult.status === 'fulfilled') {
-          setUsage(usageResult.value.memory_kind_usage ?? [])
-        } else {
-          setUsage(null)
-          nextError = usageResult.reason instanceof Error ? usageResult.reason.message : 'memory tier fetch failed'
-        }
+          if (usageResult.status === 'fulfilled') {
+            setUsage(usageResult.value.memory_kind_usage ?? [])
+          } else {
+            setUsage(null)
+            nextError = usageResult.reason instanceof Error ? usageResult.reason.message : 'memory tier fetch failed'
+          }
 
-        if (compositeResult.status === 'fulfilled') {
-          setSnapshot(compositeResult.value)
-        } else {
-          setSnapshot(null)
-          nextError ||= compositeResult.reason instanceof Error
-            ? compositeResult.reason.message
-            : 'composite fetch failed'
-        }
+          if (compositeResult.status === 'fulfilled') {
+            setSnapshot(compositeResult.value)
+          } else {
+            setSnapshot(null)
+            nextError ||= compositeResult.reason instanceof Error
+              ? compositeResult.reason.message
+              : 'composite fetch failed'
+          }
 
-        setError(nextError)
-        setLoading(false)
-      })
-      .catch(err => {
-        if (controller.signal.aborted) return
-        setError(err instanceof Error ? err.message : 'memory tier fetch failed')
-        setLoading(false)
-      })
+          setError(nextError)
+          setLoading(false)
+        })
+        .catch(err => {
+          if (controller.signal.aborted) return
+          setError(err instanceof Error ? err.message : 'memory tier fetch failed')
+          setLoading(false)
+        })
+    }
 
-    return () => { controller.abort() }
+    refresh()
+    const cleanup = setupVisibleAutoRefresh(() => refresh(), REFRESH_MS)
+
+    return () => {
+      controller.abort()
+      cleanup()
+    }
   }, [keeperName])
 
   if (loading) {


### PR DESCRIPTION
## Summary

Implements automatic refresh of the memory tier panel when the dashboard is visible, following the same pattern used by memory-subsystems.ts component.

**Changes**:
- Import `setupVisibleAutoRefresh` from the auto-refresh library
- Define `REFRESH_MS = 30_000` (30-second refresh interval)
- Extract fetch logic into a `refresh()` function
- Set up visible auto-refresh subscription on component mount
- Properly clean up the subscription on unmount alongside the existing abort controller

## Test Plan

- [ ] Dashboard memory tier panel refreshes automatically every 30 seconds when visible
- [ ] Memory tier data updates reflect recent keeper state changes
- [ ] No memory leaks: cleanup removes subscription on component unmount
- [ ] Respects visibility: refresh pauses when dashboard tab is not in focus (setupVisibleAutoRefresh behavior)

## Notes

This follows the established pattern from `memory-subsystems.ts` for consistency across dashboard components. The 30-second refresh interval matches other dashboard panels.

🤖 Generated by masc-improver keeper (task-170)