### PR TITLE
fix(mcp_server): add 3 verifier-FSM transitions to schema_json (#8474)

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -413,20 +413,54 @@ let read_event_lines config ~limit =
     ) month_dirs;
     List.rev !collected
 
+(** Issue #8474: FSM transition matrix.  Each entry mirrors a match-arm
+    in [Coord_task.transition_task_r] (lib/coord/coord_task.ml ~line
+    831).  Verifier-FSM rows ([submit_for_verification],
+    [approve_verification], [reject_verification]) are gated at runtime
+    by [MASC_VERIFICATION_FSM_ENABLED] but listed unconditionally so
+    the published schema matches the action enum
+    ([Types.valid_task_action_strings] via #8354).  The regression test
+    [test_types.ml :: fsm_transition_matrix] asserts every action
+    listed by [Coord_task.valid_next_actions_for_status] for any
+    reachable status appears here, so adding a 4th verifier action
+    fails the test before it ships with a stale schema. *)
+let task_fsm_transitions : (string * string list * string * string option) list =
+  [
+    ("claim",                   ["todo"],                                  "claimed",                None);
+    ("start",                   ["claimed"],                               "in_progress",            None);
+    ("done",                    ["claimed"; "in_progress"],                "done",                   None);
+    ("cancel",                  ["todo"; "claimed"; "in_progress"],        "cancelled",              None);
+    ("release",                 ["claimed"; "in_progress"],                "todo",                   None);
+    (* Action names match [Types.task_action_to_string] (SSOT):
+       Approve_verification -> "approve", Reject_verification -> "reject". *)
+    ("submit_for_verification", ["claimed"; "in_progress"],                "awaiting_verification",  Some "MASC_VERIFICATION_FSM_ENABLED + verifier-FSM only");
+    ("approve",                 ["awaiting_verification"],                 "done",                   Some "MASC_VERIFICATION_FSM_ENABLED + verifier != assignee");
+    ("reject",                  ["awaiting_verification"],                 "in_progress",            Some "MASC_VERIFICATION_FSM_ENABLED + verifier != assignee");
+  ]
+
+let task_fsm_transition_to_json (action, froms, to_, gate) =
+  let base =
+    [ ("action", `String action)
+    ; ("from", `List (List.map (fun s -> `String s) froms))
+    ; ("to", `String to_)
+    ]
+  in
+  let fields = match gate with
+    | None -> base
+    | Some g -> base @ [("gated_by", `String g)]
+  in
+  `Assoc fields
+
 let schema_json =
   (* Issue #8354: enums derived from Variant SSOT in [Types]. Hand-rolled
      lists used to drop [awaiting_verification] and the verification
-     actions ([submit_for_verification] / [approve] / [reject]). *)
+     actions ([submit_for_verification] / [approve] / [reject]).
+     Issue #8474: transitions matrix derived from [task_fsm_transitions]
+     (single source of truth) — used to drop the 3 verifier-FSM rows. *)
   `Assoc [
     ("task_statuses", `List (List.map (fun s -> `String s) Types.valid_task_status_strings));
     ("actions", `List (List.map (fun s -> `String s) Types.valid_task_action_strings));
-    ("transitions", `List [
-      `Assoc [("action", `String "claim"); ("from", `List [`String "todo"]); ("to", `String "claimed")];
-      `Assoc [("action", `String "start"); ("from", `List [`String "claimed"]); ("to", `String "in_progress")];
-      `Assoc [("action", `String "done"); ("from", `List [`String "claimed"; `String "in_progress"]); ("to", `String "done")];
-      `Assoc [("action", `String "cancel"); ("from", `List [`String "todo"; `String "claimed"; `String "in_progress"]); ("to", `String "cancelled")];
-      `Assoc [("action", `String "release"); ("from", `List [`String "claimed"; `String "in_progress"]); ("to", `String "todo")];
-    ]);
+    ("transitions", `List (List.map task_fsm_transition_to_json task_fsm_transitions));
     ("cas", `Assoc [
       ("field", `String "backlog.version");
       ("parameter", `String "expected_version");
@@ -442,6 +476,9 @@ let schema_markdown =
     "- done: claimed/in_progress(by you) -> done";
     "- cancel: todo/claimed/in_progress(by you) -> cancelled";
     "- release: claimed/in_progress(by you) -> todo";
+    "- submit_for_verification: claimed/in_progress(by you) -> awaiting_verification (MASC_VERIFICATION_FSM_ENABLED)";
+    "- approve: awaiting_verification -> done (verifier != assignee, MASC_VERIFICATION_FSM_ENABLED)";
+    "- reject: awaiting_verification -> in_progress (verifier != assignee, MASC_VERIFICATION_FSM_ENABLED)";
     "";
     "CAS guard: expected_version == backlog.version";
   ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -351,6 +351,56 @@ let () =
           Masc_mcp.Keeper_types_profile.valid_shared_memory_scope_strings
           Masc_mcp.Keeper_schema.shared_memory_scope_enum_strings);
     ];
+    "fsm_transition_matrix", [
+      (* Issue #8474: schema transition matrix had drifted from
+         [Coord_task.valid_next_actions_for_status] — submit/approve/
+         reject_verification missing. This test asserts every action
+         declared valid for any reachable status appears in the
+         published [task_fsm_transitions] list. *)
+      Alcotest.test_case "every valid action appears in transitions" `Quick (fun () ->
+        let reachable_statuses : Types.task_status list = [
+          Todo;
+          Claimed { assignee = "a"; claimed_at = "" };
+          InProgress { assignee = "a"; started_at = "" };
+          AwaitingVerification {
+            assignee = "a"; submitted_at = "";
+            verification_id = "v"; required_verifier_role = Reviewer;
+            deadline = None;
+          };
+          Done { assignee = "a"; completed_at = ""; notes = None };
+          Cancelled { cancelled_by = "a"; cancelled_at = ""; reason = None };
+        ] in
+        let valid_actions =
+          reachable_statuses
+          |> List.concat_map Coord_task.valid_next_actions_for_status
+          |> List.map task_action_to_string
+          |> List.sort_uniq String.compare
+        in
+        let published_actions =
+          Masc_mcp.Mcp_server.task_fsm_transitions
+          |> List.map (fun (a, _, _, _) -> a)
+          |> List.sort_uniq String.compare
+        in
+        List.iter (fun action ->
+          if not (List.mem action published_actions) then
+            Alcotest.failf
+              "action %S valid per Coord_task.valid_next_actions_for_status \
+               but missing from Mcp_server.task_fsm_transitions" action
+        ) valid_actions);
+      Alcotest.test_case "verifier-FSM transitions present" `Quick (fun () ->
+        let actions =
+          Masc_mcp.Mcp_server.task_fsm_transitions
+          |> List.map (fun (a, _, _, _) -> a)
+        in
+        List.iter (fun expected ->
+          Alcotest.(check bool) (Printf.sprintf "%s present" expected) true
+            (List.mem expected actions)
+        ) [
+          "submit_for_verification";
+          "approve";
+          "reject";
+        ]);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8474. **Real missing-transition bug fix.**

`lib/mcp_server.ml:423-429` schema_json published 5 transitions (claim/start/done/cancel/release). `Coord_task.transition_task_r` (lib/coord/coord_task.ml:831-870) implements 3 more:

| action | from | to | gate |
|---|---|---|---|
| `submit_for_verification` | `claimed` / `in_progress` | `awaiting_verification` | `MASC_VERIFICATION_FSM_ENABLED` |
| `approve` | `awaiting_verification` | `done` | flag + verifier != assignee |
| `reject` | `awaiting_verification` | `in_progress` | flag + verifier != assignee |

`Types.valid_task_action_strings` (PR #8354) added these to the action enum, but the transitions matrix was never updated — same drift class as #8354.

## Approach

- Promoted transitions matrix to typed list `task_fsm_transitions : (string * string list * string * string option) list` with `(action, from_statuses, to_status, gated_by_opt)`.
- `schema_json` transitions derived from SSOT via `task_fsm_transition_to_json`.
- `schema_markdown` extended with the 3 new rows.
- Action names use `Types.task_action_to_string` canonical strings — `Approve_verification → "approve"`, `Reject_verification → "reject"` (regression test caught this naming drift on first run).

## Verification

- `dune build` clean.
- `test_types.ml :: fsm_transition_matrix` — 2 cases:
  - `every valid action appears in transitions` (asserts SSOT-vs-published match per action).
  - `verifier-FSM transitions present` (explicit 3-row check).
- 31/31 `test_types` pass.

## Risk

- Schema clients gain 3 new transition entries — additive, no breaking change.
- `gated_by` field is optional (`Some`/`None`) — clients ignoring it get the previous shape minus the field; clients reading it learn which rows depend on `MASC_VERIFICATION_FSM_ENABLED`.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL bug
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL bug
4. `task_fsm_transitions` (#8474) — REAL bug
