### PR TITLE
fix(keeper): partial-tolerance for unexpected tool names in a turn

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1865,7 +1865,20 @@ let run_turn
            ~allowed_tool_names:all_tool_names
            ~tool_names
        in
-       if unexpected_tool_names <> [] then
+       (* Partial tolerance (#8471): when a turn mixes valid tool calls
+          with unexpected ones (LLM hallucinating Claude Code built-ins
+          like Bash/Read/Skill outside the keeper surface), do not nuke
+          the whole turn. OAS already returns tool_result="error" for the
+          unknown calls so the LLM can recover on the next step. We still
+          hard-fail when EVERY tool call is unexpected — that means the
+          turn produced no valid work. See feedback memory
+          feedback_tool-error-messages-teach-llm.md. *)
+       let valid_tool_calls_present =
+         Keeper_tool_disclosure.has_valid_tool_call
+           ~unexpected_tool_names
+           ~tool_names
+       in
+       if unexpected_tool_names <> [] && not valid_tool_calls_present then
          let reason =
            Printf.sprintf
              "keeper turn reported unexpected tool names outside keeper surface: %s"
@@ -1874,6 +1887,11 @@ let run_turn
          Log.Keeper.error "keeper:%s %s" meta.name reason;
          Error (Oas.Error.Internal reason)
        else (
+         if unexpected_tool_names <> [] then
+           Log.Keeper.warn
+             "keeper:%s unexpected_tool_partial_tolerance tools=%s (cycle continues; valid tools present)"
+             meta.name
+             (String.concat ", " unexpected_tool_names);
          let usage = Keeper_exec_context.usage_of_response result.response in
          let ctx_composition =
            build_ctx_composition_metrics

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -58,6 +58,22 @@ let unexpected_tool_names
          true))
 ;;
 
+(** [has_valid_tool_call ~unexpected_tool_names ~tool_names] returns
+    true iff at least one name in [tool_names] is absent from
+    [unexpected_tool_names] — i.e. at least one call is on the keeper
+    surface. Used by [Keeper_agent_run] (#8471) to decide whether a
+    turn mixing unknown tools with valid ones should hard-fail or
+    continue with a partial-tolerance WARN. *)
+let has_valid_tool_call
+      ~(unexpected_tool_names : string list)
+      ~(tool_names : string list)
+  : bool
+  =
+  let unexpected = Hashtbl.create (List.length unexpected_tool_names) in
+  List.iter (fun n -> Hashtbl.replace unexpected n ()) unexpected_tool_names;
+  List.exists (fun n -> not (Hashtbl.mem unexpected n)) tool_names
+;;
+
 type completion_contract =
   | Allow_text_or_tool
   | Require_tool_use

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -18,6 +18,31 @@ let test_unexpected_tool_names_reports_foreign_surface () =
        ~tool_names:
          [ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
 
+(* #8471 partial tolerance: mixed turn (valid + unexpected) must not
+   hard-fail — the valid tool call is real work and should survive. *)
+let test_has_valid_tool_call_true_when_mixed () =
+  check bool "mixed turn keeps valid tool call" true
+    (KTD.has_valid_tool_call
+       ~unexpected_tool_names:[ "Bash"; "Skill" ]
+       ~tool_names:[ "keeper_task_claim"; "Bash"; "Skill" ])
+
+(* Pure hallucination: every call is outside the surface — no valid
+   work in this turn, so keeper_agent_run correctly hard-fails. *)
+let test_has_valid_tool_call_false_when_all_unexpected () =
+  check bool "pure hallucination turn has no valid tool" false
+    (KTD.has_valid_tool_call
+       ~unexpected_tool_names:[ "Bash"; "Skill"; "Read" ]
+       ~tool_names:[ "Bash"; "Skill"; "Read" ])
+
+(* Empty turn (text-only response, no tool calls): has_valid returns
+   false. The caller's outer `unexpected_tool_names <> []` guard still
+   prevents this case from being treated as a partial-tolerance success. *)
+let test_has_valid_tool_call_false_when_empty () =
+  check bool "empty tool list returns false" false
+    (KTD.has_valid_tool_call
+       ~unexpected_tool_names:[]
+       ~tool_names:[])
+
 let () =
   run "keeper_tool_surface_guard"
     [
@@ -27,5 +52,14 @@ let () =
             test_unexpected_tool_names_accepts_keeper_surface;
           test_case "reports foreign surface" `Quick
             test_unexpected_tool_names_reports_foreign_surface;
+        ] );
+      ( "partial_tolerance",
+        [
+          test_case "mixed turn keeps valid call" `Quick
+            test_has_valid_tool_call_true_when_mixed;
+          test_case "pure hallucination has no valid" `Quick
+            test_has_valid_tool_call_false_when_all_unexpected;
+          test_case "empty tool list returns false" `Quick
+            test_has_valid_tool_call_false_when_empty;
         ] );
     ]


### PR DESCRIPTION
## Summary

**Problem** — 2026-04-18 telemetry: 26 cycle failures in a 25-min window with reason `unexpected tool names outside keeper surface: Bash/Read/Skill/Agent/WebSearch`. Claude-based keepers (adversary, cheolsu, verdict, oracle, ani1999) hallucinate Claude Code built-ins they were trained on. The post-turn guard at \`keeper_agent_run.ml:1868\` nukes the **whole turn** even when the same turn called valid keeper tools alongside unknown names. At 291s average latency, this is pure waste — OAS already returned \`tool_result=\"error\"\` for the unknown names so the LLM could recover on the next step.

**Fix** — split the guard (line 1863-1876) into two cases:

1. **Every** tool call is unexpected (pure hallucination, no valid work): keep the hard-fail + \`Internal\` reason.
2. **Mix** of valid + unexpected: WARN \`unexpected_tool_partial_tolerance tools=...\` and proceed. The valid work is preserved, \`tool_result=error\` teaches the LLM, next step naturally recovers.

Predicate \`has_valid_tool_call\` is lifted into \`Keeper_tool_disclosure\` so it's testable independently.

## Why not alias unknown names

Aliasing \`Bash\` → \`keeper_bash\` would hide the drift instead of surfacing it. WARN logs let dashboards quantify per-keeper hallucination rates and inform the real fix (persona-specific prompts telling keepers these built-ins are not on their surface).

See \`memory/feedback_tool-error-messages-teach-llm.md\` — terse errors produce recovery loops; killing the turn removes the LLM's ability to recover.

## Test plan

- [x] \`dune build --root .\` — green
- [x] \`dune build --root . @runtest\` — full suite exit 0
- [x] \`test_keeper_tool_surface_guard\` — 5 tests pass (accepts keeper surface / reports foreign / mixed keeps valid / pure hallucination none valid / empty list none valid)
- [ ] Post-merge: grep \`unexpected_tool_partial_tolerance\` to measure hallucination-per-keeper rate → inform persona prompt work

🤖 Generated with [Claude Code](https://claude.com/claude-code)