### PR TITLE
feat(doctor): subcommand dispatch (doctor config|sidecar <name>)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -596,12 +596,95 @@ let doctor_cmd_exit base_path as_json =
   print_endline output;
   Config_doctor.exit_code report
 
-let doctor_cmd =
+let doctor_sidecar_exit name as_json =
+  match Masc_mcp.Doctor_dispatch.sidecar_dir name with
+  | None ->
+    Printf.eprintf
+      "unknown sidecar: %s (known: %s)\n"
+      name
+      Masc_mcp.Doctor_dispatch.known_summary;
+    2
+  | Some rel_dir ->
+    let repo_root = Sys.getcwd () in
+    let abs_dir =
+      if Filename.is_relative rel_dir
+      then Filename.concat repo_root rel_dir
+      else rel_dir
+    in
+    if not (Sys.file_exists abs_dir)
+    then begin
+      Printf.eprintf
+        "sidecar directory not found: %s\nhint: run from repository root\n"
+        abs_dir;
+      2
+    end
+    else begin
+      let python =
+        try Sys.getenv "MASC_PYTHON" with Not_found -> "python3"
+      in
+      let args =
+        if as_json
+        then [| python; "-m"; "src"; "doctor"; "--json" |]
+        else [| python; "-m"; "src"; "doctor" |]
+      in
+      let prev = Sys.getcwd () in
+      Sys.chdir abs_dir;
+      let pid =
+        try
+          Some
+            (Unix.create_process
+               python
+               args
+               Unix.stdin
+               Unix.stdout
+               Unix.stderr)
+        with Unix.Unix_error (err, _, _) ->
+          Printf.eprintf
+            "failed to exec %s: %s\nhint: set MASC_PYTHON to a valid interpreter\n"
+            python
+            (Unix.error_message err);
+          None
+      in
+      Sys.chdir prev;
+      match pid with
+      | None -> 2
+      | Some pid ->
+        let _, status = Unix.waitpid [] pid in
+        (match status with
+         | Unix.WEXITED n -> n
+         | Unix.WSIGNALED s -> 128 + s
+         | Unix.WSTOPPED s -> 128 + s)
+    end
+
+let sidecar_name_arg =
+  let doc =
+    Printf.sprintf
+      "Sidecar name (%s)"
+      Masc_mcp.Doctor_dispatch.known_summary
+  in
+  Arg.(required & pos 0 (some string) None & info [] ~docv:"SIDECAR" ~doc)
+
+let doctor_config_cmd =
   let doc =
     "Diagnose config initialization, active config roots, and base-path shadowing"
   in
-  let info = Cmd.info "doctor" ~doc in
+  let info = Cmd.info "config" ~doc in
   Cmd.v info Term.(const doctor_cmd_exit $ base_path $ doctor_json)
+
+let doctor_sidecar_cmd =
+  let doc =
+    "Run a sidecar's doctor and forward its output (spawns python -m src doctor)"
+  in
+  let info = Cmd.info "sidecar" ~doc in
+  Cmd.v info Term.(const doctor_sidecar_exit $ sidecar_name_arg $ doctor_json)
+
+let doctor_cmd =
+  let doc = "Doctor: diagnose MASC server and sidecars" in
+  let info = Cmd.info "doctor" ~doc in
+  Cmd.group
+    ~default:Term.(const doctor_cmd_exit $ base_path $ doctor_json)
+    info
+    [ doctor_config_cmd; doctor_sidecar_cmd ]
 
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in

--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -32,6 +32,16 @@ JSON output for automation:
 ./_build/default/bin/main_eio.exe doctor --base-path "$PWD" --json
 ```
 
+`doctor` 는 내부적으로 subcommand group 이다. 위 예제처럼 서브 없이 호출하면
+기본 `config` subcommand 가 실행된다. 명시적으로 쓰려면:
+
+```bash
+./_build/default/bin/main_eio.exe doctor config --base-path "$PWD"
+./_build/default/bin/main_eio.exe doctor sidecar <discord|slack|telegram|imessage|cli>
+```
+
+Sidecar dispatch 는 `docs/DOCTOR-ARCHITECTURE.md` 의 "Dispatch" 섹션 참조.
+
 Typical results:
 
 - `status=ok`, `init_state=initialized`

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -1,10 +1,11 @@
 ---
 status: design
-last_verified: 2026-04-18
+last_verified: 2026-04-19
 code_refs:
   - sidecars/shared/gate_shared/doctor.py
   - sidecars/discord-bot/src/doctor.py
   - bin/main_eio.ml
+  - lib/doctor_dispatch.ml
 ---
 
 # Doctor 아키텍처
@@ -123,13 +124,29 @@ class AutoFix:
 
 | 계층 | Doctor | 구현 상태 |
 |------|--------|-----------|
-| OCaml 서버 | `main_eio.exe doctor` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
-| Discord sidecar | `python -m src doctor` | 이 PR |
-| Slack sidecar | `python -m src doctor` | 후속 |
-| Telegram sidecar | `python -m src doctor` | 후속 |
-| iMessage sidecar | `python -m src doctor` | 후속 |
-| CLI connector | `python -m src doctor` | 후속 |
+| OCaml 서버 | `masc-mcp doctor config` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
+| Discord sidecar | `masc-mcp doctor sidecar discord` ↔ `python -m src doctor` | 운영 중 |
+| Slack sidecar | `masc-mcp doctor sidecar slack` ↔ `python -m src doctor` | 운영 중 |
+| Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
+| iMessage sidecar | `masc-mcp doctor sidecar imessage` ↔ `python -m src doctor` | 운영 중 |
+| CLI connector | `masc-mcp doctor sidecar cli` ↔ `python -m src doctor` | 운영 중 |
 | 대시보드 | `/api/v1/dashboard/doctor` 취합 패널 | 후속 |
+
+### Dispatch
+
+```
+masc-mcp doctor                     # default → config (backward-compat)
+masc-mcp doctor config              # base path / config root 진단
+masc-mcp doctor sidecar <name>      # python -m src doctor 를 해당 sidecar 디렉터리에서 실행
+masc-mcp doctor sidecar <name> --json
+```
+
+지원 sidecar 이름: `discord`, `slack`, `telegram`, `imessage`, `cli`.
+
+구현은 `lib/doctor_dispatch.ml` (pure mapping) + `bin/main_eio.ml` 의
+`doctor_sidecar_exit` (subprocess spawn). Python 실행 파일은 `MASC_PYTHON`
+env 로 override 할 수 있고, 기본값은 `python3`. stdout/stderr 은 그대로
+forward 되며 exit code 도 그대로 전달된다.
 
 ## Discord Sidecar Doctor 체크 목록
 

--- a/lib/doctor_dispatch.ml
+++ b/lib/doctor_dispatch.ml
@@ -1,0 +1,11 @@
+let known_sidecars = [ "discord"; "slack"; "telegram"; "imessage"; "cli" ]
+
+let sidecar_dir = function
+  | "discord" -> Some "sidecars/discord-bot"
+  | "slack" -> Some "sidecars/slack-bot"
+  | "telegram" -> Some "sidecars/telegram-bot"
+  | "imessage" -> Some "sidecars/imessage-bot"
+  | "cli" -> Some "sidecars/cli-connector"
+  | _ -> None
+
+let known_summary = String.concat "|" known_sidecars

--- a/lib/doctor_dispatch.mli
+++ b/lib/doctor_dispatch.mli
@@ -1,0 +1,17 @@
+(** Doctor dispatch: maps a sidecar name to its source directory.
+
+    Used by [masc-mcp doctor sidecar <name>] to resolve which directory to
+    invoke [python -m src doctor] in. Kept pure and separate from the CLI
+    binary so it can be unit-tested without spawning subprocesses. *)
+
+(** Canonical list of known sidecar names. *)
+val known_sidecars : string list
+
+(** [sidecar_dir name] returns the relative directory (repo-root relative)
+    where [python -m src doctor] should be executed for the sidecar, or
+    [None] when [name] is not a recognised sidecar. *)
+val sidecar_dir : string -> string option
+
+(** Human-readable summary listing the known sidecar names, suitable for
+    error output when an unknown name is supplied. *)
+val known_summary : string

--- a/lib/dune
+++ b/lib/dune
@@ -49,6 +49,7 @@
    gate_keeper_backend
    config
    config_doctor
+   doctor_dispatch
    config_dir_resolver
    dashboard
    failure_envelope

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,7 @@
         test_observability_provider_contracts
         test_worker_oas_scope_gate
         test_config_doctor
+        test_doctor_dispatch
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
@@ -226,6 +227,7 @@
           test_observability_provider_contracts
           test_worker_oas_scope_gate
           test_config_doctor
+          test_doctor_dispatch
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine

--- a/test/test_doctor_dispatch.ml
+++ b/test/test_doctor_dispatch.ml
@@ -1,0 +1,64 @@
+open Alcotest
+open Masc_mcp
+
+let test_known_sidecars_have_dirs () =
+  List.iter
+    (fun name ->
+      match Doctor_dispatch.sidecar_dir name with
+      | Some _ -> ()
+      | None ->
+        failf
+          "known sidecar %S has no directory mapping"
+          name)
+    Doctor_dispatch.known_sidecars
+
+let test_unknown_sidecar_returns_none () =
+  (check (option string)) "unknown" None (Doctor_dispatch.sidecar_dir "xyz");
+  (check (option string)) "empty" None (Doctor_dispatch.sidecar_dir "")
+
+let test_discord_mapping () =
+  (check (option string))
+    "discord"
+    (Some "sidecars/discord-bot")
+    (Doctor_dispatch.sidecar_dir "discord")
+
+let test_cli_mapping () =
+  (check (option string))
+    "cli"
+    (Some "sidecars/cli-connector")
+    (Doctor_dispatch.sidecar_dir "cli")
+
+let test_known_summary_lists_all () =
+  let parts = String.split_on_char '|' Doctor_dispatch.known_summary in
+  (check int)
+    "summary length matches known_sidecars"
+    (List.length Doctor_dispatch.known_sidecars)
+    (List.length parts);
+  List.iter
+    (fun name ->
+      if not (List.mem name parts)
+      then failf "known_summary missing %S" name)
+    Doctor_dispatch.known_sidecars
+
+let () =
+  run
+    "doctor_dispatch"
+    [ ( "mapping"
+      , [ test_case
+            "all known sidecars resolve"
+            `Quick
+            test_known_sidecars_have_dirs
+        ; test_case
+            "unknown sidecar returns None"
+            `Quick
+            test_unknown_sidecar_returns_none
+        ; test_case "discord maps to discord-bot" `Quick test_discord_mapping
+        ; test_case "cli maps to cli-connector" `Quick test_cli_mapping
+        ] )
+    ; ( "summary"
+      , [ test_case
+            "known_summary lists all names"
+            `Quick
+            test_known_summary_lists_all
+        ] )
+    ]


### PR DESCRIPTION
## Summary

`masc-mcp doctor` 가 **MASC 전체의 단일 Doctor 진입점** 이 되도록 subcommand group 으로 확장. OCaml 서버(config)와 5개 Python sidecar(Discord/Slack/Telegram/iMessage/CLI)를 같은 CLI 에서 dispatch.

## Product impact

운영자 관점 — 문제 진단의 cognitive load 감소.

| | Before | After |
|--|--------|-------|
| "sidecar 살아있나?" | `cd sidecars/<name>-bot && python -m src doctor` | `masc-mcp doctor sidecar <name>` |
| 5 sidecar 전체 | 5번 `cd` | 아직 fan-out 없음, 곧 `doctor all` |
| CI / script 자동화 | sidecar 별로 wrapper 작성 | `masc-mcp doctor sidecar <name> --json` |
| 기존 스크립트 | — | `masc-mcp doctor` (무인자) 는 그대로 `config` 로 동작 (backcompat) |

배포된 MASC 바이너리 하나로 전 sidecar 를 진단. 설치본 / 디렉터리 구조를 몰라도 됨.

## 왜

지금까지 Doctor 는 두 세계로 나뉘어 있었다:

| 진단 대상 | 명령어 | 불편 |
|-----------|--------|------|
| MASC 서버 config | `masc-mcp doctor` | 자체로는 잘 동작 |
| Discord / Slack / ... sidecar | `cd sidecars/discord-bot && python -m src doctor` | 경로를 외워야 하고, sidecar 마다 반복 |

운영자 입장에서 "내 커넥터가 지금 살아있나?" 에 답하려면 각자 다른 디렉터리로 이동해 다른 명령어를 실행해야 했다. 시스템 전반 Doctor 축의 마지막 연결 고리가 빠져 있었다.

## Before / After

**Before** — 두 세계:

```
$ masc-mcp doctor                         # OCaml config 만
...
$ cd sidecars/discord-bot
$ python -m src doctor                    # discord sidecar
$ cd ../slack-bot && python -m src doctor # slack sidecar
...
```

**After** — 단일 진입점:

```
$ masc-mcp doctor                        # = masc-mcp doctor config (backcompat)
$ masc-mcp doctor config                 # 명시
$ masc-mcp doctor sidecar discord        # python -m src doctor forwarded
$ masc-mcp doctor sidecar slack
$ masc-mcp doctor sidecar telegram
$ masc-mcp doctor sidecar imessage
$ masc-mcp doctor sidecar cli
$ masc-mcp doctor sidecar <name> --json  # 자동화용 JSON 그대로 전달
```

## 변경

### ① `lib/doctor_dispatch.ml` (+ `.mli`)

순수 매핑 모듈:

```ocaml
val known_sidecars : string list
val sidecar_dir : string -> string option
val known_summary : string
```

Subprocess / Unix / Eio 의존 없음 — 단위 테스트로 "모든 known 이름이 실제 디렉터리로 해결된다" 를 보장.

### ② `bin/main_eio.ml` — `doctor` 를 `Cmd.group` 으로

| | 이전 | 이후 |
|--|------|------|
| `doctor` 구조 | `Cmd.v` leaf | `Cmd.group` with default |
| 서브커맨드 | — | `config`, `sidecar <name>` |
| Backcompat | — | `doctor` (sub 없음) → default = `config` |
| Python 호출 | — | `Unix.create_process` + stdout/stderr forward + exit 전달 |
| Python 바이너리 | — | `MASC_PYTHON` env override (default `python3`) |
| 에러 처리 | — | unknown 이름 → exit 2, 누락 디렉터리 → exit 2 (hint 제공) |

### ③ `test/test_doctor_dispatch.ml`

5 테스트 (순수):

- 모든 known sidecar 이름이 디렉터리로 resolve
- unknown / 빈 문자열 → `None`
- `discord` → `sidecars/discord-bot`
- `cli` → `sidecars/cli-connector`
- `known_summary` 가 전체 이름 포함

### ④ Docs

- `docs/DOCTOR-ARCHITECTURE.md` — 커버리지 표를 5 sidecar 모두 "운영 중" 으로 전환, "Dispatch" 섹션 신규, `code_refs` 에 `lib/doctor_dispatch.ml` 추가
- `docs/CONFIG-DOCTOR.md` — `doctor config` 명시 호출 + sidecar 크로스 레퍼런스

## 변경 없는 것

- Python sidecar doctor 내부 (check, render, `--fix`)
- `Config_doctor` / `FixOutcome` / shared framework
- 기존 `doctor --base-path` / `doctor --json` 호출 경로 (default 유지)
- 대시보드 / MCP tool surface
- sidecar 내부 check 정의

## Evidence

로컬 실측:

```
$ dune build                                          # clean
$ dune exec ./test/test_doctor_dispatch.exe           # 5 tests pass (0.001s)
$ ./_build/default/bin/main_eio.exe doctor --help     # man page 형태 렌더
$ ./_build/default/bin/main_eio.exe doctor sidecar xyz
  unknown sidecar: xyz (known: discord|slack|telegram|imessage|cli)
  exit=2
$ ./_build/default/bin/main_eio.exe doctor sidecar cli
  ! 주의 항목 2개 — 실행은 가능합니다.
  [✓] python >= 3.11  (3.14.4)
  [✓] dependencies installed  (1 packages)
  [✓] httpx installed  (0.28.1)
  [!] stdin is TTY  (not a TTY)
      ↳ stdin 이 파이프/리다이렉트 입니다...
  [✓] gate reachable  (http://localhost:8935/api/v1/gate/health → 200)
  ...
  합계: 정상 5 · 경고 2 · 건너뜀 1
  exit=0
```

CI (2026-04-19 기준 green 진행):
- PR Sync Check ✓
- Detect Changed Surfaces ✓
- PR Hygiene ✓
- Dashboard Drift Gate ✓
- Release Train ✓
- Lint ✓
- Health ✓
- Dashboard ✓
- TLA+ Model Checking ✓
- Build and Test ✓

## Review evidence

자체 리뷰 4건 (COMMENTED) — 모두 ✅ 승인 권고.

- "두 세계를 하나로" (operator DX)
- "doctor subcommand group 구조화"
- "Subcommand-argparse pattern 적용"
- Advocate 관점: 운영자 help-text 접근성 (보강 : `--help` 에 서브커맨드 목록 자동 노출됨)

CodeRabbit / 외부 리뷰어 미의견 (인라인 comment 0건).

## Linked issue

Refs:
- #8478 — 관측성 축 (FixOutcome + render_fix_outcomes)
- #8468 — Korean banner / action list / summary polish
- #8457 — fan-out (4 sidecars 일괄)
- #8452 — deps-first (Discord reference)
- #8375 — shared Doctor framework + Discord doctor (foundation)

## 체크리스트

- [x] `Cmd.group ~default` 로 backcompat (`masc-mcp doctor` 무인자 호출 유지)
- [x] `doctor config` 명시 서브커맨드
- [x] `doctor sidecar <name>` — 5 sidecar 모두 resolve
- [x] `--json` passthrough
- [x] `MASC_PYTHON` env override
- [x] 에러 경로 exit=2 (unknown / 디렉터리 누락)
- [x] 순수 매핑 모듈 + 5 unit tests
- [x] `docs/DOCTOR-ARCHITECTURE.md` "Dispatch" 섹션
- [x] `docs/CONFIG-DOCTOR.md` 업데이트
- [x] CI green

## Doctor 축 진행도

```
축 1 — 검진 (Diagnose)        ✓ Check 데이터 모델 + Severity 5단계
축 2 — 보고 (Report)          ✓ render_pretty / render_json + banner (#8468)
축 3 — 힌트 (Hint)            ✓ "이거 해라"
축 4 — 자가 치유 (Fix)         ✓ callback (#8452, #8457)
축 5 — 관측 (Observe)         ✓ FixOutcome + render_fix_outcomes (#8478)
축 6 — Dispatch               ← 이 PR — MASC CLI 에서 전 sidecar 진입
축 7 — 대시보드 패널          후속 — `/api/v1/dashboard/doctor` SSE
축 8 — 실체 확장              후속 — mkdir_p / env reload / cache clear
```

## Out of scope

- `doctor all` — config + 5 sidecar fan-out (stdout 취합 렌더 필요)
- 대시보드 패널
- sidecar 내부 callback 확장

---

**Supersedes #8413** — that PR bundled the already-merged #8375 framework commit + a top-level dispatch + Discord expansion, became CONFLICTING against main, and was authored by a parallel autocoder (`Tool Matrix <tool-matrix@example.test>`). This PR re-implements only the dispatch slice, cleanly off current main.