### PR TITLE
fix(keeper_tool_pr_review): introduce pr_review_event Variant SSOT (#8480)

### DIFF
--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -5,6 +5,40 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* Issue #8480: Variant SSOT for PR review event. Adding a new
+   constructor forces compilation in [pr_review_event_to_string],
+   [pr_review_event_of_string_opt], and [pr_review_event_to_gh_flag],
+   so the schema enum in [tool_shard.ml] (derived from
+   [valid_pr_review_event_strings]) and the gh CLI dispatcher stay in
+   lock-step. Strings are uppercase to match GitHub's review event
+   vocabulary and the canonical [gh pr review] flag mapping. *)
+type pr_review_event =
+  | Comment
+  | Approve
+  | Request_changes
+
+let pr_review_event_to_string = function
+  | Comment -> "COMMENT"
+  | Approve -> "APPROVE"
+  | Request_changes -> "REQUEST_CHANGES"
+
+let pr_review_event_of_string_opt raw =
+  match String.uppercase_ascii (String.trim raw) with
+  | "COMMENT" -> Some Comment
+  | "APPROVE" -> Some Approve
+  | "REQUEST_CHANGES" -> Some Request_changes
+  | _ -> None
+
+let pr_review_event_to_gh_flag = function
+  | Comment -> "--comment"
+  | Approve -> "--approve"
+  | Request_changes -> "--request-changes"
+
+let all_pr_review_events = [ Comment; Approve; Request_changes ]
+
+let valid_pr_review_event_strings =
+  List.map pr_review_event_to_string all_pr_review_events
+
 (* Both "pr_number" and "number" are accepted for schema-drift compat. *)
 let pr_number_of_args args =
   let from_pr = Safe_ops.json_int ~default:0 "pr_number" args in
@@ -94,15 +128,19 @@ let handle_keeper_pr_review_comment
   =
   let pr_number = pr_number_of_args args in
   let body = Safe_ops.json_string ~default:"" "body" args |> String.trim in
-  let event = Safe_ops.json_string ~default:"COMMENT" "event" args |> String.trim |> String.uppercase_ascii in
+  let event_raw = Safe_ops.json_string ~default:"COMMENT" "event" args in
+  let event_opt = pr_review_event_of_string_opt event_raw in
   let repo = Safe_ops.json_string ~default:"" "repo" args |> String.trim in
   if pr_number = 0 then
     error_json "pr_number is required."
   else if body = "" then
     error_json "body is required."
-  else if not (List.mem event ["COMMENT"; "APPROVE"; "REQUEST_CHANGES"]) then
-    error_json "event must be COMMENT, APPROVE, or REQUEST_CHANGES."
-  else
+  else match event_opt with
+  | None ->
+      error_json
+        (Printf.sprintf "event must be one of [%s]; got %S"
+           (String.concat ", " valid_pr_review_event_strings) event_raw)
+  | Some event ->
     (* Check preset: requires delivery/coding/full for mutations *)
     let preset_ok =
       match Keeper_types.tool_access_preset meta.tool_access with
@@ -124,20 +162,17 @@ let handle_keeper_pr_review_comment
         "cd %s && gh pr review %d%s --body %s %s 2>&1"
         (Filename.quote root) pr_number repo_flag
         (Filename.quote body)
-        (match event with
-         | "APPROVE" -> "--approve"
-         | "REQUEST_CHANGES" -> "--request-changes"
-         | _ -> "--comment") in
+        (pr_review_event_to_gh_flag event) in
       let st, out =
         Process_eio.run_argv_with_status ~timeout_sec:30.0
           [ "/bin/zsh"; "-lc"; cmd ] in
       Log.Keeper.info "pr_review_comment: pr=%d event=%s keeper=%s ok=%b"
-        pr_number event meta.name (st = Unix.WEXITED 0);
+        pr_number (pr_review_event_to_string event) meta.name (st = Unix.WEXITED 0);
       Yojson.Safe.to_string
         (`Assoc
             [ "ok", `Bool (st = Unix.WEXITED 0)
             ; "pr_number", `Int pr_number
-            ; "event", `String event
+            ; "event", `String (pr_review_event_to_string event)
             ; "output", `String out
             ; "keeper", `String meta.name
             ])

--- a/lib/keeper/keeper_tool_pr_review.mli
+++ b/lib/keeper/keeper_tool_pr_review.mli
@@ -2,6 +2,16 @@
 
     Extracted from keeper_exec_github.ml. *)
 
+(** Issue #8480: Variant SSOT for PR review event. Mirror in
+    [Tool_shard.pr_review_event_enum_strings] (cycle avoidance). *)
+type pr_review_event = Comment | Approve | Request_changes
+
+val pr_review_event_to_string : pr_review_event -> string
+val pr_review_event_of_string_opt : string -> pr_review_event option
+val pr_review_event_to_gh_flag : pr_review_event -> string
+val all_pr_review_events : pr_review_event list
+val valid_pr_review_event_strings : string list
+
 (** Detect "PR not found" markers in [gh] CLI output (REST 404 + GraphQL
     "could not resolve"). Exposed for unit testing the parser; keepers
     consume the structured JSON returned by [handle_keeper_pr_review_read]. *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -5,6 +5,16 @@
 
     @since 2.62.0 *)
 
+(** Issue #8480: hand-mirrored from
+    [Keeper_tool_pr_review.valid_pr_review_event_strings]. Direct
+    dependency would create a cycle (Tool_shard -> Keeper_tool_pr_review
+    -> Keeper_alerting -> Tool_shard). The sync regression test
+    [test_types.ml :: pr_review_event_ssot] asserts these stay in
+    lock-step so adding a new event in keeper_tool_pr_review.ml fails
+    the test before shipping with a stale schema. *)
+let pr_review_event_enum_strings =
+  [ "COMMENT"; "APPROVE"; "REQUEST_CHANGES" ]
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -382,7 +392,13 @@ Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
         ("pr_number", `Assoc [("type", `String "integer"); ("description", `String "PR number (preferred field name)")]);
         ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number (legacy alias for pr_number)")]);
         ("body", `Assoc [("type", `String "string"); ("description", `String "Review body text")]);
-        ("event", `Assoc [("type", `String "string"); ("enum", `List [`String "COMMENT"; `String "APPROVE"; `String "REQUEST_CHANGES"]); ("description", `String "Review event type")]);
+        (* Issue #8480: mirrors [Keeper_tool_pr_review.valid_pr_review_event_strings].
+           Direct dependency would create a cycle (Tool_shard ->
+           Keeper_tool_pr_review -> Keeper_alerting -> Tool_shard), so the
+           sync regression test [test_types.ml :: pr_review_event_ssot]
+           asserts these stay in lock-step. Same pattern as #8467
+           (sandbox_profile / network_mode / shared_memory_scope). *)
+        ("event", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) pr_review_event_enum_strings)); ("description", `String "Review event type")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "File path for inline comment (optional)")]);
         ("line", `Assoc [("type", `String "integer"); ("description", `String "Line number for inline comment (optional)")]);
       ]);

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -2,6 +2,13 @@
 
     @since 2.62.0 *)
 
+(** Issue #8480: hand-mirrored from
+    [Keeper_tool_pr_review.valid_pr_review_event_strings]. Direct
+    dependency would create a cycle (Tool_shard -> Keeper_tool_pr_review
+    -> Keeper_alerting -> Tool_shard). The sync regression test
+    [test_types.ml :: pr_review_event_ssot] catches drift. *)
+val pr_review_event_enum_strings : string list
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -480,6 +480,41 @@ let () =
           "reject";
         ]);
     ];
+    "pr_review_event_ssot", [
+      (* Issue #8480: introduces [pr_review_event] Variant where 4 sites
+         previously hand-validated raw strings. Witness covers all 3
+         constructors; mirror sync test asserts [Tool_shard]'s
+         hand-mirrored enum stays in lock-step with the SSOT (cycle
+         avoidance: Tool_shard -> Keeper_tool_pr_review -> Keeper_alerting
+         -> Tool_shard). *)
+      Alcotest.test_case "witness covers all 3 variants" `Quick (fun () ->
+        let module K = Masc_mcp.Keeper_tool_pr_review in
+        let witness e =
+          let actual = K.pr_review_event_to_string e in
+          if not (List.mem actual K.valid_pr_review_event_strings) then
+            Alcotest.failf "pr_review_event_to_string %S not in valid_pr_review_event_strings" actual
+        in
+        witness K.Comment; witness K.Approve; witness K.Request_changes;
+        Alcotest.(check int) "count" 3 (List.length K.valid_pr_review_event_strings));
+      Alcotest.test_case "of_string_opt accepts canonical and case-insensitive" `Quick (fun () ->
+        let module K = Masc_mcp.Keeper_tool_pr_review in
+        Alcotest.(check bool) "COMMENT" true (K.pr_review_event_of_string_opt "COMMENT" <> None);
+        Alcotest.(check bool) "approve (lower)" true (K.pr_review_event_of_string_opt "approve" <> None);
+        Alcotest.(check bool) "  request_changes  " true
+          (K.pr_review_event_of_string_opt "  request_changes  " <> None);
+        Alcotest.(check bool) "garbage rejected" true
+          (K.pr_review_event_of_string_opt "MERGE" = None));
+      Alcotest.test_case "gh flag mapping" `Quick (fun () ->
+        let module K = Masc_mcp.Keeper_tool_pr_review in
+        Alcotest.(check string) "comment" "--comment" (K.pr_review_event_to_gh_flag K.Comment);
+        Alcotest.(check string) "approve" "--approve" (K.pr_review_event_to_gh_flag K.Approve);
+        Alcotest.(check string) "request" "--request-changes"
+          (K.pr_review_event_to_gh_flag K.Request_changes));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_tool_pr_review.valid_pr_review_event_strings
+          Masc_mcp.Tool_shard.pr_review_event_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8480.

4 sites previously hand-validated `COMMENT`/`APPROVE`/`REQUEST_CHANGES` strings:
1. `lib/tool_shard.ml:385` — JSON Schema `enum`.
2. `lib/keeper/keeper_tool_pr_review.ml:97` — parse + uppercase.
3. `lib/keeper/keeper_tool_pr_review.ml:103` — `List.mem` validation.
4. `lib/keeper/keeper_tool_pr_review.ml:127-130` — match on string -> gh CLI flag.

No matching Variant existed. Same drift class as #8430/#8467/#8471/#8474 but **inverse direction**: introduce a Variant where none was, then refactor consumers.

## Approach

- New Variant `pr_review_event = Comment | Approve | Request_changes` in `keeper_tool_pr_review.ml` + `.mli`:
  - `pr_review_event_to_string`
  - `pr_review_event_of_string_opt` (sound partial — case-insensitive, trims, rejects garbage)
  - `pr_review_event_to_gh_flag` (canonical CLI dispatcher)
  - `all_pr_review_events`, `valid_pr_review_event_strings`
- Refactor `handle_keeper_pr_review_comment` to use the SSOT throughout.
- Schema in `tool_shard.ml` derives via local mirror (cycle: Tool_shard -> Keeper_tool_pr_review -> Keeper_alerting -> Tool_shard prevents direct dep — same pattern as #8467).

## Verification

- `dune build` clean (full clean rebuild).
- `test_types.ml :: pr_review_event_ssot` — 4 cases:
  - witness covers all 3 variants
  - of_string_opt accepts canonical + case-insensitive + rejects garbage
  - gh flag mapping for all 3
  - schema mirror == SSOT
- 36/36 `test_types` pass.

## Risk

Low. Behavior preserved: same canonical strings, same gh CLI flags, same JSON output keys. Adds compile-time guarantee that the 4 sites stay in sync.

## Drift catalog (cumulative — Variant SSOT pattern)

1. `tool_preset` (#8430) — REAL bug
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL bug
4. `task_fsm_transitions` (#8474) — REAL bug
5. `pr_review_event` (#8480) — prevention (NEW Variant)
