### PR TITLE
fix(keeper_exec_memory): introduce memory_search_source Variant SSOT (#8484)

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -6,6 +6,38 @@ module StringSet = Set.Make (String)
 
 let contains_ci = String_util.contains_substring_ci
 
+(* Issue #8484: Variant SSOT for memory search scope. Adding a new
+   constructor forces compilation in [memory_search_source_to_string]
+   AND extends [valid_memory_search_source_strings]; the schema in
+   [tool_shard.ml] mirrors the SSOT (cycle: Tool_shard ->
+   Keeper_exec_memory -> ... -> Tool_shard prevented via local mirror,
+   sync test catches drift). The previous code used a string match
+   with a wildcard `_ -> memory` branch which silently routed any
+   unknown source to memory — anti-pattern from CLAUDE.md "Unknown ->
+   Permissive Default". Now [of_string_opt] returns [None] for
+   unknown values and the caller decides the fallback explicitly. *)
+type memory_search_source =
+  | Memory
+  | History
+  | All
+
+let memory_search_source_to_string = function
+  | Memory -> "memory"
+  | History -> "history"
+  | All -> "all"
+
+let memory_search_source_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "memory" -> Some Memory
+  | "history" -> Some History
+  | "all" -> Some All
+  | _ -> None
+
+let all_memory_search_sources = [ Memory; History; All ]
+
+let valid_memory_search_source_strings =
+  List.map memory_search_source_to_string all_memory_search_sources
+
 type memory_match = {
   kind: string;
   horizon: string;
@@ -195,21 +227,29 @@ let keeper_memory_search_json
       ~(args : Yojson.Safe.t) =
   let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
   let limit = max 1 (min 10 (Safe_ops.json_int ~default:5 "limit" args)) in
-  let source = Safe_ops.json_string ~default:"memory" "source" args |> String.trim in
+  let source_raw = Safe_ops.json_string ~default:"memory" "source" args in
+  (* Issue #8484: explicit fallback to Memory for back-compat with the
+     prior wildcard branch — but unknown values are now visibly mapped,
+     not silently absorbed. *)
+  let source =
+    memory_search_source_of_string_opt source_raw
+    |> Option.value ~default:Memory
+  in
+  let source_label = memory_search_source_to_string source in
   let kind_filter = Safe_ops.json_string ~default:"" "kind" args |> String.trim in
   let result =
     match source with
-    | "history" ->
+    | History ->
       let matches = search_history ~config ~meta ~ctx_work ~query ~limit in
       let no_match = matches = [] in
       let match_jsons = List.map (fun msg -> `String msg) matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "history";
+        "source", `String source_label;
         "match_count", `Int (List.length matches);
         "matches", `List match_jsons;
       ] @ (if no_match then [ "no_match", `Bool true ] else []))
-    | "all" ->
+    | All ->
       let (bank_matches, bank_total) =
         search_memory_bank ~config ~meta ~query ~kind_filter ~limit
       in
@@ -223,16 +263,16 @@ let keeper_memory_search_json
       let no_match = total_matches = 0 in
       let bank_jsons = List.map memory_match_to_json bank_matches in
       let history_jsons = List.map (fun msg ->
-        `Assoc [ "source", `String "history"; "text", `String msg ]
+        `Assoc [ "source", `String (memory_search_source_to_string History); "text", `String msg ]
       ) history_matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "all";
+        "source", `String source_label;
         "total_candidates", `Int bank_total;
         "match_count", `Int total_matches;
         "matches", `List (bank_jsons @ history_jsons);
       ] @ (if no_match then [ "no_match", `Bool true ] else []))
-    | _ (* "memory" *) ->
+    | Memory ->
       let (matches, total_candidates) =
         search_memory_bank ~config ~meta ~query ~kind_filter ~limit
       in
@@ -240,7 +280,7 @@ let keeper_memory_search_json
       let match_jsons = List.map memory_match_to_json matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "memory";
+        "source", `String source_label;
         "total_candidates", `Int total_candidates;
         "match_count", `Int (List.length matches);
         "matches", `List match_jsons;
@@ -271,7 +311,7 @@ let keeper_memory_search_json
       "ts_unix", `Float (Time_compat.now ());
       "event", `String "memory_search";
       "query", `String query;
-      "source", `String source;
+      "source", `String source_label;
       "kind_filter", `String kind_filter;
       "match_count", `Int log_match_count;
     ] @ (match log_top_score with

--- a/lib/keeper/keeper_exec_memory.mli
+++ b/lib/keeper/keeper_exec_memory.mli
@@ -1,5 +1,15 @@
 (** Keeper memory tool handlers — search, context status. *)
 
+(** Issue #8484: Variant SSOT for memory search scope.  Mirror in
+    [Tool_shard.memory_search_source_enum_strings] (cycle avoidance,
+    sync regression test catches drift). *)
+type memory_search_source = Memory | History | All
+
+val memory_search_source_to_string : memory_search_source -> string
+val memory_search_source_of_string_opt : string -> memory_search_source option
+val all_memory_search_sources : memory_search_source list
+val valid_memory_search_source_strings : string list
+
 val keeper_memory_search_json :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -15,6 +15,14 @@
 let pr_review_event_enum_strings =
   [ "COMMENT"; "APPROVE"; "REQUEST_CHANGES" ]
 
+(** Issue #8484: hand-mirrored from
+    [Keeper_exec_memory.valid_memory_search_source_strings]. Direct
+    dependency would risk a Tool_shard -> Keeper_* -> Tool_shard cycle
+    (same shape as #8467 / #8480), so this stays a local mirror with a
+    sync regression test in [test_types.ml :: memory_search_source_ssot]. *)
+let memory_search_source_enum_strings =
+  [ "memory"; "history"; "all" ]
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -80,7 +88,9 @@ Use source='history' for raw user messages, source='all' for both.";
         ("query", `Assoc [("type", `String "string"); ("description", `String "keyword to search for")]);
         ("kind", `Assoc [("type", `String "string"); ("enum", `List [`String "goal"; `String "decision"; `String "progress"; `String "next"; `String "open_question"; `String "constraints"]); ("description", `String "Filter by memory kind")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "max results (1-10, default 5)")]);
-        ("source", `Assoc [("type", `String "string"); ("enum", `List [`String "memory"; `String "history"; `String "all"]); ("description", `String "Search scope: memory (default, structured notes), history (raw messages), or all")]);
+        (* Issue #8484: derive from local mirror that tracks
+           [Keeper_exec_memory.valid_memory_search_source_strings]. *)
+        ("source", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) memory_search_source_enum_strings)); ("description", `String "Search scope: memory (default, structured notes), history (raw messages), or all")]);
       ]);
       ("required", `List [`String "query"]);
     ];

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -9,6 +9,12 @@
     [test_types.ml :: pr_review_event_ssot] catches drift. *)
 val pr_review_event_enum_strings : string list
 
+(** Issue #8484: hand-mirrored from
+    [Keeper_exec_memory.valid_memory_search_source_strings]. Sync
+    regression test in [test_types.ml :: memory_search_source_ssot]
+    catches drift. *)
+val memory_search_source_enum_strings : string list
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -515,6 +515,35 @@ let () =
           Masc_mcp.Keeper_tool_pr_review.valid_pr_review_event_strings
           Masc_mcp.Tool_shard.pr_review_event_enum_strings);
     ];
+    "memory_search_source_ssot", [
+      (* Issue #8484: introduces [memory_search_source] Variant where 3
+         sites previously hand-validated raw strings + relied on a silent
+         _ -> memory wildcard fallback. Witness covers all 3 constructors;
+         mirror sync test asserts [Tool_shard]'s hand-mirrored enum stays
+         in lock-step with the SSOT (cycle-avoidance pattern from #8467/
+         #8480). *)
+      Alcotest.test_case "witness covers all 3 variants" `Quick (fun () ->
+        let module M = Masc_mcp.Keeper_exec_memory in
+        let witness s =
+          let actual = M.memory_search_source_to_string s in
+          if not (List.mem actual M.valid_memory_search_source_strings) then
+            Alcotest.failf "memory_search_source_to_string %S not in valid_memory_search_source_strings" actual
+        in
+        witness M.Memory; witness M.History; witness M.All;
+        Alcotest.(check int) "count" 3 (List.length M.valid_memory_search_source_strings));
+      Alcotest.test_case "of_string_opt sound partial" `Quick (fun () ->
+        let module M = Masc_mcp.Keeper_exec_memory in
+        Alcotest.(check bool) "memory" true (M.memory_search_source_of_string_opt "memory" <> None);
+        Alcotest.(check bool) "HISTORY (case)" true (M.memory_search_source_of_string_opt "HISTORY" <> None);
+        Alcotest.(check bool) "  all  (trim)" true
+          (M.memory_search_source_of_string_opt "  all  " <> None);
+        Alcotest.(check bool) "garbage rejected" true
+          (M.memory_search_source_of_string_opt "definitely-not-a-source" = None));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_exec_memory.valid_memory_search_source_strings
+          Masc_mcp.Tool_shard.memory_search_source_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8484.

3 sites string-validated `memory`/`history`/`all` + a silent `_ -> memory` wildcard branch. Two issues bundled:

1. **Drift class** (#8430-class) — schema in `tool_shard.ml:73` and dispatch in `keeper_exec_memory.ml:198-249` co-validated the same vocabulary with no underlying Variant.
2. **Anti-pattern** ("Unknown -> Permissive Default" from `CLAUDE.md`) — wildcard branch silently routed any unknown `source` to `memory` without surfacing the input.

## Approach

- New `memory_search_source = Memory | History | All` Variant in `keeper_exec_memory.ml` + `.mli`.
- Helpers: `to_string`, `of_string_opt` (sound partial), `all_*`, `valid_*_strings`.
- Refactor parse + dispatch:
  - `let source = of_string_opt raw |> Option.value ~default:Memory` — back-compat preserved but the fallback is now explicit.
  - `match source with Memory | History | All` — exhaustive, new constructor fails compilation.
  - `source_label = to_string source` reused 4× instead of 3 hardcoded literals.
- `tool_shard.ml` schema enum derives from local mirror `memory_search_source_enum_strings` (cycle-aware pattern from #8467/#8480).

## Verification

- `dune build` clean.
- `test_types.ml :: memory_search_source_ssot` — 3 cases (witness + sound partial + mirror sync).
- 40/40 `test_types` pass.

## Risk

Low. Behavior preserved (Memory still default for back-compat, same dispatch logic). Adds compile-time exhaustiveness + makes silent fallback explicit.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW Variant)
6. `memory_search_source` (#8484) — prevention + anti-pattern fix (NEW Variant)
