### PR TITLE
fix(worker_dev_tools): add remediation hint to Injection error

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -257,7 +257,12 @@ let block_reason_to_string = function
      Do NOT use: cmd='cd x && dune build' or cmd='rg foo | wc -l'. \
      To write files, use keeper_fs_edit."
   | Injection ->
-    "Shell injection syntax (;, &&, standalone &, `, $) not allowed."
+    "Shell injection syntax (;, &&, standalone &, `, $) not allowed. \
+     Run ONE command per call. Example: cmd='dune build'. \
+     Do NOT use: cmd='cd x && dune build' or cmd='cmd1 ; cmd2'. \
+     keeper_bash runs from the playground root — pass full relative \
+     paths in the command itself (cmd='rg pattern lib/keeper/file.ml'). \
+     For file writes, use keeper_fs_edit."
   | Process_substitution ->
     "Process substitution (<(...) or >(...)) is not allowed."
   | Unsafe_redirect ->


### PR DESCRIPTION
## Summary

Telemetry shows LLM keepers retry-loop on \`cmd='cd repos/... && gh issue view ...'\` and similar patterns. The \`Injection\` error returns only \"not allowed\" — no actionable remediation, so the LLM repeats the same pattern on the next step.

Contrast \`Chain_or_redirect\` (line 254-258) which hints \"Run ONE command per call. Example: cmd='dune build'. Do NOT use: cmd='cd x && dune build'\". That message works.

## Change

\`lib/worker_dev_tools.ml:260\` — \`Injection\` gets the same style of remediation + keeper_bash-specific note that it runs from playground root, so \`cd\` is never needed. Callers pass full relative paths.

## Test plan

- [x] \`dune build --root .\` green
- [x] \`test_worker_dev_tools\` — 111 tests pass (variant enumeration test includes Injection; no exact-string assertion)
- [x] \`test_keeper_bash_safety\` — 23 tests pass
- [ ] Post-merge: track \`keeper_bash blocked: Shell injection\` count in 1h windows; expect decay as LLM adapts to the hint

Feedback memory: \`feedback_tool-error-messages-teach-llm.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)