### PR TITLE
fix(keeper_fs): prevent Eio.Mutex poison on ensure_dir failure (#8475)

### DIFF
--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -16,19 +16,25 @@ let dir_mu = Eio.Mutex.create ()
 let ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 16
 
 let ensure_dir (path : string) : string =
+  (* Capture exceptions inside the mutex body so the lock exits normally,
+     then re-raise after release. Escaping an exception from
+     Eio.Mutex.use_rw poisons the mutex and breaks all subsequent
+     ensure_dir calls in the same process (Issue #8475: fleet-test
+     isolation cascade failures). *)
+  let deferred_exn = ref None in
   Eio_guard.with_mutex dir_mu (fun () ->
     if not (Hashtbl.mem ensured_dirs path) || not (Fs_compat.file_exists path) then begin
-      (try Fs_compat.mkdir_p path
-       with
-       | Eio.Cancel.Cancelled _ as exn ->
-           Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
-           raise exn
-       | exn ->
-           Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
-             path (Printexc.to_string exn);
-           raise exn);
-      Hashtbl.replace ensured_dirs path ()
+      match Fs_compat.mkdir_p path with
+      | () -> Hashtbl.replace ensured_dirs path ()
+      | exception (Eio.Cancel.Cancelled _ as exn) ->
+          Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
+          deferred_exn := Some exn
+      | exception exn ->
+          Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
+            path (Printexc.to_string exn);
+          deferred_exn := Some exn
     end);
+  (match !deferred_exn with Some exn -> raise exn | None -> ());
   path
 
 let invalidate_dir (path : string) : unit =


### PR DESCRIPTION
Closes #8475.

## 루트 원인

`lib/keeper/keeper_fs.ensure_dir`가 `Eio_guard.with_mutex dir_mu (fun () -> ...)` 안에서 `Fs_compat.mkdir_p` 예외를 그대로 `raise`.

`Eio_guard.with_mutex` → `Eio.Mutex.use_rw ~protect:true`. Eio 규칙상 **body에서 예외가 escape하면 mutex는 poisoned로 마킹**되고, 이후 모든 `use_rw`/`use_ro` 호출이 `Eio.Mutex.Poisoned`로 실패.

프로세스 단위 cascade: 한 테스트의 `ensure_dir` 실패 → 같은 executable의 모든 후속 operator/keeper 테스트가 `Poisoned` 예외로 실패.

## 관찰 사례 (Issue #8475)

| PR | 변경 scope | operator 29/31/32/33 |
|----|-----------|---------------------|
| #8441 | types null optionals | ✗ |
| #8470 | coord_task FSM warn | ✗ |
| #8473 | dashboard panel tick | ✗ |
| #8479 | **zero-code pin bump** | ✗ |

#8479가 결정적 — PR에 코드 변경이 없음에도 같은 실패 → main branch 상태 이슈 확정.

## Fix

Exception을 critical section 내부의 `ref`에 저장 → mutex body는 `()`로 정상 완료 → lock 해제 → 이후 deferred exception을 raise.

```ocaml
let deferred_exn = ref None in
Eio_guard.with_mutex dir_mu (fun () ->
  if not (Hashtbl.mem ensured_dirs path) || not (Fs_compat.file_exists path) then begin
    match Fs_compat.mkdir_p path with
    | () -> Hashtbl.replace ensured_dirs path ()
    | exception (Eio.Cancel.Cancelled _ as exn) ->
        Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
        deferred_exn := Some exn
    | exception exn ->
        Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
          path (Printexc.to_string exn);
        deferred_exn := Some exn
  end);
(match !deferred_exn with Some exn -> raise exn | None -> ());
path
```

**Semantics 보존**:
- 호출자 관점: 예외 타입 동일 (`Cancelled`, 기타)
- Log.Keeper.warn 호출 동일
- Hashtbl 상태 변화 없음 (mkdir 성공 시만 캐시)

**변화**:
- Mutex 해제 → 예외 raise **순서만 변경**

## 검증

- `dune build --root . lib/` pass.
- 로컬에서 full test 돌리려면 Eio harness 필요 — CI가 정확한 증거.
- Issue #8475에 재현 PR 목록 있음; 이 PR 머지 후 해당 PR들 rebase 시 operator 29/31/32/33 회복 기대.

## 추가 검토 필요 (follow-up)

- `keeper_fs.ml`의 다른 `Eio_guard.with_mutex` 사용처(`invalidate_dir`, `clear_dir_cache`)는 body가 `Hashtbl.remove`/`clear`로 예외 없음 → 수정 불필요.
- 다른 모듈의 같은 패턴 (`rg 'Eio_guard.with_mutex' lib/`) 스윕 권장 — 별도 PR로.
