### PR TITLE
fix(keeper_schema): mirror Keeper_status_detail.tail_order Variant SSOT (#8486)

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -26,6 +26,16 @@ let network_mode_enum_strings =
 let shared_memory_scope_enum_strings =
   [ "disabled"; "room" ]
 
+(** Issue #8486: hand-mirrored from
+    [Keeper_status_detail.valid_tail_order_strings].  Same cycle
+    constraint — Keeper_schema is upstream of Keeper_status_detail.
+    The test [test_types.ml :: tail_order_ssot] asserts this mirror
+    stays in sync with the SSOT so adding a 3rd ordering constructor
+    fails compilation in [tail_order_to_string] AND fails the test
+    here, instead of silently dropping from the JSON Schema. *)
+let tail_order_enum_strings =
+  [ "oldest_first"; "newest_first" ]
+
 let string_array_schema =
   `Assoc [
     ("type", `String "array");
@@ -350,7 +360,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tail_order", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "oldest_first"; `String "newest_first"]);
+          ("enum", `List (List.map (fun s -> `String s) tail_order_enum_strings));
           ("description", `String "Ordering for metrics/history/compaction tails and recent memory notes. Default: oldest_first (compat).");
         ]);
         ("fast", `Assoc [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -79,6 +79,15 @@ let tail_order_to_string = function
   | Oldest_first -> "oldest_first"
   | Newest_first -> "newest_first"
 
+(* Issue #8486: Variant SSOT for [tail_order]. Adding a constructor
+   forces [tail_order_to_string] exhaustiveness AND extends
+   [valid_tail_order_strings]; the schema in [Keeper_schema] mirrors
+   this list (cycle-avoidance: Keeper_schema -> Keeper_types ->
+   Keeper_types_profile -> Keeper_schema, same shape as #8467). *)
+let all_tail_orders = [ Oldest_first; Newest_first ]
+let valid_tail_order_strings =
+  List.map tail_order_to_string all_tail_orders
+
 let apply_tail_order order items =
   match order with
   | Oldest_first -> items

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -815,6 +815,24 @@ let () =
         Alcotest.(check bool) "label is not the truncated form" false
           (String.equal label "autonomous"));
     ];
+    "tail_order_ssot", [
+      (* Issue #8486: witness exhaustiveness for [Keeper_status_detail.tail_order]
+         + sync test for the [Keeper_schema.tail_order_enum_strings] mirror.
+         Same shape as #8467 (sandbox/network/shared_memory). *)
+      Alcotest.test_case "witness covers both variants" `Quick (fun () ->
+        let module S = Masc_mcp.Keeper_status_detail in
+        let witness o =
+          let actual = S.tail_order_to_string o in
+          if not (List.mem actual S.valid_tail_order_strings) then
+            Alcotest.failf "tail_order_to_string %S not in valid_tail_order_strings" actual
+        in
+        witness S.Oldest_first; witness S.Newest_first;
+        Alcotest.(check int) "count" 2 (List.length S.valid_tail_order_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tail_order mirror == SSOT"
+          Masc_mcp.Keeper_status_detail.valid_tail_order_strings
+          Masc_mcp.Keeper_schema.tail_order_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8486.

`Keeper_status_detail.tail_order` Variant (`Oldest_first | Newest_first`) already had `to_string` but `keeper_schema.ml:337` hardcoded the JSON Schema enum:
```ocaml
("enum", `List [`String "oldest_first"; `String "newest_first"]);
```

Adding a 3rd ordering constructor would silently drop from schema — identical structure to #8467 (sandbox_profile/network_mode/shared_memory_scope).

## Approach

- Add `all_tail_orders` + `valid_tail_order_strings` next to `tail_order_to_string`.
- Add `tail_order_enum_strings` local mirror in `keeper_schema.ml` (cycle-avoidance: Keeper_schema -> Keeper_types -> Keeper_types_profile -> Keeper_schema, same shape as #8467).
- Schema enum at line 337 derives from mirror.
- Witness + mirror sync regression in `test_types.ml :: tail_order_ssot`.

## Verification

- `dune build` clean.
- 41/41 `test_types` pass (2 new cases).

## Risk

Low. Same shape as #8467 (merged) — Variant exists, schema mirrors. No current missing-constructor bug detected; structural prevention only.

## Drift catalog (cumulative — Variant SSOT pattern)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW Variant)
6. `memory_search_source` (#8484) — prevention + anti-pattern fix (NEW Variant)
7. `tail_order` (#8486) — prevention
