### PR TITLE
fix(keeper_exec_fs): introduce fs_write_mode Variant SSOT (#8490)

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -1,6 +1,37 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* Issue #8490: Variant SSOT for fs write mode. Adding a constructor
+   forces compilation in [fs_write_mode_to_string] and
+   [fs_write_mode_dispatch] AND extends [valid_fs_write_mode_strings];
+   the schema in [tool_shard.ml] mirrors the SSOT (cycle avoidance
+   per #8480/#8484 pattern). The previous code used 5 hardcoded sites
+   (parse default, validate, dispatch, label normalisation, schema)
+   with an empty-string-as-overwrite back-compat — now expressed
+   explicitly via [Option.value ~default:Overwrite]. *)
+type fs_write_mode =
+  | Overwrite
+  | Append
+
+let fs_write_mode_to_string = function
+  | Overwrite -> "overwrite"
+  | Append -> "append"
+
+(* Sound partial parser: canonical strings AND the back-compat empty
+   string both decode to a real Variant. Whitespace-only treated as
+   empty for the same back-compat reason. Anything else returns None
+   so the caller decides the rejection message. *)
+let fs_write_mode_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "overwrite" | "" -> Some Overwrite
+  | "append" -> Some Append
+  | _ -> None
+
+let all_fs_write_modes = [ Overwrite; Append ]
+
+let valid_fs_write_mode_strings =
+  List.map fs_write_mode_to_string all_fs_write_modes
+
 (** keeper_fs_read max_bytes clamp. [fs_read_default_max_bytes] is the
     canonical default; [Tool_shard_limits.keeper_fs_read_default_max_bytes]
     re-exports it at a leaf module so the tool schema in tool_shard.ml
@@ -59,18 +90,22 @@ let handle_keeper_fs_edit
   =
   let path = Safe_ops.json_string ~default:"" "path" args in
   let content = Safe_ops.json_string ~default:"" "content" args in
-  let mode =
-    Safe_ops.json_string ~default:"overwrite" "mode" args |> String.lowercase_ascii
+  let mode_raw =
+    Safe_ops.json_string ~default:"overwrite" "mode" args
   in
+  let mode_opt = fs_write_mode_of_string_opt mode_raw in
   (* Early validation for 9B models that send empty/missing params *)
   if String.trim path = "" then
     error_json "path is required. Good: path='lib/foo.ml'. Bad: path=''."
   else if String.trim content = "" then
     error_json "content is required (non-empty). Writing 0 bytes is usually unintended."
-  else if mode <> "overwrite" && mode <> "append" && mode <> "" then
+  else match mode_opt with
+  | None ->
     error_json (Printf.sprintf
-      "mode must be 'overwrite' or 'append', got '%s'." mode)
-  else
+      "mode must be one of [%s], got %S."
+      (String.concat ", " valid_fs_write_mode_strings) mode_raw)
+  | Some mode ->
+  let mode_label = fs_write_mode_to_string mode in
   match resolve_keeper_path ~config ~meta ~raw_path:path with
   | Error e -> error_json e
   | Ok target ->
@@ -78,17 +113,16 @@ let handle_keeper_fs_edit
        let parent = Filename.dirname target in
        Fs_compat.mkdir_p parent;
        (match mode with
-        | "append" -> Fs_compat.append_file target content
-        | "overwrite" | "" -> Fs_compat.save_file target content
-        | other -> raise (Invalid_argument ("unsupported_mode:" ^ other)));
+        | Append -> Fs_compat.append_file target content
+        | Overwrite -> Fs_compat.save_file target content);
        Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
-         meta.name target (if mode = "" then "overwrite" else mode)
+         meta.name target mode_label
          (String.length content);
        Yojson.Safe.to_string
          (`Assoc
              [ "ok", `Bool true
              ; "path", `String target
-             ; "mode", `String (if mode = "" then "overwrite" else mode)
+             ; "mode", `String mode_label
              ; "bytes_written", `Int (String.length content)
              ])
      with

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -1,5 +1,15 @@
 (** Keeper filesystem tool handlers — read and edit. *)
 
+(** Issue #8490: Variant SSOT for fs write mode. Mirror in
+    [Tool_shard.fs_write_mode_enum_strings] (cycle avoidance, sync
+    regression test catches drift). *)
+type fs_write_mode = Overwrite | Append
+
+val fs_write_mode_to_string : fs_write_mode -> string
+val fs_write_mode_of_string_opt : string -> fs_write_mode option
+val all_fs_write_modes : fs_write_mode list
+val valid_fs_write_mode_strings : string list
+
 val handle_keeper_fs_read :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -23,6 +23,15 @@ let pr_review_event_enum_strings =
 let memory_search_source_enum_strings =
   [ "memory"; "history"; "all" ]
 
+(** Issue #8490: hand-mirrored from
+    [Keeper_exec_fs.valid_fs_write_mode_strings]. Direct dependency
+    would risk a Tool_shard -> Keeper_* -> Tool_shard cycle (same
+    shape as #8467 / #8480 / #8484). Sync regression test in
+    [test_types.ml :: fs_write_mode_ssot] catches drift. *)
+let fs_write_mode_enum_strings =
+  [ "overwrite"; "append" ]
+
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -288,7 +297,9 @@ Creates parent dirs.";
       ("properties", `Assoc [
         ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path to write")]);
         ("content", `Assoc [("type", `String "string"); ("description", `String "File content to write")]);
-        ("mode", `Assoc [("type", `String "string"); ("enum", `List [`String "overwrite"; `String "append"]); ("description", `String "Write mode (default: overwrite)")]);
+        (* Issue #8490: derive from local mirror that tracks
+           [Keeper_exec_fs.valid_fs_write_mode_strings]. *)
+        ("mode", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) fs_write_mode_enum_strings)); ("description", `String "Write mode (default: overwrite)")]);
       ]);
       ("required", `List [`String "path"; `String "content"]);
     ];

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -15,6 +15,12 @@ val pr_review_event_enum_strings : string list
     catches drift. *)
 val memory_search_source_enum_strings : string list
 
+(** Issue #8490: hand-mirrored from
+    [Keeper_exec_fs.valid_fs_write_mode_strings]. Sync regression test
+    in [test_types.ml :: fs_write_mode_ssot] catches drift. *)
+val fs_write_mode_enum_strings : string list
+
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -564,6 +564,37 @@ let () =
           Masc_mcp.Keeper_exec_memory.valid_memory_search_source_strings
           Masc_mcp.Tool_shard.memory_search_source_enum_strings);
     ];
+    "fs_write_mode_ssot", [
+      (* Issue #8490: introduces [fs_write_mode] Variant where 5 sites
+         previously hand-validated raw strings + relied on an
+         empty-string-as-overwrite back-compat. Witness covers both
+         constructors; mirror sync test asserts [Tool_shard]'s
+         hand-mirrored enum stays in lock-step with the SSOT
+         (cycle-avoidance pattern from #8467/#8480/#8484). *)
+      Alcotest.test_case "witness covers both variants" `Quick (fun () ->
+        let module F = Masc_mcp.Keeper_exec_fs in
+        let witness m =
+          let actual = F.fs_write_mode_to_string m in
+          if not (List.mem actual F.valid_fs_write_mode_strings) then
+            Alcotest.failf "fs_write_mode_to_string %S not in valid_fs_write_mode_strings" actual
+        in
+        witness F.Overwrite; witness F.Append;
+        Alcotest.(check int) "count" 2 (List.length F.valid_fs_write_mode_strings));
+      Alcotest.test_case "of_string_opt sound partial + empty back-compat" `Quick (fun () ->
+        let module F = Masc_mcp.Keeper_exec_fs in
+        Alcotest.(check bool) "overwrite" true (F.fs_write_mode_of_string_opt "overwrite" <> None);
+        Alcotest.(check bool) "APPEND (case)" true (F.fs_write_mode_of_string_opt "APPEND" <> None);
+        Alcotest.(check bool) "  empty -> Overwrite (back-compat)" true
+          (F.fs_write_mode_of_string_opt "" = Some F.Overwrite);
+        Alcotest.(check bool) "whitespace-only -> Overwrite" true
+          (F.fs_write_mode_of_string_opt "   " = Some F.Overwrite);
+        Alcotest.(check bool) "garbage rejected" true
+          (F.fs_write_mode_of_string_opt "definitely-not-a-mode" = None));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_exec_fs.valid_fs_write_mode_strings
+          Masc_mcp.Tool_shard.fs_write_mode_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8490.

5 sites string-validated `overwrite`/`append`. Two issues bundled:

1. **Drift class** (#8430-class) — schema in `tool_shard.ml:271` and dispatch in `keeper_exec_fs.ml:55-99` co-validated the same vocabulary with no underlying Variant.
2. **Empty-string-as-overwrite back-compat** scattered across 3 of 5 sites (`if mode = "" then "overwrite" else mode` repeated for label, `match ... | "overwrite" | "" -> ...` in dispatch, etc.).

## Approach

- New `fs_write_mode = Overwrite | Append` Variant in `keeper_exec_fs.ml` + `.mli`.
- Helpers: `to_string`, `of_string_opt` (sound partial: `""` and `"overwrite"` both decode to `Some Overwrite`, anything unknown returns `None` for explicit caller rejection).
- Refactor parse + validate + dispatch + label:
  - `match mode_opt with None -> error_json ... | Some mode -> ...` — explicit error path, no silent wildcard.
  - dispatch is `match mode with Append | Overwrite` — exhaustive, new constructor fails compilation.
  - `mode_label = to_string mode` reused for log + JSON output instead of 2 hardcoded if-else.
- `tool_shard.ml` schema enum derives from local mirror `fs_write_mode_enum_strings` (cycle-aware pattern from #8467/#8480/#8484).

## Verification

- `dune build` clean.
- `test_types.ml :: fs_write_mode_ssot` — 3 cases (witness + sound partial w/ empty back-compat + mirror sync).
- 42/42 `test_types` pass.

## Risk

Low. Behavior preserved (Overwrite still default, empty-string still maps to Overwrite). Adds compile-time exhaustiveness + makes empty-string back-compat explicit at one site instead of 3.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW Variant)
6. `memory_search_source` (#8484) — prevention + anti-pattern fix (NEW Variant)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW Variant)
