### PR TITLE
fix(tool_schemas_misc): mirror full config category list — 11 missing (#8493)

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -988,6 +988,20 @@ let all_categories () =
     category "session" (session_entries @ team_session_entries @ tempo_entries);
   ]
 
+(** Issue #8493: Variant SSOT for masc_config tool's [category] filter.
+    Derived from [all_categories ()] so adding a new category there
+    flows through to consumers (notably the JSON Schema enum in
+    [tool_schemas_misc.ml] which previously hand-listed only 9 of 21
+    categories — missing keeper_execution, keeper_guardrails, autonomy,
+    level2, economy, governance, channel, process, worker, web_search,
+    session). Order is deterministic (matches [all_categories ()]).
+
+    Consumers that cannot depend on this module (e.g. tool_schemas_misc
+    only depends on masc_types) hand-mirror this list with a sync
+    regression test in [test_types.ml :: config_category_ssot]. *)
+let valid_config_category_strings () =
+  List.map fst (all_categories ())
+
 let to_json ?server_meta ?generated_at ?cat () =
   let categories =
     match cat with

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -2,6 +2,25 @@
 
 open Types
 
+(** Issue #8493: hand-mirrored from
+    [Env_config_snapshot.valid_config_category_strings ()].
+    [masc_tool_schemas] only depends on [masc_types], so it cannot
+    derive directly. The sync regression test
+    [test_types.ml :: config_category_ssot] asserts these stay in
+    lock-step so adding a new category in [env_config_snapshot.ml]
+    fails the test before shipping with a stale schema. Same shape as
+    #8467 / #8480 / #8484 / #8490 mirror+sync pattern.
+
+    Order matches [all_categories ()] for UI/schema determinism. The
+    schema previously hand-listed only 9 of 21 categories — missing
+    keeper_execution, keeper_guardrails, autonomy, level2, economy,
+    governance, channel, process, worker, web_search, session. *)
+let config_category_enum_strings =
+  [ "server"; "auth"; "transport"; "storage"; "runtime"; "rate_limiting";
+    "inference"; "keeper"; "keeper_execution"; "keeper_guardrails";
+    "autonomy"; "level2"; "dashboard"; "economy"; "governance"; "channel";
+    "process"; "worker"; "web_search"; "session" ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_config";
@@ -13,7 +32,9 @@ Pass category to filter results to a single section.";
       ("properties", `Assoc [
         ("category", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "server"; `String "auth"; `String "transport"; `String "storage"; `String "runtime"; `String "rate_limiting"; `String "inference"; `String "keeper"; `String "dashboard"]);
+          (* Issue #8493: derive from local mirror that tracks
+             [Env_config_snapshot.valid_config_category_strings ()]. *)
+          ("enum", `List (List.map (fun s -> `String s) config_category_enum_strings));
           ("description", `String "Filter by config category");
         ]);
       ]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -515,6 +515,30 @@ let () =
           Masc_mcp.Keeper_tool_pr_review.valid_pr_review_event_strings
           Masc_mcp.Tool_shard.pr_review_event_enum_strings);
     ];
+    "config_category_ssot", [
+      (* Issue #8493: schema in [tool_schemas_misc.ml] hand-listed only
+         9 of 21 categories actually exposed by [Env_config_snapshot.
+         all_categories ()]. This test asserts the [Tool_schemas_misc]
+         mirror == [Env_config_snapshot] SSOT so adding a new category
+         in env_config_snapshot.ml fails the test before shipping with
+         a stale schema enum. Same shape as #8467/#8480/#8484/#8490
+         mirror+sync pattern. *)
+      Alcotest.test_case "schema mirror matches env_config_snapshot SSOT" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_schemas_misc mirror == SSOT"
+          (Env_config_snapshot.valid_config_category_strings ())
+          Tool_schemas_misc.config_category_enum_strings);
+      Alcotest.test_case "missing categories now present" `Quick (fun () ->
+        let missing_before_fix = [
+          "keeper_execution"; "keeper_guardrails"; "autonomy"; "level2";
+          "economy"; "governance"; "channel"; "process"; "worker";
+          "web_search"; "session";
+        ] in
+        let actual = Tool_schemas_misc.config_category_enum_strings in
+        List.iter (fun expected ->
+          Alcotest.(check bool) (Printf.sprintf "%s now in schema" expected) true
+            (List.mem expected actual)
+        ) missing_before_fix);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8493. **Real missing-categories bug fix — 11 of 21 categories were absent from schema.**

`tool_schemas_misc.ml:16` JSON Schema enum hand-listed only 9 categories. `Env_config_snapshot.all_categories ()` actually defines 21. LLM clients reading the schema couldn't filter by:

- `keeper_execution`
- `keeper_guardrails`
- `autonomy`
- `level2`
- `economy`
- `governance`
- `channel`
- `process`
- `worker`
- `web_search`
- `session`

Same drift class as #8430 (tool_preset Social/Delivery), #8471 (snapshot_view Sessions), #8474 (FSM verifier transitions). **4th REAL bug found via this sweep.**

## Approach

- Add `Env_config_snapshot.valid_config_category_strings : unit -> string list` derived from `List.map fst (all_categories ())` — single source of truth at the producer side.
- `tool_schemas_misc.ml` cannot depend on `masc_config` (only depends on `masc_types`), so it hand-mirrors with sync regression test. Cycle-avoidance pattern from #8467/#8480/#8484/#8490.
- Schema enum derives from local mirror via `List.map (fun s -> \`String s)`.

## Verification

- `dune build` clean.
- `test_types.ml :: config_category_ssot` — 2 cases (mirror == SSOT + 11 previously-missing categories present).
- 41/41 `test_types` pass.

## Risk

Low. Schema gains 11 categories — additive. Existing 9-category clients see no breaking change. New filter values now accepted by both schema and runtime.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW Variant)
6. `memory_search_source` (#8484) — prevention + anti-pattern fix (NEW Variant)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW Variant)
9. `config_category` (#8493) — **REAL (11 missing)**
