### PR TITLE
[codex] Retarget stale post-SSE E2E to the public MCP surface

### DIFF
--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -332,14 +332,12 @@ let tool_payload ~id ~name ~arguments =
             [ ("name", `String name); ("arguments", arguments) ] );
       ])
 
-let rec call_until_ready ~port ~retries_left =
+let rec call_status_until_ready ~port ~retries_left =
   let result =
     run_curl_post ~max_time_sec:8 ~port ~path:"/mcp"
       ~session_id:"post-sse-keepalive"
       ~payload:
-        (tool_payload ~id:201 ~name:"masc_listen"
-           ~arguments:
-             (`Assoc [ ("agent_name", `String "slowpoke"); ("timeout", `Int 4) ]))
+        (tool_payload ~id:201 ~name:"masc_status" ~arguments:(`Assoc []))
       ()
   in
   match (result.status, retries_left) with
@@ -347,21 +345,24 @@ let rec call_until_ready ~port ~retries_left =
     when retries > 0
          && contains_substr "Server state not initialized" result.body ->
       Unix.sleepf 0.5;
-      call_until_ready ~port ~retries_left:(retries - 1)
+      call_status_until_ready ~port ~retries_left:(retries - 1)
   | Some 503, retries
     when retries > 0
          && contains_substr "Server is starting up, not ready yet" result.body ->
       Unix.sleepf 0.5;
-      call_until_ready ~port ~retries_left:(retries - 1)
+      call_status_until_ready ~port ~retries_left:(retries - 1)
   | _ -> result
 
-let test_post_tools_call_streams_keepalive_before_result () =
+(* Issue #8446: public /mcp streamable POST guarantees SSE framing for
+   tools/call, but not a 30s transport keepalive inside an 8s E2E window.
+   Use a valid public tool and assert prime-event + message framing instead
+   of a stale keepalive contract tied to removed masc_listen. *)
+let test_post_tools_call_streams_sse_framing () =
   with_server @@ fun ~port ->
-  let result = call_until_ready ~port ~retries_left:40 in
+  let result = call_status_until_ready ~port ~retries_left:40 in
   require_http_ok "streaming tools/call" result;
   check int "curl exits cleanly" 0 result.curl_exit;
   check bool "prime event sent" true (contains_substr "retry: 3000" result.body);
-  check bool "keepalive sent" true (contains_substr ": keepalive" result.body);
   check bool "message event sent" true
     (contains_substr "event: message" result.body);
   let json = parse_json_body "streaming tools/call" result in
@@ -372,15 +373,14 @@ let test_post_tools_call_streams_keepalive_before_result () =
     json |> U.member "result" |> U.member "content" |> U.index 0
     |> U.member "text" |> U.to_string
   in
-  check bool "listen timeout surfaced" true
-    (contains_substr "Listening timed out after 4s" text)
+  check bool "status text present" true (String.length text > 0)
 
 let () =
   run "mcp_post_sse_e2e"
     [
       ( "mcp",
         [
-          test_case "post tools/call streams keepalive before result" `Slow
-            test_post_tools_call_streams_keepalive_before_result;
+          test_case "post tools/call streams sse framing" `Slow
+            test_post_tools_call_streams_sse_framing;
         ] );
     ]


### PR DESCRIPTION
## What changed
- replaced the stale `masc_listen` call in `test_mcp_post_sse_e2e`
- retargeted the test to `masc_status`, which is actually exposed on the public `/mcp` surface
- changed the assertion to verify streamable `tools/call` SSE framing instead of an impossible keepalive-in-8s contract

## Why it changed
The existing E2E failed before exercising transport behavior because it called a removed public tool. It also expected a keepalive comment even though transport keepalives are on a 30s cadence and the test times out after 8s.

## Impact
The test now validates the real public streamable-HTTP contract and no longer reports false regressions caused by stale tool-surface assumptions.

## Root cause
`test_mcp_post_sse_e2e` had drifted from the current public tool surface and from the actual transport keepalive timing behavior.

## Validation
- `env MASC_E2E_TESTS=true dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8446-post-sse-keepalive test/test_mcp_post_sse_e2e.exe`
- `env MASC_E2E_TESTS=true MASC_MAIN_EIO_EXE=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8446-post-sse-keepalive/_build/default/bin/main_eio.exe /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8446-post-sse-keepalive/_build/default/test/test_mcp_post_sse_e2e.exe`