### PR TITLE
[codex] Unify OCaml workflow pinning through the composite action

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -1,5 +1,5 @@
 name: Setup OCaml Toolchain
-description: Shared Linux OCaml toolchain bootstrap that avoids upstream opam binary gaps.
+description: Shared OCaml toolchain bootstrap with Linux local-opam pinning and macOS parity.
 
 inputs:
   ocaml-compiler:
@@ -18,17 +18,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Bootstrap local opam switch
+    - name: Setup OCaml (macOS)
+      if: runner.os == 'macOS'
+      uses: ocaml/setup-ocaml@v3.6.0
+      with:
+        ocaml-compiler: ${{ inputs.ocaml-compiler }}
+        dune-cache: ${{ inputs.dune-cache }}
+
+    - name: Bootstrap local opam switch (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       env:
         OCAML_COMPILER_INPUT: ${{ inputs.ocaml-compiler }}
       run: |
         set -euo pipefail
-
-        if [ "$(uname -s)" != "Linux" ]; then
-          echo "setup-ocaml-toolchain currently supports Linux runners only" >&2
-          exit 1
-        fi
 
         case "${OCAML_COMPILER_INPUT}" in
           5.4|5.4.x)
@@ -98,3 +101,10 @@ runs:
         switch_prefix="$(opam var prefix --switch="${switch_name}")"
         echo "OPAMSWITCH=${switch_name}" >> "${GITHUB_ENV}"
         echo "${switch_prefix}/bin" >> "${GITHUB_PATH}"
+
+    - name: Reject unsupported runner OS
+      if: runner.os != 'Linux' && runner.os != 'macOS'
+      shell: bash
+      run: |
+        echo "setup-ocaml-toolchain supports Linux and macOS runners only" >&2
+        exit 1

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup OCaml
         uses: ./.github/actions/setup-ocaml-toolchain
-        with:
-          ocaml-compiler: 5.4.1
 
       - name: Pin private dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,8 @@ jobs:
             scripts/check-version-truth.sh
           fi
 
-      - name: Setup OCaml (Linux)
-        if: runner.os == 'Linux'
+      - name: Setup OCaml
         uses: ./.github/actions/setup-ocaml-toolchain
-        with:
-          ocaml-compiler: 5.4.1
-
-      - name: Setup OCaml (macOS)
-        if: runner.os == 'macOS'
-        uses: ocaml/setup-ocaml@v3.6.0
-        with:
-          ocaml-compiler: 5.4.x
 
       - name: Pin private dependencies
         run: |

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Setup OCaml
         uses: ./.github/actions/setup-ocaml-toolchain
         with:
-          ocaml-compiler: 5.4.1
           dune-cache: true
 
       - name: Setup Node


### PR DESCRIPTION
## What changed
- extended `.github/actions/setup-ocaml-toolchain` to support macOS by delegating to `ocaml/setup-ocaml`
- removed the drifting macOS-only OCaml setup path from `release.yml`
- removed redundant `ocaml-compiler: 5.4.1` workflow inputs so the composite action default is the single pin owner

## Why it changed
The release workflow built macOS with `5.4.x` through a separate path, which could silently drift away from the pinned Linux toolchain version.

## Impact
Workflow OCaml pinning is now centralized in the composite action, so release, deploy, and interop workflows all inherit the same default compiler version.

## Root cause
The repository had two setup paths: a Linux-only composite action pinned to `5.4.1`, and a macOS release path using `ocaml/setup-ocaml` with `5.4.x`.

## Validation
- parsed the modified workflow/action YAML locally
- `git diff --check`
- confirmed workflow files no longer carry direct `ocaml-compiler: 5.4.1` overrides outside the composite action