### PR TITLE
[codex] Add a typed memory search source for keeper memory search

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -18,6 +18,27 @@ type memory_match = {
   score: float;
 }
 
+type memory_search_source =
+  | Memory
+  | History
+  | All
+
+let memory_search_source_to_string = function
+  | Memory -> "memory"
+  | History -> "history"
+  | All -> "all"
+
+let memory_search_source_of_string_opt = function
+  | "memory" -> Some Memory
+  | "history" -> Some History
+  | "all" -> Some All
+  | _ -> None
+
+let all_memory_search_sources = [ Memory; History; All ]
+
+let valid_memory_search_source_strings =
+  List.map memory_search_source_to_string all_memory_search_sources
+
 let search_memory_bank
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -195,21 +216,27 @@ let keeper_memory_search_json
       ~(args : Yojson.Safe.t) =
   let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
   let limit = max 1 (min 10 (Safe_ops.json_int ~default:5 "limit" args)) in
-  let source = Safe_ops.json_string ~default:"memory" "source" args |> String.trim in
+  let raw_source =
+    Safe_ops.json_string ~default:(memory_search_source_to_string Memory) "source" args
+    |> String.trim
+  in
+  let source =
+    memory_search_source_of_string_opt raw_source |> Option.value ~default:Memory
+  in
   let kind_filter = Safe_ops.json_string ~default:"" "kind" args |> String.trim in
   let result =
     match source with
-    | "history" ->
+    | History ->
       let matches = search_history ~config ~meta ~ctx_work ~query ~limit in
       let no_match = matches = [] in
       let match_jsons = List.map (fun msg -> `String msg) matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "history";
+        "source", `String (memory_search_source_to_string source);
         "match_count", `Int (List.length matches);
         "matches", `List match_jsons;
       ] @ (if no_match then [ "no_match", `Bool true ] else []))
-    | "all" ->
+    | All ->
       let (bank_matches, bank_total) =
         search_memory_bank ~config ~meta ~query ~kind_filter ~limit
       in
@@ -227,12 +254,12 @@ let keeper_memory_search_json
       ) history_matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "all";
+        "source", `String (memory_search_source_to_string source);
         "total_candidates", `Int bank_total;
         "match_count", `Int total_matches;
         "matches", `List (bank_jsons @ history_jsons);
       ] @ (if no_match then [ "no_match", `Bool true ] else []))
-    | _ (* "memory" *) ->
+    | Memory ->
       let (matches, total_candidates) =
         search_memory_bank ~config ~meta ~query ~kind_filter ~limit
       in
@@ -240,7 +267,7 @@ let keeper_memory_search_json
       let match_jsons = List.map memory_match_to_json matches in
       `Assoc ([
         "query", `String query;
-        "source", `String "memory";
+        "source", `String (memory_search_source_to_string source);
         "total_candidates", `Int total_candidates;
         "match_count", `Int (List.length matches);
         "matches", `List match_jsons;
@@ -271,7 +298,7 @@ let keeper_memory_search_json
       "ts_unix", `Float (Time_compat.now ());
       "event", `String "memory_search";
       "query", `String query;
-      "source", `String source;
+      "source", `String (memory_search_source_to_string source);
       "kind_filter", `String kind_filter;
       "match_count", `Int log_match_count;
     ] @ (match log_top_score with

--- a/lib/keeper/keeper_exec_memory.mli
+++ b/lib/keeper/keeper_exec_memory.mli
@@ -1,5 +1,15 @@
 (** Keeper memory tool handlers — search, context status. *)
 
+type memory_search_source =
+  | Memory
+  | History
+  | All
+
+val memory_search_source_to_string : memory_search_source -> string
+val memory_search_source_of_string_opt : string -> memory_search_source option
+val all_memory_search_sources : memory_search_source list
+val valid_memory_search_source_strings : string list
+
 val keeper_memory_search_json :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -16,6 +16,13 @@ type shard = {
 
 module StringMap = Map.Make(String)
 
+(* Cycle-aware mirror of Keeper_exec_memory.valid_memory_search_source_strings.
+   Tool_shard cannot depend on Keeper_exec_memory directly without reintroducing
+   the Tool_shard -> Keeper_exec_memory -> Keeper_alerting -> Tool_shard cycle.
+   Keep this list in sync with Keeper_exec_memory and guard it with tests. *)
+let keeper_memory_search_source_enum_strings =
+  [ "memory"; "history"; "all" ]
+
 (** Predefined shards *)
 
 let base_tools : Types.tool_schema list = [
@@ -70,7 +77,7 @@ Use source='history' for raw user messages, source='all' for both.";
         ("query", `Assoc [("type", `String "string"); ("description", `String "keyword to search for")]);
         ("kind", `Assoc [("type", `String "string"); ("enum", `List [`String "goal"; `String "decision"; `String "progress"; `String "next"; `String "open_question"; `String "constraints"]); ("description", `String "Filter by memory kind")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "max results (1-10, default 5)")]);
-        ("source", `Assoc [("type", `String "string"); ("enum", `List [`String "memory"; `String "history"; `String "all"]); ("description", `String "Search scope: memory (default, structured notes), history (raw messages), or all")]);
+        ("source", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) keeper_memory_search_source_enum_strings)); ("description", `String "Search scope: memory (default, structured notes), history (raw messages), or all")]);
       ]);
       ("required", `List [`String "query"]);
     ];

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module Mention = Mention
 module Keeper_execution = Masc_mcp.Keeper_execution
+module Keeper_exec_memory = Masc_mcp.Keeper_exec_memory
 module Keeper_memory = Masc_mcp.Keeper_memory
 module Keeper_memory_recall = Masc_mcp.Keeper_memory_recall
 module Keeper_world_observation = Masc_mcp.Keeper_world_observation
@@ -844,6 +845,25 @@ let test_memory_search_bank_basic () =
     let score = Yojson.Safe.Util.(first_match |> member "score" |> to_float) in
     check bool "score is positive" true (score > 0.0))
 
+let test_memory_search_unknown_source_defaults_to_memory () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir_r dir) (fun () ->
+    let config = make_test_room_config dir in
+    let meta = keeper_meta ~name:"unknown-source-keeper"
+      ~mention_targets:["unknown-source-keeper"] () in
+    write_memory_bank config "unknown-source-keeper" [
+      memory_note ~kind:"decision" ~text:"alpha in memory" ~priority:86
+        ~generation:1 ~turn:1 ~ts_unix:1000.0 ();
+    ];
+    let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+      ~name:"keeper_memory_search"
+      ~input:(`Assoc [ ("query", `String "alpha"); ("source", `String "bogus") ])
+      () in
+    let json = Yojson.Safe.from_string result in
+    check string "unknown source falls back to memory explicitly" "memory"
+      Yojson.Safe.Util.(json |> member "source" |> to_string))
+
 (** Test: kind filter narrows results to matching kind only. *)
 let test_memory_search_bank_kind_filter () =
   let dir = test_tmpdir () in
@@ -1011,6 +1031,39 @@ let test_memory_search_source_all () =
     let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
     check bool "found matches from both sources" true (match_count >= 2))
 
+let test_memory_search_source_variant_witness () =
+  let witness source =
+    let actual = Keeper_exec_memory.memory_search_source_to_string source in
+    check bool
+      (Printf.sprintf "%s present in valid_memory_search_source_strings" actual)
+      true
+      (List.mem actual Keeper_exec_memory.valid_memory_search_source_strings)
+  in
+  witness Keeper_exec_memory.Memory;
+  witness Keeper_exec_memory.History;
+  witness Keeper_exec_memory.All;
+  check int "exactly 3 canonical sources" 3
+    (List.length Keeper_exec_memory.valid_memory_search_source_strings)
+
+let test_memory_search_source_schema_enum_sync () =
+  let memory_search_schema =
+    Masc_mcp.Tool_shard.base_tools
+    |> List.find (fun (schema : Types.tool_schema) ->
+         schema.name = "keeper_memory_search")
+  in
+  let schema_enum =
+    let open Yojson.Safe.Util in
+    memory_search_schema.input_schema
+    |> member "properties"
+    |> member "source"
+    |> member "enum"
+    |> to_list
+    |> List.map to_string
+  in
+  check (list string) "schema enum mirrors variant strings"
+    Keeper_exec_memory.valid_memory_search_source_strings
+    schema_enum
+
 let () =
   run "Keeper_memory"
     [
@@ -1106,9 +1159,15 @@ let () =
             test_memory_search_bank_empty;
           test_case "no matching query returns no_match" `Quick
             test_memory_search_bank_no_match;
+          test_case "unknown source defaults to memory" `Quick
+            test_memory_search_unknown_source_defaults_to_memory;
           test_case "source=history uses legacy search" `Quick
             test_memory_search_source_history;
           test_case "source=all merges bank and history" `Quick
             test_memory_search_source_all;
+          test_case "source variant witness" `Quick
+            test_memory_search_source_variant_witness;
+          test_case "source schema enum sync" `Quick
+            test_memory_search_source_schema_enum_sync;
         ] );
     ]


### PR DESCRIPTION
## What changed
- introduced `Keeper_exec_memory.memory_search_source = Memory | History | All`
- added `to_string` / `of_string_opt` / `all_*` / `valid_*_strings` helpers
- refactored keeper memory search parse, dispatch, and emitted `source` values to use the variant
- added tests for explicit fallback behavior, variant witness coverage, and schema-enum sync

## Why it changed
The `source` vocabulary (`memory/history/all`) was validated in multiple places as raw strings, and unknown values silently fell through the wildcard branch to `memory`.

## Impact
The default-to-memory behavior remains for compatibility, but it is now explicit and the source vocabulary has a single typed owner with regression coverage.

## Root cause
`keeper_exec_memory` and `tool_shard` duplicated the same string vocabulary without a compile-time SSOT, and the runtime dispatch used a wildcard branch for the default path.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8484-memory-search-source test/test_keeper_memory.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8484-memory-search-source/_build/default/test/test_keeper_memory.exe`