### PR TITLE
[codex] Strip injected internal agent markers before tool validation

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -40,6 +40,15 @@ let canonical_transition_action_string (raw : string) : string option =
 let upsert_assoc key value fields =
   (key, value) :: List.remove_assoc key fields
 
+let strip_internal_marker_args (args : Yojson.Safe.t) : Yojson.Safe.t =
+  match args with
+  | `Assoc fields ->
+      `Assoc
+        (List.filter
+           (fun (key, _) -> String.length key = 0 || key.[0] <> '_')
+           fields)
+  | _ -> args
+
 let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
   match args with
   | `Assoc fields ->
@@ -100,6 +109,7 @@ let register_pre_hook () =
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
     let compat_args =
+      let args = strip_internal_marker_args args in
       if String.equal name "masc_transition" then
         normalize_transition_args args
       else

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -365,6 +365,29 @@ let test_registered_hook_transition_compat_status_action () =
   Alcotest.(check string) "claimed -> claim" "claim"
     (assoc_string "action" forwarded)
 
+let test_registered_hook_transition_strips_internal_agent_marker () =
+  let args =
+    `Assoc
+      [
+        ("_agent_name", `String "codex-local-admin");
+        ("agent_name", `String "codex-local-admin");
+        ("task_id", `String "task-216");
+        ("action", `String "done");
+      ]
+  in
+  let blocked, forwarded =
+    run_registered_hook
+      ~schema:masc_transition_schema
+      ~tool_name:"masc_transition"
+      ~args
+      ()
+  in
+  Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
+  Alcotest.(check bool) "_agent_name removed before schema validation" true
+    (Yojson.Safe.Util.member "_agent_name" forwarded = `Null);
+  Alcotest.(check string) "agent_name preserved" "codex-local-admin"
+    (assoc_string "agent_name" forwarded)
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -409,5 +432,7 @@ let () =
         test_registered_hook_transition_compat_to_and_note;
       Alcotest.test_case "masc_transition compat: status-like action" `Quick
         test_registered_hook_transition_compat_status_action;
+      Alcotest.test_case "masc_transition strips internal markers" `Quick
+        test_registered_hook_transition_strips_internal_agent_marker;
     ]);
   ]


### PR DESCRIPTION
## What changed
- added a pre-validation step that removes underscore-prefixed internal marker args such as `_agent_name`
- kept the existing `masc_transition` compatibility normalization (`to` -> `action`, `note` -> `notes`)
- added a regression test proving `masc_transition` is not blocked when `_agent_name` is present and `agent_name` is still preserved

## Why it changed
Public MCP HTTP requests can inject `_agent_name` from `X-MASC-Agent`. That internal transport marker should not participate in tool schema validation.

## Impact
HTTP-authenticated public MCP clients can call `masc_transition` without tripping the schema layer on `_agent_name`, while downstream identity resolution still keeps the explicit `agent_name` path intact.

## Root cause
The tool input validation pre-hook saw transport-injected `_agent_name` fields before dispatch, and `masc_transition`'s schema did not recognize them.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8282-transition-agent-inject test/test_tool_input_validation.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8282-transition-agent-inject/_build/default/test/test_tool_input_validation.exe`