### PR TITLE
feat(doctor): add `doctor all` fan-out with aggregate summary

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -678,13 +678,83 @@ let doctor_sidecar_cmd =
   let info = Cmd.info "sidecar" ~doc in
   Cmd.v info Term.(const doctor_sidecar_exit $ sidecar_name_arg $ doctor_json)
 
+let doctor_all_divider () =
+  print_endline "========================================"
+
+let doctor_all_section title =
+  print_newline ();
+  doctor_all_divider ();
+  print_endline title;
+  doctor_all_divider ()
+
+let label_for_rc = function
+  | 0 -> "정상"
+  | 1 -> "경고"
+  | 2 -> "오류"
+  | _ -> "오류"
+
+let doctor_all_exit base_path as_json =
+  if as_json
+  then begin
+    Printf.eprintf
+      "masc-mcp doctor all --json: not yet implemented (use --json on \
+       individual subcommands for now)\n";
+    2
+  end
+  else begin
+    doctor_all_section "Config Doctor";
+    let config_rc = doctor_cmd_exit base_path false in
+    let sidecar_rcs =
+      List.map
+        (fun name ->
+          doctor_all_section
+            (Printf.sprintf
+               "%s Sidecar Doctor"
+               (String.capitalize_ascii name));
+          let rc = doctor_sidecar_exit name false in
+          (name, rc))
+        Masc_mcp.Doctor_dispatch.known_sidecars
+    in
+    let all_rcs = config_rc :: List.map snd sidecar_rcs in
+    let total = List.length all_rcs in
+    let count_eq v = List.length (List.filter (( = ) v) all_rcs) in
+    let ok_count = count_eq 0 in
+    let warn_count = count_eq 1 in
+    let err_count = total - ok_count - warn_count in
+    print_newline ();
+    doctor_all_divider ();
+    Printf.printf
+      "합계: %d Doctor · 정상 %d · 경고 %d · 오류 %d\n"
+      total
+      ok_count
+      warn_count
+      err_count;
+    let breakdown =
+      ("config", config_rc) :: sidecar_rcs
+      |> List.map (fun (name, rc) ->
+             Printf.sprintf "%s=%s" name (label_for_rc rc))
+      |> String.concat " · "
+    in
+    print_endline breakdown;
+    doctor_all_divider ();
+    Masc_mcp.Doctor_dispatch.aggregate_exit_code all_rcs
+  end
+
+let doctor_all_cmd =
+  let doc =
+    "Run config + every registered sidecar doctor and show an aggregate \
+     summary"
+  in
+  let info = Cmd.info "all" ~doc in
+  Cmd.v info Term.(const doctor_all_exit $ base_path $ doctor_json)
+
 let doctor_cmd =
   let doc = "Doctor: diagnose MASC server and sidecars" in
   let info = Cmd.info "doctor" ~doc in
   Cmd.group
     ~default:Term.(const doctor_cmd_exit $ base_path $ doctor_json)
     info
-    [ doctor_config_cmd; doctor_sidecar_cmd ]
+    [ doctor_config_cmd; doctor_sidecar_cmd; doctor_all_cmd ]
 
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -130,6 +130,7 @@ class AutoFix:
 | Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
 | iMessage sidecar | `masc-mcp doctor sidecar imessage` ↔ `python -m src doctor` | 운영 중 |
 | CLI connector | `masc-mcp doctor sidecar cli` ↔ `python -m src doctor` | 운영 중 |
+| 전 계층 fan-out | `masc-mcp doctor all` | 운영 중 |
 | 대시보드 | `/api/v1/dashboard/doctor` 취합 패널 | 후속 |
 
 ### Dispatch
@@ -139,14 +140,29 @@ masc-mcp doctor                     # default → config (backward-compat)
 masc-mcp doctor config              # base path / config root 진단
 masc-mcp doctor sidecar <name>      # python -m src doctor 를 해당 sidecar 디렉터리에서 실행
 masc-mcp doctor sidecar <name> --json
+masc-mcp doctor all                 # config + 5 sidecar 연쇄 실행 + aggregate 요약
 ```
 
 지원 sidecar 이름: `discord`, `slack`, `telegram`, `imessage`, `cli`.
 
-구현은 `lib/doctor_dispatch.ml` (pure mapping) + `bin/main_eio.ml` 의
-`doctor_sidecar_exit` (subprocess spawn). Python 실행 파일은 `MASC_PYTHON`
-env 로 override 할 수 있고, 기본값은 `python3`. stdout/stderr 은 그대로
-forward 되며 exit code 도 그대로 전달된다.
+구현은 `lib/doctor_dispatch.ml` (pure mapping + `aggregate_exit_code`) +
+`bin/main_eio.ml` 의 `doctor_sidecar_exit` / `doctor_all_exit`. Python 실행
+파일은 `MASC_PYTHON` env 로 override 할 수 있고, 기본값은 `python3`.
+stdout/stderr 은 그대로 forward 되며 exit code 도 그대로 전달된다.
+
+`doctor all` 은 각 Doctor 의 stdout 을 그대로 흘려보낸 뒤 마지막에
+
+```
+========================================
+합계: 6 Doctor · 정상 3 · 경고 2 · 오류 1
+config=정상 · discord=경고 · slack=경고 · telegram=오류 · imessage=정상 · cli=정상
+========================================
+```
+
+형태의 aggregate 요약을 붙인다. 종합 exit code 는 `max(all rcs)`
+(`error>warn>ok`) 로 계산되며, 종료 신호나 알 수 없는 rc (`<0` 또는 `>2`) 는
+`error` 로 상향 처리된다. `--json` 은 아직 미지원 (각 서브커맨드 단위로만
+지원; 후속 PR 에서 통합 포맷 추가 예정).
 
 ## Discord Sidecar Doctor 체크 목록
 

--- a/lib/doctor_dispatch.ml
+++ b/lib/doctor_dispatch.ml
@@ -9,3 +9,7 @@ let sidecar_dir = function
   | _ -> None
 
 let known_summary = String.concat "|" known_sidecars
+
+let aggregate_exit_code rcs =
+  let normalise rc = if rc < 0 || rc > 2 then 2 else rc in
+  List.fold_left (fun acc rc -> max acc (normalise rc)) 0 rcs

--- a/lib/doctor_dispatch.mli
+++ b/lib/doctor_dispatch.mli
@@ -15,3 +15,9 @@ val sidecar_dir : string -> string option
 (** Human-readable summary listing the known sidecar names, suitable for
     error output when an unknown name is supplied. *)
 val known_summary : string
+
+(** [aggregate_exit_code rcs] collapses a list of doctor exit codes into a
+    single one, preserving the [error > warn > ok] priority used by every
+    Doctor renderer (ok=0, warn=1, error=2, anything else treated as at
+    least error=2). Empty list returns 0 (nothing ran → nothing to report). *)
+val aggregate_exit_code : int list -> int

--- a/test/test_doctor_dispatch.ml
+++ b/test/test_doctor_dispatch.ml
@@ -40,6 +40,27 @@ let test_known_summary_lists_all () =
       then failf "known_summary missing %S" name)
     Doctor_dispatch.known_sidecars
 
+let test_aggregate_empty_is_zero () =
+  (check int) "empty" 0 (Doctor_dispatch.aggregate_exit_code [])
+
+let test_aggregate_all_ok () =
+  (check int) "all ok" 0 (Doctor_dispatch.aggregate_exit_code [ 0; 0; 0 ])
+
+let test_aggregate_warn_wins_over_ok () =
+  (check int) "warn dominates ok" 1 (Doctor_dispatch.aggregate_exit_code [ 0; 1; 0 ])
+
+let test_aggregate_error_wins_over_warn () =
+  (check int)
+    "error dominates warn"
+    2
+    (Doctor_dispatch.aggregate_exit_code [ 1; 2; 1 ])
+
+let test_aggregate_unknown_treated_as_error () =
+  (check int)
+    "signal/junk → error"
+    2
+    (Doctor_dispatch.aggregate_exit_code [ 0; 137 ])
+
 let () =
   run
     "doctor_dispatch"
@@ -60,5 +81,15 @@ let () =
             "known_summary lists all names"
             `Quick
             test_known_summary_lists_all
+        ] )
+    ; ( "aggregate_exit_code"
+      , [ test_case "empty → 0" `Quick test_aggregate_empty_is_zero
+        ; test_case "all ok → 0" `Quick test_aggregate_all_ok
+        ; test_case "warn > ok" `Quick test_aggregate_warn_wins_over_ok
+        ; test_case "error > warn" `Quick test_aggregate_error_wins_over_warn
+        ; test_case
+            "unknown rc → error"
+            `Quick
+            test_aggregate_unknown_treated_as_error
         ] )
     ]


### PR DESCRIPTION
## Summary

`masc-mcp doctor all` — config + 5 sidecar doctor 를 한 번에 실행하고 마지막에 aggregate 요약을 붙인다. `#8481` (dispatch) 위에 올라가는 마지막 CLI 조각.

## Product impact

"내 MASC 시스템 전체 지금 건강해?" 에 한 줄 명령으로 답한다.

| | Before (#8481) | After (이 PR) |
|--|----------------|----------------|
| 전체 사이드카 스캔 | 5번 `doctor sidecar <name>` | `doctor all` 한 번 |
| aggregate 판정 | 운영자가 6개 output 수기 비교 | 마지막 줄 `정상 N · 경고 M · 오류 K` |
| CI 스모크 | 각 서브커맨드 exit code 별도 수집 | `doctor all` 한 번의 exit code (`error>warn>ok`) |

## 왜

`#8481` 로 `doctor config` / `doctor sidecar <name>` 가 통합됐지만, "전 계층" 상태를 한 번에 확인할 진입점은 여전히 없었다. 운영자 / CI / on-call 모두 6번을 돌려야 했다. 이 PR 이 그 부채를 정리.

## Before / After

**Before** (`#8481` merged state):

```
$ masc-mcp doctor config
$ masc-mcp doctor sidecar discord
$ masc-mcp doctor sidecar slack
$ masc-mcp doctor sidecar telegram
$ masc-mcp doctor sidecar imessage
$ masc-mcp doctor sidecar cli
# 6 번의 exit code 를 스크립트로 합쳐야 함
```

**After**:

```
$ masc-mcp doctor all
========================================
Config Doctor
========================================
...
========================================
Discord Sidecar Doctor
========================================
...
========================================
합계: 6 Doctor · 정상 0 · 경고 2 · 오류 4
config=경고 · discord=오류 · slack=오류 · telegram=오류 · imessage=오류 · cli=경고
========================================
$ echo $?
2
```

## 변경

### ① `Doctor_dispatch.aggregate_exit_code` (pure)

```ocaml
val aggregate_exit_code : int list -> int
```

- 기존 `error>warn>ok` 우선순위(`exit_code_for` contract) 유지
- 알 수 없는 rc (`<0` 또는 `>2` — 신호, 예외) 는 **error 로 상향**. 운영자가 침묵 실패를 놓치지 않게.
- 빈 리스트 → 0 (아무 Doctor 도 돌지 않았으면 실패 없음)

### ② `bin/main_eio.ml` — `doctor_all_exit` + `doctor_all_cmd`

- divider + section header 자체 렌더, 각 Doctor 의 기존 stdout 은 그대로 forward
- **중복 코드 없음** — `doctor_cmd_exit` / `doctor_sidecar_exit` 재사용
- `Doctor_dispatch.known_sidecars` 순서대로 순회 → 출력 안정성
- footer 는 Korean-first — `정상 N · 경고 M · 오류 K` + per-doctor breakdown (`config=경고 · discord=오류 · ...`)
- `--json` 은 exit=2 + "not yet implemented" 로 reserved (각 서브커맨드 단위 `--json` 은 이미 동작)

### ③ Tests

5 신규 pure cases (총 10 pass):

```
aggregate_exit_code:
  empty → 0
  all ok → 0
  warn > ok
  error > warn
  unknown rc → error
```

### ④ Docs

- `docs/DOCTOR-ARCHITECTURE.md` — 커버리지 표에 "전 계층 fan-out" 추가, Dispatch 섹션에 `doctor all` 예시 + aggregate 로직 문서화

## 변경 없는 것

- `doctor config` / `doctor sidecar <name>` 동작
- Python sidecar 내부
- `Cmd.group ~default` backcompat (`masc-mcp doctor` 그대로 `config`)
- MCP tool surface / 대시보드 / JSON 렌더러

## Evidence

```
$ dune build                                         # clean
$ dune exec ./test/test_doctor_dispatch.exe          # 10 tests pass (0.001s)
$ ./_build/default/bin/main_eio.exe doctor --help | grep -E "config|sidecar|all"
  ccoonnffiigg [----bbaassee--ppaatthh=_P_A_T_H] [----jjssoonn] [_O_P_T_I_O_N]…
  ssiiddeeccaarr [----jjssoonn] [_O_P_T_I_O_N]… _S_I_D_E_C_A_R
  aallll [----bbaassee--ppaatthh=_P_A_T_H] [----jjssoonn] [_O_P_T_I_O_N]…
$ ./_build/default/bin/main_eio.exe doctor all       # 상세 output 은 commit-msg 참조
$ echo $?
2   # aggregate 가 error=2 로 상향 (실측 5 sidecar 중 4개 error)
```

## Review evidence

자체 리뷰 — 다음 관점으로 검토:

1. **중복 코드**: `doctor_cmd_exit` / `doctor_sidecar_exit` 재사용 확인. fan-out 전용 로직만 새로 추가.
2. **exit code contract**: `aggregate_exit_code` 가 기존 `Severity` 우선순위(`exit_code_for`)와 일치. 5 unit tests 로 regression guard.
3. **출력 드리프트**: section header / divider / footer 모두 Korean-first. Python sidecar 의 기존 `# <Name> Sidecar Doctor` 제목과 겹치지만, OCaml 측 divider 가 명확히 구분되므로 문제 없음.
4. **JSON 미지원**: 의도적 스코프 축소. 개별 서브커맨드 `--json` 은 그대로 사용 가능하고, 통합 JSON 은 렌더 포맷 설계가 필요해 후속 PR.

## Linked issue

Refs:
- #8481 — dispatch 축 (이 PR 의 직전 단계, merged)
- #8478 — 관측성 축 (FixOutcome + render_fix_outcomes)
- #8468 — Korean banner / action list / summary polish
- #8457 — fan-out (4 sidecars 일괄)
- #8452 — deps-first (Discord reference)
- #8375 — shared Doctor framework + Discord doctor (foundation)

## 체크리스트

- [x] `doctor all` 서브커맨드 — config + 5 sidecar 순회
- [x] aggregate summary (Korean 표기)
- [x] per-doctor breakdown
- [x] `error>warn>ok` exit code 집약
- [x] unknown rc → error 상향
- [x] pure `aggregate_exit_code` + 5 unit tests
- [x] `doctor_cmd_exit` / `doctor_sidecar_exit` 재사용 (중복 없음)
- [x] `docs/DOCTOR-ARCHITECTURE.md` 업데이트
- [x] 기존 subcommand backcompat 유지

## Doctor 축 진행도

```
축 1 — 검진 (Diagnose)        ✓ Check 데이터 모델 + Severity 5단계
축 2 — 보고 (Report)          ✓ render_pretty / render_json + banner (#8468)
축 3 — 힌트 (Hint)            ✓ "이거 해라"
축 4 — 자가 치유 (Fix)         ✓ callback (#8452, #8457)
축 5 — 관측 (Observe)         ✓ FixOutcome + render_fix_outcomes (#8478)
축 6 — Dispatch               ✓ doctor config|sidecar (#8481)
축 7 — Fan-out                ← 이 PR — doctor all + aggregate
축 8 — 대시보드 패널          후속 — `/api/v1/dashboard/doctor` SSE
축 9 — 실체 확장              후속 — mkdir_p / env reload / cache clear
```

## Out of scope

- `doctor all --json` 통합 포맷 (각 서브커맨드 단위 `--json` 은 이미 동작)
- 대시보드 패널
- sidecar 내부 callback 확장
- 병렬 실행 (현재는 순차) — 병렬은 stdout interleaving 문제가 있어 별 설계 필요


Refs #8481, #8478, #8468, #8457, #8452, #8375