### PR TITLE
fix: publish config category enum ssot

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -988,6 +988,9 @@ let all_categories () =
     category "session" (session_entries @ team_session_entries @ tempo_entries);
   ]
 
+let valid_config_category_strings =
+  all_categories () |> List.map fst
+
 let to_json ?server_meta ?generated_at ?cat () =
   let categories =
     match cat with

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -2,6 +2,21 @@
 
 open Types
 
+(** Issue #8493: [masc_config] category filter strings mirror
+    [Env_config_snapshot.valid_config_category_strings]. This library
+    depends only on [masc_types], so it cannot depend on [masc_config]
+    directly without reintroducing the cycle this split avoids. The
+    sync test in [test/test_types.ml :: config_category_ssot] keeps this
+    mirror aligned with the producer-side SSOT. *)
+let config_category_enum_strings =
+  [
+    "server"; "auth"; "transport"; "storage"; "runtime";
+    "rate_limiting"; "inference"; "keeper"; "keeper_execution";
+    "keeper_guardrails"; "autonomy"; "level2"; "dashboard";
+    "economy"; "governance"; "channel"; "process"; "worker";
+    "web_search"; "session";
+  ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_config";
@@ -13,7 +28,7 @@ Pass category to filter results to a single section.";
       ("properties", `Assoc [
         ("category", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "server"; `String "auth"; `String "transport"; `String "storage"; `String "runtime"; `String "rate_limiting"; `String "inference"; `String "keeper"; `String "dashboard"]);
+          ("enum", `List (List.map (fun s -> `String s) config_category_enum_strings));
           ("description", `String "Filter by config category");
         ]);
       ]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -430,6 +430,26 @@ let () =
           Masc_mcp.Keeper_types_profile.valid_shared_memory_scope_strings
           Masc_mcp.Keeper_schema.shared_memory_scope_enum_strings);
     ];
+    "config_category_ssot", [
+      Alcotest.test_case "producer helper matches all_categories order" `Quick (fun () ->
+        Alcotest.(check (list string)) "all_categories -> names"
+          (Env_config_snapshot.all_categories () |> List.map fst)
+          Env_config_snapshot.valid_config_category_strings);
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "schema mirror"
+          Env_config_snapshot.valid_config_category_strings
+          Tool_schemas_misc.config_category_enum_strings);
+      Alcotest.test_case "missing runtime categories are now published" `Quick (fun () ->
+        let categories = Env_config_snapshot.valid_config_category_strings in
+        List.iter (fun expected ->
+          Alcotest.(check bool) (Printf.sprintf "%s present" expected) true
+            (List.mem expected categories)
+        ) [
+          "keeper_execution"; "keeper_guardrails"; "autonomy";
+          "level2"; "economy"; "governance"; "channel";
+          "process"; "worker"; "web_search"; "session";
+        ]);
+    ];
     "fsm_transition_matrix", [
       (* Issue #8474: schema transition matrix had drifted from
          [Coord_task.valid_next_actions_for_status] — submit/approve/


### PR DESCRIPTION
## Summary
- publish the full `masc_config` category vocabulary from `Env_config_snapshot`
- replace the stale hardcoded schema enum in `tool_schemas_misc` with a mirrored list that includes all runtime categories
- add regression tests that keep the producer helper and schema mirror in sync

## Root cause
`masc_config` runtime filtering supported 20 categories via `Env_config_snapshot.all_categories ()`, but the public JSON Schema still advertised only 9 hardcoded values. MCP clients reading the schema could not discover or send the newer categories.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8493-config-category-enum test/test_types.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8493-config-category-enum/_build/default/test/test_types.exe`

Closes #8493