### PR TITLE
refactor: mirror keeper tail order schema

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -26,6 +26,14 @@ let network_mode_enum_strings =
 let shared_memory_scope_enum_strings =
   [ "disabled"; "room" ]
 
+(** Issue #8486: [masc_keeper_status.tail_order] mirrors
+    [Keeper_status_detail.valid_tail_order_strings]. Direct dependency
+    would introduce a cycle via Keeper_status_detail ->
+    Keeper_alerting -> Keeper_schema, so this stays a local mirror with
+    a regression test in [test_types.ml :: keeper_tail_order_ssot]. *)
+let tail_order_enum_strings =
+  [ "oldest_first"; "newest_first" ]
+
 let string_array_schema =
   `Assoc [
     ("type", `String "array");
@@ -350,7 +358,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tail_order", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "oldest_first"; `String "newest_first"]);
+          ("enum", `List (List.map (fun s -> `String s) tail_order_enum_strings));
           ("description", `String "Ordering for metrics/history/compaction tails and recent memory notes. Default: oldest_first (compat).");
         ]);
         ("fast", `Assoc [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -79,6 +79,12 @@ let tail_order_to_string = function
   | Oldest_first -> "oldest_first"
   | Newest_first -> "newest_first"
 
+let all_tail_orders =
+  [ Oldest_first; Newest_first ]
+
+let valid_tail_order_strings =
+  List.map tail_order_to_string all_tail_orders
+
 let apply_tail_order order items =
   match order with
   | Oldest_first -> items

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -430,6 +430,22 @@ let () =
           Masc_mcp.Keeper_types_profile.valid_shared_memory_scope_strings
           Masc_mcp.Keeper_schema.shared_memory_scope_enum_strings);
     ];
+    "keeper_tail_order_ssot", [
+      Alcotest.test_case "witness covers both variants" `Quick (fun () ->
+        let witness order =
+          let actual = Masc_mcp.Keeper_status_detail.tail_order_to_string order in
+          if not (List.mem actual Masc_mcp.Keeper_status_detail.valid_tail_order_strings) then
+            Alcotest.failf "tail_order_to_string %S not in valid_tail_order_strings" actual
+        in
+        witness Masc_mcp.Keeper_status_detail.Oldest_first;
+        witness Masc_mcp.Keeper_status_detail.Newest_first;
+        Alcotest.(check int) "count" 2
+          (List.length Masc_mcp.Keeper_status_detail.valid_tail_order_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tail_order mirror"
+          Masc_mcp.Keeper_status_detail.valid_tail_order_strings
+          Masc_mcp.Keeper_schema.tail_order_enum_strings);
+    ];
     "fsm_transition_matrix", [
       (* Issue #8474: schema transition matrix had drifted from
          [Coord_task.valid_next_actions_for_status] — submit/approve/


### PR DESCRIPTION
## Summary
- add `all_tail_orders` and `valid_tail_order_strings` to the existing `tail_order` variant helper surface
- replace the hardcoded `masc_keeper_status.tail_order` schema enum with a dedicated mirror list
- add regression tests that keep the variant helper and schema mirror in sync

## Root cause
`keeper_status_detail` already had a real `tail_order` variant, but `keeper_schema` still hardcoded the JSON Schema enum separately. That meant a future constructor change could silently drift out of the published tool schema.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8486-tail-order-ssot-v2 test/test_types.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8486-tail-order-ssot-v2/_build/default/test/test_types.exe`

Closes #8486