### PR TITLE
fix(tool_agent): introduce agent_card_action + collaboration_format Variant SSOT (#8501)

### DIFF
--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -12,6 +12,54 @@ let result_to_response = function
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)
 
+(* Issue #8501: Variant SSOT for masc_agent_card.action.  Adding a
+   new constructor forces compilation in [agent_card_action_to_string]
+   AND extends [valid_agent_card_action_strings]; the schema in
+   [tool_schemas_agent.ml] mirrors the SSOT (cycle-aware, sync test).
+   The previous code used a string match with a wildcard `_ -> Get`
+   branch which silently routed any unknown action to Get. *)
+type agent_card_action =
+  | Get
+  | Refresh
+
+let agent_card_action_to_string = function
+  | Get -> "get"
+  | Refresh -> "refresh"
+
+let agent_card_action_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "get" | "" -> Some Get
+  | "refresh" -> Some Refresh
+  | _ -> None
+
+let all_agent_card_actions = [ Get; Refresh ]
+
+let valid_agent_card_action_strings =
+  List.map agent_card_action_to_string all_agent_card_actions
+
+(* Issue #8501: Variant SSOT for masc_collaboration_graph.format.  Same
+   pattern as agent_card_action above. The previous code used
+   [if format = "json" then ... else (text)] which silently routed
+   any unknown format to text. *)
+type collaboration_format =
+  | Text
+  | Json
+
+let collaboration_format_to_string = function
+  | Text -> "text"
+  | Json -> "json"
+
+let collaboration_format_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "text" | "" -> Some Text
+  | "json" -> Some Json
+  | _ -> None
+
+let all_collaboration_formats = [ Text; Json ]
+
+let valid_collaboration_format_strings =
+  List.map collaboration_format_to_string all_collaboration_formats
+
 (** Handle masc_agents *)
 let handle_agents ctx args =
   let limit = get_int args "limit" 20 |> max 1 |> min 50 in
@@ -205,17 +253,24 @@ let handle_agent_fitness ctx args =
 
 (** Handle masc_collaboration_graph *)
 let handle_collaboration_graph ctx args =
-  let format = get_string args "format" "text" in
+  (* Issue #8501: explicit Variant fallback to Text — back-compat with
+     prior `else` branch but unknown formats are visibly mapped, not
+     silently absorbed. *)
+  let format =
+    collaboration_format_of_string_opt (get_string args "format" "text")
+    |> Option.value ~default:Text
+  in
   let limit = get_int args "limit" 20 |> max 1 |> min 100 in
   let (synapses, agents) = Hebbian_eio.get_graph_data ctx.config in
-  if format = "json" then
+  match format with
+  | Json ->
     let synapses = List.filteri (fun i _ -> i < limit) synapses in
     let json = `Assoc [
       ("agents", `List (List.map (fun a -> `String a) agents));
       ("synapses", `List (List.map Hebbian_eio.synapse_to_json synapses));
     ] in
     (true, Yojson.Safe.to_string json)
-  else
+  | Text ->
     let lines =
       synapses
       |> List.sort (fun a b -> compare b.Hebbian_eio.weight a.Hebbian_eio.weight)
@@ -232,18 +287,24 @@ let handle_collaboration_graph ctx args =
 
 (** Handle masc_agent_card *)
 let handle_agent_card _ctx args =
-  let action = get_string args "action" "get" in
+  (* Issue #8501: explicit Variant fallback to Get — back-compat with
+     prior wildcard `_ -> get` but unknown actions are now mapped via
+     [Option.value], making the fallback visible at the call site. *)
+  let action =
+    agent_card_action_of_string_opt (get_string args "action" "get")
+    |> Option.value ~default:Get
+  in
   let card = Agent_card.generate_default ~schemas:Config.raw_all_tool_schemas () in
   let json = Agent_card.to_json card in
   let response = match action with
-    | "refresh" ->
+    | Refresh ->
         `Assoc [
           ("status", `String "refreshed");
           ("card", json);
           ("endpoint", `String "/.well-known/agent.json");
           ("legacy_endpoint", `String "/.well-known/agent-card.json");
         ]
-    | _ ->
+    | Get ->
         `Assoc [
           ("card", json);
           ("endpoint", `String "/.well-known/agent.json");

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -5,6 +5,23 @@ type context = {
   agent_name: string;
 }
 
+(** Issue #8501: Variant SSOT for masc_agent_card.action.  Mirror in
+    [Tool_schemas_agent.agent_card_action_enum_strings] (cycle-aware,
+    sync regression test catches drift). *)
+type agent_card_action = Get | Refresh
+val agent_card_action_to_string : agent_card_action -> string
+val agent_card_action_of_string_opt : string -> agent_card_action option
+val all_agent_card_actions : agent_card_action list
+val valid_agent_card_action_strings : string list
+
+(** Issue #8501: Variant SSOT for masc_collaboration_graph.format.
+    Mirror in [Tool_schemas_agent.collaboration_format_enum_strings]. *)
+type collaboration_format = Text | Json
+val collaboration_format_to_string : collaboration_format -> string
+val collaboration_format_of_string_opt : string -> collaboration_format option
+val all_collaboration_formats : collaboration_format list
+val valid_collaboration_format_strings : string list
+
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
 

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -1,5 +1,15 @@
 open Types
 
+(** Issue #8501: hand-mirrored from
+    [Tool_agent.valid_agent_card_action_strings] and
+    [Tool_agent.valid_collaboration_format_strings]. masc_tool_schemas
+    only depends on masc_types so it cannot derive directly. The sync
+    regression test [test_types.ml :: agent_tool_variants_ssot] catches
+    drift. Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync
+    pattern. *)
+let agent_card_action_enum_strings = [ "get"; "refresh" ]
+let collaboration_format_enum_strings = [ "text"; "json" ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_agents";
@@ -48,7 +58,9 @@ let schemas : tool_schema list = [
       ("properties", `Assoc [
         ("action", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "get"; `String "refresh"]);
+          (* Issue #8501: derive from local mirror that tracks
+             [Tool_agent.valid_agent_card_action_strings]. *)
+          ("enum", `List (List.map (fun s -> `String s) agent_card_action_enum_strings));
           ("description", `String "Action: 'get' returns current card, 'refresh' regenerates it");
         ]);
       ]);
@@ -100,7 +112,9 @@ let schemas : tool_schema list = [
       ("properties", `Assoc [
         ("format", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "text"; `String "json"]);
+          (* Issue #8501: derive from local mirror that tracks
+             [Tool_agent.valid_collaboration_format_strings]. *)
+          ("enum", `List (List.map (fun s -> `String s) collaboration_format_enum_strings));
           ("description", `String "Output format (default: text)");
           ("default", `String "text");
         ]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -623,6 +623,53 @@ let () =
           Masc_mcp.Board_votes.valid_vote_direction_strings
           Masc_mcp.Tool_shard.vote_direction_enum_strings);
     ];
+    "agent_tool_variants_ssot", [
+      (* Issue #8501: introduces [agent_card_action] and
+         [collaboration_format] Variants where 4 sites previously
+         hand-validated raw strings. Same shape as #8480/#8484/#8490
+         mirror+sync pattern. *)
+      Alcotest.test_case "agent_card_action witness covers both variants" `Quick (fun () ->
+        let module T = Masc_mcp.Tool_agent in
+        let witness a =
+          let actual = T.agent_card_action_to_string a in
+          if not (List.mem actual T.valid_agent_card_action_strings) then
+            Alcotest.failf "agent_card_action_to_string %S not in valid_agent_card_action_strings" actual
+        in
+        witness T.Get; witness T.Refresh;
+        Alcotest.(check int) "count" 2 (List.length T.valid_agent_card_action_strings));
+      Alcotest.test_case "collaboration_format witness covers both variants" `Quick (fun () ->
+        let module T = Masc_mcp.Tool_agent in
+        let witness f =
+          let actual = T.collaboration_format_to_string f in
+          if not (List.mem actual T.valid_collaboration_format_strings) then
+            Alcotest.failf "collaboration_format_to_string %S not in valid_collaboration_format_strings" actual
+        in
+        witness T.Text; witness T.Json;
+        Alcotest.(check int) "count" 2 (List.length T.valid_collaboration_format_strings));
+      Alcotest.test_case "of_string_opt sound partial + back-compat" `Quick (fun () ->
+        let module T = Masc_mcp.Tool_agent in
+        Alcotest.(check bool) "agent_card_action 'get'" true
+          (T.agent_card_action_of_string_opt "get" = Some T.Get);
+        Alcotest.(check bool) "agent_card_action '' -> Get back-compat" true
+          (T.agent_card_action_of_string_opt "" = Some T.Get);
+        Alcotest.(check bool) "agent_card_action 'REFRESH' (case)" true
+          (T.agent_card_action_of_string_opt "REFRESH" = Some T.Refresh);
+        Alcotest.(check bool) "agent_card_action garbage rejected" true
+          (T.agent_card_action_of_string_opt "delete" = None);
+        Alcotest.(check bool) "collaboration_format 'json'" true
+          (T.collaboration_format_of_string_opt "json" = Some T.Json);
+        Alcotest.(check bool) "collaboration_format '' -> Text back-compat" true
+          (T.collaboration_format_of_string_opt "" = Some T.Text);
+        Alcotest.(check bool) "collaboration_format garbage rejected" true
+          (T.collaboration_format_of_string_opt "yaml" = None));
+      Alcotest.test_case "schema mirrors stay in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "agent_card_action mirror == SSOT"
+          Masc_mcp.Tool_agent.valid_agent_card_action_strings
+          Tool_schemas_agent.agent_card_action_enum_strings;
+        Alcotest.(check (list string)) "collaboration_format mirror == SSOT"
+          Masc_mcp.Tool_agent.valid_collaboration_format_strings
+          Tool_schemas_agent.collaboration_format_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8501.

4 sites string-validated 2 small enums in `tool_agent.ml`:

1. `masc_agent_card.action` — schema `[get; refresh]` vs handler `match action with "refresh" -> ... | _ -> Get` (wildcard).
2. `masc_collaboration_graph.format` — schema `[text; json]` vs handler `if format = "json" then ... else (text)` (else-branch).

Both have silent permissive defaults — same anti-pattern as #8484/#8490.

## Approach

- Two new Variants in `tool_agent.ml` + `.mli`:
  - `agent_card_action = Get | Refresh`
  - `collaboration_format = Text | Json`
- Helpers per Variant: `to_string`, `of_string_opt` (sound partial, accepts `""` for back-compat), `all_*`, `valid_*_strings`.
- Consumers refactored:
  - `match action with Refresh | Get` — exhaustive, new constructor fails compilation.
  - `if/else` → `match format with Json | Text` — same protection.
  - `Option.value ~default:Get/Text` makes the back-compat fallback explicit at the call site.
- `tool_schemas_agent.ml` derives both enums from local mirrors (cycle avoidance: `masc_tool_schemas` only depends on `masc_types`).

## Verification

- `dune build` clean.
- `test_types.ml :: agent_tool_variants_ssot` — 4 cases (witness x2 + sound partial w/ back-compat + mirror sync x2).
- 43/43 `test_types` pass.

## Risk

Low. Behavior preserved (same defaults, same dispatch). Two Variants in one PR because both small (2 constructors each) and adjacent in handler code.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW Variant)
6. `memory_search_source` (#8484) — prevention + anti-pattern fix (NEW Variant)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW Variant)
9. `config_category` (#8493) — REAL (11 missing)
10. `agent_card_action` + `collaboration_format` (#8501) — prevention + 2 anti-pattern fixes (2 NEW Variants)
