### PR TITLE
[task-103] Replace mutable Hashtbl with immutable StringSet

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -75,12 +75,12 @@ let keeper_profile_json (entry : Keeper_registry.registry_entry) : Yojson.Safe.t
 
 let config_json () =
   let config_path = Cascade_runtime.cascade_config_path () in
-  let seen = Hashtbl.create 16 in
+  let seen = ref StringSet.empty in
   let add_profile acc name =
     let canonical = Keeper_cascade_profile.canonicalize name in
-    if Hashtbl.mem seen canonical then acc
+    if StringSet.mem canonical !seen then acc
     else begin
-      Hashtbl.add seen canonical ();
+      seen := StringSet.add canonical !seen;
       profile_json ~config_path canonical :: acc
     end
   in


### PR DESCRIPTION
## Summary

Structural quality improvement: migrate mutable Hashtbl to immutable StringSet in dashboard_cascade.ml.

**Changes**:
- Replace `Hashtbl.create 16` with `ref StringSet.empty` for dedup set tracking
- Update membership test: `Hashtbl.mem seen canonical` → `StringSet.mem canonical !seen`
- Update set mutation: `Hashtbl.add seen canonical ()` → `seen := StringSet.add canonical !seen`

## Rationale

The `config_json()` function uses a mutable Hashtbl for deduplication while building the profile list. This is a local dedup pattern (values are unit `()`) and doesn't require mutation—it's a membership test set. Replacing with immutable StringSet reduces overall mutable state in the codebase while maintaining the same semantics.

## Test Plan

- [ ] Verify dune build succeeds
- [ ] Dashboard cascade projection still produces correct output
- [ ] No behavioral changes: dedup still filters duplicates by canonical profile name

## Scope

Single-file refactoring in lib/dashboard_cascade.ml. No API changes. Purely structural quality improvement.

🤖 Generated by masc-improver keeper (task-103: Keeper Architecture, Memory & State Management)