### PR TITLE
fix(board_votes): consolidate vote_direction SSOT (#8506)

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -2,6 +2,25 @@ include Board_core
 
 let vote_direction_to_string = function Up -> "up" | Down -> "down"
 
+(* Issue #8506: Variant SSOT for vote_direction. Adding a constructor
+   forces [vote_direction_to_string] exhaustiveness AND extends
+   [valid_vote_direction_strings]; the schema in [tool_shard.ml]
+   mirrors this list (cycle-aware, sync test). Previously
+   server_bootstrap_loops.ml re-implemented the same match inline 4
+   times — those call sites now use this helper. *)
+let all_vote_directions = [ Up; Down ]
+let valid_vote_direction_strings =
+  List.map vote_direction_to_string all_vote_directions
+
+(* Sound partial parser — case-insensitive, trims whitespace, accepts
+   empty as default Up for back-compat with [tool_board.ml] which
+   defaults to "up" when the field is missing. *)
+let vote_direction_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "up" | "" -> Some Up
+  | "down" -> Some Down
+  | _ -> None
+
 let vote_log_path () =
   let base = board_base_path () in
   Filename.concat base ".masc/board_votes.jsonl"

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -144,13 +144,13 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
                   ("comment_id", `String comment_id);
                   ("author", `String author)]
       | Board_dispatch.Post_voted { post_id; voter; direction } ->
-          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          let dir = Board_votes.vote_direction_to_string direction in
           `Assoc [("type", `String "post_voted");
                   ("post_id", `String post_id);
                   ("voter", `String voter);
                   ("direction", `String dir)]
       | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
-          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          let dir = Board_votes.vote_direction_to_string direction in
           `Assoc [("type", `String "comment_voted");
                   ("comment_id", `String comment_id);
                   ("voter", `String voter);
@@ -181,13 +181,13 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
            `Assoc [("post_id", `String post_id); ("comment_id", `String comment_id);
                    ("author", `String author)])
       | Board_dispatch.Post_voted { post_id; voter; direction } ->
-          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          let dir = Board_votes.vote_direction_to_string direction in
           ("board.voted",
            Activity_graph.entity ~kind:"agent" voter,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc [("post_id", `String post_id); ("direction", `String dir)])
       | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
-          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          let dir = Board_votes.vote_direction_to_string direction in
           ("board.voted",
            Activity_graph.entity ~kind:"agent" voter,
            Some (Activity_graph.entity ~kind:"comment" comment_id),

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -32,6 +32,15 @@ let fs_write_mode_enum_strings =
   [ "overwrite"; "append" ]
 
 
+(** Issue #8506: hand-mirrored from
+    [Board_votes.valid_vote_direction_strings]. Direct dependency
+    would risk a Tool_shard -> Board_* -> Tool_shard cycle.  Sync
+    regression test in [test_types.ml :: vote_direction_ssot] catches
+    drift. Same shape as #8467 / #8480 / #8484 / #8490 mirror+sync
+    pattern. *)
+let vote_direction_enum_strings =
+  [ "up"; "down" ]
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -185,7 +194,9 @@ or disagreement with a proposal or finding.";
       ("type", `String "object");
       ("properties", `Assoc [
         ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID (format: p-xxxx...). Get from keeper_board_list results.")]);
-        ("direction", `Assoc [("type", `String "string"); ("enum", `List [`String "up"; `String "down"]); ("description", `String "Vote direction (default: up)")]);
+        (* Issue #8506: derive from local mirror that tracks
+           [Board_votes.valid_vote_direction_strings]. *)
+        ("direction", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) vote_direction_enum_strings)); ("description", `String "Vote direction (default: up)")]);
       ]);
       ("required", `List [`String "post_id"]);
     ];

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -21,6 +21,11 @@ val memory_search_source_enum_strings : string list
 val fs_write_mode_enum_strings : string list
 
 
+(** Issue #8506: hand-mirrored from
+    [Board_votes.valid_vote_direction_strings]. Sync regression test
+    in [test_types.ml :: vote_direction_ssot] catches drift. *)
+val vote_direction_enum_strings : string list
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -595,6 +595,34 @@ let () =
           Masc_mcp.Keeper_exec_fs.valid_fs_write_mode_strings
           Masc_mcp.Tool_shard.fs_write_mode_enum_strings);
     ];
+    "vote_direction_ssot", [
+      (* Issue #8506: Variant + to_string already existed (board_types/
+         board_votes), but 4 inline matches in server_bootstrap_loops.ml
+         re-implemented the same thing AND tool_shard.ml hardcoded the
+         schema enum. This test asserts the [Tool_shard] mirror stays
+         in sync with the SSOT and the witness covers both Variants. *)
+      Alcotest.test_case "witness covers both variants" `Quick (fun () ->
+        let module B = Masc_mcp.Board_votes in
+        let witness d =
+          let actual = B.vote_direction_to_string d in
+          if not (List.mem actual B.valid_vote_direction_strings) then
+            Alcotest.failf "vote_direction_to_string %S not in valid_vote_direction_strings" actual
+        in
+        witness Masc_mcp.Board_votes.Up; witness Masc_mcp.Board_votes.Down;
+        Alcotest.(check int) "count" 2 (List.length B.valid_vote_direction_strings));
+      Alcotest.test_case "of_string_opt sound partial + back-compat" `Quick (fun () ->
+        let module B = Masc_mcp.Board_votes in
+        Alcotest.(check bool) "up" true (B.vote_direction_of_string_opt "up" <> None);
+        Alcotest.(check bool) "DOWN (case)" true (B.vote_direction_of_string_opt "DOWN" <> None);
+        Alcotest.(check bool) "  empty -> Up back-compat" true
+          (B.vote_direction_of_string_opt "" = Some Masc_mcp.Board_votes.Up);
+        Alcotest.(check bool) "garbage rejected" true
+          (B.vote_direction_of_string_opt "left" = None));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Board_votes.valid_vote_direction_strings
+          Masc_mcp.Tool_shard.vote_direction_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8506.

`Board_votes.vote_direction_to_string` already mapped the existing `Board_types.vote_direction = Up | Down` Variant to canonical strings, but:

1. `lib/server/server_bootstrap_loops.ml:147,153,184,190` re-implements the same match inline 4 times.
2. `lib/tool_shard.ml:159` hardcodes the JSON Schema enum `[up; down]`.

Same drift class as #8486 (tail_order had Variant + to_string already, schema hand-mirrored).

## Approach

- Add `all_vote_directions` + `valid_vote_direction_strings` + `vote_direction_of_string_opt` next to existing `vote_direction_to_string` in `board_votes.ml`.
- Replace 4 inline matches in `server_bootstrap_loops.ml` with `Board_votes.vote_direction_to_string direction` (single SSOT call).
- Add `tool_shard.ml` local mirror `vote_direction_enum_strings` + `.mli` export. Cycle-aware pattern (Tool_shard upstream of Board_votes).
- Witness regression + mirror sync test in `test_types.ml :: vote_direction_ssot`.

## Verification

- `dune build` clean.
- 42/42 `test_types` pass.

## Risk

Low. Variant + to_string exist; just enforces SSOT. Eliminates 4 duplicated inline matches and prevents schema drift.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW)
6. `memory_search_source` (#8484) — prevention + anti-pattern (NEW)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW)
9. `config_category` (#8493) — REAL (11 missing)
10. `agent_card_action` + `collaboration_format` (#8501) — prevention (2 NEW)
11. `vote_direction` (#8506) — prevention + 4-site dedup
