### PR TITLE
refactor: type keeper fs write mode

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -9,6 +9,26 @@ let fs_read_default_max_bytes = Tool_shard_limits.keeper_fs_read_default_max_byt
 let fs_read_min_max_bytes = 512
 let fs_read_max_max_bytes = 200_000
 
+type fs_write_mode =
+  | Overwrite
+  | Append
+
+let fs_write_mode_to_string = function
+  | Overwrite -> "overwrite"
+  | Append -> "append"
+
+let fs_write_mode_of_string_opt raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "overwrite" -> Some Overwrite
+  | "append" -> Some Append
+  | _ -> None
+
+let all_fs_write_modes =
+  [ Overwrite; Append ]
+
+let valid_fs_write_mode_strings =
+  List.map fs_write_mode_to_string all_fs_write_modes
+
 let is_missing_read_path_error (e : string) =
   String.starts_with ~prefix:"path_not_found:" e
   || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
@@ -59,41 +79,40 @@ let handle_keeper_fs_edit
   =
   let path = Safe_ops.json_string ~default:"" "path" args in
   let content = Safe_ops.json_string ~default:"" "content" args in
-  let mode =
-    Safe_ops.json_string ~default:"overwrite" "mode" args |> String.lowercase_ascii
-  in
+  let raw_mode = Safe_ops.json_string ~default:"" "mode" args in
   (* Early validation for 9B models that send empty/missing params *)
   if String.trim path = "" then
     error_json "path is required. Good: path='lib/foo.ml'. Bad: path=''."
   else if String.trim content = "" then
     error_json "content is required (non-empty). Writing 0 bytes is usually unintended."
-  else if mode <> "overwrite" && mode <> "append" && mode <> "" then
-    error_json (Printf.sprintf
-      "mode must be 'overwrite' or 'append', got '%s'." mode)
   else
-  match resolve_keeper_path ~config ~meta ~raw_path:path with
-  | Error e -> error_json e
-  | Ok target ->
-    (try
-       let parent = Filename.dirname target in
-       Fs_compat.mkdir_p parent;
-       (match mode with
-        | "append" -> Fs_compat.append_file target content
-        | "overwrite" | "" -> Fs_compat.save_file target content
-        | other -> raise (Invalid_argument ("unsupported_mode:" ^ other)));
-       Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
-         meta.name target (if mode = "" then "overwrite" else mode)
-         (String.length content);
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool true
-             ; "path", `String target
-             ; "mode", `String (if mode = "" then "overwrite" else mode)
-             ; "bytes_written", `Int (String.length content)
-             ])
-     with
-     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
-     | Sys_error e -> error_json ~fields:[ "path", `String target ] e
-     | Unix.Unix_error (err, _, _) ->
-       error_json ~fields:[ "path", `String target ] (Unix.error_message err))
+  match fs_write_mode_of_string_opt raw_mode with
+  | None ->
+    error_json (Printf.sprintf
+      "mode must be 'overwrite' or 'append', got '%s'." raw_mode)
+  | Some mode ->
+    match resolve_keeper_path ~config ~meta ~raw_path:path with
+    | Error e -> error_json e
+    | Ok target ->
+      (try
+         let parent = Filename.dirname target in
+         Fs_compat.mkdir_p parent;
+         (match mode with
+          | Append -> Fs_compat.append_file target content
+          | Overwrite -> Fs_compat.save_file target content);
+         let mode_name = fs_write_mode_to_string mode in
+         Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
+           meta.name target mode_name (String.length content);
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool true
+               ; "path", `String target
+               ; "mode", `String mode_name
+               ; "bytes_written", `Int (String.length content)
+               ])
+       with
+       | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
+       | Sys_error e -> error_json ~fields:[ "path", `String target ] e
+       | Unix.Unix_error (err, _, _) ->
+         error_json ~fields:[ "path", `String target ] (Unix.error_message err))
 ;;

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -1,5 +1,14 @@
 (** Keeper filesystem tool handlers — read and edit. *)
 
+type fs_write_mode =
+  | Overwrite
+  | Append
+
+val fs_write_mode_to_string : fs_write_mode -> string
+val fs_write_mode_of_string_opt : string -> fs_write_mode option
+val all_fs_write_modes : fs_write_mode list
+val valid_fs_write_mode_strings : string list
+
 val handle_keeper_fs_read :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -18,6 +18,14 @@ module StringMap = Map.Make(String)
 
 (** Predefined shards *)
 
+(** Issue #8490: [keeper_fs_edit.mode] mirrors
+    [Keeper_exec_fs.valid_fs_write_mode_strings]. [Tool_shard] cannot
+    depend on [Keeper_exec_fs] without introducing a cycle, so this
+    stays a local mirror and [test_types.ml :: keeper_fs_mode_ssot]
+    asserts it remains aligned. *)
+let fs_write_mode_enum_strings =
+  [ "overwrite"; "append" ]
+
 let base_tools : Types.tool_schema list = [
   (* Stay silent: no-op tool for tool_choice=Any turns.
      Lets the model explicitly skip a turn without being forced
@@ -268,7 +276,7 @@ Creates parent dirs.";
       ("properties", `Assoc [
         ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path to write")]);
         ("content", `Assoc [("type", `String "string"); ("description", `String "File content to write")]);
-        ("mode", `Assoc [("type", `String "string"); ("enum", `List [`String "overwrite"; `String "append"]); ("description", `String "Write mode (default: overwrite)")]);
+        ("mode", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) fs_write_mode_enum_strings)); ("description", `String "Write mode (default: overwrite)")]);
       ]);
       ("required", `List [`String "path"; `String "content"]);
     ];

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -2,6 +2,11 @@
 
     @since 2.62.0 *)
 
+(** Issue #8490: hand-mirrored from the keeper_fs_edit runtime mode
+    vocabulary. Tool_shard cannot depend on Keeper_exec_fs without a
+    cycle, so tests keep this list aligned with runtime behavior. *)
+val fs_write_mode_enum_strings : string list
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -157,6 +157,62 @@ let test_execute_with_outcome_bad_query_is_failure () =
       check string "bad query payload shape" "structured_error"
         (payload_kind result.payload_shape))
 
+let call_keeper_fs_edit ~config ~meta ~ctx_work args =
+  KET.execute_keeper_tool_call_with_outcome
+    ~config ~meta ~ctx_work
+    ~name:"keeper_fs_edit"
+    ~input:(`Assoc args)
+    ()
+
+let parse_result_json (result : KET.executed_tool_result) =
+  Yojson.Safe.from_string result.raw_output
+
+let test_keeper_fs_edit_empty_mode_uses_overwrite () =
+  with_exec_fixture "keeper_exec_tools_fs_empty_mode"
+    (fun ~config ~meta ~ctx_work ->
+      let path = "notes.txt" in
+      let first =
+        call_keeper_fs_edit ~config ~meta ~ctx_work
+          [ ("path", `String path); ("content", `String "old") ]
+      in
+      check string "first outcome" "success"
+        (match first.outcome with `Success -> "success" | `Failure -> "failure");
+      let second =
+        call_keeper_fs_edit ~config ~meta ~ctx_work
+          [ ("path", `String path); ("content", `String "new"); ("mode", `String "") ]
+      in
+      check string "second outcome" "success"
+        (match second.outcome with `Success -> "success" | `Failure -> "failure");
+      let json = parse_result_json second in
+      check string "empty mode reports overwrite" "overwrite"
+        Yojson.Safe.Util.(member "mode" json |> to_string);
+      let target = Yojson.Safe.Util.(member "path" json |> to_string) in
+      check string "content overwritten" "new"
+        (Stdlib.In_channel.with_open_bin target Stdlib.In_channel.input_all))
+
+let test_keeper_fs_edit_append_mode_appends () =
+  with_exec_fixture "keeper_exec_tools_fs_append_mode"
+    (fun ~config ~meta ~ctx_work ->
+      let path = "append.txt" in
+      let first =
+        call_keeper_fs_edit ~config ~meta ~ctx_work
+          [ ("path", `String path); ("content", `String "hello") ]
+      in
+      check string "seed write outcome" "success"
+        (match first.outcome with `Success -> "success" | `Failure -> "failure");
+      let second =
+        call_keeper_fs_edit ~config ~meta ~ctx_work
+          [ ("path", `String path); ("content", `String "\nworld"); ("mode", `String "append") ]
+      in
+      check string "append outcome" "success"
+        (match second.outcome with `Success -> "success" | `Failure -> "failure");
+      let json = parse_result_json second in
+      check string "append mode reported" "append"
+        Yojson.Safe.Util.(member "mode" json |> to_string);
+      let target = Yojson.Safe.Util.(member "path" json |> to_string) in
+      check string "content appended" "hello\nworld"
+        (Stdlib.In_channel.with_open_bin target Stdlib.In_channel.input_all))
+
 let () =
   Masc_test_deps.init_keeper_tool_registry ();
   ignore
@@ -183,5 +239,9 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
         test_execute_with_outcome_bad_query_is_failure;
+      test_case "keeper_fs_edit empty mode overwrites" `Quick
+        test_keeper_fs_edit_empty_mode_uses_overwrite;
+      test_case "keeper_fs_edit append mode appends" `Quick
+        test_keeper_fs_edit_append_mode_appends;
     ]);
   ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -430,6 +430,12 @@ let () =
           Masc_mcp.Keeper_types_profile.valid_shared_memory_scope_strings
           Masc_mcp.Keeper_schema.shared_memory_scope_enum_strings);
     ];
+    "keeper_fs_mode_ssot", [
+      Alcotest.test_case "schema keeps canonical mode list" `Quick (fun () ->
+        Alcotest.(check (list string)) "fs_write_mode mirror"
+          [ "overwrite"; "append" ]
+          Masc_mcp.Tool_shard.fs_write_mode_enum_strings);
+    ];
     "fsm_transition_matrix", [
       (* Issue #8474: schema transition matrix had drifted from
          [Coord_task.valid_next_actions_for_status] — submit/approve/


### PR DESCRIPTION
## Summary
- introduce an `fs_write_mode` variant and helper surface for keeper file writes
- replace string-based parse/dispatch/logging in `keeper_exec_fs` with the typed mode
- mirror the schema enum in `tool_shard` and add regression coverage for schema plus runtime overwrite/append behavior

## Root cause
`keeper_fs_edit.mode` was validated, dispatched, and echoed through repeated raw strings at several sites. That created drift risk between the runtime parser/dispatcher and the published schema, and relied on a silent empty-string fallback path instead of an explicit typed parse.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8490-fs-write-mode test/test_types.exe test/test_keeper_exec_tools.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8490-fs-write-mode/_build/default/test/test_types.exe`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8490-fs-write-mode && ./_build/default/test/test_keeper_exec_tools.exe)`

Closes #8490