### PR TITLE
[structural-quality] Replace mutable Hashtbl with immutable StringMap in activity_graph.ml

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -5,6 +5,8 @@ include Activity_graph_types
 include Activity_graph_registry
 include Activity_graph_reducer
 
+module StringMap = Map.Make (String)
+
 (* ================================================================ *)
 (* File storage paths                                               *)
 (* ================================================================ *)
@@ -216,14 +218,16 @@ let graph_json config ?(kinds = []) ?(limit = 500)
     list_events_with_total config ~kinds ~after_seq:0 ~limit ?since_ms ()
   in
   let kind_counts_json =
-    let counts = Hashtbl.create 16 in
-    List.iter
-      (fun (e : event) ->
-        let prev = Option.value (Hashtbl.find_opt counts e.kind) ~default:0 in
-        Hashtbl.replace counts e.kind (prev + 1))
-      events;
+    let counts =
+      List.fold_left
+        (fun acc (e : event) ->
+          let prev = StringMap.find_opt e.kind acc |> Option.value ~default:0 in
+          StringMap.add e.kind (prev + 1) acc)
+        StringMap.empty
+        events
+    in
     `Assoc
-      (Hashtbl.fold
+      (StringMap.fold
          (fun kind count acc -> (kind, `Int count) :: acc)
          counts []
       |> List.sort (fun (a, _) (b, _) -> String.compare a b))


### PR DESCRIPTION
## Summary

Structural quality improvement: migrate mutable Hashtbl to immutable StringMap in activity_graph.ml.

**Changes**:
- Replace `Hashtbl.create 16` with `StringMap.empty` for event kind counts aggregation
- Convert imperative loop (`Hashtbl.replace`) to functional fold (`StringMap.add`)
- Update fold to use `StringMap.fold` instead of `Hashtbl.fold`

## Rationale

The `graph_json` function counts event occurrences by kind using a mutable Hashtbl. This is a local aggregation pattern (counts are immutable once computed) and doesn't require mutation semantics. Replacing with immutable StringMap reduces overall mutable state in the codebase.

## Test Plan

- [x] Verify dune build succeeds  
- [x] No behavioral changes: kind counts computed identically
- [x] Single-file, single-pattern refactoring

## Scope

Single-function refactoring in lib/activity_graph/activity_graph.ml. No API changes. Purely structural quality improvement (mutable → immutable).

Generated by masc-improver keeper (structural quality improvement task)