### PR TITLE
fix(tool_shard): mirror full sort_order list — Trending/Discussed missing (#8513)

### DIFF
--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -31,6 +31,17 @@ let memory_search_source_enum_strings =
 let fs_write_mode_enum_strings =
   [ "overwrite"; "append" ]
 
+(** Issue #8513: hand-mirrored from
+    [Board_dispatch.valid_sort_order_strings] (#8453 SSOT). Direct
+    dependency would risk a Tool_shard -> Board_* -> Tool_shard cycle.
+    Sync regression test in [test_types.ml :: sort_order_schema_ssot]
+    catches drift. The schema previously hand-listed only 3 of 5 sort
+    orders (recent/hot/updated) — Trending and Discussed were dropped,
+    so LLM clients couldn't filter by them via schema validation even
+    though [sort_order_of_string_opt] accepts them. Same shape as
+    #8430 / #8471 / #8474 / #8493 REAL drift bugs. *)
+let sort_order_enum_strings =
+  [ "hot"; "trending"; "recent"; "updated"; "discussed" ]
 
 (** Issue #8506: hand-mirrored from
     [Board_votes.valid_vote_direction_strings]. Direct dependency
@@ -169,7 +180,10 @@ and content preview for each post.";
       ("properties", `Assoc [
         ("hearth", `Assoc [("type", `String "string"); ("description", `String "Filter by topic channel (e.g. code-review, research)")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max posts to return (default: 20, max: 50)")]);
-        ("sort_by", `Assoc [("type", `String "string"); ("enum", `List [`String "recent"; `String "hot"; `String "updated"]); ("description", `String "Sort order (default: recent)")]);
+        (* Issue #8513: derive from local mirror tracking
+           [Board_dispatch.valid_sort_order_strings].  Schema used to
+           expose only 3 of 5 sort orders. *)
+        ("sort_by", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) sort_order_enum_strings)); ("description", `String "Sort order (default: recent)")]);
       ]);
     ];
   };

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -9,6 +9,12 @@
     [test_types.ml :: pr_review_event_ssot] catches drift. *)
 val pr_review_event_enum_strings : string list
 
+(** Issue #8513: hand-mirrored from
+    [Board_dispatch.valid_sort_order_strings] (#8453 SSOT). Schema
+    previously hand-listed 3 of 5 sort orders; sync regression test in
+    [test_types.ml :: sort_order_schema_ssot] catches drift. *)
+val sort_order_enum_strings : string list
+
 (** Issue #8484: hand-mirrored from
     [Keeper_exec_memory.valid_memory_search_source_strings]. Sync
     regression test in [test_types.ml :: memory_search_source_ssot]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -670,6 +670,22 @@ let () =
           Masc_mcp.Tool_agent.valid_collaboration_format_strings
           Tool_schemas_agent.collaboration_format_enum_strings);
     ];
+    "sort_order_schema_ssot", [
+      (* Issue #8513: Tool_shard.sort_order_enum_strings (used in
+         keeper_board_list schema) hand-listed only 3 of 5 sort orders
+         exposed by Board_dispatch.valid_sort_order_strings (#8453).
+         Trending and Discussed were missing. This test asserts the
+         mirror == SSOT so adding a new sort order Variant flows
+         through to the schema automatically. *)
+      Alcotest.test_case "tool_shard mirror == Board_dispatch SSOT" `Quick (fun () ->
+        Alcotest.(check (list string)) "schema mirror == sort_order SSOT"
+          Masc_mcp.Board_dispatch.valid_sort_order_strings
+          Masc_mcp.Tool_shard.sort_order_enum_strings);
+      Alcotest.test_case "Trending and Discussed now present" `Quick (fun () ->
+        let actual = Masc_mcp.Tool_shard.sort_order_enum_strings in
+        Alcotest.(check bool) "trending present" true (List.mem "trending" actual);
+        Alcotest.(check bool) "discussed present" true (List.mem "discussed" actual));
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8513. **5th REAL bug found via this sweep.**

`tool_shard.ml:134` JSON Schema `enum` for `keeper_board_list.sort_by`:
```ocaml
("enum", `List [`String "recent"; `String "hot"; `String "updated"]);
```

But `Board_dispatch.sort_order` (#8453 SSOT) has 5 constructors:
- `hot`, `recent`, `updated` ✓ in schema
- `trending`, `discussed` ✗ MISSING

`sort_order_of_string_opt` accepts all 5 + 3 aliases (`new`/`active`/`comments`). Schema only advertised 3.

## Approach

- Add `tool_shard.ml` local mirror `sort_order_enum_strings` + `.mli` export. Cycle-aware (Tool_shard upstream of Board_dispatch).
- Schema enum derives from mirror via `List.map`.
- Witness regression + mirror sync test in `test_types.ml :: sort_order_schema_ssot`.

## Verification

- `dune build` clean.
- `test_types.ml :: sort_order_schema_ssot` — 2 cases (mirror == SSOT + Trending/Discussed present).
- 51/51 `test_types` pass.

## Risk

Low. Schema gains 2 sort options — additive. Existing 3-option clients see no breaking change.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW)
6. `memory_search_source` (#8484) — prevention + anti-pattern (NEW)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW)
9. `config_category` (#8493) — REAL (11 missing)
10. `agent_card_action` + `collaboration_format` (#8501) — prevention (2 NEW)
11. `vote_direction` (#8506) — prevention + 4-site dedup
12. `sort_order_schema` (#8513) — **REAL (Trending/Discussed missing)**
