### PR TITLE
[structural-quality] Replace mutable Hashtbl with immutable StringSet in agent_tool_surfaces.ml

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -12,13 +12,13 @@ module SS = Set.Make (String)
 let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
-  let seen = Hashtbl.create (List.length schemas) in
+  let seen = ref SS.empty in
   List.filter
     (fun (schema : Types.tool_schema) ->
-      if Hashtbl.mem seen schema.name then
+      if SS.mem schema.name !seen then
         false
       else (
-        Hashtbl.add seen schema.name ();
+        seen := SS.add schema.name !seen;
         true))
     schemas
 


### PR DESCRIPTION
## Summary

Structural quality improvement: migrate mutable Hashtbl to immutable StringSet in agent_tool_surfaces.ml.

**Changes**:
- Replace `Hashtbl.create` with `ref StringSet.empty` in `dedupe_schemas` function
- Update membership test: `Hashtbl.mem seen schema.name` → `StringSet.mem schema.name !seen`
- Update set insertion: `Hashtbl.add seen schema.name ()` → `seen := StringSet.add schema.name !seen`

## Rationale

The `dedupe_schemas` function uses a mutable Hashtbl for deduplication tracking while filtering schemas. This is a local dedup pattern (values are unit `()`) and doesn't require mutation semantics. Replacing with immutable StringSet reduces mutable state in the codebase while maintaining identical semantics.

## Test Plan

- [x] Verify dune build succeeds
- [x] No behavioral changes: dedup still filters duplicate schema names
- [x] Single-file, single-function refactoring

## Scope

Single-function refactoring in lib/agent_tool_surfaces.ml. No API changes. Purely structural quality improvement (mutable → immutable).

This is the third Hashtbl→immutable migration this session (PRs #8507, #8511, this).