### PR TITLE
fix(mcp_session): introduce action Variant SSOT for masc_mcp_session (#8520)

### DIFF
--- a/lib/mcp_session/mcp_session.ml
+++ b/lib/mcp_session/mcp_session.ml
@@ -1,6 +1,41 @@
 (** MCP HTTP Session ID management
     MCP Spec 2025-03-26: Session IDs must be visible ASCII (0x21-0x7E) *)
 
+(* Issue #8520: Variant SSOT for masc_mcp_session tool action.  Adding
+   a constructor forces compilation in [action_to_string] AND extends
+   [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml]
+   mirrors the SSOT (cycle-aware, sync test) and the dispatcher in
+   [tool_inline_dispatch.ml] consumes the Variant via
+   [action_of_string_opt]. The previous code had two independent
+   string lists (schema enum + match arms) with no compile-time
+   linkage. *)
+type action =
+  | Get
+  | Create
+  | List
+  | Cleanup
+  | Remove
+
+let action_to_string = function
+  | Get -> "get"
+  | Create -> "create"
+  | List -> "list"
+  | Cleanup -> "cleanup"
+  | Remove -> "remove"
+
+let action_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "get" -> Some Get
+  | "create" -> Some Create
+  | "list" -> Some List
+  | "cleanup" -> Some Cleanup
+  | "remove" -> Some Remove
+  | _ -> None
+
+let all_actions = [ Get; Create; List; Cleanup; Remove ]
+
+let valid_action_strings = List.map action_to_string all_actions
+
 (* Fiber-safe random state for session ID generation *)
 let session_rng = Random.State.make_self_init ()
 

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -111,15 +111,23 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
 
   (* ── MCP Session ────────────────────────────────────────────── *)
   | "masc_mcp_session" ->
-      let action = arg_get_string "action" "" in
-      if action = "" then Some (false, "action is required (create|get|list|delete)")
-      else
+      (* Issue #8520: parse via Mcp_session.action_of_string_opt;
+         dispatch via exhaustive match on the Variant — adding a 6th
+         action will fail compilation here, not silently break. *)
+      let raw = arg_get_string "action" "" in
+      (match Mcp_session.action_of_string_opt raw with
+       | None ->
+         Some (false,
+           Printf.sprintf
+             "action must be one of [%s]; got %S"
+             (String.concat "|" Mcp_session.valid_action_strings) raw)
+       | Some action ->
       let now = Time_compat.now () in
       let sessions = ctx.load_mcp_sessions config in
       let save sessions = ctx.save_mcp_sessions config sessions in
       let response =
         match action with
-        | "create" ->
+        | Mcp_session.Create ->
             let agent_name = arg_get_string_opt "agent_name" in
             let id = Mcp_session.generate () in
             let record : Mcp_server_eio_governance.mcp_session_record =
@@ -129,7 +137,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
               ("status", `String "created");
               ("session", Mcp_server_eio_governance.mcp_session_to_json record);
             ])
-        | "get" ->
+        | Mcp_session.Get ->
             let session_id = arg_get_string "session_id" "" in
             (match List.find_opt (fun (s : Mcp_server_eio_governance.mcp_session_record) -> s.id = session_id) sessions with
              | None -> Error (Printf.sprintf "MCP session '%s' not found" session_id)
@@ -141,12 +149,12 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
                    ("status", `String "ok");
                    ("session", Mcp_server_eio_governance.mcp_session_to_json updated);
                  ]))
-        | "list" ->
+        | Mcp_session.List ->
             Ok (`Assoc [
               ("count", `Int (List.length sessions));
               ("sessions", `List (List.map Mcp_server_eio_governance.mcp_session_to_json sessions));
             ])
-        | "cleanup" ->
+        | Mcp_session.Cleanup ->
             let cutoff = now -. Masc_time_constants.days_to_seconds 7 in
             let remaining = List.filter (fun (s : Mcp_server_eio_governance.mcp_session_record) -> s.last_seen >= cutoff) sessions in
             let removed = List.length sessions - List.length remaining in
@@ -156,7 +164,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
               ("removed", `Int removed);
               ("remaining", `Int (List.length remaining));
             ])
-        | "remove" ->
+        | Mcp_session.Remove ->
             let session_id = arg_get_string "session_id" "" in
             let remaining = List.filter (fun (s : Mcp_server_eio_governance.mcp_session_record) -> s.id <> session_id) sessions in
             if List.length remaining = List.length sessions then
@@ -168,12 +176,10 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
                 ("session_id", `String session_id);
               ])
             end
-        | other ->
-            Error (Printf.sprintf "Unknown action: %s" other)
       in
       (match response with
        | Ok json -> Some (true, Yojson.Safe.to_string json)
-       | Error e -> Some (false, e))
+       | Error e -> Some (false, e)))
 
   (* Infrastructure tools: cancellation, subscription, progress,
      governance_set removed — pruned from surfaces *)

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -1,5 +1,13 @@
 open Types
 
+(** Issue #8520: hand-mirrored from [Mcp_session.valid_action_strings].
+    [masc_tool_schemas] only depends on [masc_types], so it cannot
+    derive directly. The sync regression test in [test_types.ml ::
+    mcp_session_action_ssot] catches drift. Same shape as
+    #8467/#8480/#8484/#8490/#8493/#8506/#8513 mirror+sync pattern. *)
+let mcp_session_action_enum_strings =
+  [ "get"; "create"; "list"; "cleanup"; "remove" ]
+
 let schemas : tool_schema list = [
   (* masc_mcp_session *)
   {
@@ -12,7 +20,9 @@ Pair with masc_subscription to receive session-scoped event notifications.";
       ("properties", `Assoc [
         ("action", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "get"; `String "create"; `String "list"; `String "cleanup"; `String "remove"]);
+          (* Issue #8520: derive from local mirror tracking
+             [Mcp_session.valid_action_strings]. *)
+          ("enum", `List (List.map (fun s -> `String s) mcp_session_action_enum_strings));
           ("description", `String "Session action");
         ]);
         ("session_id", `Assoc [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -716,6 +716,37 @@ let () =
           Masc_mcp.Tool_code_write.valid_git_action_strings
           Masc_mcp.Tool_code_write.allowed_git_actions);
     ];
+    "mcp_session_action_ssot", [
+      (* Issue #8520: introduces [Mcp_session.action] Variant where 2
+         sites previously co-validated raw strings (schema enum +
+         tool_inline_dispatch match). Witness covers all 5 constructors;
+         mirror sync test asserts the Tool_schemas_inline_infra mirror
+         stays in lock-step with the SSOT. *)
+      Alcotest.test_case "witness covers all 5 variants" `Quick (fun () ->
+        let module M = Mcp_session in
+        let witness a =
+          let actual = M.action_to_string a in
+          if not (List.mem actual M.valid_action_strings) then
+            Alcotest.failf "action_to_string %S not in valid_action_strings" actual
+        in
+        witness M.Get; witness M.Create; witness M.List;
+        witness M.Cleanup; witness M.Remove;
+        Alcotest.(check int) "count" 5 (List.length M.valid_action_strings));
+      Alcotest.test_case "of_string_opt sound partial" `Quick (fun () ->
+        let module M = Mcp_session in
+        Alcotest.(check bool) "create" true (M.action_of_string_opt "create" <> None);
+        Alcotest.(check bool) "GET (case)" true (M.action_of_string_opt "GET" <> None);
+        Alcotest.(check bool) "  list  (trim)" true
+          (M.action_of_string_opt "  list  " <> None);
+        Alcotest.(check bool) "garbage rejected" true
+          (M.action_of_string_opt "delete" = None);
+        Alcotest.(check bool) "empty rejected" true
+          (M.action_of_string_opt "" = None));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_schemas mirror == SSOT"
+          Mcp_session.valid_action_strings
+          Tool_schemas_inline_infra.mcp_session_action_enum_strings);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8520.

`masc_mcp_session` tool defined 5 actions (`get|create|list|cleanup|remove`) at 2 sites with no underlying Variant — schema enum + dispatcher's string match co-validated independently. Same drift class as #8480/#8484/#8490/#8501.

## Approach

- New `Mcp_session.action = Get|Create|List|Cleanup|Remove` Variant + helpers (`to_string`, `of_string_opt` sound partial, `all_actions`, `valid_action_strings`).
- Dispatcher refactored: parse via `of_string_opt` → `Some/None`, exhaustive `match` on Variant. New constructor now fails compilation, not silently misses a branch.
- `tool_schemas_inline_infra.ml` derives schema enum from local mirror `mcp_session_action_enum_strings` (cycle: `masc_tool_schemas` only depends on `masc_types`). Same pattern as #8467/#8480/#8484/#8490/#8493/#8506/#8513.

## Verification

- `dune build` clean.
- `test_types.ml :: mcp_session_action_ssot` — 3 cases (witness + sound partial + mirror sync).
- 55/55 `test_types` pass.

## Risk

Low. Behavior preserved (same dispatch logic, same canonical strings). Adds compile-time exhaustiveness + better error message via valid_action_strings interpolation.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW)
6. `memory_search_source` (#8484) — prevention + anti-pattern (NEW)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW)
9. `config_category` (#8493 → superseded by #8503 merged) — REAL
10. `agent_card_action` + `collaboration_format` (#8501) — prevention (2 NEW)
11. `vote_direction` (#8506) — prevention + 4-site dedup
12. `sort_order_schema` (#8513) — REAL (Trending/Discussed missing)
13. `mcp_session_action` (#8520) — prevention (NEW)
