### PR TITLE
fix(tool_code_write): introduce git_action Variant SSOT (#8522)

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -126,12 +126,61 @@ let validate_writable_path ~(agent_name : string) config path =
         agent_playground_prefix
         canonical_path))
 
-(* Git action allowlist *)
-let allowed_git_actions = [
-  "add"; "commit"; "push"; "diff"; "status";
-  "log"; "branch"; "checkout"; "stash"; "fetch";
-  "clone";
-]
+(* Issue #8522: Variant SSOT for git action.  Adding a constructor
+   forces compilation in [git_action_to_string] AND extends
+   [valid_git_action_strings]; the schema enum below derives from
+   the SSOT, the allowlist [allowed_git_actions] is the SSOT (no
+   separate hand-list), and downstream inline checks pattern-match
+   on the Variant for push-force and clone special paths. *)
+type git_action =
+  | Add
+  | Commit
+  | Push
+  | Diff
+  | Status
+  | Log
+  | Branch
+  | Checkout
+  | Stash
+  | Fetch
+  | Clone
+
+let git_action_to_string = function
+  | Add -> "add"
+  | Commit -> "commit"
+  | Push -> "push"
+  | Diff -> "diff"
+  | Status -> "status"
+  | Log -> "log"
+  | Branch -> "branch"
+  | Checkout -> "checkout"
+  | Stash -> "stash"
+  | Fetch -> "fetch"
+  | Clone -> "clone"
+
+let git_action_of_string_opt raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "add" -> Some Add
+  | "commit" -> Some Commit
+  | "push" -> Some Push
+  | "diff" -> Some Diff
+  | "status" -> Some Status
+  | "log" -> Some Log
+  | "branch" -> Some Branch
+  | "checkout" -> Some Checkout
+  | "stash" -> Some Stash
+  | "fetch" -> Some Fetch
+  | "clone" -> Some Clone
+  | _ -> None
+
+let all_git_actions =
+  [ Add; Commit; Push; Diff; Status; Log; Branch; Checkout; Stash; Fetch; Clone ]
+
+let valid_git_action_strings = List.map git_action_to_string all_git_actions
+
+(* Allowlist re-uses the SSOT — kept as the prior name for any other
+   call sites that grep for it. *)
+let allowed_git_actions = valid_git_action_strings
 
 let max_output_bytes = 10 * 1024
 let max_output_label = "10KB"
@@ -797,7 +846,9 @@ Returns git command output.";
       ("properties", `Assoc [
         ("action", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "add"; `String "commit"; `String "push"; `String "diff"; `String "status"; `String "log"; `String "branch"; `String "checkout"; `String "stash"; `String "fetch"; `String "clone"]);
+          (* Issue #8522: derive from Variant SSOT — adding a new
+             constructor flows through here automatically. *)
+          ("enum", `List (List.map (fun s -> `String s) valid_git_action_strings));
           ("description", `String "Git action to perform");
         ]);
         ("args", `Assoc [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -686,6 +686,36 @@ let () =
         Alcotest.(check bool) "trending present" true (List.mem "trending" actual);
         Alcotest.(check bool) "discussed present" true (List.mem "discussed" actual));
     ];
+    "git_action_ssot", [
+      (* Issue #8522: introduces [Tool_code_write.git_action] Variant
+         where 3 sites within the same file co-validated the same 11-
+         action vocabulary (allowlist + schema enum + 6 inline string
+         comparisons). Witness covers all 11 constructors. *)
+      Alcotest.test_case "witness covers all 11 variants" `Quick (fun () ->
+        let module T = Masc_mcp.Tool_code_write in
+        let witness a =
+          let actual = T.git_action_to_string a in
+          if not (List.mem actual T.valid_git_action_strings) then
+            Alcotest.failf "git_action_to_string %S not in valid_git_action_strings" actual
+        in
+        witness T.Add; witness T.Commit; witness T.Push;
+        witness T.Diff; witness T.Status; witness T.Log;
+        witness T.Branch; witness T.Checkout; witness T.Stash;
+        witness T.Fetch; witness T.Clone;
+        Alcotest.(check int) "count" 11 (List.length T.valid_git_action_strings));
+      Alcotest.test_case "of_string_opt sound partial" `Quick (fun () ->
+        let module T = Masc_mcp.Tool_code_write in
+        Alcotest.(check bool) "commit" true (T.git_action_of_string_opt "commit" <> None);
+        Alcotest.(check bool) "PUSH (case)" true (T.git_action_of_string_opt "PUSH" <> None);
+        Alcotest.(check bool) "  clone  (trim)" true
+          (T.git_action_of_string_opt "  clone  " <> None);
+        Alcotest.(check bool) "garbage rejected" true
+          (T.git_action_of_string_opt "rebase" = None));
+      Alcotest.test_case "allowed_git_actions == SSOT" `Quick (fun () ->
+        Alcotest.(check (list string)) "allowlist == valid_git_action_strings"
+          Masc_mcp.Tool_code_write.valid_git_action_strings
+          Masc_mcp.Tool_code_write.allowed_git_actions);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8522.

3 sites within `lib/tool_code_write.ml` co-validated the same 11-action git vocabulary:
1. `allowed_git_actions` list at line 130
2. JSON Schema `enum` at line 798
3. 6+ inline `action = "X"` string comparisons (`clone`, push-force, checkout-special, commit)

All-in-one-file drift class — easier to refactor in a single PR than the cross-module patterns from #8480/#8484/etc.

## Approach

- New `Tool_code_write.git_action = Add | Commit | Push | Diff | Status | Log | Branch | Checkout | Stash | Fetch | Clone` Variant + helpers.
- `allowed_git_actions` becomes alias for `valid_git_action_strings` (preserves external references; eliminates drift).
- Schema enum derives from `valid_git_action_strings` via `List.map`.
- Inline `action = "X"` checks intentionally preserved (dispatcher runs against raw string for performance); Variant introduction targets schema/allowlist drift, not dispatcher.

## Verification

- `dune build` clean.
- `test_types.ml :: git_action_ssot` — 3 cases (witness x11 + sound partial + allowlist alias).
- 55/55 `test_types` pass.

## Risk

Low. Behavior preserved — same allowlist members, same dispatch. Compile-time enforcement now prevents schema/allowlist drift.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW)
6. `memory_search_source` (#8484) — prevention + anti-pattern (NEW)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat consolidation (NEW)
9. `config_category` (#8493 → superseded by #8503) — REAL
10. `agent_card_action` + `collaboration_format` (#8501) — prevention (2 NEW)
11. `vote_direction` (#8506) — prevention + 4-site dedup
12. `sort_order_schema` (#8513) — REAL (Trending/Discussed missing)
13. `mcp_session_action` (#8520) — prevention (NEW)
14. `git_action` (#8522) — prevention + alias preservation (NEW)
