### PR TITLE
fix(keeper_exec_shell): introduce shell_op Variant SSOT — git_worktree missing (#8524)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1,6 +1,57 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* Issue #8524: Variant SSOT for keeper_shell op.  Adding a constructor
+   forces compilation in [shell_op_to_string] AND extends
+   [valid_shell_op_strings]; the schema in [tool_shard.ml] mirrors
+   the SSOT (cycle-aware, sync test) and [supported_ops] in
+   [handle_keeper_shell_unsupported] derives from it (replaced the
+   hand-rolled list which had drifted from the dispatcher). The
+   schema previously omitted [git_worktree] even though the
+   dispatcher and supported_ops both list it — same drift class as
+   #8430 / #8471 / #8474 / #8493 / #8513. *)
+type shell_op =
+  | Pwd
+  | Ls
+  | Cat
+  | Rg
+  | Git_status
+  | Find
+  | Head
+  | Tail
+  | Wc
+  | Tree
+  | Git_log
+  | Git_diff
+  | Git_worktree
+  | Bash
+  | Git_clone
+  | Gh
+
+let shell_op_to_string = function
+  | Pwd -> "pwd"
+  | Ls -> "ls"
+  | Cat -> "cat"
+  | Rg -> "rg"
+  | Git_status -> "git_status"
+  | Find -> "find"
+  | Head -> "head"
+  | Tail -> "tail"
+  | Wc -> "wc"
+  | Tree -> "tree"
+  | Git_log -> "git_log"
+  | Git_diff -> "git_diff"
+  | Git_worktree -> "git_worktree"
+  | Bash -> "bash"
+  | Git_clone -> "git_clone"
+  | Gh -> "gh"
+
+let all_shell_ops =
+  [ Pwd; Ls; Cat; Rg; Git_status; Find; Head; Tail; Wc; Tree;
+    Git_log; Git_diff; Git_worktree; Bash; Git_clone; Gh ]
+
+let valid_shell_op_strings = List.map shell_op_to_string all_shell_ops
+
 (** Shell operation timeout constants.
     - [io_timeout_sec]: commands that may block on network/disk I/O
       (git status, ls with large dirs, custom bash).
@@ -1377,12 +1428,11 @@ let handle_keeper_shell
           ; "error", `String "unsupported_op"
           ; "op", `String op
           ; ( "supported_ops"
+              (* Issue #8524: derive from Variant SSOT instead of a
+                 hand-rolled duplicate. *)
             , `List
                 (List.map
                    (fun name -> `String name)
-                   [ "pwd"; "ls"; "cat"; "rg"; "git_status";
-                     "find"; "head"; "tail"; "wc"; "tree";
-                     "git_log"; "git_diff"; "git_worktree"; "bash";
-                     "git_clone"; "gh" ]) )
+                   valid_shell_op_strings) )
           ])
 ;;

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -7,6 +7,17 @@
     Both tools default to the keeper playground unless an explicit
     allowed [cwd] is provided. *)
 
+(** Issue #8524: Variant SSOT for keeper_shell op.  Mirror in
+    [Tool_shard.keeper_shell_op_enum_strings] (cycle-aware, sync test
+    catches drift). Schema previously omitted git_worktree. *)
+type shell_op =
+  | Pwd | Ls | Cat | Rg | Git_status | Find | Head | Tail | Wc | Tree
+  | Git_log | Git_diff | Git_worktree | Bash | Git_clone | Gh
+
+val shell_op_to_string : shell_op -> string
+val all_shell_ops : shell_op list
+val valid_shell_op_strings : string list
+
 val handle_keeper_bash :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -62,6 +62,19 @@ let sort_order_enum_strings =
 let vote_direction_enum_strings =
   [ "up"; "down" ]
 
+(** Issue #8524: hand-mirrored from
+    [Keeper_exec_shell.valid_shell_op_strings]. Direct dependency
+    would create a Tool_shard -> Keeper_* -> Tool_shard cycle (same
+    shape as #8467/#8480/#8484/#8490). Schema previously hand-listed
+    only 15 of 16 ops — git_worktree was missing even though the
+    dispatcher accepted it and supported_ops advertised it. Sync
+    regression test in [test_types.ml :: keeper_shell_op_ssot]
+    catches drift. *)
+let keeper_shell_op_enum_strings =
+  [ "pwd"; "ls"; "cat"; "rg"; "git_status"; "find"; "head"; "tail";
+    "wc"; "tree"; "git_log"; "git_diff"; "git_worktree"; "bash";
+    "git_clone"; "gh" ]
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -359,7 +372,10 @@ git_log/git_diff for repo history, bash for curl/jq/env/which, gh for GitHub PR/
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("op", `Assoc [("type", `String "string"); ("enum", `List [`String "pwd"; `String "ls"; `String "cat"; `String "rg"; `String "git_status"; `String "find"; `String "head"; `String "tail"; `String "wc"; `String "tree"; `String "git_log"; `String "git_diff"; `String "bash"; `String "git_clone"; `String "gh"]); ("description", `String "Command to run")]);
+        (* Issue #8524: derive from local mirror tracking
+           [Keeper_exec_shell.valid_shell_op_strings].  Schema used to
+           omit git_worktree even though the handler accepted it. *)
+        ("op", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) keeper_shell_op_enum_strings)); ("description", `String "Command to run")]);
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand for op=gh, e.g. 'pr list --state open'. Do NOT put --repo in cmd; current working dir determines the repo.")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "Target path for ls/cat/rg/find/head/tail/wc/tree")]);
         ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for pwd/git_status/git_log/git_diff/git_worktree/bash. Must stay within keeper playground or an explicit allowed path.")]);

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -15,6 +15,12 @@ val pr_review_event_enum_strings : string list
     [test_types.ml :: sort_order_schema_ssot] catches drift. *)
 val sort_order_enum_strings : string list
 
+(** Issue #8524: hand-mirrored from
+    [Keeper_exec_shell.valid_shell_op_strings]. Schema previously
+    omitted git_worktree; sync regression test in
+    [test_types.ml :: keeper_shell_op_ssot] catches drift. *)
+val keeper_shell_op_enum_strings : string list
+
 (** Issue #8484: hand-mirrored from
     [Keeper_exec_memory.valid_memory_search_source_strings]. Sync
     regression test in [test_types.ml :: memory_search_source_ssot]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -766,6 +766,33 @@ let () =
           Mcp_session.valid_action_strings
           Tool_schemas_inline_infra.mcp_session_action_enum_strings);
     ];
+    "keeper_shell_op_ssot", [
+      (* Issue #8524: Keeper_exec_shell.shell_op Variant has 16
+         constructors but tool_shard.ml schema enum hand-listed only
+         15 — git_worktree was missing even though the dispatcher
+         accepted it (line 1021) and supported_ops self-advertised it
+         (line 1383). 6th REAL bug found via this sweep. Same shape
+         as #8430 / #8471 / #8474 / #8493 / #8513. *)
+      Alcotest.test_case "witness covers all 16 variants" `Quick (fun () ->
+        let module S = Masc_mcp.Keeper_exec_shell in
+        let witness o =
+          let actual = S.shell_op_to_string o in
+          if not (List.mem actual S.valid_shell_op_strings) then
+            Alcotest.failf "shell_op_to_string %S not in valid_shell_op_strings" actual
+        in
+        witness S.Pwd; witness S.Ls; witness S.Cat; witness S.Rg;
+        witness S.Git_status; witness S.Find; witness S.Head; witness S.Tail;
+        witness S.Wc; witness S.Tree; witness S.Git_log; witness S.Git_diff;
+        witness S.Git_worktree; witness S.Bash; witness S.Git_clone; witness S.Gh;
+        Alcotest.(check int) "count" 16 (List.length S.valid_shell_op_strings));
+      Alcotest.test_case "schema mirror matches SSOT" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_exec_shell.valid_shell_op_strings
+          Masc_mcp.Tool_shard.keeper_shell_op_enum_strings);
+      Alcotest.test_case "git_worktree now in schema" `Quick (fun () ->
+        Alcotest.(check bool) "git_worktree present" true
+          (List.mem "git_worktree" Masc_mcp.Tool_shard.keeper_shell_op_enum_strings));
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8524. **6th REAL bug found via this sweep — `git_worktree` was missing from schema.**

`tool_shard.ml:338` schema enum had 15 ops. `Keeper_exec_shell` dispatcher accepted 16 (`git_worktree` included). `supported_ops` self-advertisement also listed all 16. Schema/dispatcher/self-advertisement 3-way disagreement.

Symptom matrix:
- Dispatch line 1021: `| "git_worktree" -> ...` (handles)
- Aliases line 768: `"git worktree" | "worktree" -> "git_worktree"` (normalises)
- supported_ops line 1383-1386: includes `git_worktree` (advertises)
- Schema line 338: 15 ops, **`git_worktree` MISSING**

Same drift class as #8430/#8471/#8474/#8493/#8513.

## Approach

- New `Keeper_exec_shell.shell_op` Variant (16 constructors) + helpers (`to_string`, `all_*`, `valid_*_strings`).
- `supported_ops` JSON response derives from `valid_shell_op_strings` (replaces hand-rolled dup).
- `tool_shard.ml` schema enum derives from local mirror `keeper_shell_op_enum_strings` (cycle-aware, sync test).

## Verification

- Clean `dune build`.
- `test_types.ml :: keeper_shell_op_ssot` — 3 cases:
  - witness covers all 16 variants
  - schema mirror == SSOT
  - `git_worktree` explicitly present in schema (regression gate)
- 58/58 `test_types` pass.

## Risk

Low. Schema gains 1 op — additive, existing 15-op clients unchanged. Now LLM clients can use `git_worktree` via schema validation as well as the dispatcher.

## Drift catalog (cumulative)

1. `tool_preset` (#8430) — REAL
2. `sandbox_profile`/`network_mode`/`shared_memory_scope` (#8467) — prevention
3. `snapshot_view` (#8471) — REAL
4. `task_fsm_transitions` (#8474) — REAL
5. `pr_review_event` (#8480) — prevention (NEW)
6. `memory_search_source` (#8484) — prevention + anti-pattern (NEW)
7. `tail_order` (#8486) — prevention
8. `fs_write_mode` (#8490) — prevention + back-compat (NEW)
9. `config_category` (#8493 → #8503 merged) — REAL
10. `agent_card_action` + `collaboration_format` (#8501) — prevention (2 NEW)
11. `vote_direction` (#8506) — prevention + 4-site dedup
12. `sort_order_schema` (#8513) — REAL (Trending/Discussed missing)
13. `mcp_session_action` (#8520) — prevention (NEW)
14. `git_action` (#8522) — prevention + alias (NEW)
15. `keeper_shell_op` (#8524) — **REAL (git_worktree missing)** (NEW)
