### PR TITLE
[structural-quality] Remove unused open Types from a2a_tools.ml

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -1,7 +1,6 @@
 (** A2A MCP Tools - Agent-to-Agent communication protocol.
     Types and JSON conversion are in A2a_types. *)
 
-open Types
 include A2a_types
 
 module SMap = Map.Make(String)


### PR DESCRIPTION
## Summary

Structural quality improvement: eliminate unused namespace pollution in a2a_tools.ml.

**Changes**:
- Removed `open Types` (compiler-flagged dead code)
- All module references already use A2a_types via include statement
- No behavioral change

## Verification

- [x] Build succeeds (dune build @all)
- [x] OCaml compiler flagged unused open
- [x] No Types identifiers used bare in this file

## Scope

Single-line dead code elimination in lib/a2a_tools.ml. Reduces namespace pollution per OCaml best practices.

This is the fourth dead code removal this session (PRs #8508, #8510, #8512, this).

## Product impact
- no runtime behavior change; this is dead-code removal plus current OAS main compatibility on the branch

## Evidence
- compiler flagged the original `open Types` as unused
- branch now also builds against the extended OAS event metadata shape via the `evt.meta` wildcard fix

## Review evidence
- self-review confirmed `lib/a2a_tools.ml` has no bare `Types` identifiers and the change is structural only
- branch carries the same `evt.meta` compatibility fix used to unblock latest OAS-pinned CI

## Linked issue
- Refs #8508
- Refs #8510
- Refs #8512