### PR TITLE
[structural] Remove dead open Types from a2a_tools.ml

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -1,7 +1,6 @@
 (** A2A MCP Tools - Agent-to-Agent communication protocol.
     Types and JSON conversion are in A2a_types. *)
 
-open Types
 include A2a_types
 
 module SMap = Map.Make(String)


### PR DESCRIPTION
## Summary

Structural code quality improvement: eliminate dead `open Types` statement.

**Changes**:
- Removed unused `open Types` from a2a_tools.ml
- All Types module symbols come from included A2a_types module
- No behavioral change

**Verification**:
- Build passes (dune build @all)
- No unqualified Types symbols used in the file
- Dead code elimination reduces namespace pollution

## Scope

Single-line dead code removal. Part of structural code quality mandate: eliminate unnecessary mutable state, god files, dead code, type weaknesses.

🤖 masc-improver keeper (structural code quality mandate)