### PR TITLE
fix: anchor repos paths in keeper playground

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -119,8 +119,16 @@ let relative_path_targets_allowed_root ~(meta : keeper_meta) (raw : string) =
   |> List.filter Filename.is_relative
   |> List.exists boundary
 
-(* Bare filenames default to the keeper playground, but rooted-looking relative
-   paths (for example "workspace/..." or "lib/...") keep project-root/boundary semantics.
+let is_playground_lane_relative_path (raw : string) =
+  List.exists
+    (fun prefix ->
+       String.equal raw prefix
+       || String.starts_with ~prefix:(prefix ^ "/") raw)
+    [ "mind"; "repos" ]
+
+(* Bare filenames and canonical playground bundle lanes default to the keeper
+   playground, but rooted-looking relative paths (for example
+   "workspace/..." or "lib/...") keep project-root/boundary semantics.
 
    Additionally, strip the keeper's own playground prefix when the path already
    includes it.  Keeper LLMs sometimes construct paths like
@@ -171,7 +179,8 @@ let playground_relative_unless_allowed_root ~(config : Coord.config)
   in
   if trimmed = ""
      || not (Filename.is_relative trimmed)
-     || String.contains trimmed '/'
+     || (String.contains trimmed '/'
+         && not (is_playground_lane_relative_path trimmed))
      || relative_path_targets_allowed_root ~meta trimmed
   then trimmed
   else

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -58,6 +58,53 @@ let normalize_path path =
   let joined = String.concat "/" resolved in
   if is_absolute then "/" ^ joined else joined
 
+let normalize_agent_relative_path ~(config : Coord.config) ~(agent_name : string)
+    (raw_path : string) : string =
+  let trimmed = String.trim raw_path in
+  let own_bundle_rel = Keeper_alerting_path.playground_path_of_keeper agent_name in
+  let trimmed =
+    if Filename.is_relative trimmed
+       && String.length trimmed >= String.length own_bundle_rel
+       && String.starts_with ~prefix:own_bundle_rel trimmed
+    then
+      let rest =
+        String.sub trimmed (String.length own_bundle_rel)
+          (String.length trimmed - String.length own_bundle_rel)
+      in
+      if rest = "" then "." else rest
+    else trimmed
+  in
+  let trimmed =
+    if not (Filename.is_relative trimmed) then
+      let own_bundle_abs =
+        Filename.concat config.Coord.base_path own_bundle_rel
+        |> Keeper_alerting_path.strip_trailing_slashes
+      in
+      let doubled_prefix = own_bundle_abs ^ "/" ^ own_bundle_rel in
+      if String.starts_with ~prefix:doubled_prefix trimmed then
+        let rest =
+          String.sub trimmed (String.length doubled_prefix)
+            (String.length trimmed - String.length doubled_prefix)
+        in
+        Filename.concat own_bundle_abs rest
+      else trimmed
+    else trimmed
+  in
+  let is_playground_lane =
+    Filename.is_relative trimmed
+    && List.exists
+         (fun prefix ->
+            String.equal trimmed prefix
+            || String.starts_with ~prefix:(prefix ^ "/") trimmed)
+         [ "mind"; "repos" ]
+  in
+  if is_playground_lane then
+    Filename.concat
+      (Filename.concat config.Coord.base_path own_bundle_rel)
+      trimmed
+  else
+    trimmed
+
 (* Security: Validate path is within git root.
    Uses canonical path resolution to prevent .. traversal attacks. *)
 let validate_path config path =
@@ -122,6 +169,7 @@ let validate_path config path =
    Sibling write fix: iter6 #6610 in tool_code_write.ml. *)
 let validate_read_path ~agent_name config path =
   let base_path = config.Coord.base_path in
+  let path = normalize_agent_relative_path ~config ~agent_name path in
   match validate_path config path with
   | Error e -> Error e
   | Ok canonical_string ->

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -100,6 +100,7 @@ let allowed_worktree_prefixes config =
    so legacy server operations that need to touch repo worktrees
    continue to work. *)
 let validate_writable_path ~(agent_name : string) config path =
+  let path = Tool_code.normalize_agent_relative_path ~config ~agent_name path in
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
@@ -272,6 +273,7 @@ let validate_clone_url ~base_path url =
     #6527 iter 6 scoped this per-agent so agent A cannot drop a clone
     into agent B's playground/repos/ via masc_code_git action=clone. *)
 let validate_clone_cwd ~(agent_name : string) config cwd =
+  let cwd = Tool_code.normalize_agent_relative_path ~config ~agent_name cwd in
   match Tool_code.validate_path config cwd with
   | Error e -> Error e
   | Ok canonical_path ->

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -226,8 +226,8 @@ let contains_substring ~haystack ~needle =
 let test_path_rejection_explains_relative_anchor () =
   let meta = make_meta ~execution_scope:"workspace" ~name:"ani1999" () in
   with_temp_config (fun config ->
-    match KES.resolve_keeper_path ~config ~meta ~raw_path:"repos/masc-mcp" with
-    | Ok path -> fail ("expected rejection for repos/masc-mcp, got: " ^ path)
+    match KES.resolve_keeper_path ~config ~meta ~raw_path:"lib/foo.ml" with
+    | Ok path -> fail ("expected rejection for lib/foo.ml, got: " ^ path)
     | Error err ->
       check bool "preserves machine-readable prefix" true
         (String.starts_with ~prefix:"path_not_in_allowed_paths:" err);
@@ -267,6 +267,21 @@ let test_resolve_keeper_path_allows_playground_write_default () =
     match KES.resolve_keeper_path ~config ~meta ~raw_path:"notes.md" with
     | Error err -> fail ("expected playground write path, got error: " ^ err)
     | Ok path -> check string "bare file defaults into playground" expected path)
+
+let test_repos_prefix_maps_into_playground_repos () =
+  let meta = make_meta ~execution_scope:"workspace" ~name:"keeper" () in
+  with_temp_config (fun config ->
+    let expected =
+      Filename.concat
+        (Filename.concat
+           (KAP.project_root_of_config config)
+           (KAP.playground_path_of_keeper meta.name))
+        "repos/masc-mcp/lib/foo.ml"
+    in
+    match KES.resolve_keeper_path ~config ~meta
+            ~raw_path:"repos/masc-mcp/lib/foo.ml" with
+    | Error err -> fail ("expected repos/ path to resolve into playground, got: " ^ err)
+    | Ok path -> check string "repos/ goes into playground repos/" expected path)
 
 (* ── Path doubling tests ── *)
 
@@ -476,6 +491,8 @@ let () =
             test_resolve_keeper_path_blocks_workspace_repo_write_default;
           test_case "bare writes default into playground" `Quick
             test_resolve_keeper_path_allows_playground_write_default;
+          test_case "repos prefix maps into playground repos" `Quick
+            test_repos_prefix_maps_into_playground_repos;
         ] );
       ( "path_doubling_guard",
         [

--- a/test/test_tool_code_read_containment.ml
+++ b/test/test_tool_code_read_containment.ml
@@ -88,8 +88,10 @@ let make_fixture ~tag =
   let other_rel = ".masc/playground/agent-beta" in
   mkdir_p (Filename.concat base_path own_rel);
   mkdir_p (Filename.concat base_path other_rel);
+  mkdir_p (Filename.concat base_path (Filename.concat own_rel "repos/masc-mcp/lib"));
   mkdir_p (Filename.concat base_path "lib");
   touch (Filename.concat base_path (Filename.concat own_rel "own-file.ml"));
+  touch (Filename.concat base_path (Filename.concat own_rel "repos/masc-mcp/lib/demo.ml"));
   touch (Filename.concat base_path (Filename.concat other_rel "secret.env"));
   touch (Filename.concat base_path "lib/shared.ml");
   let own_abs =
@@ -138,6 +140,25 @@ let () =
     | Error e ->
         failwith
           (Printf.sprintf "expected Ok on own playground, got Error %s"
+             (Types.masc_error_to_string e)))
+
+let () =
+  test "relative_repos_prefix_maps_to_own_playground" (fun () ->
+    let config, own_abs, _other, _shared = make_fixture ~tag:"repos_prefix" in
+    let expected = Filename.concat own_abs "repos/masc-mcp/lib/demo.ml" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config "repos/masc-mcp/lib/demo.ml"
+    with
+    | Ok resolved ->
+        let expected_real =
+          try Unix.realpath expected with Unix.Unix_error _ -> expected
+        in
+        assert (resolved = expected_real)
+    | Error e ->
+        failwith
+          (Printf.sprintf
+             "expected repos/ prefix to map into own playground, got Error %s"
              (Types.masc_error_to_string e)))
 
 (* 3. Cross-keeper playground read — rejected with SSOT name. *)

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -312,6 +312,25 @@ let test_writable_path_allows_own_playground () =
   (check bool) "agent-a writing into agent-a own playground is allowed"
     false (is_error result)
 
+let test_writable_path_maps_relative_repos_prefix () =
+  let base_path = fresh_base_path () in
+  let config = make_config base_path in
+  let raw = "repos/masc-mcp/lib/demo.ml" in
+  let expected =
+    Filename.concat base_path ".masc/playground/agent-a/repos/masc-mcp/lib/demo.ml"
+    |> Masc_mcp.Tool_code.normalize_path
+  in
+  let result =
+    Tool_code_write.validate_writable_path ~agent_name:"agent-a" config raw
+  in
+  match result with
+  | Error e ->
+    fail ("expected repos/ prefix to map into own playground, got: "
+          ^ Types.masc_error_to_string e)
+  | Ok resolved ->
+    (check string) "repos/ path resolves under own playground repos"
+      expected resolved
+
 let test_writable_path_blocks_cross_agent () =
   let base_path = fresh_base_path () in
   let config = make_config base_path in
@@ -398,6 +417,8 @@ let () =
     ("per_agent_containment_6527_iter6", [
       test_case "writable_path allows own playground" `Quick
         test_writable_path_allows_own_playground;
+      test_case "writable_path maps relative repos prefix" `Quick
+        test_writable_path_maps_relative_repos_prefix;
       test_case "writable_path blocks cross-agent" `Quick
         test_writable_path_blocks_cross_agent;
       test_case "clone_cwd does not reject own repos on containment axis" `Quick


### PR DESCRIPTION
## Summary
- treat `repos/...` and `mind/...` keeper paths as canonical playground-relative lanes instead of project-root-relative paths
- apply the same mapping to `masc_code_*` read/write validation so code tools and keeper tools agree on path semantics
- add regression tests for keeper path resolution, code-read containment, and code-write containment

## Root cause
The repo's keeper-facing docs and tool descriptions told agents to use paths like `repos/masc-mcp/lib/foo.ml`, but the actual resolvers only defaulted bare filenames into the playground. Any relative path containing a slash stayed anchored at the project root, so `repos/...` resolved to `<base>/repos/...` and either failed allowlist checks or missed the real clone under `.masc/playground/<agent>/repos/...`.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8393-playground-repos-prefix test/test_keeper_allowed_paths.exe test/test_tool_code_read_containment.exe test/test_tool_code_write_coverage.exe`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8393-playground-repos-prefix && ./_build/default/test/test_keeper_allowed_paths.exe)`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8393-playground-repos-prefix && ./_build/default/test/test_tool_code_read_containment.exe)`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8393-playground-repos-prefix && ./_build/default/test/test_tool_code_write_coverage.exe)`

Closes #8393