### PR TITLE
fix: accept forward-compatible oas sse events

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -11,6 +11,13 @@ describe('SSEEventTypeSchema', () => {
     expect(SSEEventTypeSchema.parse('keeper_heartbeat')).toBe('keeper_heartbeat')
   })
 
+  it('accepts current and future oas-prefixed event types', () => {
+    expect(SSEEventTypeSchema.parse('oas:agent_failed')).toBe('oas:agent_failed')
+    expect(SSEEventTypeSchema.parse('oas:context_overflow_imminent')).toBe('oas:context_overflow_imminent')
+    expect(SSEEventTypeSchema.parse('oas:masc:keeper_gate')).toBe('oas:masc:keeper_gate')
+    expect(SSEEventTypeSchema.parse('oas:future:event')).toBe('oas:future:event')
+  })
+
   it('rejects an unknown event type', () => {
     const r = SSEEventTypeSchema.safeParse('this_is_not_a_real_event')
     expect(r.success).toBe(false)
@@ -119,6 +126,15 @@ describe('parseSSEMessage', () => {
     const msg = parseSSEMessage({ type: 'broadcast', message: 'hi' })
     expect(msg).not.toBeNull()
     expect(msg?.type).toBe('broadcast')
+  })
+
+  it('keeps unknown oas-prefixed events instead of dropping them', () => {
+    const msg = parseSSEMessage({
+      type: 'oas:slot_scheduler_observed',
+      payload: { state: 'saturated', active: 3, max_slots: 3 },
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('oas:slot_scheduler_observed')
   })
 
   it('returns null and warns on invalid input', () => {

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -14,10 +14,10 @@
 import { z } from 'zod'
 
 // --- Type discriminator (closed enum) -------------------------------------
-// Mirror of `SSEEventType` in ../types/sse.ts. Keep in sync on add/remove.
-// Strict: an unknown `type` value causes safeParse to fail and the event
-// is dropped with a console.warn.
-export const SSEEventTypeSchema = z.enum([
+// Mirror of the non-OAS literals in `SSEEventType` in ../types/sse.ts.
+// OAS bridge events stay open by prefix so a newer server does not get
+// parse-dropped the moment it adds a new `oas:*` event family.
+const FixedSSEEventTypeSchema = z.enum([
   'agent_joined',
   'agent_left',
   'broadcast',
@@ -53,30 +53,21 @@ export const SSEEventTypeSchema = z.enum([
   'governance_param_changed',
   'approval:pending',
   'approval:resolved',
-  'oas:masc:autonomy:agent_selected',
-  'oas:masc:autonomy:agent_decision',
-  'oas:masc:autonomy:agent_action_executed',
-  'oas:masc:keeper:snapshot',
-  'oas:masc:keeper:lifecycle',
-  'oas:masc:trust_updated',
-  'oas:masc:reputation_changed',
-  'oas:agent_started',
-  'oas:agent_completed',
-  'oas:tool_called',
-  'oas:tool_completed',
-  'oas:turn_started',
-  'oas:turn_completed',
-  'oas:context_compacted',
-  'oas:task_state_changed',
-  'oas:masc:harness:verdict_recorded',
-  'oas:masc:harness:pre_compact',
-  'oas:masc:harness:handoff',
   'room_truth_snapshot',
   'namespace_truth_snapshot',
   'execution_snapshot',
   'operator_snapshot',
   'operator_digest',
   'transport_health_snapshot',
+])
+
+const OasPrefixedEventTypeSchema = z
+  .string()
+  .regex(/^oas:/, 'Expected an oas:* event type')
+
+export const SSEEventTypeSchema = z.union([
+  FixedSSEEventTypeSchema,
+  OasPrefixedEventTypeSchema,
 ])
 
 export type SSEEventType = z.infer<typeof SSEEventTypeSchema>

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -60,6 +60,9 @@ export type SSEEventType =
   | 'oas:masc:harness:verdict_recorded'
   | 'oas:masc:harness:pre_compact'
   | 'oas:masc:harness:handoff'
+  // Forward-compat: the dashboard parser accepts any `oas:*` event so
+  // newer runtime bridges do not get dropped at the schema boundary.
+  | `oas:${string}`
   // Server-push snapshot events (proactive cache broadcasts)
   | 'room_truth_snapshot'
   | 'namespace_truth_snapshot'


### PR DESCRIPTION
## Summary
- keep the dashboard SSE schema closed for non-OAS events but accept any `oas:*` event type
- widen the TypeScript SSE event type so new OAS bridge events are not treated as impossible at compile time
- add schema tests covering missing current OAS events and future unknown `oas:*` events

## Root cause
The backend OAS SSE bridge was already emitting newer events such as `oas:agent_failed`, `oas:handoff_requested`, `oas:context_overflow_imminent`, `oas:context_compact_started`, `oas:content_replacement_*`, and `oas:slot_scheduler_observed`, but the dashboard Zod enum still hardcoded an older closed list. The parse boundary dropped any event missing from that enum before the runtime store or journal could see it.

## Validation
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8376-oas-sse-open-prefix/dashboard && pnpm install --frozen-lockfile)`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8376-oas-sse-open-prefix/dashboard && pnpm exec vitest run src/schemas/sse.test.ts)`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8376-oas-sse-open-prefix/dashboard && pnpm typecheck)`
- `(cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-8376-oas-sse-open-prefix/dashboard && pnpm build)`

Closes #8376