### PR TITLE
[task-103] Replace mutable Hashtbl with immutable StringSet in agent_tool_surfaces

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -12,13 +12,13 @@ module SS = Set.Make (String)
 let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
-  let seen = Hashtbl.create (List.length schemas) in
+  let seen = ref SS.empty in
   List.filter
     (fun (schema : Types.tool_schema) ->
-      if Hashtbl.mem seen schema.name then
+      if SS.mem schema.name !seen then
         false
       else (
-        Hashtbl.add seen schema.name ();
+        seen := SS.add schema.name !seen;
         true))
     schemas
 


### PR DESCRIPTION
## Summary

Structural quality improvement: migrate mutable Hashtbl to immutable StringSet in agent_tool_surfaces.ml.

**Changes**:
- Replace `Hashtbl.create` with `ref SS.empty` in `dedupe_schemas` function
- Update membership test: `Hashtbl.mem seen schema.name` → `SS.mem schema.name !seen`
- Update set insertion: `Hashtbl.add seen schema.name ()` → `seen := SS.add schema.name !seen`
- Note: `lookup_schemas_by_name_exn` Hashtbl (lines 35-50) correctly remains mutable for actual object storage

## Rationale

The `dedupe_schemas` function uses a mutable Hashtbl purely for presence tracking (unit values). This is a local dedup pattern that doesn't require mutation semantics. Replacing with immutable StringSet (already available as `SS` alias) reduces mutable state while maintaining identical semantics.

The module already includes `module SS = Set.Make (String)` (line 10), so no new dependency is introduced.

## Test Plan

- [x] Build succeeds (dune build @all)
- [x] No behavioral changes to dedupe_schemas dedup logic
- [x] Single-function refactoring, no API changes

## Scope

Single-function structural quality improvement in lib/agent_tool_surfaces.ml. Reduces mutable state in agent surface definitions per task-103 mandate.

🤖 Generated by masc-improver keeper (task-103: Keeper Architecture, Memory & State Management)