### PR TITLE
feat(doctor): dashboard panel skeleton — types + pure helpers + loader

### DIFF
--- a/dashboard/src/components/doctor-panel.test.ts
+++ b/dashboard/src/components/doctor-panel.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  doctorHeading,
+  severityChipClass,
+  severityForExitCode,
+  severityLabel,
+  summaryLine,
+  type DoctorEntry,
+  type DoctorSummary,
+} from './doctor-panel'
+
+describe('severityForExitCode', () => {
+  it('maps 0 to ok', () => {
+    expect(severityForExitCode(0)).toBe('ok')
+  })
+  it('maps 1 to warn', () => {
+    expect(severityForExitCode(1)).toBe('warn')
+  })
+  it('maps 2 to error', () => {
+    expect(severityForExitCode(2)).toBe('error')
+  })
+  it('treats signal / junk exit codes as error', () => {
+    expect(severityForExitCode(137)).toBe('error')
+    expect(severityForExitCode(-1)).toBe('error')
+  })
+})
+
+describe('severityLabel', () => {
+  it('renders Korean labels', () => {
+    expect(severityLabel(0)).toBe('정상')
+    expect(severityLabel(1)).toBe('경고')
+    expect(severityLabel(2)).toBe('오류')
+  })
+  it('unknown rc → 오류', () => {
+    expect(severityLabel(255)).toBe('오류')
+  })
+})
+
+describe('severityChipClass', () => {
+  it('uses ok palette for 0', () => {
+    const cls = severityChipClass(0)
+    expect(cls).toContain('var(--ok')
+    expect(cls).not.toContain('var(--bad')
+  })
+  it('uses warn palette for 1', () => {
+    const cls = severityChipClass(1)
+    expect(cls).toContain('var(--warn')
+  })
+  it('uses bad palette for error', () => {
+    const cls = severityChipClass(2)
+    expect(cls).toContain('var(--bad')
+  })
+})
+
+describe('doctorHeading', () => {
+  it('returns Config for config entries', () => {
+    const entry: DoctorEntry = {
+      name: 'config',
+      kind: 'config',
+      exit_code: 0,
+      payload: {},
+    }
+    expect(doctorHeading(entry)).toBe('Config')
+  })
+  it('capitalises sidecar names', () => {
+    const entry: DoctorEntry = {
+      name: 'discord',
+      kind: 'sidecar',
+      exit_code: 2,
+      payload: {},
+    }
+    expect(doctorHeading(entry)).toBe('Discord')
+  })
+  it('capitalises cli too', () => {
+    const entry: DoctorEntry = {
+      name: 'cli',
+      kind: 'sidecar',
+      exit_code: 1,
+      payload: {},
+    }
+    expect(doctorHeading(entry)).toBe('Cli')
+  })
+})
+
+describe('summaryLine', () => {
+  it('formats aggregate with Korean middot separators', () => {
+    const summary: DoctorSummary = { total: 6, ok: 3, warn: 2, error: 1 }
+    expect(summaryLine(summary)).toBe(
+      '6 Doctor · 정상 3 · 경고 2 · 오류 1',
+    )
+  })
+  it('all-ok summary shows zeros', () => {
+    const summary: DoctorSummary = { total: 6, ok: 6, warn: 0, error: 0 }
+    expect(summaryLine(summary)).toBe(
+      '6 Doctor · 정상 6 · 경고 0 · 오류 0',
+    )
+  })
+})

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -1,0 +1,96 @@
+// Doctor panel — surfaces `/api/v1/dashboard/doctor` envelope in the dashboard.
+//
+// Phase 1 skeleton: types + pure helpers + async resource loader. The actual
+// DOM component wires in a follow-up so this PR is reviewable on its own.
+// Backend contract: see `docs/DOCTOR-ARCHITECTURE.md` "Backend endpoint" section.
+
+import { get } from '../api/core'
+import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+
+export type DoctorKind = 'config' | 'sidecar'
+
+export interface DoctorEntry {
+  name: string
+  kind: DoctorKind
+  exit_code: number
+  payload: unknown
+}
+
+export interface DoctorSummary {
+  total: number
+  ok: number
+  warn: number
+  error: number
+}
+
+export interface DoctorEnvelope {
+  title: string
+  doctors: DoctorEntry[]
+  summary: DoctorSummary
+  exit_code: number
+}
+
+// `doctor all` exit-code contract (shared with OCaml `Doctor_dispatch`):
+//   0 = ok, 1 = warn, 2 = error, anything else = treat as error.
+export type DoctorSeverity = 'ok' | 'warn' | 'error'
+
+export function severityForExitCode(code: number): DoctorSeverity {
+  if (code === 0) return 'ok'
+  if (code === 1) return 'warn'
+  return 'error'
+}
+
+export function severityLabel(code: number): string {
+  switch (severityForExitCode(code)) {
+    case 'ok':
+      return '정상'
+    case 'warn':
+      return '경고'
+    case 'error':
+      return '오류'
+  }
+}
+
+// Tailwind utility class for an inline severity chip — matches the palette
+// used by feature-health (ok/warn/bad) so Doctor fits visually.
+export function severityChipClass(code: number): string {
+  switch (severityForExitCode(code)) {
+    case 'ok':
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+    case 'warn':
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+    case 'error':
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+  }
+}
+
+// Human-readable heading for a doctor entry — sidecar names get capitalised
+// for display; config stays as "Config".
+export function doctorHeading(entry: DoctorEntry): string {
+  if (entry.kind === 'config') return 'Config'
+  return entry.name.charAt(0).toUpperCase() + entry.name.slice(1)
+}
+
+// Aggregate breakdown string, e.g. "6 Doctor · 정상 3 · 경고 2 · 오류 1".
+// Korean separator (` · `) matches the CLI footer in `doctor all`.
+export function summaryLine(summary: DoctorSummary): string {
+  return (
+    `${summary.total} Doctor · ` +
+    `정상 ${summary.ok} · 경고 ${summary.warn} · 오류 ${summary.error}`
+  )
+}
+
+// Async resource — module-scoped so the same data is shared across any
+// surface that mounts the panel (follow-up PR).
+export const doctorEnvelope: AsyncResource<DoctorEnvelope> =
+  createAsyncResource()
+
+export function loadDoctor(): Promise<void> {
+  return doctorEnvelope.load(() =>
+    get<DoctorEnvelope>('/api/v1/dashboard/doctor'),
+  )
+}
+
+export async function refreshDoctor(): Promise<void> {
+  await loadDoctor()
+}


### PR DESCRIPTION
## Summary

`/api/v1/dashboard/doctor` envelope 을 소비할 TS 계약 확정. DOM wiring 은 follow-up 으로 분리.

## Product impact

축 8.5 (frontend panel) 의 foundation. 이 PR 자체로는 운영자에게 새 UI 가 보이지 않지만, 다음 PR 이 wire 하면 대시보드에 "시스템 전반 Doctor" 카드가 등장한다.

| | Before | After (이 PR) | Next PR |
|--|--------|---------------|---------|
| TS contract | 없음 | envelope types + pure helpers | — |
| Regression guard | 없음 | 14 unit tests | — |
| Panel UI | 없음 | 없음 (skeleton only) | htm 템플릿 + mount |

## 왜 skeleton-only

Panel UI (htm 템플릿, tab mount, SSE refresh, drill-down) 는 500+ lines scope. 한 PR 에 묶으면 리뷰 부담이 커지고 pure helpers 의 regression guard 가 UI 변경에 가려진다. 이 PR 은 **contract + helpers + tests** 만 두어 다음 PR 의 기반이 된다.

## Before / After

**Before** — backend endpoint 있지만 consumer 없음:
```
# masc-mcp server 측만 완성
$ curl http://localhost:8935/api/v1/dashboard/doctor
{ ... }
# dashboard/src 에는 consumer 없음
```

**After** — TS consumer 확보:
```ts
import { loadDoctor, doctorEnvelope, summaryLine } from './doctor-panel'

await loadDoctor()
const env = doctorEnvelope.value  // DoctorEnvelope | null
if (env) console.log(summaryLine(env.summary))  // "6 Doctor · 정상 3 · ..."
```

## 변경

### ① `dashboard/src/components/doctor-panel.ts`

TypeScript types:
```ts
export type DoctorKind = 'config' | 'sidecar'
export interface DoctorEntry { name, kind, exit_code, payload }
export interface DoctorSummary { total, ok, warn, error }
export interface DoctorEnvelope { title, doctors[], summary, exit_code }
export type DoctorSeverity = 'ok' | 'warn' | 'error'
```

Pure helpers (backend `Doctor_dispatch.aggregate_exit_code` contract 와 일치):
- `severityForExitCode(code)` — 0→ok / 1→warn / 2→error / 나머지→error (unknown rc 를 오류로 상향 — OCaml helper 와 동일)
- `severityLabel(code)` — 정상/경고/오류
- `severityChipClass(code)` — 기존 feature-health palette (`--ok`, `--warn`, `--bad`) 재사용
- `doctorHeading(entry)` — `kind=config` → "Config", sidecar → capitalised name
- `summaryLine(summary)` — "N Doctor · 정상 X · 경고 Y · 오류 Z" (CLI footer 와 동일 Korean middot)

Async resource (기존 `feature-health.ts` 패턴):
```ts
export const doctorEnvelope: AsyncResource<DoctorEnvelope> = createAsyncResource()
export function loadDoctor(): Promise<void>
export async function refreshDoctor(): Promise<void>
```

### ② `dashboard/src/components/doctor-panel.test.ts`

14 pure tests — regression guard:
- `severityForExitCode`: 0/1/2/137(SIGKILL)/-1 → exhaustive mapping
- `severityLabel`: 0→정상, 1→경고, 2→오류, unknown→오류
- `severityChipClass`: ok/warn/bad palette discriminator
- `doctorHeading`: config / discord / cli
- `summaryLine`: Korean middot format, all-ok case

## 변경 없는 것

- Backend endpoint (이미 #8525 MERGED)
- 다른 dashboard panel (feature-health, governance, etc.)
- 기존 빌드 / 라우팅 / tailwind config
- HTML 템플릿 — 이 PR 은 아무 DOM 변경 없음

## Evidence

```
$ pnpm install                    # clean
$ pnpm test doctor-panel
  Test Files  1 passed (1)
  Tests  14 passed (14)
  Duration  490ms
$ pnpm run typecheck              # clean (strict)
```

## Review evidence

자체 리뷰 포인트:

1. **Backend contract 일치**: `aggregate_exit_code` 의 "unknown rc → error 상향" 을 TS 에서도 그대로 반영 (SIGKILL=137 test case). OCaml ↔ TS 동작 일치.
2. **Palette 재사용**: `severityChipClass` 가 `--ok`/`--warn`/`--bad` 를 씀 (`feature-health.ts:123-130` 와 동일). 새로운 CSS var 추가 없음.
3. **Korean-first**: CLI `doctor all` footer ("합계: 6 Doctor · 정상 3 · ...") 과 동일 형식. TS 측에서도 CLI 와 일관된 표기.
4. **Async resource pattern**: `createAsyncResource` 재사용 — feature-health / harness-health 와 같은 pattern.
5. **DOM 무관**: 이 PR 은 htm 렌더링을 전혀 수정하지 않음. 리뷰어가 helper logic 만 검증하면 됨.

## Linked issue

Refs:
- #8525 — backend endpoint (이 PR 의 소비 대상, merged)
- #8518 — `doctor all --json` envelope contract
- #8502 — `doctor all` fan-out
- #8481 — dispatch
- #8478 — observability

Refs #8525 #8518 #8502 #8481 #8478

## 체크리스트

- [x] `DoctorEnvelope` / `DoctorEntry` / `DoctorSummary` types (backend 일치)
- [x] `severityForExitCode` (0/1/2/unknown→error)
- [x] `severityLabel` (Korean)
- [x] `severityChipClass` (feature-health palette 재사용)
- [x] `doctorHeading` / `summaryLine`
- [x] `loadDoctor` / `refreshDoctor` / `doctorEnvelope` (async resource)
- [x] 14 unit tests
- [x] typecheck clean
- [ ] Panel UI wiring — 후속 PR

## Doctor 축 진행도

```
축 1 — 검진 (Diagnose)        ✓
축 2 — 보고 (Report)          ✓
축 3 — 힌트 (Hint)            ✓
축 4 — 자가 치유 (Fix)         ✓
축 5 — 관측 (Observe)         ✓ (#8478)
축 6 — Dispatch               ✓ (#8481)
축 7 — Fan-out                ✓ (#8502)
축 7.5 — JSON Envelope         ✓ (#8518)
축 8 phase 1 — Backend        ✓ (#8525)
축 8.5 phase 1 — Panel TS     ← 이 PR — types + helpers
축 8.5 phase 2 — Panel UI     후속 — htm 템플릿 + mount
축 9 — Callback 실체           후속 — 운영 리스크 검토
```

## Out of scope

- htm 템플릿 / DOM 렌더링 / tab mount (phase 2)
- SSE refresh / periodic poll 통합
- Payload drill-down (config warnings, sidecar checks)
- `--fix` 버튼 / AutoFix trigger
- Callback 실체 확장
