### PR TITLE
feat(doctor): `<DoctorPanel />` component — fan-out 결과를 대시보드 카드로

### DIFF
--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -1,11 +1,17 @@
 // Doctor panel — surfaces `/api/v1/dashboard/doctor` envelope in the dashboard.
 //
-// Phase 1 skeleton: types + pure helpers + async resource loader. The actual
-// DOM component wires in a follow-up so this PR is reviewable on its own.
+// Types + pure helpers + async loader are used both by the `<DoctorPanel />`
+// component below and (in the future) by SSE-refresh wiring and CI smoke
+// tooling that consumes the same envelope shape.
 // Backend contract: see `docs/DOCTOR-ARCHITECTURE.md` "Backend endpoint" section.
 
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+import { AsyncContainer } from './common/async-container'
+import { Card } from './common/card'
+import { SectionCap } from './common/section-cap'
 
 export type DoctorKind = 'config' | 'sidecar'
 
@@ -93,4 +99,69 @@ export function loadDoctor(): Promise<void> {
 
 export async function refreshDoctor(): Promise<void> {
   await loadDoctor()
+}
+
+// ── Component ──────────────────────────────────────────────────────────
+
+function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
+  const label = severityLabel(entry.exit_code)
+  const chip = severityChipClass(entry.exit_code)
+  return html`
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+      <div class="flex items-baseline justify-between gap-2">
+        <div class="text-sm font-semibold text-[var(--text-strong)]">
+          ${doctorHeading(entry)}
+        </div>
+        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
+          ${label}
+        </span>
+      </div>
+      <div class="mt-1 text-xs text-[var(--text-muted)]">
+        ${entry.kind === 'config' ? 'Config Doctor' : `${entry.name} sidecar`} · exit ${entry.exit_code}
+      </div>
+    </div>
+  `
+}
+
+export function DoctorPanel() {
+  useEffect(() => {
+    void loadDoctor()
+  }, [])
+
+  return html`
+    <div class="space-y-4">
+      <${Card} title="Doctor" class="section">
+        <${AsyncContainer}
+          state=${doctorEnvelope.state}
+          loadingMessage="Doctor 데이터를 불러오는 중..."
+          emptyMessage="Doctor 데이터가 없습니다."
+          render=${(data: DoctorEnvelope) => html`
+            <div class="space-y-4">
+              <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+                <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <${SectionCap}>시스템 전반 Doctor<//>
+                    <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">
+                      ${summaryLine(data.summary)}
+                    </div>
+                    <div class="mt-2 text-sm leading-airy text-[var(--text-body)]">
+                      ${data.title} · <code class="text-[var(--text-muted)]">masc-mcp doctor all</code> 과 동일 결과.
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="rounded border border-[var(--white-8)] px-2.5 py-1 text-2xs text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                    onClick=${() => { void refreshDoctor() }}
+                  >새로고침</button>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                ${data.doctors.map((entry) => html`<${DoctorEntryCard} entry=${entry} />`)}
+              </div>
+            </div>
+          `}
+        />
+      </${Card}>
+    </div>
+  `
 }


### PR DESCRIPTION
## Summary

`<DoctorPanel />` 컴포넌트. `#8533` 의 types/helpers 위에 htm 렌더링을 얹어 대시보드에서 "시스템 전반 Doctor" 를 카드로 볼 수 있게 한다. Tab mount 는 다음 PR.

## Product impact

운영자가 대시보드에서 CLI 결과를 카드로 확인 가능 (단 tab mount 는 다음 PR 에서).

| | Before (#8533) | After (이 PR) | Next PR |
|--|----------------|---------------|---------|
| Types / helpers | ✓ | ✓ | — |
| 렌더링 가능 컴포넌트 | 없음 | `<DoctorPanel />` export | — |
| Tab mount | — | — | app.ts 에 추가 |
| Drill-down (검사 상세) | — | — | follow-up |

## Before / After

**Before** — 컴포넌트 없음:
```ts
import { loadDoctor } from './doctor-panel'
// render ... 수동 작성
```

**After** — 완성 카드 컴포넌트:
```ts
import { DoctorPanel } from './doctor-panel'
// app.ts 또는 surface 에서
html`<${DoctorPanel} />`
```

예상 렌더링:
```
┌─ Doctor ─────────────────────────────────────────┐
│ ┌───────────────────────────────────────────┐   │
│ │ 시스템 전반 Doctor                        │   │
│ │ 6 Doctor · 정상 3 · 경고 2 · 오류 1      │   │
│ │ MASC Doctor (전 계층) · masc-mcp doctor …  │   │
│ │                               [새로고침]   │   │
│ └───────────────────────────────────────────┘   │
│ ┌───┐ ┌───┐ ┌───┐                                │
│ │Con│ │Dis│ │Sla│  (severity chip + exit code)  │
│ └───┘ └───┘ └───┘                                │
│ ┌───┐ ┌───┐ ┌───┐                                │
│ │Tel│ │iMe│ │Cli│                                │
│ └───┘ └───┘ └───┘                                │
└──────────────────────────────────────────────────┘
```

## 변경

### `dashboard/src/components/doctor-panel.ts`

컴포넌트 2개 추가:

- `DoctorEntryCard({ entry })` — 개별 doctor 카드
  - 제목: `doctorHeading(entry)` (config / Discord / Slack / ...)
  - 우측 severity chip: `severityLabel(exit_code)` + `severityChipClass(exit_code)`
  - 부연: `"{config|sidecar name} · exit N"`

- `DoctorPanel()` — 전체 카드
  - `<Card title="Doctor" class="section">` wrapper (기존 feature-health 와 동일 primitive)
  - `<AsyncContainer>` 로 loading/empty/error 자동 처리
  - Summary header (제목 + summaryLine + 새로고침 button)
  - 6 doctor grid — 1/2/3 columns responsive
  - `useEffect(() => loadDoctor(), [])` — mount 시 1회 load

Primitive 재사용 (새 CSS/tailwind 추가 없음):
- `Card` (`./common/card`)
- `AsyncContainer` (`./common/async-container`)
- `SectionCap` (`./common/section-cap`)

## 변경 없는 것

- Types / helpers / async resource (모두 `#8533` MERGED)
- Backend endpoint (`#8525` MERGED)
- Tab mount / routing / app.ts
- Tests — 14 pure tests 그대로 유지

## 왜 mount 를 분리

`app.ts` 의 tab 구조 변경은 review 스코프가 커지고 다른 panel 순서에 영향. 이 PR 은 **렌더링 가능한 컴포넌트 export** 까지만 두어 reviewer 가 import 후 쓸 수 있되 production 에 side-effect 없이 merge 가능하게.

## Evidence

```
$ pnpm install                    # clean
$ pnpm test doctor-panel
  Test Files  1 passed (1)
  Tests  14 passed (14)           # #8533 의 pure helpers regression guard 그대로
  Duration  3.34s
$ pnpm run typecheck              # clean (strict)
```

UI 실측: 이번 tick 은 server 기동 없이 빌드만. 다음 PR (mount) 에서 실제 렌더 확인.

## Review evidence

자체 리뷰 포인트:

1. **Primitive 재사용**: `Card` / `AsyncContainer` / `SectionCap` 만 사용. 새 CSS var / tailwind class / 커스텀 primitive 없음. feature-health.ts 의 pattern 과 1:1 대응.
2. **Responsive grid**: `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` — 기존 `StatCard` grid 와 동일 breakpoints.
3. **Refresh button**: `feature-health.ts:225-227` 와 동일한 `rounded border ...` class. drift 없음.
4. **`useEffect(() => loadDoctor(), [])`**: 기존 `FeatureHealth()` 와 동일 mount-load 패턴.
5. **Tab mount 미포함**: 의도적. `app.ts` 수정은 다른 panel 순서/router 상태를 건드리므로 별 PR 이 깔끔.
6. **Drill-down 미포함**: sidecar `checks[]` / config `warnings[]` 상세는 payload 구조가 `kind` 별로 다르므로 후속 PR 에서 adapter 추가 후 구현.

## Linked issue

Refs:
- #8533 — panel skeleton (types + helpers + loader; 이 PR 의 base)
- #8525 — backend endpoint (envelope 제공)
- #8518 — `doctor all --json`
- #8502 — `doctor all` fan-out
- #8481 — dispatch

Refs #8533 #8525 #8518 #8502 #8481

## 체크리스트

- [x] `<DoctorEntryCard />` — 개별 카드 (severity chip + exit code)
- [x] `<DoctorPanel />` — Card wrapper + AsyncContainer + summary header
- [x] Primitive 재사용 (Card, AsyncContainer, SectionCap)
- [x] Responsive 3-column grid
- [x] `useEffect` mount-load
- [x] `refreshDoctor()` 새로고침 button
- [x] 14 tests pass
- [x] typecheck clean
- [ ] `app.ts` mount — 후속 PR
- [ ] Drill-down UI — 후속 PR

## Doctor 축 진행도

```
축 1 — 검진 (Diagnose)          ✓
축 2 — 보고 (Report)            ✓
축 3 — 힌트 (Hint)              ✓
축 4 — 자가 치유 (Fix)           ✓
축 5 — 관측 (Observe)           ✓ (#8478)
축 6 — Dispatch                 ✓ (#8481)
축 7 — Fan-out                  ✓ (#8502)
축 7.5 — JSON Envelope           ✓ (#8518)
축 8 phase 1 — Backend          ✓ (#8525)
축 8.5 phase 1 — Panel TS       ✓ (#8533)
축 8.5 phase 2 — Panel UI       ← 이 PR — `<DoctorPanel />` 컴포넌트
축 8.5 phase 3 — Tab mount       후속
축 8.5 phase 4 — Drill-down     후속
축 9 — Callback 실체            후속
```

## Out of scope

- `app.ts` tab mount
- SSE refresh / periodic poll 통합
- Drill-down (sidecar checks[] / config warnings[])
- `--fix` 버튼 / AutoFix trigger
- Callback 실체 확장
