### PR TITLE
feat(doctor): mount `<DoctorPanel />` as Lab inspector sub-tab

### DIFF
--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -1,12 +1,13 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { Card } from './common/card'
+import { DoctorPanel } from './doctor-panel'
 import { FeatureHealth } from './feature-health'
 import { ServerConfig } from './server-config'
 import { ExcusePatterns } from './excuse-patterns'
 import { navigate } from '../router'
 
-type InspectorSection = 'overview' | 'features' | 'config'
+type InspectorSection = 'overview' | 'features' | 'config' | 'doctor'
 
 const inspectorSection = signal<InspectorSection>('overview')
 
@@ -119,6 +120,7 @@ export function LabInspector() {
             <${InspectorTabButton} id="overview" label="개요" />
             <${InspectorTabButton} id="features" label="피처 플래그" />
             <${InspectorTabButton} id="config" label="서버 설정" />
+            <${InspectorTabButton} id="doctor" label="Doctor" />
           </div>
         </div>
       <//>
@@ -127,12 +129,14 @@ export function LabInspector() {
         ? html`<${InspectorOverview} />`
         : current === 'features'
           ? html`<${FeatureHealth} />`
-          : html`
-              <div class="flex flex-col gap-4">
-                <${ServerConfig} />
-                <${ExcusePatterns} />
-              </div>
-            `}
+          : current === 'doctor'
+            ? html`<${DoctorPanel} />`
+            : html`
+                <div class="flex flex-col gap-4">
+                  <${ServerConfig} />
+                  <${ExcusePatterns} />
+                </div>
+              `}
     </div>
   `
 }

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -39,6 +39,11 @@ async function refreshServerConfigSurface(): Promise<void> {
   await refreshServerConfig()
 }
 
+async function refreshDoctorSurface(): Promise<void> {
+  const { refreshDoctor } = await import('./components/doctor-panel')
+  await refreshDoctor()
+}
+
 type RefreshTask =
   | 'shell'
   | 'namespaceTruth'
@@ -120,6 +125,7 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
   inspector: () => {
     void refreshFeatureHealthSurface()
     void refreshServerConfigSurface()
+    void refreshDoctorSurface()
   },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },


### PR DESCRIPTION
## Summary

`<DoctorPanel />` (`#8534`) 를 Lab 탭의 inspector 안 "Doctor" sub-tab 으로 mount. 운영자가 **처음으로** 대시보드에서 시스템 전반 Doctor 를 실제로 볼 수 있다.

## Product impact

CLI → HTTP endpoint → TS 컴포넌트 → **UI 실제 가시화** 최종 연결.

| | Before | After (이 PR) |
|--|--------|---------------|
| Doctor 컴포넌트 존재 | ✓ (#8534) | ✓ |
| Doctor 를 UI 에서 볼 수 있음 | 불가 | ✓ Lab → inspector → Doctor sub-tab |
| 새로고침 | — | Lab inspector 돌아올 때 자동 + panel 새로고침 버튼 |

## 변경

### ① `dashboard/src/components/lab-inspector.ts`

```diff
+ import { DoctorPanel } from './doctor-panel'
- type InspectorSection = 'overview' | 'features' | 'config'
+ type InspectorSection = 'overview' | 'features' | 'config' | 'doctor'

  <${InspectorTabButton} id="config" label="서버 설정" />
+ <${InspectorTabButton} id="doctor" label="Doctor" />

  ${current === 'overview'
    ? html`<${InspectorOverview} />`
    : current === 'features'
      ? html`<${FeatureHealth} />`
+     : current === 'doctor'
+       ? html`<${DoctorPanel} />`
      : html`...ServerConfig + ExcusePatterns...`}
```

### ② `dashboard/src/tab-refresh.ts`

```diff
+ async function refreshDoctorSurface(): Promise<void> {
+   const { refreshDoctor } = await import('./components/doctor-panel')
+   await refreshDoctor()
+ }

  inspector: () => {
    void refreshFeatureHealthSurface()
    void refreshServerConfigSurface()
+   void refreshDoctorSurface()
  },
```

- 기존 feature-health / server-config 와 **같은 async dynamic import** 패턴
- inspector tab 진입 시 3개 surface 가 병렬로 refresh

## 변경 없는 것

- `<DoctorPanel />` 컴포넌트 (#8534)
- types / helpers / async resource (#8533)
- Backend endpoint (#8525)
- 다른 Lab sub-tab (overview, features, config)
- 다른 탭 (monitoring, command, workspace, ...)
- 라우터 / URL — `InspectorSection` 은 모듈-scoped signal, 외부 URL 영향 없음

## 왜 Lab inspector 의 sub-tab 으로

Lab 탭의 inspector 는 이미 **"피처 플래그 + 서버 설정 진단"** 맥락. Doctor 도 시스템 진단 계열이라 같은 inspector 안에 두는 게 cognitive grouping 에 맞다. 새 top-level 탭을 만들면 라우팅 + 탭 순서 + 다른 surface 간 상호작용을 건드려야 해 PR 범위가 커진다.

후속 PR 에서 필요하다면 Monitoring 등 다른 surface 에도 같은 `<DoctorPanel />` 을 재사용 가능 — 컴포넌트는 완전 독립.

## Evidence

```
$ pnpm test doctor-panel      # 14 tests pass (regression guard)
$ pnpm test tab-refresh       # 10 tests pass (기존 mount 로직 unchanged)
$ pnpm run typecheck          # clean
```

UI 실측은 서버 기동 + 브라우저 검증이 필요 — 다음 tick 에서 dogfooding.

## Review evidence

자체 리뷰 포인트:

1. **Minimal intrusion**: lab-inspector 4줄 + tab-refresh 8줄 변경. 다른 surface 영향 없음.
2. **URL / 라우팅 영향 없음**: `inspectorSection` 은 모듈-scoped preact signal. `navigate()` 호출 없음. 북마크 URL 바뀌지 않음.
3. **기존 async-import 패턴 준수**: feature-health / server-config 와 동일한 dynamic import 구조. 번들 split 유지.
4. **Refresh 동시성**: `void` 3개로 병렬 실행. 각자 독립 AsyncResource 라 race 없음.

## Linked issue

Refs:
- #8534 — `<DoctorPanel />` 컴포넌트
- #8533 — panel skeleton (types + helpers)
- #8525 — backend endpoint
- #8518 — JSON envelope
- #8502 — fan-out
- #8481 — dispatch

Refs #8534 #8533 #8525 #8518 #8502 #8481

## 체크리스트

- [x] `InspectorSection` 유니온 확장 (`'doctor'`)
- [x] Tab button + 분기 렌더링
- [x] `DoctorPanel` import
- [x] `refreshDoctorSurface` wrapper + inspector refresh 파이프라인 합류
- [x] 기존 tests 10+14 pass (regression 0)
- [x] typecheck clean
- [ ] 브라우저 UI 확인 — 다음 tick

## Doctor 축 진행도

```
축 1-5                         ✓
축 6 — Dispatch               ✓ (#8481)
축 7 — Fan-out                ✓ (#8502)
축 7.5 — JSON Envelope        ✓ (#8518)
축 8 phase 1 — Backend        ✓ (#8525)
축 8.5 phase 1 — Panel TS     ✓ (#8533)
축 8.5 phase 2 — Panel UI     ✓ (#8534)
축 8.5 phase 3 — Tab mount    ← 이 PR — Lab inspector sub-tab
축 8.5 phase 4 — Drill-down   후속 — sidecar checks[] / config warnings[]
축 9 — Callback 실체          후속 — 운영 리스크 검토 후
```

## Out of scope

- Drill-down (payload 내부 렌더링)
- `--fix` 버튼 / AutoFix UI trigger
- SSE live update (현재는 inspector 복귀 시 refresh)
- Callback 실체 확장
- 다른 탭에서 DoctorPanel 재사용
