### PR TITLE
docs(doctor): reflect phase 1 frontend panel + backend endpoint landed

### DIFF
--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -6,6 +6,10 @@ code_refs:
   - sidecars/discord-bot/src/doctor.py
   - bin/main_eio.ml
   - lib/doctor_dispatch.ml
+  - lib/server/server_routes_http_routes_dashboard.ml
+  - dashboard/src/components/doctor-panel.ts
+  - dashboard/src/components/lab-inspector.ts
+  - dashboard/src/tab-refresh.ts
 ---
 
 # Doctor 아키텍처
@@ -130,8 +134,9 @@ class AutoFix:
 | Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
 | iMessage sidecar | `masc-mcp doctor sidecar imessage` ↔ `python -m src doctor` | 운영 중 |
 | CLI connector | `masc-mcp doctor sidecar cli` ↔ `python -m src doctor` | 운영 중 |
-| 전 계층 fan-out | `masc-mcp doctor all` | 운영 중 |
-| 대시보드 | `/api/v1/dashboard/doctor` 취합 패널 | 후속 |
+| 전 계층 fan-out | `masc-mcp doctor all` (+ `--json` envelope) | 운영 중 |
+| 대시보드 Backend | `GET /api/v1/dashboard/doctor` | 운영 중 (phase 1 subprocess) |
+| 대시보드 Frontend | Lab → inspector → Doctor sub-tab | 운영 중 |
 
 ### Dispatch
 
@@ -250,11 +255,30 @@ GET /api/v1/dashboard/doctor
   이는 phase 2 에서 library 추출 + Eio.Process ~cwd 로 제거 예정.
 - 실패 시 `{error, hint}` 로 5xx 반환 — 운영자가 원인 즉시 확인 가능.
 
-### Frontend panel (후속)
+### Frontend panel (운영 중 — phase 1)
 
-대시보드 UI 는 이 endpoint 를 poll (권장 TTL 30-60s) 또는 SSE 구독하고
-각 커넥터별로 세부 섹션을 접어두며 red/yellow 가 있을 때만 자동으로 펼친다.
-`--fix` 버튼은 `callback_available` 이 `true` 인 체크에만 노출한다.
+Lab 탭 → inspector → **Doctor** sub-tab 에서 확인한다. 구현:
+
+- `dashboard/src/components/doctor-panel.ts` — types (`DoctorEnvelope`,
+  `DoctorEntry`, `DoctorSummary`), pure helpers (`severityLabel`,
+  `severityChipClass`, `summaryLine`, `doctorHeading`), async resource
+  (`loadDoctor` / `refreshDoctor`), React 컴포넌트
+  (`<DoctorPanel />`, `<DoctorEntryCard />`).
+- `dashboard/src/components/lab-inspector.ts` — "Doctor" sub-tab 등록.
+- `dashboard/src/tab-refresh.ts` — inspector refresh 파이프라인에
+  `refreshDoctorSurface` 합류. 사용자가 Lab 돌아올 때 자동 갱신.
+
+현재 UI:
+
+- Summary header — "N Doctor · 정상 X · 경고 Y · 오류 Z" + 새로고침 버튼
+- 6 doctor grid (config + 5 sidecar) — 각자 severity chip + exit code
+
+Follow-up (phase 2):
+
+- Drill-down — sidecar `checks[]` / config `warnings[]` 펼침 (`kind`
+  discriminator 로 payload 분기)
+- `--fix` 버튼 — `callback_available` 인 check 한해 AutoFix trigger
+- SSE live update — 현재는 inspector 복귀 시 refresh
 
 ### Phase 2 (후속 — in-process)
 


### PR DESCRIPTION
## Summary

Docs-only. `#8525` / `#8533` / `#8534` / `#8535` 머지 후 `DOCTOR-ARCHITECTURE.md` 가 여전히 "후속" 으로 표기해 두었던 두 섹션을 "운영 중" 으로 전환.

## Product impact

운영 내부 문서가 실제 운영 상태와 일치 — 새로 합류하는 개발자가 로드맵 대신 실제 구현 파일을 찾아갈 수 있다.

## 변경

### ① 커버리지 표

| 이전 | 이후 |
|------|------|
| `전 계층 fan-out: masc-mcp doctor all → 운영 중` | `+ (--json envelope) 명시` |
| `대시보드: /api/v1/dashboard/doctor 취합 패널 → 후속` | `운영 중 (phase 1 subprocess)` |
| — | **(신규)** `대시보드 Frontend · Lab → inspector → Doctor sub-tab · 운영 중` |

### ② Frontend panel 섹션

"후속" 섹션을 **phase 1 운영 중** 으로 재작성:
- 실제 파일 경로 (`doctor-panel.ts`, `lab-inspector.ts`, `tab-refresh.ts`) + 역할 기록
- 현재 UI 요약 (summary header / 6 doctor grid / severity chip)
- Follow-up 리스트: drill-down · `--fix` 버튼 · SSE live update

### ③ `code_refs`

- `lib/server/server_routes_http_routes_dashboard.ml`
- `dashboard/src/components/doctor-panel.ts`
- `dashboard/src/components/lab-inspector.ts`
- `dashboard/src/tab-refresh.ts`

이제 `policy-runtime-drift-gate` 패턴대로 docs 와 code 가 grep-level 로 연결.

## 변경 없는 것

- 코드 (docs-only)
- Dispatch / backend endpoint 섹션
- Phase 2 (in-process) 로드맵
- 다른 docs (CONFIG-DOCTOR, CONNECTOR-CONFIG-SCHEMA, CONNECTOR-UI-DESIGN)

## Linked issue

Refs:
- #8535 — tab mount (이 PR 이 반영하는 marker)
- #8534 — `<DoctorPanel />` 컴포넌트
- #8533 — panel skeleton (types + helpers)
- #8525 — backend endpoint
- #8518 — JSON envelope
- #8502 — fan-out
- #8481 — dispatch

Refs #8535 #8534 #8533 #8525 #8518 #8502 #8481

## 체크리스트

- [x] 커버리지 표 3행 업데이트
- [x] Frontend panel 섹션 재작성 (실제 파일 참조)
- [x] `code_refs` 에 frontend 파일 4개 추가
- [x] Follow-up (drill-down / `--fix` / SSE) 명시

## Doctor 축 진행도

```
축 1-5                         ✓
축 6 — Dispatch               ✓ (#8481)
축 7 — Fan-out                ✓ (#8502)
축 7.5 — JSON Envelope        ✓ (#8518)
축 8 phase 1 — Backend        ✓ (#8525)
축 8.5 phase 1 — Panel TS     ✓ (#8533)
축 8.5 phase 2 — Panel UI     ✓ (#8534)
축 8.5 phase 3 — Tab mount    ✓ (#8535)
축 8.5 phase 4 — Drill-down   후속
축 9 — Callback 실체          후속 — 운영 리스크 검토
축 10 — Docs 반영             ← 이 PR
```

## Out of scope

- Drill-down / `--fix` / SSE 실제 구현
- Phase 2 (in-process endpoint) 실제 구현
- CHANGELOG / release notes
