### PR TITLE
[task-071] Add accountability_risk check to preflight validation

### DIFF
--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -62,7 +62,16 @@ let handle_keeper_preflight_check
     | None -> "custom"
   in
   let () = add_check "preset" preset_ok preset_name in
-  (* Check 5: playground clone target *)
+  (* Check 5: accountability risk *)
+  let accountability_risk =
+    Keeper_accountability.accountability_risk_is_high config ~keeper_name:meta.name
+      ~agent_name:meta.name
+  in
+  let () =
+    add_check "accountability_risk" (not accountability_risk)
+      (if accountability_risk then "RISK_HIGH" else "ok")
+  in
+  (* Check 6: playground clone target *)
   let clone_target =
     let repos_path = Keeper_alerting_path.playground_repos_path meta.name in
     if repo <> "" then
@@ -79,6 +88,7 @@ let handle_keeper_preflight_check
         ; "identity", `Assoc [ "name", `String author; "email", `String email ]
         ; "preset", `String preset_name
         ; "preset_sufficient", `Bool preset_ok
+        ; "accountability_risk", `Bool accountability_risk
         ; "clone_target", `String clone_target
         ; "keeper", `String meta.name
         ])


### PR DESCRIPTION
## Summary

Adds `accountability_risk` check to keeper preflight validation. This closes the routing_hint ↔ preflight gap where keeper runtime was not verifying accountability state before autonomous operations.

## Changes

- Check 5: `accountability_risk_is_high` call in keeper_exec_preflight
- Returns RISK_HIGH if keeper has high accountability risk
- Blocks preflight if risk is high

## Test Plan

- [ ] Manual: Run preflight check on keeper with clean accountability
- [ ] Manual: Run preflight check on keeper with high accountability risk
- [ ] CI: dune build @all

Closes task-071