### PR TITLE
polish(doctor): sidecar title underline 스타일로 전환 (markdown `#` 제거)

### DIFF
--- a/sidecars/shared/gate_shared/doctor.py
+++ b/sidecars/shared/gate_shared/doctor.py
@@ -205,11 +205,15 @@ def render_pretty(
 
     레이아웃은 ``flutter doctor`` / ``brew doctor`` 외형을 참고:
 
-    1. 제목 (``# Discord Sidecar Doctor``)
+    1. 제목 (전통적 underline 스타일 — ``Discord Sidecar Doctor`` + ``====``)
     2. 배너 — 전체 상태 한 줄 요약
     3. 검사 목록 — 등록 순서 유지 (검진 흐름이 곧 읽는 순서)
     4. 조치 항목 — warn/error 에서 나온 hint + auto-fix 를 번호 목록으로
     5. 합계 — 한글 카운트
+
+    Note: `masc-mcp doctor all` 이 섹션마다 ``====`` divider 를 넣으므로,
+    사이드카 제목도 동일한 underline 을 써서 단독/통합 실행 양쪽에서
+    시각적으로 자연스럽게 이어지도록 한다 (이전의 markdown ``#`` 접두 제거).
     """
 
     if use_color is None:
@@ -218,7 +222,8 @@ def render_pretty(
     counts = _tally(checks)
 
     lines: list[str] = []
-    lines.append(f"# {title}")
+    lines.append(title)
+    lines.append("=" * len(title))
     lines.append("")
     lines.append(_banner(counts, use_color=use_color))
     lines.append("")

--- a/sidecars/shared/tests/test_doctor.py
+++ b/sidecars/shared/tests/test_doctor.py
@@ -37,6 +37,26 @@ def test_severity_symbols_render_prefix() -> None:
     assert "missing" in text and "broken" in text
 
 
+def test_title_uses_underline_style_not_markdown_heading() -> None:
+    """제목은 전통적 underline 스타일 (`Title\\n=====`) 로 렌더돼야 한다.
+
+    `masc-mcp doctor all` 섹션 divider (``====``) 와 일관된 외형 유지,
+    그리고 pretty 출력에서 markdown 기호(`# `) 가 보이지 않도록.
+    """
+
+    text = render_pretty(
+        "Discord Sidecar Doctor",
+        [Check(name="a", severity=Severity.ok, message="")],
+        use_color=False,
+    )
+    lines = text.splitlines()
+    assert lines[0] == "Discord Sidecar Doctor"
+    assert lines[1] == "=" * len("Discord Sidecar Doctor")
+    # markdown heading 기호는 제거됐어야 한다
+    assert not text.startswith("# ")
+    assert "\n# Discord" not in text
+
+
 def test_banner_all_ok() -> None:
     checks = [
         Check(name="a", severity=Severity.ok, message=""),


### PR DESCRIPTION
## Summary

Sidecar `render_pretty` 의 제목을 markdown `#` 접두 대신 **전통적 underline 스타일**로 전환. 작은 cosmetic polish — `masc-mcp doctor all` 의 `====` divider 와 시각적으로 align.

## Product impact

운영자가 terminal 에서 `doctor all` 돌릴 때 "divider 아래 `#` 타이틀이 또 있어서 어색"한 중복감을 제거.

| | Before | After |
|--|--------|-------|
| 단독 `python -m src doctor` | `# CLI Connector Doctor` | `CLI Connector Doctor` + `====================` |
| `masc-mcp doctor sidecar cli` | 그대로 (CLI 가 forward 하므로 영향 동일) | 동일하게 underline |
| `masc-mcp doctor all` 섹션 | OCaml `====` divider + Python `# Title` 중복 | OCaml divider 아래 Python 이 underline 으로 자연 이어짐 |

## Before / After

**Before** — `#` markdown heading (pretty 출력에서 어색):
```
# CLI Connector Doctor

! 주의 항목 2개 — 실행은 가능합니다.

[✓] python >= 3.11  (3.14.4)
```

**After** — underline (전통적 터미널 스타일):
```
CLI Connector Doctor
====================

! 주의 항목 2개 — 실행은 가능합니다.

[✓] python >= 3.11  (3.14.4)
```

## 변경

### `sidecars/shared/gate_shared/doctor.py`

```diff
- lines.append(f"# {title}")
+ lines.append(title)
+ lines.append("=" * len(title))
```

Docstring 업데이트 — underline 스타일 선택 이유 (`masc-mcp doctor all` divider 와의 align) 기록.

### `sidecars/shared/tests/test_doctor.py`

신규 테스트 `test_title_uses_underline_style_not_markdown_heading`:

```python
text = render_pretty("Discord Sidecar Doctor", [...], use_color=False)
lines = text.splitlines()
assert lines[0] == "Discord Sidecar Doctor"
assert lines[1] == "=" * len("Discord Sidecar Doctor")
assert not text.startswith("# ")
assert "\n# Discord" not in text  # 중간 markdown heading 도 금지
```

## 변경 없는 것

- JSON 출력 (`render_json`) — `title` 필드 그대로
- 배너 / 검사 줄 / 조치 항목 / 합계 렌더
- Severity 색 / `[✓]/[!]/[✗]` 기호
- `masc-mcp doctor all` OCaml divider
- `Check` / `AutoFix` / `FixOutcome` 데이터 모델
- Dashboard panel (`DoctorPanel` 은 pretty 텍스트를 파싱하지 않고 JSON 사용)

## Evidence

```
$ python3 -m pytest sidecars/shared/tests/test_doctor.py -q
...................                 [100%]
19 passed in 0.06s
```

(기존 18 + 신규 1. `test_action_item_marks_auto_fix_callback_available` 의 `assert "# doctor --fix 로 실행" in text` 는 comment line 이라 영향 없음.)

## Review evidence

자체 리뷰 포인트:

1. **검증 범위**: `#` prefix 가 사라졌는지 + underline 이 정확히 `len(title)` 개 `=` 인지 두 줄 모두 assertion.
2. **다른 `#` 사용처 영향 없음**: `test_action_item_marks_auto_fix_callback_available` 의 `"# doctor --fix 로 실행"` 은 action item 의 shell-style comment. 별개.
3. **JSON 렌더 무영향**: `render_json` 은 `title` 필드를 `checks`/`summary` 구조체 키로 직렬화. pretty 전용 변경.
4. **Dashboard panel 무영향**: `<DoctorPanel />` 는 HTTP endpoint `/api/v1/dashboard/doctor` 의 **JSON envelope** 을 소비. pretty 출력 파싱 없음.

## Linked issue

Refs:
- #8468 — Korean banner / action list / summary polish (같은 polish 축)
- #8375 — shared Doctor framework (이 PR 이 건드리는 `render_pretty` 의 foundation)

Refs #8468 #8375

## 체크리스트

- [x] `render_pretty` 제목 `#` → underline 전환
- [x] Docstring 에 의도 기록
- [x] 신규 test (underline 검증 + `#` 부재 검증)
- [x] 19 tests pass
- [x] JSON / 다른 렌더러 영향 없음 확인
- [ ] `masc-mcp doctor all` 실측 확인 — 다음 tick 또는 서버 재기동 후

## Out of scope

- OCaml 측 divider 변경 (OCaml 은 이미 `====` 사용)
- Action item block 에서 `# doctor --fix 로 실행` shell comment — 별개 맥락이라 유지
- Underline 문자 선택 (`-` vs `=`) — `=` 는 보다 무거운 divider 로 top-level title 에 적합
