### PR TITLE
feat(doctor): drill-down — card expand 시 checks/warnings 노출

### DIFF
--- a/dashboard/src/components/doctor-panel.test.ts
+++ b/dashboard/src/components/doctor-panel.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   doctorHeading,
+  extractConfigNotes,
+  extractSidecarChecks,
   severityChipClass,
   severityForExitCode,
   severityLabel,
@@ -95,5 +97,65 @@ describe('summaryLine', () => {
     expect(summaryLine(summary)).toBe(
       '6 Doctor · 정상 6 · 경고 0 · 오류 0',
     )
+  })
+})
+
+describe('extractSidecarChecks', () => {
+  it('returns empty for non-objects', () => {
+    expect(extractSidecarChecks(null)).toEqual([])
+    expect(extractSidecarChecks(42)).toEqual([])
+    expect(extractSidecarChecks('string')).toEqual([])
+  })
+  it('returns empty when checks field is missing or wrong type', () => {
+    expect(extractSidecarChecks({})).toEqual([])
+    expect(extractSidecarChecks({ checks: 'not-array' })).toEqual([])
+  })
+  it('filters out entries missing name or severity', () => {
+    const out = extractSidecarChecks({
+      checks: [
+        { name: 'a', severity: 'ok' },
+        { name: 'b' }, // missing severity
+        { severity: 'warn' }, // missing name
+        null,
+        { name: 'c', severity: 'error', message: 'boom', detail: 'x', hint: 'do X' },
+      ],
+    })
+    expect(out).toHaveLength(2)
+    expect(out[0]).toEqual({ name: 'a', severity: 'ok' })
+    expect(out[1]).toEqual({
+      name: 'c',
+      severity: 'error',
+      message: 'boom',
+      detail: 'x',
+      hint: 'do X',
+    })
+  })
+  it('omits empty string optional fields', () => {
+    const out = extractSidecarChecks({
+      checks: [{ name: 'a', severity: 'ok', message: '', detail: '', hint: '' }],
+    })
+    expect(out[0]).toEqual({ name: 'a', severity: 'ok' })
+  })
+})
+
+describe('extractConfigNotes', () => {
+  it('returns empty for non-objects', () => {
+    expect(extractConfigNotes(null)).toEqual({ warnings: [], next_actions: [] })
+    expect(extractConfigNotes([])).toEqual({ warnings: [], next_actions: [] })
+  })
+  it('filters non-string entries', () => {
+    const out = extractConfigNotes({
+      warnings: ['w1', 42, 'w2', null],
+      next_actions: ['a1'],
+    })
+    expect(out.warnings).toEqual(['w1', 'w2'])
+    expect(out.next_actions).toEqual(['a1'])
+  })
+  it('handles missing fields', () => {
+    expect(extractConfigNotes({})).toEqual({ warnings: [], next_actions: [] })
+    expect(extractConfigNotes({ warnings: ['only w'] })).toEqual({
+      warnings: ['only w'],
+      next_actions: [],
+    })
   })
 })

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -6,6 +6,7 @@
 // Backend contract: see `docs/DOCTOR-ARCHITECTURE.md` "Backend endpoint" section.
 
 import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
@@ -101,24 +102,159 @@ export async function refreshDoctor(): Promise<void> {
   await loadDoctor()
 }
 
+// ── Payload extractors (runtime type guards) ───────────────────────────
+// Payload is `unknown` at the envelope layer because config and sidecar
+// Doctors have different shapes. The extractors below defensively pull the
+// few fields the drill-down UI consumes.
+
+export interface SidecarCheckView {
+  name: string
+  severity: string
+  message?: string
+  detail?: string
+  hint?: string
+}
+
+export function extractSidecarChecks(payload: unknown): SidecarCheckView[] {
+  if (!payload || typeof payload !== 'object') return []
+  const p = payload as Record<string, unknown>
+  if (!Array.isArray(p.checks)) return []
+  const out: SidecarCheckView[] = []
+  for (const raw of p.checks) {
+    if (!raw || typeof raw !== 'object') continue
+    const c = raw as Record<string, unknown>
+    if (typeof c.name !== 'string' || typeof c.severity !== 'string') continue
+    const view: SidecarCheckView = { name: c.name, severity: c.severity }
+    if (typeof c.message === 'string' && c.message !== '') view.message = c.message
+    if (typeof c.detail === 'string' && c.detail !== '') view.detail = c.detail
+    if (typeof c.hint === 'string' && c.hint !== '') view.hint = c.hint
+    out.push(view)
+  }
+  return out
+}
+
+export interface ConfigNotesView {
+  warnings: string[]
+  next_actions: string[]
+}
+
+export function extractConfigNotes(payload: unknown): ConfigNotesView {
+  const empty: ConfigNotesView = { warnings: [], next_actions: [] }
+  if (!payload || typeof payload !== 'object') return empty
+  const p = payload as Record<string, unknown>
+  const filterStrings = (arr: unknown): string[] =>
+    Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : []
+  return {
+    warnings: filterStrings(p.warnings),
+    next_actions: filterStrings(p.next_actions),
+  }
+}
+
+// Map per-check severity strings (Python's Severity enum) to the shared
+// ok/warn/error chip palette used by doctor exit codes.
+function chipClassForSidecarSeverity(severity: string): string {
+  switch (severity) {
+    case 'ok':
+    case 'info':
+      return severityChipClass(0)
+    case 'warn':
+    case 'skip':
+      return severityChipClass(1)
+    case 'error':
+      return severityChipClass(2)
+    default:
+      return severityChipClass(2)
+  }
+}
+
 // ── Component ──────────────────────────────────────────────────────────
+
+function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
+  if (checks.length === 0) {
+    return html`<div class="text-xs text-[var(--text-muted)]">세부 검사 없음.</div>`
+  }
+  return html`
+    <ul class="mt-3 space-y-2">
+      ${checks.map((c) => {
+        const chip = chipClassForSidecarSeverity(c.severity)
+        return html`
+          <li class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-2">
+            <div class="flex items-baseline justify-between gap-2">
+              <div class="text-xs font-medium text-[var(--text-strong)]">${c.name}</div>
+              <span class="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
+                ${c.severity}
+              </span>
+            </div>
+            ${c.detail ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${c.detail}</div>` : ''}
+            ${c.message ? html`<div class="mt-1 text-[11px] text-[var(--text-body)]">↳ ${c.message}</div>` : ''}
+            ${c.hint ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">hint: ${c.hint}</div>` : ''}
+          </li>
+        `
+      })}
+    </ul>
+  `
+}
+
+function ConfigNotesList({ notes }: { notes: ConfigNotesView }) {
+  const { warnings, next_actions } = notes
+  if (warnings.length === 0 && next_actions.length === 0) {
+    return html`<div class="text-xs text-[var(--text-muted)]">추가 메모 없음.</div>`
+  }
+  return html`
+    <div class="mt-3 space-y-3">
+      ${warnings.length > 0
+        ? html`
+            <div>
+              <div class="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">경고</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--text-body)]">
+                ${warnings.map((w) => html`<li>${w}</li>`)}
+              </ul>
+            </div>
+          `
+        : ''}
+      ${next_actions.length > 0
+        ? html`
+            <div>
+              <div class="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">다음 조치</div>
+              <ul class="mt-1 list-disc space-y-1 pl-5 text-[11px] text-[var(--text-body)]">
+                ${next_actions.map((a) => html`<li>${a}</li>`)}
+              </ul>
+            </div>
+          `
+        : ''}
+    </div>
+  `
+}
 
 function DoctorEntryCard({ entry }: { entry: DoctorEntry }) {
   const label = severityLabel(entry.exit_code)
   const chip = severityChipClass(entry.exit_code)
+  const expanded = useSignal(false)
+  const onToggle = () => { expanded.value = !expanded.value }
   return html`
     <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-      <div class="flex items-baseline justify-between gap-2">
+      <button
+        type="button"
+        class="flex w-full items-baseline justify-between gap-2 text-left"
+        aria-expanded=${expanded.value}
+        onClick=${onToggle}
+      >
         <div class="text-sm font-semibold text-[var(--text-strong)]">
           ${doctorHeading(entry)}
+          <span class="ml-2 text-[10px] text-[var(--text-muted)]">${expanded.value ? '▾' : '▸'}</span>
         </div>
         <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
           ${label}
         </span>
-      </div>
+      </button>
       <div class="mt-1 text-xs text-[var(--text-muted)]">
         ${entry.kind === 'config' ? 'Config Doctor' : `${entry.name} sidecar`} · exit ${entry.exit_code}
       </div>
+      ${expanded.value
+        ? entry.kind === 'sidecar'
+          ? html`<${SidecarChecksList} checks=${extractSidecarChecks(entry.payload)} />`
+          : html`<${ConfigNotesList} notes=${extractConfigNotes(entry.payload)} />`
+        : ''}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

Doctor 카드를 클릭하면 payload 내부를 펼쳐 운영자가 **"이 sidecar 가 왜 경고인가"** 를 대시보드에서 바로 확인할 수 있다. 축 8.5 phase 4.

## Product impact

| | Before | After |
|--|--------|-------|
| Doctor 카드 | name + severity + exit code | 동일 + **클릭 시 상세** |
| sidecar 상세 확인 | terminal `masc-mcp doctor sidecar <name>` | 브라우저 클릭 |
| config warnings 확인 | JSON 파일 열기 또는 CLI | 클릭 한 번 |
| SSoT | CLI envelope | CLI envelope (변경 없음, UI 가 소비) |

## Before / After (UI)

**Before** — 3-column grid, 각 카드에 name/severity/exit:
```
┌───────────────┐  ┌───────────────┐  ┌───────────────┐
│ Config        │  │ Discord       │  │ Slack         │
│ Config Doctor │  │ discord side… │  │ slack side…   │
│ exit 1        │  │ exit 2        │  │ exit 2        │
└───────────────┘  └───────────────┘  └───────────────┘
```

**After** — 클릭 → expand:
```
┌─────────────────────────────────────────┐
│ Discord ▾                     [오류]    │
│ discord sidecar · exit 2                │
│ ┌─────────────────────────────────────┐ │
│ │ python >= 3.11          [OK]        │ │
│ │ 3.14.4                              │ │
│ ├─────────────────────────────────────┤ │
│ │ DISCORD_BOT_TOKEN       [ERROR]     │ │
│ │ ↳ 토큰이 설정되지 않았습니다.       │ │
│ │ hint: DISCORD_BOT_TOKEN env 설정    │ │
│ └─────────────────────────────────────┘ │
└─────────────────────────────────────────┘
```

Config 카드는 warnings[] + next_actions[] 를 bullet list 로.

## 변경

### ① Runtime type guards

Payload 는 envelope 에서 `unknown`. kind 에 따라 shape 다름 — config 는 `{warnings[], next_actions[]}`, sidecar 는 `{title, checks[], summary}`. 두 extractor 가 안전하게 필드만 추출:

```ts
export function extractSidecarChecks(payload: unknown): SidecarCheckView[]
export function extractConfigNotes(payload: unknown): ConfigNotesView
```

**Defensive**:
- 비-object → 기본값
- `checks` 가 array 가 아니면 `[]`
- 개별 check 는 name+severity 둘 다 string 일 때만 포함
- 빈 문자열 optional field 는 생략
- string 만 필터

### ② Sub-components

- `<SidecarChecksList checks>` — 각 check (name / severity chip / detail / message / hint)
- `<ConfigNotesList notes>` — warnings[] + next_actions[] bullet list
- `chipClassForSidecarSeverity(severity)` — Python `Severity` (ok/info/warn/skip/error) → doctor palette 매핑

### ③ `<DoctorEntryCard />` expand/collapse

- `useSignal(false)` state
- 클릭 button 에 `aria-expanded`
- ▸ / ▾ indicator
- kind 분기: sidecar → SidecarChecksList, config → ConfigNotesList

### ④ Tests

신규 7 pure cases:
- `extractSidecarChecks`: non-object / missing checks / filter invalid / omit empty strings
- `extractConfigNotes`: non-object / filter non-strings / missing fields

**21 tests pass** (기존 14 + 신규 7).

## 변경 없는 것

- `DoctorPanel` layout / summary header / grid
- Types (`DoctorEnvelope`, `DoctorEntry`, `DoctorSummary`, `DoctorKind`, `DoctorSeverity`)
- `severityLabel` / `severityChipClass` / `doctorHeading` / `summaryLine` / `loadDoctor`
- Backend endpoint (`/api/v1/dashboard/doctor`)
- Sidecar doctor / Config_doctor 내부 / envelope shape

## Evidence

```
$ pnpm install
$ pnpm test doctor-panel
  Test Files  1 passed (1)
  Tests  21 passed (21)
$ pnpm run typecheck
  (clean)
```

UI 실측은 server 재기동 후 (축 8 phase 1 deployment drift — 이전 handoff 참조).

## Review evidence

자체 리뷰 포인트:

1. **Defensive extraction**: `payload: unknown` 에 대해 7 tests 가 null / number / string / array / 객체 내 wrong-type 필드 모두 커버. 런타임 crash 안 함.
2. **Severity enum 매핑**: Python `Severity` 는 5단계 (ok/info/warn/skip/error) 지만 doctor palette 는 3단계 (ok/warn/error). 매핑: `info→ok`, `skip→warn`. 보수적 선택 (skip 은 실제로 건너뜀이지만 운영자에게 visibility 줌).
3. **Accessibility**: `aria-expanded` 로 스크린리더 지원. `button type="button"` 으로 form submit 방지.
4. **Re-render 최소화**: `useSignal` 로 expand 변경이 카드 단위에만 영향.
5. **Payload unchanged**: envelope JSON 을 수정 없이 소비. backend / CLI 변경 없음.

## Linked issue

Refs:
- #8539 — polish (title underline)
- #8536 — docs reflect
- #8535 — tab mount
- #8534 — `<DoctorPanel />` UI
- #8533 — panel skeleton
- #8525 — backend endpoint
- #8518 — JSON envelope

Refs #8539 #8536 #8535 #8534 #8533 #8525 #8518

## 체크리스트

- [x] `extractSidecarChecks` (defensive)
- [x] `extractConfigNotes` (defensive)
- [x] `<SidecarChecksList>` 컴포넌트
- [x] `<ConfigNotesList>` 컴포넌트
- [x] `DoctorEntryCard` expand/collapse (aria-expanded + ▸/▾)
- [x] `chipClassForSidecarSeverity` 매핑
- [x] 7 신규 pure tests
- [x] 21 tests pass / typecheck clean
- [ ] 브라우저 UI 확인 — 서버 재기동 후 dogfooding

## Doctor 축 진행도

```
축 1-5                         ✓
축 6 — Dispatch               ✓ (#8481)
축 7 — Fan-out                ✓ (#8502)
축 7.5 — JSON Envelope        ✓ (#8518)
축 8 phase 1 — Backend        ✓ (#8525)
축 8.5 phase 1 — Panel TS     ✓ (#8533)
축 8.5 phase 2 — Panel UI     ✓ (#8534)
축 8.5 phase 3 — Tab mount    ✓ (#8535)
축 8.5 phase 4 — Drill-down   ← 이 PR
축 9 — Callback 실체          후속 — 운영 리스크 검토
축 10 — Polish                ✓ (#8539)
Phase 2 — In-process endpoint  후속
```

## Out of scope

- `--fix` 버튼 — envelope 에 `callback_available` 필드 아직 없음 (축 9 전제)
- Remember-expand-state — 새로고침 후 접힘 상태로 복귀
- SSE live update
- Phase 2 in-process endpoint
