### PR TITLE
feat(doctor): "자동 치유" 배지 — callback_available 필드를 UI 에 노출

### DIFF
--- a/dashboard/src/components/doctor-panel.test.ts
+++ b/dashboard/src/components/doctor-panel.test.ts
@@ -136,6 +136,51 @@ describe('extractSidecarChecks', () => {
     })
     expect(out[0]).toEqual({ name: 'a', severity: 'ok' })
   })
+  it('extracts autofix_available from auto_fix.callback_available', () => {
+    const out = extractSidecarChecks({
+      checks: [
+        {
+          name: 'with-fix',
+          severity: 'error',
+          auto_fix: {
+            description: 'chmod 0755',
+            command: null,
+            callback_available: true,
+          },
+        },
+        {
+          name: 'no-callback',
+          severity: 'warn',
+          auto_fix: {
+            description: 'manual step',
+            command: null,
+            callback_available: false,
+          },
+        },
+      ],
+    })
+    expect(out[0]).toMatchObject({
+      name: 'with-fix',
+      autofix_available: true,
+      autofix_description: 'chmod 0755',
+    })
+    expect(out[1]).toMatchObject({
+      name: 'no-callback',
+      severity: 'warn',
+      autofix_description: 'manual step',
+    })
+    expect(out[1]?.autofix_available).toBeUndefined()
+  })
+  it('ignores malformed auto_fix field', () => {
+    const out = extractSidecarChecks({
+      checks: [
+        { name: 'a', severity: 'ok', auto_fix: null },
+        { name: 'b', severity: 'ok', auto_fix: 'bad' },
+        { name: 'c', severity: 'ok', auto_fix: {} },
+      ],
+    })
+    expect(out.every((c) => c.autofix_available === undefined)).toBe(true)
+  })
 })
 
 describe('extractConfigNotes', () => {

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -113,6 +113,13 @@ export interface SidecarCheckView {
   message?: string
   detail?: string
   hint?: string
+  /** 백엔드 envelope 의 `auto_fix.callback_available === true` 일 때만 true.
+   * UI 는 "자동 치유 가능" 배지로 노출. 실제 trigger 는 CLI 경유
+   * (`masc-mcp doctor sidecar <name> --fix`). */
+  autofix_available?: boolean
+  /** `auto_fix.description` — 자동 치유가 시도할 동작의 사람용 설명.
+   * 배지 hover/툴팁용. */
+  autofix_description?: string
 }
 
 export function extractSidecarChecks(payload: unknown): SidecarCheckView[] {
@@ -128,6 +135,12 @@ export function extractSidecarChecks(payload: unknown): SidecarCheckView[] {
     if (typeof c.message === 'string' && c.message !== '') view.message = c.message
     if (typeof c.detail === 'string' && c.detail !== '') view.detail = c.detail
     if (typeof c.hint === 'string' && c.hint !== '') view.hint = c.hint
+    if (c.auto_fix && typeof c.auto_fix === 'object') {
+      const af = c.auto_fix as Record<string, unknown>
+      if (af.callback_available === true) view.autofix_available = true
+      if (typeof af.description === 'string' && af.description !== '')
+        view.autofix_description = af.description
+    }
     out.push(view)
   }
   return out
@@ -181,13 +194,30 @@ function SidecarChecksList({ checks }: { checks: SidecarCheckView[] }) {
           <li class="rounded border border-[var(--white-8)] bg-[var(--white-3)] p-2">
             <div class="flex items-baseline justify-between gap-2">
               <div class="text-xs font-medium text-[var(--text-strong)]">${c.name}</div>
-              <span class="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
-                ${c.severity}
-              </span>
+              <div class="flex items-center gap-1">
+                ${c.autofix_available
+                  ? html`
+                      <span
+                        class="rounded-full border border-[var(--accent)]/40 bg-[var(--accent)]/10 px-1.5 py-0.5 text-[10px] text-[var(--accent)]"
+                        title=${c.autofix_description
+                          ? `자동 치유 시도: ${c.autofix_description} (CLI: masc-mcp doctor --fix)`
+                          : '자동 치유 가능 (CLI: masc-mcp doctor --fix)'}
+                      >
+                        자동 치유
+                      </span>
+                    `
+                  : ''}
+                <span class="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${chip}">
+                  ${c.severity}
+                </span>
+              </div>
             </div>
             ${c.detail ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">${c.detail}</div>` : ''}
             ${c.message ? html`<div class="mt-1 text-[11px] text-[var(--text-body)]">↳ ${c.message}</div>` : ''}
             ${c.hint ? html`<div class="mt-1 text-[11px] text-[var(--text-muted)]">hint: ${c.hint}</div>` : ''}
+            ${c.autofix_available && c.autofix_description
+              ? html`<div class="mt-1 text-[11px] text-[var(--accent)]">fix: ${c.autofix_description}</div>`
+              : ''}
           </li>
         `
       })}


### PR DESCRIPTION
## Summary

Envelope 이 이미 제공하는 `auto_fix.callback_available` 를 drill-down UI 에 **"자동 치유" 배지** 로 노출. 운영자가 "이 check 는 `doctor --fix` 로 시도 가능" 을 브라우저에서 한눈에 판단.

실제 `--fix` 실행은 **CLI 유지** — 브라우저 클릭 trigger 는 운영 리스크로 phase 1 에서 배제.

## Product impact

| | Before | After |
|--|--------|-------|
| Check 의 autofix 가능 여부 | JSON 뜯어보거나 `doctor --fix` 실행 시 확인 | drill-down 카드에 accent 배지 |
| Autofix description | CLI pretty 에서만 노출 | 배지 `title` + hint 아래 accent 텍스트 |
| `--fix` 실행 | CLI | CLI (원칙 유지) |
| 환경 | 기존 envelope 필드 재사용 | Backend 무변경 |

## 왜 UI 트리거를 추가하지 않는가

`--fix` callback 은 파일 이동 / chmod / mkdir 등 **부작용 있는 행위**. 브라우저 클릭 한 번으로 실행하면:

- HITL approval flow 부재 → 오작동 증폭
- 멀티-테넌트 환경에서 "누가 실행했나" 추적 필요
- 실패 재시도 / 로그 누적 / revert 인프라 필요

이 축 phase 1 의 원칙: **UI 는 "가능 여부" 만 노출, 실행은 terminal operator 의도로 CLI 에서**. 추후 HITL + audit 설계되면 별 PR 에서 button trigger 추가.

## Before / After (UI)

**Before** — drill-down 은 name / severity / detail / message / hint 까지만:
```
┌──────────────────────────────────────┐
│ binding paths writable      [ERROR]  │
│ /var/gate (permission denied)        │
│ ↳ binding store: /var/gate           │
│ hint: 상위 디렉터리 권한 확인        │
└──────────────────────────────────────┘
```

**After** — 자동 치유 가능 한 check 는 accent 배지 + fix 설명:
```
┌──────────────────────────────────────────────────────┐
│ binding paths writable   [자동 치유]  [ERROR]        │
│ /var/gate (permission denied)                        │
│ ↳ binding store: /var/gate                           │
│ hint: 상위 디렉터리 권한 확인                        │
│ fix: 접근 권한이 없는 상위 디렉터리에 0755 시도       │
└──────────────────────────────────────────────────────┘
```

(`title` hover 시 "자동 치유 시도: 접근 권한… (CLI: masc-mcp doctor --fix)")

## 변경

### ① `SidecarCheckView` 확장

```ts
export interface SidecarCheckView {
  name: string
  severity: string
  message?: string
  detail?: string
  hint?: string
  autofix_available?: boolean   // envelope 의 auto_fix.callback_available === true
  autofix_description?: string  // envelope 의 auto_fix.description
}
```

### ② `extractSidecarChecks` defensive 추가

- `auto_fix` 가 object + `callback_available === true` 일 때만 `autofix_available: true`
- `description` 이 string + 비어있지 않을 때만 저장
- null / 'bad' / `{}` 등 malformed 는 모두 무시 (기존 defensive 패턴 유지)

### ③ `SidecarChecksList` 렌더

- severity chip 옆에 accent 배지 (accent/40 border + accent/10 bg + accent text)
- 배지 `title`: `"자동 치유 시도: ${desc} (CLI: masc-mcp doctor --fix)"`
- 배지 아래에 `fix: ${desc}` 텍스트 (accent 색)

### ④ Tests

신규 2 cases:
- `autofix_available` 추출: callback_available=true 면 true, false/missing 면 undefined
- Malformed `auto_fix` (null / string / empty object) 안전 무시

**23 tests pass** (21 기존 + 2 신규).

## 변경 없는 것

- Envelope shape (`callback_available` 은 이미 #8375 framework 부터 존재)
- Backend endpoint (`/api/v1/dashboard/doctor`)
- Sidecar doctor / Config_doctor 내부 / shared framework
- `DoctorPanel` layout / summary / grid / Config drill-down
- 기존 extraction / severity 매핑
- CLI 실행 flow

## Evidence

```
$ pnpm install
$ pnpm test doctor-panel
  Tests  23 passed (23)
$ pnpm run typecheck
  (clean)
```

## Review evidence

자체 리뷰 포인트:

1. **Backend 무변경**: envelope 은 이미 `callback_available` 포함. 이 PR 은 frontend 한정.
2. **Defensive extraction**: 3 malformed 패턴 (null / string / empty object) 모두 테스트. 런타임 crash 불가.
3. **UI 트리거 의도적 배제**: 단순히 badge 만 — HITL 승인 인프라가 준비되기 전 클릭 trigger 추가는 운영 리스크. 본문에 명시.
4. **Accent 색 재사용**: 기존 `var(--accent)` 계열 (accent / accent/10 / accent/40) 로 drift 없이 통일.
5. **i18n**: 배지 "자동 치유" (Korean) — 기존 panel Korean-first 일관.

## Linked issue

Refs:
- #8540 — drill-down (이 PR 의 기반)
- #8539 — polish (title underline)
- #8536 — docs reflect
- #8534 — `<DoctorPanel />` UI
- #8525 — backend endpoint
- #8518 — JSON envelope
- #8375 — shared Doctor framework (`callback_available` field 의 source)

Refs #8540 #8539 #8536 #8534 #8525 #8518 #8375

## 체크리스트

- [x] `SidecarCheckView` 에 `autofix_available`/`autofix_description` 선택 필드
- [x] Defensive `auto_fix` 추출 (null/string/empty-obj 안전)
- [x] 배지 UI (accent palette + title hint)
- [x] fix description 렌더 (accent 텍스트)
- [x] 2 신규 tests (23 pass / typecheck clean)
- [x] Backend 변경 없음
- [ ] 브라우저 UI 실측 — 서버 재기동 후

## Doctor 축 진행도

```
축 1-5                         ✓
축 6-7.5                       ✓
축 8 phase 1 — Backend         ✓ (#8525)
축 8.5 phase 1~4 — UI stack    ✓ (#8533/#8534/#8535/#8540)
축 10 — Docs + Polish          ✓ (#8536, #8539)
축 11 — Autofix badge (UI)     ← 이 PR — callback_available 노출
축 9 — Callback 실체 확장       후속 — 운영 리스크 검토
축 12 — `--fix` trigger 버튼   후속 — HITL approval + audit 설계 후
Phase 2 — In-process endpoint  후속
```

## Out of scope

- 브라우저에서 `--fix` 실행 (HITL + audit 인프라 필요)
- Backend `POST /api/v1/dashboard/doctor/fix` endpoint
- Retry / rollback UI
- Phase 2 in-process endpoint
- Callback 실체 확장 (Python sidecar 내부)
