### PR TITLE
docs(changelog): add Doctor phase 1 entry (Unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Changelog
 
 
+## Unreleased
+
+### Added
+
+- **Doctor phase 1 — 시스템 전반 진단.** MASC 전체(서버 + 5 sidecar)를
+  동일한 `Check/Severity/AutoFix` 모델로 진단하는 Doctor 축을 CLI · HTTP ·
+  Dashboard 3계층으로 일괄 구축. `flutter doctor` / `brew doctor` 외형 참고.
+  - **CLI** — `masc-mcp doctor [config|sidecar <name>|all] [--json]`
+    (`bin/main_eio.ml` 의 `Cmd.group` 으로 backward-compat 유지, 무인자 호출
+    은 기존 `config` 와 동일).
+  - **Fan-out** — `doctor all` 은 config + `discord|slack|telegram|imessage|cli`
+    sidecar 를 순차 실행하고 Korean aggregate summary (`정상/경고/오류`) +
+    per-doctor breakdown 을 출력. `--json` 은 envelope 형태
+    (`{title, doctors[{name, kind, exit_code, payload}], summary, exit_code}`)
+    로 CI · 대시보드 contract 제공. `Doctor_dispatch.aggregate_exit_code` 는
+    `error > warn > ok` 우선순위와 unknown rc → error 상향을 보장.
+  - **HTTP endpoint** — `GET /api/v1/dashboard/doctor` (phase 1: self-subprocess
+    forward, `with_public_read` 권한). 실패 시 5xx + `{error, hint}` 로 운영자
+    원인 안내.
+  - **Dashboard UI** — Lab 탭 → inspector → **Doctor** sub-tab. `<DoctorPanel />`
+    이 envelope 을 poll 해 summary header + 3-column grid 로 렌더. 카드 클릭
+    시 drill-down 으로 sidecar `checks[]` 또는 config `warnings[]` 표시, 자동
+    치유 가능한 check 에는 accent 배지 (실제 `--fix` 실행은 CLI 유지).
+  - **Observability** — `doctor --fix` 가 `FixOutcome` 리스트를 캡처해
+    "자가 치유 실행:" 블록으로 실패 격리(try/except)와 결과 렌더. 세 상태
+    (fix 성공·환경 미해결 / fix 예외 / fix 미정의) 를 구분 가능.
+  - **출력 polish** — sidecar `render_pretty` 제목을 markdown `#` 대신
+    underline 스타일로 전환해 `doctor all` divider 와 시각적 일관성 확보.
+
+  관련 PR (모두 2026-04-19 merge):
+  - Framework (이전 배포): #8375 / #8406 / #8410 / #8432 / #8442 / #8452 / #8457 / #8468
+  - Observability: #8478 (FixOutcome)
+  - CLI dispatch/fan-out: #8481 #8502 #8518
+  - Backend endpoint: #8525
+  - Dashboard UI: #8533 #8534 #8535 #8540 #8541
+  - Polish / docs: #8539 #8536
+
+  Docs: `docs/DOCTOR-ARCHITECTURE.md`, `docs/CONFIG-DOCTOR.md`.
+
+  후속 (phase 2 / 축 9): server endpoint in-process 전환(Eio.Process ~cwd),
+  `--fix` 버튼 HITL approval, 실제 callback 확장.
+
+
 ## [0.10.1] - 2026-04-19
 
 ### Changed


### PR DESCRIPTION
## Summary

CHANGELOG 에 **Doctor phase 1** entry 추가 (Unreleased 섹션). 12 PR 머지 후 CHANGELOG 가 반영되지 않은 drift 정리.

## Product impact

릴리즈 노트 독자 (신규 합류 개발자, 다른 팀) 가 "이번 분기에 Doctor 축이 무엇을 제공하는가" 를 CHANGELOG 한 곳에서 파악.

## 변경

### `CHANGELOG.md`

Unreleased 섹션 신규 — Doctor phase 1 축 6개 요약:

1. **CLI** — `masc-mcp doctor [config|sidecar <name>|all] [--json]` + backcompat
2. **Fan-out** — `doctor all` Korean aggregate + envelope shape
3. **HTTP endpoint** — `GET /api/v1/dashboard/doctor` (phase 1 subprocess)
4. **Dashboard UI** — Lab → inspector → Doctor sub-tab + drill-down + autofix 배지
5. **Observability** — `FixOutcome` 3-state 구분
6. **Polish** — underline title

각 축에 관련 PR 번호 (#8375~#8541) 나열.

후속 (phase 2, 축 9) 명시 — server in-process / `--fix` 버튼 HITL / callback 실체 확장.

## 변경 없는 것

- 코드 (docs-only)
- 기존 [0.10.1] / [0.10.0] / 이전 버전 entry
- 버전 태그 (Unreleased 섹션만, 다음 릴리즈 시 `[0.11.0]` 등으로 승격)
- `docs/DOCTOR-ARCHITECTURE.md` / `docs/CONFIG-DOCTOR.md` (이미 #8536 에서 업데이트됨)

## Linked issue

Refs:
- #8541 — autofix badge
- #8540 — drill-down
- #8539 — title polish
- #8536 — docs reflect
- #8535 — tab mount
- #8534 — panel UI
- #8533 — panel skeleton
- #8525 — backend endpoint
- #8518 — JSON envelope
- #8502 — fan-out
- #8481 — dispatch
- #8478 — FixOutcome

Refs #8541 #8540 #8539 #8536 #8535 #8534 #8533 #8525 #8518 #8502 #8481 #8478

## Out of scope

- 릴리즈 버전 bump (`0.11.0` 등) — 실제 릴리즈 cut 시
- `docs/DOCTOR-ARCHITECTURE.md` (이미 phase 1 반영됨)
- Phase 2 / 축 9 실제 구현
