### PR TITLE
fix(fd-leak): close subprocess pipes on error path — 3 sites (#8538)

### DIFF
--- a/lib/doctor_dispatch.ml
+++ b/lib/doctor_dispatch.ml
@@ -39,19 +39,29 @@ let capture_sidecar_json name =
               python
               [| python; "-m"; "src"; "doctor"; "--json" |]
           in
-          let buf = Buffer.create 4096 in
-          (try
-             while true do
-               Buffer.add_channel buf ic 4096
-             done
-           with End_of_file -> ());
-          let status = Unix.close_process_in ic in
-          let rc =
-            match status with
-            | Unix.WEXITED n -> n
-            | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 2
-          in
-          Ok (Buffer.contents buf, rc)
+          (* Error-path close prevents pipe fd leak when [Buffer.add_channel]
+             raises anything other than End_of_file (Sys_error, Unix_error).
+             Dashboard polls this endpoint — a single leak per poll accumulates
+             fast. Issue #8538. *)
+          try
+            let buf = Buffer.create 4096 in
+            (try
+               while true do
+                 Buffer.add_channel buf ic 4096
+               done
+             with End_of_file -> ());
+            let status = Unix.close_process_in ic in
+            let rc =
+              match status with
+              | Unix.WEXITED n -> n
+              | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 2
+            in
+            Ok (Buffer.contents buf, rc)
+          with e ->
+            ignore
+              (try Unix.close_process_in ic
+               with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
+            raise e
         with e -> Error (Printexc.to_string e)
       in
       Sys.chdir prev;

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -342,18 +342,34 @@ let rec add_routes ~sw ~clock router =
          in
          try
            let ic = Unix.open_process_in cmd in
-           let buf = Buffer.create 8192 in
-           (try
-              while true do
-                Buffer.add_channel buf ic 4096
-              done
-            with End_of_file -> ());
-           let _ = Unix.close_process_in ic in
-           Http.Response.json
-             ~compress:true
-             ~request:req
-             (Buffer.contents buf)
-             reqd
+           (* Error-path close prevents pipe fd leak when [Buffer.add_channel]
+              raises anything other than End_of_file. Dashboard polls this
+              endpoint on an interval — a single leak per poll saturates the
+              per-process pipe limit within ~30 minutes. Issue #8538. *)
+           let buf_result =
+             try
+               let buf = Buffer.create 8192 in
+               (try
+                  while true do
+                    Buffer.add_channel buf ic 4096
+                  done
+                with End_of_file -> ());
+               Ok buf
+             with exn ->
+               ignore
+                 (try Unix.close_process_in ic
+                  with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
+               Error exn
+           in
+           (match buf_result with
+            | Error exn -> raise exn
+            | Ok buf ->
+                let _ = Unix.close_process_in ic in
+                Http.Response.json
+                  ~compress:true
+                  ~request:req
+                  (Buffer.contents buf)
+                  reqd)
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -13,15 +13,24 @@ let run_git_capture_lines ~workdir args =
         Unix.open_process_args_in "git"
           (Array.of_list argv)
       in
-      let rec loop acc =
-        match input_line ic with
-        | line -> loop (line :: acc)
-        | exception End_of_file -> List.rev acc
-      in
-      let lines = loop [] in
-      match Unix.close_process_in ic with
-      | Unix.WEXITED 0 -> Some lines
-      | _ -> None
+      (* Error-path close prevents pipe fd leak when [input_line] raises
+         mid-stream (Sys_error, Unix_error). Mirrors [build_identity.ml]
+         pattern. Issue #8538. *)
+      try
+        let rec loop acc =
+          match input_line ic with
+          | line -> loop (line :: acc)
+          | exception End_of_file -> List.rev acc
+        in
+        let lines = loop [] in
+        match Unix.close_process_in ic with
+        | Unix.WEXITED 0 -> Some lines
+        | _ -> None
+      with exn ->
+        ignore
+          (try Unix.close_process_in ic
+           with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
+        raise exn
     with Sys_error _ | Unix.Unix_error _ -> None
   in
   Eio_guard.run_in_systhread f


### PR DESCRIPTION
## Summary
Fixes #8538 — 2690 leaked PIPE fds saturating the server process within
~30 min and blocking every keeper cycle at Admission_queue.

## Root cause
Three `Unix.open_process*` call sites close the subprocess pipe only on
the success path. A mid-stream raise from `input_line` / `Buffer.add_channel`
(Sys_error, Unix_error) skips `close_process_in` and the pipe fd leaks
into the parent process.

## Sites fixed (most-to-least hot)
- `lib/server/server_routes_http_routes_dashboard.ml:344` — `/api/v1/dashboard/doctor`,
  polled on an interval by the live dashboard UI. Likely dominant leak source
  given the 30-minute saturation cadence the issue reports.
- `lib/doctor_dispatch.ml:38` — sidecar Python doctor runner invoked from
  the same dashboard route.
- `lib/worktree_live_context.ml:13` — git status/worktree probe called
  per keeper turn to hydrate live worktree context.

All three now mirror the existing safe pattern in `lib/build_identity.ml`
(close on both success and exception paths; close errors are ignored since
the subprocess may already be dead).

## Sites audited and left alone
- `lib/graphql_client.ml:78` — already uses `Fun.protect`.
- `lib/build_identity.ml:48` — already has error-path close.
- `lib/server/server_dashboard_http_runtime_info.ml:70` — already has
  error-path close.
- `lib/process/process_eio.ml::spawn_and_drain_{stdout,both}` — pipes are
  `Eio.Switch`-scoped; switch release closes them on any exception.

## Test plan
- [x] `dune build` on the 3 changed files — clean.
- [ ] Deploy + watch `lsof -p <pid> | awk '{print $5}' | sort | uniq -c`
  over ≥1h at production traffic. Pipe count should stay flat, not climb.
- [ ] Watch for Admission_queue `Host_resource_saturated` events — should
  drop to zero if this was the dominant leak path.

## Follow-up (out of scope)
Issue #8538's second mitigation ("per-PID pipe count sampler → WARN > 100")
is additional observability, not a root fix. Worth a separate PR if the
leak returns from another vector.

Closes #8538

🤖 Generated with [Claude Code](https://claude.com/claude-code)