### PR TITLE
fix(variant-ssot): add long_term to keeper_memory_search.kind enum (#8527)

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -779,6 +779,13 @@ let total_cap () : int = 12
 let kind_caps () : (string * int) list =
   [ ("constraints", 2); ("decision", 2); ("next", 2); ("goal", 2); ("progress", 2); ("open_question", 2); ("long_term", 4) ]
 
+(** SSOT for canonical memory kind strings accepted by [keeper_memory_search]
+    and produced by [keeper_memory_bank]. Mirrored (with a sync regression
+    test) in [Tool_shard.memory_kind_enum_strings] because a direct
+    dependency would create a Tool_shard -> Keeper_* -> Tool_shard cycle
+    (#8467/#8480 pattern). Issue #8527. *)
+let valid_memory_kind_strings : string list = List.map fst (kind_caps ())
+
 let cap_for_kind (caps : (string * int) list) (kind : string) : int =
   List.assoc_opt kind caps |> Option.value ~default:1
 

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -23,6 +23,16 @@ let pr_review_event_enum_strings =
 let memory_search_source_enum_strings =
   [ "memory"; "history"; "all" ]
 
+(** Issue #8527: hand-mirrored from
+    [Keeper_memory_policy.valid_memory_kind_strings] (derived from
+    [kind_caps ()]). Same cycle-avoidance pattern as #8467 / #8480 / #8484.
+    Previous hand-list dropped [long_term] even though
+    [keeper_memory_bank] actively writes long_term rows — LLMs could
+    not filter for the very rows the system writes. Sync regression
+    test in [test_types.ml :: memory_kind_ssot] catches drift. *)
+let memory_kind_enum_strings =
+  [ "constraints"; "decision"; "next"; "goal"; "progress"; "open_question"; "long_term" ]
+
 (** Issue #8490: hand-mirrored from
     [Keeper_exec_fs.valid_fs_write_mode_strings]. Direct dependency
     would risk a Tool_shard -> Keeper_* -> Tool_shard cycle (same
@@ -109,13 +119,13 @@ string-interpolating your own keeper name.";
     name = "keeper_memory_search";
     description = "Search memory for past goals, decisions, progress, or conversation history. \
 Returns scored results with metadata. Default searches the structured memory bank. \
-Use 'kind' to filter (goal, decision, progress, next, open_question, constraints). \
+Use 'kind' to filter (goal, decision, progress, next, open_question, constraints, long_term). \
 Use source='history' for raw user messages, source='all' for both.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("query", `Assoc [("type", `String "string"); ("description", `String "keyword to search for")]);
-        ("kind", `Assoc [("type", `String "string"); ("enum", `List [`String "goal"; `String "decision"; `String "progress"; `String "next"; `String "open_question"; `String "constraints"]); ("description", `String "Filter by memory kind")]);
+        ("kind", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) memory_kind_enum_strings)); ("description", `String "Filter by memory kind")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "max results (1-10, default 5)")]);
         (* Issue #8484: derive from local mirror that tracks
            [Keeper_exec_memory.valid_memory_search_source_strings]. *)

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -21,6 +21,11 @@ val sort_order_enum_strings : string list
     catches drift. *)
 val memory_search_source_enum_strings : string list
 
+(** Issue #8527: hand-mirrored from
+    [Keeper_memory_policy.valid_memory_kind_strings]. Sync regression
+    test in [test_types.ml :: memory_kind_ssot] catches drift. *)
+val memory_kind_enum_strings : string list
+
 (** Issue #8490: hand-mirrored from
     [Keeper_exec_fs.valid_fs_write_mode_strings]. Sync regression test
     in [test_types.ml :: fs_write_mode_ssot] catches drift. *)

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -564,6 +564,25 @@ let () =
           Masc_mcp.Keeper_exec_memory.valid_memory_search_source_strings
           Masc_mcp.Tool_shard.memory_search_source_enum_strings);
     ];
+    "memory_kind_ssot", [
+      (* Issue #8527: schema enum for [keeper_memory_search.kind] dropped
+         [long_term] even though [keeper_memory_bank] actively writes
+         long_term rows. Same cycle-avoidance pattern as #8484 — hand
+         mirror in Tool_shard, sync-test the mirror against the SSOT. *)
+      Alcotest.test_case "SSOT includes every kind_caps entry" `Quick (fun () ->
+        let caps = Masc_mcp.Keeper_memory_policy.kind_caps () in
+        Alcotest.(check (list string)) "derived == kind_caps keys"
+          (List.map fst caps)
+          Masc_mcp.Keeper_memory_policy.valid_memory_kind_strings);
+      Alcotest.test_case "long_term is in SSOT" `Quick (fun () ->
+        Alcotest.(check bool) "long_term present" true
+          (List.mem "long_term"
+             Masc_mcp.Keeper_memory_policy.valid_memory_kind_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_memory_policy.valid_memory_kind_strings
+          Masc_mcp.Tool_shard.memory_kind_enum_strings);
+    ];
     "fs_write_mode_ssot", [
       (* Issue #8490: introduces [fs_write_mode] Variant where 5 sites
          previously hand-validated raw strings + relied on an


### PR DESCRIPTION
## Summary
Fixes #8527. `lib/tool_shard.ml` schema enum for
\`keeper_memory_search.kind\` hand-listed 6 kinds but
\`Keeper_memory_policy.kind_caps ()\` defines 7 (long_term was dropped).
\`Keeper_memory_bank\` actively writes long_term rows, so LLMs couldn't
filter for the very kind the system produces.

Same drift class as #8430 / #8471 / #8474 / #8493 / #8513 / #8524.

## Fix
- \`Keeper_memory_policy.valid_memory_kind_strings\` — derived from
  \`kind_caps ()\` keys as SSOT.
- \`Tool_shard.memory_kind_enum_strings\` — hand mirror with the
  cycle-avoidance comment pattern from #8484 / #8490 / #8513. Schema
  derives the \`enum\` list via \`List.map\` instead of hard-coded literals.
- Tool description updated to list all 7 kinds.
- New \`memory_kind_ssot\` test group in \`test_types.ml\`:
  - SSOT == \`kind_caps\` keys
  - long_term present (regression witness)
  - \`Tool_shard\` mirror in sync

## Test
\`dune exec test/test_types.exe\` — 64/64 pass (3 new).

## Scope
Additive. Existing 6-kind clients unchanged; LLM clients gain ability
to filter long_term rows via schema validation.

Closes #8527

🤖 Generated with [Claude Code](https://claude.com/claude-code)