### PR TITLE
fix(variant-ssot): add git_worktree to keeper_shell.op enum (#8524)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -17,6 +17,16 @@ let io_timeout_sec = env_float "MASC_KEEPER_IO_TIMEOUT_SEC" 30.0
 let read_timeout_sec = env_float "MASC_KEEPER_READ_TIMEOUT_SEC" 15.0
 let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
 
+(** Canonical list of [keeper_shell.op] identifiers accepted by the
+    handler below. SSOT: the schema enum (via [Tool_shard] mirror) and
+    the [supported_ops] self-advert both derive from this list. Issue
+    #8524 fixed a drift where the hand-listed schema dropped
+    [git_worktree] even though the handler and self-advert listed it. *)
+let valid_keeper_shell_op_strings : string list =
+  [ "pwd"; "ls"; "cat"; "rg"; "git_status"; "find"; "head"; "tail";
+    "wc"; "tree"; "git_log"; "git_diff"; "git_worktree"; "bash";
+    "git_clone"; "gh" ]
+
 let normalize_gh_command (cmd : string) : string =
   let tokens =
     cmd
@@ -1380,9 +1390,6 @@ let handle_keeper_shell
             , `List
                 (List.map
                    (fun name -> `String name)
-                   [ "pwd"; "ls"; "cat"; "rg"; "git_status";
-                     "find"; "head"; "tail"; "wc"; "tree";
-                     "git_log"; "git_diff"; "git_worktree"; "bash";
-                     "git_clone"; "gh" ]) )
+                   valid_keeper_shell_op_strings) )
           ])
 ;;

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -7,6 +7,13 @@
     Both tools default to the keeper playground unless an explicit
     allowed [cwd] is provided. *)
 
+(** Canonical list of [keeper_shell.op] identifiers accepted by the
+    handler. SSOT for the schema enum (mirrored in
+    [Tool_shard.keeper_shell_op_enum_strings] to avoid a Tool_shard ->
+    Keeper_* -> Tool_shard cycle) and the [supported_ops] self-advert
+    response. Issue #8524. *)
+val valid_keeper_shell_op_strings : string list
+
 val handle_keeper_bash :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -62,6 +62,17 @@ let sort_order_enum_strings =
 let vote_direction_enum_strings =
   [ "up"; "down" ]
 
+(** Issue #8524: hand-mirrored from
+    [Keeper_exec_shell.valid_keeper_shell_op_strings]. Same
+    cycle-avoidance pattern (Tool_shard -> Keeper_* -> Tool_shard).
+    Previous hand-list dropped [git_worktree] even though the handler
+    and [supported_ops] self-advert both listed it. Sync regression
+    test in [test_types.ml :: keeper_shell_op_ssot] catches drift. *)
+let keeper_shell_op_enum_strings =
+  [ "pwd"; "ls"; "cat"; "rg"; "git_status"; "find"; "head"; "tail";
+    "wc"; "tree"; "git_log"; "git_diff"; "git_worktree"; "bash";
+    "git_clone"; "gh" ]
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
@@ -345,7 +356,7 @@ let shell_tools : Types.tool_schema list = [
   {
     name = "keeper_shell";
     description = "Run a safe project shell command. \
-ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone, gh. \
+ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, git_worktree, bash, git_clone, gh. \
 Read-only ops default to the keeper playground. \
 IMPORTANT: paths resolve automatically — use 'repos/X' not '.masc/playground/your-name/repos/X'. Never include the playground prefix in path or cwd. \
 Use cwd to target an explicit allowed directory or cloned repo. \
@@ -359,7 +370,7 @@ git_log/git_diff for repo history, bash for curl/jq/env/which, gh for GitHub PR/
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("op", `Assoc [("type", `String "string"); ("enum", `List [`String "pwd"; `String "ls"; `String "cat"; `String "rg"; `String "git_status"; `String "find"; `String "head"; `String "tail"; `String "wc"; `String "tree"; `String "git_log"; `String "git_diff"; `String "bash"; `String "git_clone"; `String "gh"]); ("description", `String "Command to run")]);
+        ("op", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) keeper_shell_op_enum_strings)); ("description", `String "Command to run")]);
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand for op=gh, e.g. 'pr list --state open'. Do NOT put --repo in cmd; current working dir determines the repo.")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "Target path for ls/cat/rg/find/head/tail/wc/tree")]);
         ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for pwd/git_status/git_log/git_diff/git_worktree/bash. Must stay within keeper playground or an explicit allowed path.")]);

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -37,6 +37,11 @@ val fs_write_mode_enum_strings : string list
     in [test_types.ml :: vote_direction_ssot] catches drift. *)
 val vote_direction_enum_strings : string list
 
+(** Issue #8524: hand-mirrored from
+    [Keeper_exec_shell.valid_keeper_shell_op_strings]. Sync regression
+    test in [test_types.ml :: keeper_shell_op_ssot] catches drift. *)
+val keeper_shell_op_enum_strings : string list
+
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -583,6 +583,25 @@ let () =
           Masc_mcp.Keeper_memory_policy.valid_memory_kind_strings
           Masc_mcp.Tool_shard.memory_kind_enum_strings);
     ];
+    "keeper_shell_op_ssot", [
+      (* Issue #8524: [keeper_shell.op] schema enum dropped git_worktree
+         even though the handler and the [supported_ops] self-advert
+         listed it — same drift class as #8430 / #8471 / #8474 / #8493.
+         The new SSOT [valid_keeper_shell_op_strings] is consumed by the
+         Tool_shard mirror and by the self-advert response, so drift now
+         fails this test at CI time. *)
+      Alcotest.test_case "git_worktree is in SSOT" `Quick (fun () ->
+        Alcotest.(check bool) "git_worktree present" true
+          (List.mem "git_worktree"
+             Masc_mcp.Keeper_exec_shell.valid_keeper_shell_op_strings));
+      Alcotest.test_case "SSOT has 16 ops" `Quick (fun () ->
+        Alcotest.(check int) "count" 16
+          (List.length Masc_mcp.Keeper_exec_shell.valid_keeper_shell_op_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "tool_shard mirror == SSOT"
+          Masc_mcp.Keeper_exec_shell.valid_keeper_shell_op_strings
+          Masc_mcp.Tool_shard.keeper_shell_op_enum_strings);
+    ];
     "fs_write_mode_ssot", [
       (* Issue #8490: introduces [fs_write_mode] Variant where 5 sites
          previously hand-validated raw strings + relied on an


### PR DESCRIPTION
## Summary
Fixes #8524. Schema enum for \`keeper_shell.op\` hand-listed 15 ops but
the handler, alias normalizer, and \`supported_ops\` self-advert all list
16 — \`git_worktree\` was missing from the schema only.

Same drift class as #8430 / #8471 / #8474 / #8493 / #8513.

## Fix
- \`Keeper_exec_shell.valid_keeper_shell_op_strings\` — 16-op SSOT
  exported via the .mli.
- \`supported_ops\` self-advert derives from the SSOT (stops the
  hand-list duplication).
- \`Tool_shard.keeper_shell_op_enum_strings\` — hand mirror with the
  cycle-avoidance comment pattern from #8484 / #8490 / #8513. Schema
  derives enum via \`List.map\`.
- Tool description updated to list 16 ops.
- New \`keeper_shell_op_ssot\` test group (3 cases): git_worktree present,
  count=16, Tool_shard mirror in sync.

## Test
\`dune exec test/test_types.exe\` — 64/64 pass (3 new).

## Scope
Additive. No breaking change to existing 15-op clients; LLM clients
gain ability to invoke \`git_worktree\` via schema validation.

Closes #8524

🤖 Generated with [Claude Code](https://claude.com/claude-code)