### PR TITLE
fix(variant-ssot): derive keeper_schema tail_order enum from Variant (#8486)

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -26,6 +26,15 @@ let network_mode_enum_strings =
 let shared_memory_scope_enum_strings =
   [ "disabled"; "room" ]
 
+(** Issue #8486: hand-mirrored from
+    [Keeper_status_detail.valid_tail_order_strings]. Same cycle-avoidance
+    pattern as #8467 — Keeper_schema cannot depend on Keeper_status_detail
+    directly. Sync regression test in [test_types.ml :: tail_order_ssot]
+    catches drift so a 3rd tail_order constructor added later fails the
+    test instead of silently dropping from the JSON Schema. *)
+let tail_order_enum_strings =
+  [ "oldest_first"; "newest_first" ]
+
 let string_array_schema =
   `Assoc [
     ("type", `String "array");
@@ -350,7 +359,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tail_order", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "oldest_first"; `String "newest_first"]);
+          ("enum", `List (List.map (fun s -> `String s) tail_order_enum_strings));
           ("description", `String "Ordering for metrics/history/compaction tails and recent memory notes. Default: oldest_first (compat).");
         ]);
         ("fast", `Assoc [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -79,6 +79,15 @@ let tail_order_to_string = function
   | Oldest_first -> "oldest_first"
   | Newest_first -> "newest_first"
 
+(** Exhaustive list of [tail_order] constructors. Used to derive the
+    schema enum via [Keeper_schema.tail_order_enum_strings] mirror so a
+    3rd constructor would silently drop from the JSON Schema without
+    the [test_types.ml :: tail_order_ssot] sync test. Issue #8486. *)
+let all_tail_orders : tail_order list = [ Oldest_first; Newest_first ]
+
+let valid_tail_order_strings : string list =
+  List.map tail_order_to_string all_tail_orders
+
 let apply_tail_order order items =
   match order with
   | Oldest_first -> items

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -583,6 +583,25 @@ let () =
           Masc_mcp.Keeper_memory_policy.valid_memory_kind_strings
           Masc_mcp.Tool_shard.memory_kind_enum_strings);
     ];
+    "tail_order_ssot", [
+      (* Issue #8486: [Keeper_status_detail.tail_order] Variant + to_string
+         already existed but the schema enum at [Keeper_schema] was a
+         hand-list — adding a 3rd ordering constructor would have silently
+         dropped from the JSON Schema. Same prevention shape as #8467. *)
+      Alcotest.test_case "witness covers all tail_order variants" `Quick (fun () ->
+        let module K = Masc_mcp.Keeper_status_detail in
+        let witness o =
+          let actual = K.tail_order_to_string o in
+          if not (List.mem actual K.valid_tail_order_strings) then
+            Alcotest.failf "tail_order_to_string %S not in valid_tail_order_strings" actual
+        in
+        witness K.Oldest_first; witness K.Newest_first;
+        Alcotest.(check int) "count" 2 (List.length K.valid_tail_order_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "Keeper_schema mirror == SSOT"
+          Masc_mcp.Keeper_status_detail.valid_tail_order_strings
+          Masc_mcp.Keeper_schema.tail_order_enum_strings);
+    ];
     "fs_write_mode_ssot", [
       (* Issue #8490: introduces [fs_write_mode] Variant where 5 sites
          previously hand-validated raw strings + relied on an


### PR DESCRIPTION
## Summary
Fixes #8486. \`Keeper_status_detail.tail_order\` Variant + \`to_string\`
already existed, but \`Keeper_schema\` hardcoded the JSON Schema enum —
adding a 3rd ordering constructor would silently drop from the schema
(same drift class as #8467 sandbox_profile).

## Fix
- \`Keeper_status_detail.all_tail_orders\` + \`valid_tail_order_strings\`
  derived from the constructor list.
- \`Keeper_schema.tail_order_enum_strings\` hand mirror with the existing
  cycle-avoidance comment pattern. Schema derives the enum via \`List.map\`
  instead of a literal.
- New \`tail_order_ssot\` test group (2 cases): witness + mirror sync.

## Test
\`dune exec test/test_types.exe\` — 63/63 pass (2 new).

## Scope
Prevention only. No current bug — both enum lists match. Change ensures
they cannot drift silently if a third ordering is added later.

Closes #8486

🤖 Generated with [Claude Code](https://claude.com/claude-code)