### PR TITLE
fix(oas-bus): expose warn_threshold via MASC_OAS_BUS_WARN_DEPTH env (#8517)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -82,8 +82,20 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Eio.Switch.on_release sw (fun () ->
     Oas_bus_instrument.unsubscribe masc_event_bus keeper_lifecycle_sub);
   (* Spawn the OAS bus depth sampler so warnings surface on stdout
-     even when /metrics is not scraped. *)
-  Oas_bus_instrument.start_sampler ~sw ~clock ();
+     even when /metrics is not scraped.
+
+     [MASC_OAS_BUS_WARN_DEPTH] lets operators raise the threshold without
+     a rebuild — fleet-wide keeper load legitimately pushes depth past
+     the 200 default at peak (issue #8517). Invalid values fall back to
+     the compile-time default. *)
+  let warn_threshold =
+    match Sys.getenv_opt "MASC_OAS_BUS_WARN_DEPTH" with
+    | Some v -> (match int_of_string_opt (String.trim v) with
+                 | Some n when n > 0 -> n
+                 | _ -> 200)
+    | None -> 200
+  in
+  Oas_bus_instrument.start_sampler ~sw ~clock ~warn_threshold ();
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       (try


### PR DESCRIPTION
## Summary
Fixes #8517. \`start_sampler\`'s \`warn_threshold\` defaults to 200 but
was never overridden at the single call site, so operators had no lever
to suppress depth-201~249 WARN floods that are operationally indistinguishable
from normal peak keeper load.

## Fix
Read \`MASC_OAS_BUS_WARN_DEPTH\` at bootstrap and pass as
\`~warn_threshold\` to \`start_sampler\`. Invalid / missing values fall
back to the existing 200 default. No behavior change for deployments
that do not set the env.

## Scope
One-line knob in \`server_bootstrap_loops.ml\`. No change to
\`oas_bus_instrument.ml\` itself (the optional arg already exists).

## Test plan
- [x] \`dune build lib/server/server_bootstrap_loops.ml\` — clean.
- [ ] Deploy with \`MASC_OAS_BUS_WARN_DEPTH=300\`, confirm 201-249 WARN
  lines stop without losing genuine saturation signals (e.g. depth 500+).

Closes #8517

🤖 Generated with [Claude Code](https://claude.com/claude-code)