### PR TITLE
refactor(fd-leak): extract With_process SSOT + fd regression test (#8538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@
   drift warnings disappear and MASC tracks the current upstream main
   truth again.
 
+### Reliability
+
+- **FD leak SSOT (#8538 Tier 2).** PR #8543 이 3 hot-path call site 에 inline
+  try/with 으로 pipe fd leak 을 막았지만, 같은 패턴을 여러 곳에서 재유도하면
+  drift 가 발생한다. 공통 combinator `With_process.with_process_in` /
+  `with_process_args_in` 을 `lib/process/with_process.ml` 에 추출하고
+  `doctor_dispatch.ml`, `server_routes_http_routes_dashboard.ml`,
+  `worktree_live_context.ml` 세 site 를 SSOT 에 귀속시켜 drift vector 제거.
+  `test/test_with_process_coverage.ml` 이 error path 별 fd 회수와 100-iter
+  stress 를 검증한다. `Fun.protect` 대신 수동 try/with 을 선택한 근거:
+  finally 에서 던져진 예외가 `Fun.Finally_raised` 로 랩핑돼 `Eio.Cancel.Cancelled`
+  의 구조적 취소 정보를 가릴 수 있음 (OCaml stdlib `Fun.protect` spec).
+  후속: `Eio.Process.parse_out` 기반 Tier 3 이관 (follow-up Issue).
 
 ## [0.10.1] - 2026-04-19
 

--- a/lib/doctor_dispatch.ml
+++ b/lib/doctor_dispatch.ml
@@ -34,34 +34,18 @@ let capture_sidecar_json name =
       let result =
         try
           let python = python_bin () in
-          let ic =
-            Unix.open_process_args_in
+          let buf, status =
+            With_process.with_process_args_in
               python
               [| python; "-m"; "src"; "doctor"; "--json" |]
+              With_process.drain_to_buffer
           in
-          (* Error-path close prevents pipe fd leak when [Buffer.add_channel]
-             raises anything other than End_of_file (Sys_error, Unix_error).
-             Dashboard polls this endpoint — a single leak per poll accumulates
-             fast. Issue #8538. *)
-          try
-            let buf = Buffer.create 4096 in
-            (try
-               while true do
-                 Buffer.add_channel buf ic 4096
-               done
-             with End_of_file -> ());
-            let status = Unix.close_process_in ic in
-            let rc =
-              match status with
-              | Unix.WEXITED n -> n
-              | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 2
-            in
-            Ok (Buffer.contents buf, rc)
-          with e ->
-            ignore
-              (try Unix.close_process_in ic
-               with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
-            raise e
+          let rc =
+            match status with
+            | Unix.WEXITED n -> n
+            | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 2
+          in
+          Ok (Buffer.contents buf, rc)
         with e -> Error (Printexc.to_string e)
       in
       Sys.chdir prev;

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -3,5 +3,5 @@
  (name masc_process)
  (public_name masc_mcp.masc_process)
  (wrapped false)
- (modules process_eio file_lock_eio exec_tap)
+ (modules process_eio file_lock_eio exec_tap with_process)
  (libraries masc_core masc_log time_compat eio eio.unix unix threads))

--- a/lib/process/with_process.ml
+++ b/lib/process/with_process.ml
@@ -1,0 +1,55 @@
+(** Exception-safe subprocess stdout capture.
+
+    SSOT for the [Unix.open_process_*] + drain + close pattern.  Extracted
+    in the post-#8543 hardening (#8538) so every call site uses the same
+    error-path close semantics.
+
+    Why not [Fun.protect]?  Its finally-callback gets its exception wrapped
+    in [Fun.Finally_raised], which masks the original exception that matters
+    to callers.  Manual [try/with] lets [Eio.Cancel.Cancelled] and other
+    in-flight exceptions propagate unchanged.
+
+    Why swallow close errors?  Per ocaml/ocaml#2447, [close_process_*] may
+    raise [Failure "equal: abstract value"] when called on already-closed
+    channels.  The close is best-effort; the primary contract is fd reclaim. *)
+
+let close_best_effort ic =
+  try ignore (Unix.close_process_in ic : Unix.process_status)
+  with Unix.Unix_error _ | Sys_error _ | Failure _ -> ()
+
+let with_process_in cmd f =
+  let ic = Unix.open_process_in cmd in
+  match f ic with
+  | result ->
+      let status = Unix.close_process_in ic in
+      (result, status)
+  | exception exn ->
+      close_best_effort ic;
+      raise exn
+
+let with_process_args_in prog argv f =
+  let ic = Unix.open_process_args_in prog argv in
+  match f ic with
+  | result ->
+      let status = Unix.close_process_in ic in
+      (result, status)
+  | exception exn ->
+      close_best_effort ic;
+      raise exn
+
+let drain_to_buffer ?(chunk = 4096) ic =
+  let buf = Buffer.create chunk in
+  (try
+     while true do
+       Buffer.add_channel buf ic chunk
+     done
+   with End_of_file -> ());
+  buf
+
+let drain_lines ic =
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  loop []

--- a/lib/process/with_process.mli
+++ b/lib/process/with_process.mli
@@ -1,0 +1,30 @@
+(** Exception-safe subprocess stdout capture — SSOT for #8538. *)
+
+val with_process_in :
+  string -> (in_channel -> 'a) -> 'a * Unix.process_status
+(** [with_process_in cmd f] opens [cmd] via [Unix.open_process_in], passes
+    the stdout channel to [f], and guarantees [Unix.close_process_in] runs
+    on every exit path.  Returns [f]'s result paired with the subprocess
+    exit status.
+
+    - If [f] raises, the channel is closed (best-effort) and the
+      exception is re-raised.
+    - [Eio.Cancel.Cancelled] is re-raised after close so Eio's structured
+      cancellation is preserved.
+    - Close errors ([Unix.Unix_error], [Sys_error],
+      [Failure "equal: abstract value"] per ocaml/ocaml#2447) are
+      swallowed on the error path; the primary contract is fd reclaim. *)
+
+val with_process_args_in :
+  string -> string array -> (in_channel -> 'a) -> 'a * Unix.process_status
+(** As [with_process_in] but uses [Unix.open_process_args_in] for exact
+    argv control. *)
+
+val drain_to_buffer : ?chunk:int -> in_channel -> Buffer.t
+(** Read [ic] to EOF into a fresh buffer using [Buffer.add_channel].
+    Default chunk size 4096.  Raises anything other than [End_of_file]
+    (e.g. [Sys_error], [Unix.Unix_error]) to the caller — combine with
+    [with_process_in] to close on such faults. *)
+
+val drain_lines : in_channel -> string list
+(** Read [ic] to EOF with [input_line], returning lines in source order. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -341,35 +341,15 @@ let rec add_routes ~sw ~clock router =
            Printf.sprintf "%s doctor all --json" (Filename.quote self_bin)
          in
          try
-           let ic = Unix.open_process_in cmd in
-           (* Error-path close prevents pipe fd leak when [Buffer.add_channel]
-              raises anything other than End_of_file. Dashboard polls this
-              endpoint on an interval — a single leak per poll saturates the
-              per-process pipe limit within ~30 minutes. Issue #8538. *)
-           let buf_result =
-             try
-               let buf = Buffer.create 8192 in
-               (try
-                  while true do
-                    Buffer.add_channel buf ic 4096
-                  done
-                with End_of_file -> ());
-               Ok buf
-             with exn ->
-               ignore
-                 (try Unix.close_process_in ic
-                  with Unix.Unix_error _ | Sys_error _ -> Unix.WEXITED 1);
-               Error exn
+           let buf, _status =
+             With_process.with_process_in cmd
+               (With_process.drain_to_buffer ~chunk:4096)
            in
-           (match buf_result with
-            | Error exn -> raise exn
-            | Ok buf ->
-                let _ = Unix.close_process_in ic in
-                Http.Response.json
-                  ~compress:true
-                  ~request:req
-                  (Buffer.contents buf)
-                  reqd)
+           Http.Response.json
+             ~compress:true
+             ~request:req
+             (Buffer.contents buf)
+             reqd
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,24 +1,22 @@
-(** Run git subprocess and capture stdout lines.
-    Offloaded to a system thread via Eio_unix.run_in_systhread to avoid
-    blocking the Eio scheduler. Falls back to direct execution when
-    called without Eio context (tests, signal handlers). *)
 let run_git_capture_lines ~workdir args =
-  let f () =
-    try
-      let argv = "git" :: "-C" :: workdir :: args in
-      Exec_tap.record
-        ~kind:Exec_tap.Unix_open_process_args_in
-        ~argv ~cwd:workdir ();
-      let lines, status =
-        With_process.with_process_args_in "git" (Array.of_list argv)
-          With_process.drain_lines
-      in
-      match status with
-      | Unix.WEXITED 0 -> Some lines
-      | _ -> None
-    with Sys_error _ | Unix.Unix_error _ -> None
-  in
-  Eio_guard.run_in_systhread f
+  try
+    let argv = [ "git"; "-C"; workdir ] @ args in
+    let raw_source = String.concat " " (List.map Filename.quote argv) in
+    match
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"system/worktree_live_context"
+        ~raw_source
+        ~summary:"worktree live context git capture"
+        ~timeout_sec:5.0
+        argv
+    with
+    | Unix.WEXITED 0, output ->
+        Some
+          (output
+          |> String.split_on_char '\n'
+          |> List.filter (fun line -> String.trim line <> ""))
+    | _ -> None
+  with Sys_error _ | Unix.Unix_error _ -> None
 
 let repo_root_for ~base_path =
   if not (Coord_git.has_git_marker base_path) then None

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,22 +1,24 @@
+(** Run git subprocess and capture stdout lines.
+    Offloaded to a system thread via Eio_unix.run_in_systhread to avoid
+    blocking the Eio scheduler. Falls back to direct execution when
+    called without Eio context (tests, signal handlers). *)
 let run_git_capture_lines ~workdir args =
-  try
-    let argv = [ "git"; "-C"; workdir ] @ args in
-    let raw_source = String.concat " " (List.map Filename.quote argv) in
-    match
-      Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"system/worktree_live_context"
-        ~raw_source
-        ~summary:"worktree live context git capture"
-        ~timeout_sec:5.0
-        argv
-    with
-    | Unix.WEXITED 0, output ->
-        Some
-          (output
-          |> String.split_on_char '\n'
-          |> List.filter (fun line -> String.trim line <> ""))
-    | _ -> None
-  with Sys_error _ | Unix.Unix_error _ -> None
+  let f () =
+    try
+      let argv = "git" :: "-C" :: workdir :: args in
+      Exec_tap.record
+        ~kind:Exec_tap.Unix_open_process_args_in
+        ~argv ~cwd:workdir ();
+      let lines, status =
+        With_process.with_process_args_in "git" (Array.of_list argv)
+          With_process.drain_lines
+      in
+      match status with
+      | Unix.WEXITED 0 -> Some lines
+      | _ -> None
+    with Sys_error _ | Unix.Unix_error _ -> None
+  in
+  Eio_guard.run_in_systhread f
 
 let repo_root_for ~base_path =
   if not (Coord_git.has_git_marker base_path) then None

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,7 @@
         test_safe_ops
         test_json_util
         test_process_eio_coverage
+        test_with_process_coverage
         test_provider_adapter
         test_worker_container_coverage
         test_resilience
@@ -480,6 +481,7 @@
         test_safe_ops
         test_json_util
         test_process_eio_coverage
+        test_with_process_coverage
         test_provider_adapter
         test_worker_container_coverage
         test_resilience

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -443,7 +443,7 @@ let () =
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         Alcotest.(check (list string)) "tool_schemas mirror == SSOT"
           Masc_mcp.Tool_misc_admin.valid_admin_section_strings
-          Masc_tool_schemas.Tool_schemas_misc.admin_section_enum_strings);
+          Tool_schemas_misc.admin_section_enum_strings);
     ];
     "config_category_ssot", [
       Alcotest.test_case "producer helper matches all_categories order" `Quick (fun () ->

--- a/test/test_with_process_coverage.ml
+++ b/test/test_with_process_coverage.ml
@@ -35,7 +35,7 @@ let test_sys_error_closes_pipe () =
          (fun _ic -> raise (Sys_error "synthetic"))
      in
      ()
-   with Sys_error "synthetic" -> raised := true);
+   with Sys_error msg when msg = "synthetic" -> raised := true);
   check bool "exception propagated" true !raised;
   (* give kernel a moment to reclaim *)
   let after = count_open_fds () in

--- a/test/test_with_process_coverage.ml
+++ b/test/test_with_process_coverage.ml
@@ -1,0 +1,108 @@
+open Alcotest
+
+module WP = Masc_mcp.With_process
+
+(* ----- fd counting helper ---------------------------------------------- *)
+
+(** Count open file descriptors for this process via lsof.  Uses WP itself
+    so that leaks in the helper surface as baseline drift, not silent. *)
+let count_open_fds () =
+  let pid = Unix.getpid () in
+  let cmd = Printf.sprintf "lsof -p %d 2>/dev/null | wc -l" pid in
+  let lines, _ = WP.with_process_in cmd WP.drain_lines in
+  match lines with
+  | [] -> 0
+  | line :: _ -> (try int_of_string (String.trim line) with _ -> 0)
+
+(* ----- tests ----------------------------------------------------------- *)
+
+let test_happy_path () =
+  let lines, status =
+    WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "hello" |]
+      WP.drain_lines
+  in
+  check (list string) "stdout lines" [ "hello" ] lines;
+  (match status with
+   | Unix.WEXITED 0 -> ()
+   | _ -> fail "expected WEXITED 0")
+
+let test_sys_error_closes_pipe () =
+  let before = count_open_fds () in
+  let raised = ref false in
+  (try
+     let _ : unit * Unix.process_status =
+       WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "fail" |]
+         (fun _ic -> raise (Sys_error "synthetic"))
+     in
+     ()
+   with Sys_error "synthetic" -> raised := true);
+  check bool "exception propagated" true !raised;
+  (* give kernel a moment to reclaim *)
+  let after = count_open_fds () in
+  check bool
+    (Printf.sprintf "fd delta bounded before=%d after=%d" before after)
+    true (after <= before + 1)
+
+let test_cancelled_closes_pipe_and_reraises () =
+  let before = count_open_fds () in
+  let raised = ref false in
+  (try
+     let _ : unit * Unix.process_status =
+       WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "c" |]
+         (fun _ic -> raise (Eio.Cancel.Cancelled (Failure "synthetic")))
+     in
+     ()
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "cancelled re-raised" true !raised;
+  let after = count_open_fds () in
+  check bool
+    (Printf.sprintf "fd delta bounded before=%d after=%d" before after)
+    true (after <= before + 1)
+
+let test_stress_no_leak () =
+  let before = count_open_fds () in
+  for _ = 1 to 100 do
+    try
+      let _ : unit * Unix.process_status =
+        WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "x" |]
+          (fun _ic -> raise (Sys_error "drop"))
+      in
+      ()
+    with Sys_error _ -> ()
+  done;
+  let after = count_open_fds () in
+  (* tolerate +2 for lsof transient fds, but NOT +100 *)
+  check bool
+    (Printf.sprintf "100-iter fd delta bounded before=%d after=%d"
+       before after)
+    true (after <= before + 2)
+
+let test_drain_to_buffer () =
+  let buf, _ =
+    WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "ab" |]
+      WP.drain_to_buffer
+  in
+  check string "buffer contents" "ab\n" (Buffer.contents buf)
+
+let () =
+  run "with_process"
+    [
+      ( "happy_path",
+        [
+          test_case "echo returns stdout" `Quick test_happy_path;
+          test_case "drain_to_buffer fills buffer" `Quick
+            test_drain_to_buffer;
+        ] );
+      ( "error_path",
+        [
+          test_case "Sys_error in callback closes pipe" `Quick
+            test_sys_error_closes_pipe;
+          test_case "Cancelled in callback closes and re-raises" `Quick
+            test_cancelled_closes_pipe_and_reraises;
+        ] );
+      ( "stress",
+        [
+          test_case "100 iterations with exceptions — fd bounded" `Quick
+            test_stress_no_leak;
+        ] );
+    ]

--- a/test/test_with_process_coverage.ml
+++ b/test/test_with_process_coverage.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-module WP = Masc_mcp.With_process
+module WP = With_process
 
 (* ----- fd counting helper ---------------------------------------------- *)
 


### PR DESCRIPTION
## Summary
This PR extracts the `With_process` SSOT for process-lifetime handling and adds fd regression coverage for the Tier 2 follow-up of #8538.

## Why (P0 #8538 — Tier 2)

Production PID 49775 accumulated **2690 PIPE file descriptors** within ~30 min, saturating the admission-queue FD gate and wedging every keeper cycle for ~14 hours. Zero git activity during that window.

#8543 patched three dashboard-polled sites with inline `try/with close; raise`. That blocks the immediate leak. **Tier 2 removes the drift vector**: every future `Unix.open_process_*` call site re-derives the same error-path dance. A single omission (seen daily in review churn) reintroduces the same saturation.

## What

- **New SSOT** `lib/process/with_process.ml` (+`.mli`) — 4 public combinators:
  - `with_process_in` / `with_process_args_in` — guarantee `close_process_in` on success, exception, and `Eio.Cancel.Cancelled`
  - `drain_to_buffer` / `drain_lines` — the two drain idioms the 3 sites used

- **Migrate** the 3 #8543 sites to the helper: -75 / +40 LOC
  - `lib/doctor_dispatch.ml` (python sidecar)
  - `lib/server/server_routes_http_routes_dashboard.ml` (/api/v1/dashboard/doctor)
  - `lib/worktree_live_context.ml` (git capture)

- **Regression test** `test/test_with_process_coverage.ml`:
  - happy path, Sys_error, Cancelled, 100-iter stress, drain_to_buffer
  - FD counter itself dogfoods `with_process_in` — helper regression corrupts own baseline

## Design decision: manual try/with vs Fun.protect

Deliberately **not** `Fun.protect`. Its finally-callback wraps raised exceptions in `Fun.Finally_raised`, masking the original — and for `Eio.Cancel.Cancelled` that breaks Eio's structured cancellation propagation. Close-side errors are swallowed per [ocaml/ocaml#2447](https://github.com/ocaml/ocaml/issues/2447) (channel hash-table abstract-equality can raise on double-close).

Sources: [OCaml Fun docs](https://ocaml.org/api/Fun.html), [discuss.ocaml.org leaking processes](https://discuss.ocaml.org/t/leaking-processes/9339), [Eio Process API](https://ocaml-multicore.github.io/eio/eio/Eio/Process/index.html).

## Not in scope (follow-ups)

- **Tier 3** — migrate remaining raw `Unix.open_process_*` (`build_identity`, `graphql_client`, `runtime_info`, `masc_tui_ansi`) to `Eio.Process.parse_out` with switch-scoped lifetime. Those are already error-path safe; migration is structural alignment with OCaml 5 / Eio idioms.
- **CI fd-bounds smoke** — add `lsof` bound to `scripts/ci/health-smoke.sh` so the helper's regression test runs in CI for every PR, not only this module's.

## Verification

Local `dune build @lib/process/all` → green. Full repo build blocked by pre-existing `agent_sdk.swarm` local-opam drift (unrelated); CI environment is authoritative.

## Test plan

- [ ] CI green
- [ ] Post-merge: restart prod server, curl /api/v1/dashboard/doctor 200x, `lsof -p $PID | grep PIPE | wc -l` < 20
- [ ] File Tier 3 follow-up Issue with call-site inventory

Refs #8538

## Product impact
- hardens process-lifetime cleanup on three hot paths that previously leaked FDs under error cases
- follow-up review on this PR should still assume the branch needs conflict cleanup before merge because the local worktree currently has unresolved merge state

## Evidence
- local `dune build @lib/process/all` was the original focused proof
- branch remains the Tier 2 extraction of the fd-leak remediation path for #8538

## Review evidence
- self-review on helper API shape (`with_process_in`, `with_process_args_in`, `drain_to_buffer`, `drain_lines`) and the three migrated call sites
- PR hygiene sections now match the expected planning surface

## Linked issue
- Refs #8538