### PR TITLE
fix(masc_tool_admin_update): admin_section Variant SSOT — 4-way drift (#8546)

### DIFF
--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -181,7 +181,7 @@ let manual_help_entry name =
             ];
           prompt_hints =
             [
-              "Use before changing auth or unit policy to confirm what is actually enforced.";
+              "Use before changing auth to confirm what is actually enforced.";
             ];
         }
   | "masc_tool_admin_update" ->
@@ -189,16 +189,26 @@ let manual_help_entry name =
         {
           name;
           short_description =
-            "Apply auth or unit-policy updates through a single admin entrypoint.";
+            "Apply auth updates through a single admin entrypoint.";
           when_to_use =
-            "Use when you need to change auth settings or update a unit policy envelope.";
+            "Use when you need to change auth settings (enable/disable, default role, token expiry).";
           key_constraints =
             [
-              "Section must be one of: auth | unit_policy.";
-              "Unit tool/model allowlists now affect command-plane routing and assignment when capability tags are present; worker-runtime per-tool enforcement is still a follow-up slice.";
+              (* Issue #8546: derive from the schema-side mirror.
+                 Tool_help_registry → Capability_registry → Tool_misc_admin
+                 is an existing chain, so referencing Tool_misc_admin here
+                 would close a cycle. The schema mirror in
+                 [Tool_schemas_misc] lives in the leaf [masc_tool_schemas]
+                 library, which the cycle-aware sync test in
+                 [test/test_types.ml :: admin_section_ssot] keeps aligned
+                 with the SSOT. Adding a section therefore flows:
+                 Variant → schema mirror → help text, with no cycle. *)
+              Printf.sprintf "Section must be one of: %s."
+                (String.concat " | "
+                   Tool_schemas_misc.admin_section_enum_strings);
             ];
           details_markdown =
-            "Delegates to the existing truthful write paths: Config mode updates, Auth config persistence, managed-operation unit policy updates, and keeper meta policy updates. Command-plane unit policy now feeds routing/assignment gates; deeper worker-runtime enforcement remains a separate step.";
+            "Delegates to the existing truthful write path: Auth config persistence (load/save under base_path).";
           doc_refs =
             [
               "docs/COMMAND-PLANE-RUNBOOK.md";

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -17,6 +17,32 @@ type context = {
   agent_name: string;
 }
 
+(** Issue #8546: Variant SSOT for [masc_tool_admin_update.section].
+
+    Schema previously listed [unit_policy] and the description hinted at
+    [keeper-policy], but the dispatcher only routed [auth] — clients
+    following the schema received [section must be one of: auth].
+
+    Adding a new section requires extending this Variant; the schema
+    enum, help text, and dispatcher error message all derive from
+    [valid_admin_section_strings], so they cannot drift. The mirror in
+    [Tool_schemas_misc.admin_section_enum_strings] stays in sync via
+    [test/test_types.ml :: admin_section_ssot] (cycle-avoidance:
+    tool_schemas → masc_mcp would cycle). *)
+type admin_section = Auth
+
+let admin_section_to_string = function
+  | Auth -> "auth"
+
+let all_admin_sections : admin_section list = [ Auth ]
+
+let valid_admin_section_strings : string list =
+  List.map admin_section_to_string all_admin_sections
+
+let admin_section_of_string_opt = function
+  | "auth" -> Some Auth
+  | _ -> None
+
 (* ================================================================ *)
 (* Local helpers (duplicated from tool_misc to avoid circular deps) *)
 (* ================================================================ *)
@@ -255,11 +281,15 @@ let handle_tool_admin_snapshot ctx args =
   (true, Yojson.Safe.to_string payload)
 
 let handle_tool_admin_update ctx args =
-  let section =
+  let raw =
     get_string args "section" "" |> String.trim |> String.lowercase_ascii
   in
-  match section with
-  | "auth" ->
+  match admin_section_of_string_opt raw with
+  | None ->
+      ( false,
+        Printf.sprintf "section must be one of: %s"
+          (String.concat " | " valid_admin_section_strings) )
+  | Some Auth ->
       let current = Auth.load_auth_config ctx.config.base_path in
       let require_token =
         match bool_arg_opt args "require_token" with
@@ -318,5 +348,3 @@ let handle_tool_admin_update ctx args =
               ]
           in
           (true, Yojson.Safe.to_string payload))
-  | _ ->
-      (false, "section must be one of: auth")

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -17,6 +17,14 @@ let config_category_enum_strings =
     "web_search"; "session";
   ]
 
+(** Issue #8546: mirror of [Tool_misc_admin.valid_admin_section_strings].
+    [tool_schemas] is a leaf library that cannot depend on [masc_mcp]
+    without introducing the cycle this split was designed to break, so
+    the section enum is duplicated here with a sync test in
+    [test/test_types.ml :: admin_section_ssot]. Add a constructor to the
+    Variant and append the matching string here when extending sections. *)
+let admin_section_enum_strings = [ "auth" ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_config";
@@ -199,15 +207,24 @@ Uses configured web-search providers with structured fallback behavior and retur
   };
   {
     name = "masc_tool_admin_update";
-    description = "Apply auth, unit-policy, or keeper-policy updates through a single admin entrypoint. \
-Use when toggling auth or updating unit/keeper policies. \
-After masc_tool_admin_snapshot to review current state before making changes.";
+    description = "Apply auth updates through a single admin entrypoint. \
+Use when toggling auth, rotating secrets, or changing the default role. \
+Run masc_tool_admin_snapshot first to review current state before making changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("section", `Assoc [
+          (* Issue #8546: hand mirror of
+             [Tool_misc_admin.valid_admin_section_strings]. tool_schemas
+             cannot depend on masc_mcp without a cycle, so the schema
+             enum is mirrored here and the sync test in
+             [test/test_types.ml :: admin_section_ssot] asserts the two
+             stay aligned. The handler dispatches Variant-exhaustively;
+             listing a string here that the dispatcher does not handle
+             would surface a "section must be one of …" error to LLM
+             clients (the original drift symptom this SSOT prevents). *)
           ("type", `String "string");
-          ("enum", `List [`String "auth"; `String "unit_policy"]);
+          ("enum", `List (List.map (fun s -> `String s) admin_section_enum_strings));
           ("description", `String "Config section to update");
         ]);
         ("enabled", `Assoc [
@@ -230,18 +247,6 @@ After masc_tool_admin_snapshot to review current state before making changes.";
         ("token_expiry_hours", `Assoc [
           ("type", `String "integer");
           ("description", `String "Token expiry in hours for section=auth");
-        ]);
-        ("unit_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Managed unit id for section=unit_policy");
-        ]);
-        ("policy", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Unit policy envelope for section=unit_policy");
-        ]);
-        ("budget", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Unit budget envelope for section=unit_policy");
         ]);
       ]);
       ("required", `List [`String "section"]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -686,6 +686,45 @@ let () =
         Alcotest.(check bool) "trending present" true (List.mem "trending" actual);
         Alcotest.(check bool) "discussed present" true (List.mem "discussed" actual));
     ];
+    "admin_section_ssot", [
+      (* Issue #8546: Variant SSOT for masc_tool_admin_update.section.
+         The schema previously listed [unit_policy] but the dispatcher
+         only routed [auth] — clients following the schema received
+         [section must be one of: auth]. The witness here covers all
+         constructors, the mirror check pins the schema enum to the SSOT,
+         and the regression case asserts the broken [unit_policy] entry
+         did not creep back in. *)
+      Alcotest.test_case "witness covers all sections" `Quick (fun () ->
+        let open Masc_mcp.Tool_misc_admin in
+        let witness s =
+          let n = admin_section_to_string s in
+          if not (List.mem n valid_admin_section_strings) then
+            Alcotest.failf
+              "admin_section_to_string %S not in valid_admin_section_strings"
+              n
+        in
+        witness Auth;
+        Alcotest.(check int) "all_admin_sections count"
+          (List.length all_admin_sections)
+          (List.length valid_admin_section_strings));
+      Alcotest.test_case "schema mirror == SSOT" `Quick (fun () ->
+        Alcotest.(check (list string))
+          "tool_schemas_misc mirror"
+          Masc_mcp.Tool_misc_admin.valid_admin_section_strings
+          Tool_schemas_misc.admin_section_enum_strings);
+      Alcotest.test_case "unit_policy is not advertised (regression #8546)" `Quick (fun () ->
+        let strs = Masc_mcp.Tool_misc_admin.valid_admin_section_strings in
+        Alcotest.(check bool) "unit_policy absent" false
+          (List.mem "unit_policy" strs);
+        Alcotest.(check bool) "unit_policy absent in schema mirror" false
+          (List.mem "unit_policy" Tool_schemas_misc.admin_section_enum_strings));
+      Alcotest.test_case "of_string_opt round-trips" `Quick (fun () ->
+        let open Masc_mcp.Tool_misc_admin in
+        Alcotest.(check bool) "auth round-trips" true
+          (admin_section_of_string_opt "auth" = Some Auth);
+        Alcotest.(check bool) "unknown returns None" true
+          (admin_section_of_string_opt "unit_policy" = None));
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8546. `masc_tool_admin_update` had a **4-way drift** between schema, description, help text, and dispatcher: schema enum advertised `unit_policy`, description hinted at `keeper-policy`, help text repeated `unit_policy`, but the handler only routed `auth` and rejected anything else with the conflicting message `"section must be one of: auth"`. Same drift class as #8430 / #8471 / #8474 / #8493 / #8513 / #8524 / #8527 / #8544 — 7th REAL bug found via the Variant SSOT sweep.

## Fix

- `Tool_misc_admin.admin_section` Variant (currently `Auth`) + `to_string` / `all_admin_sections` / `valid_admin_section_strings` / `admin_section_of_string_opt`. Adding a section means appending a constructor — schema, help, and error message refresh automatically.
- `handle_tool_admin_update` dispatches via `admin_section_of_string_opt` with exhaustive Variant match; unknown sections produce `"section must be one of: <SSOT-derived list>"` (no more conflicting hard-coded `"auth"` string).
- `Tool_schemas_misc.admin_section_enum_strings` — hand mirror with the cycle-avoidance comment (cycle: `tool_schemas → masc_mcp → tool_schemas`). Schema enum derives from this mirror.
- Removed unused `unit_id` / `policy` / `budget` schema fields that no dispatcher consumed.
- Description trimmed to current capability (`"auth"`); fictional `unit-policy` / `keeper-policy` references removed.
- `Tool_help_registry.ml` derives the constraint from the schema mirror (not from `Tool_misc_admin`) to avoid closing the existing `Tool_help_registry → Capability_registry → Tool_misc_admin` chain. Prompt hint for `masc_tool_admin_snapshot` trimmed similarly.

## Tests

`test/test_types.ml :: admin_section_ssot` — 4 cases
- witness covers `Auth` (regression-proofs adding constructors)
- schema mirror == SSOT (drift gate)
- `unit_policy` NOT advertised in either layer (regression gate for the original symptom)
- `of_string_opt` round-trips (`auth → Some Auth`, `unit_policy → None`)

## Test plan

- [x] Cycle (`Tool_help_registry → Capability_registry → Tool_misc_admin`) verified absent — `dune build lib` reports only the unrelated `agent_sdk.swarm` env miss.
- [x] Code paths preserved: existing `Auth.load_auth_config` / `Auth.save_auth_config` / `Auth.enable_auth` / `Auth.disable_auth` flows untouched.
- [ ] CI green (drift gate runs `admin_section_ssot`).

15th SSOT site overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)