### PR TITLE
fix(dashboard): close doctor subprocess pipe on every exit path

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -340,15 +340,22 @@ let rec add_routes ~sw ~clock router =
          let cmd =
            Printf.sprintf "%s doctor all --json" (Filename.quote self_bin)
          in
+         (* Fun.protect guarantees close_process_in on every exit path
+            (End_of_file, Eio.Cancel.Cancelled, read errors). Without it the
+            subprocess FD pair and the zombie child leak per request, and a
+            busy dashboard polling this endpoint exhausts the server FD
+            budget (observed 2703/3000 after ~6h of polling). *)
          try
            let ic = Unix.open_process_in cmd in
            let buf = Buffer.create 8192 in
-           (try
-              while true do
-                Buffer.add_channel buf ic 4096
-              done
-            with End_of_file -> ());
-           let _ = Unix.close_process_in ic in
+           Fun.protect
+             ~finally:(fun () -> ignore (Unix.close_process_in ic))
+             (fun () ->
+               try
+                 while true do
+                   Buffer.add_channel buf ic 4096
+                 done
+               with End_of_file -> ());
            Http.Response.json
              ~compress:true
              ~request:req


### PR DESCRIPTION
## 문제

Production 서버 (PID 49775, 14h uptime) 에서 admission queue 가 FD 2703/3000 (90%) 로 포화되어 모든 keeper turn 이 거부됨:

\`\`\`
[ERROR] [Keeper] cheolsu: keeper cycle FAILED ... error=Internal error: Masc_mcp.Admission_queue.Host_resource_saturated(\"fd count 2703 >= 90% of threshold 3000\")
\`\`\`

lsof 실측:
- 총 FD 2709 중 **2691 (99.3%) 가 PIPE**
- read/write 쌍으로 묶이는 ~1345 pipe pair 누수
- Hex node id 중복 없음 (각 pair 독립)

## 근본 원인

#8525 가 추가한 \`/api/v1/dashboard/doctor\` endpoint 가 \`Unix.open_process_in\` + \`Unix.close_process_in\` 을 raw try/with 안에 둠:

\`\`\`ocaml
try
  let ic = Unix.open_process_in cmd in
  (try while true do Buffer.add_channel buf ic 4096 done
   with End_of_file -> ());
  let _ = Unix.close_process_in ic in
  (* 응답 *)
with
| Eio.Cancel.Cancelled _ as exn -> raise exn  (* ← ic 닫지 않고 raise *)
| exn -> (* 500 응답 *)                        (* ← ic 닫지 않음 *)
\`\`\`

- \`Eio.Cancel\` (client abort, 서버 종료, timeout) 에서 \`close_process_in\` 스킵 → FD pair + zombie child 누수
- \`Buffer.add_channel\` 실패 (EIO, SIGPIPE) 에서도 동일

Dashboard polling 이 endpoint 를 주기적으로 호출하면서 cancel/error 케이스마다 1 pair 누수 → 14h 동안 1345 pair 누적.

## 수정

\`Fun.protect ~finally:(Unix.close_process_in ic)\` 로 감싸 exit-path 와 무관하게 자식 프로세스를 거둠. 기존 outer try/with 는 500 error response 로직 그대로 유지.

## Trace 재구성

| 시점 | 이벤트 |
|-----|-------|
| #8525 merge | endpoint 라이브 |
| Dashboard 에서 주기 poll 시작 | 각 cancel 마다 1 pipe pair leak |
| ~6h 경과 | FD 2703/3000 90% 초과 |
| Admission gate trip | 모든 keeper turn Host_resource_saturated |
| 사용자 보고 | cheolsu/analyst cycle FAILED 로그 |

## 테스트

- 로컬 build 는 concurrent dune (다른 worktree 의 \`main_eio.exe\` build) 와 경합으로 pending — CI 에 위임
- 변경은 lib/server/server_routes_http_routes_dashboard.ml 13 줄 추가 / 6 줄 수정, 해당 모듈에 전용 test 없음 (추가 test 는 follow-up)

## 후속

- OPS: PID 49775 재시작 완료 확인 (FD 0/3000) — 즉시 완화 됨
- 이 PR: 영구 fix
- Follow-up 검토: 다른 \`Unix.open_process_*\` 사이트 (\`build_identity.ml\`, \`graphql_client.ml\`, \`worktree_live_context.ml\`, \`doctor_dispatch.ml\`) 도 같은 패턴 점검

🤖 Generated with [Claude Code](https://claude.com/claude-code)