### PR TITLE
fix(mission): classify root-level incidents as internal attention (#8395)

### DIFF
--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -388,8 +388,15 @@ let rec evidence_preview_strings json =
       fields |> List.map snd |> List.concat_map evidence_preview_strings |> dedup_strings |> take 4
   | _ -> []
 
+(* Issue #8395: [Operator_digest] canonicalizes root-level attention to
+   [target_type="root"] but also accepts the aliases "namespace" and
+   "room" via [Operator_digest_types.is_root_alias]. This predicate
+   previously compared only to the literal "room", so root-level
+   incidents (the canonical form) fell through to the public queue.
+   Delegate to the shared alias check so every root variant is treated
+   as internal attention — identical to [Dashboard_mission_assembly]. *)
 let is_internal_attention incident =
-  String.equal (string_field "target_type" incident) "room"
+  Operator_digest_types.is_root_alias (string_field "target_type" incident)
 
 let related_sessions_for_attention incident sessions =
   let direct_session =

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -161,12 +161,13 @@ let test_dashboard_mission_projection () =
         |> List.find (fun row ->
                row |> member "agent_name" |> to_string = "llama-local-alpha")
       in
-      check bool "attention_queue present" true (attention_queue <> []);
-      (* Team_session_store removed — session-derived attention items
-         (spawn_failure_present, local64_role_gap, routing_escalation_present)
-         no longer appear. The top item is now pending_confirm_waiting. *)
-      check string "top attention kind" "pending_confirm_waiting"
-        (attention_queue |> List.hd |> member "kind" |> to_string);
+      (* After #8395 (#8563), root-level incidents are reclassified as
+         internal_signals. The clean fixture has no non-root attention
+         source — pending_confirm_waiting is root-scoped — so
+         attention_queue is expected to be empty. The pending-confirm
+         assertion has moved to internal_signals (see below). *)
+      check bool "attention_queue is public-only (empty in clean fixture)" true
+        (attention_queue = []);
       check bool "mission summary trims paused" true
         (summary |> member "paused" = `Null);
       check bool "mission summary trims active_agents" true


### PR DESCRIPTION
## Summary
Fixes #8395. `Dashboard_mission.is_internal_attention` compared only
to the literal `target_type="room"`, but `Operator_digest`
canonicalizes to `"root"` and accepts `"namespace"`/`"room"`
aliases via `Operator_digest_types.is_root_alias`. Root-level incidents
(the canonical form) leaked into the public queue.

`Dashboard_mission_assembly.is_internal_attention` — the sibling
predicate — already delegates to the alias check. The mission-side copy
was left behind when the canonicalizer was introduced.

## Fix
One-line swap from literal equality to `Operator_digest_types.is_root_alias`.
Both modules live in the same library, so no new dependency.

## Behavior
- `target_type="room"` → still internal (preserved)
- `target_type="root"` → now internal (was public, bug)
- `target_type="namespace"` → now internal (was public, bug)
- `target_type="keeper"` / anything else → still public

Closes #8395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product impact
- fixes a real classification bug: root-level incidents no longer leak into the public attention queue
- this branch now also carries the current OAS metadata compatibility fix and the matching dashboard mission test assertion update

## Evidence
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 dune exec --root . ./test/test_dashboard_mission.exe`
- fixture `pending_confirm_waiting` with `target_type="root"` now lands in `internal_signals`, and `attention_queue` is expected to be empty

## Review evidence
- self-review on the one-line predicate swap and the follow-up test correction for the changed root-target semantics
- branch also includes the `evt.meta` wildcard pattern so warning-as-error builds tolerate the added `caused_by` field

## Linked issue
- Closes #8395
- Refs #8579