### PR TITLE
chore(server): SSOT for /health/live and /health/ready (#8403)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -128,8 +128,10 @@ let make_extended_handler routes =
     let path = Http.Request.path request in
     let skip_rate_limit =
       String.equal path "/health"
-      || String.equal path "/health/live"
-      || String.equal path "/health/ready"
+      (* Issue #8403: derive probe exemptions from Server_health_paths SSOT
+         so a renamed probe stays exempt from rate limits without a
+         separate manual edit here. *)
+      || Masc_mcp.Server_health_paths.is_public path
     in
     let rl_key = Masc_mcp.Rate_limit.key_of_sockaddr client_addr in
     if (not skip_rate_limit) && not (Masc_mcp.Rate_limit.check_global ~key:rl_key) then

--- a/lib/dune
+++ b/lib/dune
@@ -107,6 +107,7 @@
    server_dashboard_http_cache
    server_dashboard_http_link_preview
    server_dashboard_http_core
+   server_health_paths
    server_routes_http
    server_routes_http_common
    server_routes_http_pages

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -385,8 +385,10 @@ let with_admin_auth handler request reqd =
 (** Public read access - no auth required (dashboard, health) *)
 let is_public_read_path path =
   String.equal path "/health"
-  || String.equal path "/health/live"
-  || String.equal path "/health/ready"
+  (* Issue #8403: derive probe whitelist from Server_health_paths SSOT
+     so adding/renaming a probe automatically refreshes the auth filter
+     instead of leaking an auth-required probe through. *)
+  || Server_health_paths.is_public path
   || String.equal path "/api/v1/gate/health"
   || String.equal path "/api/v1/gate/status"
   || String.equal path "/api/v1/gate/connectors"

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -177,7 +177,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd body ~extra_headers:cors
 
-      | `GET, "/health/live" ->
+      | `GET, p when String.equal p Server_health_paths.liveness ->
           let body =
             Yojson.Safe.to_string
               (`Assoc [
@@ -187,7 +187,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd body ~extra_headers:cors
 
-      | `GET, "/health/ready" ->
+      | `GET, p when String.equal p Server_health_paths.readiness ->
           let current = Server_startup_state.(!state) in
           let body, status =
             if current.state_ready then

--- a/lib/server/server_health_paths.ml
+++ b/lib/server/server_health_paths.ml
@@ -1,0 +1,30 @@
+(** Issue #8403: SSOT for health probe paths.
+
+    The strings ["/health/live"] and ["/health/ready"] previously
+    appeared 9 times across 5 files (HTTP/1 router, H/2 gateway, auth
+    public-read whitelist, startup-takeover liveness probe default,
+    and bin startup path filter) with no shared constant. Adding a
+    third probe (e.g. ["/health/startup"]) required hand-editing all
+    five sites, and renaming an existing probe required hand-keeping
+    the auth whitelist and startup filter aligned with the router —
+    silent drift was the failure mode (whitelist drift hid an
+    auth-required probe; route drift broke external monitors).
+
+    Callers should reference these constants by name. The list
+    [public] is what the auth/startup filters whitelist; adding a
+    new probe means adding a constant *and* appending it here, both
+    in the same module, so the whitelist cannot drift from the
+    routes.
+
+    @stability Internal *)
+
+let liveness = "/health/live"
+
+let readiness = "/health/ready"
+
+(** All public health probe paths whitelisted for unauthenticated
+    read access and treated as benign during startup takeover. *)
+let public : string list = [ liveness; readiness ]
+
+let is_public path =
+  List.exists (String.equal path) public

--- a/lib/server/server_health_paths.mli
+++ b/lib/server/server_health_paths.mli
@@ -1,0 +1,20 @@
+(** Health probe path SSOT.
+
+    Issue #8403 — see [.ml] header for context. *)
+
+val liveness : string
+(** [/health/live] *)
+
+val readiness : string
+(** [/health/ready] *)
+
+val public : string list
+(** Probe paths whitelisted for unauthenticated read access and
+    treated as benign by startup-takeover/path filters. Order is
+    deterministic; tests assert it stays aligned with [liveness] and
+    [readiness]. *)
+
+val is_public : string -> bool
+(** [is_public path] is [true] iff [path] is one of [public]. Use
+    instead of hand-coded [String.equal path "/health/live" || ...]
+    chains. *)

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -90,8 +90,8 @@ let webrtc_signaling_handler ~tool_name signaling_fn request reqd =
 let add_routes ~port ~host router =
   router
   |> Http.Router.get "/health" health_handler
-  |> Http.Router.get "/health/live" liveness_handler
-  |> Http.Router.get "/health/ready" readiness_handler
+  |> Http.Router.get Server_health_paths.liveness liveness_handler
+  |> Http.Router.get Server_health_paths.readiness readiness_handler
   |> Http.Router.get "/ws" websocket_discovery_handler
   |> Http.Router.get "/metrics" (fun request reqd ->
        with_read_auth (fun _state _req reqd ->

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -108,7 +108,7 @@ let read_status_line fd ~timeout_sec =
   in
   loop ()
 
-let probe_liveness ?(timeout_sec = 3.0) ?(path = "/health/live") port =
+let probe_liveness ?(timeout_sec = 3.0) ?(path = Server_health_paths.liveness) port =
   Safe_ops.protect ~default:false (fun () ->
     let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
     Fun.protect

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -989,6 +989,34 @@ let () =
           | None -> Alcotest.failf "phase_of_string %S returned None — round-trip broken" s
         ) all_phases);
     ];
+    "health_paths_ssot", [
+      (* Issue #8403: SSOT for /health/live and /health/ready strings.
+         The literals previously appeared 9 times across 5 files (HTTP/1
+         router, H/2 gateway, auth public-read whitelist, startup
+         takeover liveness probe default, bin rate-limit exemption)
+         with no shared constant — silent drift was the failure mode
+         (a renamed probe could leak an auth-required URL through the
+         public whitelist, or fall outside the rate-limit exemption).
+         These tests pin the constants to their literal wire format
+         (external monitors depend on them) and assert [is_public]
+         covers both probes. *)
+      Alcotest.test_case "constants pinned to wire format" `Quick (fun () ->
+        let open Masc_mcp.Server_health_paths in
+        Alcotest.(check string) "liveness wire path" "/health/live" liveness;
+        Alcotest.(check string) "readiness wire path" "/health/ready" readiness);
+      Alcotest.test_case "public lists both probes in order" `Quick (fun () ->
+        let open Masc_mcp.Server_health_paths in
+        Alcotest.(check (list string)) "public order"
+          [ "/health/live"; "/health/ready" ] public);
+      Alcotest.test_case "is_public matches probes, rejects others" `Quick (fun () ->
+        let open Masc_mcp.Server_health_paths in
+        Alcotest.(check bool) "/health/live" true (is_public "/health/live");
+        Alcotest.(check bool) "/health/ready" true (is_public "/health/ready");
+        Alcotest.(check bool) "/health (root) not in public" false
+          (is_public "/health");
+        Alcotest.(check bool) "/foo not in public" false (is_public "/foo");
+        Alcotest.(check bool) "empty path" false (is_public ""));
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8403. `/health/live` and `/health/ready` strings appeared **9 times across 5 files** with no shared constant. Renaming or adding a probe required hand-editing every site, and missing one would either leak an auth-required probe through the public whitelist, drop a probe from the rate-limit exemption, or leave external monitors hitting a 404. Same drift class as the recent Variant SSOT sweep (#8430 / #8471 / #8474 / #8493 / #8513 / #8524 / #8527 / #8546).

## Pre-fix matrix

| Layer | File | Role |
|------|------|------|
| HTTP/1 router | `server_routes_http_routes_frontend.ml:93,94` | Registers the routes |
| HTTP/2 gateway | `server_h2_gateway.ml:180,190` | Match arms |
| Auth whitelist | `server_auth.ml:388,389` | Bypasses auth for these paths |
| Rate-limit exempt | `bin/main_eio.ml:131,132` | LB probes never block |
| Startup probe | `server_startup_takeover.ml:107` | In-process liveness probe default |

## Fix

- New module `lib/server/server_health_paths` with `liveness` / `readiness` constants, `public` list, `is_public` predicate, full `.mli`. **Adding a probe means adding a constant *and* appending it to `public` in the same module** — the whitelist physically cannot drift from the routes.
- All 9 literal occurrences replaced with named references.
- HTTP/2 match arms converted to `when` guards (literal patterns cannot reference `let`-bound values; the guard form preserves exhaustiveness analysis).
- Auth whitelist and rate-limit exemption call `is_public` instead of hand-coding `String.equal path "/health/live" || ...`.

## Tests

`test/test_types.ml :: health_paths_ssot` — 3 cases
- constants pinned to wire format (`/health/live` / `/health/ready`) so external monitors stay green
- `public` list order is deterministic
- `is_public` matches both probes, rejects `/health` (root), `/foo`, `""`

## Test plan

- [x] `dune build lib` clean (only the unrelated `agent_sdk.swarm` env miss remains, see #8559).
- [x] HTTP/2 `when` guards still type-check; behavior identical because the guard expression is a constant equality.
- [ ] CI green — `health_paths_ssot` runs as part of `test_types`.

16th SSOT site overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product impact
- no health endpoint wire contract change; this PR makes the route/auth/rate-limit truth single-sourced
- current OAS main compatibility is now preserved on this branch as well

## Evidence
- `dune build lib`
- CI failure root cause matched the same OAS `Event_bus.meta.caused_by` extension now handled on this branch

## Review evidence
- self-review on `server_health_paths` call sites plus current branch compatibility with OAS event metadata extensions
- branch now includes the `evt.meta` record wildcard fix so warning-as-error builds do not break on the added `caused_by` field

## Linked issue
- Closes #8403
- Refs #8579