### PR TITLE
[codex] Add disk hygiene guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -53,6 +53,10 @@ test-all: test-unit test-contract test-transport
 # Clean build artifacts
 clean:
 	dune clean --root .
+	bash scripts/cleanup-tlc-artifacts.sh
+
+clean-tlc-artifacts:
+	bash scripts/cleanup-tlc-artifacts.sh
 
 # Run tests with coverage instrumentation
 coverage:
@@ -95,6 +99,18 @@ release-evidence:
 # Fast local-only doctor for OAS/agent_sdk pin drift in the current switch.
 doctor-oas-pin:
 	bash scripts/check-oas-pin.sh --local-only
+
+# Disk hygiene snapshot for TLC artefacts, Dune cache drift, isolated builds, worktree fan-out.
+doctor-disk-hygiene:
+	bash scripts/disk-hygiene.sh
+
+# Safe fixes only: TLC artefact cleanup + Dune cache trim.
+fix-disk-hygiene:
+	bash scripts/disk-hygiene.sh --fix
+
+# Hard reset path for cache drift: also reset ~/.cache/dune and remove stray _build_* dirs.
+fix-disk-hygiene-hard:
+	bash scripts/disk-hygiene.sh --fix --reset-dune-cache --clean-extra-build-dirs
 
 # Check OAS API surface (Event_bus variants, HttpError variants, Metrics fields)
 # against scripts/oas-api-surface.json fingerprint. Catches upstream variant/field

--- a/scripts/disk-hygiene.sh
+++ b/scripts/disk-hygiene.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# disk-hygiene.sh — inspect (and optionally fix) the main disk-growth
+# culprits observed in this repo:
+#   - TLC artefacts under specs/
+#   - global Dune cache drift under ~/.cache/dune
+#   - stray isolated build dirs (_build_*)
+#   - large worktree fan-out counts
+#
+# Safe defaults:
+#   - no deletion unless an explicit fix flag is passed
+#   - repo-local TLC cleanup is part of --fix
+#   - global Dune cache reset requires --reset-dune-cache
+#   - extra isolated build dir cleanup requires --clean-extra-build-dirs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPECS_DIR="$REPO_ROOT/specs"
+WORKTREES_DIR="$REPO_ROOT/.worktrees"
+DUNE_CACHE_DIR="${DUNE_CACHE_DIR:-$HOME/.cache/dune}"
+DUNE_CACHE_TRIM_SIZE="${DUNE_CACHE_TRIM_SIZE:-20GB}"
+
+WARN_DUNE_CACHE_MB="${MASC_DISK_HYGIENE_DUNE_CACHE_WARN_MB:-20480}"
+WARN_DUNE_CACHE_MISMATCH_MB="${MASC_DISK_HYGIENE_DUNE_CACHE_MISMATCH_WARN_MB:-4096}"
+WARN_TLC_ARTIFACTS_MB="${MASC_DISK_HYGIENE_TLC_WARN_MB:-2048}"
+WARN_EXTRA_BUILD_MB="${MASC_DISK_HYGIENE_EXTRA_BUILD_WARN_MB:-1024}"
+WARN_WORKTREE_COUNT="${MASC_DISK_HYGIENE_WORKTREE_WARN_COUNT:-100}"
+
+DO_FIX=0
+DO_RESET_DUNE_CACHE=0
+DO_CLEAN_EXTRA_BUILDS=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/disk-hygiene.sh [options]
+
+Inspect repo-local disk growth hotspots and optionally apply targeted cleanup.
+
+Options:
+  --fix                     Apply safe fixes (TLC artefact cleanup + dune cache trim)
+  --reset-dune-cache        Remove ~/.cache/dune after trim (explicit only)
+  --clean-extra-build-dirs  Remove top-level _build_* dirs (keeps _build/)
+  --trim-size=SIZE          Dune cache trim target (default: 20GB)
+  --help                    Show this help
+
+Environment overrides:
+  DUNE_CACHE_DIR
+  DUNE_CACHE_TRIM_SIZE
+  MASC_DISK_HYGIENE_DUNE_CACHE_WARN_MB
+  MASC_DISK_HYGIENE_DUNE_CACHE_MISMATCH_WARN_MB
+  MASC_DISK_HYGIENE_TLC_WARN_MB
+  MASC_DISK_HYGIENE_EXTRA_BUILD_WARN_MB
+  MASC_DISK_HYGIENE_WORKTREE_WARN_COUNT
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --fix) DO_FIX=1 ;;
+    --reset-dune-cache) DO_RESET_DUNE_CACHE=1 ;;
+    --clean-extra-build-dirs) DO_CLEAN_EXTRA_BUILDS=1 ;;
+    --trim-size=*) DUNE_CACHE_TRIM_SIZE="${1#*=}" ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "disk-hygiene: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+kb_of_path() {
+  local path="$1"
+  if [ ! -e "$path" ]; then
+    echo 0
+    return 0
+  fi
+  du -sk "$path" 2>/dev/null | awk '{print $1}'
+}
+
+human_kb() {
+  local kb="${1:-0}"
+  awk -v kb="$kb" '
+    BEGIN {
+      bytes = kb * 1024.0
+      split("B KiB MiB GiB TiB", units, " ")
+      idx = 1
+      while (bytes >= 1024.0 && idx < 5) {
+        bytes /= 1024.0
+        idx++
+      }
+      if (idx == 1 || bytes >= 10.0) printf "%.0f%s", bytes, units[idx]
+      else printf "%.1f%s", bytes, units[idx]
+    }'
+}
+
+parse_size_to_bytes() {
+  local raw
+  raw="$(printf '%s' "${1:-}" | tr -d '[:space:]')"
+  if [ -z "$raw" ]; then
+    echo 0
+    return 0
+  fi
+
+  local number unit factor
+  number="$(printf '%s' "$raw" | sed -E 's/^([0-9]+([.][0-9]+)?).*/\1/')"
+  unit="$(printf '%s' "$raw" | sed -E 's/^[0-9]+([.][0-9]+)?([A-Za-z]+)$/\2/')"
+
+  case "$unit" in
+    B) factor=1 ;;
+    kB) factor=1000 ;;
+    MB) factor=1000000 ;;
+    GB) factor=1000000000 ;;
+    TB) factor=1000000000000 ;;
+    KiB) factor=1024 ;;
+    MiB) factor=$((1024 * 1024)) ;;
+    GiB) factor=$((1024 * 1024 * 1024)) ;;
+    TiB) factor=$((1024 * 1024 * 1024 * 1024)) ;;
+    *) echo 0; return 0 ;;
+  esac
+
+  awk -v n="$number" -v f="$factor" 'BEGIN { printf "%.0f", n * f }'
+}
+
+sum_find_kb() {
+  local sum=0
+  local path kb
+  while IFS= read -r -d '' path; do
+    kb="$(du -sk "$path" 2>/dev/null | awk '{print $1}')"
+    kb="${kb:-0}"
+    sum=$((sum + kb))
+  done
+  echo "$sum"
+}
+
+status_ok=0
+status_warn=0
+
+record_item() {
+  local name="$1"
+  local status="$2"
+  local size_kb="$3"
+  local detail="$4"
+  printf '%-20s %-4s %8s  %s\n' "$name" "$status" "$(human_kb "$size_kb")" "$detail"
+  case "$status" in
+    ok) status_ok=$((status_ok + 1)) ;;
+    warn) status_warn=$((status_warn + 1)) ;;
+  esac
+}
+
+collect_metrics() {
+  status_ok=0
+  status_warn=0
+
+  local dune_actual_kb dune_actual_mb dune_logical_raw dune_logical_bytes dune_delta_mb
+  local dune_status dune_detail
+  dune_actual_kb="$(kb_of_path "$DUNE_CACHE_DIR")"
+  dune_actual_mb=$((dune_actual_kb / 1024))
+  dune_logical_raw=""
+  dune_logical_bytes=0
+  if command -v dune >/dev/null 2>&1; then
+    dune_logical_raw="$(dune cache size 2>/dev/null || true)"
+    dune_logical_bytes="$(parse_size_to_bytes "$dune_logical_raw")"
+  fi
+  dune_delta_mb=0
+  if [ "$dune_logical_bytes" -gt 0 ]; then
+    local actual_bytes
+    actual_bytes=$((dune_actual_kb * 1024))
+    if [ "$actual_bytes" -gt "$dune_logical_bytes" ]; then
+      dune_delta_mb=$(((actual_bytes - dune_logical_bytes) / 1024 / 1024))
+    fi
+  fi
+  dune_status="ok"
+  if [ "$dune_actual_mb" -ge "$WARN_DUNE_CACHE_MB" ] \
+    || [ "$dune_delta_mb" -ge "$WARN_DUNE_CACHE_MISMATCH_MB" ]; then
+    dune_status="warn"
+  fi
+  if [ "$dune_logical_bytes" -gt 0 ]; then
+    dune_detail="path=$DUNE_CACHE_DIR logical=${dune_logical_raw:-unknown} delta=${dune_delta_mb}MB"
+  else
+    dune_detail="path=$DUNE_CACHE_DIR logical=unavailable"
+  fi
+  record_item "dune_cache" "$dune_status" "$dune_actual_kb" "$dune_detail"
+
+  local tlc_states_kb tlc_trace_kb tlc_total_kb tlc_status tlc_detail
+  tlc_states_kb=0
+  tlc_trace_kb=0
+  if [ -d "$SPECS_DIR" ]; then
+    tlc_states_kb="$(
+      find "$SPECS_DIR" -type d -name states -print0 2>/dev/null | sum_find_kb
+    )"
+    tlc_trace_kb="$(
+      find "$SPECS_DIR" -type f \
+        \( -name '*_TTrace_*.bin' -o -name '*_TTrace_*.tla' -o -name 'TraceData.tla' \) \
+        -print0 2>/dev/null | sum_find_kb
+    )"
+  fi
+  tlc_total_kb=$((tlc_states_kb + tlc_trace_kb))
+  tlc_status="ok"
+  if [ $((tlc_total_kb / 1024)) -ge "$WARN_TLC_ARTIFACTS_MB" ]; then
+    tlc_status="warn"
+  fi
+  tlc_detail="states=$(human_kb "$tlc_states_kb") traces=$(human_kb "$tlc_trace_kb") path=$SPECS_DIR"
+  record_item "tlc_artifacts" "$tlc_status" "$tlc_total_kb" "$tlc_detail"
+
+  local build_main_kb extra_build_kb extra_build_count extra_build_status extra_build_detail path
+  build_main_kb="$(kb_of_path "$REPO_ROOT/_build")"
+  extra_build_kb=0
+  extra_build_count=0
+  while IFS= read -r -d '' path; do
+    extra_build_count=$((extra_build_count + 1))
+    extra_build_kb=$((extra_build_kb + $(du -sk "$path" 2>/dev/null | awk '{print $1}')))
+  done < <(find "$REPO_ROOT" -maxdepth 1 -type d -name '_build_*' -print0 2>/dev/null)
+  extra_build_status="ok"
+  if [ $((extra_build_kb / 1024)) -ge "$WARN_EXTRA_BUILD_MB" ] || [ "$extra_build_count" -gt 0 ]; then
+    extra_build_status="warn"
+  fi
+  extra_build_detail="main=$(human_kb "$build_main_kb") extra_dirs=$extra_build_count"
+  record_item "build_dirs" "$extra_build_status" "$extra_build_kb" "$extra_build_detail"
+
+  local worktree_count worktree_kb worktree_status worktree_detail
+  worktree_count=0
+  if [ -d "$WORKTREES_DIR" ]; then
+    worktree_count="$(find "$WORKTREES_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  fi
+  worktree_kb="$(kb_of_path "$WORKTREES_DIR")"
+  worktree_status="ok"
+  if [ "$worktree_count" -ge "$WARN_WORKTREE_COUNT" ]; then
+    worktree_status="warn"
+  fi
+  worktree_detail="count=$worktree_count path=$WORKTREES_DIR"
+  record_item "worktrees" "$worktree_status" "$worktree_kb" "$worktree_detail"
+}
+
+run_fixes() {
+  echo
+  echo "Applying fixes..."
+
+  "$REPO_ROOT/scripts/cleanup-tlc-artifacts.sh"
+
+  if command -v dune >/dev/null 2>&1; then
+    dune cache trim --size="$DUNE_CACHE_TRIM_SIZE" || true
+  else
+    echo "disk-hygiene: dune not found; skipping dune cache trim" >&2
+  fi
+
+  if [ "$DO_RESET_DUNE_CACHE" -eq 1 ] && [ -e "$DUNE_CACHE_DIR" ]; then
+    rm -rf "$DUNE_CACHE_DIR"
+    echo "disk-hygiene: reset dune cache at $DUNE_CACHE_DIR"
+  fi
+
+  if [ "$DO_CLEAN_EXTRA_BUILDS" -eq 1 ]; then
+    find "$REPO_ROOT" -maxdepth 1 -type d -name '_build_*' -exec rm -rf {} +
+    echo "disk-hygiene: removed stray _build_* dirs under $REPO_ROOT"
+  fi
+}
+
+echo "disk-hygiene: repo=$REPO_ROOT"
+collect_metrics
+
+if [ "$DO_FIX" -eq 1 ] || [ "$DO_RESET_DUNE_CACHE" -eq 1 ] || [ "$DO_CLEAN_EXTRA_BUILDS" -eq 1 ]; then
+  run_fixes
+  echo
+  echo "Post-fix:"
+  collect_metrics
+fi
+
+echo
+printf 'summary ok=%d warn=%d\n' "$status_ok" "$status_warn"
+
+if [ "$status_warn" -gt 0 ]; then
+  echo "notes: TLC artefacts can be cleaned safely; extra worktrees/build dirs need explicit review."
+  exit 1
+fi
+
+exit 0

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -15,6 +15,18 @@ TLC_URL="https://github.com/tlaplus/tlaplus/releases/download/v${TLC_VERSION}/tl
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+KEEP_TLC_ARTIFACTS="${KEEP_TLC_ARTIFACTS:-0}"
+
+cleanup_tlc_artifacts() {
+  if [ "$KEEP_TLC_ARTIFACTS" = "1" ]; then
+    echo "KEEP_TLC_ARTIFACTS=1 -> preserving TLC artefacts"
+    return 0
+  fi
+
+  "$REPO_ROOT/scripts/cleanup-tlc-artifacts.sh" || true
+}
+
+trap 'rc=$?; trap - EXIT; cleanup_tlc_artifacts; exit "$rc"' EXIT
 
 # Download TLC if not present
 if [ ! -f "$TLC_JAR" ]; then

--- a/test/dune
+++ b/test/dune
@@ -121,6 +121,7 @@
         test_worker_oas_scope_gate
         test_config_doctor
         test_doctor_dispatch
+        test_disk_hygiene_script
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
@@ -228,6 +229,7 @@
           test_worker_oas_scope_gate
           test_config_doctor
           test_doctor_dispatch
+          test_disk_hygiene_script
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine

--- a/test/test_disk_hygiene_script.ml
+++ b/test/test_disk_hygiene_script.ml
@@ -1,0 +1,309 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when String.trim root <> "" -> root
+  | _ -> Sys.getcwd ()
+
+let quote = Filename.quote
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "disk-hygiene-out" ".txt" in
+  let err = Filename.temp_file "disk-hygiene-err" ".txt" in
+  let wrapped =
+    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let init_repo dir =
+  ignore (run_shell ~cwd:dir "git init -q");
+  ignore (run_shell ~cwd:dir "git config user.email test@example.com");
+  ignore (run_shell ~cwd:dir "git config user.name tester")
+
+let copy_script ~repo_root rel_path =
+  let src = Filename.concat (source_root ()) rel_path in
+  let dst = Filename.concat repo_root rel_path in
+  mkdir_p (Filename.dirname dst);
+  write_file dst (read_file src);
+  Unix.chmod dst 0o755
+
+let install_fake_dune ~dir =
+  let bin_dir = Filename.concat dir "bin" in
+  mkdir_p bin_dir;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+if [ "${1:-}" = "cache" ] && [ "${2:-}" = "size" ]; then
+  printf '5.11GB\n'
+  exit 0
+fi
+if [ "${1:-}" = "cache" ] && [ "${2:-}" = "trim" ]; then
+  printf '%s\n' "$*" >>"$log_file"
+  printf 'Freed 0B (0 files removed)\n'
+  exit 0
+fi
+printf 'unexpected dune invocation: %s\n' "$*" >&2
+exit 1
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  bin_dir
+
+let install_fake_java ~dir =
+  let bin_dir = Filename.concat dir "bin-java" in
+  mkdir_p bin_dir;
+  let java_path = Filename.concat bin_dir "java" in
+  write_file java_path
+    {|#!/bin/sh
+exit 0
+|}
+  ;
+  Unix.chmod java_path 0o755;
+  bin_dir
+
+let test_disk_hygiene_fix_path () =
+  with_temp_dir "disk-hygiene-fix" (fun dir ->
+      let repo_dir = Filename.concat dir "repo" in
+      let home_dir = Filename.concat dir "home" in
+      let dune_log = Filename.concat dir "fake-dune.log" in
+      mkdir_p repo_dir;
+      mkdir_p home_dir;
+      init_repo repo_dir;
+      copy_script ~repo_root:repo_dir "scripts/cleanup-tlc-artifacts.sh";
+      copy_script ~repo_root:repo_dir "scripts/disk-hygiene.sh";
+      mkdir_p (Filename.concat repo_dir "specs/states");
+      mkdir_p (Filename.concat repo_dir "specs/keeper-state-machine");
+      mkdir_p (Filename.concat repo_dir "_build");
+      mkdir_p (Filename.concat repo_dir "_build_extra");
+      mkdir_p (Filename.concat repo_dir ".worktrees/alpha");
+      write_file (Filename.concat repo_dir "specs/states/blob") "x";
+      write_file
+        (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")
+        "trace";
+      write_file (Filename.concat repo_dir "_build/keep") "main-build";
+      write_file (Filename.concat repo_dir "_build_extra/tmp") "extra-build";
+      mkdir_p (Filename.concat home_dir ".cache/dune/db/files/v4");
+      write_file
+        (Filename.concat home_dir ".cache/dune/db/files/v4/blob")
+        (String.make 4096 'a');
+      let fake_bin = install_fake_dune ~dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("HOME", home_dir);
+          ("PATH", path);
+          ("FAKE_DUNE_LOG", dune_log);
+          ("MASC_DISK_HYGIENE_DUNE_CACHE_WARN_MB", "1");
+          ("MASC_DISK_HYGIENE_DUNE_CACHE_MISMATCH_WARN_MB", "1");
+          ("MASC_DISK_HYGIENE_TLC_WARN_MB", "1");
+          ("MASC_DISK_HYGIENE_EXTRA_BUILD_WARN_MB", "1");
+          ("MASC_DISK_HYGIENE_WORKTREE_WARN_COUNT", "5");
+        ]
+      in
+      let script = Filename.concat repo_dir "scripts/disk-hygiene.sh" in
+      let code1, stdout1, stderr1 =
+        run_shell ~cwd:repo_dir ~env
+          (Printf.sprintf "%s" (quote script))
+      in
+      check bool "warn-only run returns nonzero" true (code1 <> 0);
+      check bool "reports dune cache warning" true
+        (contains_substring stdout1 "dune_cache");
+      check bool "reports tlc artefacts warning" true
+        (contains_substring stdout1 "tlc_artifacts");
+      check bool "reports build dirs warning" true
+        (contains_substring stdout1 "build_dirs");
+      check bool "stderr empty on report run" true (String.trim stderr1 = "");
+
+      let code2, stdout2, stderr2 =
+        run_shell ~cwd:repo_dir ~env
+          (Printf.sprintf "%s --fix --reset-dune-cache --clean-extra-build-dirs"
+             (quote script))
+      in
+      if code2 <> 0 then
+        failf "disk hygiene fix failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code2 stdout2 stderr2;
+      check bool "trace data removed" false
+        (Sys.file_exists
+           (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla"));
+      check bool "states dir removed" false
+        (Sys.file_exists (Filename.concat repo_dir "specs/states"));
+      check bool "extra build dir removed" false
+        (Sys.file_exists (Filename.concat repo_dir "_build_extra"));
+      check bool "main _build preserved" true
+        (Sys.file_exists (Filename.concat repo_dir "_build"));
+      check bool "dune cache reset removed cache dir" false
+        (Sys.file_exists (Filename.concat home_dir ".cache/dune"));
+      let dune_log_contents = read_file dune_log in
+      check bool "trim invoked with default size" true
+        (contains_substring dune_log_contents "cache trim --size=20GB");
+      check bool "post-fix summary printed" true
+        (contains_substring stdout2 "Post-fix:");
+      check bool "post-fix summary is clean" true
+        (contains_substring stdout2 "summary ok=4 warn=0"))
+
+let test_tla_check_cleans_generated_artifacts_by_default () =
+  with_temp_dir "tla-check-cleanup" (fun dir ->
+      let repo_dir = Filename.concat dir "repo" in
+      let tlc_dir = Filename.concat dir "tlc" in
+      let java_bin = install_fake_java ~dir in
+      mkdir_p repo_dir;
+      init_repo repo_dir;
+      copy_script ~repo_root:repo_dir "scripts/cleanup-tlc-artifacts.sh";
+      copy_script ~repo_root:repo_dir "scripts/tla-check.sh";
+      mkdir_p (Filename.concat repo_dir "specs/states");
+      mkdir_p (Filename.concat repo_dir "specs/keeper-state-machine");
+      write_file (Filename.concat repo_dir "specs/states/blob") "x";
+      write_file
+        (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")
+        "trace";
+      write_file
+        (Filename.concat repo_dir "specs/keeper-state-machine/Foo_TTrace_1.tla")
+        "trace";
+      mkdir_p tlc_dir;
+      write_file (Filename.concat tlc_dir "tla2tools-1.8.0.jar") "jar";
+      let path =
+        Printf.sprintf "%s:%s" java_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env = [ ("PATH", path); ("TLC_DIR", tlc_dir) ] in
+      let script = Filename.concat repo_dir "scripts/tla-check.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_dir ~env (Printf.sprintf "%s" (quote script))
+      in
+      if code <> 0 then
+        failf "tla-check failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check bool "cleanup message emitted" true
+        (contains_substring stdout "cleanup-tlc-artifacts:");
+      check bool "states dir removed" false
+        (Sys.file_exists (Filename.concat repo_dir "specs/states"));
+      check bool "trace data removed" false
+        (Sys.file_exists
+           (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")))
+
+let test_tla_check_respects_keep_tlc_artifacts () =
+  with_temp_dir "tla-check-keep" (fun dir ->
+      let repo_dir = Filename.concat dir "repo" in
+      let tlc_dir = Filename.concat dir "tlc" in
+      let java_bin = install_fake_java ~dir in
+      mkdir_p repo_dir;
+      init_repo repo_dir;
+      copy_script ~repo_root:repo_dir "scripts/cleanup-tlc-artifacts.sh";
+      copy_script ~repo_root:repo_dir "scripts/tla-check.sh";
+      mkdir_p (Filename.concat repo_dir "specs/states");
+      mkdir_p (Filename.concat repo_dir "specs/keeper-state-machine");
+      write_file (Filename.concat repo_dir "specs/states/blob") "x";
+      write_file
+        (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")
+        "trace";
+      mkdir_p tlc_dir;
+      write_file (Filename.concat tlc_dir "tla2tools-1.8.0.jar") "jar";
+      let path =
+        Printf.sprintf "%s:%s" java_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [ ("PATH", path); ("TLC_DIR", tlc_dir); ("KEEP_TLC_ARTIFACTS", "1") ]
+      in
+      let script = Filename.concat repo_dir "scripts/tla-check.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_dir ~env (Printf.sprintf "%s" (quote script))
+      in
+      if code <> 0 then
+        failf "tla-check failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check bool "preserve message emitted" true
+        (contains_substring stdout "KEEP_TLC_ARTIFACTS=1");
+      check bool "states dir preserved" true
+        (Sys.file_exists (Filename.concat repo_dir "specs/states"));
+      check bool "trace data preserved" true
+        (Sys.file_exists
+           (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")))
+
+let test_makefile_exposes_disk_hygiene_targets () =
+  let makefile = read_file (Filename.concat (source_root ()) "Makefile") in
+  check bool "doctor target exists" true
+    (contains_substring makefile "doctor-disk-hygiene:");
+  check bool "safe fix target exists" true
+    (contains_substring makefile "fix-disk-hygiene:");
+  check bool "hard fix target exists" true
+    (contains_substring makefile "fix-disk-hygiene-hard:");
+  check bool "clean target runs tlc cleanup" true
+    (contains_substring makefile "bash scripts/cleanup-tlc-artifacts.sh")
+
+let () =
+  run "disk_hygiene_script"
+    [
+      ( "script",
+        [
+          test_case "disk hygiene fixes tlc cache and extra builds" `Quick
+            test_disk_hygiene_fix_path;
+          test_case "tla-check cleans artefacts by default" `Quick
+            test_tla_check_cleans_generated_artifacts_by_default;
+          test_case "tla-check keep flag preserves artefacts" `Quick
+            test_tla_check_respects_keep_tlc_artifacts;
+          test_case "makefile exposes disk hygiene targets" `Quick
+            test_makefile_exposes_disk_hygiene_targets;
+        ] );
+    ]


### PR DESCRIPTION
## What changed
- add `scripts/disk-hygiene.sh` to inspect the main disk-growth culprits in this repo: TLC artefacts, global Dune cache drift, stray `_build_*` dirs, and worktree fan-out
- add `make doctor-disk-hygiene`, `make fix-disk-hygiene`, `make fix-disk-hygiene-hard`, and `make clean-tlc-artifacts`
- extend `make clean` to run TLC artefact cleanup as part of normal local cleanup
- update `scripts/tla-check.sh` to clean generated TLC artefacts on exit by default, with `KEEP_TLC_ARTIFACTS=1` as an explicit opt-out
- add focused script coverage in `test/test_disk_hygiene_script.ml` and register it in `test/dune`

## Why
Recent disk growth came from two separate sources:
- TLC-generated `specs/**/states`, `_TTrace_*`, and `TraceData.tla` artefacts accumulating under the repo
- global `~/.cache/dune` usage drifting far beyond what `dune cache size` reported, which made routine cache trimming ineffective

The repo already had a safe TLC cleanup script, but it was not consistently wired into the paths developers actually use. This change makes the common cleanup paths and the diagnosis/fix workflow explicit.

## Impact
- `scripts/tla-check.sh` no longer leaves large TLC artefacts behind unless `KEEP_TLC_ARTIFACTS=1` is set
- developers get an explicit local hygiene doctor/fix workflow instead of ad hoc manual cleanup
- `fix-disk-hygiene-hard` gives an intentional escape hatch for Dune cache mismatch/orphan cases without making cache deletion the default behavior

## Root cause
The problem was not one source of growth but the combination of:
- unpruned TLC state/trace artefacts under `specs/`
- Dune cache file growth that could outpace or diverge from what `dune cache size`/`dune cache trim` considered active

## Validation
- `bash -n scripts/disk-hygiene.sh scripts/tla-check.sh scripts/cleanup-tlc-artifacts.sh`
- `scripts/disk-hygiene.sh --help`
- temporary-repo simulation of `scripts/disk-hygiene.sh --fix --reset-dune-cache --clean-extra-build-dirs`
- temporary-repo simulation of `scripts/tla-check.sh` default cleanup and `KEEP_TLC_ARTIFACTS=1` preserve mode

## Notes
- full Dune test execution is currently blocked in this environment by missing `agent_sdk.swarm` library resolution in the active switch, so the new OCaml test file was validated by direct script simulation rather than end-to-end `dune runtest`
