### PR TITLE
fix(operator): promote task_inject to remote action enum (#8417)

### DIFF
--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -21,13 +21,23 @@ let strict_action_enums =
     `String "namespace_pause";
     `String "namespace_resume";
     `String "social_sweep";
+    (* Issue #8417: [task_inject] has a real handler in
+       [Operator_control.dispatch] (line 119) and is advertised by
+       [Operator_pending_confirm.available_actions] (line 253).  It
+       was previously grouped with the legacy aliases, so the remote
+       operator MCP surface and the LLM judge never saw it and
+       couldn't discover the capability. The remaining entries in
+       [legacy_action_alias_enums] are genuine aliases
+       ([keeper_msg]→[keeper_message], [room_pause]→[namespace_pause],
+       [room_resume]→[namespace_resume], [autonomy_tick]→[social_sweep]). *)
+    `String "task_inject";
     `String "keeper_message";
     `String "keeper_probe";
     `String "keeper_recover";
   ]
 
 let legacy_action_alias_enums =
-  [ `String "keeper_msg"; `String "task_inject"; `String "room_pause"; `String "room_resume";
+  [ `String "keeper_msg"; `String "room_pause"; `String "room_resume";
     `String "autonomy_tick" ]
 
 let target_type_enums =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -224,7 +224,11 @@ let test_remote_operator_action_schema_is_strict () =
             | Some (`List enums) ->
                 Alcotest.(check bool) "remote excludes team_turn" false
                   (List.mem (`String "team_turn") enums);
-                Alcotest.(check bool) "remote excludes task_inject" false
+                (* Issue #8417: [task_inject] has a real handler +
+                   approval contract; promoted into the strict enum so
+                   remote operator callers and the LLM judge can
+                   discover the capability. *)
+                Alcotest.(check bool) "remote includes task_inject" true
                   (List.mem (`String "task_inject") enums);
                 Alcotest.(check bool) "remote excludes keeper_msg" false
                   (List.mem (`String "keeper_msg") enums);


### PR DESCRIPTION
## Summary
Fixes #8417. \`task_inject\` has a real handler, approval contract, and
"available action" advertisement, but \`Tool_operator.strict_action_enums\`
kept it in \`legacy_action_alias_enums\` — so remote MCP callers and the
LLM judge couldn't discover the capability even though it executed
fine when invoked through the approval surface.

The existing test assertion \`"remote excludes task_inject"\` locked the
omission in place.

## Fix
Move \`task_inject\` into \`strict_action_enums\`. Flip the coverage
test assertion. The remaining \`legacy_action_alias_enums\` entries
(\`keeper_msg\` → \`keeper_message\`, \`room_pause\` → \`namespace_pause\`,
etc.) are genuine aliases and stay hidden.

## Scope
1 lib file + 1 test assertion. No dispatcher, approval, or
confirm-queue changes — those already treat \`task_inject\` as a
first-class action.

Closes #8417

🤖 Generated with [Claude Code](https://claude.com/claude-code)