### PR TITLE
chore(net-defaults): replace inline "127.0.0.1" with SSOT helper (#8387)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -198,7 +198,8 @@ end
 module Voice = struct
   (** Default Voice MCP server host *)
   let default_host =
-    get_string ~default:"127.0.0.1" "VOICE_MCP_HOST"
+    get_string ~default:Masc_network_defaults.masc_http_default_host
+      "VOICE_MCP_HOST"
 
   (** Default Voice MCP server port *)
   let default_port =

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -12,7 +12,8 @@ let make_http_config ~host ~port : Http.config =
   | Some existing when String.trim existing <> "" -> ()
   | _ ->
       let advertised_host =
-        if Server_auth.is_unspecified_host config.host then "127.0.0.1"
+        if Server_auth.is_unspecified_host config.host then
+          Masc_network_defaults.masc_http_default_host
         else config.host
       in
       Unix.putenv "MASC_HTTP_BASE_URL"


### PR DESCRIPTION
## Summary
- \`lib/server/server_bootstrap_http.ml\` \`advertised_host\` fallback uses SSOT.
- \`lib/config/env_config_runtime.ml\` \`Voice.default_host\` uses SSOT.

## Issues
Partial closes #8387 (sites 1 + 2 of 3). Site 3 (\`masc_http_client.ml\` \`\"localhost\"\`) left untouched — different semantics (name vs literal IP).

## Changes
- 2 files, +4/-2. Both sites now reference \`Masc_network_defaults.masc_http_default_host\`.
- Matches existing pattern in \`env_config_runtime.ml:146/178\` (\`local_llm_default_url\`, \`ollama_default_url\`) and \`server_auth.ml:25\`.

## Tests
- No behavior change — literal \`\"127.0.0.1\"\` is equal to \`Masc_network_defaults.masc_http_default_host\` (line 96 of \`masc_network_defaults.ml\`).
- Relies on CI Build and Test.

## Risk
- Low. Drop-in substitution. If SSOT ever switches loopback to \`::1\` or \`0.0.0.0\`, both sites now follow automatically instead of drifting.