### PR TITLE
fix(keeper_lifecycle): derive event from phase Variant SSOT — drop hand-coded duplicate strings (#8572)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1900,6 +1900,17 @@ let publish_keeper_lifecycle ?phase ~event ~keeper_name ~detail () : unit =
   | None -> ()
 ;;
 
+(** Issue #8572: phase-derived event helper.
+
+    Use this when the lifecycle event name is the phase itself
+    (e.g. [Stopped → "stopped"]). Keeps [event_to_string] from being
+    hand-recomputed at every call site, eliminating the
+    [~phase:Stopped ~event:"crashed"]-style typo class. *)
+let publish_keeper_phase_lifecycle ~phase ~keeper_name ~detail () : unit =
+  let event = Keeper_state_machine.phase_to_string phase in
+  publish_keeper_lifecycle ~phase ~event ~keeper_name ~detail ()
+;;
+
 let publish_keeper_started ~(live_meta : keeper_meta) : unit =
   publish_keeper_lifecycle
     ~phase:Keeper_state_machine.Running
@@ -1945,8 +1956,8 @@ let record_keeper_stopped
       Keeper_state_machine.Stop_requested);
     ignore (Keeper_registry.dispatch_event ~base_path keeper_name
       Keeper_state_machine.Drain_complete);
-    publish_keeper_lifecycle ~phase:Keeper_state_machine.Stopped
-      ~event:"stopped" ~keeper_name ~detail ();
+    publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Stopped
+      ~keeper_name ~detail ();
     true)
   else
     false
@@ -1967,8 +1978,8 @@ let record_keeper_crashed
       (Keeper_state_machine.Fiber_terminated { outcome = reason }));
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
-    publish_keeper_lifecycle ~phase:Keeper_state_machine.Crashed
-      ~event:"crashed" ~keeper_name ~detail:reason ())
+    publish_keeper_phase_lifecycle ~phase:Keeper_state_machine.Crashed
+      ~keeper_name ~detail:reason ())
 ;;
 
 let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_meta) : unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -75,6 +75,20 @@ let publish_lifecycle ?phase event_name keeper_name detail () =
         ?phase ~keeper_name ~detail ()
   | None -> ()
 
+(** Issue #8572: derive the wire [event] string from [phase] so the
+    Variant SSOT stays the only source of truth.
+
+    The legacy [publish_lifecycle ~phase event_name …] still works for
+    the named custom-event sites ([dead_cleaned] / [self_preservation]
+    / [paused_pruned]) that genuinely have no phase. Phase-bearing
+    sites should call this helper instead so that renaming a phase in
+    [Keeper_state_machine] flows to every observer automatically — no
+    chance of [~phase:Stopped "crashed"]-style typo emitting a
+    contradiction. *)
+let publish_phase_lifecycle ~phase keeper_name detail () =
+  let event_name = Keeper_state_machine.phase_to_string phase in
+  publish_lifecycle ~phase event_name keeper_name detail ()
+
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
 let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
@@ -111,8 +125,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            ignore (Keeper_registry.dispatch_event ~base_path meta.name
              Keeper_state_machine.Drain_complete);
            if resolve_done `Stopped then
-             publish_lifecycle ~phase:Keeper_state_machine.Stopped
-               "stopped" meta.name "normal exit" ()
+             publish_phase_lifecycle ~phase:Keeper_state_machine.Stopped
+               meta.name "normal exit" ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -144,8 +158,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              if resolve_done (`Crashed reason) then
-               publish_lifecycle ~phase:Keeper_state_machine.Crashed
-                 "crashed" meta.name reason ()))
+               publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed
+                 meta.name reason ()))
       ~finally:(fun () ->
         (* Finally runs best-effort. Any exception raised here (including
            Eio.Cancel.Cancelled, which propagates during concurrent fiber
@@ -179,8 +193,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               ignore (Keeper_registry.dispatch_event ~base_path meta.name
                 (Keeper_state_machine.Fiber_terminated { outcome = reason }));
               if resolve_done (`Crashed reason) then
-                publish_lifecycle ~phase:Keeper_state_machine.Crashed
-                  "crashed" meta.name reason ()
+                publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed
+                  meta.name reason ()
             end
           end
         with exn ->
@@ -502,7 +516,7 @@ let sweep_and_recover (ctx : _ context) =
     ignore (Keeper_registry.dispatch_event ~base_path entry.name
       Keeper_state_machine.Restart_budget_exhausted);
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
-    publish_lifecycle ~phase:Keeper_state_machine.Dead "dead" entry.name
+    publish_phase_lifecycle ~phase:Keeper_state_machine.Dead entry.name
       (Printf.sprintf "restart budget exhausted (%d), last: %s"
          max_restarts msg) ();
     Log.Keeper.error "%s: restart budget exhausted (%d). Dead."

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -964,6 +964,31 @@ let () =
         Alcotest.(check int) "no duplicates" (List.length names)
           (List.length dedup));
     ];
+    "publish_phase_lifecycle_ssot", [
+      (* Issue #8572: phase-bearing publish_lifecycle calls used to pass
+         a hand-coded event_name string alongside the phase Variant —
+         no compile-time link, so [~phase:Stopped "crashed"] would
+         have shipped a contradictory event. The fix derives the
+         event from [Keeper_state_machine.phase_to_string]; these
+         tests pin the wire-format strings downstream consumers
+         (dashboards, audit log) depend on so a Variant rename
+         cannot silently change the event name. *)
+      Alcotest.test_case "phase_to_string emits stable wire strings" `Quick (fun () ->
+        let open Masc_mcp.Keeper_state_machine in
+        Alcotest.(check string) "Stopped" "stopped" (phase_to_string Stopped);
+        Alcotest.(check string) "Crashed" "crashed" (phase_to_string Crashed);
+        Alcotest.(check string) "Running" "running" (phase_to_string Running);
+        Alcotest.(check string) "Dead" "dead" (phase_to_string Dead));
+      Alcotest.test_case "all_phases round-trip through to_string/of_string" `Quick (fun () ->
+        let open Masc_mcp.Keeper_state_machine in
+        List.iter (fun p ->
+          let s = phase_to_string p in
+          match phase_of_string s with
+          | Some p' when phase_to_string p' = s -> ()
+          | Some _ -> Alcotest.failf "phase_of_string %S parsed to a different phase" s
+          | None -> Alcotest.failf "phase_of_string %S returned None — round-trip broken" s
+        ) all_phases);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8572. Drift hazard, 9th in the Variant SSOT sweep. `publish_lifecycle` and `publish_keeper_lifecycle` accepted **both** a `Keeper_state_machine.phase` Variant **and** a hand-coded `event_name` string. At every phase-bearing call site the two were manually kept in sync with no compile-time link — `~phase:Stopped "crashed"` would compile and ship a contradictory event.

## Pre-fix matrix

| File | Line | Phase | Hand-coded event | Match? |
|------|------|-------|------------------|--------|
| keeper_supervisor.ml | 114 | Stopped | `"stopped"` | yes (drift hazard) |
| keeper_supervisor.ml | 147 | Crashed | `"crashed"` | yes (drift hazard) |
| keeper_supervisor.ml | 182 | Crashed | `"crashed"` | yes (drift hazard) |
| keeper_supervisor.ml | 505 | Dead    | `"dead"`    | yes (drift hazard) |
| keeper_keepalive.ml  | 1939 | Stopped | `"stopped"` | yes (drift hazard) |
| keeper_keepalive.ml  | 1961 | Crashed | `"crashed"` | yes (drift hazard) |

The verb-bearing sites (`~phase:Running "started"` / `"reconciled"` / `"restarted"`) are intentionally distinct (event verb ≠ phase noun) and stay on the string form.

Same drift class as #8430 / #8471 / #8474 / #8493 / #8513 / #8524 / #8527 / #8546 / #8569.

## Fix

- New helper `Keeper_supervisor.publish_phase_lifecycle ~phase keeper_name detail ()` derives `event` from `Keeper_state_machine.phase_to_string phase`. Always agrees, by construction.
- New helper `Keeper_keepalive.publish_keeper_phase_lifecycle ~phase ~keeper_name ~detail ()` mirrors the pattern in the keepalive layer.
- 6 phase=event-name sites converted; the legacy string-form helpers survive for the genuine custom events (`dead_cleaned` / `self_preservation` / `paused_pruned` / verb-bearing).

## Tests

`test/test_types.ml :: publish_phase_lifecycle_ssot` — 2 cases
- `phase_to_string` emits stable wire strings (`Stopped→"stopped"`, `Crashed→"crashed"`, `Running→"running"`, `Dead→"dead"`) so a Variant rename cannot silently change downstream wire format.
- `all_phases` round-trip through `phase_to_string` / `phase_of_string`.

## Test plan

- [x] `dune build lib` clean.
- [x] Verb-bearing sites unchanged — only same-string sites moved to derived helper.
- [ ] CI green — `publish_phase_lifecycle_ssot` runs as part of `test_types`.

18th SSOT site overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product impact
- no lifecycle wire-format change; this removes a contradiction class between phase variants and emitted event names
- current OAS main compatibility is preserved on this branch too

## Evidence
- same-string phase/event sites now derive the emitted event from the phase SSOT
- branch matches the current OAS `Event_bus.meta` shape via the wildcard metadata pattern

## Review evidence
- self-review on the new phase-derived helper call sites in supervisor and keepalive
- branch has been rebased onto current remote head and checked against the latest OAS metadata shape

## Linked issue
- Closes #8572
- Refs #8579