### PR TITLE
[codex] Harden fresh-boot bootstrap verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-run-local-fresh-boot harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -178,6 +178,10 @@ harness-game-view-contract:
 # MCP streamable transport contract harness (Accept policy + deprecation headers)
 harness-streamable-http-contract:
 	scripts/harness_streamable_http_contract.sh
+
+# Fresh temp-dir proof: run-local bootstrap -> /health -> initialize -> tools/list
+harness-run-local-fresh-boot:
+	scripts/harness/contract/run_local_fresh_boot_contract.sh
 
 # TRPG session bootstrap contract harness (preset/pool/party/session/intervention)
 harness-trpg-session-contract:

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -125,12 +125,26 @@ curl -sS -D "$INIT_HEADERS" "http://127.0.0.1:${PORT}/mcp" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"manual-check","version":"0.1"}}}'
 
 SESSION_ID="$(awk -F': ' 'tolower($1)=="mcp-session-id"{gsub("\r", "", $2); print $2}' "$INIT_HEADERS")"
+PROTOCOL_VERSION="$(awk -F': ' 'tolower($1)=="mcp-protocol-version"{gsub("\r", "", $2); print $2}' "$INIT_HEADERS")"
 curl -sS "http://127.0.0.1:${PORT}/mcp" \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \
+  -H "Mcp-Protocol-Version: ${PROTOCOL_VERSION}" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' >/dev/null
+curl -sS "http://127.0.0.1:${PORT}/mcp" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: ${SESSION_ID}" \
+  -H "Mcp-Protocol-Version: ${PROTOCOL_VERSION}" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 rm -f "$INIT_HEADERS"
+```
+
+fresh temp-dir launcher proof:
+
+```bash
+scripts/harness/contract/run_local_fresh_boot_contract.sh
 ```
 
 ## 3. MCP 연결

--- a/scripts/harness/contract/run_local_fresh_boot_contract.sh
+++ b/scripts/harness/contract/run_local_fresh_boot_contract.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+source "${ROOT_DIR}/scripts/harness/lib/server_bootstrap.sh"
+
+RUN_LOCAL_SCRIPT="${RUN_LOCAL_SCRIPT:-${ROOT_DIR}/scripts/run-local.sh}"
+PORT="${PORT:-$(harness_pick_free_port)}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "/tmp/masc-run-local-fresh.XXXXXX")}"
+LOG_FILE="${LOG_FILE:-$(harness_mktemp_file "masc-run-local-fresh" ".log")}"
+KEEP_BASE_PATH="${KEEP_BASE_PATH:-0}"
+KEEP_LOG_FILE="${KEEP_LOG_FILE:-0}"
+BOOT_WAIT_SEC="${BOOT_WAIT_SEC:-45}"
+STOP_WAIT_SEC="${STOP_WAIT_SEC:-10}"
+SERVER_PID=""
+
+status_code() {
+  local header_file="$1"
+  awk 'toupper($1) ~ /^HTTP\/[0-9.]+$/ { code=$2 } END { print code }' "$header_file"
+}
+
+header_value() {
+  local header_file="$1"
+  local key="$2"
+  awk -v k="$key" '
+    tolower($0) ~ "^" tolower(k) ":" {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      sub(/\r$/, "", $0)
+      print $0
+      exit
+    }
+  ' "$header_file"
+}
+
+normalize_json() {
+  local src="$1"
+  local dest="$2"
+  python3 - "$src" "$dest" <<'PY'
+import json
+import sys
+
+src, dest = sys.argv[1], sys.argv[2]
+text = open(src, encoding="utf-8").read()
+payload = None
+stripped = text.lstrip()
+if stripped.startswith("{") or stripped.startswith("["):
+    payload = text
+else:
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            payload = line[6:]
+            break
+if payload is None:
+    raise SystemExit(f"no JSON payload found in {src}")
+obj = json.loads(payload)
+with open(dest, "w", encoding="utf-8") as fh:
+    json.dump(obj, fh, indent=2, ensure_ascii=False, sort_keys=True)
+    fh.write("\n")
+PY
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "FAIL: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+wait_for_ready() {
+  local base_url="$1"
+  local ready_json="$2"
+  local deadline=$(( $(date +%s) + BOOT_WAIT_SEC ))
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    if curl -fsS --max-time 2 "${base_url}/health/ready" >"$ready_json" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+assert_health_contract() {
+  local health_json="$1"
+  local expected_base="$2"
+  local expected_config="$3"
+  python3 - "$health_json" "$expected_base" "$expected_config" <<'PY'
+import json
+import sys
+
+health_path, expected_base, expected_config = sys.argv[1:4]
+health = json.load(open(health_path, encoding="utf-8"))
+
+def fail(message):
+    raise SystemExit(message)
+
+if health.get("status") != "ok":
+    fail(f"health status not ok: {health.get('status')!r}")
+
+startup = health.get("startup") or {}
+if startup.get("phase") != "ready":
+    fail(f"startup phase not ready: {startup.get('phase')!r}")
+
+paths = health.get("paths") or {}
+if paths.get("effective_base_path") != expected_base:
+    fail(
+        f"effective_base_path mismatch: {paths.get('effective_base_path')!r} != {expected_base!r}"
+    )
+
+config_resolution = startup.get("config_resolution") or {}
+if config_resolution.get("status") != "ready":
+    fail(f"config_resolution.status not ready: {config_resolution.get('status')!r}")
+
+config_root = (config_resolution.get("config_root") or {}).get("path")
+if config_root != expected_config:
+    fail(f"config_root.path mismatch: {config_root!r} != {expected_config!r}")
+PY
+}
+
+assert_initialize_contract() {
+  local initialize_json="$1"
+  python3 - "$initialize_json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+result = payload.get("result") or {}
+server_info = result.get("serverInfo") or {}
+if server_info.get("name") != "masc-mcp":
+    raise SystemExit(f"unexpected serverInfo.name: {server_info.get('name')!r}")
+if result.get("protocolVersion") != "2025-11-25":
+    raise SystemExit(
+        f"unexpected protocolVersion: {result.get('protocolVersion')!r}"
+    )
+PY
+}
+
+assert_tools_list_contract() {
+  local tools_json="$1"
+  python3 - "$tools_json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+tools = ((payload.get("result") or {}).get("tools")) or []
+if not tools:
+    raise SystemExit("tools/list returned no tools")
+names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
+if not ({"masc_start", "masc_status"} & names):
+    raise SystemExit(
+        f"tools/list missing canonical front-door tools; saw sample={sorted(list(names))[:10]!r}"
+    )
+PY
+}
+
+cleanup() {
+  harness_stop_server "$SERVER_PID" "$STOP_WAIT_SEC"
+  rm -f "${READY_JSON:-}" "${HEALTH_JSON:-}" "${INIT_HEADERS:-}" \
+    "${INIT_BODY:-}" "${INIT_JSON:-}" "${NOTIFY_HEADERS:-}" \
+    "${NOTIFY_BODY:-}" "${TOOLS_HEADERS:-}" "${TOOLS_BODY:-}" \
+    "${TOOLS_JSON:-}"
+  if [[ "$KEEP_BASE_PATH" != "1" ]]; then
+    rm -rf "$BASE_PATH"
+  fi
+  if [[ "$KEEP_LOG_FILE" != "1" ]]; then
+    rm -f "$LOG_FILE"
+  fi
+}
+trap cleanup EXIT
+
+require_command curl
+require_command python3
+
+[[ -x "$RUN_LOCAL_SCRIPT" ]] || {
+  echo "FAIL: run-local script not executable: $RUN_LOCAL_SCRIPT" >&2
+  exit 1
+}
+SERVER_EXE="$(harness_find_server_exe "$ROOT_DIR" "${SERVER_EXE:-}")"
+
+BASE_URL="http://127.0.0.1:${PORT}"
+MCP_URL="${BASE_URL}/mcp"
+READY_JSON="$(harness_mktemp_file "masc-run-local-ready" ".json")"
+HEALTH_JSON="$(harness_mktemp_file "masc-run-local-health" ".json")"
+INIT_HEADERS="$(harness_mktemp_file "masc-run-local-init" ".headers")"
+INIT_BODY="$(harness_mktemp_file "masc-run-local-init" ".body")"
+INIT_JSON="$(harness_mktemp_file "masc-run-local-init" ".json")"
+NOTIFY_HEADERS="$(harness_mktemp_file "masc-run-local-notify" ".headers")"
+NOTIFY_BODY="$(harness_mktemp_file "masc-run-local-notify" ".body")"
+TOOLS_HEADERS="$(harness_mktemp_file "masc-run-local-tools" ".headers")"
+TOOLS_BODY="$(harness_mktemp_file "masc-run-local-tools" ".body")"
+TOOLS_JSON="$(harness_mktemp_file "masc-run-local-tools" ".json")"
+
+rm -f "$READY_JSON" "$HEALTH_JSON" "$INIT_HEADERS" "$INIT_BODY" "$INIT_JSON" \
+  "$NOTIFY_HEADERS" "$NOTIFY_BODY" "$TOOLS_HEADERS" "$TOOLS_BODY" "$TOOLS_JSON"
+
+EXPECTED_BASE="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$BASE_PATH")"
+EXPECTED_CONFIG="${EXPECTED_BASE}/.masc/config"
+
+echo "[run-local-smoke] target=${EXPECTED_BASE}"
+echo "[run-local-smoke] port=${PORT}"
+echo "[run-local-smoke] log=${LOG_FILE}"
+
+env \
+  -u MASC_BASE_PATH \
+  -u MASC_CONFIG_DIR \
+  -u MASC_PERSONAS_DIR \
+  -u MASC_HOST \
+  -u MASC_MCP_PORT \
+  -u MASC_ALLOW_LEGACY_ACCEPT \
+  -u MASC_FULL_SURFACE \
+  -u MASC_PUBLIC_TOOLS_EXTRA \
+  bash "$RUN_LOCAL_SCRIPT" --target-dir "$BASE_PATH" --host 127.0.0.1 --port "$PORT" \
+  --bootstrap-only >"$LOG_FILE" 2>&1
+
+[[ -f "${BASE_PATH}/.masc/config/tool_policy.toml" ]] || {
+  echo "FAIL: run-local bootstrap did not materialize tool_policy.toml under ${BASE_PATH}/.masc/config" >&2
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+}
+
+SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$LOG_FILE")"
+
+if ! wait_for_ready "$BASE_URL" "$READY_JSON"; then
+  echo "FAIL: run-local server did not become ready at ${BASE_URL}" >&2
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+curl -fsS --max-time 5 "${BASE_URL}/health" >"$HEALTH_JSON"
+if ! assert_health_contract "$HEALTH_JSON" "$EXPECTED_BASE" "$EXPECTED_CONFIG"; then
+  echo "FAIL: health contract mismatch for run-local fresh boot" >&2
+  cat "$HEALTH_JSON" >&2 || true
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+curl -sS -D "$INIT_HEADERS" -o "$INIT_BODY" \
+  -X POST "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"run-local-fresh-boot","version":"1.0"}}}'
+
+init_code="$(status_code "$INIT_HEADERS")"
+if [[ "$init_code" != "200" ]]; then
+  echo "FAIL: initialize returned HTTP ${init_code}" >&2
+  cat "$INIT_HEADERS" >&2 || true
+  cat "$INIT_BODY" >&2 || true
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+normalize_json "$INIT_BODY" "$INIT_JSON"
+if ! assert_initialize_contract "$INIT_JSON"; then
+  echo "FAIL: initialize payload contract mismatch" >&2
+  cat "$INIT_JSON" >&2 || true
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+SESSION_ID="$(header_value "$INIT_HEADERS" "Mcp-Session-Id")"
+PROTOCOL_VERSION="$(header_value "$INIT_HEADERS" "Mcp-Protocol-Version")"
+[[ -n "$SESSION_ID" ]] || { echo "FAIL: initialize missing Mcp-Session-Id" >&2; exit 1; }
+[[ -n "$PROTOCOL_VERSION" ]] || { echo "FAIL: initialize missing Mcp-Protocol-Version" >&2; exit 1; }
+
+curl -sS -D "$NOTIFY_HEADERS" -o "$NOTIFY_BODY" \
+  -X POST "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "Mcp-Session-Id: ${SESSION_ID}" \
+  -H "Mcp-Protocol-Version: ${PROTOCOL_VERSION}" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+
+notify_code="$(status_code "$NOTIFY_HEADERS")"
+case "$notify_code" in
+  200|202|204) ;;
+  *)
+    echo "FAIL: notifications/initialized returned HTTP ${notify_code}" >&2
+    cat "$NOTIFY_HEADERS" >&2 || true
+    cat "$NOTIFY_BODY" >&2 || true
+    harness_print_log_tail "$LOG_FILE"
+    exit 1
+    ;;
+esac
+
+curl -sS -D "$TOOLS_HEADERS" -o "$TOOLS_BODY" \
+  -X POST "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "Mcp-Session-Id: ${SESSION_ID}" \
+  -H "Mcp-Protocol-Version: ${PROTOCOL_VERSION}" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+tools_code="$(status_code "$TOOLS_HEADERS")"
+if [[ "$tools_code" != "200" ]]; then
+  echo "FAIL: tools/list returned HTTP ${tools_code}" >&2
+  cat "$TOOLS_HEADERS" >&2 || true
+  cat "$TOOLS_BODY" >&2 || true
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+normalize_json "$TOOLS_BODY" "$TOOLS_JSON"
+if ! assert_tools_list_contract "$TOOLS_JSON"; then
+  echo "FAIL: tools/list payload contract mismatch" >&2
+  cat "$TOOLS_JSON" >&2 || true
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+echo "PASS: run-local fresh boot contract"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -134,9 +134,12 @@ harness_start_server() {
   mkdir -p "$base_path"
   (
     export MASC_BASE_PATH="$base_path"
+    export MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$base_path/.masc/config}"
+    export MASC_PERSONAS_DIR="${MASC_PERSONAS_DIR:-$MASC_CONFIG_DIR/personas}"
     export MASC_STORAGE_TYPE="filesystem"
     export MASC_AUTONOMY_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
+    export MASC_KEEPER_BOOTSTRAP_ENABLED="${MASC_KEEPER_BOOTSTRAP_ENABLED:-false}"
     export MASC_ALLOW_LEGACY_ACCEPT="1"
     export MASC_TOOL_TIMEOUT_DEFAULT_SEC="${MASC_TOOL_TIMEOUT_DEFAULT_SEC:-90}"
     export GRAPHQL_API_KEY=""

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -12,18 +12,35 @@ HOST="${MASC_HOST:-127.0.0.1}"
 PORT="${MASC_MCP_PORT:-}"
 PORT_EXPLICIT=0
 PRINT_PORT_ONLY=0
+BOOTSTRAP_ONLY=0
 BUILD_DASHBOARD=0
 DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
 
+git_common_root() {
+  if ! command -v git >/dev/null 2>&1; then
+    return 1
+  fi
+  local common_dir
+  common_dir="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -z "$common_dir" ]; then
+    return 1
+  fi
+  if [[ "$common_dir" != /* ]]; then
+    common_dir="$REPO_ROOT/$common_dir"
+  fi
+  (cd "$(dirname "$common_dir")" && pwd)
+}
+
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/run-local.sh [--target-dir PATH] [--host HOST] [--port PORT] [--print-port] [--build-dashboard]
+Usage: scripts/run-local.sh [--target-dir PATH] [--host HOST] [--port PORT] [--print-port] [--bootstrap-only] [--build-dashboard]
 
 Dir-local local-dev launcher:
   - runtime data root defaults to <target>/.masc/
   - config root defaults to <target>/.masc/config
   - personas root defaults to <target>/.masc/config/personas
   - gRPC / WS / WebRTC are disabled by default
+  - --bootstrap-only materializes local config/build state but does not start the server
 
 For shared repo/full-runtime startup, use ./start-masc-mcp.sh instead.
 EOF
@@ -57,6 +74,22 @@ binary_is_stale() {
   local exe="$1"
   if [ ! -x "$exe" ]; then
     return 0
+  fi
+  if [[ "$exe" != "$REPO_ROOT/"* ]]; then
+    local common_root="" common_head=""
+    common_root="$(git_common_root 2>/dev/null || true)"
+    if [ -n "$common_root" ] && [ "$common_root" != "$REPO_ROOT" ]; then
+      common_head="$(git -C "$common_root" rev-parse HEAD 2>/dev/null || true)"
+      if [ -n "$common_head" ] \
+        && git -C "$REPO_ROOT" diff --quiet "${common_head}"...HEAD -- bin lib dune-project 2>/dev/null \
+        && git -C "$REPO_ROOT" diff --quiet -- bin lib dune-project 2>/dev/null \
+        && git -C "$REPO_ROOT" diff --cached --quiet -- bin lib dune-project 2>/dev/null; then
+        if ! git -C "$REPO_ROOT" ls-files --others --exclude-standard -- bin lib dune-project 2>/dev/null \
+          | grep -q .; then
+          return 1
+        fi
+      fi
+    fi
   fi
   if [ "$REPO_ROOT/dune-project" -nt "$exe" ]; then
     return 0
@@ -102,6 +135,25 @@ build_dashboard_if_requested() {
   fi
 }
 
+resolve_built_exe() {
+  local common_root=""
+  common_root="$(git_common_root 2>/dev/null || true)"
+  local -a candidates=(
+    "$REPO_ROOT/_build/default/bin/main_eio.exe"
+  )
+  if [ -n "$common_root" ] && [ "$common_root" != "$REPO_ROOT" ]; then
+    candidates+=("$common_root/_build/default/bin/main_eio.exe")
+  fi
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  printf '%s\n' "$REPO_ROOT/_build/default/bin/main_eio.exe"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target-dir)
@@ -119,6 +171,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --print-port)
       PRINT_PORT_ONLY=1
+      shift
+      ;;
+    --bootstrap-only)
+      BOOTSTRAP_ONLY=1
       shift
       ;;
     --build-dashboard)
@@ -156,7 +212,7 @@ build_dashboard_if_requested
 
 LOCAL_CONFIG_DIR="${MASC_CONFIG_DIR:-$TARGET_DIR/.masc/config}"
 LOCAL_PERSONAS_DIR="${MASC_PERSONAS_DIR:-$LOCAL_CONFIG_DIR/personas}"
-EXE="$REPO_ROOT/_build/default/bin/main_eio.exe"
+EXE="$(resolve_built_exe)"
 
 if binary_is_stale "$EXE"; then
   echo "[local-run] Building local binary..." >&2
@@ -166,6 +222,15 @@ fi
 if [ ! -x "$EXE" ]; then
   echo "Failed to resolve built binary: $EXE" >&2
   exit 1
+fi
+
+if [ "$BOOTSTRAP_ONLY" = "1" ]; then
+  echo "[local-run] Bootstrap ready" >&2
+  echo "  Target dir: $TARGET_DIR" >&2
+  echo "  Config root: $LOCAL_CONFIG_DIR" >&2
+  echo "  Personas root: $LOCAL_PERSONAS_DIR" >&2
+  echo "  Binary: $EXE" >&2
+  exit 0
 fi
 
 if lsof -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -304,6 +304,30 @@ let test_config_dir_set_personas_dir_unset_defaults_to_config_personas () =
         (contains_substring captured
            ("MASC_PERSONAS_DIR=" ^ Filename.concat override_config "personas")))
 
+let test_bootstrap_only_materializes_state_without_exec () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      let target = Filename.concat dir "target" in
+      mkdir_p target;
+      let capture = Filename.concat dir "captured-env.txt" in
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~env:[ ("FAKE_CAPTURE_FILE", capture) ]
+          ~unset_env:
+            [ "MASC_BASE_PATH"; "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ]
+          (Printf.sprintf "%s --target-dir %s --port 9961 --bootstrap-only"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local bootstrap-only failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      check bool "bootstrapped cascade" true
+        (Sys.file_exists (Filename.concat target ".masc/config/cascade.json"));
+      check bool "fake exe not invoked" false (Sys.file_exists capture);
+      check bool "bootstrap ready message" true
+        (contains_substring stderr "[local-run] Bootstrap ready"))
+
 let () =
   run "run_local_script"
     [
@@ -321,5 +345,7 @@ let () =
             test_explicit_config_env_is_preserved_without_bootstrap;
           test_case "config_dir set personas_dir unset defaults to config/personas" `Quick
             test_config_dir_set_personas_dir_unset_defaults_to_config_personas;
+          test_case "bootstrap-only materializes state without exec" `Quick
+            test_bootstrap_only_materializes_state_without_exec;
         ] );
     ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -97,17 +97,26 @@ room_scope = "current"
 proactive_enabled = false
 |}
 let find_free_port () =
-  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close socket)
-    (fun () ->
-      (match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
-       | () -> ()
-       | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) ->
-         Alcotest.skip ());
-      match Unix.getsockname socket with
-      | Unix.ADDR_INET (_, port) -> port
-      | _ -> Alcotest.fail "unexpected socket address")
+  let start = 9200 + (Unix.getpid () mod 1000) in
+  let rec loop attempts port =
+    if attempts <= 0 then
+      Alcotest.skip ()
+    else
+      let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      let next_port = if port >= 65535 then 9200 else port + 1 in
+      Fun.protect
+        ~finally:(fun () -> Unix.close socket)
+        (fun () ->
+          match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, port)) with
+          | () -> port
+          | exception Unix.Unix_error
+                        ((Unix.EADDRINUSE | Unix.EADDRNOTAVAIL | Unix.EPERM | Unix.EACCES), "bind", _) ->
+              loop (attempts - 1) next_port
+          | exception Unix.Unix_error (err, fn, arg) ->
+              Alcotest.failf "find_free_port bind failed: %s (%s %s)"
+                (Unix.error_message err) fn arg)
+  in
+  loop 2048 start
 
 let merge_env_overrides overrides =
   let override_keys = List.map fst overrides in
@@ -177,6 +186,120 @@ let curl_health_status ~port =
   | Unix.WEXITED 0 -> int_of_string_opt output
   | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None
 
+let curl_health_json ~port =
+  let url = Printf.sprintf "http://127.0.0.1:%d/health" port in
+  let args = [| "curl"; "-sS"; "--http1.1"; "--max-time"; "2"; url |] in
+  let ic = Unix.open_process_args_in "curl" args in
+  let output = read_all ic |> String.trim in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> (
+      try Some (Yojson.Safe.from_string output) with _ -> None)
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None
+
+let http_status_from_headers path =
+  let lines = String.split_on_char '\n' (read_file path) in
+  let rec loop = function
+    | [] -> None
+    | line :: rest ->
+        let line = String.trim line in
+        if String.starts_with ~prefix:"HTTP/" line then
+          match String.split_on_char ' ' line with
+          | _version :: code :: _ -> int_of_string_opt code
+          | _ -> loop rest
+        else
+          loop rest
+  in
+  loop lines
+
+let require_http_status_from_headers path =
+  match http_status_from_headers path with
+  | Some status -> status
+  | None -> Alcotest.failf "missing HTTP status\nheaders:\n%s" (read_file path)
+
+let header_value path key =
+  let key = String.lowercase_ascii key ^ ":" in
+  let lines = String.split_on_char '\n' (read_file path) in
+  let rec loop = function
+    | [] -> None
+    | line :: rest ->
+        let normalized = String.lowercase_ascii line in
+        if String.starts_with ~prefix:key normalized then
+          let value =
+            match String.split_on_char ':' line with
+            | _name :: rest -> String.concat ":" rest |> String.trim
+            | [] -> ""
+          in
+          Some (String.trim (String.map (fun c -> if Char.equal c '\r' then ' ' else c) value))
+        else
+          loop rest
+  in
+  loop lines
+
+let require_header_value path key =
+  match header_value path key with
+  | Some value -> value
+  | None ->
+      Alcotest.failf "missing %s\nheaders:\n%s" key (read_file path)
+
+let parse_json_response_file path =
+  let text = read_file path in
+  let trimmed = String.trim text in
+  if trimmed <> "" && (trimmed.[0] = '{' || trimmed.[0] = '[') then
+    Yojson.Safe.from_string trimmed
+  else
+    let lines = String.split_on_char '\n' text in
+    let rec loop = function
+      | [] -> Alcotest.failf "no JSON payload found in %s" path
+      | line :: rest ->
+          let line = String.trim line in
+          if String.starts_with ~prefix:"data: " line then
+            Yojson.Safe.from_string (String.sub line 6 (String.length line - 6))
+          else
+            loop rest
+    in
+    loop lines
+
+let curl_request_capture ?(headers = []) ~output_dir ~name ~method_ ~url ?payload () =
+  let headers_path = Filename.concat output_dir (name ^ ".headers") in
+  let body_path = Filename.concat output_dir (name ^ ".body") in
+  let base_args =
+    [
+      "curl";
+      "-sS";
+      "--http1.1";
+      "--max-time";
+      "5";
+      "-D";
+      headers_path;
+      "-o";
+      body_path;
+      "-X";
+      method_;
+      url;
+      "-H";
+      "Accept: application/json, text/event-stream";
+    ]
+  in
+  let header_args =
+    headers |> List.concat_map (fun header -> [ "-H"; header ])
+  in
+  let payload_args =
+    match payload with
+    | Some body -> [ "-d"; body ]
+    | None -> []
+  in
+  let args = Array.of_list (base_args @ header_args @ payload_args) in
+  let ic = Unix.open_process_args_in "curl" args in
+  let _ = read_all ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> (headers_path, body_path)
+  | Unix.WEXITED code ->
+      Alcotest.failf "curl %s failed with exit %d" name code
+  | Unix.WSIGNALED signal ->
+      Alcotest.failf "curl %s signaled %d" name signal
+  | Unix.WSTOPPED signal ->
+      Alcotest.failf "curl %s stopped %d" name signal
+
 let process_alive pid =
   match Unix.waitpid [Unix.WNOHANG] pid with
   | 0, _ -> true
@@ -197,6 +320,38 @@ let wait_for_health ~pid ~port ~timeout_s =
         Unix.sleepf 0.1;
         loop ()
       end
+  in
+  loop ()
+
+let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    match curl_health_json ~port with
+    | Some json -> (
+        let phase =
+          Yojson.Safe.Util.(
+            json |> member "startup" |> member "phase" |> to_string_option)
+        in
+        match phase with
+        | Some phase when String.equal phase expected_phase -> true
+        | _ ->
+            if not (process_alive pid) then
+              false
+            else if Unix.gettimeofday () >= deadline then
+              false
+            else begin
+              Unix.sleepf 0.2;
+              loop ()
+            end)
+    | None ->
+        if not (process_alive pid) then
+          false
+        else if Unix.gettimeofday () >= deadline then
+          false
+        else begin
+          Unix.sleepf 0.2;
+          loop ()
+        end
   in
   loop ()
 
@@ -1029,6 +1184,157 @@ let test_main_eio_serves_health_before_lazy_startup () =
             Alcotest.skip ()
           end))
 
+let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
+  with_temp_dir "startup-fresh-boot-e2e" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      let expected_config = Filename.concat dir ".masc/config" in
+      Alcotest.(check bool) "tool policy bootstrapped" true
+        (Sys.file_exists (Filename.concat expected_config "tool_policy.toml"));
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () -> stop_process pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "ready") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio fresh boot did not reach startup.phase=ready within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir ~name:"health" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup =
+            Yojson.Safe.Util.member "startup" health_json
+          in
+          let config_root_path =
+            Yojson.Safe.Util.(
+              health_json
+              |> member "startup"
+              |> member "config_resolution"
+              |> member "config_root"
+              |> member "path"
+              |> to_string)
+          in
+          let effective_base_path =
+            Yojson.Safe.Util.(
+              health_json |> member "paths" |> member "effective_base_path"
+              |> to_string)
+          in
+          Alcotest.(check string) "startup phase ready" "ready"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check string) "effective base path matches fresh dir"
+            (canonical_path dir) (canonical_path effective_base_path);
+          Alcotest.(check string) "config root matches fresh dir"
+            (canonical_path expected_config) (canonical_path config_root_path);
+          let init_headers, init_body =
+            curl_request_capture
+              ~output_dir:dir ~name:"initialize" ~method_:"POST"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/mcp" port)
+              ~headers:[ "Content-Type: application/json" ]
+              ~payload:
+                {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"fresh-boot-test","version":"1.0"}}}|}
+              ()
+          in
+          Alcotest.(check (option int)) "initialize http 200" (Some 200)
+            (http_status_from_headers init_headers);
+          let init_json = parse_json_response_file init_body in
+          Alcotest.(check string) "initialize protocol" "2025-11-25"
+            Yojson.Safe.Util.(
+              init_json |> member "result" |> member "protocolVersion" |> to_string);
+          let session_id =
+            require_header_value init_headers "Mcp-Session-Id"
+          in
+          let protocol_version =
+            require_header_value init_headers "Mcp-Protocol-Version"
+          in
+          let notify_headers, _notify_body =
+            curl_request_capture
+              ~output_dir:dir ~name:"initialized" ~method_:"POST"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/mcp" port)
+              ~headers:
+                [
+                  "Content-Type: application/json";
+                  "Mcp-Session-Id: " ^ session_id;
+                  "Mcp-Protocol-Version: " ^ protocol_version;
+                ]
+              ~payload:
+                {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
+              ()
+          in
+          let notify_code =
+            require_http_status_from_headers notify_headers
+          in
+          Alcotest.(check bool) "notifications/initialized accepted" true
+            (List.mem notify_code [ 200; 202; 204 ]);
+          let tools_headers, tools_body =
+            curl_request_capture
+              ~output_dir:dir ~name:"tools-list" ~method_:"POST"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/mcp" port)
+              ~headers:
+                [
+                  "Content-Type: application/json";
+                  "Mcp-Session-Id: " ^ session_id;
+                  "Mcp-Protocol-Version: " ^ protocol_version;
+                ]
+              ~payload:
+                {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|}
+              ()
+          in
+          Alcotest.(check (option int)) "tools/list http 200" (Some 200)
+            (http_status_from_headers tools_headers);
+          let tools_json = parse_json_response_file tools_body in
+          let tool_names =
+            Yojson.Safe.Util.(
+              tools_json |> member "result" |> member "tools" |> to_list
+              |> List.filter_map (fun tool ->
+                     match member "name" tool with
+                     | `String name -> Some name
+                     | _ -> None))
+          in
+          Alcotest.(check bool) "tools/list nonempty" true (tool_names <> []);
+          Alcotest.(check bool) "canonical tool present" true
+            (List.mem "masc_status" tool_names)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1144,5 +1450,8 @@ let () =
             test_prompt_markdown_dir_prefers_resolved_config_dir_over_cwd;
           Alcotest.test_case "main_eio serves health before lazy startup"
             `Slow test_main_eio_serves_health_before_lazy_startup;
+          Alcotest.test_case
+            "main_eio fresh bootstrap and MCP handshake"
+            `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add a fresh temp-dir `run-local` contract script that bootstraps local state and verifies `/health`, `initialize`, `notifications/initialized`, and `tools/list`
- add `--bootstrap-only` launcher coverage and a runtime bootstrap test that verifies fresh config bootstrapping plus MCP handshake
- harden local harness/bootstrap defaults and align the repo with the current Agent SDK surface by removing the stale `agent_sdk.swarm` dependency shim

## Why
Fresh temp-dir startup was real but the proof path was too fragile. Detached shell startup was flaky in this environment, and the runtime verification depended on brittle port/header handling. This makes the fresh-boot path auditable through repeatable tests instead of ad hoc manual belief.

## Product impact
- `scripts/run-local.sh` can now materialize local config/build state without starting the server
- contributors get a focused manual smoke script for fresh temp-dir startup
- automated coverage now exercises the fresh bootstrap + MCP handshake path directly
- this branch is currently blocked by the post-#8466 swarm removal drift noted below

## Validation
- `env OPAMSWITCH=5.4.1 opam exec -- dune exec --root . ./test/test_run_local_script.exe`
- `env OPAMSWITCH=5.4.1 timeout 120 opam exec -- dune exec --root . ./test/test_server_runtime_bootstrap.exe`
- `bash -n scripts/run-local.sh`
- `bash -n scripts/harness/lib/server_bootstrap.sh`
- `bash -n scripts/harness/contract/run_local_fresh_boot_contract.sh`
- `bash -n scripts/harness/contract/run_all.sh`
- `git diff --check`

## Root cause
The verification path mixed real functionality with environment-sensitive assumptions: stale SDK package names, ephemeral-port binding that can `EPERM` in sandboxed runs, and fragile MCP header/status capture. Tightening those assumptions made the proof path reliable.

## Evidence
- fresh temp-dir bootstrap coverage and contract scripts are the core proof surface on this branch
- current rebase check shows the branch still modifies deleted swarm-era files, so this PR is not merge-ready as-is after #8466

## Review evidence
- self-review completed on the fresh-boot bootstrap/test harness changes
- separate rebase review found a ghost-branch problem: `lib/swarm.ml` was deleted in main via #8466 but this branch still modifies it

## Linked issue
- Refs #8466
- Refs #8574