### PR TITLE
feat(cli-connector): add AutoFix descriptions to 3 Doctor checks

### DIFF
--- a/sidecars/cli-connector/src/doctor.py
+++ b/sidecars/cli-connector/src/doctor.py
@@ -27,7 +27,7 @@ if str(_shared_root) not in sys.path:
 
 import httpx  # noqa: E402
 
-from gate_shared import Check, Doctor, Severity  # noqa: E402
+from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
 from gate_shared.doctor import (  # noqa: E402
     NETWORK_TIMEOUT_SEC,
     check_dependencies_installed,
@@ -130,6 +130,10 @@ async def check_gate_reachable() -> Check:
             detail=url,
             message=res,
             hint="MASC 서버 기동 여부 확인 (./start-masc-mcp.sh)",
+            auto_fix=AutoFix(
+                description="MASC 서버를 다른 터미널에서 기동: ./start-masc-mcp.sh",
+                command="./start-masc-mcp.sh",
+            ),
         )
     if res.status_code >= 500:
         return Check(
@@ -180,6 +184,10 @@ async def check_keepers_available() -> Check:
             detail="0 keepers",
             message="서버에 등록된 keeper 가 없습니다.",
             hint="config/keepers/*.toml 에 keeper 를 정의하거나 runtime 등록 수행",
+            auto_fix=AutoFix(
+                description="config/keepers/ 에 keeper TOML 추가 후 서버 재기동, 또는 runtime 등록 API 호출",
+                command="ls $MASC_BASE_PATH/config/keepers/",
+            ),
         )
     return Check(
         name="keepers available",
@@ -204,12 +212,17 @@ async def check_default_keeper_exists() -> Check:
     except ValueError:
         return Check(name="default keeper exists", severity=Severity.skip, message="keepers 응답 파싱 실패")
     if default not in names:
+        suggested = names[0] if names else default
         return Check(
             name="default keeper exists",
             severity=Severity.warn,
             detail=default,
             message=f"CLI_DEFAULT_KEEPER='{default}' 가 등록된 keeper 목록에 없습니다. CLI 는 여전히 직접 이름 지정으로 동작합니다.",
-            hint="python -m src <existing_keeper_name> 으로 직접 지정",
+            hint=f"등록된 keeper: {', '.join(names[:5]) or '(none)'} — python -m src <existing_keeper_name> 으로 직접 지정",
+            auto_fix=AutoFix(
+                description=f"CLI_DEFAULT_KEEPER 를 실제 등록된 keeper 로 변경 (예: '{suggested}')",
+                command=f"export CLI_DEFAULT_KEEPER={suggested}",
+            ),
         )
     return Check(
         name="default keeper exists",


### PR DESCRIPTION
## Summary

cli-connector Doctor 는 **stateless** (바인딩/파일/토큰 없음) 이라 chmod/mkdir callback 대상이 구조적으로 없지만, "이거 해라" 축의 복사-붙여넣기용 `AutoFix(description=..., command=...)` 는 CLI 운영자에게 직접 가치. 다른 4 sidecar (discord/imessage/slack/telegram) 모두 최소 1 AutoFix 를 가지는데 cli-connector 만 0 인 gap 해소.

## Product impact

| | Before | After |
|--|--------|-------|
| cli-connector 운영자 | gate unreachable / keeper 없음 / default mismatch 시 텍스트 hint만 | 복사-붙여넣기 가능한 AutoFix 명령 |
| default keeper warn | "python -m src <existing_keeper_name>" 추상 | 실제 등록된 keeper 이름 3개까지 hint 노출 |
| Dashboard drill-down | cli-connector 행은 자동 치유 배지 0 | 여전히 0 (callback=None 의도) — 배지 조건 `callback_available=true` (#8541) |
| shared 프레임워크 | 무변경 | 무변경 |

## 현황 (before)

| sidecar | Check() | AutoFix | callback |
|---------|---------|---------|----------|
| cli-connector | 7 | **0** | **0** |
| discord-bot | 11 | 2 | 1 |
| imessage-bot | 11 | 1 | 1 |
| slack-bot | 10 | 1 | 1 |
| telegram-bot | 11 | 1 | 1 |

## 변경 check 3개

| # | Check | 조건 | AutoFix |
|---|-------|------|---------|
| 1 | gate reachable | error (connect failed) | `./start-masc-mcp.sh` |
| 2 | keepers available | error (0 keepers) | `ls $MASC_BASE_PATH/config/keepers/` + description |
| 3 | default keeper exists | warn (not in names) | `export CLI_DEFAULT_KEEPER=<suggested>` — `suggested=names[0]` 으로 실제 등록 keeper 이름 제안 |

### #3 의 추가 가치: hint enrichment

변경 전: `"python -m src <existing_keeper_name> 으로 직접 지정"` — 추상적
변경 후: `"등록된 keeper: sangsu, minjae, ani1999 — python -m src <existing_keeper_name> 으로 직접 지정"` — 구체적

LLM 도 사람도 즉시 대응 가능.

## 경계 설명

**callback=None** 은 의도. sidecar 프로세스가 사용자 **환경변수** 나 **MASC 서버 프로세스 자체** 를 autofix 하는 건 경계 위반:
- `CLI_DEFAULT_KEEPER` 는 shell session 단위 → sidecar 에서 설정 불가
- `./start-masc-mcp.sh` 는 별도 프로세스 기동 → sidecar 경계 밖

CLI 는 사람이 description 을 보고 직접 실행. Doctor 가 **"내가 해주겠다"** 대신 **"이거 해라"** 로 수렴하는 건 자연스러운 축 (원래 Doctor phase 1 프롬프트의 두 모드 모두 표현).

## Evidence

```bash
$ GATE_BASE_URL=http://127.0.0.1:1 python -m src doctor --json
```

`gate reachable` check 출력 (발췌):

```json
{
  "name": "gate reachable",
  "severity": "error",
  "auto_fix": {
    "description": "MASC 서버를 다른 터미널에서 기동: ./start-masc-mcp.sh",
    "command": "./start-masc-mcp.sh",
    "callback_available": false
  }
}
```

`callback_available: false` 올바르게 직렬화 — Dashboard drill-down 의 "자동 치유" 배지에 뜨지 않음 (의도된 동작, #8541 참조).

나머지 2 check (`keepers available` error / `default keeper exists` warn) 는 서버 reachable + keeper list mismatch 상태 필요 — async mock 인프라 없이 세션 내 재현 불가. 동일 `AutoFix(description=..., command=...)` 문법 extension 이라 shared 프레임워크 render_json 이 동일 경로로 직렬화 (shared/tests/test_doctor.py 19+1 cases 가 이미 보장).

## Review evidence

자체 리뷰:

1. **프레임워크 무변경**: `gate_shared/doctor.py` 의 AutoFix/Check/render_json 수정 없음 — consumer 확장 only.
2. **sidecar 경계 존중**: callback=None 으로 shell env/서버 프로세스를 autofix 하지 않음. Description-only 는 운영자 보조 도구.
3. **Ruff clean**: `ruff check sidecars/cli-connector/src/doctor.py` → All checks passed.
4. **Hint + AutoFix 분리**: 기존 hint 유지 + AutoFix 는 구조화된 명령. Dashboard (#8541 배지) 와 CLI pretty (description text) 양쪽에 자연스럽게 노출.
5. **Keeper name privacy**: names[:5] 로 잘라서 과도한 exposure 방지 (기본 작음).

## Linked issue

Refs:
- #8541 — autofix badge (Dashboard UI, `callback_available` 체크)
- #8478 — Doctor 축 phase 1 진입점
- #8525 — backend HTTP endpoint
- #8518 — JSON envelope shape
- #8375 — shared Doctor framework (AutoFix / Severity / Check)

Refs #8541 #8478 #8525 #8518 #8375

## 변경 없는 것

- 다른 4 sidecar
- `gate_shared/doctor.py` 프레임워크
- `run_doctor()` 등록 순서 / check 수
- pyright/mypy 타입 시그니처 (AutoFix import 만 추가)

## 체크리스트

- [x] cli-connector doctor.py 에 `AutoFix` import 추가
- [x] 3 check 에 `auto_fix=AutoFix(description=..., command=...)` 삽입
- [x] `default keeper exists` 의 hint 에 실제 등록 keeper 이름 포함
- [x] ruff check clean
- [x] Empirical JSON 렌더링 검증 (1/3 paths, 나머지 2 는 pattern extension)
- [ ] CI green

## Follow-up (out of scope)

- cli-connector 에 unit test infra (pytest-asyncio + conftest) — 별도 PR
- 서버 reachable 상태에서 남은 2 check 경로 manual verification — 서버 재기동 후 dogfooding
- 다른 sidecar 의 hint enrichment (등록된 id 목록 포함 등) — 유사 패턴 이식

## Doctor 축 진행도

```
phase 1 CLI + HTTP + Dashboard              ✓ #8478~#8542 (13 PR)
phase 1 sidecar coverage                    ✓ 5/5 전부 doctor.py
phase 1 AutoFix minimum coverage            ← 이 PR — cli-connector 마지막 gap 해소
phase 2 in-process endpoint                 후속 (library extraction)
축 9 callback 실체 확장                      후속 (operational risk)
`--fix` UI trigger                          후속 (HITL + audit 선행)
```