### PR TITLE
spec(keeper_state_machine): align TLA+ event alphabet with OCaml runtime — Phase 1 (#8578)

### DIFF
--- a/specs/keeper-state-machine/KeeperStateMachine.tla
+++ b/specs/keeper-state-machine/KeeperStateMachine.tla
@@ -180,6 +180,25 @@ CompactionCompleted ==
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
 
+\* Compaction attempt failed — clears the in-flight compaction flag but
+\* deliberately leaves [context_overflow] set so the keeper re-enters
+\* Overflowed for the retry loop to decide next step. The retry-budget
+\* latch is owned by [CompactRetryExhausted] (separate event) once the
+\* caller exhausts its allowance. Mirrors [Compaction_failed] in
+\* [Keeper_state_machine.update_conditions]; added in #8578 to align the
+\* model's event alphabet with the runtime so TLC can reason about
+\* failure paths.
+CompactionFailed ==
+    /\ NotTerminal /\ compaction_active
+    /\ compaction_active' = FALSE
+    /\ UNCHANGED <<launch_pending, fiber_alive, heartbeat_healthy, turn_healthy,
+                   context_within_budget, context_handoff_needed,
+                   handoff_active, operator_paused, stop_requested,
+                   restart_budget_remaining, backoff_elapsed,
+                   guardrail_triggered, drain_complete,
+                   context_overflow, compact_retry_exhausted,
+                   restart_count>>
+
 HandoffStarted ==
     /\ NotTerminal /\ fiber_alive
     /\ ~handoff_active /\ ~compaction_active
@@ -193,6 +212,21 @@ HandoffStarted ==
                    restart_count>>
 
 HandoffCompleted ==
+    /\ NotTerminal /\ handoff_active
+    /\ handoff_active' = FALSE
+    /\ UNCHANGED <<launch_pending, fiber_alive, heartbeat_healthy, turn_healthy,
+                   context_within_budget, context_handoff_needed,
+                   compaction_active, operator_paused, stop_requested,
+                   restart_budget_remaining, backoff_elapsed,
+                   guardrail_triggered, drain_complete,
+                   context_overflow, compact_retry_exhausted,
+                   restart_count>>
+
+\* Handoff attempt failed — clears the in-flight handoff flag, leaves
+\* the rest unchanged. Mirrors [Handoff_failed] in
+\* [Keeper_state_machine.update_conditions]; added in #8578 so TLC can
+\* reason about handoff failure recovery.
+HandoffFailed ==
     /\ NotTerminal /\ handoff_active
     /\ handoff_active' = FALSE
     /\ UNCHANGED <<launch_pending, fiber_alive, heartbeat_healthy, turn_healthy,
@@ -226,6 +260,24 @@ OperatorResume ==
                    restart_count>>
 
 StopRequested ==
+    /\ NotTerminal /\ ~stop_requested
+    /\ stop_requested' = TRUE
+    /\ UNCHANGED <<launch_pending, fiber_alive, heartbeat_healthy, turn_healthy,
+                   context_within_budget, context_handoff_needed,
+                   compaction_active, handoff_active, operator_paused,
+                   restart_budget_remaining, backoff_elapsed,
+                   guardrail_triggered, drain_complete,
+                   context_overflow, compact_retry_exhausted,
+                   restart_count>>
+
+\* Operator-initiated stop. Same condition update as [StopRequested]
+\* (sets [stop_requested]); the runtime distinguishes the two by a
+\* [remove_meta] payload that controls whether the keeper meta file is
+\* deleted on stop. The condition-level effect is identical, so TLC
+\* sees the same successor states. Mirrors [Operator_stop] in
+\* [Keeper_state_machine.update_conditions]; added in #8578 so the
+\* model and runtime share the same event alphabet.
+OperatorStop ==
     /\ NotTerminal /\ ~stop_requested
     /\ stop_requested' = TRUE
     /\ UNCHANGED <<launch_pending, fiber_alive, heartbeat_healthy, turn_healthy,
@@ -393,10 +445,10 @@ Next ==
     \/ HeartbeatOk      \/ HeartbeatFailed
     \/ TurnSucceeded    \/ TurnFailed
     \/ ContextMeasured
-    \/ CompactionStarted \/ CompactionCompleted
-    \/ HandoffStarted   \/ HandoffCompleted
+    \/ CompactionStarted \/ CompactionCompleted \/ CompactionFailed
+    \/ HandoffStarted   \/ HandoffCompleted    \/ HandoffFailed
     \/ OperatorPause    \/ OperatorResume
-    \/ StopRequested    \/ DrainCompleteEv
+    \/ StopRequested    \/ OperatorStop        \/ DrainCompleteEv
     \/ FiberTerminated  \/ FiberStarted
     \/ SupervisorRestartAttempt
     \/ RestartBudgetExhausted


### PR DESCRIPTION
## Summary

Phase 1 of the FSM ↔ TLA+ ↔ OCaml audit (#8578). The OCaml `Keeper_state_machine.event` Variant emits three events the spec did not model:

| OCaml event | Condition update | Was modelled in TLA+? |
|------------|-----------------|----------------------|
| `Compaction_failed` | `compaction_active = false` (leaves `context_overflow` set) | no |
| `Handoff_failed` | `handoff_active = false` | no |
| `Operator_stop` | `stop_requested = true` (= `StopRequested` minus `remove_meta` payload) | no |

Without these actions, TLC reasons over a strict subset of the runtime event alphabet — bugs that show up only on failure or operator-stop paths are invisible to model checking. The model could prove safety properties about a system that never enters the failure transitions the production code actually fires.

Same drift class as the recent SSOT sweep (#8430 / #8471 / #8474 / #8493 / #8513 / #8524 / #8527 / #8546 / #8569 / #8572 / #8575), but at the spec/code boundary.

## Fix (Phase 1)

- Three new TLA+ actions in `KeeperStateMachine.tla`:
  - `CompactionFailed` (after `CompactionCompleted`)
  - `HandoffFailed` (after `HandoffCompleted`)
  - `OperatorStop` (after `StopRequested`)
- Each mirrors the OCaml `update_conditions` branch literally; `UNCHANGED` clauses pin every other variable so TLC sees the exact same successor states the runtime produces.
- All three appended to `Next` so TLC enables them.
- Inline commentary points back to the OCaml site so future spec editors can find the source of truth.

## NOT in this PR (follow-ups)

1. **Phase 2** — introduce `Compact_retry_exhausted` as a first-class OCaml event (currently TLA+ has `CompactRetryExhausted` but the OCaml runtime flips the flag as a side-effect of higher-level retry-loop code in `keeper_unified_turn`). Converse drift; requires call-site changes out of scope here.
2. **Drift gate** — mechanical mirror of TLA+ `Next` action set vs OCaml `event_to_string` string set (assert strict superset now, exact match after Phase 2). Either a sync test or a script that parses `.tla`; larger surface than this Phase 1 commit.

## Test plan

- [x] Spec edits preserve every existing `UNCHANGED` clause; new actions are condition-update mirrors of OCaml branches I read line-by-line in `update_conditions`.
- [x] Existing `TypeOK` and terminal-permanence invariants still hold (new actions don't introduce new variables; condition updates stay within existing type domains).
- [ ] CI green — TLC will exercise the expanded `Next` against existing properties (`DeadIsForever`, `StoppedIsForever`, `BudgetNeverRevives`, `RestartCountMonotonic`, …) under the larger event alphabet.

20th SSOT site overall — first one at the spec/code boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Product impact
- no runtime OCaml behavior change in this PR; it makes the TLA+ model cover failure and operator-stop paths the runtime already emits
- current OAS main compatibility is preserved on this branch too

## Evidence
- the spec now models `Compaction_failed`, `Handoff_failed`, and `Operator_stop` successors explicitly
- branch also carries the current OAS `Event_bus.meta` wildcard compatibility fix

## Review evidence
- self-review on the TLA+ action additions against the corresponding OCaml `update_conditions` branches
- branch includes the same metadata wildcard pattern needed for latest OAS-pinned warning-as-error builds

## Linked issue
- Closes #8578
- Refs #8579