### PR TITLE
fix(keeper_state_machine): introduce Compact_retry_exhausted event — close TLA+/OCaml latch drift (#8581)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -135,6 +135,20 @@ type event =
       limit_tokens : int option;
     }
   | Auto_compact_triggered
+  | Compact_retry_exhausted
+    (** Issue #8581: latch the [compact_retry_exhausted] condition.
+
+        Before this event existed, the field was read in [derive_phase]
+        but never set in OCaml — the right disjunct of the Paused
+        promotion ([context_overflow] /\ [compact_retry_exhausted]) was
+        dead code. The retry-loop in [keeper_unified_turn] paused the
+        keeper via [Operator_pause] instead, conflating "operator paused"
+        with "auto-compact retry budget exhausted" on dashboards.
+
+        Dispatchers should fire this BEFORE [Operator_pause] so the
+        Paused phase carries the real reason (budget exhaustion) for
+        observability, while the existing first disjunct
+        ([operator_paused]) still drives derive_phase deterministically. *)
   | Operator_compact_requested
   | Operator_clear_requested of { preserve_system : bool; reason : string }
 
@@ -183,6 +197,7 @@ let event_to_string = function
     Printf.sprintf "context_overflow_detected(%s,tokens=%d,limit=%s)"
       src r.token_count lim
   | Auto_compact_triggered -> "auto_compact_triggered"
+  | Compact_retry_exhausted -> "compact_retry_exhausted"
   | Operator_compact_requested -> "operator_compact_requested"
   | Operator_clear_requested r ->
     Printf.sprintf "operator_clear_requested(preserve_system=%b,reason=%s)"
@@ -453,6 +468,15 @@ let update_conditions (c : conditions) (ev : event) : conditions =
        keeper into [Compacting] on the next derivation without waiting
        for [Compaction_started] from the post-turn lifecycle. *)
     { c with compaction_active = true }
+  | Compact_retry_exhausted ->
+    (* Issue #8581: latch the retry-exhausted condition. Mirrors the
+       TLA+ [CompactRetryExhausted] action. The right disjunct of
+       [derive_phase]'s Paused branch — [(context_overflow &&
+       compact_retry_exhausted)] — was previously dead code because
+       no event ever set this flag; now [pause_keeper_for_overflow]
+       dispatches it before [Operator_pause] so the Paused phase
+       carries the actual reason for dashboards / observability. *)
+    { c with compact_retry_exhausted = true }
   | Operator_compact_requested ->
     (* Operator override: same as [Auto_compact_triggered] but also
        releases the retry latch so that a fresh compaction sequence
@@ -668,6 +692,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
       "limit_tokens", limit_tokens;
     ]
   | Auto_compact_triggered -> obj "auto_compact_triggered" []
+  | Compact_retry_exhausted -> obj "compact_retry_exhausted" []
   | Operator_compact_requested -> obj "operator_compact_requested" []
   | Operator_clear_requested r ->
     obj "operator_clear_requested" [

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -186,6 +186,15 @@ type event =
     (** Emitted as part of [Overflowed] entry actions to mark the
         start of auto-recovery. Sets [compaction_active] so the next
         [derive_phase] returns [Compacting]. *)
+  | Compact_retry_exhausted
+    (** Issue #8581: latches [compact_retry_exhausted]. Mirrors the
+        TLA+ [CompactRetryExhausted] action. Dispatchers fire this
+        before [Operator_pause] so the Paused phase carries the real
+        reason ("auto-compact retry budget exhausted") for operator
+        observability. Before this event existed, the
+        [compact_retry_exhausted] field was read by [derive_phase]
+        but never set in OCaml — the right disjunct of the Paused
+        promotion was dead code. *)
   | Operator_compact_requested
     (** Operator invoked [masc_keeper_compact] MCP tool. Behaves like
         [Auto_compact_triggered] but also clears [compact_retry_exhausted]

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -477,6 +477,19 @@ let pause_keeper_for_overflow
          "%s: overflow pause write_meta failed: %s"
          meta.name err);
   Keeper_registry.update_meta ~base_path:config.base_path meta.name paused_meta;
+  (* Issue #8581: latch the retry-exhausted condition BEFORE the
+     Operator_pause that drives the Paused phase. This way the Paused
+     state carries the real reason (auto-compact retry budget exhausted)
+     for dashboards / operator observability — the right disjunct of
+     [derive_phase]'s Paused branch ([context_overflow] /\
+     [compact_retry_exhausted]) reaches a real value instead of staying
+     dead code. The Operator_pause that follows still drives the actual
+     phase transition deterministically (first disjunct:
+     [operator_paused]). *)
+  dispatch_keeper_phase_event
+    ~config
+    ~keeper_name:meta.name
+    Keeper_state_machine.Compact_retry_exhausted;
   dispatch_keeper_phase_event
     ~config
     ~keeper_name:meta.name

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -833,6 +833,37 @@ let () =
           Masc_mcp.Keeper_status_detail.valid_tail_order_strings
           Masc_mcp.Keeper_schema.tail_order_enum_strings);
     ];
+    "compact_retry_exhausted_ssot", [
+      (* Issue #8581: the [compact_retry_exhausted] field was read by
+         derive_phase to promote (context_overflow + latch) to Paused
+         but never set in OCaml — the right disjunct of the Paused
+         branch was dead code. The fix introduces a first-class event
+         [Compact_retry_exhausted] that latches the field, dispatched by
+         [pause_keeper_for_overflow] before [Operator_pause]. These
+         tests pin the new event surface and the latch transition. *)
+      Alcotest.test_case "event_to_string emits stable wire string" `Quick (fun () ->
+        let open Masc_mcp.Keeper_state_machine in
+        Alcotest.(check string) "Compact_retry_exhausted wire form"
+          "compact_retry_exhausted"
+          (event_to_string Compact_retry_exhausted));
+      Alcotest.test_case "update_conditions latches the flag" `Quick (fun () ->
+        let open Masc_mcp.Keeper_state_machine in
+        let c0 = default_conditions in
+        Alcotest.(check bool) "init: flag false" false
+          c0.compact_retry_exhausted;
+        let c1 = update_conditions c0 Compact_retry_exhausted in
+        Alcotest.(check bool) "after event: flag true" true
+          c1.compact_retry_exhausted);
+      Alcotest.test_case "Operator_compact_requested clears the latch" `Quick (fun () ->
+        let open Masc_mcp.Keeper_state_machine in
+        let c =
+          update_conditions default_conditions Compact_retry_exhausted
+        in
+        Alcotest.(check bool) "latched" true c.compact_retry_exhausted;
+        let c' = update_conditions c Operator_compact_requested in
+        Alcotest.(check bool) "cleared by operator compact" false
+          c'.compact_retry_exhausted);
+    ];
     "verdict_ssot", [
       (* Issue #8436: payload-bearing variants need a witness function
          (not List.map verdict_to_string list, which would emit "WARN: "


### PR DESCRIPTION
## Summary

Closes #8581. **REAL bug 11th + Phase 2 of the FSM/TLA+/OCaml audit (#8578)**.

\`Keeper_state_machine.compact_retry_exhausted\` was read by \`derive_phase\` to promote \`(context_overflow ∧ compact_retry_exhausted) → Paused\`, reset to \`false\` by 4 event handlers, but **never set to true** anywhere in OCaml. \`rg 'compact_retry_exhausted = true' lib/\` returned no matches. The right disjunct of the Paused branch was dead code; the production Paused-from-overflow path went through \`Operator_pause\` instead, conflating "operator paused" with "auto-compact retry budget exhausted" on dashboards.

| Symptom | Source |
|---------|--------|
| Field declared | \`keeper_state_machine.ml:71\` |
| Read by \`derive_phase\` | \`keeper_state_machine.ml:334\` |
| Reset to \`false\` (×4 handlers) | \`keeper_state_machine.ml:385/436/460/466\` |
| **Never set to \`true\`** | (no occurrences in lib) |
| Spec models \`CompactRetryExhausted\` | \`KeeperStateMachine.tla:351\` |
| Production paused-from-overflow path | \`keeper_unified_turn.ml:480-483\` (Operator_pause) |

Same drift class as #8569 (channel label drift) but at a deeper layer — SSOT exists, field exists, read exists, only the writer was missing.

## Fix

- New event constructor \`Compact_retry_exhausted\` in \`Keeper_state_machine.event\`. \`update_conditions\` latches \`compact_retry_exhausted := true\`; \`event_to_string\` and JSON serialiser cover the new constructor; \`mli\` docstring describes the dispatch contract.
- \`keeper_unified_turn.pause_keeper_for_overflow\` dispatches \`Compact_retry_exhausted\` **before** the existing \`Operator_pause\`. \`derive_phase\` priority order means \`operator_paused\` still drives the Paused transition (first disjunct); the new latch records the **WHY** for dashboards (right disjunct).

## Tests

\`test/test_types.ml :: compact_retry_exhausted_ssot\` — 3 cases
- \`event_to_string\` emits stable wire string (\`compact_retry_exhausted\`) so observers stay green
- \`update_conditions\` latches the flag from \`default_conditions\` (proves the writer now exists)
- \`Operator_compact_requested\` still clears the latch (regression against the existing reset paths)

## Test plan

- [x] \`dune build lib\` clean.
- [x] Phase order preserved — \`operator_paused\` (first disjunct) keeps driving the transition; the new latch is observability-only.
- [ ] CI green — \`compact_retry_exhausted_ssot\` runs as part of \`test_types\`.

This closes the **OCaml → TLA+ direction** of the FSM audit. Phase 1 (PR #8580) added the **TLA+ → OCaml** events the spec was missing (\`CompactionFailed\` / \`HandoffFailed\` / \`OperatorStop\`). After both phases land, the OCaml \`event_to_string\` set and the TLA+ \`Next\` action set are in exact correspondence — the drift gate becomes a strict-equality test instead of a one-sided subset check.

21st SSOT site overall, second one at the spec/code boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)