### PR TITLE
[codex] set codex mcp off in built-in keepers

### DIFF
--- a/config/keepers/analyst.toml
+++ b/config/keepers/analyst.toml
@@ -12,3 +12,4 @@ telemetry_feedback_window_hours = 24
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/config/keepers/executor.toml
+++ b/config/keepers/executor.toml
@@ -12,3 +12,4 @@ telemetry_feedback_window_hours = 24
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/config/keepers/scholar.toml
+++ b/config/keepers/scholar.toml
@@ -12,3 +12,4 @@ telemetry_feedback_window_hours = 24
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -12,3 +12,4 @@ telemetry_feedback_window_hours = 24
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -53,7 +53,7 @@ OAS 0.159.0부터 비대화형 CLI transport(`transport_claude_code`, `transport
 - Gemini CLI는 hook 런타임 off 플래그가 없다. hook 제어가 필요하면 `gemini hooks <cmd>` subcommand로 keeper 기동 전에 비활성화한다.
 - "empty string = disable all" 구분이 필요한 MCP whitelist만 `OAS_GEMINI_NO_MCP` 불 env로 분리되어 있음(`Unix.putenv`로는 진짜 unset이 불가한 제약 반영).
 
-**선언적 설정 (권장)**: process env 대신 `config/keepers/<name>.toml`의 `[keeper.oas_env]` 테이블에 적어두면 턴 시작 시 `Unix.putenv`로 자동 적용된다. 4개 built-in keeper는 `OAS_CLAUDE_STRICT_MCP=1` + `OAS_GEMINI_NO_MCP=1` 기본값이 이미 들어있다. 예시:
+**선언적 설정 (권장)**: process env 대신 `config/keepers/<name>.toml`의 `[keeper.oas_env]` 테이블에 적어두면 턴 시작 시 `Unix.putenv`로 자동 적용된다. 4개 built-in keeper는 `OAS_CLAUDE_STRICT_MCP=1` + `OAS_GEMINI_NO_MCP=1` + `OAS_CODEX_CONFIG=mcp_servers={}` 기본값이 이미 들어있다. 예시:
 
 ```toml
 [keeper]
@@ -64,7 +64,7 @@ persona_name = "analyst"
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
 # Codex는 -c TOML override로만 제어 가능
-OAS_CODEX_CONFIG = "sandbox_mode=read-only"
+OAS_CODEX_CONFIG = "mcp_servers={},sandbox_mode=read-only"
 ```
 
 키는 반드시 `^OAS_(CLAUDE|CODEX|GEMINI)_.+` 패턴에 맞아야 한다. 그 외 키(`PATH`, `LD_PRELOAD`, 임의 변수 등)는 silently 드롭되어 ambient env 주입을 차단한다. bool 값은 `true`→`"1"`, `false`→`"0"`으로 자동 변환된다.


### PR DESCRIPTION
## Summary
- add `OAS_CODEX_CONFIG = "mcp_servers={}"` to all built-in keeper `oas_env` blocks
- sync the keeper user manual so the documented built-in defaults match the shipped config
- carry the current-main compatibility fixes (`a2a_tools` Types qualification and OAS `Event_bus.meta` wildcard patterns) so this branch builds on top of today's `main`

## What changed
- add `OAS_CODEX_CONFIG = "mcp_servers={}"` to all built-in keeper `oas_env` blocks
- sync the keeper user manual so the documented built-in defaults match the shipped config

## Why
The live keeper setup already relied on `OAS_GEMINI_NO_MCP=1`, but built-in keeper TOML did not disable Codex MCP by default. That allowed Codex CLI to emit MCP preamble/errors before JSON output, breaking non-interactive keeper runs. This makes the built-in config match the intended CLI-only contract.

## Validation
- `dune runtest --root . test/test_keeper_toml.exe test/test_keeper_toml_config_validation.exe`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/cli-headless-20260419 @check`

## Product impact
- built-in keepers now disable Codex MCP by default, matching the headless keeper contract already assumed in production-like runs
- branch CI now measures the keeper config change itself instead of failing on unrelated repo-wide compatibility drift

## Evidence
- built-in keeper TOML now carries `OAS_CODEX_CONFIG = "mcp_servers={}"`
- the branch now qualifies the remaining `Types.*` refs in `lib/a2a_tools.ml` and accepts the added `Event_bus.meta.caused_by` field, which were the actual reasons current-main CI failed before the keeper TOML change could be evaluated

## Review evidence
- self-review on the built-in keeper config surfaces, manual sync, and the two current-main compatibility shims required for this branch
- branch-local `@check` passes on the updated head

## Linked issue
- Refs #8584
- Refs #8579