### PR TITLE
fix(a2a_tools): qualify Types.agent after open removal (#8584)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -300,13 +300,13 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
     let filtered = match capability with
       | None -> agents
       | Some cap ->
-        List.filter (fun (a : agent) ->
+        List.filter (fun (a : Types.agent) ->
           List.mem cap a.capabilities
         ) agents
     in
     (* Include local agent card *)
     let local_card = Agent_card.generate_default ~schemas () in
-    let agents_json = List.map (fun (a : agent) ->
+    let agents_json = List.map (fun (a : Types.agent) ->
       `Assoc [
         ("name", `String a.name);
         ("status", `String (agent_status_to_string a.status));
@@ -337,7 +337,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
 let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Coord.get_agents_raw config in
-  let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
+  let agent_opt = List.find_opt (fun (a : Types.agent) -> a.name = agent_name) agents in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->


### PR DESCRIPTION
## Summary
- **main build red**. PR #8528 removed \`open Types\` but left 3 \`(a : agent)\` annotations depending on it at \`lib/a2a_tools.ml:303/309/340\`.
- Fix: qualify as \`(a : Types.agent)\`.

## Issues
Closes #8584.

## Changes
- \`lib/a2a_tools.ml\`: 3 line edits, same surgical pattern as #8508 (\`keeper_accountability.ml\` — merged).

## Tests
- \`dune build lib\` now succeeds (\`agent\` type constructor resolves).
- Pre-fix error: \`File "lib/a2a_tools.ml", line 303, characters 30-35: Error: Unbound type constructor agent\`.

## Risk
- Very low. Drop-in type qualification. No behavior change.
- Urgency: main must land this before downstream PRs can rebase cleanly.