### PR TITLE
[codex] Fix a2a_tools Types qualification regression

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -300,16 +300,16 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
     let filtered = match capability with
       | None -> agents
       | Some cap ->
-        List.filter (fun (a : agent) ->
+        List.filter (fun (a : Types.agent) ->
           List.mem cap a.capabilities
         ) agents
     in
     (* Include local agent card *)
     let local_card = Agent_card.generate_default ~schemas () in
-    let agents_json = List.map (fun (a : agent) ->
+    let agents_json = List.map (fun (a : Types.agent) ->
       `Assoc [
         ("name", `String a.name);
-        ("status", `String (agent_status_to_string a.status));
+        ("status", `String (Types.agent_status_to_string a.status));
         ("capabilities", `List (List.map (fun s -> `String s) a.capabilities));
         ("current_task", match a.current_task with
           | None -> `Null
@@ -337,7 +337,9 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
 let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Coord.get_agents_raw config in
-  let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
+  let agent_opt =
+    List.find_opt (fun (a : Types.agent) -> a.name = agent_name) agents
+  in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
@@ -406,7 +408,7 @@ let delegate config ~agent_name ~target ~message
       ~initial_message:(Some full_message)
     in
     match portal_result with
-    | Error e -> Error (masc_error_to_string e)
+    | Error e -> Error (Types.masc_error_to_string e)
     | Ok msg ->
       let task_id = generate_uuid () in
       match task_type with


### PR DESCRIPTION
## Summary
- qualify the remaining `Types`-owned identifiers in `lib/a2a_tools.ml`
- restore current-main build after `open Types` was removed in #8528 but three references still assumed it remained in scope

## What changed
- qualify the remaining `Types`-owned identifiers in `lib/a2a_tools.ml`
- replace bare `agent`, `agent_status_to_string`, and `masc_error_to_string` references with `Types.agent`, `Types.agent_status_to_string`, and `Types.masc_error_to_string`

## Why
`refactor(a2a_tools): remove unused open Types (#8528)` removed the `open Types` but left a few references in `a2a_tools.ml` still relying on that implicit scope. That broke `dune build @check` on `main` with errors like:
- `Unbound type constructor agent`
- `Unbound value masc_error_to_string`

## Product impact
- restores `a2a_tools.ml` compilation without reverting the cleanup from #8528
- keeps the original intent of the refactor intact: no global `open Types`, only explicit qualification where needed

## Root cause
This was a partial refactor regression: one file stopped opening `Types`, but some `Types`-owned symbols were still referenced as if the open remained.

## Evidence
- `Coord.get_agents_raw : config -> Types.agent list` in `lib/coord/coord_query.mli` already exposes `Types.agent` as the canonical type home
- the only required edits are the three remaining bare references in `lib/a2a_tools.ml`, so this is a pure identifier-resolution fix with no behavior change

## Review evidence
- self-review on the three lingering `Types`-owned identifiers and the absence of behavior changes outside `lib/a2a_tools.ml`
- branch validation remains `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-a2a-agent-type @check`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-a2a-agent-type @check`

## Notes
- separately from this code regression, the local shell environment also has an opam switch mismatch (`opam switch show` vs `OPAM_SWITCH_PREFIX`/`PATH`). That can produce misleading local `alcotest not found` failures, but it is not the root cause of this `a2a_tools.ml` break.

## Linked issue
- Refs #8528
- Refs #8584