### PR TITLE
fix(a2a_tools): qualify Types.* after open removal — restore main build (#8584)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -300,16 +300,16 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
     let filtered = match capability with
       | None -> agents
       | Some cap ->
-        List.filter (fun (a : agent) ->
+        List.filter (fun (a : Types.agent) ->
           List.mem cap a.capabilities
         ) agents
     in
     (* Include local agent card *)
     let local_card = Agent_card.generate_default ~schemas () in
-    let agents_json = List.map (fun (a : agent) ->
+    let agents_json = List.map (fun (a : Types.agent) ->
       `Assoc [
         ("name", `String a.name);
-        ("status", `String (agent_status_to_string a.status));
+        ("status", `String (Types.agent_status_to_string a.status));
         ("capabilities", `List (List.map (fun s -> `String s) a.capabilities));
         ("current_task", match a.current_task with
           | None -> `Null
@@ -337,7 +337,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
 let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Coord.get_agents_raw config in
-  let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
+  let agent_opt = List.find_opt (fun (a : Types.agent) -> a.name = agent_name) agents in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
@@ -406,7 +406,7 @@ let delegate config ~agent_name ~target ~message
       ~initial_message:(Some full_message)
     in
     match portal_result with
-    | Error e -> Error (masc_error_to_string e)
+    | Error e -> Error (Types.masc_error_to_string e)
     | Ok msg ->
       let task_id = generate_uuid () in
       match task_type with


### PR DESCRIPTION
## Summary

Closes #8584. Main has been failing `dune build lib` since PR #8528 merged. Three identifiers in `lib/a2a_tools.ml` still depended on `open Types`:

| line | identifier | now qualified as |
|------|------------|------------------|
| 303, 309, 340 | `(a : agent)` | `(a : Types.agent)` |
| 312 | `agent_status_to_string` | `Types.agent_status_to_string` |
| 409 | `masc_error_to_string` | `Types.masc_error_to_string` |

This keeps PR #8528's stated goal (no broad `open Types`) while restoring compilability.

## Verification

```bash
dune build --root=$PWD lib   # clean
dune build --root=$PWD       # clean (full tree)
```

The qualified style is already the convention in `tool_agent.ml`, `tool_worktree.ml`, `tool_code_write.ml` (5 call sites of `Types.masc_error_to_string`).

## Why This Slipped

PR #8528's body claimed "Build verified (dune build succeeds)". The actual main HEAD does not build; either the verification used a stale `_build/` cache, or the PR landed via admin override past CI failures. Tracking issue #8584 also asks whether the pre-merge gate should run `dune build` (full target) rather than just affected library.

## Test plan

- [x] `dune build --root=$PWD lib` clean
- [x] `dune build --root=$PWD` clean (full tree, no test targets)
- [ ] CI green