### PR TITLE
fix(wiring): harden activity and response boundaries (replay from #8415)

### DIFF
--- a/dashboard/src/api/actions.test.ts
+++ b/dashboard/src/api/actions.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ACTIVITY_TIMEOUT_MS } from '../config/constants'
+
+const {
+  get,
+  parseActivityGraphResponse,
+  parseSwimlaneResponse,
+} = vi.hoisted(() => ({
+  get: vi.fn(),
+  parseActivityGraphResponse: vi.fn(),
+  parseSwimlaneResponse: vi.fn(),
+}))
+
+vi.mock('./core', () => ({
+  get,
+  post: vi.fn(),
+}))
+
+vi.mock('./mcp', () => ({
+  callMcpTool: vi.fn(),
+}))
+
+vi.mock('./schemas/actions-activity', () => ({
+  ActionsActivitySchemaDriftError: class ActionsActivitySchemaDriftError extends Error {},
+  parseActivityGraphResponse,
+  parseSwimlaneResponse,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe('fetchActivityGraph', () => {
+  it('uses ACTIVITY_TIMEOUT_MS and omits actor headers', async () => {
+    const raw = { nodes: [], edges: [] }
+    const parsed = { nodes: [], edges: [], stats: {}, kind_counts: {}, heatmap: { matrix: [], max: 0, total: 0 }, timeline: [], generated_at: '2026-04-18T00:00:00Z', window: { limit: 0, room_id: null, kinds: [] } }
+    get.mockResolvedValue(raw)
+    parseActivityGraphResponse.mockReturnValue(parsed)
+
+    const { fetchActivityGraph } = await import('./actions')
+    const result = await fetchActivityGraph('2026-04-18T00:00:00Z')
+
+    expect(get).toHaveBeenCalledWith('/api/v1/activity/graph?since=2026-04-18T00:00:00Z', {
+      timeoutMs: ACTIVITY_TIMEOUT_MS,
+      includeActorHeader: false,
+      signal: undefined,
+    })
+    expect(parseActivityGraphResponse).toHaveBeenCalledWith(raw)
+    expect(result).toBe(parsed)
+  })
+
+  it('treats 200 not-initialized envelopes as warm-up instead of schema drift', async () => {
+    get.mockResolvedValue({ error: 'not initialized' })
+
+    const { fetchActivityGraph } = await import('./actions')
+    const result = await fetchActivityGraph('1h')
+
+    expect(parseActivityGraphResponse).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+})
+
+describe('fetchSwimlane', () => {
+  it('uses ACTIVITY_TIMEOUT_MS and omits actor headers', async () => {
+    const raw = { agents: [], spans: [] }
+    const parsed = { agents: [], spans: [], time_range: { min_ms: 0, max_ms: 0 } }
+    get.mockResolvedValue(raw)
+    parseSwimlaneResponse.mockReturnValue(parsed)
+
+    const { fetchSwimlane } = await import('./actions')
+    const result = await fetchSwimlane()
+
+    expect(get).toHaveBeenCalledWith('/api/v1/activity/swimlane', {
+      timeoutMs: ACTIVITY_TIMEOUT_MS,
+      includeActorHeader: false,
+      signal: undefined,
+    })
+    expect(parseSwimlaneResponse).toHaveBeenCalledWith(raw)
+    expect(result).toBe(parsed)
+  })
+
+  it('treats 200 not-initialized swimlane envelopes as warm-up instead of schema drift', async () => {
+    get.mockResolvedValue({ error: 'not initialized' })
+
+    const { fetchSwimlane } = await import('./actions')
+    const result = await fetchSwimlane('1h')
+
+    expect(parseSwimlaneResponse).not.toHaveBeenCalled()
+    expect(result).toBeNull()
+  })
+})

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -9,6 +9,15 @@ import {
   type SwimlaneResponse,
 } from './schemas/actions-activity'
 
+type ActivityFetchOptions = {
+  signal?: AbortSignal
+}
+
+function isNotInitializedEnvelope(raw: unknown): boolean {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return false
+  return (raw as { error?: unknown }).error === 'not initialized'
+}
+
 // --- Control Dock ---
 
 export async function sendBroadcast(agentName: string, message: string): Promise<void> {
@@ -43,13 +52,18 @@ export function fetchTaskEvents(taskId: string, limit = 50): Promise<unknown[]> 
 
 // --- Activity Graph ---
 
-export async function fetchActivityGraph(since?: string): Promise<ActivityGraphResponse | null> {
+export async function fetchActivityGraph(
+  since?: string,
+  options: ActivityFetchOptions = {},
+): Promise<ActivityGraphResponse | null> {
   const params = since ? `?since=${since}` : ''
   try {
     const raw = await get<unknown>(`/api/v1/activity/graph${params}`, {
       timeoutMs: ACTIVITY_TIMEOUT_MS,
       includeActorHeader: false,
+      signal: options.signal,
     })
+    if (isNotInitializedEnvelope(raw)) return null
     return parseActivityGraphResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err
@@ -58,13 +72,18 @@ export async function fetchActivityGraph(since?: string): Promise<ActivityGraphR
   }
 }
 
-export async function fetchSwimlane(since?: string): Promise<SwimlaneResponse | null> {
+export async function fetchSwimlane(
+  since?: string,
+  options: ActivityFetchOptions = {},
+): Promise<SwimlaneResponse | null> {
   const params = since ? `?since=${since}` : ''
   try {
     const raw = await get<unknown>(`/api/v1/activity/swimlane${params}`, {
       timeoutMs: ACTIVITY_TIMEOUT_MS,
       includeActorHeader: false,
+      signal: options.signal,
     })
+    if (isNotInitializedEnvelope(raw)) return null
     return parseSwimlaneResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -107,6 +107,52 @@ describe('post', () => {
     const headers = init.headers as Record<string, string>
     expect(headers['X-MASC-Agent'] ?? headers['x-masc-agent']).toBe('dashboard-manual-actor')
   })
+
+  it('surfaces invalid JSON in 200 operator action responses as ApiRequestError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('not-json', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(runOperatorAction({
+      actor: 'dashboard-manual-actor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'keeper-one',
+      payload: {},
+    })).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 200,
+      detail: 'invalid JSON response',
+      message: 'POST /api/v1/operator/action: invalid JSON response',
+    })
+  })
+
+  it('surfaces empty JSON in 200 operator confirm responses as ApiRequestError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(confirmOperatorAction(
+      'dashboard-manual-actor',
+      'opc_test_token',
+      'deny',
+    )).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 200,
+      detail: 'empty JSON response',
+      message: 'POST /api/v1/operator/confirm: empty JSON response',
+    })
+  })
 })
 
 describe('get bootstrap warm-up mapping', () => {
@@ -323,6 +369,24 @@ describe('get bootstrap warm-up mapping', () => {
 
     expect(data.status).toBe('ok')
     expect(data.agents).toBe(5)
+  })
+
+  it('surfaces invalid JSON in 200 GET responses as ApiRequestError', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('service unavailable', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(get('/api/v1/dashboard/governance')).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 200,
+      detail: 'invalid JSON response',
+      message: 'GET /api/v1/dashboard/governance: invalid JSON response',
+    })
   })
 })
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -364,6 +364,45 @@ async function bootstrapWarmPayload(path: string, res: Response): Promise<unknow
   }
 }
 
+async function parseJsonResponse<T>(
+  method: string,
+  path: string,
+  res: Response,
+): Promise<T> {
+  let rawText = ''
+  try {
+    rawText = await res.text()
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'failed to read response body',
+    })
+  }
+  if (rawText.trim() === '') {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'empty JSON response',
+    })
+  }
+  try {
+    return JSON.parse(rawText) as T
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'invalid JSON response',
+    })
+  }
+}
+
 export function defaultBoardVoter(): string {
   const params = getQueryParams()
   return sanitizeDashboardActorName(params.get('agent'))
@@ -395,7 +434,7 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     }
     throw await apiRequestErrorFromResponse('GET', path, res)
   }
-  const data = await res.json()
+  const data = await parseJsonResponse<T>('GET', path, res)
   // Server may return 200 OK with {"error":"not initialized"} during startup
   if (DASHBOARD_BOOTSTRAP_WARM_PATHS.has(path) && isNotInitializedEnvelope(data)) {
     const payload = bootstrapInitializingPayload(path)
@@ -475,7 +514,7 @@ export async function post<T>(
   if (!res.ok) {
     throw await apiRequestErrorFromResponse('POST', path, res)
   }
-  return res.json() as Promise<T>
+  return parseJsonResponse<T>('POST', path, res)
 }
 
 export async function patch<T>(
@@ -496,7 +535,7 @@ export async function patch<T>(
   if (!res.ok) {
     throw await apiRequestErrorFromResponse('PATCH', path, res)
   }
-  return res.json() as Promise<T>
+  return parseJsonResponse<T>('PATCH', path, res)
 }
 
 export async function postRaw(

--- a/dashboard/src/components/activity-graph-panels.test.ts
+++ b/dashboard/src/components/activity-graph-panels.test.ts
@@ -1,0 +1,124 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { signal } from '@preact/signals'
+import * as Vitest from 'vitest'
+
+const { afterEach, beforeEach, describe, expect, it } = Vitest
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+async function loadPanels(options: {
+  fetchActivityGraph: ReturnType<typeof Vitest.vi.fn>
+  getRange: () => '5m' | '1h' | '6h' | '24h' | '7d' | null
+}) {
+  Vitest.vi.resetModules()
+  Vitest.vi.doMock('../api', () => ({
+    fetchActivityGraph: options.fetchActivityGraph,
+  }))
+  Vitest.vi.doMock('../sse-store', () => ({
+    registerActivityRefresh: Vitest.vi.fn(() => () => {}),
+  }))
+  Vitest.vi.doMock('../router', () => ({
+    hashForRoute: Vitest.vi.fn(() => '#'),
+  }))
+  Vitest.vi.doMock('../observatory-filter-store', () => ({
+    currentTimeRangeFilter: Vitest.vi.fn(() => options.getRange()),
+    timeRangeLabel: Vitest.vi.fn((value: string) => value),
+  }))
+  Vitest.vi.doMock('./common/card', () => ({
+    Card: ({ children, testId, title }: { children?: unknown; testId?: string; title?: string }) =>
+      html`<section data-testid=${testId ?? undefined}><h2>${title ?? ''}</h2>${children}</section>`,
+  }))
+  Vitest.vi.doMock('./common/feedback-state', () => ({
+    EmptyState: ({ children, message }: { children?: unknown; message?: string }) =>
+      html`<div>${message ?? children}</div>`,
+    LoadingState: ({ children }: { children?: unknown }) =>
+      html`<div>${children}</div>`,
+  }))
+  Vitest.vi.doMock('./common/button', () => ({
+    ActionButton: ({ children, onClick }: { children?: unknown; onClick?: () => void }) =>
+      html`<button onClick=${onClick}>${children}</button>`,
+  }))
+  Vitest.vi.doMock('./common/filter-chips', () => ({
+    FilterChips: () => null,
+  }))
+  Vitest.vi.doMock('./common/time-ago', () => ({
+    TimeAgo: () => null,
+  }))
+  Vitest.vi.doMock('./common/sparkline', () => ({
+    Sparkline: () => null,
+  }))
+  Vitest.vi.doMock('./activity-graph-view', () => ({
+    GraphView: () => null,
+  }))
+  Vitest.vi.doMock('./activity-swimlane', () => ({
+    ActivitySwimlane: () => null,
+  }))
+  Vitest.vi.doMock('./activity-heatmap', () => ({
+    ActivityHeatmap: () => null,
+  }))
+  Vitest.vi.doMock('./keeper-phase-strip', () => ({
+    KeeperPhaseTimeline: () => null,
+  }))
+  Vitest.vi.doMock('./common/collapsible', () => ({
+    CollapsibleSection: ({ children, title }: { children?: unknown; title?: string }) =>
+      html`<section><h3>${title ?? ''}</h3>${children}</section>`,
+  }))
+  return import('./activity-graph')
+}
+
+describe('ObservatoryActivityPanels', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    Vitest.vi.resetModules()
+    Vitest.vi.clearAllMocks()
+  })
+
+  it('refetches the graph when the observatory time range changes', async () => {
+    const range = signal<'1h' | '24h'>('1h')
+    const fetchActivityGraph = Vitest.vi.fn().mockResolvedValue(null)
+
+    const { ObservatoryActivityPanels } = await loadPanels({
+      fetchActivityGraph,
+      getRange: () => range.value,
+    })
+
+    render(html`<${ObservatoryActivityPanels} />`, container)
+    await flushUi()
+
+    range.value = '24h'
+    await flushUi()
+
+    expect(fetchActivityGraph).toHaveBeenCalledTimes(2)
+    expect(fetchActivityGraph.mock.calls[0]?.[0]).toBe('1h')
+    expect(fetchActivityGraph.mock.calls[1]?.[0]).toBe('24h')
+  }, 20000)
+
+  it('shows a warm-up state when activity endpoints return not initialized', async () => {
+    const fetchActivityGraph = Vitest.vi.fn().mockResolvedValue(null)
+
+    const { ObservatoryActivityPanels } = await loadPanels({
+      fetchActivityGraph,
+      getRange: () => '1h',
+    })
+
+    render(html`<${ObservatoryActivityPanels} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="activity_graph.warming"]')).toBeTruthy()
+    expect(container.textContent).toContain('활동 분석 초기화 중')
+  }, 20000)
+})

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -3,7 +3,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { createAsyncResource } from '../lib/async-state'
+import { createManagedAsyncResource } from '../lib/async-state'
 import { Card } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
@@ -34,7 +34,7 @@ import {
 } from '../observatory-filter-store'
 import type { ActivityGraphResponse, ActivityGraphNode, ActionTimelineGroup } from '../types'
 
-const graphResource = createAsyncResource<ActivityGraphResponse | null>()
+const graphResource = createManagedAsyncResource<ActivityGraphResponse | null>(null)
 const DEFAULT_ACTIVITY_RANGE: TimeRangePreset = '1h'
 
 const actionFilter = signal<ActionTimelineFilter>('all')
@@ -79,10 +79,14 @@ function activityRange(): TimeRangePreset {
   return currentTimeRangeFilter() ?? DEFAULT_ACTIVITY_RANGE
 }
 
-function loadGraph() {
-  return graphResource.load(() => {
-    return fetchActivityGraph(activityRange())
+function loadGraphForRange(since: TimeRangePreset) {
+  return graphResource.load((signal) => {
+    return fetchActivityGraph(since, { signal })
   })
+}
+
+function loadGraph() {
+  return loadGraphForRange(activityRange())
 }
 
 function StatsRow({ data }: { data: ActivityGraphResponse }) {
@@ -336,19 +340,33 @@ function EmptyActivityGraph() {
   `
 }
 
-export { loadGraph as refreshActivityGraph }
-
-function useActivityGraphRefresh() {
-  useEffect(() => {
-    void loadGraph()
-    return registerActivityRefresh(() => {
-      void loadGraph()
-    })
-  }, [])
+function WarmingUpActivityGraph() {
+  return html`
+    <div class="flex flex-col gap-5">
+      <${Card} title="활동 분석" class="section mb-4" testId="activity_graph.warming">
+        <div class="mb-4">
+          <h2 class="monitor-headline">활동 분석 초기화 중</h2>
+          <p class="monitor-subheadline">서버가 activity feed를 아직 준비 중입니다. 초기화가 끝나면 그래프와 타임라인이 자동으로 갱신됩니다.</p>
+        </div>
+        <${LoadingState}>activity feed 워밍업 중...<//>
+      <//>
+    </div>
+  `
 }
 
-function useActivityGraphState() {
-  useActivityGraphRefresh()
+export { loadGraph as refreshActivityGraph }
+
+function useActivityGraphRefresh(since: TimeRangePreset) {
+  useEffect(() => {
+    void loadGraphForRange(since)
+    return registerActivityRefresh(() => {
+      void loadGraphForRange(since)
+    })
+  }, [since])
+}
+
+function useActivityGraphState(since: TimeRangePreset) {
+  useActivityGraphRefresh(since)
   return graphResource.state.value
 }
 
@@ -396,23 +414,25 @@ function DerivedActivityPanels({ data }: { data: ActivityGraphResponse }) {
 }
 
 export function ObservatoryActivityPanels() {
-  const state = useActivityGraphState()
-  const data = state.status === 'loaded' ? state.data : undefined
   const since = activityRange()
+  const state = useActivityGraphState(since)
+  const data = state.data ?? undefined
   const actionCount = data ? buildActionTimelineGroups(data.timeline).length : 0
 
   return html`
     <div class="flex flex-col gap-5">
-      ${state.status === 'loading' || state.status === 'idle'
+      ${state.loading && !data
         ? html`<${LoadingState}>활동 분석 패널 불러오는 중...<//>`
-        : state.status === 'error'
+        : state.error && !data
           ? html`
               <${Card} title="활동 분석" class="section" testId="activity_graph.error">
-                <${EmptyState} message=${'활동 그래프를 불러올 수 없습니다: ' + state.message} compact />
-                <${ActionButton} variant="ghost" onClick=${loadGraph}>다시 시도<//>
+                <${EmptyState} message=${'활동 그래프를 불러올 수 없습니다: ' + state.error} compact />
+                <${ActionButton} variant="ghost" onClick=${() => { void loadGraph() }}>다시 시도<//>
               <//>
             `
-          : !data || (data.stats.event_count ?? 0) === 0
+          : !data
+            ? html`<${WarmingUpActivityGraph} />`
+            : (data.stats.event_count ?? 0) === 0
             ? html`<${EmptyActivityGraph} />`
             : html`
                 <${CollapsibleSection}
@@ -431,7 +451,7 @@ export function ObservatoryActivityPanels() {
         <${KeeperPhaseTimeline} />
       <//>
 
-      ${state.status === 'loaded' && data && (data.stats.event_count ?? 0) > 0 ? html`
+      ${data && (data.stats.event_count ?? 0) > 0 ? html`
         <${CollapsibleSection} title="파생 분석">
           <${DerivedActivityPanels} data=${data} />
         <//>
@@ -439,4 +459,3 @@ export function ObservatoryActivityPanels() {
     </div>
   `
 }
-

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -12,11 +12,11 @@ import { registerActivityRefresh } from '../sse-store'
 import type { SwimlaneResponse } from '../types'
 import { selectedNodeId, highlightedAgentId } from './activity-graph-view'
 import { formatDurationMs } from '../lib/format-time'
-import { createAsyncResource } from '../lib/async-state'
+import { createManagedAsyncResource } from '../lib/async-state'
 import { escapeHtml, tooltipHtml } from '../lib/escape-html'
 import 'vis-timeline/styles/vis-timeline-graph2d.css'
 
-const swimlaneResource = createAsyncResource<SwimlaneResponse | null>()
+const swimlaneResource = createManagedAsyncResource<SwimlaneResponse | null>(null)
 type TimelineItemId = number
 
 interface SwimlaneTimelineItem {
@@ -90,7 +90,7 @@ export function spanStyle(kind: string) {
 }
 
 function loadSwimlane(since?: string) {
-  return swimlaneResource.load(() => fetchSwimlane(since))
+  return swimlaneResource.load((signal) => fetchSwimlane(since, { signal }))
 }
 
 export function ActivitySwimlane({ since }: { since?: string }) {
@@ -106,7 +106,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
   }, [since])
 
   const s = swimlaneResource.state.value
-  const data = s.status === 'loaded' ? s.data : undefined
+  const data = s.data ?? undefined
 
   useEffect(() => {
     const container = containerRef.current
@@ -205,7 +205,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
     )
   }, [data, highlightedAgentId.value])
 
-  if (s.status === 'loading' || s.status === 'idle') {
+  if (s.loading && !data) {
     return html`
       <${Card} title="활동 타임라인" testId="activity_swimlane">
         <${LoadingState}>타임라인 불러오는 중...<//>
@@ -213,15 +213,23 @@ export function ActivitySwimlane({ since }: { since?: string }) {
     `
   }
 
-  if (s.status === 'error') {
+  if (s.error && !data) {
     return html`
       <${Card} title="활동 타임라인" testId="activity_swimlane">
-        <${EmptyState}>타임라인을 불러올 수 없습니다: ${s.message}<//>
+        <${EmptyState}>타임라인을 불러올 수 없습니다: ${s.error}<//>
       <//>
     `
   }
 
-  if (!data || data.agents.length === 0) {
+  if (!data) {
+    return html`
+      <${Card} title="활동 타임라인" testId="activity_swimlane">
+        <${LoadingState}>activity feed 워밍업 중...<//>
+      <//>
+    `
+  }
+
+  if (data.agents.length === 0) {
     return html`
       <${Card} title="활동 타임라인" testId="activity_swimlane">
         <${EmptyState}>표시할 에이전트 활동 타임라인이 없습니다.<//>

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -221,8 +221,11 @@ let normalize_text raw =
   raw |> String.trim |> String.split_on_char '\n' |> List.map String.trim
   |> List.filter (fun item -> item <> "") |> String.concat " " |> String.trim
 
+let normalize_allowed_tool_name value =
+  value |> String.trim |> String.lowercase_ascii
+
 let allowed_tool tool =
-  List.mem tool
+  List.mem (normalize_allowed_tool_name tool)
     [
       "masc_governance_status";
       "masc_execution_orders";
@@ -235,10 +238,13 @@ let parse_recommended_action json =
   let action_json = json |> member "recommended_action" in
   match action_json with
   | `Assoc _ ->
-      let resolved_tool = action_json |> member "resolved_tool" |> to_string_option in
+      let resolved_tool =
+        action_json |> member "resolved_tool" |> to_string_option
+        |> Option.map normalize_allowed_tool_name
+      in
       let resolved_tool =
         match resolved_tool with
-        | Some tool when allowed_tool tool -> Some tool
+        | Some tool when tool <> "" && allowed_tool tool -> Some tool
         | _ -> None
       in
       Some

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -412,6 +412,52 @@ let test_dashboard_exposes_keeper_approval_queue () =
         fail "expected approval resume, got edit"
       | None -> fail "approval fiber did not resume")
 
+let test_recommended_action_tool_is_canonicalized () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let now = Unix.gettimeofday () in
+      let generated_at = iso8601_of_unix now in
+      let expires_at = iso8601_of_unix (now +. 3600.0) in
+      write_legacy_judgment ~base_path:dir
+        (`Assoc
+          [
+            ("target_kind", `String "agent_health");
+            ("target_id", `String "canonical-tool");
+            ("status", `String "active");
+            ("summary", `String "tool names should tolerate whitespace drift");
+            ("confidence", `Float 0.92);
+            ("generated_at", `String generated_at);
+            ("expires_at", `String expires_at);
+            ("model_used", `String "llama:test");
+            ("keeper_name", `String Lib.Dashboard_governance_judge.keeper_name);
+            ( "recommended_action",
+              `Assoc
+                [
+                  ("action_kind", `String "recover");
+                  ("resolved_tool", `String "  MASC_OPERATOR_CONFIRM  ");
+                  ("target_type", `String "agent");
+                  ("target_id", `String "canonical-tool");
+                  ("reason", `String "normalize whitespace and case");
+                ] );
+          ]);
+      let json =
+        Lib.Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
+          ~status_filter:None
+      in
+      let open Yojson.Safe.Util in
+      let judgments = json |> member "judgments" |> to_list in
+      check int "canonicalized judgment surfaced" 1 (List.length judgments);
+      let resolved_tool =
+        List.hd judgments
+        |> member "recommended_action" |> member "resolved_tool" |> to_string
+      in
+      check string "resolved_tool canonicalized" "masc_operator_confirm"
+        resolved_tool)
+
 let () =
   run "dashboard_governance"
     [
@@ -429,6 +475,8 @@ let () =
             test_governance_monitoring_uses_live_runtime;
           test_case "dashboard exposes keeper approval queue" `Quick
             test_dashboard_exposes_keeper_approval_queue;
+          test_case "recommended action tool is canonicalized" `Quick
+            test_recommended_action_tool_is_canonicalized;
           test_case "pending_ruling reflects disk truth (#7815)" `Quick
             test_pending_ruling_reflects_disk_truth;
         ] );


### PR DESCRIPTION
## Summary

Replay of the single unique commit from #8415 (\`5144195\`) that survived post-hoc review: **4 of 6 commits in #8415 were already merged via #8359**, and \`f9ca59b\` was empty after rebase (subsumed).

## Source

- Original PR: #8415 (redteam bughunt 20260418)
- Commit: \`5144195\` fix(wiring): harden activity and response boundaries

## What remains

- activity-graph.ts / activity-swimlane.ts — null/undefined boundary hardening
- dashboard_governance_judge.ml — response boundary normalization
- New tests: actions.test.ts, activity-graph-panels.test.ts

## Why split

#8415 was a bughunt dump of 6 commits. After #8359 landed, 4 commits became duplicates. Maintaining #8415 as-is would require 29-file rebase with drift risk on CSS token refactors (#8421/#8425/#8434/#8443/#8463). Atomic replay avoids the drift surface.

## Next

Will close #8415 as superseded once this is green.