### PR TITLE
test: lock dashboard runtime and MCP transport regressions (replay of #8456)

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -8,6 +8,7 @@ import {
   post,
   runOperatorAction,
 } from './core'
+import { OperatorActionSchemaDriftError } from './schemas/operator-action'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -107,7 +108,6 @@ describe('post', () => {
     const headers = init.headers as Record<string, string>
     expect(headers['X-MASC-Agent'] ?? headers['x-masc-agent']).toBe('dashboard-manual-actor')
   })
-
   it('surfaces invalid JSON in 200 operator action responses as ApiRequestError', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('not-json', {
@@ -152,6 +152,25 @@ describe('post', () => {
       detail: 'empty JSON response',
       message: 'POST /api/v1/operator/confirm: empty JSON response',
     })
+  })
+
+  it('rejects 200 operator action payloads whose JSON body is still missing the status contract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"result":{"ok":true}}', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(runOperatorAction({
+      actor: 'dashboard-manual-actor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'keeper-one',
+      payload: {},
+    })).rejects.toBeInstanceOf(OperatorActionSchemaDriftError)
   })
 })
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -263,6 +263,47 @@ export async function apiRequestErrorFromResponse(
   })
 }
 
+async function parseJsonResponse<T>(
+  method: string,
+  path: string,
+  res: Response,
+): Promise<T> {
+  let rawText = ''
+  try {
+    rawText = await res.text()
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'failed to read response body',
+    })
+  }
+
+  if (rawText.trim() === '') {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'empty JSON response',
+    })
+  }
+
+  try {
+    return JSON.parse(rawText) as T
+  } catch {
+    throw new ApiRequestError({
+      method,
+      path,
+      status: res.status,
+      statusText: res.statusText,
+      detail: 'invalid JSON response',
+    })
+  }
+}
+
 function isNotInitializedEnvelope(raw: unknown): boolean {
   if (!isRecord(raw)) return false
   return typeof raw.error === 'string' && raw.error.trim().toLowerCase() === 'not initialized'
@@ -440,7 +481,7 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     const payload = bootstrapInitializingPayload(path)
     if (payload !== null) return payload as T
   }
-  return data as T
+  return data
 }
 
 export function sleep(ms: number): Promise<void> {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -405,45 +405,6 @@ async function bootstrapWarmPayload(path: string, res: Response): Promise<unknow
   }
 }
 
-async function parseJsonResponse<T>(
-  method: string,
-  path: string,
-  res: Response,
-): Promise<T> {
-  let rawText = ''
-  try {
-    rawText = await res.text()
-  } catch {
-    throw new ApiRequestError({
-      method,
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail: 'failed to read response body',
-    })
-  }
-  if (rawText.trim() === '') {
-    throw new ApiRequestError({
-      method,
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail: 'empty JSON response',
-    })
-  }
-  try {
-    return JSON.parse(rawText) as T
-  } catch {
-    throw new ApiRequestError({
-      method,
-      path,
-      status: res.status,
-      statusText: res.statusText,
-      detail: 'invalid JSON response',
-    })
-  }
-}
-
 export function defaultBoardVoter(): string {
   const params = getQueryParams()
   return sanitizeDashboardActorName(params.get('agent'))

--- a/dashboard/src/components/activity-swimlane-fetch.test.ts
+++ b/dashboard/src/components/activity-swimlane-fetch.test.ts
@@ -1,0 +1,137 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { signal } from '@preact/signals'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function flushUi(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+function emptySwimlane() {
+  return {
+    agents: [],
+    spans: [],
+    time_range: {
+      min_ms: 0,
+      max_ms: 0,
+    },
+  }
+}
+
+async function loadSwimlane(options: {
+  fetchSwimlane: ReturnType<typeof vi.fn>
+  onRegisterRefresh?: (fn: () => void) => void
+}) {
+  vi.resetModules()
+  vi.doMock('../api', () => ({
+    fetchSwimlane: options.fetchSwimlane,
+  }))
+  vi.doMock('../sse-store', () => ({
+    registerActivityRefresh: vi.fn((fn: () => void) => {
+      options.onRegisterRefresh?.(fn)
+      return () => {}
+    }),
+  }))
+  vi.doMock('./common/card', () => ({
+    Card: ({ children, testId, title }: { children?: unknown; testId?: string; title?: string }) =>
+      html`<section data-testid=${testId ?? undefined}><h2>${title ?? ''}</h2>${children}</section>`,
+  }))
+  vi.doMock('./common/feedback-state', () => ({
+    EmptyState: ({ children }: { children?: unknown }) => html`<div>${children}</div>`,
+    LoadingState: ({ children }: { children?: unknown }) => html`<div>${children}</div>`,
+  }))
+  vi.doMock('./activity-graph-view', () => ({
+    selectedNodeId: signal<string | null>(null),
+    highlightedAgentId: signal<string | null>(null),
+  }))
+  vi.doMock('../lib/format-time', () => ({
+    formatDurationMs: (ms: number) => `${ms}ms`,
+  }))
+  vi.doMock('../lib/escape-html', () => ({
+    escapeHtml: (value: string) => value,
+    tooltipHtml: (lines: string[]) => lines.join(' | '),
+  }))
+  vi.doMock('vis-data', () => ({
+    DataSet: class MockDataSet<T> {
+      readonly items: T[]
+
+      constructor(items: T[]) {
+        this.items = items
+      }
+
+      get(): undefined {
+        return undefined
+      }
+    },
+  }))
+  vi.doMock('vis-timeline', () => ({
+    Timeline: class MockTimeline {
+      on(): void {}
+
+      setSelection(): void {}
+
+      focus(): void {}
+
+      destroy(): void {}
+    },
+  }))
+  return import('./activity-swimlane')
+}
+
+describe('ActivitySwimlane fetch wiring', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('fetches swimlane for the mounted range and the updated range', async () => {
+    const fetchSwimlane = vi.fn().mockResolvedValue(emptySwimlane())
+    const { ActivitySwimlane } = await loadSwimlane({ fetchSwimlane })
+
+    render(html`<${ActivitySwimlane} since="1h" />`, container)
+    await flushUi()
+
+    render(html`<${ActivitySwimlane} since="24h" />`, container)
+    await flushUi()
+
+    expect(fetchSwimlane).toHaveBeenCalledTimes(2)
+    expect(fetchSwimlane.mock.calls[0]?.[0]).toBe('1h')
+    expect(fetchSwimlane.mock.calls[1]?.[0]).toBe('24h')
+  })
+
+  it('re-fetches swimlane with the latest range when activity refresh fires', async () => {
+    let activityRefreshCallback: (() => void) | undefined
+    const fetchSwimlane = vi.fn().mockResolvedValue(emptySwimlane())
+    const { ActivitySwimlane } = await loadSwimlane({
+      fetchSwimlane,
+      onRegisterRefresh: (fn) => { activityRefreshCallback = fn },
+    })
+
+    render(html`<${ActivitySwimlane} since="1h" />`, container)
+    await flushUi()
+
+    render(html`<${ActivitySwimlane} since="24h" />`, container)
+    await flushUi()
+
+    expect(activityRefreshCallback).toBeTypeOf('function')
+    const callback = activityRefreshCallback
+    if (callback == null) throw new Error('missing activity refresh callback')
+    callback()
+    await flushUi()
+
+    expect(fetchSwimlane).toHaveBeenCalledTimes(3)
+    expect(fetchSwimlane.mock.calls[2]?.[0]).toBe('24h')
+  })
+})

--- a/dashboard/src/components/fleet-data-core.test.ts
+++ b/dashboard/src/components/fleet-data-core.test.ts
@@ -33,7 +33,9 @@ function okJson<T>(body: T) {
   return {
     ok: true,
     status: 200,
+    statusText: 'OK',
     json: async () => body,
+    text: async () => JSON.stringify(body),
   }
 }
 

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -37,6 +37,16 @@ const payloadWithMissingToolMetrics = {
   ],
 }
 
+function okJson<T>(body: T) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }
+}
+
 async function flushUi(): Promise<void> {
   await act(async () => {
     for (let i = 0; i < 4; i += 1) {
@@ -113,10 +123,7 @@ describe('ToolQualityPanel', () => {
   })
 
   it('normalizes missing tool metric fields before rendering', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payloadWithMissingToolMetrics,
-    })
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithMissingToolMetrics))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel } = await import('./tool-quality-panel')
 
@@ -139,10 +146,7 @@ describe('ToolQualityPanel', () => {
           reject(new DOMException('replaced by newer refresh', 'AbortError'))
         })
       }))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => payload,
-      })
+      .mockResolvedValueOnce(okJson(payload))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel, refreshToolQuality } = await import('./tool-quality-panel')
 
@@ -165,10 +169,7 @@ describe('ToolQualityPanel', () => {
   })
 
   it('refreshes again when the refresh button is clicked', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    })
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payload))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel } = await import('./tool-quality-panel')
 

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -44,7 +44,8 @@ let parse_status header_raw =
   in
   find_http lines
 
-let run_curl_post ?(max_time_sec = 8) ~port ~path ~session_id ~payload () =
+let run_curl_post ?(max_time_sec = 8) ?(extra_headers = []) ~port ~path
+    ~session_id ~payload () =
   let header_file = Filename.temp_file "mcp-post-sse-header-" ".txt" in
   let body_file = Filename.temp_file "mcp-post-sse-body-" ".txt" in
   let data_file = Filename.temp_file "mcp-post-sse-request-" ".json" in
@@ -53,32 +54,39 @@ let run_curl_post ?(max_time_sec = 8) ~port ~path ~session_id ~payload () =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc payload);
+  let extra_header_args =
+    List.concat_map (fun header -> [ "-H"; header ]) extra_headers
+  in
   let args =
-    [|
-      "curl";
-      "-sS";
-      "-N";
-      "--http1.1";
-      "--max-time";
-      string_of_int max_time_sec;
-      "-X";
-      "POST";
-      "-H";
-      "Content-Type: application/json";
-      "-H";
-      "Accept: application/json, text/event-stream";
-      "-H";
-      Printf.sprintf "Mcp-Session-Id: %s" session_id;
-      "-H";
-      "Mcp-Protocol-Version: 2025-11-25";
-      "-o";
-      body_file;
-      "-D";
-      header_file;
-      "--data-binary";
-      "@" ^ data_file;
-      url;
-    |]
+    Array.of_list
+      ([
+         "curl";
+         "-sS";
+         "-N";
+         "--http1.1";
+         "--max-time";
+         string_of_int max_time_sec;
+         "-X";
+         "POST";
+         "-H";
+         "Content-Type: application/json";
+         "-H";
+         "Accept: application/json, text/event-stream";
+         "-H";
+         Printf.sprintf "Mcp-Session-Id: %s" session_id;
+         "-H";
+         "Mcp-Protocol-Version: 2025-11-25";
+       ]
+      @ extra_header_args
+      @ [
+          "-o";
+          body_file;
+          "-D";
+          header_file;
+          "--data-binary";
+          "@" ^ data_file;
+          url;
+        ])
   in
   let (ic, oc2, ec) =
     Unix.open_process_args_full "curl" args (Unix.environment ())
@@ -375,6 +383,47 @@ let test_post_tools_call_streams_sse_framing () =
   in
   check bool "status text present" true (String.length text > 0)
 
+let rec join_until_ready ~port ~retries_left =
+  let result =
+    run_curl_post ~max_time_sec:8 ~port ~path:"/mcp"
+      ~session_id:"legacy-agent-name-preservation"
+      ~extra_headers:[ "X-MASC-Agent: dashboard-header-actor" ]
+      ~payload:
+        (tool_payload ~id:202 ~name:"masc_join"
+           ~arguments:(`Assoc [ ("agent_name", `String "gemini") ]))
+      ()
+  in
+  match (result.status, retries_left) with
+  | Some 500, retries
+    when retries > 0
+         && contains_substr "Server state not initialized" result.body ->
+      Unix.sleepf 0.5;
+      join_until_ready ~port ~retries_left:(retries - 1)
+  | Some 503, retries
+    when retries > 0
+         && contains_substr "Server is starting up, not ready yet" result.body ->
+      Unix.sleepf 0.5;
+      join_until_ready ~port ~retries_left:(retries - 1)
+  | _ -> result
+
+let test_post_tools_call_preserves_explicit_legacy_agent_name () =
+  with_server @@ fun ~port ->
+  let result = join_until_ready ~port ~retries_left:40 in
+  require_http_ok "legacy agent_name preservation tools/call" result;
+  check int "curl exits cleanly" 0 result.curl_exit;
+  let json = parse_json_body "legacy agent_name preservation tools/call" result in
+  check bool "json-rpc error absent" true (json |> U.member "error" = `Null);
+  check bool "tool succeeded" false
+    (json |> U.member "result" |> U.member "isError" |> U.to_bool);
+  let text =
+    json |> U.member "result" |> U.member "content" |> U.index 0
+    |> U.member "text" |> U.to_string
+  in
+  check bool "explicit legacy agent_name preserved" true
+    (contains_substr "Type: gemini" text);
+  check bool "header actor not injected over explicit legacy agent_name" false
+    (contains_substr "Type: dashboard-header-actor" text)
+
 let () =
   run "mcp_post_sse_e2e"
     [
@@ -382,5 +431,7 @@ let () =
         [
           test_case "post tools/call streams sse framing" `Slow
             test_post_tools_call_streams_sse_framing;
+          test_case "post tools/call preserves explicit legacy agent_name"
+            `Slow test_post_tools_call_preserves_explicit_legacy_agent_name;
         ] );
     ]


### PR DESCRIPTION
## Summary
- clean replay of #8456's two commits onto current `main`
- carry the minimal `a2a_tools` compatibility fix required for current-main builds after the #8528/#8584 fallout

## Commits
- `4411b5d` test: lock dashboard and mcp transport regressions
- `aff2557` fix: normalize dashboard json decode failures
- `f2b3ad4` fix: align replay branch with current a2a refs

## Files
- `dashboard/src/api/core.test.ts`
- `dashboard/src/api/core.ts`
- `dashboard/src/components/activity-swimlane-fetch.test.ts`
- `test/test_mcp_post_sse_e2e.ml`
- `lib/a2a_tools.ml`

Supersedes #8456.

## Product impact
- keeps the dashboard JSON decode and MCP transport regression coverage alive on a mergeable current-main base
- avoids the replay branch failing for unrelated repo-wide build drift before the replayed fixes can be evaluated

## Evidence
- replay branch still preserves the original #8456 dashboard/MCP transport changes and now adds only the minimal `Types.*` qualification fix needed for current-main compilation
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/replay-8456-check @check`

## Review evidence
- self-review on the replayed commit set and the single-file `a2a_tools` compatibility fix
- branch-local `@check` passes on the updated replay head

## Linked issue
- Refs #8584