### PR TITLE
fix(a2a_tools): qualify Types.agent / agent_status_to_string / masc_error_to_string

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -300,16 +300,16 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
     let filtered = match capability with
       | None -> agents
       | Some cap ->
-        List.filter (fun (a : agent) ->
+        List.filter (fun (a : Types.agent) ->
           List.mem cap a.capabilities
         ) agents
     in
     (* Include local agent card *)
     let local_card = Agent_card.generate_default ~schemas () in
-    let agents_json = List.map (fun (a : agent) ->
+    let agents_json = List.map (fun (a : Types.agent) ->
       `Assoc [
         ("name", `String a.name);
-        ("status", `String (agent_status_to_string a.status));
+        ("status", `String (Types.agent_status_to_string a.status));
         ("capabilities", `List (List.map (fun s -> `String s) a.capabilities));
         ("current_task", match a.current_task with
           | None -> `Null
@@ -337,7 +337,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ?(
 let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Coord.get_agents_raw config in
-  let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
+  let agent_opt = List.find_opt (fun (a : Types.agent) -> a.name = agent_name) agents in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
@@ -406,7 +406,7 @@ let delegate config ~agent_name ~target ~message
       ~initial_message:(Some full_message)
     in
     match portal_result with
-    | Error e -> Error (masc_error_to_string e)
+    | Error e -> Error (Types.masc_error_to_string e)
     | Ok msg ->
       let task_id = generate_uuid () in
       match task_type with


### PR DESCRIPTION
## Summary

PR #8528 removed `open Types` from `lib/a2a_tools.ml` but three identifiers still relied on it, leaving `origin/main` red:

| Line | Symbol | Fix |
|------|--------|-----|
| 303, 309, 340 | `(a : agent)` | `(a : Types.agent)` |
| 312 | `agent_status_to_string` | `Types.agent_status_to_string` |
| 409 | `masc_error_to_string` | `Types.masc_error_to_string` |

`Coord.get_agents_raw : config -> Types.agent list` already declares the qualifier (see `lib/coord/coord_query.mli:28`), so `Types.` is the intended home. No semantics change — purely identifier resolution.

## Why it slipped through

Most likely a stale dune cache in CI that still had the effects of `open Types` from the pre-#8528 version of the file. Fresh build from `origin/main` was red before this fix (error: `Unbound type constructor agent`).

## Product impact
- restores current-main build without reintroducing `open Types`
- keeps the cleanup from #8528 intact while making the remaining `Types` ownership explicit at the last three call sites

## Evidence
- `lib/a2a_tools.ml` now qualifies the three remaining `Types`-owned identifiers directly where they are used
- `Coord.get_agents_raw : config -> Types.agent list` already exposes the intended qualified type at the API boundary

## Review evidence
- self-review on the exact remaining identifier-resolution sites in `lib/a2a_tools.ml`
- no behavior change outside those three references and the branch remains a single-file fix

## Test plan

- [x] `dune build --root .` green on fresh checkout
- [ ] CI (lint, build, test, drift gate) green

## Linked issue
- Refs #8528
- Refs #8584