### PR TITLE
fix(dashboard): scope variant SSOT + mirror — close inline-enum drift (#8592)

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -45,6 +45,27 @@ type scope =
   | All
   | Current
 
+(** Issue #8592: SSOT helpers for [scope]. The witness function and
+    canonical string list are mirrored in the JSON Schema layer
+    ([Tool_schemas_misc.dashboard_scope_enum_strings]) — direct
+    dependency would cycle. The test [test_types.ml ::
+    dashboard_scope_ssot] asserts the mirror stays in sync. Adding a
+    new constructor here forces a compile error in [scope_to_string]
+    and fails the schema mirror test instead of silently dropping
+    from the enum. *)
+let scope_to_string = function
+  | All -> "all"
+  | Current -> "current"
+
+let all_scopes = [ All; Current ]
+
+let valid_scope_strings = List.map scope_to_string all_scopes
+
+let scope_of_string_opt = function
+  | "all" -> Some All
+  | "current" -> Some Current
+  | _ -> None
+
 (** Re-export shared types from Dashboard_labels to avoid breaking existing callers *)
 type room_snapshot = Dashboard_labels.room_snapshot = {
   room_id: string;

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -26,16 +26,13 @@ type context = {
 let handle_dashboard ctx args =
   let compact = get_bool args "compact" false in
   let scope_arg = String.lowercase_ascii (get_string args "scope" "all") in
-  let scope =
-    match scope_arg with
-    | "all" -> Ok Dashboard.All
-    | "current" -> Ok Dashboard.Current
-    | other -> Error other
-  in
-  match scope with
-  | Error other ->
-      (false, Printf.sprintf "❌ Invalid dashboard scope '%s' (expected: all | current)" other)
-  | Ok scope ->
+  match Dashboard.scope_of_string_opt scope_arg with
+  | None ->
+      (false,
+       Printf.sprintf "❌ Invalid dashboard scope '%s' (expected: %s)"
+         scope_arg
+         (String.concat " | " Dashboard.valid_scope_strings))
+  | Some scope ->
       let output =
         if compact then Dashboard.generate_compact ~scope ctx.config
         else Dashboard.generate ~scope ctx.config

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -9,6 +9,14 @@ open Types
     same as #8484 / #8490 / #8493. *)
 let admin_section_enum_strings = [ "auth" ]
 
+(** Issue #8592: hand-mirrored from [Dashboard.valid_scope_strings].
+    Cycle constraint — Tool_schemas_misc is upstream of Dashboard.
+    The test [test_types.ml :: dashboard_scope_ssot] asserts this
+    mirror stays in sync with the SSOT so adding a 3rd scope
+    constructor fails compilation in [scope_to_string] AND fails the
+    test here, instead of silently dropping from the JSON Schema. *)
+let dashboard_scope_enum_strings = [ "all"; "current" ]
+
 (** Issue #8493: [masc_config] category filter strings mirror
     [Env_config_snapshot.valid_config_category_strings]. This library
     depends only on [masc_types], so it cannot depend on [masc_config]
@@ -103,7 +111,7 @@ Use from the answering side after a prior masc_webrtc_offer call.";
         ]);
         ("scope", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "all"; `String "current"]);
+          ("enum", `List (List.map (fun s -> `String s) dashboard_scope_enum_strings));
           ("description", `String "Dashboard scope (default: all)");
           ("default", `String "all");
         ]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -443,7 +443,7 @@ let () =
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         Alcotest.(check (list string)) "tool_schemas mirror == SSOT"
           Masc_mcp.Tool_misc_admin.valid_admin_section_strings
-          Masc_tool_schemas.Tool_schemas_misc.admin_section_enum_strings);
+          Tool_schemas_misc.admin_section_enum_strings);
     ];
     "config_category_ssot", [
       Alcotest.test_case "producer helper matches all_categories order" `Quick (fun () ->
@@ -847,6 +847,40 @@ let () =
         Alcotest.(check (list string)) "tail_order mirror == SSOT"
           Masc_mcp.Keeper_status_detail.valid_tail_order_strings
           Masc_mcp.Keeper_schema.tail_order_enum_strings);
+    ];
+    "dashboard_scope_ssot", [
+      (* Issue #8592: witness exhaustiveness for [Dashboard.scope] +
+         sync test for [Tool_schemas_misc.dashboard_scope_enum_strings].
+         Same shape as #8486 (tail_order). The dashboard scope was
+         hand-rolled inline in tool_schemas_misc.ml; adding a 3rd
+         constructor would silently drop from the JSON Schema. *)
+      Alcotest.test_case "witness covers both variants" `Quick (fun () ->
+        let module D = Masc_mcp.Dashboard in
+        let witness s =
+          let actual = D.scope_to_string s in
+          if not (List.mem actual D.valid_scope_strings) then
+            Alcotest.failf "scope_to_string %S not in valid_scope_strings" actual
+        in
+        witness D.All; witness D.Current;
+        Alcotest.(check int) "count" 2 (List.length D.valid_scope_strings));
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "dashboard scope mirror == SSOT"
+          Masc_mcp.Dashboard.valid_scope_strings
+          Tool_schemas_misc.dashboard_scope_enum_strings);
+      Alcotest.test_case "scope_of_string_opt round-trips SSOT strings" `Quick (fun () ->
+        let module D = Masc_mcp.Dashboard in
+        List.iter (fun s ->
+          match D.scope_of_string_opt s with
+          | None -> Alcotest.failf "scope_of_string_opt %S returned None" s
+          | Some scope ->
+            let back = D.scope_to_string scope in
+            Alcotest.(check string) (Printf.sprintf "round-trip %S" s) s back)
+        D.valid_scope_strings);
+      Alcotest.test_case "scope_of_string_opt rejects unknown input" `Quick (fun () ->
+        Alcotest.(check (option string)) "unknown -> None"
+          None
+          (Option.map Masc_mcp.Dashboard.scope_to_string
+             (Masc_mcp.Dashboard.scope_of_string_opt "recent")));
     ];
     "compact_retry_exhausted_ssot", [
       (* Issue #8581: the [compact_retry_exhausted] field was read by


### PR DESCRIPTION
## Summary

Closes #8592, also closes #8593 (drive-by fix for broken \`Masc_tool_schemas\` prefix introduced by PR #8553).

\`Dashboard.scope = All | Current\` had no SSOT helpers; \`tool_schemas_misc.ml:99\` hand-rolled the JSON Schema enum inline. Pattern matches #8486 (tail_order) and #8467 (sandbox/network/shared_memory) — the established Variant SSOT mirror family.

## Changes

| Layer | Change |
|---|---|
| \`lib/dashboard.ml\` | + \`scope_to_string\`, \`all_scopes\`, \`valid_scope_strings\`, \`scope_of_string_opt\` |
| \`lib/tool_schemas/tool_schemas_misc.ml\` | + \`dashboard_scope_enum_strings\` mirror; replace inline literal |
| \`lib/tool_misc.ml\` | refactor handler to use \`Dashboard.scope_of_string_opt\`; error message derives valid set |
| \`test/test_types.ml\` | + \`dashboard_scope_ssot\` (witness + mirror + round-trip + reject-unknown) |

## Drive-by Fix (#8593)

Line 446 of test_types.ml referenced \`Masc_tool_schemas.Tool_schemas_misc.admin_section_enum_strings\` — non-existent module (library is \`(wrapped false)\`, consumers access \`Tool_schemas_misc.*\` directly). Introduced by PR #8553. Without removing this prefix, \`test_types.exe\` does not build on main; the new test group below it inherits the failure. Bundled into this PR since the new test depends on a buildable test_types.

## Verification

\`\`\`bash
dune build --root=\$PWD lib                 # clean
dune build --root=\$PWD test/test_types.exe # clean (was broken on main)
dune exec --root=\$PWD test/test_types.exe -- test dashboard_scope_ssot
# Test Successful, 4 tests run
\`\`\`

## Test plan

- [x] \`dune build lib\` clean
- [x] \`dune build test/test_types.exe\` clean
- [x] \`dashboard_scope_ssot\` 4/4 OK
- [ ] CI green