### PR TITLE
fix(broadcast): drop dead `format` schema field — handler ignored it (#8595)

### DIFF
--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -7,11 +7,11 @@ let message_field =
   Sg.string_field "message" ~required:true
     ~desc:"Message content to broadcast to all agents" ()
 
-let format_field =
-  Sg.string_field "format" ~required:false
-    ~desc:"Output format: compact or verbose (default: verbose)" ()
-
-let broadcast_schema = Sg.two message_field format_field
+(* Issue #8595: dropped [format_field]. The schema field was advertised
+   to LLM clients but [handle_broadcast] never read it (destructured as
+   [_format]). Removing it brings the typed PoC schema in line with the
+   production handler and the freshly de-bloated inline schema. *)
+let broadcast_schema = Sg.one message_field
 
 type broadcast_output = {
   delivered : bool;
@@ -27,7 +27,7 @@ let encode_broadcast (output : broadcast_output) : Yojson.Safe.t =
     | Some m -> [("mention", `String m)]
     | None -> [])
 
-let handle_broadcast ((message, _format) : string * string)
+let handle_broadcast (message : string)
     : (broadcast_output, string) result =
   let trimmed = String.trim message in
   if trimmed = "" then Error "Broadcast message cannot be empty"

--- a/lib/tool_broadcast_typed.mli
+++ b/lib/tool_broadcast_typed.mli
@@ -9,7 +9,7 @@ type broadcast_output = {
   mention : string option;
 }
 
-val broadcast_schema : (string * string) Agent_sdk.Tool_schema_gen.schema
+val broadcast_schema : string Agent_sdk.Tool_schema_gen.schema
 val encode_broadcast : broadcast_output -> Yojson.Safe.t
-val handle_broadcast : string * string -> (broadcast_output, string) result
-val tool : (string * string, broadcast_output) Typed_tool_masc.t
+val handle_broadcast : string -> (broadcast_output, string) result
+val tool : (string, broadcast_output) Typed_tool_masc.t

--- a/lib/tool_schemas/tool_schemas_inline_coord.ml
+++ b/lib/tool_schemas/tool_schemas_inline_coord.ml
@@ -59,7 +59,12 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
   };
   {
     name = "masc_broadcast";
-    description = "Send a message visible to ALL agents via SSE push. Use for: status updates ('Starting task X'), help requests ('@gemini can you review this?'), completions. Use @agent_name to ping specific agent. Default: verbose format.";
+    description = "Send a message visible to ALL agents via SSE push. Use for: status updates ('Starting task X'), help requests ('@gemini can you review this?'), completions. Use @agent_name to ping specific agent.";
+    (* Issue #8595: removed dead `format` enum field. The handler in
+       tool_inline_dispatch_comm.handle_broadcast never read it; the
+       typed PoC handler explicitly destructured it as `_format`.
+       Schema previously lied to LLM clients about output shape
+       customization. Same anti-pattern as #8546 admin_section. *)
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -70,12 +75,6 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
         ("message", `Assoc [
           ("type", `String "string");
           ("description", `String "Message content (use @mention for specific agents)");
-        ]);
-        ("format", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "compact"; `String "verbose"]);
-          ("description", `String "Output format: 'compact' or 'verbose' (default, JSON)");
-          ("default", `String "verbose");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "message"]);

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -11,17 +11,17 @@ let parse json =
 let test_parse_valid () =
   let json = `Assoc [("message", `String "hello world")] in
   match parse json with
-  | Ok (message, format) ->
-    Alcotest.(check string) "message" "hello world" message;
-    Alcotest.(check string) "format default" "" format
+  | Ok message ->
+    Alcotest.(check string) "message" "hello world" message
   | Error e -> Alcotest.fail ("parse failed: " ^ e)
 
-let test_parse_with_format () =
+let test_parse_extra_fields_ignored () =
+  (* Issue #8595: schema advertised a [format] field but the handler
+     ignored it. After removing [format] from the schema, an unexpected
+     [format] key must not cause a parse failure (Sg drops unknown fields). *)
   let json = `Assoc [("message", `String "hi"); ("format", `String "compact")] in
   match parse json with
-  | Ok (message, format) ->
-    Alcotest.(check string) "message" "hi" message;
-    Alcotest.(check string) "format" "compact" format
+  | Ok message -> Alcotest.(check string) "message" "hi" message
   | Error e -> Alcotest.fail ("parse failed: " ^ e)
 
 let test_parse_missing_message () =
@@ -41,13 +41,12 @@ let test_parse_wrong_type () =
 let test_parse_coerces_int_message () =
   let json = `Assoc [("message", `Int 42)] in
   match parse json with
-  | Ok (message, format) ->
-    Alcotest.(check string) "message coerced" "42" message;
-    Alcotest.(check string) "format default" "" format
+  | Ok message ->
+    Alcotest.(check string) "message coerced" "42" message
   | Error e -> Alcotest.fail ("expected coercion: " ^ e)
 
 let test_handler_success () =
-  match Tool_broadcast_typed.handle_broadcast ("hello @claude", "") with
+  match Tool_broadcast_typed.handle_broadcast "hello @claude" with
   | Ok output ->
     Alcotest.(check bool) "delivered" true output.delivered;
     Alcotest.(check string) "message" "hello @claude" output.room_message;
@@ -55,12 +54,12 @@ let test_handler_success () =
   | Error e -> Alcotest.fail ("handler failed: " ^ e)
 
 let test_handler_empty () =
-  match Tool_broadcast_typed.handle_broadcast ("   ", "") with
+  match Tool_broadcast_typed.handle_broadcast "   " with
   | Ok _ -> Alcotest.fail "expected error"
   | Error _ -> ()
 
 let test_handler_trim () =
-  match Tool_broadcast_typed.handle_broadcast ("  trimmed  ", "") with
+  match Tool_broadcast_typed.handle_broadcast "  trimmed  " with
   | Ok output -> Alcotest.(check string) "trimmed" "trimmed" output.room_message
   | Error e -> Alcotest.fail e
 
@@ -117,14 +116,16 @@ let test_to_spec () =
   Alcotest.(check bool) "requires_join" true spec.requires_join
 
 let test_params () =
+  (* Issue #8595: was 2 (message + dead format). Now 1 — schema reflects
+     handler reality. *)
   let schema = Typed_tool_masc.schema Tool_broadcast_typed.tool in
-  Alcotest.(check int) "params" 2 (List.length schema.parameters)
+  Alcotest.(check int) "params" 1 (List.length schema.parameters)
 
 let () =
   Alcotest.run "Typed_tool_masc" [
     ("parse", [
       Alcotest.test_case "valid" `Quick test_parse_valid;
-      Alcotest.test_case "with format" `Quick test_parse_with_format;
+      Alcotest.test_case "extra fields ignored (#8595)" `Quick test_parse_extra_fields_ignored;
       Alcotest.test_case "missing message" `Quick test_parse_missing_message;
       Alcotest.test_case "wrong type" `Quick test_parse_wrong_type;
       Alcotest.test_case "int coerces to string" `Quick test_parse_coerces_int_message;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -443,7 +443,7 @@ let () =
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         Alcotest.(check (list string)) "tool_schemas mirror == SSOT"
           Masc_mcp.Tool_misc_admin.valid_admin_section_strings
-          Masc_tool_schemas.Tool_schemas_misc.admin_section_enum_strings);
+          Tool_schemas_misc.admin_section_enum_strings);
     ];
     "config_category_ssot", [
       Alcotest.test_case "producer helper matches all_categories order" `Quick (fun () ->


### PR DESCRIPTION
## Summary

Closes #8595, also closes #8593 (drive-by — same fix as in PR #8594, whichever merges first wins).

\`masc_broadcast\` advertised \`format=enum[compact|verbose]\` but two handlers ignored it. Schema lied to LLM clients. Identical anti-pattern to #8546 admin_section.

## Changes

| Layer | Change |
|---|---|
| \`tool_schemas_inline_coord.ml\` | drop \`format\` field from masc_broadcast schema |
| \`tool_broadcast_typed.ml\` + \`.mli\` | \`Sg.two\` → \`Sg.one\`; \`(string * string)\` → \`string\` handler signature |
| \`test_typed_tool_masc.ml\` | 6 tests updated for unary signature; \`with format\` → \`extra fields ignored\`; param count 2 → 1 |
| \`test_types.ml:446\` | drive-by: \`Masc_tool_schemas.X\` → \`X\` (closes #8593) |

## Verification

\`\`\`bash
dune build --root=\$PWD lib       # clean
dune build --root=\$PWD           # clean (full tree, was broken on main without #8593 fix)
dune exec test/test_typed_tool_masc.exe  # 16/16 OK
\`\`\`

## Why Not Implement (Option B)

The broadcast result is a single string from \`Coord.broadcast\` — there is no obvious verbose↔compact contrast to model at the output layer. Implementing the field would require defining new semantics + tests for marginal client value. Removing it now is cheaper than letting clients depend on a non-existent contract.

## Test plan

- [x] \`dune build\` clean (lib + full)
- [x] \`test_typed_tool_masc\` 16/16 OK
- [ ] CI green