### PR TITLE
fix(compact): drop dead `~system_prompt` arg (#8597 item 1)

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -441,8 +441,11 @@ let default_dynamic_selector (obs : observation_context) : strategy list =
     @param observation Optional observation context for Dynamic strategies.
       When a strategy list contains [Dynamic], this context determines
       which concrete strategies are applied. *)
+(* Issue #8597 #1: dropped [~system_prompt]. The OAS Context_reducer
+   pipeline operates on [messages] only — the system prompt is part of
+   [messages] (role=System) when present. The labeled arg was passed by
+   keeper_compact_policy but never read. *)
 let compact
-    ~system_prompt:(_system_prompt : string)
     ~(messages : Agent_sdk.Types.message list)
     ~(strategies : strategy list)
     ?(observation : observation_context option)

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -152,8 +152,10 @@ let compact_if_needed
             (Printexc.to_string exn));
       let messages =
           let msgs_after_compact =
+            (* Issue #8597 #1: dropped [~system_prompt] arg — compact
+               ignored it (system prompt already present in messages
+               when role=System). *)
             Context_compact_oas.compact
-              ~system_prompt:(system_prompt_of_context ctx)
               ~messages:(messages_of_context ctx)
               ~strategies
               ()

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -35,7 +35,7 @@ let test_merge_contiguous_still_merges_plain_user () =
     msg Agent_sdk.Types.Assistant "Hi";
   ] in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.MergeContiguous] () in
   let user_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
     m.role = Agent_sdk.Types.User) result in
@@ -53,7 +53,7 @@ let test_compact_prune_tool_outputs () =
     msg Agent_sdk.Types.Assistant "answer";
   ] in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.PruneToolOutputs] () in
   let tool_text = Agent_sdk.Types.text_of_message (List.nth result 1) in
   check bool "tool output was pruned" true
@@ -61,14 +61,14 @@ let test_compact_prune_tool_outputs () =
 
 let test_compact_empty_messages () =
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:[]
+    ~messages:[]
     ~strategies:[Compact.PruneToolOutputs; Compact.MergeContiguous] () in
   check int "empty input = empty output" 0 (List.length result)
 
 let test_compact_single_message () =
   let msgs = [msg Agent_sdk.Types.User "hello"] in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.MergeContiguous; Compact.DropLowImportance] () in
   check bool "single message survives" true (List.length result >= 1)
 
@@ -81,7 +81,7 @@ let test_compact_drop_low_importance () =
     @ [msg Agent_sdk.Types.User "latest question"]
   in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.DropLowImportance] () in
   check bool "some messages dropped" true
     (List.length result < List.length msgs)
@@ -93,7 +93,7 @@ let test_compact_summarize_old () =
       (Printf.sprintf "message %d with enough content to be meaningful" i))
   in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.SummarizeOld] () in
   check bool "message count reduced" true
     (List.length result < List.length msgs)
@@ -113,7 +113,7 @@ let test_summarize_old_masks_tool_results_but_preserves_pairing () =
     msg Agent_sdk.Types.Assistant "Yes, there are focused compaction tests.";
   ] in
   let result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.SummarizeOld] () in
   check bool "message count reduced" true
     (List.length result < List.length msgs);
@@ -235,7 +235,7 @@ let test_dynamic_high_pressure_multi_agent () =
     context_window = 200_000; is_local_model = false } in
   let msgs = [msg Agent_sdk.Types.User "test"] in
   let _result = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
+    ~messages:msgs
     ~strategies:[Compact.Dynamic Compact.default_dynamic_selector]
     ~observation:obs () in
   (* Verify high-pressure path: PruneToolOutputs + DropLowImportance + MergeContiguous *)

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -81,8 +81,8 @@ let test_roundtrip_tool_msg () =
 
 let compact_ctx (ctx : Keeper_exec_context.working_context) strategies =
   let messages =
+    (* Issue #8597 #1: ~system_prompt dropped from compact signature. *)
     Context_compact_oas.compact
-      ~system_prompt:(ctx_system_prompt ctx)
       ~messages:(ctx_messages ctx)
       ~strategies () in
   Keeper_exec_context.sync_oas_context

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -479,8 +479,8 @@ let test_compact_syncs_oas_context () =
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "msg1") in
   let ctx = Keeper_exec_context.append ctx (Agent_sdk.Types.assistant_msg "msg2") in
   let messages =
+    (* Issue #8597 #1: ~system_prompt dropped from compact signature. *)
     Context_compact_oas.compact
-      ~system_prompt:(ctx_system_prompt ctx)
       ~messages:(ctx_messages ctx)
       ~strategies:[Context_compact_oas.MergeContiguous] () in
   let ctx = Keeper_exec_context.sync_oas_context


### PR DESCRIPTION
## Summary

First of 5 fixes from the \`~name:(_var : T)\` dead-labeled-arg audit in #8597.

\`Context_compact_oas.compact\` destructured \`_system_prompt\` and never read it. \`keeper_compact_policy.ml:155\` actively computed \`system_prompt_of_context ctx\` every compaction and threw it away.

## Why Safe

- OAS \`Context_reducer\` operates on \`messages\` only; system prompt lives in \`messages\` at role=System when present.
- Production caller count: 1 (keeper_compact_policy).
- Helper \`system_prompt_of_context\` retained — 4 other modules (token counting, sanitization, OAS dispatch) still use it.

## Changes

| File | Change |
|---|---|
| \`lib/context_compact_oas.ml\` | drop \`~system_prompt:_\` from signature |
| \`lib/keeper/keeper_compact_policy.ml\` | drop call-site arg |
| \`test/test_oas_integration.ml\` | drop arg |
| \`test/test_oas_adapters.ml\` | drop arg |
| \`test/test_context_compact_oas_coverage.ml\` | drop 8 \`~system_prompt:\"sys\"\` literals |

## Verification

\`\`\`bash
dune build --root=\$PWD                                 # clean (full tree)
dune exec test/test_context_compact_oas_coverage.exe   # 22/22 OK
\`\`\`

## Follow-ups Tracked in #8597

- #2 \`Auto_recall.fetch_from_file_context ~config\` — silent override (config received, hard-coded values used). Needs design decision: honor config or drop the param.
- #3–5 \`Keeper_hooks_oas.make_hooks\` ~config/~session/~ctx_snapshot — hook-builder. Separate PR after verifying caller chain.

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] coverage tests 22/22 OK
- [ ] CI green