### PR TITLE
fix(auto_recall): drop 3 dead labeled args from fetch_source family (#8597 item 2 expanded)

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -82,7 +82,9 @@ let estimate_tokens = Inference_utils.estimate_tokens
 (** {1 Source Fetchers} *)
 
 (** Fetch from MASC cache *)
-let fetch_from_cache (room_config : Coord_utils.config) ~(config : recall_config) ~query:_ =
+(* Issue #8597 #2: dropped [~query] — cache filtering is by tag
+   (config.cache_tags), not by query string. *)
+let fetch_from_cache (room_config : Coord_utils.config) ~(config : recall_config) =
   let entries =
     match config.cache_tags with
     | [] -> Cache_eio.list room_config ()
@@ -107,7 +109,9 @@ let fetch_from_cache (room_config : Coord_utils.config) ~(config : recall_config
   ) entries
 
 (** Fetch recent broadcasts *)
-let fetch_from_broadcasts (room_config : Coord_utils.config) ~(config : recall_config) ~query:_ =
+(* Issue #8597 #2: dropped [~query] — broadcast fetch is limit-based
+   (config.max_broadcasts), not query-ranked. *)
+let fetch_from_broadcasts (room_config : Coord_utils.config) ~(config : recall_config) =
   let messages = Coord.get_messages_raw room_config
     ~since_seq:0
     ~limit:config.max_broadcasts
@@ -129,7 +133,11 @@ let fetch_from_broadcasts (room_config : Coord_utils.config) ~(config : recall_c
   ) messages
 
 (** Fetch recently modified files from working directory *)
-let fetch_from_file_context (room_config : Coord_utils.config) ~config:(_config : recall_config) ~query =
+(* Issue #8597 #2: dropped [~config]. recall_config has no field that
+   maps to file scanning (max_files=10 / max_preview_bytes=500 are
+   hard-coded; cache_tags / max_broadcasts / max_tokens belong to other
+   sources). The arg was structurally received, semantically ignored. *)
+let fetch_from_file_context (room_config : Coord_utils.config) ~query =
   let masc_dir = Coord_utils.masc_dir room_config in
   let work_dir = Filename.dirname masc_dir in (* Parent of .masc *)
   
@@ -235,11 +243,15 @@ let fetch_from_file_context (room_config : Coord_utils.config) ~config:(_config 
   )
   |> List.filter (fun item -> String.length item.content > 10)
 
-(** Fetch from a single source (sync, no Eio) *)
+(** Fetch from a single source (sync, no Eio).
+
+    Each leaf consumes only the args it needs (#8597 #2):
+    - [Masc_cache] / [Recent_broadcasts] use [config] (tags / limit)
+    - [File_context] uses [query] for relevance ranking *)
 let fetch_source room_config ~config ~query = function
-  | Masc_cache -> fetch_from_cache room_config ~config ~query
-  | Recent_broadcasts -> fetch_from_broadcasts room_config ~config ~query
-  | File_context -> fetch_from_file_context room_config ~config ~query
+  | Masc_cache -> fetch_from_cache room_config ~config
+  | Recent_broadcasts -> fetch_from_broadcasts room_config ~config
+  | File_context -> fetch_from_file_context room_config ~query
 
 (** {1 Main API} *)
 


### PR DESCRIPTION
## Summary

Closes part of #8597 — item #2 plus 2 newly-discovered siblings.

The audit flagged \`~config:_config\` in \`fetch_from_file_context\`. Inspection of the dispatcher (\`fetch_source\`) showed it forwards both \`~config\` and \`~query\` symmetrically, but each leaf consumes only one. The other two leaves had the mirror pattern (\`~query:_\`).

## Three Dead Args (one PR)

| Function | Dead arg | Why |
|---|---|---|
| \`fetch_from_cache\` | \`~query\` | Filtering is by \`config.cache_tags\`, not query string |
| \`fetch_from_broadcasts\` | \`~query\` | Limit-based via \`config.max_broadcasts\`, not query-ranked |
| \`fetch_from_file_context\` | \`~config\` | \`recall_config\` has no field mapping to file scanning (\`max_files=10\`, \`max_preview_bytes=500\` hard-coded) |

## Refactor

\`\`\`ocaml
(* before *)
let fetch_source room_config ~config ~query = function
  | Masc_cache -> fetch_from_cache room_config ~config ~query
  | Recent_broadcasts -> fetch_from_broadcasts room_config ~config ~query
  | File_context -> fetch_from_file_context room_config ~config ~query

(* after *)
let fetch_source room_config ~config ~query = function
  | Masc_cache -> fetch_from_cache room_config ~config
  | Recent_broadcasts -> fetch_from_broadcasts room_config ~config
  | File_context -> fetch_from_file_context room_config ~query
\`\`\`

Dispatcher signature unchanged — callers don't know which source they'll dispatch to.

## Verification

\`\`\`bash
dune build --root=\$PWD                                       # clean (full tree)
dune exec test/test_auto_recall_activity_coverage.exe        # 28/28 OK
\`\`\`

## Audit #8597 Progress

- [x] #1 \`Context_compact_oas.compact ~system_prompt\` → PR #8598
- [x] #2 \`Auto_recall.fetch_source\` family → this PR (3 args, expanded scope)
- [ ] #3-5 \`Keeper_hooks_oas.make_hooks\` (\`~config\`, \`~session\`, \`~ctx_snapshot\`) — separate PR (larger surface, hooks closure)

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] auto_recall coverage tests 28/28 OK
- [ ] CI green