### PR TITLE
fix(keeper_hooks_oas): drop 3 dead labeled args from make_hooks (#8597 items 3-5, audit close)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1090,11 +1090,10 @@ let run_turn
      Failure recovery: evidence records + operator notification via board,
      not sticky blocker state. See plan: enchanted-strolling-bonbon. *)
   let base_hooks =
+    (* Issue #8597 #3-5: dropped ~config / ~session / ~ctx_snapshot —
+       the hook closure ignored them; state flows via meta_ref + callbacks. *)
     Keeper_hooks_oas.make_hooks
-      ~config
       ~meta_ref
-      ~session
-      ~ctx_snapshot
       ~generation
       ?max_cost_usd
       ?trajectory_acc

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -120,17 +120,19 @@ let emit_cost_event
     2. Destructive pattern detection — reject dangerous bash/edit commands
     3. Cost event emission — auto-emit per-turn cost to .masc/costs.jsonl
 
-    @param config Coord configuration
     @param meta_ref Mutable ref to keeper metadata
-    @param session Session context for checkpoint persistence
-    @param ctx_snapshot Immutable snapshot of working context (reserved, unused)
     @param generation Current generation counter
     @param max_cost_usd Optional cost budget (rejects tool calls above limit)
     @param destructive_check Enable destructive pattern detection (default true)
     @param pre_tool_use_guard Optional callback that can short-circuit a tool
            before execution by returning an inline override response.
     @param on_tool_executed Optional callback after each tool execution
-    @param trajectory_acc Optional trajectory accumulator for cost attribution *)
+    @param trajectory_acc Optional trajectory accumulator for cost attribution
+
+    Issue #8597 #3-5: dropped [~config], [~session], [~ctx_snapshot]. The
+    closure body never read them; the docstring even admitted [ctx_snapshot]
+    was "reserved, unused". State now flows through [meta_ref] (mutable) and
+    the explicit callbacks (pre_tool_use_guard / on_tool_executed). *)
 
 (** Suggest alternative tools from the keeper's allowed set that were
     NOT part of the repeated tool calls. Returns up to [max_suggestions]
@@ -226,10 +228,7 @@ let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
   loop 0 (List.rev entries)
 
 let make_hooks
-    ~config:(_config : Coord.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
-    ~session:(_session : Keeper_exec_context.session_context)
-    ~ctx_snapshot:(_ctx_snapshot : Keeper_exec_context.working_context)
     ~(generation : int)
     ?(max_cost_usd : float option)
     ?(destructive_check : bool = true)


### PR DESCRIPTION
## Summary

Closes the final batch of #8597 dead-labeled-arg findings. Audit fully closed after this PR.

\`Keeper_hooks_oas.make_hooks\` declared 3 labeled args the closure body never read. The docstring even labeled \`~ctx_snapshot\` as \"(reserved, unused)\" — explicit admission.

## Three Dead Args

| Arg | Type | Doc claim | Reality |
|---|---|---|---|
| \`~config\` | \`Coord.config\` | \"Coord configuration\" | Never referenced in closure |
| \`~session\` | \`Keeper_exec_context.session_context\` | \"checkpoint persistence\" | Never referenced |
| \`~ctx_snapshot\` | \`Keeper_exec_context.working_context\` | \"reserved, unused\" | Self-confessed dead |

## Why Safe

State now flows through:
- \`meta_ref\` — mutable ref to keeper_meta, survives hook fires
- \`pre_tool_use_guard\` / \`on_tool_executed\` — explicit callbacks the caller supplies; carry whatever context hooks need

Single caller (\`keeper_agent_run.ml:1093\`).

## Verification

\`\`\`bash
dune build --root=\$PWD                              # clean (full tree)
dune exec test/test_keeper_hooks_oas_provider.exe   # 3/3 OK
\`\`\`

## Audit #8597 Final Status

- [x] #1 \`Context_compact_oas.compact ~system_prompt\` → PR #8598 (merged)
- [x] #2 \`Auto_recall.fetch_source\` family (3 dead args) → PR #8599 (open, CI)
- [x] #3-5 \`Keeper_hooks_oas.make_hooks\` (3 dead args) → this PR

Total: 7 dead labeled args removed across 3 PRs from a single \`rg\` pattern.

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] hooks provider tests 3/3 OK
- [ ] CI green