### PR TITLE
fix(library): library_source variant SSOT — close 3-way drift (#8601)

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -1,7 +1,7 @@
 (** Tool_library - Agent Knowledge Library operations
 
     Manages the personal knowledge base at ~/me/docs/library/
-    - Direct experience documents only (source: direct_experience | research | experiment)
+    - Direct experience documents only (source: see [library_source])
     - YAML frontmatter with confidence scores
     - Candidates promotion flow
 *)
@@ -10,6 +10,36 @@ open Printf
 
 (** Confidence threshold for routing documents to library vs candidates. *)
 let library_confidence_threshold = 0.5
+
+(** Issue #8601: SSOT for library document [source] field. Schema enum,
+    handler validation, and module docstring previously listed the values
+    independently — the docstring drifted (claimed 3, runtime had 4).
+    The witness pattern below is the standard Variant SSOT shape used by
+    #8486 (tail_order), #8467 (sandbox_profile), #8592 (dashboard scope).
+    Adding a 5th source forces compile errors in [source_to_string] and
+    fails the [library_source_ssot] test in test_types.ml. *)
+type library_source =
+  | Direct_experience
+  | Research
+  | Experiment
+  | Observation
+
+let source_to_string = function
+  | Direct_experience -> "direct_experience"
+  | Research -> "research"
+  | Experiment -> "experiment"
+  | Observation -> "observation"
+
+let all_sources = [ Direct_experience; Research; Experiment; Observation ]
+
+let valid_source_strings = List.map source_to_string all_sources
+
+let source_of_string_opt = function
+  | "direct_experience" -> Some Direct_experience
+  | "research" -> Some Research
+  | "experiment" -> Some Experiment
+  | "observation" -> Some Observation
+  | _ -> None
 
 (* String helper - check if sub is contained in s *)
 let string_contains ~sub s =
@@ -176,11 +206,17 @@ let handle_add ctx args =
   if title = "" then (false, "title is required")
   else if content = "" then (false, "content is required")
   else begin
-    (* Validate source *)
-    let valid_sources = ["direct_experience"; "research"; "experiment"; "observation"] in
-    if not (List.mem source valid_sources) then
-      (false, sprintf "Invalid source. Must be one of: %s" (String.concat ", " valid_sources))
-    else begin
+    (* Issue #8601: validate via Variant SSOT instead of List.mem on a
+       hand-rolled string list. source_of_string_opt returns None for
+       any unknown value; the error message derives from
+       valid_source_strings so adding a new constructor updates it
+       automatically. *)
+    match source_of_string_opt source with
+    | None ->
+      (false,
+       sprintf "Invalid source. Must be one of: %s"
+         (String.concat ", " valid_source_strings))
+    | Some _ -> begin
       (* Determine destination based on confidence *)
       let dest_dir = if confidence < library_confidence_threshold then candidates_dir () else library_root () in
       let date = Time_compat.now () |> Unix.localtime in
@@ -301,7 +337,8 @@ let tool_definitions = [
   ]);
   ("masc_library_add", {|Add a new document to the library. Documents with confidence < 0.5 go to candidates/.|}, [
     ("title", "string", true, "Document title");
-    ("source", "string", true, "Source type: direct_experience, research, experiment, observation");
+    ("source", "string", true,
+     sprintf "Source type: %s" (String.concat ", " valid_source_strings));
     ("confidence", "number", true, "Confidence score 0.0-1.0");
     ("tags", "array", false, "List of tags");
     ("content", "string", true, "Document body content (markdown)");
@@ -366,8 +403,13 @@ Follow up with masc_library_promote to move candidates to the main library after
         ]);
         ("source", `Assoc [
           ("type", `String "string");
-          ("description", `String "Source type: direct_experience, research, experiment, observation");
-          ("enum", `List [`String "direct_experience"; `String "research"; `String "experiment"; `String "observation"]);
+          ("description",
+           `String
+             (sprintf "Source type: %s"
+                (String.concat ", " valid_source_strings)));
+          (* Issue #8601: enum derived from Variant SSOT. *)
+          ("enum",
+           `List (List.map (fun s -> `String s) valid_source_strings));
         ]);
         ("confidence", `Assoc [
           ("type", `String "number");

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -933,6 +933,45 @@ let () =
             Alcotest.(check string) (Printf.sprintf "round-trip %S" s) s back)
           C.valid_kind_strings);
     ];
+    "library_source_ssot", [
+      (* Issue #8601: 3-way drift — module docstring claimed 3 sources,
+         handler valid_sources had 4, schema enum had 4. The fix
+         introduces [library_source] variant + standard SSOT helpers.
+         These tests pin the witness, the all_sources count, the
+         valid string set, and round-trip behaviour. Adding a 5th
+         source forces compile errors in [source_to_string] and
+         fails this test. *)
+      Alcotest.test_case "witness covers all 4 constructors" `Quick (fun () ->
+        let module L = Masc_mcp.Tool_library in
+        let witness s =
+          let actual = L.source_to_string s in
+          if not (List.mem actual L.valid_source_strings) then
+            Alcotest.failf "source_to_string %S not in valid_source_strings" actual
+        in
+        witness L.Direct_experience;
+        witness L.Research;
+        witness L.Experiment;
+        witness L.Observation;
+        Alcotest.(check int) "count" 4 (List.length L.all_sources));
+      Alcotest.test_case "valid_source_strings pinned to wire format" `Quick (fun () ->
+        Alcotest.(check (list string)) "wire-format strings"
+          [ "direct_experience"; "research"; "experiment"; "observation" ]
+          Masc_mcp.Tool_library.valid_source_strings);
+      Alcotest.test_case "source_of_string_opt round-trips SSOT strings" `Quick (fun () ->
+        let module L = Masc_mcp.Tool_library in
+        List.iter (fun s ->
+          match L.source_of_string_opt s with
+          | None -> Alcotest.failf "source_of_string_opt %S returned None" s
+          | Some src ->
+            let back = L.source_to_string src in
+            Alcotest.(check string) (Printf.sprintf "round-trip %S" s) s back)
+        L.valid_source_strings);
+      Alcotest.test_case "source_of_string_opt rejects unknown" `Quick (fun () ->
+        Alcotest.(check (option string)) "unknown -> None"
+          None
+          (Option.map Masc_mcp.Tool_library.source_to_string
+             (Masc_mcp.Tool_library.source_of_string_opt "fabricated")));
+    ];
     "compact_retry_exhausted_ssot", [
       (* Issue #8581: the [compact_retry_exhausted] field was read by
          derive_phase to promote (context_overflow + latch) to Paused


### PR DESCRIPTION
## Summary

Closes #8601. \`masc_library_add\`'s \`source\` field had **three independent definitions** in the same file:

| Surface | Values | Count |
|---|---|---|
| Module docstring (line 4) | direct_experience, research, experiment | **3** ⚠️ |
| Handler \`valid_sources\` (line 180) | + observation | 4 |
| Schema enum (line 370) | + observation | 4 |

Docstring drifted when \`observation\` was added later. Operators reading the docstring (the public contract) assumed it was invalid.

## Standard Variant SSOT Pattern

Same shape as #8486 (tail_order), #8467 (sandbox_profile), #8592 (dashboard_scope), #8546 (admin_section). Family count: 5.

| Helper | Purpose |
|---|---|
| \`type library_source = ... \| Observation\` | 4 explicit constructors |
| \`source_to_string\` | witness — adding a constructor breaks compile |
| \`all_sources\` / \`valid_source_strings\` | iteration / wire-format |
| \`source_of_string_opt\` | parse with explicit None for unknown |

Handler now uses \`source_of_string_opt\` instead of \`List.mem\` on a hand-rolled list. Error message + schema description + tool spec table all derive from \`valid_source_strings\`.

## Verification

\`\`\`bash
dune build --root=\$PWD                                       # clean (full tree)
dune exec test/test_types.exe -- test library_source_ssot    # 4/4 OK
\`\`\`

4 test cases:
- witness covers all 4 constructors
- valid_source_strings pinned to wire format
- round-trip through to_string/of_string_opt
- reject unknown returns None

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] library_source_ssot 4/4 OK
- [ ] CI green