### PR TITLE
fix(cascade_strategy): SSOT helpers + derived parse_kind error message (#8603)

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -50,6 +50,22 @@ let kind_to_string = function
   | Sticky -> "sticky"
   | Round_robin -> "round_robin"
 
+(* Issue #8603: SSOT helpers — replace hard-coded list in [parse_kind]'s
+   Error arm so adding an 8th constructor updates the operator-visible
+   error message automatically. Same Variant SSOT shape as #8486 /
+   #8467 / #8592 / #8601. *)
+let all_kinds = [
+  Failover;
+  Capacity_aware;
+  Weighted_random;
+  Circuit_breaker_cycling;
+  Priority_tier;
+  Sticky;
+  Round_robin;
+]
+
+let valid_kind_strings = List.map kind_to_string all_kinds
+
 let parse_kind = function
   | "failover" -> Ok Failover
   | "capacity_aware" -> Ok Capacity_aware
@@ -60,10 +76,8 @@ let parse_kind = function
   | "round_robin" -> Ok Round_robin
   | other ->
     Error (Printf.sprintf
-             "unknown cascade strategy %S (expected one of: \
-              failover, capacity_aware, weighted_random, \
-              circuit_breaker_cycling, priority_tier, sticky, \
-              round_robin)" other)
+             "unknown cascade strategy %S (expected one of: %s)"
+             other (String.concat ", " valid_kind_strings))
 
 let default_sticky_ttl_ms = 300_000
 

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -131,10 +131,23 @@ type kind =
         @since 0.9.7 *)
 
 val kind_to_string : kind -> string
+
+val all_kinds : kind list
+(** All [kind] constructors in declaration order.  Adding a new
+    constructor forces compile errors in [kind_to_string] (which
+    powers [valid_kind_strings] used by the [parse_kind] error
+    message), so the operator-visible "expected one of" list stays
+    in sync automatically.  Issue #8603. *)
+
+val valid_kind_strings : string list
+(** Wire-format names for {!all_kinds}, derived via {!kind_to_string}. *)
+
 val parse_kind : string -> (kind, string) result
 (** [parse_kind s] returns [Ok kind] for known names, [Error msg] for
-    unknown values.  Callers should warn-and-fallback to [Failover]
-    rather than raise, to keep keeper startup resilient to config typos. *)
+    unknown values.  The [Error] message lists {!valid_kind_strings}
+    so it stays in sync with the variant.  Callers should warn-and-fallback
+    to [Failover] rather than raise, to keep keeper startup resilient to
+    config typos. *)
 
 (** {1 Strategy value} *)
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -882,6 +882,57 @@ let () =
           (Option.map Masc_mcp.Dashboard.scope_to_string
              (Masc_mcp.Dashboard.scope_of_string_opt "recent")));
     ];
+    "cascade_strategy_kind_ssot", [
+      (* Issue #8603: parse_kind's Error message used to hard-code the
+         7 wire-format names; an 8th constructor would silently produce
+         a stale operator-visible error. The fix exposes [all_kinds]
+         and [valid_kind_strings] derived from kind_to_string and
+         routes the error message through them. These tests pin the
+         witness exhaustiveness, the count, and that the error message
+         is derived (not hard-coded). *)
+      Alcotest.test_case "all_kinds round-trips through kind_to_string" `Quick (fun () ->
+        let module C = Masc_mcp.Cascade_strategy in
+        List.iter (fun k ->
+          let actual = C.kind_to_string k in
+          if not (List.mem actual C.valid_kind_strings) then
+            Alcotest.failf "kind_to_string %S not in valid_kind_strings" actual)
+          C.all_kinds;
+        Alcotest.(check int) "count" 7 (List.length C.all_kinds);
+        Alcotest.(check int) "strings count" 7
+          (List.length C.valid_kind_strings));
+      Alcotest.test_case "valid_kind_strings pinned to wire format" `Quick (fun () ->
+        Alcotest.(check (list string)) "wire-format names"
+          [ "failover"; "capacity_aware"; "weighted_random";
+            "circuit_breaker_cycling"; "priority_tier"; "sticky";
+            "round_robin" ]
+          Masc_mcp.Cascade_strategy.valid_kind_strings);
+      Alcotest.test_case "parse_kind error mentions every valid kind" `Quick (fun () ->
+        let module C = Masc_mcp.Cascade_strategy in
+        match C.parse_kind "fabricated_strategy" with
+        | Ok _ -> Alcotest.fail "expected Error for unknown kind"
+        | Error msg ->
+          List.iter (fun k ->
+            let needle = k in
+            let len = String.length needle in
+            let mlen = String.length msg in
+            let rec contains i =
+              if i + len > mlen then false
+              else if String.sub msg i len = needle then true
+              else contains (i + 1)
+            in
+            Alcotest.(check bool)
+              (Printf.sprintf "error message lists %S" k) true (contains 0))
+            C.valid_kind_strings);
+      Alcotest.test_case "parse_kind round-trips every valid string" `Quick (fun () ->
+        let module C = Masc_mcp.Cascade_strategy in
+        List.iter (fun s ->
+          match C.parse_kind s with
+          | Error e -> Alcotest.failf "parse_kind %S returned Error: %s" s e
+          | Ok k ->
+            let back = C.kind_to_string k in
+            Alcotest.(check string) (Printf.sprintf "round-trip %S" s) s back)
+          C.valid_kind_strings);
+    ];
     "compact_retry_exhausted_ssot", [
       (* Issue #8581: the [compact_retry_exhausted] field was read by
          derive_phase to promote (context_overflow + latch) to Paused


### PR DESCRIPTION
## Summary

Closes #8603. \`Cascade_strategy.kind\` already had a 7-constructor variant + \`kind_to_string\` + \`parse_kind\`, but the \`Error\` arm hard-coded the 7 wire-format names in the operator-visible message. Adding an 8th constructor would silently leave that list stale — the only drift surface in the file.

## Changes

| Layer | Change |
|---|---|
| \`cascade_strategy.ml\` | + \`all_kinds\`, \`valid_kind_strings\`; \`parse_kind\` Error arm derives list from SSOT |
| \`cascade_strategy.mli\` | expose helpers; doc the auto-sync invariant |
| \`test_types.ml\` | + \`cascade_strategy_kind_ssot\` (4 cases) |

## Why Lower Severity (and Still Worth It)

\`cascade_strategy.kind\` is config-file driven (TOML \`kind = \"failover\"\`), not LLM-facing schema. The drift risk is operator-visible only. Still cheap to fix — joins the 5-sibling Variant SSOT family.

## Verification

\`\`\`bash
dune build --root=\$PWD                                          # clean (full tree)
dune exec test/test_types.exe -- test cascade_strategy_kind_ssot # 4/4 OK
\`\`\`

Test cases:
1. \`all_kinds\` round-trips through \`kind_to_string\` (witness exhaustive)
2. \`valid_kind_strings\` pinned to wire format
3. \`parse_kind\` error message contains every valid kind (proves derivation, not hard-coded)
4. \`parse_kind\` round-trips every valid string

## Family Status

| # | Issue | Variant SSOT |
|---|---|---|
| 1 | #8486 | tail_order |
| 2 | #8467 | sandbox / network / shared_memory |
| 3 | #8592 | dashboard.scope |
| 4 | #8601 | library_source (PR #8602 open) |
| 5 | this | cascade_strategy.kind |

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] cascade_strategy_kind_ssot 4/4 OK
- [ ] CI green