### PR TITLE
fix(worker_types): execution_scope_of_string -> Option (REAL bug, silent privilege miscategorization, #8605)

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -146,10 +146,16 @@ let worker_meta_of_yojson json =
       | None -> None
       | Some worker_name ->
           let execution_scope =
+            (* Issue #8605: was Option.map over the variant-returning
+               [_of_string] which silently downgraded typos to
+               [Limited_code_change]. Now uses [_of_string_opt] +
+               flatten so a typo becomes [None], then
+               [execution_scope_or_default] applies its explicit default. *)
             json |> member "execution_scope" |> to_string_option
             |> Option.map (fun value ->
-                   Worker_types.execution_scope_of_string
-                     (String.lowercase_ascii (String.trim value)))
+                   String.lowercase_ascii (String.trim value))
+            |> Option.map Worker_types.execution_scope_of_string_opt
+            |> Option.join
             |> execution_scope_or_default
           in
           Some

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -216,9 +216,12 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
         | _ -> None
       in
       let execution_scope =
+        (* Issue #8605: was [Some (execution_scope_of_string s)] —
+           silently downgraded typos to [Limited_code_change]. The opt
+           version returns [None] for unknown input. *)
         match arguments |> U.member "execution_scope" with
         | `String s when s <> "" ->
-            Some (Worker_types.execution_scope_of_string s)
+            Worker_types.execution_scope_of_string_opt s
         | _ -> None
       in
        (match runtime_model_valid with

--- a/lib/worker_contract_types/worker_contract_types.ml
+++ b/lib/worker_contract_types/worker_contract_types.ml
@@ -195,10 +195,16 @@ let delivery_verdict_of_yojson (json : Yojson.Safe.t) =
               {
                 contract_id;
                 status =
+                  (* Issue #8605: was [_of_string] which silently
+                     mapped any unknown value to [Delivery_fail]. The
+                     opt version returns [None] for typos; the explicit
+                     [Delivery_fail] default is now visible at the
+                     decoder boundary. *)
                   (match member "status" json with
                   | `String value ->
-                      delivery_verdict_status_of_string
-                        (String.lowercase_ascii (String.trim value))
+                      Option.value ~default:Delivery_fail
+                        (delivery_verdict_status_of_string_opt
+                           (String.lowercase_ascii (String.trim value)))
                   | _ -> Delivery_fail);
                 summary =
                   (match member "summary" json with
@@ -309,9 +315,13 @@ let planned_worker_of_yojson (json : Yojson.Safe.t) =
             spawn_role = member "spawn_role" json |> to_string_option;
             spawn_model = member "spawn_model" json |> to_string_option;
             execution_scope =
-              Option.map
-                execution_scope_of_string
-                (member "execution_scope" json |> to_string_option);
+              (* Issue #8605: was Option.map over [_of_string] (silent
+                 typo->Limited_code_change). Now flatten via the opt
+                 version: typos surface as [None] instead of routing
+                 to a valid privilege. *)
+              Option.bind
+                (member "execution_scope" json |> to_string_option)
+                execution_scope_of_string_opt;
             thinking_enabled = member "thinking_enabled" json |> to_bool_option;
             thinking_budget = member "thinking_budget" json |> to_int_option;
             max_turns = member "max_turns" json |> to_int_option;

--- a/lib/worker_contract_types/worker_contract_types_enums.ml
+++ b/lib/worker_contract_types/worker_contract_types_enums.ml
@@ -111,21 +111,29 @@ let execution_scope_to_string = function
   | Limited_code_change -> "limited_code_change"
   | Autonomous -> "autonomous"
 
-let execution_scope_of_string = function
-  | "observe_only" -> Observe_only
-  | "autonomous" -> Autonomous
-  | _ -> Limited_code_change
+(* Issue #8605: previously returned [Limited_code_change] for any
+   unknown input — silent privilege miscategorization. Switched to
+   Option so the 3 wire names parse explicitly and typos are visible
+   to callers. See worker_types.ml for the longer rationale. *)
+let execution_scope_of_string_opt = function
+  | "observe_only" -> Some Observe_only
+  | "limited_code_change" -> Some Limited_code_change
+  | "autonomous" -> Some Autonomous
+  | _ -> None
 
 let delivery_verdict_status_to_string = function
   | Delivery_pass -> "pass"
   | Delivery_repair -> "repair"
   | Delivery_fail -> "fail"
 
-let delivery_verdict_status_of_string = function
-  | "pass" -> Delivery_pass
-  | "repair" -> Delivery_repair
-  | "fail" -> Delivery_fail
-  | _ -> Delivery_fail
+(* Issue #8605: previously fell through to [Delivery_fail] (fail-closed
+   but silent). Switched to Option so callers can distinguish a real
+   "fail" verdict from a typo'd input. *)
+let delivery_verdict_status_of_string_opt = function
+  | "pass" -> Some Delivery_pass
+  | "repair" -> Some Delivery_repair
+  | "fail" -> Some Delivery_fail
+  | _ -> None
 
 let turn_kind_to_string = function
   | Turn_note -> "note"

--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -53,9 +53,12 @@ let execution_scope_to_yojson = function
 
 let execution_scope_of_yojson = function
   | `String value ->
-      Some
-        (Worker_types.execution_scope_of_string
-           (String.lowercase_ascii (String.trim value)))
+      (* Issue #8605: was [Some (execution_scope_of_string ...)] — silently
+         downgraded any unknown string to [Limited_code_change]. The opt
+         version returns [None] for typos, surfacing the malformed input
+         to the JSON layer instead of routing it to a valid privilege. *)
+      Worker_types.execution_scope_of_string_opt
+        (String.lowercase_ascii (String.trim value))
   | `Null -> None
   | _ -> None
 

--- a/lib/worker_types.ml
+++ b/lib/worker_types.ml
@@ -24,10 +24,17 @@ let execution_scope_to_string = function
   | Limited_code_change -> "limited_code_change"
   | Autonomous -> "autonomous"
 
-let execution_scope_of_string = function
-  | "observe_only" -> Observe_only
-  | "autonomous" -> Autonomous
-  | _ -> Limited_code_change
+(* Issue #8605: returns [Some] only for the 3 wire-format names; any
+   other input (including typos like "Observe_only" with capitalisation
+   or fabricated values) returns [None]. Callers must handle [None]
+   explicitly — the previous variant-returning shape silently routed
+   unknowns to [Limited_code_change], a *valid* variant, which is silent
+   privilege miscategorization. *)
+let execution_scope_of_string_opt = function
+  | "observe_only" -> Some Observe_only
+  | "limited_code_change" -> Some Limited_code_change
+  | "autonomous" -> Some Autonomous
+  | _ -> None
 
 let worker_class_to_string = function
   | Worker_manager -> "manager"

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -35,14 +35,21 @@ let test_autonomous_scope_roundtrip () =
   let scope = Worker_types.Autonomous in
   let s = Worker_types.execution_scope_to_string scope in
   Alcotest.(check string) "to_string" "autonomous" s;
-  let back = Worker_types.execution_scope_of_string s in
-  let back_s = Worker_types.execution_scope_to_string back in
-  Alcotest.(check string) "roundtrip" "autonomous" back_s
+  (* Issue #8605: opt version returns Some for valid strings. *)
+  match Worker_types.execution_scope_of_string_opt s with
+  | None -> Alcotest.fail "expected Some for valid string"
+  | Some back ->
+    let back_s = Worker_types.execution_scope_to_string back in
+    Alcotest.(check string) "roundtrip" "autonomous" back_s
 
-let test_scope_default_is_limited () =
-  let scope = Worker_types.execution_scope_of_string "unknown_value" in
-  let s = Worker_types.execution_scope_to_string scope in
-  Alcotest.(check string) "default" "limited_code_change" s
+let test_scope_unknown_returns_none () =
+  (* Issue #8605: was test_scope_default_is_limited — asserted that
+     unknown input silently produced [Limited_code_change]. That was
+     the bug: silent privilege miscategorization. The opt version
+     correctly returns [None] so callers must apply an explicit
+     default at their layer. *)
+  Alcotest.(check bool) "unknown -> None" true
+    (Worker_types.execution_scope_of_string_opt "unknown_value" = None)
 
 (* ── Phase 2: Tool Discovery ──────────────────────────────────── *)
 
@@ -251,10 +258,12 @@ let test_team_context_build_renders_findings_without_goal () =
         (contains_s section "render me"))
 
 let test_scope_default_unchanged () =
-  (* Limited_code_change is still the default for unknown strings *)
-  let scope = Worker_types.execution_scope_of_string "whatever" in
-  let s = Worker_types.execution_scope_to_string scope in
-  Alcotest.(check string) "default scope" "limited_code_change" s;
+  (* Issue #8605: Variant SSOT semantics — unknown input returns
+     [None]; callers (e.g. worker_container.execution_scope_or_default)
+     supply the explicit default. The bug was the silent default at
+     the parsing layer. *)
+  Alcotest.(check bool) "unknown -> None" true
+    (Worker_types.execution_scope_of_string_opt "whatever" = None);
   (* Worker tools should remain a small focused set *)
   let worker_tools =
     Agent_tool_surfaces.build_tool_catalog ~role:"worker" ()
@@ -273,8 +282,8 @@ let () =
             test_lifecycle_no_strict;
           Alcotest.test_case "autonomous scope roundtrip" `Quick
             test_autonomous_scope_roundtrip;
-          Alcotest.test_case "scope default is limited_code_change" `Quick
-            test_scope_default_is_limited;
+          Alcotest.test_case "unknown scope returns None (#8605)" `Quick
+            test_scope_unknown_returns_none;
         ] );
       ( "phase2_tool_discovery",
         [


### PR DESCRIPTION
## Summary

Closes #8605. **REAL security-relevant bug** — \`execution_scope_of_string\` in two duplicate locations silently routed any unknown input to \`Limited_code_change\`, a *valid* privilege variant.

## The Bug

\`\`\`ocaml
let execution_scope_of_string = function
  | "observe_only" -> Observe_only
  | "autonomous"   -> Autonomous
  | _              -> Limited_code_change   (* danger *)
\`\`\`

Every typo became a silent privilege grant:
- \`\"Observe_only\"\` (capitalised) → Limited_code_change (intent: read-only; got: gated mutation)
- \`\"\"\` (empty)               → Limited_code_change
- \`\"supervised\"\` (fabricated) → Limited_code_change

\`execution_scope\` controls keeper privilege — read-only / gated / autonomous. Silent miscategorization at parse time bypasses the operator's stated intent.

A correct Option-typed sibling already existed at \`worker_runtime_config.ml:68\` (\`execution_scope_of_string_opt\`), added precisely because the original was wrong — but never propagated.

## Migration

| Surface | Change |
|---|---|
| 2 enum modules | Variant return → Option |
| 5 caller sites | wrap in Some/Option.map of dangerous → use opt directly + explicit default at the boundary |
| 2 tests | were asserting the bug as expected behaviour; updated to assert None contract |

\`delivery_verdict_status_of_string\` got the same migration (its catch-all was \`Delivery_fail\`, fail-closed but still typo-hiding).

## Verification

\`\`\`bash
dune build --root=\$PWD                       # clean (full tree)
dune exec test/test_autonomy_liberation.exe  # 18/18 OK
\`\`\`

## Test plan

- [x] \`dune build\` clean
- [x] autonomy_liberation 18/18 OK
- [ ] CI green