### PR TITLE
chore(ci): add check-ssot.sh ratchet guardrail (#8462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
             build=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|docs/|README\.md$|ROADMAP\.md$|CHANGELOG\.md$|dune-project$|dune-workspace$|.*\.opam$|scripts/check-doc-truth\.sh$|scripts/check-version-truth\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/gen-grpc-descriptors\.sh$)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|docs/|README\.md$|ROADMAP\.md$|CHANGELOG\.md$|dune-project$|dune-workspace$|.*\.opam$|scripts/check-doc-truth\.sh$|scripts/check-version-truth\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$)'; then
             lint=true
           fi
 
@@ -526,6 +526,11 @@ jobs:
         run: |
           chmod +x scripts/check-boundary-guard.sh
           scripts/check-boundary-guard.sh
+
+      - name: Check SSOT bypass ratchet (#8462)
+        run: |
+          chmod +x scripts/check-ssot.sh
+          scripts/check-ssot.sh
 
       - name: Build with warnings as errors
         run: |

--- a/dashboard/src/components/fleet-data-core.test.ts
+++ b/dashboard/src/components/fleet-data-core.test.ts
@@ -33,7 +33,9 @@ function okJson<T>(body: T) {
   return {
     ok: true,
     status: 200,
+    statusText: 'OK',
     json: async () => body,
+    text: async () => JSON.stringify(body),
   }
 }
 

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -37,6 +37,16 @@ const payloadWithMissingToolMetrics = {
   ],
 }
 
+function okJson<T>(body: T) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }
+}
+
 async function flushUi(): Promise<void> {
   await act(async () => {
     for (let i = 0; i < 4; i += 1) {
@@ -113,10 +123,7 @@ describe('ToolQualityPanel', () => {
   })
 
   it('normalizes missing tool metric fields before rendering', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payloadWithMissingToolMetrics,
-    })
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithMissingToolMetrics))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel } = await import('./tool-quality-panel')
 
@@ -139,10 +146,7 @@ describe('ToolQualityPanel', () => {
           reject(new DOMException('replaced by newer refresh', 'AbortError'))
         })
       }))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => payload,
-      })
+      .mockResolvedValueOnce(okJson(payload))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel, refreshToolQuality } = await import('./tool-quality-panel')
 
@@ -165,10 +169,7 @@ describe('ToolQualityPanel', () => {
   })
 
   it('refreshes again when the refresh button is clicked', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    })
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payload))
     vi.stubGlobal('fetch', fetchMock)
     const { ToolQualityPanel } = await import('./tool-quality-panel')
 

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SSOT bypass guardrail.
+#
+# Ratchet-based: each rule has a baseline count. CI fails if the count grows.
+# Baselines are lowered as SSOT-consolidation PRs land.
+#
+# See #8462 for the proposal and #8355/#8387/#8403/#8414/#8448/#8455 for
+# the bypass class this rule set targets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: check-ssot.sh requires ripgrep (rg)." >&2
+  exit 2
+fi
+
+fail=0
+
+count_rule_excluding() {
+  local pattern="$1"
+  local exclude_regex="$2"
+  shift 2
+  # grep -Ev returns 1 when all lines are filtered; avoid tripping pipefail.
+  if [ -n "$exclude_regex" ]; then
+    { rg -c --no-heading "$pattern" "$@" 2>/dev/null || true; } \
+      | { grep -Ev "$exclude_regex" || true; } \
+      | awk -F: '{sum += $2} END {print sum+0}'
+  else
+    { rg -c --no-heading "$pattern" "$@" 2>/dev/null || true; } \
+      | awk -F: '{sum += $2} END {print sum+0}'
+  fi
+}
+
+check_rule() {
+  local name="$1"
+  local baseline="$2"
+  local replacement_hint="$3"
+  local pattern="$4"
+  local exclude_regex="$5"
+  shift 5
+  local current
+  current="$(count_rule_excluding "$pattern" "$exclude_regex" "$@")"
+
+  if [ "$current" -gt "$baseline" ]; then
+    echo "ERROR[$name]: $current occurrences (baseline $baseline) — SSOT bypass grew." >&2
+    echo "  Replace with: $replacement_hint" >&2
+    echo "  Offending lines:" >&2
+    if [ -n "$exclude_regex" ]; then
+      rg -n --no-heading "$pattern" "$@" 2>/dev/null | grep -Ev "$exclude_regex" | sed 's/^/    /' >&2
+    else
+      rg -n --no-heading "$pattern" "$@" 2>/dev/null | sed 's/^/    /' >&2
+    fi
+    fail=1
+  elif [ "$current" -lt "$baseline" ]; then
+    echo "NOTE[$name]: $current occurrences (baseline $baseline). Lower the baseline in scripts/check-ssot.sh."
+  else
+    echo "OK[$name]: $current occurrences (baseline $baseline)."
+  fi
+}
+
+# SSOT-R1 — .masc path concat bypasses Coord_utils.masc_dir helper.
+# Tracked: #8355 (37 files at filing; current ratchet from main).
+# Excluded: the helper impl + backend setters where the literal IS the SSOT.
+check_rule "R1-masc-path" 26 \
+  "Coord_utils.masc_dir <config>" \
+  'Filename\.concat\s+[a-zA-Z_]+\s+"\.masc"' \
+  'coord_utils_paths_backend|coord_utils_backend_setup|coord_eio' \
+  lib
+
+# SSOT-R2 — loopback literal bypasses Masc_network_defaults.masc_http_default_host.
+# Tracked: #8387.
+# Excluded: helper definition + display-name mapping (server_auth) + URL prefix predicate.
+check_rule "R2-loopback-literal" 1 \
+  "Masc_network_defaults.masc_http_default_host" \
+  '"127\.0\.0\.1"' \
+  'masc_network_defaults|server_auth|graphql_endpoint' \
+  lib
+
+# SSOT-R4 — config filename literal.
+# Tracked: #8414. Helper to be added (Config_filenames) in the fix.
+# No exclusion — every site should eventually route through the helper.
+check_rule "R4-config-filename" 11 \
+  "Config_filenames.<name> (add helper per #8414)" \
+  '"(cascade\.json|keeper_runtime\.toml|tool_policy\.toml)"' \
+  '' \
+  lib
+
+# SSOT-R5 — health path literal bypasses Server_health_paths helper.
+# Tracked: #8403. Helper already exists at lib/server/server_health_paths.ml.
+# Baseline 0: new literals outside the helper module are immediate failures.
+check_rule "R5-health-path" 0 \
+  "Server_health_paths.liveness / .readiness" \
+  '"/health/(live|ready)"' \
+  'server_health_paths' \
+  lib
+
+# SSOT-R3 (tool-name literal) is intentionally deferred to #8448's landing:
+# the raw `"masc_..."` match is too noisy without the Tool_name.Keeper variant
+# refactor in place. Add to this script once #8448 introduces a narrow dispatch
+# pattern we can grep for.
+
+echo ""
+echo "SSOT snapshot (baselines tracked inline; lower them as SSOT PRs land):"
+echo "  Script: scripts/check-ssot.sh"
+echo "  Related issues: #8355 #8387 #8403 #8414 #8448 #8455 #8462"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Adds `scripts/check-ssot.sh` — a ratchet-based CI guard against SSOT bypass literals that the 2026-04-18 /loop kept rediscovering (#8355/#8387/#8403/#8414/#8448/#8455).

Each rule has a baseline count measured on main. CI fails if the repo grows the count. Baselines drop as SSOT-consolidation PRs land.

## Initial rule set

| Rule | Pattern | Baseline | Helper | Tracked issue |
|------|---------|----------|--------|---------------|
| R1   | `Filename.concat _ ".masc"` | 26 | `Coord_utils.masc_dir` | #8355 |
| R2   | `"127.0.0.1"` | 1 | `Masc_network_defaults.masc_http_default_host` | #8387 |
| R4   | `"cascade.json"` / `"keeper_runtime.toml"` / `"tool_policy.toml"` | 11 | `Config_filenames.*` (pending) | #8414 |
| R5   | `"/health/(live\|ready)"` | 0 | `Server_health_paths` | #8403 |

R3 (tool-name literal, #8448) is deferred — raw `"masc_..."` is too noisy without the `Tool_name.Keeper` variant refactor in place. Add R3 once #8448 lands a narrow dispatch pattern.

## Design notes

- **Ratchet not allowlist**: we have 26+11+1 = 38 existing bypasses. Allowlisting every file would be scope creep; the ratchet catches regression while leaving SSOT PRs to fix existing sites.
- **Helper exclusion**: files that *define* the SSOT (helper impl, backend setter, URL prefix predicate) are excluded from the count so that the authoritative source doesn't get counted as its own bypass.
- **Pipefail-safe**: `grep -Ev` returning 1 on empty result is guarded with `|| true` so the ratchet never misreads a zero-match as failure.

## Test plan

- [x] Ran locally on main: all four rules report `OK`
- [x] Deliberately introduced a `"/health/live"` violation under `lib/server/`: script produced `ERROR[R5-health-path]: 1 occurrences (baseline 0)` with offending line dump
- [x] Lint scope detection updated: `scripts/check-ssot.sh` added to `jobs.changes` regex so the guard runs on relevant PRs
- [ ] CI lint job picks it up on first push

## What this enables

Once merged, follow-up SSOT PRs (#8355, #8387, #8403, #8414, #8448, #8455) can lower the baselines as they consolidate bypass sites. The guard is the prerequisite that keeps those fixes from silently regressing.

Closes #8462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
