### PR TITLE
fix(voice_session_manager): status_of_string -> Option (#8612, #8605 family)

### DIFF
--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -56,11 +56,16 @@ let string_of_status = function
   | Idle -> "idle"
   | Suspended -> "suspended"
 
-let status_of_string = function
-  | "active" -> Active
-  | "idle" -> Idle
-  | "suspended" -> Suspended
-  | _ -> Idle
+(* Issue #8612: returns [Some] only for the 3 wire-format names; any
+   other input returns [None]. The previous variant-returning shape
+   silently routed unknowns to [Idle], a *valid* downstream variant,
+   which is silent JSON-decode miscategorization. Same anti-pattern
+   class as #8605 (execution_scope) and #8607 (agent_health). *)
+let status_of_string_opt = function
+  | "active" -> Some Active
+  | "idle" -> Some Idle
+  | "suspended" -> Some Suspended
+  | _ -> None
 
 let session_to_json session =
   `Assoc [
@@ -82,7 +87,15 @@ let session_of_json json =
     started_at = json |> member "started_at" |> to_float;
     last_activity = json |> member "last_activity" |> to_float;
     turn_count = json |> member "turn_count" |> to_int;
-    status = json |> member "status" |> to_string |> status_of_string;
+    (* Issue #8612: a corrupt or mis-versioned status field used to
+       silently decode as [Idle]. We now fail-closed at the boundary:
+       unknown status defaults to [Suspended] so the session is visible
+       to the operator (and won't be skipped by lifecycle GC that treats
+       Idle as "nothing to clean up"). *)
+    status =
+      json |> member "status" |> to_string
+      |> status_of_string_opt
+      |> Option.value ~default:Suspended;
   }
 
 (** {1 Creation} *)


### PR DESCRIPTION
## Summary

Closes #8612. \`Voice_session_manager.status_of_string\` silently mapped any unknown input to \`Idle\` — the sole caller (\`session_of_json\`, line 85) decoded JSON-derived status strings through it, so a corrupt or mis-versioned session file silently became \"Idle\" (which lifecycle GC treats as nothing-to-clean-up).

Same anti-pattern as #8605 (execution_scope) and #8607 (agent_health). The \`_ -> <ValidVariant>\` catch-all hides drift behind a green-looking state.

## Changes

| Layer | Change |
|---|---|
| \`status_of_string\` -> \`status_of_string_opt\` | Option-typed; unknown -> None |
| \`session_of_json\` | defaults unknown JSON status to \`Suspended\` (fail-closed, operator-visible) |

## Why \`Suspended\` Default

Three options at the boundary:
- \`Active\`: too permissive — a corrupt session marked active gets ticked
- \`Idle\`: previous (silent) default — GC skips it, session disappears
- \`Suspended\`: surfaces the unknown to operator triage; lifecycle paths that handle Suspended (manual resume) light up

Picked \`Suspended\` for fail-closed visibility.

## Verification

\`\`\`bash
dune build --root=\$PWD   # clean (full tree)
\`\`\`

## Audit Context

\`_of_string\` helper-density sweep: \`voice_session_manager\` was the only outlier. Sibling modules (\`voice_config\`, \`cdal/artifact_store\`, \`cdal/labeling\`) all use \`Ok | Error\` Result — the established safe pattern.

## Test plan

- [x] \`dune build\` clean (full tree)
- [ ] CI green