### PR TITLE
[codex] Tighten run-local fresh boot proof path

### DIFF
--- a/scripts/harness/contract/run_local_fresh_boot_contract.sh
+++ b/scripts/harness/contract/run_local_fresh_boot_contract.sh
@@ -176,7 +176,6 @@ require_command python3
   echo "FAIL: run-local script not executable: $RUN_LOCAL_SCRIPT" >&2
   exit 1
 }
-SERVER_EXE="$(harness_find_server_exe "$ROOT_DIR" "${SERVER_EXE:-}")"
 
 BASE_URL="http://127.0.0.1:${PORT}"
 MCP_URL="${BASE_URL}/mcp"
@@ -219,7 +218,20 @@ env \
   exit 1
 }
 
-SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$LOG_FILE")"
+(
+  env \
+    -u MASC_BASE_PATH \
+    -u MASC_CONFIG_DIR \
+    -u MASC_PERSONAS_DIR \
+    -u MASC_HOST \
+    -u MASC_MCP_PORT \
+    -u MASC_ALLOW_LEGACY_ACCEPT \
+    -u MASC_FULL_SURFACE \
+    -u MASC_PUBLIC_TOOLS_EXTRA \
+    MASC_KEEPER_BOOTSTRAP_ENABLED=0 \
+    bash "$RUN_LOCAL_SCRIPT" --target-dir "$BASE_PATH" --host 127.0.0.1 --port "$PORT"
+) >"$LOG_FILE" 2>&1 &
+SERVER_PID="$!"
 
 if ! wait_for_ready "$BASE_URL" "$READY_JSON"; then
   echo "FAIL: run-local server did not become ready at ${BASE_URL}" >&2

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -134,12 +134,9 @@ harness_start_server() {
   mkdir -p "$base_path"
   (
     export MASC_BASE_PATH="$base_path"
-    export MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$base_path/.masc/config}"
-    export MASC_PERSONAS_DIR="${MASC_PERSONAS_DIR:-$MASC_CONFIG_DIR/personas}"
     export MASC_STORAGE_TYPE="filesystem"
     export MASC_AUTONOMY_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
-    export MASC_KEEPER_BOOTSTRAP_ENABLED="${MASC_KEEPER_BOOTSTRAP_ENABLED:-false}"
     export MASC_ALLOW_LEGACY_ACCEPT="1"
     export MASC_TOOL_TIMEOUT_DEFAULT_SEC="${MASC_TOOL_TIMEOUT_DEFAULT_SEC:-90}"
     export GRAPHQL_API_KEY=""

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -81,10 +81,10 @@ binary_is_stale() {
     if [ -n "$common_root" ] && [ "$common_root" != "$REPO_ROOT" ]; then
       common_head="$(git -C "$common_root" rev-parse HEAD 2>/dev/null || true)"
       if [ -n "$common_head" ] \
-        && git -C "$REPO_ROOT" diff --quiet "${common_head}"...HEAD -- bin lib dune-project 2>/dev/null \
-        && git -C "$REPO_ROOT" diff --quiet -- bin lib dune-project 2>/dev/null \
-        && git -C "$REPO_ROOT" diff --cached --quiet -- bin lib dune-project 2>/dev/null; then
-        if ! git -C "$REPO_ROOT" ls-files --others --exclude-standard -- bin lib dune-project 2>/dev/null \
+        && git -C "$REPO_ROOT" diff --quiet "${common_head}"...HEAD -- bin lib proto dune-project 2>/dev/null \
+        && git -C "$REPO_ROOT" diff --quiet -- bin lib proto dune-project 2>/dev/null \
+        && git -C "$REPO_ROOT" diff --cached --quiet -- bin lib proto dune-project 2>/dev/null; then
+        if ! git -C "$REPO_ROOT" ls-files --others --exclude-standard -- bin lib proto dune-project 2>/dev/null \
           | grep -q .; then
           return 1
         fi
@@ -94,7 +94,7 @@ binary_is_stale() {
   if [ "$REPO_ROOT/dune-project" -nt "$exe" ]; then
     return 0
   fi
-  if find "$REPO_ROOT/bin" "$REPO_ROOT/lib" \
+  if find "$REPO_ROOT/bin" "$REPO_ROOT/lib" "$REPO_ROOT/proto" \
       -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
       -newer "$exe" -print -quit 2>/dev/null \
     | grep -q .; then


### PR DESCRIPTION
## Summary
- route the fresh-boot contract through the real `scripts/run-local.sh` launcher instead of starting `main_eio` directly
- narrow the smoke-path env override to `MASC_KEEPER_BOOTSTRAP_ENABLED=0` and revert unrelated harness bootstrap defaults
- extend shared-build stale detection to include `proto/` changes

## Why
PR #8574 was already merged, but its follow-up fixes landed on the old branch after merge. Those follow-ups tighten the proof path so the smoke script actually verifies the launcher contract, and they prevent stale shared binaries from masking `proto/` edits.

## Validation
- `bash -n scripts/run-local.sh`
- `bash -n scripts/harness/lib/server_bootstrap.sh`
- `bash -n scripts/harness/contract/run_local_fresh_boot_contract.sh`
- `git diff --check`
- `env OPAMSWITCH=5.4.1 opam exec -- dune exec --root . ./test/test_run_local_script.exe`
- manual launcher sequence: `run-local --bootstrap-only` then `run-local` with `MASC_KEEPER_BOOTSTRAP_ENABLED=0` reached `/health/ready`

## Notes
- This is a follow-up to merged PR #8574.
- The original branch also received a later compile-only fix on a different path; that is not included here because this PR is scoped to the post-merge proof-path cleanup only.