### PR TITLE
fix(coord): exclude terminal tasks from claim_next pool

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -7,6 +7,12 @@ open Types
 include Coord_utils
 include Coord_state
 
+let task_is_claim_pool_candidate (task : Types.task) =
+  match task.task_status with
+  | Todo -> true
+  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ ->
+      false
+
 let agent_current_task_matches_backlog backlog ~agent_name task_id =
   match
     List.find_opt
@@ -134,11 +140,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
         if priority_cmp <> 0 then priority_cmp
         else compare b.created_at a.created_at  (* Newer first to unblock stale queues *)
       ) working_tasks in
-      let unclaimed = List.filter (fun t ->
-        match t.task_status with
-        | Todo -> true
-        | _ -> false
-      ) sorted in
+      let unclaimed = List.filter task_is_claim_pool_candidate sorted in
       (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
       let all_excluded = match released_task_id with

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -331,7 +331,7 @@ end
 (* Translate one OAS event into zero or one persist_* effect. *)
 let handle_event ~base_path ~retention_days (evt : Agent_sdk.Event_bus.event)
   : unit =
-  let { Agent_sdk.Event_bus.correlation_id; run_id; ts } = evt.meta in
+  let { Agent_sdk.Event_bus.correlation_id; run_id; ts; _ } = evt.meta in
   match evt.payload with
   | Agent_sdk.Event_bus.ContextCompactStarted { agent_name; trigger } ->
     let compaction_id = synth_compaction_id ~ts_unix:ts ~keeper_name:agent_name in

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -121,7 +121,7 @@ let wrap_event ~ts ~correlation_id ~run_id ~event_type ~payload
     Reads envelope metadata ([correlation_id], [run_id], [ts]) from
     [evt.meta] and includes them in every emitted JSON object. *)
 let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t option =
-  let { Agent_sdk.Event_bus.correlation_id; run_id; ts } = evt.meta in
+  let { Agent_sdk.Event_bus.correlation_id; run_id; ts; _ } = evt.meta in
   let wrap = wrap_event ~ts ~correlation_id ~run_id in
   match evt.payload with
   | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -198,6 +198,53 @@ let test_claim_next_all_claimed () =
     Alcotest.(check bool) "no unclaimed tasks" true (str_contains result "No unclaimed")
   )
 
+let test_claim_next_skips_done_and_cancelled () =
+  with_test_env (fun config ->
+    let _ = Coord.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
+    let _ = Coord.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
+    let _ = Coord.add_task config ~title:"Todo Task" ~priority:3 ~description:"" in
+    let _ = Coord.claim_task config ~agent_name:"alice" ~task_id:"task-001" in
+    let _ = transition_done config ~agent_name:"alice" ~task_id:"task-001" ~notes:"done" in
+    (match
+       Coord.cancel_task_r config ~agent_name:"alice" ~task_id:"task-002"
+         ~reason:"cancelled"
+     with
+    | Ok _ -> ()
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e));
+
+    let result = Coord.claim_next config ~agent_name:"claude" in
+    Alcotest.(check bool) "claims the remaining todo task" true
+      (str_contains result "task-003");
+
+    let tasks = Coord.get_tasks_raw config in
+    let status_of task_id =
+      match List.find_opt (fun (t : Types.task) -> String.equal t.id task_id) tasks with
+      | Some task -> Types.task_status_to_string task.task_status
+      | None -> Alcotest.failf "missing task %s" task_id
+    in
+    Alcotest.(check string) "done task preserved" "done" (status_of "task-001");
+    Alcotest.(check string) "cancelled task preserved" "cancelled" (status_of "task-002");
+    Alcotest.(check string) "todo task claimed" "claimed" (status_of "task-003")
+  )
+
+let test_claim_next_terminal_only_backlog () =
+  with_test_env (fun config ->
+    let _ = Coord.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
+    let _ = Coord.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
+    let _ = Coord.claim_task config ~agent_name:"alice" ~task_id:"task-001" in
+    let _ = transition_done config ~agent_name:"alice" ~task_id:"task-001" ~notes:"done" in
+    (match
+       Coord.cancel_task_r config ~agent_name:"alice" ~task_id:"task-002"
+         ~reason:"cancelled"
+     with
+    | Ok _ -> ()
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e));
+
+    let result = Coord.claim_next config ~agent_name:"claude" in
+    Alcotest.(check bool) "terminal backlog reports no unclaimed tasks" true
+      (str_contains result "No unclaimed")
+  )
+
 let test_claim_next_consecutive () =
   with_test_env (fun config ->
     let _ = Coord.add_task config ~title:"First" ~priority:1 ~description:"" in
@@ -1070,6 +1117,10 @@ let () =
       Alcotest.test_case "priority order" `Quick test_claim_next_priority_order;
       Alcotest.test_case "empty backlog" `Quick test_claim_next_empty_backlog;
       Alcotest.test_case "all claimed" `Quick test_claim_next_all_claimed;
+      Alcotest.test_case "skips done/cancelled" `Quick
+        test_claim_next_skips_done_and_cancelled;
+      Alcotest.test_case "terminal-only backlog" `Quick
+        test_claim_next_terminal_only_backlog;
       Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive;
       Alcotest.test_case "reconciles stale current_task" `Quick
         test_claim_next_reconciles_stale_agent_current_task;


### PR DESCRIPTION
## Summary
- exclude `done` and `cancelled` tasks from the `claim_next` candidate pool via `task_is_claim_pool_candidate`
- add regression coverage for mixed terminal/todo backlog and terminal-only backlog cases

## Verification
- `OCAMLPARAM='_,warn-error=-9' opam exec -- dune build --root "$PWD" test/test_room_coverage.exe`
- `OCAMLPARAM='_,warn-error=-9' opam exec -- dune exec --root "$PWD" ./test/test_room_coverage.exe`
- `opam exec -- dune build --root "$PWD" @all`