### PR TITLE
fix(verification): required_verifier_role decoder fail-closed to Reviewer on typo (#8615, REAL bug, #8605 family)

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -447,8 +447,16 @@ let task_status_of_yojson json =
         let submitted_at = json |> member "submitted_at" |> to_string in
         let verification_id = json |> member "verification_id" |> to_string in
         let required_verifier_role =
+          (* Issue #8615: was [role_of_string s] (lossy default to
+             [Unassigned]). [role_satisfies ~required:Unassigned]
+             returns true for ANY agent role — that silently bypasses
+             the verification gate when the JSON value is a typo or
+             a fabricated role string. Fail closed to [Reviewer] (the
+             same default the [None] arm uses) so an unrecognised
+             value at least demands the strictest sane interpretation. *)
           match json |> member "required_verifier_role" |> to_string_option with
-          | Some s -> role_of_string s
+          | Some s ->
+              role_of_string_opt s |> Option.value ~default:Reviewer
           | None -> Reviewer in
         let deadline = json |> member "deadline" |> to_string_option in
         Ok (AwaitingVerification { assignee; submitted_at; verification_id;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -139,6 +139,65 @@ let test_awaiting_verification_in_enum () =
   Alcotest.(check bool) "awaiting_verification present"
     true (List.mem "awaiting_verification" valid_task_status_strings)
 
+(* Issue #8615: AwaitingVerification.required_verifier_role decoder
+   used to fall through [role_of_string] which silently maps unknown
+   input to [Unassigned]. [role_satisfies ~required:Unassigned _] is
+   always true, which silently bypassed the verification gate. The
+   fix routes [Some s] through [role_of_string_opt] with an explicit
+   [Reviewer] fail-closed default. These regression tests pin the
+   contract: typo + fabricated value -> Reviewer, never Unassigned. *)
+let test_required_verifier_role_typo_decodes_to_reviewer () =
+  let json =
+    `Assoc [
+      ("status", `String "awaiting_verification");
+      ("assignee", `String "alice");
+      ("submitted_at", `String "2026-04-19T12:00:00Z");
+      ("verification_id", `String "v-1");
+      (* "Reviewer" capitalised — invalid wire format *)
+      ("required_verifier_role", `String "Reviewer");
+    ]
+  in
+  match task_status_of_yojson json with
+  | Ok (AwaitingVerification { required_verifier_role; _ }) ->
+      Alcotest.(check bool) "typo defaults to Reviewer (not Unassigned)"
+        true (required_verifier_role = Reviewer)
+  | Ok _ -> Alcotest.fail "expected AwaitingVerification"
+  | Error e -> Alcotest.fail e
+
+let test_required_verifier_role_unknown_decodes_to_reviewer () =
+  let json =
+    `Assoc [
+      ("status", `String "awaiting_verification");
+      ("assignee", `String "alice");
+      ("submitted_at", `String "2026-04-19T12:00:00Z");
+      ("verification_id", `String "v-1");
+      ("required_verifier_role", `String "fabricated_role");
+    ]
+  in
+  match task_status_of_yojson json with
+  | Ok (AwaitingVerification { required_verifier_role; _ }) ->
+      Alcotest.(check bool) "fabricated -> Reviewer (not Unassigned)"
+        true (required_verifier_role = Reviewer)
+  | Ok _ -> Alcotest.fail "expected AwaitingVerification"
+  | Error e -> Alcotest.fail e
+
+let test_required_verifier_role_canonical_still_works () =
+  let json =
+    `Assoc [
+      ("status", `String "awaiting_verification");
+      ("assignee", `String "alice");
+      ("submitted_at", `String "2026-04-19T12:00:00Z");
+      ("verification_id", `String "v-1");
+      ("required_verifier_role", `String "admin");
+    ]
+  in
+  match task_status_of_yojson json with
+  | Ok (AwaitingVerification { required_verifier_role; _ }) ->
+      Alcotest.(check bool) "canonical 'admin' decodes to Admin"
+        true (required_verifier_role = Admin)
+  | Ok _ -> Alcotest.fail "expected AwaitingVerification"
+  | Error e -> Alcotest.fail e
+
 let test_actions_enum_has_verification_actions () =
   let must = ["submit_for_verification"; "approve"; "reject"] in
   List.iter (fun s ->
@@ -309,6 +368,14 @@ let () =
       Alcotest.test_case "status strings match witness" `Quick test_status_strings_match_variant_witness;
       Alcotest.test_case "awaiting_verification in enum" `Quick test_awaiting_verification_in_enum;
       Alcotest.test_case "actions enum has verification actions" `Quick test_actions_enum_has_verification_actions;
+    ];
+    "required_verifier_role_strict", [
+      Alcotest.test_case "typo (capitalised) -> Reviewer (#8615)" `Quick
+        test_required_verifier_role_typo_decodes_to_reviewer;
+      Alcotest.test_case "fabricated value -> Reviewer (#8615)" `Quick
+        test_required_verifier_role_unknown_decodes_to_reviewer;
+      Alcotest.test_case "canonical 'admin' still decodes (#8615)" `Quick
+        test_required_verifier_role_canonical_still_works;
     ];
     "agent_role_ssot", [
       Alcotest.test_case "witness covers all variants" `Quick (fun () ->


### PR DESCRIPTION
## Summary

Closes #8615. **REAL security-relevant bug**, #8605 family.

\`AwaitingVerification.required_verifier_role\` JSON decoder used the lossy \`role_of_string\` (defaults unknown input to \`Unassigned\`):

\`\`\`ocaml
| Some s -> role_of_string s     (* danger: typo -> Unassigned *)
| None   -> Reviewer              (* sensible default for missing key *)
\`\`\`

\`role_satisfies ~required:Unassigned ~agent_role:_\` returns true for **any** agent. So a JSON value like \`\"Reviewer\"\` (capitalised) or any fabricated string silently relaxed the verification gate from \"must be Reviewer\" to \"anyone, including the original worker\".

The decoder disagreed with itself:
- \`None\` arm: \`Reviewer\` (fail-closed strict)
- \`Some\`-with-typo: \`Unassigned\` (silently lax)

## Fix

Single-line surgical change at the call site (preserves \`role_of_string\` lossy behaviour for the 4+ other consumers where it's intentional backward-compat):

\`\`\`ocaml
| Some s -> role_of_string_opt s |> Option.value ~default:Reviewer
\`\`\`

## Sibling Sites Reviewed (NOT changed)

| Line | Site | Verdict |
|---|---|---|
| 318 | agent_identity metadata | lossy OK |
| 448 | tool_task | caller-side |
| 732 | \`task.required_role\` | comment confirms intent |
| 451 | **THIS** required_verifier_role | only one with self-contradicting defaults |

## Verification

\`\`\`bash
dune build --root=\$PWD                                               # clean
dune exec test/test_types.exe -- test required_verifier_role_strict  # 3/3 OK
\`\`\`

3 regression tests:
- typo (capitalised \"Reviewer\") → Reviewer (was: Unassigned)
- fabricated value → Reviewer (was: Unassigned)
- canonical \"admin\" still decodes to Admin

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] required_verifier_role_strict 3/3 OK
- [ ] CI green