### PR TITLE
chore(config): SSOT for cascade.json / tool_policy.toml / keeper_runtime.toml (#8414)

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -1,5 +1,12 @@
 module StringSet = Set.Make (String)
 
+(** SSOT for config filenames documented in [docs/TOML-RELOAD-MATRIX.md].
+    Consumed by the resolver here and by config loaders elsewhere in the
+    codebase. Issue #8414. *)
+let cascade_json_filename = "cascade.json"
+let tool_policy_toml_filename = "tool_policy.toml"
+let keeper_runtime_toml_filename = "keeper_runtime.toml"
+
 type source =
   | Env
   | Local_masc
@@ -137,7 +144,7 @@ let to_json (resolution : resolution) =
     ]
 
 let config_signature_exists config_dir =
-  let cascade = Filename.concat config_dir "cascade.json" in
+  let cascade = Filename.concat config_dir cascade_json_filename in
   let prompts = Filename.concat config_dir "prompts" in
   let keepers = Filename.concat config_dir "keepers" in
   let personas = Filename.concat config_dir "personas" in
@@ -265,9 +272,8 @@ let config_root_resolution (inputs : inputs) =
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in
   let exists =
-    match name with
-    | "cascade.json" -> existing_file path
-    | _ -> existing_dir path
+    if String.equal name cascade_json_filename then existing_file path
+    else existing_dir path
   in
   { path; exists; source = root.source }
 
@@ -296,12 +302,12 @@ let inputs_from_env () =
 
 let resolve_with inputs =
   let config_root, root_warnings = config_root_resolution inputs in
-  let cascade = child_item config_root "cascade.json" in
+  let cascade = child_item config_root cascade_json_filename in
   let prompts = child_item config_root "prompts" in
   let keepers = child_item config_root "keepers" in
   let personas, persona_warnings = personas_item inputs config_root in
   let missing_child_warnings =
-    [ ("cascade.json", cascade.exists); ("prompts", prompts.exists); ("keepers", keepers.exists); ("personas", personas.exists) ]
+    [ (cascade_json_filename, cascade.exists); ("prompts", prompts.exists); ("keepers", keepers.exists); ("personas", personas.exists) ]
     |> List.filter_map (fun (label, exists) ->
            if exists then None
            else

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -206,7 +206,9 @@ let analyze_with (inputs : inputs) =
   let repo_config_seed_path = repo_config_seed_path inputs in
   let keeper_runtime_toml_present =
     Env_config_core.existing_file
-      (Filename.concat active_config_root "keeper_runtime.toml")
+      (Filename.concat
+         active_config_root
+         Config_dir_resolver.keeper_runtime_toml_filename)
   in
   let path_diag =
     Server_base_path_diagnostics.detect

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -95,7 +95,9 @@ let resolved_config_root ~base_path =
   resolution.Config_dir_resolver.config_root.path
 
 let toml_path ~base_path =
-  Filename.concat (resolved_config_root ~base_path) "keeper_runtime.toml"
+  Filename.concat
+    (resolved_config_root ~base_path)
+    Config_dir_resolver.keeper_runtime_toml_filename
 
 let read_file path =
   try Ok (In_channel.with_open_text path In_channel.input_all)

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -192,7 +192,9 @@ let config_root_for_base_path ~base_path =
     else base_path
   in
   let direct_config = Filename.concat base_path "config" in
-  let direct_policy = Filename.concat direct_config "tool_policy.toml" in
+  let direct_policy =
+    Filename.concat direct_config Config_dir_resolver.tool_policy_toml_filename
+  in
   if Sys.file_exists direct_policy then (direct_config, [])
   else
     let inputs = Config_dir_resolver.inputs_from_env () in
@@ -202,7 +204,9 @@ let config_root_for_base_path ~base_path =
 
 let load ~base_path : (t, string) result =
   let config_root, resolution_warnings = config_root_for_base_path ~base_path in
-  let path = Filename.concat config_root "tool_policy.toml" in
+  let path =
+    Filename.concat config_root Config_dir_resolver.tool_policy_toml_filename
+  in
   match Safe_ops.read_file_safe path with
   | Error msg ->
       let warning_detail =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -113,8 +113,11 @@ let bootstrap_base_path_config_root ~base_path =
          Fs_compat.mkdir_p (Filename.concat config_root "prompts");
          Fs_compat.mkdir_p (Filename.concat config_root "keepers");
          Fs_compat.mkdir_p (Filename.concat config_root "personas");
-         if not (Sys.file_exists (Filename.concat config_root "cascade.json")) then
-           Fs_compat.save_file (Filename.concat config_root "cascade.json") "{}";
+         let cascade_path =
+           Filename.concat config_root Config_dir_resolver.cascade_json_filename
+         in
+         if not (Sys.file_exists cascade_path) then
+           Fs_compat.save_file cascade_path "{}";
          Log.Server.warn
            "bootstrapped minimal base-path config root without versioned source: %s"
            config_root);


### PR DESCRIPTION
## Summary

Closes #8414.

Three config filenames (contract surfaces documented in `docs/TOML-RELOAD-MATRIX.md`) were inlined as string literals across 5 files / 10 call sites. Hoisted into module-level constants on `lib/config_dir_resolver.ml` — the natural SSOT home since the resolver already owns path classification at boot.

## Constants added (`lib/config_dir_resolver.ml`)

```ocaml
let cascade_json_filename = "cascade.json"
let tool_policy_toml_filename = "tool_policy.toml"
let keeper_runtime_toml_filename = "keeper_runtime.toml"
```

## Call sites migrated

- `lib/config_dir_resolver.ml` — 4 sites (147, 276 pattern→`if`, 305, 310)
- `lib/server/server_runtime_bootstrap.ml` — 2 sites deduped into a single `cascade_path` binding
- `lib/keeper/keeper_tool_policy_config.ml` — 2 sites (195, 205)
- `lib/config_doctor.ml` — 1 site (209)
- `lib/keeper/keeper_runtime_config.ml` — 1 site (98)

## Notes

- Line 276 in the resolver was a literal-pattern `match`; rewritten as `if String.equal name cascade_json_filename` because OCaml patterns require literal strings — the `if` form lets the constant actually drive the decision.
- The dune comment at `lib/embedded_config/dune:13` is left as-is (build-script documentation, not runtime).

## Test plan

- [ ] CI green
- No behavior change; surface is identical. Pure SSOT chore.