### PR TITLE
fix(eio): re-raise Cancel.Cancelled at 3 bare-catch sites (#8619)

### DIFF
--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -186,7 +186,13 @@ let load_state_cached ~base_path loop_id =
              Hashtbl.replace persisted_summaries_cache loop_id (mtime, summary);
              result
          | None -> None)
-  with _ -> None
+  with
+  (* Issue #8619: re-raise cancellation so a shutdown mid-load does
+     not silently render the dashboard panel as "no data". Other
+     exceptions (Unix.stat ENOENT, JSON parse failure on a partial
+     write) keep the prior cached/None behaviour. *)
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
 
 (** Build the loops list JSON for GET /api/v1/autoresearch/loops.
     Merges in-memory active loops with persisted-only loops.

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -90,7 +90,14 @@ let config_json () =
      non-standard profile). Both paths go through [add_profile] so
      duplicates are filtered by canonical name. *)
   let keeper_entries =
-    try Keeper_registry.all () with _ -> []
+    (* Issue #8619: was [with _ -> []] which silently swallowed
+       Eio.Cancel.Cancelled. Re-raise cancellation; only fall back
+       to empty for non-cancel exceptions (e.g. registry not yet
+       initialised). *)
+    try Keeper_registry.all ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> []
   in
   let acc_after_standard =
     List.fold_left add_profile [] standard_profiles

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -15,7 +15,13 @@ let try_hydrate ~store ~sha256 ~marker =
     match Tool_blob_store.fetch store ~sha256 with
     | Some bytes -> Some bytes
     | None -> None
-  with _ ->
+  with
+  (* Issue #8619: re-raise Eio cancellation so shutdown / racing fibers
+     are not silently masked as a hydration miss. Other exceptions
+     (filesystem error, blob corruption) keep the prior degraded
+     behaviour: caller falls back to the marker string. *)
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ ->
     ignore marker;
     None
 


### PR DESCRIPTION
## Summary

Closes #8619. \`with _ ->\` swallows \`Eio.Cancel.Cancelled\` along with everything else — Eio rule violation. 3 sites flagged in primary-work paths (not cleanup):

| Site | Silent failure mode |
|---|---|
| \`dashboard_cascade.ml:93\` | empty registry on cancel |
| \`keeper_artifact_hydrator.ml:18\` | hydration silently skipped |
| \`dashboard_http_autoresearch.ml:189\` | persisted summary dropped |

Each now follows the codebase-standard re-raise pattern (used in \`a2a_tools.ml\`, \`streamable_http.ml\`, \`meta_cognition_snapshot.ml\`, \`rate_limit.ml\`):

\`\`\`ocaml
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> ... existing fallback ...
\`\`\`

## Behaviour Change

- Cancelled: re-raised (was: silently masked as data missing)
- All other exceptions: keep prior fallback shape

Operators can now distinguish \"data missing\" from \"fiber cancelled mid-fetch\" — used to be indistinguishable.

## Out of Scope

Cleanup-style sites (\`with _ -> ()\` in finally blocks, \`Unix.close\`, \`Eio.Path.unlink\`) were left alone — cleanup must always succeed.

## Verification

\`\`\`bash
dune build --root=\$PWD   # clean (full tree)
\`\`\`

## Test plan

- [x] \`dune build\` clean (full tree)
- [ ] CI green