### PR TITLE
fix(eio): re-raise Cancel.Cancelled in 3 primary-work sites (#8619)

### DIFF
--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -186,7 +186,9 @@ let load_state_cached ~base_path loop_id =
              Hashtbl.replace persisted_summaries_cache loop_id (mtime, summary);
              result
          | None -> None)
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
 
 (** Build the loops list JSON for GET /api/v1/autoresearch/loops.
     Merges in-memory active loops with persisted-only loops.

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -90,7 +90,10 @@ let config_json () =
      non-standard profile). Both paths go through [add_profile] so
      duplicates are filtered by canonical name. *)
   let keeper_entries =
-    try Keeper_registry.all () with _ -> []
+    try Keeper_registry.all ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> []
   in
   let acc_after_standard =
     List.fold_left add_profile [] standard_profiles

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -15,9 +15,11 @@ let try_hydrate ~store ~sha256 ~marker =
     match Tool_blob_store.fetch store ~sha256 with
     | Some bytes -> Some bytes
     | None -> None
-  with _ ->
-    ignore marker;
-    None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ ->
+      ignore marker;
+      None
 
 let hydrate_block ~store ~remaining
     (block : Agent_sdk.Types.content_block) : Agent_sdk.Types.content_block =


### PR DESCRIPTION
## Summary
- 3 사이트 `with _ ->` → 표준 `Cancel.Cancelled` re-raise 패턴 적용.

## Issues
Closes #8619.

## Changes
- `lib/dashboard_cascade.ml:93` — empty registry 반환 대신 cancel 전파
- `lib/keeper/keeper_artifact_hydrator.ml:18` — hydration skip 대신 cancel 전파
- `lib/dashboard/dashboard_http_autoresearch.ml:189` — summary drop 대신 cancel 전파

Pattern already in use at `a2a_tools.ml:81/266`, `streamable_http.ml:119`, `meta_cognition_snapshot.ml:22`, `rate_limit.ml:130`.

## Tests
- 순수 exception flow 확장. 기존 non-Cancel 실패 경로 동일 유지.
- Project CLAUDE.md: `Cancel.Cancelled must propagate`.

## Risk
- Low. 기존 정상 경로 영향 없음. Cancel 발생 시 now 정확한 signal 전파 (이전에는 missing data로 위장).