### PR TITLE
fix(dashboard): normalize governance disk judgments and tool float drift

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -113,6 +113,39 @@ let judgment_generated_at json =
   json |> member "generated_at" |> to_string_option |> parse_iso_opt
   |> Option.value ~default:0.0
 
+let normalize_disk_recommended_action judgment =
+  let canonical_tool =
+    match judgment |> member "recommended_action" |> member "resolved_tool" |> to_string_option with
+    | Some tool ->
+        let tool = tool |> String.trim |> String.lowercase_ascii in
+        if tool = "" then None else Some tool
+    | None -> None
+  in
+  match judgment |> member "recommended_action" with
+  | `Assoc action_fields ->
+      let normalized_action =
+        `Assoc
+          (List.map
+             (fun (key, value) ->
+               if String.equal key "resolved_tool" then
+                 ("resolved_tool", option_to_yojson (fun item -> `String item) canonical_tool)
+               else
+                 (key, value))
+             action_fields)
+      in
+      (match judgment with
+       | `Assoc fields ->
+           `Assoc
+             (List.map
+                (fun (key, value) ->
+                  if String.equal key "recommended_action" then
+                    ("recommended_action", normalized_action)
+                  else
+                    (key, value))
+                fields)
+       | other -> other)
+  | _ -> judgment
+
 let load_judgments_into_table jsons =
   let table = Hashtbl.create 32 in
   List.iter (fun json ->
@@ -172,6 +205,7 @@ let latest_judgments base_path =
 let fresh_judgments_json ~base_path ~limit =
   let now = Unix.gettimeofday () in
   latest_judgments base_path
+  |> List.map normalize_disk_recommended_action
   |> List.filter (fun j ->
     match j |> member "expires_at" |> to_string_option with
     | Some iso ->

--- a/test/test_tool_suspend_coverage.ml
+++ b/test/test_tool_suspend_coverage.ml
@@ -114,7 +114,7 @@ let test_get_float_missing () =
     (Tool_args.get_float args "duration" 1.0)
 
 let test_get_float_wrong_type () =
-  let args = `Assoc [("duration", `String "2.5")] in
+  let args = `Assoc [("duration", `String "oops")] in
   check (float 0.001) "uses default on string" 1.0
     (Tool_args.get_float args "duration" 1.0)
 


### PR DESCRIPTION
## Summary
- normalize `recommended_action.resolved_tool` when dashboard governance reads judgments back from disk, so the dashboard surface matches the canonicalized live-judge path
- keep `test_tool_suspend_coverage` aligned with current `Safe_ops.json_float` behavior by using a genuinely non-numeric string for the wrong-type case

## Why
Merged PRs `#8590`, `#8610`, `#8611`, and `#8613` moved `main` forward, but this repo-wide quick-suite drift was still sitting on `main` itself:
- `test_dashboard_governance` expected the dashboard read-path to canonicalize a stored `resolved_tool`, but `fresh_judgments_json` was returning the raw JSONL payload unchanged
- `test_tool_suspend_coverage` still treated `"2.5"` as a wrong-type input even though `Safe_ops.json_float` now intentionally accepts numeric strings

Those two failures were showing up as unrelated blockers underneath otherwise-mergeable PRs.

## Validation
- `ALCOTEST_QUICK_TESTS=1 dune exec --root . ./test/test_dashboard_governance.exe -- test projection 6 --show-errors --verbose --bail`
- `ALCOTEST_QUICK_TESTS=1 dune exec --root . ./test/test_tool_suspend_coverage.exe -- test get_float 3 --show-errors --verbose --bail`

## Notes
- This is a direct follow-up cleanup after the earlier PR wave merged ahead of the branch-local drift fixes.
- Scope is intentionally surgical: one dashboard read-path normalization and one stale test expectation.