### PR TITLE
fix(keeper_context_core): role_of_string_opt + safer Tool default for unknown role (#8623, #8605 family)

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -190,12 +190,32 @@ let role_to_string (r : Agent_sdk.Types.role) = match r with
   | System -> "system" | User -> "user"
   | Assistant -> "assistant" | Tool -> "tool"
 
-let role_of_string = function
-  | "system" -> Agent_sdk.Types.System | "user" -> Agent_sdk.Types.User
-  | "assistant" -> Agent_sdk.Types.Assistant | "tool" -> Agent_sdk.Types.Tool
-  | unknown ->
-    Log.Misc.warn "keeper_context_core: unknown role %S, defaulting to User" unknown;
-    Agent_sdk.Types.User
+(* Issue #8623: returns [Some] only for the 4 wire-format names.
+   Callers must handle [None] explicitly — the previous Variant
+   shape silently routed unknowns to [User], which misattributes
+   checkpoint messages: a "system" / "assistant" / "tool" decoded as
+   "user" causes the LLM to treat tool output as user instructions,
+   echo prior assistant replies as user input, or downgrade system
+   prompt privileges. Same anti-pattern class as #8605/#8615. *)
+let role_of_string_opt = function
+  | "system" -> Some Agent_sdk.Types.System
+  | "user" -> Some Agent_sdk.Types.User
+  | "assistant" -> Some Agent_sdk.Types.Assistant
+  | "tool" -> Some Agent_sdk.Types.Tool
+  | _ -> None
+
+(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
+   unrecognised role: tool messages are interpretive context, not
+   instructions, so misclassifying System/Assistant/User as Tool hides
+   the message rather than letting the LLM act on it. The warn log
+   preserves operator visibility. *)
+let role_of_string s =
+  match role_of_string_opt s with
+  | Some role -> role
+  | None ->
+    Log.Misc.warn
+      "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
+    Agent_sdk.Types.Tool
 
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -37,6 +37,7 @@ let append_many = Keeper_context_core.append_many
 let sync_oas_context = Keeper_context_core.sync_oas_context
 let role_to_string = Keeper_context_core.role_to_string
 let role_of_string = Keeper_context_core.role_of_string
+let role_of_string_opt = Keeper_context_core.role_of_string_opt
 let message_to_json = Keeper_context_core.message_to_json
 let message_of_json = Keeper_context_core.message_of_json
 let serialize_context = Keeper_context_core.serialize_context

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -34,6 +34,14 @@ val append_many : working_context -> Agent_sdk.Types.message list -> working_con
 val sync_oas_context : working_context -> working_context
 val role_to_string : Agent_sdk.Types.role -> string
 val role_of_string : string -> Agent_sdk.Types.role
+(** Backwards-compatible: unknown -> [Tool] (safest fallback) + warn log.
+    See {!role_of_string_opt} for the strict version. Issue #8623. *)
+
+val role_of_string_opt : string -> Agent_sdk.Types.role option
+(** Strict variant — returns [None] for unrecognised role strings.
+    Use this in checkpoint loaders / new code where silently
+    misattributing a chat-history message would corrupt the
+    LLM-visible conversation. *)
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
 val serialize_context : working_context -> string


### PR DESCRIPTION
## Summary

Closes #8623. Same anti-pattern class as #8605 / #8607 / #8612 / #8615 — silent permissive default for unrecognised input, now in the chat-history decode path.

\`Keeper_context_core.role_of_string\` routed unrecognised role strings to \`User\`. Sole caller is \`message_of_json\`, used when loading keeper conversation checkpoints. A bad role in the JSON silently misattributed the message:

| Original | Decoded as User → LLM sees |
|---|---|
| \`\"system\"\` | system prompt becomes user message — privilege downgrade |
| \`\"assistant\"\` | prior LLM reply reappears as user input — echo / hallucination |
| \`\"tool\"\` | tool output becomes \"user said this\" — LLM may act on it as instruction |

## Changes

| Layer | Change |
|---|---|
| \`role_of_string_opt\` | NEW — strict, returns None for unknown |
| \`role_of_string\` | shifted fallback from \`User\` → \`Tool\` (warn log retained) |
| \`keeper_exec_context\` | re-export \`role_of_string_opt\`; document the trade-off |

## Why \`Tool\` Default

If the function must keep a fallback (backwards compat), \`Tool\` is structurally safer than \`User\`:
- LLMs are trained to treat tool messages as data, not commands
- Misclassifying System/Assistant/User as Tool **hides** the message rather than letting the LLM act on it
- Old default (\`User\`) actively confused the conversation; new default fails-quietly

New code (especially checkpoint loaders) should use \`role_of_string_opt\` and skip messages on \`None\`.

## Verification

\`\`\`bash
dune build --root=\$PWD   # clean (full tree)
\`\`\`

## Test plan

- [x] \`dune build\` clean (full tree)
- [ ] CI green