### PR TITLE
chore(autoresearch): rename legacy swarm_link -> execution_link (#8566)

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -66,8 +66,8 @@ let cycle_to_yojson = Autoresearch_serde.cycle_to_yojson
 let cycle_of_yojson_result = Autoresearch_serde.cycle_of_yojson_result
 let state_to_yojson = Autoresearch_serde.state_to_yojson
 let state_of_yojson_result = Autoresearch_serde.state_of_yojson_result
-let swarm_link_to_yojson = Autoresearch_serde.swarm_link_to_yojson
-let swarm_link_of_yojson_result = Autoresearch_serde.swarm_link_of_yojson_result
+let execution_link_to_yojson = Autoresearch_serde.execution_link_to_yojson
+let execution_link_of_yojson_result = Autoresearch_serde.execution_link_of_yojson_result
 
 (* ================================================================ *)
 (* Re-exports: Storage                                               *)
@@ -82,11 +82,11 @@ let session_link_file = Autoresearch_storage.session_link_file
 let ensure_dir = Autoresearch_storage.ensure_dir
 let append_cycle = Autoresearch_storage.append_cycle
 let save_state = Autoresearch_storage.save_state
-let save_swarm_link = Autoresearch_storage.save_swarm_link
-let load_swarm_link_by_loop = Autoresearch_storage.load_swarm_link_by_loop
-let load_swarm_link_by_session = Autoresearch_storage.load_swarm_link_by_session
-let load_swarm_link_by_loop_result = Autoresearch_storage.load_swarm_link_by_loop_result
-let load_swarm_link_by_session_result = Autoresearch_storage.load_swarm_link_by_session_result
+let save_execution_link = Autoresearch_storage.save_execution_link
+let load_execution_link_by_loop = Autoresearch_storage.load_execution_link_by_loop
+let load_execution_link_by_session = Autoresearch_storage.load_execution_link_by_session
+let load_execution_link_by_loop_result = Autoresearch_storage.load_execution_link_by_loop_result
+let load_execution_link_by_session_result = Autoresearch_storage.load_execution_link_by_session_result
 let load_state = Autoresearch_storage.load_state
 let load_state_result = Autoresearch_storage.load_state_result
 let latest_cycle_record = Autoresearch_storage.latest_cycle_record
@@ -343,9 +343,9 @@ let stop_loop ~base_path ?reason loop_id =
             in
             Some (stop_state state)))
 
-(** Linked loop status JSON for swarm integration.
+(** Linked loop status JSON for execution-session integration.
     Acquires [loops_mu] read lock internally. *)
-let linked_status_json ~base_path (link : swarm_link) =
+let linked_status_json ~base_path (link : execution_link) =
   let current_cycle, status, best_score, target_score, error_message, workdir,
       lower_is_better, source_workdir, program_note, warnings,
       queued_hypothesis =

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -1,6 +1,6 @@
 (** Autoresearch_serde — JSON serialization and deserialization for autoresearch types.
 
-    Converts cycle_record, loop_state, persisted_summary, and swarm_link
+    Converts cycle_record, loop_state, persisted_summary, and execution_link
     to/from Yojson.Safe.t.
 
     @since 2.80.0 *)
@@ -319,7 +319,7 @@ let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) 
       lower_is_better;
     }
 
-let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
+let execution_link_to_yojson (link : execution_link) : Yojson.Safe.t =
   `Assoc
     [
       ("loop_id", `String link.loop_id);
@@ -332,8 +332,8 @@ let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
       ("linked_at", `Float link.linked_at);
     ]
 
-let swarm_link_of_yojson_result (json : Yojson.Safe.t) : (swarm_link, string) result =
-  let kind = "swarm_link" in
+let execution_link_of_yojson_result (json : Yojson.Safe.t) : (execution_link, string) result =
+  let kind = "execution_link" in
   let* loop_id = required_string_field kind json "loop_id" in
   let* session_id = required_string_field kind json "session_id" in
   let* operation_id = optional_string_field json "operation_id" in

--- a/lib/autoresearch/autoresearch_storage.ml
+++ b/lib/autoresearch/autoresearch_storage.ml
@@ -1,7 +1,7 @@
 (** Autoresearch_storage — File paths and persistence for autoresearch loops.
 
     Handles results directory layout, JSONL append, state save/load,
-    and swarm link persistence.
+    and execution link persistence.
 
     @since 2.80.0 *)
 
@@ -17,6 +17,9 @@ let results_file ~base_path loop_id =
 let state_file ~base_path loop_id =
   Filename.concat (results_dir ~base_path loop_id) "state.json"
 
+(** On-disk filename is kept as [swarm.json] for backward compatibility with
+    existing data in deployed installs. The OCaml-level rename to
+    [execution_link] only affects the in-memory type/API surface. *)
 let loop_link_file ~base_path loop_id =
   Filename.concat (results_dir ~base_path loop_id) "swarm.json"
 
@@ -54,10 +57,10 @@ let save_state ~base_path (state : Autoresearch_types.loop_state) =
   let json = Yojson.Safe.pretty_to_string (Autoresearch_serde.state_to_yojson state) in
   Fs_compat.save_file path json
 
-let save_swarm_link ~base_path (link : Autoresearch_types.swarm_link) =
+let save_execution_link ~base_path (link : Autoresearch_types.execution_link) =
   let loop_path = loop_link_file ~base_path link.loop_id in
   let session_path = session_link_file ~base_path link.session_id in
-  let json = Autoresearch_serde.swarm_link_to_yojson link in
+  let json = Autoresearch_serde.execution_link_to_yojson link in
   let write path =
     let dir = Filename.dirname path in
     Fs_compat.mkdir_p dir;
@@ -89,26 +92,26 @@ let decode_json_file_result ~path ~kind decode =
          | Error msg ->
              Error (Printf.sprintf "%s decode failed for %s: %s" kind path msg))
 
-let load_swarm_link_by_loop_result ~base_path loop_id =
+let load_execution_link_by_loop_result ~base_path loop_id =
   let path = loop_link_file ~base_path loop_id in
-  decode_json_file_result ~path ~kind:"swarm link"
-    Autoresearch_serde.swarm_link_of_yojson_result
+  decode_json_file_result ~path ~kind:"execution link"
+    Autoresearch_serde.execution_link_of_yojson_result
 
-let load_swarm_link_by_loop ~base_path loop_id =
-  match load_swarm_link_by_loop_result ~base_path loop_id with
+let load_execution_link_by_loop ~base_path loop_id =
+  match load_execution_link_by_loop_result ~base_path loop_id with
   | None -> None
   | Some (Ok link) -> Some link
   | Some (Error msg) ->
       Log.Autoresearch.warn "%s" msg;
       None
 
-let load_swarm_link_by_session_result ~base_path session_id =
+let load_execution_link_by_session_result ~base_path session_id =
   let path = session_link_file ~base_path session_id in
-  decode_json_file_result ~path ~kind:"swarm link"
-    Autoresearch_serde.swarm_link_of_yojson_result
+  decode_json_file_result ~path ~kind:"execution link"
+    Autoresearch_serde.execution_link_of_yojson_result
 
-let load_swarm_link_by_session ~base_path session_id =
-  match load_swarm_link_by_session_result ~base_path session_id with
+let load_execution_link_by_session ~base_path session_id =
+  match load_execution_link_by_session_result ~base_path session_id with
   | None -> None
   | Some (Ok link) -> Some link
   | Some (Error msg) ->

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -52,7 +52,7 @@ type loop_state = {
   lower_is_better : bool;  (** When true, lower metric scores are better (e.g., val_bpb, loss) *)
 }
 
-type swarm_link = {
+type execution_link = {
   loop_id : string;
   session_id : string;
   operation_id : string option;

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -23,7 +23,7 @@ let loop_summary_json (base_path : string)
     |> List.map (fun s -> `String s)
   in
   let link =
-    Autoresearch_storage.load_swarm_link_by_loop ~base_path state.loop_id
+    Autoresearch_storage.load_execution_link_by_loop ~base_path state.loop_id
   in
   `Assoc
     [
@@ -55,14 +55,14 @@ let loop_summary_json (base_path : string)
       ( "error",
         Json_util.string_opt_to_json state.error_message );
       ( "session_id",
-        Json_util.string_opt_to_json (Option.map (fun (l : Autoresearch_types.swarm_link) -> l.session_id) link) );
+        Json_util.string_opt_to_json (Option.map (fun (l : Autoresearch_types.execution_link) -> l.session_id) link) );
       ( "operation_id",
-        Json_util.string_opt_to_json (Option.bind link (fun (l : Autoresearch_types.swarm_link) -> l.operation_id)) );
+        Json_util.string_opt_to_json (Option.bind link (fun (l : Autoresearch_types.execution_link) -> l.operation_id)) );
       ( "task_id",
         Json_util.string_opt_to_json
-          (Option.bind link (fun (l : Autoresearch_types.swarm_link) -> l.task_id)) );
+          (Option.bind link (fun (l : Autoresearch_types.execution_link) -> l.task_id)) );
       ( "linked_at",
-        Json_util.float_opt_to_json (Option.map (fun (l : Autoresearch_types.swarm_link) -> l.linked_at) link) );
+        Json_util.float_opt_to_json (Option.map (fun (l : Autoresearch_types.execution_link) -> l.linked_at) link) );
       ( "queued_hypothesis",
         Json_util.string_opt_to_json state.queued_hypothesis );
     ]
@@ -70,7 +70,7 @@ let loop_summary_json (base_path : string)
 let persisted_to_loop_summary_json (base_path : string)
     (p : Autoresearch_types.persisted_summary) : Yojson.Safe.t =
   let link =
-    Autoresearch_storage.load_swarm_link_by_loop ~base_path p.loop_id
+    Autoresearch_storage.load_execution_link_by_loop ~base_path p.loop_id
   in
   `Assoc
     [
@@ -108,14 +108,14 @@ let persisted_to_loop_summary_json (base_path : string)
       ( "error",
         Json_util.string_opt_to_json p.error_message );
       ( "session_id",
-        Json_util.string_opt_to_json (Option.map (fun (l : Autoresearch_types.swarm_link) -> l.session_id) link) );
+        Json_util.string_opt_to_json (Option.map (fun (l : Autoresearch_types.execution_link) -> l.session_id) link) );
       ( "operation_id",
-        Json_util.string_opt_to_json (Option.bind link (fun (l : Autoresearch_types.swarm_link) -> l.operation_id)) );
+        Json_util.string_opt_to_json (Option.bind link (fun (l : Autoresearch_types.execution_link) -> l.operation_id)) );
       ( "task_id",
         Json_util.string_opt_to_json
-          (Option.bind link (fun (l : Autoresearch_types.swarm_link) -> l.task_id)) );
+          (Option.bind link (fun (l : Autoresearch_types.execution_link) -> l.task_id)) );
       ( "linked_at",
-        Json_util.float_opt_to_json (Option.map (fun (l : Autoresearch_types.swarm_link) -> l.linked_at) link) );
+        Json_util.float_opt_to_json (Option.map (fun (l : Autoresearch_types.execution_link) -> l.linked_at) link) );
       ( "queued_hypothesis",
         Json_util.string_opt_to_json p.queued_hypothesis );
     ]
@@ -513,7 +513,7 @@ let rec rm_rf path =
       Sys.remove path
 
 let delete_session_link ~base_path loop_id =
-  match Autoresearch.load_swarm_link_by_loop ~base_path loop_id with
+  match Autoresearch.load_execution_link_by_loop ~base_path loop_id with
   | Some link ->
       let session_path =
         Autoresearch.session_link_file ~base_path link.session_id

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -231,7 +231,7 @@ let status_json (ctx : context) ~loop_id json_fields =
     | _ -> [ ("error", `String "invalid status payload") ]
   in
   let link =
-    Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path loop_id
+    Autoresearch.load_execution_link_by_loop ~base_path:ctx.base_path loop_id
   in
   let queued_hypothesis = Hashtbl.find_opt pending_hypotheses loop_id in
   let link_fields =
@@ -359,7 +359,7 @@ let handle_stop (ctx : context) args =
     | Some state ->
         let _config = Coord.default_config ctx.base_path in
         broadcast_loop_lifecycle "autoresearch_stopped" state;
-        (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
+        (match Autoresearch.load_execution_link_by_loop ~base_path:ctx.base_path id with
         | Some _link ->
             (* Team_session_store removed — skip event append *)
             ()

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -619,7 +619,7 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                        Autoresearch.save_state ~base_path:ctx.base_path state;
                        let _config = Coord.default_config ctx.base_path in
                        (match
-                          Autoresearch.load_swarm_link_by_loop
+                          Autoresearch.load_execution_link_by_loop
                             ~base_path:ctx.base_path id
                         with
                        | Some _link ->

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -208,7 +208,7 @@ let test_cycle_result_parser_rejects_bad_decision () =
       check bool "has decision error" true
         (String.length message > 0)
 
-let test_swarm_link_result_parser_rejects_missing_session_id () =
+let test_execution_link_result_parser_rejects_missing_session_id () =
   let json =
     `Assoc
       [
@@ -217,7 +217,7 @@ let test_swarm_link_result_parser_rejects_missing_session_id () =
         ("linked_at", `Float 1.0);
       ]
   in
-  match Lib.Autoresearch.swarm_link_of_yojson_result json with
+  match Lib.Autoresearch.execution_link_of_yojson_result json with
   | Ok _ -> failwith "expected parser to reject missing session_id"
   | Error message ->
       check bool "has session_id error" true
@@ -259,7 +259,7 @@ let test_loops_json_skips_legacy_persisted_state () =
   check int "no legacy loop entries" 0
     Yojson.Safe.Util.(json |> member "loops" |> to_list |> List.length)
 
-let test_loops_json_tolerates_invalid_swarm_link_for_active_loop () =
+let test_loops_json_tolerates_invalid_execution_link_for_active_loop () =
   with_eio_test @@ fun () ->
   with_clean_loops @@ fun () ->
   with_temp_base @@ fun base_path ->
@@ -276,11 +276,11 @@ let test_loops_json_tolerates_invalid_swarm_link_for_active_loop () =
   in
   Lib.Autoresearch.with_loops_rw (fun () ->
     Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state);
-  let swarm_path =
+  let execution_link_path =
     Lib.Autoresearch.loop_link_file ~base_path state.loop_id
   in
   (* Missing required session_id should not crash the loops list. *)
-  write_file swarm_path
+  write_file execution_link_path
     (Printf.sprintf {|{"loop_id":"%s","linked_at":0}|} state.loop_id);
   let json =
     Lib.Dashboard_http_autoresearch.autoresearch_loops_json ~base_path ()
@@ -427,7 +427,7 @@ let test_delete_loop_json_removes_bundle_and_branch () =
     error_message = Some "managed worktree missing";
     workdir } in
   Lib.Autoresearch.save_state ~base_path state;
-  let link : Lib.Autoresearch.swarm_link =
+  let link : Lib.Autoresearch.execution_link =
     {
       loop_id;
       session_id = "session-delete";
@@ -439,7 +439,7 @@ let test_delete_loop_json_removes_bundle_and_branch () =
       linked_at = Unix.gettimeofday ();
     }
   in
-  Lib.Autoresearch.save_swarm_link ~base_path link;
+  Lib.Autoresearch.save_execution_link ~base_path link;
   match
     Lib.Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id ~requester_agent:None
   with
@@ -497,7 +497,7 @@ let test_linked_status_json_includes_task_id () =
   in
   let state = { state with loop_id; source_workdir = base_path } in
   Lib.Autoresearch.save_state ~base_path state;
-  let link : Lib.Autoresearch.swarm_link =
+  let link : Lib.Autoresearch.execution_link =
     {
       loop_id;
       session_id = "session-task";
@@ -525,7 +525,7 @@ let () =
           test_case "cycle result parser rejects bad decision" `Quick
             test_cycle_result_parser_rejects_bad_decision;
           test_case "swarm link result parser rejects missing session_id" `Quick
-            test_swarm_link_result_parser_rejects_missing_session_id;
+            test_execution_link_result_parser_rejects_missing_session_id;
         ] );
       ( "loops_json",
         [
@@ -534,7 +534,7 @@ let () =
           test_case "skips legacy persisted state" `Quick
             test_loops_json_skips_legacy_persisted_state;
           test_case "tolerates invalid swarm link for active loop" `Quick
-            test_loops_json_tolerates_invalid_swarm_link_for_active_loop;
+            test_loops_json_tolerates_invalid_execution_link_for_active_loop;
           test_case "orders live then recent" `Quick
             test_loops_json_orders_live_then_recent;
           test_case "uses state file mtime for updated_at" `Quick


### PR DESCRIPTION
## Summary

Closes #8566. The swarm-coordination subsystem was removed in #8562 and #8565. The remaining `swarm_` prefix in `lib/autoresearch/` was a naming legacy — the `swarm_link` type holds generic coordination fields (loop_id, session_id, operation_id, task_id) that link an autoresearch loop to an execution session.

## Rename surface (8 files, 45 occurrences)

- Type: `swarm_link` → `execution_link` (autoresearch_types.ml)
- Functions: `{save,load}_swarm_link*` → `{save,load}_execution_link*`
- Serde: `swarm_link_{to,of}_yojson*` → `execution_link_{to,of}_yojson*`
- Error-tag kind strings: `"swarm_link"` / `"swarm link"` → `"execution_link"` / `"execution link"`
- Docstrings: `swarm integration` / `swarm link persistence` → `execution-session integration` / `execution link persistence`
- Test local: `swarm_path` → `execution_link_path`

## Backward compatibility: disk filename preserved

The on-disk filename `swarm.json` (`autoresearch_storage.ml:24`) is **intentionally kept**. Deployed installs may hold persisted data under this name, and the OCaml-level rename does not require a disk migration to ship. Added a docstring noting the decision at the declaration site. A follow-up can add read-compat (`swarm.json` → `execution.json`) if operators later want the on-disk name to match.

## Out of scope

`swarm`-related tool permission names (`masc_autoresearch_swarm_start`), fixture/test strings, and unrelated harness script paths are left untouched — those live under their own tool-name or fixture surfaces and are not part of the autoresearch link type.

## Test plan

- [ ] CI green
- No behavior change; pure identifier rename. `git diff --stat`: 54 insertions, 51 deletions across 8 files.