### PR TITLE
chore(config): SSOT for MASC_MCP_URL env key (partial #8352)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -161,10 +161,16 @@ module Local_runtime = struct
   let worker_model_opt () =
     Sys.getenv_opt "LLAMA_WORKER_MODEL" |> trim_opt
 
+  (** Env var that overrides the default MCP endpoint URL. Exposed as
+      SSOT so out-of-process callers (e.g. [worker_runtime_docker.ml]
+      that need container-local URL rewriting) read the same literal
+      without re-inlining the string. Issue #8352. *)
+  let mcp_url_env_key = "MASC_MCP_URL"
+
   (** MASC MCP endpoint URL (formerly in Chain module).
       Defaults to {base_url}/mcp. *)
   let mcp_url () =
-    match Sys.getenv_opt "MASC_MCP_URL" |> trim_opt with
+    match Sys.getenv_opt mcp_url_env_key |> trim_opt with
     | Some url -> url
     | None -> Env_config_core.masc_http_base_url () ^ "/mcp"
 end

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -73,7 +73,7 @@ let docker_http_base_url () =
   | None -> rewrite_loopback_url (Env_config.masc_http_base_url ())
 
 let docker_mcp_url () =
-  match Sys.getenv_opt "MASC_MCP_URL" with
+  match Sys.getenv_opt Env_config_runtime.Local_runtime.mcp_url_env_key with
   | Some value when String.trim value <> "" -> rewrite_loopback_url value
   | _ -> docker_http_base_url () ^ "/mcp"
 
@@ -118,7 +118,7 @@ let allowlisted_env_pairs () =
     [
       ("MASC_BASE_PATH", "");
       ("MASC_HTTP_BASE_URL", docker_http_base_url ());
-      ("MASC_MCP_URL", docker_mcp_url ());
+      (Env_config_runtime.Local_runtime.mcp_url_env_key, docker_mcp_url ());
       ("LLAMA_SERVER_URL", docker_llama_server_url ());
     ]
   in


### PR DESCRIPTION
## Summary

Partial fix for #8352. The issue catalogues 20+ env vars whose names are inlined as string literals across many files, bypassing the `Env_config_runtime` getters. This PR addresses only the concrete example called out in the issue body — `MASC_MCP_URL` — so the narrow fix can ship without co-shipping a decision about every other env var.

## Why a separate constant (not just reuse the `mcp_url()` getter)

The docker worker (`worker_runtime_docker.ml:75`) intentionally bypasses `mcp_url()` because it needs to rewrite `localhost` → `host.docker.internal` on the raw env value before use. Routing through `mcp_url()` would perform its own default-substitution and lose that opportunity. Exposing the env-var name as a public constant (`mcp_url_env_key`) lets the docker worker read the same key without re-inlining the literal.

## Changes

- `lib/config/env_config_runtime.ml`: add `Local_runtime.mcp_url_env_key = "MASC_MCP_URL"`; `mcp_url()` now reads via the constant.
- `lib/worker_runtime_docker.ml`: 2 sites — `Sys.getenv_opt \"MASC_MCP_URL\"` (line 76) and `(\"MASC_MCP_URL\", docker_mcp_url())` override map key (line 121) — now reference `Env_config_runtime.Local_runtime.mcp_url_env_key`.

## Not in this PR

The other env-var literals listed in #8352 (`MASC_BASE_PATH`, `MASC_HTTP_BASE_URL`, `MASC_STORAGE_TYPE`, `MASC_ORCHESTRATOR_ENABLED`, etc.) are left for follow-up PRs so each can pick the right getter/constant granularity for its call sites. #8352 stays open as the umbrella.

## Test plan

- [ ] CI green
- No behavior change; pure literal hoist.