### PR TITLE
fix(board_types): align Agent_id max length 32 -> 64 with canonical Validation (#8625)

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -80,14 +80,28 @@ module Agent_id : sig
 end = struct
   type t = string
 
-  (* Agent names: alphanumeric, dash, underscore, dot. Max 32 chars *)
+  (* Agent names: alphanumeric, dash, underscore, dot.
+     Issue #8625: limit was 32, but [Validation.Agent_id.validate]
+     (used by masc_join / masc_claim_next / masc_transition) allows 64.
+     Generated worker identities like
+     [codex-task-claimer-20260419t102609z] (36 chars) joined and
+     transitioned tasks fine but were rejected by [masc_board_post]
+     because of this stricter local limit. Aligned with the canonical
+     validator. *)
+  let max_agent_id_len = 64
   let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9._-]+$|} |> Re.compile
 
   let of_string s =
     let s = String.trim s in
     let len = String.length s in
-    if len >= 1 && len <= 32 && Re.execp valid_pattern s then Ok s
-    else Error (Validation_error (Printf.sprintf "Invalid agent_id: %s" s))
+    if len >= 1 && len <= max_agent_id_len && Re.execp valid_pattern s then
+      Ok s
+    else
+      Error
+        (Validation_error
+           (Printf.sprintf
+              "Invalid agent_id: %s (max %d chars, must match %s)"
+              s max_agent_id_len "[a-zA-Z0-9._-]+"))
 
   let to_string t = t
 end

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1088,7 +1088,7 @@ let () = test "claim_next_returns_no_unclaimed_when_all_tasks_terminal" (fun () 
   ]) in
   (* Now try to claim next from a different agent in same room *)
   let agent2_ctx = make_test_ctx_with_agent "agent-2" in
-  let (success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
+  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
   (* Should report no unclaimed tasks (success=true, message contains "No") *)
   assert (String.length msg > 0);
   match String.index_opt msg 'N' with
@@ -1102,7 +1102,7 @@ let () = test "claim_next_filters_out_cancelled_tasks" (fun () ->
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Cancelled task")]) in
   let _ = Coord.cancel_task_r ctx.config ~agent_name:ctx.agent_name ~task_id:"task-001" ~reason:"not needed" in
   let agent2_ctx = make_test_ctx_with_agent "agent-claim-2" in
-  let (success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
+  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
   match String.index_opt msg 'N' with
   | Some _ -> () (* "No unclaimed" is correct *)
   | None -> failwith (Printf.sprintf "Expected no tasks available, got: %s" msg)


### PR DESCRIPTION
## Summary

Closes #8625. Two validators in the codebase disagreed on the max agent_id length:

| Validator | Limit | Used by |
|---|---|---|
| \`Validation.Agent_id.validate\` | 64 | masc_join / masc_claim_next / masc_transition |
| \`Board_types.Agent_id.of_string\` | 32 | masc_board_post |

Generated worker IDs like \`codex-task-claimer-20260419t102609z\` (36 chars) joined and transitioned tasks fine but were rejected by board posts. Reported in #8625 during task-157 delivery.

## Changes

| Layer | Change |
|---|---|
| \`board_types.ml\` | bump limit \`32 → 64\`; named constant \`max_agent_id_len\`; richer error message |
| \`test_tool_task_coverage.ml\` | drive-by: rename \`success\` → \`_success\` (pre-existing warning-as-error broke full \`dune build\` on main, unrelated to this PR's lib change) |

## Verification

\`\`\`bash
dune build --root=\$PWD lib   # clean
dune build --root=\$PWD       # clean (full tree, was broken on main without drive-by)
\`\`\`

Manual:
\`\`\`ocaml
Board_types.Agent_id.of_string \"codex-task-claimer-20260419t102609z\"
(* before: Error \"Invalid agent_id: ...\"
   after:  Ok _ *)
\`\`\`

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] manual repro of the rejected agent_id now passes
- [ ] CI green