### PR TITLE
refactor(tool): use StringSet for access policy dedupe

### DIFF
--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -1,5 +1,7 @@
 (** Tool_access_policy — shared allow/deny selector ADT for runtime tool policies. *)
 
+module StringSet = Set.Make (String)
+
 type selector =
   | Empty
   | All
@@ -15,15 +17,13 @@ type t = {
 }
 
 let dedupe_keep_order names =
-  let seen = Hashtbl.create (max 16 (List.length names)) in
-  let rec loop acc = function
+  let rec loop seen acc = function
     | [] -> List.rev acc
-    | name :: rest when Hashtbl.mem seen name -> loop acc rest
+    | name :: rest when StringSet.mem name seen -> loop seen acc rest
     | name :: rest ->
-        Hashtbl.replace seen name ();
-        loop (name :: acc) rest
+        loop (StringSet.add name seen) (name :: acc) rest
   in
-  loop [] names
+  loop StringSet.empty [] names
 
 let normalize_names names =
   names


### PR DESCRIPTION
## Summary
- replace the local `Hashtbl` in `Tool_access_policy.dedupe_keep_order` with `StringSet`
- preserve trim/filter semantics and keep-first ordering while removing mutable hash state
- advance the concrete `task-103` subtask from the healthy repo-local worktree

## Product impact
- no user-facing behavior change
- removes local mutable hash state from tool access policy normalization
- keeps trim/filter semantics and first-seen ordering intact

## Evidence
- commit `c6a8c8f08` on branch `task-103-tool-access-policy`
- changed file: `lib/tool_access_policy.ml`
- local worktree: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-103-tool-access-policy`

## Review evidence
- `git diff --check`
- `env -u DUNE_RPC opam exec -- dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-103-tool-access-policy test/test_tool_access_policy.exe`

## Linked issue
- Refs #7213

## Context
- task: `task-103` (`[Umbrella] Keeper Architecture, Memory & State Management`)
- concrete subtask: tool access policy dedupe refactor