### PR TITLE
fix(board_types): align Agent_id pattern + length (#8625 + #8633, supersedes #8631)

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -80,14 +80,33 @@ module Agent_id : sig
 end = struct
   type t = string
 
-  (* Agent names: alphanumeric, dash, underscore, dot. Max 32 chars *)
-  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9._-]+$|} |> Re.compile
+  (* Issue #8633: pattern was [^[a-zA-Z0-9._-]+$] which rejected the
+     [keeper:foo] colon-namespacing supported by the canonical
+     [Validation.Agent_id] (used by masc_join / masc_claim_next).
+     Real callers exist (server_routes_http_keeper_stream:413,
+     server_openai_compat:153). Pattern is now a strict superset of
+     both: optional single colon namespace + previously-allowed dots.
+
+     Issue #8625: length cap was 32 — also raised to 64 to match
+     [Validation.Agent_id.validate]. Generated worker IDs like
+     [codex-task-claimer-20260419t102609z] (36 chars) joined fine but
+     were rejected by board posts. (Supersedes PR #8631.) *)
+  let max_agent_id_len = 64
+  let valid_pattern =
+    Re.Pcre.re {|^[a-zA-Z0-9._-]+(:[a-zA-Z0-9._-]+)?$|} |> Re.compile
 
   let of_string s =
     let s = String.trim s in
     let len = String.length s in
-    if len >= 1 && len <= 32 && Re.execp valid_pattern s then Ok s
-    else Error (Validation_error (Printf.sprintf "Invalid agent_id: %s" s))
+    if len >= 1 && len <= max_agent_id_len && Re.execp valid_pattern s then
+      Ok s
+    else
+      Error
+        (Validation_error
+           (Printf.sprintf
+              "Invalid agent_id: %s (max %d chars, must match \
+               [a-zA-Z0-9._-]+(:[a-zA-Z0-9._-]+)?)"
+              s max_agent_id_len))
 
   let to_string t = t
 end

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1088,7 +1088,7 @@ let () = test "claim_next_returns_no_unclaimed_when_all_tasks_terminal" (fun () 
   ]) in
   (* Now try to claim next from a different agent in same room *)
   let agent2_ctx = make_test_ctx_with_agent "agent-2" in
-  let (success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
+  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
   (* Should report no unclaimed tasks (success=true, message contains "No") *)
   assert (String.length msg > 0);
   match String.index_opt msg 'N' with
@@ -1102,7 +1102,7 @@ let () = test "claim_next_filters_out_cancelled_tasks" (fun () ->
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Cancelled task")]) in
   let _ = Coord.cancel_task_r ctx.config ~agent_name:ctx.agent_name ~task_id:"task-001" ~reason:"not needed" in
   let agent2_ctx = make_test_ctx_with_agent "agent-claim-2" in
-  let (success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
+  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
   match String.index_opt msg 'N' with
   | Some _ -> () (* "No unclaimed" is correct *)
   | None -> failwith (Printf.sprintf "Expected no tasks available, got: %s" msg)


### PR DESCRIPTION
## Summary

Closes both #8625 (length drift) and #8633 (pattern drift). **Supersedes PR #8631** which only fixed length.

\`Board_types.Agent_id\` and \`Validation.Agent_id\` (canonical, used by \`masc_join\`/\`masc_claim_next\`) disagreed in **both** dimensions:

| Validator | Length | Pattern | Effect |
|---|---|---|---|
| Validation (canonical) | 64 | \`[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?\` | colon namespacing OK, no dots |
| Board (was) | 32 | \`[a-zA-Z0-9._-]+\` | dots OK, no colons, shorter |

Real-world rejections:
- \`codex-task-claimer-20260419t102609z\` (36 chars) — joined, board rejects (#8625)
- \`keeper:test\` colon-namespacing — joined (real callers in \`server_routes_http_keeper_stream:413\`, \`server_openai_compat:153\`), board rejects (#8633)

## Fix

Strict superset of both. Pattern: \`^[a-zA-Z0-9._-]+(:[a-zA-Z0-9._-]+)?$\`. Length: 64.

- accepts everything Validation accepts
- accepts everything board previously accepted
- still rejects multiple colons, leading colons, path chars, etc.

## Note on #8631

PR #8631 only addressed length. Now that #8633 also requires a pattern change in the same function, bundling them is cleaner than two sequential PRs touching the same lines. Will close #8631 once this merges.

## Drive-by (same as #8631 had)

\`test/test_tool_task_coverage.ml:1105\` — pre-existing \`unused variable success\` blocked full \`dune build\` on main. Renamed to \`_success\`.

## Verification

\`\`\`bash
dune build --root=\$PWD lib   # clean
dune build --root=\$PWD       # clean (full tree)
\`\`\`

Manual:
\`\`\`ocaml
Board_types.Agent_id.of_string \"codex-task-claimer-20260419t102609z\" -> Ok _ (#8625)
Board_types.Agent_id.of_string \"keeper:test\" -> Ok _ (#8633)
Board_types.Agent_id.of_string \"a:b:c\" -> Error _ (multi-colon still rejected)
\`\`\`

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] manual repro of both rejected cases now passes
- [x] multi-colon still rejected (no widening past intended)
- [ ] CI green