### PR TITLE
chore(event_kind): introduce variant SSOT for task.* events (#8455 Phase 1)

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -348,7 +348,12 @@ let graph_json config ?(kinds = []) ?(limit = 500)
         List.iter (fun (e : event) ->
           let idx = min (num_buckets - 1) ((e.ts_ms - min_ts) / bucket_width) in
           let (count, agents_tbl, tasks_done) = buckets.(idx) in
-          let new_tasks_done = tasks_done + (if e.kind = "task.done" then 1 else 0) in
+          let new_tasks_done =
+            tasks_done
+            + (if String.equal e.kind
+                 (Event_kind.Task.to_string Event_kind.Task.Done)
+               then 1 else 0)
+          in
           (match e.actor with
            | Some actor -> Hashtbl.replace agents_tbl actor.id true
            | None -> ());

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -374,7 +374,7 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
         version = backlog.version + 1;
       } in
       write_backlog config new_backlog;
-      emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
+      emit_task_activity config ~agent_name:"system" ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
         ~payload:
           (`Assoc
             [
@@ -437,7 +437,7 @@ let add_task_with_role ?contract config ~title ~priority ~description
         version = backlog.version + 1;
       } in
       write_backlog config new_backlog;
-      emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
+      emit_task_activity config ~agent_name:"system" ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
         ~payload:
           (`Assoc
             [
@@ -501,7 +501,7 @@ let batch_add_tasks_internal config tasks =
       List.iter
         (fun (task : Types.task) ->
           emit_task_activity config ~agent_name:"system" ~task_id:task.id
-            ~kind:"task.created"
+            ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
             ~payload:
               (`Assoc
                 [
@@ -586,7 +586,7 @@ let claim_task config ~agent_name ~task_id =
             update_local_agent_state config ~agent_name (fun agent ->
               { agent with status = Busy; current_task = Some task_id });
             ignore (broadcast config ~from_agent:agent_name ~content:(Printf.sprintf "📋 Claimed %s" task_id));
-            emit_task_activity config ~agent_name ~task_id ~kind:"task.claimed"
+            emit_task_activity config ~agent_name ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
               ~payload:(`Assoc [ ("task_id", `String task_id) ]);
             log_event config
               (Yojson.Safe.to_string
@@ -702,7 +702,7 @@ let claim_task_r config ~agent_name ~task_id
             update_local_agent_state config ~agent_name (fun agent ->
               { agent with status = Busy; current_task = Some task_id });
             ignore (broadcast config ~from_agent:agent_name ~content:(Printf.sprintf "📋 Claimed %s" task_id));
-            emit_task_activity config ~agent_name ~task_id ~kind:"task.claimed"
+            emit_task_activity config ~agent_name ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
               ~payload:(`Assoc [ ("task_id", `String task_id) ]);
             log_event config
               (Yojson.Safe.to_string
@@ -1016,15 +1016,15 @@ let transition_task_r config ~agent_name ~task_id ~action
         (match action with
          | Types.Claim ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.claimed"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
                ~payload:(`Assoc [ ("task_id", `String task_id) ])
          | Types.Start ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.started"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Started)
                ~payload:(`Assoc [ ("task_id", `String task_id) ])
          | Types.Done_action ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.done"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Done)
                ~payload:
                  (`Assoc
                    [
@@ -1033,7 +1033,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                    ])
          | Types.Cancel ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.cancelled"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Cancelled)
                ~payload:
                  (`Assoc
                    [
@@ -1042,7 +1042,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                    ])
          | Types.Release ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.released"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
                ~payload:
                  (`Assoc
                    ([
@@ -1060,15 +1060,15 @@ let transition_task_r config ~agent_name ~task_id ~action
                    | None -> []))
          | Types.Submit_for_verification ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.submit_for_verification"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Submit_for_verification)
                ~payload:(`Assoc [ ("task_id", `String task_id) ])
          | Types.Approve_verification ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.approved"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Approved)
                ~payload:(`Assoc [ ("task_id", `String task_id) ])
          | Types.Reject_verification ->
              emit_task_activity config ~agent_name ~task_id
-               ~kind:"task.rejected"
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Rejected)
                ~payload:(`Assoc [ ("task_id", `String task_id) ]));
         let duration_ms =
           match action with
@@ -1208,7 +1208,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
               let msg = if reason = "" then Printf.sprintf "🚫 Cancelled %s" task_id else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason in
               ignore (broadcast config ~from_agent:agent_name ~content:msg);
               emit_task_activity config ~agent_name ~task_id
-                ~kind:"task.cancelled"
+                ~kind:(Event_kind.Task.to_string Event_kind.Task.Cancelled)
                 ~payload:
                   (`Assoc
                     [
@@ -1319,7 +1319,7 @@ let link_task_execution_artifacts_r config ~task_id ?session_id ?operation_id
               in
               write_backlog config new_backlog;
               emit_task_activity config ~agent_name:"system" ~task_id
-                ~kind:"task.linked"
+                ~kind:(Event_kind.Task.to_string Event_kind.Task.Linked)
                 ~payload:
                   (`Assoc
                     ([

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -230,12 +230,12 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
           (match released_task_id with
            | Some rid ->
                Coord_task.emit_task_activity config ~agent_name ~task_id:rid
-                 ~kind:"task.released"
+                 ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
                  ~payload:(`Assoc [ ("task_id", `String rid) ]);
                observe_auto_release ()
            | None -> ());
           Coord_task.emit_task_activity config ~agent_name ~task_id:task.id
-            ~kind:"task.claimed"
+            ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
             ~payload:
               (`Assoc
                 [

--- a/lib/dune
+++ b/lib/dune
@@ -365,6 +365,7 @@
    trajectory
    eval_gate
    eval_harness
+   event_kind
    exec_core
    eval_calibration
    ;; Keeper contract

--- a/lib/event_kind.ml
+++ b/lib/event_kind.ml
@@ -1,0 +1,42 @@
+module Task = struct
+  type t =
+    | Created
+    | Claimed
+    | Started
+    | Released
+    | Done
+    | Cancelled
+    | Submit_for_verification
+    | Approved
+    | Rejected
+    | Linked
+
+  let to_string = function
+    | Created -> "task.created"
+    | Claimed -> "task.claimed"
+    | Started -> "task.started"
+    | Released -> "task.released"
+    | Done -> "task.done"
+    | Cancelled -> "task.cancelled"
+    | Submit_for_verification -> "task.submit_for_verification"
+    | Approved -> "task.approved"
+    | Rejected -> "task.rejected"
+    | Linked -> "task.linked"
+
+  let of_string = function
+    | "task.created" -> Some Created
+    | "task.claimed" -> Some Claimed
+    | "task.started" -> Some Started
+    | "task.released" -> Some Released
+    | "task.done" -> Some Done
+    | "task.cancelled" -> Some Cancelled
+    | "task.submit_for_verification" -> Some Submit_for_verification
+    | "task.approved" -> Some Approved
+    | "task.rejected" -> Some Rejected
+    | "task.linked" -> Some Linked
+    | _ -> None
+
+  let all =
+    [ Created; Claimed; Started; Released; Done; Cancelled;
+      Submit_for_verification; Approved; Rejected; Linked ]
+end

--- a/lib/event_kind.mli
+++ b/lib/event_kind.mli
@@ -1,0 +1,40 @@
+(** Event_kind — Compile-time verified event-kind identifiers.
+
+    Event-kind strings (["task.claimed"], ["board.voted"], …) flow
+    between emitters (coord, board, keeper) and consumers
+    (activity_graph_reducer, tool_agent_timeline, dashboard). Prior to
+    this module both sides used raw [string]; a typo on either side
+    compiled clean and silently diverged at runtime.
+
+    This module is the SSOT for the [task.*] family. Other families
+    (board.*, agent.*, keeper.*) are tracked in #8455 and will be
+    migrated in follow-up PRs on the same pattern.
+
+    Parse boundary: {!Task.of_string} at JSONL / wire ingress only;
+    internal code uses [Task.t] directly so typos become compile
+    errors. *)
+
+module Task : sig
+  type t =
+    | Created
+    | Claimed
+    | Started
+    | Released
+    | Done
+    | Cancelled
+    | Submit_for_verification
+    | Approved
+    | Rejected
+    | Linked
+
+  val to_string : t -> string
+  (** Canonical dotted-form wire name ([\"task.claimed\"] etc.). *)
+
+  val of_string : string -> t option
+  (** Inverse of {!to_string}. Returns [None] for unknown inputs so
+      consumers can opt between fail-closed and fail-open. *)
+
+  val all : t list
+  (** Exhaustive enumeration; useful for tests that want to assert
+      every variant round-trips through JSON. *)
+end

--- a/test/dune
+++ b/test/dune
@@ -657,6 +657,12 @@
  (modules test_tool_name)
  (libraries masc_test_deps))
 
+; ── Event_kind variant roundtrip (#8455) ────────────────
+(test
+ (name test_event_kind)
+ (modules test_event_kind)
+ (libraries masc_test_deps))
+
 ; ── Core Triad: State x Decision x Cascade ──────────────
 (test
  (name test_keeper_cascade_routing)

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -1,0 +1,42 @@
+(** Test Event_kind: roundtrip + coverage invariants.
+
+    The point of the variant SSOT (#8455) is that every name defined on
+    the emit side has a reverse route on the parse boundary, and that
+    [all] enumerates every variant. These tests catch drift — e.g. a
+    new variant added to [t] without extending [to_string]/[of_string]. *)
+
+open Masc_mcp
+
+let () =
+  (* Round-trip: to_string → of_string = Some original *)
+  List.iter
+    (fun v ->
+      let s = Event_kind.Task.to_string v in
+      match Event_kind.Task.of_string s with
+      | Some v' when v' = v -> ()
+      | Some _ ->
+          Printf.eprintf
+            "event_kind Task roundtrip mismatch for %s\n%!" s;
+          exit 1
+      | None ->
+          Printf.eprintf
+            "event_kind Task of_string returned None for %s\n%!" s;
+          exit 1)
+    Event_kind.Task.all;
+  (* Unknown input must not accidentally resolve *)
+  (match Event_kind.Task.of_string "task.clamied" with
+   | Some _ ->
+       prerr_endline "event_kind Task.of_string accepted a typo";
+       exit 1
+   | None -> ());
+  (* All names are dotted-form under [task.] *)
+  List.iter
+    (fun v ->
+      let s = Event_kind.Task.to_string v in
+      if not (String.length s > 5 && String.sub s 0 5 = "task.") then begin
+        Printf.eprintf
+          "event_kind Task name does not start with \"task.\": %s\n%!" s;
+        exit 1
+      end)
+    Event_kind.Task.all;
+  print_endline "test_event_kind: OK"


### PR DESCRIPTION
## Summary

Phase 1 of #8455. Event-kind strings (`task.*`, `board.*`, `agent.*`, `keeper.*`, …) flow between emitters (coord, board, keeper) and consumers (activity_graph_reducer, tool_agent_timeline, dashboard) as raw strings with no compile-time link. A typo on either side compiles clean and silently diverges at runtime.

This PR lands the variant SSOT for the `task.*` family only. Other families are follow-ups on the same pattern; #8455 stays open as the umbrella.

## New module

`lib/event_kind.ml(i)` — `Event_kind.Task.t` with 10 variants (Created, Claimed, Started, Released, Done, Cancelled, Submit_for_verification, Approved, Rejected, Linked). `to_string` / `of_string` round-trip; `all` enumerates. Parse boundary is `of_string` at JSONL/wire ingress; internal code uses `t` directly so typos become compile errors.

## Migrated emitters

- `lib/coord/coord_task.ml` — 14 `~kind:\"task.*\"` literal sites → `Event_kind.Task.to_string Event_kind.Task.<Variant>`
- `lib/coord/coord_task_schedule.ml` — 2 sites

Verification: `Event_kind.Task.Clamied` now blocks at compile — `Error: Unbound constructor Clamied. Did you mean Claimed?`

## Touched consumers

- `lib/activity_graph/activity_graph.ml:351` — `e.kind = \"task.done\"` literal → `String.equal e.kind (Event_kind.Task.to_string Event_kind.Task.Done)`

`lib/activity_graph/activity_graph_reducer.ml` keeps literal patterns because OCaml `match` requires constant strings; rewriting as 17-arm `if/else` obscures dispatch. That file is match-side, so variants still deliver their primary value (emit-path protection).

## Test

`test/test_event_kind.ml` — round-trip, known-typo rejection, prefix invariant. Mirrors `test_tool_name.ml`.

## Not in this PR

Other event-kind families (board.*, agent.*, keeper.*, decision.*, operation.*, message.*, policy.*, tool.*) land in follow-ups.

## Test plan

- [ ] CI green (including new `test_event_kind` target)
- No behavior change; pure SSOT introduction.