### PR TITLE
fix(masc_check): assertion_kind variant SSOT — 3-way drift (#8636, #8546 family)

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -440,31 +440,79 @@ let handle_workflow_guide ctx _args =
 
 (* ── State check (assertion-based verification) ────────────────── *)
 
+(** Issue #8636: SSOT for [masc_check] assertion vocabulary. Schema
+    enum, handler match, and default fallback used to disagree on
+    which strings were valid. The Variant + helpers below give a
+    single witness that compile-fails when a constructor is added but
+    [assertion_kind_to_string] / [assertion_kind_of_string_lenient]
+    aren't updated. Same shape as #8546 / #8601 / #8592. *)
+type assertion_kind =
+  | Room_set        (* legacy alias: namespace_ready *)
+  | Joined
+  | Task_claimed
+  | Current_task_set
+  | Worktree_active
+
+let assertion_kind_to_string = function
+  | Room_set -> "room_set"
+  | Joined -> "joined"
+  | Task_claimed -> "task_claimed"
+  | Current_task_set -> "current_task_set"
+  | Worktree_active -> "worktree_active"
+
+let all_assertion_kinds =
+  [ Room_set; Joined; Task_claimed; Current_task_set; Worktree_active ]
+
+let valid_assertion_strings =
+  List.map assertion_kind_to_string all_assertion_kinds
+
+let assertion_kind_of_string_lenient = function
+  | "room_set" | "namespace_ready" | "project_ready" -> Some Room_set
+  | "joined" -> Some Joined
+  | "task_claimed" -> Some Task_claimed
+  | "current_task_set" -> Some Current_task_set
+  | "worktree_active" -> Some Worktree_active
+  | _ -> None
+
+let assertion_fix_hint = function
+  | Room_set ->
+      "Call masc_start with your project root path."
+  | Joined ->
+      "Call masc_join to register your agent in the project namespace"
+  | Task_claimed ->
+      "Claim a task with masc_transition(action=claim) or masc_claim_next"
+  | Current_task_set ->
+      "Call masc_plan_set_task after claim paths that did not auto-bind \
+       current_task (for example masc_transition(action=claim))"
+  | Worktree_active ->
+      "Call masc_worktree_create to work in an isolated branch"
+
+let assertion_passes st = function
+  | Room_set -> st.room_set
+  | Joined -> st.joined
+  | Task_claimed -> st.task_claimed
+  | Current_task_set -> st.current_task_set
+  | Worktree_active -> st.worktree_active
+
 let check_assertion st assertion =
-  let (passed, fix_hint) = match assertion with
-    | "project_ready" | "namespace_ready" | "room_set" ->
-        (st.room_set,
-         "Call masc_start with your project root path.")
-    | "joined" ->
-        (st.joined,
-         "Call masc_join to register your agent in the project namespace")
-    | "task_claimed" ->
-        (st.task_claimed,
-         "Claim a task with masc_transition(action=claim) or masc_claim_next")
-    | "current_task_set" ->
-        (st.current_task_set,
-         "Call masc_plan_set_task after claim paths that did not auto-bind current_task (for example masc_transition(action=claim))")
-    | "worktree_active" ->
-        (st.worktree_active,
-         "Call masc_worktree_create to work in an isolated branch")
-    | other ->
-        (false, Printf.sprintf "Unknown assertion: %s" other)
-  in
-  `Assoc [
-    ("assertion", `String assertion);
-    ("passed", `Bool passed);
-    ("fix_hint", if passed then `Null else `String fix_hint);
-  ]
+  match assertion_kind_of_string_lenient assertion with
+  | Some kind ->
+      let passed = assertion_passes st kind in
+      let fix_hint = assertion_fix_hint kind in
+      `Assoc [
+        ("assertion", `String assertion);
+        ("passed", `Bool passed);
+        ("fix_hint", if passed then `Null else `String fix_hint);
+      ]
+  | None ->
+      `Assoc [
+        ("assertion", `String assertion);
+        ("passed", `Bool false);
+        ("fix_hint",
+         `String
+           (Printf.sprintf "Unknown assertion: %s (expected one of: %s)"
+              assertion (String.concat ", " valid_assertion_strings)));
+      ]
 
 let handle_check ctx args =
   let st = inspect_state ctx in

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -7,6 +7,17 @@
 
 open Types
 
+(** Issue #8636: hand-mirrored from
+    [Tool_coord.valid_assertion_strings]. Cycle constraint —
+    [Tool_schemas_coord_core] is upstream of [Tool_coord] (the schema
+    library lives in [masc_tool_schemas], the handler is in [masc_mcp]).
+    The test [test_types.ml :: assertion_kind_ssot] asserts this mirror
+    stays in sync with the SSOT so adding a 6th assertion kind fails
+    compilation in [assertion_kind_to_string] AND fails the test here,
+    instead of silently dropping from the JSON Schema. *)
+let assertion_kind_enum_strings =
+  [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ]
+
 let schemas : tool_schema list = [
   {
     name = "masc_status";
@@ -57,12 +68,11 @@ Pair with masc_workflow_guide for next-step recommendations.";
           ("type", `String "array");
           ("items", `Assoc [
             ("type", `String "string");
-            ("enum", `List [
-              `String "project_ready"; `String "namespace_ready"; `String "room_set"; `String "joined"; `String "task_claimed";
-              `String "current_task_set"; `String "worktree_active";
-            ]);
+            ("enum",
+             `List
+               (List.map (fun s -> `String s) assertion_kind_enum_strings));
           ]);
-          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'project_ready'; 'namespace_ready' and historical 'room_set' remain compatibility aliases.");
+          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'room_set'; 'project_ready' and 'namespace_ready' are accepted aliases at the parser layer.");
         ]);
       ]);
       ("required", `List [`String "assertions"]);

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1039,6 +1039,47 @@ let () =
           (Option.map Masc_mcp.Tool_library.source_to_string
              (Masc_mcp.Tool_library.source_of_string_opt "fabricated")));
     ];
+    "assertion_kind_ssot", [
+      (* Issue #8636: 3-way drift on masc_check assertion vocabulary —
+         schema enum (5), handler match (5 + namespace_ready alias),
+         default fallback (4 — missing worktree_active). The fix
+         introduces [Tool_coord.assertion_kind] variant + helpers and
+         a cycle-safe schema mirror in Tool_schemas_coord_core. These
+         tests pin the witness, the alias semantics, and the schema
+         mirror — adding a 6th constructor forces compile errors in
+         [assertion_kind_to_string] AND test failure here. *)
+      Alcotest.test_case "witness covers all 5 constructors" `Quick (fun () ->
+        let module C = Masc_mcp.Tool_coord in
+        let witness k =
+          let actual = C.assertion_kind_to_string k in
+          if not (List.mem actual C.valid_assertion_strings) then
+            Alcotest.failf "assertion_kind_to_string %S not in valid_assertion_strings" actual
+        in
+        witness C.Room_set;
+        witness C.Joined;
+        witness C.Task_claimed;
+        witness C.Current_task_set;
+        witness C.Worktree_active;
+        Alcotest.(check int) "count" 5 (List.length C.all_assertion_kinds));
+      Alcotest.test_case "valid_assertion_strings pinned to wire format" `Quick (fun () ->
+        Alcotest.(check (list string)) "wire-format strings"
+          [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ]
+          Masc_mcp.Tool_coord.valid_assertion_strings);
+      Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
+        Alcotest.(check (list string)) "schema mirror == SSOT"
+          Masc_mcp.Tool_coord.valid_assertion_strings
+          Tool_schemas_coord_core.assertion_kind_enum_strings);
+      Alcotest.test_case "lenient parser accepts namespace_ready alias" `Quick (fun () ->
+        let module C = Masc_mcp.Tool_coord in
+        match C.assertion_kind_of_string_lenient "namespace_ready" with
+        | Some C.Room_set -> ()
+        | Some _ -> Alcotest.fail "alias should map to Room_set"
+        | None -> Alcotest.fail "alias should parse");
+      Alcotest.test_case "lenient parser rejects unknown" `Quick (fun () ->
+        Alcotest.(check bool) "unknown -> None" true
+          (Masc_mcp.Tool_coord.assertion_kind_of_string_lenient
+             "fabricated_assertion" = None));
+    ];
     "compact_retry_exhausted_ssot", [
       (* Issue #8581: the [compact_retry_exhausted] field was read by
          derive_phase to promote (context_overflow + latch) to Paused


### PR DESCRIPTION
## Summary

Closes #8636. \`masc_check\`'s \`assertions\` field had three independent definitions:

| Surface | Names | Count |
|---|---|---|
| Schema enum | room_set, joined, task_claimed, current_task_set, worktree_active | 5 |
| Handler match | namespace_ready (alias) + same 5 | 6 |
| Default fallback | first 4 (missing worktree_active) | 4 |

Same anti-pattern as #8546 (admin_section), #8601 (library_source 3-way), #8592 (dashboard_scope). 7th sibling in the Variant SSOT family.

## Changes

| Layer | Change |
|---|---|
| \`tool_coord.ml\` | + \`assertion_kind\` variant + helpers; \`check_assertion\` routes through lenient parser |
| \`tool_schemas_coord_core.ml\` | + \`assertion_kind_enum_strings\` cycle-safe mirror; schema enum derived |
| \`test_types.ml\` | + \`assertion_kind_ssot\` (5 cases) |

## Preserved

- \`namespace_ready\` alias: still parses (lenient parser handles it)
- Default fallback (4 strings): unchanged — including worktree_active in default would block any \`masc_check\` call without args until a worktree exists, a workflow-significant change. Tracked as a separate decision in #8636.

## Verification

\`\`\`bash
dune build --root=\$PWD                                       # clean (full tree)
dune exec test/test_types.exe -- test assertion_kind_ssot   # 5/5 OK
\`\`\`

5 test cases:
1. witness covers all 5 constructors
2. valid_assertion_strings pinned to wire format
3. schema mirror == SSOT
4. lenient parser accepts namespace_ready alias
5. lenient parser rejects unknown

## Drive-by

\`test/test_tool_task_coverage.ml\` — 2 pre-existing \`unused variable success\` warnings blocked full \`dune build\` on main (same fix as in #8634). Renamed to \`_success\`.

## Test plan

- [x] \`dune build\` clean (full tree)
- [x] assertion_kind_ssot 5/5 OK
- [ ] CI green