### PR TITLE
chore(tool_name): migrate 4 hot-path call sites to Tool_name.Masc SSOT (#8448 partial)

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -200,15 +200,16 @@ let legacy_session_min_tool_names =
   (* Legacy keepers historically received canonical masc_* coordination tools,
      not the SDK alias-heavy Session_min surface. Keep this compatibility list
      explicit so missing tool_access migration remains stable after tier removal. *)
-  [
-    "masc_status";
-    "masc_tasks";
-    "masc_claim_next";
-    "masc_plan_set_task";
-    "masc_transition";
-    "masc_add_task";
-    "masc_broadcast";
-  ]
+  List.map Tool_name.Masc.to_string
+    Tool_name.Masc.[
+      Status;
+      Tasks;
+      Claim_next;
+      Plan_set_task;
+      Transition;
+      Add_task;
+      Broadcast;
+    ]
 
 let migrate_legacy_restricted_tools names =
   Custom (normalize_tool_names (legacy_keeper_internal_tool_names @ names))

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -76,10 +76,12 @@ let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
     Tool_shard schemas. *)
 
 let read_only_tools_inline =
-  ["masc_status"; "masc_who"; "masc_messages"]
+  List.map Tool_name.Masc.to_string
+    Tool_name.Masc.[ Status; Who; Messages ]
 
 let requires_join_tools_inline =
-  ["masc_broadcast"; "masc_leave"]
+  List.map Tool_name.Masc.to_string
+    Tool_name.Masc.[ Broadcast; Leave ]
 
 let mcp_context_required_tools_inline =
   Tool_schemas_inline.schemas

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -239,7 +239,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       (Printexc.to_string exn));
   (* Build read-only tool surface shared by both judges. *)
   let judge_tool_names =
-    [ "masc_status"; "masc_tasks"; "masc_agents"; "masc_board_list" ]
+    List.map Tool_name.Masc.to_string
+      Tool_name.Masc.[ Status; Tasks; Agents; Board_list ]
   in
   let judge_masc_tools =
     match

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -952,7 +952,9 @@ and add_autoresearch_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/keeper/cascade" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_status" (fun _state req reqd ->
+       with_tool_auth
+         ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Status)
+         (fun _state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            match Yojson.Safe.from_string body_str with
            | exception Yojson.Json_error _ ->


### PR DESCRIPTION
## Summary

Partial fix for #8448. The issue catalogues 51 `\"masc_status\"` / 52 `\"masc_transition\"` / etc. literal strings across 18 files that bypass the `Tool_name.Masc.to_string` variant SSOT.

Full migration is too large for one PR. This PR picks the narrow, single-expression call sites — the low-risk wins that are neither OCaml `match` patterns (which require constant literals) nor large declarative catalogs.

## Migrated (4 files)

- `lib/mcp_server_eio.ml:78-82` — `read_only_tools_inline` + `requires_join_tools_inline` built via `List.map Tool_name.Masc.to_string Tool_name.Masc.[ Status; Who; Messages ]` / `[ Broadcast; Leave ]`.
- `lib/server/server_bootstrap_loops.ml:242` — `judge_tool_names` list via the same pattern (`[ Status; Tasks; Agents; Board_list ]`).
- `lib/server/server_routes_http_routes_dashboard.ml:955` — `with_tool_auth ~tool_name:\"masc_status\"` → `Tool_name.Masc.to_string Tool_name.Masc.Status`.
- `lib/keeper/keeper_types.ml:204` — legacy keeper internal tools list (7 entries).

Typo protection verified: `Tool_name.Masc.Stauts` → `Error: Unbound constructor Stauts. Did you mean Status?`.

## Not in this PR

- **tool_permission_map.ml** (70+ entry table) — helper function change dwarfs benefit; separate PR
- **tool_catalog_surfaces.ml** (multiple curated surface lists) — each list is catalog-shaped; staged migration
- **dispatch match arms** (`match name with | \"masc_status\" -> …`) — OCaml pattern match requires literal strings, would need restructuring to hashtable dispatch
- **tool_prefilter.ml / tool_catalog.ml / mcp_server_eio_tool_profile.ml** — each has distinct shape; further bounded batches

#8448 stays open as umbrella.

## Test plan

- [ ] CI green
- No behavior change; all substitutions compile to the identical runtime string.