### PR TITLE
chore(event_kind): Board variant module + 8 call-site migrations (#8455 Phase 2)

### DIFF
--- a/lib/coord/event_kind.ml
+++ b/lib/coord/event_kind.ml
@@ -57,3 +57,26 @@ module Message = struct
 
   let all = [ Broadcast; Mentioned ]
 end
+
+module Board = struct
+  type t =
+    | Posted
+    | Commented
+    | Voted
+    | Deleted
+
+  let to_string = function
+    | Posted -> "board.posted"
+    | Commented -> "board.commented"
+    | Voted -> "board.voted"
+    | Deleted -> "board.deleted"
+
+  let of_string = function
+    | "board.posted" -> Some Posted
+    | "board.commented" -> Some Commented
+    | "board.voted" -> Some Voted
+    | "board.deleted" -> Some Deleted
+    | _ -> None
+
+  let all = [ Posted; Commented; Voted; Deleted ]
+end

--- a/lib/coord/event_kind.mli
+++ b/lib/coord/event_kind.mli
@@ -6,10 +6,10 @@
     this module both sides used raw [string]; a typo on either side
     compiled clean and silently diverged at runtime.
 
-    This module is the SSOT for the task.* and message.* families.
-    Other families (board.*, agent.*, keeper.*, ...) are tracked in
-    issue 8455 and will be migrated in follow-up PRs on the same
-    pattern.
+    This module is the SSOT for the [task.*], [message.*] and [board.*]
+    families. Other families (agent.*, keeper.*, decision.*, operation.*,
+    etc.) are tracked in #8455 and will be migrated in follow-up PRs on
+    the same pattern.
 
     Parse boundary: {!Task.of_string} at JSONL / wire ingress only;
     internal code uses [Task.t] directly so typos become compile
@@ -47,6 +47,20 @@ module Message : sig
 
   val to_string : t -> string
   (** Canonical dotted-form wire name (e.g. [message.broadcast]). *)
+
+  val of_string : string -> t option
+  val all : t list
+end
+
+module Board : sig
+  type t =
+    | Posted
+    | Commented
+    | Voted
+    | Deleted
+
+  val to_string : t -> string
+  (** Canonical dotted-form wire name ([board.posted] etc.). *)
 
   val of_string : string -> t option
   val all : t list

--- a/lib/coord/event_kind.mli
+++ b/lib/coord/event_kind.mli
@@ -60,7 +60,7 @@ module Board : sig
     | Deleted
 
   val to_string : t -> string
-  (** Canonical dotted-form wire name ([board.posted] etc.). *)
+  (** Canonical dotted-form wire name (e.g. [board.posted]). *)
 
   val of_string : string -> t option
   val all : t list

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -182,25 +182,25 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
             | Some h -> ("hearth", `String h) :: base
             | None -> base
           in
-          ("board.posted",
+          (Event_kind.Board.to_string Event_kind.Board.Posted,
            Activity_graph.entity ~kind:"agent" author,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc payload_fields)
       | Board_dispatch.Comment_added { post_id; comment_id; author } ->
-          ("board.commented",
+          (Event_kind.Board.to_string Event_kind.Board.Commented,
            Activity_graph.entity ~kind:"agent" author,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc [("post_id", `String post_id); ("comment_id", `String comment_id);
                    ("author", `String author)])
       | Board_dispatch.Post_voted { post_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
-          ("board.voted",
+          (Event_kind.Board.to_string Event_kind.Board.Voted,
            Activity_graph.entity ~kind:"agent" voter,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc [("post_id", `String post_id); ("direction", `String dir)])
       | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
-          ("board.voted",
+          (Event_kind.Board.to_string Event_kind.Board.Voted,
            Activity_graph.entity ~kind:"agent" voter,
            Some (Activity_graph.entity ~kind:"comment" comment_id),
            `Assoc [("comment_id", `String comment_id); ("direction", `String dir)])

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -120,10 +120,10 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
             ("event", `String "board_post");
             ("content_preview", `String (String.sub content 0 (min 100 (String.length content))));
           ]);
-        emit_activity config ~kind:"board.posted" ~actor:author
+        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Posted) ~actor:author
           ?subject:
             (Option.map (Activity_graph.entity ~kind:"post") post_id)
-          ~tags:[ "board"; "board.posted" ]
+          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Posted ]
           ~payload:
             (`Assoc
               [
@@ -188,9 +188,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
             ("post_id", `String post_id);
             ("content_preview", `String (String.sub content 0 (min 100 (String.length content))));
           ]);
-        emit_activity config ~kind:"board.commented" ~actor:author
+        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Commented) ~actor:author
           ~subject:(Activity_graph.entity ~kind:"post" post_id)
-          ~tags:[ "board"; "board.commented" ]
+          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Commented ]
           ~payload:
             (`Assoc
               [
@@ -243,9 +243,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         let subject_kind =
           if String.equal name "masc_board_vote" then "post" else "comment"
         in
-        emit_activity config ~kind:"board.voted" ~actor:voter
+        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Voted) ~actor:voter
           ~subject:(Activity_graph.entity ~kind:subject_kind target_id)
-          ~tags:[ "board"; "board.voted" ]
+          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Voted ]
           ~payload:
             (`Assoc
               [
@@ -266,9 +266,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("timestamp", `String (Types.now_iso ()));
         ] in
         Mcp_server.sse_broadcast state notification;
-        emit_activity config ~kind:"board.deleted" ~actor:agent_name
+        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Deleted) ~actor:agent_name
           ~subject:(Activity_graph.entity ~kind:"post" post_id)
-          ~tags:[ "board"; "board.deleted" ]
+          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Deleted ]
           ~payload:(`Assoc [ ("post_id", `String post_id) ])
           ()
       end;

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -70,4 +70,33 @@ let () =
         exit 1
       end)
     Event_kind.Message.all;
+  (* Board family: same three invariants *)
+  List.iter
+    (fun v ->
+      let s = Event_kind.Board.to_string v in
+      match Event_kind.Board.of_string s with
+      | Some v' when v' = v -> ()
+      | Some _ ->
+          Printf.eprintf
+            "event_kind Board roundtrip mismatch for %s\n%!" s;
+          exit 1
+      | None ->
+          Printf.eprintf
+            "event_kind Board of_string returned None for %s\n%!" s;
+          exit 1)
+    Event_kind.Board.all;
+  (match Event_kind.Board.of_string "board.potsed" with
+   | Some _ ->
+       prerr_endline "event_kind Board.of_string accepted a typo";
+       exit 1
+   | None -> ());
+  List.iter
+    (fun v ->
+      let s = Event_kind.Board.to_string v in
+      if not (String.length s > 6 && String.sub s 0 6 = "board.") then begin
+        Printf.eprintf
+          "event_kind Board name does not start with \"board.\": %s\n%!" s;
+        exit 1
+      end)
+    Event_kind.Board.all;
   print_endline "test_event_kind: OK"


### PR DESCRIPTION
## Summary

Phase 2 of #8455. Extends the event-kind SSOT introduced in #8635 with the `board.*` family (Posted, Commented, Voted, Deleted). Same pattern as Task.

## New variant module

`Event_kind.Board.t` — 4 variants enumerating every `board.*` event emitted in `lib/`. `to_string` / `of_string` round-trip, `all` enumerates. Parse boundary is `of_string` at ingress; internal code uses variants so typos become compile errors.

## Migrated emitters (8 sites)

| File | Sites |
|------|-------|
| `lib/tool_inline_dispatch_extra.ml` | 4 `~kind:` + 4 `~tags:` entries |
| `lib/server/server_bootstrap_loops.ml` | 4 tuple-builder sites (posted / commented / voted×2) |

Verification: `Event_kind.Board.Potsed` → `Error: Unbound constructor Potsed. Did you mean Posted?`.

## Test

`test/test_event_kind.ml` — adds round-trip / typo-rejection / prefix-invariant triple for Board, mirroring Task.

## Not in this PR

`agent.*`, `keeper.*`, `decision.*`, `operation.*`, `message.*`, `policy.*`, `tool.*` families land in follow-ups. #8455 stays open as umbrella.

## Test plan

- [ ] CI green (test_event_kind now exercises both Task and Board)
- No behavior change; pure SSOT extension.