### PR TITLE
fix(event_kind): escape *) sequence that broke docstring in #8635 (main CI hotfix)

### DIFF
--- a/lib/event_kind.mli
+++ b/lib/event_kind.mli
@@ -6,9 +6,9 @@
     this module both sides used raw [string]; a typo on either side
     compiled clean and silently diverged at runtime.
 
-    This module is the SSOT for the [task.*] family. Other families
-    (board.*, agent.*, keeper.*) are tracked in #8455 and will be
-    migrated in follow-up PRs on the same pattern.
+    This module is the SSOT for the task.* family. Other families
+    (board.*, agent.*, keeper.*, ...) are tracked in issue 8455 and
+    will be migrated in follow-up PRs on the same pattern.
 
     Parse boundary: {!Task.of_string} at JSONL / wire ingress only;
     internal code uses [Task.t] directly so typos become compile


### PR DESCRIPTION
## Summary

**URGENT — blocks CI on main and every open PR.**

The module-level docstring in `lib/event_kind.mli` introduced by #8635 contains `(board.*, agent.*, keeper.*)`. The `*)` inside `keeper.*)` terminates the `(** ... *)` comment prematurely. Everything after (`are tracked in #8455 and will be migrated ...`) becomes real OCaml code; `#8455` is then parsed as a line directive and the PPX stage fails with `Syntax error`.

Blocked CI on every PR branched from main after #8635 merged — #8637, #8640, #8643 all fail Build / Lint / Health with identical error.

## Evidence

```
File "lib/event_kind.mli", line 10, characters 33-36:
10 |     (board.*, agent.*, keeper.*) are tracked in #8455 and will be
                                       ^^^
Error: Syntax error
```

Main CI (run 24627629909) is also `conclusion: failure` with the same error.

## Fix

Replace `keeper.*)` → `keeper.*,` and promote trailing `, ...` to indicate open enumeration. Also drop `[task.*]` brackets on the first sentence because `[...]` is an odoc code span and asterisks inside can confuse nested parsers.

## Test plan

- [ ] CI green (unblocks #8637 / #8640 / #8643 once merged)
- No runtime behavior change; pure docstring fix.

## Root cause — how #8635 landed broken

The PR description's review didn't build with warnings-as-errors locally, and auto-merge fired on pending CI before the build step completed. The `*)` sequence is easy to miss in review because `.*)` looks visually like regex. Adding a lint rule to reject unescaped `*)` inside OCaml docstrings is tracked separately (out of scope here — hotfix priority).