### PR TITLE
chore(event_kind): Message variant module + 2 emitter migrations (#8455 Phase 3)

### DIFF
--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -44,12 +44,14 @@ let emit_message_activity config ~from_agent ~content ~mention
         Log.Misc.warn "message activity emit failed (%s): %s" kind
           (Printexc.to_string exn)
   in
-  emit ~kind:"message.broadcast" ~tags:[ "message"; "broadcast" ] ();
+  emit
+    ~kind:(Event_kind.Message.to_string Event_kind.Message.Broadcast)
+    ~tags:[ "message"; "broadcast" ] ();
   match mention with
   | Some target when String.trim target <> "" ->
       emit
         ~subject:Coord_hooks.{ kind = "agent"; id = target }
-        ~kind:"message.mentioned"
+        ~kind:(Event_kind.Message.to_string Event_kind.Message.Mentioned)
         ~tags:[ "message"; "mention" ] ()
   | _ -> ()
 

--- a/lib/coord/event_kind.ml
+++ b/lib/coord/event_kind.ml
@@ -40,3 +40,20 @@ module Task = struct
     [ Created; Claimed; Started; Released; Done; Cancelled;
       Submit_for_verification; Approved; Rejected; Linked ]
 end
+
+module Message = struct
+  type t =
+    | Broadcast
+    | Mentioned
+
+  let to_string = function
+    | Broadcast -> "message.broadcast"
+    | Mentioned -> "message.mentioned"
+
+  let of_string = function
+    | "message.broadcast" -> Some Broadcast
+    | "message.mentioned" -> Some Mentioned
+    | _ -> None
+
+  let all = [ Broadcast; Mentioned ]
+end

--- a/lib/coord/event_kind.mli
+++ b/lib/coord/event_kind.mli
@@ -6,9 +6,10 @@
     this module both sides used raw [string]; a typo on either side
     compiled clean and silently diverged at runtime.
 
-    This module is the SSOT for the task.* family. Other families
-    (board.*, agent.*, keeper.*, ...) are tracked in issue 8455 and
-    will be migrated in follow-up PRs on the same pattern.
+    This module is the SSOT for the task.* and message.* families.
+    Other families (board.*, agent.*, keeper.*, ...) are tracked in
+    issue 8455 and will be migrated in follow-up PRs on the same
+    pattern.
 
     Parse boundary: {!Task.of_string} at JSONL / wire ingress only;
     internal code uses [Task.t] directly so typos become compile
@@ -37,4 +38,16 @@ module Task : sig
   val all : t list
   (** Exhaustive enumeration; useful for tests that want to assert
       every variant round-trips through JSON. *)
+end
+
+module Message : sig
+  type t =
+    | Broadcast
+    | Mentioned
+
+  val to_string : t -> string
+  (** Canonical dotted-form wire name ([\"message.broadcast\"] etc.). *)
+
+  val of_string : string -> t option
+  val all : t list
 end

--- a/lib/coord/event_kind.mli
+++ b/lib/coord/event_kind.mli
@@ -46,7 +46,7 @@ module Message : sig
     | Mentioned
 
   val to_string : t -> string
-  (** Canonical dotted-form wire name ([\"message.broadcast\"] etc.). *)
+  (** Canonical dotted-form wire name (e.g. [message.broadcast]). *)
 
   val of_string : string -> t option
   val all : t list

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -41,4 +41,33 @@ let () =
         exit 1
       end)
     Event_kind.Task.all;
+  (* Message family *)
+  List.iter
+    (fun v ->
+      let s = Event_kind.Message.to_string v in
+      match Event_kind.Message.of_string s with
+      | Some v' when v' = v -> ()
+      | Some _ ->
+          Printf.eprintf
+            "event_kind Message roundtrip mismatch for %s\n%!" s;
+          exit 1
+      | None ->
+          Printf.eprintf
+            "event_kind Message of_string returned None for %s\n%!" s;
+          exit 1)
+    Event_kind.Message.all;
+  (match Event_kind.Message.of_string "message.brodacast" with
+   | Some _ ->
+       prerr_endline "event_kind Message.of_string accepted a typo";
+       exit 1
+   | None -> ());
+  List.iter
+    (fun v ->
+      let s = Event_kind.Message.to_string v in
+      if not (String.length s > 8 && String.sub s 0 8 = "message.") then begin
+        Printf.eprintf
+          "event_kind Message name does not start with \"message.\": %s\n%!" s;
+        exit 1
+      end)
+    Event_kind.Message.all;
   print_endline "test_event_kind: OK"


### PR DESCRIPTION
## Summary

Phase 3 of #8455. Extends the event-kind SSOT with the `message.*` family (Broadcast, Mentioned). Same pattern as Task (#8635) and Board (#8643).

## New variant module

`Event_kind.Message.t` — 2 variants. Parse boundary same as prior families: `of_string` at wire ingress, `to_string` at emit sites.

## Migrated emitters (2 sites)

- `lib/coord/coord_broadcast.ml:47,52` — both emit sites for `message.broadcast` and `message.mentioned` now reference the variant.

Verification: `Event_kind.Message.Brodacast` → `Error: Unbound constructor Brodacast. Did you mean Broadcast?`.

## Test

`test/test_event_kind.ml` — round-trip, typo-rejection, prefix-invariant triple for Message.

## Not in this PR

agent.*, keeper.*, decision.*, operation.*, policy.*, tool.* families land in follow-ups. #8455 stays open as umbrella.

## Test plan

- [ ] CI green
- No behavior change; pure SSOT extension.