### PR TITLE
chore(config): SSOT for MASC_BASE_PATH / MASC_BASE_PATH_INPUT env keys (#8352 Phase 2)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -217,6 +217,13 @@ let get_port ~default name =
 
 (** {1 Core Path / Storage} *)
 
+(** Env var names exposed as SSOT constants so out-of-process callers
+    that read/write the variable by name (docker worker putenv, sidecar
+    lookup, config doctor diagnostics, runtime-bootstrap putenv) can
+    reference the same literal. Issue 8352. *)
+let base_path_env_key = "MASC_BASE_PATH"
+let base_path_input_env_key = "MASC_BASE_PATH_INPUT"
+
 (** Project base path for .masc data directory.
     Used by board, checkpoint, thompson_sampling, voice, keeper.
     Set at startup; may be overridden from inside the running process via
@@ -224,11 +231,11 @@ let get_port ~default name =
     running server.
     Returns None when MASC_BASE_PATH is unset or empty. *)
 let base_path_source_opt () =
-  match raw_value_opt "MASC_BASE_PATH_INPUT" |> trim_opt with
-  | Some value -> Some ("MASC_BASE_PATH_INPUT", value)
+  match raw_value_opt base_path_input_env_key |> trim_opt with
+  | Some value -> Some (base_path_input_env_key, value)
   | None ->
-      (match raw_value_opt "MASC_BASE_PATH" |> trim_opt with
-       | Some value -> Some ("MASC_BASE_PATH", value)
+      (match raw_value_opt base_path_env_key |> trim_opt with
+       | Some value -> Some (base_path_env_key, value)
        | None -> None)
 
 let base_path_raw_opt () =

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -61,7 +61,7 @@ let server_entries =
     entry ~default:Env_config_core.default_host "MASC_HOST" "Server bind host";
     entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
-    entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";
+    entry ~default:"(cwd)" Env_config_core.base_path_env_key "Base storage directory";
     entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
     entry ~default:Masc_network_defaults.masc_http_default_host
       "MASC_HTTP_HOST" "HTTP server listen host";

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -102,7 +102,7 @@ let current_inputs ~base_path_input ~default_base_path () =
     | Some source -> Some source
     | None ->
         let inherited_env_matches =
-          match Sys.getenv_opt "MASC_BASE_PATH" with
+          match Sys.getenv_opt Env_config_core.base_path_env_key with
           | Some existing ->
               String.equal
                 (Env_config_core.normalize_masc_base_path_input existing)

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -114,7 +114,7 @@ let sync_test_base_path_env resolved_path =
     match Env_config_core.base_path_opt () with
     | Some current when String.equal current resolved_path -> ()
     | _ ->
-        Unix.putenv "MASC_BASE_PATH" resolved_path;
+        Unix.putenv Env_config_core.base_path_env_key resolved_path;
         Unix.putenv "MASC_TEST_SYNCED_BASE_PATH" resolved_path;
         Log.Coord.info "Synchronized MASC_BASE_PATH=%s for test executable %s"
           resolved_path (Filename.basename Sys.executable_name)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -50,7 +50,7 @@ let runtime_base_path ?base_path () =
   match trim_opt base_path with
   | Some path -> path
   | None -> (
-      match Sys.getenv_opt "MASC_BASE_PATH" with
+      match Sys.getenv_opt Env_config_core.base_path_env_key with
       | Some p when String.length (String.trim p) > 0 -> String.trim p
       | _ -> Sys.getcwd ())
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -182,8 +182,10 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   ensure_default_oas_cascade_timeout_env ();
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
   Exec_tap.install_from_env ();
-  Unix.putenv "MASC_BASE_PATH_INPUT" (Option.value ~default:"" input_base_path);
-  Unix.putenv "MASC_BASE_PATH" base_path;
+  Unix.putenv
+    Env_config_core.base_path_input_env_key
+    (Option.value ~default:"" input_base_path);
+  Unix.putenv Env_config_core.base_path_env_key base_path;
   bootstrap_base_path_config_root ~base_path;
   (* Apply keeper runtime overrides from the resolved config root's
      keeper_runtime.toml. Must run before any module that reads

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -103,7 +103,7 @@ let allowlisted_env_pairs () =
       "GOOGLE_CLOUD_PROJECT";
       "GOOGLE_CLOUD_LOCATION";
       "MASC_STORAGE_TYPE";
-      "MASC_BASE_PATH";
+      Env_config_core.base_path_env_key;
       "MASC_CONFIG_DIR";
     ]
   in
@@ -116,7 +116,7 @@ let allowlisted_env_pairs () =
   in
   let overrides =
     [
-      ("MASC_BASE_PATH", "");
+      (Env_config_core.base_path_env_key, "");
       ("MASC_HTTP_BASE_URL", docker_http_base_url ());
       (Env_config_runtime.Local_runtime.mcp_url_env_key, docker_mcp_url ());
       ("LLAMA_SERVER_URL", docker_llama_server_url ());


### PR DESCRIPTION
## Summary

Second batch for #8352. Follows the same pattern as #8629 (MASC_MCP_URL, now merged). Adds SSOT constants for `MASC_BASE_PATH` + `MASC_BASE_PATH_INPUT` — 9 literal sites across 7 files.

## New constants (`lib/config/env_config_core.ml`)

```ocaml
let base_path_env_key = "MASC_BASE_PATH"
let base_path_input_env_key = "MASC_BASE_PATH_INPUT"
```

## Migrated call sites

| File | Site | Reason to read raw name |
|------|------|-------------------------|
| `env_config_core.ml:230-231` | `base_path_source_opt` | self-reference to own constants |
| `coord_utils_backend_setup.ml:117` | test env sync `putenv` | |
| `server_runtime_bootstrap.ml:185-186` | startup `putenv` (both env keys) | |
| `server_routes_http_routes_sidecar.ml:53` | sidecar lookup | |
| `config_doctor.ml:105` | doctor diagnostics | |
| `worker_runtime_docker.ml:106,119` | container env inheritance key + override map entry | |
| `env_config_snapshot.ml:64` | snapshot catalog entry | |

Several sites cannot just read via `base_path_opt()` because they legitimately need the raw env-var name string (container inheritance keys, `putenv` calls, user-facing diagnostics). Exposing the name as a constant lets them stop re-inlining the literal.

## Not in this PR

Other env vars in #8352 umbrella (`MASC_HTTP_BASE_URL`, `MASC_STORAGE_TYPE`, `MASC_ORCHESTRATOR_ENABLED`, `MASC_KEEPER_*`, `MASC_HTTP_PORT`, etc.) land in follow-ups.

## Test plan

- [ ] CI green
- No behavior change; pure literal hoist.