### PR TITLE
chore(dashboard): remove dead operation_severity helper (#8645)

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -370,12 +370,11 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
           ]);
   }
 
-let operation_severity ~(status : string) ~blocker_summary =
-  match status with
-  | "failed" | "cancelled" -> Tone_bad
-  | "paused" -> Tone_warn
-  | _ when Option.is_some blocker_summary -> Tone_warn
-  | _ -> Tone_ok
+(* Issue #8645: removed dead [operation_severity ~status ~blocker_summary]
+   helper — zero callers in lib/test, not exposed via .mli. The body
+   also carried the #8605 anti-pattern (catch-all to [Tone_ok]). If
+   future code needs status-based severity, re-introduce with a Variant
+   input + exhaustive match instead of a string. *)
 
 let build_operation_contexts () =
   []


### PR DESCRIPTION
## Summary

Closes #8645. Re-spun from closed #8646 which bundled this with the #8635 main fix that #8647 already shipped.

\`Dashboard_execution_builders.operation_severity\` had zero callers (verified via \`rg\`). Body also carried the #8605 anti-pattern (\`_ -> Tone_ok\` silent permissive default). Same shape as #8609 (wait_mode) and #8651 (operator_digest_event).

## Verification

\`\`\`bash
rg "operation_severity"   # 0 results
dune build --root=\$PWD    # clean (full tree)
\`\`\`

## Test plan

- [x] dune build clean
- [x] zero remaining call sites
- [ ] CI green