### PR TITLE
fix(dashboard): cache patchers cover all 10 lifecycle events (#8396)

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -134,33 +134,51 @@ let _transport_health_cache =
         );
       ])
 
+(* Issue #8396: cache patchers used to recognise only 7 lifecycle event
+   names while [Keeper_lifecycle_events.all_event_names] now publishes
+   10. The drift left dashboard rows stale until the next full
+   recompute when the supervisor emitted [dead_cleaned],
+   [self_preservation], [paused_pruned], or the phase-derived [running].
+
+   The 4 patchers below remain string-typed (cache rows deserialise
+   from JSON), but each [match] now covers every name in the SSOT.
+   The sync test in [test/test_types.ml :: lifecycle_event_cache_patcher_coverage]
+   asserts every name in [Keeper_lifecycle_events.all_event_names]
+   returns [Some] from at least one of these patchers. *)
+
 let keepalive_running_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" -> Some true
-  | "resumed" -> Some true
+  | "started" | "restarted" | "reconciled" | "running" -> Some true
+  | "resumed" | "self_preservation" -> Some true
   | "paused" -> Some true
+  | "paused_pruned" -> Some false   (* prune == removed from supervision *)
+  | "dead_cleaned" -> Some false    (* cleanup == no longer alive *)
   | "stopped" | "crashed" | "dead" -> Some false
   | _ -> None
 
 let phase_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" -> Some "running"
-  | "resumed" -> Some "running"
+  | "started" | "restarted" | "reconciled" | "running" -> Some "running"
+  | "resumed" | "self_preservation" -> Some "running"
   | "paused" -> Some "paused"
+  | "paused_pruned" -> Some "stopped"
   | "stopped" -> Some "stopped"
   | "crashed" -> Some "crashed"
-  | "dead" -> Some "dead"
+  | "dead" | "dead_cleaned" -> Some "dead"
   | _ -> None
 
 let pipeline_stage_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" -> Some "idle"
-  | "resumed" -> Some "idle"
+  | "started" | "restarted" | "reconciled" | "running" -> Some "idle"
+  | "resumed" | "self_preservation" -> Some "idle"
   | "paused" -> Some "paused"
-  | "stopped" | "dead" -> Some "offline"
+  | "paused_pruned" -> Some "offline"
+  | "stopped" | "dead" | "dead_cleaned" -> Some "offline"
   | "crashed" -> Some "crashed"
   | _ -> None
 
 let paused_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" | "resumed" -> Some false
-  | "paused" | "stopped" -> Some true
+  | "started" | "restarted" | "reconciled" | "resumed" | "running"
+  | "self_preservation" -> Some false
+  | "paused" | "paused_pruned" | "stopped" -> Some true
+  | "dead" | "dead_cleaned" | "crashed" -> Some false
   | _ -> None
 
 let keeper_agent_status_opt row =

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1121,6 +1121,50 @@ let () =
         Alcotest.(check int) "no duplicates" (List.length names)
           (List.length dedup));
     ];
+    "lifecycle_event_cache_patcher_coverage", [
+      (* Issue #8396: dashboard cache patchers used to recognise only
+         a 7-name subset of [Keeper_lifecycle_events.all_event_names].
+         When the supervisor emitted [dead_cleaned] / [self_preservation]
+         / [paused_pruned] / [running] (phase-derived), cached rows
+         stayed stale until the next full recompute. These tests pin
+         the invariant that *every* SSOT event name produces a [Some]
+         from at least one of the 4 patchers — a new event added to
+         the SSOT without updating the patcher fails this test. *)
+      Alcotest.test_case "every SSOT event has at least one patcher hit" `Quick (fun () ->
+        let module S = Masc_mcp.Server_dashboard_http_execution_surfaces in
+        let module L = Masc_mcp.Keeper_lifecycle_events in
+        List.iter (fun event ->
+          let any =
+            S.keepalive_running_of_lifecycle_event event <> None
+            || S.phase_of_lifecycle_event event <> None
+            || S.pipeline_stage_of_lifecycle_event event <> None
+            || S.paused_of_lifecycle_event event <> None
+          in
+          Alcotest.(check bool)
+            (Printf.sprintf "%s patched by at least one patcher" event)
+            true any)
+          L.all_event_names);
+      Alcotest.test_case "every SSOT event hits keepalive_running patcher" `Quick (fun () ->
+        let module S = Masc_mcp.Server_dashboard_http_execution_surfaces in
+        let module L = Masc_mcp.Keeper_lifecycle_events in
+        List.iter (fun event ->
+          Alcotest.(check bool)
+            (Printf.sprintf "%s -> Some" event) true
+            (S.keepalive_running_of_lifecycle_event event <> None))
+          L.all_event_names);
+      Alcotest.test_case "every SSOT event hits phase patcher" `Quick (fun () ->
+        let module S = Masc_mcp.Server_dashboard_http_execution_surfaces in
+        let module L = Masc_mcp.Keeper_lifecycle_events in
+        List.iter (fun event ->
+          Alcotest.(check bool)
+            (Printf.sprintf "%s -> Some" event) true
+            (S.phase_of_lifecycle_event event <> None))
+          L.all_event_names);
+      Alcotest.test_case "unknown event still returns None" `Quick (fun () ->
+        let module S = Masc_mcp.Server_dashboard_http_execution_surfaces in
+        Alcotest.(check bool) "fabricated -> None" true
+          (S.keepalive_running_of_lifecycle_event "fabricated_event" = None));
+    ];
     "publish_phase_lifecycle_ssot", [
       (* Issue #8572: phase-bearing publish_lifecycle calls used to pass
          a hand-coded event_name string alongside the phase Variant —


### PR DESCRIPTION
## Summary

Closes #8396. The 4 cache patchers in \`server_dashboard_http_execution_surfaces.ml\` recognised only a 7-name subset of \`Keeper_lifecycle_events.all_event_names\` (10 names since the #8575 SSOT extraction). When the supervisor emitted \`dead_cleaned\` / \`self_preservation\` / \`paused_pruned\` / \`running\`, cached dashboard rows stayed stale until the next full recompute.

## Changes

| Patcher | New coverage |
|---|---|
| \`keepalive_running_of_lifecycle_event\` | + self_preservation, paused_pruned, dead_cleaned, running |
| \`phase_of_lifecycle_event\` | same |
| \`pipeline_stage_of_lifecycle_event\` | same |
| \`paused_of_lifecycle_event\` | same |

Mappings:
- \`self_preservation\` → running (active recovery, alive)
- \`paused_pruned\` → stopped/offline + paused=true (pruned from supervision)
- \`dead_cleaned\` → dead/offline + not running (cleanup completed)
- \`running\` → running/idle (phase-derived, neutral state)

## Sync Test

\`test/test_types.ml :: lifecycle_event_cache_patcher_coverage\` (4 cases) — every name in \`all_event_names\` must produce \`Some\` from at least one patcher. Adding a new event to \`Keeper_lifecycle_events\` without updating the patcher will fail the test.

## Verification

\`\`\`bash
dune build --root=\$PWD                                            # clean
dune exec test/test_types.exe -- test lifecycle_event_cache_patcher_coverage
# 4/4 OK
\`\`\`

## Test plan

- [x] dune build clean (full tree)
- [x] cache patcher coverage 4/4 OK
- [ ] CI green