### PR TITLE
fix(dashboard): cache keeper accountability summaries per request

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -233,6 +233,14 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
           (Printexc.to_string exn);
         []
   in
+  let accountability_summary =
+    if compact || Keeper_decision_audit.decision_layer_level () < 3 then
+      (fun ~keeper_name ~agent_name ->
+        Keeper_exec_status_metrics.accountability_summary_json config
+          ~keeper_name ~agent_name)
+    else
+      Keeper_exec_status_metrics.accountability_summary_lookup config
+  in
   (* Parallel keeper I/O: each keeper's metadata + metrics reads run concurrently.
      Results are collected into a shared ref array, then filter_map'd. *)
   let results = Array.make (List.length names) None in
@@ -650,8 +658,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                     `List (List.filteri (fun i _ -> i < 10) keeper_events)
                   in
                   let accountability =
-                    Keeper_exec_status_metrics.accountability_summary_json config
-                      ~keeper_name:m.name ~agent_name:m.agent_name
+                    accountability_summary ~keeper_name:m.name
+                      ~agent_name:m.agent_name
                   in
                   `Assoc [
                     ("reputation", reputation);

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -46,6 +46,7 @@ type claim_snapshot = {
 
 let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 let store_cache_mu = Eio.Mutex.create ()
+let window_read_count_for_testing_ref : int option ref = ref None
 
 let task_commitment_expiry_sec = 72.0 *. 3600.0
 let completion_claim_expiry_sec = 24.0 *. 3600.0
@@ -245,6 +246,9 @@ let resolution_event_of_json json =
   | _ -> None
 
 let read_window_entries (config : Coord_query.config) =
+  (match !window_read_count_for_testing_ref with
+  | Some count -> window_read_count_for_testing_ref := Some (count + 1)
+  | None -> ());
   let now = Time_compat.now () in
   let since = event_date_string (now -. (float_of_int summary_window_days *. 86400.0)) in
   let until = event_date_string now in
@@ -531,16 +535,10 @@ let risk_band_of_metrics ~evidence_coverage ~unsupported_completion_rate
   else
     "high"
 
-let accountability_summary_json (config : Coord_query.config) ~keeper_name
-    ~agent_name =
-  let now = Time_compat.now () in
-  let cutoff = now -. (float_of_int summary_window_days *. 86400.0) in
-  let snapshots =
-    materialize_claims (read_window_entries config)
-    |> List.filter (fun snapshot ->
-           String.equal snapshot.claim.agent_name agent_name
-           && created_at_unix snapshot.claim >= cutoff)
-  in
+let summary_cutoff now =
+  now -. (float_of_int summary_window_days *. 86400.0)
+
+let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
   let supported_claims = ref 0 in
   let resolved_claims = ref 0 in
   let unsupported_completion_claims = ref 0 in
@@ -549,6 +547,7 @@ let accountability_summary_json (config : Coord_query.config) ~keeper_name
   let supported_task_commitments = ref 0 in
   let resolved_task_commitments = ref 0 in
   let recent_supported_claims = ref 0 in
+  let cutoff = summary_cutoff now in
   List.iter
     (fun (snapshot : claim_snapshot) ->
       let status = effective_status ~now snapshot in
@@ -657,6 +656,45 @@ let accountability_summary_json (config : Coord_query.config) ~keeper_name
       ("routing_hint", `String routing_hint);
       ("history", `List history);
     ]
+
+let accountability_summary_lookup (config : Coord_query.config) =
+  let now = Time_compat.now () in
+  let cutoff = summary_cutoff now in
+  let by_agent : (string, claim_snapshot list) Hashtbl.t = Hashtbl.create 32 in
+  (* Request-local pre-aggregation: the dashboard rebuilds this lookup per
+     render, so the next request naturally refreshes the window contents. *)
+  materialize_claims (read_window_entries config)
+  |> List.iter (fun snapshot ->
+         if created_at_unix snapshot.claim >= cutoff then
+           let existing =
+             match Hashtbl.find_opt by_agent snapshot.claim.agent_name with
+             | Some items -> items
+             | None -> []
+           in
+           Hashtbl.replace by_agent snapshot.claim.agent_name
+             (snapshot :: existing));
+  fun ~keeper_name ~agent_name ->
+    let snapshots =
+      match Hashtbl.find_opt by_agent agent_name with
+      | Some items -> items
+      | None -> []
+    in
+    summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots
+
+let accountability_summary_json (config : Coord_query.config) ~keeper_name
+    ~agent_name =
+  accountability_summary_lookup config ~keeper_name ~agent_name
+
+let enable_window_read_count_for_testing () =
+  window_read_count_for_testing_ref := Some 0
+
+let disable_window_read_count_for_testing () =
+  window_read_count_for_testing_ref := None
+
+let window_read_count_for_testing () =
+  match !window_read_count_for_testing_ref with
+  | Some count -> count
+  | None -> 0
 
 let accountability_risk_is_high config ~keeper_name ~agent_name =
   match accountability_summary_json config ~keeper_name ~agent_name with

--- a/lib/keeper/keeper_accountability.mli
+++ b/lib/keeper/keeper_accountability.mli
@@ -38,6 +38,16 @@ val accountability_summary_json :
   agent_name:string ->
   Yojson.Safe.t
 
+val accountability_summary_lookup :
+  Coord_query.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  Yojson.Safe.t
+
+val enable_window_read_count_for_testing : unit -> unit
+val disable_window_read_count_for_testing : unit -> unit
+val window_read_count_for_testing : unit -> int
+
 val accountability_risk_is_high :
   Coord_query.config ->
   keeper_name:string ->

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -611,6 +611,9 @@ let latest_tool_audit_snapshot_from_files config ~keeper_name =
   | Some _ as snapshot -> snapshot
   | None -> latest_tool_audit_snapshot_from_metrics config keeper_name
 
+let accountability_summary_lookup config =
+  Keeper_accountability.accountability_summary_lookup config
+
 let accountability_summary_json config ~keeper_name ~agent_name =
   Keeper_accountability.accountability_summary_json config ~keeper_name
     ~agent_name

--- a/lib/keeper/keeper_exec_status_metrics.mli
+++ b/lib/keeper/keeper_exec_status_metrics.mli
@@ -15,5 +15,10 @@ val summarize_metrics_lines :
 val empty_tool_audit_snapshot : tool_audit_snapshot
 val latest_tool_audit_snapshot_from_files :
   Coord.config -> keeper_name:string -> tool_audit_snapshot option
+val accountability_summary_lookup :
+  Coord.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  Yojson.Safe.t
 val accountability_summary_json :
   Coord.config -> keeper_name:string -> agent_name:string -> Yojson.Safe.t

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -258,6 +258,95 @@ let test_synthetic_claims_do_not_dilute_unsupported_rate () =
       check string "risk band should be high" "high"
         (string_member "risk_band" summary))
 
+let test_summary_lookup_reads_window_once_for_multiple_agents () =
+  with_room (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      List.iter
+        (fun (claim_id, keeper_name, agent_name, subject) ->
+          append_accountability_event config.base_path ~created_at
+            (`Assoc
+               [
+                 ("event_type", `String "claim_created");
+                 ("claim_id", `String claim_id);
+                 ("agent_name", `String agent_name);
+                 ("keeper_name", `String keeper_name);
+                 ("kind", `String "completion_claim");
+                 ("subject", `String subject);
+                 ("surface", `String "keeper_turn");
+                 ("created_at", `String created_at);
+                 ("evidence_refs", `List []);
+                 ("synthetic", `Bool false);
+               ]))
+        [
+          ("acct-a", "keeper-a", "keeper-a-agent", "Ship A");
+          ("acct-b", "keeper-b", "keeper-b-agent", "Ship B");
+        ];
+      Keeper_accountability.enable_window_read_count_for_testing ();
+      let read_count =
+        Fun.protect
+          ~finally:Keeper_accountability.disable_window_read_count_for_testing
+          (fun () ->
+            let lookup =
+              Keeper_accountability.accountability_summary_lookup config
+            in
+            let summary_a =
+              lookup ~keeper_name:"keeper-a" ~agent_name:"keeper-a-agent"
+            in
+            let summary_b =
+              lookup ~keeper_name:"keeper-b" ~agent_name:"keeper-b-agent"
+            in
+            check string "agent a risk" "high"
+              (string_member "risk_band" summary_a);
+            check string "agent b risk" "high"
+              (string_member "risk_band" summary_b);
+            Keeper_accountability.window_read_count_for_testing ())
+      in
+      check int "window read count" 1 read_count)
+
+let test_summary_json_rereads_window_per_agent () =
+  with_room (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      List.iter
+        (fun (claim_id, keeper_name, agent_name, subject) ->
+          append_accountability_event config.base_path ~created_at
+            (`Assoc
+               [
+                 ("event_type", `String "claim_created");
+                 ("claim_id", `String claim_id);
+                 ("agent_name", `String agent_name);
+                 ("keeper_name", `String keeper_name);
+                 ("kind", `String "completion_claim");
+                 ("subject", `String subject);
+                 ("surface", `String "keeper_turn");
+                 ("created_at", `String created_at);
+                 ("evidence_refs", `List []);
+                 ("synthetic", `Bool false);
+               ]))
+        [
+          ("acct-json-a", "keeper-json-a", "keeper-json-a-agent", "Ship A");
+          ("acct-json-b", "keeper-json-b", "keeper-json-b-agent", "Ship B");
+        ];
+      Keeper_accountability.enable_window_read_count_for_testing ();
+      let read_count =
+        Fun.protect
+          ~finally:Keeper_accountability.disable_window_read_count_for_testing
+          (fun () ->
+            ignore
+              (Keeper_accountability.accountability_summary_json config
+                 ~keeper_name:"keeper-json-a"
+                 ~agent_name:"keeper-json-a-agent");
+            ignore
+              (Keeper_accountability.accountability_summary_json config
+                 ~keeper_name:"keeper-json-b"
+                 ~agent_name:"keeper-json-b-agent");
+            Keeper_accountability.window_read_count_for_testing ())
+      in
+      check int "window read count" 2 read_count)
+
 (* --- Attribution tests --- *)
 
 module A = Masc_mcp.Attribution
@@ -352,6 +441,10 @@ let () =
             `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
           test_case "synthetic claims do not dilute unsupported rate" `Quick
             test_synthetic_claims_do_not_dilute_unsupported_rate;
+          test_case "summary lookup reads window once" `Quick
+            test_summary_lookup_reads_window_once_for_multiple_agents;
+          test_case "summary json rereads window per agent" `Quick
+            test_summary_json_rereads_window_per_agent;
         ] );
       ( "attribution",
         [


### PR DESCRIPTION
## Summary
- build a request-local accountability summary lookup for the keeper dashboard so one render reads the 14-day accountability window once instead of once per keeper
- keep the legacy per-agent path for compact mode or low decision-layer mode, while routing the hot dashboard path through the cached lookup
- add regression coverage that proves the lookup path reads once and the legacy path still rereads per agent

## Product impact
- reduces dashboard render pressure by removing repeated 14-day accountability ledger rescans from the hot keeper overview path
- keeps compact mode and low decision-layer mode behavior unchanged while improving the default dashboard path
- lowers the risk of dashboard timeout pressure when keeper count grows

## Changed files
- `lib/dashboard/dashboard_http_keeper.ml`
- `lib/keeper/keeper_accountability.ml`
- `lib/keeper/keeper_accountability.mli`
- `lib/keeper/keeper_exec_status_metrics.ml`
- `lib/keeper/keeper_exec_status_metrics.mli`
- `test/test_keeper_accountability.ml`

## Review evidence
- Targeted build: `OCAMLPARAM='_,warn-error=-9' opam exec -- dune build --root . ./test/test_keeper_accountability.exe`
- Targeted tests: `_build/default/test/test_keeper_accountability.exe test --color=never --json accountability 4,5`
- Result: `success=2 failures=0`
- Regression guard: `summary lookup reads window once` asserts read count `1`, while `summary json rereads window per agent` asserts read count `2`

## Linked issue
- `Refs #7162`

## Notes
- lookup invalidation is request-local: the dashboard rebuilds the lookup on each render, so subsequent requests naturally re-read the latest accountability window
- compact mode and lower decision-layer mode intentionally keep the legacy per-agent summary path