### PR TITLE
keeper: expose routing hint during preflight

### DIFF
--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -1,5 +1,12 @@
 open Keeper_types
 
+let json_string_field name = function
+  | `Assoc fields -> (
+      match List.assoc_opt name fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
 let handle_keeper_preflight_check
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -63,9 +70,20 @@ let handle_keeper_preflight_check
   in
   let () = add_check "preset" preset_ok preset_name in
   (* Check 5: accountability risk *)
+  let accountability_summary =
+    Keeper_accountability.accountability_summary_json config ~keeper_name:meta.name
+      ~agent_name:meta.agent_name
+  in
+  let risk_band =
+    json_string_field "risk_band" accountability_summary
+    |> Option.value ~default:"unknown"
+  in
+  let routing_hint =
+    json_string_field "routing_hint" accountability_summary
+    |> Option.value ~default:"normal_routing"
+  in
   let accountability_risk =
-    Keeper_accountability.accountability_risk_is_high config ~keeper_name:meta.name
-      ~agent_name:meta.name
+    String.equal risk_band "high"
   in
   let () =
     add_check "accountability_risk" (not accountability_risk)
@@ -89,6 +107,8 @@ let handle_keeper_preflight_check
         ; "preset", `String preset_name
         ; "preset_sufficient", `Bool preset_ok
         ; "accountability_risk", `Bool accountability_risk
+        ; "risk_band", `String risk_band
+        ; "routing_hint", `String routing_hint
         ; "clone_target", `String clone_target
         ; "keeper", `String meta.name
         ])

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -36,6 +36,10 @@ let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent
                ("name", `String name);
                ("agent_name", `String agent_name);
                ("trace_id", `String "test-trace-accountability");
+               ( "tool_access",
+                 Keeper_types.tool_access_to_json
+                   (Keeper_types.Preset
+                      { preset = Keeper_types.Full; also_allow = [] }) );
              ])
   with
   | Ok meta -> meta
@@ -194,6 +198,38 @@ let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
         "⚠ Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
         (string_member "routing_warning" result))
 
+let test_preflight_exposes_routing_hint_for_high_risk_keeper () =
+  with_room (fun config ->
+      let meta = make_test_meta () in
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-high-risk-preflight");
+             ("agent_name", `String "keeper-sangsu-agent");
+             ("keeper_name", `String "keeper-sangsu");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Prior claim");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      let result =
+        Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work:(make_ctx_work ())
+          ~name:"keeper_preflight_check" ~input:(`Assoc []) ()
+        |> Yojson.Safe.from_string
+      in
+      check bool "accountability risk present" true
+        (Yojson.Safe.Util.(result |> member "accountability_risk" |> to_bool));
+      check string "risk band exposed" "high" (string_member "risk_band" result);
+      check string "routing hint exposed" "manual_review_recommended"
+        (string_member "routing_hint" result))
+
 let test_synthetic_claims_do_not_dilute_unsupported_rate () =
   (* Regression: synthetic completion claims (created by task_transition "done")
      must NOT be counted in total_completion_claims, otherwise they dilute the
@@ -350,6 +386,8 @@ let () =
             test_stale_completion_claim_sets_high_risk;
           test_case "claim tool exposes routing warning for high risk keeper"
             `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
+          test_case "preflight exposes routing hint for high risk keeper"
+            `Quick test_preflight_exposes_routing_hint_for_high_risk_keeper;
           test_case "synthetic claims do not dilute unsupported rate" `Quick
             test_synthetic_claims_do_not_dilute_unsupported_rate;
         ] );


### PR DESCRIPTION
## Summary
- compute accountability summary during preflight using the same keeper/agent identity tuple as claim
- expose `risk_band` and `routing_hint` on the preflight response before claim mutation
- add a regression test covering a high-risk keeper preflight response

## Testing
- env -u DUNE_RPC opam exec -- dune runtest --root . test/test_keeper_accountability.exe
- env -u DUNE_RPC opam exec -- dune runtest --root . test/test_keeper_task_dispatch.exe

## Context
- task-071
- follow-up for PR7162 routing-hint preflight behavior