### PR TITLE
refactor: room/namespace -> basePath single source of truth

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -410,6 +410,7 @@ let inspect_state ctx =
 
 let state_to_json st =
   `Assoc [
+    ("project_ready", `Bool st.room_set);
     ("namespace_ready", `Bool st.room_set);
     ("room_set", `Bool st.room_set);
     ("joined", `Bool st.joined);
@@ -441,7 +442,7 @@ let handle_workflow_guide ctx _args =
 
 let check_assertion st assertion =
   let (passed, fix_hint) = match assertion with
-    | "namespace_ready" | "room_set" ->
+    | "project_ready" | "namespace_ready" | "room_set" ->
         (st.room_set,
          "Call masc_start with your project root path.")
     | "joined" ->
@@ -467,7 +468,7 @@ let check_assertion st assertion =
 
 let handle_check ctx args =
   let st = inspect_state ctx in
-  let default_assertions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ] in
+  let default_assertions = [ "project_ready"; "joined"; "task_claimed"; "current_task_set" ] in
   let assertions =
     match Yojson.Safe.Util.member "assertions" args with
     | `List items ->

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -58,11 +58,11 @@ Pair with masc_workflow_guide for next-step recommendations.";
           ("items", `Assoc [
             ("type", `String "string");
             ("enum", `List [
-              `String "room_set"; `String "joined"; `String "task_claimed";
+              `String "project_ready"; `String "namespace_ready"; `String "room_set"; `String "joined"; `String "task_claimed";
               `String "current_task_set"; `String "worktree_active";
             ]);
           ]);
-          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Historical key 'room_set' means project scope configured.");
+          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'project_ready'; 'namespace_ready' and historical 'room_set' remain compatibility aliases.");
         ]);
       ]);
       ("required", `List [`String "assertions"]);

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -23,6 +23,8 @@ let empty = { next_steps = []; preconditions = []; common_mistakes = [] }
 
 let s tool reason = { tool; reason }
 
+let project_ready = "project_ready"
+
 let transition_action args =
   let open Yojson.Safe.Util in
   match args |> member "action" |> to_string_option with
@@ -58,7 +60,7 @@ let after_join ~success =
         [ s "masc_status" "Check current namespace state and available tasks";
           s "masc_transition" "Claim an existing task if available (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
-      preconditions = [ "room_set" ];
+      preconditions = [ project_ready ];
       common_mistakes =
         [ "Skipping masc_status — you may duplicate work another agent claimed" ] }
   else
@@ -73,7 +75,7 @@ let after_status ~success =
         [ s "masc_transition" "Claim a task from the available list (action=claim)";
           s "masc_add_task" "Add a new task if the list is empty";
           s "masc_workflow_guide" "Get personalized guidance for your current state" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
@@ -87,14 +89,14 @@ let after_claim_auto_bound ~success =
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated worktree for this task";
           s "masc_heartbeat" "Signal liveness before starting long work" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "Forgetting masc_worktree_create — working on main branch directly" ] }
   else
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
           s "masc_add_task" "Create a task if none exist" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_transition_claim ~success =
@@ -102,7 +104,7 @@ let after_transition_claim ~success =
     { next_steps =
         [ s "masc_plan_set_task" "Bind claimed task as your planning current_task";
           s "masc_worktree_create" "Create an isolated worktree for this task" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "masc_transition(action=claim) only claims backlog ownership — it does not bind planning current_task";
           "Forgetting masc_worktree_create — working on main branch directly" ] }
@@ -110,7 +112,7 @@ let after_transition_claim ~success =
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
           s "masc_add_task" "Create a task if none exist" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_transition_start ~success =
@@ -119,13 +121,13 @@ let after_transition_start ~success =
         [ s "masc_heartbeat" "Signal liveness before and during longer work";
           s "masc_broadcast" "Share that you started active implementation";
           s "masc_transition" "Mark the task complete when implementation is finished (action=done)" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ];
+      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check the task state before retrying the transition";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_transition_release_or_cancel ~success =
@@ -134,13 +136,13 @@ let after_transition_release_or_cancel ~success =
         [ s "masc_status" "Check the remaining backlog after releasing or cancelling the task";
           s "masc_transition" "Claim another task if work should continue (action=claim)";
           s "masc_add_task" "Create a replacement task only if the cancelled work still needs tracking" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check task state and ownership before retrying";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_transition_generic ~success =
@@ -148,14 +150,14 @@ let after_transition_generic ~success =
     { next_steps =
         [ s "masc_status" "Refresh namespace state after the transition";
           s "masc_workflow_guide" "Inspect the next recommended step for your current state" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "masc_transition follow-up depends on action. claim may require masc_plan_set_task, while done/release/cancel do not." ] }
   else
     { next_steps =
         [ s "masc_status" "Check task state before retrying the transition";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_add_task ~success =
@@ -163,13 +165,13 @@ let after_add_task ~success =
     { next_steps =
         [ s "masc_transition" "Claim the task you just created (action=claim)";
           s "masc_status" "Verify the task appears in the list" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "Creating a task without claiming it — another agent may take it" ] }
   else
     { next_steps =
         [ s "masc_status" "Check namespace state for errors" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 let after_plan_set_task ~success =
@@ -177,13 +179,13 @@ let after_plan_set_task ~success =
     { next_steps =
         [ s "masc_worktree_create" "Create worktree for isolated work";
           s "masc_heartbeat" "Signal liveness before starting long work" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      preconditions = [ project_ready; "joined"; "task_claimed" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_transition" "Claim a task first (action=claim)";
           s "masc_status" "Verify your claimed task exists" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "Calling plan_set_task without a claimed task" ] }
 
@@ -192,7 +194,7 @@ let after_heartbeat ~success =
     { next_steps =
         [ s "masc_broadcast" "Share progress with other agents";
           s "masc_transition" "Mark task complete when finished (action=done)" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
@@ -206,12 +208,12 @@ let after_done ~success =
         [ s "masc_status" "Check for remaining tasks";
           s "masc_transition" "Pick up the next task (action=claim)";
           s "masc_leave" "Leave the namespace if all work is complete" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check task state — it may already be completed" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
 
 (* ── Common tools ────────────────────────────────────────────────── *)
@@ -220,12 +222,12 @@ let after_broadcast ~success =
   if success then
     { next_steps =
         [ s "masc_heartbeat" "Keep your presence alive" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_join" "Ensure you are in the namespace" ];
-      preconditions = [ "room_set" ];
+      preconditions = [ project_ready ];
       common_mistakes = [] }
 
 let after_worktree_create ~success =
@@ -233,13 +235,13 @@ let after_worktree_create ~success =
     { next_steps =
         [ s "masc_heartbeat" "Signal liveness before starting work";
           s "masc_broadcast" "Let other agents know you started work" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      preconditions = [ project_ready; "joined"; "task_claimed" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_plan_set_task" "Ensure current_task is set";
           s "masc_status" "Check namespace configuration" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      preconditions = [ project_ready; "joined"; "task_claimed" ];
       common_mistakes = [] }
 
 (* ── Main dispatch ───────────────────────────────────────────────── *)
@@ -338,7 +340,7 @@ let current_state_guidance ~room_set ~joined ~task_claimed
   else if not joined then
     { next_steps =
         [ s "masc_join" "Register your agent identity in the project namespace" ];
-      preconditions = [ "room_set" ];
+      preconditions = [ project_ready ];
       common_mistakes =
         [ "Operating without joining — other agents cannot see or coordinate with you" ] }
   else if not task_claimed then
@@ -346,20 +348,20 @@ let current_state_guidance ~room_set ~joined ~task_claimed
         [ s "masc_status" "Check available tasks";
           s "masc_transition" "Claim an existing task (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
-      preconditions = [ "room_set"; "joined" ];
+      preconditions = [ project_ready; "joined" ];
       common_mistakes =
         [ "Modifying code without a claimed task — changes are untracked" ] }
   else if not current_task_set then
     { next_steps =
         [ s "masc_plan_set_task" "Bind your claimed task as current_task" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      preconditions = [ project_ready; "joined"; "task_claimed" ];
       common_mistakes =
         [ "Some claim paths leave planning current_task unset. This commonly happens after masc_transition(action=claim)." ] }
   else if not worktree_active then
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated git worktree for this task";
           s "masc_heartbeat" "Signal liveness if worktree is not needed" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ];
+      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set" ];
       common_mistakes =
         [ "Working directly on main branch without a worktree" ] }
   else if session_active then
@@ -367,12 +369,12 @@ let current_state_guidance ~room_set ~joined ~task_claimed
         [ s "masc_status" "Refresh repo coordination state";
           s "masc_heartbeat" "Keep your presence alive during work";
           s "masc_transition" "Mark the task complete when work is done (action=done)" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active"; "session_active" ];
+      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set"; "worktree_active"; "session_active" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_heartbeat" "Signal liveness while working";
           s "masc_broadcast" "Share progress with teammates";
           s "masc_transition" "Mark task complete when finished (action=done)" ];
-      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
+      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
       common_mistakes = [] }

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -212,6 +212,18 @@ let () = test "dispatch_check_claim_next_marks_current_task_set" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_check_project_ready_alias" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  match Tool_coord.dispatch ctx ~name:"masc_check"
+          ~args:(`Assoc [("assertions", `List [`String "project_ready"])]) with
+  | Some (success, result) ->
+      assert success;
+      let json = Yojson.Safe.from_string result in
+      assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
+  | None -> failwith "dispatch returned None"
+)
+
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -18,6 +18,16 @@ let check_has_tool steps tool_name =
 let check_not_empty msg steps =
   check bool msg true (List.length steps > 0)
 
+let check_has_precondition g expected =
+  check bool
+    (Printf.sprintf "preconditions contain %s" expected)
+    true (List.mem expected g.WG.preconditions)
+
+let check_lacks_precondition g unexpected =
+  check bool
+    (Printf.sprintf "preconditions omit %s" unexpected)
+    false (List.mem unexpected g.WG.preconditions)
+
 (* ── Golden Path 1: Coord/Task Hygiene ────────────────────────────── *)
 
 let test_start_success () =
@@ -35,7 +45,8 @@ let test_join_success () =
   let g = WG.next_steps ~tool_name:"masc_join" ~success:true in
   check_has_tool g.next_steps "masc_status";
   check_has_tool g.next_steps "masc_transition";
-  check bool "join has preconditions" true (List.length g.preconditions > 0)
+  check_has_precondition g "project_ready";
+  check_lacks_precondition g "room_set"
 
 let test_join_failure () =
   let g = WG.next_steps ~tool_name:"masc_join" ~success:false in
@@ -174,7 +185,21 @@ let test_transition_claim_call_guidance () =
       ~args:(`Assoc [ ("action", `String "claim"); ("task_id", `String "task-001") ])
       ~success:true
   in
-  check_has_tool g.next_steps "masc_plan_set_task"
+  check_has_tool g.next_steps "masc_plan_set_task";
+  check_has_precondition g "project_ready";
+  check_lacks_precondition g "room_set"
+
+let test_add_task_success_uses_project_ready () =
+  let g = WG.next_steps ~tool_name:"masc_add_task" ~success:true in
+  check_has_tool g.next_steps "masc_transition";
+  check_has_precondition g "project_ready";
+  check_lacks_precondition g "room_set"
+
+let test_broadcast_success_uses_project_ready () =
+  let g = WG.next_steps ~tool_name:"masc_broadcast" ~success:true in
+  check_has_tool g.next_steps "masc_heartbeat";
+  check_has_precondition g "project_ready";
+  check_lacks_precondition g "room_set"
 
 let test_transition_done_call_guidance () =
   let g =
@@ -247,6 +272,8 @@ let () =
       test_case "complete_task removed" `Quick test_complete_task_removed;
       test_case "transition generic is safe" `Quick test_transition_generic_is_safe;
       test_case "transition claim call guidance" `Quick test_transition_claim_call_guidance;
+      test_case "add_task uses project_ready" `Quick test_add_task_success_uses_project_ready;
+      test_case "broadcast uses project_ready" `Quick test_broadcast_success_uses_project_ready;
       test_case "transition done call guidance" `Quick test_transition_done_call_guidance;
       test_case "transition release call guidance" `Quick test_transition_release_call_guidance;
     ];


### PR DESCRIPTION
## Summary
- unify room/namespace derived paths around `basePath` in coord and workflow guidance surfaces
- update schema and workflow guide references so generated guidance matches the single-source path model
- add coverage for coord output and workflow guide expectations

## Testing
- env -u DUNE_RPC opam exec -- dune runtest --root . test/test_tool_coord_coverage.exe
- env -u DUNE_RPC opam exec -- dune runtest --root . test/test_workflow_guide.exe

## Context
- task-119
- Epic #7261