### PR TITLE
chore(tool_permission): drop dead swarm_start entries (#8661)

### DIFF
--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -66,8 +66,12 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_policy_approve", CanBroadcast);
     ("masc_cleanup_zombies", CanBroadcast);
     ("masc_autoresearch_start", CanAdmin);
-    ("masc_autoresearch_swarm_start", CanAdmin);
-    ("masc_repo_synthesis_swarm_start", CanAdmin);
+    (* Issue #8661: dropped masc_autoresearch_swarm_start /
+       masc_repo_synthesis_swarm_start — tools were retired with the
+       swarm cleanup (#8559) and tests in test_tool_access_policy.ml
+       and test_tool_shard_coverage.ml already pin them as not present.
+       Permission map entries were dead surface granting CanAdmin to
+       non-existent tools. *)
     ("masc_autoresearch_cycle", CanAdmin);
     ("masc_autoresearch_inject", CanAdmin);
     ("masc_autoresearch_stop", CanAdmin);


### PR DESCRIPTION
## Summary

Closes #8661. \`lib/tool_permission_map.ml:69-70\` granted CanAdmin to two retired tools that no longer exist:
- \`masc_autoresearch_swarm_start\`
- \`masc_repo_synthesis_swarm_start\`

Tests in \`test_tool_access_policy.ml\` and \`test_tool_shard_coverage.ml\` already pin these tools as **not present** in shards/schemas. Permission map entries were pure dead surface (same class as #8559 / #8394 / #8651).

## Verification

\`\`\`bash
rg "masc_autoresearch_swarm_start|masc_repo_synthesis_swarm_start" lib/tool_schemas/ lib/tool_catalog*.ml
# (no output)
dune build --root=\$PWD   # clean
\`\`\`

## Test plan

- [x] dune build clean
- [x] zero remaining tool registrations
- [ ] CI green