### PR TITLE
chore(config): SSOT for MASC_HTTP_BASE_URL env key (#8352 Phase 3)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -189,7 +189,7 @@ let rec masc_http_base_url () =
   | Error msg -> raise (Config_error msg)
 
 and masc_http_base_url_result () =
-  match raw_value_opt "MASC_HTTP_BASE_URL" |> trim_opt with
+  match raw_value_opt http_base_url_env_key |> trim_opt with
   | Some base -> Ok (strip_trailing_slashes base)
   | None ->
       let host =
@@ -223,6 +223,7 @@ let get_port ~default name =
     reference the same literal. Issue 8352. *)
 let base_path_env_key = "MASC_BASE_PATH"
 let base_path_input_env_key = "MASC_BASE_PATH_INPUT"
+let http_base_url_env_key = "MASC_HTTP_BASE_URL"
 
 (** Project base path for .masc data directory.
     Used by board, checkpoint, thompson_sampling, voice, keeper.

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -183,6 +183,11 @@ let cluster_name () =
   | Some name -> name
   | None -> "default"
 
+(** SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352).
+    Defined here (above [masc_http_base_url]) so the constant is in scope
+    before first use. *)
+let http_base_url_env_key = "MASC_HTTP_BASE_URL"
+
 let rec masc_http_base_url () =
   match masc_http_base_url_result () with
   | Ok base -> base
@@ -223,7 +228,8 @@ let get_port ~default name =
     reference the same literal. Issue 8352. *)
 let base_path_env_key = "MASC_BASE_PATH"
 let base_path_input_env_key = "MASC_BASE_PATH_INPUT"
-let http_base_url_env_key = "MASC_HTTP_BASE_URL"
+(* http_base_url_env_key is defined above (before masc_http_base_url) so the
+   SSOT constant is in scope at first use. *)
 
 (** Project base path for .masc data directory.
     Used by board, checkpoint, thompson_sampling, voice, keeper.

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -59,7 +59,7 @@ let server_entries =
   [
     entry ~default:Masc_network_defaults.masc_http_default_port_s "MASC_HTTP_PORT" "HTTP server port";
     entry ~default:Env_config_core.default_host "MASC_HOST" "Server bind host";
-    entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
+    entry ~default:"(derived)" Env_config_core.http_base_url_env_key "Public HTTP base URL";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" Env_config_core.base_path_env_key "Base storage directory";
     entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -470,12 +470,13 @@ let legacy_voice_base_url_opt () =
       Some (Printf.sprintf "http://%s:%s" host port)
 
 let http_listener_env_explicit () =
-  Option.is_some (Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt)
+  Option.is_some
+    (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
   || Option.is_some (Sys.getenv_opt "MASC_HOST" |> trim_opt)
   || Option.is_some (Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt)
 
 let default_voice_session_base_url () =
-  match Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt with
+  match Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt with
   | Some base_url -> normalize_base_url base_url
   | None ->
       if http_listener_env_explicit () then

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -8,7 +8,7 @@ let make_http_config ~host ~port : Http.config =
   let config = { Http.default_config with port; host } in
   Unix.putenv "MASC_HOST" config.host;
   Unix.putenv "MASC_HTTP_PORT" (string_of_int config.port);
-  (match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+  (match Sys.getenv_opt Env_config_core.http_base_url_env_key with
   | Some existing when String.trim existing <> "" -> ()
   | _ ->
       let advertised_host =
@@ -16,7 +16,8 @@ let make_http_config ~host ~port : Http.config =
           Masc_network_defaults.masc_http_default_host
         else config.host
       in
-      Unix.putenv "MASC_HTTP_BASE_URL"
+      Unix.putenv
+        Env_config_core.http_base_url_env_key
         (Printf.sprintf "http://%s:%d" advertised_host config.port));
   config
 

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -83,7 +83,7 @@ let context_from_env ?(include_configured = false) ~allow_legacy_accept () =
     Printf.sprintf "http://%s:%d" default_host (configured_http_port ())
   in
   let base_url =
-    match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+    match Sys.getenv_opt Env_config_core.http_base_url_env_key with
     | Some raw -> (
         match trim_nonempty raw with
         | Some value -> normalize_loopback_base_url value

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -117,7 +117,7 @@ let allowlisted_env_pairs () =
   let overrides =
     [
       (Env_config_core.base_path_env_key, "");
-      ("MASC_HTTP_BASE_URL", docker_http_base_url ());
+      (Env_config_core.http_base_url_env_key, docker_http_base_url ());
       (Env_config_runtime.Local_runtime.mcp_url_env_key, docker_mcp_url ());
       ("LLAMA_SERVER_URL", docker_llama_server_url ());
     ]


### PR DESCRIPTION
## Summary

Third batch for #8352 (after #8629 `MASC_MCP_URL` and #8650 `MASC_BASE_PATH`). Adds `http_base_url_env_key` SSOT constant and migrates 7 literal sites across 6 files.

## New constant (`lib/config/env_config_core.ml`)

```ocaml
let http_base_url_env_key = "MASC_HTTP_BASE_URL"
```

## Migrated call sites

| File | Site |
|------|------|
| `env_config_core.ml:192` | `masc_http_base_url_result` self-reference |
| `provider_adapter.ml:473,478` | `http_listener_env_explicit` + `default_voice_session_base_url` |
| `transport_read_model.ml:86` | startup URL lookup |
| `server/server_bootstrap_http.ml:11,19` | getenv + putenv pair |
| `worker_runtime_docker.ml:120` | container override map entry |
| `config/env_config_snapshot.ml:62` | snapshot catalog entry |

Same rationale as prior #8352 PRs — out-of-process and bootstrap call sites legitimately need the raw env-var name; constant prevents literal drift.

## Not in this PR

`MASC_HOST`, `MASC_HTTP_PORT`, `MASC_STORAGE_TYPE`, `MASC_ORCHESTRATOR_ENABLED`, `MASC_KEEPER_*`. #8352 stays open as umbrella.

## Test plan

- [ ] CI green
- No behavior change; pure literal hoist.