### PR TITLE
chore(config): SSOT for MASC_STORAGE_TYPE env key (#8352 Phase 4)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -274,10 +274,13 @@ let sb_path () =
   | Ok path -> path
   | Error msg -> raise (Config_error msg)
 
+(** SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). *)
+let storage_type_env_key = "MASC_STORAGE_TYPE"
+
 (** Storage backend type. Set at runtime by server_runtime_bootstrap.
     Valid: "filesystem", "memory". *)
 let storage_type () =
-  match raw_value_opt "MASC_STORAGE_TYPE" |> trim_opt with
+  match raw_value_opt storage_type_env_key |> trim_opt with
   | Some raw -> (
       match String.lowercase_ascii (String.trim raw) with
       | "filesystem" | "file" | "jsonl" | "auto" -> "filesystem"

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -108,7 +108,7 @@ let rate_limiting_entries =
 
 let storage_entries =
   [
-    entry ~default:"filesystem" "MASC_STORAGE_TYPE"
+    entry ~default:"filesystem" Env_config_core.storage_type_env_key
       "Backend storage type (filesystem only)";
     entry ~default:"1000" "MASC_PUBSUB_MAX_MESSAGES"
       "Max pubsub messages per batch";

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -221,7 +221,7 @@ let auto_detect_backend () =
 (** Storage type from environment variable.
     Defaults to filesystem when MASC_STORAGE_TYPE is not set. *)
 let storage_type_from_env () =
-  match env_opt "MASC_STORAGE_TYPE" with
+  match env_opt Env_config_core.storage_type_env_key with
   | Some raw ->
       let value = String.lowercase_ascii (String.trim raw) in
       (match value with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -6,7 +6,7 @@ module Mcp_server = Mcp_server
 module Mcp_eio = Mcp_server_eio
 
 let force_jsonl_fallback_env () =
-  Unix.putenv "MASC_STORAGE_TYPE" "filesystem"
+  Unix.putenv Env_config_core.storage_type_env_key "filesystem"
 
 let requested_backend_mode () =
   Env_config_core.storage_type ()

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -102,7 +102,7 @@ let allowlisted_env_pairs () =
     @ [
       "GOOGLE_CLOUD_PROJECT";
       "GOOGLE_CLOUD_LOCATION";
-      "MASC_STORAGE_TYPE";
+      Env_config_core.storage_type_env_key;
       Env_config_core.base_path_env_key;
       "MASC_CONFIG_DIR";
     ]


### PR DESCRIPTION
## Summary

Fourth batch for #8352 (after #8629 MASC_MCP_URL, #8650 MASC_BASE_PATH, #8663 MASC_HTTP_BASE_URL). Adds `storage_type_env_key` SSOT constant + 5 literal migrations across 5 files.

## Constant

```ocaml
(* lib/config/env_config_core.ml *)
let storage_type_env_key = "MASC_STORAGE_TYPE"
```

## Migrated sites

| File | Site |
|------|------|
| `env_config_core.ml:283` | `storage_type()` self-reference |
| `coord_utils_backend_setup.ml:224` | `storage_type_from_env` |
| `server/server_runtime_bootstrap.ml:9` | `force_jsonl_fallback_env` putenv |
| `worker_runtime_docker.ml:105` | container inheritance key |
| `env_config_snapshot.ml:111` | snapshot catalog entry |

Same rationale as prior phases — out-of-process and bootstrap sites need the raw env-var name.

## Test plan

- [ ] CI green
- No behavior change; pure literal hoist.