### PR TITLE
fix(keeper_exec_status): expose strict keeper_health parser + log unknown wire (#8670)

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -38,15 +38,30 @@ let keeper_health_to_string = function
   | KH_zombie -> "zombie"
   | KH_dead -> "dead"
 
-let keeper_health_of_string = function
-  | "healthy" -> KH_healthy
-  | "idle" -> KH_idle
-  | "offline" -> KH_offline
-  | "stale" -> KH_stale
-  | "degraded" -> KH_degraded
-  | "zombie" -> KH_zombie
-  | "dead" -> KH_dead
-  | _ -> KH_offline
+(** Issue #8670: strict parser returning [None] on unknown strings so
+    drift (producer typo, future variant) is visible to callers instead
+    of silently masquerading as [KH_offline]. Mirrors the #8636 lenient
+    parser pattern (option-typed reverse route on the parse boundary). *)
+let keeper_health_of_string_opt = function
+  | "healthy" -> Some KH_healthy
+  | "idle" -> Some KH_idle
+  | "offline" -> Some KH_offline
+  | "stale" -> Some KH_stale
+  | "degraded" -> Some KH_degraded
+  | "zombie" -> Some KH_zombie
+  | "dead" -> Some KH_dead
+  | _ -> None
+
+(** Back-compat wrapper for callers not yet migrated to the option form.
+    Logs the unknown string once per call so drift is operator-visible
+    even when callers do not branch on it. *)
+let keeper_health_of_string s =
+  match keeper_health_of_string_opt s with
+  | Some h -> h
+  | None ->
+      Log.Keeper.warn
+        "keeper_health_of_string: unknown wire string %S → KH_offline fallback (#8670)" s;
+      KH_offline
 
 let keeper_continuity_to_string = function
   | Continuity_healthy -> "healthy"

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -26,6 +26,14 @@ val augment_keeper_diagnostic_json :
   Yojson.Safe.t
 
 val keeper_health_to_string : keeper_health -> string
+
+(** Strict parse: returns [None] when the wire string is not one of the
+    seven canonical keeper_health labels. Prefer this over
+    [keeper_health_of_string] for new code so drift is visible. *)
+val keeper_health_of_string_opt : string -> keeper_health option
+
+(** Back-compat parse: returns [KH_offline] on unknown strings and
+    logs a warning so the typo is operator-visible. Issue #8670. *)
 val keeper_health_of_string : string -> keeper_health
 val keeper_continuity_to_string : keeper_continuity -> string
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -387,9 +387,40 @@ let test_runtime_surface_exposes_social_model_resolution_fields () =
   check (option string) "blank last_need omitted" None
     (runtime |> member "last_need" |> to_string_option)
 
+(* Issue #8670: parser must round-trip every constructor and reject
+   unknown strings. The previous catch-all silently mapped typos to
+   KH_offline, masking drift between dashboard producers and consumers. *)
+let test_parser_roundtrip_all_constructors () =
+  let all : KT.keeper_health list =
+    [ KH_healthy; KH_idle; KH_offline; KH_stale;
+      KH_degraded; KH_zombie; KH_dead ]
+  in
+  List.iter (fun h ->
+    let wire = ES.keeper_health_to_string h in
+    match ES.keeper_health_of_string_opt wire with
+    | Some h' when h' = h -> ()
+    | Some _ -> Alcotest.failf "roundtrip mismatch for %s" wire
+    | None -> Alcotest.failf "of_string_opt rejected canonical wire %S" wire)
+  all
+
+let test_parser_rejects_unknown () =
+  Alcotest.(check (option string)) "typo → None" None
+    (Option.map ES.keeper_health_to_string
+       (ES.keeper_health_of_string_opt "healty"));
+  Alcotest.(check (option string)) "future variant → None" None
+    (Option.map ES.keeper_health_to_string
+       (ES.keeper_health_of_string_opt "compacting"))
+
 let () =
   run "keeper_exec_status"
     [
+      ( "health_state_parser",
+        [
+          test_case "round-trip covers all 7 constructors" `Quick
+            test_parser_roundtrip_all_constructors;
+          test_case "rejects unknown wire strings" `Quick
+            test_parser_rejects_unknown;
+        ] );
       ( "health_state",
         [
           test_case "keepalive running overrides stale last_seen" `Quick


### PR DESCRIPTION
## Summary

`keeper_health_of_string` silently mapped unknown wire strings to `KH_offline`, masking producer/consumer drift. Closes #8670 (#8605 anti-pattern class).

## Change

- New `keeper_health_of_string_opt : string -> keeper_health option` (strict, drift-visible).
- Existing `keeper_health_of_string` becomes a thin wrapper that:
  - Falls back to `KH_offline` for back-compat.
  - **Logs `Log.Keeper.warn` once per unknown wire** so operators see the typo even if callers don't branch on it.
- Tests: round-trip every constructor through `to_string ∘ of_string_opt`; assert unknown strings (`"healty"`, `"compacting"`) return `None`.

## Why option-typed (not `KH_unknown of string`)

`keeper_health` is matched in 6+ places across `keeper_exec_status.ml` and `operator_control_snapshot.ml`. Adding a constructor would require touching every match. Option-typed parser keeps the variant total and pushes the unknown-handling decision to the boundary.

Same pattern as the #8636 `assertion_kind_of_string_lenient` mirror.

## Test Plan
- [x] `dune build` green
- [x] `_build/default/test/test_keeper_exec_status.exe test health_state_parser` — 2 tests pass
- [ ] CI green

## Related
- #8605 (catch-all anti-pattern catalog)
- #8615 (`required_verifier_role` fail-closed)
- #8636 (`assertion_kind` SSOT — same parser shape)
- #8377 (silent failure family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
