### PR TITLE
[task-054] Introduce Room read protocol boundary

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -114,15 +114,15 @@ let judgment_generated_at json =
   |> Option.value ~default:0.0
 
 let normalize_disk_recommended_action judgment =
-  let canonical_tool =
-    match judgment |> member "recommended_action" |> member "resolved_tool" |> to_string_option with
-    | Some tool ->
-        let tool = tool |> String.trim |> String.lowercase_ascii in
-        if tool = "" then None else Some tool
-    | None -> None
-  in
   match judgment |> member "recommended_action" with
   | `Assoc action_fields ->
+      let canonical_tool =
+        match List.assoc_opt "resolved_tool" action_fields with
+        | Some (`String tool) ->
+            let tool = tool |> String.trim |> String.lowercase_ascii in
+            if tool = "" then None else Some tool
+        | _ -> None
+      in
       let normalized_action =
         `Assoc
           (List.map

--- a/lib/dune
+++ b/lib/dune
@@ -153,6 +153,7 @@
    web_dashboard
    credits_dashboard
    repo_synthesis_benchmark
+   room_protocol
 
    inference_utils
    ;; WebRTC modules removed — use ocaml-webrtc library directly

--- a/lib/room_protocol.ml
+++ b/lib/room_protocol.ml
@@ -1,0 +1,72 @@
+type status = {
+  cluster : string;
+  project : string;
+  tempo_interval_s : float;
+  paused : bool;
+}
+
+let status config =
+  let room_state = Coord.read_state config in
+  let tempo = Tempo.get_tempo config in
+  {
+    cluster = Env_config_core.cluster_name ();
+    project = room_state.project;
+    tempo_interval_s = tempo.current_interval_s;
+    paused = room_state.paused;
+  }
+
+let task_status_matches status_filter (task : Types.task) =
+  match status_filter with
+  | None -> true
+  | Some status ->
+      String.equal status (Types.string_of_task_status task.task_status)
+
+let is_terminal_task (task : Types.task) =
+  match task.task_status with
+  | Types.Done _ -> `Done
+  | Types.Cancelled _ -> `Cancelled
+  | _ -> `Active
+
+let tasks ?status_filter ?(include_done = false) ?(include_cancelled = false)
+    config =
+  Coord.get_tasks_raw config
+  |> List.filter (task_status_matches status_filter)
+  |> List.filter (fun task ->
+         match status_filter with
+         | Some _ -> true
+         | None -> (
+             match is_terminal_task task with
+             | `Done -> include_done
+             | `Cancelled -> include_cancelled
+             | `Active -> true))
+
+let task_assignee (task : Types.task) =
+  match task.task_status with
+  | Claimed { assignee; _ }
+  | InProgress { assignee; _ }
+  | Done { assignee; _ } ->
+      Some assignee
+  | _ -> None
+
+let agents ?status_filter config =
+  let agents =
+    try Coord.get_agents_raw config
+    with Invalid_argument _ -> []
+  in
+  match status_filter with
+  | None -> agents
+  | Some status ->
+      List.filter
+        (fun (agent : Types.agent) ->
+          String.equal status (Types.string_of_agent_status agent.status))
+        agents
+
+let messages ?agent_filter ~since_seq ~limit config =
+  let messages = Coord.get_messages_raw config ~since_seq ~limit in
+  match agent_filter with
+  | None -> messages
+  | Some agent ->
+      List.filter
+        (fun (message : Types.message) ->
+          String.equal agent message.from_agent)
+        messages

--- a/lib/room_protocol.mli
+++ b/lib/room_protocol.mli
@@ -1,0 +1,34 @@
+(** Room_protocol exposes the read-side room boundary used by HTTP routes.
+
+    It keeps route modules from depending directly on the Coord implementation
+    hub while preserving the existing response shape. *)
+
+type status = {
+  cluster : string;
+  project : string;
+  tempo_interval_s : float;
+  paused : bool;
+}
+
+val status : Coord.config -> status
+
+val tasks :
+  ?status_filter:string ->
+  ?include_done:bool ->
+  ?include_cancelled:bool ->
+  Coord.config ->
+  Types.task list
+
+val task_assignee : Types.task -> string option
+
+val agents :
+  ?status_filter:string ->
+  Coord.config ->
+  Types.agent list
+
+val messages :
+  ?agent_filter:string ->
+  since_seq:int ->
+  limit:int ->
+  Coord.config ->
+  Types.message list

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -16,13 +16,12 @@ module Keeper_stream = Server_routes_http_keeper_stream
   |> Http.Router.get "/api/v1/status" (fun request reqd ->
        with_read_auth (fun state _req reqd ->
          let config = state.Mcp_server.room_config in
-         let room_state = Coord.read_state config in
-         let tempo = Tempo.get_tempo config in
+         let status = Room_protocol.status config in
          let json = `Assoc [
-           ("cluster", `String (Env_config_core.cluster_name ()));
-           ("project", `String room_state.project);
-           ("tempo_interval_s", `Float tempo.current_interval_s);
-           ("paused", `Bool room_state.paused);
+           ("cluster", `String status.cluster);
+           ("project", `String status.project);
+           ("tempo_interval_s", `Float status.tempo_interval_s);
+           ("paused", `Bool status.paused);
          ] in
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
@@ -34,31 +33,9 @@ module Keeper_stream = Server_routes_http_keeper_stream
          let include_cancelled = bool_query_param req "include_cancelled" ~default:false in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
-         let tasks = Coord.get_tasks_raw config in
          let filtered =
-           match status_filter with
-           | None -> tasks
-           | Some status ->
-               List.filter (fun (t : Types.task) ->
-                 String.equal status (Types.string_of_task_status t.task_status)
-               ) tasks
-         in
-         let filtered =
-           match status_filter with
-           | Some _ -> filtered
-           | None ->
-               List.filter (fun (t : Types.task) ->
-                 let is_done = match t.task_status with
-                   | Types.Done _ -> true
-                   | _ -> false
-                 in
-                 let is_cancelled = match t.task_status with
-                   | Types.Cancelled _ -> true
-                   | _ -> false
-                 in
-                 (include_done || not is_done) &&
-                 (include_cancelled || not is_cancelled)
-               ) filtered
+           Room_protocol.tasks ?status_filter ~include_done
+             ~include_cancelled config
          in
          let total = List.length filtered in
          let page =
@@ -74,12 +51,8 @@ module Keeper_stream = Server_routes_http_keeper_stream
                ("status", `String (Types.string_of_task_status t.task_status));
                ("priority", `Int t.priority);
                ( "assignee",
-                 match t.task_status with
-                 | Claimed { assignee; _ }
-                 | InProgress { assignee; _ }
-                 | Done { assignee; _ } ->
-                     `String assignee
-                 | _ -> `Null );
+                 Json_util.string_opt_to_json
+                   (Room_protocol.task_assignee t) );
                ("created_at", `String t.created_at);
              ]
            in
@@ -105,20 +78,11 @@ module Keeper_stream = Server_routes_http_keeper_stream
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let agents =
-           try Coord.get_agents_raw config
-           with Invalid_argument _ -> []
+           Room_protocol.agents ?status_filter config
          in
-         let filtered =
-           match status_filter with
-           | None -> agents
-           | Some status ->
-               List.filter (fun (a : Types.agent) ->
-                 String.equal status (Types.string_of_agent_status a.status)
-               ) agents
-         in
-         let total = List.length filtered in
+         let total = List.length agents in
          let page =
-           filtered
+           agents
            |> List.filteri (fun idx _ -> idx >= offset && idx < offset + limit)
          in
          let agents_json = List.map (fun (a : Types.agent) ->
@@ -148,14 +112,8 @@ module Keeper_stream = Server_routes_http_keeper_stream
          let since_seq = int_query_param req "since_seq" ~default:0 in
          let limit = int_query_param req "limit" ~default:20 in
          let agent_filter = query_param req "agent" in
-         let msgs = Coord.get_messages_raw config ~since_seq ~limit:500 in
          let filtered =
-           match agent_filter with
-           | None -> msgs
-           | Some agent ->
-               List.filter (fun (m : Types.message) ->
-                 String.equal agent m.from_agent
-               ) msgs
+           Room_protocol.messages ?agent_filter ~since_seq ~limit:500 config
          in
          let total = List.length filtered in
          let page = filtered |> List.filteri (fun idx _ -> idx < limit) in

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -345,6 +345,27 @@ let test_http_read_surface_contracts () =
     (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
        {|"/api/v1/messages" (fun request reqd ->
        with_read_auth|});
+  check bool "room route delegates status reads to protocol boundary" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Room_protocol.status config");
+  check bool "room route delegates task reads to protocol boundary" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Room_protocol.tasks ?status_filter");
+  check bool "room route delegates agent reads to protocol boundary" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Room_protocol.agents ?status_filter config");
+  check bool "room route delegates message reads to protocol boundary" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Room_protocol.messages ?agent_filter");
+  check bool "room route does not read Coord directly" true
+    (file_not_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Coord.");
+  check bool "room route does not read Tempo directly" true
+    (file_not_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       "Tempo.");
+  check bool "room protocol owns the Coord read boundary" true
+    (file_contains_pattern "lib/room_protocol.ml"
+       "Coord.get_tasks_raw config");
   check bool "provider run status route now requires read auth" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        {|"/api/v1/agent-runs/" (fun request reqd ->


### PR DESCRIPTION
## Summary

Implements the task-054 Room hub protocol boundary pilot.

- Add `Room_protocol` / `Room_protocol_intf` style read boundary as `lib/room_protocol.ml` + `.mli`.
- Move `/api/v1/status`, `/api/v1/tasks`, `/api/v1/agents`, and `/api/v1/messages` room reads in `server_routes_http_routes_room.ml` through `Room_protocol`.
- Preserve existing JSON response shape and query behavior.
- Add source guards so the route module cannot regress to direct `Coord` / `Tempo` reads.
- Follow-up fix at `d3be895356382773ecaec380af57b24e6a8b372c`: tolerate legacy governance judgments with missing/null `recommended_action`.

## Product Impact

Operators should see the same Room HTTP API behavior and response shape. Internally, the Room read implementation is now behind a protocol boundary, reducing direct route coupling to the Room implementation hub and creating a smaller dependency surface for future Room refactors.

The governance follow-up only affects dashboard projection robustness for legacy judgment files. It keeps old/null `recommended_action` records from crashing the dashboard governance normalization path.

## Current CI Verdict

Merged-head post-merge audit: local governance regression fixed, but merge landed while required checks were still red via Build/Test quick-suite timeout (#8231 recurrence) and CI Gate failure.

CI run `24631985496` for merged head `d3be895356382773ecaec380af57b24e6a8b372c`:

- [x] `PR Sync Check`: success
- [x] `Detect Changed Surfaces`: success
- [x] `PR Hygiene`: success
- [x] `Dashboard Drift Gate`: success
- [x] `Release Train`: success
- [x] `Lint`: success
- [x] `OAS Pin Consistency`: success
- [x] `Health`: success
- [x] `Doc Truth`: success
- [x] `Dashboard`: skipped for this run
- [x] `TLA+ Model Checking`: skipped for this run
- [ ] `Build and Test`: failure, job `72020848219`, `Run tests (quick suite)` timed out after `elapsed_sec=1200`, exit `124`
- [ ] `CI Gate`: failure because required checks are red

Post-body-update Planning Hygiene run `24633072020` for the same head completed successfully (`pr-hygiene` job `72023675274`).

The failed quick-suite log has no assertion failure marker. The latest suites near timeout include `mcp_tool_matrix` and `keeper_tool_matrix`, and the log reports `keeper_tool_matrix` registering `112` matrix cases plus the `112 schemas (~51KB)` tool-policy warning. This matches #8231 recurrence rather than a task-054-local Room protocol regression.

## Dependency Delta

Before this PR, `lib/server/server_routes_http_routes_room.ml` directly depended on the Room implementation hub for read data:

- `Coord.read_state`
- `Tempo.get_tempo`
- `Coord.get_tasks_raw`
- `Coord.get_agents_raw`
- `Coord.get_messages_raw`

After this PR:

- `server_routes_http_routes_room.ml` direct `Coord` / `Tempo` refs: `0`
- `server_routes_http_routes_room.ml` `Room_protocol.*` refs: `5`
- `room_protocol.{ml,mli}` owns the read-side `Coord` / `Tempo` boundary.

This creates the first protocol/interface cut for a dependent Room HTTP cluster without changing public route behavior.

## Evidence

- Modified modules:
  - `lib/room_protocol.ml`
  - `lib/room_protocol.mli`
  - `lib/server/server_routes_http_routes_room.ml`
  - `lib/dune`
  - `test/test_ci_hardening_source.ml`
  - `lib/dashboard_governance_judge.ml`
  - `test/test_dashboard_governance.ml`
- Dependent cluster migrated: `server_routes_http_routes_room` now uses `Room_protocol` for status, task, agent, and message reads.
- Source guard added to prevent the HTTP route module from reintroducing direct `Coord` / `Tempo` reads.
- Regression added for legacy governance judgment projection with missing `recommended_action`.
- #8231 recurrence evidence posted as issue comment `4276269650` for PR #8674.

## Verification

Initial boundary verification:

- [x] `env -u DUNE_RPC dune build --root . --build-dir _build_task054 @install`
- [x] `env -u DUNE_RPC dune build --root . --build-dir _build_task054 ./test/test_ci_hardening_source.exe`
- [x] `./_build_task054/default/test/test_ci_hardening_source.exe`
  - 33 tests passed

Latest governance follow-up verification for `d3be895356382773ecaec380af57b24e6a8b372c`:

- [x] `git diff --check`
- [x] `env -u DUNE_RPC opam exec -- dune exec --root . ./test/test_dashboard_governance.exe`
- [x] `env -u DUNE_RPC opam exec -- dune build --root . --build-dir _build_task054 ./test/test_ci_hardening_source.exe && ./_build_task054/default/test/test_ci_hardening_source.exe`
- [x] `env -u DUNE_RPC opam exec -- dune build --root . bin/main_eio.exe`
- [x] GitHub Planning Hygiene rerun `24633072020` / `pr-hygiene` job `72023675274`: success

Post-merge audit for the merged head is not green: `Build and Test` failed with the #8231 quick-suite timeout recurrence, and `CI Gate` failed as a result.

## Review Evidence

- Local diff reviewed against task-054 completion contract.
- Planning-hygiene comment addressed by adding `Product Impact`, `Evidence`, `Review Evidence`, and `Linked Issue` sections.
- Post-body-update Planning Hygiene rerun passed for the same head.
- Verdict evidence gap addressed by adding latest commit, rerun commands, and current CI status.
- Current blocker is now explicit: local governance regression is fixed, but merged-head post-merge audit remains red due to #8231 recurrence.

## Linked Issue

Refs task-054.
Related: #8231.

## Task Contract Evidence

- Room public surface: `Room_protocol.{ml,mli}` added.
- Dependent cluster migrated: `server_routes_http_routes_room` now uses `Room_protocol` for status, task, agent, and message reads.
- Dependency evidence included above.