### PR TITLE
fix: restore governance dashboard CI after OAS pin bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,10 @@
 
 ### Changed
 
-- **OAS pin ratchet → `main@cfcd85a9`.** Keeps the `0.160.1` dependency
-  floor but advances the runtime pin past `f70fd95e` to pick up OAS
-  #1018's stale Swarm-semantics doc cleanup, so local `check-oas-pin`
-  drift warnings disappear and MASC tracks the current upstream main
-  truth again.
+- **OAS pin bump → `v0.162.0`.** Raises the `agent_sdk` dependency floor
+  from `0.161.0` to `0.162.0` and pins OAS `main@3b0409d2`, pulling in
+  the provider-registry context-window fix (#1040) plus the 0.162.0
+  release rollup (#1042) without leaving `check-oas-pin` drift warnings.
 
 ### Reliability
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ All protocols run concurrently from a single Eio fiber pool:
 ### Tech Stack
 
 - **OCaml 5.4+** with Eio structured concurrency (no Lwt)
-- **agent_sdk** >= 0.160.1 (OAS agent runtime; pinned floor in `masc_mcp.opam` and `dune-project`)
+- **agent_sdk** >= 0.162.0 (OAS agent runtime; pinned floor in `masc_mcp.opam` and `dune-project`)
 - **mcp_protocol** >= 1.3.0 (MCP JSON-RPC contract)
 - **h2-eio** (HTTP/2), **grpc-direct** (gRPC), **ocaml-webrtc** (WebRTC)
 - **caqti** + PostgreSQL (optional), **sqlite3** (fallback), **neo4j_bolt** (optional graph)

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -133,6 +133,7 @@ let captured_stderr_or_empty path_opt =
   | None -> ""
 
 let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
+    ?(timeout_sec = 60.0)
     (argv : string list)
     ~(on_error : string -> string -> 'a)
     ~(on_success : Unix.process_status -> string -> string -> 'a) : 'a =
@@ -228,28 +229,105 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
             on_error "stdout pipe unavailable during Unix fallback capture" ""
         | Some stdout_r ->
             stdout_r_ref := None;
-            let rec waitpid_retry () =
+            let rec waitpid_blocking () =
               try Unix.waitpid [] pid
-              with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_retry ()
+              with
+              | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_blocking ()
+              | Unix.Unix_error (Unix.ECHILD, _, _) -> (pid, Unix.WEXITED 127)
             in
-            let status, stdout, stderr =
-              Eio_guard.run_in_systhread (fun () ->
-                let status_ref = ref None in
-                let ic = Unix.in_channel_of_descr stdout_r in
-                let stdout =
-                  Fun.protect
-                    ~finally:(fun () ->
-                      In_channel.close ic;
-                      let (_pid, status) = waitpid_retry () in
-                      status_ref := Some status)
-                    (fun () -> In_channel.input_all ic)
+            let kill_and_wait status_ref =
+              (try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ());
+              if Option.is_none !status_ref then
+                let (_pid, status) = waitpid_blocking () in
+                status_ref := Some status
+            in
+            let waitpid_nohang () =
+              try
+                match Unix.waitpid [ Unix.WNOHANG ] pid with
+                | 0, _ -> None
+                | _, status -> Some status
+              with
+              | Unix.Unix_error (Unix.EINTR, _, _) -> None
+              | Unix.Unix_error (Unix.ECHILD, _, _) -> Some (Unix.WEXITED 127)
+            in
+            let stdout_buf = Buffer.create 1024 in
+            let chunk = Bytes.create 4096 in
+            let read_available () =
+              let rec loop () =
+                try
+                  match Unix.read stdout_r chunk 0 (Bytes.length chunk) with
+                  | 0 -> `Eof
+                  | n ->
+                      Buffer.add_subbytes stdout_buf chunk 0 n;
+                      loop ()
+                with
+                | Unix.Unix_error
+                    ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) ->
+                    `Would_block
+                | Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+              in
+              loop ()
+            in
+            let timeout_sec = max 0.001 timeout_sec in
+            let deadline = Unix.gettimeofday () +. timeout_sec in
+            let timed_out = ref false in
+            let status_ref = ref None in
+            let stdout_eof = ref false in
+            Unix.set_nonblock stdout_r;
+            while (not !stdout_eof) && not !timed_out do
+              if Unix.gettimeofday () >= deadline then begin
+                timed_out := true;
+                kill_and_wait status_ref;
+                ignore (read_available () : [ `Eof | `Would_block ])
+              end else begin
+                let remaining = max 0.0 (deadline -. Unix.gettimeofday ()) in
+                let readable =
+                  try
+                    let ready, _, _ =
+                      Unix.select [ stdout_r ] [] [] (min 0.05 remaining)
+                    in
+                    ready <> []
+                  with Unix.Unix_error (Unix.EINTR, _, _) -> false
                 in
+                if readable then
+                  match read_available () with
+                  | `Eof -> stdout_eof := true
+                  | `Would_block -> ()
+              end
+            done;
+            while (not !timed_out) && Option.is_none !status_ref do
+              match waitpid_nohang () with
+              | Some status -> status_ref := Some status
+              | None ->
+                  if Unix.gettimeofday () >= deadline then begin
+                    timed_out := true;
+                    kill_and_wait status_ref
+                  end else
+                    Unix.sleepf
+                      (min 0.05
+                         (max 0.0 (deadline -. Unix.gettimeofday ())))
+            done;
+            close_quietly stdout_r;
+            let status =
+              if !timed_out then Unix.WEXITED 124
+              else
                 match !status_ref with
-                | Some status ->
-                    let stderr = captured_stderr_or_empty !stderr_path_ref in
-                    (status, stdout, stderr)
+                | Some status -> status
                 | None ->
-                    raise (Failure "waitpid status missing after Unix fallback capture"))
+                    let (_pid, status) = waitpid_blocking () in
+                    status
+            in
+            let stdout = Buffer.contents stdout_buf in
+            let stderr = captured_stderr_or_empty !stderr_path_ref in
+            let stderr =
+              if !timed_out && String.trim stdout = ""
+                 && String.trim stderr = ""
+              then
+                process_error_output
+                  ~label:(String.concat " " (List.map Filename.quote argv))
+                  ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec)
+                  ()
+              else stderr
             in
             cleanup ();
             on_success status stdout stderr)
@@ -262,40 +340,43 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
          cleanup ();
          on_error (reason_of_exn_for_output exn) stderr)
 
-let run_unix_argv_fallback ?env (argv : string list) : string =
+let run_unix_argv_fallback ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env argv
+  with_unix_capture ?env ~timeout_sec argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
       process_error_output ~label ~reason ~stderr ())
-    ~on_success:(fun _status stdout _stderr -> stdout)
+    ~on_success:(fun status stdout stderr ->
+      output_for_status ~status ~stdout ~stderr)
 
-let run_unix_argv_with_status_split_fallback ?env ?cwd (argv : string list) :
+let run_unix_argv_with_status_split_fallback ?(timeout_sec = 60.0) ?env ?cwd (argv : string list) :
     Unix.process_status * string * string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env ?cwd ~capture_stderr:true argv
+  with_unix_capture ?env ?cwd ~timeout_sec ~capture_stderr:true argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
       (Unix.WEXITED 127, "", process_error_output ~label ~reason ~stderr ()))
     ~on_success:(fun status stdout stderr ->
       (status, stdout, stderr))
 
-let run_unix_argv_with_stdin_fallback ?env ~(stdin_content : string)
+let run_unix_argv_with_stdin_fallback ?(timeout_sec = 60.0) ?env ~(stdin_content : string)
     (argv : string list) : string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env ~stdin_content argv
+  with_unix_capture ?env ~timeout_sec ~stdin_content argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
       process_error_output ~label ~reason ~stderr ())
-    ~on_success:(fun _status stdout _stderr -> stdout)
+    ~on_success:(fun status stdout stderr ->
+      output_for_status ~status ~stdout ~stderr)
 
 let run_unix_argv_with_stdin_and_status_split_fallback
+    ?(timeout_sec = 60.0)
     ?env
     ?cwd
     ~(stdin_content : string)
     (argv : string list) : Unix.process_status * string * string =
   let label = String.concat " " (List.map Filename.quote argv) in
-  with_unix_capture ?env ?cwd ~stdin_content ~capture_stderr:true argv
+  with_unix_capture ?env ?cwd ~timeout_sec ~stdin_content ~capture_stderr:true argv
     ~on_error:(fun reason stderr ->
       Log.Misc.error "[Process_eio] Unix fallback error: %s — %s" label reason;
       (Unix.WEXITED 127, "", process_error_output ~label ~reason ~stderr ()))
@@ -365,11 +446,12 @@ let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
 
 let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv ~argv ?env ();
-  if not (is_initialized ()) then run_unix_argv_fallback ?env argv
+  if not (is_initialized ()) then
+    run_unix_argv_fallback ~timeout_sec ?env argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_fallback ?env argv
+        run_unix_argv_fallback ~timeout_sec ?env argv
     | Ok pm, Ok clk, Ok cwd ->
         let buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
@@ -390,7 +472,7 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_fallback ?env argv
+              run_unix_argv_fallback ~timeout_sec ?env argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);
@@ -399,11 +481,11 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
 let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin ~argv ?env ();
   if not (is_initialized ()) then
-    run_unix_argv_with_stdin_fallback ?env ~stdin_content argv
+    run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_stdin_fallback ?env ~stdin_content argv
+        run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
     | Ok pm, Ok clk, Ok cwd ->
         let buf = Buffer.create 1024 in
         let label = String.concat " " (List.map Filename.quote argv) in
@@ -425,7 +507,7 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_with_stdin_fallback ?env ~stdin_content argv
+              run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);
@@ -439,12 +521,12 @@ let run_argv_with_stdin_and_status_split
     (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_stdin_and_status ~argv ?env ();
   if not (is_initialized ()) then
-    run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd ~stdin_content
-      argv
+    run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env ?cwd
+      ~stdin_content argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd
+        run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env ?cwd
           ~stdin_content argv
     | Ok pm, Ok clk, Ok default_cwd ->
         let effective_cwd =
@@ -484,8 +566,8 @@ let run_argv_with_stdin_and_status_split
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_with_stdin_and_status_split_fallback ?env ?cwd
-                ~stdin_content argv
+              run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec
+                ?env ?cwd ~stdin_content argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);
@@ -510,11 +592,11 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
     (argv : string list) : Unix.process_status * string * string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status ~argv ?env ?cwd ();
   if not (is_initialized ()) then
-    run_unix_argv_with_status_split_fallback ?env ?cwd argv
+    run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
   else
     match get_proc_mgr (), get_clock (), get_cwd_default () with
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
-        run_unix_argv_with_status_split_fallback ?env ?cwd argv
+        run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
     | Ok pm, Ok clk, Ok default_cwd ->
         let effective_cwd =
           match cwd with
@@ -552,7 +634,7 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
               Log.Misc.warn
                 "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
                 label (Printexc.to_string exn);
-              run_unix_argv_with_status_split_fallback ?env ?cwd argv
+              run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
             ) else (
               Log.Misc.error "[Process_eio] argv error: %s — %s" label
                 (Printexc.to_string exn);

--- a/scripts/harness/workload/keeper_campaign.sh
+++ b/scripts/harness/workload/keeper_campaign.sh
@@ -160,13 +160,38 @@ record_campaign_event() {
 replay_campaign_fsm() {
   local events_file="$1"
   local output_file="$2"
-  local bin_path="$REPO_ROOT/_build/default/bin/keeper_campaign_fsm.exe"
-  if [[ -x "$bin_path" ]]; then
-    "$bin_path" replay "$events_file" "$output_file" >/dev/null
-  else
-    dune exec --root "$REPO_ROOT" ./bin/keeper_campaign_fsm.exe -- \
-      replay "$events_file" "$output_file" >/dev/null
+  local explicit="${KEEPER_CAMPAIGN_FSM_EXE:-}"
+  local dune_build_dir="${DUNE_BUILD_DIR:-_build}"
+  local repo_build_dir="$REPO_ROOT/$dune_build_dir"
+  if [[ "$dune_build_dir" = /* ]]; then
+    repo_build_dir="$dune_build_dir"
   fi
+
+  local -a candidates=()
+  if [[ -n "$explicit" ]]; then
+    candidates+=("$explicit")
+  fi
+  candidates+=(
+    "$repo_build_dir/default/bin/keeper_campaign_fsm.exe"
+    "$REPO_ROOT/_build/default/bin/keeper_campaign_fsm.exe"
+    "$REPO_ROOT/bin/keeper_campaign_fsm.exe"
+  )
+
+  local bin_path
+  for bin_path in "${candidates[@]}"; do
+    if [[ -x "$bin_path" ]]; then
+      "$bin_path" replay "$events_file" "$output_file" >/dev/null
+      return 0
+    fi
+  done
+
+  if [[ "$(normalize_bool "${MASC_HARNESS_ALLOW_DUNE_EXEC_FALLBACK:-1}")" != "1" ]]; then
+    echo "keeper_campaign_fsm executable not found; build with: dune build --root . ./bin/keeper_campaign_fsm.exe" >&2
+    return 1
+  fi
+
+  dune exec --root "$REPO_ROOT" ./bin/keeper_campaign_fsm.exe -- \
+    replay "$events_file" "$output_file" >/dev/null
 }
 
 models_json() {

--- a/test/dune
+++ b/test/dune
@@ -1002,7 +1002,13 @@
 (test
  (name test_harness_shell_helpers)
  (modules test_harness_shell_helpers)
- (libraries alcotest unix))
+ (deps %{exe:../bin/keeper_campaign_fsm.exe})
+ (action
+  (setenv KEEPER_CAMPAIGN_FSM_EXE %{exe:../bin/keeper_campaign_fsm.exe}
+   (setenv MASC_HARNESS_ALLOW_DUNE_EXEC_FALLBACK 0
+    (run %{test}))))
+ (libraries alcotest unix)
+)
 
 
 (test

--- a/test/test_harness_shell_helpers.ml
+++ b/test/test_harness_shell_helpers.ml
@@ -61,6 +61,51 @@ let contains_substring haystack needle =
   in
   nlen = 0 || loop 0
 
+let executable path =
+  Sys.file_exists path
+  &&
+  try
+    Unix.access path [ Unix.X_OK ];
+    true
+  with Unix.Unix_error _ -> false
+
+let keeper_campaign_fsm_exe () =
+  let root = source_root () in
+  let absolute path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
+    else path
+  in
+  let dune_build_dir =
+    match Sys.getenv_opt "DUNE_BUILD_DIR" with
+    | Some value when String.trim value <> "" -> value
+    | _ -> "_build"
+  in
+  let build_root =
+    if Filename.is_relative dune_build_dir then
+      Filename.concat root dune_build_dir
+    else
+      dune_build_dir
+  in
+  let candidates =
+    match Sys.getenv_opt "KEEPER_CAMPAIGN_FSM_EXE" with
+    | Some path when String.trim path <> "" ->
+      [
+        absolute path;
+        Filename.concat build_root "default/bin/keeper_campaign_fsm.exe";
+        Filename.concat root "_build/default/bin/keeper_campaign_fsm.exe";
+      ]
+    | _ ->
+      [
+        Filename.concat build_root "default/bin/keeper_campaign_fsm.exe";
+        Filename.concat root "_build/default/bin/keeper_campaign_fsm.exe";
+      ]
+  in
+  match List.find_opt executable candidates with
+  | Some path -> path
+  | None ->
+    failf "keeper_campaign_fsm.exe not found; candidates:\n%s"
+      (String.concat "\n" candidates)
+
 let test_server_bootstrap_temp_helpers () =
   with_temp_dir "harness-bootstrap-temp" (fun dir ->
       let script =
@@ -119,12 +164,13 @@ let test_keeper_campaign_harness_dry_run () =
       let script =
         Filename.concat (source_root ()) "scripts/harness_keeper_campaign.sh"
       in
+      let fsm_exe = keeper_campaign_fsm_exe () in
       let run_dir = Filename.concat dir "artifacts" in
       let code, _stdout, stderr =
         run_bash ~cwd:(source_root ())
           (Printf.sprintf
-             "DRY_RUN=1 START_SERVER=0 RUN_DIR=%s %s"
-             (quote run_dir) (quote script))
+             "DRY_RUN=1 START_SERVER=0 RUN_DIR=%s KEEPER_CAMPAIGN_FSM_EXE=%s MASC_HARNESS_ALLOW_DUNE_EXEC_FALLBACK=0 %s"
+             (quote run_dir) (quote fsm_exe) (quote script))
       in
       if code <> 0 then
         failf "keeper campaign dry run failed (%d): %s" code stderr;
@@ -151,9 +197,7 @@ let test_keeper_campaign_harness_dry_run () =
 
 let test_keeper_campaign_cli_replay () =
   with_temp_dir "keeper-campaign-cli" (fun dir ->
-      let exe =
-        Filename.concat (source_root ()) "_build/default/bin/keeper_campaign_fsm.exe"
-      in
+      let exe = keeper_campaign_fsm_exe () in
       let events_path = Filename.concat dir "events.jsonl" in
       let output_path = Filename.concat dir "state.json" in
       let events =

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -66,6 +66,14 @@ let test_run_argv_with_status_fallback_surfaces_spawn_error () =
   check bool "missing command output surfaced" true
     (contains output "process_eio_error")
 
+let test_run_argv_with_status_fallback_enforces_timeout () =
+  Process_eio.reset_for_testing ();
+  let status, _output =
+    Process_eio.run_argv_with_status ~timeout_sec:1.0 [ "/bin/sleep"; "5" ]
+  in
+  let code = match status with Unix.WEXITED c -> c | _ -> -1 in
+  check int "fallback timeout exit code" 124 code
+
 let test_init_exposes_complete_runtime () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -213,6 +221,8 @@ let () =
             test_run_argv_fallback_surfaces_spawn_error;
           test_case "argv-with-status-fallback-surfaces-spawn-error" `Quick
             test_run_argv_with_status_fallback_surfaces_spawn_error;
+          test_case "argv-with-status-fallback-enforces-timeout" `Quick
+            test_run_argv_with_status_fallback_enforces_timeout;
           test_case "init-exposes-complete-runtime" `Quick
             test_init_exposes_complete_runtime;
         ] );

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -49,6 +49,17 @@ let rec waitpid_nointr pid =
   | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_nointr pid
   | Unix.Unix_error (Unix.ECHILD, _, _) -> None
 
+let with_dev_null_fds f =
+  let in_fd = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let out_fd = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  let err_fd = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () ->
+      close_quietly in_fd;
+      close_quietly out_fd;
+      close_quietly err_fd)
+    (fun () -> f ~in_fd ~out_fd ~err_fd)
+
 let wait_until ~timeout_sec f =
   let deadline = Unix.gettimeofday () +. timeout_sec in
   let rec loop () =
@@ -123,8 +134,9 @@ let spawn_forever_process ?argv0 ~ignore_sigterm () =
         else
           "while :; do sleep 1; done"
       in
-      Unix.create_process "/bin/sh" [| name; "-c"; script |]
-        Unix.stdin Unix.stdout Unix.stderr
+      with_dev_null_fds (fun ~in_fd ~out_fd ~err_fd ->
+          Unix.create_process "/bin/sh" [| name; "-c"; script |]
+            in_fd out_fd err_fd)
   | None ->
       match Unix.fork () with
       | 0 ->


### PR DESCRIPTION
## Summary
- align README/changelog OAS pin notes with the merged `agent_sdk` 0.162.0 pin
- prevent the keeper campaign dry-run harness test from invoking nested `dune exec` inside `dune test`; the harness now resolves `keeper_campaign_fsm.exe` from `KEEPER_CAMPAIGN_FSM_EXE`/`DUNE_BUILD_DIR`, and the test wires the executable through Dune action deps
- detach startup takeover test shell stdio from CI stdout/stderr so orphaned `sleep` children cannot keep the quick-suite tee pipe open after the test process exits
- enforce `Process_eio` Unix fallback timeouts so worker-runtime subprocess timeout tests cannot hang when the Eio process runtime has not been initialized

## Product impact
- Documents the current OAS/agent SDK pin state after the 0.162.0 update.
- Removes three CI-only quick-suite hang vectors so the PR queue can make progress.
- Keeps argv-based subprocess timeouts consistent between initialized Eio runtime paths and Unix fallback test paths.

## Evidence
- Local OAS pin check passes for `main@3b0409d265405ce294c271f646b819dfca958683` with matching API fingerprint.
- GitHub reports the PR branch as mergeable with no content conflicts.
- Failed GitHub Build/Test logs showed timeout after `test_tool_code_read_containment.exe` plus cleanup of an orphan `sleep` process, matching the stdio inheritance issue in `test_server_startup_takeover.ml`.
- Direct local reproduction showed `test_worker_runtime.exe` hanging in `process_timeout`; root cause was `Process_eio` falling back to timeout-less Unix capture when the global Eio process runtime was uninitialized.
- Branch was rebased onto main after #8723; the governance null handling commit was dropped because it is already present on main via #8695.

## Review evidence
- PR is waiting for GitHub CI rerun after pushed commit `ad817cc34`.
- Hygiene sections were added after the initial planning-hygiene bot warning.

## Linked issue
Refs #8668

## Validation
- `bash scripts/check-oas-pin.sh`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_pin_validate dune build --root . -j 4`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_pin_validate dune runtest --root . test/test_harness_shell_helpers.exe --no-buffer`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_dashboard_gov_fix dune build --root . test/test_dashboard_governance.exe`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_dashboard_gov_fix ./_build_dashboard_gov_fix/default/test/test_dashboard_governance.exe`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_codex_oas8675 dune runtest --root . test/test_server_startup_takeover.exe --no-buffer`
- `env CI_TEST_TIMEOUT_SEC=30 CI_TEST_HEARTBEAT_SEC=5 OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_codex_oas8675 scripts/ci-run-tests.sh "dune runtest --root . test/test_server_startup_takeover.exe --no-buffer"`
- `bash scripts/check-oas-pin.sh` after rebase
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_codex_oas8675_rebase dune runtest --root . test/test_server_startup_takeover.exe --no-buffer`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_process_timeout_fix dune runtest --root . test/test_process_eio_coverage.exe --no-buffer`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_process_timeout_fix dune runtest --root . test/test_worker_runtime.exe --no-buffer`
- `env OPAMSWITCH=5.4.1 OPAM_SWITCH_PREFIX=/Users/dancer/.opam/5.4.1 DUNE_BUILD_DIR=_build_process_timeout_fix dune build --root . -j 4`
- `git diff --check`

## CI Timeout Root Cause
The quick suite timeout was not a failing assertion. Diagnostics showed three hang classes: `test_harness_shell_helpers.exe` could block in `scripts/harness_keeper_campaign.sh` via nested `dune exec`; the startup takeover test could leave a shell child inheriting CI stdout/stderr; and `test_worker_runtime.exe` could hang because `Process_eio`'s Unix fallback path ignored the requested timeout when Eio process globals were not initialized. This patch removes the nested-Dune path, redirects the forever-process test shell through `/dev/null`, and makes Unix fallback process capture enforce the same timeout contract as the Eio-native path.