### PR TITLE
feat(config): expose detailed config provenance

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -127,12 +127,22 @@ export async function fetchAgentRelations(agentName: string): Promise<AgentRelat
   return parseAgentRelationsResponse(raw)
 }
 
+export type ConfigEntrySource = 'env' | 'default' | 'derived' | 'runtime'
+
+export interface ConfigEntryProvenance {
+  kind: ConfigEntrySource
+  detail: string
+  derived_from?: string[]
+}
+
 export interface ConfigEntry {
   env: string
   description: string
   value: string | null
   default: string
-  source: 'env' | 'default'
+  source: ConfigEntrySource
+  source_detail?: string
+  provenance?: ConfigEntryProvenance
   sensitive: boolean
 }
 

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -43,12 +43,15 @@ function matchesSearch(entry: ConfigEntry, query: string): boolean {
   return (
     entry.env.toLowerCase().includes(lower) ||
     entry.description.toLowerCase().includes(lower) ||
+    entry.source.toLowerCase().includes(lower) ||
+    (entry.source_detail ?? '').toLowerCase().includes(lower) ||
     (entry.value ?? '').toLowerCase().includes(lower)
   )
 }
 
 function EntryRow({ entry }: { entry: ConfigEntry }) {
-  const isDefault = entry.source === 'default'
+  const isEnv = entry.source === 'env'
+  const isDefault = entry.source !== 'env'
   const valueClass = entry.sensitive
     ? 'text-[var(--text-muted)] italic'
     : isDefault
@@ -60,20 +63,26 @@ function EntryRow({ entry }: { entry: ConfigEntry }) {
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
-          ${!isDefault ? html`
+          ${isEnv ? html`
             <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
+          ` : null}
+          ${!isEnv && entry.source !== 'default' ? html`
+            <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--bg-panel-hover)] text-[var(--text-muted)]">${entry.source}</span>
           ` : null}
           ${entry.sensitive ? html`
             <span class="text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--warn-10)] text-[var(--warn)]">sensitive</span>
           ` : null}
         </div>
         <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>
+        ${entry.source_detail ? html`
+          <div class="text-3xs text-[var(--text-muted)] mt-0.5">source: ${entry.source_detail}</div>
+        ` : null}
       </div>
       <div class="text-right shrink-0">
         <div class=${`text-xs font-mono ${valueClass}`}>
           ${entry.value ?? entry.default}
         </div>
-        ${!isDefault && entry.default ? html`
+        ${isEnv && entry.default ? html`
           <div class="text-3xs text-[var(--text-muted)] mt-0.5">
             default: ${entry.default}
           </div>
@@ -87,7 +96,7 @@ function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[]
   const query = searchQuery.value
   const filtered = entries.filter(e => matchesSearch(e, query))
   const isExpanded = expandedCategories.value.has(name)
-  const customCount = filtered.filter(e => e.source !== 'default').length
+  const customCount = filtered.filter(e => e.source === 'env').length
 
   if (filtered.length === 0) return null
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -30,12 +30,56 @@ type entry = {
   sensitive : bool;
 }
 
+type source_provenance = {
+  kind : string;
+  detail : string;
+  derived_from : string list;
+}
+
 let entry ?(sensitive = false) ~default env_name description =
   let sensitive = sensitive || is_sensitive_name env_name in
   { env_name; description; default_display = default; sensitive }
 
+let default_provenance e =
+  match e.default_display with
+  | "(derived)" ->
+      {
+        kind = "derived";
+        detail = "computed by runtime config helpers from related settings";
+        derived_from = [];
+      }
+  | "(cwd)" ->
+      {
+        kind = "runtime";
+        detail = "resolved from the process working directory or base path";
+        derived_from = [];
+      }
+  | _ ->
+      { kind = "default"; detail = "compiled default value"; derived_from = [] }
+
+let source_provenance e raw =
+  match raw with
+  | Some _ ->
+      {
+        kind = "env";
+        detail = "environment variable " ^ e.env_name;
+        derived_from = [];
+      }
+  | None -> default_provenance e
+
+let provenance_to_json p =
+  `Assoc
+    ([
+       ("kind", `String p.kind);
+       ("detail", `String p.detail);
+     ]
+    @
+    if p.derived_from = [] then []
+    else [ ("derived_from", `List (List.map (fun v -> `String v) p.derived_from)) ])
+
 let read_entry e =
   let raw = Env_config_core.trim_opt (Sys.getenv_opt e.env_name) in
+  let provenance = source_provenance e raw in
   let display_value =
     match raw with
     | None -> None
@@ -48,7 +92,9 @@ let read_entry e =
       ("description", `String e.description);
       ("value", Json_util.string_opt_to_json display_value);
       ("default", `String e.default_display);
-      ("source", `String (if raw = None then "default" else "env"));
+      ("source", `String provenance.kind);
+      ("source_detail", `String provenance.detail);
+      ("provenance", provenance_to_json provenance);
       ("sensitive", `Bool e.sensitive);
     ]
 

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -281,21 +281,58 @@ let runtime_surface_json config (meta : keeper_meta) =
      @ social_runtime_fields_json meta
      @ runtime_blocker_fields_json config meta)
 
+let existing_path_json ?source path =
+  let fields =
+    [
+      ("path", `String path);
+      ("exists", `Bool (Fs_compat.file_exists path));
+    ]
+  in
+  let fields =
+    match source with
+    | Some value -> ("source", `String value) :: fields
+    | None -> fields
+  in
+  `Assoc (List.rev fields)
+
+let optional_existing_path_json ?source = function
+  | Some path -> existing_path_json ?source path
+  | None -> `Null
+
+let override_field_source_json ~default_source_kind ~default_manifest_path field =
+  `Assoc
+    [
+      ("field", `String field);
+      ("source", `String "live_meta");
+      ("default_source_kind", Json_util.string_opt_to_json default_source_kind);
+      ("default_manifest_path", Json_util.string_opt_to_json default_manifest_path);
+    ]
+
 let source_provenance_json config (meta : keeper_meta) =
   let snapshot = keeper_default_source_snapshot meta.name in
   let override_fields = live_override_fields meta snapshot.defaults in
+  let resolution = Config_dir_resolver.resolve () in
+  let live_meta_path = keeper_meta_path config meta.name in
+  let default_manifest_path = snapshot.defaults.manifest_path in
+  let default_source_kind = snapshot.source_kind in
   `Assoc
     [
-      ("live_meta_path", `String (keeper_meta_path config meta.name));
-      ( "default_manifest_path",
-        match snapshot.defaults.manifest_path with
-        | Some path -> `String path
-        | None -> `Null );
-      ( "default_source_kind",
-        match snapshot.source_kind with
-        | Some kind -> `String kind
-        | None -> `Null );
+      ("live_meta_path", `String live_meta_path);
+      ("live_meta", existing_path_json ~source:"runtime_overlay" live_meta_path);
+      ("default_manifest_path", Json_util.string_opt_to_json default_manifest_path);
+      ( "default_manifest",
+        optional_existing_path_json ?source:default_source_kind default_manifest_path );
+      ("default_source_kind", Json_util.string_opt_to_json default_source_kind);
+      ("active_config_root", `String resolution.config_root.path);
+      ( "active_config_root_source",
+        `String (Config_dir_resolver.source_to_string resolution.config_root.source) );
+      ("config_resolution", Config_dir_resolver.to_json resolution);
       ("precedence", `List [ `String "live_meta"; `String "toml"; `String "persona" ]);
       ("has_live_override", `Bool (override_fields <> []));
       ("override_fields", string_list_to_json override_fields);
+      ( "override_field_sources",
+        `List
+          (List.map
+             (override_field_source_json ~default_source_kind ~default_manifest_path)
+             override_fields) );
     ]

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -259,6 +259,10 @@ let test_to_json_masks_sensitive_values_and_tracks_sources () =
       let entry = find_config_entry json "MASC_ADMIN_TOKEN" in
       let open Yojson.Safe.Util in
       check string "source is env" "env" (entry |> member "source" |> to_string);
+      check string "source detail names env" "environment variable MASC_ADMIN_TOKEN"
+        (entry |> member "source_detail" |> to_string);
+      check string "provenance kind is env" "env"
+        (entry |> member "provenance" |> member "kind" |> to_string);
       check bool "marked sensitive" true (entry |> member "sensitive" |> to_bool);
       check string "masked token" "supe***"
         (entry |> member "value" |> to_string))
@@ -271,6 +275,22 @@ let test_to_json_treats_blank_env_as_default () =
       check string "blank source is default" "default"
         (entry |> member "source" |> to_string);
       check bool "blank value omitted" true (entry |> member "value" = `Null))
+
+let test_to_json_exposes_derived_and_runtime_provenance () =
+  with_env "MASC_HTTP_BASE_URL" "   " (fun () ->
+      with_env Env_config.base_path_env_key "   " (fun () ->
+          let json = Env_config.to_json () in
+          let base_url = find_config_entry json "MASC_HTTP_BASE_URL" in
+          let base_path = find_config_entry json Env_config.base_path_env_key in
+          let open Yojson.Safe.Util in
+          check string "derived source" "derived"
+            (base_url |> member "source" |> to_string);
+          check string "derived provenance kind" "derived"
+            (base_url |> member "provenance" |> member "kind" |> to_string);
+          check string "runtime source" "runtime"
+            (base_path |> member "source" |> to_string);
+          check string "runtime provenance kind" "runtime"
+            (base_path |> member "provenance" |> member "kind" |> to_string)))
 
 (* ============================================================
    print_summary Tests
@@ -555,6 +575,8 @@ let () =
         test_to_json_masks_sensitive_values_and_tracks_sources;
       test_case "to_json treats blank env as default" `Quick
         test_to_json_treats_blank_env_as_default;
+      test_case "to_json exposes derived and runtime provenance" `Quick
+        test_to_json_exposes_derived_and_runtime_provenance;
     ];
     "print_summary", [
       test_case "no error" `Quick test_print_summary_no_error;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -963,6 +963,17 @@ proactive_enabled = true
         (json |> member "proactive" |> member "enabled" |> to_bool);
       Alcotest.(check string) "default source kind" "toml"
         (json |> member "sources" |> member "default_source_kind" |> to_string);
+      Alcotest.(check string) "active config root" config_dir
+        (json |> member "sources" |> member "active_config_root" |> to_string);
+      Alcotest.(check string) "active config root source" "env"
+        (json |> member "sources" |> member "active_config_root_source" |> to_string);
+      Alcotest.(check string) "live meta source" "runtime_overlay"
+        (json |> member "sources" |> member "live_meta" |> member "source" |> to_string);
+      Alcotest.(check string) "default manifest source" "toml"
+        (json |> member "sources" |> member "default_manifest" |> member "source" |> to_string);
+      Alcotest.(check string) "config resolution source" "env"
+        (json |> member "sources" |> member "config_resolution"
+         |> member "config_root" |> member "source" |> to_string);
       Alcotest.(check bool) "live override flagged" true
         (json |> member "sources" |> member "has_live_override" |> to_bool);
       Alcotest.(check string) "auto team session removed" "removed"
@@ -973,6 +984,19 @@ proactive_enabled = true
       in
       Alcotest.(check bool) "override field proactive" true
         (List.mem "proactive.enabled" override_fields);
+      let override_field_sources =
+        json |> member "sources" |> member "override_field_sources" |> to_list
+      in
+      Alcotest.(check bool) "override field source proactive" true
+        (List.exists
+           (fun item ->
+              String.equal
+                (item |> member "field" |> to_string)
+                "proactive.enabled"
+              && String.equal
+                   (item |> member "source" |> to_string)
+                   "live_meta")
+           override_field_sources);
       Alcotest.(check bool) "initiative surface removed" true
         (json |> member "initiative" = `Null);
       Alcotest.(check int) "total input tokens surfaced" 1200


### PR DESCRIPTION
## Summary
- add source/provenance details to server config snapshot entries
- show non-env config provenance in the dashboard server config UI
- expand keeper config sources with live meta, default manifest, active config root, config resolution, and per-override provenance

## Verification
- git diff --check
- opam exec -- dune build --root "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-056-config-provenance" test/test_operator_control.exe
- opam exec -- ./_build/default/test/test_operator_control.exe
- opam exec -- dune build --root "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-056-config-provenance" @install
- opam exec -- dune build --root "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-056-config-provenance" test/test_env_config_coverage.exe
- opam exec -- ./_build/default/test/test_env_config_coverage.exe test path_helpers 12
- pnpm install --offline --frozen-lockfile
- pnpm typecheck

## Notes
- Full test_env_config_coverage currently has three unrelated path-helper failures in this local shell because MASC_BASE_PATH resolves to /Users/dancer/me; the new provenance test passes when run directly.
