### PR TITLE
chore(config): SSOT for MASC_HOST / MASC_HTTP_PORT env keys (#8352 Phase 5)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -145,8 +145,15 @@ let get_bool_deprecated ~default ~primary ~deprecated =
 let default_http_port = Masc_network_defaults.masc_http_default_port_s
 let default_http_port_int = Masc_network_defaults.masc_http_default_port
 
+(** SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352).
+    Defined here so in-process readers and out-of-process callers
+    (snapshot, provider_adapter presence check, bootstrap putenv)
+    share one literal. *)
+let host_env_key = "MASC_HOST"
+let http_port_env_key = "MASC_HTTP_PORT"
+
 let masc_http_port () =
-  match raw_value_opt "MASC_HTTP_PORT" |> trim_opt with
+  match raw_value_opt http_port_env_key |> trim_opt with
   | Some port -> port
   | None -> Masc_network_defaults.masc_http_default_port_s
 
@@ -155,7 +162,7 @@ let masc_http_port_int () =
     ~default:Masc_network_defaults.masc_http_default_port (masc_http_port ())
 
 let masc_host_opt () =
-  raw_value_opt "MASC_HOST" |> trim_opt
+  raw_value_opt host_env_key |> trim_opt
 
 let default_host = Masc_network_defaults.masc_http_default_host
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -57,8 +57,8 @@ let category name entries =
 
 let server_entries =
   [
-    entry ~default:Masc_network_defaults.masc_http_default_port_s "MASC_HTTP_PORT" "HTTP server port";
-    entry ~default:Env_config_core.default_host "MASC_HOST" "Server bind host";
+    entry ~default:Masc_network_defaults.masc_http_default_port_s Env_config_core.http_port_env_key "HTTP server port";
+    entry ~default:Env_config_core.default_host Env_config_core.host_env_key "Server bind host";
     entry ~default:"(derived)" Env_config_core.http_base_url_env_key "Public HTTP base URL";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" Env_config_core.base_path_env_key "Base storage directory";

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -470,10 +470,9 @@ let legacy_voice_base_url_opt () =
       Some (Printf.sprintf "http://%s:%s" host port)
 
 let http_listener_env_explicit () =
-  Option.is_some
-    (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
-  || Option.is_some (Sys.getenv_opt "MASC_HOST" |> trim_opt)
-  || Option.is_some (Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt)
+  Option.is_some (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
+  || Option.is_some (Sys.getenv_opt Env_config_core.host_env_key |> trim_opt)
+  || Option.is_some (Sys.getenv_opt Env_config_core.http_port_env_key |> trim_opt)
 
 let default_voice_session_base_url () =
   match Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt with

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -6,8 +6,8 @@ module Http = Http_server_eio
 
 let make_http_config ~host ~port : Http.config =
   let config = { Http.default_config with port; host } in
-  Unix.putenv "MASC_HOST" config.host;
-  Unix.putenv "MASC_HTTP_PORT" (string_of_int config.port);
+  Unix.putenv Env_config_core.host_env_key config.host;
+  Unix.putenv Env_config_core.http_port_env_key (string_of_int config.port);
   (match Sys.getenv_opt Env_config_core.http_base_url_env_key with
   | Some existing when String.trim existing <> "" -> ()
   | _ ->
@@ -16,8 +16,7 @@ let make_http_config ~host ~port : Http.config =
           Masc_network_defaults.masc_http_default_host
         else config.host
       in
-      Unix.putenv
-        Env_config_core.http_base_url_env_key
+      Unix.putenv Env_config_core.http_base_url_env_key
         (Printf.sprintf "http://%s:%d" advertised_host config.port));
   config
 


### PR DESCRIPTION
## Summary
Fifth batch for #8352. Two new constants + 6 literal migrations across 4 files.

## New constants (lib/config/env_config_core.ml)
- `host_env_key = "MASC_HOST"`
- `http_port_env_key = "MASC_HTTP_PORT"`

Placed above `masc_http_port` / `masc_host_opt` to avoid the forward-reference trap that tripped #8663.

## Migrated call sites
- `env_config_core.ml` — `masc_http_port`, `masc_host_opt` internals.
- `provider_adapter.ml:473-475` — `http_listener_env_explicit` three getenv probes.
- `server/server_bootstrap_http.ml:9-11,19` — putenv pair + existing `http_base_url_env_key` read.
- `config/env_config_snapshot.ml:60-62` — catalog entries.

Test files keep string literals (`with_env` helpers) intentionally.

## Not in this PR
MASC_STORAGE_TYPE (done in #8664), MASC_ORCHESTRATOR_ENABLED, MASC_CONFIG_DIR, MASC_KEEPER_* land in follow-ups. #8352 stays open.

No behavior change; pure literal hoist.

## Test plan
- [x] `dune build lib/` passes.
- [ ] CI green (Build / Lint / Health / PR Sync).

Refs #8352