### PR TITLE
chore(config): SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env keys (#8352 Phase 6)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -295,13 +295,18 @@ let storage_type () =
       | other -> other)
   | None -> "filesystem"
 
+(** SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352).
+    Shared by snapshot catalog and docker worker inheritance list. *)
+let config_dir_env_key = "MASC_CONFIG_DIR"
+let personas_dir_env_key = "MASC_PERSONAS_DIR"
+
 (** Config directory override. *)
 let config_dir_opt () =
-  raw_value_opt "MASC_CONFIG_DIR" |> trim_opt
+  raw_value_opt config_dir_env_key |> trim_opt
 
 (** Personas directory override. *)
 let personas_dir_opt () =
-  raw_value_opt "MASC_PERSONAS_DIR" |> trim_opt
+  raw_value_opt personas_dir_env_key |> trim_opt
 
 (** {1 Relay Calibration} *)
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -741,11 +741,11 @@ let path_entries =
       "Base path resolution source override; None when unset";
     entry ~default:"(none)" "MASC_BASE_PATH_STRICT"
       "Fail-fast on base path resolution issues";
-    entry ~default:"(none)" "MASC_CONFIG_DIR"
+    entry ~default:"(none)" Env_config_core.config_dir_env_key
       "Config directory override; None when unset";
     entry ~default:"(none)" "MASC_DATA_DIR"
       "Data directory override; None=<base_path>/data";
-    entry ~default:"(none)" "MASC_PERSONAS_DIR"
+    entry ~default:"(none)" Env_config_core.personas_dir_env_key
       "Personas directory override; None when unset";
   ]
 

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -104,7 +104,7 @@ let allowlisted_env_pairs () =
       "GOOGLE_CLOUD_LOCATION";
       Env_config_core.storage_type_env_key;
       Env_config_core.base_path_env_key;
-      "MASC_CONFIG_DIR";
+      Env_config_core.config_dir_env_key;
     ]
   in
   let inherited =


### PR DESCRIPTION
## Summary
Sixth batch for #8352. Two new constants + 4 literal migrations across 3 files.

## New constants (lib/config/env_config_core.ml)
- `config_dir_env_key = "MASC_CONFIG_DIR"`
- `personas_dir_env_key = "MASC_PERSONAS_DIR"`

Placed next to the existing readers (`config_dir_opt`, `personas_dir_opt`).

## Migrated call sites
- `env_config_core.ml` — `config_dir_opt`, `personas_dir_opt` internals.
- `config/env_config_snapshot.ml:744,748` — catalog entries.
- `worker_runtime_docker.ml:107` — container-inherited keys list; previously had `"MASC_CONFIG_DIR"` literal alongside `Env_config_core.base_path_env_key`, now consistent.

Test files keep string literals (`with_env` helpers) intentionally.

## Not in this PR
MASC_ORCHESTRATOR_ENABLED (4 sites), MASC_KEEPER_* etc. land in follow-ups. #8352 stays open.

No behavior change; pure literal hoist.

## Test plan
- [ ] CI green (Build / Lint / Health / PR Sync).

Refs #8352