### PR TITLE
fix(governance-judge): guard null recommended_action (main CI unblock)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -114,15 +114,15 @@ let judgment_generated_at json =
   |> Option.value ~default:0.0
 
 let normalize_disk_recommended_action judgment =
-  let canonical_tool =
-    match judgment |> member "recommended_action" |> member "resolved_tool" |> to_string_option with
-    | Some tool ->
-        let tool = tool |> String.trim |> String.lowercase_ascii in
-        if tool = "" then None else Some tool
-    | None -> None
-  in
   match judgment |> member "recommended_action" with
   | `Assoc action_fields ->
+      let canonical_tool =
+        match List.assoc_opt "resolved_tool" action_fields with
+        | Some (`String tool) ->
+            let tool = tool |> String.trim |> String.lowercase_ascii in
+            if tool = "" then None else Some tool
+        | _ -> None
+      in
       let normalized_action =
         `Assoc
           (List.map


### PR DESCRIPTION
## Summary

Main CI is red since #8668 merge: every open PR inherits `Build and Test` + `TLA+` + `CI Gate` FAILURE. Root cause is a latent bug in `normalize_disk_recommended_action` (added by #8626) triggered by legacy judgments that lack `recommended_action`.

## Root cause

`lib/dashboard/dashboard_governance_judge.ml:118` unconditionally chains `member "resolved_tool"` onto the result of `member "recommended_action"`. When the judgment JSON has no `recommended_action` key, Yojson returns `` `Null ``; then `member` on `` `Null `` raises:

```
Yojson__Safe.Util.Type_error("Can't get member 'resolved_tool' of non-object type null", ...)
```

## Fix

Move the `resolved_tool` canonicalization inside the `` `Assoc action_fields `` branch, using `List.assoc_opt` instead of another `member` call. No behavior change when `recommended_action` is present as an object.

## Verification

- `dune exec test/test_dashboard_governance.exe` → 9/9 pass including `projection 2 — empty judgment disk scan uses cooldown`
- Clean 1-file diff (+7 -7)

## Follow-up

Once merged, #8643/#8639/#8672/#8673/#8679 rebase should clear Build and Test / CI Gate automatically.
