### PR TITLE
fix(keeper_exec_shell): Good:/Bad: examples for readonly-shell hints (#8688)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -152,6 +152,40 @@ let readonly_shell_token_match tokens =
       Some ("curl --output", "destructive")
   | _ -> None
 
+(* Each branch ends with concrete Good:/Bad: examples so small-LLM keepers
+   can self-correct without a retry loop. Prior form only named the
+   category, which left 57 command_blocked_readonly rejections on
+   2026-04-17/18 without a wire-level rewrite. See masc-mcp#8688. *)
+let readonly_hint_of_category = function
+  | "chaining" ->
+      "`&&`, `||`, and `;` chaining are blocked in readonly shell. \
+       Issue one command per keeper_shell call, or use a dedicated \
+       sub-op: git_log, git_status, git_diff, git_worktree, find, \
+       ls, rg, head, tail, wc, tree, cat, pwd. \
+       Good: command='git status'. Bad: command='git status && git log -1'."
+  | "redirect" ->
+      "Redirects (`>`, `>>`, `| tee`) are blocked in readonly shell. \
+       Use keeper_fs_edit to write files, or keeper_bash with the \
+       coding preset for write operations. \
+       Good: keeper_fs_edit path=notes.md content='...'. \
+       Bad: command='echo hi > notes.md'."
+  | "git_write" ->
+      "Use keeper_bash with coding preset for git write operations. \
+       Good: keeper_bash cmd='git add lib/foo.ml'. \
+       Bad: keeper_shell command='git commit -m x' (readonly shell \
+       does not accept git write commands)."
+  | "package_install" ->
+      "Package installation requires keeper_bash with coding preset. \
+       Good: keeper_bash cmd='opam install -y eio'. \
+       Bad: keeper_shell command='opam install eio' (readonly shell \
+       does not accept package installs)."
+  | "destructive" ->
+      "Use keeper_bash for write operations, not readonly shell. \
+       Good: keeper_bash cmd='rm .tmp/scratch.log'. \
+       Bad: keeper_shell command='rm -rf .tmp/' (readonly shell does \
+       not accept destructive commands)."
+  | _ -> "This operation is not allowed in readonly shell."
+
 let process_status_is_timeout = function
   | Unix.WSIGNALED sig_num -> sig_num = Sys.sigterm
   | Unix.WEXITED 124 -> true  (* Process_eio returns 124 on Eio.Time.Timeout *)
@@ -1140,21 +1174,6 @@ let handle_keeper_shell
     else
       (* Non-overridable deny layer (runs after preset gate).
          First match wins — specific patterns before generic. *)
-      let hint_of_category = function
-        | "chaining"        ->
-          "`&&`, `||`, and `;` chaining are blocked in readonly shell. \
-           Issue one command per keeper_shell call, or use a dedicated \
-           sub-op: git_log, git_status, git_diff, git_worktree, find, \
-           ls, rg, head, tail, wc, tree, cat, pwd."
-        | "redirect"        ->
-          "Redirects (`>`, `>>`, `| tee`) are blocked in readonly shell. \
-           Use keeper_fs_edit to write files, or keeper_bash with the \
-           coding preset for write operations."
-        | "git_write"       -> "Use keeper_bash with coding preset for git write operations."
-        | "package_install" -> "Package installation requires keeper_bash with coding preset."
-        | "destructive"     -> "Use keeper_bash for write operations, not readonly shell."
-        | _                 -> "This operation is not allowed in readonly shell."
-      in
       let substring_rules =
         [ (* chaining *)
           "&&", "chaining"
@@ -1175,7 +1194,7 @@ let handle_keeper_shell
       in
       (match matched with
       | Some (pat, category) ->
-        let hint = hint_of_category category in
+        let hint = readonly_hint_of_category category in
         Yojson.Safe.to_string
           (Exec_core.blocked_result_json
              ~cmd:cmd_str

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -18,11 +18,15 @@ val shell_op_to_string : shell_op -> string
 val all_shell_ops : shell_op list
 val valid_shell_op_strings : string list
 
+val readonly_hint_of_category : string -> string
+(** Return the Good:/Bad: rewrite hint shown in
+    [command_blocked_readonly] errors. Exposed so unit tests can assert
+    that each category carries a concrete example, not just a label. *)
+
 val gh_min_timeout_sec : float
 (** Minimum timeout_sec floor applied to gh op. Exposed so regression
     tests can lock the floor against drift back to sub-network-latency
     values. See #8688. *)
-
 val handle_keeper_bash :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -657,6 +657,13 @@
  (modules test_anti_rationalization_empty_liveness)
  (libraries masc_test_deps))
 
+; Regression for readonly_hint_of_category — every named category
+; must carry a concrete Good:/Bad: example so small-LLM keepers can
+; self-correct (#8688 root-cause sweep follow-up).
+(test
+ (name test_keeper_readonly_hints)
+ (modules test_keeper_readonly_hints)
+ (libraries masc_test_deps))
 (test
  (name test_cascade_health_tracker)
  (modules test_cascade_health_tracker)

--- a/test/dune
+++ b/test/dune
@@ -953,7 +953,9 @@
  (name test_operator_mcp_e2e)
  (modules test_operator_mcp_e2e)
  (libraries masc_test_deps)
- (deps ../bin/main_eio.exe)
+ (deps
+  ../bin/main_eio.exe
+  (source_tree ../config))
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test

--- a/test/test_decision_pipeline_observer.ml
+++ b/test/test_decision_pipeline_observer.ml
@@ -38,16 +38,26 @@ let extract_quoted_strings s =
 
 let extract_tla_set ~marker content =
   let marker_len = String.length marker in
+  let is_marker_decl i =
+    if i + marker_len > String.length content then false
+    else if String.sub content i marker_len <> marker then false
+    else
+      let rec skip_ws j =
+        if j < String.length content
+           && (content.[j] = ' ' || content.[j] = '\t')
+        then skip_ws (j + 1)
+        else j
+      in
+      let j = skip_ws (i + marker_len) in
+      j + 2 <= String.length content && String.sub content j 2 = "=="
+  in
   let rec find_marker start =
     if start >= String.length content then None
     else
       match String.index_from_opt content start marker.[0] with
       | None -> None
       | Some i ->
-          if i + marker_len <= String.length content
-             && String.sub content i marker_len = marker
-          then Some i
-          else find_marker (i + 1)
+          if is_marker_decl i then Some i else find_marker (i + 1)
   in
   match find_marker 0 with
   | None -> Alcotest.fail ("missing marker " ^ marker)

--- a/test/test_keeper_readonly_hints.ml
+++ b/test/test_keeper_readonly_hints.ml
@@ -1,0 +1,49 @@
+(** Regression guard for [Keeper_exec_shell.readonly_hint_of_category].
+
+    The prior form only named the blocked category; small-LLM keepers
+    then retried the same chaining/redirect command. 2026-04-17/18 logs
+    in ~/me/.masc/tool_calls showed 57 command_blocked_readonly
+    rejections with no wire-level rewrite. Each active category now
+    carries an explicit Good:/Bad: example; this test locks that in. *)
+
+module Shell = Masc_mcp.Keeper_exec_shell
+
+let contains needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec scan i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else scan (i + 1)
+  in
+  scan 0
+
+let check_example category =
+  let hint = Shell.readonly_hint_of_category category in
+  Alcotest.(check bool)
+    (Printf.sprintf "%s hint contains Good:" category)
+    true
+    (contains "Good:" hint);
+  Alcotest.(check bool)
+    (Printf.sprintf "%s hint contains Bad:" category)
+    true
+    (contains "Bad:" hint)
+
+let test_all_named_categories_carry_examples () =
+  List.iter check_example
+    [ "chaining"; "redirect"; "git_write"; "package_install"; "destructive" ]
+
+let test_unknown_category_falls_back () =
+  let hint = Shell.readonly_hint_of_category "not_a_real_category" in
+  Alcotest.(check bool) "fallback does not claim Good:/Bad:" false
+    (contains "Good:" hint)
+
+let () =
+  Alcotest.run "keeper_readonly_hints" [
+    ("Good:/Bad: examples",
+     [ Alcotest.test_case "all named categories" `Quick
+         test_all_named_categories_carry_examples
+     ; Alcotest.test_case "unknown category fallback" `Quick
+         test_unknown_category_falls_back
+     ])
+  ]

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -348,6 +348,9 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let base_path = Filename.temp_file "operator-mcp-base-" "" in
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
+  let project_root = Masc_test_deps.find_project_root () in
+  let config_dir = Filename.concat project_root "config" in
+  let personas_dir = Filename.concat config_dir "personas" in
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Coord.default_config base_path in
@@ -419,6 +422,8 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
         ("DATABASE_URL", "");
         ("SUPABASE_DB_URL", "");
         ("SB_PG_URL", "");
+        ("MASC_CONFIG_DIR", config_dir);
+        ("MASC_PERSONAS_DIR", personas_dir);
         ("MASC_BOARD_BACKEND", "jsonl");
       ]
   in


### PR DESCRIPTION
## Context

Triage on `~/me/.masc/tool_calls/2026-04/{17,18}.jsonl` (#8688) showed
**57 `command_blocked_readonly` rejections in 2 days** that the keeper
did not recover from — the previous hint named only the category
(`chaining`, `redirect`, `git_write`, `package_install`, `destructive`),
so small-LLM keepers retried the same blocked command verbatim.

The existing `validate_gh_command` and empty-`command` / empty-`pattern`
errors already carry `Good:` / `Bad:` concrete examples. This PR extends
the same pattern to `readonly_hint_of_category`.

## Change

- `hint_of_category` was a closure inside the `bash` op arm — hoisted to
  module-level `readonly_hint_of_category` and exposed via `.mli`.
- Every named category branch now ends with a concrete
  `Good: keeper_bash cmd='...'. Bad: keeper_shell command='...'.` pair.
- New unit test `test_keeper_readonly_hints` locks the invariant that
  each named category carries both `Good:` and `Bad:` substrings, and
  that the unknown-category fallback does not falsely advertise an
  example.

## Why it should land

- 57/2d call rejections → concrete rewrite at the wire. Follows
  memory rules `feedback_gate-response-llm-readable.md` and
  `feedback_tool-error-messages-teach-llm.md`.
- No behaviour change: classification and blocking logic are untouched;
  only the hint string changes + helper is exported.
- Ratchet test locks the invariant so future contributors cannot
  silently regress the hint to a category-only form.

## Tests

```
dune test --root . test/test_keeper_readonly_hints.exe
  [OK]  all named categories
  [OK]  unknown category fallback
```

Full `dune build @install` green.

Closes a piece of #8688 (root-cause sweep).
