### PR TITLE
fix(tool_task): embed concrete good-notes example in rejection msg (#8688)

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -131,16 +131,30 @@ let can_review_completion ~(task_opt : Types.task option) ~(agent_name : string)
        | _ -> false)
   | None -> false
 
+(* Concrete example handed to the keeper when the anti-rationalization
+   gate rejects a completion. Prior form said only "describe actual
+   work"; small-LLM keepers retried the same perfunctory notes
+   (37 Tool_task completion rejects observed on 2026-04-17/18 in
+   ~/me/.masc/tool_calls). The example shows the expected density:
+   what changed, which files, what verification ran. See #8688. *)
+let completion_notes_example =
+  "Example of accepted notes: 'Added Event_kind.Board variant to \
+   lib/coord/event_kind.{ml,mli}, migrated 8 call-sites in \
+   coord_task.ml and activity_graph.ml, test_event_kind round-trip \
+   green, CI green on PR #NNNN.'"
+
 let completion_rejection_message ?(allow_force = false) reason =
   if allow_force then
     Printf.sprintf
       "Completion rejected by anti-rationalization gate: %s\n\
        Revise your completion notes to describe actual work, then retry.\n\
-       Use force=true to override (operator only)." reason
+       %s\n\
+       Use force=true to override (operator only)." reason completion_notes_example
   else
     Printf.sprintf
       "Completion rejected by anti-rationalization gate: %s\n\
-       Revise your completion notes to describe actual work, then retry." reason
+       Revise your completion notes to describe actual work, then retry.\n\
+       %s" reason completion_notes_example
 
 let parse_task_contract args =
   match args |> member "contract" with

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -26,6 +26,17 @@ val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result optio
 
 val schemas : Types.tool_schema list
 
+val completion_notes_example : string
+(** Concrete example of accepted completion notes. Referenced in the
+    rejection message so the keeper sees the expected density, not
+    just "describe actual work". See #8688. *)
+
+val completion_rejection_message : ?allow_force:bool -> string -> string
+(** Build the wire-level message returned when the anti-rationalization
+    gate rejects a completion. Always embeds
+    [completion_notes_example]. Exposed for regression tests that lock
+    in the example substring. *)
+
 (** [is_cross_model_verdict result] is [true] iff [result] has both
     [generator_cascade = Some g] and [evaluator_cascade] non-empty,
     and [g <> evaluator_cascade].

--- a/test/dune
+++ b/test/dune
@@ -641,6 +641,13 @@
  (modules test_keeper_gh_timeout_floor)
  (libraries masc_test_deps))
 
+; Regression for Tool_task.completion_rejection_message — every
+; rejection must embed completion_notes_example so the keeper sees
+; a concrete density of accepted notes (#8688 root-cause sweep).
+(test
+ (name test_tool_task_completion_example)
+ (modules test_tool_task_completion_example)
+ (libraries masc_test_deps))
 (test
  (name test_cascade_health_tracker)
  (modules test_cascade_health_tracker)

--- a/test/test_tool_task_completion_example.ml
+++ b/test/test_tool_task_completion_example.ml
@@ -1,0 +1,49 @@
+(** Regression guard for [Tool_task.completion_rejection_message].
+
+    2026-04-17/18 ~/me/.masc/tool_calls showed 37 completion rejects
+    where the keeper retried the same perfunctory notes because the
+    rejection text said only "describe actual work". The message must
+    now always embed [completion_notes_example] so small-LLM keepers
+    see the expected density. See #8688. *)
+
+module TT = Masc_mcp.Tool_task
+
+let contains needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec scan i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else scan (i + 1)
+  in
+  scan 0
+
+let test_message_includes_example () =
+  let msg = TT.completion_rejection_message "verdict text" in
+  Alcotest.(check bool) "rejection msg includes example" true
+    (contains TT.completion_notes_example msg);
+  Alcotest.(check bool) "rejection msg keeps reason" true
+    (contains "verdict text" msg)
+
+let test_allow_force_variant_includes_example () =
+  let msg = TT.completion_rejection_message ~allow_force:true "verdict text" in
+  Alcotest.(check bool) "force variant includes example" true
+    (contains TT.completion_notes_example msg);
+  Alcotest.(check bool) "force variant keeps force hint" true
+    (contains "force=true" msg)
+
+let test_example_nonempty () =
+  Alcotest.(check bool) "example is nontrivial" true
+    (String.length TT.completion_notes_example > 40)
+
+let () =
+  Alcotest.run "tool_task_completion_example" [
+    ("completion_rejection_message",
+     [ Alcotest.test_case "plain variant embeds example" `Quick
+         test_message_includes_example
+     ; Alcotest.test_case "force variant embeds example" `Quick
+         test_allow_force_variant_includes_example
+     ; Alcotest.test_case "example string is substantive" `Quick
+         test_example_nonempty
+     ])
+  ]


### PR DESCRIPTION
## Context

Triage of `~/me/.masc/tool_calls/2026-04/{17,18}.jsonl` (#8688) logged
**37 `Tool_task` completion rejects in 2 days** where the keeper sent
a fresh call with the same perfunctory notes. The prior rejection
text named the quality floor (`describe actual work, then retry`) but
gave no wire-level density example, so the keeper guessed and retried
with roughly the same content.

Sibling to #8704 (readonly-shell hints).

## Change

- `tool_task.ml` introduces `completion_notes_example`, a single-
  sentence exemplar showing "what changed, which files, what
  verification" density the gate accepts.
- `completion_rejection_message` now embeds that example in both the
  plain and `~allow_force:true` variants — directly after
  `describe actual work, then retry.` and before any operator
  override hint.
- Both helpers are exported via `tool_task.mli`.
- New `test_tool_task_completion_example` locks three invariants:
  plain variant embeds the example, force variant embeds the example
  and still carries `force=true`, and the example is a
  nontrivially-sized string (>40 chars).

## Why it should land

- 37/2d keeper retries addressed at the wire.
- Pure message-text change + helper export; no behavioural logic
  touched.
- Follows memory `feedback_gate-response-llm-readable` and
  `feedback_tool-error-messages-teach-llm`.

## Tests

```
$ dune test --root . test/test_tool_task_completion_example.exe
  [OK]  plain variant embeds example
  [OK]  force variant embeds example
  [OK]  example string is substantive
```

Full `dune build @install` green.

Closes a piece of #8688.
