### PR TITLE
[codex] Add OCaml north star guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-run-local-fresh-boot harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak bonsai-dashboard bonsai-dashboard-if-available dev-bonsai-dashboard clean-bonsai-dashboard
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ocaml-health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-run-local-fresh-boot harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak bonsai-dashboard bonsai-dashboard-if-available dev-bonsai-dashboard clean-bonsai-dashboard
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -181,6 +181,13 @@ health:
 	@mkdir -p .health
 	bash scripts/health_snapshot.sh --json-out .health/health-snapshot.json
 	@echo "Health snapshot: .health/health-snapshot.json"
+
+# Warn-only OCaml north-star snapshot. This reports risk-pattern counts without
+# changing CI policy or the public OAS/MCP/task semantics.
+ocaml-health:
+	@mkdir -p .health
+	bash scripts/ocaml-north-star-health.sh --json-out .health/ocaml-north-star-health.json
+	@echo "OCaml north-star snapshot: .health/ocaml-north-star-health.json"
 
 # Build and run a Valgrind-based startup/MCP smoke check for memory leaks
 check-memory-leak:

--- a/docs/OCAML-NORTH-STAR.md
+++ b/docs/OCAML-NORTH-STAR.md
@@ -1,0 +1,93 @@
+# OCaml North Star
+
+This document defines the OCaml quality direction for `masc-mcp`.
+It is intentionally spec-preserving: it does not change MASC, OAS, MCP,
+task lifecycle, execution policy, or deterministic/non-deterministic
+boundaries.
+
+## Non-Negotiables
+
+- Do not change public OAS/MCP wire shapes as part of quality work.
+- Do not change task lifecycle semantics inside a refactor.
+- Do not change deterministic/non-deterministic implementation boundaries
+  without a separate RFC and explicit review.
+- Do not change execution policy, approval policy, or tool semantics as a
+  side effect of making code cleaner.
+- Do not optimize for performance without benchmark evidence.
+- Do not edit `~/me` root workspace files for this program; work inside the
+  target repo and its own `.worktrees/`.
+
+## What "Excellent OCaml" Means Here
+
+The project should use OCaml's strengths to make existing behavior easier to
+trust:
+
+- model protocol and lifecycle states with algebraic data types;
+- keep JSON, strings, filesystem paths, process arguments, and model output at
+  typed boundaries;
+- expose narrow `.mli` contracts for stable modules;
+- return typed `result` values for expected failures;
+- reserve exceptions for cancellation, programmer errors, or low-level
+  library boundaries;
+- use Eio structured concurrency with explicit resource ownership;
+- keep mutation bounded behind modules with a clear owner;
+- measure allocation and latency before replacing clear code with clever code.
+
+## Implementation Pattern
+
+For each improvement:
+
+1. Write behavior-locking tests for current semantics.
+2. Extract pure state transitions or decoding logic without changing the wire
+   shape.
+3. Keep effectful shells thin: file I/O, Eio fibers, process execution, HTTP,
+   SSE, and provider calls belong at the edge.
+4. Prefer existing canonical types:
+   `Types_auth.masc_error` for user-facing operation errors and
+   `Failure_envelope.t` for operator evidence.
+5. Run the local checks relevant to touched files.
+
+## Initial Focus Areas
+
+- Task lifecycle: lock the current transition table before extracting a pure
+  FSM kernel from `Coord_task`.
+- Keeper scheduling: lock semaphore, fairness, and cancellation invariants
+  before changing queue implementation details.
+- Process and sidecar execution: prove equivalence before replacing shell
+  string paths with argv-only paths.
+- Typed OAS/codecs: keep wire compatibility, improve error locality, and make
+  schema drift visible.
+
+## Health Tracking
+
+`make ocaml-health` is observational by default. It reports risk-pattern
+counts but does not fail CI. Promote individual checks to ratchets only after
+their baseline and intended scope are reviewed.
+
+Tracked patterns include production `failwith`, `invalid_arg`, `assert false`,
+`Obj.magic`, direct `Sys.command`, raw process spawning, manual mutex
+lock/unlock, broad exception catches, and untyped JSON utility use.
+
+## Evidence
+
+- OCaml language strengths and module system: https://ocaml.org/about
+  checked 2026-04-19, confidence High.
+- OCaml release/tooling changelog: https://ocaml.org/changelog checked
+  2026-04-19, confidence High.
+- Effect handlers and direct-style concurrency:
+  https://dl.acm.org/doi/10.1145/3453483.3454039 checked 2026-04-19,
+  confidence High.
+- Local data-race freedom:
+  https://kcsrk.info/papers/pldi18-memory.pdf checked 2026-04-19,
+  confidence High.
+- Tail Modulo Cons:
+  https://arxiv.org/abs/2411.19397 checked 2026-04-19, confidence High.
+- OCaml module scoping and local open:
+  https://arxiv.org/pdf/1905.06543 checked 2026-04-19, confidence High.
+- QCheck state-machine testing:
+  https://janmidtgaard.dk/papers/Midtgaard%3AOCaml20.pdf checked
+  2026-04-19, confidence High.
+- Flambda 2 local PDFs:
+  `/Users/dancer/Downloads/Flambda 2 OCaml 2023.pdf` and
+  `/Users/dancer/Downloads/icfp23-ocaml-paper11.pdf`, checked locally with
+  `pdfinfo` and `pdftotext` on 2026-04-19, confidence High.

--- a/docs/OCAML-NORTH-STAR.md
+++ b/docs/OCAML-NORTH-STAR.md
@@ -60,8 +60,9 @@ For each improvement:
 
 ## Health Tracking
 
-`make ocaml-health` is observational by default. It reports risk-pattern
-counts but does not fail CI. Promote individual checks to ratchets only after
+`make ocaml-health` is observational by default. It reports ripgrep text-hit
+counts but does not fail CI. These counts are triage signals and may include
+comments or string literals; promote individual checks to ratchets only after
 their baseline and intended scope are reviewed.
 
 Tracked patterns include production `failwith`, `invalid_arg`, `assert false`,

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -829,128 +829,29 @@ let transition_task_r config ~agent_name ~task_id ~action
       let now = now_iso () in
       let now_ts = Time_compat.now () in
       let action_s = Types.task_action_to_string action in
-      let* (new_status, set_current) =
-        match action, task.task_status with
-        | Types.Claim, Types.Todo ->
-            Ok (Types.Claimed { assignee = agent_name; claimed_at = now }, Some task_id)
-        | Types.Claim, (Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ }) when assignee = agent_name ->
-            (* Idempotent: already claimed by me; do not trigger backlog/activity rewrites. *)
-            Ok (task.task_status, None)
-        | Types.Start, Types.Claimed { assignee; _ } when assignee = agent_name ->
-            Ok (Types.InProgress { assignee = agent_name; started_at = now }, Some task_id)
-        | Types.Start, Types.InProgress { assignee; _ } when assignee = agent_name ->
-            (* Idempotent: already in progress by me; do not trigger backlog/activity rewrites. *)
-            Ok (task.task_status, None)
-        | (Types.Claim | Types.Start), Types.Done _ ->
-            (* Idempotent: already done, no-op *)
-            Ok (task.task_status, None)
-        | Types.Done_action, Types.Claimed { assignee; _ } when assignee = agent_name || force ->
-            (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress.
-               Log WARN so dashboards can surface keepers that skip Start. The
-               jump is still permitted for client compatibility; strictness
-               ratchet follows once keeper_task_start is exposed. *)
-            Log.RoomTask.warn
-              "fsm_drift claimed_to_done_skip task=%s agent=%s force=%b"
-              task_id agent_name force;
-            Ok (Types.Done {
-              assignee = agent_name;
-              completed_at = now;
-              notes = if notes = "" then None else Some notes;
-            }, None)
-        | Types.Done_action, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-            Ok (Types.Done {
-              assignee = agent_name;
-              completed_at = now;
-              notes = if notes = "" then None else Some notes;
-            }, None)
-        | Types.Done_action, Types.Done _ ->
-            (* Idempotent: already done, return current state unchanged *)
-            Ok (task.task_status, None)
-        | Types.Cancel, Types.Cancelled _ ->
-            (* Idempotent: already cancelled *)
-            Ok (task.task_status, None)
-        | Types.Cancel, Types.Todo ->
-            Ok (Types.Cancelled {
-              cancelled_by = agent_name;
-              cancelled_at = now;
-              reason = if reason = "" then None else Some reason;
-            }, None)
-        | Types.Cancel, Types.Claimed { assignee; _ }
-        | Types.Cancel, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-            Ok (Types.Cancelled {
-              cancelled_by = agent_name;
-              cancelled_at = now;
-              reason = if reason = "" then None else Some reason;
-            }, None)
-        | Types.Release, Types.Claimed { assignee; _ }
-        | Types.Release, Types.InProgress { assignee; _ } when assignee = agent_name || force ->
-            Ok (Types.Todo, None)
-        | Types.Release, Types.Todo ->
-            (* Idempotent: already in backlog, nothing to release.
-               Logged at debug so that callers passing a wrong task_id
-               (e.g. confused the target of a multi-task release) can
-               still detect the no-op without seeing it as an error. *)
-            Log.RoomTask.debug
-              "release on already-todo task %s — no-op" task_id;
-            Ok (task.task_status, None)
-        | Types.Start, Types.Claimed { assignee; _ } when assignee = agent_name || force ->
-            Ok (Types.InProgress {
-              assignee = agent_name;
-              started_at = now;
-            }, None)
-        | Types.Submit_for_verification, Types.Claimed { assignee; _ }
-        | Types.Submit_for_verification, Types.InProgress { assignee; _ }
-          when assignee = agent_name
-               && Env_config_runtime.Verification.fsm_enabled () ->
-            (* Keepers are prompted with Claim -> Work -> Done and do not
-               always emit an explicit Start transition before completing.
-               Allow submission from Claimed so the verifier FSM matches the
-               public task lifecycle instead of requiring a hidden extra step. *)
-            (* [Random_id] is the shared leaf helper used by both
-               [masc_coord] here and [masc_mcp.Verification.generate_id],
-               so the vrf- id algorithm is now defined once (#7544
-               follow-up — original PR left these two copies because
-               the helper didn't exist yet). *)
-            let verification_id =
-              Random_id.prefixed ~prefix:"vrf-" ~bytes:16
-            in
-            Ok (Types.AwaitingVerification {
-              assignee;
-              submitted_at = now;
-              verification_id;
-              required_verifier_role = Reviewer;
-              deadline = None;
-            }, None)
-        | Types.Approve_verification, Types.AwaitingVerification { assignee; verification_id; _ }
-          when agent_name <> assignee
-               && Env_config_runtime.Verification.fsm_enabled () ->
-            Ok (Types.Done {
-              assignee;
-              completed_at = now;
-              notes = Some (Printf.sprintf "Approved by %s (vrf:%s)%s"
-                agent_name verification_id
-                (if notes = "" then "" else " — " ^ notes));
-            }, None)
-        | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
-          when agent_name <> assignee
-               && Env_config_runtime.Verification.fsm_enabled () ->
-            Ok (Types.InProgress {
-              assignee;
-              started_at = now;
-            }, None)
-        | Types.Approve_verification, Types.AwaitingVerification { assignee; _ }
-          when agent_name = assignee ->
-            Error (Types.TaskInvalidState
-              "Self-approval not allowed: verifier must be a different agent")
-        | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
-          when agent_name = assignee ->
-            Error (Types.TaskInvalidState
-              "Self-rejection not allowed: verifier must be a different agent")
-        | (Types.Submit_for_verification | Types.Approve_verification
-          | Types.Reject_verification), _
-          when not (Env_config_runtime.Verification.fsm_enabled ()) ->
-            Error (Types.TaskInvalidState "Verification FSM not enabled (MASC_VERIFICATION_FSM_ENABLED=false)")
-        | _ ->
+      let* decision =
+        match
+          Coord_task_lifecycle.decide
+            ~verification_enabled:(Env_config_runtime.Verification.fsm_enabled ())
+            ~new_verification_id:(fun () ->
+              Random_id.prefixed ~prefix:"vrf-" ~bytes:16)
+            ~agent_name ~task_id ~task_status:task.task_status ~action ~now
+            ~force ~notes ~reason
+        with
+        | Ok decision -> Ok decision
+        | Error Coord_task_lifecycle.Self_approval ->
+            Error
+              (Types.TaskInvalidState
+                 "Self-approval not allowed: verifier must be a different agent")
+        | Error Coord_task_lifecycle.Self_rejection ->
+            Error
+              (Types.TaskInvalidState
+                 "Self-rejection not allowed: verifier must be a different agent")
+        | Error Coord_task_lifecycle.Verification_disabled ->
+            Error
+              (Types.TaskInvalidState
+                 "Verification FSM not enabled (MASC_VERIFICATION_FSM_ENABLED=false)")
+        | Error Coord_task_lifecycle.Invalid_transition ->
             let assignee_hint =
               match task_assignee_of_status task.task_status with
               | Some a when a <> agent_name ->
@@ -1021,6 +922,26 @@ let transition_task_r config ~agent_name ~task_id ~action
                 (task_status_to_string task.task_status) action_s task_id agent_name
                 assignee_hint actions_hint remediation))
       in
+      let new_status = decision.Coord_task_lifecycle.new_status in
+      let set_current = decision.set_current in
+      (match decision.drift with
+       | Some Coord_task_lifecycle.Claimed_to_done_skip ->
+           (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress.
+              Log WARN so dashboards can surface keepers that skip Start. The
+              jump is still permitted for client compatibility; strictness
+              ratchet follows once keeper_task_start is exposed. *)
+           Log.RoomTask.warn
+             "fsm_drift claimed_to_done_skip task=%s agent=%s force=%b"
+             task_id agent_name force
+       | None -> ());
+      (match action, task.task_status with
+       | Types.Release, Types.Todo ->
+           (* Idempotent: already in backlog, nothing to release.
+              Logged at debug so that callers passing a wrong task_id
+              (e.g. confused the target of a multi-task release) can
+              still detect the no-op without seeing it as an error. *)
+           Log.RoomTask.debug "release on already-todo task %s — no-op" task_id
+       | _ -> ());
       if new_status = task.task_status && set_current = None then
         (* Idempotent no-op: status unchanged, skip write/events.
            Match None explicitly so set_current=Some is never silently dropped. *)

--- a/lib/coord/coord_task_lifecycle.ml
+++ b/lib/coord/coord_task_lifecycle.ml
@@ -1,0 +1,110 @@
+(** Spec-preserving task lifecycle transition helper. *)
+
+type drift = Claimed_to_done_skip
+
+type invalid =
+  | Self_approval
+  | Self_rejection
+  | Verification_disabled
+  | Invalid_transition
+
+type decision =
+  { new_status : Types.task_status
+  ; set_current : string option
+  ; drift : drift option
+  }
+
+let option_of_non_empty value = if String.equal value "" then None else Some value
+let ok ?drift ?set_current new_status = Ok { new_status; set_current; drift }
+
+let done_status ~agent_name ~now ~notes =
+  Types.Done
+    { assignee = agent_name; completed_at = now; notes = option_of_non_empty notes }
+;;
+
+let cancelled_status ~agent_name ~now ~reason =
+  Types.Cancelled
+    { cancelled_by = agent_name; cancelled_at = now; reason = option_of_non_empty reason }
+;;
+
+let decide
+      ~verification_enabled
+      ~new_verification_id
+      ~agent_name
+      ~task_id
+      ~task_status
+      ~action
+      ~now
+      ~force
+      ~notes
+      ~reason
+  =
+  match action, task_status with
+  | Types.Claim, Types.Todo ->
+    ok ~set_current:task_id (Types.Claimed { assignee = agent_name; claimed_at = now })
+  | Types.Claim, (Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ })
+    when String.equal assignee agent_name -> ok task_status
+  | Types.Start, Types.Claimed { assignee; _ } when String.equal assignee agent_name ->
+    ok ~set_current:task_id (Types.InProgress { assignee = agent_name; started_at = now })
+  | Types.Start, Types.InProgress { assignee; _ } when String.equal assignee agent_name ->
+    ok task_status
+  | (Types.Claim | Types.Start), Types.Done _ -> ok task_status
+  | Types.Done_action, Types.Claimed { assignee; _ }
+    when String.equal assignee agent_name || force ->
+    ok ~drift:Claimed_to_done_skip (done_status ~agent_name ~now ~notes)
+  | Types.Done_action, Types.InProgress { assignee; _ }
+    when String.equal assignee agent_name || force ->
+    ok (done_status ~agent_name ~now ~notes)
+  | Types.Done_action, Types.Done _ -> ok task_status
+  | Types.Cancel, Types.Cancelled _ -> ok task_status
+  | Types.Cancel, Types.Todo -> ok (cancelled_status ~agent_name ~now ~reason)
+  | Types.Cancel, Types.Claimed { assignee; _ }
+  | Types.Cancel, Types.InProgress { assignee; _ }
+    when String.equal assignee agent_name || force ->
+    ok (cancelled_status ~agent_name ~now ~reason)
+  | Types.Release, Types.Claimed { assignee; _ }
+  | Types.Release, Types.InProgress { assignee; _ }
+    when String.equal assignee agent_name || force -> ok Types.Todo
+  | Types.Release, Types.Todo -> ok task_status
+  | Types.Start, Types.Claimed { assignee; _ }
+    when String.equal assignee agent_name || force ->
+    ok (Types.InProgress { assignee = agent_name; started_at = now })
+  | Types.Submit_for_verification, Types.Claimed { assignee; _ }
+  | Types.Submit_for_verification, Types.InProgress { assignee; _ }
+    when String.equal assignee agent_name && verification_enabled ->
+    ok
+      (Types.AwaitingVerification
+         { assignee
+         ; submitted_at = now
+         ; verification_id = new_verification_id ()
+         ; required_verifier_role = Types.Reviewer
+         ; deadline = None
+         })
+  | ( Types.Approve_verification
+    , Types.AwaitingVerification { assignee; verification_id; _ } )
+    when (not (String.equal agent_name assignee)) && verification_enabled ->
+    ok
+      (Types.Done
+         { assignee
+         ; completed_at = now
+         ; notes =
+             Some
+               (Printf.sprintf
+                  "Approved by %s (vrf:%s)%s"
+                  agent_name
+                  verification_id
+                  (if String.equal notes "" then "" else " — " ^ notes))
+         })
+  | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
+    when (not (String.equal agent_name assignee)) && verification_enabled ->
+    ok (Types.InProgress { assignee; started_at = now })
+  | Types.Approve_verification, Types.AwaitingVerification { assignee; _ }
+    when String.equal agent_name assignee -> Error Self_approval
+  | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
+    when String.equal agent_name assignee -> Error Self_rejection
+  | Types.Submit_for_verification, _
+  | Types.Approve_verification, _
+  | Types.Reject_verification, _
+    when not verification_enabled -> Error Verification_disabled
+  | _ -> Error Invalid_transition
+;;

--- a/lib/coord/coord_task_lifecycle.mli
+++ b/lib/coord/coord_task_lifecycle.mli
@@ -1,0 +1,32 @@
+(** Spec-preserving task lifecycle transition helper.
+
+    This module centralizes the status-calculation part of
+    [Coord_task.transition_task_r]. It does not write storage, emit events,
+    update agent mirrors, or change public wire semantics. *)
+
+type drift = Claimed_to_done_skip
+
+type invalid =
+  | Self_approval
+  | Self_rejection
+  | Verification_disabled
+  | Invalid_transition
+
+type decision =
+  { new_status : Types.task_status
+  ; set_current : string option
+  ; drift : drift option
+  }
+
+val decide
+  :  verification_enabled:bool
+  -> new_verification_id:(unit -> string)
+  -> agent_name:string
+  -> task_id:string
+  -> task_status:Types.task_status
+  -> action:Types.task_action
+  -> now:string
+  -> force:bool
+  -> notes:string
+  -> reason:string
+  -> (decision, invalid) result

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -24,6 +24,7 @@
   coord_query
   coord_status
   coord_task
+  coord_task_lifecycle
   coord_task_schedule
   event_kind
   coord_git

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -60,6 +60,12 @@ let () =
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 
+let turn_semaphore_value_for_test () =
+  Eio.Semaphore.get_value turn_semaphore
+
+let autonomous_turn_semaphore_value_for_test () =
+  Eio.Semaphore.get_value autonomous_turn_semaphore
+
 type autonomous_waiter =
   {
     ticket : int;
@@ -358,6 +364,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       let semaphore_wait_ms =
         int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
       f ~semaphore_wait_ms)
+;;
+
+let with_keeper_turn_slot_for_test ~keeper_name ~channel f =
+  with_keeper_turn_slot ~keeper_name ~channel f
 ;;
 
 (** Optional gRPC client + env — WORM Atomic: set at server bootstrap

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -180,6 +180,27 @@ let record_autonomous_completion ~(keeper_name : string) : unit =
     Hashtbl.replace last_autonomous_completion keeper_name
       (Time_compat.now ()))
 
+type keeper_turn_slot_state = {
+  acquired_autonomous : bool ref;
+  acquired_turn : bool ref;
+  autonomous_ticket : int option ref;
+}
+
+let release_keeper_turn_slot ~keeper_name state =
+  Option.iter
+    (fun ticket -> drop_autonomous_waiter ~ticket)
+    !(state.autonomous_ticket);
+  (* Release exactly what we acquired. Order does not matter because
+     these two semaphores do not contend with each other. *)
+  if !(state.acquired_turn) then Eio.Semaphore.release turn_semaphore;
+  if !(state.acquired_autonomous) then begin
+    (* Stamp completion time BEFORE releasing the semaphore so that
+       [maybe_yield_for_fairness] can measure the correct interval
+       when this keeper's heartbeat loops back immediately. *)
+    record_autonomous_completion ~keeper_name;
+    Eio.Semaphore.release autonomous_turn_semaphore
+  end
+
 let reset_autonomous_completion_for_test () : unit =
   with_completion_table (fun () ->
     Hashtbl.reset last_autonomous_completion)
@@ -301,9 +322,13 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
      path fires (Semaphore_wait_timeout, Eio.Cancel.Cancelled, or any
      other). This keeps resource cleanup independent of Eio.Semaphore's
      internal cancel-race handling. *)
-  let acquired_autonomous = ref false in
-  let acquired_turn = ref false in
-  let autonomous_ticket = ref None in
+  let slot_state =
+    {
+      acquired_autonomous = ref false;
+      acquired_turn = ref false;
+      autonomous_ticket = ref None;
+    }
+  in
   let acquire_bounded ~label sem =
     match Eio_context.get_clock_opt () with
     | Some clock ->
@@ -332,18 +357,7 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       Eio.Semaphore.acquire sem
   in
   Fun.protect
-    ~finally:(fun () ->
-      Option.iter (fun ticket -> drop_autonomous_waiter ~ticket) !autonomous_ticket;
-      (* Release exactly what we acquired. Order does not matter because
-         these two semaphores do not contend with each other. *)
-      if !acquired_turn then Eio.Semaphore.release turn_semaphore;
-      if !acquired_autonomous then begin
-        (* Stamp completion time BEFORE releasing the semaphore so that
-           [maybe_yield_for_fairness] can measure the correct interval
-           when this keeper's heartbeat loops back immediately. *)
-        record_autonomous_completion ~keeper_name;
-        Eio.Semaphore.release autonomous_turn_semaphore
-      end)
+    ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
     (fun () ->
       if is_autonomous then begin
         (* Fairness cooldown: if this keeper recently completed a turn and
@@ -352,15 +366,15 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
            See [maybe_yield_for_fairness] and #6810. *)
         maybe_yield_for_fairness ~keeper_name;
         let ticket = enqueue_autonomous_waiter ~keeper_name in
-        autonomous_ticket := Some ticket;
+        slot_state.autonomous_ticket := Some ticket;
         wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0;
         acquire_bounded ~label:"autonomous" autonomous_turn_semaphore;
-        acquired_autonomous := true;
+        slot_state.acquired_autonomous := true;
         drop_autonomous_waiter ~ticket;
-        autonomous_ticket := None
+        slot_state.autonomous_ticket := None
       end;
       acquire_bounded ~label:"turn" turn_semaphore;
-      acquired_turn := true;
+      slot_state.acquired_turn := true;
       let semaphore_wait_ms =
         int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
       f ~semaphore_wait_ms)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -48,6 +48,10 @@ val reset_autonomous_turn_queue_for_test : unit -> unit
 (** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
 val autonomous_waiter_snapshot_for_test : unit -> string list
 
+(** Test-only snapshots of the current semaphore availability. *)
+val turn_semaphore_value_for_test : unit -> int
+val autonomous_turn_semaphore_value_for_test : unit -> int
+
 (** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit
@@ -62,6 +66,13 @@ val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float ->
 
 (** Test-only: clear all per-keeper completion timestamps. *)
 val reset_autonomous_completion_for_test : unit -> unit
+
+(** Test-only wrapper around the keeper turn slot acquisition path. *)
+val with_keeper_turn_slot_for_test :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> 'a) ->
+  'a
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Coord.config -> Board_dispatch.keeper_board_signal -> unit

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -331,6 +331,12 @@ let runtime_sidecar_script_result ?base_path id =
               `start-masc-mcp.sh --sidecar-root /path/to/masc-mcp`."
              id script)
 
+let sidecar_start_shell_command ~base_path ~script =
+  Printf.sprintf
+    "MASC_BASE_PATH=%s setsid nohup %s start </dev/null >/dev/null 2>&1 &"
+    (Filename.quote base_path)
+    (Filename.quote script)
+
 (** Clamp the [?lines=N] query param to [1, 1000]. Pure so unit tests
     can pin the upper bound without a request mock. *)
 let clamp_lines = function
@@ -804,12 +810,7 @@ let handle_start state request reqd =
               restart. Only [script] is interpolated, and the path comes from
               a resolved directory + fixed filename, so [Filename.quote] gives
               a closed-shell injection surface. *)
-           let cmd =
-             Printf.sprintf
-               "MASC_BASE_PATH=%s setsid nohup %s start </dev/null >/dev/null 2>&1 &"
-               (Filename.quote base_path)
-               (Filename.quote script)
-           in
+           let cmd = sidecar_start_shell_command ~base_path ~script in
            let _ = Sys.command cmd in
            respond_json request reqd ~status:`Accepted
              (`Assoc [

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -370,7 +370,10 @@ let read_status_json ~base_path id =
   in
   if Sys.file_exists path then
     let body = read_file path in
-    let parsed = try Some (Yojson.Safe.from_string body) with _ -> None in
+    let parsed =
+      try Some (Yojson.Safe.from_string body)
+      with Yojson.Json_error _ -> None
+    in
     `Assoc [
       ("ok", `Bool true);
       ("available", `Bool true);
@@ -660,7 +663,7 @@ let parse_body_pairs body_str : ((string * string) list, string) result =
       ) assoc in
       Ok pairs
   | _ -> Error "body must be a JSON object"
-  | exception _ -> Error "body is not valid JSON"
+  | exception Yojson.Json_error _ -> Error "body is not valid JSON"
 
 (** GET /api/v1/sidecar/config?name=<id>
 

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -621,12 +621,12 @@ let atomic_write_file ~(path : string) (content : string) : (unit, string) resul
   try
     let oc = open_out tmp in
     Fun.protect
-      ~finally:(fun () -> try close_out oc with _ -> ())
+      ~finally:(fun () -> close_out_noerr oc)
       (fun () -> output_string oc content);
     Sys.rename tmp path;
     Ok ()
   with exn ->
-    (try Sys.remove tmp with _ -> ());
+    (try Sys.remove tmp with Sys_error _ -> ());
     Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
 
 (** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
@@ -692,7 +692,7 @@ let handle_get_config _state request reqd =
       else
         let content =
           try In_channel.with_open_text path In_channel.input_all
-          with _ -> ""
+          with Sys_error _ -> ""
         in
         (match Keeper_toml_loader.parse_toml content with
          | Error msg ->

--- a/scripts/ocaml-north-star-health.sh
+++ b/scripts/ocaml-north-star-health.sh
@@ -16,7 +16,8 @@ Options:
   -h, --help         Show this help.
 
 This check is warn-only by design. It reports OCaml north-star risk-pattern
-counts without changing CI pass/fail policy.
+text-hit counts without changing CI pass/fail policy. Counts are triage
+signals and may include comments or string literals.
 EOF
 }
 
@@ -85,8 +86,9 @@ cat <<EOF
 checked_at: $now_iso
 branch: $branch
 head: $head_sha
+counting_method: ripgrep text scan (comments/string literals may be included)
 
-Production scope: lib bin
+Production text-scan scope: lib bin
   failwith: $prod_failwith
   invalid_arg: $prod_invalid_arg
   assert false: $prod_assert_false
@@ -98,7 +100,7 @@ Production scope: lib bin
   broad catch (with _): $prod_broad_catch
   Yojson.Safe.Util: $prod_yojson_util
 
-All OCaml scope: lib bin test
+All OCaml text-scan scope: lib bin test
   failwith: $all_failwith
   assert false: $all_assert_false
   Obj.magic: $all_obj_magic
@@ -114,6 +116,10 @@ if [ -n "$JSON_OUT" ]; then
   "branch": "$branch",
   "head": "$head_sha",
   "mode": "warn_only",
+  "counting_method": "ripgrep_text_scan",
+  "notes": {
+    "counts_may_include_comments_and_string_literals": true
+  },
   "counts": {
     "prod_failwith": $prod_failwith,
     "prod_invalid_arg": $prod_invalid_arg,

--- a/scripts/ocaml-north-star-health.sh
+++ b/scripts/ocaml-north-star-health.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+JSON_OUT=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ocaml-north-star-health.sh [options]
+
+Options:
+  --json-out <path>  Write the observational snapshot as JSON.
+  -h, --help         Show this help.
+
+This check is warn-only by design. It reports OCaml north-star risk-pattern
+counts without changing CI pass/fail policy.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json-out)
+      JSON_OUT="${2:-}"
+      if [ -z "$JSON_OUT" ]; then
+        echo "ERROR: --json-out requires a path" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+count_pattern() {
+  local scope="$1"
+  local pattern="$2"
+  rg -n "$pattern" $scope -g '*.{ml,mli}' 2>/dev/null | awk 'END {print NR+0}'
+}
+
+count_prod() {
+  count_pattern "lib bin" "$1"
+}
+
+count_all() {
+  count_pattern "lib bin test" "$1"
+}
+
+now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+head_sha="$(git rev-parse HEAD)"
+
+prod_failwith="$(count_prod 'failwith')"
+prod_invalid_arg="$(count_prod 'invalid_arg')"
+prod_assert_false="$(count_prod 'assert false')"
+prod_obj_magic="$(count_prod 'Obj\.magic')"
+prod_sys_command="$(count_prod 'Sys\.command')"
+prod_unix_process="$(count_prod 'Unix\.create_process|Unix\.create_process_env|Unix\.waitpid')"
+prod_manual_mutex="$(count_prod 'Mutex\.(lock|unlock)')"
+prod_fun_protect="$(count_prod 'Fun\.protect')"
+prod_broad_catch="$(count_prod 'with[[:space:]]+_')"
+prod_yojson_util="$(count_prod 'Yojson\.Safe\.Util')"
+
+all_failwith="$(count_all 'failwith')"
+all_assert_false="$(count_all 'assert false')"
+all_obj_magic="$(count_all 'Obj\.magic')"
+
+cat <<EOF
+=== OCaml North Star Health (warn-only) ===
+checked_at: $now_iso
+branch: $branch
+head: $head_sha
+
+Production scope: lib bin
+  failwith: $prod_failwith
+  invalid_arg: $prod_invalid_arg
+  assert false: $prod_assert_false
+  Obj.magic: $prod_obj_magic
+  Sys.command: $prod_sys_command
+  Unix process primitives: $prod_unix_process
+  manual Mutex.lock/unlock: $prod_manual_mutex
+  Fun.protect: $prod_fun_protect
+  broad catch (with _): $prod_broad_catch
+  Yojson.Safe.Util: $prod_yojson_util
+
+All OCaml scope: lib bin test
+  failwith: $all_failwith
+  assert false: $all_assert_false
+  Obj.magic: $all_obj_magic
+
+status: warn-only; no CI failure policy is applied.
+EOF
+
+if [ -n "$JSON_OUT" ]; then
+  mkdir -p "$(dirname "$JSON_OUT")"
+  cat > "$JSON_OUT" <<EOF
+{
+  "checked_at": "$now_iso",
+  "branch": "$branch",
+  "head": "$head_sha",
+  "mode": "warn_only",
+  "counts": {
+    "prod_failwith": $prod_failwith,
+    "prod_invalid_arg": $prod_invalid_arg,
+    "prod_assert_false": $prod_assert_false,
+    "prod_obj_magic": $prod_obj_magic,
+    "prod_sys_command": $prod_sys_command,
+    "prod_unix_process": $prod_unix_process,
+    "prod_manual_mutex": $prod_manual_mutex,
+    "prod_fun_protect": $prod_fun_protect,
+    "prod_broad_catch": $prod_broad_catch,
+    "prod_yojson_util": $prod_yojson_util,
+    "all_failwith": $all_failwith,
+    "all_assert_false": $all_assert_false,
+    "all_obj_magic": $all_obj_magic
+  }
+}
+EOF
+  echo "JSON snapshot: $JSON_OUT"
+fi

--- a/test/dune
+++ b/test/dune
@@ -97,6 +97,7 @@
         ; test_contract_composer removed (team session cleanup)
         test_cdal_conformance
         test_task_stage
+        test_ocaml_north_star_task_lifecycle
         ; test_risk_digest removed (team session cleanup)
         test_artifact_store
         test_tool_blob_store
@@ -204,6 +205,7 @@
           ; test_contract_composer removed (team session cleanup)
           test_cdal_conformance
           test_task_stage
+          test_ocaml_north_star_task_lifecycle
           ; test_risk_digest removed (team session cleanup)
           test_artifact_store
           test_tool_blob_store

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -109,6 +109,45 @@ let test_delay_decreases_with_elapsed_time () =
   KK.drop_autonomous_waiter_for_test ticket;
   Alcotest.(check bool) "delay decreases over time" true (delay_1s > delay_3s)
 
+let test_reactive_slot_released_when_body_raises () =
+  Eio_main.run @@ fun _env ->
+  let before = KK.turn_semaphore_value_for_test () in
+  let completed =
+    try
+      Some
+        (KK.with_keeper_turn_slot_for_test ~keeper_name:"reactive-test"
+           ~channel:Masc_mcp.Keeper_world_observation.Reactive
+           (fun ~semaphore_wait_ms:_ -> raise Exit))
+    with Exit -> None
+  in
+  Alcotest.(check bool) "body exception propagated" true
+    (Option.is_none completed);
+  Alcotest.(check int) "turn semaphore restored" before
+    (KK.turn_semaphore_value_for_test ())
+
+let test_autonomous_slot_released_when_body_raises () =
+  Eio_main.run @@ fun _env ->
+  KK.reset_autonomous_turn_queue_for_test ();
+  KK.reset_autonomous_completion_for_test ();
+  let before_turn = KK.turn_semaphore_value_for_test () in
+  let before_autonomous = KK.autonomous_turn_semaphore_value_for_test () in
+  let completed =
+    try
+      Some
+        (KK.with_keeper_turn_slot_for_test ~keeper_name:"autonomous-test"
+           ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+           (fun ~semaphore_wait_ms:_ -> raise Exit))
+    with Exit -> None
+  in
+  Alcotest.(check bool) "body exception propagated" true
+    (Option.is_none completed);
+  Alcotest.(check int) "turn semaphore restored" before_turn
+    (KK.turn_semaphore_value_for_test ());
+  Alcotest.(check int) "autonomous semaphore restored" before_autonomous
+    (KK.autonomous_turn_semaphore_value_for_test ());
+  Alcotest.(check (list string)) "autonomous queue drained" []
+    (KK.autonomous_waiter_snapshot_for_test ())
+
 let () =
   Alcotest.run "Keeper_semaphore_fairness"
     [
@@ -130,5 +169,12 @@ let () =
             (with_fresh_state test_reset_clears_completion_table);
           Alcotest.test_case "delay decreases with elapsed time" `Quick
             (with_fresh_state test_delay_decreases_with_elapsed_time);
+        ] );
+      ( "slot_release",
+        [
+          Alcotest.test_case "reactive slot released when body raises" `Quick
+            (with_fresh_state test_reactive_slot_released_when_body_raises);
+          Alcotest.test_case "autonomous slot released when body raises" `Quick
+            (with_fresh_state test_autonomous_slot_released_when_body_raises);
         ] );
     ]

--- a/test/test_ocaml_north_star_task_lifecycle.ml
+++ b/test/test_ocaml_north_star_task_lifecycle.ml
@@ -1,0 +1,219 @@
+(** Behavior-locking tests for the current task lifecycle.
+
+    These tests document existing semantics before any north-star refactor.
+    They intentionally do not introduce a new FSM or change transition policy. *)
+
+open Alcotest
+open Masc_mcp
+
+let counter = ref 0
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let with_config f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-ocaml-north-star-%d-%d"
+         (int_of_float (Unix.gettimeofday () *. 1000.0))
+         !counter)
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Coord.default_config dir in
+       ignore (Coord.init config ~agent_name:(Some "worker"));
+       f config)
+;;
+
+let add_task config =
+  ignore
+    (Coord.add_task
+       config
+       ~title:"north-star task"
+       ~priority:3
+       ~description:"behavior lock");
+  match (Coord.read_backlog config).tasks with
+  | task :: _ -> task.id
+  | [] -> fail "fixture task not created"
+;;
+
+let task config task_id =
+  match
+    List.find_opt
+      (fun (task : Types.task) -> String.equal task.id task_id)
+      (Coord.read_backlog config).tasks
+  with
+  | Some task -> task
+  | None -> fail ("task not found: " ^ task_id)
+;;
+
+let status_name config task_id =
+  (task config task_id).task_status |> Types.task_status_to_string
+;;
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error err -> fail (label ^ ": " ^ Types.masc_error_to_string err)
+;;
+
+let expect_invalid_transition label = function
+  | Error (Types.TaskInvalidState msg) -> msg
+  | Error err -> fail (label ^ ": unexpected error " ^ Types.masc_error_to_string err)
+  | Ok msg -> fail (label ^ ": unexpectedly succeeded: " ^ msg)
+;;
+
+let transition config ~agent_name ~task_id ~action ?(notes = "") ?(reason = "") () =
+  Coord.transition_task_r config ~agent_name ~task_id ~action ~notes ~reason ()
+;;
+
+let test_claim_start_done_path () =
+  with_config (fun config ->
+    let task_id = add_task config in
+    check string "initial" "todo" (status_name config task_id);
+    ignore
+      (transition config ~agent_name:"worker" ~task_id ~action:Types.Claim ()
+       |> expect_ok "claim");
+    check string "after claim" "claimed" (status_name config task_id);
+    ignore
+      (transition config ~agent_name:"worker" ~task_id ~action:Types.Start ()
+       |> expect_ok "start");
+    check string "after start" "in_progress" (status_name config task_id);
+    ignore
+      (transition
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Done_action
+         ~notes:"tests pass"
+         ()
+       |> expect_ok "done");
+    check string "after done" "done" (status_name config task_id);
+    match (task config task_id).task_status with
+    | Types.Done { assignee; notes; _ } ->
+      check string "assignee" "worker" assignee;
+      check (option string) "notes" (Some "tests pass") notes
+    | other -> fail ("expected done, got " ^ Types.task_status_to_string other))
+;;
+
+let test_done_from_todo_is_rejected () =
+  with_config (fun config ->
+    let task_id = add_task config in
+    let msg =
+      transition config ~agent_name:"worker" ~task_id ~action:Types.Done_action ()
+      |> expect_invalid_transition "done from todo"
+    in
+    check
+      bool
+      "remediation mentions claim"
+      true
+      (Astring.String.is_infix ~affix:"action=claim" msg);
+    check string "status preserved" "todo" (status_name config task_id))
+;;
+
+let test_release_from_claimed_returns_to_todo () =
+  with_config (fun config ->
+    let task_id = add_task config in
+    ignore
+      (transition config ~agent_name:"worker" ~task_id ~action:Types.Claim ()
+       |> expect_ok "claim");
+    ignore
+      (transition config ~agent_name:"worker" ~task_id ~action:Types.Release ()
+       |> expect_ok "release");
+    check string "released" "todo" (status_name config task_id);
+    check int "cycle count increments" 1 (task config task_id).cycle_count)
+;;
+
+let test_cancel_from_todo_is_terminal () =
+  with_config (fun config ->
+    let task_id = add_task config in
+    ignore
+      (transition
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Cancel
+         ~reason:"not needed"
+         ()
+       |> expect_ok "cancel");
+    check string "cancelled" "cancelled" (status_name config task_id);
+    let msg =
+      transition config ~agent_name:"worker" ~task_id ~action:Types.Claim ()
+      |> expect_invalid_transition "claim cancelled"
+    in
+    check
+      bool
+      "terminal remediation"
+      true
+      (Astring.String.is_infix ~affix:"already cancelled" msg))
+;;
+
+let test_done_is_idempotent_terminal () =
+  with_config (fun config ->
+    let task_id = add_task config in
+    ignore
+      (transition config ~agent_name:"worker" ~task_id ~action:Types.Claim ()
+       |> expect_ok "claim");
+    ignore
+      (transition
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Done_action
+         ~notes:"first"
+         ()
+       |> expect_ok "done");
+    let before_version = (Coord.read_backlog config).version in
+    ignore
+      (transition
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Done_action
+         ~notes:"second"
+         ()
+       |> expect_ok "done idempotent");
+    let after_backlog = Coord.read_backlog config in
+    check
+      int
+      "idempotent done does not rewrite backlog"
+      before_version
+      after_backlog.version;
+    match (task config task_id).task_status with
+    | Types.Done { notes; _ } ->
+      check (option string) "original notes" (Some "first") notes
+    | other -> fail ("expected done, got " ^ Types.task_status_to_string other))
+;;
+
+let () =
+  Alcotest.run
+    "ocaml_north_star_task_lifecycle"
+    [ ( "current semantics"
+      , [ test_case "claim start done path" `Quick test_claim_start_done_path
+        ; test_case "done from todo is rejected" `Quick test_done_from_todo_is_rejected
+        ; test_case
+            "release from claimed returns to todo"
+            `Quick
+            test_release_from_claimed_returns_to_todo
+        ; test_case
+            "cancel from todo is terminal"
+            `Quick
+            test_cancel_from_todo_is_terminal
+        ; test_case "done is idempotent terminal" `Quick test_done_is_idempotent_terminal
+        ] )
+    ]
+;;

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -310,6 +310,24 @@ let test_coerce_rejects_oversized_value () =
   | Error _ -> ()
   | Ok _ -> failf "9000-byte value should be rejected by max_value_bytes guard"
 
+let test_parse_body_pairs_coerces_scalar_values () =
+  check (result (list (pair string string)) string)
+    "scalar JSON values are stringified for downstream type coercion"
+    (Ok [ ("PORT", "3000"); ("ENABLED", "true"); ("EMPTY", "") ])
+    (Routes.parse_body_pairs {|{"PORT":3000,"ENABLED":true,"EMPTY":null}|})
+
+let test_parse_body_pairs_rejects_non_object () =
+  check (result (list (pair string string)) string)
+    "non-object JSON rejected"
+    (Error "body must be a JSON object")
+    (Routes.parse_body_pairs {|["PORT",3000]|})
+
+let test_parse_body_pairs_rejects_invalid_json () =
+  check (result (list (pair string string)) string)
+    "invalid JSON rejected"
+    (Error "body is not valid JSON")
+    (Routes.parse_body_pairs {|{"PORT":|})
+
 let () =
   run "sidecar_lifecycle_routes"
     [
@@ -361,5 +379,11 @@ let () =
           test_case "coerce: integer ok/err"      `Quick test_coerce_integer_accepts_and_rejects;
           test_case "coerce: boolean variants"    `Quick test_coerce_boolean_accepts_variants;
           test_case "coerce: oversized rejected"  `Quick test_coerce_rejects_oversized_value;
+          test_case "parse body pairs: scalars" `Quick
+            test_parse_body_pairs_coerces_scalar_values;
+          test_case "parse body pairs: non-object" `Quick
+            test_parse_body_pairs_rejects_non_object;
+          test_case "parse body pairs: invalid JSON" `Quick
+            test_parse_body_pairs_rejects_invalid_json;
         ] );
     ]

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -328,6 +328,25 @@ let test_parse_body_pairs_rejects_invalid_json () =
     (Error "body is not valid JSON")
     (Routes.parse_body_pairs {|{"PORT":|})
 
+let test_atomic_write_file_replaces_content () =
+  with_temp_dir "sidecar-atomic-write" (fun dir ->
+      let path = Filename.concat dir "nested/config.toml" in
+      Routes.ensure_parent_dir path;
+      check (result unit string)
+        "initial write"
+        (Ok ())
+        (Routes.atomic_write_file ~path "TOKEN = \"old\"\n");
+      check string "initial content"
+        "TOKEN = \"old\"\n"
+        (In_channel.with_open_text path In_channel.input_all);
+      check (result unit string)
+        "replacement write"
+        (Ok ())
+        (Routes.atomic_write_file ~path "TOKEN = \"new\"\n");
+      check string "replacement content"
+        "TOKEN = \"new\"\n"
+        (In_channel.with_open_text path In_channel.input_all))
+
 let () =
   run "sidecar_lifecycle_routes"
     [
@@ -385,5 +404,7 @@ let () =
             test_parse_body_pairs_rejects_non_object;
           test_case "parse body pairs: invalid JSON" `Quick
             test_parse_body_pairs_rejects_invalid_json;
+          test_case "atomic write replaces content" `Quick
+            test_atomic_write_file_replaces_content;
         ] );
     ]

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -214,6 +214,26 @@ let test_today_log_file_falls_back_to_project_root_log () =
         log_path
         (Routes.today_log_file ~base_path ~project_root "discord"))
 
+let test_start_shell_command_matches_detached_contract () =
+  let base_path = "/tmp/masc runtime root" in
+  let script = "/tmp/masc runtime root/sidecars/discord-bot/run.sh" in
+  check string "detached start command"
+    (Printf.sprintf
+       "MASC_BASE_PATH=%s setsid nohup %s start </dev/null >/dev/null 2>&1 &"
+       (Filename.quote base_path)
+       (Filename.quote script))
+    (Routes.sidecar_start_shell_command ~base_path ~script)
+
+let test_start_shell_command_quotes_shell_meta () =
+  let base_path = "/tmp/runtime;touch /tmp/pwned" in
+  let script = "/tmp/sidecars/discord-bot/run.sh && id" in
+  check string "shell metacharacters are quoted, not escaped ad hoc"
+    (Printf.sprintf
+       "MASC_BASE_PATH=%s setsid nohup %s start </dev/null >/dev/null 2>&1 &"
+       (Filename.quote base_path)
+       (Filename.quote script))
+    (Routes.sidecar_start_shell_command ~base_path ~script)
+
 (* ---- Config write helpers (PUT /api/v1/sidecar/config). ---- *)
 
 let test_escape_quotes_and_backslash () =
@@ -324,6 +344,13 @@ let () =
       ( "invariants",
         [
           test_case "known_ids size = 4" `Quick test_known_ids_size_matches_dashboard;
+        ] );
+      ( "start_command",
+        [
+          test_case "detached command contract" `Quick
+            test_start_shell_command_matches_detached_contract;
+          test_case "quotes shell metacharacters" `Quick
+            test_start_shell_command_quotes_shell_meta;
         ] );
       ( "config_write_helpers",
         [


### PR DESCRIPTION
## Summary
- add a spec-preserving OCaml north-star document for `masc-mcp`
- add a warn-only `make ocaml-health` snapshot for OCaml risk-pattern counts
- clarify that the health snapshot is a ripgrep text-scan triage signal, not semantic proof; comments/string literals may be included
- add behavior-locking tests for the current task lifecycle semantics before future FSM refactors
- extract the task lifecycle status-calculation logic into `Coord_task_lifecycle` while keeping storage, logging, events, random verification id generation timing, and public semantics in `Coord_task.transition_task_r`
- lock keeper turn-slot release invariants so reactive/autonomous semaphore slots and the autonomous FIFO queue are restored when the turn body raises
- extract the keeper turn-slot cleanup path into a small helper after the invariants are covered
- extract sidecar start command rendering into a pure helper and pin the exact detached shell command/quoting contract before any future process-execution refactor
- narrow sidecar JSON parsing catches to `Yojson.Json_error` and add config body parser tests for scalar coercion/non-object/syntax-error paths
- narrow sidecar config cleanup/read fallback catches and add an atomic-write replacement test; current health text-scan broad catches drop from 32 to 28

## Product impact
- Establishes a long-lived OCaml quality baseline for `masc-mcp` without changing OAS/MCP wire shape, task lifecycle semantics, keeper scheduling semantics, or sidecar process execution semantics.
- Gives future refactors a measurable, warn-only health snapshot and behavior-locking tests before any semantic migration.

## Evidence
- North-star guardrails are documented in `docs/OCAML-NORTH-STAR.md` with source references and explicit anti-goals.
- `make ocaml-health` reports text-scan risk counts and stays warn-only.
- Sidecar broad catch text-scan count dropped from 32 to 28 after narrowing sidecar JSON/config cleanup catches.

## Review evidence
- `bash -n scripts/ocaml-north-star-health.sh`
- `bash scripts/ocaml-north-star-health.sh`
- `make ocaml-health`
- `opam exec -- dune build --root . ./test/test_ocaml_north_star_task_lifecycle.exe`
- `opam exec -- dune exec --root . ./test/test_ocaml_north_star_task_lifecycle.exe`
- `opam exec -- dune exec --root . ./test/test_verification_fsm.exe`
- `opam exec -- dune build --root . ./test/test_keeper_semaphore_fairness.exe`
- `opam exec -- dune exec --root . ./test/test_keeper_semaphore_fairness.exe`
- `opam exec -- dune exec --root . ./test/test_sidecar_lifecycle_routes.exe`
- `opam exec -- dune build --root . ./test/test_sidecar_lifecycle_routes.exe`
- `opam exec -- ocamlformat --check lib/coord/coord_task_lifecycle.ml lib/coord/coord_task_lifecycle.mli test/test_ocaml_north_star_task_lifecycle.ml`
- `git diff --check`

## Linked issue
Refs #8738

## Guardrails
- no `~/me` root changes
- no OAS/MCP wire-shape changes
- no task lifecycle semantic changes
- no deterministic/non-deterministic boundary changes
- no sidecar process execution semantic changes
- no CI failure policy change from the new health script

## Notes
- `opam exec -- dune fmt --root . --preview` still reports broad pre-existing repository formatting drift, so I only formatted and checked the new OCaml files.
- `opam exec -- ocamlformat --check test/test_keeper_semaphore_fairness.ml` fails on the pre-existing file-wide formatting style; I avoided applying whole-file formatting to prevent unrelated churn.
- `opam exec -- dune build --root . @check` stayed silent/sleeping for over 6 minutes and was stopped; targeted build/test passed.
- A killed/stalled dune process left an empty `_build/.lock`; I removed that stale build artifact and reran the targeted tests serially.