### PR TITLE
feat(exec): Legendary Bash P1-P6 — typed exec pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@
 
 - **`Docker_with_git` sandbox profile + git/gh per-command dispatch.** New `sandbox_profile = "docker_with_git"` keeps every `Docker_hardened` guard (cap-drop, no-new-privs, read-only rootfs, tmpfs, pids/memory limits, no nested runtimes) but adds `--network bridge` and read-only mounts for `~/.config/gh`, `~/.gitconfig`, optionally `~/.ssh` (opt-in via `MASC_KEEPER_SANDBOX_SSH_DIR`). Optional `GH_TOKEN` env forward via `MASC_KEEPER_SANDBOX_GH_TOKEN`. A `Docker_hardened` keeper still gets git/gh access for free: `keeper_bash` automatically routes commands whose first token is `git` or `gh` through the new profile (toggle `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false` to disable). Closes the gap that left coding keepers with `repo clone 차단: allowed org mismatch` board posts and 16 days of zero `keeper_bash` git activity.
 
+- **Legendary Bash P1–P6 (`feature/legendary-bash-p1`, PR #8721).**
+  Reworks `keeper_bash` along six coordinated axes.  Every surface
+  is additive and opt-in; the default JSON shape is unchanged.
+  - **P1 — typed semantic exit.**  New `Exec_semantic` variant
+    (`Ok / Fail / Timeout / Signaled / Git_not_a_repo / Oom_killed /
+    Policy_denied / Tool_missing / Permission_denied`) with
+    heuristic interpretation of exit codes 126/127/128 and dmesg
+    OOM hints.  Gated by `MASC_BASH_SEMANTIC_EXIT`.
+  - **P2 — background task lifecycle.**  `Bg_task.spawn/read/kill`
+    plus `keeper_bash_output` / `keeper_bash_kill` mirror
+    claude-code's `BashOutput` / `KillShell`.  pgid-owned children
+    enable tree-kill; PID-file persistence
+    (`<base>/.masc/keeper/<name>/bg/*.pid`) plus a startup
+    `reap_orphans` hook recover stranded groups after restart.
+  - **P3 — head+tail output cap.**  `Exec_buffer` keeps the first
+    and last 500 KB of each stream in memory with an overlap-aware
+    `bytes_dropped` counter.  Controlled by `MASC_BASH_OUTPUT_CAP`
+    / `MASC_BASH_CAP_HEAD` / `MASC_BASH_CAP_TAIL`.
+  - **P4 — auto-background race.**  `Exec_run.run_with_auto_bg`
+    spawns a `Bg_task` and races its exit against
+    `MASC_BLOCKING_BUDGET_MS` (default 15 000 ms) via
+    `Eio.Fiber.first`.  Budget expiry returns `{promoted: true,
+    background_task_id, partial_output, bytes_dropped, budget_ms,
+    hint}`.  Gated by `MASC_BASH_AUTO_BG`; falls back to the
+    blocking path when no Eio clock is available.
+  - **P5 — AST-shadow safety layer.**  `Worker_dev_tools`
+    classifies every `Eval_gate.destructive_patterns` entry into an
+    8-arm `destructive_class` and runs the existing regex allowlist
+    in parallel with the `Masc_exec_bash_parser` AST gate.  The
+    legacy↔shadow diff harness (`test/test_gate_diff.ml`) pins the
+    flip covenant: no `Eval_gate` pattern may slip into
+    `Legacy_deny_shadow_allow`.
+  - **P6 — verifiable markers.**  `Cdal_judge.of_exec_outcome`
+    translates `(semantic, stdout, stderr)` into a typed marker
+    list (`Test_pass {count}`, `Build_ok`, `Lint_clean`,
+    `Git_clean`, …) with `Exact | Heuristic` confidence, so the
+    verifier cascade can consume structured proofs instead of regex
+    scraping.  Emitted when `MASC_BASH_VERIFIABLE_MARKERS` is set.
+
+  All six phases land behind flags so operators can soak each axis
+  independently before default flip.  See
+  `docs/ENV-CONTRACT.md §4` for the flag matrix.
+
 ### Changed
 
 - **OAS pin bump → `main@36490371` (v0.163.0).** Single-commit upstream bump for `pipeline: handle Nudge decision in before_turn` (oas#1065). Without this, `before_turn` hooks returning `Hooks.Nudge` were silently dropped by `pipeline.ml stage_input` (`_ -> ()` fall-through). Effect on masc-mcp: the work-discovery nudge wired in PR #8805 (1089-char Samchon schema text) now actually reaches the LLM. 3 SSOT axes bumped per `feedback_oas-pin-must-bump-version-floor`: `scripts/oas-agent-sdk-pin.sh`, `dune-project`, `masc_mcp.opam`. Generated docs re-synced via `scripts/sync-oas-pin-docs.sh`. Live verification: post-deploy, `keeper:<name> before_turn: injecting work_discovery nudge` log lines should be followed by `tool_call` events from the same keeper (currently 10 fires + 0 follow-up actions over the live server's 2 hour uptime).

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -111,7 +111,36 @@ Examples:
   [`resolve()`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/config_dir_resolver.ml#L321)
   caches the result, so root changes are boot-static.
 
-### 4. Test-only boot overrides
+### 4. Legendary Bash exec gates (`request_dynamic`, additive-only)
+
+Flags introduced by the P1–P6 exec rework. Each is opt-in: the
+default keeps the pre-Legendary JSON shape and execution path, and
+turning a flag on only adds new fields or new code branches. No
+field is ever removed by these flags, so downstream consumers
+never break by enabling them.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `MASC_BASH_SEMANTIC_EXIT` | off | Emits a `return_code_interpretation` object (typed `semantic_exit`) alongside the raw `status`. See `lib/exec/exec_semantic.mli`. |
+| `MASC_BASH_OUTPUT_CAP` | on (500 KB head + 500 KB tail each) | Head+tail truncation via `Exec_buffer`. `MASC_BASH_CAP_HEAD` / `MASC_BASH_CAP_TAIL` override the per-stream caps. See `lib/exec/exec_buffer.mli`. |
+| `MASC_BASH_AUTO_BG` | off | Foreground commands that outrun `MASC_BLOCKING_BUDGET_MS` (default 15 000 ms) auto-promote to a `Bg_task`. Response gains `{promoted, background_task_id, partial_output, …}`. See `lib/exec/exec_run.mli`. |
+| `MASC_BLOCKING_BUDGET_MS` | 15 000 | Foreground race budget. Consumed only when `MASC_BASH_AUTO_BG` is on; otherwise inert. |
+| `MASC_BASH_AST_ONLY` | off | Single-gate AST shadow (dual-gate is the default). Flip requires a prod N=1000 zero-diff window per the flip covenant test (`test_gate_diff.ml`). |
+| `MASC_BASH_VERIFIABLE_MARKERS` | off | Emits `verifiable_markers` from `Cdal_judge.of_exec_outcome` so the verifier cascade can consume typed `Test_pass {count}`, `Build_ok`, etc. without regex scraping. See `lib/cdal_judge.mli`. |
+
+Representative code paths:
+
+- [`exec_semantic.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/exec/exec_semantic.ml)
+- [`exec_buffer.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/exec/exec_buffer.ml)
+- [`exec_run.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/exec/exec_run.ml)
+- [`cdal_judge.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/cdal_judge.ml)
+- [`worker_dev_tools.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/worker_dev_tools.ml) — legacy↔shadow diff harness
+
+Because every flag here is `request_dynamic` on the keeper-bash path
+(read at tool-invocation time), operators can flip a flag without a
+restart and the next `keeper_bash` call picks it up.
+
+### 5. Test-only boot overrides
 
 The following flags exist only to make OCaml test executables deterministic:
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -173,8 +173,8 @@ let privileged_public_tool_names : string list =
   [ "masc_spawn"; "masc_worktree_create"; "masc_worktree_remove" ]
 
 let privileged_keeper_tool_names : string list =
-  [ "keeper_bash"; "keeper_fs_edit";
-    "masc_worktree_create" ]
+  [ "keeper_bash"; "keeper_bash_kill"; "keeper_bash_output";
+    "keeper_fs_edit"; "masc_worktree_create" ]
 
 (* Derived from Tool_catalog_surfaces.keeper_internal_replacement (SSOT).
    Returns the masc_* backend name for aliased tools, identity otherwise. *)

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -196,3 +196,240 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
   } in
   let judgment_hash = Cdal_types.compute_judgment_hash verdict_without_hash in
   { verdict_without_hash with judgment_hash }
+
+(* ================================================================ *)
+(* Exec-outcome verifiable markers (Legendary Bash P6 Tick 15).     *)
+(*                                                                  *)
+(* The goal is to lift structured signals out of a finished bash    *)
+(* invocation *without* the verifier cascade having to regex the    *)
+(* raw output.  Heuristics here are deliberately conservative:      *)
+(* when we cannot pin the output to a known producer (dune, cargo,  *)
+(* eslint, git status), we return [] and let the caller keep the    *)
+(* raw bytes as evidence.  False positives poison the cascade, so   *)
+(* confidence defaults to [`Heuristic]; only [`Exact] markers are   *)
+(* granted "proof" status downstream.                               *)
+(* ================================================================ *)
+
+type marker_confidence = [ `Exact | `Heuristic ]
+
+type verifiable_marker =
+  | Test_pass of { count : int; confidence : marker_confidence }
+  | Test_fail of { count : int; confidence : marker_confidence }
+  | Build_ok  of { confidence : marker_confidence }
+  | Build_fail of { confidence : marker_confidence }
+  | Lint_clean of { confidence : marker_confidence }
+  | Lint_dirty of { count : int; confidence : marker_confidence }
+  | Git_clean of { confidence : marker_confidence }
+  | Git_dirty of { confidence : marker_confidence }
+  | Git_not_a_repo
+
+let conf_to_string = function
+  | `Exact -> "exact"
+  | `Heuristic -> "heuristic"
+
+let marker_to_string = function
+  | Test_pass { count; confidence } ->
+      Printf.sprintf "test_pass:%d:%s" count (conf_to_string confidence)
+  | Test_fail { count; confidence } ->
+      Printf.sprintf "test_fail:%d:%s" count (conf_to_string confidence)
+  | Build_ok { confidence } -> "build_ok:" ^ conf_to_string confidence
+  | Build_fail { confidence } -> "build_fail:" ^ conf_to_string confidence
+  | Lint_clean { confidence } -> "lint_clean:" ^ conf_to_string confidence
+  | Lint_dirty { count; confidence } ->
+      Printf.sprintf "lint_dirty:%d:%s" count (conf_to_string confidence)
+  | Git_clean { confidence } -> "git_clean:" ^ conf_to_string confidence
+  | Git_dirty { confidence } -> "git_dirty:" ^ conf_to_string confidence
+  | Git_not_a_repo -> "git_not_a_repo:exact"
+
+(* --- low-level text helpers (no re lib; keep deps thin) --- *)
+
+let contains_sub s sub =
+  let ls = String.length s and lsub = String.length sub in
+  if lsub = 0 then true
+  else if lsub > ls then false
+  else
+    let rec loop i =
+      if i + lsub > ls then false
+      else if String.sub s i lsub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let contains_ci s sub =
+  contains_sub (String.lowercase_ascii s) (String.lowercase_ascii sub)
+
+(* Counts occurrences of a fixed substring. *)
+let count_sub s sub =
+  let ls = String.length s and lsub = String.length sub in
+  if lsub = 0 || lsub > ls then 0
+  else
+    let rec loop i acc =
+      if i + lsub > ls then acc
+      else if String.sub s i lsub = sub then loop (i + lsub) (acc + 1)
+      else loop (i + 1) acc
+    in
+    loop 0 0
+
+(* Producer classifiers — match on a few unambiguous strings each
+   tool emits.  The raw stream is concatenated stdout ^ stderr. *)
+
+let looks_like_dune_build out =
+  contains_sub out "dune build" ||
+  contains_sub out "ocamlc " ||
+  contains_sub out "ocamlopt "
+
+let looks_like_dune_runtest out =
+  contains_sub out "dune runtest" ||
+  contains_sub out "Alcotest" ||
+  contains_sub out "Testing `"
+
+let looks_like_cargo out =
+  contains_sub out "Compiling " ||
+  contains_sub out "running " && contains_sub out " target/"
+
+let looks_like_git_status out =
+  contains_sub out "nothing to commit" ||
+  contains_sub out "Changes not staged" ||
+  contains_sub out "Untracked files" ||
+  contains_sub out "Changes to be committed"
+
+let looks_like_lint_eslint out =
+  contains_ci out "eslint" || contains_ci out "problem"
+
+(* Test count extraction.  Alcotest / cargo-test lines commonly look
+   like one of:
+
+     "Test Successful in 0.003s. 8 tests run."      (int BEFORE marker)
+     "12 tests passed."                              (int BEFORE marker)
+     "test result: ok. 12 passed; 0 failed; ..."    (int AFTER marker)
+
+   Strategy: per line, for each known marker we check whether the
+   marker appears and then scan the line in the appropriate direction
+   starting from the marker position.  First match wins; 0 means
+   "no producer-specific pattern matched". *)
+
+let split_lines s =
+  String.split_on_char '\n' s
+
+let first_int_before line pos =
+  let rec skip_ws i =
+    if i < 0 then i
+    else if line.[i] = ' ' || line.[i] = '\t' then skip_ws (i - 1)
+    else i
+  in
+  let end_ = skip_ws (pos - 1) in
+  if end_ < 0 then None
+  else if not (line.[end_] >= '0' && line.[end_] <= '9') then None
+  else
+    let rec start_of i =
+      if i < 0 then 0
+      else if line.[i] >= '0' && line.[i] <= '9' then start_of (i - 1)
+      else i + 1
+    in
+    let start = start_of end_ in
+    int_of_string_opt (String.sub line start (end_ - start + 1))
+
+let first_int_after line pos =
+  let ls = String.length line in
+  let rec skip_ws i =
+    if i >= ls then i
+    else if line.[i] = ' ' || line.[i] = '\t' then skip_ws (i + 1)
+    else i
+  in
+  let start = skip_ws pos in
+  if start >= ls then None
+  else if not (line.[start] >= '0' && line.[start] <= '9') then None
+  else
+    let buf = Buffer.create 8 in
+    let rec loop i =
+      if i >= ls then ()
+      else
+        let c = line.[i] in
+        if c >= '0' && c <= '9' then begin
+          Buffer.add_char buf c; loop (i + 1)
+        end
+    in
+    loop start;
+    int_of_string_opt (Buffer.contents buf)
+
+let find_sub_in line sub =
+  let ls = String.length line and lsub = String.length sub in
+  if lsub = 0 || lsub > ls then None
+  else
+    let rec loop i =
+      if i + lsub > ls then None
+      else if String.sub line i lsub = sub then Some i
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_count_from_output out =
+  let markers_before = [ "tests run"; "tests passed"; "test passed" ] in
+  let markers_after = [ "test result: ok. "; "passed:" ] in
+  let rec per_line = function
+    | [] -> 0
+    | line :: rest ->
+        let found_before =
+          List.find_map (fun m ->
+            match find_sub_in line m with
+            | None -> None
+            | Some pos -> first_int_before line pos) markers_before
+        in
+        (match found_before with
+         | Some n -> n
+         | None ->
+             let found_after =
+               List.find_map (fun m ->
+                 match find_sub_in line m with
+                 | None -> None
+                 | Some pos -> first_int_after line (pos + String.length m))
+                 markers_after
+             in
+             (match found_after with
+              | Some n -> n
+              | None -> per_line rest))
+  in
+  per_line (split_lines out)
+
+let of_exec_outcome ~semantic ~stdout ~stderr =
+  let out = stdout ^ "\n" ^ stderr in
+  let semantic : Masc_exec.Exec_semantic.t = semantic in
+  match semantic with
+  | `Git_not_a_repo -> [ Git_not_a_repo ]
+  | `Ok ->
+      if looks_like_dune_runtest out then
+        let n = test_count_from_output out in
+        [ Test_pass { count = n; confidence = `Heuristic } ]
+      else if looks_like_dune_build out then
+        [ Build_ok { confidence = `Heuristic } ]
+      else if looks_like_cargo out then
+        [ Build_ok { confidence = `Heuristic } ]
+      else if looks_like_git_status out then begin
+        if contains_sub out "nothing to commit" then
+          [ Git_clean { confidence = `Exact } ]
+        else
+          [ Git_dirty { confidence = `Exact } ]
+      end
+      else if looks_like_lint_eslint out then begin
+        (* No problem lines → clean. *)
+        if not (contains_ci out "error") && not (contains_ci out "warning")
+        then [ Lint_clean { confidence = `Heuristic } ]
+        else
+          let n = count_sub out "error " + count_sub out "warning " in
+          [ Lint_dirty { count = n; confidence = `Heuristic } ]
+      end
+      else []
+  | `Fail _ ->
+      if looks_like_dune_runtest out then
+        let n = test_count_from_output out in
+        [ Test_fail { count = n; confidence = `Heuristic } ]
+      else if looks_like_dune_build out then
+        [ Build_fail { confidence = `Heuristic } ]
+      else if looks_like_cargo out then
+        [ Build_fail { confidence = `Heuristic } ]
+      else if looks_like_lint_eslint out then
+        let n = count_sub out "error " + count_sub out "warning " in
+        [ Lint_dirty { count = n; confidence = `Heuristic } ]
+      else []
+  | `Timeout _ | `Signaled _ | `Oom_killed -> []
+  | `Policy_denied _ | `Tool_missing _ | `Permission_denied _ -> []

--- a/lib/cdal_judge.mli
+++ b/lib/cdal_judge.mli
@@ -28,3 +28,42 @@ val check_required_artifact : Cdal_loader.loaded_bundle -> Cdal_types.check_resu
     Current OAS v1 evidence is warning-only, so review requirements remain
     [Inconclusive] until explicit verification occurs downstream. *)
 val check_review_requirement : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** {2 Exec-outcome verifiable markers (Legendary Bash P6)}
+
+    Structured evidence lifted out of a completed shell command's
+    semantic exit + stdout/stderr, so the verifier cascade can route
+    without regex scraping.  Each marker carries a confidence label:
+    [`Exact] means the signal was derived from an authoritative
+    status (e.g. process exit code), [`Heuristic] means it was
+    inferred from the output text and should be cross-checked before
+    being treated as proof. *)
+
+type marker_confidence = [ `Exact | `Heuristic ]
+
+type verifiable_marker =
+  | Test_pass of { count : int; confidence : marker_confidence }
+  | Test_fail of { count : int; confidence : marker_confidence }
+  | Build_ok  of { confidence : marker_confidence }
+  | Build_fail of { confidence : marker_confidence }
+  | Lint_clean of { confidence : marker_confidence }
+  | Lint_dirty of { count : int; confidence : marker_confidence }
+  | Git_clean of { confidence : marker_confidence }
+  | Git_dirty of { confidence : marker_confidence }
+  | Git_not_a_repo
+
+val of_exec_outcome :
+  semantic:Masc_exec.Exec_semantic.t ->
+  stdout:string ->
+  stderr:string ->
+  verifiable_marker list
+(** Classify a completed exec outcome.  Returns the empty list when
+    no signal can be lifted — callers must treat absence as {i "no
+    evidence"}, not as failure.  Markers do not overlap; a single
+    command produces zero or one domain-specific marker (tests,
+    build, lint, git) though different domains may coexist when the
+    output covers several. *)
+
+val marker_to_string : verifiable_marker -> string
+(** Stable wire tag, e.g. ["test_pass:2:exact"].  Intended for
+    JSON emission and test assertions; not a pretty-printer. *)

--- a/lib/coord/coord_utils_paths_backend.ml
+++ b/lib/coord/coord_utils_paths_backend.ml
@@ -7,7 +7,7 @@ open Coord_utils_backend_setup
     match [masc_root_dir] exactly: default cluster -> [<base>/.masc/],
     non-default -> [<base>/.masc/clusters/<sanitized>/]. *)
 let masc_root_dir_from ~base_path ~cluster_name =
-  let masc_root = Filename.concat base_path ".masc" in
+  let masc_root = Common.masc_dir_from_base_path ~base_path in
   match cluster_name with
   | "" | "default" -> masc_root
   | other ->

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -32,6 +32,11 @@ let protect ~module_name ~finally_label ~finally f =
              ~during_exception:true ~backtrace:bt2 ex2);
       Printexc.raise_with_backtrace ex bt
 
+let masc_dirname = ".masc"
+
+let masc_dir_from_base_path ~base_path =
+  Filename.concat base_path masc_dirname
+
 (** Maximum output bytes for tool responses. SSOT for the 64KB cap. *)
 let max_tool_output_bytes = 65_536
 

--- a/lib/dune
+++ b/lib/dune
@@ -796,6 +796,9 @@
    masc_process
    ;; Typed exec approval substrate (RFC v5)
    masc_mcp.masc_exec
+   ;; Bash subset parser (RFC v5 A1) — for shadow AST telemetry
+   ;; in worker_dev_tools pending regex-to-AST migration.
+   masc_mcp.masc_exec_bash_parser
    ;; Autoresearch leaf modules (types, serde, storage, metric, git, file)
    masc_autoresearch
    ;; Board types (extracted sub-library — first step toward board isolation)

--- a/lib/eval_gate.mli
+++ b/lib/eval_gate.mli
@@ -28,6 +28,12 @@ val default_config : gate_config
 val normalize_command : string -> string
 (** Normalize a shell command for pattern matching. *)
 
+val destructive_patterns : (string * string) list
+(** The canonical 19-entry substring pattern catalogue used by
+    [detect_destructive]. Exposed so the AST shadow classifier
+    (see [Worker_dev_tools.classify_destructive]) can enforce
+    a covenant that every pattern maps to a typed class. *)
+
 val detect_destructive : string -> (string * string) option
 (** Returns [(pattern, description)] if command matches a destructive pattern. *)
 

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,4 +5,4 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
- (libraries masc_process unix))
+ (libraries masc_process eio unix))

--- a/lib/exec/exec_buffer.ml
+++ b/lib/exec/exec_buffer.ml
@@ -1,0 +1,128 @@
+(* Head+tail truncating byte accumulator.
+
+   Design choices:
+   - Head is a plain [Buffer.t] capped at [head_cap]; cheap append
+     until the cap is reached, then no-op.
+   - Tail is a fixed-size [Bytes.t] ring buffer of size [tail_cap].
+     Writes wrap around; reads rotate the ring into linear order when
+     [tail] / [render] is called.
+   - When head + tail together would cover the entire stream (i.e.
+     [total_bytes <= head_cap + tail_cap]), the tail ring still holds
+     the last [tail_cap] bytes, but the head already holds the first
+     [head_cap].  The [bytes_dropped] counter ensures that overlap
+     between head and tail does NOT inflate the perceived loss — see
+     the check in [render].  Net: tiny streams render identically to
+     the raw stream. *)
+
+type t = {
+  head_cap : int;
+  tail_cap : int;
+  head_buf : Buffer.t;
+  tail_ring : Bytes.t;
+  mutable tail_size : int;       (* bytes currently stored, <= tail_cap *)
+  mutable tail_write : int;      (* next slot to write, < tail_cap *)
+  mutable total : int;
+}
+
+let create ~head_cap ~tail_cap =
+  if head_cap < 0 || tail_cap < 0 then
+    invalid_arg "Exec_buffer.create: caps must be >= 0";
+  {
+    head_cap;
+    tail_cap;
+    head_buf = Buffer.create (min head_cap 4096);
+    tail_ring = Bytes.make tail_cap '\x00';
+    tail_size = 0;
+    tail_write = 0;
+    total = 0;
+  }
+
+let total_bytes t = t.total
+
+(* A byte is "retained" if it ended up in the head (because it landed
+   before head_cap was full) OR it is still in the tail ring at
+   observation time.  Overlap between head and tail counts once. *)
+let retained t =
+  let head_len = Buffer.length t.head_buf in
+  if t.total <= t.head_cap then head_len
+  else
+    let union = head_len + t.tail_size in
+    min t.total union
+
+let bytes_dropped t = t.total - retained t
+
+let add_bytes_inner t buf off len =
+  if len <= 0 then ()
+  else begin
+    (* Append to head until head_cap reached. *)
+    let head_len = Buffer.length t.head_buf in
+    let head_room = max 0 (t.head_cap - head_len) in
+    let take_head = min head_room len in
+    if take_head > 0 then
+      Buffer.add_subbytes t.head_buf buf off take_head;
+    (* All input also flows through the tail ring. When len > tail_cap
+       only the last tail_cap bytes land; older bytes are skipped. *)
+    if t.tail_cap > 0 then begin
+      let skip =
+        if len > t.tail_cap then len - t.tail_cap else 0
+      in
+      let src_off = off + skip in
+      let src_len = len - skip in
+      (* Two-phase write to handle ring wrap. *)
+      let first = min src_len (t.tail_cap - t.tail_write) in
+      Bytes.blit buf src_off t.tail_ring t.tail_write first;
+      let second = src_len - first in
+      if second > 0 then
+        Bytes.blit buf (src_off + first) t.tail_ring 0 second;
+      t.tail_write <- (t.tail_write + src_len) mod t.tail_cap;
+      t.tail_size <- min t.tail_cap (t.tail_size + src_len)
+    end;
+    t.total <- t.total + len
+  end
+
+let add_bytes t buf off len =
+  if off < 0 || len < 0 || off + len > Bytes.length buf then
+    invalid_arg "Exec_buffer.add_bytes: out-of-range slice";
+  add_bytes_inner t buf off len
+
+let add_string t s =
+  add_bytes_inner t (Bytes.unsafe_of_string s) 0 (String.length s)
+
+let head t = Buffer.contents t.head_buf
+
+let tail t =
+  if t.tail_size = 0 then ""
+  else
+    let out = Bytes.create t.tail_size in
+    let start = (t.tail_write - t.tail_size + t.tail_cap) mod t.tail_cap in
+    let first = min t.tail_size (t.tail_cap - start) in
+    Bytes.blit t.tail_ring start out 0 first;
+    let second = t.tail_size - first in
+    if second > 0 then
+      Bytes.blit t.tail_ring 0 out first second;
+    Bytes.unsafe_to_string out
+
+let render t =
+  (* If we retained everything, stitching head+tail back would
+     duplicate the overlap.  Prefer the direct pieces to avoid that. *)
+  if t.total <= t.head_cap then head t
+  else if t.total <= t.tail_cap && t.head_cap = 0 then tail t
+  else if bytes_dropped t = 0 then
+    (* Full coverage but via two non-empty buffers that share bytes.
+       Emit the head verbatim, then only the tail bytes that sit past
+       head_cap. *)
+    let head_s = head t in
+    let tail_s = tail t in
+    let extra =
+      if t.total <= String.length head_s then ""
+      else
+        let overlap = t.head_cap - (t.total - String.length tail_s) in
+        if overlap <= 0 then tail_s
+        else if overlap >= String.length tail_s then ""
+        else String.sub tail_s overlap (String.length tail_s - overlap)
+    in
+    head_s ^ extra
+  else
+    let dropped = bytes_dropped t in
+    Printf.sprintf "%s\n...(truncated %d bytes)...\n%s"
+      (head t) dropped (tail t)

--- a/lib/exec/exec_buffer.mli
+++ b/lib/exec/exec_buffer.mli
@@ -1,0 +1,43 @@
+(** Head+tail truncating byte accumulator — Phase 3 of the Legendary
+    Bash roadmap.
+
+    Mirrors claude-code's [EndTruncatingAccumulator] but retains BOTH
+    the head and tail of the stream, which keeps opening banners
+    (usage strings, config echoes) and closing summaries (final exit
+    status, error tails) readable when the middle is elided.
+
+    Semantics:
+    - The first [head_cap] bytes are written once to the head buffer
+      and then frozen — subsequent writes never mutate those bytes.
+    - The last [tail_cap] bytes are held in a ring buffer.  When new
+      bytes arrive, the oldest tail bytes are overwritten.
+    - [total_bytes] is the cumulative count of bytes ever offered via
+      [add_*], independent of truncation.
+    - [bytes_dropped] is the count of bytes that were not retained in
+      either the head or the tail.  Zero means the full stream fit.
+
+    Not thread-safe.  Callers that drain concurrent producers must
+    serialise access.  In the intended use (single-pipe drainer per
+    fd), the producer is sequential, so no lock is required. *)
+
+type t
+
+val create : head_cap:int -> tail_cap:int -> t
+(** [head_cap] and [tail_cap] are byte budgets.  A value of [0] means
+    "retain nothing from this end".  Negative values are rejected. *)
+
+val add_string : t -> string -> unit
+val add_bytes : t -> bytes -> int -> int -> unit
+(** [add_bytes t buf off len] appends [buf.[off .. off+len-1]]. *)
+
+val total_bytes : t -> int
+val bytes_dropped : t -> int
+val head : t -> string
+val tail : t -> string
+
+val render : t -> string
+(** Returns [head] unchanged when nothing was dropped; otherwise
+    [head ^ separator ^ tail] where separator is a single-line
+    [\n...(truncated N bytes)...\n] marker.  The separator is only
+    present when [bytes_dropped > 0] so golden tests on small outputs
+    remain byte-identical to the raw stream. *)

--- a/lib/exec/exec_run.ml
+++ b/lib/exec/exec_run.ml
@@ -1,0 +1,173 @@
+(* Tick 10: foreground / background race for keeper_bash.
+
+   Structure:
+   1. Bg_task.spawn  -> a detached pgid-owned child with ring buffers.
+   2. Eio.Fiber.first races two sub-fibers:
+        (a) poll loop   — Bg_task.read at [poll_interval_ms] cadence,
+                          accumulating stdout/stderr.  Exits when
+                          Bg_task reports [closed = true] with a
+                          terminal [status].  Returns [`Done state].
+        (b) budget timer — [Eio.Time.sleep clock budget_sec].
+                          Returns [`Budget_expired].
+   3. Whichever fiber wins chooses the branch:
+        - `Done   -> Completed
+        - `Budget_expired -> one final drain, Promoted.
+
+   Invariants:
+   - On promotion the task is intentionally NOT killed.  Caller owns
+     the handle and is expected to poll via keeper_bash_output or to
+     call keeper_bash_kill.
+   - Cumulative output is a simple [Buffer.t] append of every
+     [read]'s [*_since] slices.  Because [read] is pull-based with
+     ring buffers underneath, concatenating every slice yields the
+     full observed stream minus whatever Bg_task's ring dropped.
+     [bytes_dropped_*] carries that loss forward. *)
+
+(* [Bg_task] is unqualified: [masc_process] is wrapped:false. *)
+
+type completed = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+}
+
+type promoted = {
+  task_id : Bg_task.task_id;
+  partial_stdout : string;
+  partial_stderr : string;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+}
+
+type outcome =
+  | Completed of completed
+  | Promoted of promoted
+  | Spawn_error of Bg_task.spawn_error
+
+let default_budget_ms () =
+  match Sys.getenv_opt "MASC_BLOCKING_BUDGET_MS" with
+  | None -> 15_000
+  | Some s ->
+    (match int_of_string_opt (String.trim s) with
+     | Some n -> n
+     | None -> 15_000)
+
+(* Drain accumulator tracking cumulative byte offsets into each
+   stream.  [since_stdout]/[since_stderr] feed back to Bg_task.read
+   so every poll only surfaces fresh bytes. *)
+type accum = {
+  stdout : Buffer.t;
+  stderr : Buffer.t;
+  mutable since_stdout : int;
+  mutable since_stderr : int;
+  mutable dropped_stdout : int;
+  mutable dropped_stderr : int;
+  mutable status : Unix.process_status option;
+  mutable closed : bool;
+}
+
+let mk_accum () = {
+  stdout = Buffer.create 1024;
+  stderr = Buffer.create 256;
+  since_stdout = 0;
+  since_stderr = 0;
+  dropped_stdout = 0;
+  dropped_stderr = 0;
+  status = None;
+  closed = false;
+}
+
+let drain_once ~task acc =
+  match Bg_task.read task
+          ~since_stdout:acc.since_stdout
+          ~since_stderr:acc.since_stderr with
+  | Error _ ->
+    (* Unknown / read_failed: treat as a dead task so the race
+       settles.  The caller will see the accumulator's current
+       state; no partial status recovery here. *)
+    acc.closed <- true
+  | Ok snap ->
+    Buffer.add_string acc.stdout snap.stdout_since;
+    Buffer.add_string acc.stderr snap.stderr_since;
+    acc.since_stdout <- acc.since_stdout + String.length snap.stdout_since;
+    acc.since_stderr <- acc.since_stderr + String.length snap.stderr_since;
+    acc.dropped_stdout <- snap.bytes_dropped_stdout;
+    acc.dropped_stderr <- snap.bytes_dropped_stderr;
+    acc.status <- snap.status;
+    acc.closed <- snap.closed
+
+let run_with_auto_bg
+    ~clock
+    ?(poll_interval_ms = 50)
+    ?base_path
+    ~budget_ms
+    ~keeper
+    ~argv
+    ~cwd
+    ~envp
+    ~timeout_sec
+    () =
+  match
+    Bg_task.spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec ()
+  with
+  | Error e -> Spawn_error e
+  | Ok task ->
+    let acc = mk_accum () in
+    let poll_sec = max 0.001 (float_of_int poll_interval_ms /. 1000.) in
+    let disabled = budget_ms <= 0 in
+    let winner : [ `Done | `Budget_expired ] =
+      Eio.Fiber.first
+        (fun () ->
+           let rec loop () =
+             drain_once ~task acc;
+             if acc.closed then `Done
+             else begin
+               Eio.Time.sleep clock poll_sec;
+               loop ()
+             end
+           in
+           loop ())
+        (fun () ->
+           if disabled then begin
+             (* Unbounded: block forever so the poll fiber wins.
+                Using a very large sleep instead of a Promise avoids
+                introducing a new synchronisation primitive. *)
+             Eio.Time.sleep clock 1.0e9;
+             `Budget_expired
+           end
+           else begin
+             Eio.Time.sleep clock (float_of_int budget_ms /. 1000.);
+             `Budget_expired
+           end)
+    in
+    begin match winner with
+    | `Done ->
+      let status =
+        match acc.status with
+        | Some s -> s
+        | None -> Unix.WEXITED 0
+        (* Drain-after-close without a status is a Bg_task
+           bookkeeping slip; default to success so we do not
+           invent a failure code. *)
+      in
+      Completed {
+        status;
+        stdout = Buffer.contents acc.stdout;
+        stderr = Buffer.contents acc.stderr;
+        bytes_dropped_stdout = acc.dropped_stdout;
+        bytes_dropped_stderr = acc.dropped_stderr;
+      }
+    | `Budget_expired ->
+      (* Final drain so the Promoted snapshot carries every byte
+         the child emitted up to budget_expire time. *)
+      drain_once ~task acc;
+      Promoted {
+        task_id = task;
+        partial_stdout = Buffer.contents acc.stdout;
+        partial_stderr = Buffer.contents acc.stderr;
+        bytes_dropped_stdout = acc.dropped_stdout;
+        bytes_dropped_stderr = acc.dropped_stderr;
+      }
+    end

--- a/lib/exec/exec_run.mli
+++ b/lib/exec/exec_run.mli
@@ -1,0 +1,67 @@
+(** Auto-background race — Phase 4 of the Legendary Bash roadmap.
+
+    Mirrors claude-code's foreground-shell auto-promotion: run a
+    command in the foreground, but if it outruns a blocking budget,
+    hand it off to the background-task registry and return a
+    [Promoted] ref so the caller can continue polling.
+
+    Design (Tick 10): {e bg-first with early settlement}.  Every
+    invocation spawns a {!Bg_task} (from [masc_process]) from the start so
+    tree-kill, PID-file persistence, and ring-buffered drains are
+    always available.  A short-lived poll fiber drains the task
+    while racing a budget timer via {!Eio.Fiber.first}.  Whichever
+    fiber wins picks the outcome:
+    - exit before budget -> [Completed] (caller cleans up; bg_task
+      auto-closes on read-after-exit in a future tick)
+    - budget expires first -> [Promoted] (task keeps running, caller
+      gets partial output + a handle)
+
+    This sidesteps the "switch hand-off" problem suggested by the
+    plan: because we never start a foreground-only process, there is
+    no fiber to transplant.  The pgid-owned child in Bg_task was
+    already the right unit of ownership. *)
+
+type completed = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+}
+
+type promoted = {
+  task_id : Bg_task.task_id;
+  partial_stdout : string;
+  partial_stderr : string;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+}
+
+type outcome =
+  | Completed of completed
+  | Promoted of promoted
+  | Spawn_error of Bg_task.spawn_error
+
+val default_budget_ms : unit -> int
+(** Reads [MASC_BLOCKING_BUDGET_MS].  Defaults to [15_000] to match
+    claude-code's foreground timeout.  A value of [0] or negative
+    disables the race (behaves as unbounded foreground). *)
+
+val run_with_auto_bg :
+  clock:_ Eio.Time.clock ->
+  ?poll_interval_ms:int ->
+  ?base_path:string ->
+  budget_ms:int ->
+  keeper:string ->
+  argv:string list ->
+  cwd:string ->
+  envp:string array ->
+  timeout_sec:float ->
+  unit ->
+  outcome
+(** Spawn [argv] as a Bg_task, then race its completion against
+    [budget_ms].  [poll_interval_ms] defaults to [50] — tight enough
+    to catch a fast-exiting command inside the budget without burning
+    CPU on idle polls.  [timeout_sec] is the upper-bound wall clock
+    that Bg_task enforces even after promotion (pass [0.0] to
+    disable). *)

--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -32,6 +32,20 @@ let stderr_hints_oom stderr =
   || contains lower "killed (oom)"
   || contains lower "cannot allocate memory"
 
+let first_token s =
+  let len = String.length s in
+  let rec skip_ws i =
+    if i >= len then i
+    else match s.[i] with ' ' | '\t' | '\n' -> skip_ws (i + 1) | _ -> i
+  in
+  let rec take_nonws i =
+    if i >= len then i
+    else match s.[i] with ' ' | '\t' | '\n' -> i | _ -> take_nonws (i + 1)
+  in
+  let start = skip_ws 0 in
+  let stop = take_nonws start in
+  if start = stop then "" else String.sub s start (stop - start)
+
 let interpret ~argv ~status ~stdout:_ ~stderr =
   match status with
   | Unix.WEXITED 0 -> `Ok
@@ -53,6 +67,11 @@ let interpret ~argv ~status ~stdout:_ ~stderr =
       `Oom_killed
   | Unix.WSIGNALED n -> `Signaled n
   | Unix.WSTOPPED n -> `Signaled n
+
+let interpret_cmd ~cmd ~status ~output =
+  let head = first_token cmd in
+  let argv = if head = "" then [] else [ head ] in
+  interpret ~argv ~status ~stdout:"" ~stderr:output
 
 let to_hint = function
   | `Ok -> None

--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -1,0 +1,103 @@
+type t =
+  [ `Ok
+  | `Fail of int
+  | `Timeout of float
+  | `Signaled of int
+  | `Git_not_a_repo
+  | `Oom_killed
+  | `Policy_denied of string
+  | `Tool_missing of string
+  | `Permission_denied of string ]
+
+let is_git_argv = function
+  | "git" :: _ -> true
+  | bin :: _ when Filename.basename bin = "git" -> true
+  | _ -> false
+
+let stderr_hints_oom stderr =
+  let lower = String.lowercase_ascii stderr in
+  let contains s sub =
+    let ls = String.length s and lb = String.length sub in
+    if lb = 0 || lb > ls then false
+    else
+      let rec loop i =
+        if i + lb > ls then false
+        else if String.sub s i lb = sub then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  contains lower "out of memory"
+  || contains lower "oom-killer"
+  || contains lower "killed (oom)"
+  || contains lower "cannot allocate memory"
+
+let interpret ~argv ~status ~stdout:_ ~stderr =
+  match status with
+  | Unix.WEXITED 0 -> `Ok
+  | Unix.WEXITED 127 ->
+      let tool = match argv with
+        | x :: _ -> Filename.basename x
+        | [] -> ""
+      in
+      `Tool_missing tool
+  | Unix.WEXITED 126 ->
+      let path = match argv with
+        | x :: _ -> x
+        | [] -> ""
+      in
+      `Permission_denied path
+  | Unix.WEXITED 128 when is_git_argv argv -> `Git_not_a_repo
+  | Unix.WEXITED code -> `Fail code
+  | Unix.WSIGNALED n when n = Sys.sigkill && stderr_hints_oom stderr ->
+      `Oom_killed
+  | Unix.WSIGNALED n -> `Signaled n
+  | Unix.WSTOPPED n -> `Signaled n
+
+let to_hint = function
+  | `Ok -> None
+  | `Fail n -> Some (Printf.sprintf "command exited with code %d" n)
+  | `Timeout s -> Some (Printf.sprintf "timed out after %.1fs" s)
+  | `Signaled n -> Some (Printf.sprintf "process terminated by signal %d" n)
+  | `Git_not_a_repo ->
+      Some "git exit 128 — cwd is not inside a git repository"
+  | `Oom_killed ->
+      Some "process was OOM-killed — try a smaller input or higher mem limit"
+  | `Policy_denied rule ->
+      Some (Printf.sprintf "policy denied: %s" rule)
+  | `Tool_missing tool ->
+      Some (Printf.sprintf "tool not found on PATH: %s" tool)
+  | `Permission_denied path ->
+      Some (Printf.sprintf "EACCES: cannot execute %s" path)
+
+type payload_value =
+  [ `String of string
+  | `Int of int
+  | `Float of float ]
+
+let to_kind = function
+  | `Ok -> "ok"
+  | `Fail _ -> "fail"
+  | `Timeout _ -> "timeout"
+  | `Signaled _ -> "signaled"
+  | `Git_not_a_repo -> "git_not_a_repo"
+  | `Oom_killed -> "oom_killed"
+  | `Policy_denied _ -> "policy_denied"
+  | `Tool_missing _ -> "tool_missing"
+  | `Permission_denied _ -> "permission_denied"
+
+let to_payload : t -> (string * payload_value) list = function
+  | `Ok -> []
+  | `Fail n -> [ "exit_code", `Int n ]
+  | `Timeout s -> [ "seconds", `Float s ]
+  | `Signaled n -> [ "signal", `Int n ]
+  | `Git_not_a_repo -> []
+  | `Oom_killed -> []
+  | `Policy_denied rule -> [ "rule", `String rule ]
+  | `Tool_missing tool -> [ "tool", `String tool ]
+  | `Permission_denied path -> [ "path", `String path ]
+
+let enabled () =
+  match Sys.getenv_opt "MASC_BASH_SEMANTIC_EXIT" with
+  | Some ("1" | "true" | "TRUE") -> true
+  | _ -> false

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -1,0 +1,78 @@
+(** Post-execution semantic classification of a completed shell command.
+
+    This layer is {b orthogonal} to [Verdict]:
+    - [Verdict] answers {i "may this command run?"} (pre-exec gate,
+      produces [Trusted_argv.t] or denies).
+    - [Exec_semantic] answers {i "how should the caller interpret the
+      exit status of a command that already ran?"} (post-exec hint).
+
+    Inspired by claude-code's [interpretCommandResult] in
+    [src/utils/Shell.ts]. The OpenAI Codex harness blog posts
+    ("harness-engineering", "unlocking-the-codex-harness") frame this
+    as turning raw OS return codes into typed markers the agent loop
+    can reason over without string scraping.
+
+    Rollout: additive JSON field. Gated by [MASC_BASH_SEMANTIC_EXIT]
+    env flag during the bake-in window (see
+    [planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md]
+    Phase 1). *)
+
+type t =
+  [ `Ok
+  | `Fail of int
+  | `Timeout of float
+  | `Signaled of int
+  | `Git_not_a_repo
+  | `Oom_killed
+  | `Policy_denied of string
+  | `Tool_missing of string
+  | `Permission_denied of string ]
+(** Polymorphic variant so downstream modules can narrow the set in
+    their own match arms without introducing a module dependency. *)
+
+val interpret :
+  argv:string list ->
+  status:Unix.process_status ->
+  stdout:string ->
+  stderr:string ->
+  t
+(** Map a finished [Unix.process_status] plus captured output into a
+    semantic classification.
+
+    Heuristics (ported from claude-code [interpretCommandResult]):
+    - exit 128 on [git …]  -> [`Git_not_a_repo]
+    - exit 127             -> [`Tool_missing]
+    - exit 126             -> [`Permission_denied]
+    - SIGKILL w/ OOM token -> [`Oom_killed]
+    - SIGTERM              -> [`Signaled]
+    - otherwise exit 0     -> [`Ok]
+    - otherwise exit n     -> [`Fail n]
+
+    [interpret] is total and never raises. *)
+
+val to_hint : t -> string option
+(** Human-readable operator hint for LLM consumption. None for [`Ok]. *)
+
+type payload_value =
+  [ `String of string
+  | `Int of int
+  | `Float of float ]
+(** Minimal sum to describe variant payloads without forcing a
+    [Yojson] dependency on [masc_exec]. The JSON envelope itself is
+    rendered by the caller (e.g. [Exec_core] uses [Yojson.Safe]). *)
+
+val to_kind : t -> string
+(** Stable string tag for the semantic variant — e.g. ["ok"], ["fail"],
+    ["git_not_a_repo"]. Additive-only: new variants extend the set but
+    never rename or remove an existing tag. *)
+
+val to_payload : t -> (string * payload_value) list
+(** Variant-specific key/value pairs (e.g. [("exit_code", `Int 2)]).
+    Empty for nullary variants. *)
+
+val enabled : unit -> bool
+(** Runtime feature flag reader. Reads [MASC_BASH_SEMANTIC_EXIT]; when
+    set to ["1"] or ["true"] the caller should emit the semantic field.
+    The interpret/to_json functions themselves are always safe to call;
+    the flag only gates whether producers include the result in the
+    user-visible response. *)

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -39,6 +39,20 @@ val interpret :
 (** Map a finished [Unix.process_status] plus captured output into a
     semantic classification.
 
+    Callers that only have a merged [output] string (e.g.
+    [Exec_core.outcome]) should use [interpret_cmd] instead. *)
+
+val interpret_cmd :
+  cmd:string ->
+  status:Unix.process_status ->
+  output:string ->
+  t
+(** Best-effort [interpret] for call sites that carry a single
+    [cmd:string] instead of an [argv] list and a merged
+    [output:string] (stdout ++ stderr) instead of split streams.
+    The first whitespace-separated token is treated as the argv head
+    for tool-name heuristics; OOM detection scans the merged output.
+
     Heuristics (ported from claude-code [interpretCommandResult]):
     - exit 128 on [git …]  -> [`Git_not_a_repo]
     - exit 127             -> [`Tool_missing]
@@ -49,6 +63,8 @@ val interpret :
     - otherwise exit n     -> [`Fail n]
 
     [interpret] is total and never raises. *)
+
+    (* interpret_cmd doc intentionally above; keeps interpret doc local. *)
 
 val to_hint : t -> string option
 (** Human-readable operator hint for LLM consumption. None for [`Ok]. *)

--- a/lib/exec/parser/dune
+++ b/lib/exec/parser/dune
@@ -4,6 +4,7 @@
 
 (library
  (name masc_exec_bash_parser)
+ (public_name masc_mcp.masc_exec_bash_parser)
  (wrapped true)
  (libraries masc_exec))
 

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
-        test_exec_gate_runtime)
+        test_exec_gate_runtime test_exec_semantic)
  (libraries masc_exec masc_exec_bash_parser masc_process unix))

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -4,4 +4,4 @@
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json)
  (libraries masc_exec masc_exec_bash_parser masc_process
-            eio eio_main yojson str unix))
+            alcotest eio eio_main yojson str unix))

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -4,4 +4,4 @@
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json)
  (libraries masc_exec masc_exec_bash_parser masc_process
-            alcotest eio eio_main yojson str unix))
+            masc_core alcotest eio eio_main yojson str unix))

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,5 +1,7 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
-        test_exec_gate_runtime test_exec_semantic test_exec_buffer)
- (libraries masc_exec masc_exec_bash_parser masc_process unix))
+        test_exec_gate_runtime test_exec_semantic test_exec_buffer
+        test_exec_run)
+ (libraries masc_exec masc_exec_bash_parser masc_process
+            eio eio_main str unix))

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -1,5 +1,5 @@
 (tests
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
-        test_exec_gate_runtime test_exec_semantic)
+        test_exec_gate_runtime test_exec_semantic test_exec_buffer)
  (libraries masc_exec masc_exec_bash_parser masc_process unix))

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -2,6 +2,6 @@
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
-        test_exec_run)
+        test_exec_run test_exec_run_json)
  (libraries masc_exec masc_exec_bash_parser masc_process
-            eio eio_main str unix))
+            eio eio_main yojson str unix))

--- a/lib/exec/test/test_exec_buffer.ml
+++ b/lib/exec/test/test_exec_buffer.ml
@@ -3,14 +3,10 @@
 open Masc_exec
 
 let check_eq ctx expected actual =
-  if expected <> actual then
-    failwith
-      (Printf.sprintf "%s: expected %S, got %S" ctx expected actual)
+  Alcotest.(check string) ctx expected actual
 
 let check_int ctx expected actual =
-  if expected <> actual then
-    failwith
-      (Printf.sprintf "%s: expected %d, got %d" ctx expected actual)
+  Alcotest.(check int) ctx expected actual
 
 (* Small inputs fit fully inside head_cap and render byte-identical. *)
 let test_small_input_no_truncation () =
@@ -75,17 +71,17 @@ let test_head_cap_zero () =
   Exec_buffer.add_string b "abcdefg";
   check_eq "head empty" "" (Exec_buffer.head b);
   check_eq "tail last 4" "defg" (Exec_buffer.tail b);
-  check_eq "render" "defg" (Exec_buffer.render b)
+  check_eq "render" "\n...(truncated 3 bytes)...\ndefg" (Exec_buffer.render b)
 
 (* Negative caps rejected. *)
 let test_negative_caps_rejected () =
   (try
      let _ = Exec_buffer.create ~head_cap:(-1) ~tail_cap:4 in
-     failwith "negative head_cap not rejected"
+     Alcotest.fail "negative head_cap not rejected"
    with Invalid_argument _ -> ());
   (try
      let _ = Exec_buffer.create ~head_cap:4 ~tail_cap:(-1) in
-     failwith "negative tail_cap not rejected"
+     Alcotest.fail "negative tail_cap not rejected"
    with Invalid_argument _ -> ())
 
 (* add_bytes out-of-range rejected. *)
@@ -94,7 +90,7 @@ let test_add_bytes_oob () =
   let buf = Bytes.of_string "abcd" in
   try
     Exec_buffer.add_bytes b buf 2 10;
-    failwith "oob not rejected"
+    Alcotest.fail "oob not rejected"
   with Invalid_argument _ -> ()
 
 let () =

--- a/lib/exec/test/test_exec_buffer.ml
+++ b/lib/exec/test/test_exec_buffer.ml
@@ -1,0 +1,109 @@
+(* Head+tail truncating accumulator: property + golden tests. *)
+
+open Masc_exec
+
+let check_eq ctx expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %S, got %S" ctx expected actual)
+
+let check_int ctx expected actual =
+  if expected <> actual then
+    failwith
+      (Printf.sprintf "%s: expected %d, got %d" ctx expected actual)
+
+(* Small inputs fit fully inside head_cap and render byte-identical. *)
+let test_small_input_no_truncation () =
+  let b = Exec_buffer.create ~head_cap:16 ~tail_cap:16 in
+  Exec_buffer.add_string b "hello, world";
+  check_int "total" 12 (Exec_buffer.total_bytes b);
+  check_int "dropped" 0 (Exec_buffer.bytes_dropped b);
+  check_eq "render" "hello, world" (Exec_buffer.render b)
+
+(* Input exactly equal to head_cap + tail_cap — no truncation,
+   separator must not appear. *)
+let test_boundary_no_separator () =
+  let b = Exec_buffer.create ~head_cap:4 ~tail_cap:4 in
+  Exec_buffer.add_string b "aabbccdd";
+  check_int "total" 8 (Exec_buffer.total_bytes b);
+  check_int "dropped" 0 (Exec_buffer.bytes_dropped b);
+  check_eq "render" "aabbccdd" (Exec_buffer.render b)
+
+(* Middle elision: head, tail, and "(truncated N bytes)" separator. *)
+let test_truncation_separator () =
+  let b = Exec_buffer.create ~head_cap:4 ~tail_cap:4 in
+  Exec_buffer.add_string b "HEADxxxxxxxxxxxxxxTAIL";
+  let n = String.length "HEADxxxxxxxxxxxxxxTAIL" in
+  check_int "total" n (Exec_buffer.total_bytes b);
+  check_eq "head" "HEAD" (Exec_buffer.head b);
+  check_eq "tail" "TAIL" (Exec_buffer.tail b);
+  let expected =
+    Printf.sprintf "HEAD\n...(truncated %d bytes)...\nTAIL"
+      (Exec_buffer.bytes_dropped b)
+  in
+  check_eq "render" expected (Exec_buffer.render b)
+
+(* Ring buffer must reflect only the most-recent tail_cap bytes even
+   after many writes. *)
+let test_tail_ring_rotates () =
+  let b = Exec_buffer.create ~head_cap:0 ~tail_cap:5 in
+  for i = 1 to 20 do
+    Exec_buffer.add_string b (Printf.sprintf "%d" (i mod 10))
+  done;
+  check_int "total" 20 (Exec_buffer.total_bytes b);
+  check_eq "last 5" "67890" (Exec_buffer.tail b)
+
+(* 1 MB input with 512-byte caps — realistic head/tail budget. *)
+let test_large_stream_caps () =
+  let head_cap = 512 and tail_cap = 512 in
+  let b = Exec_buffer.create ~head_cap ~tail_cap in
+  let chunk = Bytes.make 4096 'x' in
+  for _ = 1 to 256 do
+    Exec_buffer.add_bytes b chunk 0 (Bytes.length chunk)
+  done;
+  check_int "total" (256 * 4096) (Exec_buffer.total_bytes b);
+  check_int "head retained" head_cap
+    (String.length (Exec_buffer.head b));
+  check_int "tail retained" tail_cap
+    (String.length (Exec_buffer.tail b));
+  let drop_expected = (256 * 4096) - head_cap - tail_cap in
+  check_int "dropped" drop_expected (Exec_buffer.bytes_dropped b)
+
+(* Zero head_cap: only tail is kept. *)
+let test_head_cap_zero () =
+  let b = Exec_buffer.create ~head_cap:0 ~tail_cap:4 in
+  Exec_buffer.add_string b "abcdefg";
+  check_eq "head empty" "" (Exec_buffer.head b);
+  check_eq "tail last 4" "defg" (Exec_buffer.tail b);
+  check_eq "render" "defg" (Exec_buffer.render b)
+
+(* Negative caps rejected. *)
+let test_negative_caps_rejected () =
+  (try
+     let _ = Exec_buffer.create ~head_cap:(-1) ~tail_cap:4 in
+     failwith "negative head_cap not rejected"
+   with Invalid_argument _ -> ());
+  (try
+     let _ = Exec_buffer.create ~head_cap:4 ~tail_cap:(-1) in
+     failwith "negative tail_cap not rejected"
+   with Invalid_argument _ -> ())
+
+(* add_bytes out-of-range rejected. *)
+let test_add_bytes_oob () =
+  let b = Exec_buffer.create ~head_cap:8 ~tail_cap:8 in
+  let buf = Bytes.of_string "abcd" in
+  try
+    Exec_buffer.add_bytes b buf 2 10;
+    failwith "oob not rejected"
+  with Invalid_argument _ -> ()
+
+let () =
+  test_small_input_no_truncation ();
+  test_boundary_no_separator ();
+  test_truncation_separator ();
+  test_tail_ring_rotates ();
+  test_large_stream_caps ();
+  test_head_cap_zero ();
+  test_negative_caps_rejected ();
+  test_add_bytes_oob ();
+  print_endline "exec_buffer: 8/8 passed"

--- a/lib/exec/test/test_exec_run.ml
+++ b/lib/exec/test/test_exec_run.ml
@@ -21,6 +21,7 @@
    Alcotest_lwt, just Eio + Bg_task. *)
 
 open Alcotest
+open Masc_exec
 
 let keeper = "exec_run_test"
 

--- a/lib/exec/test/test_exec_run.ml
+++ b/lib/exec/test/test_exec_run.ml
@@ -27,8 +27,11 @@ let keeper = "exec_run_test"
 
 let clean_bg_dir ~base_path =
   let bg_dir =
-    Filename.concat (Filename.concat (Filename.concat base_path ".masc")
-      (Filename.concat "keeper" keeper)) "bg"
+    Filename.concat
+      (Filename.concat
+         (Common.masc_dir_from_base_path ~base_path)
+         (Filename.concat "keeper" keeper))
+      "bg"
   in
   if Sys.file_exists bg_dir then
     let files = try Sys.readdir bg_dir with _ -> [||] in

--- a/lib/exec/test/test_exec_run.ml
+++ b/lib/exec/test/test_exec_run.ml
@@ -1,0 +1,128 @@
+(* Tick 10: foreground / background race harness.
+
+   These tests exercise the two winning branches of
+   [Exec_run.run_with_auto_bg] against a real [Eio_main.run] clock:
+
+   1. Fast command (sleep 0.05) inside a 2 s budget -> [Completed].
+      Proves the poll fiber wins and fully drains stdout before the
+      budget timer fires.
+
+   2. Slow command (sleep 5) against a 0.2 s budget -> [Promoted].
+      Proves the timer fiber wins, the snapshot preserves partial
+      output, and the returned [task_id] is still alive so a caller
+      could keep polling.  We kill the task at the end to avoid
+      leaking the long sleep.
+
+   3. [default_budget_ms] env override round-trip.
+
+   The tests live under [lib/exec/test] rather than [test/] so they
+   only pull in [masc_exec] + [masc_process], keeping the build graph
+   local.  This makes the test loop fast: no MCP server, no
+   Alcotest_lwt, just Eio + Bg_task. *)
+
+open Alcotest
+
+let keeper = "exec_run_test"
+
+let clean_bg_dir ~base_path =
+  let bg_dir =
+    Filename.concat (Filename.concat (Filename.concat base_path ".masc")
+      (Filename.concat "keeper" keeper)) "bg"
+  in
+  if Sys.file_exists bg_dir then
+    let files = try Sys.readdir bg_dir with _ -> [||] in
+    Array.iter (fun f ->
+      try Sys.remove (Filename.concat bg_dir f) with _ -> ())
+      files
+
+let test_fast_command_completes () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = Filename.get_temp_dir_name () in
+  clean_bg_dir ~base_path;
+  let out =
+    Exec_run.run_with_auto_bg
+      ~clock
+      ~poll_interval_ms:20
+      ~base_path
+      ~budget_ms:2000
+      ~keeper
+      ~argv:[ "/bin/sh"; "-c"; "printf hi" ]
+      ~cwd:(Sys.getcwd ())
+      ~envp:(Unix.environment ())
+      ~timeout_sec:5.0
+      ()
+  in
+  match out with
+  | Exec_run.Completed r ->
+    check string "stdout" "hi" r.stdout;
+    (match r.status with
+     | Unix.WEXITED 0 -> ()
+     | _ -> fail "expected WEXITED 0")
+  | Exec_run.Promoted _ -> fail "fast command should not promote"
+  | Exec_run.Spawn_error _ -> fail "spawn failed"
+
+let test_slow_command_promotes () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = Filename.get_temp_dir_name () in
+  clean_bg_dir ~base_path;
+  let out =
+    Exec_run.run_with_auto_bg
+      ~clock
+      ~poll_interval_ms:20
+      ~base_path
+      ~budget_ms:200
+      ~keeper
+      ~argv:[ "/bin/sh"; "-c"; "printf early; sleep 5; printf late" ]
+      ~cwd:(Sys.getcwd ())
+      ~envp:(Unix.environment ())
+      ~timeout_sec:30.0
+      ()
+  in
+  match out with
+  | Exec_run.Completed _ ->
+    fail "slow command should have hit the budget"
+  | Exec_run.Spawn_error _ -> fail "spawn failed"
+  | Exec_run.Promoted p ->
+    (* We saw "early" but not "late" — budget fires before sleep 5
+       resolves.  Killing cleans up the long sleep. *)
+    let saw_early =
+      try
+        let _ = Str.search_forward (Str.regexp "early") p.partial_stdout 0 in
+        true
+      with Not_found -> false
+    in
+    check bool "saw early output" true saw_early;
+    let saw_late =
+      try
+        let _ = Str.search_forward (Str.regexp "late") p.partial_stdout 0 in
+        true
+      with Not_found -> false
+    in
+    check bool "did not see late output" false saw_late;
+    let _ = Bg_task.kill p.task_id ~signal:Sys.sigterm ~grace_sec:0.2 in
+    ()
+
+let test_default_budget_env () =
+  let prior = try Some (Sys.getenv "MASC_BLOCKING_BUDGET_MS") with Not_found -> None in
+  Unix.putenv "MASC_BLOCKING_BUDGET_MS" "777";
+  let v = Exec_run.default_budget_ms () in
+  check int "env honoured" 777 v;
+  (match prior with
+   | None -> Unix.putenv "MASC_BLOCKING_BUDGET_MS" ""
+   | Some v -> Unix.putenv "MASC_BLOCKING_BUDGET_MS" v)
+
+let () =
+  run "exec_run" [
+    ("race", [
+      test_case "fast command completes inside budget" `Quick
+        test_fast_command_completes;
+      test_case "slow command promotes to bg" `Slow
+        test_slow_command_promotes;
+    ]);
+    ("config", [
+      test_case "default_budget_ms honours env" `Quick
+        test_default_budget_env;
+    ]);
+  ]

--- a/lib/exec/test/test_exec_run_json.ml
+++ b/lib/exec/test/test_exec_run_json.ml
@@ -22,8 +22,11 @@ open Masc_exec
 
 let clean_bg_dir ~base_path ~keeper =
   let bg_dir =
-    Filename.concat (Filename.concat (Filename.concat base_path ".masc")
-      (Filename.concat "keeper" keeper)) "bg"
+    Filename.concat
+      (Filename.concat
+         (Common.masc_dir_from_base_path ~base_path)
+         (Filename.concat "keeper" keeper))
+      "bg"
   in
   if Sys.file_exists bg_dir then
     let files = try Sys.readdir bg_dir with _ -> [||] in

--- a/lib/exec/test/test_exec_run_json.ml
+++ b/lib/exec/test/test_exec_run_json.ml
@@ -1,0 +1,123 @@
+(* Tick 11: JSON-shape pinning for the keeper_bash auto-bg hookup.
+
+   The keeper_bash handler translates
+   [Masc_exec.Exec_run.outcome] to JSON at line 953-ish of
+   [lib/keeper/keeper_exec_shell.ml].  Rather than spin up the full
+   MCP stack to observe that translation, this test rebuilds the
+   promotion payload inline using the same Exec_run outcome and
+   pins the key set clients will see after [MASC_BASH_AUTO_BG=1]
+   and a budget expiry.
+
+   The keys pinned here form the public contract:
+
+     ok, promoted, background_task_id, cmd, cwd, partial_output,
+     bytes_dropped, budget_ms, hint
+
+   Adding a key is additive and safe; removing one breaks every
+   LLM that learned to poll `background_task_id` or react to
+   `promoted: true`. *)
+
+open Alcotest
+open Masc_exec
+
+let clean_bg_dir ~base_path ~keeper =
+  let bg_dir =
+    Filename.concat (Filename.concat (Filename.concat base_path ".masc")
+      (Filename.concat "keeper" keeper)) "bg"
+  in
+  if Sys.file_exists bg_dir then
+    let files = try Sys.readdir bg_dir with _ -> [||] in
+    Array.iter (fun f ->
+      try Sys.remove (Filename.concat bg_dir f) with _ -> ())
+      files
+
+let render_promoted_payload
+    ~(cmd : string)
+    ~(cwd : string)
+    ~(budget_ms : int)
+    (p : Exec_run.promoted) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("ok", `Bool false);
+      ("promoted", `Bool true);
+      ( "background_task_id",
+        `String (Bg_task.task_id_to_string p.task_id) );
+      ("cmd", `String cmd);
+      ("cwd", `String cwd);
+      ("partial_output", `String p.partial_stdout);
+      ("bytes_dropped", `Int p.bytes_dropped_stdout);
+      ("budget_ms", `Int budget_ms);
+      ( "hint",
+        `String
+          (Printf.sprintf
+             "Command exceeded MASC_BLOCKING_BUDGET_MS=%d. Still \
+              running in background; poll with keeper_bash_output or \
+              stop with keeper_bash_kill."
+             budget_ms) );
+    ]
+
+let key_set json =
+  match json with
+  | `Assoc pairs -> List.map fst pairs |> List.sort compare
+  | _ -> []
+
+let expected_keys =
+  [
+    "background_task_id"; "budget_ms"; "bytes_dropped"; "cmd"; "cwd";
+    "hint"; "ok"; "partial_output"; "promoted";
+  ]
+
+let test_promoted_json_shape () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = Filename.get_temp_dir_name () in
+  let keeper = "exec_run_json_test" in
+  clean_bg_dir ~base_path ~keeper;
+  let cmd = "printf hello; sleep 5" in
+  let cwd = Sys.getcwd () in
+  let budget_ms = 150 in
+  let out =
+    Exec_run.run_with_auto_bg
+      ~clock
+      ~poll_interval_ms:20
+      ~base_path
+      ~budget_ms
+      ~keeper
+      ~argv:[ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
+      ~cwd
+      ~envp:(Unix.environment ())
+      ~timeout_sec:30.0
+      ()
+  in
+  match out with
+  | Exec_run.Completed _ ->
+    fail "budget 150ms + sleep 5 should promote"
+  | Exec_run.Spawn_error _ -> fail "spawn failed"
+  | Exec_run.Promoted p ->
+    let payload = render_promoted_payload ~cmd ~cwd ~budget_ms p in
+    (* Key set pinning *)
+    check (list string) "promoted keys" expected_keys (key_set payload);
+    (* Value-level checks on the public fields *)
+    (match payload with
+     | `Assoc pairs ->
+       let get k = List.assoc k pairs in
+       check bool "ok=false" false
+         (match get "ok" with `Bool b -> b | _ -> true);
+       check bool "promoted=true" true
+         (match get "promoted" with `Bool b -> b | _ -> false);
+       check bool "task_id nonempty" true
+         (match get "background_task_id" with
+          | `String s -> String.length s > 0
+          | _ -> false);
+       check int "budget_ms echoed" budget_ms
+         (match get "budget_ms" with `Int n -> n | _ -> -1)
+     | _ -> fail "payload must be `Assoc");
+    let _ = Bg_task.kill p.task_id ~signal:Sys.sigterm ~grace_sec:0.2 in
+    ()
+
+let () =
+  run "exec_run_json" [
+    ("shape", [
+      test_case "promoted payload pinning" `Slow test_promoted_json_shape;
+    ]);
+  ]

--- a/lib/exec/test/test_exec_semantic.ml
+++ b/lib/exec/test/test_exec_semantic.ml
@@ -1,0 +1,145 @@
+(** Exec_semantic — post-exec classification tests.
+
+    Exhaustive table-driven coverage of [interpret] heuristics and
+    stability of [to_json] shape. *)
+
+open Masc_exec
+
+let ws code = Unix.WEXITED code
+let wsig n = Unix.WSIGNALED n
+
+let test_ok () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "ls" ]
+      ~status:(ws 0)
+      ~stdout:""
+      ~stderr:""
+    = `Ok)
+
+let test_fail_generic () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "ls" ]
+      ~status:(ws 2)
+      ~stdout:""
+      ~stderr:"ls: cannot access …"
+    = `Fail 2)
+
+let test_tool_missing () =
+  match
+    Exec_semantic.interpret
+      ~argv:[ "notarealtool"; "--help" ]
+      ~status:(ws 127)
+      ~stdout:""
+      ~stderr:"bash: notarealtool: command not found"
+  with
+  | `Tool_missing "notarealtool" -> ()
+  | _ -> assert false
+
+let test_permission_denied () =
+  match
+    Exec_semantic.interpret
+      ~argv:[ "/tmp/not-executable" ]
+      ~status:(ws 126)
+      ~stdout:""
+      ~stderr:"permission denied"
+  with
+  | `Permission_denied "/tmp/not-executable" -> ()
+  | _ -> assert false
+
+let test_git_not_a_repo () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "git"; "status" ]
+      ~status:(ws 128)
+      ~stdout:""
+      ~stderr:"fatal: not a git repository"
+    = `Git_not_a_repo)
+
+let test_git_not_a_repo_via_path () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "/opt/homebrew/bin/git"; "log" ]
+      ~status:(ws 128)
+      ~stdout:""
+      ~stderr:""
+    = `Git_not_a_repo)
+
+let test_non_git_128_is_fail () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "curl"; "example.com" ]
+      ~status:(ws 128)
+      ~stdout:""
+      ~stderr:""
+    = `Fail 128)
+
+let test_oom_killed () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "big-mem-hog" ]
+      ~status:(wsig Sys.sigkill)
+      ~stdout:""
+      ~stderr:"kernel: Out of memory: killed process 4242"
+    = `Oom_killed)
+
+let test_signaled_plain () =
+  match
+    Exec_semantic.interpret
+      ~argv:[ "sleep"; "999" ]
+      ~status:(wsig Sys.sigterm)
+      ~stdout:""
+      ~stderr:""
+  with
+  | `Signaled n -> assert (n = Sys.sigterm)
+  | _ -> assert false
+
+let test_kind_stable_strings () =
+  assert (Exec_semantic.to_kind `Ok = "ok");
+  assert (Exec_semantic.to_kind (`Fail 2) = "fail");
+  assert (Exec_semantic.to_kind `Git_not_a_repo = "git_not_a_repo");
+  assert (Exec_semantic.to_kind `Oom_killed = "oom_killed");
+  assert (Exec_semantic.to_kind (`Tool_missing "foo") = "tool_missing")
+
+let test_payload_nullary_empty () =
+  assert (Exec_semantic.to_payload `Ok = []);
+  assert (Exec_semantic.to_payload `Git_not_a_repo = []);
+  assert (Exec_semantic.to_payload `Oom_killed = [])
+
+let test_payload_fail_has_exit_code () =
+  match Exec_semantic.to_payload (`Fail 42) with
+  | [ ("exit_code", `Int 42) ] -> ()
+  | _ -> assert false
+
+let test_payload_tool_missing_has_tool () =
+  match Exec_semantic.to_payload (`Tool_missing "foo") with
+  | [ ("tool", `String "foo") ] -> ()
+  | _ -> assert false
+
+let test_enabled_flag_default_off () =
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "";
+  assert (not (Exec_semantic.enabled ()))
+
+let test_enabled_flag_on () =
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "1";
+  assert (Exec_semantic.enabled ());
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" ""
+
+let () =
+  test_ok ();
+  test_fail_generic ();
+  test_tool_missing ();
+  test_permission_denied ();
+  test_git_not_a_repo ();
+  test_git_not_a_repo_via_path ();
+  test_non_git_128_is_fail ();
+  test_oom_killed ();
+  test_signaled_plain ();
+  test_kind_stable_strings ();
+  test_payload_nullary_empty ();
+  test_payload_fail_has_exit_code ();
+  test_payload_tool_missing_has_tool ();
+  test_enabled_flag_default_off ();
+  test_enabled_flag_on ();
+  print_endline "test_exec_semantic: ok"

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -607,6 +607,52 @@ let semantic_fields_of_executed (result : executed_result) :
     in
     ("semantic_exit", semantic_obj) :: (rci_field @ marker_field)
 
+(* Tick 9: head+tail output cap — opt-in via MASC_BASH_OUTPUT_CAP.
+   Defaults match the claude-code EndTruncatingAccumulator shape
+   (500 KB head + 500 KB tail).  Overrides via MASC_BASH_CAP_HEAD /
+   MASC_BASH_CAP_TAIL let keepers experiment without code changes.
+   Applies only to JSON emission; the record keeps the original
+   bytes so semantic interpretation and marker inference see the
+   full stream. *)
+let default_head_cap = 512 * 1024
+let default_tail_cap = 512 * 1024
+
+let env_int key =
+  match Sys.getenv_opt key with
+  | None | Some "" -> None
+  | Some s -> (try Some (int_of_string (String.trim s)) with _ -> None)
+
+let output_cap_enabled () =
+  match Sys.getenv_opt "MASC_BASH_OUTPUT_CAP" with
+  | Some ("1" | "true" | "TRUE" | "yes") -> true
+  | _ -> false
+
+let cap_output_for_json output =
+  if not (output_cap_enabled ()) then (output, None)
+  else
+    let head_cap =
+      Option.value ~default:default_head_cap (env_int "MASC_BASH_CAP_HEAD")
+    in
+    let tail_cap =
+      Option.value ~default:default_tail_cap (env_int "MASC_BASH_CAP_TAIL")
+    in
+    let head_cap = max 0 head_cap and tail_cap = max 0 tail_cap in
+    let b = Masc_exec.Exec_buffer.create ~head_cap ~tail_cap in
+    Masc_exec.Exec_buffer.add_string b output;
+    let rendered = Masc_exec.Exec_buffer.render b in
+    let total = Masc_exec.Exec_buffer.total_bytes b in
+    let dropped = Masc_exec.Exec_buffer.bytes_dropped b in
+    let meta : Yojson.Safe.t =
+      `Assoc
+        [
+          ("total_bytes", `Int total);
+          ("bytes_dropped", `Int dropped);
+          ("head_cap", `Int head_cap);
+          ("tail_cap", `Int tail_cap);
+        ]
+    in
+    (rendered, Some meta)
+
 let outcome_to_json ?(extra = []) = function
   | Executed result ->
       let hint_fields =
@@ -614,6 +660,12 @@ let outcome_to_json ?(extra = []) = function
         | Some hint ->
             [ ("hint", `String hint); ("recovery_hint", `String hint) ]
         | None -> []
+      in
+      let capped_output, output_cap_field = cap_output_for_json result.output in
+      let cap_field =
+        match output_cap_field with
+        | None -> []
+        | Some meta -> [ ("output_cap", meta) ]
       in
       `Assoc
         ([
@@ -623,7 +675,10 @@ let outcome_to_json ?(extra = []) = function
          @ [
              ( "status",
                Keeper_alerting_path.process_status_to_json result.process_status );
-             ("output", `String result.output);
+             ("output", `String capped_output);
+           ]
+         @ cap_field
+         @ [
              ( "semantic_status",
                `String (string_of_semantic_status result.semantic_status) );
              ("classification", classification_to_json result.classification);

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -525,6 +525,41 @@ let semantic_payload_to_yojson (key, value) =
   in
   (key, v)
 
+(* Tick 16: opt-in flag for verifiable marker emission.  Rolled out
+   separately from [Exec_semantic] (MASC_BASH_SEMANTIC_EXIT) so the
+   cdal_judge heuristic layer can bake in without affecting JSON
+   shape for callers that only care about [semantic_exit]. *)
+let markers_enabled () =
+  match Sys.getenv_opt "MASC_BASH_VERIFIABLE_MARKERS" with
+  | Some ("1" | "true" | "TRUE" | "yes") -> true
+  | _ -> false
+
+let verifiable_marker_to_json (m : Cdal_judge.verifiable_marker) :
+    Yojson.Safe.t =
+  let tag (kind : string) ?(count = None) (confidence : string) : Yojson.Safe.t
+    =
+    let base =
+      [ ("kind", `String kind); ("confidence", `String confidence) ]
+    in
+    match count with
+    | None -> `Assoc base
+    | Some n -> `Assoc (base @ [ ("count", `Int n) ])
+  in
+  let conf_str = function `Exact -> "exact" | `Heuristic -> "heuristic" in
+  match m with
+  | Test_pass { count; confidence } ->
+      tag "test_pass" ~count:(Some count) (conf_str confidence)
+  | Test_fail { count; confidence } ->
+      tag "test_fail" ~count:(Some count) (conf_str confidence)
+  | Build_ok { confidence } -> tag "build_ok" (conf_str confidence)
+  | Build_fail { confidence } -> tag "build_fail" (conf_str confidence)
+  | Lint_clean { confidence } -> tag "lint_clean" (conf_str confidence)
+  | Lint_dirty { count; confidence } ->
+      tag "lint_dirty" ~count:(Some count) (conf_str confidence)
+  | Git_clean { confidence } -> tag "git_clean" (conf_str confidence)
+  | Git_dirty { confidence } -> tag "git_dirty" (conf_str confidence)
+  | Git_not_a_repo -> tag "git_not_a_repo" "exact"
+
 let semantic_fields_of_executed (result : executed_result) :
     (string * Yojson.Safe.t) list =
   if not (Masc_exec.Exec_semantic.enabled ()) then []
@@ -553,7 +588,24 @@ let semantic_fields_of_executed (result : executed_result) :
       | None -> []
       | Some h -> [ "return_code_interpretation", `String h ]
     in
-    ("semantic_exit", semantic_obj) :: rci_field
+    let marker_field =
+      if not (markers_enabled ()) then []
+      else
+        (* Foreground exec merges stdout+stderr via "2>&1" at the
+           keeper layer, so feed the merged stream as stdout and an
+           empty stderr.  Background tasks (keeper_bash_output) will
+           get a separate path when Tick 7's split reaches here. *)
+        let markers =
+          Cdal_judge.of_exec_outcome ~semantic:sem
+            ~stdout:result.output ~stderr:""
+        in
+        match markers with
+        | [] -> []
+        | _ ->
+            [ ( "verifiable_markers",
+                `List (List.map verifiable_marker_to_json markers) ) ]
+    in
+    ("semantic_exit", semantic_obj) :: (rci_field @ marker_field)
 
 let outcome_to_json ?(extra = []) = function
   | Executed result ->

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -516,6 +516,45 @@ let build_blocked_outcome ~cmd ~error ~reason ?hint ?(retryability = Self_correc
       summary;
     }
 
+let semantic_payload_to_yojson (key, value) =
+  let v : Yojson.Safe.t =
+    match value with
+    | `String s -> `String s
+    | `Int i -> `Int i
+    | `Float f -> `Float f
+  in
+  (key, v)
+
+let semantic_fields_of_executed (result : executed_result) :
+    (string * Yojson.Safe.t) list =
+  if not (Masc_exec.Exec_semantic.enabled ()) then []
+  else
+    let sem =
+      Masc_exec.Exec_semantic.interpret_cmd
+        ~cmd:result.command
+        ~status:result.process_status
+        ~output:result.output
+    in
+    let kind = Masc_exec.Exec_semantic.to_kind sem in
+    let payload_fields =
+      Masc_exec.Exec_semantic.to_payload sem
+      |> List.map semantic_payload_to_yojson
+    in
+    let hint_field =
+      match Masc_exec.Exec_semantic.to_hint sem with
+      | None -> []
+      | Some h -> [ "hint", `String h ]
+    in
+    let semantic_obj : Yojson.Safe.t =
+      `Assoc (("kind", `String kind) :: payload_fields @ hint_field)
+    in
+    let rci_field =
+      match Masc_exec.Exec_semantic.to_hint sem with
+      | None -> []
+      | Some h -> [ "return_code_interpretation", `String h ]
+    in
+    ("semantic_exit", semantic_obj) :: rci_field
+
 let outcome_to_json ?(extra = []) = function
   | Executed result ->
       let hint_fields =
@@ -540,7 +579,8 @@ let outcome_to_json ?(extra = []) = function
              ("summary", `String result.summary);
              ("artifact_refs", `List (List.map artifact_ref_to_json result.artifact_refs));
            ]
-         @ hint_fields)
+         @ hint_fields
+         @ semantic_fields_of_executed result)
   | Blocked_result result ->
       `Assoc
         ([

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1019,20 +1019,115 @@ let handle_keeper_bash
                  | Error (Bg_task.Invalid_cwd msg) ->
                      error_json (Printf.sprintf "invalid cwd: %s" msg)
                end
-               else
-                 let argv = [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ] in
-                 let st, out =
-                   Process_eio.run_argv_with_status ~cwd ~timeout_sec argv
+               else begin
+                 (* Tick 11: Foreground path with optional auto-background
+                    race.  When [MASC_BASH_AUTO_BG] is enabled and an Eio
+                    clock is available, route through
+                    [Masc_exec.Exec_run.run_with_auto_bg]: the command
+                    spawns as a Bg_task, races its exit against
+                    [MASC_BLOCKING_BUDGET_MS] (default 15000), and on
+                    budget expiry returns a [Promoted] handle the LLM
+                    can poll via [keeper_bash_output].  Without the
+                    flag, fall back to the legacy blocking call so
+                    existing consumers see no shape change. *)
+                 let auto_bg_enabled =
+                   match Sys.getenv_opt "MASC_BASH_AUTO_BG" with
+                   | Some ("1" | "true" | "yes" | "on") -> true
+                   | _ -> false
                  in
-                 Yojson.Safe.to_string
-                   (Exec_core.process_result_json
-                      ~base_path:root
-                      ~keeper_name:meta.name
-                      ~cmd
-                      ~extra:[ "cwd", `String cwd ]
-                      ~status:st
-                      ~output:out
-                      ())))
+                 let argv_merged =
+                   [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
+                 in
+                 match
+                   if auto_bg_enabled
+                   then Eio_context.get_clock_opt ()
+                   else None
+                 with
+                 | None ->
+                   let st, out =
+                     Process_eio.run_argv_with_status
+                       ~cwd ~timeout_sec argv_merged
+                   in
+                   Yojson.Safe.to_string
+                     (Exec_core.process_result_json
+                        ~base_path:root
+                        ~keeper_name:meta.name
+                        ~cmd
+                        ~extra:[ "cwd", `String cwd ]
+                        ~status:st
+                        ~output:out
+                        ())
+                 | Some clock ->
+                   let budget_ms = Masc_exec.Exec_run.default_budget_ms () in
+                   let outcome =
+                     Masc_exec.Exec_run.run_with_auto_bg
+                       ~clock
+                       ~base_path:root
+                       ~budget_ms
+                       ~keeper:meta.name
+                       ~argv:argv_merged
+                       ~cwd
+                       ~envp:(Unix.environment ())
+                       ~timeout_sec
+                       ()
+                   in
+                   (match outcome with
+                    | Masc_exec.Exec_run.Completed r ->
+                      Yojson.Safe.to_string
+                        (Exec_core.process_result_json
+                           ~base_path:root
+                           ~keeper_name:meta.name
+                           ~cmd
+                           ~extra:[ "cwd", `String cwd ]
+                           ~status:r.status
+                           ~output:r.stdout
+                           ())
+                    | Masc_exec.Exec_run.Promoted p ->
+                      Log.Keeper.info
+                        "BG_PROMOTE: keeper=%s task_id=%s budget_ms=%d cmd=%s"
+                        meta.name
+                        (Bg_task.task_id_to_string p.task_id)
+                        budget_ms
+                        cmd_for_log;
+                      Yojson.Safe.to_string
+                        (`Assoc
+                          [
+                            ("ok", `Bool false);
+                            ("promoted", `Bool true);
+                            ( "background_task_id",
+                              `String
+                                (Bg_task.task_id_to_string p.task_id) );
+                            ("cmd", `String cmd);
+                            ("cwd", `String cwd);
+                            ("partial_output", `String p.partial_stdout);
+                            ( "bytes_dropped",
+                              `Int p.bytes_dropped_stdout );
+                            ("budget_ms", `Int budget_ms);
+                            ( "hint",
+                              `String
+                                (Printf.sprintf
+                                   "Command exceeded \
+                                    MASC_BLOCKING_BUDGET_MS=%d. Still \
+                                    running in background; poll with \
+                                    keeper_bash_output or stop with \
+                                    keeper_bash_kill."
+                                   budget_ms) );
+                          ])
+                    | Masc_exec.Exec_run.Spawn_error
+                        (Bg_task.Spawn_failed e) ->
+                      error_json
+                        (Printf.sprintf
+                           "auto-bg spawn failed: %s" e)
+                    | Masc_exec.Exec_run.Spawn_error
+                        (Bg_task.Too_many_tasks { keeper = k; limit }) ->
+                      error_json
+                        (Printf.sprintf
+                           "keeper %s exceeded background task limit (%d)"
+                           k limit)
+                    | Masc_exec.Exec_run.Spawn_error
+                        (Bg_task.Invalid_cwd msg) ->
+                      error_json (Printf.sprintf "invalid cwd: %s" msg))
+               end))
 ;;
 
 (* ============================================================ *)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -792,6 +792,9 @@ let handle_keeper_bash
     |> Worker_dev_tools.truncate_for_log
   in
   let timeout_sec = clamp_shell_timeout ~default:io_timeout_sec args in
+  let run_in_background =
+    Safe_ops.json_bool ~default:false "run_in_background" args
+  in
   (* Write access is config-driven via permissions.shell_write_presets *)
   let write_enabled =
     match Keeper_types.tool_access_preset meta.tool_access with
@@ -971,20 +974,178 @@ let handle_keeper_bash
                   && Worker_dev_tools.is_write_operation cmd then
                  Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
                    meta.name cwd cmd_for_log in_playground;
-               let st, out =
-                 Process_eio.run_argv_with_status ~cwd ~timeout_sec
-                   [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
-               in
-               Yojson.Safe.to_string
-                 (Exec_core.process_result_json
-                    ~base_path:root
-                    ~keeper_name:meta.name
-                    ~cmd
-                    ~extra:[ "cwd", `String cwd ]
-                    ~status:st
-                    ~output:out
-                    ())))
+               let argv = [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ] in
+               if run_in_background then begin
+                 match
+                   Bg_task.spawn
+                     ~keeper:meta.name
+                     ~argv
+                     ~cwd
+                     ~envp:(Unix.environment ())
+                     ~timeout_sec
+                 with
+                 | Ok tid ->
+                     Log.Keeper.info
+                       "BG_SPAWN: keeper=%s task_id=%s cmd=%s"
+                       meta.name (Bg_task.task_id_to_string tid) cmd_for_log;
+                     Yojson.Safe.to_string
+                       (`Assoc
+                         [
+                           ("ok", `Bool true);
+                           ( "background_task_id",
+                             `String (Bg_task.task_id_to_string tid) );
+                           ("cmd", `String cmd);
+                           ("cwd", `String cwd);
+                           ( "hint",
+                             `String
+                               "Task running in background. Poll with \
+                                keeper_bash_output or stop with \
+                                keeper_bash_kill." );
+                         ])
+                 | Error (Bg_task.Spawn_failed e) ->
+                     error_json
+                       (Printf.sprintf "background spawn failed: %s" e)
+                 | Error (Bg_task.Too_many_tasks { keeper = k; limit }) ->
+                     error_json
+                       (Printf.sprintf
+                          "keeper %s exceeded background task limit (%d)"
+                          k limit)
+                 | Error (Bg_task.Invalid_cwd msg) ->
+                     error_json (Printf.sprintf "invalid cwd: %s" msg)
+               end
+               else
+                 let st, out =
+                   Process_eio.run_argv_with_status ~cwd ~timeout_sec argv
+                 in
+                 Yojson.Safe.to_string
+                   (Exec_core.process_result_json
+                      ~base_path:root
+                      ~keeper_name:meta.name
+                      ~cmd
+                      ~extra:[ "cwd", `String cwd ]
+                      ~status:st
+                      ~output:out
+                      ())))
 ;;
+
+(* ============================================================ *)
+(* Legendary Bash P2 — background-task siblings (Tick 6b).       *)
+(* keeper_bash_output + keeper_bash_kill mirror claude-code's     *)
+(* BashOutput / KillShell so an agent can poll and stop tasks    *)
+(* spawned with run_in_background = true.                         *)
+(* ============================================================ *)
+
+let status_to_json_opt = function
+  | None -> `Null
+  | Some st -> Keeper_alerting_path.process_status_to_json st
+
+let handle_keeper_bash_output
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t) =
+  let _ = config in
+  let raw_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
+  let since_stdout = Safe_ops.json_int ~default:0 "since_stdout" args in
+  let since_stderr = Safe_ops.json_int ~default:0 "since_stderr" args in
+  if raw_id = "" then
+    error_json
+      "task_id is required. Example: task_id='bgt-<timestamp>-<seq>-<pid>'."
+  else
+    let tid = Bg_task.task_id_of_string_exn raw_id in
+    match Bg_task.read tid ~since_stdout ~since_stderr with
+    | Error (Bg_task.Unknown_task _) ->
+        error_json
+          (Printf.sprintf
+             "no background task with id=%s (already reaped or never spawned)"
+             raw_id)
+    | Error (Bg_task.Read_failed msg) ->
+        error_json (Printf.sprintf "bash_output read failed: %s" msg)
+    | Ok snap ->
+        let tid_str = Bg_task.task_id_to_string tid in
+        let semantic_fields =
+          if not (Masc_exec.Exec_semantic.enabled ()) then []
+          else match snap.status with
+          | None -> []
+          | Some st ->
+              let merged = snap.stdout_since ^ snap.stderr_since in
+              let sem =
+                Masc_exec.Exec_semantic.interpret_cmd
+                  ~cmd:"" ~status:st ~output:merged
+              in
+              [
+                ( "return_code_interpretation",
+                  match Masc_exec.Exec_semantic.to_hint sem with
+                  | None -> `Null
+                  | Some h -> `String h );
+              ]
+        in
+        Log.Keeper.info
+          "BG_OUTPUT: keeper=%s task_id=%s closed=%b"
+          meta.name tid_str snap.closed;
+        Yojson.Safe.to_string
+          (`Assoc
+            ([
+               ("ok", `Bool true);
+               ("task_id", `String tid_str);
+               ("stdout_since", `String snap.stdout_since);
+               ("stderr_since", `String snap.stderr_since);
+               ("closed", `Bool snap.closed);
+               ("status", status_to_json_opt snap.status);
+               ("bytes_dropped_stdout", `Int snap.bytes_dropped_stdout);
+               ("bytes_dropped_stderr", `Int snap.bytes_dropped_stderr);
+             ]
+             @ semantic_fields))
+
+let signal_of_name_or_num args =
+  match Safe_ops.json_string ~default:"" "signal" args |> String.uppercase_ascii with
+  | "" | "TERM" | "SIGTERM" -> Sys.sigterm
+  | "KILL" | "SIGKILL" -> Sys.sigkill
+  | "INT" | "SIGINT" -> Sys.sigint
+  | "HUP" | "SIGHUP" -> Sys.sighup
+  | "QUIT" | "SIGQUIT" -> Sys.sigquit
+  | raw ->
+      (* Accept numeric form too. *)
+      (try int_of_string raw with _ -> Sys.sigterm)
+
+let handle_keeper_bash_kill
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t) =
+  let _ = config in
+  let raw_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
+  let signal = signal_of_name_or_num args in
+  let grace_sec =
+    let raw = Safe_ops.json_float ~default:2.0 "grace_sec" args in
+    if raw < 0.0 then 0.0
+    else if raw > 30.0 then 30.0
+    else raw
+  in
+  if raw_id = "" then
+    error_json
+      "task_id is required. Example: task_id='bgt-<timestamp>-<seq>-<pid>'."
+  else
+    let tid = Bg_task.task_id_of_string_exn raw_id in
+    match Bg_task.kill tid ~signal ~grace_sec with
+    | Error (Bg_task.Unknown_task_kill _) ->
+        error_json
+          (Printf.sprintf
+             "no background task with id=%s (already reaped or never spawned)"
+             raw_id)
+    | Error (Bg_task.Kill_failed msg) ->
+        error_json (Printf.sprintf "bash_kill failed: %s" msg)
+    | Ok () ->
+        let tid_str = Bg_task.task_id_to_string tid in
+        Log.Keeper.info
+          "BG_KILL: keeper=%s task_id=%s signal=%d grace=%.2f"
+          meta.name tid_str signal grace_sec;
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("ok", `Bool true);
+              ("task_id", `String tid_str);
+              ("signal", `Int signal);
+              ("grace_sec", `Float grace_sec);
+            ])
 
 let handle_keeper_shell
       ~(config : Coord.config)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -974,15 +974,21 @@ let handle_keeper_bash
                   && Worker_dev_tools.is_write_operation cmd then
                  Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
                    meta.name cwd cmd_for_log in_playground;
-               let argv = [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ] in
+               (* Tick 7: background mode keeps stdout/stderr separate
+                  so [keeper_bash_output] can report them distinctly.
+                  Foreground mode merges via [2>&1] for backward
+                  compatibility with the single [output] JSON field. *)
                if run_in_background then begin
+                 let argv = [ "/bin/bash"; "-lc"; cmd ] in
                  match
                    Bg_task.spawn
+                     ~base_path:root
                      ~keeper:meta.name
                      ~argv
                      ~cwd
                      ~envp:(Unix.environment ())
                      ~timeout_sec
+                     ()
                  with
                  | Ok tid ->
                      Log.Keeper.info
@@ -1014,6 +1020,7 @@ let handle_keeper_bash
                      error_json (Printf.sprintf "invalid cwd: %s" msg)
                end
                else
+                 let argv = [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ] in
                  let st, out =
                    Process_eio.run_argv_with_status ~cwd ~timeout_sec argv
                  in

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -39,6 +39,22 @@ val handle_keeper_bash :
   args:Yojson.Safe.t ->
   string
 
+val handle_keeper_bash_output :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+(** Legendary Bash P2: poll pending stdout/stderr from a background
+    task spawned via [keeper_bash] with [run_in_background=true]. *)
+
+val handle_keeper_bash_kill :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  args:Yojson.Safe.t ->
+  string
+(** Legendary Bash P2: terminate a background task's process group
+    (SIGTERM → grace → SIGKILL). Idempotent. *)
+
 val handle_keeper_shell :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -246,6 +246,12 @@ let execute_keeper_tool_call_with_outcome
     | "keeper_bash" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_bash ~config ~meta ~args)
+    | "keeper_bash_output" ->
+      make_executed_tool_result
+        (Keeper_exec_shell.handle_keeper_bash_output ~config ~meta ~args)
+    | "keeper_bash_kill" ->
+      make_executed_tool_result
+        (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
     | "keeper_shell" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_shell ~config ~meta ~args)

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -70,8 +70,11 @@ type state = {
    Written best-effort; failures are logged but do not abort spawn. *)
 
 let bg_dir_of ~base_path ~keeper =
-  Filename.concat (Filename.concat (Filename.concat base_path ".masc")
-    (Filename.concat "keeper" keeper)) "bg"
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path)
+       (Filename.concat "keeper" keeper))
+    "bg"
 
 let pid_file_of ~base_path ~keeper ~task_id =
   Filename.concat (bg_dir_of ~base_path ~keeper) (task_id ^ ".pid")
@@ -297,7 +300,9 @@ let reap_orphans ~base_path =
   if base_path = "" then 0
   else
     let keeper_root =
-      Filename.concat (Filename.concat base_path ".masc") "keeper"
+      Filename.concat
+        (Common.masc_dir_from_base_path ~base_path)
+        "keeper"
     in
     if not (is_dir keeper_root) then 0
     else

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -1,0 +1,58 @@
+(* Phase 2 Tick 4: signatures + switch scaffolding only. Runtime
+   machinery (pgid setup, ring buffers, reaper) lands in Tick 5. Every
+   [spawn]/[read]/[kill] today returns a "not yet implemented" error so
+   that downstream wiring PRs can compile against the real types
+   without the feature being live. *)
+
+type task_id = string
+
+let task_id_to_string t = t
+let task_id_of_string_exn s =
+  if s = "" then invalid_arg "Bg_task.task_id_of_string_exn: empty handle";
+  s
+
+type snapshot = {
+  stdout_since : string;
+  stderr_since : string;
+  closed : bool;
+  status : Unix.process_status option;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+}
+
+type spawn_error =
+  | Spawn_failed of string
+  | Too_many_tasks of { keeper : string; limit : int }
+  | Invalid_cwd of string
+
+type read_error =
+  | Unknown_task of task_id
+  | Read_failed of string
+
+type kill_error =
+  | Unknown_task_kill of task_id
+  | Kill_failed of string
+
+(* Registry is a placeholder so that [list] can return []. When Tick 5
+   lands this becomes a [Hashtbl.t] keyed by task_id plus an Eio.Mutex
+   guarding it. *)
+let _registry : (string, task_id list) Hashtbl.t = Hashtbl.create 16
+
+let not_implemented reason =
+  Spawn_failed (Printf.sprintf "bg_task.spawn not implemented yet: %s" reason)
+
+let spawn ~sw:_ ~env:_ ~keeper:_ ~argv:_ ~cwd:_ ~envp:_ ~timeout_sec:_ =
+  Error (not_implemented "awaiting Tick 5")
+
+let read _id ~since_stdout:_ ~since_stderr:_ =
+  Error (Read_failed "bg_task.read not implemented yet: awaiting Tick 5")
+
+let kill _id ~signal:_ ~grace_sec:_ =
+  Error (Kill_failed "bg_task.kill not implemented yet: awaiting Tick 5")
+
+let list ~keeper =
+  match Hashtbl.find_opt _registry keeper with
+  | Some ids -> ids
+  | None -> []
+
+let reap_orphans ~base_path:_ = 0

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -59,7 +59,43 @@ type state = {
   mutable closed : bool;
   mutable stdout_eof : bool;
   mutable stderr_eof : bool;
+  pid_file : string option;
+      (** Full path to the persistence sidecar when
+          [~base_path] was supplied at spawn. Deleted on close/kill. *)
 }
+
+(* Tick 7: PID-file helpers. Path convention:
+     <base_path>/.masc/keeper/<keeper>/bg/<task_id>.pid
+   Contents: three lines — pid, pgid, started_at (unix seconds).
+   Written best-effort; failures are logged but do not abort spawn. *)
+
+let bg_dir_of ~base_path ~keeper =
+  Filename.concat (Filename.concat (Filename.concat base_path ".masc")
+    (Filename.concat "keeper" keeper)) "bg"
+
+let pid_file_of ~base_path ~keeper ~task_id =
+  Filename.concat (bg_dir_of ~base_path ~keeper) (task_id ^ ".pid")
+
+let rec ensure_dir path =
+  if Sys.file_exists path then ()
+  else begin
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    (try Unix.mkdir path 0o755
+     with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  end
+
+let try_write_pid_file path ~pid ~pgid ~started_at =
+  try
+    ensure_dir (Filename.dirname path);
+    let oc = open_out_gen [ Open_wronly; Open_creat; Open_trunc ] 0o644 path in
+    Printf.fprintf oc "%d\n%d\n%f\n" pid pgid started_at;
+    close_out oc
+  with _ -> ()
+
+let try_delete_pid_file = function
+  | None -> ()
+  | Some path -> (try Unix.unlink path with _ -> ())
 
 let registry : (string, state) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Mutex.create ()
@@ -139,17 +175,29 @@ let poll_state st =
     if st.status <> None && st.stdout_eof && st.stderr_eof then begin
       st.closed <- true;
       (try Unix.close st.handle.stdout_fd with _ -> ());
-      (try Unix.close st.handle.stderr_fd with _ -> ())
+      (try Unix.close st.handle.stderr_fd with _ -> ());
+      try_delete_pid_file st.pid_file
     end
   end
 
-let spawn ~keeper ~argv ~cwd ~envp ~timeout_sec =
+let spawn ?base_path ~keeper ~argv ~cwd ~envp ~timeout_sec () =
   match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
   | Error e -> Error (Spawn_failed e)
   | Ok handle ->
       try_set_nonblock handle.stdout_fd;
       try_set_nonblock handle.stderr_fd;
       let tid = fresh_id () in
+      let pid_file =
+        match base_path with
+        | None | Some "" -> None
+        | Some bp ->
+            let path = pid_file_of ~base_path:bp ~keeper ~task_id:tid in
+            try_write_pid_file path
+              ~pid:handle.pid
+              ~pgid:handle.pgid
+              ~started_at:handle.started_at;
+            Some path
+      in
       let st =
         {
           handle;
@@ -161,6 +209,7 @@ let spawn ~keeper ~argv ~cwd ~envp ~timeout_sec =
           closed = false;
           stdout_eof = false;
           stderr_eof = false;
+          pid_file;
         }
       in
       with_reg (fun () -> Hashtbl.replace registry tid st);
@@ -197,6 +246,11 @@ let kill tid ~signal ~grace_sec =
       (try
          Process_eio.tree_kill ~pgid:st.handle.pgid ~signal ~grace_sec;
          with_reg (fun () -> poll_state st);
+         (* Best-effort PID file cleanup: if poll_state did not
+            observe EOF yet (slow-closing FDs), at least unlink the
+            sidecar so the next reap cycle does not flag a live
+            task as orphan. *)
+         if st.closed then try_delete_pid_file st.pid_file;
          Ok ()
        with e -> Error (Kill_failed (Printexc.to_string e)))
 
@@ -206,4 +260,69 @@ let list ~keeper =
       (fun tid st acc -> if st.keeper = keeper then tid :: acc else acc)
       registry [])
 
-let reap_orphans ~base_path:_ = 0
+(* Directory walk helpers — avoid Filename.Infix / extra deps. *)
+
+let safe_readdir dir =
+  try Array.to_list (Sys.readdir dir) with _ -> []
+
+let is_dir p = try Sys.is_directory p with _ -> false
+
+let read_pid_file path =
+  try
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let pid = int_of_string (String.trim (input_line ic)) in
+      let pgid = int_of_string (String.trim (input_line ic)) in
+      Some (pid, pgid))
+  with _ -> None
+
+let pid_is_live pid =
+  try Unix.kill pid 0; true
+  with
+  | Unix.Unix_error (Unix.ESRCH, _, _) -> false
+  (* EPERM means pid exists but we lack permission — still considered
+     live for orphan detection. *)
+  | Unix.Unix_error (Unix.EPERM, _, _) -> true
+  | _ -> false
+
+let live_task_ids () =
+  with_reg (fun () ->
+    Hashtbl.fold (fun tid _ acc -> tid :: acc) registry [])
+
+(* Scan <base_path>/.masc/keeper/*/bg/*.pid, SIGKILL any pgroup whose
+   task_id is absent from the live registry, and delete the sidecar.
+   Stale files whose leader pid no longer exists are also removed.
+   Returns the count of files removed. *)
+let reap_orphans ~base_path =
+  if base_path = "" then 0
+  else
+    let keeper_root =
+      Filename.concat (Filename.concat base_path ".masc") "keeper"
+    in
+    if not (is_dir keeper_root) then 0
+    else
+      let live = live_task_ids () in
+      let reaped = ref 0 in
+      List.iter (fun keeper ->
+        let bg_dir = Filename.concat (Filename.concat keeper_root keeper) "bg" in
+        if is_dir bg_dir then
+          List.iter (fun entry ->
+            if Filename.check_suffix entry ".pid" then begin
+              let task_id = Filename.chop_suffix entry ".pid" in
+              let path = Filename.concat bg_dir entry in
+              let live_here = List.mem task_id live in
+              if live_here then ()
+              else begin
+                (match read_pid_file path with
+                 | Some (pid, pgid) when pid_is_live pid ->
+                     (* Orphan: live pgroup, no registry entry. *)
+                     Process_eio.tree_kill ~pgid
+                       ~signal:Sys.sigterm ~grace_sec:1.0
+                 | _ -> ());
+                (try Unix.unlink path with _ -> ());
+                incr reaped
+              end
+            end)
+            (safe_readdir bg_dir))
+        (safe_readdir keeper_root);
+      !reaped

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -1,12 +1,28 @@
-(* Phase 2 Tick 4: signatures + switch scaffolding only. Runtime
-   machinery (pgid setup, ring buffers, reaper) lands in Tick 5. Every
-   [spawn]/[read]/[kill] today returns a "not yet implemented" error so
-   that downstream wiring PRs can compile against the real types
-   without the feature being live. *)
+(* Tick 6a: pull-based implementation.
+
+   Design choice: the first pass stays free of Eio fibers / threads.
+   Instead of push-based drainers, [read] pulls whatever is pending on
+   the child's stdout/stderr pipes via non-blocking [Unix.read] each
+   time it is called.  Rationale:
+   - Simpler lifecycle: no long-lived switch to manage, no fiber
+     leakage surface.
+   - Matches the MCP request/response cadence — the LLM polls by
+     calling [keeper_bash_output], so there is always a natural
+     trigger for draining.
+   - Back-pressure: the OS pipe buffer (~64 KB on Linux, larger on
+     macOS) absorbs short silences; long silences block the child on
+     write until the next pull.  Acceptable for Tick 6a; Tick 7 will
+     layer on a push-based ring-buffer + backing file so slow
+     readers don't stall producers.
+
+   The [~sw] and [~env] parameters of {!spawn} are accepted for API
+   stability but ignored today; they return when Tick 7 introduces
+   the daemon switch. *)
 
 type task_id = string
 
 let task_id_to_string t = t
+
 let task_id_of_string_exn s =
   if s = "" then invalid_arg "Bg_task.task_id_of_string_exn: empty handle";
   s
@@ -33,26 +49,161 @@ type kill_error =
   | Unknown_task_kill of task_id
   | Kill_failed of string
 
-(* Registry is a placeholder so that [list] can return []. When Tick 5
-   lands this becomes a [Hashtbl.t] keyed by task_id plus an Eio.Mutex
-   guarding it. *)
-let _registry : (string, task_id list) Hashtbl.t = Hashtbl.create 16
+type state = {
+  handle : Process_eio.detached_handle;
+  keeper : string;
+  timeout_sec : float;
+  stdout_buf : Buffer.t;
+  stderr_buf : Buffer.t;
+  mutable status : Unix.process_status option;
+  mutable closed : bool;
+  mutable stdout_eof : bool;
+  mutable stderr_eof : bool;
+}
 
-let not_implemented reason =
-  Spawn_failed (Printf.sprintf "bg_task.spawn not implemented yet: %s" reason)
+let registry : (string, state) Hashtbl.t = Hashtbl.create 16
+let registry_mu = Mutex.create ()
+let id_counter = ref 0
 
-let spawn ~sw:_ ~env:_ ~keeper:_ ~argv:_ ~cwd:_ ~envp:_ ~timeout_sec:_ =
-  Error (not_implemented "awaiting Tick 5")
+let with_reg f =
+  Mutex.lock registry_mu;
+  match f () with
+  | v -> Mutex.unlock registry_mu; v
+  | exception e -> Mutex.unlock registry_mu; raise e
 
-let read _id ~since_stdout:_ ~since_stderr:_ =
-  Error (Read_failed "bg_task.read not implemented yet: awaiting Tick 5")
+let fresh_id () =
+  with_reg (fun () ->
+    incr id_counter;
+    Printf.sprintf "bgt-%d-%06d-%d"
+      (int_of_float (Unix.gettimeofday ()))
+      !id_counter
+      (Unix.getpid ()))
 
-let kill _id ~signal:_ ~grace_sec:_ =
-  Error (Kill_failed "bg_task.kill not implemented yet: awaiting Tick 5")
+let try_set_nonblock fd = try Unix.set_nonblock fd with _ -> ()
+
+(* [drain_fd_to_buf buf fd] reads every byte currently available on
+   [fd] without blocking. Returns [true] if EOF was observed. *)
+let drain_fd_to_buf buf fd =
+  let chunk = Bytes.create 4096 in
+  let rec loop () =
+    let readable =
+      try
+        let r, _, _ = Unix.select [ fd ] [] [] 0.0 in
+        r
+      with _ -> []
+    in
+    if readable = [] then false
+    else
+      match Unix.read fd chunk 0 (Bytes.length chunk) with
+      | 0 -> true
+      | n -> Buffer.add_subbytes buf chunk 0 n; loop ()
+      | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> false
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+      | exception _ -> true
+  in
+  loop ()
+
+(* Called under [registry_mu]. Drains pipes, reaps if exited, kills
+   on timeout. *)
+let poll_state st =
+  if st.closed then ()
+  else begin
+    if not st.stdout_eof then begin
+      let eof = drain_fd_to_buf st.stdout_buf st.handle.stdout_fd in
+      st.stdout_eof <- eof
+    end;
+    if not st.stderr_eof then begin
+      let eof = drain_fd_to_buf st.stderr_buf st.handle.stderr_fd in
+      st.stderr_eof <- eof
+    end;
+    (match st.status with
+     | Some _ -> ()
+     | None ->
+         (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
+          | 0, _ -> ()
+          | _, s -> st.status <- Some s
+          | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
+              st.status <- Some (Unix.WEXITED 0)
+          | exception _ -> ()));
+    if st.status = None
+       && st.timeout_sec > 0.0
+       && Unix.gettimeofday () -. st.handle.started_at > st.timeout_sec
+    then begin
+      Process_eio.tree_kill ~pgid:st.handle.pgid
+        ~signal:Sys.sigterm ~grace_sec:2.0;
+      (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
+       | 0, _ -> ()
+       | _, s -> st.status <- Some s
+       | exception _ -> ())
+    end;
+    if st.status <> None && st.stdout_eof && st.stderr_eof then begin
+      st.closed <- true;
+      (try Unix.close st.handle.stdout_fd with _ -> ());
+      (try Unix.close st.handle.stderr_fd with _ -> ())
+    end
+  end
+
+let spawn ~keeper ~argv ~cwd ~envp ~timeout_sec =
+  match Process_eio.spawn_detached ~argv ~env:envp ~cwd with
+  | Error e -> Error (Spawn_failed e)
+  | Ok handle ->
+      try_set_nonblock handle.stdout_fd;
+      try_set_nonblock handle.stderr_fd;
+      let tid = fresh_id () in
+      let st =
+        {
+          handle;
+          keeper;
+          timeout_sec;
+          stdout_buf = Buffer.create 4096;
+          stderr_buf = Buffer.create 4096;
+          status = None;
+          closed = false;
+          stdout_eof = false;
+          stderr_eof = false;
+        }
+      in
+      with_reg (fun () -> Hashtbl.replace registry tid st);
+      Ok tid
+
+let bufsub buf since =
+  let len = Buffer.length buf in
+  if since < 0 || since >= len then ""
+  else Buffer.sub buf since (len - since)
+
+let read tid ~since_stdout ~since_stderr =
+  let st_opt = with_reg (fun () -> Hashtbl.find_opt registry tid) in
+  match st_opt with
+  | None -> Error (Unknown_task tid)
+  | Some st ->
+      (try
+         with_reg (fun () -> poll_state st);
+         Ok
+           {
+             stdout_since = bufsub st.stdout_buf since_stdout;
+             stderr_since = bufsub st.stderr_buf since_stderr;
+             closed = st.closed;
+             status = st.status;
+             bytes_dropped_stdout = 0;
+             bytes_dropped_stderr = 0;
+           }
+       with e -> Error (Read_failed (Printexc.to_string e)))
+
+let kill tid ~signal ~grace_sec =
+  let st_opt = with_reg (fun () -> Hashtbl.find_opt registry tid) in
+  match st_opt with
+  | None -> Error (Unknown_task_kill tid)
+  | Some st ->
+      (try
+         Process_eio.tree_kill ~pgid:st.handle.pgid ~signal ~grace_sec;
+         with_reg (fun () -> poll_state st);
+         Ok ()
+       with e -> Error (Kill_failed (Printexc.to_string e)))
 
 let list ~keeper =
-  match Hashtbl.find_opt _registry keeper with
-  | Some ids -> ids
-  | None -> []
+  with_reg (fun () ->
+    Hashtbl.fold
+      (fun tid st acc -> if st.keeper = keeper then tid :: acc else acc)
+      registry [])
 
 let reap_orphans ~base_path:_ = 0

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -2,20 +2,21 @@
     roadmap.
 
     Maps claude-code's [backgroundTaskId] / [BashOutput] / [KillShell]
-    triad onto OCaml/Eio primitives:
-    - [Eio.Switch] per task gives type-safe cancellation propagation;
-      every child fiber and every spawned process lives inside the
-      switch's scope, so a [cancel] transitively tears them down.
-    - pgid-based tree-kill (via [Unix.setpgid] in the child and
-      [Unix.kill (-pgid)] in the parent) reaches grandchildren that a
-      naïve [Unix.kill pid] would leak.
-    - Append-only backing files on disk (\`.masc/keeper/<name>/bg/<id>.out\`
-      / [.err]) avoid the JS [StreamWrapper] model — readers [Read]
-      against a ring-buffer view with a [bytes_dropped] counter.
+    triad onto OCaml Unix primitives.
 
-    Implementation arrives in Tick 5. This mli is the contract so
-    downstream modules (tool_shard, keeper_exec_shell) can start
-    depending on the types in parallel. *)
+    Tick 6a (current): pull-based.  [read] drains whatever is pending
+    on the child's pipes without blocking.  No long-lived fiber, no
+    Eio switch — the MCP polling loop IS the drain cadence.  Child
+    runs in its own session via {!Process_eio.spawn_detached};
+    tree-kill via [Unix.kill (-pgid)] reaches descendants.
+
+    Tick 7 (planned): introduce a daemon switch and push-based
+    drainers so slow readers can't stall producers, plus
+    append-only backing files under
+    \`.masc/keeper/<name>/bg/<id>.{out,err}\` for persistence across
+    reader restarts.  That tick will reintroduce a [val init :
+    sw:Eio.Switch.t -> env:Eio_unix.Stdenv.base -> unit] hook
+    separately from [spawn] so this signature stays stable. *)
 
 type task_id = private string
 (** Opaque UUID-like handle. Constructible only via [spawn]. *)
@@ -53,20 +54,19 @@ type spawn_error =
   | Invalid_cwd of string
 
 val spawn :
-  sw:Eio.Switch.t ->
-  env:Eio_unix.Stdenv.base ->
   keeper:string ->
   argv:string list ->
   cwd:string ->
   envp:string array ->
   timeout_sec:float ->
   (task_id, spawn_error) result
-(** Fork a long-lived shell task, attach it to [sw]. The task keeps
-    running until it exits, [timeout_sec] elapses (SIGTERM -> grace ->
-    SIGKILL), or the switch is cancelled. The underlying process
-    starts in its own process group; tree-kill addresses
-    [-pgid]. Output is tee'd to the backing files and to the in-memory
-    ring buffers. *)
+(** Fork a long-lived shell task.  Runs until it exits, until
+    [timeout_sec] elapses (SIGTERM -> grace -> SIGKILL), or until
+    {!kill} is invoked.  The child starts in its own session; tree-kill
+    addresses [-pgid].
+
+    [timeout_sec = 0.0] disables the timeout — typical for keeper
+    polling loops that expect to {!kill} explicitly. *)
 
 type read_error =
   | Unknown_task of task_id

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -54,11 +54,13 @@ type spawn_error =
   | Invalid_cwd of string
 
 val spawn :
+  ?base_path:string ->
   keeper:string ->
   argv:string list ->
   cwd:string ->
   envp:string array ->
   timeout_sec:float ->
+  unit ->
   (task_id, spawn_error) result
 (** Fork a long-lived shell task.  Runs until it exits, until
     [timeout_sec] elapses (SIGTERM -> grace -> SIGKILL), or until
@@ -66,7 +68,13 @@ val spawn :
     addresses [-pgid].
 
     [timeout_sec = 0.0] disables the timeout — typical for keeper
-    polling loops that expect to {!kill} explicitly. *)
+    polling loops that expect to {!kill} explicitly.
+
+    [base_path] when supplied enables PID-file persistence at
+    \`<base_path>/.masc/keeper/<keeper>/bg/<task_id>.pid\`.  The file
+    records \`pid\\npgid\\nstarted_at\\n\` so {!reap_orphans} can recover
+    stranded process groups across keeper restarts.  When omitted,
+    no filesystem state is written. *)
 
 type read_error =
   | Unknown_task of task_id

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -1,0 +1,104 @@
+(** Background shell task lifecycle — Phase 2 of the Legendary Bash
+    roadmap.
+
+    Maps claude-code's [backgroundTaskId] / [BashOutput] / [KillShell]
+    triad onto OCaml/Eio primitives:
+    - [Eio.Switch] per task gives type-safe cancellation propagation;
+      every child fiber and every spawned process lives inside the
+      switch's scope, so a [cancel] transitively tears them down.
+    - pgid-based tree-kill (via [Unix.setpgid] in the child and
+      [Unix.kill (-pgid)] in the parent) reaches grandchildren that a
+      naïve [Unix.kill pid] would leak.
+    - Append-only backing files on disk (\`.masc/keeper/<name>/bg/<id>.out\`
+      / [.err]) avoid the JS [StreamWrapper] model — readers [Read]
+      against a ring-buffer view with a [bytes_dropped] counter.
+
+    Implementation arrives in Tick 5. This mli is the contract so
+    downstream modules (tool_shard, keeper_exec_shell) can start
+    depending on the types in parallel. *)
+
+type task_id = private string
+(** Opaque UUID-like handle. Constructible only via [spawn]. *)
+
+val task_id_to_string : task_id -> string
+
+val task_id_of_string_exn : string -> task_id
+(** Rehydrate a task_id from JSON at the MCP boundary. Raises
+    [Invalid_argument] on a syntactically invalid handle — callers must
+    be the MCP layer that accepted the string as a tool argument. *)
+
+type snapshot = {
+  stdout_since : string;
+      (** Bytes emitted on stdout since [since]. *)
+  stderr_since : string;
+      (** Bytes emitted on stderr since [since]. *)
+  closed : bool;
+      (** True once the process has exited. No further bytes will
+          arrive after a [closed = true] snapshot. *)
+  status : Unix.process_status option;
+      (** Raw process status. Use
+          {!Exec_semantic.interpret} in [masc_exec] to turn this into
+          a typed classification; bg_task itself stays
+          semantics-agnostic to avoid a circular sub-library
+          dependency. *)
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+      (** Head-drop counters for the ring buffers; non-zero means the
+          caller read too late to see every byte. *)
+}
+
+type spawn_error =
+  | Spawn_failed of string
+  | Too_many_tasks of { keeper : string; limit : int }
+  | Invalid_cwd of string
+
+val spawn :
+  sw:Eio.Switch.t ->
+  env:Eio_unix.Stdenv.base ->
+  keeper:string ->
+  argv:string list ->
+  cwd:string ->
+  envp:string array ->
+  timeout_sec:float ->
+  (task_id, spawn_error) result
+(** Fork a long-lived shell task, attach it to [sw]. The task keeps
+    running until it exits, [timeout_sec] elapses (SIGTERM -> grace ->
+    SIGKILL), or the switch is cancelled. The underlying process
+    starts in its own process group; tree-kill addresses
+    [-pgid]. Output is tee'd to the backing files and to the in-memory
+    ring buffers. *)
+
+type read_error =
+  | Unknown_task of task_id
+  | Read_failed of string
+
+val read :
+  task_id ->
+  since_stdout:int ->
+  since_stderr:int ->
+  (snapshot, read_error) result
+(** Non-blocking snapshot of the task's output. [since_*] are byte
+    offsets into the cumulative stream; the returned [stdout_since]
+    contains bytes at offsets [>= since_stdout]. *)
+
+type kill_error =
+  | Unknown_task_kill of task_id
+  | Kill_failed of string
+
+val kill :
+  task_id ->
+  signal:int ->
+  grace_sec:float ->
+  (unit, kill_error) result
+(** Send [signal] to the pgroup; if the process is still alive after
+    [grace_sec], escalate to [SIGKILL]. Idempotent on
+    already-dead tasks. *)
+
+val list : keeper:string -> task_id list
+(** All currently-tracked tasks owned by [keeper]. *)
+
+val reap_orphans : base_path:string -> int
+(** Startup hook: read PID files under \`.masc/keeper/*/bg/*.pid\`,
+    SIGKILL any pgroup whose leader is no longer in the live task
+    map, and delete the stale PID files. Returns the number of
+    reaped orphans. *)

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -3,5 +3,5 @@
  (name masc_process)
  (public_name masc_mcp.masc_process)
  (wrapped false)
- (modules process_eio file_lock_eio exec_tap with_process)
+ (modules process_eio file_lock_eio exec_tap with_process bg_task)
  (libraries masc_core masc_log time_compat eio eio.unix unix threads))

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -650,3 +650,118 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env ?cwd
     run_argv_with_status_split ~timeout_sec ?env ?cwd argv
   in
   (status, output_for_status ~status ~stdout ~stderr)
+
+(* ============================================================ *)
+(* Detached (background) spawn primitives — P2 Legendary Bash   *)
+(* ============================================================ *)
+
+type detached_handle = {
+  pid : int;
+  pgid : int;
+  stdout_fd : Unix.file_descr;
+  stderr_fd : Unix.file_descr;
+  started_at : float;
+}
+
+let spawn_detached ~argv ~env ~cwd =
+  match argv with
+  | [] -> Error "spawn_detached: empty argv"
+  | bin :: _ ->
+      (try
+         let out_r, out_w = Unix.pipe ~cloexec:true () in
+         let err_r, err_w = Unix.pipe ~cloexec:true () in
+         let devnull =
+           Unix.openfile "/dev/null" [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0
+         in
+         (* Use fork/exec instead of create_process_env so the child
+            can [setpgrp] before [execvpe].  OCaml's Unix module does
+            not expose [setpgid(pid, pgid)] for the parent to call on
+            a child, so the child has to establish its own process
+            group authoritatively.  A short window between fork and
+            setpgrp still leaves the child in the parent's group — any
+            signal delivered to the parent group in that window would
+            also reach the child.  Acceptable for background shells;
+            signal-race-free semantics would require posix_spawn with
+            POSIX_SPAWN_SETPGROUP via Ctypes, a follow-up item. *)
+         let pid = Unix.fork () in
+         if pid = 0 then begin
+           (* --- CHILD --- *)
+           (* [Unix.setsid] creates a new session AND a new process
+              group with the child as leader.  OCaml's stdlib does not
+              expose [setpgid], so [setsid] is the portable way to
+              guarantee a new group.  Side effect: the child detaches
+              from the parent's controlling terminal, which matches
+              the "background shell" semantics we want. *)
+           (try ignore (Unix.setsid ()) with _ -> ());
+           (try
+              if cwd <> "" then Unix.chdir cwd
+            with _ -> Unix._exit 126);
+           Unix.dup2 devnull Unix.stdin;
+           Unix.dup2 out_w Unix.stdout;
+           Unix.dup2 err_w Unix.stderr;
+           Unix.close out_r; Unix.close err_r;
+           Unix.close out_w; Unix.close err_w; Unix.close devnull;
+           (try Unix.execvpe bin (Array.of_list argv) env
+            with _ -> Unix._exit 127)
+         end else begin
+           (* --- PARENT --- *)
+           Unix.close out_w;
+           Unix.close err_w;
+           Unix.close devnull;
+           Ok
+             {
+               pid;
+               pgid = pid;
+               stdout_fd = out_r;
+               stderr_fd = err_r;
+               started_at = Unix.gettimeofday ();
+             }
+         end
+       with
+       | Unix.Unix_error (err, fn, arg) ->
+           Error
+             (Printf.sprintf "spawn_detached %s: %s (%s %s)"
+                bin (Unix.error_message err) fn arg)
+       | exn ->
+           Error
+             (Printf.sprintf "spawn_detached %s: %s" bin
+                (Printexc.to_string exn)))
+
+let is_pgid_alive ~pgid =
+  try
+    Unix.kill (-pgid) 0;
+    true
+  with
+  | Unix.Unix_error (Unix.ESRCH, _, _) -> false
+  | Unix.Unix_error (Unix.EPERM, _, _) ->
+      (* EPERM means the process exists but we can't signal it —
+         conservative "alive" answer. *)
+      true
+  | _ -> false
+
+let tree_kill ~pgid ~signal ~grace_sec =
+  let safe_kill s =
+    try Unix.kill (-pgid) s
+    with
+    | Unix.Unix_error (Unix.ESRCH, _, _) -> ()
+    | Unix.Unix_error (Unix.EPERM, _, _) ->
+        (* macOS can return EPERM after all processes in the group
+           have exited but the session object lingers. Treat as
+           "already gone". *)
+        ()
+  in
+  safe_kill signal;
+  if grace_sec > 0.0 then begin
+    let deadline = Unix.gettimeofday () +. grace_sec in
+    let step = min 0.1 (grace_sec /. 10.0) in
+    let rec wait_loop () =
+      if not (is_pgid_alive ~pgid) then ()
+      else if Unix.gettimeofday () >= deadline then
+        safe_kill Sys.sigkill
+      else begin
+        (try ignore (Unix.select [] [] [] step) with _ -> ());
+        wait_loop ()
+      end
+    in
+    wait_loop ()
+  end

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -79,3 +79,53 @@ val run_argv_with_status_split :
   (Unix.process_status * string * string)
 (** Like [run_argv_with_status], but returns
     [(status, stdout, stderr)] without combining stderr into stdout. *)
+
+(** {1 Detached (background) spawn primitives — P2 foundation} *)
+
+type detached_handle = {
+  pid : int;
+      (** Child process PID (also the process-group leader). *)
+  pgid : int;
+      (** Process group ID; always equal to [pid] for tree-kill. *)
+  stdout_fd : Unix.file_descr;
+      (** Read end of child's stdout pipe. Caller owns and must close. *)
+  stderr_fd : Unix.file_descr;
+      (** Read end of child's stderr pipe. Caller owns and must close. *)
+  started_at : float;
+      (** [Unix.gettimeofday ()] at spawn time. *)
+}
+
+val spawn_detached :
+  argv:string list ->
+  env:string array ->
+  cwd:string ->
+  (detached_handle, string) result
+(** Fork a child in its own process group and return immediately with
+    a handle containing PID, PGID, and the caller-owned read ends of
+    stdout/stderr. The child runs until it exits or is signaled — it
+    does NOT die with the current Eio switch.
+
+    Tree-kill: [Unix.kill (-handle.pgid) signal] reaches every
+    descendant (grandchildren included). Use {!tree_kill} for the
+    SIGTERM → grace → SIGKILL sequence.
+
+    Bypasses the [proc_mgr] so the child is not tracked by Eio;
+    callers are responsible for [Unix.waitpid] reaping (directly or
+    via a long-lived daemon fiber in [Bg_task]).
+
+    The argv-only API is intentional: no shell interpolation,
+    matching the rest of this module. *)
+
+val tree_kill :
+  pgid:int ->
+  signal:int ->
+  grace_sec:float ->
+  unit
+(** Escalating tree-kill. Signals the process group [-pgid] with
+    [signal]; after [grace_sec], if any member survives, escalates to
+    SIGKILL. Idempotent — safe to call on already-dead groups. *)
+
+val is_pgid_alive : pgid:int -> bool
+(** True when [-pgid] responds to signal 0, i.e. at least one member
+    of the group is still alive. *)
+

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -128,4 +128,3 @@ val tree_kill :
 val is_pgid_alive : pgid:int -> bool
 (** True when [-pgid] responds to signal 0, i.e. at least one member
     of the group is still alive. *)
-

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -47,6 +47,8 @@ let keeper_internal_tools =
        Dispatch still accepts it for backward compat. *)
     "keeper_shell";
     "keeper_bash";
+    "keeper_bash_output";
+    "keeper_bash_kill";
     "keeper_voice_speak";
     (* keeper_voice_listen is keeper-only; there is no public masc_voice_listen
        counterpart on MCP surfaces. *)

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -7,6 +7,8 @@
 module Keeper = struct
   type t =
     | Bash
+    | Bash_kill
+    | Bash_output
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
@@ -53,6 +55,8 @@ module Keeper = struct
 
   let to_string = function
     | Bash -> "keeper_bash"
+    | Bash_kill -> "keeper_bash_kill"
+    | Bash_output -> "keeper_bash_output"
     | Board_cleanup -> "keeper_board_cleanup"
     | Board_comment -> "keeper_board_comment"
     | Board_comment_vote -> "keeper_board_comment_vote"
@@ -99,6 +103,8 @@ module Keeper = struct
 
   let of_string = function
     | "keeper_bash" -> Some Bash
+    | "keeper_bash_kill" -> Some Bash_kill
+    | "keeper_bash_output" -> Some Bash_output
     | "keeper_board_cleanup" -> Some Board_cleanup
     | "keeper_board_comment" -> Some Board_comment
     | "keeper_board_comment_vote" -> Some Board_comment_vote

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -6,9 +6,7 @@
 
 module Keeper = struct
   type t =
-    | Bash
-    | Bash_kill
-    | Bash_output
+    | Bash | Bash_kill | Bash_output
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
@@ -52,7 +50,6 @@ module Keeper = struct
     | Voice_sessions
     | Voice_speak
     | Write
-
   let to_string = function
     | Bash -> "keeper_bash"
     | Bash_kill -> "keeper_bash_kill"
@@ -100,7 +97,6 @@ module Keeper = struct
     | Voice_sessions -> "keeper_voice_sessions"
     | Voice_speak -> "keeper_voice_speak"
     | Write -> "keeper_write"
-
   let of_string = function
     | "keeper_bash" -> Some Bash
     | "keeper_bash_kill" -> Some Bash_kill

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -6,6 +6,8 @@
 module Keeper : sig
   type t =
     | Bash
+    | Bash_kill
+    | Bash_output
     | Board_cleanup
     | Board_comment
     | Board_comment_vote

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -401,15 +401,50 @@ Violations are blocked. Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='rg foo | wc -l'. \
 Runs in the keeper playground by default; use cwd to target an explicit allowed directory. \
 Paths resolve automatically — never include '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. \
-For read-only ops use keeper_shell, for file edits use keeper_fs_edit.";
+For read-only ops use keeper_shell, for file edits use keeper_fs_edit. \
+Set run_in_background=true for long-running tasks (returns background_task_id; \
+poll with keeper_bash_output, terminate with keeper_bash_kill).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "Single command only. No chaining/pipe/redirect. Example: 'dune build', 'rg pattern lib/'")]);
         ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for the command. Must stay within keeper playground or an explicit allowed path.")]);
-        ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
+        ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180). For run_in_background=true, 0 disables the timeout.")]);
+        ("run_in_background", `Assoc [("type", `String "boolean"); ("description", `String "Default false. When true, returns immediately with background_task_id; poll output via keeper_bash_output, stop via keeper_bash_kill.")]);
       ]);
       ("required", `List [`String "cmd"]);
+    ];
+  };
+  {
+    name = "keeper_bash_output";
+    description = "Fetch incremental output from a background shell task \
+spawned via keeper_bash with run_in_background=true. Non-blocking: returns \
+whatever stdout/stderr bytes are currently buffered beyond the given offsets. \
+Poll repeatedly until closed=true. Mirrors claude-code BashOutput semantics.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "background_task_id returned by keeper_bash. Example: 'bgt-1713600000-000001-12345'.")]);
+        ("since_stdout", `Assoc [("type", `String "integer"); ("description", `String "Cumulative byte offset at which to start reading stdout. Use 0 for the first call, then the running length returned previously.")]);
+        ("since_stderr", `Assoc [("type", `String "integer"); ("description", `String "Same cursor for stderr. Note: in the current implementation keeper_bash redirects stderr into stdout so stderr_since is usually empty.")]);
+      ]);
+      ("required", `List [`String "task_id"]);
+    ];
+  };
+  {
+    name = "keeper_bash_kill";
+    description = "Terminate a background shell task. Sends [signal] (default SIGTERM) \
+to the task's process group, waits up to grace_sec seconds, and escalates to \
+SIGKILL if any member survives. Idempotent — safe to call on already-exited tasks. \
+Mirrors claude-code KillShell semantics.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "background_task_id returned by keeper_bash.")]);
+        ("signal", `Assoc [("type", `String "string"); ("description", `String "Signal name (TERM, KILL, INT, HUP, QUIT) or number. Default TERM.")]);
+        ("grace_sec", `Assoc [("type", `String "number"); ("description", `String "Seconds to wait for graceful exit before SIGKILL escalation. Default 2.0, max 30.")]);
+      ]);
+      ("required", `List [`String "task_id"]);
     ];
   };
 ]

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1541,3 +1541,87 @@ let shadow_parse_outcome (cmd : string) : string =
 let cross_check_command ~legacy cmd =
   (legacy, shadow_parse_outcome cmd)
 
+(* ================================================================ *)
+(* Tick 13 (P5 continued) — typed destructive classes.              *)
+(*                                                                  *)
+(* [Eval_gate.destructive_patterns] currently exposes a flat list   *)
+(* of (substring, description) tuples.  The verifier cascade and    *)
+(* the shadow AST gate both want a typed discriminant so routing    *)
+(* logic does not depend on the free-form description string.       *)
+(*                                                                  *)
+(* [destructive_class_of_cmd] is the pure mapping used by Tick 14's *)
+(* golden diff: for every one of Eval_gate's 19 patterns there must *)
+(* be exactly one [destructive_class] that matches — the test suite *)
+(* enforces the covenant.                                           *)
+(* ================================================================ *)
+
+type destructive_class =
+  | Recursive_delete        (* rm -rf / rm -r / rmdir *)
+  | Sql_destructive         (* drop table, drop database, truncate, delete from *)
+  | Forced_git_mutation     (* git push --force, git reset --hard, git clean -f *)
+  | Privilege_escalation    (* chmod 777 *)
+  | Filesystem_format       (* mkfs *)
+  | Device_write            (* > /dev/, dd if= *)
+  | Process_signal          (* kill -9, pkill *)
+  | System_control          (* shutdown, reboot *)
+
+let destructive_class_to_string = function
+  | Recursive_delete -> "recursive_delete"
+  | Sql_destructive -> "sql_destructive"
+  | Forced_git_mutation -> "forced_git_mutation"
+  | Privilege_escalation -> "privilege_escalation"
+  | Filesystem_format -> "filesystem_format"
+  | Device_write -> "device_write"
+  | Process_signal -> "process_signal"
+  | System_control -> "system_control"
+
+(* Substring → class mapping.  Each entry mirrors one row in
+   [Eval_gate.destructive_patterns].  Order matters: longer
+   substrings come first so "rm -rf" matches before "rm -r". *)
+let destructive_class_substrings : (string * destructive_class) list = [
+  "rm -rf",            Recursive_delete;
+  "rm -r",             Recursive_delete;
+  "rmdir",             Recursive_delete;
+  "drop table",        Sql_destructive;
+  "drop database",     Sql_destructive;
+  "truncate table",    Sql_destructive;
+  "delete from",       Sql_destructive;
+  "git push --force",  Forced_git_mutation;
+  "git push -f",       Forced_git_mutation;
+  "git reset --hard",  Forced_git_mutation;
+  "git clean -f",      Forced_git_mutation;
+  "chmod 777",         Privilege_escalation;
+  "mkfs",              Filesystem_format;
+  "> /dev/",           Device_write;
+  "dd if=",            Device_write;
+  "kill -9",           Process_signal;
+  "pkill",             Process_signal;
+  "shutdown",          System_control;
+  "reboot",            System_control;
+]
+
+(* Case-insensitive substring-hit test without a regex engine. *)
+let contains_sub_ci (s : string) (sub : string) : bool =
+  let ls = String.length s and lsub = String.length sub in
+  if lsub = 0 then true
+  else if lsub > ls then false
+  else
+    let s = String.lowercase_ascii s and sub = String.lowercase_ascii sub in
+    let rec loop i =
+      if i + lsub > ls then false
+      else if String.sub s i lsub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
+(* Returns the matching class (first hit in declaration order) plus
+   the literal substring that triggered, so callers can log both
+   the typed tag and the provenance.  [None] means "no known
+   destructive pattern found" — the caller is still free to apply
+   structural checks (rm with -r -f split flags, git push to a
+   protected branch, etc.) on top. *)
+let classify_destructive cmd : (destructive_class * string) option =
+  List.find_map (fun (sub, cls) ->
+    if contains_sub_ci cmd sub then Some (cls, sub) else None)
+    destructive_class_substrings
+

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1625,3 +1625,99 @@ let classify_destructive cmd : (destructive_class * string) option =
     if contains_sub_ci cmd sub then Some (cls, sub) else None)
     destructive_class_substrings
 
+(* ================================================================ *)
+(* Tick 14 (P5 continued) — legacy ↔ shadow diff harness.           *)
+(*                                                                  *)
+(* Pure diff producer: given a command string, render both the      *)
+(* legacy regex verdict and the shadow AST/destructive verdict      *)
+(* into a single [gate_diff] record.  The flag flip (plan decision  *)
+(* point 2) is gated on this harness showing zero                   *)
+(* [Legacy_allow_shadow_deny] OR [Legacy_deny_shadow_allow] rows    *)
+(* across N=1000 prod calls.  Until then the record is consumed by  *)
+(* telemetry only.                                                  *)
+(* ================================================================ *)
+
+type legacy_verdict =
+  | Legacy_allow
+  | Legacy_reject_by_allowlist
+  | Legacy_reject_destructive of string
+      (** The matching substring from [Eval_gate.destructive_patterns],
+          NOT the description.  Callers that need the free-form
+          description can look it up in [destructive_patterns]. *)
+
+type shadow_verdict =
+  | Shadow_allow of { parse_tag : string }
+      (** Parser and destructive classifier both clean. [parse_tag] is
+          the tag from [shadow_parse_outcome] so callers can tell
+          [parsed_simple] apart from [too_complex:*] at triage time. *)
+  | Shadow_parse_unsupported of { parse_tag : string }
+      (** Grammar did not accept the command (parse_error,
+          parse_aborted:*, too_complex:*).  Not a deny — means the
+          AST gate cannot yet express an opinion.  Callers in
+          observation mode should still fall back to the regex
+          verdict; in flip mode they must conservatively reject. *)
+  | Shadow_deny_destructive of destructive_class * string
+      (** [classify_destructive] matched; the [string] is the
+          triggering substring. *)
+
+type gate_diff =
+  | Agree
+      (** Legacy and shadow reached the same allow/deny decision. *)
+  | Legacy_allow_shadow_deny
+      (** Legacy regex allowed but shadow identified destructive
+          content. Indicates legacy under-blocks — must be fixed
+          BEFORE flip (otherwise flip is a safety regression). *)
+  | Legacy_deny_shadow_allow
+      (** Legacy rejected but shadow saw nothing dangerous.
+          Indicates legacy over-blocks — needs analysis to
+          determine whether legacy is too conservative or shadow
+          is missing coverage. *)
+  | Shadow_cannot_parse
+      (** Grammar upgrade needed; legacy decision stands. *)
+
+let classify_legacy cmd : legacy_verdict =
+  match validate_command cmd with
+  | Ok () ->
+      (match Eval_gate.detect_destructive cmd with
+       | Some (substring, _desc) -> Legacy_reject_destructive substring
+       | None -> Legacy_allow)
+  | Error _ -> Legacy_reject_by_allowlist
+
+let classify_shadow cmd : shadow_verdict =
+  let parse_tag = shadow_parse_outcome cmd in
+  (* Destructive classifier runs on the raw string regardless of
+     parser success — the substring catalogue does not need AST
+     structure. This keeps the shadow path meaningful on commands
+     the grammar has not yet upgraded to support. *)
+  match classify_destructive cmd with
+  | Some (cls, sub) -> Shadow_deny_destructive (cls, sub)
+  | None ->
+      if parse_tag = "parsed_simple" then Shadow_allow { parse_tag }
+      else Shadow_parse_unsupported { parse_tag }
+
+let diff_of_verdicts ~legacy ~shadow : gate_diff =
+  match legacy, shadow with
+  (* Grammar gap is surfaced first — the flip is blocked on a
+     shadow opinion, so Shadow_parse_unsupported is always a signal
+     worth tracking regardless of the legacy decision. *)
+  | _, Shadow_parse_unsupported _ -> Shadow_cannot_parse
+  | Legacy_allow, Shadow_allow _ -> Agree
+  (* Allowlist rejects are policy (which bins are permitted),
+     orthogonal to the destructive/safety gate — treat as agreement
+     since shadow is not authoritative on binary selection. *)
+  | Legacy_reject_by_allowlist, _ -> Agree
+  | Legacy_reject_destructive _, Shadow_deny_destructive _ -> Agree
+  | Legacy_allow, Shadow_deny_destructive _ -> Legacy_allow_shadow_deny
+  | Legacy_reject_destructive _, Shadow_allow _ -> Legacy_deny_shadow_allow
+
+let diff_command cmd : gate_diff * legacy_verdict * shadow_verdict =
+  let legacy = classify_legacy cmd in
+  let shadow = classify_shadow cmd in
+  (diff_of_verdicts ~legacy ~shadow, legacy, shadow)
+
+let gate_diff_to_string = function
+  | Agree -> "agree"
+  | Legacy_allow_shadow_deny -> "legacy_allow_shadow_deny"
+  | Legacy_deny_shadow_allow -> "legacy_deny_shadow_allow"
+  | Shadow_cannot_parse -> "shadow_cannot_parse"
+

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1649,10 +1649,11 @@ type shadow_verdict =
   | Shadow_allow of { parse_tag : string }
       (** Parser and destructive classifier both clean. [parse_tag] is
           the tag from [shadow_parse_outcome] so callers can tell
-          [parsed_simple] apart from [too_complex:*] at triage time. *)
+          [parsed_simple] apart from the too_complex family at triage
+          time. *)
   | Shadow_parse_unsupported of { parse_tag : string }
-      (** Grammar did not accept the command (parse_error,
-          parse_aborted:*, too_complex:*).  Not a deny — means the
+      (** Grammar did not accept the command (parse_error, or any of
+          the parse_aborted / too_complex subtags).  Not a deny — means the
           AST gate cannot yet express an opinion.  Callers in
           observation mode should still fall back to the regex
           verdict; in flip mode they must conservatively reject. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1486,3 +1486,58 @@ let make_readonly_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t
   [ make_file_read ?workdir ?on_exec ();
     make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock ]
 
+(* ================================================================ *)
+(* Tick 12 (P5, reduced scope) — shadow AST parse observation.      *)
+(*                                                                  *)
+(* The existing regex allowlist ([validate_command] above) remains  *)
+(* the authoritative gate.  This helper runs the typed bash parser  *)
+(* (Masc_exec.Parser.Bash.parse_string) in parallel and maps the    *)
+(* outcome to a coarse, stable tag string.  Callers that want to    *)
+(* build prod observability can log the tag alongside the regex     *)
+(* verdict; when the tag distribution has baked in (plan decision   *)
+(* point 2: "N=1000 prod 호출 무결 후 flag 전환"), the gate can    *)
+(* migrate in a follow-up without touching the regex layer.         *)
+(*                                                                  *)
+(* The helper never panics — the parser catches every Menhir/Lex    *)
+(* exception internally and surfaces them via Parsed.t.             *)
+(* ================================================================ *)
+
+let too_complex_reason_tag (r : Masc_exec.Parsed.reason_too_complex) =
+  match r with
+  | `Heredoc -> "heredoc"
+  | `Here_string -> "here_string"
+  | `Cmd_subst -> "cmd_subst"
+  | `Proc_subst -> "proc_subst"
+  | `Subshell -> "subshell"
+  | `Arith_expansion -> "arith_expansion"
+  | `Control_flow -> "control_flow"
+  | `Logic_op -> "logic_op"
+  | `Function_def -> "function_def"
+  | `Glob_brace -> "glob_brace"
+  | `Background -> "background"
+  | `Unknown_construct s -> "unknown:" ^ s
+
+let aborted_reason_tag (r : Masc_exec.Parsed.reason_aborted) =
+  match r with
+  | `Timeout_50ms -> "timeout_50ms"
+  | `Depth_limit -> "depth_limit"
+  | `Token_limit_50k -> "token_limit_50k"
+
+(* Coarse outcome tags.  Stable strings so downstream telemetry can
+   histogram them without re-parsing. *)
+let shadow_parse_outcome (cmd : string) : string =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed _ -> "parsed_simple"
+  | Masc_exec.Parsed.Parse_error _ -> "parse_error"
+  | Masc_exec.Parsed.Parse_aborted r ->
+      "parse_aborted:" ^ aborted_reason_tag r
+  | Masc_exec.Parsed.Too_complex r ->
+      "too_complex:" ^ too_complex_reason_tag r
+
+(* Legacy verdict ↔ shadow verdict cross-check.  Returns a tuple of
+   legacy allow/deny + shadow tag, so telemetry can spot "legacy
+   allows but shadow cannot parse" drift without needing two
+   separate call sites.  Intentionally side-effect free. *)
+let cross_check_command ~legacy cmd =
+  (legacy, shadow_parse_outcome cmd)
+

--- a/test/dune
+++ b/test/dune
@@ -423,6 +423,7 @@
         test_cdal_types
         test_cdal_loader
         test_cdal_judge
+        test_cdal_verifiable_markers
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate
@@ -578,6 +579,7 @@
         test_cdal_types
         test_cdal_loader
         test_cdal_judge
+        test_cdal_verifiable_markers
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate

--- a/test/dune
+++ b/test/dune
@@ -318,6 +318,7 @@
         test_tool_local_runtime_probe
         test_board_ttl
         test_worker_dev_tools
+        test_shadow_parse
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge
@@ -474,6 +475,7 @@
         test_tool_local_runtime_probe
         test_board_ttl
         test_worker_dev_tools
+        test_shadow_parse
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge

--- a/test/dune
+++ b/test/dune
@@ -320,6 +320,7 @@
         test_worker_dev_tools
         test_shadow_parse
         test_destructive_class
+        test_gate_diff
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge
@@ -478,6 +479,7 @@
         test_worker_dev_tools
         test_shadow_parse
         test_destructive_class
+        test_gate_diff
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge

--- a/test/dune
+++ b/test/dune
@@ -334,6 +334,7 @@
         test_process_eio_coverage
         test_with_process_coverage
         test_bg_task_stub
+        test_process_eio_detached
         test_provider_adapter
         test_worker_container_coverage
         test_resilience
@@ -488,6 +489,7 @@
         test_process_eio_coverage
         test_with_process_coverage
         test_bg_task_stub
+        test_process_eio_detached
         test_provider_adapter
         test_worker_container_coverage
         test_resilience

--- a/test/dune
+++ b/test/dune
@@ -333,6 +333,7 @@
         test_json_util
         test_process_eio_coverage
         test_with_process_coverage
+        test_bg_task_stub
         test_provider_adapter
         test_worker_container_coverage
         test_resilience
@@ -486,6 +487,7 @@
         test_json_util
         test_process_eio_coverage
         test_with_process_coverage
+        test_bg_task_stub
         test_provider_adapter
         test_worker_container_coverage
         test_resilience

--- a/test/dune
+++ b/test/dune
@@ -319,6 +319,7 @@
         test_board_ttl
         test_worker_dev_tools
         test_shadow_parse
+        test_destructive_class
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge
@@ -476,6 +477,7 @@
         test_board_ttl
         test_worker_dev_tools
         test_shadow_parse
+        test_destructive_class
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -1,0 +1,55 @@
+(* Tick 4 smoke tests — verify the Bg_task signatures compile and the
+   stub returns structured errors. Real lifecycle tests land in Tick 5
+   together with the pgid/ring-buffer implementation. *)
+
+open Alcotest
+
+let test_task_id_roundtrip () =
+  let tid = Bg_task.task_id_of_string_exn "abc-123" in
+  check string "roundtrip" "abc-123" (Bg_task.task_id_to_string tid)
+
+let test_task_id_empty_rejected () =
+  match Bg_task.task_id_of_string_exn "" with
+  | exception Invalid_argument _ -> ()
+  | _ -> fail "empty id must raise"
+
+let test_list_empty_for_unknown_keeper () =
+  let ids = Bg_task.list ~keeper:"no-such-keeper" in
+  check int "empty list" 0 (List.length ids)
+
+let test_read_stub_errors () =
+  let tid = Bg_task.task_id_of_string_exn "stub" in
+  match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+  | Error (Bg_task.Read_failed msg) ->
+      check bool "stub message mentions Tick 5" true
+        (String.length msg > 0)
+  | _ -> fail "stub read must return Read_failed"
+
+let test_kill_stub_errors () =
+  let tid = Bg_task.task_id_of_string_exn "stub" in
+  match Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:1.0 with
+  | Error (Bg_task.Kill_failed _) -> ()
+  | _ -> fail "stub kill must return Kill_failed"
+
+let test_reap_orphans_returns_zero () =
+  check int "no orphans at boot" 0
+    (Bg_task.reap_orphans ~base_path:"/tmp/no-such-base")
+
+let () =
+  run "bg_task_stub"
+    [
+      ( "signatures",
+        [
+          test_case "task_id roundtrip" `Quick test_task_id_roundtrip;
+          test_case "empty task_id rejected" `Quick
+            test_task_id_empty_rejected;
+          test_case "list on unknown keeper is empty" `Quick
+            test_list_empty_for_unknown_keeper;
+          test_case "stub read returns Read_failed" `Quick
+            test_read_stub_errors;
+          test_case "stub kill returns Kill_failed" `Quick
+            test_kill_stub_errors;
+          test_case "reap_orphans returns 0 pre-impl" `Quick
+            test_reap_orphans_returns_zero;
+        ] );
+    ]

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -27,6 +27,7 @@ let sp
       ~keeper ~argv ~cwd
       ~envp:(env_of_current ())
       ~timeout_sec
+      ()
   with
   | Ok tid -> tid
   | Error _ -> failwith "spawn failed"
@@ -112,6 +113,86 @@ let test_reap_orphans_returns_zero () =
   check int "no orphans at boot" 0
     (Bg_task.reap_orphans ~base_path:"/tmp/no-such-base")
 
+(* Tick 7 integration: when spawn is given ~base_path, a PID file
+   appears at <base>/.masc/keeper/<k>/bg/<tid>.pid. After kill and
+   close, the file is unlinked. *)
+let test_pid_file_created_and_cleaned () =
+  let base = Filename.temp_file "bg_task_tick7" "" in
+  Unix.unlink base;
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      try
+        let keeper_dir = Filename.concat (Filename.concat base ".masc") "keeper" in
+        let rec rm path =
+          if Sys.is_directory path then begin
+            Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
+            Unix.rmdir path
+          end else Unix.unlink path
+        in
+        if Sys.file_exists keeper_dir then rm keeper_dir
+      with _ -> ())
+    (fun () ->
+      let tid =
+        match
+          Bg_task.spawn ~base_path:base ~keeper:"kp-pid"
+            ~argv:[ "/bin/sleep"; "5" ]
+            ~cwd:"" ~envp:(env_of_current ()) ~timeout_sec:0.0 ()
+        with
+        | Ok t -> t
+        | Error _ -> failwith "spawn failed"
+      in
+      ignore (Unix.select [] [] [] 0.1);
+      let pid_path =
+        Filename.concat base
+          (Printf.sprintf ".masc/keeper/kp-pid/bg/%s.pid"
+             (Bg_task.task_id_to_string tid))
+      in
+      check bool "pid file exists mid-run" true (Sys.file_exists pid_path);
+      ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:1.0);
+      ignore (poll_for_closed tid);
+      check bool "pid file gone after close" false (Sys.file_exists pid_path))
+
+(* reap_orphans removes a stale pid file whose pid is no longer live
+   and whose task_id is absent from the registry. *)
+let test_reap_orphans_removes_stale_file () =
+  let base = Filename.temp_file "bg_task_reap" "" in
+  Unix.unlink base;
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      try
+        let keeper_dir = Filename.concat (Filename.concat base ".masc") "keeper" in
+        let rec rm path =
+          if Sys.is_directory path then begin
+            Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
+            Unix.rmdir path
+          end else Unix.unlink path
+        in
+        if Sys.file_exists keeper_dir then rm keeper_dir
+      with _ -> ())
+    (fun () ->
+      let bg_dir =
+        Filename.concat base ".masc/keeper/kp-reap/bg"
+      in
+      let rec mkp p =
+        if Sys.file_exists p then ()
+        else begin
+          let parent = Filename.dirname p in
+          if parent <> p then mkp parent;
+          try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+        end
+      in
+      mkp bg_dir;
+      let stale = Filename.concat bg_dir "ghost-tid.pid" in
+      let oc = open_out stale in
+      (* PID 999999 assumed dead on any reasonable test host *)
+      output_string oc "999999\n999999\n0.0\n";
+      close_out oc;
+      let n = Bg_task.reap_orphans ~base_path:base in
+      check bool "reaped at least one" true (n >= 1);
+      check bool "stale file removed" false (Sys.file_exists stale))
+
 let () =
   run "bg_task"
     [
@@ -123,8 +204,15 @@ let () =
             test_list_empty_for_unknown_keeper;
           test_case "unknown id returns structured errors" `Quick
             test_unknown_task_errors;
-          test_case "reap_orphans pre-impl returns 0" `Quick
+          test_case "reap_orphans on missing base returns 0" `Quick
             test_reap_orphans_returns_zero;
+        ] );
+      ( "persistence",
+        [
+          test_case "pid file created and cleaned on close" `Quick
+            test_pid_file_created_and_cleaned;
+          test_case "reap_orphans removes stale pid file" `Quick
+            test_reap_orphans_removes_stale_file;
         ] );
       ( "lifecycle",
         [

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -1,12 +1,41 @@
-(* Tick 4 smoke tests — verify the Bg_task signatures compile and the
-   stub returns structured errors. Real lifecycle tests land in Tick 5
-   together with the pgid/ring-buffer implementation. *)
+(* Tick 6a: Bg_task pull-based implementation tests.
+
+   File name still [test_bg_task_stub.ml] from Tick 4; behaviour is
+   now integration coverage, not stub assertions.  A rename requires
+   updating two sibling dune stanzas — left for a follow-up. *)
 
 open Alcotest
 
-let test_task_id_roundtrip () =
-  let tid = Bg_task.task_id_of_string_exn "abc-123" in
-  check string "roundtrip" "abc-123" (Bg_task.task_id_to_string tid)
+let wait_until ~timeout_s f =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if f () then true
+    else if Unix.gettimeofday () >= deadline then false
+    else (ignore (Unix.select [] [] [] 0.02); loop ())
+  in
+  loop ()
+
+let env_of_current () = Unix.environment ()
+
+let sp
+    ?(keeper = "test-keeper")
+    ?(cwd = "")
+    ?(timeout_sec = 0.0)
+    argv =
+  match
+    Bg_task.spawn
+      ~keeper ~argv ~cwd
+      ~envp:(env_of_current ())
+      ~timeout_sec
+  with
+  | Ok tid -> tid
+  | Error _ -> failwith "spawn failed"
+
+let poll_for_closed tid =
+  wait_until ~timeout_s:3.0 (fun () ->
+    match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+    | Ok s -> s.closed
+    | Error _ -> false)
 
 let test_task_id_empty_rejected () =
   match Bg_task.task_id_of_string_exn "" with
@@ -14,42 +43,98 @@ let test_task_id_empty_rejected () =
   | _ -> fail "empty id must raise"
 
 let test_list_empty_for_unknown_keeper () =
-  let ids = Bg_task.list ~keeper:"no-such-keeper" in
+  let ids = Bg_task.list ~keeper:"no-such-keeper-xyz" in
   check int "empty list" 0 (List.length ids)
 
-let test_read_stub_errors () =
-  let tid = Bg_task.task_id_of_string_exn "stub" in
+let test_echo_roundtrip () =
+  let tid = sp ~keeper:"kp1" [ "/bin/echo"; "hello" ] in
+  let closed = poll_for_closed tid in
+  check bool "child closed" true closed;
   match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
-  | Error (Bg_task.Read_failed msg) ->
-      check bool "stub message mentions Tick 5" true
-        (String.length msg > 0)
-  | _ -> fail "stub read must return Read_failed"
+  | Error _ -> fail "read after close failed"
+  | Ok s ->
+      check string "stdout captured" "hello\n" s.stdout_since;
+      check string "stderr empty" "" s.stderr_since;
+      (match s.status with
+       | Some (Unix.WEXITED 0) -> ()
+       | _ -> fail "echo must exit 0")
 
-let test_kill_stub_errors () =
-  let tid = Bg_task.task_id_of_string_exn "stub" in
-  match Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:1.0 with
-  | Error (Bg_task.Kill_failed _) -> ()
-  | _ -> fail "stub kill must return Kill_failed"
+let test_since_offset_skips_prefix () =
+  let tid = sp ~keeper:"kp2" [ "/bin/echo"; "abcdef" ] in
+  let _ = poll_for_closed tid in
+  match Bg_task.read tid ~since_stdout:3 ~since_stderr:0 with
+  | Error _ -> fail "read failed"
+  | Ok s -> check string "suffix only" "def\n" s.stdout_since
+
+let test_kill_closes_task () =
+  let tid = sp ~keeper:"kp3" [ "/bin/sleep"; "30" ] in
+  (* let child actually establish its pgroup *)
+  ignore (Unix.select [] [] [] 0.2);
+  (match Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:1.0 with
+   | Ok () -> ()
+   | Error _ -> fail "kill failed");
+  let closed = poll_for_closed tid in
+  check bool "closed after kill" true closed
+
+let test_list_tracks_keeper () =
+  let k = "kp-list" in
+  let t1 = sp ~keeper:k [ "/bin/sleep"; "2" ] in
+  let t2 = sp ~keeper:k [ "/bin/sleep"; "2" ] in
+  let ids = Bg_task.list ~keeper:k in
+  check bool "contains t1"
+    true (List.mem t1 ids);
+  check bool "contains t2"
+    true (List.mem t2 ids);
+  ignore (Bg_task.kill t1 ~signal:Sys.sigterm ~grace_sec:1.0);
+  ignore (Bg_task.kill t2 ~signal:Sys.sigterm ~grace_sec:1.0);
+  ignore (poll_for_closed t1);
+  ignore (poll_for_closed t2)
+
+let test_unknown_task_errors () =
+  let tid = Bg_task.task_id_of_string_exn "bogus-nonexistent" in
+  (match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+   | Error (Bg_task.Unknown_task _) -> ()
+   | _ -> fail "read on bogus id must be Unknown_task");
+  match Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.1 with
+  | Error (Bg_task.Unknown_task_kill _) -> ()
+  | _ -> fail "kill on bogus id must be Unknown_task_kill"
+
+let test_timeout_enforced () =
+  let tid = sp ~keeper:"kp4" ~timeout_sec:0.3 [ "/bin/sleep"; "10" ] in
+  let closed = wait_until ~timeout_s:3.0 (fun () ->
+    match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
+    | Ok s -> s.closed
+    | Error _ -> false)
+  in
+  check bool "closed via timeout" true closed
 
 let test_reap_orphans_returns_zero () =
   check int "no orphans at boot" 0
     (Bg_task.reap_orphans ~base_path:"/tmp/no-such-base")
 
 let () =
-  run "bg_task_stub"
+  run "bg_task"
     [
       ( "signatures",
         [
-          test_case "task_id roundtrip" `Quick test_task_id_roundtrip;
           test_case "empty task_id rejected" `Quick
             test_task_id_empty_rejected;
           test_case "list on unknown keeper is empty" `Quick
             test_list_empty_for_unknown_keeper;
-          test_case "stub read returns Read_failed" `Quick
-            test_read_stub_errors;
-          test_case "stub kill returns Kill_failed" `Quick
-            test_kill_stub_errors;
-          test_case "reap_orphans returns 0 pre-impl" `Quick
+          test_case "unknown id returns structured errors" `Quick
+            test_unknown_task_errors;
+          test_case "reap_orphans pre-impl returns 0" `Quick
             test_reap_orphans_returns_zero;
+        ] );
+      ( "lifecycle",
+        [
+          test_case "echo roundtrip" `Quick test_echo_roundtrip;
+          test_case "since offset skips prefix" `Quick
+            test_since_offset_skips_prefix;
+          test_case "kill closes task" `Quick test_kill_closes_task;
+          test_case "list tracks keeper's tasks" `Quick
+            test_list_tracks_keeper;
+          test_case "timeout enforcement fires tree_kill" `Quick
+            test_timeout_enforced;
         ] );
     ]

--- a/test/test_cdal_verifiable_markers.ml
+++ b/test/test_cdal_verifiable_markers.ml
@@ -1,0 +1,119 @@
+(* P6 Tick 15: Cdal_judge.of_exec_outcome verifiable marker tests.
+
+   Covers the four domain classifiers (test / build / lint / git)
+   plus the pass-through semantics for terminal states the plan
+   declares non-emitting (timeout, signaled, policy_denied, etc.). *)
+
+open Alcotest
+
+let marker_list : Cdal_judge.verifiable_marker list testable =
+  let pp fmt ms =
+    Format.fprintf fmt "[%s]"
+      (String.concat "; " (List.map Cdal_judge.marker_to_string ms))
+  in
+  let eq a b =
+    List.length a = List.length b
+    && List.for_all2
+         (fun x y -> Cdal_judge.marker_to_string x = Cdal_judge.marker_to_string y)
+         a b
+  in
+  testable pp eq
+
+let call ?(stdout = "") ?(stderr = "") semantic =
+  Cdal_judge.of_exec_outcome ~semantic ~stdout ~stderr
+
+let test_git_not_a_repo_exact () =
+  check marker_list "single Git_not_a_repo marker"
+    [ Cdal_judge.Git_not_a_repo ]
+    (call `Git_not_a_repo)
+
+let test_ok_with_nothing_known_emits_empty () =
+  check marker_list "unknown producer yields []"
+    []
+    (call ~stdout:"hello world" `Ok)
+
+let test_dune_build_ok_heuristic () =
+  let stdout = "[dune build] compiling lib/foo.ml\nocamlopt -c lib/foo.ml\n" in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Build_ok { confidence = `Heuristic } ] -> ()
+  | other ->
+      fail ("expected Build_ok heuristic, got "
+            ^ String.concat ","
+                (List.map Cdal_judge.marker_to_string other))
+
+let test_dune_build_fail_heuristic () =
+  let stdout = "dune build\nError: this expression has type int\n" in
+  match call ~stdout (`Fail 1) with
+  | [ Cdal_judge.Build_fail { confidence = `Heuristic } ] -> ()
+  | _ -> fail "expected Build_fail"
+
+let test_alcotest_pass_counts () =
+  let stdout =
+    "Testing `exec_buffer'.\nThis run has ID `abc`.\n\
+     exec_buffer\n  SUCCESS\n\n\
+     Full test results in `/tmp/test-out`.\n\
+     Test Successful in 0.003s. 8 tests run.\n"
+  in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Test_pass { count = 8; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_pass { count; _ } ] ->
+      fail (Printf.sprintf "expected count=8, got %d" count)
+  | _ -> fail "expected Test_pass marker"
+
+let test_git_status_clean_exact () =
+  let stdout = "On branch main\nnothing to commit, working tree clean\n" in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Git_clean { confidence = `Exact } ] -> ()
+  | _ -> fail "expected Git_clean Exact"
+
+let test_git_status_dirty_exact () =
+  let stdout =
+    "On branch main\nChanges not staged for commit:\n\tmodified: a.ml\n"
+  in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Git_dirty { confidence = `Exact } ] -> ()
+  | _ -> fail "expected Git_dirty Exact"
+
+let test_timeout_emits_nothing () =
+  check marker_list "timeout yields []" [] (call (`Timeout 5.0))
+
+let test_policy_denied_emits_nothing () =
+  check marker_list "policy_denied yields []" []
+    (call (`Policy_denied "rm -rf /"))
+
+let test_tool_missing_emits_nothing () =
+  check marker_list "tool_missing yields []" []
+    (call (`Tool_missing "cargo"))
+
+let test_marker_wire_format () =
+  check string "test_pass wire"
+    "test_pass:3:heuristic"
+    (Cdal_judge.marker_to_string
+       (Cdal_judge.Test_pass { count = 3; confidence = `Heuristic }));
+  check string "git_not_a_repo wire"
+    "git_not_a_repo:exact"
+    (Cdal_judge.marker_to_string Cdal_judge.Git_not_a_repo)
+
+let () =
+  run "cdal_verifiable_markers" [
+    ("semantic_passthrough", [
+      test_case "git_not_a_repo emits single marker" `Quick
+        test_git_not_a_repo_exact;
+      test_case "timeout emits nothing" `Quick test_timeout_emits_nothing;
+      test_case "policy_denied emits nothing" `Quick
+        test_policy_denied_emits_nothing;
+      test_case "tool_missing emits nothing" `Quick
+        test_tool_missing_emits_nothing;
+    ]);
+    ("classifiers", [
+      test_case "unknown ok → []" `Quick test_ok_with_nothing_known_emits_empty;
+      test_case "dune build ok" `Quick test_dune_build_ok_heuristic;
+      test_case "dune build fail" `Quick test_dune_build_fail_heuristic;
+      test_case "alcotest pass count" `Quick test_alcotest_pass_counts;
+      test_case "git status clean" `Quick test_git_status_clean_exact;
+      test_case "git status dirty" `Quick test_git_status_dirty_exact;
+    ]);
+    ("wire", [
+      test_case "marker_to_string stable" `Quick test_marker_wire_format;
+    ]);
+  ]

--- a/test/test_cdal_verifiable_markers.ml
+++ b/test/test_cdal_verifiable_markers.ml
@@ -5,6 +5,7 @@
    declares non-emitting (timeout, signaled, policy_denied, etc.). *)
 
 open Alcotest
+open Masc_mcp
 
 let marker_list : Cdal_judge.verifiable_marker list testable =
   let pp fmt ms =

--- a/test/test_destructive_class.ml
+++ b/test/test_destructive_class.ml
@@ -1,0 +1,77 @@
+(* Tick 13: typed destructive classification.
+
+   Core covenant: every row in Eval_gate.destructive_patterns must
+   classify to exactly one destructive_class via the AST-shadow
+   mapping.  If Eval_gate adds a new pattern and Worker_dev_tools
+   does not, this test fails loudly — preventing silent coverage
+   drift between the regex allowlist and the typed classifier. *)
+
+open Alcotest
+
+let classify =
+  Masc_mcp.Worker_dev_tools.classify_destructive
+
+let class_to_string =
+  Masc_mcp.Worker_dev_tools.destructive_class_to_string
+
+let class_name_of_cmd cmd =
+  match classify cmd with
+  | Some (cls, _) -> class_to_string cls
+  | None -> "no_match"
+
+let test_all_patterns_classify () =
+  let patterns = Masc_mcp.Eval_gate.destructive_patterns in
+  List.iter (fun (pat, desc) ->
+    match classify pat with
+    | Some _ -> ()
+    | None ->
+        fail (Printf.sprintf
+                "Eval_gate pattern %S (%s) has no destructive_class mapping"
+                pat desc)
+  ) patterns
+
+let test_longest_match_wins () =
+  (* rm -rf should hit Recursive_delete via the "rm -rf" prefix, not
+     "rm -r" — both map to Recursive_delete anyway but the first
+     match in declaration order should be the longer one. *)
+  match classify "rm -rf /tmp/foo" with
+  | Some (_, sub) -> check string "matched substring" "rm -rf" sub
+  | None -> fail "expected match"
+
+let test_case_insensitive () =
+  check string "uppercase SQL" "sql_destructive"
+    (class_name_of_cmd "DROP TABLE users")
+
+let test_no_match_for_benign () =
+  check string "ls benign" "no_match" (class_name_of_cmd "ls -la")
+
+let test_class_names_stable () =
+  let open Masc_mcp.Worker_dev_tools in
+  check string "recursive_delete" "recursive_delete"
+    (destructive_class_to_string Recursive_delete);
+  check string "forced_git_mutation" "forced_git_mutation"
+    (destructive_class_to_string Forced_git_mutation);
+  check string "system_control" "system_control"
+    (destructive_class_to_string System_control)
+
+let test_coverage_count () =
+  (* Plan Phase 5 cites 19 destructive patterns. *)
+  let patterns = Masc_mcp.Eval_gate.destructive_patterns in
+  check int "19 destructive patterns" 19 (List.length patterns)
+
+let () =
+  run "destructive_class" [
+    ("covenant", [
+      test_case "every eval_gate pattern classifies" `Quick
+        test_all_patterns_classify;
+      test_case "19 patterns present" `Quick test_coverage_count;
+    ]);
+    ("matching", [
+      test_case "longest substring wins" `Quick test_longest_match_wins;
+      test_case "case insensitive" `Quick test_case_insensitive;
+      test_case "benign command → no_match" `Quick test_no_match_for_benign;
+    ]);
+    ("wire", [
+      test_case "class names stable" `Quick test_class_names_stable;
+    ]);
+  ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -233,6 +233,68 @@ let test_semantic_flag_isolation () =
     | `Null -> ()
     | _ -> fail "semantic_exit must stay absent after flag flips off")
 
+(* ---------- P6 Tick 16: verifiable_markers JSON integration -------------- *)
+
+let with_markers_flag enabled f =
+  let prev = Sys.getenv_opt "MASC_BASH_VERIFIABLE_MARKERS" in
+  Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" (if enabled then "1" else "");
+  let restore () =
+    match prev with
+    | Some v -> Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" v
+    | None -> Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" ""
+  in
+  match f () with
+  | v -> restore (); v
+  | exception e -> restore (); raise e
+
+let test_markers_absent_when_flag_off () =
+  with_semantic_flag true (fun () ->
+    with_markers_flag false (fun () ->
+      let json =
+        run_json ~cmd:"git status" ~status:(Unix.WEXITED 128)
+          ~output:"fatal: not a git repository"
+      in
+      match json |> member "verifiable_markers" with
+      | `Null -> ()
+      | _ -> fail "markers must be absent when flag is off"))
+
+let test_markers_absent_when_semantic_off () =
+  (* Markers require semantic; flag-on alone without semantic is no-op. *)
+  with_semantic_flag false (fun () ->
+    with_markers_flag true (fun () ->
+      let json =
+        run_json ~cmd:"git status" ~status:(Unix.WEXITED 128)
+          ~output:"fatal: not a git repository"
+      in
+      match json |> member "verifiable_markers" with
+      | `Null -> ()
+      | _ -> fail "markers require semantic flag to also be on"))
+
+let test_markers_git_not_a_repo () =
+  with_semantic_flag true (fun () ->
+    with_markers_flag true (fun () ->
+      let json =
+        run_json ~cmd:"git status" ~status:(Unix.WEXITED 128)
+          ~output:"fatal: not a git repository"
+      in
+      let markers = json |> member "verifiable_markers" |> to_list in
+      check int "one marker" 1 (List.length markers);
+      let m = List.hd markers in
+      check string "kind" "git_not_a_repo" (m |> member "kind" |> to_string);
+      check string "confidence" "exact"
+        (m |> member "confidence" |> to_string)))
+
+let test_markers_unknown_output_emits_absent () =
+  (* No producer pattern → no marker list field. *)
+  with_semantic_flag true (fun () ->
+    with_markers_flag true (fun () ->
+      let json =
+        run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"hello world"
+      in
+      match json |> member "verifiable_markers" with
+      | `Null -> ()
+      | _ -> fail "unknown output must not emit a marker list"))
+
 let () =
   run "exec_core"
     [
@@ -268,5 +330,16 @@ let () =
             `Quick test_semantic_tool_missing_payload;
           test_case "flag flip isolates state" `Quick
             test_semantic_flag_isolation;
+        ] );
+      ( "verifiable_markers",
+        [
+          test_case "absent when markers flag off" `Quick
+            test_markers_absent_when_flag_off;
+          test_case "absent when semantic flag off" `Quick
+            test_markers_absent_when_semantic_off;
+          test_case "git_not_a_repo emits exact marker" `Quick
+            test_markers_git_not_a_repo;
+          test_case "unknown output emits no marker field" `Quick
+            test_markers_unknown_output_emits_absent;
         ] );
     ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -295,6 +295,61 @@ let test_markers_unknown_output_emits_absent () =
       | `Null -> ()
       | _ -> fail "unknown output must not emit a marker list"))
 
+(* ---------- P3 Tick 9: output_cap env-gated head+tail truncation --------- *)
+
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key (Option.value ~default:"" value);
+  let restore () =
+    match prev with
+    | Some v -> Unix.putenv key v
+    | None -> Unix.putenv key ""
+  in
+  match f () with
+  | v -> restore (); v
+  | exception e -> restore (); raise e
+
+let test_output_cap_absent_by_default () =
+  with_env "MASC_BASH_OUTPUT_CAP" None (fun () ->
+    let json =
+      run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"hello"
+    in
+    check string "output untouched" "hello" (json |> member "output" |> to_string);
+    match json |> member "output_cap" with
+    | `Null -> ()
+    | _ -> fail "output_cap must be absent when flag is off")
+
+let test_output_cap_on_preserves_small_output () =
+  with_env "MASC_BASH_OUTPUT_CAP" (Some "1") (fun () ->
+    let json =
+      run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"short"
+    in
+    check string "short output unchanged" "short"
+      (json |> member "output" |> to_string);
+    let cap = json |> member "output_cap" in
+    check int "total_bytes=5" 5 (cap |> member "total_bytes" |> to_int);
+    check int "bytes_dropped=0" 0 (cap |> member "bytes_dropped" |> to_int))
+
+let test_output_cap_truncates_large_output () =
+  with_env "MASC_BASH_OUTPUT_CAP" (Some "1") (fun () ->
+    with_env "MASC_BASH_CAP_HEAD" (Some "8") (fun () ->
+      with_env "MASC_BASH_CAP_TAIL" (Some "8") (fun () ->
+        let long = "HEADAAAA" ^ String.make 256 'X' ^ "TAILBBBB" in
+        let json =
+          run_json ~cmd:"cat big" ~status:(Unix.WEXITED 0) ~output:long
+        in
+        let out = json |> member "output" |> to_string in
+        (* separator format from Exec_buffer.render *)
+        if not (String.length out > 0 && String.length out < String.length long)
+        then fail "output should be shorter than input when capped";
+        let cap = json |> member "output_cap" in
+        check int "total_bytes" (String.length long)
+          (cap |> member "total_bytes" |> to_int);
+        let dropped = cap |> member "bytes_dropped" |> to_int in
+        if dropped <= 0 then fail "bytes_dropped must be positive";
+        check int "head_cap=8" 8 (cap |> member "head_cap" |> to_int);
+        check int "tail_cap=8" 8 (cap |> member "tail_cap" |> to_int))))
+
 let () =
   run "exec_core"
     [
@@ -341,5 +396,14 @@ let () =
             test_markers_git_not_a_repo;
           test_case "unknown output emits no marker field" `Quick
             test_markers_unknown_output_emits_absent;
+        ] );
+      ( "output_cap",
+        [
+          test_case "absent by default" `Quick
+            test_output_cap_absent_by_default;
+          test_case "small output unchanged, cap metadata emitted"
+            `Quick test_output_cap_on_preserves_small_output;
+          test_case "large output truncated with bytes_dropped > 0"
+            `Quick test_output_cap_truncates_large_output;
         ] );
     ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -156,6 +156,83 @@ let test_inline_only_keeps_artifact_refs_empty () =
       let refs = json |> member "artifact_refs" |> to_list in
       check int "no artifact ref" 0 (List.length refs))
 
+(* ---------- P1 Tick 3: Exec_semantic JSON integration ------------------ *)
+
+let with_semantic_flag enabled f =
+  let prev = Sys.getenv_opt "MASC_BASH_SEMANTIC_EXIT" in
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" (if enabled then "1" else "");
+  let restore () =
+    match prev with
+    | Some v -> Unix.putenv "MASC_BASH_SEMANTIC_EXIT" v
+    | None -> Unix.putenv "MASC_BASH_SEMANTIC_EXIT" ""
+  in
+  match f () with
+  | v -> restore (); v
+  | exception e -> restore (); raise e
+
+let run_json ~cmd ~status ~output =
+  Masc_mcp.Exec_core.process_result_json
+    ~base_path:"/tmp"
+    ~keeper_name:"exec-core-semantic"
+    ~cmd
+    ~status
+    ~output
+    ()
+
+let test_semantic_off_by_default () =
+  with_semantic_flag false (fun () ->
+    let json = run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"" in
+    match json |> member "semantic_exit" with
+    | `Null -> ()
+    | _ -> fail "semantic_exit must be absent when flag is off")
+
+let test_semantic_ok_when_flag_on () =
+  with_semantic_flag true (fun () ->
+    let json = run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"" in
+    let sem = json |> member "semantic_exit" in
+    check string "kind=ok" "ok" (sem |> member "kind" |> to_string))
+
+let test_semantic_fail_carries_exit_code () =
+  with_semantic_flag true (fun () ->
+    let json = run_json ~cmd:"ls /no/such/path"
+                 ~status:(Unix.WEXITED 2) ~output:"ls: …" in
+    let sem = json |> member "semantic_exit" in
+    check string "kind=fail" "fail" (sem |> member "kind" |> to_string);
+    check int "exit_code=2" 2 (sem |> member "exit_code" |> to_int);
+    check bool "rci present" true
+      (match json |> member "return_code_interpretation" with
+       | `String _ -> true | _ -> false))
+
+let test_semantic_git_not_a_repo () =
+  with_semantic_flag true (fun () ->
+    let json = run_json ~cmd:"git status" ~status:(Unix.WEXITED 128)
+                 ~output:"fatal: not a git repository" in
+    let sem = json |> member "semantic_exit" in
+    check string "kind=git_not_a_repo" "git_not_a_repo"
+      (sem |> member "kind" |> to_string))
+
+let test_semantic_tool_missing_payload () =
+  with_semantic_flag true (fun () ->
+    let json = run_json ~cmd:"notarealtool --help"
+                 ~status:(Unix.WEXITED 127)
+                 ~output:"bash: notarealtool: command not found" in
+    let sem = json |> member "semantic_exit" in
+    check string "kind=tool_missing" "tool_missing"
+      (sem |> member "kind" |> to_string);
+    check string "tool=notarealtool" "notarealtool"
+      (sem |> member "tool" |> to_string))
+
+let test_semantic_flag_isolation () =
+  (* Flipping off after on must hide the field again. *)
+  with_semantic_flag true (fun () ->
+    let _ = run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"" in
+    ());
+  with_semantic_flag false (fun () ->
+    let json = run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"" in
+    match json |> member "semantic_exit" with
+    | `Null -> ()
+    | _ -> fail "semantic_exit must stay absent after flag flips off")
+
 let () =
   run "exec_core"
     [
@@ -177,5 +254,19 @@ let () =
             test_large_output_persists_artifact;
           test_case "inline only keeps artifact refs empty" `Quick
             test_inline_only_keeps_artifact_refs_empty;
+        ] );
+      ( "semantic_exit",
+        [
+          test_case "flag off by default hides field" `Quick
+            test_semantic_off_by_default;
+          test_case "ok kind on exit 0" `Quick test_semantic_ok_when_flag_on;
+          test_case "fail kind carries exit_code" `Quick
+            test_semantic_fail_carries_exit_code;
+          test_case "git exit 128 maps to git_not_a_repo" `Quick
+            test_semantic_git_not_a_repo;
+          test_case "exit 127 maps to tool_missing with tool payload"
+            `Quick test_semantic_tool_missing_payload;
+          test_case "flag flip isolates state" `Quick
+            test_semantic_flag_isolation;
         ] );
     ]

--- a/test/test_gate_diff.ml
+++ b/test/test_gate_diff.ml
@@ -1,0 +1,109 @@
+(* Tick 14: legacy ↔ shadow diff harness.
+
+   These tests pin the diff taxonomy on a canonical corpus so the
+   eventual flag flip (decision point 2 of the plan) can simply
+   gate on a CI job that re-runs this harness against prod traces
+   and asserts zero [Legacy_allow_shadow_deny] rows. *)
+
+open Alcotest
+
+module W = Masc_mcp.Worker_dev_tools
+
+let diff_tag cmd =
+  let d, _, _ = W.diff_command cmd in
+  W.gate_diff_to_string d
+
+let test_simple_ls_agrees () =
+  check string "ls agree" "agree" (diff_tag "ls")
+
+let test_rm_rf_agrees_on_deny () =
+  (* Legacy: rm without both -r and -f bundled into single flag
+     does not hit the structural short-circuit, but Eval_gate
+     catches "rm -rf" substring, so legacy denies.
+     Shadow: classify_destructive hits Recursive_delete.
+     Diff: agree. *)
+  check string "rm -rf agree on deny" "agree" (diff_tag "rm -rf /tmp/x")
+
+let test_benign_disallowed_command_yields_agree () =
+  (* `foo` is not in the allowlist; legacy rejects by allowlist,
+     shadow parses "foo" as parsed_simple with no destructive hit.
+     Per diff_of_verdicts, Legacy_reject_by_allowlist short-circuits
+     to Agree so the harness does not flag every disallowed-but-safe
+     command as a diff. *)
+  check string "benign unknown bin → agree" "agree" (diff_tag "foo bar")
+
+let test_unsupported_grammar_is_shadow_cannot_parse () =
+  (* Pipeline is not yet parsed as simple; legacy disagrees or
+     agrees depending on allowlist, but the shadow says
+     parse-unsupported, so diff is [Shadow_cannot_parse] — the
+     grammar upgrade queue target. *)
+  let d, _, _ = W.diff_command "ls | wc -l" in
+  check string "pipe parse-unsupported"
+    "shadow_cannot_parse" (W.gate_diff_to_string d)
+
+let test_sql_destructive_agrees () =
+  (* `drop table foo` is denied by legacy (Eval_gate) and by shadow
+     (Sql_destructive). *)
+  check string "drop table agree" "agree" (diff_tag "drop table users")
+
+let test_diff_command_returns_triple_shape () =
+  let d, legacy, shadow = W.diff_command "ls" in
+  (match d with W.Agree -> () | _ -> fail "ls should agree");
+  (match legacy with
+   | W.Legacy_allow -> ()
+   | _ -> fail "ls is in legacy allowlist");
+  (match shadow with
+   | W.Shadow_allow { parse_tag = "parsed_simple" } -> ()
+   | _ -> fail "ls shadow should be parsed_simple")
+
+let test_destructive_class_surfaced_on_shadow_deny () =
+  let _, _, shadow = W.diff_command "git push --force origin main" in
+  match shadow with
+  | W.Shadow_deny_destructive (cls, _) ->
+      check string "forced_git_mutation" "forced_git_mutation"
+        (W.destructive_class_to_string cls)
+  | _ -> fail "expected Shadow_deny_destructive"
+
+let test_all_eval_gate_patterns_are_agree_or_shadow_cannot_parse () =
+  (* Critical covenant for the flip: no Eval_gate pattern may land
+     in [Legacy_deny_shadow_allow].  Either the shadow denies too
+     (Agree) or it cannot yet parse (Shadow_cannot_parse).  If a
+     pattern slips into [Legacy_deny_shadow_allow], the flip would
+     unblock real destructive commands. *)
+  let patterns = Masc_mcp.Eval_gate.destructive_patterns in
+  List.iter (fun (pat, desc) ->
+    let d, _, _ = W.diff_command pat in
+    match d with
+    | W.Agree | W.Shadow_cannot_parse -> ()
+    | W.Legacy_deny_shadow_allow ->
+        fail (Printf.sprintf
+                "flip blocker: %S (%s) is legacy_deny_shadow_allow"
+                pat desc)
+    | W.Legacy_allow_shadow_deny ->
+        fail (Printf.sprintf
+                "inverted gap: %S (%s) is legacy_allow_shadow_deny"
+                pat desc))
+    patterns
+
+let () =
+  run "gate_diff" [
+    ("smoke", [
+      test_case "simple ls agrees" `Quick test_simple_ls_agrees;
+      test_case "rm -rf deny agree" `Quick test_rm_rf_agrees_on_deny;
+      test_case "unknown bin still agree" `Quick
+        test_benign_disallowed_command_yields_agree;
+      test_case "sql destructive agree" `Quick test_sql_destructive_agrees;
+      test_case "pipe parse unsupported" `Quick
+        test_unsupported_grammar_is_shadow_cannot_parse;
+    ]);
+    ("shape", [
+      test_case "diff_command triple shape" `Quick
+        test_diff_command_returns_triple_shape;
+      test_case "shadow deny exposes class" `Quick
+        test_destructive_class_surfaced_on_shadow_deny;
+    ]);
+    ("flip_covenant", [
+      test_case "no eval_gate pattern is legacy_deny_shadow_allow" `Quick
+        test_all_eval_gate_patterns_are_agree_or_shadow_cannot_parse;
+    ]);
+  ]

--- a/test/test_gate_diff.ml
+++ b/test/test_gate_diff.ml
@@ -32,14 +32,12 @@ let test_benign_disallowed_command_yields_agree () =
      command as a diff. *)
   check string "benign unknown bin → agree" "agree" (diff_tag "foo bar")
 
-let test_unsupported_grammar_is_shadow_cannot_parse () =
-  (* Pipeline is not yet parsed as simple; legacy disagrees or
-     agrees depending on allowlist, but the shadow says
-     parse-unsupported, so diff is [Shadow_cannot_parse] — the
-     grammar upgrade queue target. *)
+let test_pipeline_shadow_agrees_with_legacy_policy () =
+  (* Pipeline parsing is now covered by the shadow parser. Legacy still
+     owns allowlist policy, so a benign disallowed pipeline is [Agree],
+     not a parser-coverage gap. *)
   let d, _, _ = W.diff_command "ls | wc -l" in
-  check string "pipe parse-unsupported"
-    "shadow_cannot_parse" (W.gate_diff_to_string d)
+  check string "pipe agrees" "agree" (W.gate_diff_to_string d)
 
 let test_sql_destructive_agrees () =
   (* `drop table foo` is denied by legacy (Eval_gate) and by shadow
@@ -93,8 +91,8 @@ let () =
       test_case "unknown bin still agree" `Quick
         test_benign_disallowed_command_yields_agree;
       test_case "sql destructive agree" `Quick test_sql_destructive_agrees;
-      test_case "pipe parse unsupported" `Quick
-        test_unsupported_grammar_is_shadow_cannot_parse;
+      test_case "pipeline shadow agrees with legacy policy" `Quick
+        test_pipeline_shadow_agrees_with_legacy_policy;
     ]);
     ("shape", [
       test_case "diff_command triple shape" `Quick

--- a/test/test_process_eio_detached.ml
+++ b/test/test_process_eio_detached.ml
@@ -84,13 +84,22 @@ let test_tree_kill_sigterm () =
   with
   | Error e -> failf "spawn failed: %s" e
   | Ok h ->
-      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:2.0;
-      let dead =
-        wait_until ~timeout_s:3.0 (fun () ->
-          not (P.is_pgid_alive ~pgid:h.pgid))
+      let alive =
+        wait_until ~timeout_s:1.0 (fun () ->
+          P.is_pgid_alive ~pgid:h.pgid)
       in
+      check bool "pgroup reaches alive state" true alive;
+      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:2.0;
+      let status = ref None in
+      let exited =
+        wait_until ~timeout_s:3.0 (fun () ->
+          match waitpid_nohang h.pid with
+          | Some s -> status := Some s; true
+          | None -> false)
+      in
+      check bool "child exited after tree_kill" true exited;
+      let dead = not (P.is_pgid_alive ~pgid:h.pgid) in
       check bool "pgroup dead after tree_kill" true dead;
-      ignore (Unix.waitpid [] h.pid);
       Unix.close h.stdout_fd; Unix.close h.stderr_fd
 
 let test_tree_kill_escalates_to_sigkill () =
@@ -104,13 +113,22 @@ let test_tree_kill_escalates_to_sigkill () =
   with
   | Error e -> failf "spawn failed: %s" e
   | Ok h ->
-      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:0.5;
-      let dead =
-        wait_until ~timeout_s:2.0 (fun () ->
-          not (P.is_pgid_alive ~pgid:h.pgid))
+      let alive =
+        wait_until ~timeout_s:1.0 (fun () ->
+          P.is_pgid_alive ~pgid:h.pgid)
       in
+      check bool "pgroup reaches alive state" true alive;
+      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:0.5;
+      let status = ref None in
+      let exited =
+        wait_until ~timeout_s:2.0 (fun () ->
+          match waitpid_nohang h.pid with
+          | Some s -> status := Some s; true
+          | None -> false)
+      in
+      check bool "child exited after escalation" true exited;
+      let dead = not (P.is_pgid_alive ~pgid:h.pgid) in
       check bool "SIGKILL reached stubborn child" true dead;
-      ignore (Unix.waitpid [] h.pid);
       Unix.close h.stdout_fd; Unix.close h.stderr_fd
 
 (* TODO (Tick 7): grandchild reach test.  A naive

--- a/test/test_process_eio_detached.ml
+++ b/test/test_process_eio_detached.ml
@@ -1,0 +1,173 @@
+(* Tick 5: integration tests for [Process_eio.spawn_detached] and
+   [tree_kill]. These spawn real child processes so they stay under
+   [`Quick] time budget by using tiny payloads. *)
+
+open Alcotest
+module P = Process_eio
+
+let read_all_fd fd =
+  let buf = Buffer.create 256 in
+  let chunk = Bytes.create 4096 in
+  let rec loop () =
+    match Unix.read fd chunk 0 (Bytes.length chunk) with
+    | 0 -> ()
+    | n -> Buffer.add_subbytes buf chunk 0 n; loop ()
+    | exception Unix.Unix_error ((Unix.EINTR | Unix.EAGAIN), _, _) -> loop ()
+    | exception Unix.Unix_error (_, _, _) -> ()
+  in
+  loop ();
+  Buffer.contents buf
+
+let waitpid_nohang pid =
+  match Unix.waitpid [ Unix.WNOHANG ] pid with
+  | 0, _ -> None
+  | _, status -> Some status
+  | exception Unix.Unix_error (Unix.ECHILD, _, _) -> Some (Unix.WEXITED 0)
+
+let wait_until ~timeout_s f =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if f () then true
+    else if Unix.gettimeofday () >= deadline then false
+    else (ignore (Unix.select [] [] [] 0.02); loop ())
+  in
+  loop ()
+
+let env_of_current () = Unix.environment ()
+
+let test_echo_roundtrip () =
+  match
+    P.spawn_detached
+      ~argv:[ "/bin/echo"; "legendary-bash" ]
+      ~env:(env_of_current ())
+      ~cwd:""
+  with
+  | Error e -> failf "spawn_detached failed: %s" e
+  | Ok h ->
+      (* Wait for the child to exit before reading — echo is tiny. *)
+      let exited =
+        wait_until ~timeout_s:2.0 (fun () ->
+          match waitpid_nohang h.pid with Some _ -> true | None -> false)
+      in
+      check bool "child exited" true exited;
+      let stdout = read_all_fd h.stdout_fd in
+      let stderr = read_all_fd h.stderr_fd in
+      Unix.close h.stdout_fd;
+      Unix.close h.stderr_fd;
+      check string "stdout captured" "legendary-bash\n" stdout;
+      check string "stderr empty" "" stderr
+
+let test_pgid_equals_pid () =
+  match
+    P.spawn_detached ~argv:[ "/bin/sleep"; "2" ]
+      ~env:(env_of_current ()) ~cwd:""
+  with
+  | Error e -> failf "spawn failed: %s" e
+  | Ok h ->
+      check int "pgid equals pid" h.pid h.pgid;
+      (* There is a fork/setsid race — the parent may observe the
+         pgid before the child has finished establishing its own
+         session.  Poll briefly so the test is deterministic. *)
+      let alive_within =
+        wait_until ~timeout_s:1.0 (fun () ->
+          P.is_pgid_alive ~pgid:h.pgid)
+      in
+      check bool "pgroup reaches alive state" true alive_within;
+      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:1.0;
+      ignore (Unix.waitpid [] h.pid);
+      Unix.close h.stdout_fd; Unix.close h.stderr_fd
+
+let test_tree_kill_sigterm () =
+  match
+    P.spawn_detached ~argv:[ "/bin/sleep"; "30" ]
+      ~env:(env_of_current ()) ~cwd:""
+  with
+  | Error e -> failf "spawn failed: %s" e
+  | Ok h ->
+      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:2.0;
+      let dead =
+        wait_until ~timeout_s:3.0 (fun () ->
+          not (P.is_pgid_alive ~pgid:h.pgid))
+      in
+      check bool "pgroup dead after tree_kill" true dead;
+      ignore (Unix.waitpid [] h.pid);
+      Unix.close h.stdout_fd; Unix.close h.stderr_fd
+
+let test_tree_kill_escalates_to_sigkill () =
+  (* A shell that traps SIGTERM and refuses to die. Parent sends
+     SIGTERM, grace expires, tree_kill must escalate to SIGKILL. *)
+  let script = "trap '' TERM; sleep 30" in
+  match
+    P.spawn_detached
+      ~argv:[ "/bin/sh"; "-c"; script ]
+      ~env:(env_of_current ()) ~cwd:""
+  with
+  | Error e -> failf "spawn failed: %s" e
+  | Ok h ->
+      P.tree_kill ~pgid:h.pgid ~signal:Sys.sigterm ~grace_sec:0.5;
+      let dead =
+        wait_until ~timeout_s:2.0 (fun () ->
+          not (P.is_pgid_alive ~pgid:h.pgid))
+      in
+      check bool "SIGKILL reached stubborn child" true dead;
+      ignore (Unix.waitpid [] h.pid);
+      Unix.close h.stdout_fd; Unix.close h.stderr_fd
+
+(* TODO (Tick 7): grandchild reach test.  A naive
+   [sh -c 'sleep 30 & wait'] keeps the shell as a zombie after
+   SIGTERM, and [kill(-pgid, 0)] on macOS returns 0 on zombie
+   pgroups, which makes [is_pgid_alive] report the group "alive"
+   indefinitely until someone waitpid's the leader.  Tick 7 will
+   introduce a dedicated waitpid reaper inside [Bg_task] which
+   resolves this naturally; for Tick 5, the primitive layer has
+   been validated via the single-process SIGTERM and SIGKILL cases
+   above. *)
+
+let test_empty_argv_rejected () =
+  match P.spawn_detached ~argv:[] ~env:(env_of_current ()) ~cwd:"" with
+  | Error msg ->
+      check bool "error mentions empty" true
+        (let lower = String.lowercase_ascii msg in
+         let re = Str.regexp_string "empty" in
+         (try let _ = Str.search_forward re lower 0 in true
+          with Not_found -> false))
+  | Ok _ -> fail "empty argv must not spawn"
+
+let test_missing_binary_reports_error () =
+  (* We can't easily distinguish "fork failed" vs "child exec failed"
+     here because exec errors manifest as exit 127 inside the child.
+     This test just verifies spawn_detached returns a handle — the
+     exec failure surfaces later via waitpid. *)
+  match
+    P.spawn_detached
+      ~argv:[ "/no/such/tool/for/test_legendary_bash" ]
+      ~env:(env_of_current ()) ~cwd:""
+  with
+  | Error _ -> () (* Some systems may reject at fork time *)
+  | Ok h ->
+      let exited =
+        wait_until ~timeout_s:1.0 (fun () ->
+          match waitpid_nohang h.pid with Some _ -> true | None -> false)
+      in
+      check bool "child exited" true exited;
+      Unix.close h.stdout_fd; Unix.close h.stderr_fd
+
+let () =
+  run "process_eio_detached"
+    [
+      ( "spawn_detached",
+        [
+          test_case "echo roundtrip" `Quick test_echo_roundtrip;
+          test_case "pgid equals pid" `Quick test_pgid_equals_pid;
+          test_case "empty argv rejected" `Quick test_empty_argv_rejected;
+          test_case "missing binary handled" `Quick
+            test_missing_binary_reports_error;
+        ] );
+      ( "tree_kill",
+        [
+          test_case "SIGTERM kills pgroup" `Quick test_tree_kill_sigterm;
+          test_case "SIGKILL escalation after grace" `Quick
+            test_tree_kill_escalates_to_sigkill;
+          (* grandchild coverage deferred to Tick 7 — see module-level TODO. *)
+        ] );
+    ]

--- a/test/test_shadow_parse.ml
+++ b/test/test_shadow_parse.ml
@@ -1,0 +1,68 @@
+(* Tick 12 (P5 reduced): shadow AST parse observation.
+
+   These tests pin the tag taxonomy that telemetry will histogram
+   during the prod-observation window before the regex allowlist is
+   actually replaced.  They do NOT assert any behavioural gate —
+   the legacy regex is still the authoritative path. *)
+
+open Alcotest
+
+let tag cmd = Masc_mcp.Worker_dev_tools.shadow_parse_outcome cmd
+
+let test_simple_ls_parses () =
+  check string "plain ls is parsed_simple"
+    "parsed_simple" (tag "ls")
+
+let test_simple_bin_with_arg_parses () =
+  check string "ls -l is parsed_simple"
+    "parsed_simple" (tag "ls -l")
+
+let test_empty_command_is_parse_error () =
+  (* An empty string does not match the grammar start symbol, so the
+     parser surfaces it as Parse_error.  Regex allowlist would reject
+     it earlier, but telemetry still captures the outcome. *)
+  match tag "" with
+  | "parse_error" -> ()
+  | other -> fail ("expected parse_error, got " ^ other)
+
+let is_non_simple_tag t =
+  t = "parse_error"
+  || String.starts_with ~prefix:"too_complex" t
+  || String.starts_with ~prefix:"parse_aborted" t
+
+let test_shell_chain_marks_unsupported () =
+  (* `a && b` is definitely not simple-command.  The parser either
+     surfaces Parse_error or Too_complex:* — both are valid signals
+     that the string falls outside the current AST gate's coverage.
+     We accept either tag so the test does not fight parser-coverage
+     upgrades (A1-PR-N) that may reclassify constructs. *)
+  let t = tag "ls && rm -rf /" in
+  if not (is_non_simple_tag t) then fail ("unexpected tag: " ^ t)
+
+let test_pipe_marks_unsupported () =
+  let t = tag "ls | wc -l" in
+  if not (is_non_simple_tag t) then fail ("unexpected tag: " ^ t)
+
+let test_cross_check_pairs_legacy_and_shadow () =
+  let legacy_ok = Ok () in
+  let legacy, shadow =
+    Masc_mcp.Worker_dev_tools.cross_check_command ~legacy:legacy_ok "ls"
+  in
+  (match legacy with Ok () -> () | Error _ -> fail "legacy preserved");
+  check string "shadow=parsed_simple" "parsed_simple" shadow
+
+let () =
+  run "shadow_parse" [
+    ("tagging", [
+      test_case "simple ls" `Quick test_simple_ls_parses;
+      test_case "simple bin with arg" `Quick test_simple_bin_with_arg_parses;
+      test_case "empty command tag" `Quick test_empty_command_is_parse_error;
+      test_case "shell chain unsupported" `Quick
+        test_shell_chain_marks_unsupported;
+      test_case "pipe unsupported" `Quick test_pipe_marks_unsupported;
+    ]);
+    ("cross_check", [
+      test_case "cross_check preserves legacy result" `Quick
+        test_cross_check_pairs_legacy_and_shadow;
+    ]);
+  ]

--- a/test/test_shadow_parse.ml
+++ b/test/test_shadow_parse.ml
@@ -39,9 +39,8 @@ let test_shell_chain_marks_unsupported () =
   let t = tag "ls && rm -rf /" in
   if not (is_non_simple_tag t) then fail ("unexpected tag: " ^ t)
 
-let test_pipe_marks_unsupported () =
-  let t = tag "ls | wc -l" in
-  if not (is_non_simple_tag t) then fail ("unexpected tag: " ^ t)
+let test_pipe_parses () =
+  check string "pipe is parsed_simple" "parsed_simple" (tag "ls | wc -l")
 
 let test_cross_check_pairs_legacy_and_shadow () =
   let legacy_ok = Ok () in
@@ -59,7 +58,7 @@ let () =
       test_case "empty command tag" `Quick test_empty_command_is_parse_error;
       test_case "shell chain unsupported" `Quick
         test_shell_chain_marks_unsupported;
-      test_case "pipe unsupported" `Quick test_pipe_marks_unsupported;
+      test_case "pipe parses" `Quick test_pipe_parses;
     ]);
     ("cross_check", [
       test_case "cross_check preserves legacy result" `Quick


### PR DESCRIPTION
## Summary

End-to-end rework of `keeper_bash` across six coordinated phases, elevating the shell exec path from a regex-gated `run_argv_with_status` to a typed, background-capable, verifier-aware surface modelled after claude-code's `BashTool` semantics and the OpenAI Codex harness-engineering themes (tool verifiability, stateful environment, scaffolding over model). Every phase is flag-gated and additive — default JSON shape unchanged.

Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`

## Phases landed

| Phase | Outcome | Flag | Backing module |
|---|---|---|---|
| P1 | Typed `semantic_exit` (9-arm variant) | `MASC_BASH_SEMANTIC_EXIT` | `lib/exec/exec_semantic.ml` |
| P2 | `Bg_task` lifecycle + `keeper_bash_output` / `keeper_bash_kill` | always on | `lib/process/bg_task.ml` |
| P3 | Head+tail byte cap (500 KB + 500 KB) with overlap-aware drop counter | `MASC_BASH_OUTPUT_CAP` (+ `CAP_HEAD` / `CAP_TAIL`) | `lib/exec/exec_buffer.ml` |
| P4 | Auto-background race on `MASC_BLOCKING_BUDGET_MS` (default 15 s) | `MASC_BASH_AUTO_BG` | `lib/exec/exec_run.ml` |
| P5 | AST shadow gate + legacy↔shadow diff harness + flip covenant | `MASC_BASH_AST_ONLY` (flip-gate) | `lib/worker_dev_tools.ml` |
| P6 | `Cdal_judge.verifiable_markers` for verifier cascade consumption | `MASC_BASH_VERIFIABLE_MARKERS` | `lib/cdal_judge.ml` |

Full flag matrix: `docs/ENV-CONTRACT.md §4`.

## Product impact

- **Agents get a legendary weapon.** Long-running commands no longer block the agent loop: `{promoted: true, background_task_id, partial_output, ...}` is returned when a shell outruns the blocking budget, and the LLM resumes polling via `keeper_bash_output`. Tree-kill via pgid is always available.
- **Verifier cascade can stop regex-scraping.** `Test_pass {count}` / `Build_ok` / `Git_clean` / `Lint_clean` carry `Exact | Heuristic` confidence, directly consumable by #7598's cdal_verdict pipeline.
- **Safety covenant is machine-enforced.** The flip covenant test (`test_gate_diff.ml`) guarantees no `Eval_gate.destructive_patterns` entry can slip into `Legacy_deny_shadow_allow` — AST gate flip cannot silently regress destructive blocking.
- **Zero-regression rollout.** Every new field is flag-gated; default shape is byte-identical to pre-PR output.

## Evidence

- **Tests added (all green local):**
  - `lib/exec/test/test_exec_semantic.ml` — 13 cases, semantic classification
  - `lib/exec/test/test_exec_buffer.ml` — 8 cases, head+tail accumulator
  - `lib/exec/test/test_exec_run.ml` — 3 cases, foreground/bg race
  - `lib/exec/test/test_exec_run_json.ml` — key-set pinning for `Promoted` payload
  - `test/test_bg_task_stub.ml` — 7 cases, Bg_task spawn/read/kill + orphan reaper
  - `test/test_process_eio_detached.ml` — pgid tree-kill integration
  - `test/test_exec_core.ml` — 6 cases, `semantic_exit` + `output_cap` JSON integration
  - `test/test_shadow_parse.ml` — 6 cases, shadow AST parse observation
  - `test/test_destructive_class.ml` — 7 cases, 19-pattern covenant
  - `test/test_gate_diff.ml` — 8 cases, legacy↔shadow diff + flip covenant
  - `test/test_cdal_verifiable_markers.ml` — 11 cases, marker emission
- **Contract pins:** JSON key-sets for `Promoted` outcome and `verifiable_markers` emission are alcotest-pinned; removing any field fails the suite.
- **Covenant gate:** `test_all_eval_gate_patterns_are_agree_or_shadow_cannot_parse` iterates every destructive pattern; a 20th entry added to `Eval_gate` without a `Worker_dev_tools` classifier mapping fails CI.

## Review evidence

- Self-review across 18 commits (P1 through P6 + comment-syntax fix + docs sweep).
- Structural review confirmed no cross-repo API breakage: `Exec_run`, `Exec_semantic`, `Bg_task`, `Cdal_judge.verifiable_marker` are new exports; existing `process_result_json` remains signature-compatible (`?semantic` argument is optional and defaults to off).
- Comment-syntax bug in `worker_dev_tools.ml` caught by CI Lint (line 1655 `*)` premature close) and fixed in commit `55220af94`.
- External model review (CodeRabbit / cross-agent) not yet requested on this PR.

## Linked issue

Refs #7598 — verification contract infrastructure (cdal_judge / AwaitingVerification) that P6 plugs into.
Refs #8652 — umbrella Legendary Bash initiative (plan file tracked under `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`).

## Rollout plan

1. Merge with all flags off (current state).
2. Enable flags incrementally in operator-controlled keepers for prod soak.
3. After N=1000 traces on P5 show zero `Legacy_deny_shadow_allow` diff, flip `MASC_BASH_AST_ONLY` default.
4. Once `MASC_BASH_AUTO_BG` soaks, consider defaulting it on after collecting `promoted` rate data.

## Not in this PR

- `MASC_BASH_AST_ONLY` default flip (requires prod observation).
- `MASC_BASH_AUTO_BG` default flip (plan decision point 3: opt-in only for now).
- Streaming sink for `Exec_buffer` integration into `spawn_and_drain_both` (Tick 8 deferred).
- Upstream `keeper_bash_output` parity review (polling cadence tuning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
