### PR TITLE
fix(anti_rationalization): empty evaluator response -> approve by liveness (#8688)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -448,6 +448,16 @@ let review
            Log.Task.info "[anti-rationalization] verdict via text fallback";
            (match parse_verdict text with
             | Ok v -> (v, Llm_text_fallback, None)
+            | Error "empty review output" ->
+              (* An evaluator that returns empty text is not producing
+                 unknown-format output (ADR D3 target); it is producing
+                 no signal, indistinguishable from an unavailable
+                 evaluator. Approve by liveness — same policy as the
+                 [Error err] branch below — instead of blaming the
+                 completing keeper for an evaluator-side gap. Observed
+                 35 rejects in 2 days (#8688, ~/me/.masc/tool_calls). *)
+              Log.Task.warn "[anti-rationalization] evaluator returned empty text (approving by liveness)";
+              ( Approve, Fallback, Some "evaluator returned empty response" )
             | Error parse_err ->
               (* ADR D3: parse failure is NOT silently approved.
                  Use Reject instead of Approve for unknown format. *)

--- a/test/dune
+++ b/test/dune
@@ -648,6 +648,15 @@
  (name test_tool_task_completion_example)
  (modules test_tool_task_completion_example)
  (libraries masc_test_deps))
+
+; Precondition pin: parse_verdict "" must return exactly
+; Error "empty review output" so the liveness-approve branch in
+; Anti_rationalization.review keeps matching (#8688).
+(test
+ (name test_anti_rationalization_empty_liveness)
+ (modules test_anti_rationalization_empty_liveness)
+ (libraries masc_test_deps))
+
 (test
  (name test_cascade_health_tracker)
  (modules test_cascade_health_tracker)

--- a/test/test_anti_rationalization_empty_liveness.ml
+++ b/test/test_anti_rationalization_empty_liveness.ml
@@ -1,0 +1,46 @@
+(** Ratchet: [Anti_rationalization.review] treats an empty evaluator
+    response as "evaluator unavailable" (approve by liveness) rather
+    than rejecting the completing keeper.
+
+    35 rejections in 2 days on 2026-04-17/18 (#8688,
+    ~/me/.masc/tool_calls) surfaced where the evaluator returned an
+    empty text block; the gate rejected the keeper with
+    "review format unrecognized: empty review output" even though
+    the keeper had no role in the evaluator's failure.
+
+    This test pins the precondition — [parse_verdict ""] MUST return
+    exactly [Error "empty review output"] — so the matcher branch in
+    [review] continues to trigger the liveness-approve path. If
+    [parse_verdict] starts returning a different error string for
+    empty input, the branch silently falls through to [Format_reject]
+    again and this assertion surfaces the regression. *)
+
+module AR = Masc_mcp.Anti_rationalization
+
+let test_empty_verdict_emits_canonical_error () =
+  match AR.parse_verdict "" with
+  | Error msg ->
+      Alcotest.(check string)
+        "empty text gives canonical 'empty review output' error"
+        "empty review output" msg
+  | Ok _ ->
+      Alcotest.fail "parse_verdict \"\" should return Error"
+
+let test_whitespace_only_verdict_also_empty () =
+  match AR.parse_verdict "   \n\t  " with
+  | Error msg ->
+      Alcotest.(check string)
+        "whitespace-only text trims to empty"
+        "empty review output" msg
+  | Ok _ ->
+      Alcotest.fail "parse_verdict of whitespace should return Error"
+
+let () =
+  Alcotest.run "anti_rationalization_empty_liveness" [
+    ("parse_verdict empty precondition",
+     [ Alcotest.test_case "exactly empty" `Quick
+         test_empty_verdict_emits_canonical_error
+     ; Alcotest.test_case "whitespace-only" `Quick
+         test_whitespace_only_verdict_also_empty
+     ])
+  ]


### PR DESCRIPTION
## Context

Triage in #8688 (`~/me/.masc/tool_calls/2026-04/{17,18}.jsonl`) logged
**35 completion rejects in 2 days** with the literal text
`"review format unrecognized: empty review output"`. The completing
keeper had no role in the failure — the evaluator LLM returned an
empty text block, and the gate treated that identically to "malformed
verdict".

Those two are semantically different:

- **Malformed verdict** (ADR D3 target) — garbage JSON or prose that
  does not parse. Must NOT silently approve. Keeps format-reject.
- **Empty response** — evaluator produced no signal at all, same
  observational shape as the LLM being unavailable.

The `Error err` branch just below already approves by liveness for
the unavailable case. This PR routes `Error "empty review output"` to
the same emission.

## Change

- New pattern arm in `lib/anti_rationalization.ml` for
  `Error "empty review output"` →
  `(Approve, Fallback, Some "evaluator returned empty response")`.
- `Format_reject` path stays identical for every other parse error.
- New `test_anti_rationalization_empty_liveness` pins the
  parser's empty-input contract (`parse_verdict ""` and whitespace-
  only input must return exactly `Error "empty review output"`) so a
  future change to the parser message cannot silently bypass the new
  match arm.

## Why it should land

- 35/2d false positives on completing keepers, converted to liveness
  approval with an explicit `fallback_reason` so audit logs still
  trace the path.
- No behaviour change for parsed verdicts (Approve/Reject) or
  genuinely malformed format.
- Touches only `lib/anti_rationalization.ml`, so the TLA+ path filter
  (`specs/|lib/keeper/|lib/oas_*.ml|Makefile`) does not fire — avoids
  the main-branch TLA+ regression that currently blocks keeper-
  touching PRs.

## Tests

```
$ dune test --root . test/test_anti_rationalization_empty_liveness.exe
  [OK]  exactly empty
  [OK]  whitespace-only
```

Full `dune build @install` green.

Closes a piece of #8688.
