### PR TITLE
ci(tla): skip KeeperStateMachine to unblock PR queue (#8710)

### DIFF
--- a/specs/Makefile
+++ b/specs/Makefile
@@ -31,7 +31,11 @@ endif
 # Specs with known failures (parsing/evaluation errors under CI tla2tools).
 # Remove from this list as specs are fixed. Each entry is a basename (no .cfg).
 # KeeperWorkPipeline: clean spec violates invariant (exit 13) — model needs fix, not path issue.
-KNOWN_FAILURES ?= KeeperTraceSpec KeeperOASBridge KeeperWorkPipeline
+# KeeperStateMachine: CompactionClearsOverflow invariant contradicts CompactionFailed
+# action (Failed deliberately preserves context_overflow for retry). Tracked in #8710;
+# proper fix requires discriminating CompactionCompleted vs CompactionFailed in the
+# invariant. Temporary skip unblocks PR queue (30+ PRs inheriting this fail).
+KNOWN_FAILURES ?= KeeperTraceSpec KeeperOASBridge KeeperWorkPipeline KeeperStateMachine
 
 # Buggy specs whose current invariant/model is documented as non-violating.
 # Remove from this list once the buggy cfg asserts a stronger property.


### PR DESCRIPTION
## Summary

Add \`KeeperStateMachine\` to \`specs/Makefile\` \`KNOWN_FAILURES\` list as a temporary unblock. 30+ MERGEABLE PRs currently inherit this required-check failure even though they do not touch \`specs/\`.

## Issues

- Unblocks: #8710 (KeeperStateMachine TLA model check fails in PR sweep)
- Tracks proper fix: #8710 remains open with design discussion

## Changes

- \`specs/Makefile\`: add \`KeeperStateMachine\` to \`KNOWN_FAILURES\` with comment explaining the root cause and pointer to #8710.

## Tests

- Root cause already confirmed by local TLC repro (see #8710 comment 2): \`CompactionClearsOverflow\` invariant violated by \`CompactionFailed\` action's deliberate context_overflow preservation.
- CI should now pass \`TLA+ Model Checking\` step (the spec is marked SKIP rather than CHECK).
- No functional/runtime change — only a CI configuration workaround.

## Risk

- **Temporary regression coverage gap** for KeeperStateMachine until #8710 is fixed. Other 10+ specs (including KeeperOASAdvanced, KeeperReconcileLiveness, KeeperSocialModelMagenticLedger, KeeperTurnCycle) remain CHECK-ed.
- Pattern already established by three existing entries (\`KeeperTraceSpec\`, \`KeeperOASBridge\`, \`KeeperWorkPipeline\`).

Closes: the queue block, not the spec bug. #8710 stays OPEN until proper invariant narrowing lands.