### PR TITLE
fix(http_server_eio): log + report loopback fallback on invalid host (#8725)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -622,14 +622,29 @@ let error_handler _client_addr ?request:_ error start_response =
 let run ~sw ~net ~clock config routes =
   Discovery_cache.set_env ~sw ~net;
   let request_handler = make_request_handler routes in
-  (* Parse IP address using Ipaddr library then convert to Eio format *)
-  let ip = match Ipaddr.of_string config.host with
-    | Ok addr -> Eio.Net.Ipaddr.of_raw (Ipaddr.to_octets addr)
-    | Error _ -> Eio.Net.Ipaddr.V4.loopback (* fallback to 127.0.0.1 *)
+  let fallback_host = Masc_network_defaults.masc_http_default_host in
+  (* Parse IP address using Ipaddr library then convert to Eio format.
+     Issue #8725: log + report the effective bind host on parse failure
+     so a typo in [config.host] does not silently degrade to loopback
+     while the startup banner still claims the misconfigured value. *)
+  let ip, effective_host =
+    match Ipaddr.of_string config.host with
+    | Ok addr -> Eio.Net.Ipaddr.of_raw (Ipaddr.to_octets addr), config.host
+    | Error (`Msg msg) ->
+        Log.Http.warn
+          "http_server_eio: invalid host %S (%s) → loopback %s fallback (#8725)"
+          config.host msg fallback_host;
+        Eio.Net.Ipaddr.V4.loopback, fallback_host
   in
   let addr = `Tcp (ip, config.port) in
   let socket = Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:config.max_connections addr in
-  Printf.printf "🚀 MASC MCP Server listening on http://%s:%d\n" config.host config.port;
+  if String.equal effective_host config.host then
+    Printf.printf "🚀 MASC MCP Server listening on http://%s:%d\n"
+      effective_host config.port
+  else
+    Printf.printf
+      "🚀 MASC MCP Server listening on http://%s:%d (configured=%s, parse failed → loopback)\n"
+      effective_host config.port config.host;
   Printf.printf "   Graceful shutdown: SIGTERM/SIGINT supported\n%!";
 
   let initial_backoff_s = 0.05 in


### PR DESCRIPTION
## Summary

`config.host` parse 실패 시 silent loopback fallback + banner는 원본 host 출력 → 운영자에게 거짓 보고. 보안적으론 fail-secure지만 운영 misleading.

## Fix (Option B)

1. `effective_host` 추적 — parse 실패 시 `Log.Http.warn` + `"127.0.0.1"` 사용
2. Banner는 `effective_host` 출력. parse 실패 시 `(configured=<원본>, parse failed → loopback)` 추가 표시

Fail-secure 동작 보존, observability만 개선.

## Test plan

- [x] `dune build lib/` green
- [ ] CI quick-suite green
- [ ] manual: invalid host로 기동 시 banner와 로그 정확성 확인

Closes #8725