### PR TITLE
[M-W1.2] attribution.ml: stdlib Result.Syntax 전환 파일럿

### DIFF
--- a/lib/attribution.ml
+++ b/lib/attribution.ml
@@ -62,7 +62,7 @@ let to_yojson (t : t) : Yojson.Safe.t =
 
 (* --- Parsing --- *)
 
-let ( let* ) = Result.bind
+open Result.Syntax
 
 let require_field fields key =
   match List.assoc_opt key fields with


### PR DESCRIPTION
Part of OCaml Best-of-Best North-Star — Wave 1 파일럿.

## Context
Epic: jeong-sik/me#1022 · Milestone W1: jeong-sik/me#1023

북극성 문서 K-02 (Result.Syntax) 파일럿. `lib/attribution.ml:65`의 수제 `let ( let* ) = Result.bind`를 stdlib `Result.Syntax`(OCaml 4.14+, 5.4에서 기본 탑재)로 교체.

## Diff
```
- let ( let* ) = Result.bind
+ open Result.Syntax
```

파일당 1줄 변경. 동작 의미 동등 (`Result.Syntax.( let* )` = `Result.bind`, 추가로 `let+`도 사용 가능).

## Metric 영향

| Metric | 이전 | 이후 | 변동 |
|--------|------|------|------|
| 수제 `let ( let* ) = Result.bind` 파일 수 | 10 | 9 | -1 |
| 파일 사용 `Result.Syntax` | 0 | 1 | +1 |
| `open Result.Syntax` 도입 | 0 | 1 | +1 |

## 근거
- **Stream D Key-D-04**: `Result.Syntax`는 OCaml 5.4 stdlib 기본. 수제 `let*` 대체 가능
- **Stream C Key-C-06**: `ppx_let`은 ROI 음수, `Result.Syntax`가 우월한 대안

출처: `~/me/.worktrees/research/ocaml-north-star-iter0/knowledge/research/2026-04-19-ocaml-best-of-best-north-star.md` (Section 2.3 K-02)

## Anti-goal 자가 체크
- [x] 추상화 남용 금지 — 추상화 제거(수제 → stdlib)
- [x] 카고 컬팅 금지 — 이미 같은 repo에 `lib/core/result_syntax.ml`이 있고 stdlib으로 일관화
- [x] Hype 금지 — 측정 가능 metric만
- [x] 전면 refactor 금지 — 1 파일, 1줄
- [x] main 수정 금지 — worktree + Draft
- [x] 학술적 완벽주의 금지 — 파일럿
- [x] 근거 날조 금지 — Stream D/C 실제 출처

## Test plan
- [ ] CI green (dune build + tests)
- [ ] `rg 'Result.Syntax' lib/attribution.ml` = 1
- [ ] attribution.ml 동작 회귀 없음 (test/test_attribution* 존재 시 통과)

## Follow-up (merge 후)
- 동일 패턴 9 파일 반복 적용 (M-W1.2 나머지): autoresearch_serde, tool_args(let*! 유지), tool_agent, cdal_loader, result_syntax.ml(stdlib re-export로), worker_runtime_helper_protocol, cdal_types, local/worker_container_runners