### PR TITLE
fix(keeper_exec_status): strict keeper_health_of_string_opt + warn (#8670)

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -38,15 +38,28 @@ let keeper_health_to_string = function
   | KH_zombie -> "zombie"
   | KH_dead -> "dead"
 
-let keeper_health_of_string = function
-  | "healthy" -> KH_healthy
-  | "idle" -> KH_idle
-  | "offline" -> KH_offline
-  | "stale" -> KH_stale
-  | "degraded" -> KH_degraded
-  | "zombie" -> KH_zombie
-  | "dead" -> KH_dead
-  | _ -> KH_offline
+(** Strict parser. Returns [None] on unknown wire so callers can route
+    explicitly (drop / fallback / route). See #8670 / #8605. *)
+let keeper_health_of_string_opt = function
+  | "healthy" -> Some KH_healthy
+  | "idle" -> Some KH_idle
+  | "offline" -> Some KH_offline
+  | "stale" -> Some KH_stale
+  | "degraded" -> Some KH_degraded
+  | "zombie" -> Some KH_zombie
+  | "dead" -> Some KH_dead
+  | _ -> None
+
+(** Back-compat wrapper: unknown wire still falls back to [KH_offline] but a
+    [Log.Keeper.warn] is emitted so producer/consumer drift surfaces in
+    operator logs instead of silently misreporting a live keeper as offline. *)
+let keeper_health_of_string s =
+  match keeper_health_of_string_opt s with
+  | Some v -> v
+  | None ->
+      Log.Keeper.warn
+        "keeper_health: unknown wire %S -> KH_offline (drift; see #8670)" s;
+      KH_offline
 
 let keeper_continuity_to_string = function
   | Continuity_healthy -> "healthy"

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -26,7 +26,12 @@ val augment_keeper_diagnostic_json :
   Yojson.Safe.t
 
 val keeper_health_to_string : keeper_health -> string
+
+val keeper_health_of_string_opt : string -> keeper_health option
+(** Strict: [None] on unknown wire (see #8670 / #8605). *)
+
 val keeper_health_of_string : string -> keeper_health
+(** Back-compat: unknown -> [KH_offline] with [Log.Keeper.warn] so drift surfaces. *)
 val keeper_continuity_to_string : keeper_continuity -> string
 
 val keeper_health_state :


### PR DESCRIPTION
## Summary

Close #8670. Apply standardized #8605-class fix: silent permissive default → strict `_opt` + back-compat wrapper with `Log.Keeper.warn`.

| | Before | After |
|--|--|--|
| Unknown wire (`"healty"`, future variant `"compacting"`) | silently → `KH_offline` (operator reads "dead") | `_opt`: `None` / wrapper: `KH_offline` + warn |
| Drift visibility | none — live keeper appears offline silently | warn surfaces in operator logs |
| Public API | `_of_string` only | `_of_string_opt` (strict) + back-compat wrapper |

## Why this matters

`KH_offline` is the **most damaging fallback** for this enum: a healthy keeper that hits this path looks dead on the dashboard with zero log trace. False-negative health → operator either ignores a real outage signal (alert fatigue) or restarts a healthy keeper (churn).

## Pattern alignment

Same fix shape as PR #8689 / #8692 / #8706 / #8736.

## Test plan
- [x] `dune build` green
- [x] 4 callers verified (`operator_control_snapshot.ml:94`, `keeper_exec_status.ml:449/485`) — back-compat wrapper preserves all behaviour
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)