### PR TITLE
fix(oas_sse_bridge): drop string roundtrip in For_testing.of_stage (#8677)

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -547,11 +547,13 @@ module For_testing = struct
       attempts = pending.attempts;
       appended = pending.appended; }
 
-  let of_stage (stage : bridge_relay_stage) =
-    match relay_stage_to_string stage with
-    | "append" -> Append
-    | "broadcast" -> Broadcast
-    | _ -> Broadcast
+  (* Direct match between outer and For_testing variants — no string roundtrip,
+     no permissive default. If a third constructor is added to the outer
+     [relay_stage], OCaml exhaustiveness check fires here so the test mirror
+     stays in sync with the runtime variant. See #8677 / #8605. *)
+  let of_stage : bridge_relay_stage -> relay_stage = function
+    | Append -> Append
+    | Broadcast -> Broadcast
 
   let of_result (result : bridge_relay_result) =
     match result with


### PR DESCRIPTION
## Summary

Close #8677. Apply standardized #8605-class fix using the **exhaustive-match template** (both types are internal to the same module — type-stable, no external producer drift to absorb).

| | Before | After |
|--|--|--|
| 3rd outer constructor (e.g., `Sidecar`) | silently → `Broadcast` in test mirror | OCaml exhaustiveness fires at compile time |
| Mechanism | string roundtrip + permissive default | direct variant match |
| Test mirror sync | manual / silent drift | enforced by type system |

## Pattern selection

This is the second fix template (vs. wire-string `_opt + warn`):
- **Wire-string parser** (#8689 / #8692 / #8706 / #8736 / #8740): external producer can drift independently → back-compat wrapper + warn.
- **Internal type-stable** (this PR, #8697 / #8700): both sides under our compile graph → exhaustive match converts new constructor into a compile error.

## Surface

- `lib/oas_sse_bridge.ml:550-556` only.
- `For_testing` consumed by `test/test_oas_integration.ml` (21 tests).

## Test plan
- [x] `dune build` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)