### PR TITLE
test(transport): add executable-docs guard for truth harness

### DIFF
--- a/docs/TRANSPORT-PRACTICAL-PLAYBOOK.md
+++ b/docs/TRANSPORT-PRACTICAL-PLAYBOOK.md
@@ -35,8 +35,11 @@ Before changing transport health reporting, run the truth harness:
 ./scripts/harness/transport/verify_truth.sh
 ```
 
-This is an explicit drift harness, not part of `run_all.sh` by default. It
-returns non-zero when reported truth and live probe truth disagree.
+This is the explicit drift harness. It is included in
+`./scripts/harness/transport/run_all.sh` and therefore also runs in the CI
+transport harness suite. Run it directly when iterating on transport truth so
+reported truth vs. live probe drift fails fast without waiting for the full
+suite. It returns non-zero when those surfaces disagree.
 
 It bootstraps an isolated server when needed and compares:
 

--- a/scripts/harness/transport/run_all.sh
+++ b/scripts/harness/transport/run_all.sh
@@ -42,6 +42,7 @@ run_harness "${SCRIPT_DIR}/verify_h2c_autodetect.sh"
 run_harness "${SCRIPT_DIR}/verify_ws.sh"
 run_harness "${SCRIPT_DIR}/verify_webrtc_signaling.sh"
 run_harness "${SCRIPT_DIR}/verify_truth.sh"
+run_harness "${SCRIPT_DIR}/verify_playbook_consistency.sh"
 
 echo ""
 echo "================================================================"

--- a/scripts/harness/transport/verify_playbook_consistency.sh
+++ b/scripts/harness/transport/verify_playbook_consistency.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYBOOK="${SCRIPT_DIR}/../../../docs/TRANSPORT-PRACTICAL-PLAYBOOK.md"
+RUN_ALL="${SCRIPT_DIR}/run_all.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "${PLAYBOOK}" ]] || fail "missing playbook: ${PLAYBOOK}"
+[[ -f "${RUN_ALL}" ]] || fail "missing run_all.sh: ${RUN_ALL}"
+
+grep -Fq 'run_harness "${SCRIPT_DIR}/verify_truth.sh"' "${RUN_ALL}" \
+  || fail "run_all.sh no longer invokes verify_truth.sh"
+
+grep -Fq './scripts/harness/transport/verify_truth.sh' "${PLAYBOOK}" \
+  || fail "playbook no longer documents verify_truth.sh"
+
+grep -Fq '`./scripts/harness/transport/run_all.sh`' "${PLAYBOOK}" \
+  || fail "playbook no longer documents run_all.sh inclusion"
+
+grep -Fq 'CI' "${PLAYBOOK}" \
+  || fail "playbook no longer documents the CI transport harness path"
+
+echo "PASS: transport playbook stays aligned with verify_truth.sh/run_all.sh/CI relationship"


### PR DESCRIPTION
## Status
- `next-slice-exists only`
- follow-up only; not part of task-057 current approve gate
- local guard checks pass, but this PR head has no PR-triggered CI/path evidence yet
- do not read this PR as `guard-valid` or `required-path-safe` until its own CI/path exercise exists

## Current Evidence
- base branch: `task-057-transport-truth-harness` (`9915f1ebd2891e1cb0f3a50af9dfde64572892dc`)
- head branch: `task-057-executable-docs-guard` (`d5865aa72039c3320cc4926b19930c31b1575635`)
- PR-triggered workflow runs on the head commit: `0`
- combined status entries on the head commit: `0`

## Summary
- add `scripts/harness/transport/verify_playbook_consistency.sh`
- run that guard from `scripts/harness/transport/run_all.sh`
- update `docs/TRANSPORT-PRACTICAL-PLAYBOOK.md` so it matches the actual `run_all.sh` behavior

## Scope Boundary
- base branch is `task-057-transport-truth-harness` on purpose
- this is the separate recurrence-prevention slice discussed in the task-057 verification thread
- current task-057 gate stays on PR `#8678` proof 3 (`required-path exercise`) and should not use this PR as approve evidence

## Local Verification Only
- `bash -n scripts/harness/transport/run_all.sh scripts/harness/transport/verify_playbook_consistency.sh`
- `git diff --check -- docs/TRANSPORT-PRACTICAL-PLAYBOOK.md scripts/harness/transport/run_all.sh scripts/harness/transport/verify_playbook_consistency.sh`
- `bash scripts/harness/transport/verify_playbook_consistency.sh`

## What Is Still Missing
- PR-triggered workflow runs on this head
- path-exercise evidence for the changed `run_all.sh` path on this PR
- any claim that this PR is ready to merge or that it proves task-057 approve readiness
