### PR TITLE
fix: auto-sync planning current_task after task transitions

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -78,6 +78,33 @@ let validate_task_id task_id =
   if task_id = "" then Error (Types.TaskNotFound "")
   else Ok task_id
 
+let sync_planning_current_task_with_owned_task (ctx : context) =
+  let actual_name =
+    try Coord.resolve_agent_name ctx.config ctx.agent_name
+    with
+    | Sys_error _ | Yojson.Json_error _ -> ctx.agent_name
+    | exn ->
+        Log.Task.warn "resolve_agent_name failed for %s: %s" ctx.agent_name
+          (Printexc.to_string exn);
+        ctx.agent_name
+  in
+  let matches_you assignee =
+    String.equal assignee ctx.agent_name || String.equal assignee actual_name
+  in
+  let owned_task =
+    Coord.get_tasks_raw ctx.config
+    |> List.find_map (fun (task : Types.task) ->
+           match task.task_status with
+           | Types.Claimed { assignee; _ }
+           | Types.InProgress { assignee; _ }
+           | Types.AwaitingVerification { assignee; _ } ->
+               if matches_you assignee then Some task.id else None
+           | Types.Todo | Types.Done _ | Types.Cancelled _ -> None)
+  in
+  match owned_task with
+  | Some task_id -> Planning_eio.set_current_task ctx.config ~task_id
+  | None -> Planning_eio.clear_current_task ctx.config
+
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_cascade : string option)
@@ -464,7 +491,7 @@ let handle_claim ctx args =
        (match preset_warning with
         | Some warning -> Log.Task.warn "%s (agent=%s)" warning ctx.agent_name
         | None -> ());
-       Planning_eio.set_current_task ctx.config ~task_id;
+       sync_planning_current_task_with_owned_task ctx;
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");
          ("task_id", `String task_id);
@@ -485,8 +512,8 @@ let handle_claim_next ctx _args =
   let task_filter = preset_task_filter ~agent_preset in
   let result = Coord.claim_next_r ctx.config ~agent_name:ctx.agent_name ~task_filter () in
   let message = match result with
-    | Coord.Claim_next_claimed { task_id; message; _ } ->
-        Planning_eio.set_current_task ctx.config ~task_id;
+    | Coord.Claim_next_claimed { message; _ } ->
+        sync_planning_current_task_with_owned_task ctx;
         message
     | Coord.Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
     | Coord.Claim_next_no_eligible { preset_filtered; _ } when preset_filtered > 0 ->
@@ -513,9 +540,14 @@ let handle_release ctx args =
        then
          (false, "Strict task release requires handoff_context.summary")
        else
-         result_to_response
-           (Coord.release_task_r ctx.config ~agent_name:ctx.agent_name ~task_id
-              ?expected_version ?handoff_context ()))
+         let result =
+           Coord.release_task_r ctx.config ~agent_name:ctx.agent_name ~task_id
+             ?expected_version ?handoff_context ()
+         in
+         (match result with
+          | Ok _ -> sync_planning_current_task_with_owned_task ctx
+          | Error _ -> ());
+         result_to_response result)
 
 let transition_known_args =
   [
@@ -562,6 +594,7 @@ and handle_cancel_task ctx args =
   (* Record failed metric on cancellation *)
   (match result with
    | Ok _ ->
+       sync_planning_current_task_with_owned_task ctx;
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));
          agent_id = ctx.agent_name;
@@ -796,6 +829,9 @@ and handle_transition ctx args =
     | None -> None
   in
   let result = try_transition 0 in
+  (match result with
+   | Ok _ -> sync_planning_current_task_with_owned_task ctx
+   | Error _ -> ());
   (* Notify A2A subscribers on successful transition *)
   (match result with
    | Ok _ ->

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -102,12 +102,11 @@ let after_claim_auto_bound ~success =
 let after_transition_claim ~success =
   if success then
     { next_steps =
-        [ s "masc_plan_set_task" "Bind claimed task as your planning current_task";
-          s "masc_worktree_create" "Create an isolated worktree for this task" ];
+        [ s "masc_worktree_create" "Create an isolated worktree for this task";
+          s "masc_heartbeat" "Signal liveness before starting long work" ];
       preconditions = [ project_ready; "joined" ];
       common_mistakes =
-        [ "masc_transition(action=claim) only claims backlog ownership — it does not bind planning current_task";
-          "Forgetting masc_worktree_create — working on main branch directly" ] }
+        [ "Forgetting masc_worktree_create — working on main branch directly" ] }
   else
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
@@ -152,7 +151,7 @@ let after_transition_generic ~success =
           s "masc_workflow_guide" "Inspect the next recommended step for your current state" ];
       preconditions = [ project_ready; "joined" ];
       common_mistakes =
-        [ "masc_transition follow-up depends on action. claim may require masc_plan_set_task, while done/release/cancel do not." ] }
+        [ "masc_transition follow-up depends on action. claim should auto-bind current_task, while done/release/cancel may clear it." ] }
   else
     { next_steps =
         [ s "masc_status" "Check task state before retrying the transition";
@@ -356,7 +355,7 @@ let current_state_guidance ~room_set ~joined ~task_claimed
         [ s "masc_plan_set_task" "Bind your claimed task as current_task" ];
       preconditions = [ project_ready; "joined"; "task_claimed" ];
       common_mistakes =
-        [ "Some claim paths leave planning current_task unset. This commonly happens after masc_transition(action=claim)." ] }
+        [ "Legacy or out-of-band claim paths can leave planning current_task stale. Call masc_plan_set_task to realign." ] }
   else if not worktree_active then
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated git worktree for this task";

--- a/test/dune
+++ b/test/dune
@@ -930,7 +930,9 @@
  (name test_operator_mcp_e2e)
  (modules test_operator_mcp_e2e)
  (libraries masc_test_deps)
- (deps ../bin/main_eio.exe)
+ (deps
+  ../bin/main_eio.exe
+  (source_tree ../config))
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
 
 (test

--- a/test/test_decision_pipeline_observer.ml
+++ b/test/test_decision_pipeline_observer.ml
@@ -38,16 +38,26 @@ let extract_quoted_strings s =
 
 let extract_tla_set ~marker content =
   let marker_len = String.length marker in
+  let is_marker_decl i =
+    if i + marker_len > String.length content then false
+    else if String.sub content i marker_len <> marker then false
+    else
+      let rec skip_ws j =
+        if j < String.length content
+           && (content.[j] = ' ' || content.[j] = '\t')
+        then skip_ws (j + 1)
+        else j
+      in
+      let j = skip_ws (i + marker_len) in
+      j + 2 <= String.length content && String.sub content j 2 = "=="
+  in
   let rec find_marker start =
     if start >= String.length content then None
     else
       match String.index_from_opt content start marker.[0] with
       | None -> None
       | Some i ->
-          if i + marker_len <= String.length content
-             && String.sub content i marker_len = marker
-          then Some i
-          else find_marker (i + 1)
+          if is_marker_decl i then Some i else find_marker (i + 1)
   in
   match find_marker 0 with
   | None -> Alcotest.fail ("missing marker " ^ marker)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -932,7 +932,9 @@ let test_handle_request_tools_call_transition_claim_guidance () =
     Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
   in
   let steps = workflow_next_step_names response in
-  Alcotest.(check bool) "claim guidance includes plan_set_task" true
+  Alcotest.(check (option string)) "claim binds current_task" (Some "task-001")
+    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+  Alcotest.(check bool) "claim guidance omits plan_set_task" false
     (List.mem "masc_plan_set_task" steps);
   cleanup_dir base_path
 

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -348,6 +348,9 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let base_path = Filename.temp_file "operator-mcp-base-" "" in
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
+  let project_root = Masc_test_deps.find_project_root () in
+  let config_dir = Filename.concat project_root "config" in
+  let personas_dir = Filename.concat config_dir "personas" in
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Coord.default_config base_path in
@@ -419,6 +422,8 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
         ("DATABASE_URL", "");
         ("SUPABASE_DB_URL", "");
         ("SB_PG_URL", "");
+        ("MASC_CONFIG_DIR", config_dir);
+        ("MASC_PERSONAS_DIR", personas_dir);
         ("MASC_BOARD_BACKEND", "jsonl");
       ]
   in

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -159,7 +159,7 @@ let () = test "dispatch_removed_named_room_tools" (fun () ->
   assert (Tool_coord.dispatch ctx ~name:"masc_room_enter" ~args = None)
 )
 
-let () = test "dispatch_check_transition_claim_requires_plan_task" (fun () ->
+let () = test "dispatch_check_transition_claim_auto_binds_current_task" (fun () ->
   Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -181,11 +181,7 @@ let () = test "dispatch_check_transition_claim_requires_plan_task" (fun () ->
   | Some (success, result) ->
       assert success;
       let json = Yojson.Safe.from_string result in
-      assert (Yojson.Safe.Util.member "all_passed" json = `Bool false);
-      assert (
-        Yojson.Safe.Util.member "fix_hint" json
-        = `String
-            "Call masc_plan_set_task to choose or re-sync the active task when current_task is unset, stale, or ambiguous")
+      assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
   | None -> failwith "dispatch returned None"
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -793,7 +793,7 @@ let () = test "handle_claim_next_prefers_live_keeper_preset" (fun () ->
   | _ -> failwith ("expected exactly one task: " ^ result)
 )
 
-let () = test "transition_claim_leaves_planning_current_task_unset" (fun () ->
+let () = test "transition_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition claim")]) in
   let (success, _result) =
@@ -801,6 +801,44 @@ let () = test "transition_claim_leaves_planning_current_task_unset" (fun () ->
       (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
   in
   assert success;
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001")
+)
+
+let () = test "transition_release_clears_planning_current_task" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition release")]) in
+  let (success_claim, _result) =
+    Tool_task.handle_transition ctx
+      (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
+  in
+  assert success_claim;
+  let (success_release, _result) =
+    Tool_task.handle_transition ctx
+      (`Assoc [("task_id", `String "task-001"); ("action", `String "release")])
+  in
+  assert success_release;
+  assert (Planning_eio.get_current_task ctx.config = None)
+)
+
+let () = test "transition_done_clears_planning_current_task" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition done")]) in
+  let (success_claim, _result) =
+    Tool_task.handle_transition ctx
+      (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
+  in
+  assert success_claim;
+  let (success_done, result) =
+    Tool_task.handle_transition ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "done");
+          ("notes", `String "Implemented the transport parity checks and verified the result.");
+        ])
+  in
+  assert success_done;
+  assert (not (str_contains result "rejected"));
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -185,7 +185,9 @@ let test_transition_claim_call_guidance () =
       ~args:(`Assoc [ ("action", `String "claim"); ("task_id", `String "task-001") ])
       ~success:true
   in
-  check_has_tool g.next_steps "masc_plan_set_task";
+  check_has_tool g.next_steps "masc_worktree_create";
+  check bool "claim guidance omits plan_set_task" false
+    (List.exists (fun (s : WG.step) -> s.tool = "masc_plan_set_task") g.next_steps);
   check_has_precondition g "project_ready";
   check_lacks_precondition g "room_set"
 


### PR DESCRIPTION
## Summary
- auto-sync planning `current_task` to the owned backlog task after claim/release/cancel/transition success
- update workflow guidance so `masc_transition(action=claim)` reflects the new auto-bind behavior
- add regressions for transition claim/release/done plus `masc_check` integration

## Product impact
- removes a real control-plane drift where backlog ownership and planning `current_task` could disagree after successful task transitions
- makes post-claim guidance match runtime behavior so operators do not cargo-cult `masc_plan_set_task` after `masc_transition(action=claim)`

## Evidence
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-163-owned-current-drift-v3 ./test/test_tool_task_coverage.exe`
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-163-owned-current-drift-v3 ./test/test_tool_coord_coverage.exe`
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-163-owned-current-drift-v3 ./test/test_workflow_guide.exe`
- `git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-163-owned-current-drift-v3 diff --check`

## Review evidence
- task-163 board thread: local patch plus regression packet locked before PR open
- issue #8755 captures the owned/current drift problem statement, reproduction, and intended behavior

## Linked issue
- Refs #8755

## Context
- fixes task-163 owned/current drift where `masc_transition(action=claim)` could leave planning `current_task` stale relative to owned backlog state
