### PR TITLE
[codex] Preserve recent tool window semantics in operator snapshot

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -173,12 +173,87 @@ let recent_messages_json config =
   |> List.map Types.message_to_yojson
   |> fun rows -> `List rows
 
+let merge_tool_name_lists primary secondary =
+  let seen = Hashtbl.create 16 in
+  let add acc raw_name =
+    let name = String.trim raw_name in
+    if name = "" || Hashtbl.mem seen name then acc
+    else (
+      Hashtbl.replace seen name ();
+      name :: acc)
+  in
+  List.rev
+    (List.fold_left add []
+       (List.concat [ primary; secondary ]))
+
+let tool_names_of_recent_json (json : Yojson.Safe.t) =
+  let tools_used =
+    match U.member "tools_used" json with
+    | `List items ->
+        List.filter_map
+          (function
+            | `String value ->
+                let trimmed = String.trim value in
+                if trimmed = "" then None else Some trimmed
+            | _ -> None)
+          items
+    | _ -> []
+  in
+  let single_tool =
+    match U.member "tool" json with
+    | `String value ->
+        let trimmed = String.trim value in
+        if trimmed = "" then [] else [ trimmed ]
+    | _ -> []
+  in
+  merge_tool_name_lists single_tool tools_used
+
+let collect_recent_tool_names ?(limit = 8) (lines : string list) =
+  let ordered = List.rev lines in
+  let rec loop acc remaining = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | line :: rest -> (
+        try
+          let json = Yojson.Safe.from_string line in
+          let tools = tool_names_of_recent_json json in
+          let merged = merge_tool_name_lists (List.rev acc) tools in
+          let capped =
+            if List.length merged <= limit then merged
+            else List.filteri (fun idx _ -> idx < limit) merged
+          in
+          loop (List.rev capped) (limit - List.length capped) rest
+        with Yojson.Json_error _ ->
+          loop acc remaining rest)
+  in
+  loop [] limit ordered
+
+let recent_tool_names_from_files config keeper_name =
+  let decision_lines =
+    let path = Keeper_types.keeper_decision_log_path config keeper_name in
+    if Fs_compat.file_exists path then
+      Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120
+    else []
+  in
+  let metrics_lines =
+    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let dated = Dated_jsonl.read_recent_lines store 120 in
+    if dated <> [] then dated
+    else
+      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120
+  in
+  merge_tool_name_lists
+    (collect_recent_tool_names decision_lines)
+    (collect_recent_tool_names metrics_lines)
+
 let keeper_tool_audit_fields ?(include_allowed_tools = true) config
     (meta : Keeper_types.keeper_meta) =
   let fallback_allowed =
     if include_allowed_tools then Keeper_exec_tools.keeper_allowed_tool_names meta
     else []
   in
+  let recent_tool_names = recent_tool_names_from_files config meta.name in
   let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
   let fallback_snapshot =
     match
@@ -217,6 +292,7 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
   | Some task, Some result ->
       if task.seq > result.seq then
         ( task.allowed_tools,
+          recent_tool_names,
           result.tool_names,
           Some result.tool_call_count,
           fallback_snapshot.latest_action_source,
@@ -224,6 +300,7 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
           Some task.created_at )
       else
         ( task.allowed_tools,
+          merge_tool_name_lists result.tool_names recent_tool_names,
           result.tool_names,
           Some result.tool_call_count,
           fallback_snapshot.latest_action_source,
@@ -231,6 +308,7 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
           Some result.updated_at )
   | Some task, None ->
       ( task.allowed_tools,
+        recent_tool_names,
         [],
         None,
         fallback_snapshot.latest_action_source,
@@ -238,6 +316,7 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
         Some task.created_at )
   | None, Some result ->
       ( fallback_allowed,
+        merge_tool_name_lists result.tool_names recent_tool_names,
         result.tool_names,
         Some result.tool_call_count,
         fallback_snapshot.latest_action_source,
@@ -245,6 +324,7 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
         Some result.updated_at )
   | None, None ->
       ( fallback_allowed,
+        recent_tool_names,
         fallback_snapshot.latest_tool_names,
         fallback_snapshot.latest_tool_call_count,
         fallback_snapshot.latest_action_source,
@@ -359,15 +439,18 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    |> Keeper_exec_status.augment_keeper_diagnostic_json
                         ~meta ~keepalive_running ~keepalive_started_at ~now_ts
                  in
-                 let allowed_tool_names, latest_tool_names, latest_tool_call_count,
-                     latest_action_source, tool_audit_source, tool_audit_at =
+                 let allowed_tool_names, recent_tool_names, latest_tool_names,
+                     latest_tool_call_count, latest_action_source,
+                     tool_audit_source, tool_audit_at =
                    if lightweight then
-                     let _, latest_tool_names, latest_tool_call_count,
-                         latest_action_source, tool_audit_source, tool_audit_at =
+                     let _, recent_tool_names, latest_tool_names,
+                         latest_tool_call_count, latest_action_source,
+                         tool_audit_source, tool_audit_at =
                        keeper_tool_audit_fields ~include_allowed_tools:false
                          config meta
                      in
                      ( [],
+                       recent_tool_names,
                        latest_tool_names,
                        latest_tool_call_count,
                        latest_action_source,
@@ -445,7 +528,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("noop_turn_count", `Int meta.runtime.noop_turn_count);
                        ("allowed_tool_names", `List (List.map (fun value -> `String value) allowed_tool_names));
                        ("latest_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
-                       ("recent_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
+                       ("recent_tool_names", `List (List.map (fun value -> `String value) recent_tool_names));
                        ("latest_tool_call_count", option_to_json (fun value -> `Int value) latest_tool_call_count);
                        ("latest_action_source", string_option_to_json latest_action_source);
                        ("tool_audit_source", string_option_to_json tool_audit_source);

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -162,6 +162,14 @@ let test_dashboard_execution_fixture () =
         check int "offline worker briefs" 1 (List.length offline_worker_briefs);
         check string "continuity skill route summary" "scene-director · +1 · judgment"
           (continuity_briefs |> List.hd |> member "skill_route_summary" |> to_string);
+        check (list string) "continuity recent tools keep window semantics"
+          [ "masc_keeper_status"; "masc_board_post" ]
+          (continuity_briefs |> List.hd |> member "recent_tool_names"
+         |> to_list |> List.map to_string);
+        check (list string) "continuity latest tools stay latest-only"
+          [ "masc_board_post" ]
+          (continuity_briefs |> List.hd |> member "latest_tool_names"
+         |> to_list |> List.map to_string);
         check string "continuity recent output stays concrete"
           "Prepared the next scene transition and handoff summary"
           (continuity_briefs |> List.hd |> member "recent_output_preview" |> to_string);

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -35,6 +35,11 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_snapshot_lightweight_summary_keeps_tool_audit;
+          Alcotest.test_case
+            "snapshot lightweight summary keeps recent tools distinct from latest"
+            `Quick
+            Test_operator_control_snapshot
+            .test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest;
           Alcotest.test_case "snapshot waiters share inflight result" `Quick
             Test_operator_control_snapshot
             .test_snapshot_waiters_share_inflight_result;

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -304,6 +304,84 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
         Yojson.Safe.Util.
           (keeper |> member "latest_tool_names" |> to_list |> List.map to_string))
 
+let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "owner"));
+      ignore (Coord.join config ~agent_name:"owner" ~capabilities:[] ());
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "owner";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let keeper_name = "lightweight-recent-tools" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Keep recent tool names distinct from latest");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+      Fs_compat.append_jsonl decision_path
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
+            ("selected_mode", `String "tool_use");
+            ("tool_call_count", `Int 2);
+            ("tools_used", `List [ `String "masc_status"; `String "masc_tasks" ]);
+          ]);
+      for _ = 1 to 20 do
+        Fs_compat.append_jsonl decision_path
+          (`Assoc
+            [
+              ("ts", `String (Types.now_iso ()));
+              ("selected_mode", `String "text_response");
+              ("tool_call_count", `Int 0);
+              ("tools_used", `List []);
+            ])
+      done;
+      let json =
+        Operator_control.snapshot_json ~view:"summary"
+          ~include_keepers:true ~include_messages:false
+          ~lightweight_summary:true
+          (operator_ctx env sw config "owner")
+      in
+      let keeper =
+        match
+          Yojson.Safe.Util.(json |> member "keepers" |> member "items" |> to_list)
+          |> List.find_opt (fun row ->
+                 Yojson.Safe.Util.(row |> member "name" |> to_string) = keeper_name)
+        with
+        | Some keeper -> keeper
+        | None -> Alcotest.fail "expected keeper in lightweight snapshot"
+      in
+      Alcotest.(check (list string)) "recent tool names retain recent window"
+        [ "masc_status"; "masc_tasks" ]
+        Yojson.Safe.Util.
+          (keeper |> member "recent_tool_names" |> to_list |> List.map to_string);
+      Alcotest.(check (list string)) "latest tool names stay latest-only"
+        []
+        Yojson.Safe.Util.
+          (keeper |> member "latest_tool_names" |> to_list |> List.map to_string))
+
 let test_snapshot_waiters_share_inflight_result () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## What changed
- stop aliasing `recent_tool_names` to `latest_tool_names` in the operator snapshot path
- derive a real recent tool window from recent decision-log and metrics lines while keeping `latest_tool_names` as the last-audit snapshot
- add regression coverage for lightweight operator snapshots and dashboard execution continuity briefs

## Why
The agent directory and execution surfaces labeled a field as "recent tools" but effectively showed only the latest turn's tools. When the latest keeper turn was text-only, the UI dropped recent tool history and misleadingly showed no recent tools even though telemetry existed.

## Impact
- operator-facing keeper cards now keep a short recent tool window even when the most recent turn is text-only
- `latest_tool_names` semantics stay unchanged for last-turn / last-audit consumers
- tests now lock the distinction between recent-window and latest-only tool summaries

## Root cause
`recent_tool_names` in `operator_control_snapshot` was populated directly from `latest_tool_names`, so downstream execution projections inherited last-turn semantics instead of recent-window semantics.

## Validation
- `opam exec -- dune build --root . test/test_operator_control.exe test/test_dashboard_execution.exe`
- `opam exec -- _build/default/test/test_operator_control.exe`
- `opam exec -- _build/default/test/test_dashboard_execution.exe`
- `git diff --check`
