### PR TITLE
fix(governance_pipeline): confirm_threshold fail-CLOSED on unknown level (#7641)

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -40,12 +40,22 @@ let generate_trace_id () =
 
 (* ── Policy Decision ────────────────────────────────────────── *)
 
-(** Minimum risk level that requires confirmation for each governance level. *)
+(** Minimum risk level that requires confirmation for each governance level.
+
+    Security gate: unknown level (typo, future variant) is fail-CLOSED — it
+    requires confirmation for [Critical] risk and warns the operator instead
+    of silently allowing every tool through. Mirrors the fail-closed posture
+    of [audit_threshold] just below. See #7641 / #8605. *)
 let confirm_threshold = function
   | "paranoid" -> Some Medium
   | "enterprise" -> Some High
   | "production" -> Some Critical
-  | "development" | _ -> None
+  | "development" -> None
+  | other ->
+      Log.Governance.warn
+        "confirm_threshold: unknown governance_level %S -> fail-closed (require confirm at Critical); see #7641"
+        other;
+      Some Critical
 
 let keeper_confirm_threshold = function
   | "production" -> Some High

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -662,14 +662,16 @@ let test_blocked_response_structure_claim_next () =
    | _ -> Alcotest.fail "paranoid should block claim_next");
   cleanup_tmpdir tmpdir
 
-(* ── Unknown governance level defaults to development ──────── *)
+(* ── Unknown governance level fail-CLOSED on critical (#7641) ──────── *)
 
-let test_unknown_governance_level_allows_all () =
+let test_unknown_governance_level_fail_closed_on_critical () =
+  (* Security gate: typo / unknown level no longer silently allows every tool.
+     Mirrors fail-closed posture of audit_threshold. See #7641. *)
   let d = Gp.decide ~governance_level:"nonexistent"
     ~tool_name:"masc_delete_room" ~input:`Null in
   (match d.action with
-   | `Allow -> ()
-   | _ -> Alcotest.fail "unknown governance level should behave like development")
+   | `Require_confirm _ -> ()
+   | _ -> Alcotest.fail "unknown governance level should require confirm on critical risk")
 
 (* ── Case-insensitive tool name matching ────────────────────── *)
 
@@ -928,8 +930,8 @@ let () =
         test_paranoid_confirms_high;
       Alcotest.test_case "paranoid confirms critical" `Quick
         test_paranoid_confirms_critical;
-      Alcotest.test_case "unknown level allows all" `Quick
-        test_unknown_governance_level_allows_all;
+      Alcotest.test_case "unknown level fail-closed on critical (#7641)" `Quick
+        test_unknown_governance_level_fail_closed_on_critical;
     ];
     "trace_id", [
       Alcotest.test_case "has gov_ prefix" `Quick test_decision_has_trace_id;


### PR DESCRIPTION
## Summary

Close #7641. Security-gate variant of the #8605 silent-permissive-default class. The fail-OPEN posture of `confirm_threshold` was directly asymmetric to its sibling `audit_threshold` which already fails CLOSED on unknown.

| | Before | After |
|--|--|--|
| Typo ("Production" capitalised, "prod", "stg") | `None` → `\`Allow` (every Critical tool runs without confirm) | `Some Critical` + `Log.Governance.warn` |
| `audit_threshold` posture | fail-CLOSED (`_ -> Some High`) | unchanged |
| Symmetry with audit | broken | restored |

## Why fail-closed (not fail-open with verbose log)

`confirm_threshold` is a **security policy gate**, not a UX affordance — module header explicitly cites Lethal Trifecta + Rule of Two. Unknown should be a distinct failure variant, not collapsed into the laxest named branch. Operator misconfig surfaces as Critical-tool confirm prompts + warn line, not as silent unguarded execution.

## Test impact

`test_unknown_governance_level_allows_all` previously **asserted the buggy behavior** ("unknown should behave like development → \`Allow"). Replaced with `test_unknown_governance_level_fail_closed_on_critical` which mirrors the new posture. All 84 governance tests pass locally.

## Surface

- `lib/governance_pipeline.ml:43-58` (confirm_threshold + keeper_confirm_threshold inheritance)
- `test/test_governance_pipeline.ml:665-672, 932-933`

## Pattern alignment

Same root cause as #8689 / #8692 / #8736 / #8740 / #8746 (silent permissive default). This is the third template — **security-gate fail-closed + warn** — distinct from wire-string parser (`_opt + warn`) and internal exhaustive-match.

## Test plan
- [x] `dune build` green
- [x] `dune runtest test/test_governance_pipeline.ml` green (84 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)