### PR TITLE
chore(config): SSOT for logging/observability env keys (#8352 Phase 10)

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -334,22 +334,28 @@ let tool_auth_strict () =
 
 (** {1 Logging / Telemetry} *)
 
+(** SSOT for logging / observability env-var names (issue 8352). *)
+let log_level_env_key = "MASC_LOG_LEVEL"
+let telemetry_enabled_env_key = "MASC_TELEMETRY_ENABLED"
+let parse_warn_env_key = "MASC_PARSE_WARN"
+let governance_level_env_key = "MASC_GOVERNANCE_LEVEL"
+
 (** Log level string (e.g. "debug", "info", "warn", "error"). *)
 let log_level_opt () =
-  raw_value_opt "MASC_LOG_LEVEL" |> trim_opt
+  raw_value_opt log_level_env_key |> trim_opt
 
 (** Whether telemetry tracking is enabled. Default: true. *)
 let telemetry_enabled () =
-  get_bool ~default:true "MASC_TELEMETRY_ENABLED"
+  get_bool ~default:true telemetry_enabled_env_key
 
 (** Whether to log parse warnings. Default: false. *)
 let parse_warn_enabled () =
-  get_bool ~default:false "MASC_PARSE_WARN"
+  get_bool ~default:false parse_warn_env_key
 
 (** Governance level. Set at runtime by server_runtime_bootstrap.
     Valid: "production", "development", etc. Default: "production". *)
 let governance_level () =
-  get_string ~default:"production" "MASC_GOVERNANCE_LEVEL"
+  get_string ~default:"production" governance_level_env_key
   |> String.lowercase_ascii
 
 (** {1 Build Identity} *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -131,14 +131,14 @@ let runtime_entries =
     entry ~default:"(none)" "MASC_CDAL_ENABLED"
       "Contract-driven agent loop proof capture (feature flag)";
     entry ~default:"true" "MASC_DISPATCH_V2" "Enable V2 dispatch engine";
-    entry ~default:"(auto)" "MASC_LOG_LEVEL" "Log level override";
-    entry ~default:"false" "MASC_PARSE_WARN" "Enable JSON parse warnings";
-    entry ~default:"production" "MASC_GOVERNANCE_LEVEL"
+    entry ~default:"(auto)" Env_config_core.log_level_env_key "Log level override";
+    entry ~default:"false" Env_config_core.parse_warn_env_key "Enable JSON parse warnings";
+    entry ~default:"production" Env_config_core.governance_level_env_key
       "Governance enforcement level";
     entry ~default:"(none)" "MASC_AUTO_RESPOND" "Auto-respond mode";
     entry ~default:"(none)" "MASC_SLOT_YIELD_ENABLED"
       "Release LLM slot during tool execution (feature flag)";
-    entry ~default:"true" "MASC_TELEMETRY_ENABLED"
+    entry ~default:"true" Env_config_core.telemetry_enabled_env_key
       "Enable telemetry collection";
   ]
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -60,7 +60,7 @@ let all_flags : flag list = [
     default = false; category = "transport";
     lifecycle = Active; since = "2.140.0" };
 
-  { env_name = "MASC_TELEMETRY_ENABLED";
+  { env_name = Env_config_core.telemetry_enabled_env_key;
     description = "Telemetry/span collection";
     default = true; category = "transport";
     lifecycle = Active; since = "2.50.0" };
@@ -81,7 +81,7 @@ let all_flags : flag list = [
     default = true; category = "tool";
     lifecycle = Active; since = "2.100.0" };
 
-  { env_name = "MASC_PARSE_WARN";
+  { env_name = Env_config_core.parse_warn_env_key;
     description = "Log JSON parse warnings";
     default = false; category = "tool";
     lifecycle = Active; since = "2.60.0" };


### PR DESCRIPTION
## Summary

Extract 4 observability env-var string literals into `Env_config_core` SSOT constants:

- `log_level_env_key = "MASC_LOG_LEVEL"`
- `telemetry_enabled_env_key = "MASC_TELEMETRY_ENABLED"`
- `parse_warn_env_key = "MASC_PARSE_WARN"`
- `governance_level_env_key = "MASC_GOVERNANCE_LEVEL"`

## Migrated call sites (9 across 3 files)

- `lib/config/env_config_core.ml` ×4 — primary readers (`log_level_opt`, `telemetry_enabled`, `parse_warn_enabled`, `governance_level`)
- `lib/config/feature_flag_registry.ml` ×2 — `MASC_TELEMETRY_ENABLED`, `MASC_PARSE_WARN` registry entries
- `lib/config/env_config_snapshot.ml` ×4 — runtime_entries catalog (log_level, parse_warn, governance_level, telemetry_enabled)

## Scope constraint

`lib/masc_log/log.ml:108` keeps the `"MASC_LOG_LEVEL"` literal. `masc_log` is below `env_config_core` in the dep graph (`env_config_core` calls `Log.Misc.warn`), so importing the SSOT constant there would create a dependency cycle. The duplicate reader can be unified via a small infrastructure refactor in a separate PR.

## Test plan

- [x] `rg '"MASC_LOG_LEVEL"\|"MASC_TELEMETRY_ENABLED"\|"MASC_PARSE_WARN"\|"MASC_GOVERNANCE_LEVEL"' lib/` returns only the 4 SSOT declarations + the documented `masc_log` reader
- [ ] CI: Build and Test + Lint + TLA+ green

Refs: #8352