### PR TITLE
refactor(operator): migrate 4 files to stdlib Result.Syntax (M-W1 step 2)

### DIFF
--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -1,5 +1,5 @@
 open Tool_args
-open Result_syntax
+open Result.Syntax
 
 include Operator_control_action
 

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -1,7 +1,7 @@
 open Tool_args
 include Operator_control_snapshot
 
-open Result_syntax
+open Result.Syntax
 
 let judgment_surface_enums =
   [ "command.namespace"; "intervene" ]

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -1,5 +1,5 @@
 open Operator_pending_confirm
-open Result_syntax
+open Result.Syntax
 
 include Operator_digest_types
 (* Operator_digest_session removed — team session cleanup *)

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -1,6 +1,6 @@
 open Yojson.Safe.Util
 
-open Result_syntax
+open Result.Syntax
 
 type target_type =
   | Coord


### PR DESCRIPTION
## Summary

`lib/operator/` 4개 파일의 `open Result_syntax` (로컬 wrapper) → `open Result.Syntax` (stdlib)로 이관. behavior 불변, 동일 `let*`/`let+` 연산자 — source만 stdlib으로 전환.

## 변경

| 파일 | 라인 |
|------|------|
| `operator_control.ml:2` | `open Result_syntax` → `open Result.Syntax` |
| `operator_control_action.ml:4` | `open Result_syntax` → `open Result.Syntax` |
| `operator_digest.ml:2` | `open Result_syntax` → `open Result.Syntax` |
| `operator_judgment.ml:3` | `open Result_syntax` → `open Result.Syntax` |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `open Result_syntax` call site | 15 | 11 |
| `open Result.Syntax` 직접 사용 | 5 (직전 5 PR) | 9 |

## 왜 지금

M-W1 Result.Syntax 공고 단계 2 — call-site 이관 1차 배치.
- 단계 1 (#8749 Draft): wrapper 모듈을 stdlib re-export로 축소
- **단계 2 (이 PR): `operator/` 4곳 call-site 이관**
- 단계 이후: coord/server/voice/local/lib 배치별 이관
- 마지막: wrapper 모듈 + `.mli` 삭제

`operator/` cluster는 의미 단위로 묶이는 4파일 — surgical 범위.

## 근거

- OCaml Stdlib `Result.Syntax`: [ocaml.org/manual/5.4/api/Result.html](https://ocaml.org/manual/5.4/api/Result.html)
- 로컬 빌드: `dune build lib/operator --root=.` ✅ pass (no errors)

## Anti-goal 자가 체크

- [x] 추상화 남용 없음
- [x] 근거 출처 명시 (stdlib docs)
- [x] surgical (4 파일, 4 logical line)
- [x] behavior-preserving (시그니처 완전 동일)
- [x] `ppx_let` 도입 안 함 (북극성 rejection list 준수)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023
- 관련: #8735 #8739 #8742 #8743 #8744 #8749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
