### PR TITLE
fix(backend_setup): warn on unknown MASC_STORAGE_TYPE; close 2 wildcards (#8737)

### DIFF
--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -219,7 +219,13 @@ let auto_detect_backend () =
   "filesystem"
 
 (** Storage type from environment variable.
-    Defaults to filesystem when MASC_STORAGE_TYPE is not set. *)
+    Defaults to filesystem when MASC_STORAGE_TYPE is not set.
+
+    Unknown / typo'd values (e.g. "postgres", "redis", "memoryy") used to
+    silently pass through and the downstream wildcard in [backend_config_for]
+    collapsed them into [FileSystem] with no log trace. Now an unknown value
+    is warned and explicitly normalised to "filesystem", so the operator sees
+    the drift. See #8737 / #8605. *)
 let storage_type_from_env () =
   match env_opt Env_config_core.storage_type_env_key with
   | Some raw ->
@@ -227,7 +233,11 @@ let storage_type_from_env () =
       (match value with
        | "filesystem" | "file" | "jsonl" | "auto" -> "filesystem"
        | "memory" -> "memory"
-       | other -> other)
+       | other ->
+           Log.Backend.warn
+             "MASC_STORAGE_TYPE=%S not recognised (known: filesystem|file|jsonl|auto|memory) -> using filesystem; see #8737"
+             other;
+           "filesystem")
   | None -> auto_detect_backend ()
 
 (* ============================================ *)
@@ -257,10 +267,18 @@ let backend_config_for base_path =
     | Some name -> name
     | None -> "default"
   in
+  (* Exhaustive over the values that [storage_type_from_env] now produces
+     ("memory" | "filesystem"). The wildcard branch is defensive; if it ever
+     fires the upstream sanitiser regressed and we want to know. *)
   let backend_type =
     match storage_type with
     | "memory" -> Backend_types.Memory
-    | _ -> Backend_types.FileSystem
+    | "filesystem" -> Backend_types.FileSystem
+    | other ->
+        Log.Backend.warn
+          "backend_config_for: storage_type=%S bypassed sanitiser -> defaulting to FileSystem; see #8737"
+          other;
+        Backend_types.FileSystem
   in
   let masc_root = Filename.concat base_path ".masc" in
   let cluster_segment =

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -462,6 +462,24 @@ let test_storage_type_auto_is_deprecated () =
       check string "auto falls back to filesystem" "filesystem"
         (Coord_utils.storage_type_from_env ()))
 
+(* #8737: unknown / typo'd MASC_STORAGE_TYPE values used to silently pass
+   through and then collapse into FileSystem in [backend_config_for] with no
+   log. The sanitiser now normalises any unknown value to "filesystem" (with
+   a Log.Backend.warn surfaced separately) so downstream is exhaustive. *)
+let test_storage_type_unknown_normalised_to_filesystem () =
+  with_envs
+    (pg_env_bindings ~masc_storage_type:"postgres" ())
+    (fun () ->
+      check string "unknown postgres normalised to filesystem" "filesystem"
+        (Coord_utils.storage_type_from_env ()))
+
+let test_storage_type_typo_normalised_to_filesystem () =
+  with_envs
+    (pg_env_bindings ~masc_storage_type:"memoryy" ())
+    (fun () ->
+      check string "typo memoryy normalised to filesystem" "filesystem"
+        (Coord_utils.storage_type_from_env ()))
+
 (* ============================================================
    safe_filename Tests
    ============================================================ *)
@@ -697,6 +715,8 @@ let () =
       test_case "defaults to filesystem" `Quick test_storage_type_defaults_to_filesystem;
       test_case "legacy url does not auto select" `Quick test_storage_type_legacy_url_does_not_auto_select;
       test_case "auto is deprecated" `Quick test_storage_type_auto_is_deprecated;
+      test_case "unknown normalised to filesystem (#8737)" `Quick test_storage_type_unknown_normalised_to_filesystem;
+      test_case "typo normalised to filesystem (#8737)" `Quick test_storage_type_typo_normalised_to_filesystem;
     ];
     "safe_filename", [
       test_case "normal" `Quick test_safe_filename_normal;


### PR DESCRIPTION
## Summary

Close #8737. **Two-stage silent fallback** in `coord_utils_backend_setup.ml` removed. `MASC_STORAGE_TYPE=postgres` (or any typo) used to land on FileSystem with zero log trace; operator had no signal that their intended backend was ignored.

| Stage | Before | After |
|--|--|--|
| `storage_type_from_env` | `other -> other` (passthrough) | `other -> warn + "filesystem"` |
| `backend_config_for` | `_ -> FileSystem` (silent collapse) | exhaustive `"memory" \| "filesystem"`; defensive wildcard with warn |

## Why warn+normalise (not fail-closed)

Storage backend isn't a security gate — fail-closed would refuse to start the server, which is harsher than the bug warrants. The warn+normalise stance keeps the existing default behaviour observable: operator sees the typo in logs, no production outage from a typo.

## Test plan
- [x] `dune build` green
- [x] 79 `Coord_utils Coverage` tests pass (77 existing + 2 new for `postgres`/`memoryy`)
- [ ] CI green

## Pattern alignment

Same #8605 anti-pattern (silent permissive default), env-parser variant. Wire-string-parser-style fix template. Matches #8689 / #8692 / #8706 / #8736 / #8740 / #8746 / #8759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)