### PR TITLE
refactor(voice): migrate 2 files to stdlib Result.Syntax (M-W1 step 3)

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -1,7 +1,7 @@
 (** Voice_bridge — TTS synthesis, MCP voice sessions, conferences. *)
 
 include Voice_bridge_core
-open Result_syntax
+open Result.Syntax
 
 let safe_agent_id value =
   String.map

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -49,7 +49,7 @@ type t = {
   local_playback : local_playback_config;
 }
 
-open Result_syntax
+open Result.Syntax
 
 let default_elevenlabs_base_url = "https://api.elevenlabs.io/v1"
 


### PR DESCRIPTION
## Summary

`lib/voice/` 2 파일의 `open Result_syntax` → `open Result.Syntax` (stdlib).

## 변경

| 파일 | 라인 |
|------|------|
| `voice_bridge.ml:4` | `open Result_syntax` → `open Result.Syntax` |
| `voice_config.ml:52` | `open Result_syntax` → `open Result.Syntax` |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `open Result_syntax` 잔여 | 11 | 9 |
| stdlib `Result.Syntax` 직접 사용 | 9 | 11 |

## 왜 지금

M-W1 Result.Syntax 공고 단계 3 — call-site 이관 2차 batch (`voice/` cluster, 의미 단위).

## 근거

- OCaml Stdlib `Result.Syntax`: [ocaml.org/manual/5.4/api/Result.html](https://ocaml.org/manual/5.4/api/Result.html)
- 로컬 빌드: `dune build lib/voice --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (2 파일, 2 line)
- [x] behavior-preserving
- [x] 근거 출처 명시
- [x] `ppx_let` 도입 안 함

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023
- 관련: #8735 #8739 #8742 #8743 #8744 #8749 #8762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
