### PR TITLE
fix(worker_contract): exhaustive default_execution_scope_for_worker_class (#8765)

### DIFF
--- a/lib/worker_contract_types/worker_contract_types.ml
+++ b/lib/worker_contract_types/worker_contract_types.ml
@@ -7,9 +7,16 @@ open Yojson.Safe.Util
 
 let dedup_strings = Dashboard_utils.dedup_strings
 
+(* Privilege boundary: each [worker_class] must explicitly choose its default
+   execution scope. The previous [_ -> Observe_only] catch-all was safe today
+   (least privilege) but silently denied any new worker_class an elevated
+   default — a maintainer adding [Worker_executor_v2] would never see the
+   decision needed to be made. Exhaustive match converts each new constructor
+   into a compile error here, forcing the choice. See #8605 family. *)
 let default_execution_scope_for_worker_class = function
   | Some Worker_executor -> Limited_code_change
-  | _ -> Observe_only
+  | Some (Worker_manager | Worker_scout | Worker_librarian | Worker_metacog)
+  | None -> Observe_only
 
 let effective_execution_scope ~worker_class execution_scope =
   match execution_scope with


### PR DESCRIPTION
## Summary

Close #8765. SDK-boundary variant of #8605 anti-pattern: replace `_ -> Observe_only` with exhaustive match.

| | Before | After |
|--|--|--|
| New `worker_class` (e.g., `Worker_executor_v2`) | silently → `Observe_only` (denies elevated default) | OCaml exhaustiveness fires at compile time |
| Mechanism | wildcard catch-all | per-variant explicit arm |
| Privilege decision | invisible | enforced by type system |

## Why exhaustive (not warn-and-default)

Both sides live in the same compile graph (variants defined in `worker_contract_types_enums.ml`). For internal type-stable boundaries the right tool is exhaustive match — turns the silent risk into a build-time failure rather than a runtime log line.

## Pattern alignment

Third application of SDK-boundary template. Same shape as PR #8697 (`completion_contract_of_tool_choice`) and #8700 (`call_profile`).

## Test plan
- [x] `dune build` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)