### PR TITLE
fix(keeper_accountability): exhaustive effective_status over claim_kind (#8768)

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -280,10 +280,15 @@ let effective_status ~(now : float) (snapshot : claim_snapshot) =
   | Some resolution -> resolution.status
   | None ->
       let age = now -. created_at_unix snapshot.claim in
+      (* Per-constructor exhaustive match: a new [claim_kind] (e.g.,
+         Verification_claim) triggers a compile error here so its expiry
+         rule is an explicit decision, not silently inherited from the
+         old wildcard arm. See #8768 / #8765 family. *)
       match snapshot.claim.kind with
-      | Task_commitment when age > task_commitment_expiry_sec -> Expired
-      | Completion_claim when age > completion_claim_expiry_sec -> Unsupported
-      | _ -> Pending
+      | Task_commitment ->
+          if age > task_commitment_expiry_sec then Expired else Pending
+      | Completion_claim ->
+          if age > completion_claim_expiry_sec then Unsupported else Pending
 
 let open_recent_claim ~(now : float) snapshots ~agent_name ~kind ~subject ~task_id
     ~max_age_sec =


### PR DESCRIPTION
## Summary

Close #8768. SDK-boundary template — replace `_ -> Pending` with per-constructor match. Same shape as #8697 / #8700 / #8766.

| | Before | After |
|--|--|--|
| New `claim_kind` (e.g. `Verification_claim`) | silently → `Pending` (inherits open behaviour, expiry rule decision lost) | OCaml exhaustiveness fires at compile time |
| Mechanism | wildcard with two `when`-guarded predecessors | per-constructor `if/else` |
| Runtime behaviour for current 2 constructors | unchanged | unchanged |

## Why exhaustive

`claim_kind` is a closed internal variant (\`Task_commitment | Completion_claim\`) defined in the same module. New constructors are added by maintainers in this repo — exactly when exhaustive match buys the most: build-time forcing function on the design decision (does this new claim_kind have its own expiry? if so what timeout?).

## Test plan
- [x] `dune build` green
- [x] no existing tests for `effective_status` (so no test churn)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)