### PR TITLE
refactor(server): migrate 2 files to stdlib Result.Syntax (M-W1 step 4)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -183,7 +183,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in
-  let open Result_syntax in
+  let open Result.Syntax in
   ignore (
     let* () =
       match validate_mcp_session_profile ~profile session_id with

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -1,4 +1,4 @@
-open Result_syntax
+open Result.Syntax
 
 module SMap = Map.Make(String)
 


### PR DESCRIPTION
## Summary

`lib/server/` 2 파일의 `open Result_syntax` → `open Result.Syntax` (stdlib).

## 변경

| 파일 | 형태 |
|------|------|
| `server_mcp_transport_http_session.ml:1` | file-level `open` |
| `server_mcp_transport_http.ml:186` | inline `let open ... in` |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `open Result_syntax` 잔여 | 9 | 7 |
| stdlib `Result.Syntax` 직접 사용 | 11 | 13 |

## 왜 지금

M-W1 Result.Syntax 공고 단계 4 — call-site 이관 3차 batch (`server/` cluster).

## 근거

- [ocaml.org/manual/5.4/api/Result.html](https://ocaml.org/manual/5.4/api/Result.html)
- `dune build lib/server --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (2 파일, 2 line)
- [x] behavior-preserving
- [x] 근거 출처 명시

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023
- 관련: #8735 #8739 #8742 #8743 #8744 #8749 #8762 #8764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
