### PR TITLE
refactor(coord+local): migrate 2 files to stdlib Result.Syntax (M-W1 step 5)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -618,7 +618,7 @@ let claim_task config ~agent_name ~task_id =
     the claim is rejected if the roles do not match. *)
 let claim_task_r config ~agent_name ~task_id
     ?(agent_role = Types_core.Unassigned) () : string Types.masc_result =
-  let open Result_syntax in
+  let open Result.Syntax in
   let* () = if not (is_initialized config) then Error Types.NotInitialized else Ok () in
   let* () =
     match validate_agent_name_r agent_name, validate_task_id_r task_id with
@@ -795,7 +795,7 @@ let derive_release_do_not_reclaim_reason (task : Types.task) handoff_context =
 let transition_task_r config ~agent_name ~task_id ~action
     ?expected_version ?(notes="") ?(reason="") ?handoff_context
     ?(force=false) () : string Types.masc_result =
-  let open Result_syntax in
+  let open Result.Syntax in
   let* () = if not (is_initialized config) then Error Types.NotInitialized else Ok () in
   let* () =
     match validate_agent_name_r agent_name, validate_task_id_r task_id with

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -1,7 +1,7 @@
 open Printf
 open Yojson.Safe.Util
 
-open Result_syntax
+open Result.Syntax
 
 (** Exponential moving average weights for latency smoothing.
     ema_decay + ema_alpha = 1.0. Higher decay = more weight to history. *)


### PR DESCRIPTION
## Summary

`lib/coord/` + `lib/local/` 파일의 `Result_syntax` → `Result.Syntax` (stdlib).

## 변경

| 파일 | 형태 | 치환 수 |
|------|------|---------|
| `coord/coord_task.ml:621,798` | inline `let open ... in` | 2 |
| `local/local_runtime_pool.ml:4` | file-level `open` | 1 |

총 2 파일, 3 logical line.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `open Result_syntax` 잔여 (lib sites) | 14 | 11 |
| stdlib `Result.Syntax` 직접 사용 | 13 | 16 |

## 왜 지금

M-W1 Result.Syntax 공고 단계 5 — call-site 이관 4차 batch.

## 근거

- [ocaml.org/manual/5.4/api/Result.html](https://ocaml.org/manual/5.4/api/Result.html)
- `dune build lib/coord lib/local --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical
- [x] behavior-preserving
- [x] 근거 출처 명시

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023
- 관련: #8735 #8739 #8742 #8743 #8744 #8749 #8762 #8764 #8771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
