### PR TITLE
refactor(lib-root): final Result.Syntax batch — 3 files (M-W1 step 6/final)

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -458,7 +458,7 @@ type tools_list_params = {
   cursor : string option;
 }
 
-open Result_syntax
+open Result.Syntax
 
 let strict_assoc_params params =
   match params with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -7,7 +7,7 @@
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
-open Result_syntax
+open Result.Syntax
 
 (* ================================================================ *)
 (* Cascade profile defaults (moved from Cascade module)              *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -14,7 +14,7 @@
     @since Phase 5 — OAS Agent.run adapter for workers *)
 
 open Printf
-open Result_syntax
+open Result.Syntax
 
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.model                          *)


### PR DESCRIPTION
## Summary

`lib/` 루트의 3 파일 `open Result_syntax` → `open Result.Syntax` (stdlib). M-W1 call-site 이관의 **마지막 batch** — 이 PR 이후 wrapper 모듈은 더 이상 참조 없음.

## 변경

| 파일 | 라인 |
|------|------|
| `mcp_server_eio_tool_profile.ml:461` | `open Result_syntax` → `open Result.Syntax` |
| `oas_worker_named.ml:10` | 동일 |
| `worker_oas.ml:17` | 동일 |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `open Result_syntax` 잔여 (call site) | 3 | **0** |
| stdlib `Result.Syntax` 직접 사용 | 16 | 19 |
| wrapper 모듈 정의 | 1 (`core/result_syntax.ml`) | 1 (unused after #8749+#8762+#8764+#8771+#8772+this merge) |

## 왜 지금

M-W1 Result.Syntax 공고 단계 6 (final call-site batch). 다음 단계:
- **단계 7 (후속 PR)**: `core/result_syntax.ml` + `.mli` 모듈 완전 삭제, `lib/core/dune`의 `modules` 목록에서 제거

## 근거

- [ocaml.org/manual/5.4/api/Result.html](https://ocaml.org/manual/5.4/api/Result.html)
- 로컬 빌드: `dune build lib --root=.` ✅ pass (전체 lib 컴파일 성공)

## Anti-goal 자가 체크

- [x] surgical (3 파일, 3 line)
- [x] behavior-preserving
- [x] 근거 출처 명시
- [x] `ppx_let` 도입 안 함

## 누적 PR 체인

M-W1 전체 진행 (모두 Draft):
- 파일 특화: #8735 #8739 #8742 #8743 #8744
- Shim 전환: #8749
- Batch: #8762 (operator) #8764 (voice) #8771 (server) #8772 (coord+local) **#이 PR (lib-root)**

머지 후 단계 7 PR에서 wrapper 모듈 삭제 예정.

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
