### PR TITLE
fix(keeper.capabilities): upgrade tool-error handling guidance (RFC #8760 R1)

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -15,7 +15,22 @@ NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path
 NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). Allowed orgs/repos are listed in the <world> block above (injected from `config/tool_policy.toml` at boot).
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call.
 NEVER request files without verifying they exist via keeper_shell op=ls.
-When a tool call fails, read the error message carefully. Do not retry with the same arguments.
+## Tool error grammar (how to read a failed tool result)
+
+Every failed tool call returns a JSON envelope like:
+  `{"ok": false, "error": "<short class>", "detail": {..., "hint": "<actionable fix>"}}`
+
+The `error` field is a short class. The `detail.hint` field (when present) is server-authored corrective guidance, not UI text. Read `hint` first.
+
+When a tool call fails:
+1. Read `error` and `detail.hint` carefully.
+2. If the hint points at a concrete fix (e.g. "retry with `--repo OWNER/NAME`" or "relative paths anchor at project root"), retry in the SAME turn with arguments rewritten per the hint. This is encouraged — it is NOT a "same-args retry".
+3. If you cannot resolve the error after one hint-guided retry, do NOT silently end the turn. Either:
+   - switch to a different tool/approach and say WHY in your next message, or
+   - ask the operator via keeper_broadcast (include the tool name, error class, and what you tried).
+4. Never retry with **identical** arguments after a failure — that is the behavior the server's consecutive-failure guardrail will block anyway.
+
+Short form: hint → fix args → retry once → if still stuck, judgment request. Do NOT end a turn on a silent tool error.
 
 keeper_bash examples:
   BAD:  cmd="git log --oneline | head -5"          (pipe blocked)


### PR DESCRIPTION
## Context

Triage of `~/me/.masc/tool_calls/2026-04/{17,18}.jsonl` (#8688) showed
that server-side hints already present in the error envelope
(`handoff_context.summary is required (non-empty ...)`,
`relative paths anchor at project root`, `gh_command_blocked` with
Good:/Bad:) still see 40–50 rejections/day per class.

Diagnosis (RFC #8760): this is **not** "LLM ignores hints". The
per-keeper `max_consecutive_tool_failures` guardrail at
`lib/keeper/keeper_tools_oas.ml:167` handles same-args loops within one
instance. The 40-50/day counts come from **different keepers** each
making the mistake once — a cross-instance learning gap not addressed
by server-side hint polish alone.

## Change

`config/prompts/keeper.capabilities.md` line 18 currently says:

> When a tool call fails, read the error message carefully. Do not
> retry with the same arguments.

This one-liner conflates two distinct behaviors:
- retry with **identical** args (server already blocks via consecutive-
  failure guardrail)
- retry with **hint-corrected** args (server encourages, LLM may be
  unsure because the line says "do not retry")

This PR replaces the single line with an explicit tool error grammar
section — 4 steps, with concrete wording, encouraging same-turn
hint-corrected retry and forbidding silent turn termination after an
error.

## Why it should land

- Prompt text only. No code path, test, or runtime behavior changed.
- Addresses the "새가슴" (chicken-hearted) behavior directly — keepers
  currently stop on error because the prompt tells them to.
- Measurable: `scripts/sweep-tool-error-signatures.sh` from #8767 emits
  per-(tool, sig) daily counts. 2-week target after rollout: ≥40% drop
  on the 3 named classes above. If the drop does not materialize, we
  know prompt guidance is not the lever and R3 (turn classifier
  recoverable-error branch) is next.

## Follow-ups (separate PRs from RFC #8760)

- R2: auto-generate per-keeper cheatsheet from the top-N misuse classes
  and inject into the system prompt.
- R3: `keeper_turn_intent.classify` should treat
  "last_tool_call = recoverable failure" as Cognitive (force another
  LLM pass).

## Tests

No new tests — prompt-only change. Existing `capabilities` prompt is
loaded at runtime via `Prompt_registry`, so no build artifacts are
invalidated.

Related: #8688, #8760, #8767.
