### PR TITLE
[task-163] Add multi-assignment current binding semantics

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -141,6 +141,82 @@ let task_assignee = function
   | Types.Cancelled { cancelled_by; _ } -> cancelled_by
   | Types.Todo -> "unclaimed"
 
+let active_task_assignee = function
+  | Types.Claimed { assignee; _ }
+  | Types.InProgress { assignee; _ }
+  | Types.AwaitingVerification { assignee; _ } ->
+      Some assignee
+  | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
+
+let assigned_task_ids ~matches_you tasks =
+  List.filter_map
+    (fun (task : Types.task) ->
+      match active_task_assignee task.task_status with
+      | Some assignee when matches_you assignee -> Some task.id
+      | Some _ | None -> None)
+    tasks
+
+type current_binding = {
+  assigned_task_ids : string list;
+  primary_owned : string option;
+  planning_current : string option;
+  current_is_assigned : bool;
+  effective_current : string option;
+  drift_reason : string option;
+  current_task_set : bool;
+  claim_first_suppressed : bool;
+}
+
+let resolve_current_binding ~assigned_task_ids ~planning_current =
+  let primary_owned =
+    match assigned_task_ids with
+    | id :: _ -> Some id
+    | [] -> None
+  in
+  let current_is_assigned =
+    match planning_current with
+    | Some current ->
+        List.exists (fun task_id -> String.equal task_id current)
+          assigned_task_ids
+    | None -> false
+  in
+  let drift_reason =
+    match primary_owned, planning_current with
+    | None, None -> None
+    | Some _, None -> None
+    | None, Some _ -> Some "no_owned"
+    | Some owned, Some current when String.equal owned current -> None
+    | Some _, Some _ when current_is_assigned -> Some "secondary_assignment"
+    | Some _, Some _ -> Some "stale_focus"
+  in
+  let effective_current =
+    match primary_owned, planning_current with
+    | Some owned, Some current when String.equal owned current -> Some current
+    | Some _, Some current when current_is_assigned -> Some current
+    | Some owned, Some _ -> Some owned
+    | Some owned, None -> Some owned
+    | None, Some _ | None, None -> None
+  in
+  let current_task_set =
+    match primary_owned, planning_current with
+    | Some owned, Some current when String.equal owned current -> true
+    | _ -> false
+  in
+  {
+    assigned_task_ids;
+    primary_owned;
+    planning_current;
+    current_is_assigned;
+    effective_current;
+    drift_reason;
+    current_task_set;
+    claim_first_suppressed = assigned_task_ids <> [];
+  }
+
+let task_id_list_label = function
+  | [] -> "[]"
+  | ids -> "[" ^ String.concat "," ids ^ "]"
+
 let agent_status_icon ~is_zombie = function
   | _ when is_zombie -> "💀"
   | Types.Busy -> "🔴"
@@ -225,18 +301,16 @@ let status_summary_string (ctx : context) =
   in
   let active_tasks = List.rev active_tasks in
   let shown_active_tasks = take_items max_active_tasks_display active_tasks in
-  let your_task =
-    active_tasks
-    |> List.find_map (fun (task : Types.task) ->
-           let assignee = task_assignee task.task_status in
-           if matches_you assignee then Some task.id else None)
+  let assigned_task_ids = assigned_task_ids ~matches_you active_tasks in
+  let binding =
+    resolve_current_binding ~assigned_task_ids ~planning_current:current_task
   in
   let guidance =
     Workflow_guide.current_state_guidance
       ~room_set:true
       ~joined
-      ~task_claimed:(Option.is_some your_task)
-      ~current_task_set:(Option.is_some current_task)
+      ~task_claimed:(binding.assigned_task_ids <> [])
+      ~current_task_set:binding.current_task_set
       ~worktree_active ~session_active:false
   in
   let suggested_next =
@@ -252,11 +326,29 @@ let status_summary_string (ctx : context) =
     else
       items
     |> fun items ->
-    if Option.is_some your_task && Option.is_none current_task then
+    if binding.assigned_task_ids <> [] && Option.is_none binding.planning_current then
       items
       @ [ "You own a task but planning current_task is unset. Call masc_plan_set_task." ]
     else
       items
+    |> fun items ->
+    (match binding.drift_reason with
+    | Some "secondary_assignment" ->
+        items
+        @ [
+            "Multiple assigned tasks detected. Current focus is also assigned; choose or reconcile the active lane before claiming new work.";
+          ]
+    | Some "stale_focus" ->
+        items
+        @ [
+            "Owned/current drift detected. Planning current_task is not assigned to you; treat primary_owned as the safe task lane.";
+          ]
+    | Some "no_owned" ->
+        items
+        @ [
+            "Planning current_task is set but no active task is assigned to you; clear or rebind current_task before following it.";
+          ]
+    | Some _ | None -> items)
     |> fun items ->
     if zombie_count > 0 then
       items
@@ -265,7 +357,7 @@ let status_summary_string (ctx : context) =
     else
       items
     |> fun items ->
-    if todo_count > 0 && Option.is_none your_task then
+    if todo_count > 0 && binding.assigned_task_ids = [] then
       items
       @ [ Printf.sprintf "%d unclaimed task(s) are available right now."
             todo_count ]
@@ -288,8 +380,18 @@ let status_summary_string (ctx : context) =
   Buffer.add_string buf
     (Printf.sprintf
        "🧭 You: agent=%s | joined=%s | owned=%s | current=%s | worktree=%s\n"
-       actual_name (bool_flag joined) (option_or_dash your_task)
+       actual_name (bool_flag joined) (option_or_dash binding.primary_owned)
        (option_or_dash current_task) (bool_flag worktree_active));
+  Buffer.add_string buf
+    (Printf.sprintf
+       "🔎 Task binding: assigned_set=%s | primary_owned=%s | planning_current=%s | current_is_assigned=%s | effective_current=%s | drift_reason=%s | claim_first_suppressed=%s\n"
+       (task_id_list_label binding.assigned_task_ids)
+       (option_or_dash binding.primary_owned)
+       (option_or_dash binding.planning_current)
+       (bool_flag binding.current_is_assigned)
+       (option_or_dash binding.effective_current)
+       (option_or_dash binding.drift_reason)
+       (bool_flag binding.claim_first_suppressed));
   if suggested_next <> [] then
     Buffer.add_string buf
       (Printf.sprintf "💡 Suggested next: %s\n"
@@ -385,22 +487,22 @@ let inspect_state ctx =
        with Sys_error _ | Yojson.Json_error _ -> false)
     else false
   in
-  let task_claimed =
+  let binding =
     if joined then
-      let actual_name = Coord.resolve_agent_name ctx.config ctx.agent_name in
-      Coord.get_tasks_raw ctx.config
-      |> List.exists (fun (task : Types.task) ->
-             match task.task_status with
-             | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ }
-             | Types.AwaitingVerification { assignee; _ } ->
-                 assignee = ctx.agent_name || assignee = actual_name
-             | Types.Todo | Types.Done _ | Types.Cancelled _ -> false)
-    else false
+      let actual_name = safe_resolve_agent_name ctx ~joined in
+      let matches_you assignee =
+        String.equal assignee ctx.agent_name || String.equal assignee actual_name
+      in
+      let assigned_task_ids =
+        Coord.get_tasks_raw ctx.config |> assigned_task_ids ~matches_you
+      in
+      resolve_current_binding ~assigned_task_ids
+        ~planning_current:(safe_current_task ctx ~joined)
+    else
+      resolve_current_binding ~assigned_task_ids:[] ~planning_current:None
   in
-  let current_task_set =
-    if joined then Option.is_some (Planning_eio.get_current_task ctx.config)
-    else false
-  in
+  let task_claimed = binding.assigned_task_ids <> [] in
+  let current_task_set = binding.current_task_set in
   let worktree_active =
     if room_set then
       status_worktree_active ctx
@@ -482,8 +584,8 @@ let assertion_fix_hint = function
   | Task_claimed ->
       "Claim a task with masc_transition(action=claim) or masc_claim_next"
   | Current_task_set ->
-      "Call masc_plan_set_task after claim paths that did not auto-bind \
-       current_task (for example masc_transition(action=claim))"
+      "Call masc_plan_set_task to choose or re-sync the active task when \
+       current_task is unset, stale, or ambiguous"
   | Worktree_active ->
       "Call masc_worktree_create to work in an isolated branch"
 

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -185,7 +185,7 @@ let () = test "dispatch_check_transition_claim_requires_plan_task" (fun () ->
       assert (
         Yojson.Safe.Util.member "fix_hint" json
         = `String
-            "Call masc_plan_set_task after claim paths that did not auto-bind current_task (for example masc_transition(action=claim))")
+            "Call masc_plan_set_task to choose or re-sync the active task when current_task is unset, stale, or ambiguous")
   | None -> failwith "dispatch returned None"
 )
 
@@ -209,6 +209,44 @@ let () = test "dispatch_check_claim_next_marks_current_task_set" (fun () ->
       assert success;
       let json = Yojson.Safe.from_string result in
       assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_status_multi_assignment_current_requires_disambiguation" (fun () ->
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  let _ = Coord.add_task ctx.config ~title:"Primary lane" ~priority:2 ~description:"" in
+  let _ = Coord.add_task ctx.config ~title:"Secondary lane" ~priority:2 ~description:"" in
+  ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
+  ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-002");
+  Planning_eio.set_current_task ctx.config ~task_id:"task-002";
+  (match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "owned=task-001 | current=task-002");
+      assert (str_contains result "assigned_set=[task-001,task-002]");
+      assert (str_contains result "primary_owned=task-001");
+      assert (str_contains result "planning_current=task-002");
+      assert (str_contains result "current_is_assigned=yes");
+      assert (str_contains result "effective_current=task-002");
+      assert (str_contains result "drift_reason=secondary_assignment");
+      assert (str_contains result "claim_first_suppressed=yes");
+      assert (str_contains result "Multiple assigned tasks detected");
+      assert (not (str_contains result "task-002 is stale focus"))
+  | None -> failwith "dispatch returned None");
+  match Tool_coord.dispatch ctx ~name:"masc_check"
+          ~args:(`Assoc [("assertions", `List [`String "task_claimed"; `String "current_task_set"])]) with
+  | Some (success, result) ->
+      assert success;
+      let json = Yojson.Safe.from_string result in
+      assert (Yojson.Safe.Util.member "all_passed" json = `Bool false);
+      assert (
+        Yojson.Safe.Util.member "fix_hint" json
+        = `String
+            "Call masc_plan_set_task to choose or re-sync the active task when current_task is unset, stale, or ambiguous")
   | None -> failwith "dispatch returned None"
 )
 


### PR DESCRIPTION
## Summary

Adds the multi-assignment conformance slice requested by #8757 for task-163.

## Product impact

Operators can distinguish a stale `current_task` from a real secondary assignment when the same agent has more than one assigned task. This prevents claim-first/read-path automation from treating a valid secondary lane as a stale focus bug.

## Changes

- Introduces a shared current binding read model in `tool_coord.ml`:
  - `assigned_set`
  - `primary_owned`
  - `planning_current`
  - `current_is_assigned`
  - `effective_current`
  - `drift_reason`
  - `claim_first_suppressed`
- Keeps the existing `owned` / `current` status line compatible, while adding an explicit `Task binding` line for operator-facing disambiguation.
- Treats `current_task_set` as aligned primary ownership, not raw planning-current presence.
- Distinguishes `secondary_assignment` from `stale_focus` so a second real assignment is not hidden as stale local focus.
- Adds regression coverage for the live counterexample shape: same agent owns `task-001` and `task-002`, while planning current points at the secondary task.

## Evidence

The motivating live counterexample was tracked in the task-163 drift thread: an agent can have multiple assigned tasks while the status surface exposes only one `owned` slot. In that shape, `owned` is a primary display projection, not the full ownership truth.

## Verification

Local checks run after the final push:

- `env -u DUNE_RPC opam exec -- dune build --root . ./test/test_tool_coord_coverage.exe`
- `timeout 30s _build/default/test/test_tool_coord_coverage.exe` (23 tests)
- `git diff --check`
- `env -u DUNE_RPC opam exec -- dune build --root . @all`

Remote CI for head `4be6d13d9ff68a0281f0b7d51aa67b20803aa7ff` is still in progress at the time this body was updated; completed jobs are green so far, while Build and Test, Health, and Lint have not reached terminal status yet.

## Review evidence

Reviewers should verify that `secondary_assignment` is used only when the planning current is still in the assigned set, and that `stale_focus` remains reserved for planning current values outside the assigned set.

## Linked issue

Refs #8757
Refs #8755