### PR TITLE
fix(activity_graph): strict node_status_of_string_opt + warn wrapper (#8777)

### DIFF
--- a/lib/activity_graph.mli
+++ b/lib/activity_graph.mli
@@ -19,7 +19,12 @@ type node_status =
   | Observed | Coord | Unset
 
 val node_status_to_string : node_status -> string
+
+val node_status_of_string_opt : string -> node_status option
+(** Strict: [None] on unknown wire (see #8777 / #8605). *)
+
 val node_status_of_string : string -> node_status
+(** Back-compat: unknown -> [Observed] with [Log.Misc.warn] so drift surfaces. *)
 
 (** Span status variant (separate lifecycle from node status).
     @since 7182 *)

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -33,20 +33,35 @@ let node_status_to_string = function
   | Stopped -> "stopped" | Finalized -> "finalized"
   | Observed -> "observed" | Coord -> "room" | Unset -> ""
 
-let node_status_of_string = function
-  | "active" -> Active | "offline" -> Offline | "spawned" -> Spawned
-  | "retired" -> Retired | "compacting" -> Compacting | "handoff" -> Handoff
-  | "autonomy" -> Autonomy | "guardrail" -> Guardrail
-  | "todo" -> Todo | "claimed" -> Claimed | "in_progress" -> In_progress
-  | "done" -> Done | "cancelled" -> Cancelled
-  | "posted" -> Posted | "discussed" -> Discussed
-  | "open" -> Open | "resolved" -> Resolved
-  | "approved" -> Approved | "denied" -> Denied
-  | "running" -> Running | "paused" -> Paused
-  | "stopped" -> Stopped | "finalized" -> Finalized
-  | "observed" -> Observed | "room" -> Coord
-  | "" -> Unset
-  | _ -> Observed  (* fail-open: unknown status treated as generic *)
+(** Strict parser. Returns [None] on unknown wire so callers can react
+    explicitly (drop / fallback / route). See #8777 / #8605. *)
+let node_status_of_string_opt = function
+  | "active" -> Some Active | "offline" -> Some Offline | "spawned" -> Some Spawned
+  | "retired" -> Some Retired | "compacting" -> Some Compacting | "handoff" -> Some Handoff
+  | "autonomy" -> Some Autonomy | "guardrail" -> Some Guardrail
+  | "todo" -> Some Todo | "claimed" -> Some Claimed | "in_progress" -> Some In_progress
+  | "done" -> Some Done | "cancelled" -> Some Cancelled
+  | "posted" -> Some Posted | "discussed" -> Some Discussed
+  | "open" -> Some Open | "resolved" -> Some Resolved
+  | "approved" -> Some Approved | "denied" -> Some Denied
+  | "running" -> Some Running | "paused" -> Some Paused
+  | "stopped" -> Some Stopped | "finalized" -> Some Finalized
+  | "observed" -> Some Observed | "room" -> Some Coord
+  | "" -> Some Unset
+  | _ -> None
+
+(** Back-compat wrapper: unknown wire still falls back to [Observed] but a
+    [Log.Misc.warn] is emitted so producer/consumer drift surfaces in
+    operator logs instead of silently misclassifying the node. The previous
+    `_ -> Observed` arm was explicitly documented as "fail-open"; that
+    posture is preserved here, just observable. See #8777. *)
+let node_status_of_string s =
+  match node_status_of_string_opt s with
+  | Some v -> v
+  | None ->
+      Log.Misc.warn
+        "activity_graph: unknown node_status wire %S -> Observed (drift; see #8777)" s;
+      Observed
 
 (** Span status: separate from node_status (different lifecycle).
     @since 7182 *)


### PR DESCRIPTION
## Summary

Close #8777. Sibling fix to #8684 / PR #8736 — same module (`activity_graph_types.ml`), same wire-string parser template.

| | Before | After |
|--|--|--|
| Unknown wire (typo, future producer variant) | silently → `Observed` (comment: "fail-open: unknown status treated as generic") | `_opt`: `None` / wrapper: `Observed` + `Log.Misc.warn` |
| Drift visibility | none — node misclassified silently | warn surfaces in operator logs |
| Public API | `_of_string` only | `_of_string_opt` (strict) + back-compat wrapper |

## Why this is worth a small fix

The arm comment explicitly admits the fail-open posture: `(* fail-open: unknown status treated as generic *)`. The maintainer documented the issue but never lifted it. This patch surfaces the drift in logs without changing runtime behaviour.

## Pattern alignment

Same template as PR #8689 / #8692 / #8706 / #8736 (this PR's direct precedent — sibling function in the same module) / #8740. Wire-string parser → `_opt + warn` template.

## Test plan
- [x] `dune build` green
- [x] 0 callers in lib/test (verified by `rg`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)