### PR TITLE
docs(spec): OCaml<->TLA+ phase mapping in KeeperCompactionLifecycle (#8642 family)

### DIFF
--- a/specs/keeper-state-machine/KeeperCompactionLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompactionLifecycle.tla
@@ -9,6 +9,32 @@
 \* It is intentionally a projection, not a full copy of post-turn policy.
 \* The runtime does not expose a compaction retry counter; only the
 \* boolean retry-exhausted latch is modeled here.
+\*
+\* OCaml ↔ TLA+ mapping (see also #8642 family — KeeperContextLifecycle,
+\* KeeperCoreTriad, KeeperGenerationLineage, KeeperReconcileLiveness):
+\*
+\*   spec phase  | OCaml Keeper_state_machine.phase  | source of truth
+\*   ------------+-----------------------------------+----------------
+\*   "Running"   | Running                           | lib/keeper/keeper_state_machine.ml:8
+\*   "Overflowed"| Overflowed                        | lib/keeper/keeper_state_machine.ml:10
+\*   "Compacting"| Compacting                        | lib/keeper/keeper_state_machine.ml:11
+\*   "Paused"    | Paused                            | lib/keeper/keeper_state_machine.ml:14
+\*
+\* Out-of-scope OCaml phases (intentional projection — not modelled here):
+\*   Offline, Failing, HandingOff, Draining, Crashed
+\*
+\* The 4-phase projection captures only the overflow/compaction recovery
+\* loop. Other lifecycle transitions (boot/shutdown/handoff/crash) live in
+\* sibling specs (e.g. KeeperContextLifecycle for boot/handoff/draining,
+\* KeeperCircuitBreaker for crash/failing).
+\*
+\* compaction_stage variant ↔ OCaml: TLA models {accumulating, compacting,
+\* done}; OCaml runtime uses the same labels in
+\* lib/keeper/keeper_registry.ml + lib/keeper/keeper_state_machine.ml
+\* (search "compaction_stage").
+\*
+\* retry_exhausted boolean ↔ OCaml: latched by Compact_retry_exhausted
+\* event; cleared by Compaction_completed (lib/keeper/keeper_state_machine.ml).
 
 EXTENDS TLC
 


### PR DESCRIPTION
## Summary

5th spec to receive the OCaml↔TLA+ mapping comment (after #8702, #8719's batch of 3). KeeperCompactionLifecycle is a 4-phase projection of the 9-phase OCaml lifecycle — the comment makes that scope explicit so a maintainer adding a runtime phase knows whether this spec needs updating.

| | Before | After |
|--|--|--|
| Phase mapping | implicit | explicit table TLA → OCaml constructor + line |
| Out-of-scope phases | hidden | named: Offline, Failing, HandingOff, Draining, Crashed |
| compaction_stage / retry_exhausted | TLA-only | linked to OCaml runtime locations |

## Pattern alignment

Same comment shape as PR #8702 (KeeperContextLifecycle) and PR #8719 (KeeperCoreTriad / KeeperGenerationLineage / KeeperReconcileLiveness). Comment-only; no behaviour change.

## Test plan
- [x] No code change — TLA spec semantics unchanged
- [ ] CI green (TLA model checking unaffected by header comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)