### PR TITLE
refactor(core): delete Result_syntax wrapper module (M-W1 step 7/final)

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard result_syntax executor_pool_ref text_similarity string_util)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref text_similarity string_util)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log))

--- a/lib/core/result_syntax.ml
+++ b/lib/core/result_syntax.ml
@@ -1,8 +1,0 @@
-(** Result_syntax — thin re-export of stdlib [Stdlib.Result.Syntax].
-
-    Historical: defined [let*]/[let+] locally before call sites migrated.
-    OCaml 4.14+ provides the same operators in [Stdlib.Result.Syntax];
-    this module is kept as a compatibility alias while call sites migrate
-    directly to [open Result.Syntax]. *)
-
-include Stdlib.Result.Syntax

--- a/lib/core/result_syntax.mli
+++ b/lib/core/result_syntax.mli
@@ -1,5 +1,0 @@
-(** Result_syntax — thin re-export of stdlib [Stdlib.Result.Syntax].
-
-    Kept as a compatibility alias; prefer [open Result.Syntax] at call sites. *)
-
-include module type of Stdlib.Result.Syntax


### PR DESCRIPTION
## Summary

M-W1 Result.Syntax 공고 **최종 단계 (7/7)** — `lib/core/result_syntax.{ml,mli}` wrapper 모듈 삭제.

## 변경

| 파일 | 변경 |
|------|------|
| `lib/core/result_syntax.ml` | 삭제 |
| `lib/core/result_syntax.mli` | 삭제 |
| `lib/core/dune` | `(modules ...)` 목록에서 `result_syntax` 제거 |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `Result_syntax` 참조 (lib) | 2 (모듈 자신만) | **0** |
| wrapper shim 유지 | yes | no |
| stdlib `Result.Syntax` 직접 사용 | 19 | 19 (불변) |

## 선행 조건

모든 call-site 이관 PR이 main에 머지된 상태 (#8735 #8739 #8742 #8743 #8744 #8749 #8762 #8764 #8771 #8772 #8774).

## 근거

- 로컬 빌드: `dune build lib --root=.` ✅ pass (wrapper 제거 후 전체 lib 컴파일 성공)
- `rg "Result_syntax" lib/` → 결과 0 (자기 참조 없음)

## Anti-goal 자가 체크

- [x] surgical (3 파일, 모듈 전체 제거 1곳)
- [x] behavior-preserving (모든 call-site가 이미 stdlib 사용 중)
- [x] 근거 검증 (빌드 pass + grep 0)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 — **이 PR로 M-W1 완전 종료**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
