### PR TITLE
[task-162] Rename last_delivery_surface to delivery_surface_view

### DIFF
--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -63,6 +63,27 @@ The following direct registry mutation helpers update fields that the composite 
 - `set_turn_selected_model`
 - `mark_turn_finished`
 
+Current code cross-check: `keeper_unified_turn.ml` still calls these helpers directly in the live turn path
+(`1711-1731`, `1781-1836`, `1934-2074` in the 2026-04-18 tree), so this is not dead API
+surface. The helpers are active, but they remain silent with respect to
+`keeper_composite_changed`.
+
+| Helper | Current direct caller(s) | Composite fields touched | Emits `keeper_composite_changed`? |
+| --- | --- | --- | --- |
+| `mark_turn_started` | `keeper_unified_turn.ml:1716` | installs `current_turn_observation`, initializes `turn_phase=prompting`, resets compaction stage | No |
+| `mark_turn_measurement` | `keeper_unified_turn.ml:1718` | binds pending measurement into the current turn snapshot | No |
+| `set_turn_decision_stage` | `keeper_unified_turn.ml:1722` | updates `decision_stage` to `guard_ok` when measurement is present | No |
+| `set_turn_cascade_state` | `keeper_unified_turn.ml:1782`, `1818`, `1834` | updates `cascade_state`, and via `turn_phase_of_cascade_state` also changes `turn_phase` | No |
+| `set_turn_phase` | `keeper_unified_turn.ml:1786`, `1934`, `1979`, `1987`, `2033`, `2067`, `2072` | forces `turn_phase` during terminal/compaction/error paths | No |
+| `set_turn_selected_model` | `keeper_unified_turn.ml:1831` | stores `selected_model` after a successful cascade attempt | No |
+| `mark_turn_finished` | `keeper_unified_turn.ml:1730` (finally block) | clears `current_turn_observation`, ending the live turn snapshot | No |
+
+By contrast, the nearby `dispatch_keeper_phase_event` calls in the overflow-retry path
+(`keeper_unified_turn.ml:1939-1946`) eventually go through
+`Keeper_registry.dispatch_event_with_audit`, so those phase-machine events *do* emit
+`keeper_composite_changed`. The gap is therefore real: direct turn-mutation helpers update
+observer-visible composite fields without producing the composite tick.
+
 That means `keeper_composite_changed` is not a complete “all composite mutations” stream. It is specifically tied to successful `dispatch_event*` applications.
 
 ## Keeper Heartbeat Snapshot Timing

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -75,6 +75,23 @@ let nonempty_opt value =
   let trimmed = String.trim value in
   if String.equal trimmed "" then None else Some trimmed
 
+let delivery_surface_view_of_meta (meta : Keeper_types.keeper_meta) =
+  match
+    Keeper_social_model_types.speech_act_of_string meta.runtime.last_speech_act
+  with
+  | Some speech_act ->
+      Some
+        (Keeper_social_model_types.default_delivery_surface_of_speech_act
+           speech_act)
+  | None -> None
+
+let delivery_surface_view_source_of_meta (meta : Keeper_types.keeper_meta) =
+  match
+    Keeper_social_model_types.speech_act_of_string meta.runtime.last_speech_act
+  with
+  | Some _ -> Some "derived_from_last_speech_act"
+  | None -> None
+
 let previous_state_of_meta (meta : Keeper_types.keeper_meta) =
   let runtime = meta.runtime in
   let speech_act =

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -62,6 +62,10 @@ type accountability_claim = {
 
 val speech_act_to_string : speech_act -> string
 val delivery_surface_to_string : delivery_surface -> string
+val delivery_surface_view_of_meta :
+  Keeper_types.keeper_meta -> delivery_surface option
+val delivery_surface_view_source_of_meta :
+  Keeper_types.keeper_meta -> string option
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
 val is_known_social_model : string -> bool

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -244,9 +244,19 @@ let social_model_resolution_fields_json (meta : keeper_meta) =
   ]
 
 let social_runtime_fields_json (meta : keeper_meta) =
+  let delivery_surface_view =
+    Keeper_social_model.delivery_surface_view_of_meta meta
+    |> Option.map Keeper_social_model.delivery_surface_to_string
+  in
+  let delivery_surface_view_source =
+    Keeper_social_model.delivery_surface_view_source_of_meta meta
+  in
   social_model_resolution_fields_json meta
   @ [
       ("last_speech_act", trimmed_string_json meta.runtime.last_speech_act);
+      ("delivery_surface_view", Json_util.string_opt_to_json delivery_surface_view);
+      ( "delivery_surface_view_source",
+        Json_util.string_opt_to_json delivery_surface_view_source );
       ( "last_social_transition_reason",
         trimmed_string_json meta.runtime.last_social_transition_reason );
       ("last_blocker", trimmed_string_json meta.runtime.last_blocker);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1082,6 +1082,13 @@ let handle_keeper_status ctx args : tool_result =
                if String.trim m.runtime.last_speech_act = ""
                then `Null
                else `String m.runtime.last_speech_act);
+             ("delivery_surface_view",
+               Json_util.string_opt_to_json
+                 (Keeper_social_model.delivery_surface_view_of_meta m
+                  |> Option.map Keeper_social_model.delivery_surface_to_string));
+             ("delivery_surface_view_source",
+               Json_util.string_opt_to_json
+                 (Keeper_social_model.delivery_surface_view_source_of_meta m));
              ("last_transition_reason",
                if String.trim m.runtime.last_social_transition_reason = ""
                then `Null

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -458,6 +458,13 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        tool_audit_at )
                    else keeper_tool_audit_fields config meta
                  in
+                 let delivery_surface_view =
+                   Keeper_social_model.delivery_surface_view_of_meta meta
+                   |> Option.map Keeper_social_model.delivery_surface_to_string
+                 in
+                 let delivery_surface_view_source =
+                   Keeper_social_model.delivery_surface_view_source_of_meta meta
+                 in
                  let surface_status =
                    if not agent_exists then "offline"
                    else Keeper_exec_status.keeper_surface_status ~agent_status:agent_json ~diagnostic
@@ -533,6 +540,19 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("latest_action_source", string_option_to_json latest_action_source);
                        ("tool_audit_source", string_option_to_json tool_audit_source);
                        ("tool_audit_at", string_option_to_json tool_audit_at);
+                       ( "last_speech_act",
+                         string_option_to_json
+                           (let value = String.trim meta.runtime.last_speech_act in
+                            if value = "" then None else Some value) );
+                       ("delivery_surface_view", string_option_to_json delivery_surface_view);
+                       ( "delivery_surface_view_source",
+                         string_option_to_json delivery_surface_view_source );
+                       ( "last_social_transition_reason",
+                         string_option_to_json
+                           (let value =
+                              String.trim meta.runtime.last_social_transition_reason
+                            in
+                            if value = "" then None else Some value) );
                        ("proactive_enabled", `Bool meta.proactive.enabled);
                        ("proactive_idle_sec", `Int meta.proactive.idle_sec);
                        ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -199,6 +199,15 @@ let keeper_list_row_json ~runtime_class config name =
               if String.trim meta.runtime.last_speech_act = ""
               then `Null
               else `String meta.runtime.last_speech_act );
+            ( "delivery_surface_view",
+              Json_util.string_opt_to_json
+                (Keeper_social_model.delivery_surface_view_of_meta meta
+                 |> Option.map Keeper_social_model.delivery_surface_to_string)
+            );
+            ( "delivery_surface_view_source",
+              Json_util.string_opt_to_json
+                (Keeper_social_model.delivery_surface_view_source_of_meta meta)
+            );
             ( "last_social_transition_reason",
               if String.trim meta.runtime.last_social_transition_reason = ""
               then `Null

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -378,6 +378,12 @@ let test_runtime_surface_exposes_social_model_resolution_fields () =
   check string "last speech act"
     "stay_silent"
     (runtime |> member "last_speech_act" |> to_string);
+  check string "delivery surface view"
+    "silent"
+    (runtime |> member "delivery_surface_view" |> to_string);
+  check string "delivery surface view source"
+    "derived_from_last_speech_act"
+    (runtime |> member "delivery_surface_view_source" |> to_string);
   check string "transition reason"
     "tool_only:stay_silent"
     (runtime |> member "last_social_transition_reason" |> to_string);


### PR DESCRIPTION
Distinguish derived operator surface values from recorded runtime facts by renaming and labeling derivation source.