### PR TITLE
fix(worker_dev_tools): redirect cd-chain pattern to cwd= argument (#8688)

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -279,15 +279,19 @@ let block_reason_to_string = function
   | Empty_command -> "command must not be empty"
   | Chain_or_redirect ->
     "Blocked: chaining (&&/||/;) and redirects (|/>) are not allowed. \
-     Run ONE command per call. Example: cmd='dune build'. \
-     Do NOT use: cmd='cd x && dune build' or cmd='rg foo | wc -l'. \
-     To write files, use keeper_fs_edit."
+     Run ONE command per call. \
+     To change directory, use the `cwd` argument instead of `cd` — \
+     Good: cwd='repos/masc-mcp', cmd='dune build'. \
+     Bad:  cmd='cd repos/masc-mcp && dune build'. \
+     For pipelines like `rg foo | wc -l`, run the primary command and \
+     process output at the LLM layer. To write files, use keeper_fs_edit."
   | Injection ->
     "Shell injection syntax (;, &&, standalone &, `, $) not allowed. \
-     Run ONE command per call. Example: cmd='dune build'. \
-     Do NOT use: cmd='cd x && dune build' or cmd='cmd1 ; cmd2'. \
-     keeper_bash runs from the playground root — pass full relative \
-     paths in the command itself (cmd='rg pattern lib/keeper/file.ml'). \
+     Run ONE command per call. \
+     To change directory, use the `cwd` argument — \
+     Good: cwd='repos/masc-mcp', cmd='dune build'. \
+     Bad:  cmd='cd repos/masc-mcp && dune build' or cmd='cmd1 ; cmd2'. \
+     Relative paths resolve from `cwd` (defaults to playground root). \
      For file writes, use keeper_fs_edit."
   | Process_substitution ->
     "Process substitution (<(...) or >(...)) is not allowed."


### PR DESCRIPTION
## Context

Triage of `~/me/.masc/tool_calls/2026-04/18.jsonl` for `command_blocked`
(#8688 + #8760) shows the top subclass is `cd X && dune build` style
chained commands:

- 10/day classified as `Injection` (`&&` as injection char)
- 4/day classified as `Chain_or_redirect`

The old hint said:

> "...Do NOT use: cmd='cd x && dune build'. keeper_bash runs from the
> playground root — pass full relative paths in the command itself."

Problem: keeper_bash already accepts a `cwd` argument
(`lib/keeper/keeper_exec_shell.ml:219`), and it is the simpler fix.
The hint never named it, so keepers kept trying the forbidden chain
pattern.

## Change

`lib/worker_dev_tools.ml` — rewrite both `Chain_or_redirect` and
`Injection` hint strings with explicit Good:/Bad: examples:

```
Good: cwd='repos/masc-mcp', cmd='dune build'
Bad:  cmd='cd repos/masc-mcp && dune build'
```

String-only change. No classifier behavior touched, no new branches,
no new fields.

## Why it should land

- Pure hint rewrite. The `cwd` path already works — this PR just
  teaches the LLM about it post-failure.
- Extension of the Good:/Bad: pattern established in #8704 / #8712 /
  #8734 — pairs with RFC #8760 R1 (#8775) that tells keepers to read
  the hint and retry.
- Empirically targeted (14/day rejections in the two modified branches).

## Tests

Full `dune build lib/` green. No new unit test — the fix is a
substring change on an error string, easier to validate end-to-end
than at unit level.

Relates to #8688, #8760.
