### PR TITLE
build(dune): bump lang 3.17 → 3.22 to match toolchain (M-W1 step 8)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.17)
+(lang dune 3.22)
 
 (using menhir 3.0)
 
@@ -26,7 +26,7 @@
  (description "MASC Protocol: File-based coordination for Claude, Gemini, and Codex agents")
  (depends
   (ocaml (>= 5.4))
-  (dune (>= 3.17))
+  (dune (>= 3.22))
   ; External dependencies (opam pin)
   (mcp_protocol (>= 1.3.0))
   (ocaml-webrtc (>= 0.2.3))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -12,7 +12,7 @@ doc: "https://github.com/jeong-sik/masc-mcp"
 bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
   "ocaml" {>= "5.4"}
-  "dune" {>= "3.17" & >= "3.17"}
+  "dune" {>= "3.22" & >= "3.22"}
   "mcp_protocol" {>= "1.3.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
@@ -81,3 +81,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/jeong-sik/masc-mcp.git"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
## Summary

`dune-project` 선언을 실측 toolchain에 정렬: `(lang dune 3.17)` → `(lang dune 3.22)`, dune 의존성 `>= 3.17` → `>= 3.22`. `masc_mcp.opam`은 dune이 자동 재생성.

## 변경

| 파일 | 변경 |
|------|------|
| `dune-project:1` | `(lang dune 3.17)` → `(lang dune 3.22)` |
| `dune-project:29` | `(dune (>= 3.17))` → `(dune (>= 3.22))` |
| `masc_mcp.opam` | auto-regenerated: `"dune" {>= "3.22" & >= "3.22"}` + `x-maintenance-intent: ["(latest)"]` |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `(lang dune X)` 선언 | 3.17 | 3.22 |
| dune 의존성 floor | 3.17 | 3.22 |
| 실제 사용 중인 dune (로컬/CI) | 3.22.0 | 3.22.0 (동일) |

## 왜 지금

북극성 지표 M-W1.1 — 선언과 실측 정렬. 이전까지 `(lang dune 3.17)`은 뒤쳐진 선언이었음 (실측은 3.22.0). 3.17 → 3.22 syntax 차이는 **호환 (addition-only)**, 전체 dune build pass.

## 근거

- `opam exec -- dune --version` → `3.22.0` (실측)
- `opam exec -- ocaml --version` → `5.4.1` (실측, `(ocaml (>= 5.4))`와 호환)
- 로컬 빌드: `dune build --root=.` ✅ pass (no warnings, no errors)

## Anti-goal 자가 체크

- [x] surgical (2 파일, 3 logical line)
- [x] behavior-preserving (syntax 상위호환, 3.17 기반 문법 모두 유효)
- [x] 실측 근거 (실제 toolchain 버전 기반)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (M-W1 step 8 — dune lang alignment)

다음 단계: oas repo에 동일 작업 (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
