### PR TITLE
docs(spec): producer/consumer/defense mapping in KeeperDwellMonotone (#8642 family)

### DIFF
--- a/specs/keeper-state-machine/KeeperDwellMonotone.tla
+++ b/specs/keeper-state-machine/KeeperDwellMonotone.tla
@@ -25,6 +25,37 @@
 \*               transition, modelling a forgotten clamp-to-now.
 \*               DwellNonNegative MUST be violated.  If it passes, the
 \*               invariant is too weak and must be strengthened.
+\*
+\* Implementation mapping (spec ↔ runtime, see #8642 family):
+\*
+\*   Producer side — phase transition stamps entry timestamp:
+\*     lib/keeper/keeper_registry.ml:919
+\*       Keeper_transition_audit.record_transition {
+\*         ...; wall_clock_at_decision = now; ... }
+\*     The OCaml side stamps [wall_clock_at_decision = now] at the moment
+\*     of each transition apply, satisfying the spec discipline that
+\*     entry_at := now (not future, not stale).  [now] comes from
+\*     [Time_compat.now ()] which is wall-clock monotonic in practice
+\*     (system clock).
+\*
+\*   Consumer side — dashboard derives dwell from the latest transition:
+\*     dashboard/src/components/keeper-detail.ts:1167-1168
+\*       const [phaseEnteredAtSec, ...] = useState<number | null>(null)
+\*       // sourced from fetchKeeperTransitions(...).transitions[0]
+\*       //   .wall_clock_at_decision
+\*
+\*   Defense in depth — frontend clamp guards a misbehaving clock:
+\*     dashboard/src/components/keeper-phase-indicator.ts:113
+\*       formatDuration(Math.max(0, Date.now()/1000 - phaseEnteredAtSec))
+\*     Even if [phaseEnteredAtSec > Date.now()/1000] (clock skew between
+\*     server and client, or a missed clamp on the producer), the dwell
+\*     UI never shows a negative duration.  This is independent of the
+\*     spec — the spec ensures the producer side is correct so the clamp
+\*     should never fire in practice.
+\*
+\* Out of scope here (sibling specs):
+\*   - phase _selection_ logic (KeeperConditionsGovernPhase, KeeperStateMachine)
+\*   - per-turn time accounting (KeeperTurnCycle)
 
 EXTENDS Integers, TLC
 


### PR DESCRIPTION
## Summary

6th spec to receive the OCaml ↔ TLA+ mapping comment (after #8702, #8719's batch of 3, #8780). KeeperDwellMonotone is a cross-language spec — OCaml stamps `wall_clock_at_decision = now`, TypeScript dashboard derives dwell from it. The mapping comment now calls out both sides plus the frontend `Math.max(0, ...)` defense in depth.

## Surface
- `specs/keeper-state-machine/KeeperDwellMonotone.tla` — header comment only.
- 30 added lines, 0 removed. No spec semantics changed.

## Why

Two-language spec is the easiest place to lose track of which side enforces what. Without the mapping, a maintainer changing the OCaml stamp site or the TS clamp could silently break the spec invariant.

## Pattern alignment

Same shape as #8702 / #8719 / #8780. Comment-only. TLA model checking unaffected.

## Test plan
- [x] No code change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)