### PR TITLE
docs(spec): OCaml<->TLA+ mapping in KeeperCircuitBreaker (#8642 family)

### DIFF
--- a/specs/keeper-state-machine/KeeperCircuitBreaker.tla
+++ b/specs/keeper-state-machine/KeeperCircuitBreaker.tla
@@ -1,6 +1,32 @@
 ---- MODULE KeeperCircuitBreaker ----
 \* Circuit Breaker state machine for keeper tool failure recovery.
 \* Verifies safety (no false trips) and mutation-tests the class isolation property.
+\*
+\* OCaml ↔ TLA+ mapping (see #8642 family):
+\*
+\*   spec variable    | OCaml location                                          | semantic
+\*   -----------------+---------------------------------------------------------+---------
+\*   Threshold        | lib/keeper/keeper_failure_circuit_breaker.ml:118        | `let threshold = 3` (matches spec CONSTANT)
+\*   count            | lib/keeper/keeper_failure_circuit_breaker.ml:64         | `mutable consecutive_count : int`
+\*   currentClass     | lib/keeper/keeper_failure_circuit_breaker.ml:63         | `mutable consecutive_class : error_class`
+\*   tripped          | lib/keeper/keeper_failure_circuit_breaker.ml (record_   | `record_failure` returns whether hint was injected this step
+\*                    | failure return value)                                   |
+\*   ErrorClasses     | lib/keeper/keeper_failure_circuit_breaker.ml:17-22      | `type error_class = Path_not_found | Path_not_allowed | Cwd_not_directory | Shell_exit_nonzero | Other`
+\*
+\* Scope projection: spec models 3 error classes
+\* (path_not_found, path_not_allowed, other); OCaml has 5
+\* (Path_not_found, Path_not_allowed, Cwd_not_directory, Shell_exit_nonzero, Other).
+\* The two extra OCaml classes (Cwd_not_directory, Shell_exit_nonzero)
+\* fold into the spec's "other" partition for class-isolation checking —
+\* the property the spec verifies (a class streak is broken by any
+\* different class) holds independently of how many "different" classes
+\* exist. Adding new OCaml classes does NOT require spec update.
+\*
+\* Bug Model (feedback_tla-spec-audit-outcome-trichotomy):
+\*   Clean cfg : SafetyInvariant + ClassIsolation pass.
+\*   Buggy cfg : models a counter that fails to reset on class change
+\*               (would inject hints based on cross-class accumulation).
+\*               Class-isolation property MUST be violated.
 
 EXTENDS Integers, Sequences, FiniteSets
 


### PR DESCRIPTION
## Summary

7th spec to receive the OCaml ↔ TLA+ mapping comment. Corrects an earlier sweep miss — I initially flagged KeeperCircuitBreaker as a possible orphan because the obvious grep for \`circuit_breaker\` hit \`lib/core/circuit_breaker.ml\` (a different concept: agent-level Closed/Open/HalfOpen breaker). The real mapping is \`lib/keeper/keeper_failure_circuit_breaker.ml\` (consecutive-tool-failure hint injection), discovered by searching for the spec's concrete \`ErrorClasses\` literals (\`path_not_found\`, \`path_not_allowed\`).

## Mapping table (in spec header)

| Spec | OCaml |
|--|--|
| \`Threshold = 3\` | \`let threshold = 3\` (line 118) |
| \`count\` | \`consecutive_count\` (line 64) |
| \`currentClass\` | \`consecutive_class : error_class\` (line 63) |
| \`tripped\` | \`record_failure\` return signaling hint injected |
| \`ErrorClasses\` | \`type error_class\` (5 OCaml constructors fold into 3 spec classes via "other") |

## Scope projection note

Spec models 3 error classes; OCaml has 5. The 2 extra OCaml classes (\`Cwd_not_directory\`, \`Shell_exit_nonzero\`) fold into the spec's \`"other"\` partition. The class-isolation property the spec verifies is independent of how many \`"different"\` classes exist — adding new OCaml classes does NOT require spec update. Comment makes that scope decision explicit.

## Pattern alignment

Same shape as #8702 / #8719 / #8780 / #8786. Comment-only.

## Lesson learned

Earlier I drafted issue #8787 (KeeperOASBridge orphan spec). That diagnosis stands — KeeperOASBridge has no OCaml mapping under any name. KeeperCircuitBreaker is the **opposite outcome**: it looked orphan to a quick grep but a content-grep on the spec's literal ErrorClasses values found the real impl. Sweep methodology updated: when a TLA spec looks orphan, also grep for the spec's CONSTANT values and string literals before filing the orphan issue.

## Test plan
- [x] No code change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)