### PR TITLE
fix(keeper_alerting_path): suggest concrete playground prefix for repos/mind paths (#8688)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -171,6 +171,29 @@ let absolute_allowed_paths_result ~(config : Coord.config)
     project-root anchor rule lets the keeper correct on the next call without
     re-trying the same broken interpretation. See
     [memory/feedback_tool-error-messages-teach-llm.md]. *)
+(** Look for a playground-root allowed path (contains ".masc/playground/")
+    and return the first match. Used to suggest a concrete rewrite when the
+    raw path looks like a playground-subdir pattern that was not prepended. *)
+let playground_root_of_allowed (allowed_norms : string list) : string option =
+  List.find_opt
+    (fun p ->
+      let marker = "/.masc/playground/" in
+      let mlen = String.length marker in
+      let slen = String.length p in
+      let rec find i =
+        if i + mlen > slen then false
+        else if String.sub p i mlen = marker then true
+        else find (i + 1)
+      in
+      find 0)
+    allowed_norms
+
+let raw_looks_like_playground_subdir (raw : string) : bool =
+  starts_with ~prefix:"repos/" raw
+  || starts_with ~prefix:"mind/" raw
+  || raw = "repos"
+  || raw = "mind"
+
 let format_path_rejection ~(raw : string) ~(resolved : string)
     ~(allowed_norms : string list) : string =
   let resolved_hint =
@@ -181,9 +204,21 @@ let format_path_rejection ~(raw : string) ~(resolved : string)
     else
       ""
   in
+  let playground_hint =
+    if raw_looks_like_playground_subdir raw then
+      match playground_root_of_allowed allowed_norms with
+      | Some pg ->
+        Printf.sprintf
+          ". Your raw path starts with 'repos/' or 'mind/'; prepend your \
+           playground root (try path=%s/%s) or call keeper_context_status \
+           and use the playground_repos / playground_mind variables."
+          pg raw
+      | None -> ""
+    else ""
+  in
   Printf.sprintf
-    "path_not_in_allowed_paths: %s%s (allowed: [%s])"
-    raw resolved_hint (String.concat ", " allowed_norms)
+    "path_not_in_allowed_paths: %s%s (allowed: [%s])%s"
+    raw resolved_hint (String.concat ", " allowed_norms) playground_hint
 
 let resolve_keeper_target_path ~(config : Coord.config)
     ~(allowed_paths : string list) ~(raw_path : string)


### PR DESCRIPTION
## Context

#8688 triage of `~/me/.masc/tool_calls/2026-04/18.jsonl` surfaced the
single largest per-tool error class on that day:

- `masc_code_search path=repos/masc-mcp/lib` — **42/day**
- `masc_code_search path=repos/masc-mcp`       — 35/day
- `masc_code_read  path=...`                    — 48/day

All return the same `path_not_in_allowed_paths` error. The existing
hint says:

> `... relative paths anchor at project root, not playground (resolved=...)`

This is correct but not actionable: the keeper LLM receives the
resolved absolute path that failed and still cannot infer what
*should* have been passed — it keeps retrying variants of `repos/...`.

## Change

When the raw path matches a playground-subdir pattern (starts with
`repos/` or `mind/`) AND the allowed-paths set contains a
`/.masc/playground/` entry, the error message is extended with a
concrete suggestion:

```
... Your raw path starts with 'repos/' or 'mind/'; prepend your
playground root (try path=<pg>/<raw>) or call keeper_context_status
and use the playground_repos / playground_mind variables.
```

`<pg>` is the playground root the keeper is actually permitted to use.

Unmatched patterns retain the old message — this is additive only.

## Why it should land

- Pure message augmentation. `ok`/`error` fields unchanged. No new
  fields, no classifier branch changed, no control flow touched.
- Actively targets the top-N error class on 2026-04-18 (42 + 35 + 48 =
  125 rejections in one day from one combined pattern).
- Pairs with #8775 (RFC #8760 R1 — tool error grammar in keeper
  capabilities prompt) which told keepers to read the hint and retry
  with the corrected args; this PR ensures that hint is actually
  corrective rather than descriptive.

## Tests

`dune build lib/` green. The helpers are pure functions; an end-to-end
test would require a full keeper fixture, deferred to a follow-up if
regressions appear.

Follows feedback_tool-error-messages-teach-llm.

Relates to #8688, #8760.
