### PR TITLE
feat(streamable_http): mark session.last_seen [@atomic] to fix unlocked race (Wave 2 pilot)

### DIFF
--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -13,7 +13,7 @@ type transport = Streamable_HTTP
 type session = {
   id: string;
   created_at: float;
-  mutable last_seen: float;
+  mutable last_seen: float [@atomic];
   transport: transport;
   mutable subscriptions: string list;
 }

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -16,7 +16,7 @@ type transport = Streamable_HTTP
 type session = {
   id: string;                 (** Unique session ID (UUID) *)
   created_at: float;          (** Unix timestamp *)
-  mutable last_seen: float;   (** Last activity timestamp *)
+  mutable last_seen: float [@atomic];   (** Last activity timestamp; atomic read/write for unlocked concurrent update via [Session.touch]. *)
   transport: transport;       (** Transport type for this session *)
   mutable subscriptions: string list; (** Event types subscribed *)
 }


### PR DESCRIPTION
## Summary

Wave 2 `[@atomic]` pilot 1곳. `lib/streamable_http.ml`의 `session.last_seen` 필드에 OCaml 5.4 mainline `[@atomic]` attribute 적용.

## 문제

```ocaml
module Session = struct
  let mutex = Eio.Mutex.create ()
  let with_lock f = Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())

  let create ...  = with_lock (fun () -> ...)  (* mutex *)
  let find id     = with_lock (fun () -> ...)  (* mutex *)
  let remove id   = with_lock (fun () -> ...)  (* mutex *)

  let touch session =
    session.last_seen <- Time_compat.now ()   (* ← NO LOCK *)
```

파일 헤더는 "Thread-safe session storage using Mutex"라 주장하지만 `touch`만 lock 없이 바로 mutation. HTTP 요청 handler(`request_handler` 경로)가 fiber로 병렬 실행되므로 실질적 race.

## 해결

`last_seen` 필드에 `[@atomic]` 부착 — OCaml 5.4 mainline attribute. 해당 필드 read/write는 memory ordering guarantee (release store / acquire load), Mutex 없이 safe.

```diff
 type session = {
   id: string;
   created_at: float;
-  mutable last_seen: float;
+  mutable last_seen: float [@atomic];
   transport: transport;
   mutable subscriptions: string list;
 }
```

`.mli`도 동일 변경. `Session.touch` 코드 변경 없음 — attribute만으로 atomic semantics 적용.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `[@atomic]` record 필드 | 0 | **1** (hot path 첫 사례) |
| unprotected mutation | 1 (last_seen) | 0 |
| 관련 lock 추가 | — | 0 (attribute only) |

## 왜 지금

북극성 지표 "`[@atomic]` 커버리지 hot path 10곳"의 **첫 1곳**. 파일럿 대상으로 안전 조건 전부 충족:
- 단일 float 필드 (tearing 없음, ABA 없음)
- 독립적 업데이트 (다른 필드와 atomically 바꿀 필요 없음)
- 명시적 race 증거 (`touch` 만 lock 없음)
- 공식 mainline attribute (OxCaml fork 아님)

## 근거

- OCaml 5.4 manual [@atomic] attribute: https://ocaml.org/manual/5.4/attributes.html
- 로컬 컴파일 검증: `/tmp/atomic-test`에서 `[@atomic]` dune 3.22 + OCaml 5.4.1로 minimal repro build pass
- masc-mcp 전체 빌드: `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (2 파일 = `.ml` + `.mli`, 2 line 변경)
- [x] 근거 명확 (race 실증 + 공식 attribute)
- [x] 벤치 주장 없음 — 정확성(race 제거) 목적만 claim, 성능은 claim 안 함
- [x] OxCaml preview 아닌 mainline 5.4 기능

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2 pilot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
