### PR TITLE
feat(runtime_events): install listener + reserve masc turn event handles (Wave 2A pilot)

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref text_similarity string_util)
- (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log))
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events text_similarity string_util)
+ (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/core/masc_runtime_events.ml
+++ b/lib/core/masc_runtime_events.ml
@@ -1,0 +1,24 @@
+(** Runtime_events event registrations for masc-mcp (Wave 2A pilot).
+
+    Registers user event tags/handles and provides a start helper so that
+    Olly (or a custom [Runtime_events.Callbacks] consumer) can observe
+    both stock OCaml runtime events (GC, phases) and future masc-specific
+    turn events.
+
+    This pilot only installs the listener and reserves event handles;
+    emit sites will be added in follow-up PRs (worker turn boundary,
+    keeper turn boundary). *)
+
+type Runtime_events.User.tag +=
+  | Turn_start
+  | Turn_end
+
+let ev_turn_start =
+  Runtime_events.User.register "masc.turn.start"
+    Turn_start Runtime_events.Type.unit
+
+let ev_turn_end =
+  Runtime_events.User.register "masc.turn.end"
+    Turn_end Runtime_events.Type.unit
+
+let start_listener () = Runtime_events.start ()

--- a/lib/core/masc_runtime_events.mli
+++ b/lib/core/masc_runtime_events.mli
@@ -1,0 +1,22 @@
+(** Runtime_events event registrations for masc-mcp (Wave 2A pilot).
+
+    Consumed by Olly or custom [Runtime_events.Callbacks] programs.
+    Emit sites for [ev_turn_start]/[ev_turn_end] will be added in
+    follow-up PRs; this module currently only installs the listener
+    and reserves event handles. *)
+
+type Runtime_events.User.tag +=
+  | Turn_start
+  | Turn_end
+
+val ev_turn_start : unit Runtime_events.User.t
+(** Reserved: emit at the beginning of an agent turn. *)
+
+val ev_turn_end : unit Runtime_events.User.t
+(** Reserved: emit at the end of an agent turn. *)
+
+val start_listener : unit -> unit
+(** Install the Runtime_events ring buffer listener.
+
+    Idempotent-safe per [Runtime_events] semantics. Should be called
+    once, early inside the [Eio_main.run] entry. *)

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -685,6 +685,7 @@ exception Shutdown
 (** Convenience function to start server *)
 let start ?(config = default_config) ?(routes = default_routes) () =
   Eio_main.run @@ fun env ->
+  Masc_runtime_events.start_listener ();
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
 


### PR DESCRIPTION
## Summary

Wave 2A 최소 파일럿 — OCaml 5 `Runtime_events` 관찰성 기반 설치. 새 모듈 `Masc_runtime_events`가 event 핸들을 등록하고 HTTP 서버 시작 시점에서 listener 활성화.

## 변경

| 파일 | 내용 |
|------|------|
| `lib/core/masc_runtime_events.ml` (new) | 2 user event tag 등록 (`Turn_start`, `Turn_end`) + `start_listener` |
| `lib/core/masc_runtime_events.mli` (new) | 공개 시그니처 |
| `lib/core/dune` | `masc_runtime_events` 모듈 + `runtime_events` 라이브러리 추가 |
| `lib/http_server_eio.ml:688` | `Masc_runtime_events.start_listener ()` 호출 (Eio_main.run 진입 직후) |

## 이번 PR 하는 일

- `Runtime_events.start ()` 설치 — Olly 등 외부 consumer가 **GC/runtime phase event** 전부 observe 가능
- 2개 user event 핸들 등록 (`masc.turn.start`, `masc.turn.end`) — **reserved, 아직 emit 안 함**

## 이번 PR 하지 않는 일 (다음 PR로 분리)

- worker turn 경계 emit (`worker_oas.ml:511`)
- keeper turn 경계 emit (`keeper_agent_run.ml:413`)
- Runtime_events 소비 툴/대시보드
- 성능 벤치

이 PR은 **인프라 설치 only** — emit은 event 핸들이 merge된 뒤 follow-up PR에서 호출.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `Runtime_events` 참조 수 (lib) | **0** | 4 (module `.ml`/`.mli`, dune, server start) |
| 등록된 masc user event | 0 | 2 (reserved) |
| GC/phase observability 가능 | no | **yes** (Olly immediate) |

## 왜 지금

북극성 Wave 2 지표 "Runtime_events 트레이싱 (eio loop + turn pipeline)"의 1단계. minimal pilot로 인프라만 먼저 세팅.

## 근거

- OCaml 5.4.1 공식 `Runtime_events` API (`/Users/dancer/.opam/5.4.1/lib/ocaml/runtime_events/runtime_events.mli`)
- API 검증: `/tmp/rte-test`에서 `User.register` + `User.write` + `start` minimal repro build pass
- masc-mcp 전체 빌드: `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (4 파일, 핵심 변경 1 호출)
- [x] behavior-preserving (Runtime_events listener는 시작만, emit 없음)
- [x] 근거 인용 (공식 mli 경로)
- [x] 성능 주장 없음 — observability 가능성만 claim

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A pilot — infra)

다음 PR: worker turn emit (`Masc_runtime_events.ev_turn_start` 호출 at `worker_oas.ml:511`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
