### PR TITLE
docs(changelog): CDAL verification audit Added entries (#8715 #8731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,24 @@
   후속 (phase 2 / 축 9): server endpoint in-process 전환(Eio.Process ~cwd),
   `--fix` 버튼 HITL approval, 실제 callback 확장.
 
+- **CDAL verdict attribution on verification approve/reject legs (#8731).**
+  `tool_task.ml` 의 `Approve_verification` / `Reject_verification` 핸들러에
+  `Cdal_verdict_gate.gate_check` 호출을 추가. FSM-enabled 경로는
+  `Done_action` 를 우회하기 때문에 기존 CDAL gate 가 verification 승인
+  시점에 동작하지 않아 `/api/v1/attribution/summary` 에 `cdal_verdict`
+  gate 가 0 entries 로 남았다. 이제 `Env_config_runtime.Cdal.gate_enabled()`
+  (default true) 가 켜진 환경에서 approve/reject 양쪽이 verdict lookup +
+  `Dashboard_attribution` ring 기록을 남긴다.
+
+- **Verifier-role affordance gating (#8715).**
+  `keeper_unified_turn.ml` 의 `observed_triggers_of_observation` /
+  `observed_affordances_of_observation` 에 `?meta` optional param 을 추가하고
+  `pending_verification` trigger 및 `task_verify` affordance 를
+  `is_verifier_role_keeper` 가 참인 keeper 에만 노출한다. 그 외 persona 는
+  world observation 에서 verification 관련 신호를 보지 않으므로 fleet 노이즈
+  감소. `?meta=None` 호출은 legacy surface-to-all 유지 (diagnostics / snapshot
+  caller 호환).
+
 ### Changed
 
 - **OAS pin bump → `main@54f4aeab` (v0.162.0 + Gemini policy fix).**


### PR DESCRIPTION
## Summary

Append two Unreleased → Added entries in `CHANGELOG.md` for the PRs that landed earlier today:

- **#8731** — `Cdal_verdict_gate.gate_check` wired into `Approve_verification` / `Reject_verification` handlers in `tool_task.ml`. FSM-enabled verification bypassed `Done_action` so the CDAL gate never recorded `cdal_verdict` attribution on approve/reject. `Env_config_runtime.Cdal.gate_enabled()` (default true) now governs the call at both legs.
- **#8715** — `keeper_unified_turn.{ml,mli}` gains `?meta` on `observed_triggers_of_observation` / `observed_affordances_of_observation`. `pending_verification` trigger + `task_verify` affordance are scoped to keepers whose persona declares the verifier role (`is_verifier_role_keeper`). `?meta=None` keeps the legacy surface-to-all diagnostics behaviour.

## Scope guard

- Only CHANGELOG. No ROADMAP / SPEC-INDEX edits — those files track higher-level reliability themes and do not enumerate CDAL gate wiring.
- No version bump. `scripts/check-version-truth.sh` already green (package `0.10.1` == latest release `0.10.1`); entries go under Unreleased.

## Verification

```
$ bash scripts/check-doc-truth.sh
Version truth OK: package=0.10.1 latest_release=0.10.1
Doc truth OK: front-door docs and key specs are aligned with current repo truth
Doc code_refs OK: every frontmatter code_refs path exists in the repo

$ bash scripts/check-version-truth.sh
Version truth OK: package=0.10.1 latest_release=0.10.1
```

## Context

Closes the PR 5 doc-sync step from the 2026-04-19 `/loop` CDAL audit plan. The original plan proposed a 5-PR split; #8715 and #8731 were the only feature changes needed because the UI layer (Kanban column, task detail verdict lineage, verifier persona, TLA+ lifecycle spec) was already present on `main` at probe time.