### PR TITLE
ci: stop cancelling main CI runs (auto-merge train protection)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pr-sync-check:


### PR DESCRIPTION
## Summary

- `cancel-in-progress: true`가 push와 pull_request 양쪽에 적용되어, auto-merge train(현재 10+ PR)에서 main push가 prior CI를 매번 취소.
- 결과: **마지막 GREEN main CI는 17:26Z (2시간+ 전, sha 017c61c3)**. 이후 5+ push 모두 CI cancelled로 끝, 0 green proof.
- Fix: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. PR 브랜치는 기존대로 cancel(불필요한 minute 절약), push to main/develop은 항상 완주.

## Reproduction

```bash
gh run list --repo jeong-sik/masc-mcp --branch main --workflow CI --limit 5 --json conclusion,headSha,createdAt
# 모두 cancelled, 가장 최근 success는 17:26 sha 017c61c3
```

## Why this matters

main은 protected branch라 모든 commit이 검증되어야 함. 하지만 auto-merge train이 빠르면:
- PR1 squash merge → main push → CI 시작
- 2분 후 PR2 squash merge → main push → CI cancel + 새 CI 시작
- 반복

그래서 main 위 N개 commit이 GREEN 증명 없이 누적. 누군가 release하거나 binary 굽는 시점에 어느 sha가 actually green인지 모호함.

## Test plan

- [ ] 머지 후 main push 5건이 각자 독립 CI 결과를 가지는지 확인
- [ ] PR push spam 시 PR CI는 여전히 cancel되는지 확인 (불필요한 비용 방지)
- [ ] 같은 분 안의 main push 2건이 둘 다 끝까지 실행되는지 확인

## Risk

낮음. PR 동작은 변하지 않음. main만 CI minute 더 씀. 동시 main push 2건이면 둘 다 실행되니 GitHub Actions queue 약간 증가. trade-off 가치 있음 — main GREEN 증명 회복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
