### PR TITLE
feat(relay): mark calibration.correction_factor [@atomic] for cross-fiber read (Wave 2B #2)

### DIFF
--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -47,7 +47,11 @@ type handoff_payload = {
 (** Context estimation calibration state *)
 type calibration_state = {
   mutable samples: (int * int) list;  (* (estimated, actual) pairs *)
-  mutable correction_factor: float;    (* multiplied to estimate *)
+  mutable correction_factor: float [@atomic];
+    (* multiplied to estimate; read cross-fiber by [estimate_context]
+       so the field is marked [@atomic] for release-store/acquire-load
+       semantics. The compound update (samples+factor) in
+       [record_actual_tokens] is not itself atomic — see module doc. *)
 }
 
 let calibration = {


### PR DESCRIPTION
## Summary

Wave 2B `[@atomic]` 2번째 파일럿 — `lib/relay.ml` 의 global `calibration.correction_factor` 필드.

## 문제

`calibration`은 **global singleton** (line 53). 두 경로에서 접근:

**Writers** (lock 없음):
- `record_actual_tokens` (line 75): `calibration.correction_factor <- new_factor`

**Readers** (lock 없음):
- `get_calibration_info` (line 89): JSON dump용
- `estimate_context` (line 158): `let factor = calibration.correction_factor in ... *.  factor` — 실제 토큰 추정에 곱함

Writer는 worker/keeper fiber에서 호출 가능 (token 사용량 실측 후 보정), reader `estimate_context`는 각 turn 시작 시 호출. **multi-fiber 병행 read/write** 증거 확실.

ARM/Apple Silicon multicore에서 C11 release/acquire 없이 stale read 가능. 즉, 최신 보정 결과를 다른 fiber가 바로 못 볼 위험.

## 해결

`correction_factor` 필드에 `[@atomic]` 부착 — OCaml 5.4 mainline, release-store/acquire-load 강제. Mutex 없이 memory ordering 확보.

```diff
 type calibration_state = {
   mutable samples: (int * int) list;
-  mutable correction_factor: float;    (* multiplied to estimate *)
+  mutable correction_factor: float [@atomic];
+    (* multiplied to estimate; ... *)
 }
```

## 한계 (정직 고지)

- **이 PR이 고치는 것**: `correction_factor` 단일 필드 read/write의 memory ordering.
- **이 PR이 고치지 않는 것**: `samples` 리스트 + `correction_factor` **복합 업데이트** race. 두 fiber가 동시에 `record_actual_tokens`를 호출하면 한쪽 업데이트가 손실될 수 있음. 이건 `[@atomic]`으로 해결 불가 — 전체 업데이트를 Mutex로 감싸야 함.

현재 시스템은 moving-average라 개별 샘플 손실은 calibration drift 노이즈 수준 (블로킹 이슈 아님). Read 쪽의 memory visibility 부재가 더 명확한 correctness 문제라 우선 해결.

follow-up PR 후보: `calibration` 전체를 `Eio.Mutex`로 감싸기.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `[@atomic]` 필드 (masc-mcp) | 1 | **2** (→ hot path 10 목표) |
| relay.ml 내 unprotected float read/write | 1 (correction_factor) | 0 (read/write level) |
| 남은 race (samples 복합 업데이트) | 1 | 1 (follow-up) |

## 근거

- OCaml 5.4 `[@atomic]` attribute: https://ocaml.org/manual/5.4/attributes.html
- 로컬 빌드: `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (1 파일, 1 attribute)
- [x] 파셜 해결 **정직 명시** (samples race 별도)
- [x] 근거 구체 (line 75/89/158, 실제 call path)
- [x] mainline 5.4 (OxCaml 아님)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2B, 2nd of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
