### PR TITLE
[codex] Fix operator digest guidance target fallback

### DIFF
--- a/lib/operator/operator_digest_guidance.ml
+++ b/lib/operator/operator_digest_guidance.ml
@@ -6,23 +6,27 @@
 
 module U = Yojson.Safe.Util
 
-let judgment_surface_for_target_type = function
-  | "root" | "room" | "namespace" -> "command.namespace"
-  | _ -> "command.namespace"
+let normalize_target_type value =
+  String.trim value |> String.lowercase_ascii
 
-let judgment_target_type_of_string = function
-  | "root" | "room" | "namespace" -> Operator_judgment.Coord
-  | _ -> Operator_judgment.Coord
+let judgment_surface_for_target_type target_type =
+  if Operator_digest_types.is_root_alias target_type then Some "command.namespace"
+  else None
 
 let fresh_operator_judgment config ~target_type ~target_id =
-  let judgment_target_type = judgment_target_type_of_string target_type in
-  let surface = judgment_surface_for_target_type target_type in
+  let target_type = normalize_target_type target_type in
   match
-    Operator_judgment.latest_active config ~surface
-      ~target_type:judgment_target_type ~target_id
+    ( Operator_judgment.target_type_of_string target_type,
+      judgment_surface_for_target_type target_type )
   with
-  | Some value when Operator_judgment.is_fresh value ->
-      Some (Operator_judgment.to_yojson value)
+  | Some judgment_target_type, Some surface -> (
+      match
+        Operator_judgment.latest_active config ~surface
+          ~target_type:judgment_target_type ~target_id
+      with
+      | Some value when Operator_judgment.is_fresh value ->
+          Some (Operator_judgment.to_yojson value)
+      | _ -> None)
   | _ -> None
 
 let judgment_summary_json judgment_json =

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -62,6 +62,10 @@ let () =
             `Quick
             Test_operator_control_judgment
             .test_digest_room_ignores_stale_operator_judgment;
+          Alcotest.test_case
+            "guidance ignores unsupported target type" `Quick
+            Test_operator_control_judgment
+            .test_guidance_ignores_unsupported_target_type;
           Alcotest.test_case "operator judgment write and latest roundtrip"
             `Quick
             Test_operator_control_judgment

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -88,6 +88,35 @@ let test_digest_room_ignores_stale_operator_judgment () =
       Alcotest.(check bool) "judgment missing" true
         (Yojson.Safe.Util.member "judgment" digest = `Null))
 
+let test_guidance_ignores_unsupported_target_type () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      record_operator_judgment config ~surface:"command.namespace"
+        ~target_type:Operator_judgment.Coord ~target_id:None
+        ~summary:"Root guidance must not leak to keeper targets."
+        ~fresh_for_sec:90.0 ();
+      let fields =
+        Operator_digest_guidance.active_guidance_fields ~config ~actor:"operator"
+          ~target_type:"keeper" ~target_id:None ~fallback_recommendations:[]
+          ~fallback_summary:(`Assoc [ ("count", `Int 0) ])
+      in
+      let guidance = `Assoc fields in
+      Alcotest.(check string) "judgment owner fallback" "fallback_read_model"
+        Yojson.Safe.Util.(guidance |> member "judgment_owner" |> to_string);
+      Alcotest.(check bool) "authoritative judgment unavailable" false
+        Yojson.Safe.Util.
+          (guidance |> member "authoritative_judgment_available" |> to_bool);
+      Alcotest.(check string) "active guidance layer fallback" "fallback"
+        Yojson.Safe.Util.(guidance |> member "active_guidance_layer" |> to_string);
+      Alcotest.(check bool) "judgment missing" true
+        (Yojson.Safe.Util.member "judgment" guidance = `Null))
+
 let test_operator_judgment_write_and_latest_roundtrip () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary

Fixes #8785 by removing the local `judgment_target_type_of_string` fallback that mapped every target type to `Operator_judgment.Coord`.

## Root Cause

`operator_digest_guidance` had its own parser for digest guidance judgment targets. That parser returned `Coord` for both supported aliases and unknown target types, so a root/namespace judgment could be considered for unsupported targets such as `keeper`.

## Changes

- Normalize guidance target strings before lookup.
- Reuse `Operator_judgment.target_type_of_string` as the central parser.
- Return fallback guidance when the digest guidance target is unsupported.
- Add a regression test proving root guidance does not leak to a `keeper` target.

## Validation

- `dune build --root .`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune exec --root . test/test_operator_control.exe -- -q`
- `git diff --check`