### PR TITLE
fix(bonsai-dashboard): stub OxCaml arch primitives for js_of_ocaml runtime

### DIFF
--- a/dashboard_bonsai/src/dune
+++ b/dashboard_bonsai/src/dune
@@ -1,4 +1,5 @@
 (library
  (name dashboard_bonsai_lib)
  (libraries bonsai_web virtual_dom brr yojson)
+ (js_of_ocaml (javascript_files runtime_stubs.js))
  (preprocess (pps ppx_jane ppx_css js_of_ocaml-ppx)))

--- a/dashboard_bonsai/src/runtime_stubs.js
+++ b/dashboard_bonsai/src/runtime_stubs.js
@@ -1,0 +1,12 @@
+// js_of_ocaml runtime stubs for OxCaml-only primitives.
+//
+// OxCaml 5.2.0+ox introduces Sys.arch_amd64 / Sys.arch_arm64 unboxed primitives
+// referenced by the basement library. Stock js_of_ocaml 6 runtime does not
+// define these. We return 0 (false) for both because the bundle runs in a
+// browser, not on a native CPU.
+
+//Provides: caml_sys_const_arch_amd64 const
+function caml_sys_const_arch_amd64 () { return 0; }
+
+//Provides: caml_sys_const_arch_arm64 const
+function caml_sys_const_arch_arm64 () { return 0; }


### PR DESCRIPTION
## 증상

`/dashboard/b/` 가 빈 화면. DevTools Console:

```
Uncaught TypeError: runtime.caml_sys_const_arch_amd64 is not a function
    at blackbox.ml:1:1
```

번들이 첫 evaluation 단계(`basement` lib 초기화)에서 죽기 때문에 `Bonsai.Start.start` 자체가 실행되지 않음. PR #8690 머지 직후 첫 실사용에서 발견.

## 원인

OxCaml 5.2.0+ox(`bonsai-dashboard` switch)는 stock OCaml 5.x 에 없는 `Sys.arch_amd64` / `Sys.arch_arm64` unboxed primitive 를 추가한다. `basement` 라이브러리가 이를 호출하는데, stock js_of_ocaml 6 runtime 에는 두 함수가 정의돼 있지 않다.

## 수정

`dashboard_bonsai/src/runtime_stubs.js` 에 stub 등록:

```js
//Provides: caml_sys_const_arch_amd64 const
function caml_sys_const_arch_amd64 () { return 0; }

//Provides: caml_sys_const_arch_arm64 const
function caml_sys_const_arch_arm64 () { return 0; }
```

브라우저는 native CPU 가 아니므로 둘 다 0(false). `(js_of_ocaml (javascript_files runtime_stubs.js))` 로 라이브러리에 묶어서 모든 의존 executable 에 자동 link.

## 검증

- `bonsai-dashboard` switch 에서 `dune build` 통과
- `_build/default/bin/main.bc.js` 안에 `function caml_sys_const_arch_amd64` 정의 1개 confirm
- 로컬 서버(:8935) 에 새 번들 cp → 강제 새로고침 시 화면 렌더 (별도 확인 필요)

## 후속 (이 PR 범위 밖)

- 산출물 SSOT: `Makefile bonsai-dashboard` target 이 worktree 안 `assets/` 에만 cp 함. main repo 위치 sync 자동화 필요.
- Bundle filename hashing: `main.bc.js` 고정명 + `Cache-Control: immutable` 조합이라 fix 배포 시 강제 새로고침 필요. `main.<sha>.bc.js` 패턴으로 전환 검토.