### PR TITLE
docs(spec): expand OCaml<->TLA+ mapping in KeeperCampaignLifecycle (#8642 family)

### DIFF
--- a/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
@@ -4,6 +4,38 @@
 \* Mirrors: lib/keeper/keeper_campaign_fsm.ml
 \* Goal: prove that campaign verdicts come from a separate mission FSM, not from
 \* runtime keeper lifecycle phases.
+\*
+\* OCaml ↔ TLA+ mapping (see #8642 family):
+\*
+\*   spec phase string     | OCaml campaign phase variant                          | line
+\*   ----------------------+-------------------------------------------------------+-----
+\*   "bootstrapping"       | Bootstrapping                                         | lib/keeper/keeper_campaign_fsm.ml:8
+\*   "claiming_task"       | Claiming_task                                         | (same module, around line 9)
+\*   "task_bound"          | Task_bound                                            | lib/keeper/keeper_campaign_fsm.ml:10
+\*   (round-trip via)      | phase_to_string / phase_of_string                     | lib/keeper/keeper_campaign_fsm.ml:71-93
+\*
+\*   spec variable        | OCaml snapshot field                                   | source
+\*   ---------------------+--------------------------------------------------------+--------
+\*   taskBound (boolean)  | snapshot.task_id <> None                               | derivable from snapshot.task_id
+\*   compactionCount      | snapshot.compaction_count                              | snapshot record
+\*   handoffCount         | snapshot.handoff_count                                 | snapshot record
+\*   continuityGoal/Task  | snapshot.continuity_*                                  | snapshot record
+\*
+\* Verdict mapping ↔ OCaml: spec verdicts come from
+\* lib/keeper/keeper_campaign_fsm.ml:99 (`verdict_of_phase`) — confirms
+\* the spec's design goal that verdicts derive ONLY from the campaign FSM
+\* phase, never from the runtime keeper lifecycle phase (which lives in
+\* lib/keeper/keeper_state_machine.ml — orthogonal axis).
+\*
+\* Event mapping ↔ OCaml: spec actions correspond to
+\* lib/keeper/keeper_campaign_fsm.ml:33 (`type event`) — Task_bound_observed,
+\* etc. apply via `apply_event` at line 287.
+\*
+\* Scope: spec models the pure mission FSM. The runtime keeper lifecycle
+\* (Offline / Running / Crashed / etc.) is intentionally OUT OF SCOPE
+\* and lives in sibling specs (KeeperStateMachine, KeeperContextLifecycle).
+\* Adding a new keeper lifecycle phase does NOT require updating this
+\* spec; adding a new campaign phase DOES.
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary

9th spec to receive the standard OCaml ↔ TLA+ mapping comment. The spec already had a one-line \`Mirrors:\` pointer; this PR expands it to the full table format consistent with the family.

## Why expand the existing pointer

A single \`Mirrors: lib/...\` pointer tells you the impl exists. It doesn't tell you:
- which TLA variable maps to which OCaml field
- which line discharges the spec's design goal
- which axis is in/out of scope when a maintainer adds a new constructor

The expanded table format (used in 8 prior PRs) answers all three. Particularly important here because the spec's stated goal — "campaign verdicts come from a separate mission FSM, not from runtime keeper lifecycle phases" — is exactly the kind of architectural boundary that future code can silently cross. Naming \`verdict_of_phase\` (line 99) as the discharging function makes the boundary auditable.

## Pattern alignment

Same shape as #8702 / #8719 / #8780 / #8786 / #8788 / #8791. Comment-only.

## Test plan
- [x] No code change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)