### PR TITLE
fix(relay): serialize calibration compound update under Mutex

### DIFF
--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -48,10 +48,9 @@ type handoff_payload = {
 type calibration_state = {
   mutable samples: (int * int) list;  (* (estimated, actual) pairs *)
   mutable correction_factor: float [@atomic];
-    (* multiplied to estimate; read cross-fiber by [estimate_context]
-       so the field is marked [@atomic] for release-store/acquire-load
-       semantics. The compound update (samples+factor) in
-       [record_actual_tokens] is not itself atomic — see module doc. *)
+    (* Multiplied to estimate. Written under [calibration_lock] together
+       with [samples]; read without the lock by [estimate_context] via the
+       [@atomic] release-store/acquire-load guarantee. *)
 }
 
 let calibration = {
@@ -59,28 +58,39 @@ let calibration = {
   correction_factor = 1.0;
 }
 
+(* Serialises writers of the compound [samples+correction_factor] update.
+   Readers of [correction_factor] rely on [@atomic] and do not take the lock. *)
+let calibration_lock = Mutex.create ()
+
 (** Record actual token count vs estimated for calibration.
     Keeps the last 10 samples and updates a moving-average correction factor. *)
 let record_actual_tokens ~estimated ~actual =
   let enabled = Env_config_core.relay_calibration_enabled () in
   if enabled then begin
-    calibration.samples <- (estimated, actual) :: calibration.samples;
-    if List.length calibration.samples > 10 then
-      calibration.samples <- List.filteri (fun i _ -> i < 10) calibration.samples;
-    let ratios = List.filter_map (fun (e, a) ->
-      if e > 0 then Some (float_of_int a /. float_of_int e) else None
-    ) calibration.samples in
-    match ratios with
-    | [] -> ()
-    | rs ->
-      let sum = List.fold_left (+.) 0.0 rs in
-      let new_factor = sum /. float_of_int (List.length rs) in
-      let prev_factor = calibration.correction_factor in
-      calibration.correction_factor <- new_factor;
+    let log_event =
+      Mutex.protect calibration_lock (fun () ->
+        calibration.samples <- (estimated, actual) :: calibration.samples;
+        if List.length calibration.samples > 10 then
+          calibration.samples <- List.filteri (fun i _ -> i < 10) calibration.samples;
+        let ratios = List.filter_map (fun (e, a) ->
+          if e > 0 then Some (float_of_int a /. float_of_int e) else None
+        ) calibration.samples in
+        match ratios with
+        | [] -> None
+        | rs ->
+          let sum = List.fold_left (+.) 0.0 rs in
+          let new_factor = sum /. float_of_int (List.length rs) in
+          let prev_factor = calibration.correction_factor in
+          calibration.correction_factor <- new_factor;
+          Some (new_factor, prev_factor, List.length rs))
+    in
+    match log_event with
+    | None -> ()
+    | Some (new_factor, prev_factor, n) ->
       if new_factor > 1.5 || new_factor < 0.5 then
         Log.warn ~ctx:"relay"
           "calibration drift: correction_factor=%.2f (was %.2f, %d samples)"
-          new_factor prev_factor (List.length rs)
+          new_factor prev_factor n
       else if abs_float (new_factor -. prev_factor) > 0.1 then
         Log.debug ~ctx:"relay"
           "calibration updated: correction_factor=%.2f (was %.2f)"


### PR DESCRIPTION
## Summary

Wave 2B follow-up to PR #8797 — close the race I explicitly flagged in that PR body.

## 문제

`relay.ml record_actual_tokens`는 compound read-modify-write를 수행:

```
samples <- new_sample :: samples        (* prepend *)
samples <- truncate_to_10 samples       (* truncate *)
ratios = compute_from samples           (* read *)
correction_factor <- avg ratios         (* write *)
```

`[@atomic]`(PR #8797)은 **`correction_factor` 필드 read/write의 memory ordering**만 보장. 두 writer fiber가 이 4단계를 interleave하면:

- 중간 sample이 truncate에 밀려 drop
- 한 writer의 factor 계산이 다른 writer의 samples 상태를 관찰 (moving-average denominator 불일치)

즉, `[@atomic]`는 field-level, **transaction-level race는 별개**.

## 해결

Module-level `Stdlib.Mutex.t`로 compound update 구간 serialize.

```diff
+let calibration_lock = Mutex.create ()

 let record_actual_tokens ~estimated ~actual =
   ...
-  if enabled then begin
-    calibration.samples <- ...
-    ...
-    calibration.correction_factor <- new_factor;
-    Log.warn ...  (* inside critical region *)
+  if enabled then begin
+    let log_event =
+      Mutex.protect calibration_lock (fun () ->
+        calibration.samples <- ...
+        ...
+        calibration.correction_factor <- new_factor;
+        Some (new_factor, prev_factor, n))
+    in
+    match log_event with
+    | None -> ()
+    | Some (new_factor, prev_factor, n) ->
+      Log.warn ...  (* outside critical region *)
```

두 설계 결정:
1. **Stdlib.Mutex vs Eio.Mutex**: test는 Eio 밖에서 호출 (`test/test_relay_coverage.ml:826`). Critical section이 짧아 domain-blocking 영향 미미. `Stdlib.Mutex` 선택.
2. **Log outside critical section**: feedback-memory `eio-traceln-outside-critical-section` 원칙. captured locals로 lock 해제 후 로깅.

## `[@atomic]`는 그대로

Reader (`estimate_context`, line 162)는 여전히 **lock 없이** `correction_factor` 읽음. `[@atomic]`이 visibility 보장. Lock은 writer↔writer 경쟁만 차단.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| `[@atomic]` 필드 (masc-mcp) | 2 | 2 (유지) |
| relay.ml writer compound race | **1** | 0 |
| relay.ml 전체 unprotected race | 1 | 0 |
| Mutex 추가 | — | 1 (module-scoped) |

## 근거

- 호출 경로: `record_actual_tokens`는 worker/keeper fiber 양쪽에서 호출 가능 (PR #8797 분석).
- OCaml 5.1+ `Mutex.protect` — exception-safe critical section.
- 로컬 빌드: `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (1 파일, 1 함수 + 1 lock 선언)
- [x] behavior-preserving (lock contention 없을 때 동일 결과, 있을 때만 serialize)
- [x] 근거 구체 (feedback-memory 2건 명시)
- [x] Scope 제한: 다른 writer 패턴 건드리지 않음 (`get_calibration_info` 등 별개)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2B follow-up)

Closes the partial-fix disclosure in PR #8797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)