### PR TITLE
feat(bonsai-dashboard): cache-bust bundle URL with mtime query string

### DIFF
--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -285,8 +285,20 @@ let serve_dashboard_static name request reqd =
 let bonsai_asset_root () =
   Filename.concat (assets_root ()) "dashboard_bonsai"
 
-let bonsai_index_html =
-  {|<!doctype html>
+(* Bundle version — mtime of main.bc.js, appended to the script src as a
+   query string so the browser refetches whenever the bundle is rebuilt.
+   Cache-Control on the bundle itself stays [immutable] (1 year) for cheap
+   reloads of unchanged code; the URL change is what defeats the cache. *)
+let bonsai_bundle_version () =
+  let bundle_path = Filename.concat (bonsai_asset_root ()) "main.bc.js" in
+  try
+    let st = Unix.stat bundle_path in
+    Printf.sprintf "%d" (Float.to_int st.st_mtime)
+  with _ -> "0"
+
+let bonsai_index_html () =
+  Printf.sprintf
+    {|<!doctype html>
 <html lang="en" data-theme="dark-fantasy">
 <head>
 <meta charset="utf-8">
@@ -301,13 +313,14 @@ let bonsai_index_html =
 </head>
 <body>
 <div id="app"></div>
-<script src="/dashboard/b/assets/main.bc.js"></script>
+<script src="/dashboard/b/assets/main.bc.js?v=%s"></script>
 </body>
 </html>
 |}
+    (bonsai_bundle_version ())
 
 let serve_bonsai_index _request reqd =
-  Http.Response.html bonsai_index_html reqd
+  Http.Response.html (bonsai_index_html ()) reqd
 
 let serve_bonsai_static name request reqd =
   let path = Filename.concat (bonsai_asset_root ()) name in


### PR DESCRIPTION
## 증상

번들이 [Cache-Control: public, max-age=31536000, immutable] 로 서빙됨. 변경 없는 reload 는 0 RTT 라 좋지만, 새 번들 배포 시 브라우저는 강제 새로고침(Cmd+Shift+R) 전까지 stale 사본을 계속 사용한다.

#8799 (runtime stub fix) 배포 시 그대로 발생: 디스크에는 새 번들이 있고 curl 로도 잘 받아지는데, DevTools 콘솔은 옛 TypeError 를 계속 던졌다. 사용자가 hard refresh 해야만 fix 가 보임.

## 수정

[bonsai_index_html] 을 함수로 바꾸고, 번들의 mtime 을 script src 의 query string 으로 박는다:

```html
<script src="/dashboard/b/assets/main.bc.js?v=<unix-timestamp>"></script>
```

브라우저는 URL 이 다르면 별개 리소스로 간주하므로 rebuild 가 자동으로 캐시를 깨뜨린다. 번들 자체의 [Cache-Control: immutable] 은 유지 — 변경 없을 땐 그대로 캐시 hit, mtime 동일하면 URL 도 동일.

[Unix.stat] 호출은 HTML 요청당 1회로 가벼움. 자산 요청은 영향 없음.

## 검증

- [dune build lib/] 통과
- 함수 시그니처 변경 1곳 ([bonsai_index_html] 상수 → 함수 호출), [serve_bonsai_index] 가 [()] 인자 호출하도록 수정
- 다음 fix PR 머지 후 서버 재기동 시: 사용자가 일반 새로고침만 해도 새 번들 받아짐