### PR TITLE
feat(bonsai-dashboard): versal opening on JOURNAL heading

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -317,10 +317,13 @@ stylesheet
   .header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: flex-end;
     border-bottom: 1px solid #2a1a14;
     padding-bottom: 0.75rem;
+    gap: 1rem;
   }
+
+  .header_lead { flex: 1; min-width: 0; }
 
   .eyebrow {
     font-family: 'Noto Sans KR', -apple-system, sans-serif;
@@ -339,6 +342,53 @@ stylesheet
     text-transform: uppercase;
     color: #e8d8b8;
     margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  .versal {
+    font-family: 'EB Garamond', 'Cinzel', serif;
+    font-size: 3.5rem;
+    line-height: 0.82;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    background: linear-gradient(180deg, #e8d8b8 0%, #8a6a28 55%, #5a3028 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: 0 0 18px rgba(138, 106, 40, 0.28);
+    margin-right: 4px;
+    align-self: flex-start;
+    padding-top: 6px;
+  }
+
+  .title_rest {
+    font-family: 'Cinzel', serif;
+    font-weight: 400;
+    font-size: 1rem;
+    letter-spacing: 0.3em;
+    color: #b8a488;
+    text-transform: uppercase;
+  }
+
+  .title_rule {
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, #5a3028 0%, transparent 100%);
+    margin-left: 10px;
+    margin-right: 10px;
+    align-self: center;
+  }
+
+  .folio {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    color: #5a3028;
+    text-transform: none;
   }
 
   .meta {
@@ -919,8 +969,17 @@ let render_response (response : Logs_types.response) : Node.t =
     ; Node.div
         ~attrs:[ Style.header ]
         [ Node.div
+            ~attrs:[ Style.header_lead ]
             [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "log ring · in-memory" ]
-            ; Node.h1 ~attrs:[ Style.title ] [ Node.text "journal" ]
+            ; Node.h1
+                ~attrs:[ Style.title ]
+                [ Node.span ~attrs:[ Style.versal ] [ Node.text "J" ]
+                ; Node.span ~attrs:[ Style.title_rest ] [ Node.text "ournal" ]
+                ; Node.span ~attrs:[ Style.title_rule ] []
+                ; Node.span
+                    ~attrs:[ Style.folio ]
+                    [ Node.text "folio xii · recto" ]
+                ]
             ]
         ; Node.span
             ~attrs:[ Style.meta ]


### PR DESCRIPTION
## 의도

Logs view 의 section heading (\`journal\`) 이 평평한 1.25rem Cinzel 단일 텍스트라 시각 anchor 가 없었다. MASC Design System 의 section opening 은 **versal**(필사본 illuminated capital) — 첫 글자를 3.5rem 으로 키운 brass-gradient capital, 나머지는 small-caps 본문 톤, 그 뒤로 brass fade rule 이 우측으로 뻗다가 folio-style mono pagination 으로 닫힘.

같은 \`background-clip: text\` + linear-gradient 기법은 이미 row-level drop cap (\`message_lead::first-letter\`) 에서 검증됨. 이번 PR 은 같은 패턴을 section-heading 스케일에서 재사용.

## 변경

CSS only:
- \`.header\` → \`flex-end\` baseline + \`gap: 1rem\`
- \`.header_lead { flex: 1 }\` 추가 — heading row 가 가로폭 다 먹어야 brass rule 이 제대로 뻗음
- \`.title\` → flex row 컨테이너 (versal + rest + rule + folio 정렬)
- \`.versal\` 신규 (3.5rem brass gradient capital)
- \`.title_rest\` 신규 (1rem Cinzel small-caps body)
- \`.title_rule\` 신규 (1px brass→transparent fade)
- \`.folio\` 신규 (10px JetBrains Mono pagination)

마크업:
\`\`\`html
<h1 class="title">
  <span class="versal">J</span>
  <span class="title_rest">ournal</span>
  <span class="title_rule"></span>
  <span class="folio">folio xii · recto</span>
</h1>
\`\`\`

\`seq up to N\` meta 는 우측 baseline 에 보존.

## 출처

- 시안: \`docs/bonsai-migration/visual-pitch.html\` iter 17
- 동일 기법 선례: \`logs_view.ml\` \`.message_lead::first-letter\` (row drop cap)

## 검증

- \`bonsai-dashboard\` switch 에서 \`dune build\` 통과
- 로직 변경 없음, 시각만
- 라이브 서버에 새 번들 배포 — 강제 새로고침 시 versal "J" + brass rule + folio 표시