### PR TITLE
feat(runtime-events): emit turn start/end around run_worker_via_oas

### DIFF
--- a/lib/core/masc_runtime_events.ml
+++ b/lib/core/masc_runtime_events.ml
@@ -21,4 +21,7 @@ let ev_turn_end =
   Runtime_events.User.register "masc.turn.end"
     Turn_end Runtime_events.Type.unit
 
+let emit_turn_start () = Runtime_events.User.write ev_turn_start ()
+let emit_turn_end ()   = Runtime_events.User.write ev_turn_end ()
+
 let start_listener () = Runtime_events.start ()

--- a/lib/core/masc_runtime_events.mli
+++ b/lib/core/masc_runtime_events.mli
@@ -10,10 +10,23 @@ type Runtime_events.User.tag +=
   | Turn_end
 
 val ev_turn_start : unit Runtime_events.User.t
-(** Reserved: emit at the beginning of an agent turn. *)
+(** Event handle for the beginning of an agent turn.  Prefer
+    [emit_turn_start] for emission; exposed here so that callers
+    building custom [Runtime_events.Callbacks.add_user_event] handlers
+    can register a consumer. *)
 
 val ev_turn_end : unit Runtime_events.User.t
-(** Reserved: emit at the end of an agent turn. *)
+(** Event handle for the end of an agent turn.  See [ev_turn_start]. *)
+
+val emit_turn_start : unit -> unit
+(** Record a turn-start event in the Runtime_events ring buffer.
+    Safe to call from any fiber; the underlying write is a single
+    domain-local buffer append. *)
+
+val emit_turn_end : unit -> unit
+(** Record a turn-end event in the Runtime_events ring buffer.  Pair
+    with [emit_turn_start] around the turn body (the observer pairs
+    them by seq). *)
 
 val start_listener : unit -> unit
 (** Install the Runtime_events ring buffer listener.

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -523,6 +523,9 @@ let rec run_worker_via_oas
     ?contract
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
+  Masc_runtime_events.emit_turn_start ();
+  Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+  @@ fun () ->
   let session_id = meta.mcp_session_id in
   let worker_name = meta.worker_name in
   let heartbeat_cbs =


### PR DESCRIPTION
## Summary

Wave 2A follow-up to PR #8792 — 첫 번째 `Runtime_events` emit site. `#8792`가 listener install + event 핸들 reserve만 했고 emit은 없었음. 이 PR에서 `worker_oas.ml run_worker_via_oas` entry/exit에 발송.

## 변경

| 파일 | 내용 |
|------|------|
| `lib/core/masc_runtime_events.ml` | `emit_turn_start` / `emit_turn_end` 헬퍼 추가 |
| `lib/core/masc_runtime_events.mli` | 헬퍼 시그니처 + 문서 |
| `lib/worker_oas.ml:526` | entry 지점 + `Fun.protect ~finally` 쌍 발송 |

## 설계 선택

**Helper pattern (not direct `Runtime_events.User.write`)**:
- Consumer(`worker_oas.ml` in `lib/`)가 `runtime_events` 라이브러리 직접 depend 할 필요 없음
- `masc_core`가 `runtime_events` 소유 유지, lib/dune libraries 목록 확장 없음
- API 진화 시 (payload 추가 등) consumer 코드 변경 최소화

**`Fun.protect ~finally`**:
- Result monad early-return (`let*`)도, 예외도 모두 finally 실행 → turn_start/end 쌍 보장
- 기존 코드 구조 변경 없음 (body 그대로, 한 겹만 감쌈)

```diff
     () : (Worker_container_types.run_result, string) result =
+  Masc_runtime_events.emit_turn_start ();
+  Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+  @@ fun () ->
   let session_id = meta.mcp_session_id in
   ...
```

## Scope

이 PR **하는 것**: `run_worker_via_oas` 1곳.

이 PR **하지 않는 것** (follow-up):
- `resume_worker_via_oas` (같은 파일, parallel variant)
- `keeper_agent_run.ml run_turn`
- `Runtime_events.Callbacks` consumer 툴
- 이벤트 payload 확장 (`turn_seq`, `worker_name` 등)

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| Runtime_events emit sites (masc-mcp) | **0** | 1 |
| masc.turn.* 이벤트 실제 발송 | no | yes (worker turn) |
| 관찰 가능 turn boundary | none | worker run entry/exit |

## 검증

- `dune build --root=.` ✅ pass
- `Fun.protect` 시그니처: OCaml 5.1+ `Fun.protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a`
- `Runtime_events.User.write` 시그니처: `'a Runtime_events.User.t -> 'a -> unit` (에러 없음)

## Anti-goal 자가 체크

- [x] surgical (3 파일, 핵심 call-site 1곳)
- [x] behavior-preserving (`Fun.protect`는 값 그대로 return; turn_start는 side-effect only)
- [x] 의존성 경계 유지 (lib/dune libraries 변경 없음)
- [x] 성능 주장 없음 — observability 가능성 추가만 claim

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A emit 1 of 3)

다음 PR 후보: `resume_worker_via_oas` + `keeper_agent_run.ml run_turn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)