### PR TITLE
feat(runtime-events): emit turn start/end around resume_worker_via_oas

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -578,6 +578,9 @@ and resume_worker_via_oas
     ?(approval : Oas.Hooks.approval_callback =
       Approval_callbacks.reject_by_default)
     () : (Worker_container_types.run_result, string) result =
+  Masc_runtime_events.emit_turn_start ();
+  Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+  @@ fun () ->
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in
   let heartbeat_cbs =


### PR DESCRIPTION
## Summary

Wave 2A emit #2 — #8806 패턴을 `resume_worker_via_oas`(체크포인트 재개 variant)에 동일 적용. 이제 두 워커 진입점 모두 `Runtime_events`로 관찰 가능.

## 변경

`lib/worker_oas.ml:581` — 3줄 추가 (emit_turn_start + Fun.protect finally).

동일 설계:
- entry 지점 emit_turn_start
- Fun.protect ~finally:emit_turn_end — Result early-return과 예외 모두 대응
- control flow 변경 없음, 시그니처 변경 없음

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| Runtime_events emit sites | 1 | 2 |
| 관찰 가능 worker entry path | run_worker_via_oas only | + resume_worker_via_oas |

## 검증

- `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (1 파일, 3줄)
- [x] behavior-preserving
- [x] mirror structure of #8806 — 일관성

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A emit 2 of 3)

다음: `keeper_agent_run.ml run_turn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)