### PR TITLE
feat(runtime-events): emit turn start/end around keeper run_turn

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -441,6 +441,9 @@ let run_turn
       ()
   : (run_result, Oas.Error.sdk_error) result
   =
+  Masc_runtime_events.emit_turn_start ();
+  Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+  @@ fun () ->
   (* 0. Resolve inference parameters via Cascade_inference *)
   let temperature =
     match temperature with


### PR DESCRIPTION
## Summary

Wave 2A emit #3 (triplet 완성) — `Keeper_agent_run.run_turn` 인스트루멘트. #8806/#8807의 worker 쪽에 이어 keeper 쪽도 동일 패턴.

이제 masc-mcp의 모든 에이전트 turn 진입점에서 `masc.turn.start` / `masc.turn.end` 쌍 발송:

| 진입점 | PR |
|--------|-----|
| `worker_oas.ml run_worker_via_oas` | #8806 |
| `worker_oas.ml resume_worker_via_oas` | #8807 |
| `keeper_agent_run.ml run_turn` | **이 PR** |

## 변경

`lib/keeper/keeper_agent_run.ml:443` — 3줄 추가 (emit_turn_start + Fun.protect finally).

동일 surgical 패턴:
- entry 지점 `emit_turn_start`
- `Fun.protect ~finally:emit_turn_end` — Result early-return과 예외 모두 대응
- control flow 변경 없음

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| Runtime_events emit sites | 2 | **3** (worker run / worker resume / keeper) |
| masc 에이전트 turn observability | 워커만 | **워커 + 키퍼 전체** |

## 검증

- `dune build --root=.` ✅ pass

## Anti-goal 자가 체크

- [x] surgical (1 파일, 3줄)
- [x] behavior-preserving (Fun.protect은 값 그대로 return)
- [x] emit-only (consumer/dashboard 작업 분리)

## Wave 2A 회고

#8792 (listener + reserve) → #8806 (첫 emit) → #8807 (parallel worker) → 이 PR (keeper).

완료된 것: emit 인프라, 3개 진입점 커버, zero behavior 변경.

Follow-up 후보:
- 이벤트 payload 확장 (`turn_seq`, `worker_name`, `cascade_name`)
- `Runtime_events.Callbacks` consumer / Olly 통합 스크립트
- Dashboard hook (관찰된 turn boundary 시각화)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)