### PR TITLE
fix(dashboard): wire cdal_gate JSON from Dashboard_attribution summary

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -161,8 +161,27 @@ let compute_outcomes_rollup
         ("unknown", `Int !unknown_v);
         ("top_failure_reasons", `List top_failure_reasons);
       ]);
-      (* cdal_gate: null until CDAL verdict gate (#7531) merges. *)
-      ("cdal_gate", `Null);
+      (* cdal_gate: populate from Dashboard_attribution ring.
+         Scope is global (CDAL attribution is gate-keyed, not per-keeper),
+         but visibility in the per-keeper diagnostic is still useful — it
+         confirms the verdict gate is live and surfaces recent outcomes. *)
+      ("cdal_gate",
+        (match
+           List.find_opt
+             (fun (s : Dashboard_attribution.gate_summary) ->
+               String.equal s.gate "cdal_verdict")
+             (Dashboard_attribution.summary ())
+         with
+         | None -> `Null
+         | Some s ->
+             `Assoc [
+               ("scope", `String "global");
+               ("passed", `Int s.passed);
+               ("policy_failed", `Int s.policy_failed);
+               ("transition_blocked", `Int s.transition_blocked);
+               ("partial_pass", `Int s.partial_pass);
+               ("total", `Int s.total);
+             ]));
       ("last_verdict_at", last_verdict_at);
     ]);
   ]


### PR DESCRIPTION
## Summary

Drop the \`cdal_gate: null\` stub in \`lib/dashboard/dashboard_http_keeper.ml\` that was left over from PR #7531 (merged) and start emitting real counts from \`Dashboard_attribution.summary ()\`.

## Context

\`/loop 20m\` CDAL audit turned up two gaps this week:
- #8715 gated \`task_verify\` affordance to verifier-role keepers (merged).
- #8731 wired \`Cdal_verdict_gate.gate_check\` into \`Approve_verification\` / \`Reject_verification\` legs (merged).

The verdict gate has been recording attribution via \`Dashboard_attribution.record\` for weeks, but the keeper diagnostic JSON was still returning \`cdal_gate: null\` — a leftover placeholder from PR #7531. Result: the Preact dashboard (\`validation.cdal_gate\` in \`dashboard/src/types/core.ts\`) never had non-null data to render, matching the user's observation that CDAL verification is invisible in the UI.

## Change

\`\`\`ocaml
-      (* cdal_gate: null until CDAL verdict gate (#7531) merges. *)
-      ("cdal_gate", \`Null);
+      (* cdal_gate: populate from Dashboard_attribution ring.
+         Scope is global (CDAL attribution is gate-keyed, not per-keeper),
+         but visibility in the per-keeper diagnostic is still useful — it
+         confirms the verdict gate is live and surfaces recent outcomes. *)
+      ("cdal_gate",
+        (match
+           List.find_opt
+             (fun (s : Dashboard_attribution.gate_summary) ->
+               String.equal s.gate "cdal_verdict")
+             (Dashboard_attribution.summary ())
+         with
+         | None -> \`Null
+         | Some s -> ...))
\`\`\`

- \`scope: "global"\` field flags the semantic so UI consumers don't treat the counts as per-keeper.
- Field stays nullable (empty ring → \`Null\`) to preserve the existing TS contract.

## Verification

- \`dune build --root . @check\` clean.
- No new tests: the only behavioural change is replacing a hardcoded null with an \`Assoc\` when the attribution ring has cdal_verdict entries. Consumed by Preact \`validation.cdal_gate\`.

## Scope guard

Single file, 1 diff hunk. No schema rename, no dashboard-side type changes. Follows "placeholder > fake state" — only emits an \`Assoc\` when real data exists.