### PR TITLE
refactor(runtime-events): use span type for masc.turn (native pairing)

### DIFF
--- a/lib/core/masc_runtime_events.ml
+++ b/lib/core/masc_runtime_events.ml
@@ -1,27 +1,27 @@
-(** Runtime_events event registrations for masc-mcp (Wave 2A pilot).
+(** Runtime_events event registrations for masc-mcp (Wave 2A).
 
-    Registers user event tags/handles and provides a start helper so that
-    Olly (or a custom [Runtime_events.Callbacks] consumer) can observe
-    both stock OCaml runtime events (GC, phases) and future masc-specific
-    turn events.
+    Registers a user event handle for agent turns and provides a
+    start helper so that Olly (or a custom [Runtime_events.Callbacks]
+    consumer) can observe both stock OCaml runtime events (GC,
+    phases) and masc-specific turn-boundary events.
 
-    This pilot only installs the listener and reserves event handles;
-    emit sites will be added in follow-up PRs (worker turn boundary,
-    keeper turn boundary). *)
+    The turn event uses [Runtime_events.Type.span] so consumers pair
+    [Begin]/[End] bounds natively — no external correlation id is
+    required.  Writers always call [emit_turn_start] and
+    [emit_turn_end] as a pair (see the [Fun.protect] usage at the
+    call sites in [worker_oas] and [keeper_agent_run]). *)
 
 type Runtime_events.User.tag +=
-  | Turn_start
-  | Turn_end
+  | Turn
 
-let ev_turn_start =
-  Runtime_events.User.register "masc.turn.start"
-    Turn_start Runtime_events.Type.unit
+let ev_turn =
+  Runtime_events.User.register "masc.turn"
+    Turn Runtime_events.Type.span
 
-let ev_turn_end =
-  Runtime_events.User.register "masc.turn.end"
-    Turn_end Runtime_events.Type.unit
+let emit_turn_start () =
+  Runtime_events.User.write ev_turn Runtime_events.Type.Begin
 
-let emit_turn_start () = Runtime_events.User.write ev_turn_start ()
-let emit_turn_end ()   = Runtime_events.User.write ev_turn_end ()
+let emit_turn_end () =
+  Runtime_events.User.write ev_turn Runtime_events.Type.End
 
 let start_listener () = Runtime_events.start ()

--- a/lib/core/masc_runtime_events.mli
+++ b/lib/core/masc_runtime_events.mli
@@ -1,32 +1,27 @@
-(** Runtime_events event registrations for masc-mcp (Wave 2A pilot).
+(** Runtime_events event registrations for masc-mcp (Wave 2A).
 
     Consumed by Olly or custom [Runtime_events.Callbacks] programs.
-    Emit sites for [ev_turn_start]/[ev_turn_end] will be added in
-    follow-up PRs; this module currently only installs the listener
-    and reserves event handles. *)
+    [ev_turn] is a span event: consumers receive [Begin]/[End] bounds
+    via a single [Runtime_events.Type.span] handler. *)
 
 type Runtime_events.User.tag +=
-  | Turn_start
-  | Turn_end
+  | Turn
 
-val ev_turn_start : unit Runtime_events.User.t
-(** Event handle for the beginning of an agent turn.  Prefer
-    [emit_turn_start] for emission; exposed here so that callers
-    building custom [Runtime_events.Callbacks.add_user_event] handlers
-    can register a consumer. *)
-
-val ev_turn_end : unit Runtime_events.User.t
-(** Event handle for the end of an agent turn.  See [ev_turn_start]. *)
+val ev_turn : Runtime_events.Type.span Runtime_events.User.t
+(** Span event bracketing an agent turn.  Consumers register with
+    [Runtime_events.Callbacks.add_user_event Runtime_events.Type.span]
+    to receive both bounds keyed by timestamp; no external
+    correlation id is needed. *)
 
 val emit_turn_start : unit -> unit
-(** Record a turn-start event in the Runtime_events ring buffer.
-    Safe to call from any fiber; the underlying write is a single
-    domain-local buffer append. *)
+(** Record the opening bound ([Begin]) of a turn span in the
+    Runtime_events ring buffer.  Safe to call from any fiber; the
+    underlying write is a single domain-local buffer append. *)
 
 val emit_turn_end : unit -> unit
-(** Record a turn-end event in the Runtime_events ring buffer.  Pair
-    with [emit_turn_start] around the turn body (the observer pairs
-    them by seq). *)
+(** Record the closing bound ([End]) of a turn span.  Pair with
+    [emit_turn_start] around the turn body (the consumer pairs them
+    by domain+timestamp). *)
 
 val start_listener : unit -> unit
 (** Install the Runtime_events ring buffer listener.


### PR DESCRIPTION
## Summary

Wave 2A refinement — 두 `unit` 이벤트(`masc.turn.start`, `masc.turn.end`)를 **하나의 `span` 이벤트**(`masc.turn`)로 교체. `Runtime_events.Type.span`은 `Begin`/`End` bound를 native로 지원하는 내장 타입 — Olly와 custom consumer가 외부 correlation id 없이 자동 페어링.

## 변경

| Before | After |
|--------|-------|
| `type tag += Turn_start \| Turn_end` | `type tag += Turn` |
| `ev_turn_start : unit Runtime_events.User.t` | `ev_turn : Runtime_events.Type.span Runtime_events.User.t` |
| `ev_turn_end : unit Runtime_events.User.t` | *(제거)* |
| `masc.turn.start`, `masc.turn.end` 이벤트 이름 | `masc.turn` (단일) |

**Caller API 변경 없음**:
- `Masc_runtime_events.emit_turn_start ()` / `emit_turn_end ()` 시그니처·이름 유지
- 3개 call site (worker_oas run/resume, keeper_agent_run run_turn) 건드리지 않음
- 내부적으로 `Runtime_events.User.write ev_turn Begin/End` 호출로 변경

## 제거 안전성

`rg -n 'Masc_runtime_events\.ev_turn_start|Masc_runtime_events\.ev_turn_end'` → 0 hits
`rg -n 'Turn_start\|Turn_end'` → 0 hits
모듈 외부에서 handle/tag 직접 참조 없음.

## Consumer 이득

Before (외부 페어링 필요):
```ocaml
(* 두 콜백 등록 + 별도 상관관계 관리 *)
Callbacks.add_user_event Type.unit
  (fun _ts _domain ev () ->
     match ev with
     | Turn_start -> ... (* 자체적으로 stack/timestamp 기록 *)
     | Turn_end -> ... (* 페어 매칭 로직 *)
     | _ -> ())
```

After (native 페어링):
```ocaml
(* 단일 콜백, Runtime_events가 span 의미론 제공 *)
Callbacks.add_user_event Type.span
  (fun _ts _domain ev bound ->
     match ev, bound with
     | Turn, Begin -> ...
     | Turn, End -> ...
     | _ -> ())
```

Olly (`olly trace`)는 span event를 duration bar로 시각화 — 수동 페어링 불필요.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| 등록된 user event tags | 2 (Turn_start, Turn_end) | **1** (Turn, span type) |
| consumer 페어링 로직 | 직접 구현 필요 | Runtime_events native |
| 이벤트 pair integrity 관찰 가능 | no (consumer 구현 의존) | **yes** (duration + drop 둘 다) |

## 검증

- `dune build --root=.` ✅ pass
- OCaml 5.4.1 `Runtime_events.Type.span` 공식 API (mli `Runtime_events.Type.span : span t` where `type span = Begin | End`)

## Anti-goal 자가 체크

- [x] surgical (2 파일: `.ml` + `.mli`)
- [x] caller API preserved (emit_* 시그니처 동일)
- [x] removed surface 사전 grep 검증 (0 external ref)
- [x] idiomatic OCaml 5 Runtime_events (span = built-in span semantics, 커스텀 correlation 제거)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A payload refinement)

이전 PR: #8792 (infra), #8806/#8807/#8809 (emit sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)