### PR TITLE
fix(bonsai-dashboard): report arm64=true in arch stubs to satisfy basement

### DIFF
--- a/dashboard_bonsai/src/runtime_stubs.js
+++ b/dashboard_bonsai/src/runtime_stubs.js
@@ -1,12 +1,30 @@
 // js_of_ocaml runtime stubs for OxCaml-only primitives.
 //
-// OxCaml 5.2.0+ox introduces Sys.arch_amd64 / Sys.arch_arm64 unboxed primitives
-// referenced by the basement library. Stock js_of_ocaml 6 runtime does not
-// define these. We return 0 (false) for both because the bundle runs in a
-// browser, not on a native CPU.
+// OxCaml 5.2.0+ox introduces Sys.arch_amd64 / Sys.arch_arm64 unboxed
+// primitives referenced by the basement library. Stock js_of_ocaml 6
+// runtime does not define these, and basement raises
+//   Failure "Cannot determine architecture: must be amd64 or arm64"
+// when both return 0 — so we must report exactly one as true.
+//
+// Detect via navigator.userAgent: M-series Macs report the host arch in
+// the UA string. Default to arm64 when unknown — most modern dev/prod
+// targets (Apple Silicon, AWS Graviton) are arm64, and Bonsai is a
+// browser bundle so the value only feeds runtime branches that are
+// always JS-emulated anyway. The choice is cosmetic; what matters is
+// that exactly one of the two reports true.
 
 //Provides: caml_sys_const_arch_amd64 const
-function caml_sys_const_arch_amd64 () { return 0; }
+function caml_sys_const_arch_amd64 () {
+  if (typeof navigator !== 'undefined' && navigator.userAgent) {
+    return /Intel|x86_64|amd64|x64|Win64|WOW64/i.test(navigator.userAgent) ? 1 : 0;
+  }
+  return 0;
+}
 
 //Provides: caml_sys_const_arch_arm64 const
-function caml_sys_const_arch_arm64 () { return 0; }
+function caml_sys_const_arch_arm64 () {
+  if (typeof navigator !== 'undefined' && navigator.userAgent) {
+    return /Intel|x86_64|amd64|x64|Win64|WOW64/i.test(navigator.userAgent) ? 0 : 1;
+  }
+  return 1;
+}


### PR DESCRIPTION
## 증상

\`/dashboard/b/\` 빈 화면, 콘솔:

\`\`\`
Fatal error: exception Failure("Cannot determine architecture: must be amd64 or arm64")
    at sys.js:94
\`\`\`

#8799 후속. Stub 자체는 등록됐는데 둘 다 \`return 0\` 이라 basement 가 "어느 arch 도 아님" 으로 판단해서 raise.

## 수정

\`navigator.userAgent\` 로 분기:

- Intel Mac / x86_64 / Win64 → amd64=1, arm64=0
- 그 외 (Apple Silicon, ARM Linux) → amd64=0, arm64=1
- navigator 없으면 arm64 default (modern Apple Silicon / Graviton dominant)

브라우저 환경에서 실제 native arch 값은 cosmetic — basement 가 \"하나는 true\" 만 요구하면 OK. 두 stub 이 mutually exclusive 한 결과 반환하도록 같은 regex 를 양쪽에서 재사용.

## 검증

- bonsai-dashboard switch 빌드 통과, \`function caml_sys_const_arch_arm64\` 1개 정의 confirm
- 라이브 서버 sync (64.5 MB)
- M3 Max (사용자 환경) 에서 강제 새로고침 시 화면 렌더 (별도 확인 필요)

## 후속

cache-bust PR #8803 머지 + 서버 재기동 시점부터는 강제 새로고침 불필요.