### PR TITLE
fix(bonsai-dashboard): stub OxCaml domain TLS primitives

### DIFF
--- a/dashboard_bonsai/src/runtime_stubs.js
+++ b/dashboard_bonsai/src/runtime_stubs.js
@@ -28,3 +28,31 @@ function caml_sys_const_arch_arm64 () {
   }
   return 1;
 }
+
+// OxCaml extends OCaml 5's Domain Local Storage (DLS, already in jsoo
+// runtime) with Thread Local Storage (TLS) primitives. Stock js_of_ocaml
+// 6 has no TLS stubs, so the bundle throws on first init:
+//   TypeError: runtime.caml_domain_tls_set is not a function
+//     at init (domain.ml:578)
+//
+// Browser bundles are single-threaded, so TLS reduces to a global map
+// keyed by the slot identifier. Same shape as the runtime's DLS
+// implementation, just under a separate global to keep the namespaces
+// independent (in case OxCaml ever uses both for distinct values in
+// the same program).
+
+//Provides: caml_domain_tls_set
+function caml_domain_tls_set (key, value) {
+  globalThis.__caml_tls = globalThis.__caml_tls || Object.create(null);
+  globalThis.__caml_tls[key] = value;
+  return 0;
+}
+
+//Provides: caml_domain_tls_get
+function caml_domain_tls_get (key) {
+  var tls = globalThis.__caml_tls;
+  if (tls && Object.prototype.hasOwnProperty.call(tls, key)) {
+    return tls[key];
+  }
+  return 0;
+}


### PR DESCRIPTION
## 증상

Arch stub fix(#8813) 적용 후 다음 init 단계에서 또 다른 누락 primitive:

\`\`\`
Uncaught TypeError: runtime.caml_domain_tls_set is not a function
    at init (domain.ml:578)
\`\`\`

#8799 trilogy 의 3 번째 missing primitive set.

## 원인

OxCaml 은 OCaml 5 의 Domain Local Storage (DLS, jsoo runtime 에 이미 있음) 위에 Thread Local Storage (TLS) primitive 를 추가. \`runtime.caml_domain_tls_set\` / \`caml_domain_tls_get\` 두 함수가 jsoo 6 에 없어서 init 에서 죽는다.

검증:
\`\`\`
$ grep "function caml_domain_(d|t)ls_(set|get)" main.bc.js
function caml_domain_dls_compare_and_set ... (DLS — exists)
function caml_domain_dls_get ... (DLS — exists)
function caml_domain_dls_set ... (DLS — exists)
function caml_domain_spawn ... (exists)
# tls — missing
\`\`\`

## 수정

\`runtime_stubs.js\` 에 2 개 stub 추가. 브라우저는 single-threaded 라 TLS 는 global map 1 개로 환원:

\`\`\`js
//Provides: caml_domain_tls_set
function caml_domain_tls_set (key, value) {
  globalThis.__caml_tls = globalThis.__caml_tls || Object.create(null);
  globalThis.__caml_tls[key] = value;
  return 0;
}
\`\`\`

DLS 와 namespace 분리 (\`__caml_tls\` vs jsoo 의 DLS 내부 storage) — 만약 OxCaml 이 두 store 를 distinct value 로 쓰면 충돌 안 남.

## 검증

- bonsai-dashboard switch 빌드 통과
- bundle 안에 \`function caml_domain_tls_set\` 1 개 정의 confirm
- 라이브 sync 완료