### PR TITLE
test(runtime-events): end-to-end span round-trip for masc.turn

### DIFF
--- a/test/deps/dune
+++ b/test/deps/dune
@@ -55,6 +55,7 @@
    (re_export qcheck-alcotest)
    (re_export qcheck-core)
    (re_export re)
+   (re_export runtime_events)
    (re_export str)
    (re_export time_compat)
    (re_export unix)

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -135,7 +135,7 @@
         test_memory_hooks
         test_mid_turn_resume
         test_lockfree_atomic)
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_masc_runtime_events.ml
+++ b/test/test_masc_runtime_events.ml
@@ -1,0 +1,49 @@
+(** End-to-end round-trip test for Masc_runtime_events.
+
+    Emits a Begin/End span via [emit_turn_start]/[emit_turn_end] into
+    the current-process ring buffer and reads it back through an
+    in-process cursor with [Runtime_events.Callbacks.add_user_event].
+
+    This validates:
+    - the listener is actually started by [start_listener]
+    - the span-typed write carries [Begin]/[End] bounds through the
+      buffer intact
+    - consumers using [Runtime_events.Type.span] receive both bounds
+      keyed to the same registered event handle ("masc.turn"). *)
+
+let test_turn_span_roundtrip () =
+  Masc_runtime_events.start_listener ();
+  let cursor = Runtime_events.create_cursor None in
+
+  Masc_runtime_events.emit_turn_start ();
+  Masc_runtime_events.emit_turn_end ();
+
+  let bounds_seen = ref [] in
+  let span_cb _ring_idx _ts ev (bound : Runtime_events.Type.span) =
+    if Runtime_events.User.name ev = "masc.turn" then
+      bounds_seen := bound :: !bounds_seen
+  in
+  let callbacks =
+    Runtime_events.Callbacks.create ()
+    |> Runtime_events.Callbacks.add_user_event
+         Runtime_events.Type.span span_cb
+  in
+  let _n = Runtime_events.read_poll cursor callbacks None in
+  Runtime_events.free_cursor cursor;
+
+  let observed = List.rev !bounds_seen in
+  match observed with
+  | [ Runtime_events.Type.Begin; Runtime_events.Type.End ] -> ()
+  | _ ->
+    Alcotest.failf
+      "expected [Begin; End], got %d event(s)"
+      (List.length observed)
+
+let () =
+  Alcotest.run "masc_runtime_events"
+    [ ( "span-roundtrip"
+      , [ Alcotest.test_case
+            "emit_turn_start/emit_turn_end visible to in-process cursor"
+            `Quick test_turn_span_roundtrip
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Wave 2A 끝으로 end-to-end 검증 — `Runtime_events` 파이프라인이 실제 observable signal을 생산함을 증명. Begin/End span을 emit하고 in-process cursor로 읽어서 순서 보존과 User.name 매칭을 확인.

## 변경

| 파일 | 내용 |
|------|------|
| `test/test_masc_runtime_events.ml` (new) | `span-roundtrip` alcotest case |
| `test/dune` | `test_masc_runtime_events` 를 names + modules 양쪽에 추가 |
| `test/deps/dune` | `(re_export runtime_events)` 추가 (Callbacks/Type.span 참조 가능하게) |

## 검증 대상

1. **Listener 활성화** — `start_listener` 호출 후 collection 실제 동작
2. **Begin/End 보존** — span 페이로드가 ring buffer 왕복에서 손실 없음
3. **User.name 매칭** — consumer가 "masc.turn" 키로 핸들러 호출받음
4. **순서** — emit 순서(Begin → End)가 read 순서와 일치

테스트 패턴:
```ocaml
Masc_runtime_events.start_listener ();
let cursor = Runtime_events.create_cursor None in
Masc_runtime_events.emit_turn_start ();
Masc_runtime_events.emit_turn_end ();

let bounds_seen = ref [] in
let span_cb _ _ ev bound =
  if Runtime_events.User.name ev = "masc.turn" then
    bounds_seen := bound :: !bounds_seen
in
let callbacks =
  Runtime_events.Callbacks.create ()
  |> Runtime_events.Callbacks.add_user_event
       Runtime_events.Type.span span_cb
in
let _ = Runtime_events.read_poll cursor callbacks None in

match List.rev !bounds_seen with
| [Begin; End] -> ()  (* pass *)
| _ -> Alcotest.failf "..."
```

## 로컬 실행 결과

```
Testing 'masc_runtime_events'.
  [OK]  span-roundtrip  0  emit_turn_start/emit_turn_end visible to in-process cursor
Test Successful in 0.001s. 1 test run.
```

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| Runtime_events round-trip 검증 | 없음 (emit만 있고 read 테스트 없음) | **1 test** |
| 파이프라인 회귀 감지 가능 | no | yes |

## Anti-goal 자가 체크

- [x] surgical (test 1개 + dune 2줄)
- [x] 실제 pipeline 검증 (mock 아님, 실제 ring buffer 왕복)
- [x] 최소 추가 dep (`runtime_events`만, 이미 transitively 존재)
- [x] mock-on-mock 아님 — emit_turn_* 소스와 consumer가 실제 코드

## Wave 2A 회고 (이 PR로 완결)

| PR | 역할 |
|----|------|
| #8792 | Listener install + event reserve |
| #8806/#8807/#8809 | 3 emit sites (worker run/resume + keeper) |
| #8812 | span type 리팩터 (native Begin/End) |
| **this** | end-to-end 검증 |

파이프라인 완성. 관찰자(Olly/custom)는 이제 `masc.turn` span으로 turn duration과 pair integrity 모두 측정 가능.

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 2A complete + validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)