### PR TITLE
perf(dashboard): TTL-cache git rev-parse HEAD in runtime_resolution_json

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -57,23 +57,68 @@ let path_relative_to ~root path =
     Some (String.sub path (String.length root + 1) (String.length path - String.length root - 1))
   else None
 
+(* Per-path TTL cache for `git rev-parse --short HEAD`.  Each miss forks
+   git and can take seconds on large worktrees (~/me etc.), yet HEAD
+   changes infrequently, and every dashboard shell refresh calls this
+   twice (workspace + base).  Serving cached values keeps snapshot_json
+   off the 5 s git-probe budget on the hot path. *)
+let git_rev_parse_short_ttl_sec = 60.0
+
+let git_rev_parse_short_cache :
+    (string, string option * float) Hashtbl.t =
+  Hashtbl.create 4
+
+let git_rev_parse_short_mu = Stdlib.Mutex.create ()
+
+let git_rev_parse_short_cached_lookup dir ~now =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () ->
+      match Hashtbl.find_opt git_rev_parse_short_cache dir with
+      | Some (value, ts) when now -. ts <= git_rev_parse_short_ttl_sec ->
+          Some value
+      | _ -> None)
+
+let git_rev_parse_short_cache_store dir value ~now =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () ->
+      Hashtbl.replace git_rev_parse_short_cache dir (value, now))
+
+let git_rev_parse_short_probe dir =
+  let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"system/runtime_info"
+      ~raw_source
+      ~summary:"dashboard runtime git probe"
+      ~timeout_sec:5.0
+      argv
+  with
+  | Unix.WEXITED 0, output -> trim_to_option output
+  | _ -> None
+
 let git_rev_parse_short path =
   match trim_to_option path with
   | None -> None
   | Some dir when not (Sys.file_exists dir) -> None
   | Some dir ->
-      let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
-      let raw_source = String.concat " " (List.map Filename.quote argv) in
-      (match
-         Masc_exec.Exec_gate.run_argv_with_status
-           ~actor:"system/runtime_info"
-           ~raw_source
-           ~summary:"dashboard runtime git probe"
-           ~timeout_sec:5.0
-           argv
-       with
-       | Unix.WEXITED 0, output -> trim_to_option output
-       | _ -> None)
+      let now = Time_compat.now () in
+      (match git_rev_parse_short_cached_lookup dir ~now with
+       | Some value -> value
+       | None ->
+           let value = git_rev_parse_short_probe dir in
+           git_rev_parse_short_cache_store dir value ~now;
+           value)
+
+let clear_git_rev_parse_short_cache_for_tests () =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () -> Hashtbl.clear git_rev_parse_short_cache)
 
 let path_item_json ~source path =
   `Assoc


### PR DESCRIPTION
## Problem

Runtime logs were surfacing:

```
[Process_eio] Timeout after 5s: 'git' '-C' '/Users/dancer/me' 'rev-parse' '--short' 'HEAD'
[Dashboard] [snapshot_json] keepers_json: 3100ms
```

`git_rev_parse_short` (`lib/server/server_dashboard_http_runtime_info.ml:60`) had no cache. Every dashboard shell refresh called it twice (`config.workspace_path` + `config.base_path`) via `runtime_resolution_json`, itself invoked from the hot `dashboard_shell_http_json` fiber group (`server_dashboard_http_core.ml:990`).

On a large repo (`~/me` with many worktrees) each fork+exec routinely hit the 5 s `Masc_exec.Exec_gate` timeout, so every snapshot paid up to 10 s of git-probe time — and thundered multiple callers at once during SSE polling.

## Root cause

The adjacent `dashboard_runtime_probe_cache` already uses a 30 s TTL Atomic cache for the Ollama probe. The git probe was simply missed in that design: HEAD changes infrequently, forks are expensive, yet nothing memoised them.

## Fix

Add a per-path TTL cache keyed on `dir`:

- `git_rev_parse_short_ttl_sec = 60.0`
- `Hashtbl (string, option * float)` behind a short `Stdlib.Mutex` critical section (lookup/store only — never held across the fork)
- On miss, fork once, store `(value, now)`
- `clear_git_rev_parse_short_cache_for_tests` helper matches the existing dashboard-probe reset pattern

Mutex choice follows `feedback_ocaml5-mutex-selection.md`: `Stdlib.Mutex` is safe because the critical section never yields (no Eio calls inside the lock), and the fork runs outside the lock.

## Impact

- `snapshot_json` runtime_resolution step drops from worst-case ~10 s to near-zero on cache hits.
- First request per 60 s window still pays the git probe, but only one path at a time (2 paths total), so contention is trivial.
- Stale HEAD display is bounded to 60 s, acceptable for a dashboard diagnostic.

## Validation

- `dune build --root . @check` ✓ (silent pass)
- Surgical change — only `git_rev_parse_short` rewritten; caller sites in `runtime_resolution_json` untouched.

## Scope guard

Does **not** touch:
- `keepers_json` path (separate issue — 3100 ms there likely comes from fanned-out per-keeper `Keeper_exec_status.parse_agent_status` I/O, to be investigated separately)
- `masc_plan_get` auth error (config gap, separate)
- Gemini `GlobToolInvocation` stack overflow (upstream CLI bug)

## Related

Surfaced during masc-mcp CDAL-verification /loop investigation (#8811 siblings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)