### PR TITLE
refactor(telemetry): normalize tool-output blob sentinel to structured _blob object

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1407,12 +1407,24 @@ export function fetchKeeperToolStats(
 
 // ── Keeper tool call log (full I/O) ──────────────────────
 
+// Output is either an inline string (legacy / small payload) or a
+// normalized blob descriptor — see lib/keeper_tool_call_log.ml
+// `blob_aware_output_json`. The renderer must accept both shapes.
+export type ToolCallOutputBlob = {
+  _blob: {
+    sha256: string
+    bytes: number
+    mime: string
+    preview: string
+  }
+}
+
 export type ToolCallEntry = {
   ts: number
   keeper: string
   tool: string
   input: unknown
-  output: string
+  output: string | ToolCallOutputBlob
   success: boolean
   duration_ms: number
   model?: string
@@ -1422,6 +1434,28 @@ type ToolCallsResponse = {
   keeper: string
   count: number
   entries: ToolCallEntry[]
+}
+
+function decodeToolCallOutput(raw: unknown): string | ToolCallOutputBlob {
+  if (typeof raw === 'string') return raw
+  if (
+    isRecord(raw) &&
+    isRecord(raw._blob) &&
+    typeof raw._blob.sha256 === 'string' &&
+    typeof raw._blob.bytes === 'number' &&
+    typeof raw._blob.mime === 'string' &&
+    typeof raw._blob.preview === 'string'
+  ) {
+    return {
+      _blob: {
+        sha256: raw._blob.sha256,
+        bytes: raw._blob.bytes,
+        mime: raw._blob.mime,
+        preview: raw._blob.preview,
+      },
+    }
+  }
+  return ''
 }
 
 function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
@@ -1434,7 +1468,7 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     keeper,
     tool,
     input: raw.input,
-    output: asString(raw.output, ''),
+    output: decodeToolCallOutput(raw.output),
     success: asBoolean(raw.success, false),
     duration_ms: asNumber(raw.duration_ms, 0),
     model: asString(raw.model),

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -35,11 +35,19 @@ function tryPrettyJson(s: string): string | null {
 }
 
 // Tool output may be (a) a raw string, (b) a JSON blob we logged as a string,
-// or (c) a [masc:blob ...] sentinel produced by Tool_output.encode_for_oas
-// when the bytes exceeded the inline threshold. Render all three as
-// human-readable pretty JSON when possible so the inspector matches what
-// Input already does via [formatInput].
-export function formatOutput(output: string): string {
+// (c) a [masc:blob ...] sentinel produced by Tool_output.encode_for_oas
+// when the bytes exceeded the inline threshold (legacy encoding, kept for
+// jsonl entries written before the normalization change), or (d) a
+// normalized blob descriptor object {_blob: {...}} written by the current
+// keeper_tool_call_log. Render all four uniformly as human-readable text.
+export function formatOutput(output: string | { _blob: { sha256: string; bytes: number; mime: string; preview: string } }): string {
+  if (output == null) return '(empty)'
+  if (typeof output === 'object') {
+    const { sha256, bytes, mime, preview } = output._blob
+    const prettyPreview = tryPrettyJson(preview) ?? preview
+    const shaShort = sha256.slice(0, 12)
+    return `[masc:blob sha256=${shaShort}\u2026 bytes=${bytes} mime=${mime}]\n${prettyPreview}`
+  }
   if (!output) return '(empty)'
   const marker = parseToolBlobMarker(output)
   if (marker !== null) {

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -244,9 +244,17 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
         (match List.assoc_opt "result_bytes" fields with
          | Some (`Int i) -> i
          | _ ->
-           (* Fallback: use output string length for old entries *)
+           (* Fallback for old entries that pre-date [result_bytes].
+              Output may be either an inline string (legacy) or a
+              normalized blob object {"_blob":{...,"bytes":N,...}}
+              (new format introduced when sentinel double-escape was
+              eliminated from the telemetry layer). *)
            (match List.assoc_opt "output" fields with
             | Some (`String s) -> String.length s
+            | Some (`Assoc [("_blob", `Assoc blob)]) ->
+              (match List.assoc_opt "bytes" blob with
+               | Some (`Int n) -> n
+               | _ -> 0)
             | _ -> 0))
       | _ -> 0
     in
@@ -293,8 +301,19 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     (* failure category *)
     if not ok then begin
       let output =
-        Safe_ops.json_string_opt "output" record
-        |> Option.value ~default:""
+        match record with
+        | `Assoc fields ->
+          (match List.assoc_opt "output" fields with
+           | Some (`String s) -> s
+           | Some (`Assoc [("_blob", `Assoc blob)]) ->
+             (* Normalized blob object — failure classifier wants the
+                preview (where the error JSON body lives) rather than
+                the sentinel envelope. *)
+             (match List.assoc_opt "preview" blob with
+              | Some (`String p) -> p
+              | _ -> "")
+           | _ -> "")
+        | _ -> ""
       in
       let cat = classify_failure_output output
       in

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -102,6 +102,33 @@ let reset_for_testing () =
   Hashtbl.reset pending_truncation;
   Hashtbl.reset pending_turn_context
 
+(** [blob_aware_output_json safe_output] wraps a tool-output string for
+    persistence as the [output] field. When [safe_output] is the OCaml
+    [%S]-quoted [masc:blob ...] sentinel produced by
+    [Tool_output.encode_for_oas], the wire format escapes the inner
+    preview JSON twice (OCaml string-literal + JSON string), which makes
+    the telemetry record illegible and inflates disk usage by 30-40%.
+
+    We decode the sentinel and emit a structured object instead:
+      {"_blob": {"sha256":"...", "bytes":N, "mime":"...", "preview":"..."}}
+
+    Non-sentinel outputs keep the historical [String _] shape so that
+    older readers (dashboard, jq scripts) keep working. The dashboard
+    consumers are updated in the same change to accept either shape. *)
+let blob_aware_output_json (output : string) : Yojson.Safe.t =
+  match Tool_output.decode_from_oas output with
+  | Tool_output.Stored { sha256; bytes; preview; mime } ->
+      `Assoc
+        [ ("_blob",
+           `Assoc
+             [ ("sha256", `String sha256)
+             ; ("bytes", `Int bytes)
+             ; ("mime", `String mime)
+             ; ("preview", `String preview)
+             ])
+        ]
+  | Tool_output.Inline _ -> `String output
+
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
   (* Per-leaf sentinel-aware truncation. Previously
      [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
@@ -194,13 +221,14 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       in
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
+      let output_json = blob_aware_output_json safe_output in
       let json =
         `Assoc
           ([ ("ts", `Float (Time_compat.now ()))
            ; ("keeper", `String keeper_name)
            ; ("tool", `String tool_name)
            ; ("input", safe_input)
-           ; ("output", `String safe_output)
+           ; ("output", output_json)
            ; ("success", `Bool success)
            ; ("duration_ms", `Float duration_ms)
            ]

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -383,6 +383,68 @@ let test_output_valid_utf8_untouched () =
         Alcotest.(check string) "valid UTF-8 preserved verbatim" korean output
     | _ -> Alcotest.fail "expected exactly one entry")
 
+(* When the tool output is the OCaml [%S]-quoted [masc:blob ...] sentinel
+   produced by Tool_output.encode_for_oas, the persisted record must
+   normalize it into a structured _blob object so that telemetry readers
+   (UI, jq scripts) see a clean JSON shape instead of doubly-escaped
+   string fields. *)
+let test_output_blob_sentinel_normalized () =
+  with_tmp_log (fun () ->
+    let sentinel =
+      Tool_output.encode_for_oas
+        (Tool_output.Stored {
+          sha256 = String.make 64 'a';
+          bytes = 6436;
+          mime = "text/plain";
+          preview = "{\"ok\":true,\"result\":\"42\"}";
+        })
+    in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"tool_blob"
+      ~input:(`Assoc []) ~output_text:sentinel
+      ~success:true ~duration_ms:1.0 ();
+    let results = Keeper_tool_call_log.read_recent ~n:1 () in
+    Alcotest.(check int) "entry persisted" 1 (List.length results);
+    match results with
+    | [ json ] ->
+      let output =
+        match json with
+        | `Assoc fields -> List.assoc_opt "output" fields
+        | _ -> None
+      in
+      (match output with
+       | Some (`Assoc [("_blob", `Assoc blob)]) ->
+         let sha = Safe_ops.json_string ~default:"" "sha256" (`Assoc blob) in
+         let bytes = Safe_ops.json_int ~default:0 "bytes" (`Assoc blob) in
+         let mime = Safe_ops.json_string ~default:"" "mime" (`Assoc blob) in
+         let preview = Safe_ops.json_string ~default:"" "preview" (`Assoc blob) in
+         Alcotest.(check string) "sha256 round-trips" (String.make 64 'a') sha;
+         Alcotest.(check int) "bytes round-trips" 6436 bytes;
+         Alcotest.(check string) "mime round-trips" "text/plain" mime;
+         Alcotest.(check string) "preview round-trips"
+           "{\"ok\":true,\"result\":\"42\"}" preview
+       | Some (`String s) ->
+         Alcotest.failf "expected normalized _blob object, got string: %s" s
+       | _ -> Alcotest.fail "missing/unexpected output field")
+    | _ -> Alcotest.fail "expected exactly one entry")
+
+(* Inline outputs (below the externalization threshold) must stay as
+   plain JSON strings so legacy jq pipelines and the UI's string-render
+   path keep working. *)
+let test_output_inline_string_preserved () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"tool_inline"
+      ~input:(`Assoc []) ~output_text:"small inline result"
+      ~success:true ~duration_ms:1.0 ();
+    let results = Keeper_tool_call_log.read_recent ~n:1 () in
+    match results with
+    | [ json ] ->
+      let s = Safe_ops.json_string ~default:"" "output" json in
+      Alcotest.(check string) "inline output stays a string"
+        "small inline result" s
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 let () =
   Alcotest.run "keeper_tool_call_log"
     [ ( "read_recent",
@@ -409,5 +471,11 @@ let () =
             test_output_invalid_utf8_sanitized
         ; eio_test "valid UTF-8 preserved verbatim"
             test_output_valid_utf8_untouched
+        ] )
+    ; ( "blob_normalize",
+        [ eio_test "blob sentinel persists as structured _blob object"
+            test_output_blob_sentinel_normalized
+        ; eio_test "inline string output stays a JSON string"
+            test_output_inline_string_preserved
         ] )
     ]


### PR DESCRIPTION
## Summary

Tool I/O 텔레메트리에 찍히는 record가 sentinel string + multi-level escape로 거의 읽을 수 없던 문제 (디스크 30-40% overhead + 화면에 `\\\"` 잔해)를 근본 fix.

```
# Before — sentinel + escape on escape on escape
"output": "[masc:blob sha256=2d5b... preview=\"{\\\"ok\\\":true,...\"]"

# After — structured object, JSON.stringify가 자연 pretty
"output": {
  "_blob": {
    "sha256": "2d5b...",
    "bytes": 6436,
    "mime": "text/plain",
    "preview": "{\"ok\":true,...}"
  }
}
```

근본 원인: `Tool_output.encode_for_oas`의 `%S` (OCaml string-literal escape) → JSON serializer의 string escape → `JSON.stringify` 다시 escape. 3중 escape.

## Backward compat

- Inline string outputs (sub-threshold) → 기존 `String _` shape 유지. legacy jq pipeline 안 깨짐.
- Backend reader (`dashboard_http_tool_quality`) — `String | _blob` 양쪽 처리.
- Frontend reader (`api/dashboard.ts`) — type union `string | ToolCallOutputBlob` + decoder.
- Frontend renderer (`keeper-tool-call-inspector`) — 두 shape 모두 pretty render. **이미 디스크에 있는 옛 sentinel string entries는 기존 `parseToolBlobMarker` path로 변함없이 렌더**.

## Files

- `lib/keeper_tool_call_log.ml` — `blob_aware_output_json` helper + apply
- `lib/dashboard/dashboard_http_tool_quality.ml` — 2 read sites가 양쪽 shape 처리
- `test/test_keeper_tool_call_log.ml` — `blob_normalize` 신규 suite (2 tests)
- `dashboard/src/api/dashboard.ts` — type + decoder
- `dashboard/src/components/keeper-tool-call-inspector.ts` — `formatOutput` 양쪽 처리

## Verification

- `dune build --root .` — clean
- `dune exec --root . test/test_keeper_tool_call_log.exe` — **15/15 pass** (기존 13 + 신규 2)
- `pnpm typecheck` — clean
- `pnpm test src/keeper-store-normalize.test.ts` — 22/22 pass

## Out of scope

- LLM input layer (`tool_bridge.maybe_externalize` + `keeper_artifact_hydrator`)는 변경 없음. 텔레메트리 layer만의 normalization.
- `Tool_output.encode_for_oas`의 `%S` format은 LLM context history와 hydrator round-trip을 위해 보존. (변경 시 ripple effect 큼.)
