### PR TITLE
feat(response): add .mli to formalise the MCP response envelope

### DIFF
--- a/lib/response/response.mli
+++ b/lib/response/response.mli
@@ -1,0 +1,163 @@
+(** Standardised API response envelope shared across MCP tools.
+
+    Every MCP tool return value flows through a {!t} so clients get a
+    uniform shape: a {!success} flag, a JSON payload, a human-readable
+    {!message}, structured {!errors} with recovery hints, and an
+    emission timestamp.
+
+    Prefer the constructor helpers ({!ok}, {!error}, {!validation_error}
+    …) over building a {!t} literal by hand — they stamp the timestamp
+    and enforce the shape agreed upon with the tool host.
+
+    Usage:
+    {[
+      Response.ok ~message:"Task claimed"
+        (`Assoc [("task_id", `String "task-001")])
+      |> Response.to_string
+    ]}
+*)
+
+(** {1 Types} *)
+
+(** Severity level on a structured error entry. *)
+type severity =
+  | Fatal    (** Operation completely failed. *)
+  | Warning  (** Partial success or recoverable issue. *)
+  | Info     (** Informational, no action needed. *)
+
+(** One structured error produced by a tool, with machine-readable
+    [code], a human-readable [message] and zero or more
+    [recovery_hints]. *)
+type error_detail = {
+  code: string;
+  severity: severity;
+  message: string;
+  recovery_hints: string list;
+}
+
+(** Canonical tool response envelope.  [success] is the quick-check
+    flag; [data] is the tool-specific payload; [errors] carries fatal
+    errors (when [success = false]) or warnings (when [success = true]
+    via {!ok_with_warnings}). *)
+type t = {
+  success: bool;
+  data: Yojson.Safe.t;
+  message: string;
+  errors: error_detail list;
+  timestamp: float;
+}
+
+(** {1 Severity conversions} *)
+
+val severity_to_string : severity -> string
+(** Canonical lower-case name: ["fatal" | "warning" | "info"]. *)
+
+val severity_of_string : string -> (severity, string) result
+(** Parse the canonical lower-case name; returns [Error msg] on
+    anything else (unknown inputs are not silently downgraded). *)
+
+val severity_of_string_default : ?default:severity -> string -> severity
+(** Parse like {!severity_of_string} but fall back to [default]
+    ([Info] if not given) on any unknown input.  Retained for
+    backwards-compatibility with callers that cannot surface a parse
+    error. *)
+
+val to_severity : severity -> Severity.t
+(** Project the local {!severity} enum onto the cross-module
+    [Severity.t] used by other subsystems ([Fatal -> Critical], etc.). *)
+
+(** {1 Serialization} *)
+
+val error_to_json : error_detail -> Yojson.Safe.t
+val to_json : t -> Yojson.Safe.t
+val to_string : t -> string
+(** [to_string r] is the pretty-printed JSON of [r]. *)
+
+(** {1 Constructors — success} *)
+
+val ok : ?message:string -> Yojson.Safe.t -> t
+(** [ok ~message data] builds a success response; default [message]
+    is ["OK"]. *)
+
+val ok_with_warnings :
+  ?message:string -> warnings:error_detail list -> Yojson.Safe.t -> t
+(** Success with attached non-fatal [warnings] carried on
+    {!error_detail}s. *)
+
+(** {1 Constructors — error} *)
+
+val error :
+  ?data:Yojson.Safe.t ->
+  code:string ->
+  message:string ->
+  ?hints:string list ->
+  unit -> t
+(** [error ~code ~message ?hints ()] builds a single-error failure
+    response at [Fatal] severity. *)
+
+val errors :
+  ?data:Yojson.Safe.t ->
+  message:string ->
+  error_detail list -> t
+(** Failure response with multiple pre-built {!error_detail}s (each
+    with its own severity). *)
+
+(** {1 Constructors — individual [error_detail]s} *)
+
+val make_error :
+  code:string ->
+  ?severity:severity ->
+  message:string ->
+  ?hints:string list ->
+  unit -> error_detail
+(** Default severity is [Fatal]. *)
+
+val make_warning :
+  code:string ->
+  message:string ->
+  ?hints:string list ->
+  unit -> error_detail
+
+val make_info :
+  code:string ->
+  message:string ->
+  unit -> error_detail
+
+(** {1 Common error kinds}
+
+    These wrap {!error} with a canonical [code], a formatted
+    [message], and curated recovery hints; prefer them over ad-hoc
+    {!error} calls so codes stay consistent across tools. *)
+
+val validation_error : field:string -> reason:string -> t
+val not_found        : resource:string -> id:string -> t
+val already_exists   : resource:string -> id:string -> t
+val permission_denied : action:string -> resource:string -> t
+val conflict         : resource:string -> reason:string -> t
+val timeout          : operation:string -> t
+
+(** {1 Drift-specific responses} *)
+
+val drift_detected :
+  similarity:float ->
+  drift_type:string ->
+  threshold:float ->
+  details:string ->
+  t
+(** Emits a [Warning]-severity response whose recovery hints are
+    selected by [drift_type] (["factual" | "semantic" | "structural"]
+    — anything else gets generic hints). *)
+
+val handoff_verified : similarity:float -> t
+(** Success envelope for a verified handoff, reporting [similarity]. *)
+
+(** {1 Task-specific responses}
+
+    These route status strings through [Types.task_status_to_string]
+    so the value returned here matches what other emitters/parsers
+    see — see the comment in the implementation (issues #8364, #8412)
+    for why this matters. *)
+
+val task_claimed       : task_id:string -> agent:string -> t
+val task_already_claimed : task_id:string -> claimed_by:string -> t
+val task_completed     : task_id:string -> agent:string -> notes:string -> t


### PR DESCRIPTION
## Summary

Wave 3 **`.mli` coverage** 첫 번째 파일 — `lib/response/response.ml` (333줄, `public_name masc_mcp.response`). 공통 MCP 응답 envelope의 공개 API를 명시화.

## 변경

`lib/response/response.mli` 신규 생성 (163줄). `.ml`에 바디는 유지, 서명을 분리해 문서화.

### 섹션 구성

1. **Types** — `severity` / `error_detail` / `t`
2. **Severity conversions** — `severity_to_string` / `_of_string` / `_of_string_default` / `to_severity` (cross-module `Severity.t` bridge)
3. **Serialization** — `error_to_json` / `to_json` / `to_string`
4. **Constructors — success** — `ok` / `ok_with_warnings`
5. **Constructors — error** — `error` / `errors`
6. **`error_detail` builders** — `make_error` / `make_warning` / `make_info`
7. **Common error kinds** — `validation_error` / `not_found` / `already_exists` / `permission_denied` / `conflict` / `timeout`
8. **Drift-specific** — `drift_detected` / `handoff_verified`
9. **Task-specific** — `task_claimed` / `task_already_claimed` / `task_completed`

### 주요 문서화 지점

- `severity_of_string_default` — unknown 입력을 silent fallback하는 backwards-compat 함수임을 명시 (소프트웨어 개발 원칙 "Unknown → Permissive Default" 안티패턴 경고)
- `task_claimed` / `task_completed` — **issue #8364/#8412** 인용, `Types.task_status_to_string` 라우팅 유지 이유 명시. Variant SSOT 이탈 방지.

## Scope

이 PR **하는 것**:
- `.mli` 1개 추가
- 기존 `.ml` 바디 그대로 (한 줄도 건드리지 않음)

이 PR **하지 않는 것**:
- export 추가/제거 (검증: `dune build` pass, 경고 0)
- 구현 변경
- 다른 모듈 `.mli`

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli`/`.ml` | 289/671 = 43% | **290/671 = ~43.1%** (+1 file) |
| lib/response/ 공개 API 문서화 | 부분 (ocamldoc 주석만) | 완전 (섹션 구조 + 이슈 인용) |
| task_status string SSOT 문서화 | 코드 주석 only | `.mli` 기준 문서화 |

## 검증

- `dune build --root=.` ✅ pass (어떤 경고도 없음 → 누락/잉여 export 없음)
- 바디 변경 0 → 행동 불변

## Anti-goal 자가 체크

- [x] surgical (1 파일 추가, 0 파일 수정)
- [x] behavior-preserving
- [x] 근거 있음 (#8364, #8412 인용으로 future drift 방지)
- [x] 과도한 추상화 없음 (기존 구조 그대로 문서화만)

## Epic/Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 .mli coverage — first target)

다음 .mli 후보: `lib/cdal_types.ml`, `lib/worker_oas.ml`, `lib/attribution.ml`, 혹은 scout 재스캔으로 300+ 라인 unhidden 모듈 추출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)