### PR TITLE
feat(bonsai-dashboard): vertical brass gutter + dual fade on tape

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -402,6 +402,51 @@ stylesheet
   .tape {
     display: flex;
     flex-direction: column;
+    position: relative;
+    padding-left: 1.5rem;
+    isolation: isolate;
+  }
+
+  /* Vertical brass thread running down the left margin — anchors the
+     time gutter and reads as a continuous "spine" for the row sequence. */
+  .tape::before {
+    content: "";
+    position: absolute;
+    left: 0.6rem;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: linear-gradient(180deg,
+      transparent 0%,
+      #5a3028 6%,
+      #2a1a14 92%,
+      transparent 100%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Top fade — entries appear out of darkness as they scroll past the HUD. */
+  .tape::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 28px;
+    background: linear-gradient(180deg, #0a0706 0%, rgba(10, 7, 6, 0) 100%);
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  /* Symmetric bottom fade so old entries dissolve into the page floor
+     before the roster strip. Sibling element (not pseudo) so it can sit
+     after the row stream in DOM order without breaking sticky positioning. */
+  .tape_end {
+    position: relative;
+    height: 32px;
+    background: linear-gradient(180deg, rgba(10, 7, 6, 0) 0%, #0a0706 100%);
+    margin-top: -8px;
+    pointer-events: none;
   }
 
   .row {
@@ -588,20 +633,11 @@ stylesheet
     color: #4a3a32;
   }
 
+  /* Wrapper kept for backward compatibility with the existing render
+     code; the top fade now lives on .tape::after, so the old sticky
+     pseudo is no longer needed. */
   .tape_fade {
     position: relative;
-  }
-
-  .tape_fade::before {
-    content: "";
-    position: sticky;
-    top: 58px;
-    display: block;
-    height: 24px;
-    margin-bottom: -24px;
-    pointer-events: none;
-    z-index: 2;
-    background: linear-gradient(180deg, #0a0706 0%, rgba(10, 7, 6, 0) 100%);
   }
 
   .roster {
@@ -963,7 +999,9 @@ let render_response (response : Logs_types.response) : Node.t =
       in
       Node.div
         ~attrs:[ Style.tape_fade ]
-        [ Node.div ~attrs:[ Style.tape ] rendered ]
+        [ Node.div ~attrs:[ Style.tape ] rendered
+        ; Node.div ~attrs:[ Style.tape_end ] []
+        ]
   in
   let brand_row =
     Node.div


### PR DESCRIPTION
## 의도

Tape 영역의 좌측 여백에 brass 세로 실 (vertical thread) 을 두고 row sequence 의 \"척추\" 시각 anchor 로 삼는다. 양 끝 (top/bottom) 에 fade 를 추가해서 entries 가 어둠 속에서 떠올랐다가 다시 사라지는 인상.

## 변경

CSS:
- \`.tape\` → \`position: relative\`, \`padding-left: 1.5rem\`, \`isolation: isolate\`
- \`.tape::before\` 신규 (좌측 1px brass vertical line, top/bottom 으로 부드럽게 fade)
- \`.tape::after\` 신규 (top fade, 28px high)
- \`.tape_end\` 신규 (DOM sibling element 로 bottom fade — sticky 와 충돌 없음)
- \`.tape_fade::before\` 제거 (top fade 가 \`.tape::after\` 로 이동)

OCaml view (1 line):
\`\`\`ocaml
[ Node.div ~attrs:[ Style.tape ] rendered
; Node.div ~attrs:[ Style.tape_end ] []
]
\`\`\`

## 미완 (follow-up)

- Tick labels (예: \"—22:16\" 매 N row) — row schema 에 timestamp grouping 추가 후 별도 PR
- 시안 \`docs/bonsai-migration/visual-pitch.html\` iter 13 의 \`.tick\` selector 가 그 자리

## 검증

- bonsai-dashboard switch 빌드 통과
- 라이브 sync (64.5 MB)
- 강제 새로고침 시 좌측 brass thread + 위/아래 fade 보임