### PR TITLE
fix(bonsai-dashboard): TLS stub shape — entire array, not dict by key

### DIFF
--- a/dashboard_bonsai/src/runtime_stubs.js
+++ b/dashboard_bonsai/src/runtime_stubs.js
@@ -31,28 +31,26 @@ function caml_sys_const_arch_arm64 () {
 
 // OxCaml extends OCaml 5's Domain Local Storage (DLS, already in jsoo
 // runtime) with Thread Local Storage (TLS) primitives. Stock js_of_ocaml
-// 6 has no TLS stubs, so the bundle throws on first init:
-//   TypeError: runtime.caml_domain_tls_set is not a function
-//     at init (domain.ml:578)
+// 6 has no TLS stubs.
 //
-// Browser bundles are single-threaded, so TLS reduces to a global map
-// keyed by the slot identifier. Same shape as the runtime's DLS
-// implementation, just under a separate global to keep the namespaces
-// independent (in case OxCaml ever uses both for distinct values in
-// the same program).
+// Shape matters: jsoo's DLS get/set take/return the *entire* OCaml array
+// as a single argument (see runtime: caml_domain_dls_set(a){caml_domain_dls = a;}).
+// OxCaml's TLS uses the same convention — basement calls Array.blit on
+// the value returned by tls_get, so it must be an OCaml array, not a
+// dict keyed by slot ids. An earlier dict-based stub (#8816) crashed
+// with Invalid_argument("Array.blit") for exactly this reason.
+//
+// Browser bundles are single-threaded, so TLS reduces to one global
+// array. [0] is the OCaml empty-array tag — basement initialises real
+// values via blit on first use.
 
 //Provides: caml_domain_tls_set
-function caml_domain_tls_set (key, value) {
-  globalThis.__caml_tls = globalThis.__caml_tls || Object.create(null);
-  globalThis.__caml_tls[key] = value;
+function caml_domain_tls_set (a) {
+  globalThis.__caml_tls_storage = a;
   return 0;
 }
 
 //Provides: caml_domain_tls_get
-function caml_domain_tls_get (key) {
-  var tls = globalThis.__caml_tls;
-  if (tls && Object.prototype.hasOwnProperty.call(tls, key)) {
-    return tls[key];
-  }
-  return 0;
+function caml_domain_tls_get (_unit) {
+  return globalThis.__caml_tls_storage || [0];
 }


### PR DESCRIPTION
## 증상

\`\`\`
Fatal error: exception Invalid_argument("Array.blit")
\`\`\`

#8816 (TLS stub) 적용 후 다음 init 단계에서 발생.

## 원인

#8816 의 stub 은 dict 기반 (slot key → value). 잘못된 shape. jsoo 의 DLS 는 단일 OCaml array 를 통째로 set/get 하는 패턴이고, OxCaml 의 basement 도 같은 convention 을 따른다 — \`tls_get\` 의 return 값에 \`Array.blit\` 을 직접 호출.

jsoo runtime 의 DLS:
\`\`\`js
function caml_domain_dls_get(_unit){return caml_domain_dls;}
function caml_domain_dls_set(a){caml_domain_dls = a;}
\`\`\`

dict 가 array shape 으로 들어가니 \`Array.blit\` 이 length 등 OCaml array tag 를 못 찾아서 raise.

## 수정

같은 entire-array convention 으로 변경:

\`\`\`js
function caml_domain_tls_set (a) {
  globalThis.__caml_tls_storage = a;
  return 0;
}

function caml_domain_tls_get (_unit) {
  return globalThis.__caml_tls_storage || [0];
}
\`\`\`

\`[0]\` 은 OCaml 의 empty-array tag — basement 가 첫 사용에서 \`Array.blit\` 으로 실제 값을 채움.

## 검증

- bonsai-dashboard switch 빌드 통과
- 라이브 sync (64.5 MB)
- 강제 새로고침 시 \`Array.blit\` 안 던지고 다음 init 단계로 진행