### PR TITLE
feat(bonsai-dashboard): moonrise narrative strip between HUD and toolbar

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -242,6 +242,71 @@ stylesheet
   .hud_v_ok   { color: #5a7a3a; }
   .hud_v_warn { color: #a06a1a; }
 
+  /* Moonrise strip — narrative interlude between the HUD readout and
+     the filter toolbar. Reads as a quiet status bar that names the
+     watch, the time of day, and who is at the helm. */
+  .moonrise {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 8px 14px;
+    background:
+      linear-gradient(90deg,
+        rgba(138, 106, 40, 0.10) 0%,
+        transparent 45%,
+        rgba(160, 24, 24, 0.06) 100%),
+      #0f0b09;
+    border: 1px solid #2a1a14;
+    border-radius: 2px;
+    font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
+    font-variant: small-caps;
+    letter-spacing: 0.08em;
+    font-size: 12px;
+    color: #b8a488;
+  }
+
+  .moon_glyph {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 28% 28%, #e8d8b8 0%, #8a6a28 55%, #5a3028 100%);
+    box-shadow:
+      0 0 10px rgba(232, 216, 184, 0.22),
+      inset 0 0 0 1px rgba(232, 216, 184, 0.12);
+    flex-shrink: 0;
+  }
+
+  .moon_lead {
+    font-family: 'Cinzel', serif;
+    font-variant: normal;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: #e8d8b8;
+    font-size: 10px;
+  }
+
+  .moon_sep {
+    color: #5a3028;
+    font-variant: normal;
+  }
+
+  .moon_mono {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    font-variant: normal;
+    letter-spacing: 0.04em;
+    color: #8a6a28;
+  }
+
+  .moon_tail {
+    margin-left: auto;
+    color: #6a5848;
+    font-variant: normal;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
   .toolbar {
     display: flex;
     align-items: center;
@@ -1049,11 +1114,28 @@ let render_response (response : Logs_types.response) : Node.t =
       ; Node.button ~attrs:[ Style.btn_ghost ] [ Node.text "refresh" ]
       ]
   in
+  let moonrise =
+    Node.div
+      ~attrs:[ Style.moonrise ]
+      [ Node.span ~attrs:[ Style.moon_glyph ] []
+      ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text "the watch is on" ]
+      ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
+      ; Node.span [ Node.text "lit by a half moon" ]
+      ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
+      ; Node.span ~attrs:[ Style.moon_mono ] [ Node.text "23:50 local" ]
+      ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
+      ; Node.span
+          ~attrs:[ Style.moon_mono ]
+          [ Node.text "base=/tmp/masc-bonsai-dev" ]
+      ; Node.span ~attrs:[ Style.moon_tail ] [ Node.text "operator · vincent" ]
+      ]
+  in
   Node.div
     ~attrs:[ Style.root ]
     [ brand_row
     ; view_heartbeat ()
     ; view_hud response
+    ; moonrise
     ; toolbar
     ; Node.div
         ~attrs:[ Style.header ]


### PR DESCRIPTION
## 의도

HUD readout (정량 측정값) 과 filter toolbar (제어) 사이에 narrative interlude 한 줄. \"the watch is on · lit by a half moon · 23:50 local · base=...\" + 우측 \"OPERATOR · VINCENT\". 단순 status bar 가 아니라 시안 (필사본/저택) 톤을 유지한 quiet 한 narration.

## 변경

CSS:
- \`.moonrise\` (전체 strip — small caps EB Garamond, brass+blood double gradient ground)
- \`.moon_glyph\` (radial gradient micro-moon, 14×14 px)
- \`.moon_lead\` (Cinzel small-caps lead 텍스트)
- \`.moon_sep\` (blood-red \"·\" 구분자)
- \`.moon_mono\` (mono — 시간/경로용)
- \`.moon_tail\` (우측 anchored operator)

OCaml view: 9 \`Node.span\` 으로 구성된 \`moonrise\` 섹션을 \`render_response\` 안에 추가, \`view_hud response\` 와 \`toolbar\` 사이 sibling 으로 배치.

## Placeholder

\`23:50 local\`, \`base=/tmp/masc-bonsai-dev\`, \`operator · vincent\` — session context surface (시간 / base path / operator) 가 wire 되면 live 값으로 교체. 시안: iter 14.

## 검증

- bonsai-dashboard switch 빌드 통과
- 라이브 sync (64.5 MB)