### PR TITLE
docs(spec): OCaml<->TLA+ mapping in KeeperMemoryLifecycle (#8642 family)

### DIFF
--- a/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
@@ -11,6 +11,61 @@
 \*   - overflow/handoff do not silently drop retained notes,
 \*   - handoff clears stale short-term notes,
 \*   - each tier stays within its configured bound.
+\*
+\* OCaml <-> TLA+ mapping (see #8642 family):
+\*
+\*   spec variable    | OCaml field / source                              | location
+\*   -----------------+--------------------------------------------------+--------
+\*   short_mem        | rows with horizon = "short_term"                 | lib/keeper/keeper_memory_policy.ml:155
+\*   mid_mem          | rows with horizon = "mid_term"                   | lib/keeper/keeper_memory_policy.ml:156
+\*   long_mem         | rows with horizon = "long_term"                  | lib/keeper/keeper_memory_policy.ml:157
+\*   open_short       | unresolved short-term notes (open_question kind) | lib/keeper/keeper_memory_bank.ml
+\*   provenanced      | rows with non-empty trace_id / source            | lib/keeper/keeper_memory_bank.ml
+\*   generation       | snapshot.generation field                        | snapshot record
+\*   overflowed       | derived: short_mem cardinality > MaxShort        | runtime check
+\*
+\* Tier vocabulary (string-typed, intentionally not a variant today):
+\*   lib/keeper/keeper_memory_policy.ml:155-157
+\*     `let short_term_horizon = "short_term"`
+\*     `let mid_term_horizon   = "mid_term"`
+\*     `let long_term_horizon  = "long_term"`
+\*
+\* Producer (kind -> tier classification):
+\*   lib/keeper/keeper_memory_policy.ml:159-164  memory_horizon_of_kind
+\*   lib/keeper/keeper_memory_policy.ml:166-175  memory_horizon_of_json
+\*
+\* Persistence / promotion sites:
+\*   lib/keeper/keeper_memory_bank.ml:550   `let horizon = memory_horizon_of_kind kind`
+\*   lib/keeper/keeper_memory_recall.ml:104 recall path uses same horizon function
+\*   lib/keeper/keeper_compact_policy.ml    overflow + handoff scheduling
+\*   lib/keeper/keeper_compact_audit.ml     ledger trail (provenance source)
+\*
+\* SCOPE DRIFT (worth knowing, NOT a spec violation):
+\*   memory_horizon_of_kind silently routes unknown kinds to mid_term_horizon
+\*   (lib/keeper/keeper_memory_policy.ml:164  `| _ -> mid_term_horizon`).
+\*   The spec invariants (ProvenanceRequired, RecoveryBounded, NoSilentLoss)
+\*   hold regardless of WHICH tier a note lands in -- the drift is UPSTREAM
+\*   of the spec vocabulary. A typo'd kind ("goalss") gets the wrong tier
+\*   with no signal. Tracked separately for the standard #8605 wire-string
+\*   fix template (strict _opt + warn-and-default wrapper).
+\*
+\* Bug Model (BuggyCompactOverflow already in this spec):
+\*   Clean cfg : NoSilentLoss holds (lost_notes = {}).
+\*   Buggy cfg : compaction trims short tier WITHOUT promoting to mid;
+\*               dropped notes accumulate in lost_notes -- NoSilentLoss
+\*               MUST be violated.
+\*
+\* Adding new tiers / horizons:
+\*   - new horizon constant -> spec needs a new tier variable + cap + invariant
+\*   - new kind keyword     -> only producer side (memory_horizon_of_kind);
+\*                             does NOT require spec update unless it lands
+\*                             in a new tier
+\*
+\* Out-of-scope (intentionally not modelled here):
+\*   - reward-model evaluation (lib/keeper/keeper_memory.ml include chain)
+\*   - recall scoring (keeper_memory_recall.ml -- separate retrieval axis)
+\*   - keeper-runtime compaction trigger thresholds (keeper_compact_policy.ml)
+\*     this spec uses generic MaxShort/MaxMid/MaxLong constants instead
 
 EXTENDS Naturals, FiniteSets
 


### PR DESCRIPTION
## Summary

Adds the standard OCaml<->TLA+ mapping comment block to `specs/keeper-state-machine/KeeperMemoryLifecycle.tla`. Comment-only; no spec rules changed.

## Why this mapping is unique

The spec uses an *abstract* tiered-memory vocabulary (\`short_mem / mid_mem / long_mem\`), but the OCaml producer keeps the tier vocabulary as **string-typed horizons** (\`"short_term" / "mid_term" / "long_term"\`) at \`lib/keeper/keeper_memory_policy.ml:155-157\`. The mapping makes the string<->variable correspondence explicit.

## Discovered SCOPE DRIFT (NOT a spec violation)

While mapping, I noticed `memory_horizon_of_kind` (\`keeper_memory_policy.ml:159-164\`) silently routes unknown \`kind\` strings to `mid_term_horizon`:

```ocaml
| "next" | "open_question" | "progress" -> short_term_horizon
| "goal" | "decision" | "constraints" -> mid_term_horizon
| "long_term" -> long_term_horizon
| _ -> mid_term_horizon                 (* silent permissive default *)
```

Spec safety properties (\`ProvenanceRequired\`, \`RecoveryBounded\`, \`NoSilentLoss\`) hold regardless of WHICH tier a note lands in — the drift is **upstream of the spec vocabulary** so spec invariants don't catch it.

Tracked separately as **#8826** for the standard #8605 wire-string fix template (strict \`_opt\` + warn-and-default wrapper).

## Constructor-addition guidance

| Change | Spec update required? |
|---|---|
| New `horizon` constant | YES — new tier variable + cap + invariant |
| New `kind` keyword (lands in existing tier) | NO — producer side only |

OUT OF SCOPE: reward-model evaluation (\`keeper_memory.ml\` include chain), recall scoring (\`keeper_memory_recall.ml\` — separate retrieval axis), compaction trigger thresholds (\`keeper_compact_policy.ml\` — this spec uses generic \`MaxShort/MaxMid/MaxLong\` constants).

## Test plan

- [x] No code change; spec rules unchanged
- [x] Comment block follows #8642 family template
- [x] Companion issue #8826 filed for the silent-default anti-pattern