### PR TITLE
fix(memory_policy): strict classifier + warn on silent default (#8826)

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -156,23 +156,50 @@ let short_term_horizon = "short_term"
 let mid_term_horizon = "mid_term"
 let long_term_horizon = "long_term"
 
-let memory_horizon_of_kind (kind : string) : string =
+(* Strict classifier: returns [None] for unknown kinds so callers can
+   distinguish "rule fired" from "fall-through default". See #8826. *)
+let memory_horizon_of_kind_opt (kind : string) : string option =
   match String.lowercase_ascii (String.trim kind) with
-  | "next" | "open_question" | "progress" -> short_term_horizon
-  | "goal" | "decision" | "constraints" -> mid_term_horizon
-  | "long_term" -> long_term_horizon
-  | _ -> mid_term_horizon
+  | "next" | "open_question" | "progress" -> Some short_term_horizon
+  | "goal" | "decision" | "constraints" -> Some mid_term_horizon
+  | "long_term" -> Some long_term_horizon
+  | _ -> None
 
-let memory_horizon_of_json ~(kind : string) (json : Yojson.Safe.t) : string =
+(* Back-compat wrapper: warns once per unknown kind and falls back to
+   [mid_term_horizon] (the legacy permissive default). The explicit warn
+   converts the silent #8605-family fallback into an observable signal
+   without changing the legacy classification result. *)
+let memory_horizon_of_kind (kind : string) : string =
+  match memory_horizon_of_kind_opt kind with
+  | Some h -> h
+  | None ->
+      Log.Memory.warn
+        "memory_horizon_of_kind: unknown kind %S -> mid_term (drift; see #8826)"
+        kind;
+      mid_term_horizon
+
+(* Strict JSON horizon parser: returns [None] for missing or unknown
+   horizon strings so callers can decide whether to consult [kind] or
+   reject the row. *)
+let memory_horizon_of_json_opt (json : Yojson.Safe.t) : string option =
   match
     Safe_ops.json_string ~default:"" "horizon" json
     |> String.trim
     |> String.lowercase_ascii
   with
-  | "short_term" -> short_term_horizon
-  | "mid_term" -> mid_term_horizon
-  | "long_term" -> long_term_horizon
-  | _ -> memory_horizon_of_kind kind
+  | "short_term" -> Some short_term_horizon
+  | "mid_term" -> Some mid_term_horizon
+  | "long_term" -> Some long_term_horizon
+  | _ -> None
+
+(* Back-compat wrapper: when the JSON [horizon] is absent or unknown we
+   fall through to [memory_horizon_of_kind kind] (which itself warns on
+   unknown). The cascade is preserved exactly; the new wrapper just
+   exposes a strict variant for new callers. *)
+let memory_horizon_of_json ~(kind : string) (json : Yojson.Safe.t) : string =
+  match memory_horizon_of_json_opt json with
+  | Some h -> h
+  | None -> memory_horizon_of_kind kind
 
 let trim_nonempty (s : string) : string option =
   let t = String.trim s in

--- a/test/dune
+++ b/test/dune
@@ -370,6 +370,7 @@
         test_task_dispatch
         test_drift_guard_core
         test_verify_handoff_tool
+        test_memory_horizon_classifier
         test_param_type_classifier
         test_tool_contract_truth
         test_file_lock_eio
@@ -530,6 +531,7 @@
         test_task_dispatch
         test_drift_guard_core
         test_verify_handoff_tool
+        test_memory_horizon_classifier
         test_param_type_classifier
         test_tool_contract_truth
         test_file_lock_eio

--- a/test/test_memory_horizon_classifier.ml
+++ b/test/test_memory_horizon_classifier.ml
@@ -1,0 +1,123 @@
+(** Tests for keeper_memory_policy strict horizon classifiers (#8826).
+
+    Verifies that:
+    - the strict [_opt] variants return [Some] only for documented
+      vocabulary,
+    - unknown wire strings return [None] (no silent permissive default),
+    - the back-compat wrappers preserve the legacy [mid_term_horizon]
+      fallback so existing callers see no behaviour change. *)
+
+open Alcotest
+
+module Policy = Masc_mcp.Keeper_memory_policy
+
+let test_known_kinds_return_some () =
+  check (option string) "next -> short_term"
+    (Some Policy.short_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "next");
+  check (option string) "open_question -> short_term"
+    (Some Policy.short_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "open_question");
+  check (option string) "progress -> short_term"
+    (Some Policy.short_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "progress");
+  check (option string) "goal -> mid_term"
+    (Some Policy.mid_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "goal");
+  check (option string) "decision -> mid_term"
+    (Some Policy.mid_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "decision");
+  check (option string) "constraints -> mid_term"
+    (Some Policy.mid_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "constraints");
+  check (option string) "long_term -> long_term"
+    (Some Policy.long_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "long_term")
+
+let test_unknown_kinds_return_none () =
+  check (option string) "typo returns None"
+    None
+    (Policy.memory_horizon_of_kind_opt "goalss");
+  check (option string) "future kind returns None"
+    None
+    (Policy.memory_horizon_of_kind_opt "hypothesis");
+  check (option string) "empty string returns None"
+    None
+    (Policy.memory_horizon_of_kind_opt "");
+  check (option string) "whitespace returns None"
+    None
+    (Policy.memory_horizon_of_kind_opt "   ")
+
+let test_case_and_whitespace_normalised () =
+  check (option string) "uppercase normalised"
+    (Some Policy.mid_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "GOAL");
+  check (option string) "leading/trailing whitespace trimmed"
+    (Some Policy.short_term_horizon)
+    (Policy.memory_horizon_of_kind_opt "  next  ")
+
+let test_wrapper_preserves_legacy_default () =
+  (* Back-compat: unknown kind still falls back to mid_term_horizon
+     (with a warn line going to the log). *)
+  check string "unknown kind -> mid_term legacy"
+    Policy.mid_term_horizon
+    (Policy.memory_horizon_of_kind "definitely_not_a_kind");
+  check string "known kind unchanged"
+    Policy.short_term_horizon
+    (Policy.memory_horizon_of_kind "next")
+
+let test_json_strict_classifier () =
+  let json_with horizon =
+    `Assoc [ ("horizon", `String horizon); ("kind", `String "next") ]
+  in
+  check (option string) "JSON short_term -> Some"
+    (Some Policy.short_term_horizon)
+    (Policy.memory_horizon_of_json_opt (json_with "short_term"));
+  check (option string) "JSON mid_term -> Some"
+    (Some Policy.mid_term_horizon)
+    (Policy.memory_horizon_of_json_opt (json_with "mid_term"));
+  check (option string) "JSON long_term -> Some"
+    (Some Policy.long_term_horizon)
+    (Policy.memory_horizon_of_json_opt (json_with "long_term"));
+  check (option string) "JSON unknown -> None"
+    None
+    (Policy.memory_horizon_of_json_opt (json_with "unrecognised"));
+  check (option string) "JSON missing horizon -> None"
+    None
+    (Policy.memory_horizon_of_json_opt (`Assoc [ ("kind", `String "next") ]))
+
+let test_json_wrapper_falls_back_to_kind () =
+  let json_unknown =
+    `Assoc [ ("horizon", `String "unknown_horizon"); ("kind", `String "next") ]
+  in
+  check string "JSON unknown horizon falls through to kind classification"
+    Policy.short_term_horizon
+    (Policy.memory_horizon_of_json ~kind:"next" json_unknown);
+  let json_known =
+    `Assoc [ ("horizon", `String "long_term"); ("kind", `String "next") ]
+  in
+  check string "JSON known horizon takes precedence over kind"
+    Policy.long_term_horizon
+    (Policy.memory_horizon_of_json ~kind:"next" json_known)
+
+let () =
+  Alcotest.run "memory_horizon_classifier"
+    [
+      ( "strict classifier",
+        [
+          test_case "known kinds return Some" `Quick
+            test_known_kinds_return_some;
+          test_case "unknown kinds return None" `Quick
+            test_unknown_kinds_return_none;
+          test_case "case and whitespace normalised" `Quick
+            test_case_and_whitespace_normalised;
+          test_case "JSON strict classifier" `Quick test_json_strict_classifier;
+        ] );
+      ( "back-compat wrappers",
+        [
+          test_case "wrapper preserves legacy default" `Quick
+            test_wrapper_preserves_legacy_default;
+          test_case "JSON wrapper falls back to kind" `Quick
+            test_json_wrapper_falls_back_to_kind;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Closes **#8826** — `memory_horizon_of_kind` (\`lib/keeper/keeper_memory_policy.ml:159-164\`) silently routed every unknown \`kind\` to `mid_term_horizon`. The #8605 anti-pattern: typo'd or future \`kind\` strings got the wrong tier with no signal, and the spec invariants in **KeeperMemoryLifecycle** could not catch it because the drift is *upstream* of the spec vocabulary.

## Changes

Standard #8642 family wire-string template applied to two functions:

- `memory_horizon_of_kind_opt : string -> string option` (strict).
- `memory_horizon_of_kind` wrapper now calls the strict variant and `Log.Memory.warn`s on the fall-through. Legacy result (\`mid_term_horizon\`) is preserved so back-compat is exact.
- Same template for `memory_horizon_of_json`: new `memory_horizon_of_json_opt` + wrapper preserves the existing two-stage cascade (JSON horizon → kind classification).

## Test plan

New \`test/test_memory_horizon_classifier.ml\` (6 tests, all green):

- [x] known kinds return \`Some\` for the documented vocabulary
- [x] unknown / typo / empty / whitespace-only kinds return \`None\`
- [x] case + whitespace are normalised before matching
- [x] JSON strict classifier returns \`None\` for missing or unknown horizon
- [x] back-compat wrapper preserves the legacy \`mid_term_horizon\` default
- [x] JSON wrapper falls back through to kind classification when horizon is unknown

```
dune exec ./test/test_memory_horizon_classifier.exe
Test Successful in 0.002s. 6 tests run.
```

## Companion

Companion to **PR #8827** (KeeperMemoryLifecycle TLA+ mapping that surfaced the drift). Same #8642 family template as #8736 / #8740 / #8779.