### PR TITLE
observability(keepers_json): log per-keeper fiber wait/work timing

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -353,8 +353,23 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
   Eio.Fiber.all
     (List.mapi
        (fun idx name () ->
+         (* Two-phase timing so we can distinguish semaphore contention
+            from per-keeper I/O cost when dashboard snapshots stall.
+            Emits [keepers_json:NAME wait=… work=…] only when either
+            half exceeds the same 500ms threshold used by the outer
+            [timed] helper, keeping the log quiet on healthy snapshots. *)
+         let t_wait_start = Time_compat.now () in
          Eio.Semaphore.acquire _keeper_sem;
-         Fun.protect ~finally:(fun () -> Eio.Semaphore.release _keeper_sem)
+         let t_work_start = Time_compat.now () in
+         let wait_ms = (t_work_start -. t_wait_start) *. 1000.0 in
+         Fun.protect
+           ~finally:(fun () ->
+             Eio.Semaphore.release _keeper_sem;
+             let work_ms = (Time_compat.now () -. t_work_start) *. 1000.0 in
+             if work_ms > 500.0 || wait_ms > 500.0 then
+               Log.Dashboard.info
+                 "[keepers_json:%s] wait=%.0fms work=%.0fms" name wait_ms
+                 work_ms)
            (fun () ->
          results.(idx) <-
            (try


### PR DESCRIPTION
## Problem

Production logs surface \`[snapshot_json] keepers_json: 3100ms\` routinely (#8822), but we only have the aggregate — we cannot tell yet whether the 3 s comes from:

1. Uniform I/O pressure across 16 keepers (~775 ms each under 4-way concurrency)
2. Semaphore queue saturation (fibers waiting, not working)
3. One outlier keeper blocking (e.g. a large meta or slow tool-use audit)

Each of those implies a different fix — blanket cache, concurrency tuning, or targeted per-keeper investigation.

## Change

Two-phase per-fiber timing inside \`operator_control_snapshot.ml\` \`keepers_json\`:

- **wait_ms**: time queued on \`_keeper_sem\` (semaphore cap = 4)
- **work_ms**: time spent in the per-keeper I/O + JSON construction chain

Emit \`[keepers_json:NAME] wait=W ms work=X ms\` only when either half exceeds 500 ms — the same threshold the existing \`timed\` helper uses. Keeps healthy snapshots silent.

## Scope

- Observation-only. No caching, no concurrency change, no behaviour change for callers.
- No new env var — uses the existing \`Log.Dashboard.info\` channel, so dashboard already sees these lines.
- The two \`Time_compat.now\` calls are the only added runtime cost (~ns).

## Validation

- \`dune build --root . @check\` ✓ (silent)
- Diff is additive around the existing \`Fun.protect\` shape — fiber body preserved verbatim inside the new inner closure.

## Next step (after merge)

Capture one live snapshot window from server logs. If \`wait\` dominates across all keepers → raise \`_keeper_snapshot_max_concurrency\`. If \`work\` dominates uniformly → add a TTL cache to \`load_keeper_profile_defaults\` + \`parse_agent_status\`. If one keeper is an outlier → investigate that keeper's \`meta.json\` / tool-audit file size.

## Related

- #8822 (keepers_json perf tracking issue)
- Sibling to #8818 (dashboard git TTL cache — merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)