### PR TITLE
fix(sdk_tool_contract): strict param_type_of_schema + warn on silent default (#8832)

### DIFF
--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -366,15 +366,32 @@ let rec validate_json_value ?label schema value =
 let validate_input_json schema json =
   validate_json_value ~label:"input" schema json
 
-let param_type_of_schema schema =
+(* Strict classifier: returns [None] for unknown JSON Schema types so
+   callers can distinguish "rule fired" from "fall-through default".
+   See #8832. *)
+let param_type_of_schema_opt schema : Agent_sdk.Types.param_type option =
   match schema_type schema with
-  | "string" -> Agent_sdk.Types.String
-  | "integer" -> Agent_sdk.Types.Integer
-  | "number" -> Agent_sdk.Types.Number
-  | "boolean" -> Agent_sdk.Types.Boolean
-  | "array" -> Agent_sdk.Types.Array
-  | "object" -> Agent_sdk.Types.Object
-  | _ -> Agent_sdk.Types.String
+  | "string" -> Some Agent_sdk.Types.String
+  | "integer" -> Some Agent_sdk.Types.Integer
+  | "number" -> Some Agent_sdk.Types.Number
+  | "boolean" -> Some Agent_sdk.Types.Boolean
+  | "array" -> Some Agent_sdk.Types.Array
+  | "object" -> Some Agent_sdk.Types.Object
+  | _ -> None
+
+(* Back-compat wrapper: warns once per unknown JSON Schema type and falls
+   back to [String] (the legacy permissive default mirrored by the
+   upstream Agent_sdk.Mcp.json_schema_type_to_param_type). The warn
+   converts the silent #8605-family fallback into an observable signal
+   without changing the tool-registration result. *)
+let param_type_of_schema schema =
+  match param_type_of_schema_opt schema with
+  | Some t -> t
+  | None ->
+      Log.Misc.warn
+        "param_type_of_schema: unknown JSON Schema type %S -> String (drift; see #8832)"
+        (schema_type schema);
+      Agent_sdk.Types.String
 
 let tool_params_of_input_schema schema =
   let required = required_names schema in

--- a/test/dune
+++ b/test/dune
@@ -370,6 +370,7 @@
         test_task_dispatch
         test_drift_guard_core
         test_verify_handoff_tool
+        test_param_type_classifier
         test_tool_contract_truth
         test_file_lock_eio
         test_error_logging_coverage
@@ -529,6 +530,7 @@
         test_task_dispatch
         test_drift_guard_core
         test_verify_handoff_tool
+        test_param_type_classifier
         test_tool_contract_truth
         test_file_lock_eio
         test_error_logging_coverage

--- a/test/test_param_type_classifier.ml
+++ b/test/test_param_type_classifier.ml
@@ -1,0 +1,104 @@
+(** Tests for sdk_tool_contract strict param_type classifier (#8832).
+
+    Verifies that:
+    - the strict [_opt] variant returns [Some] only for documented
+      JSON Schema vocabulary,
+    - unknown types (e.g. "null", future JSON Schema 2020-12 keywords)
+      return [None] (no silent permissive default),
+    - the back-compat wrapper preserves the legacy [String] fallback so
+      existing tool registrations see no behaviour change. *)
+
+open Alcotest
+
+module Contract = Masc_mcp.Sdk_tool_contract
+
+let schema_with_type t = `Assoc [ ("type", `String t) ]
+
+let param_type_testable =
+  let open Agent_sdk.Types in
+  Alcotest.testable
+    (fun fmt -> function
+      | String -> Format.fprintf fmt "String"
+      | Integer -> Format.fprintf fmt "Integer"
+      | Number -> Format.fprintf fmt "Number"
+      | Boolean -> Format.fprintf fmt "Boolean"
+      | Array -> Format.fprintf fmt "Array"
+      | Object -> Format.fprintf fmt "Object")
+    ( = )
+
+let test_known_types_return_some () =
+  let open Agent_sdk.Types in
+  check (option param_type_testable) "string -> Some String"
+    (Some String)
+    (Contract.param_type_of_schema_opt (schema_with_type "string"));
+  check (option param_type_testable) "integer -> Some Integer"
+    (Some Integer)
+    (Contract.param_type_of_schema_opt (schema_with_type "integer"));
+  check (option param_type_testable) "number -> Some Number"
+    (Some Number)
+    (Contract.param_type_of_schema_opt (schema_with_type "number"));
+  check (option param_type_testable) "boolean -> Some Boolean"
+    (Some Boolean)
+    (Contract.param_type_of_schema_opt (schema_with_type "boolean"));
+  check (option param_type_testable) "array -> Some Array"
+    (Some Array)
+    (Contract.param_type_of_schema_opt (schema_with_type "array"));
+  check (option param_type_testable) "object -> Some Object"
+    (Some Object)
+    (Contract.param_type_of_schema_opt (schema_with_type "object"))
+
+let test_unknown_types_return_none () =
+  check (option param_type_testable) "null -> None"
+    None
+    (Contract.param_type_of_schema_opt (schema_with_type "null"));
+  check (option param_type_testable) "typo'd type -> None"
+    None
+    (Contract.param_type_of_schema_opt (schema_with_type "strng"));
+  check (option param_type_testable) "future JSON Schema 2020-12 type -> None"
+    None
+    (Contract.param_type_of_schema_opt (schema_with_type "tuple"))
+
+let test_wrapper_preserves_legacy_default () =
+  (* Back-compat: unknown type still falls back to String (with a warn
+     line going to the log). *)
+  let open Agent_sdk.Types in
+  check param_type_testable "unknown type -> String legacy"
+    String
+    (Contract.param_type_of_schema (schema_with_type "null"));
+  check param_type_testable "known type unchanged"
+    Integer
+    (Contract.param_type_of_schema (schema_with_type "integer"))
+
+let test_no_type_field_falls_through_schema_type () =
+  (* schema_type returns "object" when no "type" field but properties
+     exist; "string" otherwise. The strict classifier should still hit
+     a known branch for both cases (no warn). *)
+  let open Agent_sdk.Types in
+  check (option param_type_testable) "no type, no properties -> Some String"
+    (Some String)
+    (Contract.param_type_of_schema_opt (`Assoc []));
+  let with_properties =
+    `Assoc [ ("properties", `Assoc [ ("a", `Assoc []) ]) ]
+  in
+  check (option param_type_testable) "no type, has properties -> Some Object"
+    (Some Object)
+    (Contract.param_type_of_schema_opt with_properties)
+
+let () =
+  Alcotest.run "param_type_classifier"
+    [
+      ( "strict classifier",
+        [
+          test_case "known JSON Schema types return Some" `Quick
+            test_known_types_return_some;
+          test_case "unknown JSON Schema types return None" `Quick
+            test_unknown_types_return_none;
+          test_case "no type field still resolves via schema_type" `Quick
+            test_no_type_field_falls_through_schema_type;
+        ] );
+      ( "back-compat wrapper",
+        [
+          test_case "wrapper preserves legacy String default" `Quick
+            test_wrapper_preserves_legacy_default;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Closes **#8832** — `param_type_of_schema` (\`lib/sdk_tool_contract.ml:369-377\`) silently routed every unknown JSON Schema type to `Agent_sdk.Types.String`. The #8605 anti-pattern: a schema declaring \`\"type\": \"null\"\`, a JSON Schema 2020-12 keyword, or a typo silently became \`String\`, and tool input validation ran against the wrong type with no signal in the log.

## Changes

Standard #8642 family wire-string template:

- `param_type_of_schema_opt : schema -> param_type option` (strict).
- `param_type_of_schema` wrapper now calls the strict variant and `Log.Misc.warn`s on the fall-through. Legacy result (\`String\`) is preserved exactly so back-compat is bit-identical.

The warn mirrors the upstream `Agent_sdk.Mcp.json_schema_type_to_param_type` wildcard (\`lib/agent_sdk/protocol/mcp_schema.ml:14\`) which has the same silent default with an explicit unit test asserting it. The masc-mcp side now surfaces the drift while remaining behaviourally identical to upstream until the SDK adds a \`Null\` / \`Unknown\` constructor.

## Test plan

New \`test/test_param_type_classifier.ml\` (4 tests, all green):

- [x] known JSON Schema types return \`Some\` for the documented vocabulary
- [x] \`\"null\"\` / typo'd / future-2020-12 keywords return \`None\`
- [x] schema_type fallback (no \`\"type\"\` field, with/without properties) still resolves via known branches without warn
- [x] back-compat wrapper preserves the legacy \`String\` default

```
dune exec ./test/test_param_type_classifier.exe
Test Successful in 0.002s. 4 tests run.
```

## Companion / pattern siblings

Same template as #8736, #8740, #8779, #8828 — fourth #8605-family fix in the current sweep.