### PR TITLE
[codex] Gate approval detail behind admin permission

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -315,6 +315,24 @@ let list_pending_dashboard_json () : Yojson.Safe.t =
   ) (Atomic.get pending) [] in
   `List (sort_entries_by_requested_at entries)
 
+let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =
+  `Assoc [
+    ("id", `String entry.id);
+    ("keeper_name", `String entry.keeper_name);
+    ("tool_name", `String entry.tool_name);
+    ("risk_level", `String (risk_level_to_string entry.risk_level));
+    ("requested_at", `Float entry.requested_at);
+    ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
+    ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+    ("input", entry.input);
+    ("input_preview", `String (input_preview_of_json entry.input));
+  ]
+
+let get_pending_json ~id : Yojson.Safe.t option =
+  match SMap.find_opt id (Atomic.get pending) with
+  | None -> None
+  | Some entry -> Some (pending_entry_detail_json entry)
+
 let pending_count () : int =
   SMap.cardinal (Atomic.get pending)
 

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -133,6 +133,8 @@ let public_mcp_surface_tools =
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
+    (* HITL approval queue *)
+    "masc_approval_get";
     (* Shared memory lane — keeper-context-gated at dispatch time. *)
     "masc_team_memory_read"; "masc_team_memory_write"; "masc_team_memory_search";
     (* Board extended *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -90,6 +90,14 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
   | "masc_approval_pending" ->
       let json = Keeper_approval_queue.list_pending_json () in
       Some (true, Yojson.Safe.to_string json)
+  | "masc_approval_get" ->
+      let id = arg_get_string "id" "" in
+      if id = "" then Some (false, "id is required")
+      else
+        (match Keeper_approval_queue.get_pending_json ~id with
+         | Some json -> Some (true, Yojson.Safe.to_string json)
+         | None ->
+           Some (false, Printf.sprintf "approval %s not found or already resolved" id))
   | "masc_approval_resolve" ->
       let id = arg_get_string "id" "" in
       let decision_str = arg_get_string "decision" "approve" in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -97,7 +97,10 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
         (match Keeper_approval_queue.get_pending_json ~id with
          | Some json -> Some (true, Yojson.Safe.to_string json)
          | None ->
-           Some (false, Printf.sprintf "approval %s not found or already resolved" id))
+           Some (false,
+             Printf.sprintf
+               "approval %s is no longer pending or was not found. Refresh with masc_approval_pending before approving/rejecting."
+               id))
   | "masc_approval_resolve" ->
       let id = arg_get_string "id" "" in
       let decision_str = arg_get_string "decision" "approve" in

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -33,6 +33,8 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_agent_fitness", CanReadState);
     ("masc_dashboard", CanReadState);
     ("masc_check", CanReadState);
+    ("masc_approval_pending", CanReadState);
+    ("masc_approval_get", CanAdmin);
     ("masc_collaboration_graph", CanReadState);
     ("masc_get_metrics", CanReadState);
     ("masc_plan_get_task", CanReadState);
@@ -61,6 +63,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_keeper_compact", CanBroadcast);
     ("masc_keeper_clear", CanBroadcast);
     ("masc_keeper_create_from_persona", CanBroadcast);
+    ("masc_approval_resolve", CanAdmin);
     ("masc_operator_confirm", CanBroadcast);
     ("masc_operation_start", CanBroadcast);
     ("masc_policy_approve", CanBroadcast);

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -41,6 +41,24 @@ Pair with masc_subscription to receive session-scoped event notifications.";
   (* masc_cancellation, masc_subscription, masc_progress,
      masc_governance_set removed: pruned from surfaces *)
 
+  (* masc_approval_get *)
+  {
+    name = "masc_approval_get";
+    description = "Operator/admin-only detail view. Fetch one pending HITL approval by id, including the full input JSON. \
+Use after finding an approval id in the dashboard or pending approval queue when the preview is insufficient for an operator decision. \
+Requires the same privileged approval surface as resolving an approval.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Pending approval id, for example appr_abc123def456");
+        ]);
+      ]);
+      ("required", `List [`String "id"]);
+    ];
+  };
+
   (* masc_spawn *)
   {
     name = "masc_spawn";

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -6,6 +6,7 @@
 open Alcotest
 
 module Config = Masc_mcp.Config
+module Auth = Masc_mcp.Auth
 module Tool_catalog = Masc_mcp.Tool_catalog
 
 let dummy_schema name : Types.tool_schema =
@@ -36,6 +37,16 @@ let test_all_tool_schemas_non_empty () =
 let test_all_tool_names_contains_pause () =
   check bool "masc_pause registered" true
     (List.mem "masc_pause" (Config.all_tool_names ()))
+
+let test_all_tool_names_contains_approval_get () =
+  check bool "masc_approval_get registered" true
+    (List.mem "masc_approval_get" (Config.all_tool_names ()))
+
+let test_approval_get_requires_admin_permission () =
+  check bool "approval_get admin-only" true
+    (Auth.permission_for_tool "masc_approval_get" = Some Types.CanAdmin);
+  check bool "approval_resolve admin-only" true
+    (Auth.permission_for_tool "masc_approval_resolve" = Some Types.CanAdmin)
 
 let test_all_tool_names_omit_removed_mode_tools () =
   let names = Config.all_tool_names () in
@@ -68,6 +79,10 @@ let () =
             test_all_tool_schemas_non_empty;
           test_case "all_tool_names contains pause" `Quick
             test_all_tool_names_contains_pause;
+          test_case "all_tool_names contains approval_get" `Quick
+            test_all_tool_names_contains_approval_get;
+          test_case "approval get requires admin permission" `Quick
+            test_approval_get_requires_admin_permission;
           test_case "removed mode tools omitted" `Quick
             test_all_tool_names_omit_removed_mode_tools;
           test_case "visible is subset of all" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -9,8 +9,50 @@
 
 module GP = Masc_mcp.Governance_pipeline
 module AQ = Masc_mcp.Keeper_approval_queue
+module Mcp_eio = Masc_mcp.Mcp_server_eio
 
 let check = Alcotest.(check string)
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_hitl_approval_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.is_directory path then begin
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  n_len = 0 || loop 0
+
+let execute_approval_get args =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"approval-get-test"
+        state ~name:"masc_approval_get" ~arguments:args)
 
 (* ── 1. Risk classification ──────────────────────────────── *)
 
@@ -316,6 +358,116 @@ let test_background_pending_reuses_existing_entry () =
   Alcotest.(check bool) "second callback not attached to duplicate submit" true
     (Option.is_none !second_callback)
 
+let test_approval_queue_get_pending_detail () =
+  Eio_main.run @@ fun _env ->
+  let initial_count = AQ.pending_count () in
+  let callback_result = ref None in
+  let input =
+    `Assoc [
+      ("path", `String "/tmp/danger");
+      ("reason", `String "operator needs full input");
+      ("nested", `Assoc [("mode", `String "detail")]);
+    ]
+  in
+  let id =
+    AQ.submit_pending
+      ~keeper_name:"detail-keeper"
+      ~tool_name:"masc_code_delete"
+      ~input
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> callback_result := Some decision)
+  in
+  let open Yojson.Safe.Util in
+  let detail =
+    match AQ.get_pending_json ~id with
+    | Some json -> json
+    | None -> Alcotest.fail "expected pending approval detail"
+  in
+  Alcotest.(check string) "detail id" id (detail |> member "id" |> to_string);
+  Alcotest.(check string) "detail keeper" "detail-keeper"
+    (detail |> member "keeper_name" |> to_string);
+  Alcotest.(check string) "detail tool" "masc_code_delete"
+    (detail |> member "tool_name" |> to_string);
+  Alcotest.(check string) "detail risk" "critical"
+    (detail |> member "risk_level" |> to_string);
+  Alcotest.(check string) "detail includes full input"
+    (Yojson.Safe.to_string input)
+    (detail |> member "input" |> Yojson.Safe.to_string);
+  Alcotest.(check bool) "detail includes preview" true
+    (String.length (detail |> member "input_preview" |> to_string) > 0);
+  Alcotest.(check bool) "missing detail returns none" true
+    (Option.is_none (AQ.get_pending_json ~id:"missing-approval"));
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  Alcotest.(check bool) "callback fired" true
+    (match !callback_result with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
+  Alcotest.(check int) "entry removed"
+    initial_count (AQ.pending_count ())
+
+let test_approval_get_dispatch_success () =
+  let initial_count = AQ.pending_count () in
+  let callback_result = ref None in
+  let input =
+    `Assoc [
+      ("path", `String "/tmp/operator-only");
+      ("payload", `Assoc [("secret", `String "full-input")]);
+    ]
+  in
+  let id =
+    AQ.submit_pending
+      ~keeper_name:"dispatch-detail-keeper"
+      ~tool_name:"masc_code_delete"
+      ~input
+      ~risk_level:AQ.Critical
+      ~on_resolution:(fun decision -> callback_result := Some decision)
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")))
+    (fun () ->
+      let ok, payload =
+        execute_approval_get (`Assoc [("id", `String id)])
+      in
+      Alcotest.(check bool) "dispatch approval_get success" true ok;
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string payload in
+      Alcotest.(check string) "dispatch detail id" id
+        (json |> member "id" |> to_string);
+      Alcotest.(check string) "dispatch includes full input"
+        (Yojson.Safe.to_string input)
+        (json |> member "input" |> Yojson.Safe.to_string));
+  Alcotest.(check int) "dispatch cleanup removes pending"
+    initial_count (AQ.pending_count ());
+  Alcotest.(check bool) "cleanup rejects callback" true
+    (match !callback_result with Some (Agent_sdk.Hooks.Reject _) -> true | _ -> false)
+
+let test_approval_get_dispatch_missing_id () =
+  let ok, msg = execute_approval_get (`Assoc [("id", `String "")]) in
+  Alcotest.(check bool) "missing id fails" false ok;
+  Alcotest.(check bool) "missing id message" true
+    (contains_substring msg "id is required")
+
+let test_approval_get_dispatch_not_found () =
+  let ok, msg =
+    execute_approval_get (`Assoc [("id", `String "appr_missing")])
+  in
+  Alcotest.(check bool) "not found fails" false ok;
+  Alcotest.(check bool) "not found message" true
+    (contains_substring msg "not found or already resolved")
+
+let test_approval_get_rejects_reader_role () =
+  match
+    Masc_mcp.Auth.authorize_tool_for_role ~agent_name:"reader"
+      ~role:Types.Reader ~tool_name:"masc_approval_get"
+  with
+  | Error (Types.Forbidden _) -> ()
+  | Error err ->
+      Alcotest.fail
+        (Printf.sprintf "expected forbidden, got %s"
+           (Types.masc_error_to_string err))
+  | Ok () -> Alcotest.fail "reader should not be allowed to call approval_get"
+
 (* ── 4. Approval callback integration ────────────────────── *)
 
 let test_callback_approves_low_risk () =
@@ -412,6 +564,16 @@ let () =
         test_background_pending_callback_and_keeper_lookup;
       Alcotest.test_case "background pending reuses existing entry" `Quick
         test_background_pending_reuses_existing_entry;
+      Alcotest.test_case "get pending detail includes full input" `Quick
+        test_approval_queue_get_pending_detail;
+      Alcotest.test_case "dispatch approval_get success" `Quick
+        test_approval_get_dispatch_success;
+      Alcotest.test_case "dispatch approval_get missing id" `Quick
+        test_approval_get_dispatch_missing_id;
+      Alcotest.test_case "dispatch approval_get not found" `Quick
+        test_approval_get_dispatch_not_found;
+      Alcotest.test_case "approval_get rejects reader role" `Quick
+        test_approval_get_rejects_reader_role;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -454,7 +454,9 @@ let test_approval_get_dispatch_not_found () =
   in
   Alcotest.(check bool) "not found fails" false ok;
   Alcotest.(check bool) "not found message" true
-    (contains_substring msg "not found or already resolved")
+    (contains_substring msg "no longer pending");
+  Alcotest.(check bool) "not found next action" true
+    (contains_substring msg "Refresh with masc_approval_pending")
 
 let test_approval_get_rejects_reader_role () =
   match


### PR DESCRIPTION
## Summary

- Add `masc_approval_get` as a pending HITL approval detail tool that returns the full approval input for one approval id.
- Gate `masc_approval_get` and `masc_approval_resolve` as `CanAdmin`, while keeping `masc_approval_pending` read-only.
- Document `masc_approval_get` as an operator/admin-only full-input detail surface.
- Add dispatch/auth regressions for success, empty id, not found, reader denial, registration, and permission mapping.
- Return an actionable stale-detail message that tells operators to refresh with `masc_approval_pending` when an approval is no longer pending or was not found.

## Why

Issue #8831 identified that the List/Detail approval PoC exposed full approval input by id without an explicit role boundary. The detail surface carries high-sensitivity payloads, so it must not be treated like a light pending-list preview.

The board review also identified a stale-detail UX gap: after a pending approval is resolved elsewhere, the operator should not get a dead-end `not found` response without the next recovery action.

## Validation

- `opam exec -- dune build --root "$PWD" test/test_hitl_approval.exe test/test_config_coverage.exe test/test_auth.exe`
- `opam exec -- _build/default/test/test_hitl_approval.exe` (24 tests)
- `opam exec -- _build/default/test/test_config_coverage.exe` (9 tests)
- `opam exec -- _build/default/test/test_auth.exe` (29 tests)
- `git diff --check`

## Follow-up

This PR closes the role boundary by requiring admin/operator permission for full approval input. If “same-scope” means tenant/session-level filtering beyond `CanAdmin`, that needs a separate policy design and implementation.