### PR TITLE
fix(keeper_composite_observer): exhaustive ksm_phase in live_turn_phase (#8605 family)

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -258,6 +258,12 @@ let derive_ksm_phase (phase : Keeper_state_machine.phase) : ksm_phase =
   | Keeper_state_machine.Restarting
   | Keeper_state_machine.Dead -> Ksm_stable
 
+(* Exhaustive on [ksm_phase]: the prior wildcard hid the design
+   decision for new ksm_phase variants and made the dashboard report
+   Turn_idle for keepers in Ksm_failing / Ksm_overflowed when there is
+   no live observation. Spelling each branch out turns a future
+   ksm_phase addition into a compile error and makes the chosen
+   mapping auditable. (#8605 family -- exhaustive-match template) *)
 let live_turn_phase (entry : Keeper_registry.registry_entry) =
   match entry.current_turn_observation with
   | Some obs -> obs.turn_phase
@@ -266,7 +272,10 @@ let live_turn_phase (entry : Keeper_registry.registry_entry) =
        | Ksm_compacting -> Turn_compacting
        | Ksm_handing_off
        | Ksm_draining -> Turn_finalizing
-       | _ -> Turn_idle)
+       | Ksm_running
+       | Ksm_failing
+       | Ksm_overflowed
+       | Ksm_stable -> Turn_idle)
 
 let live_decision_stage (entry : Keeper_registry.registry_entry) =
   match entry.current_turn_observation with


### PR DESCRIPTION
## Summary

`live_turn_phase` (\`lib/keeper/keeper_composite_observer.ml:261-269\`) used `_ -> Turn_idle` when there was no live observation. The wildcard collapsed `Ksm_failing` / `Ksm_overflowed` into `Turn_idle` on the dashboard — Turn_idle for a failing or overflowed keeper is misleading — and would silently relabel any future `ksm_phase` variant as `Turn_idle`.

## Change

Spell every `ksm_phase` branch out:

```ocaml
| Ksm_compacting                 -> Turn_compacting
| Ksm_handing_off | Ksm_draining -> Turn_finalizing
| Ksm_running   | Ksm_failing
| Ksm_overflowed | Ksm_stable    -> Turn_idle
```

`ksm_phase` is defined locally in this module, so the compiler now turns a future `ksm_phase` addition into a **build error** and forces a deliberate mapping decision rather than a silent `Turn_idle`. This is the exhaustive-match template (#8697 / #8700 / #8746 / #8766 / #8770) applied to the dashboard's turn-phase derivation.

## Behaviour preservation

Every existing `ksm_phase` value maps to the same `turn_phase` as before:

| Before (\`_\` arm) | After (explicit) |
|---|---|
| Ksm_running       | Ksm_running   -> Turn_idle |
| Ksm_failing       | Ksm_failing   -> Turn_idle |
| Ksm_overflowed    | Ksm_overflowed -> Turn_idle |
| Ksm_stable        | Ksm_stable    -> Turn_idle |

## Test plan

No tests added — exhaustiveness is compiler-enforced. A unit test would just re-verify what the exhaustiveness check already guarantees. `dune build @check` passes.

```
dune build --root . @check
(silent — no errors)
```