### PR TITLE
feat(bonsai-dashboard): add right aside (340px focus + evs)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -30,13 +30,17 @@ stylesheet
     color: #b8a488;
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-size: 15px;
-    padding: 1.5rem 2.5rem 4rem 244px;
+    padding: 1.5rem calc(340px + 24px) 4rem 244px;
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
     isolation: isolate;
   }
 
+  @media (max-width: 1280px) {
+    .root { padding-right: 2.5rem; }
+    .aside { display: none; }
+  }
   @media (max-width: 880px) {
     .root { padding-left: 1.25rem; }
     .nav  { display: none; }
@@ -971,6 +975,204 @@ stylesheet
     text-transform: uppercase;
   }
   .nav_foot_v { color: #6a5848; }
+
+  /* ─── right aside (340px, fixed) ───
+     dashboard_v2 aside: focus card + chronicle evs stream.
+     현재는 static skeleton. 추후 Var 연결. */
+  .aside {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 340px;
+    height: 100vh;
+    padding: 22px 18px 28px;
+    background: linear-gradient(180deg, #16100a 0%, #0e0806 100%);
+    border-left: 1px solid #2a1a14;
+    box-shadow: inset 1px 0 0 rgba(138, 106, 40, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    overflow-y: auto;
+    z-index: 5;
+  }
+
+  .aside_h {
+    font-family: 'Cinzel', serif;
+    font-size: 11px;
+    letter-spacing: 0.28em;
+    color: #8a6a28;
+    text-transform: uppercase;
+    margin: 0 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .aside_h::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, #5a3028, transparent);
+  }
+  .aside_h_tail {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: #6a5848;
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+    text-transform: none;
+  }
+
+  /* ─── focus card ─── */
+  .focus {
+    position: relative;
+    padding: 16px 16px 14px;
+    background: linear-gradient(180deg, #241a12 0%, #14100a 100%);
+    border: 1px solid #5a4618;
+  }
+  .focus::before {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    border: 1px solid #5a3028;
+    pointer-events: none;
+  }
+  .focus_who {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .focus_portrait {
+    width: 46px;
+    height: 46px;
+    border: 1px solid #8a6a28;
+    background: linear-gradient(135deg, #2a1f14, #0e0806);
+    display: grid;
+    place-items: center;
+    font-family: 'Cinzel', serif;
+    font-size: 18px;
+    color: #8a6a28;
+    flex-shrink: 0;
+  }
+  .focus_name_col { flex: 1; }
+  .focus_name {
+    font-family: 'Cinzel', serif;
+    font-size: 16px;
+    color: #8a6a28;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+  .focus_role {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-style: italic;
+    font-size: 11px;
+    color: #6a5848;
+    margin-top: 2px;
+  }
+
+  .ctx_bar { margin-top: 14px; position: relative; }
+  .ctx_lbl {
+    display: flex;
+    justify-content: space-between;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: #6a5848;
+    margin-bottom: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .ctx_lbl_v { color: #e8d8b8; }
+  .vial {
+    height: 8px;
+    background: #0a0604;
+    border: 1px solid #2a1a14;
+    position: relative;
+    overflow: hidden;
+  }
+  .vial_fill {
+    display: block;
+    height: 100%;
+    width: 64%;
+    background: linear-gradient(90deg, #8a6a20, #d4a940);
+    box-shadow: 0 0 6px rgba(138, 106, 40, 0.45);
+  }
+  .vial::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(90deg, transparent 0 19px, rgba(0, 0, 0, 0.5) 19px 20px);
+    pointer-events: none;
+  }
+
+  .focus_stats {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px 14px;
+    margin-top: 14px;
+  }
+  .focus_stat_l {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    color: #6a5848;
+    text-transform: uppercase;
+  }
+  .focus_stat_v {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 12px;
+    color: #e8d8b8;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ─── chronicle evs stream ─── */
+  .evs { display: flex; flex-direction: column; }
+  .evrow {
+    display: grid;
+    grid-template-columns: 52px 12px 1fr;
+    gap: 10px;
+    padding: 8px 0;
+    border-bottom: 1px dashed #2a1a14;
+    align-items: baseline;
+  }
+  .evrow:last-child { border-bottom: 0; }
+  .evrow_t {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: #6a5848;
+    font-variant-numeric: tabular-nums;
+  }
+  .evrow_mk {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    align-self: center;
+    justify-self: center;
+    background: #5a4618;
+  }
+  .evrow_ok  .evrow_mk { background: #5a7a3a; box-shadow: 0 0 6px #5a7a3a; }
+  .evrow_warn .evrow_mk { background: #8a6a28; box-shadow: 0 0 6px #8a6a28; }
+  .evrow_bad  .evrow_mk { background: #a01818; box-shadow: 0 0 6px #a01818; }
+  .evrow_b {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-size: 12px;
+    color: #b8a488;
+    line-height: 1.45;
+  }
+  .evrow_b_em { color: #e8d8b8; font-style: italic; }
+  .evrow_b_code {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: #8a6a28;
+    background: rgba(138, 106, 40, 0.08);
+    padding: 0 5px;
+    border: 1px solid #2a1a14;
+  }
+  .evrow_bad .evrow_b_code {
+    color: #a01818;
+    background: rgba(160, 24, 24, 0.08);
+  }
 |}]
 
 let level_class level =
@@ -1317,6 +1519,109 @@ let render_response (response : Logs_types.response) : Node.t =
           ]
       ]
   in
+  let aside_h ?tail label =
+    let tail_node =
+      match tail with
+      | None -> []
+      | Some t ->
+        [ Node.span ~attrs:[ Style.aside_h_tail ] [ Node.text t ] ]
+    in
+    Node.div ~attrs:[ Style.aside_h ] (Node.text label :: tail_node)
+  in
+  let focus_stat l v =
+    Node.div
+      ~attrs:[]
+      [ Node.div ~attrs:[ Style.focus_stat_l ] [ Node.text l ]
+      ; Node.div ~attrs:[ Style.focus_stat_v ] [ Node.text v ]
+      ]
+  in
+  let focus_card =
+    Node.div
+      ~attrs:[ Style.focus ]
+      [ Node.div
+          ~attrs:[ Style.focus_who ]
+          [ Node.div ~attrs:[ Style.focus_portrait ] [ Node.text "L" ]
+          ; Node.div
+              ~attrs:[ Style.focus_name_col ]
+              [ Node.div ~attrs:[ Style.focus_name ] [ Node.text "Luna" ]
+              ; Node.div
+                  ~attrs:[ Style.focus_role ]
+                  [ Node.text "dungeon master · alchemist" ]
+              ]
+          ]
+      ; Node.div
+          ~attrs:[ Style.ctx_bar ]
+          [ Node.div
+              ~attrs:[ Style.ctx_lbl ]
+              [ Node.span [ Node.text "context" ]
+              ; Node.span
+                  ~attrs:[ Style.ctx_lbl_v ]
+                  [ Node.text "64%" ]
+              ]
+          ; Node.div
+              ~attrs:[ Style.vial ]
+              [ Node.span ~attrs:[ Style.vial_fill ] [] ]
+          ]
+      ; Node.div
+          ~attrs:[ Style.focus_stats ]
+          [ focus_stat "turn" "47 / 60"
+          ; focus_stat "heartbeat" "3s"
+          ; focus_stat "mem" "128k"
+          ; focus_stat "latency" "812ms"
+          ]
+      ]
+  in
+  let ev ?(level = `Info) t body_inline =
+    let attrs =
+      match level with
+      | `Info -> [ Style.evrow ]
+      | `Ok -> [ Style.evrow; Style.evrow_ok ]
+      | `Warn -> [ Style.evrow; Style.evrow_warn ]
+      | `Bad -> [ Style.evrow; Style.evrow_bad ]
+    in
+    Node.div
+      ~attrs
+      [ Node.div ~attrs:[ Style.evrow_t ] [ Node.text t ]
+      ; Node.div ~attrs:[ Style.evrow_mk ] []
+      ; Node.div ~attrs:[ Style.evrow_b ] body_inline
+      ]
+  in
+  let evs_stream =
+    Node.div
+      ~attrs:[ Style.evs ]
+      [ ev ~level:`Ok "23:50" [ Node.text "Luna answered the "
+                              ; Node.span ~attrs:[ Style.evrow_b_em ] [ Node.text "third bell" ]
+                              ; Node.text "."
+                              ]
+      ; ev ~level:`Warn "23:47" [ Node.text "storm sealed "
+                                ; Node.span ~attrs:[ Style.evrow_b_code ] [ Node.text "west_wing" ]
+                                ]
+      ; ev ~level:`Info "23:42" [ Node.text "DM narrates the manor under storm." ]
+      ; ev ~level:`Bad "23:29" [ Node.text "keeper "
+                               ; Node.span ~attrs:[ Style.evrow_b_code ] [ Node.text "brass-owl" ]
+                               ; Node.text " crashed mid-turn."
+                               ]
+      ; ev ~level:`Info "23:14" [ Node.text "round "
+                                ; Node.span ~attrs:[ Style.evrow_b_em ] [ Node.text "T3" ]
+                                ; Node.text " opens — DM's turn."
+                                ]
+      ]
+  in
+  let aside =
+    Node.div
+      ~attrs:[ Style.aside ]
+      [ Node.div
+          ~attrs:[]
+          [ aside_h ~tail:"ctx 64%" "focus · keeper"
+          ; focus_card
+          ]
+      ; Node.div
+          ~attrs:[]
+          [ aside_h ~tail:"5 / ∞" "chronicle · recent"
+          ; evs_stream
+          ]
+      ]
+  in
   Node.div
     ~attrs:[ Style.root ]
     [ nav
@@ -1347,6 +1652,7 @@ let render_response (response : Logs_types.response) : Node.t =
     ; tape
     ; view_roster ()
     ; Node.div ~attrs:[ Style.signet ] [ Node.text "M" ]
+    ; aside
     ]
 ;;
 


### PR DESCRIPTION
## Summary

PR #8830 (좌측 nav 220px)에 이어 dashboard_v2 shell의 **우측 aside 340px** 도입. 이제 3-column shell layout이 처음 완성된다 — 좌: nav / 중: main(logs journal) / 우: aside(focus + chronicle).

## aside 구성

### focus · keeper (brass-framed card)
- 46px portrait (Cinzel "L")
- name "Luna" + role "dungeon master · alchemist"
- context vial (64%, brass fill, tick marks every 20px)
- 2×2 stats grid (turn 47/60, heartbeat 3s, mem 128k, latency 812ms)

### chronicle · recent (evs stream)
- 5 rows: `52px ts | 8px mark | body`
- level marks with glow: `ok`(bile #5a7a3a) / `warn`(brass #8a6a28) / `bad`(blood #a01818)
- inline 변형: `.evrow_b_em` (italic bone) / `.evrow_b_code` (mono brass chip)

## 디자인 토큰 정합

`colors_and_type.css` 1:1:
- bg: `#16100a → #0e0806` blood-panel vertical
- focus bg: `#241a12 → #14100a` brass-ember
- border: `#5a4618` (brass-dim), `::before` inset `#5a3028` (scab)
- 타입: Cinzel(name) / EB Garamond(role, body) / JetBrains Mono(ts, stats)

## Layout

- `.aside`: `position: fixed`, right:0, top:0, 340px × 100vh, `overflow-y: auto`
- `.root` padding-right: `calc(340px + 24px)`
- `@media (max-width: 1280px)`: aside 숨김 + padding 복원

## Test plan

- [x] `dune build --root .` (bonsai-dashboard switch) — 62MB bundle
- [ ] Admin merge → main repo rebuild + restart → `/dashboard/b/` 우측 패널 확인
- [ ] 1280px 이하 responsive 동작
- [ ] main 영역 scroll vs aside overflow 각각 독립 동작

## 남은 shell 단계

- view_roster / signet이 현재 main column에 남아있음 (aside와 역할 중복). 다음 PR에서 roster를 aside 안으로 이동, signet은 nav 하단 or 제거.
- Var 연결 (static mock → real keeper/events).
- grid-template-columns로 fixed positioning 정식 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
