### PR TITLE
feat(bonsai-dashboard): wire aside evs to live Logs_var (WARN+/ERROR)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1586,26 +1586,63 @@ let render_response (response : Logs_types.response) : Node.t =
       ; Node.div ~attrs:[ Style.evrow_b ] body_inline
       ]
   in
-  let evs_stream =
-    Node.div
-      ~attrs:[ Style.evs ]
-      [ ev ~level:`Ok "23:50" [ Node.text "Luna answered the "
-                              ; Node.span ~attrs:[ Style.evrow_b_em ] [ Node.text "third bell" ]
-                              ; Node.text "."
-                              ]
-      ; ev ~level:`Warn "23:47" [ Node.text "storm sealed "
-                                ; Node.span ~attrs:[ Style.evrow_b_code ] [ Node.text "west_wing" ]
-                                ]
-      ; ev ~level:`Info "23:42" [ Node.text "DM narrates the manor under storm." ]
-      ; ev ~level:`Bad "23:29" [ Node.text "keeper "
-                               ; Node.span ~attrs:[ Style.evrow_b_code ] [ Node.text "brass-owl" ]
-                               ; Node.text " crashed mid-turn."
-                               ]
-      ; ev ~level:`Info "23:14" [ Node.text "round "
-                                ; Node.span ~attrs:[ Style.evrow_b_em ] [ Node.text "T3" ]
-                                ; Node.text " opens — DM's turn."
-                                ]
+  (* live evs: WARN/ERROR만 필터, 최근 5개. mock→real 전환. *)
+  let hhmm_of_ts (ts : string) : string =
+    (* "2026-04-19T17:12:03Z" -> "17:12" *)
+    if String.length ts >= 16
+    then String.sub ts ~pos:11 ~len:5
+    else ts
+  in
+  let ev_of_entry (e : Logs_types.entry) : Node.t =
+    let level : [ `Info | `Ok | `Warn | `Bad ] =
+      match e.normalized_level with
+      | "ERROR" -> `Bad
+      | "WARN" -> `Warn
+      | _ -> `Info
+    in
+    let body =
+      [ Node.text e.message
+      ; Node.text " "
+      ; Node.span ~attrs:[ Style.evrow_b_code ] [ Node.text e.module_ ]
       ]
+    in
+    ev ~level (hhmm_of_ts e.ts) body
+  in
+  let evs_stream =
+    let filtered =
+      List.filter response.entries ~f:(fun e ->
+        match e.normalized_level with
+        | "WARN" | "ERROR" -> true
+        | _ -> false)
+    in
+    let top_five =
+      match List.length filtered with
+      | n when n <= 5 -> filtered
+      | _ -> List.take filtered 5
+    in
+    match top_five with
+    | [] ->
+      Node.div
+        ~attrs:[ Style.evs ]
+        [ Node.div
+            ~attrs:[ Style.evrow ]
+            [ Node.div ~attrs:[ Style.evrow_t ] [ Node.text "—" ]
+            ; Node.div ~attrs:[ Style.evrow_mk ] []
+            ; Node.div
+                ~attrs:[ Style.evrow_b ]
+                [ Node.text "조용하다 · 경고 없음" ]
+            ]
+        ]
+    | rows -> Node.div ~attrs:[ Style.evs ] (List.map rows ~f:ev_of_entry)
+  in
+  let evs_tail =
+    let total_alarms =
+      List.count response.entries ~f:(fun e ->
+        match e.normalized_level with
+        | "WARN" | "ERROR" -> true
+        | _ -> false)
+    in
+    Printf.sprintf "%d / ∞" total_alarms
   in
   let aside =
     Node.div
@@ -1617,7 +1654,7 @@ let render_response (response : Logs_types.response) : Node.t =
           ]
       ; Node.div
           ~attrs:[]
-          [ aside_h ~tail:"5 / ∞" "chronicle · recent"
+          [ aside_h ~tail:evs_tail "chronicle · recent"
           ; evs_stream
           ]
       ]


### PR DESCRIPTION
## Summary

PR #8839에서 도입한 우측 aside의 **chronicle · recent** 섹션을 `Logs_var.var`(실 JSON 응답)에 연결. 하드코딩 5개 mock 문장을 live WARN/ERROR 필터로 교체.

**드디어 aside도 실 데이터** — "아직 mock이냐?" 물음에 대한 답.

## 변경

- `ev_of_entry : Logs_types.entry -> Node.t`
  - ts `"2026-04-19T17:12:03Z"` → `"17:12"` (String.sub pos:11 len:5)
  - normalized_level 매핑: `ERROR→`Bad`, `WARN→`Warn`, other→`Info`
  - body: `message + module_(evrow_b_code chip)`
- filter: `normalized_level ∈ {"WARN","ERROR"}`
- `List.take filtered 5`
- empty state: "조용하다 · 경고 없음"
- `aside_h ~tail`: 고정 "5 / ∞" → live `"{alarm_count} / ∞"`

## 여전히 static

- focus card (Luna · 64% · 47/60 · 812ms) — keepers endpoint 필요
- 별도 PR: `GET /dashboard/b/api/keepers/focus` Record + yojson

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 `/dashboard/b/` 우측 chronicle 섹션이 실제 로그 WARN/ERROR만 표시
- [ ] aside_h 카운트가 `HUD seq up to N`과 정합 (info 제외한 실 alarm만)
- [ ] WARN/ERROR 0개일 때 "조용하다 · 경고 없음" empty state 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)
