### PR TITLE
feat(keeper): surface tok/s + latency_ms in turn-end log

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -320,8 +320,22 @@ let make_hooks
            Prometheus.inc_counter
              "masc_after_turn_telemetry_missing_total"
              ~labels:[("model", model)] ());
-        Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
-          meta.name turn meta.runtime.usage.total_turns model total_tok;
+        let fmt_tok_s = function
+          | Some v -> Printf.sprintf "%.1f" v
+          | None -> "-"
+        in
+        let prompt_tok_s, decode_tok_s, latency_ms =
+          match response.telemetry with
+          | Some { timings = Some t; request_latency_ms; _ } ->
+              fmt_tok_s t.prompt_per_second,
+              fmt_tok_s t.predicted_per_second,
+              request_latency_ms
+          | _ -> "-", "-", 0
+        in
+        Log.Keeper.info
+          "keeper:%s turn=%d total_turns=%d model=%s tokens=%d prompt_tok_s=%s decode_tok_s=%s latency_ms=%d"
+          meta.name turn meta.runtime.usage.total_turns model total_tok
+          prompt_tok_s decode_tok_s latency_ms;
         (* Emit per-turn cost event for task attribution.
            cost_usd from OAS Pricing.annotate_response_cost (oas#393 resolved). *)
         (match trajectory_acc with


### PR DESCRIPTION
## 문제

세션 벤치에서 `predicted_per_second = 0.6 tok/s`가 측정됐는데 로그 tail에는 그 수치가 없었다. OAS `backend_ollama.ml`이 `response.telemetry.timings`를 이미 계산해 MASC에 넘기고 있고, `keeper_hooks_oas.ml`이 Prometheus histogram에 기록도 하지만 **텍스트 로그 한 줄에는 빠져 있어** `Log.Keeper.info` grep만으로는 속도 확인이 불가능했다.

## 변경

`lib/keeper/keeper_hooks_oas.ml:323` turn-end log에 필드 3개 추가:

```
keeper:<name> turn=N total_turns=N model=X tokens=N \
  prompt_tok_s=<f> decode_tok_s=<f> latency_ms=<n>
```

- `telemetry.timings` 없을 때는 `-` 로 표기 → "측정 불가" vs "0 tok/s" 구분
- Prometheus 경로(line 306-322)는 그대로, 텍스트 로그만 보강

## Why not OAS

OAS는 SDK 경계상 로깅하지 않고 timings만 emit. MASC가 consumer로서 로그를 찍는 게 `feedback_masc-oas-layer-boundary.md` 기준. Cross-repo pin bump 불필요.

## Test

- `dune build --root .` : green
- `dune build --root . @runtest` : 113/114 pass. 1 fail = `keeper_tool_matrix/matrix.025`로 Gemini/Codex CLI 인증 pre-existing sandbox flake (이 PR과 무관).

## Sample (expected)

```
[Keeper] keeper:sangsu turn=7 total_turns=42 model=ollama:qwen3.6:35b-a3b-mlx-bf16 \
  tokens=1420 prompt_tok_s=412.3 decode_tok_s=39.8 latency_ms=18432
```

Queue wait가 길 때 `latency_ms` >> decode 시간으로 즉시 감지 가능.
