### PR TITLE
refactor(coord): agent lifecycle hook string -> variant (#8605 family)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -72,7 +72,14 @@ let task_action_of_transition : Types.task_action -> Audit_log.action = function
     | Types.Reject_verification) as action ->
       Audit_log.Custom ("task_" ^ Types.task_action_to_string action)
 
-let observe_agent_lifecycle config ~agent_id ~event_kind ~details =
+(* #8605 family: replaced four parallel string switches on [event_kind]
+   with a single [agent_lifecycle_event] variant. The compiler now
+   forces every dispatch to cover Lifecycle_join / Lifecycle_rejoin /
+   Lifecycle_leave explicitly, so a future event variant cannot silently
+   coalesce into the catch-all "join" branch. JSON wire format is
+   preserved via [agent_lifecycle_event_to_string]. *)
+let observe_agent_lifecycle config ~agent_id ~(event : Coord_hooks.agent_lifecycle_event) ~details =
+  let event_kind = Coord_hooks.agent_lifecycle_event_to_string event in
   let details =
     merge_detail_fields
       [
@@ -83,30 +90,28 @@ let observe_agent_lifecycle config ~agent_id ~event_kind ~details =
       details
   in
   let level =
-    match event_kind with
-    | "leave" -> Log.Info
-    | _ -> Log.Info
+    match event with
+    | Lifecycle_join | Lifecycle_rejoin | Lifecycle_leave -> Log.Info
   in
   let message =
-    match event_kind with
-    | "rejoin" -> Printf.sprintf "agent rejoined: %s" agent_id
-    | "leave" -> Printf.sprintf "agent left: %s" agent_id
-    | _ -> Printf.sprintf "agent joined: %s" agent_id
+    match event with
+    | Lifecycle_join -> Printf.sprintf "agent joined: %s" agent_id
+    | Lifecycle_rejoin -> Printf.sprintf "agent rejoined: %s" agent_id
+    | Lifecycle_leave -> Printf.sprintf "agent left: %s" agent_id
   in
   Log.emit level ~module_name:"Coord" ~details message;
-  (match event_kind with
-   | "leave" -> Prometheus.dec_gauge "masc_active_agents" ()
-   | "join" | "rejoin" -> Prometheus.inc_gauge "masc_active_agents" ()
-   | _ -> ());
+  (match event with
+   | Lifecycle_leave -> Prometheus.dec_gauge "masc_active_agents" ()
+   | Lifecycle_join | Lifecycle_rejoin -> Prometheus.inc_gauge "masc_active_agents" ());
   let audit_details =
-    match event_kind with
-    | "rejoin" -> merge_detail_fields [ ("rejoin", `Bool true) ] details
-    | _ -> details
+    match event with
+    | Lifecycle_rejoin -> merge_detail_fields [ ("rejoin", `Bool true) ] details
+    | Lifecycle_join | Lifecycle_leave -> details
   in
   let action =
-    match event_kind with
-    | "leave" -> Audit_log.Leave
-    | _ -> Audit_log.Join
+    match event with
+    | Lifecycle_leave -> Audit_log.Leave
+    | Lifecycle_join | Lifecycle_rejoin -> Audit_log.Join
   in
   (* Audit and telemetry require Eio context (Eio.Mutex).
      Silently skip when running in non-Eio test context. *)
@@ -114,11 +119,11 @@ let observe_agent_lifecycle config ~agent_id ~event_kind ~details =
     Audit_log.log_action config ~agent_id ~action
       ~details:audit_details ~outcome:Audit_log.Success ();
     if telemetry_enabled () then
-      match event_kind with
-      | "leave" -> Telemetry_eio.track_agent_left config ~agent_id ~reason:"leave"
-      | "rejoin" ->
+      match event with
+      | Lifecycle_leave ->
+          Telemetry_eio.track_agent_left config ~agent_id ~reason:"leave"
+      | Lifecycle_join | Lifecycle_rejoin ->
           Telemetry_eio.track_agent_joined config ~agent_id ()
-      | _ -> Telemetry_eio.track_agent_joined config ~agent_id ()
   with Stdlib.Effect.Unhandled _ -> ())
 
 (* #8605 family: replaced four parallel string switches on [transition]
@@ -247,8 +252,8 @@ let () = Atomic.set Coord_hooks.hebbian_on_task_cancelled_fn (fun config ~agent_
       end
     ) active_agents)
 
-let () = Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun config ~agent_id ~event_kind ~details ->
-    observe_agent_lifecycle config ~agent_id ~event_kind ~details)
+let () = Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun config ~agent_id ~event ~details ->
+    observe_agent_lifecycle config ~agent_id ~event ~details)
 
 let () = Atomic.set Coord_hooks.observe_task_transition_fn (fun config ~agent_name ~task_id ~transition ~details ->
     (Atomic.get Coord_hooks.on_task_mutation_fn) ();

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -77,17 +77,33 @@ let hebbian_on_task_cancelled_fn
      agent_name:string -> active_agents:string list -> unit) Atomic.t
   = Atomic.make (fun _config ~agent_name:_ ~active_agents:_ -> ())
 
+(** Closed enum for the agent lifecycle hook. Replaces the previous
+    [event_kind:string] surface (#8605 family): the variant lets the
+    compiler enforce exhaustive dispatch on every consumer, and the
+    string<->variant mapping is centralised in the helpers below so the
+    JSON wire format ("join" / "rejoin" / "leave") stays exactly the
+    same. *)
+type agent_lifecycle_event =
+  | Lifecycle_join
+  | Lifecycle_rejoin
+  | Lifecycle_leave
+
+let agent_lifecycle_event_to_string = function
+  | Lifecycle_join -> "join"
+  | Lifecycle_rejoin -> "rejoin"
+  | Lifecycle_leave -> "leave"
+
 (** Shared observability hook for join/rejoin/leave events.
     Upper layers can mirror state transitions to audit, telemetry, and logs
     without introducing circular dependencies into room sub-modules. *)
 let observe_agent_lifecycle_fn
   : (Coord_utils_backend_setup.config ->
      agent_id:string ->
-     event_kind:string ->
+     event:agent_lifecycle_event ->
      details:Yojson.Safe.t ->
      unit) Atomic.t
   = Atomic.make
-      (fun _config ~agent_id:_ ~event_kind:_ ~details:_ -> ())
+      (fun _config ~agent_id:_ ~event:_ ~details:_ -> ())
 
 (** Shared observability hook for task transitions.
     Used by room task modules so every successful state transition is logged

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -107,7 +107,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
            nickname agent_type new_session_id (now_iso ()));
          (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
-           ~event_kind:"rejoin"
+           ~event:Coord_hooks.Lifecycle_rejoin
            ~details:
              (`Assoc
                [
@@ -171,7 +171,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
     (now_iso ()));
   (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
-    ~event_kind:"join"
+    ~event:Coord_hooks.Lifecycle_join
     ~details:
       (`Assoc
         [
@@ -229,7 +229,7 @@ let leave config ~agent_name =
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
     (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:actual_name
-      ~event_kind:"leave"
+      ~event:Coord_hooks.Lifecycle_leave
       ~details:`Null;
 
     (* Record co-presence relationships via hook (async, non-blocking) *)

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -11,9 +11,7 @@
 lib/sdk_tool_contract.ml:377
 lib/activity_graph/activity_graph_types.ml:89
 # coord.ml:132 (observe_task_transition) eliminated by #8846.
-# coord.ml:81/102 (observe_agent_lifecycle) still string-based; lines shifted to
-# 88/109 after #8846's insertions. Migration pending in #8842.
-lib/coord.ml:88
-lib/coord.ml:109
+# coord.ml:88/109 (observe_agent_lifecycle) eliminated by this PR
+# (agent_lifecycle_event variant migration).
 lib/eval_harness.ml:370
 lib/types/types_auth.ml:83

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -94,8 +94,8 @@ let test_join_uses_default_namespace () =
       Fun.protect
         ~finally:(fun () -> Atomic.set Coord_hooks.observe_agent_lifecycle_fn previous_hook)
         (fun () ->
-          Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun _config ~agent_id:_ ~event_kind ~details:_ ->
-              captured_event_kind := Some event_kind);
+          Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun _config ~agent_id:_ ~event ~details:_ ->
+              captured_event_kind := Some (Coord_hooks.agent_lifecycle_event_to_string event));
           let result =
             Coord.join config ~agent_name:"claude"
               ~capabilities:[ "debug" ] ()


### PR DESCRIPTION
## Summary

`Coord_hooks.observe_agent_lifecycle_fn` took `event_kind:string` and `observe_agent_lifecycle` dispatched on it through SIX parallel string switches (level, log message, prometheus gauge, audit_details, action, telemetry). Each catch-all silently treated typos and any future event kind as \"join\".

All three call sites pass one of three literal strings: \"join\" / \"rejoin\" / \"leave\" — a closed enum hiding behind a string surface (#8605 anti-pattern).

## Change

- **Coord_hooks**: add `type agent_lifecycle_event = Lifecycle_join | Lifecycle_rejoin | Lifecycle_leave` and `agent_lifecycle_event_to_string` for the JSON wire format.
- Hook signature: `event_kind:string` → `event:agent_lifecycle_event`.
- **coord.ml**: 6 internal switches replaced with exhaustive variant matches. JSON wire format (\"join\" / \"rejoin\" / \"leave\") preserved via `agent_lifecycle_event_to_string` at the audit-details boundary.
- **coord_lifecycle.ml**: 3 call sites pass the variant directly.
- **test_multi_room**: hook capture converts the variant back to string for the existing assertion.

The compiler now forces every dispatch to cover all three lifecycle events, so a future event variant cannot silently coalesce into the catch-all \"join\" branch.

## Behaviour preservation

| Wire string | Variant | Side effects |
|---|---|---|
| \"join\" | Lifecycle_join | inc gauge, log \"joined\", action=Join, telemetry=joined |
| \"rejoin\" | Lifecycle_rejoin | inc gauge, log \"rejoined\", details adds rejoin=true, action=Join, telemetry=joined |
| \"leave\" | Lifecycle_leave | dec gauge, log \"left\", action=Leave, telemetry=left |

All three string values map to the same side effects as before.

## Test plan

- [x] `dune build @check` — green
- [x] `dune exec ./test/test_multi_room.exe` — 4/4 tests pass including the lifecycle hook capture (\"join uses default namespace\")
- [x] JSON wire format preserved (audit log + Prometheus + telemetry stay bit-identical)

```
Test Successful in 0.179s. 4 tests run.
```

## Pattern siblings

Same #8605 family string→variant migration template. Companion to:
- #8736 / #8740 / #8779 / #8828 / #8833 (wire-string template)
- #8835 (exhaustive-match template)