### PR TITLE
fix(dashboard): suppress mermaid bomb SVG leak on parse error

### DIFF
--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -44,7 +44,7 @@ function getMermaid(): Promise<MermaidApi> {
   const promise = mermaidPromise ?? (mermaidPromise = importMermaid())
   return promise.then(mermaid => {
     if (mermaidConfigured) return mermaid
-    mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' })
+    mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict', suppressErrorRendering: true })
     mermaidConfigured = true
     return mermaid
   }).catch((err) => {

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -18,6 +18,7 @@ async function getMermaid(): Promise<MermaidApi> {
     startOnLoad: false,
     theme: 'dark',
     securityLevel: 'strict',
+    suppressErrorRendering: true,
   })
   mermaidConfigured = true
   return mermaid


### PR DESCRIPTION
## Summary

Dashboard 하단에 보이는 \`Syntax error in text / mermaid version 11.14.0\` bomb은 **Mermaid 11이 parse 실패 시 document.body에 렌더링한 뒤 예외를 throw하는 side-effect 잔재**다. 우리 render 래퍼(\`mermaid-graph.ts\`, \`markdown.ts\`)는 exception만 잡아 \`setError()\`로 사용자 피드백을 제공하지만, 이미 body에 삽입된 bomb DOM은 정리되지 않아 section을 넘나들 때도 고아로 남는다 (tools section처럼 mermaid를 안 쓰는 화면에도 노출).

## Root cause

Mermaid \`render()\`는 parse 실패 시
1. 내장 bomb SVG를 \`document.body\`에 삽입
2. 예외 throw

순서로 동작. 호출자 try/catch는 (2)만 캐치, (1)은 누수.

## Fix

두 \`mermaid.initialize\` 호출 지점에 \`suppressErrorRendering: true\` 추가. 이 옵션은 (1) side-effect 자체를 disable. 우리 래퍼가 이미 \`EmptyState\`로 에러 표시하므로 내장 bomb은 순수 노이즈였다.

## Files

- \`dashboard/src/components/common/mermaid-graph.ts\` (L17-22)
- \`dashboard/src/components/common/markdown.ts\` (L47)

## Verification

- \`pnpm typecheck\` — clean (TS가 MermaidConfig field임을 검증)
- \`pnpm test src/components/common/markdown.test.ts\` — 25/25 pass

## Backward compat

Ok path는 영향 없음. error path는 우리 \`EmptyState\` + \`fallbackText\` 경로가 계속 동작. 변하는 건 **body leak 제거**뿐.