### PR TITLE
feat(dashboard): surface human intervention on awaiting_verification

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -250,13 +250,22 @@ function ContractSection({ task }: { task: Task }) {
 
       ${isAwaitingVerification ? html`
         <div class="rounded border border-accent/30 bg-[var(--accent-5)] px-4 py-3">
-          <div class="text-xs font-medium text-accent">Verifier Keeper 검증 중</div>
+          <div class="flex items-center justify-between gap-3 flex-wrap">
+            <div class="text-xs font-medium text-accent">Verifier Keeper 검증 중</div>
+            <a
+              href=${`#workspace?section=verification&task=${encodeURIComponent(task.id)}`}
+              class="rounded border border-accent/50 bg-[var(--accent-10)] px-2.5 py-1 text-3xs font-semibold uppercase tracking-1 text-accent hover:bg-[var(--accent-20)]"
+              title="검증 패널에서 이 태스크를 직접 승인/반려"
+            >검증에 개입 →</a>
+          </div>
           <div class="mt-1 text-2xs text-text-body">
             Submitter: <span class="font-mono">${verifierAssignee ?? '(unknown)'}</span>
           </div>
           <div class="mt-0.5 text-2xs text-text-muted">
             다른 keeper가 completion_contract의 정량 기준을 독립 실측 중입니다.
             통과 시 approve_verification → done, 미충족 시 reject_verification → in_progress로 복귀.
+            인간 판단이 필요하면 우측 상단 버튼으로 검증 패널에서 직접 승인/반려할 수 있습니다
+            (operator: 접두어로 감사 로그에 기록).
           </div>
         </div>
       ` : null}

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -32,6 +32,7 @@ import {
   createManagedAsyncResource,
   type ManagedAsyncResource,
 } from '../lib/async-state'
+import { route } from '../router'
 
 const AUTO_REFRESH_MS = 15_000
 const DEFAULT_LIMIT = 100
@@ -485,6 +486,19 @@ export function VerificationRequestsPanel() {
       resource.cancel()
     }
   }, [resource])
+
+  // Deep-link support: task-detail-overlay renders a "검증에 개입" link with
+  // ?task=<id> so operators land on this panel pre-filtered to the pending
+  // request they came from. Treat the URL as a one-shot hint — write the
+  // task id into the shared search signal once on mount (and whenever the
+  // route param changes), but leave subsequent typing in the search input
+  // untouched so operators can widen the filter manually.
+  const taskParam = route.value.params.task
+  useEffect(() => {
+    if (taskParam && searchQuery.value !== taskParam) {
+      searchQuery.value = taskParam
+    }
+  }, [taskParam])
 
   const current = resource.state.value
   const data = current.data ?? null


### PR DESCRIPTION
## Problem

User feedback during the CDAL-verification /loop:

> 승인 되는거하고 반려되는거하고 내가 뭐 개입도 안되고 ㅋ

The path from "I'm looking at an \`awaiting_verification\` task" to "I can actually act on it" was invisible. The backend and the standalone verification panel both support operator override — the task detail overlay just never told the user, and offered no way to get there.

## Audit of what was already in place

- \`POST /api/v1/verification/resolve\` accepts operator-initiated approve/reject. Verifier identity is prefixed with \`operator:\` (\`server_routes_http_routes_verification.ml:32-35\`) so audit and attribution can distinguish dashboard verdicts from peer-agent verdicts.
- \`VerificationRequestsPanel\` (\`verification-requests-panel.ts\`) renders a two-step confirm-approve / compose-reject flow wired to \`resolveVerificationRequest\`.
- But \`task-detail-overlay.ts:251-262\` only described what the Verifier Keeper was doing ("통과 시 approve_verification → done, 미충족 시 reject_verification → in_progress로 복귀"). No entry point, no link.

## Change

Two surgical edits:

1. **\`task-detail-overlay.ts\`** — render a "검증에 개입 →" anchor inside the \`isAwaitingVerification\` block, linking to \`#workspace?section=verification&task=<id>\`. Reuses the hash-route contract; no new component, no new state.

2. **\`verification-requests-panel.ts\`** — read \`route.value.params.task\` on mount, set \`searchQuery.value\` so the panel lands pre-filtered to the task. A dependency on \`taskParam\` alone avoids clobbering manual typing — operators can still widen the filter after arrival.

## Why two files, not three

- No backend change — endpoint and audit semantics already handle operator override.
- No new component — reusing \`VerificationRequestsPanel\` preserves the tested two-step confirm flow (avoids UX divergence and second-source drift).
- No new API call or dependency.

## Visual verification plan

- Screenshots pending (awaiting local dashboard node_modules install).
- \`do-not-merge\` label suggested until visual verification completes.

## Scope guard

- Does **not** add inline approve/reject buttons to the task detail overlay itself. That would duplicate \`VerificationRequestsPanel\`'s confirm flow and split the audit surface. Follow-up issue if we want the shortcut.
- Does **not** alter the verification panel's existing behaviour when no \`task\` param is present.
- Does **not** touch the Bonsai dashboard (\`dashboard_bonsai/\`) — scope is the Preact dashboard.

## Related

- Part of the CDAL-verification /loop investigation.
- Sibling to #8715 (verifier auto-claim), #8731 (verdict attribution), #8818 (dashboard perf), #8822 (keepers_json perf), #8829 (keepers_json timing), #8837 (OAS gemini fail-fast pin).

## Test plan

- [ ] \`pnpm typecheck\` (in CI — no local node_modules in this worktree)
- [ ] \`pnpm test\` (in CI)
- [ ] Manual: open a task in \`awaiting_verification\` state → click "검증에 개입 →" → lands on verification panel filtered to that task → operator confirms approve → observe \`operator:dashboard\` entry in Dashboard_attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)