### PR TITLE
refactor(coord+keeper): task transition hook string -> Types.task_action variant (#8605 family)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -57,13 +57,20 @@ let merge_detail_fields fields details =
   | `Null -> `Assoc fields
   | other -> `Assoc (fields @ [ ("payload", other) ])
 
-let task_action_of_transition = function
-  | "claim" -> Audit_log.ClaimTask
-  | "start" -> Audit_log.StartTask
-  | "done" -> Audit_log.DoneTask
-  | "cancel" -> Audit_log.CancelTask
-  | "release" -> Audit_log.ReleaseTask
-  | other -> Audit_log.Custom ("task_" ^ other)
+(* Exhaustive on [Types.task_action]: a new variant becomes a compile
+   error here so the audit-log mapping cannot silently fall into the
+   [Custom "task_<other>"] catch-all that the prior string-typed
+   classifier produced. (#8605 family -- exhaustive-match template) *)
+let task_action_of_transition : Types.task_action -> Audit_log.action = function
+  | Types.Claim -> Audit_log.ClaimTask
+  | Types.Start -> Audit_log.StartTask
+  | Types.Done_action -> Audit_log.DoneTask
+  | Types.Cancel -> Audit_log.CancelTask
+  | Types.Release -> Audit_log.ReleaseTask
+  | (Types.Submit_for_verification
+    | Types.Approve_verification
+    | Types.Reject_verification) as action ->
+      Audit_log.Custom ("task_" ^ Types.task_action_to_string action)
 
 let observe_agent_lifecycle config ~agent_id ~event_kind ~details =
   let details =
@@ -114,13 +121,20 @@ let observe_agent_lifecycle config ~agent_id ~event_kind ~details =
       | _ -> Telemetry_eio.track_agent_joined config ~agent_id ()
   with Stdlib.Effect.Unhandled _ -> ())
 
+(* #8605 family: replaced four parallel string switches on [transition]
+   with [Types.task_action] variant matches. The compiler now forces
+   every dispatch to cover all 8 task_action constructors, so a future
+   action variant cannot silently coalesce into the catch-all "no-op"
+   branch. JSON wire format ("claim" / "start" / "done" / ...) is
+   preserved via [Types.task_action_to_string]. *)
 let observe_task_transition_event config ~agent_name ~task_id
-    ~transition ~details =
+    ~(transition : Types.task_action) ~details =
+  let transition_s = Types.task_action_to_string transition in
   let details =
     merge_detail_fields
       [
         ("event_family", `String "task_transition");
-        ("transition", `String transition);
+        ("transition", `String transition_s);
         ("task_id", `String task_id);
         ("agent_id", `String agent_name);
       ]
@@ -128,11 +142,13 @@ let observe_task_transition_event config ~agent_name ~task_id
   in
   let level =
     match transition with
-    | "cancel" -> Log.Warn
-    | _ -> Log.Info
+    | Types.Cancel -> Log.Warn
+    | (Types.Claim | Types.Start | Types.Done_action | Types.Release
+      | Types.Submit_for_verification | Types.Approve_verification
+      | Types.Reject_verification) -> Log.Info
   in
   let message =
-    Printf.sprintf "task %s %s by %s" task_id transition agent_name
+    Printf.sprintf "task %s %s by %s" task_id transition_s agent_name
   in
   Log.emit level ~module_name:"Task" ~details message;
   (try
@@ -141,15 +157,17 @@ let observe_task_transition_event config ~agent_name ~task_id
       ~details ~outcome:Audit_log.Success ();
     if telemetry_enabled () then
       match transition with
-      | "start" ->
+      | Types.Start ->
           Telemetry_eio.track_task_started config ~task_id ~agent_id:agent_name
-      | "done" | "cancel" ->
+      | Types.Done_action | Types.Cancel ->
           let duration_ms =
             Safe_ops.json_int ~default:0 "duration_ms" details
           in
           Telemetry_eio.track_task_completed config ~task_id ~duration_ms
-            ~success:(String.equal transition "done")
-      | _ -> ()
+            ~success:(transition = Types.Done_action)
+      | (Types.Claim | Types.Release
+        | Types.Submit_for_verification | Types.Approve_verification
+        | Types.Reject_verification) -> ()
   with Stdlib.Effect.Unhandled _ -> ());
   (try
      Keeper_accountability.record_task_transition config ~agent_name ~task_id

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -91,12 +91,15 @@ let observe_agent_lifecycle_fn
 
 (** Shared observability hook for task transitions.
     Used by room task modules so every successful state transition is logged
-    consistently regardless of which tool or transport triggered it. *)
+    consistently regardless of which tool or transport triggered it.
+    #8605 family: [transition] is the canonical [Types.task_action]
+    variant -- typos at call sites fail to compile and the JSON wire
+    format is centralised in [Types.task_action_to_string]. *)
 let observe_task_transition_fn
   : (Coord_utils_backend_setup.config ->
      agent_name:string ->
      task_id:string ->
-     transition:string ->
+     transition:task_action ->
      details:Yojson.Safe.t ->
      unit) Atomic.t
   = Atomic.make

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -261,7 +261,7 @@ let task_transition_details ~from_status ~to_status ?notes ?reason ?duration_ms
     @ optional_field "duration_ms"
         (Option.map (fun value -> `Int value) duration_ms))
 
-let observe_task_transition config ~agent_name ~task_id ~transition ~details =
+let observe_task_transition config ~agent_name ~task_id ~(transition : Types.task_action) ~details =
   (Atomic.get Coord_hooks.observe_task_transition_fn) config ~agent_name
     ~task_id ~transition ~details
 
@@ -599,7 +599,7 @@ let claim_task config ~agent_name ~task_id =
                      ("ts", `String (now_iso ()));
                    ]));
             observe_task_transition config ~agent_name ~task_id
-              ~transition:"claim"
+              ~transition:Types.Claim
               ~details:
                 (task_transition_details ~from_status:Types.Todo
                    ~to_status:
@@ -714,7 +714,7 @@ let claim_task_r config ~agent_name ~task_id
                      ("ts", `String (now_iso ()));
                    ]));
             observe_task_transition config ~agent_name ~task_id
-              ~transition:"claim"
+              ~transition:Types.Claim
               ~details:
                 (task_transition_details ~from_status:Types.Todo
                    ~to_status:
@@ -1072,7 +1072,7 @@ let transition_task_r config ~agent_name ~task_id ~action
           | Types.Reject_verification -> None
         in
         observe_task_transition config ~agent_name ~task_id
-          ~transition:action_s
+          ~transition:action
           ~details:
             (task_transition_details
                ~from_status:task.task_status ~to_status:new_status
@@ -1217,7 +1217,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                       ?reason:(if reason = "" then None else Some reason)
                       ()));
               observe_task_transition config ~agent_name ~task_id
-                ~transition:"cancel"
+                ~transition:Types.Cancel
                 ~details:
                   (task_transition_details ~from_status:task.task_status
                      ~to_status:

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -62,7 +62,7 @@ val task_transition_details :
 
 val observe_task_transition :
   config -> agent_name:string -> task_id:string ->
-  transition:string -> details:Yojson.Safe.t -> unit
+  transition:Types.task_action -> details:Yojson.Safe.t -> unit
 
 (** {1 Task creation} *)
 

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -97,7 +97,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
         match previous_claim with
         | Some prev ->
             Coord_task.observe_task_transition config ~agent_name ~task_id:prev.id
-              ~transition:"release"
+              ~transition:Types.Release
               ~details:
                 (Coord_task.task_transition_details ~from_status:prev.task_status
                    ~to_status:Types.Todo
@@ -267,7 +267,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
             "{\"type\":\"task_claim_next\",\"agent\":\"%s\",\"task\":\"%s\",\"priority\":%d,\"ts\":\"%s\"}"
             agent_name task.id task.priority (now_iso ()));
           Coord_task.observe_task_transition config ~agent_name ~task_id:task.id
-            ~transition:"claim"
+            ~transition:Types.Claim
             ~details:
               (Coord_task.task_transition_details ~from_status:Types.Todo
                  ~to_status:

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -436,31 +436,39 @@ let maybe_support_recent_completion_claim config ~agent_name ~task_id ~evidence_
           supporting_evidence_refs = normalize_refs evidence_refs;
         }
 
+(* #8605 family: exhaustive on [Types.task_action]. The previous
+   string match silently no-oped for typos and any future transition
+   string. With the variant the compiler now forces a deliberate
+   decision for every task_action constructor; verification-related
+   actions explicitly produce no commitment side effects -- their
+   accountability tracking lives in [record_completion_claim]. *)
 let record_task_transition (config : Coord_query.config) ~agent_name ~task_id
-    ~transition ~details =
+    ~(transition : Types.task_action) ~details =
   if not (is_keeper_agent_name agent_name) then ()
   else
     match transition with
-    | "claim" | "start" ->
+    | Types.Claim | Types.Start ->
         create_task_commitment config ~agent_name ~task_id
           ~surface:"task_transition"
-    | "done" ->
+    | Types.Done_action ->
         let base_refs = [ "task:" ^ task_id ] in
         resolve_recent_task_commitment config ~agent_name ~task_id
           ~status:Supported ~reason:(Some "task_done")
           ~evidence_refs:base_refs ~max_age_sec:task_commitment_expiry_sec;
         maybe_support_recent_completion_claim config ~agent_name ~task_id
           ~evidence_refs:base_refs
-    | "release" | "cancel" ->
+    | Types.Release | Types.Cancel ->
         let reason =
           match json_string_opt "reason" details with
           | Some value when String.trim value <> "" -> Some (String.trim value)
-          | _ -> Some transition
+          | _ -> Some (Types.task_action_to_string transition)
         in
         resolve_recent_task_commitment config ~agent_name ~task_id
           ~status:Partial ~reason
           ~evidence_refs:[ "task:" ^ task_id ] ~max_age_sec:task_commitment_expiry_sec
-    | _ -> ()
+    | Types.Submit_for_verification
+    | Types.Approve_verification
+    | Types.Reject_verification -> ()
 
 let supporting_refs_for_turn ~trace_id ~turn_number strong_evidence_refs =
   normalize_refs

--- a/lib/keeper/keeper_accountability.mli
+++ b/lib/keeper/keeper_accountability.mli
@@ -13,7 +13,7 @@ val record_task_transition :
   Coord_query.config ->
   agent_name:string ->
   task_id:string ->
-  transition:string ->
+  transition:Types.task_action ->
   details:Yojson.Safe.t ->
   unit
 


### PR DESCRIPTION
## Summary

`Coord_hooks.observe_task_transition_fn` took `transition:string` and SIX parallel string switches (level, audit-action map, telemetry, plus 3 in `Keeper_accountability.record_task_transition`) silently treated typos and any future task action as no-op or `Custom("task_" ^ other)`.

All 6 call sites either pass a literal that maps directly to a `Types.task_action` constructor or already stringify a `task_action` via `Types.task_action_to_string` — a closed enum hiding behind a string surface (#8605 anti-pattern).

## Why this is the right surface to migrate

- `Types.task_action` already exists with 8 constructors and a `task_action_to_string` round-trip.
- The `coord_task.ml` codebase already follows this convention for sibling hooks (\`transition_event_type\` variant introduced by #7520 with a comment: \"Variant instead of free-form string so typos at call-sites fail to compile\").
- Only `coord_task.ml:1075` is dynamic — and even there, the source is `let action_s = Types.task_action_to_string action`, so we just remove the redundant stringification.

## Change

- **Coord_hooks**: hook signature `transition:string` → `transition:Types.task_action`.
- **coord.ml**:
  - `task_action_of_transition`: exhaustive on `Types.task_action` (`Submit_for_verification` / `Approve_verification` / `Reject_verification` explicitly land in `Audit_log.Custom`).
  - `observe_task_transition_event`: 3 internal string switches replaced with exhaustive variant matches. JSON wire format (`\"claim\" / \"start\" / \"done\" / ...`) preserved via `Types.task_action_to_string` at the audit-detail merge boundary.
  - hook installer pass-through unchanged in shape.
- **coord_task.ml** + **.mli**: wrapper signature change.
- **coord_task.ml** (4 sites): `~transition:\"claim\" | \"cancel\"` → `~transition:Types.Claim | Types.Cancel`; line 1075 passes `action` directly (drops the `_to_string` conversion).
- **coord_task_schedule.ml** (2 sites): same pattern.
- **keeper_accountability.ml** + **.mli**: `record_task_transition` exhaustive on `Types.task_action`. `Release | Cancel` reason fallback uses `Types.task_action_to_string transition` to keep the JSON-preserved label.

## Behaviour preservation

| Call site (literal) | Variant | Before's silent destination | After (explicit) |
|---|---|---|---|
| `\"claim\"` (3) | `Types.Claim` | (matched) | (same) |
| `\"start\"` | `Types.Start` | (matched) | (same) |
| `\"done\"` | `Types.Done_action` | (matched) | (same) |
| `\"cancel\"` | `Types.Cancel` | (matched) | (same) |
| `\"release\"` | `Types.Release` | (matched) | (same) |
| `Submit_for_verification`, etc. | (variant) | `_ -> ()` / `Custom(\"task_\" ^ str)` | explicit no-op / explicit `Custom(...)` (bit-identical) |

## Test plan

- [x] `dune build @check` green
- [x] `dune exec ./test/test_multi_room.exe` 4/4 pass (covers the lifecycle-hook capture path)
- [x] JSON wire format preserved (\"transition\" field in audit details, Custom audit label, telemetry success bool)

```
Test Successful in 0.128s. 4 tests run.
```

## Pattern siblings

7th #8605 family fix in the current sweep. Same string→variant template as #8842 (\`agent_lifecycle_event\`); other templates: wire-string-strict (#8736/#8740/#8779/#8828/#8833), exhaustive-match (#8835).