### PR TITLE
docs(post_verifier): add .mli surface contract

### DIFF
--- a/lib/post_verifier.mli
+++ b/lib/post_verifier.mli
@@ -1,0 +1,69 @@
+(** Post Verifier — 3-dimension output verification gate for agents.
+
+    Deterministic heuristic checks across Relevance, Quality, Safety.
+    Each dimension yields a verdict; overall verdict is the strongest
+    negative across dimensions (Fail > Warn > Pass).
+
+    @since 2.71.0 *)
+
+(** {1 Types} *)
+
+(** Single-dimension verdict. [Warn] and [Fail] carry a human-readable reason. *)
+type verdict =
+  | Pass
+  | Warn of string
+  | Fail of string
+
+(** Verification dimension. *)
+type dimension =
+  | Relevance  (** Content has substance — minimum length, not filler. *)
+  | Quality    (** Well-formed — no character/token repetition, coherent. *)
+  | Safety     (** No shouting / spam indicators. *)
+
+(** Per-dimension result pair (used by {!to_dimension_results}). *)
+type dimension_result = {
+  dimension : dimension;
+  verdict : verdict;
+}
+
+(** Aggregate result across all three dimensions.
+    [overall] is [Fail] if any dimension failed, else [Warn] if any warned,
+    else [Pass]. *)
+type verification_result = {
+  relevance : verdict;
+  quality : verdict;
+  safety : verdict;
+  overall : verdict;
+}
+
+(** {1 Verification} *)
+
+(** Verify [content] across Relevance, Quality, Safety. Side effect:
+    records per-dimension {!Heuristic_metrics} observations tagged with
+    provenance [Post_verifier _]. *)
+val verify : content:string -> verification_result
+
+(** [true] when [overall] is [Pass] or [Warn], [false] on [Fail]. *)
+val is_acceptable : verification_result -> bool
+
+(** {1 Serialization / display} *)
+
+(** Render a verdict as ["pass"], ["warn(reason)"], or ["fail(reason)"]. *)
+val verdict_to_string : verdict -> string
+
+(** Render a dimension as ["relevance"], ["quality"], or ["safety"]. *)
+val dimension_to_string : dimension -> string
+
+(** JSON shape for telemetry:
+    {[
+      { "relevance": "pass",
+        "quality": "warn(reason)",
+        "safety": "pass",
+        "overall": "warn(reason)",
+        "acceptable": true }
+    ]} *)
+val result_to_json : verification_result -> Yojson.Safe.t
+
+(** Flatten a {!verification_result} into a list of three
+    {!dimension_result} entries (Relevance, Quality, Safety). *)
+val to_dimension_results : verification_result -> dimension_result list


### PR DESCRIPTION
## Summary

Wave 3 `.mli` 커버리지 2번째 — `lib/post_verifier.ml` (262줄) 외부 표면을 69줄 `.mli`로 명시화.

## 왜 post_verifier인가

- **단일 책임**: 3-dimension verification gate (Relevance / Quality / Safety). 의존성 leaf에 가까움.
- **명확한 public/private 경계**: 13개 helper가 모두 내부용, public surface는 6개 value + 4개 type.
- **외부 소비자 1건 확인**: `lib/thompson_sampling.ml:442` 가 `Post_verifier.verdict` 와 생성자 `Pass/Warn/Fail`만 pattern-match. `thompson_sampling.mli:123` 에도 이미 `verdict:Post_verifier.verdict` 시그니처 있음 — 본 PR로 그 참조가 더 안정화됨.

## 공개 표면 (.mli)

```ocaml
type verdict = Pass | Warn of string | Fail of string
type dimension = Relevance | Quality | Safety
type dimension_result = { dimension : dimension; verdict : verdict }
type verification_result = { relevance; quality; safety; overall : verdict }

val verify : content:string -> verification_result
val is_acceptable : verification_result -> bool
val verdict_to_string : verdict -> string
val dimension_to_string : dimension -> string
val result_to_json : verification_result -> Yojson.Safe.t
val to_dimension_results : verification_result -> dimension_result list
```

## 숨긴 표면 (13개)

| 구분 | 심볼 |
|------|------|
| String helpers | `is_whitespace`, `content_length`, `is_formatting_char`, `has_char_repetition`, `uppercase_ratio`, `line_count`, `is_repetitive_tokens` |
| Filler detection | `filler_phrases`, `contains_filler` |
| Thresholds | `min_content_chars`, `warn_long_content_chars` |
| Per-dimension checks | `check_relevance`, `check_quality`, `check_safety` |

모두 `lib/` + `test/` + `scripts/` 전역 grep으로 외부 참조 0건 확인.

## 검증

- `dune build --root=. lib/` → exit 0
- `dune exec test/test_post_verifier.exe` → **22/22 tests pass** (relevance 6 / quality 6 / safety 3 / overall 3 / serialization 4)
- `thompson_sampling` pattern-match 호환 유지 (Post_verifier.Pass / Warn _ / Fail _)

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 (수) | 290 | **291** |
| Wave 3 `.mli` 커버리지 진행 | 1/113 | **2/113** (~1.77%) |
| post_verifier 외부 표면 | 암묵적 (262줄 ml 전체) | 명시적 (69줄 mli, 10개 value/type) |

## 근거

- OCaml 5.4 interface files 공식 가이드: https://ocaml.org/manual/5.4/modules.html
- **Anti-goal 자가 체크**: [x] 1 파일 생성만 (기존 ml 무수정) [x] partial 아님 (표면 전체 명시) [x] 구체 line 증거 (thompson_sampling.ml:442, .mli:123) [x] mainline 5.4

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage, 2nd of ~113)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
