### PR TITLE
feat(bonsai-dashboard): serve MASC DS :root tokens as static CSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ocaml-health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-run-local-fresh-boot harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak bonsai-dashboard bonsai-dashboard-if-available dev-bonsai-dashboard clean-bonsai-dashboard
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean clean-tlc-artifacts coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps sync-oas-pin-docs doctor-oas-pin doctor-oas-drift doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard dashboard-drift-check dashboard-drift-regen dev-setup fmt fmt-check health ocaml-health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-run-local-fresh-boot harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak bonsai-dashboard bonsai-dashboard-if-available dev-bonsai-dashboard clean-bonsai-dashboard bonsai-dashboard-tokens
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -29,6 +29,11 @@ bonsai-dashboard:
 	mkdir -p assets/dashboard_bonsai
 	rm -f assets/dashboard_bonsai/main.bc.js
 	cp dashboard_bonsai/_build/default/bin/main.bc.js assets/dashboard_bonsai/main.bc.js
+	# MASC Design System 토큰을 정적 자원으로 함께 배포.
+	# 서버는 /dashboard/b/assets/colors_and_type.css로 이 파일을 서빙하고,
+	# bonsai_index_html은 이 경로를 <link>로 참조한다. 추후 ppx_css 리터럴
+	# 값을 var(--bg-deep) 등으로 점진 교체할 때 :root가 준비되어 있어야 한다.
+	cp dashboard_bonsai/static/colors_and_type.css assets/dashboard_bonsai/colors_and_type.css
 
 # Build Bonsai only if the OxCaml switch exists. Used by `build-all` so a
 # single `make` run builds both main masc-mcp and the Bonsai island when
@@ -51,6 +56,12 @@ dev-bonsai-dashboard:
 
 clean-bonsai-dashboard:
 	rm -rf dashboard_bonsai/_build assets/dashboard_bonsai
+
+# Deploy only the design-tokens stylesheet. Useful during a DS-only iteration
+# where the bundle itself hasn't changed but the :root palette did.
+bonsai-dashboard-tokens:
+	mkdir -p assets/dashboard_bonsai
+	cp dashboard_bonsai/static/colors_and_type.css assets/dashboard_bonsai/colors_and_type.css
 
 # Build everything: main masc-mcp + Preact dashboard + Bonsai (if available).
 # Note: `dune build` at the repo root only compiles the main OCaml — the

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -1,0 +1,454 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC — Colors & Type
+   The brand runs across 4 themes (Dark Fantasy / Cyberpunk /
+   Terminal / Parchment) but Dark Fantasy is the canonical voice.
+   This file defines the Dark Fantasy tokens as :root defaults and
+   offers the other three as [data-theme] overrides, plus the
+   Paper/Ink dashboard inversion (used as the docs/light surface).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Local fonts — copied from viewer/assets/fonts */
+@font-face {
+  font-family: 'Cinzel';
+  src: url('fonts/Cinzel-Regular.ttf') format('truetype');
+  font-weight: 400 700;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Noto Sans KR';
+  src: url('fonts/NotoSansKR-Regular.ttf') format('truetype');
+  font-weight: 300 700;
+  font-display: swap;
+}
+/* Webfonts the viewer also uses — fetched from Google when available */
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Share+Tech+Mono&display=swap');
+
+/* ── Dark Fantasy (default) — Visceral · decay-forward ── */
+:root,
+[data-theme="dark-fantasy"] {
+  /* Base surfaces — wet stone, blood-soaked wood */
+  --bg-deep:        #0a0706;     /* pitch with a red undertone */
+  --bg-panel:       #14100d;     /* rotted wood */
+  --bg-panel-alt:   #1b1612;     /* card base */
+  --bg-card:        #221815;     /* bruised meat */
+  --bg-card-hover:  #2e211c;
+
+  /* Borders — scabbed, stitched leather */
+  --border-main:      #2a1a14;
+  --border-highlight: #5a3028;   /* scab / raw wound */
+
+  /* Text — bone and bandage */
+  --text-bright:  #e8d8b8;       /* clean bone */
+  --text-primary: #b8a488;       /* dirty bandage */
+  --text-dim:     #6a5848;       /* mold dust */
+
+  /* Accents — blood is primary now; brass demoted to warning */
+  --accent-blood:    #a01818;    /* fresh arterial */
+  --accent-blood-dim:#5a0f0f;    /* dried clot */
+  --accent-viscera:  #c94a3a;    /* raw flesh / inflamed */
+  --accent-bile:     #6a7a3a;    /* sickly yellow-green */
+  --accent-mold:     #3a5a48;    /* cold mold */
+  --accent-brass:    #8a6a28;    /* tarnished gold, rare */
+  --accent-brass-dim:#5a4618;
+  --accent-bone:     #d8c8a0;
+  --accent-ink:      #3a2a5a;    /* arcane violet, rarer */
+  --accent-ember:    #c4461a;    /* dying ember */
+  --accent-glow:     rgba(160, 24, 24, 0.28);
+  --accent-blood-glow: rgba(201, 74, 58, 0.32);
+
+  /* Status — blood, bile, mold */
+  --status-ok:    #5a7a3a;       /* bile / queasy green */
+  --status-warn:  #a06a1a;       /* burnt ember */
+  --status-bad:   #a01818;       /* blood */
+  --status-idle:  #4a3a32;       /* dried mold */
+
+  /* Type stacks */
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* Shape */
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+
+  /* Spacing (4px grid) */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+
+  /* Scrollbar */
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}
+
+/* ── Cyberpunk ─────────────────────────────────────────── */
+[data-theme="cyberpunk"] {
+  --bg-deep:      #05000f;
+  --bg-panel:     #0d0821;
+  --bg-panel-alt: #130e2a;
+  --bg-card:      #1a1235;
+  --bg-card-hover:#221a42;
+  --border-main:      #2a1a4a;
+  --border-highlight: #6a2fd6;
+  --text-bright:  #f5f0ff;
+  --text-primary: #e0d4ff;
+  --text-dim:     #6a5d8d;
+  --accent-brass: #00ffcc;
+  --accent-brass-dim: #008866;
+  --accent-blood: #ff2266;
+  --accent-ink:   #6a2fd6;
+  --accent-glow:  rgba(0, 255, 204, 0.12);
+  --status-ok:   #00ffcc;
+  --status-warn: #ffaa00;
+  --status-bad:  #ff2266;
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+/* ── Terminal ──────────────────────────────────────────── */
+[data-theme="terminal"] {
+  --bg-deep:      #000800;
+  --bg-panel:     #001200;
+  --bg-panel-alt: #001a00;
+  --bg-card:      #002200;
+  --bg-card-hover:#003000;
+  --border-main:      #0a3a0a;
+  --border-highlight: #00aa00;
+  --text-bright:  #00ff00;
+  --text-primary: #00cc00;
+  --text-dim:     #006600;
+  --accent-brass: #00ff00;
+  --accent-brass-dim: #009900;
+  --accent-blood: #ffcc00;
+  --accent-ink:   #00aaaa;
+  --accent-glow:  rgba(0, 255, 0, 0.08);
+  --status-ok:   #00ff00;
+  --status-warn: #ffcc00;
+  --status-bad:  #ff4400;
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+/* ── Parchment (in-app warm theme) ─────────────────────── */
+[data-theme="parchment"] {
+  --bg-deep:      #1a1610;
+  --bg-panel:     #241f18;
+  --bg-panel-alt: #2e2820;
+  --bg-card:      #332d24;
+  --bg-card-hover:#3d362c;
+  --border-main:      #4a3f30;
+  --border-highlight: #6a5d48;
+  --text-bright:  #f0e4cc;
+  --text-primary: #d4c4a0;
+  --text-dim:     #8a7d68;
+  --accent-brass: #c4a050;
+  --accent-brass-dim: #8a7035;
+  --accent-blood: #8b4513;
+  --accent-ink:   #556b2f;
+  --accent-glow:  rgba(196, 160, 80, 0.1);
+}
+
+/* ── Paper / Ink (docs + light-surface inversion) ──────── */
+[data-theme="paper"] {
+  color-scheme: light;
+  --paper:   #F5F2EA;
+  --paper-2: #EFEBE0;
+  --paper-3: #E5E0D1;
+  --paper-4: #D8D2BF;
+  --ink:     #151515;
+  --ink-2:   #2E2E2C;
+  --ink-3:   #515049;
+  --ink-4:   #74726A;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  --forest:  #2D5F4E;  --forest-fill:#CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill: #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill: #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill: #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill: #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:  #E0D4DE;
+  --teal:    #236874;  --teal-fill:  #CEDEE2;
+
+  --bg-deep:      var(--paper);
+  --bg-panel:     var(--paper-2);
+  --bg-panel-alt: var(--paper-3);
+  --bg-card:      var(--paper-2);
+  --bg-card-hover:var(--paper-3);
+  --border-main:      rgba(21,21,21,0.22);
+  --border-highlight: rgba(21,21,21,0.48);
+  --text-bright:  var(--ink);
+  --text-primary: var(--ink-2);
+  --text-dim:     var(--ink-4);
+  --accent-brass: var(--brass);
+  --accent-brass-dim: var(--brass-fill);
+  --accent-blood: var(--brick);
+  --accent-ink:   var(--slate);
+  --accent-glow:  rgba(140,106,30,0.12);
+  --status-ok:   var(--forest);
+  --status-warn: var(--ember);
+  --status-bad:  var(--brick);
+  --status-idle: var(--ink-5);
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SEMANTIC ELEMENT DEFAULTS
+   Opinionated tags so a bare HTML file looks like MASC.
+   ══════════════════════════════════════════════════════════════ */
+
+html, body {
+  background: var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, .display {
+  font-family: var(--font-display);
+  color: var(--text-bright);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 400;
+  margin: 0;
+}
+
+h1 { font-size: 42px; letter-spacing: 0.2em; text-shadow: 0 0 40px var(--accent-glow); }
+h2 { font-size: 24px; letter-spacing: 0.14em; color: var(--accent-brass); }
+h3 { font-size: 16px; letter-spacing: 0.12em; color: var(--accent-brass); }
+h4 { font-size: 13px; letter-spacing: 0.1em;  color: var(--text-primary); }
+
+p, li { font-family: var(--font-body); color: var(--text-primary); }
+
+.overline, .eyebrow {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+code, pre, .mono, .tabular-nums {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+a { color: var(--accent-brass); text-decoration: none; border-bottom: 1px dotted var(--accent-brass-dim); }
+a:hover { color: var(--text-bright); border-bottom-color: var(--text-bright); }
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--border-main);
+  margin: var(--space-5) 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   UTILITY PRIMITIVES
+   Minimal set used by preview cards & UI kit. Components live in
+   ui_kits/, not here.
+   ══════════════════════════════════════════════════════════════ */
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-card);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  box-shadow: var(--shadow-panel);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel-alt);
+  color: var(--text-dim);
+}
+.pill.ok    { color: var(--status-ok);   border-color: color-mix(in oklab, var(--status-ok)   40%, transparent); }
+.pill.warn  { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.pill.bad   { color: var(--status-bad);  border-color: color-mix(in oklab, var(--status-bad)  40%, transparent); }
+.pill.brass { color: var(--accent-brass);border-color: color-mix(in oklab, var(--accent-brass)40%, transparent); }
+
+.btn {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt);
+  color: var(--text-primary);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s, transform 0.08s;
+}
+.btn:hover { border-color: var(--accent-brass-dim); color: var(--accent-brass); }
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+  border-color: var(--accent-brass);
+  color: var(--accent-brass);
+  box-shadow: var(--shadow-inset);
+}
+.btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
+.btn.ghost { background: transparent; }
+
+.input {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 6px 10px;
+  background: var(--bg-panel-alt);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+}
+.input:focus { outline: none; border-color: var(--accent-brass-dim); }
+
+.dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; background: var(--text-dim); }
+.dot.ok   { background: var(--status-ok);   box-shadow: 0 0 6px var(--status-ok); }
+.dot.warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.dot.bad  { background: var(--status-bad);  box-shadow: 0 0 6px var(--status-bad); }
+
+/* ══════════════════════════════════════════════════════════════
+   TEXTURES — parchment grain, blood, wax, scratches
+   Apply via `.tex-parchment`, `.tex-blood`, `.tex-wax`, `.tex-scratch`.
+   They're SVG-data-URI backgrounds that layer on top of any surface.
+   ══════════════════════════════════════════════════════════════ */
+.tex-parchment {
+  background-image:
+    radial-gradient(ellipse at 20% 15%, rgba(255,230,180,0.04), transparent 50%),
+    radial-gradient(ellipse at 80% 85%, rgba(90,40,10,0.08), transparent 55%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 0.1  0 0 0 0 0.08  0 0 0 0 0.06  0 0 0 0.55 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.35'/></svg>");
+  background-blend-mode: multiply, multiply, normal;
+}
+.tex-blood {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='360' height='360' viewBox='0 0 360 360'><g fill='%23a01818' opacity='0.55'><ellipse cx='48' cy='36' rx='14' ry='5' transform='rotate(-12 48 36)'/><path d='M52 40c2 8-1 18-6 22-4-6-3-16 6-22Z'/><ellipse cx='230' cy='180' rx='22' ry='8'/><path d='M240 188c3 12-1 30-10 34-6-10-5-24 10-34Z'/><circle cx='300' cy='80' r='3'/><circle cx='310' cy='90' r='2'/><circle cx='120' cy='300' r='4'/><circle cx='130' cy='310' r='2'/><ellipse cx='150' cy='260' rx='10' ry='4' transform='rotate(25 150 260)'/></g></svg>");
+  background-size: 360px 360px;
+}
+.tex-wax {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='300'><g fill='%23e8d8b0' opacity='0.35'><path d='M40 20c6 18-4 30-12 30 4-12 0-22 12-30Z'/><circle cx='28' cy='52' r='4'/><circle cx='36' cy='58' r='3'/><path d='M220 160c8 22-6 40-14 38 2-14 0-28 14-38Z'/><circle cx='208' cy='200' r='5'/></g></svg>");
+  background-size: 300px 300px;
+}
+.tex-scratch {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g stroke='%23e8d8b0' stroke-opacity='0.07' stroke-width='0.6' fill='none'><path d='M0 80 L400 60'/><path d='M40 0 L80 400'/><path d='M0 240 L400 260'/><path d='M200 0 L240 400'/><path d='M0 340 L400 320'/><path d='M320 0 L340 400'/></g></svg>");
+}
+.tex-mold {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='340' height='340'><g opacity='0.55'><circle cx='40' cy='60' r='18' fill='%233a5a48' opacity='0.4'/><circle cx='50' cy='70' r='10' fill='%236a7a3a' opacity='0.35'/><circle cx='260' cy='120' r='24' fill='%233a5a48' opacity='0.35'/><circle cx='270' cy='130' r='12' fill='%236a7a3a' opacity='0.3'/><circle cx='150' cy='280' r='20' fill='%233a5a48' opacity='0.3'/><circle cx='80' cy='220' r='14' fill='%236a7a3a' opacity='0.3'/><circle cx='310' cy='260' r='16' fill='%233a5a48' opacity='0.35'/></g></svg>");
+  background-size: 340px 340px;
+  filter: blur(1.5px);
+}
+.tex-viscera {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g fill='none' stroke='%23a01818' stroke-opacity='0.4' stroke-width='1.4'><path d='M40 60c20 0 20 20 10 30s-30 10-20 30 40 5 40 25 -30 15 -40 30'/><path d='M260 140c20 0 25 25 10 35s-40 10-30 35 45 10 45 30'/><path d='M120 300c25-5 40 10 30 25s-30 10-40 30'/></g></svg>");
+  background-size: 400px 400px;
+  opacity: 0.85;
+}
+.tex-noise {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.9  0 0 0 0 0.85  0 0 0 0 0.7  0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+/* ══════════════════════════════════════════════════════════════
+   GOTHIC FRAMES — corner tabs, arch, sarcophagus
+   Wrap any element with .frame-gothic to get corner carvings.
+   ══════════════════════════════════════════════════════════════ */
+.frame-gothic {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  box-shadow: var(--shadow-inset), var(--shadow-panel);
+}
+.frame-gothic::before,
+.frame-gothic::after {
+  content: ""; position: absolute; width: 14px; height: 14px;
+  border: 1px solid var(--accent-brass); pointer-events: none;
+}
+.frame-gothic::before { top: -1px; left: -1px; border-right: 0; border-bottom: 0; }
+.frame-gothic::after  { bottom: -1px; right: -1px; border-left: 0; border-top: 0; }
+
+.frame-arch {
+  position: relative;
+  border: 1px solid var(--accent-brass-dim);
+  border-radius: 120px 120px 2px 2px / 60px 60px 2px 2px;
+  padding: 28px 20px 16px;
+  background: var(--bg-card);
+}
+.frame-arch::before {
+  content: ""; position: absolute; inset: 6px; border: 1px solid var(--border-highlight);
+  border-radius: inherit; pointer-events: none;
+}
+
+.frame-sarc {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  clip-path: polygon(
+    12px 0, calc(100% - 12px) 0, 100% 12px,
+    100% calc(100% - 12px), calc(100% - 12px) 100%,
+    12px 100%, 0 calc(100% - 12px), 0 12px
+  );
+  background: var(--bg-card);
+}
+
+/* Glyph usage: <svg class="gl"><use href=".../atlas.svg#skull"/></svg> */
+.gl { width: 16px; height: 16px; display: inline-block; vertical-align: -3px; color: currentColor; }
+.gl-lg { width: 24px; height: 24px; vertical-align: -6px; }
+.gl-xl { width: 40px; height: 40px; }
+.gl-brass { color: var(--accent-brass); }
+.gl-blood { color: var(--accent-blood); }
+.gl-bone  { color: var(--accent-bone); }
+
+/* Drop cap for gothic body text */
+.dropcap::first-letter {
+  font-family: var(--font-display);
+  float: left; font-size: 54px; line-height: 0.9;
+  padding: 6px 10px 0 0; color: var(--accent-blood);
+  text-shadow: 0 0 24px var(--accent-blood-glow);
+}
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb, var(--border-main)); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover, var(--border-highlight)); }

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -289,14 +289,21 @@ let bonsai_asset_root () =
    query string so the browser refetches whenever the bundle is rebuilt.
    Cache-Control on the bundle itself stays [immutable] (1 year) for cheap
    reloads of unchanged code; the URL change is what defeats the cache. *)
-let bonsai_bundle_version () =
-  let bundle_path = Filename.concat (bonsai_asset_root ()) "main.bc.js" in
+let bonsai_asset_mtime filename =
+  let path = Filename.concat (bonsai_asset_root ()) filename in
   try
-    let st = Unix.stat bundle_path in
+    let st = Unix.stat path in
     Printf.sprintf "%d" (Float.to_int st.st_mtime)
   with _ -> "0"
 
+let bonsai_bundle_version () = bonsai_asset_mtime "main.bc.js"
+let bonsai_tokens_version () = bonsai_asset_mtime "colors_and_type.css"
+
 let bonsai_index_html () =
+  (* [colors_and_type.css] is the MASC Design System SSOT — :root palette,
+     font stacks, and utility primitives. Served from assets/dashboard_bonsai/
+     (copied there by `make bonsai-dashboard`). If the file isn't present,
+     the <link> 404s and the inline <style> fallback keeps the page readable. *)
   Printf.sprintf
     {|<!doctype html>
 <html lang="en" data-theme="dark-fantasy">
@@ -307,6 +314,7 @@ let bonsai_index_html () =
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+KR:wght@300;400;500;700&display=swap">
+<link rel="stylesheet" href="/dashboard/b/assets/colors_and_type.css?v=%s">
 <style>
   html, body { background: #0a0706; margin: 0; }
 </style>
@@ -317,6 +325,7 @@ let bonsai_index_html () =
 </body>
 </html>
 |}
+    (bonsai_tokens_version ())
     (bonsai_bundle_version ())
 
 let serve_bonsai_index _request reqd =


### PR DESCRIPTION
## Summary

MASC Design System의 `colors_and_type.css`(다크판타지 `:root` 토큰 SSOT)를 Bonsai 대시보드 정적 자원으로 함께 배포. 다음 PR부터 ppx_css 리터럴에서 `#8a6a28` 대신 `var(--accent-brass)` 형태로 점진 교체 가능해진다.

## 왜

지금까지 `logs_view.ml`의 ppx_css 블록은 헥스 리터럴로 고정됐다:
```css
color: #8a6a28;  /* brass */
border-color: #2a1a14;  /* scabbed leather */
```
디자인 시스템에서 토큰 값이 바뀌면 매번 `logs_view.ml`을 고쳐야 한다. `:root`를 :SPA 위에 올려두면:
```css
color: var(--accent-brass);
border-color: var(--border-main);
```
번들 재빌드 없이 `make bonsai-dashboard-tokens` 한 줄로 테마 교체 가능.

## 변경

- **`dashboard_bonsai/static/colors_and_type.css`** (신규, 454줄)
  `/Users/dancer/Downloads/MASC Design System/colors_and_type.css` 원본 복사. dark-fantasy 기본 + cyberpunk/terminal/parchment/paper 테마 오버라이드 + 텍스처 유틸(`tex-parchment`, `tex-blood`, `tex-wax`, `tex-mold`, `tex-viscera`, `tex-scratch`, `tex-noise`) + gothic frame primitives(`frame-gothic`, `frame-arch`, `frame-sarc`) + `.dropcap`, glyph helpers.

- **`Makefile`**
  - `bonsai-dashboard`: `cp dashboard_bonsai/static/colors_and_type.css assets/...`
  - 신규 `bonsai-dashboard-tokens`: 번들 안 건드리고 토큰만 교체하는 경로.
  - `.PHONY`에 신규 타겟 추가.

- **`lib/server/server_routes_http_pages.ml`**
  - `bonsai_asset_mtime filename` generic helper로 리팩터.
  - `bonsai_bundle_version` + `bonsai_tokens_version` 두 사이트.
  - `<head>`에 `<link rel="stylesheet" href="/dashboard/b/assets/colors_and_type.css?v={mtime}">` 추가.
  - 404 시 inline `<style>` fallback 유지.

## Test plan

- [x] `dune build --root . @check` — no errors.
- [ ] 머지 후 `make bonsai-dashboard` → `assets/dashboard_bonsai/colors_and_type.css` 생성 확인.
- [ ] `curl -I http://127.0.0.1:8935/dashboard/b/assets/colors_and_type.css` → `200 OK`, `Content-Type: text/css; charset=utf-8`.
- [ ] 브라우저에서 `getComputedStyle(document.documentElement).getPropertyValue('--accent-brass')` → `#8a6a28`.
- [ ] DevTools Network에서 `colors_and_type.css?v=<mtime>` 로드 확인.

## 후속

- 별도 PR: `logs_view.ml`의 ppx_css 리터럴을 `var(--*)` 토큰으로 점진 교체.
- 별도 PR: `data-theme` 토글 UI (footer keymap) — 다크판타지 ↔ terminal ↔ cyberpunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
