### PR TITLE
fix(dashboard): replace CSS var() with literal hex in composite FSM classDef

### DIFF
--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -73,4 +73,17 @@ describe('buildCompositeFsmMermaid', () => {
     // the mutator's read-modify-write but is not directly renderable.
     expect(src).toMatch(/kcb_warning\s*-\.->\s*kcb_cooling/)
   })
+
+  it('uses literal hex colors in classDef (no CSS var()), since values are emitted as raw SVG attrs', () => {
+    // Mermaid writes classDef color/fill/stroke verbatim into SVG
+    // attributes. CSS custom properties don't resolve on attr paths
+    // Mermaid uses during layout/text measurement, and a mixed classDef
+    // has caused parse failures that leaked the library's "Syntax error"
+    // bomb SVG into document.body (related: PR #8843).
+    const classDefLines = src.split('\n').filter(l => /^\s*classDef\s+/.test(l))
+    expect(classDefLines.length).toBeGreaterThan(0)
+    for (const line of classDefLines) {
+      expect(line).not.toMatch(/var\(--/)
+    }
+  })
 })

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -109,7 +109,7 @@ const MERMAID_COMPOSITE: string = `flowchart TB
 
   classDef terminal fill:#1f0f0f,stroke:#7f1d1d,color:#fca5a5
   classDef stable   fill:#0f1a0f,stroke:#166534,color:#86efac
-  classDef motion   fill:#1a1305,stroke:#a16207,color:var(--yellow-100)
+  classDef motion   fill:#1a1305,stroke:#a16207,color:#fde68a
   classDef error    fill:#1e0a0a,stroke:#b91c1c,color:#fca5a5
 
   class ksm_stopped,ksm_dead terminal


### PR DESCRIPTION
## Summary

#8843의 root cause. 이전 PR은 \`suppressErrorRendering: true\`로 Mermaid의 내장 bomb SVG leak을 차단했지만, 정작 **bomb을 유발하던 소스 자체**는 수정하지 않았다. 이 PR이 그 실소스를 고친다.

## Root cause

\`composite-fsm-flowchart.ts\`의 4개 classDef 중 \`motion\` 하나만 CSS 변수를 사용:

\`\`\`
classDef terminal fill:#1f0f0f,stroke:#7f1d1d,color:#fca5a5
classDef stable   fill:#0f1a0f,stroke:#166534,color:#86efac
classDef motion   fill:#1a1305,stroke:#a16207,color:var(--yellow-100)   ← odd one
classDef error    fill:#1e0a0a,stroke:#b91c1c,color:#fca5a5
\`\`\`

Mermaid는 classDef의 color/fill/stroke 값을 **SVG attribute로 그대로 기록**한다. layout/text 측정 경로는 computed style이 아닌 raw attribute lookup을 쓰므로 CSS 변수는 해석되지 않는다. 이 일관성 불일치가 특정 빌드에서 parse failure를 유발해 #8843의 bomb leak을 낳은 것으로 추정.

## Fix

\`var(--yellow-100)\` → \`#fde68a\` (\`styles/variables.css:119\`의 그 값 그대로). 다른 3개와 패턴 일치.

## Regression guard

\`composite-fsm-flowchart.test.ts\`에 회귀 테스트 1개 추가:
- 모든 classDef 라인이 \`var(--\`를 포함하지 않아야 한다

## Verification

- \`pnpm test src/components/composite-fsm-flowchart.test.ts\` — **10/10 pass** (기존 9 + 신규 1)
- \`pnpm typecheck\` — clean

Follow-up to #8843.