### PR TITLE
refactor(oas_events): publish_task_transition string -> Types.task_action (#8605 sibling of #8846)

### DIFF
--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -54,12 +54,18 @@ let publish_board_post (_bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
   ] in
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.board_post", payload)))
 
-(** Publish a task state change event to the shared Event_bus. *)
-let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~transition =
+(** Publish a task state change event to the shared Event_bus.
+    #8605 family: [transition] is the canonical [Types.task_action]
+    variant -- typos at call sites fail to compile. JSON wire format
+    ("claim" / "start" / "done" / ...) is preserved via
+    [Types.task_action_to_string]. Sibling refactor of #8846 (the
+    Coord-side hook for the same transition vocabulary). *)
+let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
+    ~(transition : Types.task_action) =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("task_id", `String task_id);
-    ("transition", `String transition);
+    ("transition", `String (Types.task_action_to_string transition));
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.task_transition", payload)))

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -101,7 +101,7 @@ let test_event_bus_task_transition () =
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_task_transition bus ~agent_name:"worker"
-    ~task_id:"task-1" ~transition:"done";
+    ~task_id:"task-1" ~transition:Types_core.Done_action;
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with


### PR DESCRIPTION
## Summary

Sibling of **#8846** — the OAS Event_bus side of the same task transition vocabulary. \`Coord_hooks.observe_task_transition_fn\` was migrated to \`Types.task_action\` there; \`Oas_events.publish_task_transition\` still took \`transition:string\` and serialised it directly into the \`\"masc.task_transition\"\` payload. Same #8605 anti-pattern: typos at caller sites would silently land on the bus as garbage transition labels with no signal.

## Scope

- \`lib/oas_events.ml\` — \`publish_task_transition\` signature (\`transition:string\` → \`transition:Types.task_action\`) plus \`Types.task_action_to_string\` at the JSON wire boundary.
- \`test/test_oas_integration.ml\` — caller passes \`Types_core.Done_action\` (only consumer in the repo today).

## Discovery context (worth knowing)

\`publish_task_transition\` has **zero production callers** in \`lib/\` — only the test consumes it. Likely scaffolding from #1060 (OAS v0.23 integration, March 2026) intended for a later wiring that never landed.

Refactoring to variant rather than deleting because:

- The type-safe surface is cheap to keep.
- Any future production wiring will inherit compile-time exhaustiveness for free.
- Deletion would also work — happy to switch to delete if a reviewer prefers; both options are documented in the PR rationale.

## Behaviour preservation

JSON wire format (\`\"done\"\` / \`\"claim\"\` / ...) is bit-identical via \`Types.task_action_to_string\`.

## Test plan

```
dune build @check                     # green
./_build/default/test/test_oas_integration.exe
[OK]  oas_events  2  task transition event.
Test Successful in 7.017s. 21 tests run.
```

## Pattern siblings

8th #8605 family fix in the current sweep. Same string→variant template as #8842 (\`agent_lifecycle_event\`) and #8846 (\`Coord_hooks.observe_task_transition_fn\`).