### PR TITLE
feat(keeper): define single sandbox contract

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -6,13 +6,13 @@ category: keeper
 ## Rules (violating these wastes your turn budget)
 
 Before any file or path operation, follow this order:
-1. Call keeper_context_status. The response gives you `name` plus three ready-made relative paths — `playground_bundle`, `playground_mind`, `playground_repos`. Use these directly instead of reconstructing paths yourself.
-2. If you need a subpath (e.g. a specific repo), append to `playground_repos` — e.g. `{playground_repos}/{repo-name}/{file}`.
+1. Call keeper_context_status. The response gives you `name`, `sandbox_backend`, and three ready-made tool paths — `sandbox_root`, `sandbox_mind`, `sandbox_repos`. Use these directly instead of reconstructing paths yourself.
+2. If you need a subpath (e.g. a specific repo), append to `sandbox_repos` — e.g. `{sandbox_repos}/{repo-name}/{file}`.
 3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.
 
-NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/{your-name}/`. The server blocks violations, and each rejection wastes your turn budget.
-NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). Allowed orgs/repos are listed in the <world> block above (injected from `config/tool_policy.toml` at boot).
+NEVER operate outside your sandbox. ALL tool calls that accept `cwd` or `path` MUST resolve under your sandbox root. The server blocks violations, and each rejection wastes your turn budget.
+NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_shell op=gh for GitHub, keeper_tasks_list for tasks). Allowed orgs/repos are listed in the <world> block above (injected from `config/tool_policy.toml` at boot).
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call.
 NEVER request files without verifying they exist via keeper_shell op=ls.
 ## Tool error grammar (how to read a failed tool result)
@@ -24,7 +24,7 @@ The `error` field is a short class. The `detail.hint` field (when present) is se
 
 When a tool call fails:
 1. Read `error` and `detail.hint` carefully.
-2. If the hint points at a concrete fix (e.g. "retry with `--repo OWNER/NAME`" or "relative paths anchor at project root"), retry in the SAME turn with arguments rewritten per the hint. This is encouraged — it is NOT a "same-args retry".
+2. If the hint points at a concrete fix (e.g. "retry with `--repo OWNER/NAME`" or "use sandbox-relative path `repos/...`"), retry in the SAME turn with arguments rewritten per the hint. This is encouraged — it is NOT a "same-args retry".
 3. If you cannot resolve the error after one hint-guided retry, do NOT silently end the turn. Either:
    - switch to a different tool/approach and say WHY in your next message, or
    - ask the operator via keeper_broadcast (include the tool name, error class, and what you tried).
@@ -36,7 +36,7 @@ keeper_bash examples:
   BAD:  cmd="git log --oneline | head -5"          (pipe blocked)
   GOOD: keeper_shell op=git_log count=5              (use dedicated op)
   BAD:  cmd="cd repos && ls"                         (chaining blocked)
-  GOOD: keeper_shell op=ls path={playground_repos}    (single op with path from keeper_context_status)
+  GOOD: keeper_shell op=ls path={sandbox_repos}       (single op with path from keeper_context_status)
 
 ## What you can do with your tools
 
@@ -49,17 +49,17 @@ File operations:
 - Git history: keeper_shell with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Delivery/Full preset). ONE command per call — no pipes, chaining, or redirects.
-- Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable scope: your playground only.
-- GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
+- Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable scope: your sandbox only.
+- GitHub CLI: keeper_shell op=gh with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
 
 Workspace:
-- Your playground is `.masc/playground/{your-name}/` with three subdirs:
+- Your sandbox has three lanes:
   - `mind/` — notes, drafts, scratchpads
   - `repos/` — git clones (one per repo, e.g. `repos/masc-mcp/`) — this is your default coding workspace
-  - bundle root — general workspace files
-- All paths come from keeper_context_status: use `playground_bundle`, `playground_mind`, `playground_repos` directly.
-- Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{playground_repos}/{repo}/` automatically.
-- Worktrees: live inside clones at `.masc/playground/{your-name}/repos/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
+  - `.` — general workspace files
+- All paths come from keeper_context_status: use `sandbox_root`, `sandbox_mind`, `sandbox_repos` directly.
+- Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{sandbox_repos}/{repo}/` automatically.
+- Worktrees: live inside clones at `repos/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
 
 Clone-then-worktree rule (two turns, never one):
 1. If `repos/` is empty, clone first: `keeper_shell op=git_clone url=...`

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -23,7 +23,7 @@ What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
 - **Tools**: call `keeper_tool_search` to discover what tools you have access to. Your tool set depends on your preset policy. If you are unsure whether a tool exists, search first.
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
-- **GitHub**: if `keeper_github` is available, you can create branches, PRs, and even improve the codebase — including yourself.
+- **GitHub**: if `keeper_shell op=gh` is available, you can inspect PRs/issues and open draft PRs after pushing from a prepared worktree.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
 - **Shell**: read files and run queries (`keeper_fs_read`, `keeper_shell`).
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -6,36 +6,38 @@ template_variables: [allowed_orgs, denied_repos]
 
 ## Paths and Identity
 
-Call keeper_context_status to learn your keeper name. Then use it in paths below.
-Playground is your default sandbox, relative to the server `base_path`:
-- `.masc/playground/{your-name}/` — bundle root (general workspace)
-- `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
-- `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees live *inside* your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/` (typically `{your-name}-<task_id>`).
+Call keeper_context_status to learn your keeper name and sandbox paths.
+Your sandbox is the only filesystem ground you farm. It may be backed by a
+local directory, Docker, a VM, or a cloud service, but tool paths stay the same:
+- `.` — sandbox root
+- `mind/` — notes, drafts, scratchpads
+- `repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
+Repo worktrees live *inside* your sandbox clone at `repos/<REPO_NAME>/.worktrees/<branch-or-task>/` (typically `{your-name}-<task_id>`).
 - Directory name: `{your-name}-<task_id>` (e.g. `sangsu-fix-bug`)
 - Git branch: `{your-name}/<task_id>` (e.g. `sangsu/fix-bug`)
 - `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), or pass `repo_name=<clone>` to pick a specific one.
-- The returned path always starts with `.masc/playground/{your-name}/repos/`.
-- Never use a server-root-relative worktree path — the harness rejects it as `write_outside_playground_blocked`.
+- The returned path always starts with `repos/<REPO_NAME>/.worktrees/`.
+- Never use a server-root-relative worktree path — the harness rejects it as outside your sandbox.
 - Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist or cause doubling errors):
 - `/repos/...`
 - `/playground/...`
 - `/home/.../repos/...`
-- `.worktrees/...` (server-root relative — worktrees must live inside your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/...`)
-- `.masc/playground/{your-name}/repos/...` as a tool path argument — the tool resolves this prefix automatically, so just use `repos/...`
+- `.worktrees/...` (server-root relative — worktrees must live inside your sandbox clone at `repos/<REPO_NAME>/.worktrees/...`)
+- `.masc/playground/{your-name}/repos/...` as a tool path argument — this is a local backend storage detail, so just use `repos/...`
 - Any guessed absolute path outside the path returned by your tools
 
 ## Path Resolution Rule
 
-Tools automatically resolve paths relative to your playground root `.masc/playground/{your-name}/`.
+Tools automatically resolve paths relative to your sandbox root.
 When passing `path` or `cwd` to keeper tools:
 - Use: `repos/masc-mcp/lib/foo.ml`
+- Use: `mind/notes.md`
 - NOT: `.masc/playground/{your-name}/repos/masc-mcp/lib/foo.ml`
 - NOT: `/Users/.../playground/{your-name}/repos/...`
 
-Including the playground prefix causes path doubling errors. The tool adds the prefix for you.
+Including a host storage prefix causes path doubling errors. The tool maps your sandbox path for you.
 
 ## Project
 

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -159,7 +159,7 @@ These are still accepted by the loader, but for consistency they should be used 
 | `proactive_enabled` | bool | Override default proactive scheduling |
 | `proactive_idle_sec`, `proactive_cooldown_sec` | int | Proactive scheduling intervals |
 | `room_signal_prompt_enabled` | bool | Override room-signal prompt behavior |
-| `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on playground default |
+| `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on the single sandbox root |
 | `tool_also_allow` | string array | Extra tool names added to the preset surface |
 | `also_allow` | string array | Backward-compat alias for `tool_also_allow` (will warn as "unknown key" after deprecation) |
 | `tool_denylist` | string array | Tool names blocked regardless of preset |
@@ -200,10 +200,10 @@ tool_also_allow = ["masc_team_memory_read", "masc_team_memory_write", "masc_team
 
 Operational intent:
 
-- private writable lane: `.masc/playground/<keeper>/...`
+- private writable lane: the keeper sandbox. The current local/docker storage path is `.masc/playground/<keeper>/...`, but keeper tools should use sandbox-relative paths such as `repos/<repo>` and `mind/<file>`.
 - shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
 - no arbitrary shared writable shell directory
-- `docker_hardened`는 `allowed_paths=["*"]`를 거부하고, private playground root 밖 경로도 허용하지 않는다
+- `docker_hardened`는 `allowed_paths=["*"]`를 거부하고, private sandbox root 밖 경로도 허용하지 않는다
 
 ### Removed / forbidden fields (hard-rejected)
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -297,8 +297,8 @@ spawn 시 인자로 직접 설정하는 필드.
 
 의미:
 
-- keeper shell write는 자기 playground 안에서만 허용된다.
-- `docker_hardened`는 keeper_bash를 ephemeral Docker sandbox로 실행한다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private playground mount, network=`none`이다.
+- keeper shell write는 자기 sandbox 안에서만 허용된다. 현재 local/docker backend의 디스크 구현은 `.masc/playground/<keeper>/`이지만 keeper-facing 경로는 `.` / `mind` / `repos`이다.
+- `docker_hardened`는 keeper_bash를 ephemeral Docker sandbox로 실행한다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private sandbox mount, network=`none`이다.
 - `docker_with_git`은 `docker_hardened`의 보안 가드를 모두 유지하면서 `--network bridge` + `~/.config/gh` / `~/.gitconfig` read-only mount + `GH_TOKEN` env forward 를 추가한다. git/gh CLI 가 컨테이너 안에서 동작한다. `~/.ssh` mount 는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
 - 기본 dispatch: keeper의 `sandbox_profile` 이 `docker_hardened` 여도 `keeper_bash` 의 cmd 가 `git` 또는 `gh` 로 시작하면 자동으로 `docker_with_git` 으로 라우팅된다 (`MASC_KEEPER_SANDBOX_GIT_DISPATCH=false` 로 비활성화 가능). 즉 git/gh 외 모든 명령은 여전히 network=none 의 hardened 컨테이너에서 실행된다.
 - `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -121,21 +121,38 @@ let origin_head_branch root =
       | branch :: _ -> Some branch
       | [] -> None)
 
+let unique_strings values =
+  List.fold_left
+    (fun acc value ->
+      let value = String.trim value in
+      if value = "" || List.mem value acc then acc else acc @ [ value ])
+    [] values
+
+let auto_base_branch_candidates root =
+  unique_strings
+    (match origin_head_branch root with
+     | Some head -> [ head; "main"; "master"; "develop" ]
+     | None -> [ "main"; "master"; "develop" ])
+
 let resolve_base_branch root base_branch =
-  if remote_branch_exists root base_branch then Ok (base_branch, None)
+  let base_branch = String.trim base_branch in
+  if base_branch = "" || String.equal base_branch "auto" then
+    match List.find_opt (remote_branch_exists root) (auto_base_branch_candidates root) with
+    | Some resolved -> Ok (resolved, None)
+    | None ->
+        Error
+          (IoError
+             "Base branch auto-detect failed: no origin/HEAD, origin/main, origin/master, or origin/develop found.")
+  else if remote_branch_exists root base_branch then Ok (base_branch, None)
   else
-    let candidates =
-      match origin_head_branch root with
-      | Some head -> [head; "main"; "master"]
-      | None -> ["main"; "master"]
-    in
-    match List.find_opt (remote_branch_exists root) candidates with
+    match List.find_opt (remote_branch_exists root) (auto_base_branch_candidates root) with
     | Some fallback -> Ok (fallback, Some base_branch)
     | None ->
         Error
           (IoError
              (Printf.sprintf
-                "Base branch origin/%s not found and no fallback branch detected." base_branch))
+                "Base branch origin/%s not found and no origin/HEAD, origin/main, origin/master, or origin/develop fallback detected."
+                base_branch))
 
 (* ============================================ *)
 (* Worktree Operations                          *)
@@ -162,9 +179,11 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
             (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
                worktree_path branch_name worktree_path)
         else (
-          (* Fetch origin first *)
-          let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
-          match resolve_base_branch root base_branch with
+          (* Fetch origin first; never create from a silently stale remote ref. *)
+          let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+          if fetch_exit <> 0 then
+            Error (IoError "Failed to fetch origin before worktree creation.")
+          else match resolve_base_branch root base_branch with
           | Error e -> Error e
           | Ok (resolved_base, fallback_from) ->
               let note =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -119,10 +119,10 @@ let link_worktree_to_task config ~task_id ~worktree_info =
 
 (** Create worktree for agent - Result version
     @param link_task If true, links worktree info to the task in backlog (default: true)
-    @param repo_name If set, target the keeper's playground clone at
+    @param repo_name If set, target the keeper's sandbox repo clone at
            [.masc/playground/<agent>/repos/<repo_name>/] directly. If
            unset, scan [repos/] and use the first git clone found
-           (alphabetical). A playground clone is required. *)
+           (alphabetical). A sandbox repo clone is required. *)
 let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
@@ -132,13 +132,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    (* Prefer a keeper's playground clone under
+    (* Prefer a keeper's sandbox repo clone under
        [.masc/playground/<agent>/repos/]. The layout is the SSOT in
        [Playground_paths] (masc_config). If [repo_name] is supplied,
        target that clone directly; otherwise scan the directory and
        pick the first git clone (alphabetical). Keepers may work on
        any repo their [tool_policy.toml] allows, but the worktree root
-       must come from a playground clone. *)
+       must come from a sandbox repo clone. *)
     let resolve_keeper_repo_root () =
       let repos_dir =
         Filename.concat config.base_path
@@ -218,7 +218,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
         Error
           (IoError
              (Printf.sprintf
-                "No playground git clone found under %s for agent %s. %s"
+                "No sandbox git clone found under %s for agent %s. %s"
                 repos_dir agent_name hint))
     in
     match resolve_keeper_repo_root () with
@@ -269,10 +269,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  Repo: %s%s\n\nNext: cd %s"
                 worktree_path branch_name repo_name link_note worktree_path)
           end else begin
-            (* Fetch origin first *)
-            let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
-
-            match Coord_git.resolve_base_branch root base_branch with
+            (* Fetch origin first; stale remotes must be explicit, not hidden. *)
+            let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+            if fetch_exit <> 0 then
+              Error
+                (IoError
+                   "Failed to fetch origin before worktree creation. Verify network/auth and retry so the task starts from the latest remote ref.")
+            else match Coord_git.resolve_base_branch root base_branch with
             | Error e -> Error e
             | Ok (resolved_base, fallback_from) ->
                 let note = match fallback_from with
@@ -379,7 +382,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
         Error
           (IoError
              (Printf.sprintf
-                "Worktree %s not found under playground clones in %s"
+                "Worktree %s not found under sandbox repo clones in %s"
                 worktree_name repos_dir))
     in
     match resolve_existing_worktree_root () with

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -15,6 +15,7 @@ let normalize_failure_text (text : string) : string =
   let prefix_rules =
     [
       ("path_not_in_allowed_paths:", "path_not_in_allowed_paths");
+      ("path_outside_sandbox:", "path_outside_sandbox");
       ("path_not_found_under_allowed_roots:", "path_not_found_under_allowed_roots");
       ("path_outside_project_root:", "path_outside_project_root");
       ("allowed_paths_normalized_empty:", "allowed_paths_normalized_empty");

--- a/lib/dune
+++ b/lib/dune
@@ -409,6 +409,7 @@
    keeper_memory_bank
    keeper_memory_recall
    keeper_skill_routing
+   keeper_sandbox
    keeper_alerting
    keeper_alerting_path
    keeper_timing
@@ -663,6 +664,7 @@
   tool_autoresearch_broadcast
   tool_autoresearch_cycle
   keeper_skill_routing
+  keeper_sandbox
   keeper_alerting_path
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http

--- a/lib/dune
+++ b/lib/dune
@@ -410,6 +410,7 @@
    keeper_memory_recall
    keeper_skill_routing
    keeper_sandbox
+   keeper_repo_readiness
    keeper_alerting
    keeper_alerting_path
    keeper_timing

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -165,10 +165,10 @@ let absolute_allowed_paths_result ~(config : Coord.config)
   else
     Ok normalized
 
-(** Build a [path_not_in_allowed_paths] error message that teaches the LLM
+(** Build a sandbox boundary error message that teaches the LLM
     *why* the path was rejected — not just *that* it was. Bare "X not allowed"
     triggers retry loops; including the resolved candidate plus the
-    project-root anchor rule lets the keeper correct on the next call without
+    sandbox boundary rule lets the keeper correct on the next call without
     re-trying the same broken interpretation. See
     [memory/feedback_tool-error-messages-teach-llm.md]. *)
 (** Look for a playground-root allowed path (contains ".masc/playground/")
@@ -199,7 +199,7 @@ let format_path_rejection ~(raw : string) ~(resolved : string)
   let resolved_hint =
     if Filename.is_relative raw && resolved <> raw then
       Printf.sprintf
-        "; relative paths anchor at project root, not playground (resolved=%s)"
+        "; relative paths are checked against your sandbox boundary (resolved=%s)"
         resolved
     else
       ""
@@ -209,15 +209,16 @@ let format_path_rejection ~(raw : string) ~(resolved : string)
       match playground_root_of_allowed allowed_norms with
       | Some pg ->
         Printf.sprintf
-          ". Your raw path starts with 'repos/' or 'mind/'; prepend your \
-           playground root (try path=%s/%s) or call keeper_context_status \
-           and use the playground_repos / playground_mind variables."
-          pg raw
+          ". Your raw path already looks sandbox-relative. Use it as-is \
+           (for example path=%S) and do not prepend %s; call \
+           keeper_context_status and use sandbox_repos / sandbox_mind if \
+           unsure."
+          raw pg
       | None -> ""
     else ""
   in
   Printf.sprintf
-    "path_not_in_allowed_paths: %s%s (allowed: [%s])%s"
+    "path_outside_sandbox: %s%s (sandbox roots: [%s])%s"
     raw resolved_hint (String.concat ", " allowed_norms) playground_hint
 
 let resolve_keeper_target_path ~(config : Coord.config)
@@ -268,6 +269,7 @@ let playground_path_of_keeper = Playground_paths.bundle_root
 let playground_mind_path = Playground_paths.mind_path
 let playground_repos_path = Playground_paths.repos_path
 let playground_bundle_paths = Playground_paths.bundle_paths
+let sandbox_path_of_keeper name = Keeper_sandbox.allowed_root_rel ~name
 
 let ensure_playground_bundle ~(config : Coord.config) ~(name : string) : string list =
   let root = project_root_of_config config in
@@ -276,31 +278,31 @@ let ensure_playground_bundle ~(config : Coord.config) ~(name : string) : string 
   |> List.map Keeper_fs.ensure_dir
 
 (** Compute effective read allowed_paths from keeper meta.
-    Returns the playground bundle paths plus any explicit [allowed_paths]
+    Returns the single sandbox root plus any explicit [allowed_paths]
     entries. [["*"]] means full-access opt-in: the resulting empty list is
     interpreted by the OAS worker builder as "skip path restriction".
     Workspace/local scope no longer grants extra hardcoded paths; every
     additional path must be listed explicitly in [allowed_paths]. *)
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
-  let playground_paths = playground_bundle_paths meta.name in
+  let sandbox_paths = Keeper_sandbox.allowed_path_roots ~name:meta.name in
   match meta.allowed_paths with
   | ["*"] -> []
-  | explicit -> playground_paths @ explicit
+  | explicit -> sandbox_paths @ explicit
 
 (** Compute effective write allowed_paths from keeper meta.
-    Returns the playground bundle paths plus any explicit [allowed_paths]
+    Returns the single sandbox root plus any explicit [allowed_paths]
     entries. [["*"]] means full-access opt-in (empty allowlist signals
     "skip path restriction" to the OAS worker builder). Workspace/local
     scope no longer grants extra hardcoded paths; every additional path
     must be listed explicitly in [allowed_paths]. *)
 let effective_write_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
-  let playground_paths = playground_bundle_paths meta.name in
+  let sandbox_paths = Keeper_sandbox.allowed_path_roots ~name:meta.name in
   match meta.allowed_paths with
   | ["*"] -> []
-  | explicit -> playground_paths @ explicit
+  | explicit -> sandbox_paths @ explicit
 
 (** Resolve a path for read-only access within the keeper's effective
-    allowlist. The allowlist is usually the keeper playground bundle
+    allowlist. The allowlist is usually the keeper sandbox root
     plus any explicit custom paths; explicit ["*"] still means full
     project-root access. *)
 let resolve_keeper_read_path ~(config : Coord.config)

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -370,15 +370,15 @@ let keeper_context_status_json
            horizon,
            `Int count)
   in
-  (* Give the keeper the three canonical playground paths from the SSOT
-     so it does not need to re-interpolate ".masc/playground/<name>/..."
-     strings every turn. These are relative to the server base_path. *)
+  (* Give the keeper sandbox-relative paths from the SSOT so it never needs
+     to interpolate host storage paths such as ".masc/playground/<name>/". *)
+  let sandbox = Keeper_sandbox.of_meta ~config ~meta in
   let playground_bundle = Playground_paths.bundle_root meta.name in
   let playground_mind = Playground_paths.mind_path meta.name in
   let playground_repos = Playground_paths.repos_path meta.name in
   Yojson.Safe.to_string
     (`Assoc
-        [ "name", `String meta.name
+        ([ "name", `String meta.name
         ; "trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
         ; "generation", `Int meta.runtime.generation
         ; "context_ratio", `Float ctx_ratio
@@ -386,16 +386,18 @@ let keeper_context_status_json
         ; "context_max", `Int ctx_work.max_tokens
         ; "message_count", `Int (List.length (messages_of_context ctx_work))
         ; "last_model_used", `String meta.runtime.usage.last_model_used
-        ; "playground_bundle", `String playground_bundle
+        ]
+        @ Keeper_sandbox.context_status_fields sandbox
+        @
+        [ (* Legacy aliases kept for one release. Prompts use sandbox_*.
+             Values are still present for old keeper continuations. *)
+          "playground_bundle", `String playground_bundle
         ; "playground_mind", `String playground_mind
         ; "playground_repos", `String playground_repos
-        (* Tool-ready short paths: use these directly as path/cwd arguments
-           in keeper_shell, keeper_bash, keeper_fs_read.  The tool handler
-           resolves them relative to your playground root. *)
         ; "tool_paths", `Assoc
-            [ "mind", `String "mind"
-            ; "repos", `String "repos"
-            ; "bundle", `String "."
+            [ "mind", `String sandbox.mind_arg
+            ; "repos", `String sandbox.repos_arg
+            ; "bundle", `String sandbox.root_arg
             ]
         ; ( "continuity_state"
           , match continuity with
@@ -404,7 +406,7 @@ let keeper_context_status_json
         ; "continuity_summary", `String continuity_summary
         ; "recovery_source", `String recovery_source
         ; "memory_tier_summary", `Assoc memory_tier_summary
-        ])
+        ]))
 ;;
 
 (* --- Memory bank search (structured notes from [STATE] blocks) --- *)

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -89,14 +89,37 @@ let handle_keeper_preflight_check
     add_check "accountability_risk" (not accountability_risk)
       (if accountability_risk then "RISK_HIGH" else "ok")
   in
-  (* Check 6: playground clone target *)
-  let clone_target =
-    let repos_path = Keeper_alerting_path.playground_repos_path meta.name in
-    if repo <> "" then
-      Filename.concat repos_path (Filename.basename repo)
-    else
-      Filename.concat repos_path (Filename.basename root)
+  (* Check 6: sandbox clone target *)
+  let repo_name_arg =
+    Safe_ops.json_string ~default:"" "repo_name" args |> String.trim
   in
+  let clone_target =
+    let repo_name =
+      if repo_name_arg <> "" then repo_name_arg
+      else Keeper_repo_readiness.repo_name_of_repo_arg ~project_root:root repo
+    in
+    Filename.concat
+      (Keeper_alerting_path.playground_repos_path meta.name)
+      repo_name
+  in
+  (* Check 6: sandbox repo readiness *)
+  let repo_readiness =
+    Keeper_repo_readiness.inspect ~config ~keeper_name:meta.name
+      ?repo_name:(if repo_name_arg = "" then None else Some repo_name_arg)
+      ~repo ~default_branch:!default_branch ()
+  in
+  let repo_ready =
+    match repo_readiness with
+    | `Assoc fields -> (
+        match List.assoc_opt "ok" fields with
+        | Some (`Bool ok) -> ok
+        | _ -> false)
+    | _ -> false
+  in
+  let repo_state =
+    json_string_field "state" repo_readiness |> Option.value ~default:"unknown"
+  in
+  let () = add_check "repo_readiness" repo_ready repo_state in
   Yojson.Safe.to_string
     (`Assoc
         [ "ok", `Bool !all_ok
@@ -110,5 +133,6 @@ let handle_keeper_preflight_check
         ; "risk_band", `String risk_band
         ; "routing_hint", `String routing_hint
         ; "clone_target", `String clone_target
+        ; "repo_readiness", repo_readiness
         ; "keeper", `String meta.name
         ])

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -96,9 +96,7 @@ let keeper_effective_write_allowed_paths ~(meta : keeper_meta) =
 
 let keeper_playground_root ~(config : Coord.config) ~(meta : keeper_meta) =
   ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
-  Filename.concat
-    (Keeper_alerting_path.project_root_of_config config)
-    (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  Keeper_sandbox.host_root_abs ~config meta.name
 ;;
 
 let keeper_default_write_root ~(config : Coord.config) ~(meta : keeper_meta) =
@@ -126,16 +124,15 @@ let is_playground_lane_relative_path (raw : string) =
        || String.starts_with ~prefix:(prefix ^ "/") raw)
     [ "mind"; "repos" ]
 
-(* Bare filenames and canonical playground bundle lanes default to the keeper
-   playground, but rooted-looking relative paths (for example
+(* Bare filenames and canonical sandbox lanes default to the keeper sandbox,
+   but rooted-looking relative paths (for example
    "workspace/..." or "lib/...") keep project-root/boundary semantics.
 
-   Additionally, strip the keeper's own playground prefix when the path already
-   includes it.  Keeper LLMs sometimes construct paths like
+   Additionally, strip the keeper's legacy playground prefix when the path
+   already includes it.  Keeper LLMs sometimes construct paths like
    ".masc/playground/<name>/repos" (relative) or
    "<base>/.masc/playground/<name>/.masc/playground/<name>/repos" (absolute,
-   doubled) because they concatenate the playground root they see in tool
-   output with the playground-relative path from the prompt.  Stripping early
+   doubled).  Stripping early
    prevents the downstream resolver from doubling the prefix again. *)
 let playground_relative_unless_allowed_root ~(config : Coord.config)
     ~(meta : keeper_meta) (raw : string) : string =

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -435,9 +435,7 @@ let keeper_sandbox_container_name (meta : keeper_meta) =
     (int_of_float (Unix.gettimeofday () *. 1000.0))
 
 let keeper_private_container_root (meta : keeper_meta) =
-  Filename.concat
-    Env_config_keeper.DockerPlayground.container_playground_root
-    (Playground_paths.sanitize_keeper_name meta.name)
+  Keeper_sandbox.container_root meta.name
 
 let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
     host_cwd =

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -7,7 +7,7 @@
     next tool call.
 
     Error classes are coarse categories (path_not_found, cwd_not_directory,
-    path_not_in_allowed_paths) — not exact error strings. This prevents
+    path_not_in_allowed_paths/path_outside_sandbox) — not exact error strings. This prevents
     near-miss variants from resetting the counter. *)
 
 (* ================================================================ *)
@@ -26,7 +26,7 @@ let classify_error (error_msg : string) : error_class =
   else
     let contains sub = String_util.contains_substring error_msg sub in
     if contains "path_not_found" then Path_not_found
-    else if contains "path_not_in_allowed" then Path_not_allowed
+    else if contains "path_not_in_allowed" || contains "path_outside_sandbox" then Path_not_allowed
     else if contains "cwd_not_directory" then Cwd_not_directory
     else if contains "No such file or directory" then Path_not_found
     else if contains "exit" && contains "code" then Shell_exit_nonzero

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -1,0 +1,203 @@
+(** Keeper repository readiness.
+
+    This is a read-only probe for the single keeper sandbox repo clone under
+    [.masc/playground/<keeper>/repos/<repo>/]. It gives preflight callers a
+    concrete answer about whether code work can safely start from that clone. *)
+
+type command_result =
+  { ok : bool
+  ; output : string
+  ; status : Unix.process_status
+  }
+
+let run_git ~timeout_sec ~clone_path args =
+  let argv = [ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args in
+  let status, output =
+    Process_eio.run_argv_with_status ~timeout_sec argv
+  in
+  { ok = status = Unix.WEXITED 0; output = String.trim output; status }
+
+let safe_is_dir path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let safe_repo_component s =
+  s <> "" && s <> "." && s <> ".."
+  && not (String.contains s '/')
+  && not (String.contains s '\\')
+  && not (String.contains s '\x00')
+  && String.for_all
+       (fun c ->
+         (c >= 'A' && c <= 'Z')
+         || (c >= 'a' && c <= 'z')
+         || (c >= '0' && c <= '9')
+         || c = '-'
+         || c = '_'
+         || c = '.')
+       s
+
+let repo_name_of_repo_arg ~project_root repo =
+  let trimmed = String.trim repo in
+  if trimmed = "" then Filename.basename project_root
+  else
+    let base = Filename.basename trimmed in
+    if Filename.check_suffix base ".git" then
+      String.sub base 0 (String.length base - 4)
+    else base
+
+let clone_path ~(config : Coord.config) ~keeper_name ~repo_name =
+  Filename.concat config.base_path
+    (Filename.concat (Playground_paths.repos_path keeper_name) repo_name)
+
+let first_line_opt s =
+  match
+    String.split_on_char '\n' s
+    |> List.map String.trim
+    |> List.filter (fun line -> line <> "")
+  with
+  | [] -> None
+  | line :: _ -> Some line
+
+let parse_ahead_behind output =
+  match String.split_on_char '\t' (String.trim output) with
+  | [ behind; ahead ] -> (
+      match int_of_string_opt behind, int_of_string_opt ahead with
+      | Some behind, Some ahead -> Some (ahead, behind)
+      | _ -> None)
+  | _ -> None
+
+let string_opt_field name = function
+  | None -> [ name, `Null ]
+  | Some value -> [ name, `String value ]
+
+let int_opt_field name = function
+  | None -> [ name, `Null ]
+  | Some value -> [ name, `Int value ]
+
+let inspect
+    ~(config : Coord.config)
+    ~keeper_name
+    ?repo_name
+    ?(repo = "")
+    ?(default_branch = "main")
+    ()
+  =
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  let derived_repo_name =
+    match repo_name with
+    | Some name when String.trim name <> "" -> String.trim name
+    | _ -> repo_name_of_repo_arg ~project_root repo
+  in
+  let clone_path = clone_path ~config ~keeper_name ~repo_name:derived_repo_name in
+  let common_fields state ok next_action extra =
+    `Assoc
+      ([
+         "ok", `Bool ok;
+         "state", `String state;
+         "keeper", `String keeper_name;
+         "repo", `String repo;
+         "repo_name", `String derived_repo_name;
+         "clone_path", `String clone_path;
+         "sandbox_repos", `String (Playground_paths.repos_path keeper_name);
+         "default_branch", `String default_branch;
+         "next_action", `String next_action;
+       ]
+      @ extra)
+  in
+  if not (safe_repo_component derived_repo_name) then
+    common_fields "invalid_repo_name" false
+      "Pass repo_name as a single directory name under repos/; no slashes or path traversal."
+      [
+        "exists", `Bool false;
+        "is_git_repo", `Bool false;
+        "has_origin", `Bool false;
+      ]
+  else if not (safe_is_dir clone_path) then
+    common_fields "missing_clone" false
+      "Clone the repo into sandbox repos/ first with keeper_shell op=git_clone, then create a worktree."
+      [
+        "exists", `Bool false;
+        "is_git_repo", `Bool false;
+        "has_origin", `Bool false;
+      ]
+  else
+    let inside =
+      run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
+    in
+    if not inside.ok then
+      common_fields "not_git_repo" false
+        "This sandbox repo directory is not a git clone; reclone it under repos/."
+        [
+          "exists", `Bool true;
+          "is_git_repo", `Bool false;
+          "has_origin", `Bool false;
+          "git_error", `String inside.output;
+        ]
+    else
+      let status =
+        run_git ~timeout_sec:10.0 ~clone_path [ "status"; "--porcelain" ]
+      in
+      let dirty = status.ok && String.trim status.output <> "" in
+      let branch =
+        run_git ~timeout_sec:5.0 ~clone_path [ "branch"; "--show-current" ]
+        |> fun r -> if r.ok then first_line_opt r.output else None
+      in
+      let head =
+        run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--short"; "HEAD" ]
+        |> fun r -> if r.ok then first_line_opt r.output else None
+      in
+      let upstream =
+        run_git ~timeout_sec:5.0 ~clone_path
+          [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
+      in
+      let upstream_name = if upstream.ok then first_line_opt upstream.output else None in
+      let ahead, behind =
+        match upstream_name with
+        | None -> None, None
+        | Some _ -> (
+            let counts =
+              run_git ~timeout_sec:10.0 ~clone_path
+                [ "rev-list"; "--left-right"; "--count"; "@{upstream}...HEAD" ]
+            in
+            if counts.ok then
+              match parse_ahead_behind counts.output with
+              | Some (ahead, behind) -> Some ahead, Some behind
+              | None -> None, None
+            else None, None)
+      in
+      let origin =
+        run_git ~timeout_sec:5.0 ~clone_path [ "remote"; "get-url"; "origin" ]
+      in
+      let has_origin = origin.ok && String.trim origin.output <> "" in
+      let state, ok, next_action =
+        if not status.ok then
+          "status_failed", false,
+          "Run keeper_shell op=git_status in this repo; repair git status before starting work."
+        else if not has_origin then
+          "missing_origin", false,
+          "Set or reclone origin before worktree creation; latest cannot be verified without origin."
+        else if dirty then
+          "dirty", false,
+          "Commit, stash, or move existing changes before creating a fresh task worktree."
+        else
+          match behind with
+          | Some n when n > 0 ->
+              "behind_upstream", false,
+              "Fetch/rebase the sandbox clone or create a new worktree from the fetched origin branch."
+          | _ -> "ready", true, "Create a task worktree from the fetched origin branch before editing."
+      in
+      common_fields state ok next_action
+        ([
+           "exists", `Bool true;
+           "is_git_repo", `Bool true;
+           "dirty", `Bool dirty;
+           "has_origin", `Bool has_origin;
+           "origin_url",
+           (if has_origin then `String origin.output else `Null);
+           "status_ok", `Bool status.ok;
+         ]
+        @ string_opt_field "branch" branch
+        @ string_opt_field "head" head
+        @ string_opt_field "upstream" upstream_name
+        @ int_opt_field "ahead" ahead
+        @ int_opt_field "behind" behind)

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -32,7 +32,8 @@ let strip_trailing_slashes path =
 
 let backend_of_profile = function
   | Keeper_types.Legacy_local -> Local
-  | Keeper_types.Docker_hardened -> Docker_hardened
+  | Keeper_types.Docker_hardened | Keeper_types.Docker_with_git ->
+      Docker_hardened
 
 let backend_to_string = function
   | Local -> "local"

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -1,0 +1,98 @@
+(** Keeper sandbox contract.
+
+    Keeper-facing tools expose exactly one logical sandbox.  The current
+    local storage implementation is still [.masc/playground/<keeper>], but
+    that path is an implementation detail of the local/docker backends. *)
+
+type backend =
+  | Local
+  | Docker_hardened
+
+type t =
+  { keeper_name : string
+  ; sandbox_id : string
+  ; backend : backend
+  ; sandbox_profile : string
+  ; network_mode : string
+  ; host_root_rel : string
+  ; host_root_abs : string
+  ; container_root : string option
+  ; root_arg : string
+  ; mind_arg : string
+  ; repos_arg : string
+  ; task_overlay_pattern : string
+  }
+
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let backend_of_profile = function
+  | Keeper_types.Legacy_local -> Local
+  | Keeper_types.Docker_hardened -> Docker_hardened
+
+let backend_to_string = function
+  | Local -> "local"
+  | Docker_hardened -> "docker_hardened"
+
+let sandbox_id_of_name name =
+  "keeper:" ^ Playground_paths.sanitize_keeper_name name
+
+let host_root_rel name =
+  Playground_paths.bundle_root name
+
+let host_root_abs ~(config : Coord.config) name =
+  Filename.concat config.base_path (host_root_rel name)
+
+let container_root name =
+  Filename.concat
+    Env_config_keeper.DockerPlayground.container_playground_root
+    (Playground_paths.sanitize_keeper_name name)
+
+let of_meta ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : t =
+  let backend = backend_of_profile meta.sandbox_profile in
+  { keeper_name = meta.name
+  ; sandbox_id = sandbox_id_of_name meta.name
+  ; backend
+  ; sandbox_profile = Keeper_types.sandbox_profile_to_string meta.sandbox_profile
+  ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
+  ; host_root_rel = host_root_rel meta.name
+  ; host_root_abs = host_root_abs ~config meta.name
+  ; container_root =
+      (match backend with
+       | Local -> None
+       | Docker_hardened -> Some (container_root meta.name))
+  ; root_arg = "."
+  ; mind_arg = "mind"
+  ; repos_arg = "repos"
+  ; task_overlay_pattern = "repos/<repo>/.worktrees/<keeper>-<task_id>"
+  }
+
+let allowed_root_rel ~(name : string) : string =
+  Playground_paths.bundle_root name
+
+let allowed_path_roots ~(name : string) : string list =
+  [ allowed_root_rel ~name ]
+
+let storage_lifetime = "persistent_base_task_overlay"
+
+let context_status_fields (t : t) : (string * Yojson.Safe.t) list =
+  [ "sandbox_id", `String t.sandbox_id
+  ; "sandbox_backend", `String (backend_to_string t.backend)
+  ; "sandbox_profile", `String t.sandbox_profile
+  ; "sandbox_network_mode", `String t.network_mode
+  ; "sandbox_lifetime", `String storage_lifetime
+  ; "sandbox_root", `String t.root_arg
+  ; "sandbox_mind", `String t.mind_arg
+  ; "sandbox_repos", `String t.repos_arg
+  ; "sandbox_task_overlay_pattern", `String t.task_overlay_pattern
+  ; ( "sandbox_paths"
+    , `Assoc
+        [ "root", `String t.root_arg
+        ; "mind", `String t.mind_arg
+        ; "repos", `String t.repos_arg
+        ] )
+  ]

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1162,9 +1162,17 @@ let handle_keeper_status ctx args : tool_result =
                    (Coord_utils.safe_filename m.name)
                    (Coord_utils.safe_filename (Keeper_id.Trace_id.to_string m.runtime.trace_id)))));
            ]);
-           (let playground_rel = Keeper_alerting_path.playground_path_of_keeper m.name in
+           (let sandbox = Keeper_sandbox.of_meta ~config:ctx.config ~meta:m in
+           let playground_rel = Keeper_alerting_path.playground_path_of_keeper m.name in
            let playground_abs = Filename.concat ctx.config.base_path playground_rel in
            "execution_context", `Assoc [
+             ("sandbox_id", `String sandbox.sandbox_id);
+             ("sandbox_backend", `String (Keeper_sandbox.backend_to_string sandbox.backend));
+             ("sandbox_root", `String sandbox.root_arg);
+             ("sandbox_repos", `String sandbox.repos_arg);
+             ("sandbox_mind", `String sandbox.mind_arg);
+             ("sandbox_host_root", `String sandbox.host_root_abs);
+             ("sandbox_container_root", Json_util.string_opt_to_json sandbox.container_root);
              ("playground_path", `String playground_rel);
              ("default_cwd", `String playground_abs);
              ("private_workspace_root", `String playground_abs);

--- a/lib/meta_cognition_rules.ml
+++ b/lib/meta_cognition_rules.ml
@@ -150,6 +150,7 @@ let tension_rules =
             [
               "path validator";
               "path_not_in_allowed_paths";
+              "path_outside_sandbox";
               "path-matching function";
               "allowed paths actually match";
               "allowed path string is identical";

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -5,8 +5,8 @@ let schemas : tool_schema list = [
     name = "masc_worktree_create";
     description = "Create an isolated Git worktree for a task. \
 Requires task_id (REQUIRED). Example: task_id='fix-login', task_id='feature/auth'. \
-The worktree is rooted in your playground clone — typically at \
-.masc/playground/<your-name>/repos/<repo>/.worktrees/<agent>-<task_id>. \
+The worktree is rooted in your sandbox repo clone — typically at \
+repos/<repo>/.worktrees/<agent>-<task_id>. \
 Repo resolution: pass repo_name to target a specific clone, otherwise \
 the first git clone under your repos/ is used (alphabetical). Clone \
 the target repo first with keeper_shell op=git_clone if your repos/ \
@@ -25,12 +25,12 @@ masc_worktree_remove.";
         ]);
         ("base_branch", `Assoc [
           ("type", `String "string");
-          ("description", `String "Base branch (default: auto-detect). Rarely needed.");
-          ("default", `String "develop");
+          ("description", `String "Base branch (default: auto). Rarely needed. Auto resolves origin/HEAD, then origin/main, origin/master, origin/develop.");
+          ("default", `String "auto");
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Optional. Disambiguates which sandbox repo clone to use when you have multiple repos under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
           (* Negative lookahead is not supported by JSON Schema Draft 7
              (used by most MCP clients), so the pattern below only
              enforces the character class. The ".", ".." special cases

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -454,12 +454,13 @@ let keeper_preflight_tools : Types.tool_schema list = [
   {
     name = "keeper_preflight_check";
     description = "Validate prerequisites before starting autonomous work: \
-gh auth, repo access, keeper identity, preset level, clone target path. \
+gh auth, repo access, keeper identity, preset level, repo readiness. \
 Returns structured JSON with all check results. Read-only, no side effects.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name) to check access for")]);
+        ("repo_name", `Assoc [("type", `String "string"); ("description", `String "Optional sandbox repo directory name under repos/ when it differs from the GitHub repo basename")]);
       ]);
       ("required", `List [`String "repo"]);
     ];

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -116,9 +116,9 @@ Use to timestamp events, check elapsed time, or include current time in reports.
     name = "keeper_context_status";
     description = "Check your own context window usage and session state. Returns: \
 name (your keeper name), context_ratio (0.0-1.0), context_tokens, context_max, \
-message_count, generation, last_model_used, continuity_summary, and your three \
-canonical playground paths (playground_bundle, playground_mind, playground_repos) \
-relative to the server base_path, plus tool_paths (mind, repos, bundle) which you can pass \
+message_count, generation, last_model_used, continuity_summary, and canonical \
+sandbox paths (sandbox_root, sandbox_mind, sandbox_repos) plus backend/profile \
+metadata. sandbox paths are tool-ready and can be passed \
 directly as path or cwd to keeper tools without prefix. Use when deciding whether to compact context, \
 extend turns, hand off to the next generation, or resolve a path without \
 string-interpolating your own keeper name.";
@@ -359,12 +359,12 @@ let shell_tools : Types.tool_schema list = [
     name = "keeper_shell";
     description = "Run a safe project shell command. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone, gh. \
-Read-only ops default to the keeper playground. \
-IMPORTANT: paths resolve automatically — use 'repos/X' not '.masc/playground/your-name/repos/X'. Never include the playground prefix in path or cwd. \
+Read-only ops default to the keeper sandbox. \
+IMPORTANT: paths resolve automatically — use 'repos/X' or 'mind/X'. Never include host paths like '.masc/playground/your-name/repos/X' in path or cwd. \
 Use cwd to target an explicit allowed directory or cloned repo. \
 find REQUIRES pattern param (e.g. pattern=\"*.ml\"). \
 bash op: single command only, no chaining (&&, ||, |, ; are blocked), no redirects (>, >>). \
-git_clone: clone a repo into your playground (url required, sandboxed to .masc/playground/<name>/). \
+git_clone: clone a repo into your sandbox repos/ lane (url required). \
 gh op: run a gh CLI subcommand with cmd=\"<subcommand>\" (e.g. cmd=\"pr list --state open\"). Always run `gh pr list` first before referencing a PR number to avoid hallucinations. Dangerous commands (repo delete, auth logout, secret set/delete) are blocked. \
 If path not found, clone the repo first with op=git_clone. \
 Use rg for pattern search, find for path discovery, head/tail for line ranges, \
@@ -378,14 +378,14 @@ git_log/git_diff for repo history, bash for curl/jq/env/which, gh for GitHub PR/
         ("op", `Assoc [("type", `String "string"); ("enum", `List (List.map (fun s -> `String s) keeper_shell_op_enum_strings)); ("description", `String "Command to run")]);
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand for op=gh, e.g. 'pr list --state open'. Do NOT put --repo in cmd; current working dir determines the repo.")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "Target path for ls/cat/rg/find/head/tail/wc/tree")]);
-        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for pwd/git_status/git_log/git_diff/git_worktree/bash. Must stay within keeper playground or an explicit allowed path.")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for pwd/git_status/git_log/git_diff/git_worktree/bash. Must stay within the keeper sandbox or an explicit allowed path.")]);
         ("pattern", `Assoc [("type", `String "string"); ("description", `String "Search pattern for rg, or name glob for find (REQUIRED for find, e.g. \"*.ml\")")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "Result limit for ls/rg/find/tree, or line count for git_log")]);
         ("lines", `Assoc [("type", `String "integer"); ("description", `String "Number of lines for head/tail (default 20, max 200)")]);
         ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String "Max bytes for cat")]);
         ("command", `Assoc [("type", `String "string"); ("description", `String "Single shell command for bash op. No chaining (&&/||/;/|) or redirects (>/>>) allowed. Read-only.")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds for bash op (default: 30, max: 180)")]);
-        ("url", `Assoc [("type", `String "string"); ("description", `String "Git repo URL for git_clone op (e.g. 'https://github.com/org/repo'). Clones into .masc/playground/<your_name>/.")]);
+        ("url", `Assoc [("type", `String "string"); ("description", `String "Git repo URL for git_clone op (e.g. 'https://github.com/org/repo'). Clones into sandbox repos/.")]);
       ]);
       ("required", `List [`String "op"]);
     ];
@@ -399,8 +399,8 @@ let coding_keeper_bridge_tools : Types.tool_schema list = [
 NO chaining (&&, ||, ;), NO pipes (|), NO redirects (> >>). \
 Violations are blocked. Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='rg foo | wc -l'. \
-Runs in the keeper playground by default; use cwd to target an explicit allowed directory. \
-Paths resolve automatically — never include '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. \
+Runs in the keeper sandbox by default; use cwd to target an explicit allowed directory. \
+Paths resolve automatically — never include host storage prefixes such as '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. \
 For read-only ops use keeper_shell, for file edits use keeper_fs_edit. \
 Set run_in_background=true for long-running tasks (returns background_task_id; \
 poll with keeper_bash_output, terminate with keeper_bash_kill).";
@@ -408,7 +408,7 @@ poll with keeper_bash_output, terminate with keeper_bash_kill).";
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "Single command only. No chaining/pipe/redirect. Example: 'dune build', 'rg pattern lib/'")]);
-        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for the command. Must stay within keeper playground or an explicit allowed path.")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for the command. Must stay within the keeper sandbox or an explicit allowed path.")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180). For run_in_background=true, 0 disables the timeout.")]);
         ("run_in_background", `Assoc [("type", `String "boolean"); ("description", `String "Default false. When true, returns immediately with background_task_id; poll output via keeper_bash_output, stop via keeper_bash_kill.")]);
       ]);

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -10,6 +10,8 @@ type context = {
 
 type tool_result = bool * string
 
+let default_base_branch = "auto"
+
 (* Individual handlers *)
 let handle_worktree_create ctx args =
   (* LLM may omit agent_name in args; fall back to context agent_name.
@@ -48,7 +50,7 @@ let handle_worktree_create ctx args =
   | Error msg -> (false, msg)
   | Ok agent_name ->
   let raw_task_id = get_string args "task_id" "" in
-  let base_branch = get_string args "base_branch" "develop" in
+  let base_branch = get_string args "base_branch" default_base_branch in
   (* repo_name comes straight from MCP tool args. Reject anything that
      isn't a single safe directory component so it cannot escape
      [.masc/playground/<keeper>/repos/]. Coord.worktree_create_r also
@@ -72,7 +74,7 @@ let handle_worktree_create ctx args =
       ( None,
         Some (Printf.sprintf
           "repo_name %S is invalid. Use a single directory name \
-           under your playground repos/ (e.g. repo_name='masc-mcp'). \
+           under sandbox repos/ (e.g. repo_name='masc-mcp'). \
            Allowed characters: [A-Za-z0-9._-]. No slashes, no \
            path traversal, no '.'/'..' specials." bad) )
   in

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -7,6 +7,8 @@ type context = {
 
 type tool_result = bool * string
 
+val default_base_branch : string
+
 val handle_worktree_create : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_remove : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_list : context -> Yojson.Safe.t -> tool_result

--- a/scripts/validate-prompt-paths.sh
+++ b/scripts/validate-prompt-paths.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # validate-prompt-paths.sh — keeper prompt/config drift gate for #6527.
 #
-# Invariant: every `.worktrees/<...>` reference in config/ must be preceded
-# by a playground prefix (`.masc/playground/.../`). A bare `.worktrees/...`
-# string teaches keepers a server-root relative path that the harness blocks
-# (iter3 cwd_outside_playground / iter6 write_outside_playground_blocked).
+# Invariant: every `.worktrees/<...>` reference in config/ must be inside a
+# keeper sandbox repo path.  The model-facing canonical form is now
+# `repos/<repo>/.worktrees/...`; legacy `.masc/playground/.../repos/...`
+# remains accepted as a compatibility form.  A bare `.worktrees/...` string
+# teaches keepers a server-root relative path that the harness blocks.
 #
 # Re-run locally:
 #   bash scripts/validate-prompt-paths.sh
 #
 # Exit codes:
-#   0 — all .worktrees/ references are playground-prefixed (OK)
+#   0 — all .worktrees/ references are sandbox-repo rooted (OK)
 #   1 — bare .worktrees/... reference found (drift)
 #   2 — required tool missing
 
@@ -49,7 +50,7 @@ done
 drift_hits="$(
   rg --no-heading --with-filename --line-number --color=never \
      '\.worktrees/' "${SEARCH_ROOTS[@]}" \
-    | rg -v '\.masc/playground/' \
+    | rg -v 'repos/[^[:space:]]*\.worktrees/|\.masc/playground/' \
     || true
 )"
 
@@ -59,12 +60,12 @@ if [ -n "$drift_hits" ]; then
 
 Keepers see every config/prompts, config/keepers/*.toml, and config/personas/*
 as part of their system prompt. A bare `.worktrees/<branch>` path is relative
-to the server root, not the keeper playground — the harness rejects it
-as write_outside_playground_blocked / cwd_outside_playground (#6527 iter3/iter6).
+to the server root, not the keeper sandbox — the harness rejects it as outside
+the sandbox boundary.
 
-Every .worktrees reference in config/ MUST be prefixed with the playground
-path, for example:
-  .masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/
+Every .worktrees reference in config/ MUST be rooted in a sandbox repo path,
+for example:
+  repos/<REPO_NAME>/.worktrees/<branch-or-task>/
 
 Offending lines:
 EOF
@@ -74,5 +75,5 @@ EOF
   exit 1
 fi
 
-echo "✓ validate-prompt-paths: all .worktrees/ references are playground-rooted"
+echo "✓ validate-prompt-paths: all .worktrees/ references are sandbox-repo rooted"
 exit 0

--- a/test/dune
+++ b/test/dune
@@ -59,6 +59,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_repo_readiness
         test_keeper_tool_surface_guard
         test_keeper_pr_review
         test_keeper_execution_scope
@@ -168,6 +169,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_repo_readiness
           test_keeper_tool_surface_guard
           test_keeper_pr_review
           test_keeper_execution_scope

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -280,7 +280,14 @@ let test_preflight_exposes_routing_hint_for_high_risk_keeper () =
         (Yojson.Safe.Util.(result |> member "accountability_risk" |> to_bool));
       check string "risk band exposed" "high" (string_member "risk_band" result);
       check string "routing hint exposed" "manual_review_recommended"
-        (string_member "routing_hint" result))
+        (string_member "routing_hint" result);
+      let repo_readiness =
+        Yojson.Safe.Util.(result |> member "repo_readiness")
+      in
+      check string "repo readiness state exposed" "missing_clone"
+        (Yojson.Safe.Util.(repo_readiness |> member "state" |> to_string));
+      check bool "repo readiness blocks code start without clone" false
+        (Yojson.Safe.Util.(repo_readiness |> member "ok" |> to_bool)))
 
 let test_synthetic_claims_do_not_dilute_unsupported_rate () =
   (* Regression: synthetic completion claims (created by task_transition "done")

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -1,11 +1,12 @@
 (** Test suite for Keeper_alerting_path.effective_allowed_paths.
-    Verifies playground-only defaults, wildcard handling, and explicit
+    Verifies single-sandbox defaults, wildcard handling, and explicit
     allowed_paths behavior. Workspace/local scope no longer grants any
     hardcoded repo-root or state paths. *)
 
 open Alcotest
 module KAP = Masc_mcp.Keeper_alerting_path
 module KES = Masc_mcp.Keeper_exec_shared
+module KS = Masc_mcp.Keeper_sandbox
 module KT = Masc_mcp.Keeper_types
 module KTU = Masc_mcp.Keeper_turn_up_args
 
@@ -23,15 +24,13 @@ let make_meta ?(execution_scope = "observe_only") ?(allowed_paths = [])
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
-let playground_bundle name =
-  [ KAP.playground_path_of_keeper name;
-    KAP.playground_mind_path name;
-    KAP.playground_repos_path name ]
+let sandbox_roots name =
+  [ KAP.sandbox_path_of_keeper name ]
 
 (* After #6527 iter 4, `.worktrees/` is no longer a workspace default.
    New worktrees land inside the keeper's own
    `.masc/playground/<keeper>/repos/<clone>/.worktrees/...` and are
-   already covered by the playground bundle paths above. *)
+   already covered by the sandbox root above. *)
 let with_temp_dir prefix f =
   let path = Filename.temp_file prefix "" in
   Sys.remove path;
@@ -53,15 +52,15 @@ let with_temp_dir prefix f =
 let test_observe_only_empty_paths () =
   let meta = make_meta ~execution_scope:"observe_only" ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "observe_only + [] = playground bundle"
-    (playground_bundle "t") effective
+  check (list string) "observe_only + [] = sandbox root"
+    (sandbox_roots "t") effective
 
 let test_observe_only_explicit_paths () =
   let meta = make_meta ~execution_scope:"observe_only"
       ~allowed_paths:["src/"; "lib/"] ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "observe_only + explicit = playground bundle + explicit"
-    (playground_bundle "t" @ ["src/"; "lib/"]) effective
+  check (list string) "observe_only + explicit = sandbox root + explicit"
+    (sandbox_roots "t" @ ["src/"; "lib/"]) effective
 
 (* ── workspace scope ── *)
 
@@ -69,29 +68,29 @@ let test_workspace_empty_paths_playground_only () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"sangsu" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "workspace + [] = playground bundle only"
-    (playground_bundle "sangsu") effective
+  check (list string) "workspace + [] = sandbox root only"
+    (sandbox_roots "sangsu") effective
 
 let test_workspace_explicit_paths () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["src/"; "docs/"] ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "workspace + explicit = playground bundle + explicit"
-    (playground_bundle "t" @ ["src/"; "docs/"]) effective
+  check (list string) "workspace + explicit = sandbox root + explicit"
+    (sandbox_roots "t" @ ["src/"; "docs/"]) effective
 
 let test_workspace_write_paths_playground_only () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"sangsu" () in
   let effective = KAP.effective_write_allowed_paths ~meta in
-  check (list string) "workspace write defaults are playground-only"
-    (playground_bundle "sangsu") effective
+  check (list string) "workspace write defaults are sandbox-only"
+    (sandbox_roots "sangsu") effective
 
 let test_workspace_write_paths_preserve_explicit_overrides () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["workspace/yousleepwhen/oas/"] ~name:"t" () in
   let effective = KAP.effective_write_allowed_paths ~meta in
   check (list string) "explicit write override preserved"
-    (playground_bundle "t" @ ["workspace/yousleepwhen/oas/"]) effective
+    (sandbox_roots "t" @ ["workspace/yousleepwhen/oas/"]) effective
 
 let test_workspace_star_wildcard () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -104,8 +103,8 @@ let test_workspace_star_wildcard () =
 let test_local_empty_paths () =
   let meta = make_meta ~execution_scope:"local" ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "local + [] = playground bundle"
-    (playground_bundle "t") effective
+  check (list string) "local + [] = sandbox root"
+    (sandbox_roots "t") effective
 
 (* ── wildcard handling ── *)
 
@@ -119,22 +118,22 @@ let test_star_wildcard_any_scope () =
 
 let test_explicit_paths_any_scope () =
   let paths = ["lib/keeper/"; "test/"] in
-  let expected = playground_bundle "t" @ ["lib/keeper/"; "test/"] in
+  let expected = sandbox_roots "t" @ ["lib/keeper/"; "test/"] in
   List.iter (fun scope ->
     let meta = make_meta ~execution_scope:scope ~allowed_paths:paths ~name:"t" () in
     let effective = KAP.effective_allowed_paths ~meta in
-    check (list string) (scope ^ " + explicit = playground bundle + explicit")
+    check (list string) (scope ^ " + explicit = sandbox root + explicit")
       expected effective
   ) ["observe_only"; "workspace"; "local"]
 
-(* ── keeper name in playground default ── *)
+(* ── keeper name in sandbox default ── *)
 
 let test_playground_default_uses_keeper_name () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"cdal-formalist" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "name embedded in playground path"
-    (playground_bundle "cdal-formalist") effective
+  check (list string) "name embedded in sandbox path"
+    (sandbox_roots "cdal-formalist") effective
 
 (* ── playground path ── *)
 
@@ -148,7 +147,7 @@ let test_playground_always_present () =
   List.iter (fun scope ->
     let meta = make_meta ~execution_scope:scope ~name:"abc" () in
     let effective = KAP.effective_allowed_paths ~meta in
-    check bool (scope ^ " has playground")
+    check bool (scope ^ " has sandbox root")
       true (List.mem ".masc/playground/abc/" effective)
   ) scopes
 
@@ -206,6 +205,39 @@ let test_default_roots_use_playground_with_full_access () =
       ~allowed_paths:["*"] ~name:"keeper" () in
   check_default_roots_use_playground meta
 
+let test_sandbox_contract_reports_single_tool_root () =
+  let meta = make_meta ~execution_scope:"workspace" ~name:"keeper" () in
+  with_temp_config (fun config ->
+    let sb = KS.of_meta ~config ~meta in
+    check string "sandbox id" "keeper:keeper" sb.sandbox_id;
+    check string "sandbox root arg" "." sb.root_arg;
+    check string "sandbox repos arg" "repos" sb.repos_arg;
+    check string "host root rel uses existing disk layout"
+      ".masc/playground/keeper/" sb.host_root_rel;
+    check (option string) "local has no container root" None sb.container_root)
+
+let test_sandbox_contract_reports_docker_container_root () =
+  let meta =
+    let json = `Assoc [
+      ("name", `String "keeper");
+      ("agent_name", `String "agent-keeper");
+      ("trace_id", `String "trace-keeper");
+      ("goal", `String "test");
+      ("execution_scope", `String "workspace");
+      ("sandbox_profile", `String "docker_hardened");
+      ("network_mode", `String "none");
+    ] in
+    match KT.meta_of_json json with
+    | Ok meta -> meta
+    | Error err -> fail ("docker meta: " ^ err)
+  in
+  with_temp_config (fun config ->
+    let sb = KS.of_meta ~config ~meta in
+    check string "docker backend" "docker_hardened"
+      (KS.backend_to_string sb.backend);
+    check (option string) "docker has private container root"
+      (Some "/home/keeper/playground/keeper") sb.container_root)
+
 (* Error UX: rejection messages must teach the LLM why the path failed,
    not just that it failed. The relative-path case is the common one — bare
    "X not allowed" sends the keeper into a retry loop guessing alternatives.
@@ -223,17 +255,17 @@ let contains_substring ~haystack ~needle =
     in
     scan 0
 
-let test_path_rejection_explains_relative_anchor () =
+let test_path_rejection_explains_sandbox_boundary () =
   let meta = make_meta ~execution_scope:"workspace" ~name:"ani1999" () in
   with_temp_config (fun config ->
     match KES.resolve_keeper_path ~config ~meta ~raw_path:"lib/foo.ml" with
     | Ok path -> fail ("expected rejection for lib/foo.ml, got: " ^ path)
     | Error err ->
       check bool "preserves machine-readable prefix" true
-        (String.starts_with ~prefix:"path_not_in_allowed_paths:" err);
-      check bool "includes relative-anchor explanation" true
+        (String.starts_with ~prefix:"path_outside_sandbox:" err);
+      check bool "includes sandbox-boundary explanation" true
         (contains_substring ~haystack:err
-           ~needle:"relative paths anchor at project root");
+           ~needle:"sandbox boundary");
       check bool "includes resolved candidate" true
         (contains_substring ~haystack:err ~needle:"resolved="))
 
@@ -251,8 +283,8 @@ let test_resolve_keeper_path_blocks_workspace_repo_write_default () =
     match KES.resolve_keeper_path ~config ~meta ~raw_path:"lib/foo.ml" with
     | Ok path -> fail ("expected write rejection, got: " ^ path)
     | Error err ->
-      check bool "rejects repo-root write outside playground" true
-        (String.starts_with ~prefix:"path_not_in_allowed_paths:" err))
+      check bool "rejects repo-root write outside sandbox" true
+        (String.starts_with ~prefix:"path_outside_sandbox:" err))
 
 let test_resolve_keeper_path_allows_playground_write_default () =
   let meta = make_meta ~execution_scope:"workspace" ~name:"keeper" () in
@@ -448,34 +480,41 @@ let () =
     [
       ( "effective_allowed_paths",
         [
-          test_case "observe_only + [] = [playground]" `Quick
+          test_case "observe_only + [] = [sandbox root]" `Quick
             test_observe_only_empty_paths;
-          test_case "observe_only + explicit = playground + explicit" `Quick
+          test_case "observe_only + explicit = sandbox root + explicit" `Quick
             test_observe_only_explicit_paths;
-          test_case "workspace + [] = playground only" `Quick
+          test_case "workspace + [] = sandbox root only" `Quick
             test_workspace_empty_paths_playground_only;
-          test_case "workspace + explicit = playground + explicit" `Quick
+          test_case "workspace + explicit = sandbox root + explicit" `Quick
             test_workspace_explicit_paths;
-          test_case "workspace write defaults are playground-only" `Quick
+          test_case "workspace write defaults are sandbox-only" `Quick
             test_workspace_write_paths_playground_only;
           test_case "workspace write defaults preserve explicit overrides" `Quick
             test_workspace_write_paths_preserve_explicit_overrides;
           test_case "workspace + [*] = full access" `Quick
             test_workspace_star_wildcard;
-          test_case "local + [] = [playground]" `Quick
+          test_case "local + [] = [sandbox root]" `Quick
             test_local_empty_paths;
           test_case "[*] wildcard any scope" `Quick
             test_star_wildcard_any_scope;
           test_case "explicit paths any scope" `Quick
             test_explicit_paths_any_scope;
-          test_case "keeper name in playground default" `Quick
+          test_case "keeper name in sandbox default" `Quick
             test_playground_default_uses_keeper_name;
+        ] );
+      ( "sandbox_contract",
+        [
+          test_case "single local sandbox root" `Quick
+            test_sandbox_contract_reports_single_tool_root;
+          test_case "docker backend reports container root" `Quick
+            test_sandbox_contract_reports_docker_container_root;
         ] );
       ( "playground",
         [
           test_case "path sanitizes keeper name" `Quick
             test_playground_path_sanitizes_name;
-          test_case "playground always in allowed_paths" `Quick
+          test_case "sandbox root always in allowed_paths" `Quick
             test_playground_always_present;
           test_case "ensure playground bundle creates subdirs" `Quick
             test_ensure_playground_bundle_creates_subdirs;
@@ -483,8 +522,8 @@ let () =
             test_default_roots_use_playground_with_explicit_paths;
           test_case "default roots stay in playground with full access" `Quick
             test_default_roots_use_playground_with_full_access;
-          test_case "rejection explains relative-anchor + resolved candidate" `Quick
-            test_path_rejection_explains_relative_anchor;
+          test_case "rejection explains sandbox boundary + resolved candidate" `Quick
+            test_path_rejection_explains_sandbox_boundary;
           test_case "absolute path rejection still works" `Quick
             test_path_rejection_omits_resolved_for_absolute;
           test_case "workspace repo writes blocked by default" `Quick

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -584,6 +584,12 @@ let test_keeper_context_status_reports_recovery_source_and_tiers () =
     in
     check string "recovery source exposed" "progress_log"
       Yojson.Safe.Util.(json |> member "recovery_source" |> to_string);
+    check string "sandbox root is tool-ready" "."
+      Yojson.Safe.Util.(json |> member "sandbox_root" |> to_string);
+    check string "sandbox repos is tool-ready" "repos"
+      Yojson.Safe.Util.(json |> member "sandbox_repos" |> to_string);
+    check string "sandbox backend is local by default" "local"
+      Yojson.Safe.Util.(json |> member "sandbox_backend" |> to_string);
     check int "long-term count exposed" 1
       Yojson.Safe.Util.(json |> member "memory_tier_summary" |> member "long_term" |> to_int))
 

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -1,0 +1,83 @@
+(** Keeper_repo_readiness tests. *)
+
+open Alcotest
+
+let temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec loop n =
+    let path =
+      Filename.concat base
+        (Printf.sprintf "%s-%d-%06d" prefix (Unix.getpid ()) n)
+    in
+    if Sys.file_exists path then loop (n + 1)
+    else (
+      Unix.mkdir path 0o755;
+      path)
+  in
+  loop (Random.int 1_000_000)
+
+let mkdir_p path =
+  let rec ensure dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else (
+      ensure (Filename.dirname dir);
+      Unix.mkdir dir 0o755)
+  in
+  ensure path
+
+let json_bool key json =
+  Yojson.Safe.Util.(json |> member key |> to_bool)
+
+let json_string key json =
+  Yojson.Safe.Util.(json |> member key |> to_string)
+
+let test_missing_clone () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "missing_clone" (json_string "state" json);
+  check string "repo_name" "masc-mcp" (json_string "repo_name" json);
+  check bool "exists" false (json_bool "exists" json)
+
+let test_non_git_clone () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let clone_path =
+    Masc_mcp.Keeper_repo_readiness.clone_path ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp"
+  in
+  mkdir_p clone_path;
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "not_git_repo" (json_string "state" json);
+  check bool "exists" true (json_bool "exists" json);
+  check bool "is_git_repo" false (json_bool "is_git_repo" json)
+
+let test_invalid_repo_name () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"../escape" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "invalid_repo_name" (json_string "state" json)
+
+let () =
+  Random.self_init ();
+  run "Keeper_repo_readiness"
+    [
+      "inspect",
+      [
+        test_case "missing clone" `Quick test_missing_clone;
+        test_case "non-git clone" `Quick test_non_git_clone;
+        test_case "invalid repo_name" `Quick test_invalid_repo_name;
+      ];
+    ]

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -375,9 +375,9 @@ let test_path_allowed_paths_filter () =
       ~config ~allowed_paths:["lib"] ~raw_path:"src/bar.ml" in
     check bool "src path rejected" true (Result.is_error err_result);
     let err = Result.get_error err_result in
-    check bool "error mentions allowed_paths" true
+    check bool "error mentions sandbox boundary" true
       (try let _ = Str.search_forward
-        (Str.regexp_string "path_not_in_allowed_paths") err 0 in true
+        (Str.regexp_string "path_outside_sandbox") err 0 in true
        with Not_found -> false)))
 
 let test_path_allowed_paths_filter_strips_all_trailing_slashes () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -712,11 +712,15 @@ let test_prompt_includes_operational_tool_guidance () =
   check bool "mentions server-managed heartbeat" true
     (contains_substring sys "Heartbeat is server-managed")
 
-let test_capabilities_prompt_distinguishes_playground_and_worktree () =
+let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.capabilities" in
-  check bool "playground paths documented" true
-    (contains_substring prompt ".masc/playground/");
-  check bool "playground is default coding workspace" true
+  check bool "sandbox paths documented" true
+    (contains_substring prompt "sandbox_repos");
+  check bool "local backend host path not model-facing" false
+    (contains_substring prompt "ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground");
+  check bool "github shorthand removed" false
+    (contains_substring prompt "keeper_github");
+  check bool "sandbox is default coding workspace" true
     (contains_substring prompt "default coding workspace");
   check bool "git path documented via keeper_bash" true
     (contains_substring prompt "keeper_bash cmd='git status'");
@@ -725,18 +729,18 @@ let test_capabilities_prompt_distinguishes_playground_and_worktree () =
   check bool "legacy pr workflow removed from prompt" false
     (contains_substring prompt "keeper_pr_workflow")
 
-let test_world_prompt_distinguishes_playground_and_worktree () =
+let test_world_prompt_distinguishes_sandbox_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.world" in
-  check bool "world prompt names playground sandbox" true
-    (contains_substring prompt "Playground is your default sandbox");
+  check bool "world prompt names single sandbox" true
+    (contains_substring prompt "Your sandbox is the only filesystem ground");
   (* Keep the containment clause asserted so bare server-root `.worktrees/...`
      paths cannot drift back in. *)
-  check bool "world prompt names worktree workflow inside playground" true
+  check bool "world prompt names worktree workflow inside sandbox" true
     (contains_substring prompt
-       "Repo worktrees live *inside* your playground clone");
-  check bool "world prompt names canonical playground-rooted worktree path" true
+       "Repo worktrees live *inside* your sandbox clone");
+  check bool "world prompt names canonical sandbox-relative worktree path" true
     (contains_substring prompt
-       ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
+       "repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
 
 let test_system_prompt_prefers_bash_and_gh_pr_lane () =
   let sys =
@@ -757,6 +761,8 @@ let test_system_prompt_prefers_bash_and_gh_pr_lane () =
   check bool "mentions gh create path" true
     (contains_substring sys
        "keeper_shell op=gh (PR/issues via gh CLI; after git push");
+  check bool "does not advertise removed keeper_github" false
+    (contains_substring sys "keeper_github");
   check bool "legacy pr workflow removed" false
     (contains_substring sys "keeper_pr_workflow")
 
@@ -3371,10 +3377,10 @@ let () =
             test_prompt_mentions_extend_turns_guidance;
           test_case "includes operational tool guidance" `Quick
             test_prompt_includes_operational_tool_guidance;
-          test_case "distinguishes playground and worktree" `Quick
-            test_capabilities_prompt_distinguishes_playground_and_worktree;
-          test_case "world prompt distinguishes playground and worktree" `Quick
-            test_world_prompt_distinguishes_playground_and_worktree;
+          test_case "distinguishes sandbox and worktree" `Quick
+            test_capabilities_prompt_distinguishes_sandbox_and_worktree;
+          test_case "world prompt distinguishes sandbox and worktree" `Quick
+            test_world_prompt_distinguishes_sandbox_and_worktree;
           test_case "prefers submit over legacy workflow" `Quick
             test_system_prompt_prefers_bash_and_gh_pr_lane;
           test_case "includes autonomous trigger section" `Quick

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -54,6 +54,13 @@ let test_path_error_is_normalized () =
   check string "path boundary error normalized"
     "path_not_in_allowed_paths" (classify output)
 
+let test_sandbox_path_error_is_normalized () =
+  let output =
+    {|{"ok":false,"error":"path_outside_sandbox: lib/foo.ml (sandbox roots: [/tmp/demo])"}|}
+  in
+  check string "sandbox path boundary error normalized"
+    "path_outside_sandbox" (classify output)
+
 let test_message_error_is_normalized () =
   let output =
     {|{"status":"error","message":"query looks like it may contain secrets; refine it before using web search"}|}
@@ -95,6 +102,8 @@ let () =
            test_case "no error key -> unknown_error" `Quick test_no_error_key_is_unknown;
            test_case "nested JSON after prefix" `Quick test_nested_json_in_error_prefix;
            test_case "path error normalized" `Quick test_path_error_is_normalized;
+           test_case "sandbox path error normalized" `Quick
+             test_sandbox_path_error_is_normalized;
            test_case "message-only error normalized" `Quick test_message_error_is_normalized;
            test_case "signaled status classified" `Quick test_signaled_status_is_classified;
            test_case "timeout error preserved" `Quick test_timeout_error_is_preserved;

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -21,11 +21,13 @@ let test_get_string_missing () =
 
 let test_get_string_base_branch () =
   let args = `Assoc [("base_branch", `String "main")] in
-  check string "extracts branch" "main" (Tool_args.get_string args "base_branch" "develop")
+  check string "extracts branch" "main"
+    (Tool_args.get_string args "base_branch" Tool_worktree.default_base_branch)
 
 let test_get_string_base_branch_default () =
   let args = `Assoc [] in
-  check string "uses develop default" "develop" (Tool_args.get_string args "base_branch" "develop")
+  check string "uses auto default" "auto"
+    (Tool_args.get_string args "base_branch" Tool_worktree.default_base_branch)
 
 (* ============================================================
    Context Creation Tests


### PR DESCRIPTION
## Summary
- Adds `Keeper_sandbox` as the single keeper sandbox contract over existing local/Docker storage.
- Exposes sandbox-relative context fields (`sandbox_root`, `sandbox_mind`, `sandbox_repos`, backend/profile metadata) while keeping `playground_*` as compatibility aliases.
- Collapses default keeper effective paths to one sandbox root and updates prompts/tool docs away from project-root/playground confusion and stale `keeper_github` guidance.
- Surfaces sandbox context in keeper status/detail and updates prompt path drift validation for sandbox-relative worktrees.

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-sandbox-contract lib/masc_mcp.cmxa`
- `bash scripts/validate-prompt-paths.sh`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-sandbox-contract test/test_keeper_allowed_paths.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-sandbox-contract test/test_keeper_unified.exe -- test unified_prompt 4-6`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-sandbox-contract test/test_keeper_memory.exe -- test recovery_context 1`
- Docker smoke:
  - `docker info`
  - `docker image inspect ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff`
  - `docker run ... --network none -v <worktree>:/home/keeper/playground/smoke:ro --workdir /home/keeper/playground/smoke ... pwd`
  - `docker run ... --network none -v <worktree>:/home/keeper/playground/smoke:ro --workdir /home/keeper/playground/smoke ... ls dune-project`

## Caveat
- A full `dune build --root ...` after rebasing hit stale test artifact/interface mismatch errors around `Keeper_exec_shell` in unrelated test executables. A clean library build and focused touched suites pass.