### PR TITLE
feat(bonsai-dashboard): hero page_sub live + heartbeat bar tooltips

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1379,13 +1379,25 @@ let heartbeat_bars : (int * [ `Info | `Warn | `Error | `Idle ]) list =
 ;;
 
 let view_heartbeat () =
-  let bar (height, level) =
+  let bar i (height, level) =
     let cls =
       match level with
       | `Warn -> Some Style.heartbeat_bar_warn
       | `Error -> Some Style.heartbeat_bar_error
       | `Idle -> Some Style.heartbeat_bar_idle
       | `Info -> None
+    in
+    let level_name =
+      match level with
+      | `Warn -> "WARN"
+      | `Error -> "ERROR"
+      | `Idle -> "idle"
+      | `Info -> "info"
+    in
+    let total = List.length heartbeat_bars in
+    let t_ago = total - 1 - i in
+    let tip =
+      Printf.sprintf "t-%d · %s · ticks %d" t_ago level_name height
     in
     let base_attrs =
       match cls with
@@ -1396,7 +1408,8 @@ let view_heartbeat () =
     let style =
       Attr.style (Css_gen.create ~field:"height" ~value:(Printf.sprintf "%dpx" h))
     in
-    Node.div ~attrs:(style :: base_attrs) []
+    let title_attr = Attr.create "title" tip in
+    Node.div ~attrs:(title_attr :: style :: base_attrs) []
   in
   Node.div
     ~attrs:[ Style.heartbeat ]
@@ -1411,7 +1424,7 @@ let view_heartbeat () =
         ]
     ; Node.div
         ~attrs:[ Style.heartbeat_track ]
-        (List.map ~f:bar heartbeat_bars)
+        (List.mapi ~f:bar heartbeat_bars)
     ]
 ;;
 
@@ -1760,27 +1773,41 @@ let render_response (response : Logs_types.response) : Node.t =
     ; brand_row
     ; view_heartbeat ()
     ; view_hud response
-    ; Node.div
-        ~attrs:[ Style.page_head ]
-        [ Node.div
-            ~attrs:[ Style.page_head_lead ]
-            [ Node.div
-                ~attrs:[ Style.page_tag ]
-                [ Node.text "chronicle · quiet fox · day iv" ]
-            ; Node.h1
-                ~attrs:[ Style.page_h1 ]
-                [ Node.text "the watch "
-                ; Node.span
-                    ~attrs:[ Style.page_h1_blood ]
-                    [ Node.text "under storm" ]
-                ]
-            ; Node.p
-                ~attrs:[ Style.page_sub ]
-                [ Node.text
-                    "네 명의 키퍼가 홀을 지킨다. Luna는 세 번째 종에 \
-                     응답했고, DM은 폭풍이 서쪽 동을 봉하는 장면을 서술한다."
-                ]
-            ]
+    ; (let warn_n =
+         List.count response.entries ~f:(fun e ->
+           String.equal e.normalized_level "WARN")
+       in
+       let err_n =
+         List.count response.entries ~f:(fun e ->
+           String.equal e.normalized_level "ERROR")
+       in
+       let sub_text =
+         match response.entries with
+         | [] ->
+           "저택은 조용하다. 아무도 아직 말하지 않았고, 폭풍은 아직 문을 두드리지 않았다."
+         | _ ->
+           Printf.sprintf
+             "네 명의 키퍼가 홀을 지킨다. 마지막 %d행을 들었고, 경보 %d · 경고 %d이 울렸다."
+             response.total
+             err_n
+             warn_n
+       in
+       Node.div
+         ~attrs:[ Style.page_head ]
+         [ Node.div
+             ~attrs:[ Style.page_head_lead ]
+             [ Node.div
+                 ~attrs:[ Style.page_tag ]
+                 [ Node.text "chronicle · quiet fox · day iv" ]
+             ; Node.h1
+                 ~attrs:[ Style.page_h1 ]
+                 [ Node.text "the watch "
+                 ; Node.span
+                     ~attrs:[ Style.page_h1_blood ]
+                     [ Node.text "under storm" ]
+                 ]
+             ; Node.p ~attrs:[ Style.page_sub ] [ Node.text sub_text ]
+             ]
         ; Node.div
             ~attrs:[ Style.page_actions ]
             [ Node.button
@@ -1794,7 +1821,7 @@ let render_response (response : Logs_types.response) : Node.t =
                 ; Node.text "advance round"
                 ]
             ]
-        ]
+        ])
     ; moonrise
     ; toolbar
     ; Node.div


### PR DESCRIPTION
## Summary

data + UX 두 갈래 개선을 한 PR에 묶는다.

### data — hero `page_sub` live

지금까지 hero 서술문은 static ("네 명의 키퍼가 홀을 지킨다. Luna는 세 번째 종에..."). 이제 **실 response 카운트**로 매 갱신마다 재생성:

| 상황 | 문구 |
|---|---|
| `entries = []` | "저택은 조용하다. 아무도 아직 말하지 않았고, 폭풍은 아직 문을 두드리지 않았다." |
| 있음 | "네 명의 키퍼가 홀을 지킨다. 마지막 **%d**행을 들었고, 경보 **%d** · 경고 **%d**이 울렸다." |

- `response.total` / `ERROR count` / `WARN count` — 모두 기존 entries에서 유도.
- 키퍼 수는 아직 `"네 명의"` 고정 — roster endpoint 미도입.

### UX — heartbeat bar native tooltip

60개 pulse bar에 `title` 속성 부여. 브라우저 기본 tooltip이라 **추가 CSS/JS 없이 hover로 즉시**:

```
t-47 · WARN · ticks 41
t-12 · info · ticks 22
t-3  · ERROR · ticks 72
```

- `List.mapi`로 index → `t_ago = total - 1 - i` 매핑 (오래된 것부터 왼쪽에 있는 현재 배치와 일치).
- level name: `WARN` / `ERROR` (대문자, 로그 level 와 동일) · `idle` / `info` (소문자, 배경 상태).

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 hero 밑에 "경보 X · 경고 Y" 숫자가 HUD seq up to N과 정합
- [ ] entries 없는 상태(서버 막 기동)에서는 quiet state 문구
- [ ] heartbeat bar 60개 모두 hover에 native tooltip 등장

## 남은 live/UX 작업

- `"네 명의"` 고정 문구 → `roster endpoint` 또는 `keeper_status Var` 연결.
- action button `preflight` / `advance round`에 실 핸들러.
- moonrise의 `base=/tmp/masc-bonsai-dev` 도 실 config 값.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
