### PR TITLE
RFC-0006 Phase A.1: Keeper_tool_alias data module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -458,6 +458,7 @@
    keeper_hooks_oas
    keeper_extend_turns
    keeper_llm_bridge
+   keeper_tool_alias
    keeper_tool_disclosure
    keeper_turn_telemetry
    keeper_approval_queue
@@ -629,6 +630,7 @@
   keeper_rollover
   keeper_approval_queue
   keeper_post_turn
+  keeper_tool_alias
   keeper_tool_disclosure
   keeper_turn_telemetry
   keeper_exec_context

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -1,0 +1,57 @@
+(** Keeper_tool_alias — see .mli for contract.
+
+    The mapping below is the single source of truth for LLM-facing tool
+    surface naming. Reviewers: any change here must keep [to_public]
+    total (every internal name has a defined behavior) and
+    [to_internal] partial (only Anthropic-Code cognates resolve). *)
+
+(* (public_name, internal_name).
+   Keep alphabetical by public name to make diffs reviewable. *)
+let aliases : (string * string) list =
+  [
+    "Bash", "keeper_bash";
+    "Edit", "keeper_fs_edit";
+    "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.2 *)
+    "Read", "keeper_fs_read";
+    "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
+  ]
+
+(* Anthropic Code surface names without a keeper cognate. The disclosure
+   check should not nuke a turn solely because these appeared — instead a
+   teaching tool_result tells the LLM what surface to use. RFC-0006 §3.1. *)
+let hallucinated_builtins =
+  [ "Agent"; "Skill"; "WebSearch"; "WebFetch"; "TodoWrite"; "NotebookEdit" ]
+
+let public_to_internal_tbl =
+  let t = Hashtbl.create (List.length aliases) in
+  List.iter (fun (pub, internal) -> Hashtbl.replace t pub internal) aliases;
+  t
+
+let internal_to_public_tbl =
+  (* When two public names share an internal target (Edit/Write -> keeper_fs_edit)
+     the first occurrence wins so [to_public] is stable. *)
+  let t = Hashtbl.create (List.length aliases) in
+  List.iter
+    (fun (pub, internal) ->
+      if not (Hashtbl.mem t internal) then Hashtbl.replace t internal pub)
+    aliases;
+  t
+
+let to_internal name = Hashtbl.find_opt public_to_internal_tbl name
+
+let to_public internal =
+  match Hashtbl.find_opt internal_to_public_tbl internal with
+  | Some public -> public
+  | None -> internal
+
+let canonicalize_observed names =
+  List.map (fun n -> match to_internal n with Some i -> i | None -> n) names
+
+let hallucinated_set =
+  let t = Hashtbl.create (List.length hallucinated_builtins) in
+  List.iter (fun n -> Hashtbl.replace t n ()) hallucinated_builtins;
+  t
+
+let is_hallucinated_builtin name = Hashtbl.mem hallucinated_set name
+
+let all_aliases () = aliases

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -1,0 +1,49 @@
+(** Keeper_tool_alias — bidirectional map between LLM-facing tool names
+    (Anthropic Code built-ins like [Bash], [Read]) and the internal
+    keeper surface names ([keeper_bash], [keeper_fs_read], ...).
+
+    Phase A of RFC-0006. This module is data-only; no runtime path
+    consults it yet. Subsequent PRs will:
+
+    - register the public names with OAS so the LLM can call [Bash]
+      successfully (Phase A.2);
+    - canonicalize via [to_internal] before the disclosure check in
+      [keeper_agent_run.ml:1875] so [Bash] resolves to [keeper_bash]
+      and is not flagged unexpected (Phase A.3).
+
+    The internal name remains the SSOT for metrics, decisions.jsonl,
+    audit logs and dashboards. *)
+
+(** [to_internal public_name] returns the internal [keeper_*] name when
+    [public_name] is a known alias. Returns [None] otherwise.
+
+    Examples: [to_internal "Bash" = Some "keeper_bash"],
+    [to_internal "Skill" = None] (no cognate; surface should emit a
+    teaching error per RFC-0006 §3.1). *)
+val to_internal : string -> string option
+
+(** [to_public internal_name] returns the LLM-facing alias for an
+    internal [keeper_*] tool. Falls back to [internal_name] verbatim
+    when the tool has no Anthropic Code cognate (board/task/etc.). *)
+val to_public : string -> string
+
+(** [canonicalize_observed names] maps every recognized public alias
+    to its internal name and leaves all other names untouched. Used
+    by the disclosure check to treat [Bash] as [keeper_bash] when
+    counting unexpected tools. *)
+val canonicalize_observed : string list -> string list
+
+(** [hallucinated_builtins] lists the public names from the Anthropic
+    Code surface that have **no** cognate in the keeper surface
+    (e.g. [Skill], [Agent], [WebSearch]). These should be flagged with
+    a teaching message rather than nuking the turn. *)
+val hallucinated_builtins : string list
+
+(** [is_hallucinated_builtin name] is [true] iff [name] appears in
+    [hallucinated_builtins]. *)
+val is_hallucinated_builtin : string -> bool
+
+(** [all_aliases ()] returns the full alias table as
+    [(public, internal)] pairs. Stable order; suitable for tests and
+    documentation generation. *)
+val all_aliases : unit -> (string * string) list

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,7 @@
         test_approval_callback_wired
         test_keeper_discovered_tools
         test_keeper_tool_affinity
+        test_keeper_tool_alias
         test_keeper_github_read_only
         test_worktree_live_context
         test_tool_input_validation
@@ -195,6 +196,7 @@
           test_approval_callback_wired
           test_keeper_discovered_tools
           test_keeper_tool_affinity
+          test_keeper_tool_alias
           test_keeper_github_read_only
           test_worktree_live_context
           test_tool_input_validation

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -1,0 +1,104 @@
+(** Tests for Keeper_tool_alias.
+
+    Phase A.1 of RFC-0006. The module is data-only at this point;
+    these tests pin the alias table so subsequent runtime wiring
+    (Phase A.2/A.3) can rely on stable contracts. *)
+
+module Alias = Masc_mcp.Keeper_tool_alias
+
+let test_known_aliases_resolve () =
+  Alcotest.(check (option string)) "Bash -> keeper_bash"
+    (Some "keeper_bash") (Alias.to_internal "Bash");
+  Alcotest.(check (option string)) "Read -> keeper_fs_read"
+    (Some "keeper_fs_read") (Alias.to_internal "Read");
+  Alcotest.(check (option string)) "Edit -> keeper_fs_edit"
+    (Some "keeper_fs_edit") (Alias.to_internal "Edit");
+  Alcotest.(check (option string)) "Write -> keeper_fs_edit"
+    (Some "keeper_fs_edit") (Alias.to_internal "Write");
+  Alcotest.(check (option string)) "Grep -> keeper_shell"
+    (Some "keeper_shell") (Alias.to_internal "Grep")
+
+let test_unknown_returns_none () =
+  Alcotest.(check (option string)) "Skill has no cognate"
+    None (Alias.to_internal "Skill");
+  Alcotest.(check (option string)) "keeper_bash is internal, not public"
+    None (Alias.to_internal "keeper_bash");
+  Alcotest.(check (option string)) "empty string"
+    None (Alias.to_internal "");
+  Alcotest.(check (option string)) "case sensitive"
+    None (Alias.to_internal "bash")
+
+let test_to_public_round_trip () =
+  Alcotest.(check string) "keeper_bash -> Bash"
+    "Bash" (Alias.to_public "keeper_bash");
+  Alcotest.(check string) "keeper_fs_read -> Read"
+    "Read" (Alias.to_public "keeper_fs_read");
+  Alcotest.(check string) "keeper_shell -> Grep"
+    "Grep" (Alias.to_public "keeper_shell");
+  (* Edit/Write collapse: first occurrence wins for stability *)
+  Alcotest.(check string) "keeper_fs_edit -> Edit (first wins)"
+    "Edit" (Alias.to_public "keeper_fs_edit")
+
+let test_to_public_pass_through () =
+  (* Tools without an Anthropic Code cognate should fall through verbatim. *)
+  Alcotest.(check string) "keeper_board_post passes through"
+    "keeper_board_post" (Alias.to_public "keeper_board_post");
+  Alcotest.(check string) "unknown name passes through"
+    "anything" (Alias.to_public "anything")
+
+let test_canonicalize_observed () =
+  let input = [ "Bash"; "keeper_board_post"; "Read"; "Skill"; "Write" ] in
+  let expected =
+    [ "keeper_bash"; "keeper_board_post"; "keeper_fs_read"; "Skill"; "keeper_fs_edit" ]
+  in
+  Alcotest.(check (list string)) "mixed list canonicalizes only known aliases"
+    expected (Alias.canonicalize_observed input)
+
+let test_hallucinated_builtins () =
+  Alcotest.(check bool) "Skill is hallucinated"
+    true (Alias.is_hallucinated_builtin "Skill");
+  Alcotest.(check bool) "Agent is hallucinated"
+    true (Alias.is_hallucinated_builtin "Agent");
+  Alcotest.(check bool) "WebSearch is hallucinated"
+    true (Alias.is_hallucinated_builtin "WebSearch");
+  Alcotest.(check bool) "Bash is NOT hallucinated (has cognate)"
+    false (Alias.is_hallucinated_builtin "Bash");
+  Alcotest.(check bool) "keeper_bash is NOT hallucinated"
+    false (Alias.is_hallucinated_builtin "keeper_bash")
+
+let test_no_overlap_alias_and_hallucinated () =
+  let aliased = List.map fst (Alias.all_aliases ()) in
+  List.iter
+    (fun b ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s must not appear in alias table" b)
+         false (List.mem b aliased))
+    Alias.hallucinated_builtins
+
+let test_alias_table_is_stable () =
+  let pairs = Alias.all_aliases () in
+  Alcotest.(check int) "five canonical aliases" 5 (List.length pairs);
+  (* Round-trip: every alias should round-trip via to_internal then to_public,
+     except where collapse happens (Write -> keeper_fs_edit -> Edit). *)
+  List.iter
+    (fun (public, internal) ->
+       Alcotest.(check (option string))
+         (Printf.sprintf "%s resolves to %s" public internal)
+         (Some internal) (Alias.to_internal public))
+    pairs
+
+let () =
+  Alcotest.run "Keeper_tool_alias"
+    [
+      ( "alias-table",
+        [
+          Alcotest.test_case "known aliases resolve" `Quick test_known_aliases_resolve;
+          Alcotest.test_case "unknown returns None" `Quick test_unknown_returns_none;
+          Alcotest.test_case "to_public round-trip" `Quick test_to_public_round_trip;
+          Alcotest.test_case "to_public pass-through" `Quick test_to_public_pass_through;
+          Alcotest.test_case "canonicalize_observed" `Quick test_canonicalize_observed;
+          Alcotest.test_case "hallucinated builtins" `Quick test_hallucinated_builtins;
+          Alcotest.test_case "no overlap" `Quick test_no_overlap_alias_and_hallucinated;
+          Alcotest.test_case "table is stable" `Quick test_alias_table_is_stable;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
First step of RFC-0006 (#8854, RFC PR #8853): introduce the bidirectional alias table between LLM-facing Anthropic Code names and the internal \`keeper_*\` surface.

**Data-only**. No runtime path consults this module yet. That lands in:
- Phase A.2 — OAS dual registration so the LLM can call \`Bash\` and the SDK actually dispatches.
- Phase A.3 — canonicalize tool names at \`keeper_agent_run.ml:1875\` so an all-hallucinated turn no longer hard-fails.

Splitting like this keeps the alias table reviewable in isolation.

## Why this is not the full fix
Shipping just this PR will **not** reduce the 18% turn loss in #8778 — the disclosure check still nukes turns. The follow-up Phase A.2 / A.3 PRs will. This PR is the contract everyone else can rely on.

## Alias table

| Public (LLM) | Internal (keeper) |
|--------------|--------------------|
| Bash         | keeper_bash        |
| Edit         | keeper_fs_edit     |
| Grep         | keeper_shell       |
| Read         | keeper_fs_read     |
| Write        | keeper_fs_edit     |

\`Skill\`, \`Agent\`, \`WebSearch\`, \`WebFetch\`, \`TodoWrite\`, \`NotebookEdit\` have no cognate and are listed as \`hallucinated_builtins\` so Phase A.3 can emit a teaching error instead of a hard fail.

## Test plan
- [x] \`dune build @check\` passes.
- [x] \`dune runtest test/test_keeper_tool_alias.exe\`: 8 / 8 pass.
- [ ] CI required checks green.

## Follow-ups
- Phase A.2: OAS dual registration in \`tool_shard.ml\` + dispatch route.
- Phase A.3: canonicalize observed names at the disclosure check.
- Phase B-1: minjae-only docker exec for Read/Grep/keeper_shell.

## Refs
- RFC PR #8853
- Tracking issue #8854
- Predecessor #8778

🤖 Generated with [Claude Code](https://claude.com/claude-code)