### PR TITLE
refactor(oas+keeper): publish_keeper_lifecycle string -> lifecycle_event variant (#8856)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1911,12 +1911,15 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     m
 ;;
 
-let publish_keeper_lifecycle ?phase ~event ~keeper_name ~detail () : unit =
+(* #8856: hook takes the unified
+   [Keeper_lifecycle_events.lifecycle_event] variant. *)
+let publish_keeper_lifecycle
+    ~(event : Keeper_lifecycle_events.lifecycle_event)
+    ~keeper_name ~detail () : unit =
   match get_bus () with
   | Some bus ->
     Oas_events.publish_keeper_lifecycle
       bus
-      ?phase
       ~event
       ~keeper_name
       ~detail
@@ -1924,21 +1927,18 @@ let publish_keeper_lifecycle ?phase ~event ~keeper_name ~detail () : unit =
   | None -> ()
 ;;
 
-(** Issue #8572: phase-derived event helper.
-
-    Use this when the lifecycle event name is the phase itself
-    (e.g. [Stopped → "stopped"]). Keeps [event_to_string] from being
-    hand-recomputed at every call site, eliminating the
-    [~phase:Stopped ~event:"crashed"]-style typo class. *)
+(** Phase-event helper: the wire event name IS the phase name. *)
 let publish_keeper_phase_lifecycle ~phase ~keeper_name ~detail () : unit =
-  let event = Keeper_state_machine.phase_to_string phase in
-  publish_keeper_lifecycle ~phase ~event ~keeper_name ~detail ()
+  publish_keeper_lifecycle
+    ~event:(Keeper_lifecycle_events.Phase_event phase)
+    ~keeper_name ~detail ()
 ;;
 
 let publish_keeper_started ~(live_meta : keeper_meta) : unit =
   publish_keeper_lifecycle
-    ~phase:Keeper_state_machine.Running
-    ~event:"started"
+    ~event:(Keeper_lifecycle_events.Custom_event
+              { verb = Keeper_lifecycle_events.Started;
+                phase = Some Keeper_state_machine.Running })
     ~keeper_name:live_meta.name
     ~detail:"keepalive"
     ()

--- a/lib/keeper/keeper_lifecycle_events.ml
+++ b/lib/keeper/keeper_lifecycle_events.ml
@@ -71,3 +71,42 @@ let phase_derived_event_strings : string list =
     half the lifecycle stream. *)
 let all_event_names : string list =
   valid_custom_event_strings @ phase_derived_event_strings
+
+(** {1 Unified lifecycle event sum type (#8856 / #8605 family)}
+
+    [publish_keeper_lifecycle] previously took [event:string ?phase] --
+    a typo at any of the supervisor/keepalive call sites silently
+    landed on the bus as a garbage event name. The runtime SSOT test
+    in [test_types.ml :: lifecycle_events_ssot] caught drift at CI
+    time but not at compile time.
+
+    This sum type unifies the two pre-existing typed vocabularies
+    ([t] for the 6 custom verbs, [Keeper_state_machine.phase] for the
+    4 phase-derived names) so the wire string is computed inside
+    [Oas_events.publish_keeper_lifecycle] from a fully-typed argument.
+    A typo at the call site is now a build error.
+
+    Note: importing [Keeper_state_machine] here breaks the
+    "dependency-free" claim in the module-level docstring above. The
+    trade-off is intentional -- the type-level coupling is essentially
+    free (no runtime FSM behaviour pulled in) and gives compile-time
+    typo elimination for the entire wire vocabulary. *)
+(* The legacy [?phase:_ ~event:_] surface allowed a Custom verb to
+   carry a phase context (e.g. ~event:"started" ~phase:Running emits
+   event="started" phase="running" on the wire). The [Custom_event]
+   constructor preserves this; [Phase_event] is the case where the
+   wire event name IS the phase. The two cases produce different JSON
+   payloads (Phase_event emits the phase string in BOTH "event" and
+   "phase" fields; Custom_event emits the verb in "event" and the
+   optional phase in "phase"). *)
+type lifecycle_event =
+  | Custom_event of { verb : t; phase : Keeper_state_machine.phase option }
+  | Phase_event of Keeper_state_machine.phase
+
+let lifecycle_event_to_string = function
+  | Custom_event { verb; _ } -> to_string verb
+  | Phase_event p -> Keeper_state_machine.phase_to_string p
+
+let lifecycle_event_phase = function
+  | Custom_event { phase; _ } -> phase
+  | Phase_event p -> Some p

--- a/lib/keeper/keeper_lifecycle_events.mli
+++ b/lib/keeper/keeper_lifecycle_events.mli
@@ -22,3 +22,17 @@ val phase_derived_event_strings : string list
 (** Custom + phase-derived. Subscribe to this whole list to avoid
     silently missing half the supervisor stream. *)
 val all_event_names : string list
+
+(** {1 Unified lifecycle event sum type (#8856)}
+
+    Wire vocabulary for [Oas_events.publish_keeper_lifecycle]. The
+    [Custom_event] case carries an optional phase context that the
+    legacy [?phase] argument used to provide; [Phase_event] is the case
+    where the wire event name IS the phase name. *)
+type lifecycle_event =
+  | Custom_event of { verb : t; phase : Keeper_state_machine.phase option }
+  | Phase_event of Keeper_state_machine.phase
+
+val lifecycle_event_to_string : lifecycle_event -> string
+val lifecycle_event_phase :
+  lifecycle_event -> Keeper_state_machine.phase option

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -68,26 +68,25 @@ let committed_tools_of_ambiguous_blocker (blocker : string) =
 
 (* ── Event publishing ────────────────────────────────────── *)
 
-let publish_lifecycle ?phase event_name keeper_name detail () =
+(* #8856 / #8605 family: single helper takes the unified
+   [Keeper_lifecycle_events.lifecycle_event] variant. The legacy
+   [publish_lifecycle ?phase event_name] (string event_name) and
+   [publish_phase_lifecycle ~phase] are folded into [publish_lifecycle
+   ~event] -- the compiler now enforces that every call site picks
+   either Custom_event (with optional phase context) or Phase_event,
+   eliminating the [~phase:Stopped ~event:"crashed"] typo class
+   originally addressed at runtime by #8572 / #8575. *)
+let publish_lifecycle
+    ~(event : Keeper_lifecycle_events.lifecycle_event) keeper_name detail () =
   match Keeper_keepalive.get_bus () with
   | Some bus ->
-      Oas_events.publish_keeper_lifecycle bus ~event:event_name
-        ?phase ~keeper_name ~detail ()
+      Oas_events.publish_keeper_lifecycle bus ~event ~keeper_name ~detail ()
   | None -> ()
 
-(** Issue #8572: derive the wire [event] string from [phase] so the
-    Variant SSOT stays the only source of truth.
-
-    The legacy [publish_lifecycle ~phase event_name …] still works for
-    the named custom-event sites ([dead_cleaned] / [self_preservation]
-    / [paused_pruned]) that genuinely have no phase. Phase-bearing
-    sites should call this helper instead so that renaming a phase in
-    [Keeper_state_machine] flows to every observer automatically — no
-    chance of [~phase:Stopped "crashed"]-style typo emitting a
-    contradiction. *)
+(** Phase-event helper: the wire event name IS the phase name. *)
 let publish_phase_lifecycle ~phase keeper_name detail () =
-  let event_name = Keeper_state_machine.phase_to_string phase in
-  publish_lifecycle ~phase event_name keeper_name detail ()
+  publish_lifecycle ~event:(Keeper_lifecycle_events.Phase_event phase)
+    keeper_name detail ()
 
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
@@ -237,8 +236,11 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name
       live_meta;
     launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg;
-    publish_lifecycle ~phase:Keeper_state_machine.Running
-      "started" meta.name "supervised" ()
+    publish_lifecycle
+      ~event:(Keeper_lifecycle_events.Custom_event
+                { verb = Keeper_lifecycle_events.Started;
+                  phase = Some Keeper_state_machine.Running })
+      meta.name "supervised" ()
   end
 
 let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
@@ -359,8 +361,11 @@ let reconcile_keepalive_keepers (ctx : _ context) =
              if not dominated_by_sweep then begin
                supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
                if Keeper_registry.is_running ~base_path meta.name then begin
-                 publish_lifecycle ~phase:Keeper_state_machine.Running
-                   "reconciled" meta.name "durable keeper" ();
+                 publish_lifecycle
+                   ~event:(Keeper_lifecycle_events.Custom_event
+                             { verb = Keeper_lifecycle_events.Reconciled;
+                               phase = Some Keeper_state_machine.Running })
+                   meta.name "durable keeper" ();
                  Log.Keeper.info "%s: reconciled durable keeper" meta.name
                end
              end
@@ -389,20 +394,31 @@ let cleanup_dead_tombstone (ctx : _ context)
       in
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
       if persisted_paused then begin
-        publish_lifecycle "dead_cleaned" entry.name "paused meta persisted" ();
+        publish_lifecycle
+          ~event:(Keeper_lifecycle_events.Custom_event
+                    { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+          entry.name "paused meta persisted" ();
         Log.Keeper.info "%s: dead tombstone cleaned up" entry.name
       end else begin
-        publish_lifecycle "dead_cleaned" entry.name
-          "meta write failed, unregistered anyway" ();
+        publish_lifecycle
+          ~event:(Keeper_lifecycle_events.Custom_event
+                    { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+          entry.name "meta write failed, unregistered anyway" ();
         Log.Keeper.warn "%s: dead tombstone unregistered despite meta write failure" entry.name
       end
   | Ok None ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-      publish_lifecycle "dead_cleaned" entry.name "meta missing" ();
+      publish_lifecycle
+        ~event:(Keeper_lifecycle_events.Custom_event
+                  { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name "meta missing" ();
       Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name
   | Error err ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-      publish_lifecycle "dead_cleaned" entry.name
+      publish_lifecycle
+        ~event:(Keeper_lifecycle_events.Custom_event
+                  { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name
         (Printf.sprintf "meta read error: %s" err) ();
       Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)"
         entry.name err
@@ -444,7 +460,11 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
       Log.Keeper.warn
         "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s)"
         (List.length dominant_entries) n_total ratio dominant_key;
-      publish_lifecycle "self_preservation" "supervisor"
+      publish_lifecycle
+        ~event:(Keeper_lifecycle_events.Custom_event
+                  { verb = Keeper_lifecycle_events.Self_preservation;
+                    phase = None })
+        "supervisor"
         (Printf.sprintf "%d/%d suppressed, cohort=%s"
            (List.length dominant_entries) n_total dominant_key) ();
       Keeper_crash_persistence.enqueue_sp_event
@@ -547,8 +567,11 @@ let sweep_and_recover (ctx : _ context) =
           ~restart_count:attempt ~last_restart_ts:now
           ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
         launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg;
-        publish_lifecycle ~phase:Keeper_state_machine.Running
-          "restarted" old_entry.name
+        publish_lifecycle
+          ~event:(Keeper_lifecycle_events.Custom_event
+                    { verb = Keeper_lifecycle_events.Restarted;
+                      phase = Some Keeper_state_machine.Running })
+          old_entry.name
           (Printf.sprintf "attempt %d" attempt) ();
         Log.Keeper.info "%s: restarted (attempt %d, backoff %.0fs)"
           old_entry.name attempt (backoff_delay (attempt - 1))
@@ -587,7 +610,11 @@ let sweep_and_recover (ctx : _ context) =
                let path = Keeper_types.keeper_meta_path ctx.config name in
                (try
                   Sys.remove path;
-                  publish_lifecycle "paused_pruned" name
+                  publish_lifecycle
+                    ~event:(Keeper_lifecycle_events.Custom_event
+                              { verb = Keeper_lifecycle_events.Paused_pruned;
+                                phase = None })
+                    name
                     (Printf.sprintf "last_updated=%s" meta.updated_at) ();
                   Log.Keeper.info "%s: stale paused meta pruned" name
                 with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -152,16 +152,27 @@ let publish_keeper_snapshot (_bus : Agent_sdk.Event_bus.t) ~keeper_name
     stream; the sync test in [test_types.ml ::
     lifecycle_events_ssot] asserts every literal still emitted by
     [Keeper_supervisor] / [Keeper_keepalive] lives in the SSOT. *)
-let publish_keeper_lifecycle (_bus : Agent_sdk.Event_bus.t) ?phase ~event
+(* #8856 / #8605 family: [event] is now the unified
+   [Keeper_lifecycle_events.lifecycle_event] variant -- typos at the
+   16 supervisor/keepalive call sites fail to compile. JSON wire
+   format ("event" + optional "phase" field) is preserved
+   bit-identically:
+     - Custom_event { verb; phase = None }  -> event=verb, phase=null
+     - Custom_event { verb; phase = Some p } -> event=verb, phase=p
+     - Phase_event p                          -> event=p, phase=p
+   The legacy ?phase optional argument is folded into the variant. *)
+let publish_keeper_lifecycle (_bus : Agent_sdk.Event_bus.t)
+    ~(event : Keeper_lifecycle_events.lifecycle_event)
     ~keeper_name ~detail () =
   let phase_json =
-    match phase with
+    match Keeper_lifecycle_events.lifecycle_event_phase event with
     | Some phase ->
       `String (Keeper_state_machine.phase_to_string phase)
     | None -> `Null
   in
+  let event_str = Keeper_lifecycle_events.lifecycle_event_to_string event in
   let payload = `Assoc [
-    ("event", `String event);
+    ("event", `String event_str);
     ("keeper_name", `String keeper_name);
     ("phase", phase_json);
     ("detail", `String detail);

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -117,9 +117,10 @@ let test_event_bus_keeper_lifecycle_includes_phase () =
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_keeper_lifecycle bus
-    ~event:"started"
+    ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
+              { verb = Masc_mcp.Keeper_lifecycle_events.Started;
+                phase = Some Masc_mcp.Keeper_state_machine.Running })
     ~keeper_name:"keeper-a"
-    ~phase:Masc_mcp.Keeper_state_machine.Running
     ~detail:"supervised"
     ();
   let events = Event_bus.drain sub in
@@ -172,9 +173,10 @@ let test_keeper_lifecycle_envelope_agent_name () =
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_keeper_lifecycle bus
-    ~event:"started"
+    ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
+              { verb = Masc_mcp.Keeper_lifecycle_events.Started;
+                phase = Some Masc_mcp.Keeper_state_machine.Running })
     ~keeper_name:"masc-improver"
-    ~phase:Masc_mcp.Keeper_state_machine.Running
     ~detail:"supervised"
     ();
   let events = Event_bus.drain sub in
@@ -264,9 +266,10 @@ let test_oas_sse_bridge_broadcasts_lifecycle_to_observers () =
             Oas_sse_bridge.start_with_interval ~drain_interval_s:0.1
               ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
             Oas_events.publish_keeper_lifecycle bus
-              ~event:"started"
+              ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
+                        { verb = Masc_mcp.Keeper_lifecycle_events.Started;
+                          phase = Some Masc_mcp.Keeper_state_machine.Running })
               ~keeper_name:"keeper-a"
-              ~phase:Masc_mcp.Keeper_state_machine.Running
               ~detail:"supervised"
               ();
             Eio.Time.sleep (Eio.Stdenv.clock env) 0.6;


### PR DESCRIPTION
## Summary

Closes **#8856** — the highest-fan-out #8605 family migration in the current sweep. \`Oas_events.publish_keeper_lifecycle\` previously took \`(?phase ~event:string)\` — a typo at any of the supervisor/keepalive call sites silently landed on the bus as a garbage event name. The runtime SSOT test (\`test_types.ml :: lifecycle_events_ssot\`) caught drift at CI time but **not at compile time**.

Quoting the existing in-tree motivation:
- #8572: *\"so that renaming a phase in [Keeper_state_machine] flows to every observer automatically — no chance of [~phase:Stopped \"crashed\"]-style typo emitting a contradiction.\"*
- #8575: *\"This module pins the vocabulary in one place.\"*

This PR closes the loop at the type system.

## Sum type unification

```ocaml
type lifecycle_event =
  | Custom_event of { verb : t; phase : Keeper_state_machine.phase option }
  | Phase_event of Keeper_state_machine.phase
```

Preserves the legacy JSON dual-emit semantics (the \`?phase\` parameter could be set alongside a Custom verb to attach phase context):

| Variant | event field | phase field |
|---|---|---|
| `Custom_event { verb; phase = None }` | verb | `null` |
| `Custom_event { verb; phase = Some p }` | verb | phase string |
| `Phase_event p` | phase string | phase string |

## Footprint

- \`lib/keeper/keeper_lifecycle_events.ml\` (+ \`.mli\`) — variant + helpers (\`lifecycle_event_to_string\`, \`lifecycle_event_phase\`).
- \`lib/oas_events.ml\` — signature change (\`?phase\` folded into variant).
- \`lib/keeper/keeper_supervisor.ml\` — helper collapse + 8 call sites migrated (3 dual-emit Custom+Phase, 5 Custom-only, plus 5 phase-helper sites unchanged).
- \`lib/keeper/keeper_keepalive.ml\` — helper collapse + \`publish_keeper_started\` migrated.
- \`test/test_oas_integration.ml\` — 3 call sites updated.

## Behaviour preservation

- JSON wire format on \`\"masc.keeper.lifecycle\"\` preserved bit-identically.
- `test_types.ml :: lifecycle_events_ssot` 4/4 pass (kept as belt-and-suspenders).
- `test_oas_integration.ml` 21/21 pass.

## Compile-time gate now active

- Adding a new `Keeper_lifecycle_events.t` verb forces an update to `lifecycle_event_to_string` and `all_custom_events`.
- Adding a new `Keeper_state_machine.phase` forces consideration at every `Phase_event` call site.
- A typo at the call site no longer compiles instead of landing on the bus as garbage.

## Test plan

```
dune build @check                                    # green
./_build/default/test/test_oas_integration.exe       # 21/21
./_build/default/test/test_types.exe                 # 116/116 (incl. lifecycle_events_ssot 4/4)
```

## Pattern siblings

9th #8605 family fix in the current sweep. Same string→variant template as **#8842** (`agent_lifecycle_event`), **#8846** (`Coord_hooks.observe_task_transition_fn`), **#8851** (`Oas_events.publish_task_transition`). This is the highest-fan-out instance (16 call sites in 2 modules + scaffold tests).