### PR TITLE
feat(bonsai-dashboard): URL hash -> data-theme switcher

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -1,7 +1,58 @@
 open! Core
 open! Bonsai_web
+open Js_of_ocaml
+
+(* URL hash로 data-theme 선택. colors_and_type.css가 이미 SPA head에
+   :root palette 5종을 공급하므로 <html data-theme="..."> 한 줄로 전체
+   팔레트가 즉시 전환된다.
+
+   해시 예:
+     http://127.0.0.1:8935/dashboard/b/#cyberpunk
+     http://127.0.0.1:8935/dashboard/b/#terminal
+     http://127.0.0.1:8935/dashboard/b/#dark (또는 해시 없음)
+
+   hashchange 이벤트도 listen해 전환을 즉시 반영한다. 세션 간 persistence는
+   아직 없음 (localStorage 미사용) — URL이 SSOT. *)
+
+let normalize_theme_token s =
+  match String.lowercase s with
+  | "cyber" | "cyberpunk" -> Some "cyberpunk"
+  | "term" | "terminal" -> Some "terminal"
+  | "parchment" -> Some "parchment"
+  | "paper" -> Some "paper"
+  | "dark" | "dark-fantasy" -> Some "dark-fantasy"
+  | _ -> None
+;;
+
+let current_hash_theme () =
+  let hash = Js.to_string Dom_html.window##.location##.hash in
+  match String.chop_prefix hash ~prefix:"#" with
+  | None -> None
+  | Some "" -> None
+  | Some rest -> normalize_theme_token rest
+;;
+
+let apply_theme theme =
+  Dom_html.document##.documentElement##setAttribute
+    (Js.string "data-theme")
+    (Js.string theme)
+;;
+
+let install_theme_listener () =
+  (match current_hash_theme () with
+   | Some t -> apply_theme t
+   | None -> ());
+  let on_hashchange _ =
+    (match current_hash_theme () with
+     | Some t -> apply_theme t
+     | None -> apply_theme "dark-fantasy");
+    Js._true
+  in
+  Dom_html.window##.onhashchange := Dom_html.handler on_hashchange
+;;
 
 let () =
+  install_theme_listener ();
   Start.start ~bind_to_element_with_id:"app" Dashboard_bonsai_lib.App.root;
   Dashboard_bonsai_lib.Logs_fetch.run ();
   Dashboard_bonsai_lib.Logs_fetch.start_polling ()


### PR DESCRIPTION
## Summary

#8848에서 깔린 `:root` 토큰 공급선 + #8861의 `var(--*)` 치환 위에 **URL 해시 기반 data-theme 스위처** 도입. 첫 실제 테마 전환 엔트리포인트.

## 사용

```
/dashboard/b/#cyberpunk   → neon violet + cyan
/dashboard/b/#terminal    → CRT green
/dashboard/b/#parchment   → warm scholar
/dashboard/b/#paper       → light docs inversion
/dashboard/b/  (no hash)  → dark-fantasy (default)
```

북마크/공유 URL만으로 테마 고정 가능. SSOT = URL.

## 동작

1. **초기 parse**: `Start.start` 전에 `install_theme_listener` 호출 → 첫 paint부터 올바른 팔레트 적용 (flash-of-wrong-theme 없음)
2. **hashchange listener**: `window.onhashchange` 등록 → 해시 바꾸는 즉시 `<html data-theme="...">` 업데이트
3. **fallback**: 빈 해시로 돌아가면 `dark-fantasy`로 복원
4. **normalize**: `cyber` ↔ `cyberpunk`, `term` ↔ `terminal`, `dark` ↔ `dark-fantasy` 단축어 허용

## 구현

- `dashboard_bonsai/bin/main.ml` 51줄 추가
- js_of_ocaml의 `Dom_html.window##.location##.hash` / `Dom_html.document##.documentElement##setAttribute` 직접 사용 — Bonsai state machine 경유 안 함 (document root 조작이라 local state로 모델링 부적합)
- 의존성 추가 없음 (`js_of_ocaml` 이미 dep)

## 남음

- nav_foot 또는 footer에 chip UI (5개 테마 중 클릭) → URL hash 업데이트
- localStorage 백업 (URL 없이도 이전 선택 기억)
- action on operator 조합 — admin만 테마 전환 같은 통제

## Test plan

- [x] `dune build --root .` (bonsai-dashboard switch) — 62MB
- [ ] `/dashboard/b/#cyberpunk` 로드 → 보라/시안 팔레트
- [ ] `/dashboard/b/#terminal` → CRT 초록
- [ ] 해시 없이 로드 → dark-fantasy default
- [ ] DevTools Console에서 `location.hash = '#paper'` → 즉시 light 팔레트 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)
