### PR TITLE
fix(checkpoint_store): exhaustive classify_sdk_error + Sdk_other_error variant (#8605 family)

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -249,6 +249,12 @@ type checkpoint_load_error =
   | Store_error of string
   | Parse_error of string
   | Io_error of string
+  (** Catch-all for SDK errors outside the Io / Serialization families
+      (Api / Agent / Mcp / Config / Orchestration / A2a / Internal).
+      Distinct from Io_error so observers can tell a local
+      checkpoint-store I/O failure apart from an SDK-level failure that
+      surfaced during a load. (#8605 family) *)
+  | Sdk_other_error of string
 
 (* Checkpoint-load failures classify as [Not_found] only when the
    underlying SDK error is genuinely "this file does not exist on first
@@ -293,6 +299,14 @@ let is_not_found_detail (detail : string) : bool =
   || String.starts_with ~prefix:"eio.io fs not_found" d  (* Eio.Io (Fs Not_found _) *)
   || has_substring d "no such file or directory"
 
+(* #8605 family: exhaustive on Agent_sdk.Error.sdk_error top-level
+   variants. The previous wildcard collapsed Api / Agent / Mcp / Config
+   / Orchestration / A2a / Internal errors into Io_error, hiding
+   non-IO failures from the dashboard. The wildcards on Io _ and
+   Serialization _ remain narrow (one level deep) so future inner
+   variants land in the semantically correct category, but a future
+   top-level sdk_error variant becomes a build error and forces a
+   deliberate routing decision. *)
 let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   match e with
   | Io (FileOpFailed r) ->
@@ -304,7 +318,9 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
       Parse_error (sprintf "version mismatch: expected %d, got %d" r.expected r.got)
   | Serialization (UnknownVariant r) ->
       Parse_error (sprintf "unknown variant %s: %s" r.type_name r.value)
-  | _ -> Io_error (Agent_sdk.Error.to_string e)
+  | Api _ | Agent _ | Mcp _ | Config _
+  | Orchestration _ | A2a _ | Internal _ ->
+      Sdk_other_error (Agent_sdk.Error.to_string e)
 
 let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
     (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1237,6 +1237,8 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
        Log.Keeper.error "keeper:%s OAS checkpoint store error: %s" trace_id detail
    | Error (Io_error detail) ->
        Log.Keeper.error "keeper:%s OAS checkpoint I/O error: %s" trace_id detail
+   | Error (Sdk_other_error detail) ->
+       Log.Keeper.error "keeper:%s OAS checkpoint SDK error: %s" trace_id detail
    | Error Not_found | Ok _ -> ());
   let oas_checkpoint = Result.to_option oas_result in
   let legacy_checkpoint =

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -329,7 +329,7 @@ let recover_latest_checkpoint_for_overflow_retry
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
   in
   (match oas_result with
-   | Error (Parse_error d | Store_error d | Io_error d) ->
+   | Error (Parse_error d | Store_error d | Io_error d | Sdk_other_error d) ->
        Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
          (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d
    | Error Not_found | Ok _ -> ());

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1368,6 +1368,7 @@ let test_keeper_checkpoint_store_oas_missing_returns_none () =
               | Parse_error d -> "parse:" ^ d
               | Store_error d -> "store:" ^ d
               | Io_error d -> "io:" ^ d
+              | Sdk_other_error d -> "sdk_other:" ^ d
               | Not_found -> "not_found"))))
 
 let test_keeper_checkpoint_store_writes_oas_history () =


### PR DESCRIPTION
## Summary

`Keeper_checkpoint_store.classify_sdk_error` (\`lib/keeper/keeper_checkpoint_store.ml:296-307\`) used `_ -> Io_error (...)` to catch every `Agent_sdk.Error.sdk_error` variant outside `Io` and `Serialization`. The wildcard collapsed **`Api / Agent / Mcp / Config / Orchestration / A2a / Internal`** errors into `Io_error` — so non-IO SDK failures landed on the dashboard tagged \"I/O error\", hiding their real category from operators.

## Two-tier exhaustive fix

**New `checkpoint_load_error` constructor**:
```ocaml
| Sdk_other_error of string
  (** Catch-all for SDK errors outside the Io / Serialization families
      (Api / Agent / Mcp / Config / Orchestration / A2a / Internal).
      Distinct from Io_error so observers can tell a local
      checkpoint-store I/O failure apart from an SDK-level failure that
      surfaced during a load. *)
```

**`classify_sdk_error` becomes exhaustive at the top level**:
```ocaml
| Api _ | Agent _ | Mcp _ | Config _
| Orchestration _ | A2a _ | Internal _ ->
    Sdk_other_error (Agent_sdk.Error.to_string e)
```

Inner `Io _` and `Serialization _` wildcards stay narrow (one level deep) so future inner variants land in the semantically correct category. Adding a future top-level `sdk_error` variant becomes a build error.

## Compiler-guided downstream fixes

The exhaustive change forced 3 downstream consumers to learn the new constructor (proof the wildcard had been hiding the same category drift everywhere):

| Site | Change |
|---|---|
| `keeper_context_core.ml:1240` (OAS load logger) | Added `Error (Sdk_other_error d) -> Log.Keeper.error \"...SDK error: %s\"` |
| `keeper_post_turn.ml:332` (overflow retry logger) | Extended or-pattern: `Parse_error d \| Store_error d \| Io_error d \| Sdk_other_error d` |
| `test/test_oas_worker.ml:1370` (assertion fallback message) | Added `Sdk_other_error d -> \"sdk_other:\" ^ d` |

Each consumer was using `_` for errors before, so behaviour is identical at runtime — but the compiler had to confirm every site actually has a deliberate plan for the new case.

## Test plan

```
dune build @check                           # green
./_build/default/test/test_oas_worker.exe   # 62/62 pass
```

## Pattern siblings

10th #8605 family fix in the current sweep. Same exhaustive-match template as **#8835** (`live_turn_phase`) but applied to an external SDK type, with a new domain constructor (`Sdk_other_error`) absorbing cases that don't fit the existing categories.