### PR TITLE
docs(types): batch-2 .mli for a2a/backend/meta_cognition types (3 files)

### DIFF
--- a/lib/a2a_types.mli
+++ b/lib/a2a_types.mli
@@ -1,0 +1,92 @@
+(** A2A MCP Tools — A2A Protocol wrapped as MCP tools.
+
+    Enables MCP clients (Claude Code, Cursor) to perform A2A-style
+    agent-to-agent communication without a separate gRPC client.
+
+    @see <https://github.com/google/A2A> A2A specification *)
+
+(** {1 Delegate artifact} *)
+
+type artifact = {
+  name : string;
+  mime_type : string;
+  data : string;  (** base64 encoded or raw text *)
+}
+[@@deriving yojson, show]
+
+(** {1 Delegate task types} *)
+
+type task_type =
+  | Sync    (** Wait for completion. *)
+  | Async   (** Return immediately with task ID. *)
+  | Stream  (** Stream results as they arrive. *)
+[@@deriving show]
+
+val task_type_of_string : string -> (task_type, string) result
+
+(** {1 Delegate result} *)
+
+type delegate_result = {
+  task_id : string;
+  status : string;
+  result : string option;
+  artifacts : artifact list;
+}
+[@@deriving yojson, show]
+
+(** {1 Subscription event types} *)
+
+type event_type =
+  | TaskUpdate
+  | Broadcast
+  | Completion
+  | Error
+  | HeartbeatTask
+      (** Agent embodiment request — Worker should invoke MODEL. *)
+[@@deriving show]
+
+val event_type_of_string : string -> (event_type, string) result
+
+(** {1 A2A v0.3 Task State Machine}
+
+    @see <https://a2a-protocol.org/latest/specification/> *)
+
+type a2a_task_state =
+  | Working         (** Processing in progress. *)
+  | Completed       (** Successfully finished. *)
+  | Failed          (** Processing error. *)
+  | Canceled        (** Client-requested cancellation. *)
+  | Rejected        (** Server rejected execution. *)
+  | Input_required  (** Awaiting additional client input. *)
+  | Auth_required   (** Awaiting client authentication. *)
+[@@deriving show]
+
+val a2a_task_state_to_string : a2a_task_state -> string
+
+val a2a_task_state_of_string : string -> (a2a_task_state, string) result
+
+(** Map MASC internal task status to A2A v0.3 state.
+
+    - [Todo]/[Claimed]/[InProgress]/[AwaitingVerification] → [Working]
+    - [Done] → [Completed]
+    - [Cancelled] → [Canceled] *)
+val masc_status_to_a2a : Types.task_status -> a2a_task_state
+
+(** {1 A2A v0.3 Task Status object} *)
+
+type a2a_task_status = {
+  state : a2a_task_state;
+  timestamp : string;
+  message : string option;
+}
+
+val a2a_task_status_to_json : a2a_task_status -> Yojson.Safe.t
+
+(** {1 A2A protocol version} *)
+
+(** Default version string when no header is supplied. *)
+val default_a2a_version : string
+
+(** [parse_a2a_version header]: returns the trimmed header value when
+    present and non-empty; otherwise returns {!default_a2a_version}. *)
+val parse_a2a_version : string option -> string

--- a/lib/backend/backend_types.mli
+++ b/lib/backend/backend_types.mli
@@ -1,0 +1,91 @@
+(** Backend_types — shared types for Backend modules.
+
+    Single source of truth for error types, config, and shared utilities
+    used by all [_eio] backend implementations. *)
+
+(** {1 Error Types — no silent failures} *)
+
+type error =
+  | NotFound of string
+  | AlreadyExists of string
+  | IOError of string
+  | InvalidKey of string
+  | ConnectionFailed of string
+  | BackendNotSupported of string
+[@@deriving show]
+
+(** Result alias pinned to [error]. *)
+type 'a result = ('a, error) Stdlib.result
+
+(** {1 Backend selection} *)
+
+type backend_type =
+  | Memory
+  | FileSystem
+[@@deriving show, eq]
+
+(** {1 Health} *)
+
+type health_result = {
+  latency_ms : float;
+  is_healthy : bool;
+}
+
+(** {1 Config} *)
+
+type config = {
+  backend_type : backend_type;
+  base_path : string;
+  node_id : string;
+  cluster_name : string;
+  pubsub_max_messages : int;
+}
+
+(** Currently returns a fixed literal (1000). Kept as a function to
+    allow future env-var override without API change. *)
+val pubsub_max_messages_from_env : unit -> int
+
+(** Generate a node identifier of the form
+    ["<hostname>-<pid>-<rand4hex>"], suitable for
+    single-instance disambiguation in logs. *)
+val generate_node_id : unit -> string
+
+(** Default config: [FileSystem] backend rooted at [".masc"], cluster
+    ["default"], and [pubsub_max_messages = pubsub_max_messages_from_env ()]. *)
+val default_config : config
+
+(** {1 Status reporting} *)
+
+(** Serialise [config] as a JSON object — [backend_type] is rendered
+    as ["memory"] or ["filesystem"]; [pubsub_max_messages] is omitted. *)
+val get_status : config -> Yojson.Safe.t
+
+(** {1 Safety utilities} *)
+
+(** Clamp [ttl_seconds] to [1 .. Masc_time_constants.day_int]. Non-positive
+    inputs collapse to [1]; values above 24h collapse to [day_int]. *)
+val validate_ttl : int -> int
+
+(** [acquire_flock fd]: [Unix.F_TLOCK] — non-blocking exclusive lock.
+    Returns [true] on success, [false] on [EAGAIN]/[EACCES] or any other error. *)
+val acquire_flock : Unix.file_descr -> bool
+
+(** Best-effort release — logs a warning on failure. *)
+val release_flock : Unix.file_descr -> unit
+
+(** {1 In-Memory Pub/Sub} shared by Memory + FileSystem backends. *)
+module Pubsub_mem : sig
+  type t
+
+  val create : unit -> t
+
+  (** [publish t ~channel ~message] invokes every subscriber callback on
+      [channel] with [message]. Returns the number of subscribers notified
+      ([Ok 0] when no subscribers). Subscriber exceptions are logged;
+      [Eio.Cancel.Cancelled] is re-raised. *)
+  val publish : t -> channel:string -> message:string -> int result
+
+  (** Append [callback] to the subscriber list for [channel]. *)
+  val subscribe :
+    t -> channel:string -> callback:(string -> unit) -> unit result
+end

--- a/lib/meta_cognition_types.mli
+++ b/lib/meta_cognition_types.mli
@@ -1,0 +1,152 @@
+(** Meta_cognition_types — types and utilities for room-level meta-cognition.
+
+    Shared type definitions and leaf utility functions used across the
+    meta-cognition sub-modules.
+
+    @since God file decomposition — extracted from [meta_cognition.ml]. *)
+
+(** {1 Source evidence} *)
+
+type source = {
+  ref_id : string;
+  author : string;
+  text : string;
+  created_at : float;
+  hearth : string option;
+  target_author : string option;
+}
+
+type governance_case = {
+  id : string;
+  title : string;
+  status : string;
+}
+
+(** {1 Rule predicates (callback-bearing)} *)
+
+type belief_rule = {
+  id : string;
+  claim : string;
+  support : source -> bool;
+  challenge : source -> bool;
+}
+
+type tension_rule = {
+  id : string;
+  topic : string;
+  kind : string;
+  matches : source -> bool;
+}
+
+type desire_rule = {
+  id : string;
+  desired_state : string;
+  desire_type : string;
+  actionability : string;
+  matches : source -> bool;
+}
+
+(** {1 Social graph} *)
+
+type social_edge = {
+  from_agent : string;
+  to_agent : string;
+  edge_type : string;
+  weight : int;
+  evidence_refs : string list;
+  last_seen_at : float;
+}
+
+(** {1 Aggregated summaries} *)
+
+type belief_summary = {
+  id : string option;
+  claim : string option;
+  status : string option;
+  confidence : float option;
+  support_agent_count : int option;
+  challenge_agent_count : int option;
+  evidence_refs : string list;
+  challenge_refs : string list;
+}
+
+type tension_summary = {
+  id : string option;
+  topic : string option;
+  kind : string option;
+  severity : string option;
+  recurrence_count : int option;
+  needs_operator : bool;
+  evidence_refs : string list;
+}
+
+type desire_summary = {
+  id : string option;
+  desired_state : string option;
+  desire_type : string option;
+  actionability : string option;
+  strength : float option;
+  evidence_refs : string list;
+}
+
+type summary_input = {
+  stagnation_score : float;
+  belief_count : int;
+  contested_belief_count : int;
+  dominant_belief : belief_summary option;
+  top_tension : tension_summary option;
+  top_desire : desire_summary option;
+}
+
+(** {1 Salience classification} *)
+
+type salience =
+  | Stable
+  | Contested_belief
+  | Operator_tension
+  | Operator_desire
+  | Stagnant_room
+
+type interpretation = {
+  primary_salience : salience;
+  secondary_saliences : salience list;
+  reason : string;
+  target_id : string option;
+  evidence_refs : string list;
+}
+
+type digest_ref = {
+  post_id : string;
+  title : string;
+  created_at : string;
+  updated_at : string option;
+  hearth : string option;
+  digest_key : string;
+  matches_summary : bool;
+}
+
+(** {1 Leaf utilities} *)
+
+(** [take n xs]: first [n] elements of [xs], or the whole list when
+    [n >= List.length xs]. Returns [[]] for [n <= 0]. *)
+val take : int -> 'a list -> 'a list
+
+(** Trim, drop empty, and dedup a list of strings (ASCII compare order). *)
+val unique_non_empty : string list -> string list
+
+(** [clamp ~min_v ~max_v v] clips [v] into the closed interval [[min_v, max_v]]. *)
+val clamp : min_v:'a -> max_v:'a -> 'a -> 'a
+
+val salience_to_string : salience -> string
+
+(** [preview ?max_len text] collapses newlines to spaces and truncates to
+    roughly [max_len] bytes (default 120), appending ["…"] when clipped.
+    Uses {!String_util.utf8_safe} so multi-byte boundaries are preserved. *)
+val preview : ?max_len:int -> string -> string
+
+(** Case-insensitive substring match. *)
+val contains_ci : string -> string -> bool
+
+(** [contains_any_ci haystack needles] is [true] when any of [needles]
+    is a case-insensitive substring of [haystack]. *)
+val contains_any_ci : string -> string list -> bool


### PR DESCRIPTION
## Summary

Wave 3 batch 2 — `.mli` 3개 파일 추가 (mid-size types 모듈). 바디 무수정.

## 대상 파일 (3개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/a2a_types.mli` | 130 | 93 | 5 variant + 3 record + state machine + A2A v0.3 mapping |
| `lib/backend/backend_types.mli` | 139 | 90 | error + config + health + nested Pubsub_mem |
| `lib/meta_cognition_types.mli` | 164 | 146 | 10 record + salience variant + 6 leaf util |

## 설계 노트

### backend_types
- `Pubsub_mem` nested sig: `type t` abstract + `create/publish/subscribe` 공개.
- 공유 `type 'a result = ('a, error) Stdlib.result` alias가 Pubsub_mem sig 안에서 `int result`, `unit result` 로 참조됨 (1-arg 적용).
- `default_config` 값 노출 (.ml 모듈 수준 let binding 그대로).

### a2a_types
- `[@@deriving yojson, show]` 유지 → ppx가 `artifact_of_yojson`, `show_artifact` 등 자동 생성.
- MASC → A2A v0.3 state mapping (`masc_status_to_a2a`) 공개.
- task_state 7개 constructor, event_type 5개 constructor 노출.

### meta_cognition_types
- `belief_rule`, `tension_rule`, `desire_rule` 은 함수형 필드(`source -> bool`) 포함한 predicate record. mli에 그대로 복사.
- 6개 leaf util (`take`, `unique_non_empty`, `clamp`, `preview`, `contains_ci`, `contains_any_ci`).
- `@since God file decomposition` 주석 유지.

## 검증

- `dune build --root=.` → **exit 0**
- 외부 consumer (test/ + lib/coord/ + lib/operator/) 컴파일 유지.

## 현재까지 진행

| 누적 PR | 파일 수 | 상태 |
|---------|---------|------|
| #8821 (response.mli, Wave 3 첫 파일) | 1 | MERGED |
| #8847 (post_verifier.mli) | 1 | MERGED |
| #8859 (batch-1 pure-types 6개) | 6 | MERGED |
| **#이 PR (batch-2)** | **3** | Open |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 297 | **300** |
| Wave 3 진행 | 8/113 (7.08%) | **11/113 (9.73%)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] `[@@deriving X]` 유지 (ppx 호환)
- [x] 에러 유형·생성자·필드명 ml과 1:1 매칭
- [x] hype 금지 (정량치만)

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
