### PR TITLE
fix(sdk_tool_contract): param_type_of_schema — split into strict _opt + warning wrapper (#8832)

### DIFF
--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -366,15 +366,33 @@ let rec validate_json_value ?label schema value =
 let validate_input_json schema json =
   validate_json_value ~label:"input" schema json
 
-let param_type_of_schema schema =
+(* Strict classifier: returns [None] for unknown JSON Schema wire types
+   so callers can distinguish "rule fired" from "fall-through default".
+   See #8832. *)
+let param_type_of_schema_opt schema : Agent_sdk.Types.param_type option =
   match schema_type schema with
-  | "string" -> Agent_sdk.Types.String
-  | "integer" -> Agent_sdk.Types.Integer
-  | "number" -> Agent_sdk.Types.Number
-  | "boolean" -> Agent_sdk.Types.Boolean
-  | "array" -> Agent_sdk.Types.Array
-  | "object" -> Agent_sdk.Types.Object
-  | _ -> Agent_sdk.Types.String
+  | "string" -> Some Agent_sdk.Types.String
+  | "integer" -> Some Agent_sdk.Types.Integer
+  | "number" -> Some Agent_sdk.Types.Number
+  | "boolean" -> Some Agent_sdk.Types.Boolean
+  | "array" -> Some Agent_sdk.Types.Array
+  | "object" -> Some Agent_sdk.Types.Object
+  | _ -> None
+
+(* Back-compat wrapper: warns on unknown wire type and falls back to
+   [String] (the legacy permissive default). The explicit warn converts
+   the silent #8605-family fallback into an observable signal without
+   changing the classification result. New callers should prefer
+   [param_type_of_schema_opt] and decide how to handle [None]
+   explicitly. *)
+let param_type_of_schema schema =
+  match param_type_of_schema_opt schema with
+  | Some t -> t
+  | None ->
+      Log.Misc.warn
+        "param_type_of_schema: unknown JSON Schema type %S -> String (drift; see #8832)"
+        (schema_type schema);
+      Agent_sdk.Types.String
 
 let tool_params_of_input_schema schema =
   let required = required_names schema in

--- a/test/dune
+++ b/test/dune
@@ -44,6 +44,7 @@
         test_multi_room test_worktree_detection test_bounded test_mention
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier
+        test_param_type_of_schema
         test_keeper_cascade_profile
         test_keeper_hooks_oas_provider
         test_keeper_memory
@@ -152,6 +153,7 @@
           test_multi_room test_worktree_detection test_bounded test_mention
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier
+          test_param_type_of_schema
           test_keeper_cascade_profile
           test_keeper_hooks_oas_provider
           test_keeper_memory

--- a/test/test_param_type_of_schema.ml
+++ b/test/test_param_type_of_schema.ml
@@ -1,0 +1,101 @@
+(* Test param_type_of_schema_opt (strict) and param_type_of_schema
+   (back-compat with warn). Fixes #8832. *)
+
+open Alcotest
+
+module Sdk = Masc_mcp.Sdk_tool_contract
+module Types = Agent_sdk.Types
+
+let param_type_testable =
+  let pp fmt t =
+    let s =
+      match t with
+      | Types.String -> "String"
+      | Types.Integer -> "Integer"
+      | Types.Number -> "Number"
+      | Types.Boolean -> "Boolean"
+      | Types.Array -> "Array"
+      | Types.Object -> "Object"
+    in
+    Format.fprintf fmt "%s" s
+  in
+  testable pp ( = )
+
+(* Build a minimal JSON Schema with the given "type" field. *)
+let schema_with_type wire : Yojson.Safe.t =
+  `Assoc [ ("type", `String wire) ]
+
+let test_known_wire_types_return_some () =
+  let cases =
+    [ ("string", Types.String)
+    ; ("integer", Types.Integer)
+    ; ("number", Types.Number)
+    ; ("boolean", Types.Boolean)
+    ; ("array", Types.Array)
+    ; ("object", Types.Object)
+    ]
+  in
+  List.iter
+    (fun (wire, expected) ->
+      match Sdk.param_type_of_schema_opt (schema_with_type wire) with
+      | Some actual ->
+          check param_type_testable
+            (Printf.sprintf "wire %S -> Some" wire)
+            expected actual
+      | None -> failf "wire %S: expected Some, got None" wire)
+    cases
+
+let test_unknown_wire_types_return_none () =
+  let unknown_wires = [ "null"; ""; "union"; "Number" (* case-sensitive *); "int32"; "foo" ] in
+  List.iter
+    (fun wire ->
+      match Sdk.param_type_of_schema_opt (schema_with_type wire) with
+      | None -> ()
+      | Some actual ->
+          failf "wire %S: expected None, got Some %s" wire
+            (Format.asprintf "%a" (Fmt.of_to_string (fun t ->
+               match t with
+               | Types.String -> "String"
+               | Types.Integer -> "Integer"
+               | Types.Number -> "Number"
+               | Types.Boolean -> "Boolean"
+               | Types.Array -> "Array"
+               | Types.Object -> "Object"))
+               actual))
+    unknown_wires
+
+let test_back_compat_wrapper_returns_string_for_unknown () =
+  (* The back-compat wrapper falls back to String for unknown wire types
+     so existing callers continue to receive the legacy classification.
+     The log.warn side effect is not asserted here; see runtime logs. *)
+  let cases = [ "null"; ""; "foo"; "union" ] in
+  List.iter
+    (fun wire ->
+      check param_type_testable
+        (Printf.sprintf "wire %S -> String (back-compat)" wire)
+        Types.String
+        (Sdk.param_type_of_schema (schema_with_type wire)))
+    cases
+
+let test_back_compat_wrapper_preserves_known () =
+  (* Known wire types must pass through unchanged. *)
+  check param_type_testable "string -> String" Types.String
+    (Sdk.param_type_of_schema (schema_with_type "string"));
+  check param_type_testable "integer -> Integer" Types.Integer
+    (Sdk.param_type_of_schema (schema_with_type "integer"));
+  check param_type_testable "boolean -> Boolean" Types.Boolean
+    (Sdk.param_type_of_schema (schema_with_type "boolean"))
+
+let () =
+  run "param_type_of_schema"
+    [ ( "strict_classifier_opt"
+      , [ test_case "known wire types -> Some" `Quick test_known_wire_types_return_some
+        ; test_case "unknown wire types -> None" `Quick test_unknown_wire_types_return_none
+        ] )
+    ; ( "back_compat_wrapper"
+      , [ test_case "unknown wire -> String fallback" `Quick
+            test_back_compat_wrapper_returns_string_for_unknown
+        ; test_case "known wire passthrough" `Quick
+            test_back_compat_wrapper_preserves_known
+        ] )
+    ]


### PR DESCRIPTION
Closes #8832.

## Summary

\`lib/sdk_tool_contract.ml:369-377\`의 \`param_type_of_schema\`가 알 수 없는 JSON Schema wire type을 **조용히 \`String\`으로 분류** 하던 문제 (root-cause:SIL, #8605 family). \`"type": "null"\`, \`"type": ["string","null"]\` (2020-12 union syntax), 향후 추가될 keyword가 signal 없이 \`String\`이 되어 input validation이 잘못된 타입을 통과시켰다.

## Fix (#8605 family wire-string template)

#8828의 \`memory_horizon_of_kind\` 템플릿과 동일:

- \`param_type_of_schema_opt : schema -> Agent_sdk.Types.param_type option\` 신규. 미지 wire → \`None\`.
- \`param_type_of_schema\`는 back-compat wrapper로 개편. \`_opt\` 위임 → \`None\`에서 \`Log.Misc.warn\`으로 관찰 가능한 drift signal + 레거시 fallback \`String\` 유지.

알려진 wire type과 fallback 결과 모두 행동 변화 0, 로그에만 drift가 드러난다.

## Verification

- \`dune build --root .\` — clean
- \`dune exec --root . test/test_param_type_of_schema.exe\` — **4/4 pass**
  - 알려진 6 wire → \`Some\`
  - 미지 6 wire (\`"null"\`, \`""\`, \`"union"\`, case-sensitive \`"Number"\`, \`"int32"\`, \`"foo"\`) → \`None\`
  - wrapper unknown → \`String\` fallback
  - wrapper known passthrough (string/integer/boolean)

## Files

- \`lib/sdk_tool_contract.ml\` (L369-397, 기존 9라인 → 27라인)
- \`test/test_param_type_of_schema.ml\` (신규, 4 tests)
- \`test/dune\` (2개소 등록)

## Out of scope

- Upstream OAS \`Mcp_schema.json_schema_type_to_param_type\` — issue body 명시대로 별도 추적.
- JSON Schema 2020-12 union syntax (\`"type": ["string","null"]\`) — \`string_member\`가 list를 reject하므로 현재 path는 \`None → String + warn\`로 strict 개선. richer union parser는 별도 변경.