### PR TITLE
fix(lint): sync #8605 allowlist after #8846 (main CI broken)

### DIFF
--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -10,8 +10,10 @@
 # #8605 umbrella — tracked in https://github.com/jeong-sik/masc-mcp/issues/8605
 lib/sdk_tool_contract.ml:377
 lib/activity_graph/activity_graph_types.ml:89
-lib/coord.ml:81
-lib/coord.ml:102
-lib/coord.ml:132
+# coord.ml:132 (observe_task_transition) eliminated by #8846.
+# coord.ml:81/102 (observe_agent_lifecycle) still string-based; lines shifted to
+# 88/109 after #8846's insertions. Migration pending in #8842.
+lib/coord.ml:88
+lib/coord.ml:109
 lib/eval_harness.ml:370
 lib/types/types_auth.ml:83


### PR DESCRIPTION
## Summary

Main CI is failing since #8846 merged: the allowlist line numbers for `lib/coord.ml` shifted from 81/102/132 to 88/109 (and 132's instance was fully eliminated). The lint gate flags 88 and 109 as new violations on every push.

## Cause

Line-number allowlist is fragile against upstream refactors that insert or remove lines above an allowlisted position. #8846 added a new variant declaration + migration scaffolding in coord.ml, shifting subsequent lines down.

## Fix

Sync allowlist to current line positions:
- Remove `coord.ml:132` (eliminated by #8846 — task_transition already variant).
- Update `coord.ml:81 -> 88` and `coord.ml:102 -> 109` (observe_agent_lifecycle still string, pending #8842).

Local `./scripts/lint/no-unknown-permissive-default.sh` → clean.

## Follow-up

The manual resync cost is a symptom. Open issue candidate: migrate allowlist to content-hash (survives line shifts) or inline `(* lint:allow-8605-permissive *)` directive (travels with the code). Filed after this unblocks main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)