### PR TITLE
perf(keepers_json): raise concurrency cap 4 → 16 (empirical wait/work data)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -332,9 +332,28 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
         fallback_snapshot.tool_audit_at )
 
 (* Concurrency cap for parallel keeper snapshot fibers.
-   Prevents memory bursts when many keepers are processed simultaneously.
-   Each keeper fiber does filesystem I/O + heavy JSON construction (~50 fields). *)
-let _keeper_snapshot_max_concurrency = 4
+   Originally 4 to guard against memory bursts when many keepers are
+   processed simultaneously.  Live measurement via #8829 over 48 samples
+   showed this cap was the dominant cost, not the per-keeper I/O:
+
+       wait avg=1334ms max=4424ms   (queued on semaphore)
+       work avg=604ms  max=3088ms   (meta/agent/profile I/O + JSON)
+       ratio wait/work = 2.21x
+
+   Raising to 16 matches the current fleet size so no fiber queues on
+   the semaphore in the common case.  The original memory concern was
+   written when keepers were a new surface; modern machines absorb the
+   per-fiber JSON construction (~50 fields × 16 keepers ≈ a few MB)
+   without visible pressure.  Env-overridable via
+   [MASC_KEEPER_SNAPSHOT_CONCURRENCY] for operators on tight memory
+   envelopes (e.g. CI runners) who still want the old behaviour. *)
+let _keeper_snapshot_max_concurrency =
+  match Sys.getenv_opt "MASC_KEEPER_SNAPSHOT_CONCURRENCY" with
+  | Some s ->
+      (match int_of_string_opt (String.trim s) with
+       | Some n when n >= 1 && n <= 64 -> n
+       | _ -> 16)
+  | None -> 16
 
 let _keeper_sem = Eio.Semaphore.make _keeper_snapshot_max_concurrency
 


### PR DESCRIPTION
## Summary

Raise \`_keeper_snapshot_max_concurrency\` from 4 to 16, matching the fleet size, based on empirical per-fiber timing data that #8829 started emitting.

## Empirical evidence

48 samples from the running server (\`/Users/dancer/me/.masc/logs/system_log_2026-04-20.jsonl\`) against the post-#8818 baseline:

| metric | avg | max |
|--------|-----|-----|
| wait (semaphore queue) | 1334 ms | 4424 ms |
| work (per-fiber I/O + JSON) | 604 ms | 3088 ms |
| ratio wait/work | 2.21× | |

Wait dominates work 2:1. The worst-case fiber spent 4.4 s queued on \`_keeper_sem\`.

## Why now, not earlier

The 4-wide cap was written when the keeper count was much smaller and memory pressure was an open concern. 16 keepers × JSON fields (~50 fields each) × a few KB per field = low-MB peak — trivial on a modern host.

## Change

- Default cap: \`4 → 16\` (matches current fleet size).
- Env override: \`MASC_KEEPER_SNAPSHOT_CONCURRENCY=<1..64>\` for CI runners / tight memory envelopes. Invalid values fall back to **16** (failing back to "slightly more parallel" rather than the historical "mysteriously slow").
- Comment block updated with the measurement data so the next reader sees both the old rationale and why we revised it.

## Expected effect

Queue time collapses in the common case. Predicted \`keepers_json\` p50 drops from ~700 ms (post-#8818) to ~250 ms. Max tail should drop by roughly the queue depth factor (up to 4×).

## Scope guard

- Does **not** add caching to \`load_keeper_profile_defaults\` / \`parse_agent_status\` / \`keeper_tool_audit_fields\`. Work-side outliers (\`max=3088 ms\`) point at a slow path inside individual keeper I/O chains — #8822 remains open for the targeted cache once we have per-sub-op timing.
- Does **not** change the fiber body or error handling.
- Does **not** raise concurrency for other snapshot collectors (persistent_agents_json, etc.) — scope is the keeper lane where we have measurements.

## Related

- #8818 (dashboard git rev-parse TTL cache — merged, reduced 3100 ms → ~700 ms)
- #8829 (keepers_json wait/work timing — merged, produced the measurements above)
- #8822 (keepers_json perf tracking issue, open — work-side outliers remain)

## Test plan

- [x] \`dune build --root . @check\` clean
- [ ] CI Build and Test
- [ ] Post-merge: re-sample \`[keepers_json:NAME] wait=… work=…\` over 48+ entries — expect wait avg < work avg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)