### PR TITLE
[codex] Add connector-specific copy labels

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -649,6 +649,15 @@ describe('ConnectorStatusPanel', () => {
     expect(chip).toBeTruthy()
     expect(chip!.getAttribute('aria-label')).toContain('not running')
     expect(chip!.textContent).toContain('Not running')
+
+    const copyLabels = Array.from(panel!.querySelectorAll<HTMLButtonElement>('[data-copy-button]'))
+      .map(button => button.getAttribute('aria-label'))
+    expect(copyLabels).toEqual([
+      'Copy Discord sidecar start command',
+      'Copy Discord sidecar tail logs command',
+      'Copy Discord sidecar status command',
+      'Copy Discord sidecar stop command',
+    ])
   })
 
   it('shows no-keepers empty state when keeper directory is empty', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -984,6 +984,12 @@ function ConnectorLivePanel({
       ${showSidecarOffEmpty
         ? (() => {
             const cmds = sidecarCommands(connectorId)
+            const copyLabels = {
+              start: `Copy ${connectorName} sidecar start command`,
+              tail: `Copy ${connectorName} sidecar tail logs command`,
+              status: `Copy ${connectorName} sidecar status command`,
+              stop: `Copy ${connectorName} sidecar stop command`,
+            }
             // Informational amber tone (Railway / Vercel idle-service
             // convention): "needs action, not broken". Earlier this
             // panel inherited the connector accent gradient (iMessage =
@@ -1023,16 +1029,36 @@ function ConnectorLivePanel({
                   Click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal.
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
-                  <${CopyableCode} label="start" command=${cmds.start} variant="primary" />
+                  <${CopyableCode}
+                    label="start"
+                    command=${cmds.start}
+                    ariaLabel=${copyLabels.start}
+                    variant="primary"
+                  />
                 </div>
                 <div class="mt-2">
                   <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--text-dim)]">
                     Or for diagnostics
                   </div>
                   <div class="grid grid-cols-1 gap-1.5" data-sidecar-secondary-cmds>
-                    <${CopyableCode} label="tail logs" command=${cmds.tail} variant="secondary" />
-                    <${CopyableCode} label="status" command=${cmds.status} variant="secondary" />
-                    <${CopyableCode} label="stop" command=${cmds.stop} variant="secondary" />
+                    <${CopyableCode}
+                      label="tail logs"
+                      command=${cmds.tail}
+                      ariaLabel=${copyLabels.tail}
+                      variant="secondary"
+                    />
+                    <${CopyableCode}
+                      label="status"
+                      command=${cmds.status}
+                      ariaLabel=${copyLabels.status}
+                      variant="secondary"
+                    />
+                    <${CopyableCode}
+                      label="stop"
+                      command=${cmds.stop}
+                      ariaLabel=${copyLabels.stop}
+                      variant="secondary"
+                    />
                   </div>
                 </div>
                 <${SetupGuideCard} connectorId=${connectorId} />


### PR DESCRIPTION
## Summary

Adds connector-specific accessible names to the connector sidecar copy buttons so screen-reader users can distinguish the start, tail logs, status, and stop commands for the active connector.

## Product impact

The sidecar-off panel still renders the same visible labels, but copy buttons now expose connector-aware `aria-label`s such as `Copy Discord sidecar start command` instead of generic labels like `Copy start`.

This is a narrow accessibility slice of the broader first-run connector UX issue. It does **not** close the warning/status next-action copy lane from #8849.

## Evidence

- Updated `dashboard/src/components/connector-status.ts` to pass explicit `ariaLabel` values into `CopyableCode` for sidecar commands.
- Updated `dashboard/src/components/connector-status.test.ts` to assert the four connector-specific copy-button accessible names.
- Board context: MASC connector UX thread identified the copy-button accessibility gap and narrowed this PR to labels plus regression coverage.

## Review evidence

Local checks from `masc-mcp/.worktrees/a11y-connector-copy-labels/dashboard`:

- `pnpm typecheck` passed
- `pnpm exec eslint src/components/connector-status.ts src/components/connector-status.test.ts` passed
- `pnpm exec vitest run src/components/connector-status.test.ts --no-file-parallelism --maxWorkers=1` passed: 24 tests

## Linked issue

Refs #8849.

Partial coverage only: this PR addresses the command-copy accessible-name criterion. The first-run warning/status block next-action criterion remains open for a follow-up slice.