### PR TITLE
Add next-action copy to connector first-run warnings

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -412,6 +412,9 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('Gate metrics unavailable')
     expect(text).toContain('Gate-advertised connector runtime is visible')
     expect(text).toContain('keeper directory unavailable, manual entry only')
+    expect(text).toContain('Next: continue with manual entry now')
+    expect(text).toContain('config/keepers/')
+    expect(text).toContain('/api/v1/gate/keepers')
 
     // Directory-error panel uses informational amber + left stripe so
     // operators don't read the accent-gradient-tinted neutral
@@ -424,6 +427,30 @@ describe('ConnectorStatusPanel', () => {
     // Named chip: "Directory error" is what AT hears.
     const dirChip = dirPanel!.querySelector('[aria-label]')
     expect(dirChip?.getAttribute('aria-label')).toContain('unavailable')
+  })
+
+  it('pairs connector API failures with a browser/server next action', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockRejectedValue(new Error('GET /api/v1/gate/connectors: 503 Service Unavailable'))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const warningPanel = container.querySelector('[data-connector-warning-panel]') as HTMLElement | null
+    expect(warningPanel).not.toBeNull()
+    const text = warningPanel!.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(text).toContain('Connector API unavailable')
+    expect(text).toContain('Cause: GET /api/v1/gate/connectors: 503 Service Unavailable')
+    expect(text).toContain('Next: refresh the dashboard')
+    expect(text).toContain('/api/v1/gate/connectors')
   })
 
   it('prefers backend-advertised connector status over derived booleans', async () => {
@@ -632,6 +659,9 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('Sidecar not started')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
+    expect(text).toContain('Cause: no sidecar status file has been observed at /tmp/discord_status.json')
+    expect(text).toContain('Next: click Start to spawn via the backend')
+    expect(text).toContain('Use status and tail logs if it stays offline')
 
     // Regression guard for the screenshot bug: when a connector card's
     // brand accent is green (iMessage), the outer card renders a green

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -933,7 +933,22 @@ function ConnectorLivePanel({
         : null}
 
       ${connectorError || connector?.error
-        ? html`<div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]">${connectorError ?? connector?.error}</div>`
+        ? html`
+            <div class="mt-3 rounded border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs text-[var(--warn)]" data-connector-warning-panel>
+              <div class="font-semibold text-[var(--text-body)]">
+                ${connectorError ? 'Connector API unavailable' : 'Sidecar status warning'}
+              </div>
+              <div class="mt-1">
+                <span class="font-medium">Cause: </span> ${connectorError ?? connector?.error}
+              </div>
+              <div class="mt-1">
+                <span class="font-medium">Next: </span>
+                ${connectorError
+                  ? html`refresh the dashboard or check <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/connectors</code> on ${connector?.gate_base_url || 'the Gate server'}.`
+                  : html`run the ${connectorName} status command and inspect <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code>.`}
+              </div>
+            </div>
+          `
         : null}
 
       <${SidecarLogViewer} connectorId=${connectorId} />
@@ -952,7 +967,12 @@ function ConnectorLivePanel({
                 <span aria-hidden="true">⚠</span>
                 <span>Directory error</span>
               </span>
-              keeper directory unavailable, manual entry only
+              <div class="mt-1">
+                <span class="font-medium">Cause: </span> keeper directory unavailable, manual entry only.
+              </div>
+              <div class="mt-1">
+                <span class="font-medium">Next: </span> continue with manual entry now, then restore <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> or fix <code class="rounded bg-[var(--white-4)] px-1">/api/v1/gate/keepers</code> before relying on directory suggestions.
+              </div>
             </div>
           `
         : null}
@@ -1026,7 +1046,12 @@ function ConnectorLivePanel({
                   </div>
                 </div>
                 <div class="text-2xs text-[var(--warn)]/80">
-                  Click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal.
+                  <div>
+                    <span class="font-medium">Cause: </span> no sidecar status file has been observed at <code class="rounded bg-[var(--white-4)] px-1">${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}</code>.
+                  </div>
+                  <div class="mt-1">
+                    <span class="font-medium">Next: </span> click <strong>Start</strong> to spawn via the backend, or copy the command below to run it from a terminal. Use <strong>status</strong> and <strong>tail logs</strong> if it stays offline.
+                  </div>
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
                   <${CopyableCode}


### PR DESCRIPTION
## Summary

- Adds explicit Cause/Next copy to connector API warning, keeper-directory-unavailable, and sidecar-not-started states.
- Keeps the #8869 copy-button accessibility slice separate from this warning/status recovery-copy slice.
- Adds dashboard regression coverage for API failure next action, keeper directory next action, and sidecar-off next action copy.

## Verification

- `pnpm typecheck`
- `pnpm exec eslint src/components/connector-status.ts src/components/connector-status.test.ts`
- `pnpm exec vitest run src/components/connector-status.test.ts --no-file-parallelism --maxWorkers=1`

Refs #8870
Refs #8849