### PR TITLE
docs(keeper_runtime_config): realign semaphore_wait_timeout_sec 60 vs 150 (#7638 Bug B)

### DIFF
--- a/lib/keeper/keeper_runtime_config.mli
+++ b/lib/keeper/keeper_runtime_config.mli
@@ -52,7 +52,7 @@ val resolve_overrides :
     {[
       [autonomous]
       max_turns_per_call          = 7
-      semaphore_wait_timeout_sec  = 150
+      semaphore_wait_timeout_sec  = 60
 
       [reactive]
       max_turns_per_call          = 15


### PR DESCRIPTION
Closes #7638 Bug B (Bug A landed in #7472).

## Summary

\`lib/keeper/keeper_runtime_config.mli:55\`가 \`semaphore_wait_timeout_sec = 150\`으로 명시하지만 실제 런타임 기본값은 \`lib/keeper/keeper_keepalive.ml:149\`에서 \`60.0\` — #6608 이후로 short-fail-fast 의도(\"60s 안에 slot 획득 실패면 다음 heartbeat cycle로 재시도\")가 정책이지만 mli 문서는 업데이트 누락.

## Fix

1-line doc change — 150 → 60. keepalive 소스를 SSOT로 삼고 mli 문서만 맞춤.

## No test

Drift가 docstring 안의 TOML snippet에 있어 parser가 없음. 테스트 대신 mli와 ml 둘 다 \`60\`으로 일치시키는 방식을 택. 추후 기본값 바꿀 때 grep \`semaphore_wait_timeout_sec\`로 두 곳 동시 보정 가능.

## Files

- \`lib/keeper/keeper_runtime_config.mli\` (L55)

## Verification

- \`dune build --root .\` — clean