### PR TITLE
Add sidecar desired-state reconciliation guard

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -337,6 +337,186 @@ let sidecar_start_shell_command ~base_path ~script =
     (Filename.quote base_path)
     (Filename.quote script)
 
+type desired_state =
+  | Desired_running
+  | Desired_stopped
+
+type desired_record = {
+  connector_id : string;
+  desired_state : desired_state;
+  generation : int;
+  updated_by : string;
+  updated_at : string;
+}
+
+type observed_state =
+  | Observed_available
+  | Observed_unavailable
+
+type reconcile_result =
+  | Reconcile_started
+  | Reconcile_noop of string
+
+let desired_state_to_string = function
+  | Desired_running -> "running"
+  | Desired_stopped -> "stopped"
+
+let desired_state_of_string = function
+  | "running" -> Some Desired_running
+  | "stopped" -> Some Desired_stopped
+  | _ -> None
+
+let observed_state_to_string = function
+  | Observed_available -> "available"
+  | Observed_unavailable -> "unavailable"
+
+let reconcile_result_to_string = function
+  | Reconcile_started -> "started"
+  | Reconcile_noop reason -> "noop:" ^ reason
+
+let desired_record_json record =
+  `Assoc [
+    ("connector_id", `String record.connector_id);
+    ("desired_state", `String (desired_state_to_string record.desired_state));
+    ("generation", `Int record.generation);
+    ("updated_by", `String record.updated_by);
+    ("updated_at", `String record.updated_at);
+  ]
+
+let desired_record_of_json = function
+  | `Assoc fields -> (
+      match
+        ( List.assoc_opt "connector_id" fields,
+          List.assoc_opt "desired_state" fields,
+          List.assoc_opt "generation" fields,
+          List.assoc_opt "updated_by" fields,
+          List.assoc_opt "updated_at" fields )
+      with
+      | Some (`String connector_id), Some (`String desired_state), Some (`Int generation),
+        Some (`String updated_by), Some (`String updated_at) ->
+          desired_state_of_string desired_state
+          |> Option.map (fun desired_state ->
+                 { connector_id; desired_state; generation; updated_by; updated_at })
+      | _ -> None)
+  | _ -> None
+
+let sidecar_desired_path ~base_path id =
+  Filename.concat base_path
+    (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_desired.json" id)
+
+let read_desired_record ~base_path id =
+  let path = sidecar_desired_path ~base_path id in
+  if not (Sys.file_exists path) then
+    None
+  else
+    try read_file path |> Yojson.Safe.from_string |> desired_record_of_json
+    with Sys_error _ | Yojson.Json_error _ -> None
+
+let isoish_now () =
+  let tm = Unix.gmtime (Unix.time ()) in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+
+(** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
+    tries to rename into it. *)
+let ensure_parent_dir path =
+  let dir = Filename.dirname path in
+  let rec mk d =
+    if Sys.file_exists d then ()
+    else begin
+      mk (Filename.dirname d);
+      try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  mk dir
+
+(** Atomic write: tmp file + rename. POSIX rename is atomic so a
+    concurrent reader sees either the old file or the new one, never a
+    half-written one. Inlined here rather than reaching into
+    Keeper_toml_loader (which keeps it as a private helper). *)
+let atomic_write_file ~(path : string) (content : string) : (unit, string) result =
+  let tmp = path ^ ".tmp" in
+  try
+    let oc = open_out tmp in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc content);
+    Sys.rename tmp path;
+    Ok ()
+  with exn ->
+    (try Sys.remove tmp with Sys_error _ -> ());
+    Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
+
+let write_desired_record ?updated_at ~base_path ~id ~updated_by desired_state =
+  let previous = read_desired_record ~base_path id in
+  let generation =
+    match previous with
+    | Some record -> record.generation + 1
+    | None -> 1
+  in
+  let record =
+    {
+      connector_id = id;
+      desired_state;
+      generation;
+      updated_by;
+      updated_at = Option.value updated_at ~default:(isoish_now ());
+    }
+  in
+  let path = sidecar_desired_path ~base_path id in
+  ensure_parent_dir path;
+  match atomic_write_file ~path (Yojson.Safe.to_string (desired_record_json record) ^ "\n") with
+  | Ok () -> Ok record
+  | Error _ as error -> error
+
+let observed_state_of_status_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "available" fields with
+      | Some (`Bool true) -> Observed_available
+      | _ -> Observed_unavailable)
+  | _ -> Observed_unavailable
+
+let reconcile_desired_once ~current_generation ~observed_state ~start_shell record =
+  if record.generation <> current_generation then
+    Reconcile_noop "stale_generation"
+  else
+    match (record.desired_state, observed_state) with
+    | Desired_running, Observed_unavailable ->
+        start_shell ();
+        Reconcile_started
+    | Desired_running, Observed_available -> Reconcile_noop "already_available"
+    | Desired_stopped, _ -> Reconcile_noop "desired_stopped"
+
+let reconcile_preview record observed_state =
+  match (record.desired_state, observed_state) with
+  | Desired_running, Observed_unavailable -> "would_start"
+  | Desired_running, Observed_available -> "noop:already_available"
+  | Desired_stopped, _ -> "noop:desired_stopped"
+
+let lifecycle_json ~base_path id status_json =
+  let observed_state = observed_state_of_status_json status_json in
+  match read_desired_record ~base_path id with
+  | None ->
+      `Assoc [
+        ("desired_state", `Null);
+        ("desired_generation", `Null);
+        ("observed_state", `String (observed_state_to_string observed_state));
+        ("reconcile_result", `String "none");
+      ]
+  | Some record ->
+      `Assoc [
+        ("desired_state", `String (desired_state_to_string record.desired_state));
+        ("desired_generation", `Int record.generation);
+        ("desired_updated_by", `String record.updated_by);
+        ("desired_updated_at", `String record.updated_at);
+        ("observed_state", `String (observed_state_to_string observed_state));
+        ("reconcile_result", `String (reconcile_preview record observed_state));
+      ]
+
+let append_assoc key value = function
+  | `Assoc fields -> `Assoc (fields @ [ (key, value) ])
+  | json -> json
+
 (** Clamp the [?lines=N] query param to [1, 1000]. Pure so unit tests
     can pin the upper bound without a request mock. *)
 let clamp_lines = function
@@ -368,7 +548,8 @@ let read_status_json ~base_path id =
       ~base_path
       id
   in
-  if Sys.file_exists path then
+  let status =
+    if Sys.file_exists path then
     let body = read_file path in
     let parsed =
       try Some (Yojson.Safe.from_string body)
@@ -380,12 +561,14 @@ let read_status_json ~base_path id =
       ("status_path", `String path);
       ("status", Option.value parsed ~default:`Null);
     ]
-  else
+    else
     `Assoc [
       ("ok", `Bool true);
       ("available", `Bool false);
       ("status_path", `String path);
     ]
+  in
+  append_assoc "sidecar_lifecycle" (lifecycle_json ~base_path id status) status
 
 let handle_status state request reqd =
   match parse_name request with
@@ -404,29 +587,40 @@ let handle_stop state request reqd =
            respond_json request reqd ~status:`Service_unavailable
              (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
        | Ok script ->
-           let (_status, stdout) =
-             Process_eio.run_argv_with_status ~timeout_sec:5.0
-               [ script; "stop" ]
-           in
-           let trimmed = String.trim stdout in
-           let signaled_marker =
-             Printf.sprintf "Sent SIGTERM to %s-bot processes." id
-           in
-           let signaled =
-             let needle_len = String.length signaled_marker in
-             let rec contains i =
-               if i + needle_len > String.length trimmed then false
-               else if String.equal (String.sub trimmed i needle_len) signaled_marker then true
-               else contains (i + 1)
-             in
-             contains 0
-           in
-           respond_json request reqd ~status:`OK
-             (`Assoc [
-                ("ok", `Bool true);
-                ("signaled", `Bool signaled);
-                ("note", `String trimmed);
-              ]))
+           (match
+              write_desired_record ~base_path ~id ~updated_by:"http:stop"
+                Desired_stopped
+            with
+            | Error msg ->
+                respond_json request reqd ~status:`Internal_server_error
+                  (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
+            | Ok desired ->
+                let (_status, stdout) =
+                  Process_eio.run_argv_with_status ~timeout_sec:5.0
+                    [ script; "stop" ]
+                in
+                let trimmed = String.trim stdout in
+                let signaled_marker =
+                  Printf.sprintf "Sent SIGTERM to %s-bot processes." id
+                in
+                let signaled =
+                  let needle_len = String.length signaled_marker in
+                  let rec contains i =
+                    if i + needle_len > String.length trimmed then false
+                    else if String.equal (String.sub trimmed i needle_len) signaled_marker then true
+                    else contains (i + 1)
+                  in
+                  contains 0
+                in
+                respond_json request reqd ~status:`OK
+                  (`Assoc [
+                     ("ok", `Bool true);
+                     ("signaled", `Bool signaled);
+                     ("note", `String trimmed);
+                     ("desired_state", `String (desired_state_to_string desired.desired_state));
+                     ("desired_generation", `Int desired.generation);
+                     ("stop_semantics", `String "synchronous_stop_with_desired_fence");
+                   ])))
 
 let handle_logs state request reqd =
   match parse_name request with
@@ -612,36 +806,6 @@ let config_toml_path ~base_path id =
   Filename.concat base_path
     (Printf.sprintf ".gate/runtime/%s/config.toml" id)
 
-(** Atomic write: tmp file + rename. POSIX rename is atomic so a
-    concurrent reader sees either the old file or the new one, never a
-    half-written one. Inlined here rather than reaching into
-    Keeper_toml_loader (which keeps it as a private helper). *)
-let atomic_write_file ~(path : string) (content : string) : (unit, string) result =
-  let tmp = path ^ ".tmp" in
-  try
-    let oc = open_out tmp in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc content);
-    Sys.rename tmp path;
-    Ok ()
-  with exn ->
-    (try Sys.remove tmp with Sys_error _ -> ());
-    Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
-
-(** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
-    tries to rename into it. *)
-let ensure_parent_dir path =
-  let dir = Filename.dirname path in
-  let rec mk d =
-    if Sys.file_exists d then ()
-    else begin
-      mk (Filename.dirname d);
-      try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
-  in
-  mk dir
-
 (** Parse a JSON body of the form [{"<KEY>": "<VALUE>", ...}] into a
     list of pairs. All values are expected as JSON strings (the
     dashboard form emits them that way) — richer JSON types are
@@ -809,18 +973,38 @@ let handle_start state request reqd =
            respond_json request reqd ~status:`Service_unavailable
              (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
        | Ok script ->
-           (* Detach: run via setsid + nohup so the sidecar survives backend
-              restart. Only [script] is interpolated, and the path comes from
-              a resolved directory + fixed filename, so [Filename.quote] gives
-              a closed-shell injection surface. *)
-           let cmd = sidecar_start_shell_command ~base_path ~script in
-           let _ = Sys.command cmd in
-           respond_json request reqd ~status:`Accepted
-             (`Assoc [
-                ("ok", `Bool true);
-                ("id", `String id);
-                ("note", `String "sidecar spawn requested; poll /api/v1/sidecar/status?name=...");
-              ]))
+           (match
+              write_desired_record ~base_path ~id ~updated_by:"http:start"
+                Desired_running
+            with
+            | Error msg ->
+                respond_json request reqd ~status:`Internal_server_error
+                  (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
+            | Ok desired ->
+                (* Detach: run via setsid + nohup so the sidecar survives backend
+                   restart. Only [script] is interpolated, and the path comes from
+                   a resolved directory + fixed filename, so [Filename.quote] gives
+                   a closed-shell injection surface. *)
+                let cmd = sidecar_start_shell_command ~base_path ~script in
+                let status_json = read_status_json ~base_path id in
+                let observed_state = observed_state_of_status_json status_json in
+                let reconcile_result =
+                  reconcile_desired_once
+                    ~current_generation:desired.generation
+                    ~observed_state
+                    ~start_shell:(fun () -> ignore (Sys.command cmd))
+                    desired
+                in
+                respond_json request reqd ~status:`Accepted
+                  (`Assoc [
+                     ("ok", `Bool true);
+                     ("id", `String id);
+                     ("desired_state", `String (desired_state_to_string desired.desired_state));
+                     ("desired_generation", `Int desired.generation);
+                     ("observed_state", `String (observed_state_to_string observed_state));
+                     ("reconcile_result", `String (reconcile_result_to_string reconcile_result));
+                     ("note", `String "sidecar desired state updated; poll /api/v1/sidecar/status?name=...");
+                   ])))
 
 (** Register sidecar lifecycle routes on the router. *)
 let add_routes ~sw:_ ~clock:_ router =

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -234,6 +234,123 @@ let test_start_shell_command_quotes_shell_meta () =
        (Filename.quote script))
     (Routes.sidecar_start_shell_command ~base_path ~script)
 
+let test_desired_store_increments_generation () =
+  with_temp_dir "sidecar-desired-store" (fun base_path ->
+      let first =
+        Routes.write_desired_record
+          ~updated_at:"2026-04-20T00:00:00Z"
+          ~base_path
+          ~id:"discord"
+          ~updated_by:"test"
+          Routes.Desired_running
+      in
+      let second =
+        Routes.write_desired_record
+          ~updated_at:"2026-04-20T00:00:01Z"
+          ~base_path
+          ~id:"discord"
+          ~updated_by:"test"
+          Routes.Desired_stopped
+      in
+      match (first, second, Routes.read_desired_record ~base_path "discord") with
+      | Ok first, Ok second, Some persisted ->
+          check int "first generation" 1 first.generation;
+          check int "second generation" 2 second.generation;
+          check int "persisted generation" 2 persisted.generation;
+          check string "persisted desired state" "stopped"
+            (Routes.desired_state_to_string persisted.desired_state)
+      | _ -> failf "desired writes should succeed and persist")
+
+let test_reconcile_stale_generation_does_not_start () =
+  let shell_called = ref false in
+  let delayed : Routes.desired_record =
+    {
+      Routes.connector_id = "discord";
+      desired_state = Routes.Desired_running;
+      generation = 1;
+      updated_by = "test";
+      updated_at = "2026-04-20T00:00:00Z";
+    }
+  in
+  let result =
+    Routes.reconcile_desired_once
+      ~current_generation:2
+      ~observed_state:Routes.Observed_unavailable
+      ~start_shell:(fun () -> shell_called := true)
+      delayed
+  in
+  check bool "stale reconcile must not shell start" false !shell_called;
+  check string "stale generation result"
+    "noop:stale_generation"
+    (Routes.reconcile_result_to_string result)
+
+let test_reconcile_running_unavailable_starts_once () =
+  let shell_calls = ref 0 in
+  let desired : Routes.desired_record =
+    {
+      Routes.connector_id = "discord";
+      desired_state = Routes.Desired_running;
+      generation = 3;
+      updated_by = "test";
+      updated_at = "2026-04-20T00:00:00Z";
+    }
+  in
+  let result =
+    Routes.reconcile_desired_once
+      ~current_generation:3
+      ~observed_state:Routes.Observed_unavailable
+      ~start_shell:(fun () -> incr shell_calls)
+      desired
+  in
+  check int "current running reconcile shells once" 1 !shell_calls;
+  check string "started result" "started" (Routes.reconcile_result_to_string result)
+
+let test_reconcile_stopped_noops () =
+  let shell_called = ref false in
+  let desired : Routes.desired_record =
+    {
+      Routes.connector_id = "discord";
+      desired_state = Routes.Desired_stopped;
+      generation = 4;
+      updated_by = "test";
+      updated_at = "2026-04-20T00:00:00Z";
+    }
+  in
+  let result =
+    Routes.reconcile_desired_once
+      ~current_generation:4
+      ~observed_state:Routes.Observed_unavailable
+      ~start_shell:(fun () -> shell_called := true)
+      desired
+  in
+  check bool "stopped reconcile must not shell start" false !shell_called;
+  check string "stopped result" "noop:desired_stopped"
+    (Routes.reconcile_result_to_string result)
+
+let test_status_json_includes_lifecycle_shape () =
+  with_temp_dir "sidecar-lifecycle-status" (fun base_path ->
+      (match
+         Routes.write_desired_record
+           ~updated_at:"2026-04-20T00:00:00Z"
+           ~base_path
+           ~id:"discord"
+           ~updated_by:"test"
+           Routes.Desired_running
+       with
+       | Ok _ -> ()
+       | Error msg -> failf "desired write failed: %s" msg);
+      let json = Routes.read_status_json ~base_path "discord" in
+      let open Yojson.Safe.Util in
+      let lifecycle = json |> member "sidecar_lifecycle" in
+      check string "desired_state" "running"
+        (lifecycle |> member "desired_state" |> to_string);
+      check int "desired_generation" 1
+        (lifecycle |> member "desired_generation" |> to_int);
+      check string "observed_state" "unavailable"
+        (lifecycle |> member "observed_state" |> to_string);
+      check string "reconcile_result" "would_start"
+        (lifecycle |> member "reconcile_result" |> to_string))
+
 (* ---- Config write helpers (PUT /api/v1/sidecar/config). ---- *)
 
 let test_escape_quotes_and_backslash () =
@@ -388,6 +505,18 @@ let () =
             test_start_shell_command_matches_detached_contract;
           test_case "quotes shell metacharacters" `Quick
             test_start_shell_command_quotes_shell_meta;
+        ] );
+      ( "desired_state",
+        [
+          test_case "desired store increments generation" `Quick
+            test_desired_store_increments_generation;
+          test_case "stale generation reconcile does not start" `Quick
+            test_reconcile_stale_generation_does_not_start;
+          test_case "running + unavailable starts once" `Quick
+            test_reconcile_running_unavailable_starts_once;
+          test_case "stopped desired no-ops" `Quick test_reconcile_stopped_noops;
+          test_case "status JSON includes lifecycle shape" `Quick
+            test_status_json_includes_lifecycle_shape;
         ] );
       ( "config_write_helpers",
         [


### PR DESCRIPTION
## Summary

Implements the first narrow #8872 sidecar lifecycle reconciliation slice:

- adds a sidecar desired-state store at `.gate/runtime/<id>/sidecar_lifecycle_desired.json`
- records `desired_state`, `generation`, `updated_by`, and `updated_at`
- makes `/api/v1/sidecar/start` write `running` desired state and run a one-shot reconcile against observed status
- keeps `/api/v1/sidecar/stop` synchronous, but writes `stopped` with a higher generation first to fence delayed start reconciles
- adds `sidecar_lifecycle` status payload fields: desired state/generation, observed state, and reconcile result preview
- adds regression coverage for stale-generation no-op behavior

## Product impact

Operators get a first explicit desired/observed lifecycle model for connector sidecars instead of treating start/stop as blind one-shot buttons. The first slice keeps stop synchronous while adding a generation fence so a delayed `running gen=1` reconcile cannot resurrect a sidecar after `stopped gen=2` has been written.

## Scope

This is intentionally only the first slice. It does not add crash-loop/log-tail automation, a dashboard redesign, or async stop semantics.

## Evidence

- cwd: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-8872-sidecar-reconcile`
- canonical_repo_root: `/Users/dancer/me/workspace/yousleepwhen/masc-mcp`
- checked_ref: `66ee42801`
- base: `origin/main` at `bc57b16d8`
- status payload includes `sidecar_lifecycle` desired/observed/generation/reconcile fields
- tests cover stale-generation no-op behavior and lifecycle payload shape

## Review evidence

```bash
git diff --check
opam exec -- dune build --root "$PWD" test/test_sidecar_lifecycle_routes.exe
opam exec -- "$PWD/_build/default/test/test_sidecar_lifecycle_routes.exe"
opam exec -- dune build --root "$PWD"
```

Results:

- `test_sidecar_lifecycle_routes.exe`: 33 tests pass
- full `dune build --root "$PWD"`: pass

## Linked issue

Refs #8872

## Notes

The wrong-root negative proof from `find repos/masc-mcp -name '*sidecar*'` should not be reused as product evidence. Negative source searches must include cwd, canonical repo root, checked ref, and command.