### PR TITLE
feat(bonsai-dashboard): active theme chip highlight (cascading CSS)

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -39,9 +39,12 @@ let apply_theme theme =
 ;;
 
 let install_theme_listener () =
+  (* 첫 paint부터 data-theme 를 항상 설정한다. hash 없으면 dark-fantasy.
+     이렇게 해야 cascading selector `html[data-theme="..."]` 기반의
+     active chip 하이라이트가 default 상태에서도 매칭된다. *)
   (match current_hash_theme () with
    | Some t -> apply_theme t
-   | None -> ());
+   | None -> apply_theme "dark-fantasy");
   let on_hashchange _ =
     (match current_hash_theme () with
      | Some t -> apply_theme t

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1006,6 +1006,26 @@ stylesheet
     border-color: var(--accent-brass-dim);
     color: var(--accent-brass);
   }
+  .theme_chip_active {
+    border-color: var(--accent-brass);
+    color: var(--accent-brass);
+    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+    box-shadow: 0 0 0 1px rgba(138, 106, 40, 0.25) inset;
+  }
+
+  /* active chip via declarative CSS only — listener가 <html data-theme>
+     값을 세팅하면 cascading selector가 해당 chip에 active 스타일을 자동
+     적용. Bonsai state 경유 없이도 동작한다. */
+  html[data-theme="dark-fantasy"] .theme_chip[data-chip-theme="dark"],
+  html[data-theme="cyberpunk"]    .theme_chip[data-chip-theme="cyber"],
+  html[data-theme="terminal"]     .theme_chip[data-chip-theme="term"],
+  html[data-theme="parchment"]    .theme_chip[data-chip-theme="parchment"],
+  html[data-theme="paper"]        .theme_chip[data-chip-theme="paper"] {
+    border-color: var(--accent-brass);
+    color: var(--accent-brass);
+    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+    box-shadow: 0 0 0 1px rgba(138, 106, 40, 0.25) inset;
+  }
 
   /* ─── right aside (340px, fixed) ───
      dashboard_v2 aside: focus card + chronicle evs stream.
@@ -1653,6 +1673,7 @@ let render_response (response : Logs_types.response) : Node.t =
            Node.div
              ~attrs:
                [ Style.theme_chip
+               ; Attr.create "data-chip-theme" name
                ; Attr.on_click (fun _ ->
                    Effect.of_sync_fun
                      (fun () ->


### PR DESCRIPTION
## Summary

#8875의 theme chip에 **active 하이라이트** 추가. 현재 팔레트에 해당하는 chip에만 brass ring + gradient 배경이 자동 적용된다.

## 구현 — declarative CSS only

- chip에 `data-chip-theme="<name>"` 속성 부여 (`dark`/`cyber`/`term`/`parchment`/`paper`)
- cascading selector 5조:
  ```css
  html[data-theme="dark-fantasy"] .theme_chip[data-chip-theme="dark"],
  html[data-theme="cyberpunk"]    .theme_chip[data-chip-theme="cyber"],
  html[data-theme="terminal"]     .theme_chip[data-chip-theme="term"],
  html[data-theme="parchment"]    .theme_chip[data-chip-theme="parchment"],
  html[data-theme="paper"]        .theme_chip[data-chip-theme="paper"] {
    border-color: var(--accent-brass);
    color: var(--accent-brass);
    background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
    box-shadow: 0 0 0 1px rgba(138, 106, 40, 0.25) inset;
  }
  ```
- `bin/main.ml`의 `install_theme_listener` 초기 분기 수정: hash 없어도 명시적으로 `apply_theme "dark-fantasy"` 호출 → `<html data-theme>`가 항상 세팅되어 default 상태에서도 selector 매칭.

## 왜 이 경로

- **Bonsai state 경유 없음**: chip 각자는 stateless. `<html>`의 단일 attribute만 보면 됨.
- **JS classList.toggle 루프 없음**: DOM mutation을 추가로 수행하지 않아도 브라우저 CSS 엔진이 cascading selector를 자동 매칭.
- **Theme 추가 시 확장 용이**: 새 테마 넣을 때 hash parser + selector 한 줄씩만 추가.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] `/dashboard/b/` 기본 로드 → `[dark]` chip이 brass ring (default data-theme="dark-fantasy")
- [ ] `[cyber]` 클릭 → neon 팔레트 전환 + `[cyber]` chip이 active, `[dark]`는 비활성
- [ ] `[paper]` → light 팔레트 + `[paper]`만 active
- [ ] URL 직접 변경 `.../#terminal` → `[term]` chip active 반영

## 남은 UX

- localStorage persistence (URL 없어도 직전 선택 기억)
- chip row에 구분선 추가 (dark/cyber: 다크계열, parch/paper: 라이트계열)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
