### PR TITLE
chore(exec): flip MASC_BASH_SEMANTIC_EXIT default to on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 
 ## Unreleased
 
+### Changed
+
+- **`MASC_BASH_SEMANTIC_EXIT` flipped to on by default.** Post-
+  Legendary-Bash-P1 (#8721) rollout step: every `keeper_bash`
+  response now carries the typed `semantic_exit` variant and the
+  `return_code_interpretation` hint without requiring an operator
+  opt-in.  Fields are purely additive — no existing key is removed
+  or renamed, so consumers that parse `status` directly are
+  unaffected.  Explicit opt-out: set the env to `0` / `false` /
+  `no` / `off`.  The flag itself survives one more minor bump to
+  let downstream consumers confirm compatibility before removal.
+
 ### Added
 
 - **`Docker_with_git` sandbox profile + git/gh per-command dispatch.** New `sandbox_profile = "docker_with_git"` keeps every `Docker_hardened` guard (cap-drop, no-new-privs, read-only rootfs, tmpfs, pids/memory limits, no nested runtimes) but adds `--network bridge` and read-only mounts for `~/.config/gh`, `~/.gitconfig`, optionally `~/.ssh` (opt-in via `MASC_KEEPER_SANDBOX_SSH_DIR`). Optional `GH_TOKEN` env forward via `MASC_KEEPER_SANDBOX_GH_TOKEN`. A `Docker_hardened` keeper still gets git/gh access for free: `keeper_bash` automatically routes commands whose first token is `git` or `gh` through the new profile (toggle `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false` to disable). Closes the gap that left coding keepers with `repo clone 차단: allowed org mismatch` board posts and 16 days of zero `keeper_bash` git activity.

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -121,7 +121,7 @@ never break by enabling them.
 
 | Variable | Default | Effect |
 | --- | --- | --- |
-| `MASC_BASH_SEMANTIC_EXIT` | off | Emits a `return_code_interpretation` object (typed `semantic_exit`) alongside the raw `status`. See `lib/exec/exec_semantic.mli`. |
+| `MASC_BASH_SEMANTIC_EXIT` | **on** (post flip PR) | Emits a `return_code_interpretation` object (typed `semantic_exit`) alongside the raw `status`. Set to `0` / `false` / `no` / `off` to opt out and restore the pre-P1 byte-identical shape. See `lib/exec/exec_semantic.mli`. |
 | `MASC_BASH_OUTPUT_CAP` | on (500 KB head + 500 KB tail each) | Head+tail truncation via `Exec_buffer`. `MASC_BASH_CAP_HEAD` / `MASC_BASH_CAP_TAIL` override the per-stream caps. See `lib/exec/exec_buffer.mli`. |
 | `MASC_BASH_AUTO_BG` | off | Foreground commands that outrun `MASC_BLOCKING_BUDGET_MS` (default 15 000 ms) auto-promote to a `Bg_task`. Response gains `{promoted, background_task_id, partial_output, …}`. See `lib/exec/exec_run.mli`. |
 | `MASC_BLOCKING_BUDGET_MS` | 15 000 | Foreground race budget. Consumed only when `MASC_BASH_AUTO_BG` is on; otherwise inert. |

--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -117,6 +117,14 @@ let to_payload : t -> (string * payload_value) list = function
   | `Permission_denied path -> [ "path", `String path ]
 
 let enabled () =
+  (* Plan decision point 5: after P1 merge the semantic fields flip
+     to default-on.  They are purely additive JSON keys, so no
+     downstream consumer parses them as required — turning the
+     flag on by default surfaces the typed exit classification to
+     every [keeper_bash] response without an operator opt-in.
+     [MASC_BASH_SEMANTIC_EXIT=0] remains the explicit off switch
+     for the rare caller that wants the pre-P1 byte-identical
+     shape.  A later minor bump will remove the flag entirely. *)
   match Sys.getenv_opt "MASC_BASH_SEMANTIC_EXIT" with
-  | Some ("1" | "true" | "TRUE") -> true
-  | _ -> false
+  | Some ("0" | "false" | "FALSE" | "no" | "off") -> false
+  | _ -> true

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -87,8 +87,14 @@ val to_payload : t -> (string * payload_value) list
     Empty for nullary variants. *)
 
 val enabled : unit -> bool
-(** Runtime feature flag reader. Reads [MASC_BASH_SEMANTIC_EXIT]; when
-    set to ["1"] or ["true"] the caller should emit the semantic field.
-    The interpret/to_json functions themselves are always safe to call;
-    the flag only gates whether producers include the result in the
+(** Runtime feature flag reader. Reads [MASC_BASH_SEMANTIC_EXIT].
+
+    Default (post-#8721): [true] — the semantic field is emitted
+    unless an operator explicitly opts out with
+    [MASC_BASH_SEMANTIC_EXIT=0] (or ["false" / "FALSE" / "no" / "off"]).
+
+    The flag survives one more minor bump to let downstream
+    consumers confirm compatibility before it is removed.  The
+    [interpret] / [to_json] functions are always safe to call; the
+    flag only gates whether producers include the result in the
     user-visible response. *)

--- a/lib/exec/test/test_exec_semantic.ml
+++ b/lib/exec/test/test_exec_semantic.ml
@@ -117,11 +117,21 @@ let test_payload_tool_missing_has_tool () =
   | [ ("tool", `String "foo") ] -> ()
   | _ -> assert false
 
-let test_enabled_flag_default_off () =
+(* Post-#8721: MASC_BASH_SEMANTIC_EXIT defaults to on.  The flag
+   now serves as an explicit opt-out ("0" / "false" / …) rather
+   than opt-in, and the unset case resolves to [true]. *)
+let test_enabled_flag_default_on () =
   Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "";
-  assert (not (Exec_semantic.enabled ()))
+  assert (Exec_semantic.enabled ())
 
-let test_enabled_flag_on () =
+let test_enabled_flag_explicit_off () =
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "0";
+  assert (not (Exec_semantic.enabled ()));
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "false";
+  assert (not (Exec_semantic.enabled ()));
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" ""
+
+let test_enabled_flag_explicit_on () =
   Unix.putenv "MASC_BASH_SEMANTIC_EXIT" "1";
   assert (Exec_semantic.enabled ());
   Unix.putenv "MASC_BASH_SEMANTIC_EXIT" ""
@@ -140,6 +150,7 @@ let () =
   test_payload_nullary_empty ();
   test_payload_fail_has_exit_code ();
   test_payload_tool_missing_has_tool ();
-  test_enabled_flag_default_off ();
-  test_enabled_flag_on ();
+  test_enabled_flag_default_on ();
+  test_enabled_flag_explicit_off ();
+  test_enabled_flag_explicit_on ();
   print_endline "test_exec_semantic: ok"

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -159,8 +159,11 @@ let test_inline_only_keeps_artifact_refs_empty () =
 (* ---------- P1 Tick 3: Exec_semantic JSON integration ------------------ *)
 
 let with_semantic_flag enabled f =
+  (* Post-flip: empty string means "default", which is now ON.
+     Use explicit "0" for the off case so the test intention is
+     preserved regardless of the default. *)
   let prev = Sys.getenv_opt "MASC_BASH_SEMANTIC_EXIT" in
-  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" (if enabled then "1" else "");
+  Unix.putenv "MASC_BASH_SEMANTIC_EXIT" (if enabled then "1" else "0");
   let restore () =
     match prev with
     | Some v -> Unix.putenv "MASC_BASH_SEMANTIC_EXIT" v
@@ -179,7 +182,10 @@ let run_json ~cmd ~status ~output =
     ~output
     ()
 
-let test_semantic_off_by_default () =
+let test_semantic_hidden_on_explicit_off () =
+  (* Post-flip: the only way the semantic field vanishes is an
+     explicit operator opt-out.  Covers the "byte-identical
+     pre-P1 shape" path for rare callers that need it. *)
   with_semantic_flag false (fun () ->
     let json = run_json ~cmd:"ls" ~status:(Unix.WEXITED 0) ~output:"" in
     match json |> member "semantic_exit" with
@@ -374,8 +380,8 @@ let () =
         ] );
       ( "semantic_exit",
         [
-          test_case "flag off by default hides field" `Quick
-            test_semantic_off_by_default;
+          test_case "explicit opt-out hides field" `Quick
+            test_semantic_hidden_on_explicit_off;
           test_case "ok kind on exit 0" `Quick test_semantic_ok_when_flag_on;
           test_case "fail kind carries exit_code" `Quick
             test_semantic_fail_carries_exit_code;


### PR DESCRIPTION
## Summary

Legendary Bash plan decision point 5: "Phase 1 머지 직후 `MASC_BASH_SEMANTIC_EXIT=1` flag-on (additive 필드라 무파손), 다음 minor bump에서 flag 제거."

P1 landed in #8721. This is the first post-merge default flip.

## Product impact

Every `keeper_bash` response now carries a typed `semantic_exit` variant and a human-readable `return_code_interpretation` hint by default. Agents can read exit semantics without scraping stderr or reasoning over raw POSIX exit codes (127 vs 128 vs 126 vs dmesg).

The field is purely additive — no existing JSON key is removed or renamed. Downstream consumers that parse `status` alone are byte-identically unaffected.

Explicit opt-out still available: `MASC_BASH_SEMANTIC_EXIT=0` (or `false` / `FALSE` / `no` / `off`) restores the pre-P1 shape.

## Evidence

- `lib/exec/exec_semantic.ml` :: `enabled ()` — unset env → `true`; explicit off tokens enumerated.
- `test_exec_semantic` — `default_on` replaces `default_off`; `explicit_off` covers the opt-out token set (`0` / `false`).
- `test_exec_core.with_semantic_flag` — helper updated to use `"0"` (not `""`) for the off path so it survives future default changes.
- `docs/ENV-CONTRACT.md §4` + `CHANGELOG [Unreleased] Changed` updated in the same PR.

## Review evidence

- Self-review on a fresh worktree off `origin/main`.
- No other `MASC_BASH_*` flag touched; scope is exactly one env read.

## Linked issue

Refs #8721 — Legendary Bash P1–P6, which added the flag in its default-off state.

## Rollout

The flag itself is kept so consumers preferring the byte-identical pre-P1 shape get one more minor bump of grace before removal. A follow-up chore PR at the next minor will delete `enabled ()` and every `if Exec_semantic.enabled () then …` gate, making the typed `semantic_exit` always-emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)