### PR TITLE
chore(tool_name): migrate 3 auto_responder call sites to Tool_name.Masc SSOT (#8448)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -270,7 +270,11 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
         ("capabilities", `List [`String "model-auto-responder"]);
       ]
     in
-    match masc_call ~sw ~tool_name:"masc_join" ~args:join_args with
+    match
+      masc_call ~sw
+        ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Join)
+        ~args:join_args
+    with
     | Error e ->
         debug_log (Printf.sprintf "MASC_JOIN_FAILED: %s" e);
         Log.AutoResponder.error "Failed to join MASC (%s)" e
@@ -284,12 +288,20 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
         | Some nickname ->
             let msg = Printf.sprintf "@%s %s" mention response in
             let broadcast_args = `Assoc [("agent_name", `String nickname); ("message", `String msg)] in
-            (try ignore (masc_call ~sw ~tool_name:"masc_broadcast" ~args:broadcast_args)
+            (try
+               ignore
+                 (masc_call ~sw
+                    ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Broadcast)
+                    ~args:broadcast_args)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn -> Log.AutoResponder.error "broadcast failed: %s" (Printexc.to_string exn));
             let leave_args = `Assoc [("agent_name", `String nickname)] in
-            (try ignore (masc_call ~sw ~tool_name:"masc_leave" ~args:leave_args)
+            (try
+               ignore
+                 (masc_call ~sw
+                    ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Leave)
+                    ~args:leave_args)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn -> Log.AutoResponder.error "leave failed: %s" (Printexc.to_string exn));


### PR DESCRIPTION
Follow-up to #8640 (hot-path migration under #8448).

## Summary

\`lib/auto_responder.ml\`의 3 raw 리터럴(\`"masc_join"\`, \`"masc_broadcast"\`, \`"masc_leave"\`)을 \`Tool_name.Masc.to_string\` SSOT 경유로 변경. 앞으로 variant rename 시 이 call site들은 compile error로 조기 검출.

## Before / After

\`\`\`ocaml
(* Before *)
masc_call ~sw ~tool_name:"masc_broadcast" ~args:broadcast_args

(* After *)
masc_call ~sw
  ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Broadcast)
  ~args:broadcast_args
\`\`\`

## Behaviour change

0. 각 리터럴은 \`Tool_name.Masc.to_string\` 반환값과 byte-for-byte 동일. \`dune build --root .\`로 verify.

## Files

- \`lib/auto_responder.ml\` (L273, L287, L292)

## #8448 migration progress

- [x] #8640: 4 hot-path sites (keeper_types, mcp_server_eio, server_bootstrap_loops, server_routes_http_routes_dashboard)
- [x] **This PR**: 3 auto_responder sites
- [ ] Remaining: tool_permission_map (87 literals), tool_catalog_surfaces (110), tool_prefilter (48), tool_catalog (55), ...

## Verification

- \`dune build --root .\` — clean