### PR TITLE
docs(logic): batch-4 .mli for tool_args/governance_pipeline_risk/tool_task_schemas (3 files)

### DIFF
--- a/lib/governance_pipeline_risk.mli
+++ b/lib/governance_pipeline_risk.mli
@@ -1,0 +1,62 @@
+(** Governance pipeline — risk assessment and trifecta capability analysis.
+
+    Implements Simon Willison's "Lethal Trifecta" detection:
+    an agent simultaneously holding
+    (1) untrusted external input,
+    (2) sensitive data access, and
+    (3) state modification capability = security incident.
+
+    Meta AI's "Rule of Two" mitigation: when all 3 capability classes are
+    active, escalate [State_modification] tools to at least [High] risk
+    to fire HITL gates earlier.
+
+    Capability classification and risk patterns live in code (not TOML)
+    because a change is a security policy change requiring review. *)
+
+open Governance_pipeline_types
+
+(** {1 Tool capability classification} *)
+
+(** Lookup the capability classes declared for [tool_name].
+    Returns [[]] when the tool is not classified. *)
+val tool_capabilities : string -> capability_class list
+
+(** {1 Trifecta assessment} *)
+
+(** [assess_trifecta ~active_tool_names] scans the active tool set and
+    returns [(class_count, has_external, has_sensitive, has_state_mod)].
+
+    [class_count] is the number of capability classes present (0–3).
+    The trifecta is active when [class_count = 3]. *)
+val assess_trifecta :
+  active_tool_names:string list -> int * bool * bool * bool
+
+(** [combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk
+    ~input] lifts [base_risk] to at least [High] when the trifecta is
+    active and [tool_name] has [State_modification] capability.
+
+    [keeper_shell] read-only github ops are exempt (checked via
+    [Keeper_tool_registry.is_read_only_with_input]). *)
+val combinatorial_risk_escalation :
+  trifecta_active:bool ->
+  tool_name:string ->
+  base_risk:risk_level ->
+  input:Yojson.Safe.t ->
+  risk_level
+
+(** {1 Risk assessment} *)
+
+(** [assess_risk ~tool_name ~input] computes the final risk level for a
+    tool invocation by combining:
+
+    {ul
+    {- payload-based classification (destructive content detection,
+       empty-overwrite guard) — [Critical] short-circuit}
+    {- metadata (Tool_catalog.destructive / readonly flags)}
+    {- explicit per-tool overrides}
+    {- [masc_transition] action pattern matching}
+    {- substring pattern matching over [tool_name]}
+    {- keeper mutation floor ([High] minimum for
+       [keeper_fs_edit] / [keeper_write] / non-read-only [keeper_shell])}} *)
+val assess_risk :
+  tool_name:string -> input:Yojson.Safe.t -> risk_level

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -1,0 +1,161 @@
+(** Tool_args — tool-convention argument extraction wrappers over
+    {!Safe_ops} plus canonical error/OK response helpers.
+
+    All [tool_*.ml] files should [open Tool_args] instead of defining
+    local helpers.
+
+    {b Signature convention}: [get_TYPE args key default] (positional,
+    args first) — bridges tool-file convention to the labeled
+    {!Safe_ops} API [Safe_ops.json_TYPE ~default key args].
+
+    {b Empty-string filtering}: {!get_string_opt} treats [""] as [None],
+    matching the majority tool convention. *)
+
+(** {1 Permissive extractors}
+
+    Return the [default] (or [None] for [_opt] variants) on missing or
+    type-mismatched input; never raise. *)
+
+val get_string : Yojson.Safe.t -> string -> string -> string
+
+val get_int : Yojson.Safe.t -> string -> int -> int
+
+val get_float : Yojson.Safe.t -> string -> float -> float
+
+val get_bool : Yojson.Safe.t -> string -> bool -> bool
+
+(** [None] on missing {b or} empty-string value. *)
+val get_string_opt : Yojson.Safe.t -> string -> string option
+
+val get_int_opt : Yojson.Safe.t -> string -> int option
+
+val get_float_opt : Yojson.Safe.t -> string -> float option
+
+val get_bool_opt : Yojson.Safe.t -> string -> bool option
+
+val get_string_list : Yojson.Safe.t -> string -> string list
+
+(** {1 Machine-readable error codes}
+
+    MCP clients match on [error_code] to decide retry / escalation /
+    display paths.
+
+    @since 2.163.0 *)
+
+type error_code =
+  | Validation_error      (** Missing or invalid input parameters. *)
+  | Not_found             (** Requested resource does not exist. *)
+  | Auth_required         (** Authentication needed. *)
+  | Permission_denied     (** Authenticated but not authorized. *)
+  | Conflict              (** Resource state conflict (e.g. already claimed). *)
+  | Rate_limited          (** Too many requests. *)
+  | Timeout               (** Operation timed out. *)
+  | Not_implemented       (** Feature exists in schema but not in runtime. *)
+  | Internal_error        (** Unexpected server-side failure. *)
+  | Precondition_failed   (** Required precondition not met (e.g. room not joined). *)
+
+val error_code_to_string : error_code -> string
+
+(** {1 Canonical error / OK response helpers}
+
+    New tool handlers should use these instead of local helpers.
+    Returns either a JSON string or the [(bool * string)] pair matching
+    the standard tool dispatch signature. *)
+
+(** [{"status":"error","message":"…"}] *)
+val error_response : string -> string
+
+(** [{"status":"error","error_code":"…","message":"…"}] — preferred. *)
+val error_response_typed : code:error_code -> string -> string
+
+(** [{"status":"ok", <fields>}] *)
+val ok_response : (string * Yojson.Safe.t) list -> string
+
+val error_result : string -> bool * string
+
+val error_result_typed : code:error_code -> string -> bool * string
+
+val ok_result : (string * Yojson.Safe.t) list -> bool * string
+
+(** {1 Required field extractors (Parse, Don't Validate)}
+
+    Return [Ok value] on success, [Error json_error_string] on missing /
+    empty input. Combine with {!val-(let*!)} for early-return chaining. *)
+
+(** Trim whitespace; reject empty. *)
+val get_string_required : Yojson.Safe.t -> string -> (string, string) result
+
+val get_int_required : Yojson.Safe.t -> string -> (int, string) result
+
+(** Monadic bind for [(value, error_json) result] → [(bool * string)].
+    Chains required field extractions with early error return. *)
+val ( let*! ) :
+  ('a, string) result -> ('a -> bool * string) -> bool * string
+
+(** {1 Structured field validation}
+
+    Machine-readable field-path error feedback — callers receive which
+    field failed, what was expected, what was received, enabling
+    deterministic self-correction.
+
+    @since 2.170.0
+    @see <https://github.com/jeong-sik/masc-mcp/issues/4963> *)
+
+type field_constraint =
+  | Required           (** Field must be present. *)
+  | Non_empty          (** String must not be empty after trimming. *)
+  | Type_string        (** Value must be a JSON string. *)
+  | Type_int           (** Value must be a JSON integer. *)
+  | Type_float         (** Value must be a JSON number. *)
+  | Type_bool          (** Value must be a JSON boolean. *)
+  | Min_int of int     (** Integer must be >= min. *)
+  | Max_int of int     (** Integer must be <= max. *)
+  | One_of of string list  (** String must be one of the listed values. *)
+
+val field_constraint_to_string : field_constraint -> string
+
+type field_error = {
+  field : string;
+  constraint_violated : field_constraint;
+  message : string;
+  expected : string option;
+  received : string option;
+}
+
+val field_error_to_yojson : field_error -> Yojson.Safe.t
+
+(** [{"status":"error","error_code":"validation_error",
+    "field_errors":[…],"message":"N field error(s)"}] *)
+val validation_error_response : field_error list -> string
+
+val validation_error_result : field_error list -> bool * string
+
+(** {1 Field validators}
+
+    Each returns [Ok value] or [Error field_error]. Use {!validate_all}
+    to collect multiple errors before returning. *)
+
+val validate_string_required :
+  Yojson.Safe.t -> string -> (string, field_error) result
+
+val validate_int_required :
+  Yojson.Safe.t -> string -> (int, field_error) result
+
+val validate_int_range :
+  Yojson.Safe.t ->
+  string ->
+  min_v:int ->
+  max_v:int ->
+  default:int ->
+  (int, field_error) result
+
+val validate_one_of :
+  Yojson.Safe.t ->
+  string ->
+  allowed:string list ->
+  default:string ->
+  (string, field_error) result
+
+(** Collect any [Error]s from [results]; returns [Ok ()] when all pass. *)
+val validate_all :
+  (unit, field_error) result list -> (unit, field_error list) result

--- a/lib/tool_task_schemas.mli
+++ b/lib/tool_task_schemas.mli
@@ -1,0 +1,14 @@
+(** Tool_task_schemas — MCP tool schema definitions for task operations.
+
+    Pure data module. Consumed by the MCP tool registry at startup to
+    advertise task-related tool input/output shapes to clients.
+
+    @since God file decomposition — extracted from [tool_task.ml] *)
+
+(** Static list of [Types.tool_schema] records, one per task operation
+    (masc_add_task, masc_claim_task, masc_claim_next, masc_transition,
+    masc_task_state, …). Each entry carries [name], [description], and
+    [input_schema] (JSON Schema object).
+
+    Immutable at runtime. *)
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary

Wave 3 batch 4 — `_types*` 모듈군에서 pure-logic 모듈로 전환. `.mli` 3개, 바디 무수정.

## 대상 파일 (3개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/tool_args.mli` | 253 | 163 | permissive + required extractors + error/ok helpers + structured validation |
| `lib/governance_pipeline_risk.mli` | 261 | 60 | Lethal Trifecta + risk assessment (narrow surface 4 val) |
| `lib/tool_task_schemas.mli` | 261 | 14 | 정적 데이터 — 단일 `schemas : Types.tool_schema list` |

## 설계 노트

### tool_args (widely-opened module)
- **모든 `tool_*.ml`이 `open Tool_args`** 하므로 표면을 **보수적으로 넓게** 노출 (internal helper 없음).
- 3-tier API:
  1. **Permissive** — `get_string`/`get_int`/…/`get_string_opt` (default fallback, 예외 없음)
  2. **Required** — `get_string_required`/`get_int_required` → `Ok v | Error json_err`
  3. **Structured validation** — `validate_*` → `Ok v | Error field_error`
- `error_code` enum (10 variants) + `field_constraint` enum (9 variants) — MCP 클라이언트가 프로그램적으로 분류 가능.
- `let*!` monadic bind operator 노출.

### governance_pipeline_risk (narrow public surface)
- 외부 소비자(`governance_pipeline.ml`) 가 쓰는 **4 function**만 노출:
  - `tool_capabilities`
  - `assess_trifecta ~active_tool_names`
  - `combinatorial_risk_escalation`
  - `assess_risk ~tool_name ~input`
- Internal helper 15+ (risk_overrides, critical/high/medium_patterns, classify_name, collect_string_values, has_destructive_payload, keeper_mutation_requires_high_floor 등) 모두 hide.
- Simon Willison Lethal Trifecta + Meta AI Rule of Two 근거 module doc 보존.

### tool_task_schemas (statically one binding)
- ml 261줄, mli 14줄 — **19× 크기 차**. static JSON schema list.
- `val schemas : Types.tool_schema list` 하나만 공개.
- 소비자: `agent_tool_surfaces.ml` + `test/test_tool_input_validation.ml`.

## 검증

- `dune build --root=.` (전체) → **exit 0**
- `open Tool_args` 경로(~15개 tool_*.ml) 컴파일 유지

## 현재 누적 (세션)

| # | PR | 파일 수 | 상태 |
|---|----|---------|------|
| 1 | #8821 (response.mli) | 1 | MERGED |
| 2 | #8847 (post_verifier.mli) | 1 | MERGED |
| 3 | #8859 (batch-1 pure-types 6) | 6 | MERGED |
| 4 | #8865 (batch-2 mid-types 3) | 3 | MERGED |
| 5 | #8877 (batch-3 mid-types 3) | 3 | MERGED |
| **6** | **이 PR (batch-4 logic 3)** | **3** | Open |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 303 | **306** |
| Wave 3 진행 | 14/113 (12.39%) | **17/113 (15.04%)** |

## 다음 batch 후보 (batch-5)

Logic 계속:
- `lib/run_eio.ml` (267), `lib/coord/coord_portal.ml` (261), `lib/tool_inline_dispatch.ml` (270), `lib/dashboard/dashboard_http_monitoring.ml` (272), `lib/meta_cognition_rules.ml` (272)

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] internal helper hide (governance_pipeline_risk 15+ helper)
- [x] `open Tool_args` 호환 유지 (보수적 surface 공개)
- [x] hype 금지 (정량치만)

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
