### PR TITLE
feat(bonsai-dashboard): persist theme choice to localStorage

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -2,17 +2,23 @@ open! Core
 open! Bonsai_web
 open Js_of_ocaml
 
-(* URL hash로 data-theme 선택. colors_and_type.css가 이미 SPA head에
-   :root palette 5종을 공급하므로 <html data-theme="..."> 한 줄로 전체
-   팔레트가 즉시 전환된다.
+(* URL hash + localStorage 기반 data-theme 선택.
+
+   우선순위 (초기 paint):
+     1. URL hash (#cyberpunk, #paper ...) — 공유 링크의 SSOT
+     2. localStorage["masc.bonsai.theme"] — 이전 세션 기억
+     3. dark-fantasy (default)
+
+   hashchange / chip 클릭으로 theme 바뀌면 localStorage에도 저장해서
+   다음 방문에 URL 없이도 같은 테마로 복원. 단, URL이 존재하면 URL
+   우선 — 공유 링크가 stored 값을 덮어쓴다.
 
    해시 예:
      http://127.0.0.1:8935/dashboard/b/#cyberpunk
      http://127.0.0.1:8935/dashboard/b/#terminal
-     http://127.0.0.1:8935/dashboard/b/#dark (또는 해시 없음)
+*)
 
-   hashchange 이벤트도 listen해 전환을 즉시 반영한다. 세션 간 persistence는
-   아직 없음 (localStorage 미사용) — URL이 SSOT. *)
+let storage_key = "masc.bonsai.theme"
 
 let normalize_theme_token s =
   match String.lowercase s with
@@ -22,6 +28,25 @@ let normalize_theme_token s =
   | "paper" -> Some "paper"
   | "dark" | "dark-fantasy" -> Some "dark-fantasy"
   | _ -> None
+;;
+
+let local_storage () =
+  Js.Optdef.to_option Dom_html.window##.localStorage
+
+let read_stored_theme () =
+  match local_storage () with
+  | None -> None
+  | Some storage ->
+    (match Js.Opt.to_option (storage##getItem (Js.string storage_key)) with
+     | None -> None
+     | Some v -> normalize_theme_token (Js.to_string v))
+;;
+
+let write_stored_theme theme =
+  match local_storage () with
+  | None -> ()
+  | Some storage ->
+    storage##setItem (Js.string storage_key) (Js.string theme)
 ;;
 
 let current_hash_theme () =
@@ -35,16 +60,22 @@ let current_hash_theme () =
 let apply_theme theme =
   Dom_html.document##.documentElement##setAttribute
     (Js.string "data-theme")
-    (Js.string theme)
+    (Js.string theme);
+  write_stored_theme theme
+;;
+
+let resolve_initial_theme () =
+  match current_hash_theme () with
+  | Some t -> t
+  | None ->
+    (match read_stored_theme () with
+     | Some t -> t
+     | None -> "dark-fantasy")
 ;;
 
 let install_theme_listener () =
-  (* 첫 paint부터 data-theme 를 항상 설정한다. hash 없으면 dark-fantasy.
-     이렇게 해야 cascading selector `html[data-theme="..."]` 기반의
-     active chip 하이라이트가 default 상태에서도 매칭된다. *)
-  (match current_hash_theme () with
-   | Some t -> apply_theme t
-   | None -> apply_theme "dark-fantasy");
+  (* 초기 paint: URL hash > localStorage > dark-fantasy *)
+  apply_theme (resolve_initial_theme ());
   let on_hashchange _ =
     (match current_hash_theme () with
      | Some t -> apply_theme t


### PR DESCRIPTION
## Summary

`#8863` (hash switcher) + `#8875` (chip UI) + `#8878` (active highlight) 뒤에 오는 마지막 UX 조각: **theme choice를 localStorage에 보관**. URL 없이도 이전 세션 선택을 기억.

## 우선순위 (초기 paint)

```
1. URL hash (#cyberpunk, #paper)       — 공유 링크 SSOT
2. localStorage["masc.bonsai.theme"]  — 이전 세션
3. dark-fantasy                       — default
```

공유 링크가 **항상** 우선. URL이 있으면 stored 값을 덮어쓴다 (explicit intent).

## 구현

- `local_storage()` — `Js.Optdef.to_option`으로 안전 접근 (Safari Private Mode, 쿠키 차단 등에서 `undefined`일 수 있음)
- `read_stored_theme` / `write_stored_theme` helpers
- `apply_theme` 내부에서 항상 write → hash 변경이든 chip 클릭이든 어느 경로든 persist 보장 (duplicate write OK)
- `resolve_initial_theme` — 3-step priority chain

~30줄 추가. `logs_view.ml` 무변경.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] `[cyber]` 클릭 후 페이지 새로고침 (URL에 hash 없이) → cyberpunk 유지
- [ ] `/dashboard/b/#paper` 로드 → paper 팔레트 + localStorage 갱신
- [ ] DevTools Application → Local Storage → `masc.bonsai.theme` = `paper`
- [ ] Private Mode에서도 에러 없이 동작 (localStorage unavailable path)
- [ ] `localStorage.clear()` 후 리로드 → dark-fantasy default

## DS token delivery 완성도

| 층 | PR | 상태 |
|---|---|---|
| CSS supply line | #8848 | MERGED |
| hex → var(--*) | #8861 | MERGED |
| URL hash switcher | #8863 | MERGED |
| chip UI | #8875 | MERGED |
| chip active highlight | #8878 | MERGED |
| **localStorage persist** | **이 PR** | Draft |

5종 테마 live 전환 + 기억 + 공유 — DS delivery 스택이 여기서 일단락된다. 다음 작업은 UI Kit 자체 (dashboard_v2의 다른 섹션 포팅) 또는 실 데이터 endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
