### PR TITLE
chore(tool_name): migrate 2 more call sites (governance_pipeline_risk + keeper_tool_policy) to Tool_name.Masc SSOT (#8448)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -231,7 +231,10 @@ let baseline_risk ~tool_name ~input =
       match List.assoc_opt tool_name risk_overrides with
       | Some level -> level
       | None ->
-          if String.equal tool_name "masc_transition" then
+          if
+            String.equal tool_name
+              (Tool_name.Masc.to_string Tool_name.Masc.Transition)
+          then
             match transition_action input with
             | Some action -> classify_name action
             | None -> Low

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -218,10 +218,11 @@ let keeper_supported_masc_schemas (schemas : Types.tool_schema list) =
      author/voter fields. Exposing both leads to the LLM calling the raw
      masc_* variant without the required author, causing "author is required". *)
   let has_keeper_board_wrapper name =
-    match name with
-    | "masc_board_comment" | "masc_board_post"
-    | "masc_board_vote" | "masc_board_delete" -> true
-    | _ -> false
+    let eq v = String.equal name (Tool_name.Masc.to_string v) in
+    eq Tool_name.Masc.Board_comment
+    || eq Tool_name.Masc.Board_post
+    || eq Tool_name.Masc.Board_vote
+    || eq Tool_name.Masc.Board_delete
   in
   List.filter (fun (s : Types.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name


### PR DESCRIPTION
Follow-up to #8640 and #8881 (#8448 migration series).

## Sites migrated (2, 5 literals total)

### \`lib/governance_pipeline_risk.ml:234\`
Single-site \`String.equal tool_name "masc_transition"\` → \`Tool_name.Masc.(to_string Transition)\`.

### \`lib/keeper/keeper_tool_policy.ml:222-223\`
4-variant match \`"masc_board_comment" | ..._post | ..._vote | ..._delete\` → 4 explicit \`Tool_name.Masc.(to_string Board_*)\` comparisons via local \`eq\` helper. \`of_string\`-based form은 unknown-input의 drift 가능성 때문에 의도적으로 회피.

## Behaviour change

0. 각 리터럴은 대응하는 \`Tool_name.Masc.to_string\` 반환값과 byte-for-byte 동일. \`dune build --root .\` clean.

## #8448 progress

- [x] #8640: keeper_types, mcp_server_eio, server_bootstrap_loops, server_routes_http_routes_dashboard (4 sites)
- [x] #8881: auto_responder (3 sites)
- [x] **This PR**: governance_pipeline_risk + keeper_tool_policy (2 sites, 5 literals)
- [ ] Remaining large targets: tool_permission_map (87), tool_catalog_surfaces (110), tool_prefilter (48), tool_catalog (55)
- [ ] Downstream-lib barriers: \`lib/tool_schemas/*\` lives in \`masc_types\` lib which cannot depend on \`masc_mcp\` where \`Tool_name\` resides — requires lifting \`Tool_name\` to \`masc_types\` (larger refactor).

## Verification

- \`dune build --root .\` — clean