### PR TITLE
fix(cascade): starvation guard on priority_tier + circuit_breaker_cycling

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -188,9 +188,14 @@ let priority_tier_order adapter ctx ~tiers ~cycle cands =
   | [] -> []
   | _ ->
     let in_tier c = List.mem (adapter.health_key c) allowed in
-    cands
-    |> List.filter in_tier
-    |> filter_capacity adapter ctx
+    let tier_cands = List.filter in_tier cands in
+    (* Starvation guard: if every tier candidate reports capacity=0, fall
+       through with the unfiltered tier list so at least one call is
+       attempted and the real upstream error (rate limit, auth) surfaces
+       instead of silently exhausting the cascade.  Mirrors
+       weighted_shuffle's guard at [weighted_shuffle]:140-145. *)
+    let with_capacity = filter_capacity adapter ctx tier_cands in
+    if with_capacity = [] then tier_cands else with_capacity
 
 (* ── Sticky ─────────────────────────────────────────────────────── *)
 
@@ -249,9 +254,13 @@ let order_candidates t ~adapter ~ctx ~cycle cands =
   | Weighted_random ->
     weighted_shuffle adapter ctx cands
   | Circuit_breaker_cycling ->
-    cands
-    |> filter_cooldown adapter ctx
-    |> filter_capacity adapter ctx
+    let cooled = filter_cooldown adapter ctx cands in
+    (* Starvation guard: same pattern as priority_tier_order.  When all
+       candidates report capacity=0 the cascade would otherwise exit
+       with no real call attempt — prefer to try once and let the real
+       error surface. *)
+    let with_capacity = filter_capacity adapter ctx cooled in
+    if with_capacity = [] then cooled else with_capacity
   | Priority_tier ->
     priority_tier_order adapter ctx ~tiers:t.tiers ~cycle cands
   | Sticky ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -162,6 +162,25 @@ let test_cb_cycling_excludes_cooldown_and_busy () =
   check (list string) "cooldown 'a' + busy 'b' filtered, 'c' (unknown) kept"
     ["c"] (names ordered)
 
+let test_cb_cycling_starvation_guard () =
+  (* Cooldown filter passes both 'a' and 'b', but capacity reports 0 for
+     both.  Guard must return the post-cooldown list instead of empty so
+     a real call is attempted (otherwise cascade exhausts with no
+     upstream error signal). *)
+  let h = H.create () in
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let table = [
+    (List.nth cands 0).url, mk_capacity_info ~total:1 ~active:1;
+    (List.nth cands 1).url, mk_capacity_info ~total:1 ~active:1;
+  ] in
+  let ctx = mk_ctx ~health:h ~capacity:(stub_capacity table) () in
+  let strat = mk_t S.Circuit_breaker_cycling
+      ~cycle:{ max_cycles = 3; backoff_base_ms = 100; backoff_cap_ms = 1000 }
+  in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "all-busy cooled list → fall through non-empty"
+    ["a"; "b"] (names ordered)
+
 (* ── Cycle policy + backoff ───────────────────────────────────── *)
 
 let test_default_cycle_policy_backward_compat () =
@@ -419,6 +438,22 @@ let test_priority_tier_capacity_filter () =
   let ctx = mk_ctx ~capacity:(stub_capacity table) () in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "tier 0 with 'a' busy → only 'b'" ["b"] (names ordered)
+
+let test_priority_tier_starvation_guard () =
+  (* All tier candidates report capacity=0.  Without the guard the
+     cascade would exit empty and surface as "all candidates filtered
+     after N cycle(s)"; with it, the tier list itself is returned so
+     at least one real call is attempted. *)
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let table = [
+    (List.nth cands 0).url, mk_capacity_info ~total:1 ~active:1;
+    (List.nth cands 1).url, mk_capacity_info ~total:1 ~active:1;
+  ] in
+  let strat = mk_t S.Priority_tier ~tiers:[["a"; "b"]] in
+  let ctx = mk_ctx ~capacity:(stub_capacity table) () in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "all-busy tier → fall through with tier list"
+    ["a"; "b"] (names ordered)
 
 (* ── Phase B: Sticky (S6) ──────────────────────────────────── *)
 
@@ -862,6 +897,8 @@ let () =
     "circuit_breaker_cycling", [
       test_case "excludes cooldown and busy" `Quick
         test_cb_cycling_excludes_cooldown_and_busy;
+      test_case "all-busy cooled list falls through (starvation guard)" `Quick
+        test_cb_cycling_starvation_guard;
     ];
     "cycle_policy", [
       test_case "default policy backward-compat" `Quick
@@ -912,6 +949,8 @@ let () =
         test_priority_tier_clamps_overflow;
       test_case "tier respects capacity filter" `Quick
         test_priority_tier_capacity_filter;
+      test_case "all-busy tier falls through (starvation guard)" `Quick
+        test_priority_tier_starvation_guard;
     ];
     "sticky", [
       test_case "record_choice → pinned on next call" `Quick


### PR DESCRIPTION
## Summary

`priority_tier` 와 `circuit_breaker_cycling` strategy에 starvation guard 추가. 모든 후보가 capacity=0 이면 실제 호출 0회 시도하고 cascade exhausted — "새가슴" 패턴. `weighted_shuffle` 은 이미 같은 guard 有 (`lib/cascade/cascade_strategy.ml:140-145`), 두 strategy만 비대칭이었음.

## Product impact

- Fleet 안정성 회복: cascade_exhausted `all candidates filtered after N cycle(s)` 신호 제거. 2026-04-20 2h49m 관찰창에서 192건 / 분당 1.1건 발생.
- Provider health tracker 정확도 향상: capacity=0 상황에서도 실제 호출이 이루어져 upstream 오류(429/503)가 cascade_health_tracker 로 전달됨. 이전엔 경직된 capacity 힌트로 자가갱신 막힘.
- 비정상 path 에서 호출 1~N 증가. 정상 path 영향 없음.

## Evidence

실측 (`~/me/.masc/logs/system_log_2026-04-20.jsonl`, 2026-04-19T22:17Z → 2026-04-20T01:06Z):

| signature | count | strategy |
|---|---|---|
| `all candidates filtered after 3 cycle(s) (strategy=priority_tier)` | 169 | cost_tier_ladder (poe) |
| `all candidates filtered after 6 cycle(s) (strategy=circuit_breaker_cycling)` | 23 | resilient_breaker |

두 strategy 모두 capacity filter 실행 후 결과 `[]` → oas_worker_named:654-669 `cascade_exhausted_after_filter` 호출 → `Cascade_exhausted` error. 실제 provider 호출 0회. Rate limit / auth / network upstream signal 하나도 표면화되지 않음.

## Review evidence

- Build: `dune build --root .` 성공
- Unit tests: `dune exec --root . -- test/test_cascade_strategy.exe` → 51/51 pass (신규 starvation guard 2건 포함)
  - `test_priority_tier_starvation_guard`
  - `test_cb_cycling_starvation_guard`
- Diff stat: 2 files, +54/-6

## Linked issue

Refs observed failures in fleet log 2026-04-20. No dedicated issue — 감지 즉시 수정.

## 기술 세부

변경 1 — `priority_tier_order`:
```ocaml
let tier_cands = List.filter in_tier cands in
let with_capacity = filter_capacity adapter ctx tier_cands in
if with_capacity = [] then tier_cands else with_capacity
```

변경 2 — `Circuit_breaker_cycling` branch:
```ocaml
let cooled = filter_cooldown adapter ctx cands in
let with_capacity = filter_capacity adapter ctx cooled in
if with_capacity = [] then cooled else with_capacity
```

동작 원칙: capacity 신호는 힌트, 실측이 아님. 전부 busy 로 보여도 최소 1회는 실제 호출을 시도해 진짜 upstream 오류가 드러나야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)