### PR TITLE
chore(exec_core): flip MASC_BASH_VERIFIABLE_MARKERS default to on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ### Changed
 
+- **`MASC_BASH_VERIFIABLE_MARKERS` flipped to on by default.**
+  Post-Legendary-Bash-P6 (#8721) rollout step paralleling the
+  `SEMANTIC_EXIT` flip: every `keeper_bash` response now carries
+  the `verifiable_markers` array (typed `Test_pass {count}`,
+  `Build_ok`, `Lint_clean`, `Git_clean`, each with
+  `Exact | Heuristic` confidence) when the heuristic matches.
+  Empty-result callers are omitted, so consumers that don't parse
+  the key remain byte-compatible.  Explicit opt-out: set the env
+  to `0` / `false` / `no` / `off`.  The flag itself survives one
+  more minor bump before removal.
+
 - **`MASC_BASH_SEMANTIC_EXIT` flipped to on by default.** Post-
   Legendary-Bash-P1 (#8721) rollout step: every `keeper_bash`
   response now carries the typed `semantic_exit` variant and the

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -126,7 +126,7 @@ never break by enabling them.
 | `MASC_BASH_AUTO_BG` | off | Foreground commands that outrun `MASC_BLOCKING_BUDGET_MS` (default 15 000 ms) auto-promote to a `Bg_task`. Response gains `{promoted, background_task_id, partial_output, …}`. See `lib/exec/exec_run.mli`. |
 | `MASC_BLOCKING_BUDGET_MS` | 15 000 | Foreground race budget. Consumed only when `MASC_BASH_AUTO_BG` is on; otherwise inert. |
 | `MASC_BASH_AST_ONLY` | off | Single-gate AST shadow (dual-gate is the default). Flip requires a prod N=1000 zero-diff window per the flip covenant test (`test_gate_diff.ml`). |
-| `MASC_BASH_VERIFIABLE_MARKERS` | off | Emits `verifiable_markers` from `Cdal_judge.of_exec_outcome` so the verifier cascade can consume typed `Test_pass {count}`, `Build_ok`, etc. without regex scraping. See `lib/cdal_judge.mli`. |
+| `MASC_BASH_VERIFIABLE_MARKERS` | **on** (post flip PR) | Emits `verifiable_markers` from `Cdal_judge.of_exec_outcome` so the verifier cascade can consume typed `Test_pass {count}`, `Build_ok`, etc. without regex scraping. Set to `0` / `false` / `no` / `off` to opt out. See `lib/cdal_judge.mli`. |
 
 Representative code paths:
 

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -525,14 +525,19 @@ let semantic_payload_to_yojson (key, value) =
   in
   (key, v)
 
-(* Tick 16: opt-in flag for verifiable marker emission.  Rolled out
-   separately from [Exec_semantic] (MASC_BASH_SEMANTIC_EXIT) so the
-   cdal_judge heuristic layer can bake in without affecting JSON
-   shape for callers that only care about [semantic_exit]. *)
+(* Tick 16 introduced the flag opt-in; Tick 21 flips it to
+   default-on.  The verifier cascade (#7598) and any agent that
+   consumes [Test_pass {count}] / [Build_ok] / [Lint_clean] /
+   [Git_clean] now get them without an explicit operator switch.
+   Field is additive only (empty list is omitted), so callers
+   that ignore the [verifiable_markers] key remain byte-compatible.
+   Explicit opt-out: [MASC_BASH_VERIFIABLE_MARKERS=0] (or
+   ["false" / "FALSE" / "no" / "off"]).  The flag itself survives
+   one more minor bump before removal. *)
 let markers_enabled () =
   match Sys.getenv_opt "MASC_BASH_VERIFIABLE_MARKERS" with
-  | Some ("1" | "true" | "TRUE" | "yes") -> true
-  | _ -> false
+  | Some ("0" | "false" | "FALSE" | "no" | "off") -> false
+  | _ -> true
 
 let verifiable_marker_to_json (m : Cdal_judge.verifiable_marker) :
     Yojson.Safe.t =

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -242,8 +242,11 @@ let test_semantic_flag_isolation () =
 (* ---------- P6 Tick 16: verifiable_markers JSON integration -------------- *)
 
 let with_markers_flag enabled f =
+  (* Post-flip: the unset env resolves to ON.  Use "0" for the
+     off path so this helper keeps its pre-flip semantics
+     (enabled=false => markers absent) irrespective of the default. *)
   let prev = Sys.getenv_opt "MASC_BASH_VERIFIABLE_MARKERS" in
-  Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" (if enabled then "1" else "");
+  Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" (if enabled then "1" else "0");
   let restore () =
     match prev with
     | Some v -> Unix.putenv "MASC_BASH_VERIFIABLE_MARKERS" v


### PR DESCRIPTION
## Summary

Second post-P6 default flip after #8879 (SEMANTIC_EXIT). `verifiable_markers` — typed `Test_pass {count}` / `Build_ok` / `Lint_clean` / `Git_clean` with `Exact | Heuristic` confidence — now ship on every `keeper_bash` response by default.

## Product impact

- **Verifier cascade (#7598) stops regex-scraping test output.** Marker list is consumed as-is.
- **Every agent gains Build_ok / Test_pass semantics** without operator opt-in. A keeper that runs `dune runtest` learns whether the suite passed from the typed marker, not stderr substring matching.
- Empty marker list is still omitted, so consumers that don't parse the key are byte-compatible.

## Evidence

- `lib/exec_core.ml :: markers_enabled ()` — match inversion. Explicit off tokens enumerated.
- `test_exec_core.with_markers_flag` — updated to use `"0"` for the off path (future-proof against default changes).
- Alcotest suites under `test/test_exec_core.ml` and `test/test_cdal_verifiable_markers.ml` remain green — they already used the helper.

## Review evidence

- Self-review on a fresh worktree off `origin/main`.
- Mirrors #8879's pattern: single-line match flip, match-order preserved, helper updated, docs + CHANGELOG in same PR.

## Linked issue

Refs #8721 — Legendary Bash P6 introduced the flag default-off.
Refs #8879 — companion SEMANTIC_EXIT flip (merged).
Refs #7598 — verifier cascade that consumes the markers.

## Rollout

Flag kept for one more minor bump, then removed. No dual-consumer path. Opt-out honoured via `MASC_BASH_VERIFIABLE_MARKERS={0|false|no|off}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)