### PR TITLE
fix(activity_graph): strict span_status_of_string_opt + warn wrapper (#8605 family)

### DIFF
--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -76,17 +76,33 @@ let span_status_to_string = function
   | Span_finalized -> "finalized" | Span_stopped -> "stopped"
   | Span_ended -> "ended"
 
-let span_status_of_string = function
-  | "open" -> Span_open
-  | "completed" -> Span_completed
-  | "released" -> Span_released
-  | "cancelled" -> Span_cancelled
-  | "left" -> Span_left
-  | "retired" -> Span_retired
-  | "finalized" -> Span_finalized
-  | "stopped" -> Span_stopped
-  | "ended" -> Span_ended
-  | _ -> Span_ended
+(** Strict parser. Returns [None] on unknown wire so callers can react
+    explicitly (drop / fallback / route). Mirror of [node_status_of_string_opt]
+    introduced in #8779. See #8605. *)
+let span_status_of_string_opt = function
+  | "open" -> Some Span_open
+  | "completed" -> Some Span_completed
+  | "released" -> Some Span_released
+  | "cancelled" -> Some Span_cancelled
+  | "left" -> Some Span_left
+  | "retired" -> Some Span_retired
+  | "finalized" -> Some Span_finalized
+  | "stopped" -> Some Span_stopped
+  | "ended" -> Some Span_ended
+  | _ -> None
+
+(** Back-compat wrapper: unknown wire still falls back to [Span_ended]
+    (the legacy permissive default), but a [Log.Misc.warn] is emitted so
+    producer/consumer drift surfaces in operator logs instead of silently
+    misclassifying the span as terminal. Same template as
+    [node_status_of_string] (#8779). See #8605. *)
+let span_status_of_string s =
+  match span_status_of_string_opt s with
+  | Some v -> v
+  | None ->
+      Log.Misc.warn
+        "activity_graph: unknown span_status wire %S -> Span_ended (drift; see #8605)" s;
+      Span_ended
 
 type entity_ref = {
   kind : string;

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -46,7 +46,13 @@ type span_status =
 
 val span_status_to_string : span_status -> string
 
-(** Lenient parser: unknown wire collapses to [Span_ended]. *)
+(** Strict parser: returns [None] on unknown wire so callers can react
+    explicitly. Mirror of {!node_status_of_string_opt}. See #8605. *)
+val span_status_of_string_opt : string -> span_status option
+
+(** Back-compat parser: unknown wire still collapses to [Span_ended]
+    but emits a [Log.Misc.warn] so producer/consumer drift surfaces in
+    operator logs instead of silently misclassifying the span. *)
 val span_status_of_string : string -> span_status
 
 (** {1 Graph entities} *)

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -9,7 +9,8 @@
 
 # #8605 umbrella — tracked in https://github.com/jeong-sik/masc-mcp/issues/8605
 lib/sdk_tool_contract.ml:377
-lib/activity_graph/activity_graph_types.ml:89
+# activity_graph_types.ml:89 (span_status_of_string) eliminated by this PR --
+# strict _opt + warn-and-default wrapper template (mirrors #8779 node_status).
 # coord.ml:132 (observe_task_transition) eliminated by #8846.
 # coord.ml:88/109 (observe_agent_lifecycle) eliminated by this PR
 # (agent_lifecycle_event variant migration).

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -281,6 +281,19 @@ let test_span_status_of_string_keeps_legacy_unknown_fallback () =
     (Activity_graph.span_status_of_string "definitely-not-a-status"
      |> Activity_graph.span_status_to_string)
 
+let test_span_status_of_string_opt_returns_none_for_unknown () =
+  (* #8605 family: strict variant exposes unknown wires explicitly so
+     callers can react instead of being silently coerced to Span_ended. *)
+  check (option string) "unknown -> None" None
+    (Activity_graph.span_status_of_string_opt "definitely-not-a-status"
+     |> Option.map Activity_graph.span_status_to_string);
+  check (option string) "ended -> Some ended" (Some "ended")
+    (Activity_graph.span_status_of_string_opt "ended"
+     |> Option.map Activity_graph.span_status_to_string);
+  check (option string) "open -> Some open" (Some "open")
+    (Activity_graph.span_status_of_string_opt "open"
+     |> Option.map Activity_graph.span_status_to_string)
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -305,5 +318,7 @@ let () =
             test_span_status_of_string_handles_ended_round_trip;
           test_case "span_status keeps unknown fallback" `Quick
             test_span_status_of_string_keeps_legacy_unknown_fallback;
+          test_case "span_status_opt None for unknown" `Quick
+            test_span_status_of_string_opt_returns_none_for_unknown;
         ] );
     ]


### PR DESCRIPTION
## Summary

\`span_status_of_string\` at \`lib/activity_graph/activity_graph_types.ml:79\` silently coerced any unknown wire string to \`Span_ended\` — the #8605 anti-pattern. A typo'd status (\"opem\") or future variant got marked terminal with no signal in the log.

## Fix (standard wire-string-strict template, mirror of #8779)

```ocaml
let span_status_of_string_opt = function
  | "open" -> Some Span_open  | ... 
  | _ -> None

let span_status_of_string s =
  match span_status_of_string_opt s with
  | Some v -> v
  | None ->
      Log.Misc.warn
        \"activity_graph: unknown span_status wire %S -> Span_ended (drift; see #8605)\" s;
      Span_ended
```

Behaviour preserved bit-identically: every existing call site that hit the legacy fallback still gets `Span_ended`; the warn line is the only new effect.

## Companion

Mirror of **#8779** (`node_status_of_string`). Note: **PR #8736** attempted this exact fix earlier but was closed without merging; this PR re-applies the template using the standardized form that landed for `node_status`.

## .mli updated

Added `val span_status_of_string_opt : string -> span_status option` to `activity_graph_types.mli` so the strict parser is exposed alongside the back-compat one.

## Test plan

- [x] New `_opt` test in `test/test_activity_graph.ml:284` (None for unknown, Some for known wires)
- [x] Existing legacy fallback test still passes (`Span_ended` preserved)
- [x] 10/10 tests pass; `dune build @check` green

```
Test Successful in 0.214s. 10 tests run.
```

## Lint allowlist

`lib/activity_graph/activity_graph_types.ml:89` entry removed with elimination-path comment.

## Pattern siblings

**12th #8605 family fix** in the current sweep. Catalog now spans:

1. wire-string-strict (#8736 / #8740 / #8779 / **8828** / **8833** / **this**)
2. exhaustive-match (**8835** / **8864**)
3. warn-and-default (**8833** / **8828** / **this**)
4. string→variant migration (**8842** / **8846** / **8851** / **8862**)
5. lift-nested-match (**8889**)