### PR TITLE
feat(bonsai-dashboard): .sec section marker + 2 live placements (log ring, keepers)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1319,6 +1319,58 @@ stylesheet
     border-radius: 50%;
     background: currentColor;
   }
+
+  /* ─── .sec section marker ───
+     dashboard_v2 전역 section title 패턴 — 작은 lozenge 글리프 + Cinzel
+     제목 + italic sub + hairline gradient + 우측 mono meta. page-head
+     아래 각 섹션(tape, keepers, context pressure 등)에 등장해 "지금
+     무엇을 보고 있는가"를 한 줄로 알린다. */
+  .sec {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    margin: 8px 0 2px;
+  }
+  .sec_glyph {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-brass);
+    box-shadow: 0 0 6px rgba(138, 106, 40, 0.35);
+    align-self: center;
+  }
+  .sec_h {
+    font-family: 'Cinzel', serif;
+    font-size: 12px;
+    letter-spacing: 0.26em;
+    color: var(--accent-brass);
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .sec_sub {
+    font-family: 'EB Garamond', Georgia, serif;
+    font-style: italic;
+    color: var(--text-dim);
+    font-size: 12px;
+  }
+  .sec_hr {
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      var(--border-highlight) 0%,
+      var(--border-main) 60%,
+      transparent 100%
+    );
+  }
+  .sec_r {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+  }
+  .sec_r_v { color: var(--text-bright); }
 |}]
 
 let level_class level =
@@ -1916,7 +1968,44 @@ let render_response (response : Logs_types.response) : Node.t =
             ~attrs:[ Style.meta ]
             [ Node.text (Printf.sprintf "seq up to %d" response.total) ]
         ]
+    ; Node.div
+        ~attrs:[ Style.sec ]
+        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "log ring" ]
+        ; Node.span
+            ~attrs:[ Style.sec_sub ]
+            [ Node.text "in-memory chronicle · newest on top" ]
+        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span
+            ~attrs:[ Style.sec_r ]
+            [ Node.text "rows "
+            ; Node.span
+                ~attrs:[ Style.sec_r_v ]
+                [ Node.text
+                    (Printf.sprintf "%d"
+                       (List.length response.entries))
+                ]
+            ; Node.text " / total "
+            ; Node.span
+                ~attrs:[ Style.sec_r_v ]
+                [ Node.text (Printf.sprintf "%d" response.total) ]
+            ]
+        ]
     ; tape
+    ; Node.div
+        ~attrs:[ Style.sec ]
+        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "keepers" ]
+        ; Node.span
+            ~attrs:[ Style.sec_sub ]
+            [ Node.text "four hold the halls · one listens through the storm" ]
+        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span
+            ~attrs:[ Style.sec_r ]
+            [ Node.text "slot "
+            ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "iv" ]
+            ]
+        ]
     ; view_roster ()
     ; Node.div ~attrs:[ Style.signet ] [ Node.text "M" ]
     ; aside


### PR DESCRIPTION
## Summary

dashboard_v2 전역 **section title 패턴 `.sec`** 도입. 각 섹션 위에 작은 brass lozenge + Cinzel 제목 + italic sub + hairline gradient + 우측 mono meta. 지금까지 섹션 전환이 시각적으로 약했던 걸 "지금 무엇을 보고 있는가" 라인으로 해결.

## 구조

```
⎔  LOG RING  in-memory chronicle · newest on top  ─────────  rows 8 / total 12
```

- **`.sec_glyph`**: 6px 원 + brass glow (0 0 6px rgba(138,106,40,0.35))
- **`.sec_h`**: Cinzel 12px letter-0.26em brass uppercase
- **`.sec_sub`**: EB Garamond italic dim 12px
- **`.sec_hr`**: `border-highlight → border-main → transparent` 3-stop gradient
- **`.sec_r`**: JetBrains Mono 11px tabular dim / `.sec_r_v`: bright

## 배치 2곳

### 1. `tape` 앞 (live)
```
⎔ log ring · in-memory chronicle · newest on top · rows {N} / total {M}
```
`entries 수` / `response.total` — response 바뀔 때마다 자동 갱신.

### 2. `view_roster` 앞 (static)
```
⎔ keepers · four hold the halls · one listens through the storm · slot iv
```
roster endpoint 없으니 "slot iv" 고정. 향후 live로.

## 남은 활용

dashboard_v2의 context pressure chart, swimlanes, keeper detail list 등 **각 섹션 위에 동일 `.sec` 마커**. 일관된 IA.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 tape 위에 brass lozenge + "LOG RING" 제목 + "rows N / total M" 실시간 갱신
- [ ] 테마 전환 (`#cyberpunk` 등) 시 sec_glyph/brass가 각 테마 accent로 자동 전환 (`var(--accent-brass)` 덕분)
- [ ] 빈 response → `rows 0 / total 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
