### PR TITLE
docs(logic): batch-5 .mli for run_eio + dashboard_http_monitoring (2 files)

### DIFF
--- a/lib/dashboard/dashboard_http_monitoring.mli
+++ b/lib/dashboard/dashboard_http_monitoring.mli
@@ -1,0 +1,30 @@
+(** Dashboard HTTP monitoring — tool-call health, board, and governance
+    JSON builders for the dashboard server.
+
+    Extracted from [server_dashboard_http.ml]. All builders are pure
+    reads of on-disk stores ([Audit_log], board state, governance log)
+    plus wall-clock time; no side effects apart from reading. *)
+
+(** [tool_call_health_json ?now_ts config] aggregates [ToolCall] actions
+    from the audit log within a 1-hour window, partitioned by outcome
+    and per tool. [~now_ts] is injectable for tests (defaults to
+    [Unix.gettimeofday ()]). *)
+val tool_call_health_json :
+  ?now_ts:float -> Coord.config -> Yojson.Safe.t
+
+(** [board_monitoring_json ~now_ts] returns a JSON snapshot of the
+    internal board plus a boolean [needs_attention] flag. *)
+val board_monitoring_json : now_ts:float -> Yojson.Safe.t * bool
+
+(** [governance_monitoring_json ~now_ts ~base_path] summarises governance
+    state rooted at [base_path]. Second element is [needs_attention]
+    (e.g. stale pending rulings). *)
+val governance_monitoring_json :
+  now_ts:float -> base_path:string -> Yojson.Safe.t * bool
+
+(** Point-in-time slot occupancy / queue depth snapshot. *)
+val slot_monitoring_json : unit -> Yojson.Safe.t
+
+(** Per-executor outcome counts (success / failure / cancelled)
+    aggregated from the audit log. *)
+val executor_outcomes_json : Coord.config -> Yojson.Safe.t

--- a/lib/run_eio.mli
+++ b/lib/run_eio.mli
@@ -1,0 +1,126 @@
+(** Execution Memory (Run) — track task runs in [.masc/runs/{task_id}].
+
+    Pure synchronous filesystem operations. Per task, the following
+    files live under the run directory:
+
+    - [run.json]       — metadata ({!run_record} serialised)
+    - [plan.md]        — planning document
+    - [deliverable.md] — task output
+    - [log.jsonl]      — append-only event log ({!log_entry}) *)
+
+(** {1 Types} *)
+
+type run_record = {
+  task_id : string;
+  agent_name : string option;
+  plan : string;
+  deliverable : string;
+  created_at : string;
+  updated_at : string;
+}
+
+type log_entry = {
+  timestamp : string;
+  note : string;
+}
+
+(** {1 JSON serde}
+
+    [_to_json] always succeeds; [_of_json] returns [None] on missing
+    required fields (logs via [Log.Misc.error]). *)
+
+val run_record_to_json : run_record -> Yojson.Safe.t
+
+val run_record_of_json : Yojson.Safe.t -> run_record option
+
+val log_entry_to_json : log_entry -> Yojson.Safe.t
+
+val log_entry_of_json : Yojson.Safe.t -> log_entry option
+
+(** {1 Path builders} *)
+
+val runs_dir : Coord_utils.config -> string
+
+val run_dir : Coord_utils.config -> string -> string
+
+val run_json_path : Coord_utils.config -> string -> string
+
+val plan_path : Coord_utils.config -> string -> string
+
+val deliverable_path : Coord_utils.config -> string -> string
+
+val log_path : Coord_utils.config -> string -> string
+
+(** Create {!run_dir} and parents if missing. *)
+val ensure_run_dir : Coord_utils.config -> string -> unit
+
+val now_iso : unit -> string
+
+(** [""] when the file does not exist. *)
+val read_text_file : string -> string
+
+(** Creates parent directories as needed. *)
+val write_text_file : string -> string -> unit
+
+(** {1 Run lifecycle}
+
+    [init] / [update_plan] / [set_deliverable] / [append_log] implement
+    read-modify-write safety via per-[run.json] file locks to prevent
+    lost updates across concurrent fibers. *)
+
+val write_run : Coord_utils.config -> run_record -> unit
+
+val read_run :
+  Coord_utils.config -> string -> (run_record, string) result
+
+(** [init config ~task_id ~agent_name] creates the run directory,
+    default [plan.md] / [deliverable.md] / [log.jsonl], and writes an
+    initial [run.json]. *)
+val init :
+  Coord_utils.config ->
+  task_id:string ->
+  agent_name:string option ->
+  (run_record, string) result
+
+(** File-locked read-modify-write on [run.json]. *)
+val update_plan :
+  Coord_utils.config ->
+  task_id:string ->
+  content:string ->
+  (run_record, string) result
+
+(** File-locked append to [log.jsonl]. *)
+val append_log :
+  Coord_utils.config ->
+  task_id:string ->
+  note:string ->
+  (log_entry, string) result
+
+(** File-locked read-modify-write on [run.json]. *)
+val set_deliverable :
+  Coord_utils.config ->
+  task_id:string ->
+  content:string ->
+  (run_record, string) result
+
+(** {1 Queries} *)
+
+(** [read_logs ?limit ()] returns all log entries when [limit] is
+    absent; otherwise the last [limit] entries (tail). *)
+val read_logs :
+  Coord_utils.config ->
+  task_id:string ->
+  ?limit:int ->
+  unit ->
+  log_entry list
+
+(** Bundle {!run_record} + plan text + deliverable text + last 50 logs
+    into a single JSON object. *)
+val get :
+  Coord_utils.config ->
+  task_id:string ->
+  (Yojson.Safe.t, string) result
+
+(** List all runs under {!runs_dir} as
+    [{"count": N, "runs": [...]}]. *)
+val list : Coord_utils.config -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

Wave 3 batch 5 — `.mli` 2 파일 추가. coord_portal은 `include Coord_portal` drift 리스크로 보류, batch 크기 축소.

## 대상 파일 (2개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/run_eio.mli` | 267 | 118 | task run 저장 모듈 (2 record + 22 val) |
| `lib/dashboard/dashboard_http_monitoring.mli` | 272 | 33 | 5 JSON builder (tool_call/board/governance/slot/executor) |

## 설계 노트

### run_eio
- **Config 타입**: `Coord_utils.config`를 명시 — `open Coord_utils`의 ml 관용을 mli에서 풀어서 표기.
- **file-lock 안전성 doc 유지**: `update_plan` / `set_deliverable` / `append_log` 의 read-modify-write 락 디시플린은 mli doc comment에 재기록. 향후 리팩터링 시 락 제거 방지.
- **Tail 제한 read_logs**: `?limit` 가 present 면 마지막 N 엔트리, absent 면 전체. mli doc에 명시.

### dashboard_http_monitoring
- **`governance_monitoring_json` 반환 튜플 교정**: ml 시그니처 `Yojson.Safe.t * bool` 확인 후 mli에 반영. 초안에서 `Yojson.Safe.t`로 잘못 선언 → dune build 에러로 즉시 catch.
- **`needs_attention` 플래그**: `governance_monitoring_json` 과 `board_monitoring_json` 둘 다 두 번째 필드가 attention flag — #7815 관련 pending ruling staleness 감지.
- **Testability**: `tool_call_health_json ?now_ts` 주입 가능. mli에 명시.

## 배치 축소 이유 (정직 고지)

원 계획은 3 파일(+coord_portal) 이었으나:
- `coord.ml` 에서 `include Coord_portal` 사용 — mli 작성 시 Coord 전체 signature가 제약됨.
- 공개 함수 9개 중 일부가 내부 lockless read 설계와 결합 → mli drift 없이 작성하려면 Coord 상위까지 확인 필요.
- 다음 batch에서 Coord umbrella 포함 재조사 후 처리.

## 검증

- `dune build --root=.` → **exit 0**
- 두 번째 build에서 governance_monitoring_json tuple drift 수정 (`Yojson.Safe.t` → `Yojson.Safe.t * bool`).

## 현재 누적 (세션)

| # | PR | 파일 수 | 상태 |
|---|----|---------|------|
| 1 | #8821 | 1 | MERGED |
| 2 | #8847 | 1 | MERGED |
| 3 | #8859 | 6 | MERGED |
| 4 | #8865 | 3 | MERGED |
| 5 | #8877 | 3 | MERGED |
| 6 | #8886 | 3 | MERGED |
| **7** | **이 PR** | **2** | Open |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 306 | **308** |
| Wave 3 진행 | 17/113 (15.04%) | **19/113 (16.81%)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] return 타입 정확성 확인 (governance_monitoring_json 초안 catch)
- [x] lock 디시플린 doc 보존
- [x] batch 크기 축소 근거 정직 고지

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
