### PR TITLE
fix(auth): add plan_set_task/plan_clear_task to TaskOpsLimit rate bucket (closes #8873 Option 1)

### DIFF
--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -71,6 +71,12 @@ let limit_for_category config = function
 (** Map tool to rate limit category *)
 let category_for_tool = function
   | "masc_broadcast" -> BroadcastLimit
+  (* plan_set_task / plan_clear_task added in #8873: per-task plan-slot
+     writes are semantically equivalent to set_current_task /
+     complete_task, so they belong to the same TaskOpsLimit (30/min)
+     bucket rather than silently falling through to GeneralLimit
+     (10/min). masc_batch_add_tasks intentionally omitted pending a
+     maintainer call on whether a batch burns 1 or N tokens. *)
   | "masc_add_task"
   | "masc_claim_next"
   | "masc_claim_task"
@@ -79,6 +85,8 @@ let category_for_tool = function
   | "masc_release_task"
   | "masc_cancel_task"
   | "masc_update_priority"
+  | "masc_plan_set_task"
+  | "masc_plan_clear_task"
   | "masc_transition" -> TaskOpsLimit
   | _ -> GeneralLimit
 

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -17,4 +17,4 @@ lib/coord.ml:88
 lib/coord.ml:109
 # eval_harness.ml:370 eliminated by lifting nested string match to outer
 # pattern (this PR — was a provably unreachable dead branch).
-lib/types/types_auth.ml:83
+lib/types/types_auth.ml:91

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1013,9 +1013,22 @@ let test_category_for_tool_task_ops () =
   check bool "masc_add_task" true (Types.category_for_tool "masc_add_task" = Types.TaskOpsLimit);
   check bool "masc_transition" true (Types.category_for_tool "masc_transition" = Types.TaskOpsLimit)
 
+(* Regression guard for #8873: plan-slot writes must share the
+   TaskOpsLimit (30/min) bucket with the other per-task ops, not fall
+   through to GeneralLimit (10/min). *)
+let test_category_for_tool_plan_slot_writes () =
+  check bool "masc_plan_set_task" true
+    (Types.category_for_tool "masc_plan_set_task" = Types.TaskOpsLimit);
+  check bool "masc_plan_clear_task" true
+    (Types.category_for_tool "masc_plan_clear_task" = Types.TaskOpsLimit)
+
 let test_category_for_tool_general () =
   check bool "masc_status" true (Types.category_for_tool "masc_status" = Types.GeneralLimit);
-  check bool "unknown" true (Types.category_for_tool "unknown_tool" = Types.GeneralLimit)
+  check bool "unknown" true (Types.category_for_tool "unknown_tool" = Types.GeneralLimit);
+  (* masc_batch_add_tasks intentionally stays in GeneralLimit until a
+     maintainer call on batch rate-limiting (#8873). *)
+  check bool "masc_batch_add_tasks" true
+    (Types.category_for_tool "masc_batch_add_tasks" = Types.GeneralLimit)
 
 (* ============================================================
    more masc_error_to_string Tests (coverage for all variants)
@@ -1649,6 +1662,7 @@ let () =
     "category_for_tool", [
       test_case "broadcast" `Quick test_category_for_tool_broadcast;
       test_case "task_ops" `Quick test_category_for_tool_task_ops;
+      test_case "plan_slot_writes (#8873)" `Quick test_category_for_tool_plan_slot_writes;
       test_case "general" `Quick test_category_for_tool_general;
     ];
     "masc_error_extended", [


### PR DESCRIPTION
Closes #8873 (Option 1 scope).

## Summary

\`Types_auth.category_for_tool\`가 3개 task-write 도구를 \`GeneralLimit\`(10/min)로 조용히 떨어뜨리던 문제 중 **recommended Option 1**(plan_set_task, plan_clear_task 2개)을 \`TaskOpsLimit\`(30/min)로 명시 등록. keeper가 plan-slot 여러 번 쓰면 의도된 30/min 대신 10/min으로 throttle되던 drift 해소.

## Scope decision

\`masc_batch_add_tasks\`는 일부러 GeneralLimit에 남김. 이슈가 "batch N adds가 token 1개인지 N개인지 maintainer call 필요"로 명시했고, per-item multiplier 설계가 별도 PR 영역이기 때문. \`general\` 테스트에 \`masc_batch_add_tasks -> GeneralLimit\` assertion을 박아 향후 조용한 이동 방지.

## Files

- \`lib/types/types_auth.ml\` (L72-90: 2라인 추가, 결정 근거 docstring)
- \`test/test_types_coverage.ml\` (+1 신규 test + general test에 batch_add_tasks pin)

## Verification

- \`dune build --root .\` — clean
- \`dune exec --root . test/test_types_coverage.exe\` — **188/188 pass**
  - 신규 \`plan_slot_writes (#8873)\`: 두 신규 매핑 모두 TaskOpsLimit
  - 업데이트된 \`general\`: batch_add_tasks는 GeneralLimit 고정

## Out of scope

- \`masc_batch_add_tasks\` 분류 — maintainer call 대기 (이슈 body 명시)
- 250+ read-only 도구의 wildcard fallback — 설계상 primary path (이슈 body 명시)