### PR TITLE
feat(bonsai-dashboard): moonrise clock ticks real browser time every 1s

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -85,9 +85,50 @@ let install_theme_listener () =
   Dom_html.window##.onhashchange := Dom_html.handler on_hashchange
 ;;
 
+(* Moonrise clock — dashboard hero 아래 narrative strip의 "23:50 local"
+   자리에 실제 브라우저 로컬 시각을 매초 투영. Bonsai state 경유
+   안 함 — moonrise 한 element의 textContent 하나만 바꾸면 되니
+   document.querySelectorAll("[data-moon-clock]") 직접 접근이 더 경제적. *)
+
+let pad2 n =
+  if n < 10 then Printf.sprintf "0%d" n else Printf.sprintf "%d" n
+;;
+
+let now_local_text () =
+  let d = new%js Js.date_now in
+  Printf.sprintf
+    "%s:%s:%s local"
+    (pad2 d##getHours)
+    (pad2 d##getMinutes)
+    (pad2 d##getSeconds)
+;;
+
+let tick_moon_clocks () =
+  let nodes =
+    Dom_html.document##querySelectorAll (Js.string "[data-moon-clock]")
+  in
+  let text = Js.string (now_local_text ()) in
+  for i = 0 to nodes##.length - 1 do
+    match Js.Opt.to_option (nodes##item i) with
+    | None -> ()
+    | Some el -> el##.textContent := Js.some text
+  done
+;;
+
+let install_moon_clock () =
+  tick_moon_clocks ();
+  let _id =
+    Dom_html.window##setInterval
+      (Js.wrap_callback tick_moon_clocks)
+      (Js.number_of_float 1000.0)
+  in
+  ()
+;;
+
 let () =
   install_theme_listener ();
   Start.start ~bind_to_element_with_id:"app" Dashboard_bonsai_lib.App.root;
   Dashboard_bonsai_lib.Logs_fetch.run ();
-  Dashboard_bonsai_lib.Logs_fetch.start_polling ()
+  Dashboard_bonsai_lib.Logs_fetch.start_polling ();
+  install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1660,7 +1660,12 @@ let render_response (response : Logs_types.response) : Node.t =
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span [ Node.text "lit by a half moon" ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
-      ; Node.span ~attrs:[ Style.moon_mono ] [ Node.text "23:50 local" ]
+      ; Node.span
+          ~attrs:
+            [ Style.moon_mono
+            ; Attr.create "data-moon-clock" ""
+            ]
+          [ Node.text "—:— local" ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span
           ~attrs:[ Style.moon_mono ]


### PR DESCRIPTION
## Summary

moonrise narrative strip의 `"23:50 local"` 하드코딩을 **매초 업데이트되는 실제 브라우저 로컬 시각**으로 교체. 대시보드가 처음으로 "살아있는" 시각 요소를 가진다.

## 구현

- **`logs_view.ml`**: moon_mono span에 `data-moon-clock=""` 속성. 초기 placeholder `"—:— local"`.
- **`bin/main.ml`**:
  - `pad2` — `09:05:01` 형태로 0-패딩
  - `now_local_text` — `Js.date_now`로 `hh:mm:ss local`
  - `tick_moon_clocks` — `querySelectorAll("[data-moon-clock]")` 일괄 순회 후 `textContent` 업데이트 (미래에 여러 곳에서 같은 clock 쓸 가능성 고려)
  - `install_moon_clock` — 즉시 1회 tick + `setInterval(… 1000ms)`
  - `Js.number_of_float 1000.0` — setInterval 두 번째 인자 타입 매칭 (`Js.number_t` 필요, float 직접 X)

## 왜 Bonsai state 안 쓰나

moon clock은 render cycle 밖이다. 매초 Virtual_dom diff 돌리는 것보다 `textContent` 직접 업데이트가 훨씬 경제적. 그리고 clock 하나의 변화는 전체 logs_view 갱신을 트리거할 이유가 없음 (scope 격리).

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 moonrise에 실 시각 노출, 매초 tick
- [ ] 초기 로드 직후 1초 내에 placeholder `—:— local` → `HH:MM:SS local`
- [ ] 탭 비활성화 후 복귀해도 시각 정상

## 남은 live 연결

- moonrise의 `base=/tmp/masc-bonsai-dev` — 서버 config endpoint 필요
- moonrise의 `operator · vincent` — identity endpoint 필요
- nav crumbs `chronicle › logs · 저널` — 현재 section 기반 (router 없음이라 logs 고정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
