### PR TITLE
feat(worker_dev_tools): dark-launch shadow logger for AST gate flip prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 ## Unreleased
 
+### Added
+
+- **`MASC_BASH_AST_SHADOW_LOG` dark-launch observer.**  With the
+  flag set to a truthy value every `keeper_bash` call runs
+  `Worker_dev_tools.diff_command` side-by-side with the live regex
+  gate and emits a structured log line
+  (`gate_diff_shadow keeper=… cmd_hash=… diff=… legacy=… shadow=…`)
+  for every non-`Agree` outcome.  Command strings are hashed to a
+  12-hex MD5 prefix before logging so no raw shell fragments leak
+  to the log stream.  Default off; behavior is unchanged when
+  disabled.  This is the evidence-collection step before the
+  `MASC_BASH_AST_ONLY` default flip, which still waits on an
+  N=1000 zero-diff window per the plan.
+
 ### Changed
 
 - **`MASC_BASH_VERIFIABLE_MARKERS` flipped to on by default.**

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -126,6 +126,7 @@ never break by enabling them.
 | `MASC_BASH_AUTO_BG` | off | Foreground commands that outrun `MASC_BLOCKING_BUDGET_MS` (default 15 000 ms) auto-promote to a `Bg_task`. Response gains `{promoted, background_task_id, partial_output, …}`. See `lib/exec/exec_run.mli`. |
 | `MASC_BLOCKING_BUDGET_MS` | 15 000 | Foreground race budget. Consumed only when `MASC_BASH_AUTO_BG` is on; otherwise inert. |
 | `MASC_BASH_AST_ONLY` | off | Single-gate AST shadow (dual-gate is the default). Flip requires a prod N=1000 zero-diff window per the flip covenant test (`test_gate_diff.ml`). |
+| `MASC_BASH_AST_SHADOW_LOG` | off | Dark-launch observer: runs `Worker_dev_tools.diff_command` alongside the live gate on every `keeper_bash` call and emits a `gate_diff_shadow` log line for every non-`Agree` outcome (hashed `cmd_hash`, never the raw command). Use this to accumulate prod evidence before the `AST_ONLY` flip. No behavior change. |
 | `MASC_BASH_VERIFIABLE_MARKERS` | **on** (post flip PR) | Emits `verifiable_markers` from `Cdal_judge.of_exec_outcome` so the verifier cascade can consume typed `Test_pass {count}`, `Build_ok`, etc. without regex scraping. Set to `0` / `false` / `no` / `off` to opt out. See `lib/cdal_judge.mli`. |
 
 Representative code paths:

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -804,7 +804,27 @@ let handle_keeper_bash
   if cmd = ""
   then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."
 
-  else
+  else begin
+    (* Tick 22: dark-launch shadow logger.  Runs
+       [Worker_dev_tools.diff_command] side-by-side with the
+       live gate and emits a structured line for every non-[Agree]
+       outcome so operators can collect flip-blocker evidence
+       (Legacy_deny_shadow_allow) and inverted-gap cases
+       (Legacy_allow_shadow_deny) from real traffic without
+       changing any behavior.  Flag-gated by
+       [MASC_BASH_AST_SHADOW_LOG]; default off. *)
+    (if Worker_dev_tools.shadow_diff_log_enabled () then
+       let diff, legacy, shadow = Worker_dev_tools.diff_command cmd in
+       match diff with
+       | Worker_dev_tools.Agree -> ()
+       | _ ->
+         Log.Keeper.info
+           "gate_diff_shadow keeper=%s cmd_hash=%s diff=%s legacy=%s shadow=%s"
+           meta.name
+           (Worker_dev_tools.cmd_hash_for_log cmd)
+           (Worker_dev_tools.gate_diff_to_string diff)
+           (Worker_dev_tools.legacy_verdict_to_tag legacy)
+           (Worker_dev_tools.shadow_verdict_to_tag shadow));
     (* Resolve cwd early — needed for playground detection before validation. *)
     match resolve_keeper_shell_write_cwd ~config ~meta ~args with
     | Error e -> error_json e
@@ -1128,6 +1148,7 @@ let handle_keeper_bash
                         (Bg_task.Invalid_cwd msg) ->
                       error_json (Printf.sprintf "invalid cwd: %s" msg))
                end))
+  end
 ;;
 
 (* ============================================================ *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1722,3 +1722,34 @@ let gate_diff_to_string = function
   | Legacy_deny_shadow_allow -> "legacy_deny_shadow_allow"
   | Shadow_cannot_parse -> "shadow_cannot_parse"
 
+(* Tick 22: stable log tags for legacy and shadow verdicts.
+   Exposed for the dark-launch shadow logger in keeper_exec_shell
+   — a per-call [diff_command] invocation emits a structured line
+   using these strings so operators can grep for
+   [Legacy_deny_shadow_allow] (flip blockers) or
+   [Legacy_allow_shadow_deny] (safety regressions) in the keeper
+   log stream without needing a separate metrics pipeline. *)
+let legacy_verdict_to_tag = function
+  | Legacy_allow -> "legacy_allow"
+  | Legacy_reject_by_allowlist -> "legacy_reject_by_allowlist"
+  | Legacy_reject_destructive _ -> "legacy_reject_destructive"
+
+let shadow_verdict_to_tag = function
+  | Shadow_allow _ -> "shadow_allow"
+  | Shadow_parse_unsupported _ -> "shadow_parse_unsupported"
+  | Shadow_deny_destructive _ -> "shadow_deny_destructive"
+
+(* Deterministic 12-hex-char digest of the command.  MD5 is used
+   strictly for log-line de-duplication, never for security; it
+   stops arbitrary shell fragments from leaking into log streams
+   while still letting operators aggregate identical diff
+   occurrences across processes. *)
+let cmd_hash_for_log (cmd : string) : string =
+  let hex = Digest.to_hex (Digest.string cmd) in
+  if String.length hex >= 12 then String.sub hex 0 12 else hex
+
+let shadow_diff_log_enabled () =
+  match Sys.getenv_opt "MASC_BASH_AST_SHADOW_LOG" with
+  | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
+  | _ -> false
+


### PR DESCRIPTION
## Summary

Adds `MASC_BASH_AST_SHADOW_LOG` — an opt-in, **behavior-preserving** observer that runs the shadow AST gate (`Worker_dev_tools.diff_command`) alongside the live regex gate on every `keeper_bash` call and emits one structured log line per non-`Agree` outcome. This is the evidence-collection pipe the plan needs before the `MASC_BASH_AST_ONLY` default flip (which still waits on an N=1000 zero-diff window per `test_gate_diff.ml`'s flip covenant).

## Product impact

- **Operators can start measuring today.** `grep 'gate_diff_shadow' keeper.log` produces an exact count of `Legacy_deny_shadow_allow` (flip blockers) and `Legacy_allow_shadow_deny` (safety regressions) per keeper per command family.
- **No behavior change.** The live regex gate still decides allow/deny. Shadow result is logged, nothing else.
- **Privacy-safe.** Command text never reaches the log stream. Logged as `cmd_hash=<12-hex-md5>` — deterministic for cross-process aggregation but opaque to anyone skimming shell history.

## Evidence

- `Worker_dev_tools.{legacy_verdict_to_tag, shadow_verdict_to_tag, cmd_hash_for_log, shadow_diff_log_enabled}` — new building blocks (no .mli, module has never had one).
- `keeper_exec_shell.handle_keeper_bash` — the observer sits at the entry point, just after the `cmd = ""` guard and before cwd resolve, so it covers every invocation regardless of destructive guard or sandbox profile.
- Behavior change surface: zero. When the flag is unset, `shadow_diff_log_enabled ()` short-circuits and no `diff_command` call happens.

## Review evidence

- Self-review on fresh worktree off `origin/main` (6a0a76911).
- Ran `git diff origin/main --stat` and walked each changed file.

## Linked issue

Refs #8721 — Legendary Bash P5 added `diff_command` and the flip covenant test.
Refs #8879 — SEMANTIC_EXIT flip PR (merged).
Refs #8891 — VERIFIABLE_MARKERS flip PR (merged).

## Rollout

1. Merge with flag off.
2. Operators set `MASC_BASH_AST_SHADOW_LOG=1` on a subset of keepers.
3. Monitor for a week; count non-`Agree` lines.
4. If `Legacy_allow_shadow_deny` > 0, fix the covenant gap before considering flip.
5. If `Legacy_deny_shadow_allow` is small enough to review manually, proceed to `AST_ONLY` flip PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)