### PR TITLE
docs(spec): mark KeeperCounterCausality as future-design (#8795 Option 2 lite)

### DIFF
--- a/specs/keeper-state-machine/KeeperCounterCausality.tla
+++ b/specs/keeper-state-machine/KeeperCounterCausality.tla
@@ -1,4 +1,20 @@
 ---- MODULE KeeperCounterCausality ----
+\* ── STATUS: FUTURE-DESIGN INVARIANT (not yet implemented) ────────────
+\* This spec verifies an invariant a *future* feature must hold, not a
+\* current runtime guarantee. As of 2026-04-20:
+\*   - rg "last_cause|last_incremented|last_bumped" lib/ -t ml -> 0 hits
+\*   - .claude/plans/curried-moseying-whisper.md (referenced below) -> 0 hits
+\* The OCaml side has the counters themselves
+\* (lib/dashboard/dashboard_http_keeper.ml:763-776) but no
+\* {last_incremented_at, last_cause_event} pair paired with them; the
+\* Agent Modal hover tooltip described in the redesign is not wired.
+\* NOT in scripts/tla-check.sh runner -- this spec records the design
+\* intent for when the cause-stamping extension lands; once the runtime
+\* implements the field, drop this banner and add the spec to the runner
+\* alongside the standard #8642-family OCaml<->TLA+ mapping comment.
+\* See #8795 for the full audit.
+\* ─────────────────────────────────────────────────────────────────────
+\*
 \* Keeper counter / event causality invariant.
 \*
 \* This spec models the minimal invariant the Agent Modal hover tooltip


### PR DESCRIPTION
## Summary

Closes **#8795** with **Option 2 (lite)** — adds a STATUS banner to \`specs/keeper-state-machine/KeeperCounterCausality.tla\` without renaming the file or changing CI runner config (the spec is already not in \`scripts/tla-check.sh\`).

## Diagnosis (re-verified today)

The spec verifies an invariant for the `{last_incremented_at, last_cause_event}` pair that a redesign plan intended to add. Today:

- `rg \"last_cause|last_incremented|last_bumped\" lib/ -t ml` → **0 hits**
- The referenced plan doc `.claude/plans/curried-moseying-whisper.md` → **missing**
- OCaml has the counters (`compaction_count`, `handoff_count_total` etc.) but no cause-stamping extension

## Why Option 2 lite vs Option 3 retire

Sibling **#8787 (KeeperOASBridge)** was a *full* orphan — retired in PR **#8900**. This spec is **partial orphan**: the runtime concept (counters) exists, only the cause-stamping extension is missing. Retiring would lose the recorded design intent for the future feature.

Status banner is the right disposition for partial orphans:
- Future maintainers reading the spec see \"this isn't implemented yet\" up front.
- Design intent is preserved verbatim in the spec file.
- No file rename → existing tooling, RFC references, and search index untouched.
- No CI runner change needed (spec wasn't in the runner anyway).

## When the design lands

The banner explicitly tells implementers what to do:

1. Drop the banner
2. Add the spec to `scripts/tla-check.sh` runner
3. Add the standard #8642-family OCaml↔TLA+ mapping comment

## Test plan

- [x] No code change; spec rules unchanged
- [x] Banner is a comment block, no TLA+ semantic effect
- [ ] No CI required for comment-only spec edits