### PR TITLE
feat(bonsai-dashboard): swimlane strip (keeper cycle activity)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1371,6 +1371,120 @@ stylesheet
     letter-spacing: 0.04em;
   }
   .sec_r_v { color: var(--text-bright); }
+
+  /* ─── swimlane strip ───
+     dashboard_v2 의 keeper-activity timeline 을 도입. 140px meta |
+     1fr track. track 위의 frame은 도구 카테고리별 배경색 (llm / tool /
+     err / wait). 현재는 static mock — cycle 내 각 키퍼의 "어떤 도구를
+     얼마나 오래" 를 시각화. 추후 session/turn trace endpoint 연결. */
+  .swim {
+    border: 1px solid var(--border-main);
+    background: rgba(14, 10, 8, 0.4);
+    margin-top: 6px;
+  }
+  .swim_axis {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    border-bottom: 1px solid var(--border-main);
+  }
+  .swim_axis_sp {
+    border-right: 1px solid var(--border-main);
+    padding: 6px 14px;
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .swim_axis_ax {
+    position: relative;
+    height: 24px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-dim);
+  }
+  .swim_tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid var(--border-main);
+  }
+  .swim_tick_lbl {
+    position: absolute;
+    top: 6px;
+    left: 4px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .swim_lane {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    border-bottom: 1px solid var(--border-main);
+  }
+  .swim_lane:last-child { border-bottom: 0; }
+  .swim_lane_meta {
+    border-right: 1px solid var(--border-main);
+    padding: 8px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .swim_dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--status-ok);
+    flex-shrink: 0;
+    box-shadow: 0 0 6px var(--status-ok);
+  }
+  .swim_dot_warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+  .swim_dot_bad { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
+  .swim_nm {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 12px;
+    color: var(--text-bright);
+    letter-spacing: 0.04em;
+    flex: 1;
+  }
+  .swim_nm_dead {
+    color: var(--text-dim);
+    text-decoration: line-through;
+    text-decoration-color: var(--accent-blood);
+  }
+  .swim_stat {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+  .swim_track {
+    position: relative;
+    height: 32px;
+    background: repeating-linear-gradient(to right, transparent 0 99px, rgba(120, 100, 80, 0.05) 99px 100px);
+  }
+  .swim_frame {
+    position: absolute;
+    top: 9px;
+    height: 14px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--bg-deep);
+    padding: 0 4px;
+    line-height: 14px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    border: 1px solid transparent;
+    cursor: default;
+    border-radius: 1px;
+  }
+  .swim_frame:hover { border-color: var(--text-bright); z-index: 2; }
+  .swim_frame_llm  { background: #6a7a9c; }
+  .swim_frame_tool { background: #8a7a3a; }
+  .swim_frame_err  { background: var(--accent-blood); color: var(--text-bright); }
+  .swim_frame_wait { background: #2a2520; color: var(--text-dim); }
+  .swim_frame_think { background: #4a4a5a; color: var(--text-primary); }
 |}]
 
 let level_class level =
@@ -1570,6 +1684,122 @@ let view_roster () =
         ~state_label:"idle · ok" ~when_:"2m"
     ; slot ~sigil:"I" ~name:"improver" ~state:`Failed
         ~state_label:"paused · auth" ~when_:"7m"
+    ]
+;;
+
+(* ─── swimlane mock ───
+   lane = keeper activity over the last cycle. frame = tool call span.
+   left/width는 % (track 가로 기준). 실 데이터 endpoint 생기기 전까지
+   mock. *)
+type swim_frame_kind = [ `Llm | `Tool | `Err | `Wait | `Think ]
+
+let swim_frame_class = function
+  | `Llm -> Style.swim_frame_llm
+  | `Tool -> Style.swim_frame_tool
+  | `Err -> Style.swim_frame_err
+  | `Wait -> Style.swim_frame_wait
+  | `Think -> Style.swim_frame_think
+;;
+
+let swim_frame ~(kind : swim_frame_kind) ~left ~width ~label =
+  let style =
+    Attr.create
+      "style"
+      (Printf.sprintf "left:%d%%; width:%d%%" left width)
+  in
+  Node.div
+    ~attrs:[ Style.swim_frame; swim_frame_class kind; style ]
+    [ Node.text label ]
+;;
+
+type swim_lane_status = [ `Live | `Warn | `Dead ]
+
+let view_swim_lane ~name ~stat ~status ~frames =
+  let dot_cls =
+    match status with
+    | `Live -> Style.swim_dot
+    | `Warn -> Style.swim_dot_warn
+    | `Dead -> Style.swim_dot_bad
+  in
+  let nm_attrs =
+    match status with
+    | `Dead -> [ Style.swim_nm; Style.swim_nm_dead ]
+    | _ -> [ Style.swim_nm ]
+  in
+  Node.div
+    ~attrs:[ Style.swim_lane ]
+    [ Node.div
+        ~attrs:[ Style.swim_lane_meta ]
+        [ Node.span ~attrs:[ Style.swim_dot; dot_cls ] []
+        ; Node.span ~attrs:nm_attrs [ Node.text name ]
+        ; Node.span ~attrs:[ Style.swim_stat ] [ Node.text stat ]
+        ]
+    ; Node.div ~attrs:[ Style.swim_track ] frames
+    ]
+;;
+
+let view_swimlanes () =
+  let axis_ticks =
+    List.init 6 ~f:(fun i ->
+      let left_pct = i * 20 in
+      let style =
+        Attr.create "style" (Printf.sprintf "left:%d%%" left_pct)
+      in
+      Node.div
+        ~attrs:[ Style.swim_tick; style ]
+        [ Node.span
+            ~attrs:[ Style.swim_tick_lbl ]
+            [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
+        ])
+  in
+  Node.div
+    ~attrs:[ Style.swim ]
+    [ Node.div
+        ~attrs:[ Style.swim_axis ]
+        [ Node.div
+            ~attrs:[ Style.swim_axis_sp ]
+            [ Node.text "keeper · cycle" ]
+        ; Node.div ~attrs:[ Style.swim_axis_ax ] axis_ticks
+        ]
+    ; view_swim_lane
+        ~name:"luna"
+        ~stat:"reading"
+        ~status:`Live
+        ~frames:
+          [ swim_frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
+          ; swim_frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
+          ; swim_frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
+          ; swim_frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
+          ; swim_frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
+          ]
+    ; view_swim_lane
+        ~name:"brass-owl"
+        ~stat:"retrying"
+        ~status:`Warn
+        ~frames:
+          [ swim_frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
+          ; swim_frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
+          ; swim_frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
+          ; swim_frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
+          ]
+    ; view_swim_lane
+        ~name:"moth"
+        ~stat:"idle · listening"
+        ~status:`Live
+        ~frames:
+          [ swim_frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
+          ; swim_frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
+          ; swim_frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
+          ]
+    ; view_swim_lane
+        ~name:"ash-hound"
+        ~stat:"crashed t-34"
+        ~status:`Dead
+        ~frames:
+          [ swim_frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
+          ; swim_frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
+          ; swim_frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
+          ]
     ]
 ;;
 
@@ -2012,6 +2242,21 @@ let render_response (response : Logs_types.response) : Node.t =
             ]
         ]
     ; view_roster ()
+    ; Node.div
+        ~attrs:[ Style.sec ]
+        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "cycle activity" ]
+        ; Node.span
+            ~attrs:[ Style.sec_sub ]
+            [ Node.text "last 60 minutes · one lane per keeper" ]
+        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span
+            ~attrs:[ Style.sec_r ]
+            [ Node.text "mock · trace endpoint "
+            ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
+            ]
+        ]
+    ; view_swimlanes ()
     ; Node.div ~attrs:[ Style.signet ] [ Node.text "M" ]
     ; aside
     ]


### PR DESCRIPTION
## Summary

dashboard_v2 의 핵심 visualization **swimlane strip** 을 Bonsai 로 포팅. 각 keeper의 cycle activity를 한 줄 timeline으로 — "누가 지난 60분 동안 무엇을 얼마나 오래 했는가".

## 구조

```
⎔ CYCLE ACTIVITY · last 60 minutes · one lane per keeper ─── mock · trace endpoint pending

│ KEEPER · CYCLE │ t-60    t-48    t-36    t-24    t-12    t0
├────────────────┼─────────────────────────────────────────────
│ ● luna         │ [llm][read][think][llm       ][edit     ]
│   reading      │
├────────────────┼─────────────────────────────────────────────
│ ● brass-owl    │ [llm  ][fetch][wait          ][fetch]
│   retrying     │
├────────────────┼─────────────────────────────────────────────
│ ● moth         │ [wait              ][llm  ][wait            ]
│   idle         │
├────────────────┼─────────────────────────────────────────────
│ ● ~~ash-hound~ │ [llm ][exec][✕err]
│   crashed t-34 │
└────────────────┴─────────────────────────────────────────────
```

## Frame 카테고리

| class | 색 | 역할 |
|---|---|---|
| `llm` | `#6a7a9c` muted blue-gray | LLM inference |
| `tool` | `#8a7a3a` muted brass | tool call |
| `think` | `#4a4a5a` slate | reasoning |
| `wait` | `#2a2520` bg-ish | idle/waiting |
| `err` | `var(--accent-blood)` | failure |

dashboard_v2의 `--t-*` 색상 팔레트 도입. 추후 `colors_and_type.css`에 token화 고려.

## 구현

- `swim_frame` helper — left%/width% inline style (via `Attr.create "style" …`)
- `view_swim_lane` — name/stat/status(`Live|Warn|Dead`)/frames
- `view_swimlanes` — 4 lane mock + 6 axis tick (`t-60 → t0`)

render 위치: `view_roster` 뒤 새 `.sec` marker + `view_swimlanes`.

## 여전히 mock

- 4 lane 전부 하드코딩. 실 데이터는 **session trace endpoint** 필요 (keeper별 per-cycle tool span 리스트).
- axis는 % 기반 — 실 데이터 연결 시 timestamp → % 변환 helper 도입.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 roster 아래 4-lane swimlane 노출
- [ ] hover 시 frame에 bone border (`:hover { border-color: var(--text-bright) }`)
- [ ] `ash-hound`가 line-through + blood 색으로
- [ ] 테마 전환 (`#cyberpunk`)에서 axis tick / border가 neon 팔레트로 자동 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)
