### PR TITLE
docs(logic): batch-6 .mli for server_base_path_diagnostics + file_lock_eio (2 files)

### DIFF
--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -1,0 +1,91 @@
+(** File_lock_eio — cooperative per-key locking via [Eio.Mutex] + [flock].
+
+    Two-layer locking for local filesystem paths:
+
+    + {b Eio.Mutex} (cooperative) — prevents blocking the Eio fiber
+      scheduler; serialises fibers within the process so most contention
+      is resolved cooperatively.
+    + {b Unix.lockf F_TLOCK} (non-blocking) — preserves cross-process
+      safety; acquired after the Eio.Mutex. If another process holds
+      the flock the caller yields and retries.
+
+    Distributed backend paths (non-local keys in
+    [room_utils_ops.ml]) are not affected. *)
+
+(** {1 Tuning constants} *)
+
+(** Cap on tracked per-path entries. When exceeded, entries with
+    [Atomic.get active = 0] older than {!stale_lock_seconds} are
+    pruned. *)
+val max_lock_entries : int
+
+(** Staleness threshold for inactive entries (seconds). *)
+val stale_lock_seconds : float
+
+(** {1 Low-level flock helpers}
+
+    Used by non-Eio systhread contexts. Prefer {!with_lock} for
+    ordinary callers. *)
+
+(** Non-blocking [F_TLOCK] with retry. On success returns the open
+    file descriptor holding the lock. On timeout closes the fd and
+    raises [Failure]. [clock] is accepted but ignored in this variant
+    (systhread-friendly). *)
+val acquire_flock_retry :
+  ?clock:'a option ->
+  lock_path:string ->
+  mode:Unix.open_flag list ->
+  perm:int ->
+  ?max_attempts:int ->
+  ?sleep_sec:float ->
+  caller:string ->
+  unit ->
+  Unix.file_descr
+
+(** Fiber-friendly wrapper around {!acquire_flock_retry}. Systhread
+    is used for [openfile], [F_TLOCK], and retry sleeps (unless a
+    clock is supplied, in which case [Eio.Time.sleep] yields to the
+    Eio scheduler). *)
+val acquire_flock_retry_cooperative :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  lock_path:string ->
+  mode:Unix.open_flag list ->
+  perm:int ->
+  ?max_attempts:int ->
+  ?sleep_sec:float ->
+  caller:string ->
+  unit ->
+  Unix.file_descr
+
+(** Convenience wrapper using [O_CREAT;O_WRONLY], mode [0o644],
+    caller tag ["File_lock_eio"]. *)
+val acquire_flock_fd :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  string ->
+  Unix.file_descr
+
+(** [release_flock_fd fd] unlocks (best-effort) and closes [fd]. *)
+val release_flock_fd : Unix.file_descr -> unit
+
+(** {1 High-level scoped locking} *)
+
+(** [with_mutex path f] runs [f] while holding the cooperative
+    per-[path] Eio.Mutex only. Use for in-memory backends that need
+    single-process fiber serialisation but have no filesystem
+    artifact to flock. *)
+val with_mutex : string -> (unit -> 'a) -> 'a
+
+(** [with_lock ?clock path f] runs [f] while holding both the
+    cooperative Eio.Mutex and an OS-level flock on [path ^ ".lock"].
+    The flock uses non-blocking F_TLOCK retries — max 200 attempts,
+    ~2s total with default sleeps. *)
+val with_lock :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  string ->
+  (unit -> 'a) ->
+  'a
+
+(** {1 Diagnostics} *)
+
+(** Current number of tracked lock paths. *)
+val lock_count : unit -> int

--- a/lib/server_base_path_diagnostics.mli
+++ b/lib/server_base_path_diagnostics.mli
@@ -1,0 +1,71 @@
+(** Diagnose runtime base-path facts with a single authoritative [.masc] root.
+
+    The runtime no longer treats a cwd-local [.masc] tree as a second live
+    authority. Cwd-relative fields remain {b observational only} so health
+    and startup payloads can explain where the process was launched from
+    without reviving stale-path warnings or abort paths. *)
+
+(** {1 Diagnostic record}
+
+    All fields are observed at detection time; the record is immutable. *)
+type t = {
+  process_cwd : string;
+  input_base_path : string option;
+  effective_base_path : string;
+  effective_masc_root : string;
+  env_masc_base_path : string option;
+  resolution_source : string option;
+  effective_has_masc_dir : bool;
+  effective_legacy_dirs : string list;
+      (** Subset of {["perpetual"; "resident-keepers"; "rooms"]} present
+          under [effective_masc_root]. *)
+  roots_diverge : bool;
+      (** [true] when the normalised process cwd differs from
+          [effective_base_path]. *)
+  strict_mode_requested : bool;
+  startup_rejected : bool;
+  startup_abort_eligible : bool;
+  warning : string option;
+}
+
+(** {1 Detection} *)
+
+(** [detect ?cwd ?env_masc_base_path ?strict ?input_base_path
+    ?resolution_source ~effective_base_path ~effective_masc_root ()]
+    observes paths from disk + env and returns a populated {!t}.
+
+    - [cwd] defaults to [Sys.getcwd ()].
+    - [strict] defaults to the [MASC_BASE_PATH_STRICT] env flag
+      (accepts [1|true|yes]).
+    - [resolution_source] falls back to
+      [MASC_BASE_PATH_RESOLUTION_SOURCE] env var.
+
+    All paths are normalised through [Unix.realpath] with best-effort
+    fallback to the absolute form. *)
+val detect :
+  ?cwd:string ->
+  ?env_masc_base_path:string ->
+  ?strict:bool ->
+  ?input_base_path:string ->
+  ?resolution_source:string ->
+  effective_base_path:string ->
+  effective_masc_root:string ->
+  unit ->
+  t
+
+(** Reserved for future strict-mode enforcement; currently always [false]. *)
+val strict_violation : t -> bool
+
+(** {1 Reporting} *)
+
+(** Multi-line startup output suitable for [Log.Server.info] — skips
+    fields that are [None] or uninformative. *)
+val startup_lines : t -> string list
+
+(** Emit [diag.warning] once per process lifetime at WARN (or DEBUG
+    after the first call). No-op when [warning = None]. *)
+val log_startup_warning : t -> unit
+
+(** JSON serialisation including [strict_violation]. Option fields are
+    omitted when [None] (not emitted as [null]). *)
+val to_yojson : t -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

Wave 3 batch 6 — `.mli` 2 파일 (infra 모듈). 바디 무수정.

## 대상 파일 (2개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/server_base_path_diagnostics.mli` | 192 | 72 | 14 필드 record `t` + detect + serialize + startup logging |
| `lib/process/file_lock_eio.mli` | 194 | 91 | 2-layer lock (Eio.Mutex + flock F_TLOCK) primitives |

## 설계 노트

### server_base_path_diagnostics
- **Optional-arg label type 정정 (draft→final)**: 첫 작성에서 `?env_masc_base_path:string option` 으로 선언했으나 OCaml optional-arg semantics에서는 body가 `trim_opt` 로 string option을 다루면 **label type = string** (body가 auto-wrap). 
- 첫 빌드에 `config_doctor.ml:219`, `server_routes_http_runtime.ml:88`, `server_dashboard_http_core.ml:893` 에서 `string option option` expected 에러 → `string option` → `string` 수정.
- 14 record field, 4 public function, 8+ internal helper (trim_opt, strip_trailing_slashes, normalize_path, dir_exists, legacy_dirs_under, strict_mode_env_enabled, _logged_once, option_field) hide.

### file_lock_eio
- **2-layer 락 디시플린 문서화**: Eio.Mutex (fiber-cooperative) + Unix flock F_TLOCK (cross-process). 둘 다 mli 모듈 doc에 명시.
- **Public surface**: 2 tuning const (max_lock_entries, stale_lock_seconds), 4 flock helper, 2 scoped API (with_mutex, with_lock), 1 diagnostic (lock_count).
- **Internal hide**: `lock_entry` / `table_state` record (Atomic.t + Eio.Mutex.t 포함 — 외부 노출 시 mutation 위험), `table` state, `atomic_update*`, `publish_entries`, `prune_stale_entries`, `get_entry/release_entry`, `run_blocking_lock_op`, `SMap`.
- 외부 소비 확인: `File_lock_eio.{acquire_flock_retry, release_flock_fd, with_mutex, with_lock, lock_count}` 만 사용됨 (backend.ml, hebbian_eio.ml, coord_utils_ops.ml, test/).

## 검증

- `dune build --root=.` → exit 0 (optional-arg label 수정 후 통과)
- 4 external caller 컴파일 유지 (config_doctor, server_runtime_bootstrap, server_routes_http_runtime, server_dashboard_http_core)

## 현재 누적 (세션)

| # | PR | 파일 수 | 상태 |
|---|----|---------|------|
| 1 | #8821 | 1 | MERGED |
| 2 | #8847 | 1 | MERGED |
| 3 | #8859 | 6 | MERGED |
| 4 | #8865 | 3 | MERGED |
| 5 | #8877 | 3 | MERGED |
| 6 | #8886 | 3 | MERGED |
| 7 | #8898 | 2 | MERGED |
| **8** | **이 PR** | **2** | Open |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 308 | **310** |
| Wave 3 진행 | 19/113 (16.81%) | **21/113 (18.58%)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] OCaml optional-arg semantics 정확 반영 (label type vs body type)
- [x] internal state (Atomic/Eio.Mutex) abstract 유지
- [x] hype 금지 (정량치만)

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
