### PR TITLE
test: cover lifecycle auth preflight

### DIFF
--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1530,6 +1530,84 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
   cleanup_dir base_path
 
+let check_task_still_todo config task_id =
+  match
+    Masc_mcp.Coord.get_tasks_raw config
+    |> List.find_opt (fun (task : Types.task) -> task.id = task_id)
+  with
+  | Some { Types.task_status = Types.Todo; _ } -> ()
+  | Some task ->
+      Alcotest.failf "expected %s to remain todo, got %s" task_id
+        (Types.task_status_to_string task.task_status)
+  | None -> Alcotest.failf "expected task %s to exist" task_id
+
+let check_auth_preflight_result ~tool_name ok msg =
+  Alcotest.(check bool) (tool_name ^ " rejected before handler") false ok;
+  Alcotest.(check bool) (tool_name ^ " reports auth/credential blocker") true
+    (contains_substring msg "Token required"
+     || contains_substring msg "Unauthorized"
+     || contains_substring msg "No credential")
+
+let test_execute_tool_claim_next_requires_auth_before_mutation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore
+    (Masc_mcp.Coord.add_task state.room_config ~title:"claim-next-auth-preflight"
+       ~priority:2 ~description:"");
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock state
+      ~name:"masc_claim_next"
+      ~arguments:(`Assoc [ ("agent_name", `String "uncredentialed-agent") ])
+  in
+  check_auth_preflight_result ~tool_name:"masc_claim_next" ok msg;
+  check_task_still_todo state.room_config "task-001";
+  Alcotest.(check (option string)) "no current task after rejected claim_next" None
+    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+  cleanup_dir base_path
+
+let test_execute_tool_transition_requires_auth_before_mutation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore
+    (Masc_mcp.Coord.add_task state.room_config ~title:"transition-auth-preflight"
+       ~priority:2 ~description:"");
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock state
+      ~name:"masc_transition"
+      ~arguments:
+        (`Assoc
+          [
+            ("agent_name", `String "uncredentialed-agent");
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+  in
+  check_auth_preflight_result ~tool_name:"masc_transition" ok msg;
+  check_task_still_todo state.room_config "task-001";
+  Alcotest.(check (option string)) "no current task after rejected transition" None
+    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+  cleanup_dir base_path
+
 let test_execute_tool_mcp_session_ignores_term_persistence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2515,6 +2593,10 @@ let eio_tests = [
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "generated agent_name uses token identity", `Quick,
     test_execute_tool_generated_agent_name_uses_token_identity;
+  "claim_next auth preflight blocks mutation", `Quick,
+    test_execute_tool_claim_next_requires_auth_before_mutation;
+  "transition auth preflight blocks mutation", `Quick,
+    test_execute_tool_transition_requires_auth_before_mutation;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
   (* Legacy governance convo room test removed *)
 ]


### PR DESCRIPTION
## Summary

Add MCP execute-level regressions for the remaining #8892 control-plane credential path.

This covers direct lifecycle tool calls from an auth-required room when no credential/token is available:

- `masc_claim_next` rejects before claiming a task
- `masc_transition(action=claim)` rejects before mutating a task
- both cases leave the task in `todo` and do not bind planning `current_task`

## Why

PR #8897 merged the read-model/status mitigation for #8892, but it explicitly left direct lifecycle mutation entrypoints out of scope. These tests lock the existing server auth preflight behavior so the direct mutation path cannot regress while #8892 remains open for the broader credential-routing design.

## Verification

- `opam exec -- dune build --root "$PWD" test/test_mcp_server_eio.exe`
- `opam exec -- _build/default/test/test_mcp_server_eio.exe --color=never` (61 tests)
- `git diff --check`

Refs #8892