### PR TITLE
[codex] Reduce MASC log WARN backpressure

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1710,6 +1710,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let post_commit_failure_reason = ref None in
       let paused_meta_override = ref None in
       let current_turn_overflow_blocker = ref None in
+      let event_bus_drain_active = Atomic.make true in
+      let turn_event_bus_mu = Stdlib.Mutex.create () in
       let mark_paused_after_overflow ~run_meta ~reason =
         let paused_meta =
           pause_keeper_for_overflow
@@ -1737,6 +1739,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          ToolCompleted pops the oldest input for that tool_name. *)
       let pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t =
         Hashtbl.create 8
+      in
+      let with_turn_event_bus_lock f =
+        Stdlib.Mutex.lock turn_event_bus_mu;
+        Fun.protect
+          ~finally:(fun () -> Stdlib.Mutex.unlock turn_event_bus_mu)
+          f
       in
       let push_pending_input tool_name input =
         let q =
@@ -1782,18 +1790,46 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           events
       in
       let drain_turn_event_bus () =
-        let events =
-          match event_bus_sub, Keeper_event_bus.get () with
-          | Some sub, Some _bus -> Oas_bus_instrument.drain sub
-          | _ -> []
-        in
-        process_tool_events_for_side_effects events;
-        let summary = summarize_turn_event_bus events in
-        turn_event_bus :=
-          merge_turn_event_bus_summary !turn_event_bus summary;
-        !turn_event_bus
+        with_turn_event_bus_lock (fun () ->
+          let events =
+            match event_bus_sub, Keeper_event_bus.get () with
+            | Some sub, Some _bus -> Oas_bus_instrument.drain sub
+            | _ -> []
+          in
+          process_tool_events_for_side_effects events;
+          let summary = summarize_turn_event_bus events in
+          turn_event_bus :=
+            merge_turn_event_bus_summary !turn_event_bus summary;
+          !turn_event_bus)
+      in
+      let committed_mutating_tools_snapshot () =
+        with_turn_event_bus_lock (fun () ->
+          committed_mutating_tools !mutating_tools_committed)
+      in
+      let start_background_turn_event_bus_drain ~clock =
+        match event_bus_sub, Eio_context.get_switch_opt () with
+        | Some _, Some sw ->
+            Eio.Fiber.fork ~sw (fun () ->
+              let rec loop () =
+                if Atomic.get event_bus_drain_active then begin
+                  (try
+                     ignore (drain_turn_event_bus ())
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                       Log.Keeper.warn
+                         "%s: keeper_turn event-bus drain failed: %s"
+                         meta.name (Printexc.to_string exn));
+                  Eio.Time.sleep clock 0.25;
+                  loop ()
+                end
+              in
+              loop ())
+        | _ -> ()
       in
       let unsubscribe_event_bus () =
+        Atomic.set event_bus_drain_active false;
+        ignore (drain_turn_event_bus ());
         match event_bus_sub, Keeper_event_bus.get () with
         | Some sub, Some bus -> Oas_bus_instrument.unsubscribe bus sub
         | _ -> ()
@@ -1824,6 +1860,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let timeout_sec =
             Env_config_keeper.KeeperKeepalive.turn_timeout_sec
           in
+          start_background_turn_event_bus_drain ~clock;
           let turn_deadline = Eio.Time.now clock +. timeout_sec in
           let remaining_turn_budget_s () =
             Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
@@ -1941,9 +1978,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 Ok result
             | Error err ->
                 let _ = drain_turn_event_bus () in
-                let committed_tools =
-                  committed_mutating_tools !mutating_tools_committed
-                in
+                let committed_tools = committed_mutating_tools_snapshot () in
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
                         committed_tools
@@ -2117,9 +2152,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             in
             Log.Keeper.error "%s: %s" meta.name msg;
             let _ = drain_turn_event_bus () in
-            let committed_tools =
-              committed_mutating_tools !mutating_tools_committed
-            in
+            let committed_tools = committed_mutating_tools_snapshot () in
             if committed_tools <> []
                && Keeper_tool_registry.all_tools_reconcile_safe
                     committed_tools
@@ -2237,9 +2270,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                  The keeper is paused and an explicit continue gate is
                  raised for the operator. Approving the gate auto-resumes
                  the keeper; rejecting it leaves the keeper paused. *)
-              let committed_tools =
-                committed_mutating_tools !mutating_tools_committed
-              in
+              let committed_tools = committed_mutating_tools_snapshot () in
               let failure_reason =
                 Option.value
                   ~default:
@@ -2316,9 +2347,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name
               (Some failure_reason);
-            let committed_tools =
-              committed_mutating_tools !mutating_tools_committed
-            in
+            let committed_tools = committed_mutating_tools_snapshot () in
             Log.Keeper.info
               "%s: reconcile-required failure latched as %s after committed tools [%s]"
               meta.name

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -68,7 +68,20 @@ let git_rev_parse_short_cache :
     (string, string option * float) Hashtbl.t =
   Hashtbl.create 4
 
+let git_rev_parse_short_in_flight : (string, unit) Hashtbl.t =
+  Hashtbl.create 4
+
 let git_rev_parse_short_mu = Stdlib.Mutex.create ()
+
+let git_rev_parse_short_probe_hook_for_tests :
+    (string -> string option) option Atomic.t =
+  Atomic.make None
+
+let set_git_rev_parse_short_probe_hook_for_tests hook =
+  Atomic.set git_rev_parse_short_probe_hook_for_tests (Some hook)
+
+let clear_git_rev_parse_short_probe_hook_for_tests () =
+  Atomic.set git_rev_parse_short_probe_hook_for_tests None
 
 let git_rev_parse_short_cached_lookup dir ~now =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
@@ -80,26 +93,79 @@ let git_rev_parse_short_cached_lookup dir ~now =
           Some value
       | _ -> None)
 
-let git_rev_parse_short_cache_store dir value ~now =
+let git_rev_parse_short_cached_any dir =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      Hashtbl.replace git_rev_parse_short_cache dir (value, now))
+      Hashtbl.find_opt git_rev_parse_short_cache dir
+      |> Option.map fst)
+
+let git_rev_parse_short_try_begin_refresh dir =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () ->
+      if Hashtbl.mem git_rev_parse_short_in_flight dir then false
+      else begin
+        Hashtbl.replace git_rev_parse_short_in_flight dir ();
+        true
+      end)
+
+let git_rev_parse_short_finish_refresh dir value ~now =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () ->
+      Hashtbl.replace git_rev_parse_short_cache dir (value, now);
+      Hashtbl.remove git_rev_parse_short_in_flight dir)
+
+let git_rev_parse_short_cancel_refresh dir =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () -> Hashtbl.remove git_rev_parse_short_in_flight dir)
 
 let git_rev_parse_short_probe dir =
-  let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
-  let raw_source = String.concat " " (List.map Filename.quote argv) in
-  match
-    Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"system/runtime_info"
-      ~raw_source
-      ~summary:"dashboard runtime git probe"
-      ~timeout_sec:5.0
-      argv
+  match Atomic.get git_rev_parse_short_probe_hook_for_tests with
+  | Some hook -> hook dir
+  | None ->
+      let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
+      let raw_source = String.concat " " (List.map Filename.quote argv) in
+      match
+        Masc_exec.Exec_gate.run_argv_with_status
+          ~actor:"system/runtime_info"
+          ~raw_source
+          ~summary:"dashboard runtime git probe"
+          ~timeout_sec:5.0
+          argv
+      with
+      | Unix.WEXITED 0, output -> trim_to_option output
+      | _ -> None
+
+let git_rev_parse_short_refresh dir =
+  try
+    let value = git_rev_parse_short_probe dir in
+    git_rev_parse_short_finish_refresh dir value ~now:(Time_compat.now ());
+    value
   with
-  | Unix.WEXITED 0, output -> trim_to_option output
-  | _ -> None
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      git_rev_parse_short_cancel_refresh dir;
+      raise exn
+
+let maybe_refresh_git_rev_parse_short_in_background dir =
+  match Eio_context.get_switch_opt () with
+  | None -> ()
+  | Some sw ->
+      if git_rev_parse_short_try_begin_refresh dir then
+        Eio.Fiber.fork ~sw (fun () ->
+          try ignore (git_rev_parse_short_refresh dir) with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Dashboard.warn
+                "dashboard runtime git probe refresh failed for %s: %s"
+                dir (Printexc.to_string exn))
 
 let git_rev_parse_short path =
   match trim_to_option path with
@@ -109,16 +175,32 @@ let git_rev_parse_short path =
       let now = Time_compat.now () in
       (match git_rev_parse_short_cached_lookup dir ~now with
        | Some value -> value
-       | None ->
-           let value = git_rev_parse_short_probe dir in
-           git_rev_parse_short_cache_store dir value ~now;
-           value)
+       | None -> (
+           match git_rev_parse_short_cached_any dir with
+           | Some stale ->
+               maybe_refresh_git_rev_parse_short_in_background dir;
+               stale
+           | None ->
+               if git_rev_parse_short_try_begin_refresh dir then
+                 git_rev_parse_short_refresh dir
+               else
+                 git_rev_parse_short_cached_any dir |> Option.value ~default:None))
 
 let clear_git_rev_parse_short_cache_for_tests () =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
-    (fun () -> Hashtbl.clear git_rev_parse_short_cache)
+    (fun () ->
+      Hashtbl.clear git_rev_parse_short_cache;
+      Hashtbl.clear git_rev_parse_short_in_flight)
+
+let seed_git_rev_parse_short_cache_for_tests dir value ~refreshed_at =
+  Stdlib.Mutex.lock git_rev_parse_short_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
+    (fun () ->
+      Hashtbl.replace git_rev_parse_short_cache dir (value, refreshed_at);
+      Hashtbl.remove git_rev_parse_short_in_flight dir)
 
 let path_item_json ~source path =
   `Assoc

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,4 +1,16 @@
-let run_git_capture_lines ~workdir args =
+type git_capture_hook =
+  workdir:string -> string list -> string list option
+
+let git_capture_hook_for_tests : git_capture_hook option Atomic.t =
+  Atomic.make None
+
+let set_git_capture_hook_for_tests hook =
+  Atomic.set git_capture_hook_for_tests (Some hook)
+
+let clear_git_capture_hook_for_tests () =
+  Atomic.set git_capture_hook_for_tests None
+
+let run_git_capture_lines_once ~workdir args =
   try
     let argv = [ "git"; "-C"; workdir ] @ args in
     let raw_source = String.concat " " (List.map Filename.quote argv) in
@@ -18,20 +30,94 @@ let run_git_capture_lines ~workdir args =
     | _ -> None
   with Sys_error _ | Unix.Unix_error _ -> None
 
+let run_git_capture_lines ~workdir args =
+  match Atomic.get git_capture_hook_for_tests with
+  | Some hook -> hook ~workdir args
+  | None ->
+      let rec loop attempts_left =
+        match run_git_capture_lines_once ~workdir args with
+        | Some _ as result -> result
+        | None when attempts_left > 0 -> loop (attempts_left - 1)
+        | None -> None
+      in
+      loop 1
+
+let nearest_git_root path =
+  let rec walk dir =
+    let marker = Filename.concat dir ".git" in
+    if Sys.file_exists marker then Some dir
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then None else walk parent
+  in
+  try walk path with Sys_error _ -> None
+
 let repo_root_for ~base_path =
   if not (Coord_git.has_git_marker base_path) then None
-  else
-  match run_git_capture_lines ~workdir:base_path [ "rev-parse"; "--show-toplevel" ] with
-  | Some (root :: _) ->
-      let root = String.trim root in
-      if root = "" then None else Some root
-  | _ -> None
+  else nearest_git_root base_path
 
-let current_status_lines ~repo_root =
-  run_git_capture_lines ~workdir:repo_root [ "status"; "--porcelain" ]
+type status_cache_entry = {
+  lines : string list;
+  refreshed_at : float;
+}
+
+let status_cache : (string, status_cache_entry) Hashtbl.t =
+  Hashtbl.create 4
+
+let status_cache_mu = Stdlib.Mutex.create ()
+
+let status_cache_ttl_sec () =
+  match Sys.getenv_opt "MASC_WORKTREE_STATUS_CACHE_TTL_S" with
+  | Some raw -> (
+      match float_of_string_opt (String.trim raw) with
+      | Some ttl when ttl >= 0.0 && ttl <= 10.0 -> ttl
+      | _ -> 1.0)
+  | None -> 1.0
+
+let status_cache_lookup repo_root ~now ~ttl =
+  if ttl <= 0.0 then None
+  else begin
+    Stdlib.Mutex.lock status_cache_mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
+      (fun () ->
+        match Hashtbl.find_opt status_cache repo_root with
+        | Some entry when now -. entry.refreshed_at <= ttl ->
+            Some entry.lines
+        | _ -> None)
+  end
+
+let status_cache_store repo_root lines ~now ~ttl =
+  if ttl > 0.0 && lines <> [] then begin
+    Stdlib.Mutex.lock status_cache_mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
+      (fun () ->
+        Hashtbl.replace status_cache repo_root { lines; refreshed_at = now })
+  end
+
+let clear_status_cache_for_tests () =
+  Stdlib.Mutex.lock status_cache_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
+    (fun () -> Hashtbl.clear status_cache)
+
+let current_status_lines_uncached ~repo_root =
+  run_git_capture_lines ~workdir:repo_root
+    [ "--no-optional-locks"; "status"; "--porcelain" ]
   |> Option.value ~default:[]
   |> List.map String.trim
   |> List.filter (fun line -> line <> "")
+
+let current_status_lines ~repo_root =
+  let now = Time_compat.now () in
+  let ttl = status_cache_ttl_sec () in
+  match status_cache_lookup repo_root ~now ~ttl with
+  | Some lines -> lines
+  | None ->
+      let lines = current_status_lines_uncached ~repo_root in
+      status_cache_store repo_root lines ~now:(Time_compat.now ()) ~ttl;
+      lines
 
 let state_dir ~repo_root =
   Filename.concat (Filename.concat repo_root ".masc") "live-context"

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -320,6 +320,38 @@ let test_waiter_timeout_returns_error_not_cached ~clock () =
   in
   check_json "owner result survives waiter timeout" (`String "owner_done") final
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> Unix.rmdir dir) (fun () -> f dir)
+
+let test_runtime_git_cache_returns_stale_and_refreshes ~clock () =
+  let module Runtime = Server_dashboard_http_runtime_info in
+  Runtime.clear_git_rev_parse_short_cache_for_tests ();
+  with_temp_dir "runtime-git-cache" (fun dir ->
+      Runtime.seed_git_rev_parse_short_cache_for_tests dir (Some "old")
+        ~refreshed_at:(Time_compat.now () -. 120.0);
+      let probes = Atomic.make 0 in
+      Runtime.set_git_rev_parse_short_probe_hook_for_tests (fun _ ->
+          Atomic.incr probes;
+          Eio.Time.sleep clock 0.05;
+          Some "new");
+      Fun.protect
+        ~finally:(fun () ->
+          Runtime.clear_git_rev_parse_short_probe_hook_for_tests ();
+          Runtime.clear_git_rev_parse_short_cache_for_tests ())
+        (fun () ->
+          Alcotest.(check (option string))
+            "expired cache returns stale immediately"
+            (Some "old") (Runtime.git_rev_parse_short dir);
+          Eio.Time.sleep clock 0.15;
+          Alcotest.(check (option string))
+            "background refresh stores fresh value"
+            (Some "new") (Runtime.git_rev_parse_short dir);
+          Alcotest.(check int) "single background probe" 1
+            (Atomic.get probes)))
+
 (* -- Harness ---------------------------------------------------------------- *)
 
 let () =
@@ -353,6 +385,8 @@ let () =
       ( "concurrency",
         [
           test_case "stampede protection" `Quick test_stampede;
+          test_case "runtime git cache stale-first refresh" `Quick
+            (test_runtime_git_cache_returns_stale_and_refreshes ~clock);
         ] );
       ( "timeout",
         [

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -24,8 +24,13 @@ let with_eio_runtime f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_guard.enable ();
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
   Fun.protect
     ~finally:(fun () ->
+      Process_eio.reset_for_testing ();
       Eio_guard.disable ();
       Fs_compat.clear_fs ())
     f
@@ -48,11 +53,13 @@ let init_repo dir =
 let test_capture_only_on_change () =
   with_temp_dir "worktree-live-context" (fun dir ->
       init_repo dir;
+      Wlc.clear_status_cache_for_tests ();
       check (option string) "clean repo produces no block" None
         (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
       check (option string) "clean repo stays quiet after state write" None
         (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
       write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+      Wlc.clear_status_cache_for_tests ();
       let first =
         Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"
       in
@@ -73,8 +80,10 @@ let test_capture_distinguishes_new_changes () =
   with_temp_dir "worktree-live-context" (fun dir ->
       init_repo dir;
       write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+      Wlc.clear_status_cache_for_tests ();
       ignore (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
       write_file (Filename.concat dir "other.md") "new notes\n";
+      Wlc.clear_status_cache_for_tests ();
       let second =
         Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"
       in
@@ -93,11 +102,49 @@ let test_capture_change_block_in_eio_runtime () =
   with_temp_dir "worktree-live-context" (fun dir ->
       init_repo dir;
       write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+      Wlc.clear_status_cache_for_tests ();
       with_eio_runtime (fun () ->
         let first = Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a" in
         check bool "changed repo produces block in eio" true (Option.is_some first);
         check (option string) "same change not repeated in eio" None
           (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a")))
+
+let test_current_status_lines_uses_short_cache_and_no_optional_locks () =
+  Wlc.clear_status_cache_for_tests ();
+  let calls = ref [] in
+  Wlc.set_git_capture_hook_for_tests (fun ~workdir:_ args ->
+      calls := args :: !calls;
+      Some [ " M sample.ml" ]);
+  Fun.protect
+    ~finally:(fun () ->
+      Wlc.clear_git_capture_hook_for_tests ();
+      Wlc.clear_status_cache_for_tests ())
+    (fun () ->
+      let first = Wlc.current_status_lines ~repo_root:"/tmp/repo" in
+      let second = Wlc.current_status_lines ~repo_root:"/tmp/repo" in
+      check (list string) "first status" [ "M sample.ml" ] first;
+      check (list string) "second status" [ "M sample.ml" ] second;
+      check int "git status called once" 1 (List.length !calls);
+      check (list string) "git status args"
+        [ "--no-optional-locks"; "status"; "--porcelain" ]
+        (List.hd !calls))
+
+let test_current_status_lines_does_not_cache_clean_status () =
+  Wlc.clear_status_cache_for_tests ();
+  let calls = ref 0 in
+  Wlc.set_git_capture_hook_for_tests (fun ~workdir:_ _args ->
+      incr calls;
+      Some []);
+  Fun.protect
+    ~finally:(fun () ->
+      Wlc.clear_git_capture_hook_for_tests ();
+      Wlc.clear_status_cache_for_tests ())
+    (fun () ->
+      check (list string) "first clean status" []
+        (Wlc.current_status_lines ~repo_root:"/tmp/repo");
+      check (list string) "second clean status" []
+        (Wlc.current_status_lines ~repo_root:"/tmp/repo");
+      check int "clean status is not cached" 2 !calls)
 
 let () =
   run "Worktree_live_context"
@@ -109,5 +156,9 @@ let () =
             test_capture_distinguishes_new_changes;
           test_case "works in Eio runtime" `Quick
             test_capture_change_block_in_eio_runtime;
+          test_case "status cache uses no optional locks" `Quick
+            test_current_status_lines_uses_short_cache_and_no_optional_locks;
+          test_case "status cache skips clean status" `Quick
+            test_current_status_lines_does_not_cache_clean_status;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Drain keeper turn OAS event-bus subscriptions during long turns so subscription queues do not build up until turn teardown.
- Add a short, conservative live-context git status cache using `--no-optional-locks`, while avoiding caching clean status so fresh file changes are not hidden.
- Replace the live-context repo-root subprocess probe with local `.git` marker walking.
- Add stale-first dashboard/runtime `git rev-parse --short HEAD` caching with an in-flight refresh guard to reduce repeated probe stampedes.
- Add focused regression coverage for status caching and stale-first git refresh behavior.

## Why

Recent MASC logs showed repeated WARN/ERROR pressure around keeper-turn OAS event-bus backpressure and git probe timeouts against the `~/me` base path. The changes reduce hot-path subprocess churn and keep event-bus queues from accumulating during long keeper turns.

## Validation

- `dune exec --root . ./test/test_worktree_live_context.exe --display=short --no-buffer`
- `dune exec --root . ./test/test_dashboard_cache.exe --display=short --no-buffer`
- `dune exec --root . ./test/test_oas_bus_instrument.exe --display=short --no-buffer`
- `dune exec --root . ./test/test_keeper_unified.exe --display=short --no-buffer`
- `dune exec --root . ./test/test_dashboard_namespace_truth.exe --display=short --no-buffer`
- `dune build --root . --display=short --no-buffer`
- `git diff --check`

## Notes

This PR does not restart the running local MASC service. Live log reduction should be verified after deploying or restarting with this branch build.