### PR TITLE
fix(social_model): warn on silent speech_act default at runtime carry-over (#8605 family)

### DIFF
--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -95,9 +95,7 @@ let delivery_surface_view_source_of_meta (meta : Keeper_types.keeper_meta) =
 let previous_state_of_meta (meta : Keeper_types.keeper_meta) =
   let runtime = meta.runtime in
   let speech_act =
-    match Keeper_social_model_types.speech_act_of_string runtime.last_speech_act with
-    | Some speech_act -> Some speech_act
-    | None -> None
+    Keeper_social_model_types.speech_act_of_string runtime.last_speech_act
   in
   let active_desire = nonempty_opt runtime.last_active_desire in
   let current_intention = nonempty_opt runtime.last_current_intention in
@@ -106,7 +104,22 @@ let previous_state_of_meta (meta : Keeper_types.keeper_meta) =
   match speech_act, active_desire, current_intention, blocker, need with
   | None, None, None, None, None -> None
   | _ ->
-      let speech_act = Option.value ~default:Inform speech_act in
+      (* #8605 family: when carry-state has any field but speech_act is
+         missing or unparseable, default to Inform (the neutral verb).
+         Warn so producer/consumer drift surfaces in operator logs --
+         a future speech_act constructor unknown to this build silently
+         became Inform before this was instrumented. *)
+      let speech_act =
+        match speech_act with
+        | Some v -> v
+        | None ->
+            let raw = runtime.last_speech_act in
+            if String.trim raw <> "" then
+              Log.Keeper.warn
+                "previous_state_of_meta: unparseable last_speech_act %S -> Inform (drift; see #8605)"
+                raw;
+            Keeper_social_model_types.Inform
+      in
       Some
         {
           social_model = normalize_social_model meta.social_model;


### PR DESCRIPTION
## Summary

`Keeper_social_model.previous_state_of_meta` silently coerced an unparseable `runtime.last_speech_act` to `Inform` via `Option.value ~default:Inform speech_act` — the #8605 anti-pattern at the *consumer* boundary.

The producer (`speech_act_of_string`) already follows the good opt pattern (`_ -> None`), but the consumer wraps the `None` into a default constructor with no signal. A future `speech_act` constructor unknown to this build would silently become `Inform` here without any operator log entry.

## Why the lint script didn't catch this

`scripts/lint/no-unknown-permissive-default.sh` scans match-arm wildcards (`| _ -> Constructor`). It does not scan `Option.value ~default:Constructor` patterns. **New category** for the sweep — consumer-side silent defaults that wrap an upstream opt.

## Fix

- Inline the no-op identity match (was `Some x -> Some x | None -> None`).
- Replace `Option.value ~default:Inform` with explicit match + `Log.Keeper.warn` that fires only when the raw input is **non-empty** (an actual unparseable wire string, not a clean absent state).

```ocaml
let speech_act =
  match speech_act with
  | Some v -> v
  | None ->
      let raw = runtime.last_speech_act in
      if String.trim raw <> \"\" then
        Log.Keeper.warn
          \"previous_state_of_meta: unparseable last_speech_act %S -> Inform (drift; see #8605)\" raw;
      Keeper_social_model_types.Inform
in
```

Result is bit-identical: `Inform` is still the carry-over default; the warn line is the only new effect.

## Test plan

- [x] `dune build @check` green
- [x] `test_keeper_social_model_magentic_ledger_fsm.exe` 5/5 pass

## Pattern siblings

13th #8605 family fix in the current sweep. Catalog now spans 6 templates:

1. wire-string-strict (#8736 / #8740 / #8779 / #8828 / #8833 / #8895)
2. exhaustive-match (#8835 / #8864)
3. warn-and-default (#8833 / #8828 / **this PR** — consumer side)
4. string→variant migration (#8842 / #8846 / #8851 / #8862)
5. lift-nested-match (#8889)
6. **consumer-side Option.value warn (this PR — new template)**