### PR TITLE
RFC-0006 Phase A.3: canonicalize aliases before disclosure check

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1959,10 +1959,23 @@ let run_turn
        let tool_names =
          Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
+       (* RFC-0006 Phase A.3: canonicalize Anthropic Code built-in names
+          (Bash/Read/Edit/Grep/Write) to their keeper_* internal cognates
+          before the surface check. Without this, the disclosure check
+          flags every Bash/Read call as "unexpected" and nukes turns where
+          the LLM only used the alias names (≈18% of turns per #8778).
+
+          Phase A.2 (OAS dual registration) makes the actual call succeed
+          end-to-end. This step alone just stops the turn loss. Names with
+          no cognate (Skill/Agent/WebSearch) remain unexpected and may
+          still trigger a teaching error — see Keeper_tool_alias.is_hallucinated_builtin. *)
+       let canonical_tool_names =
+         Keeper_tool_alias.canonicalize_observed tool_names
+       in
        let unexpected_tool_names =
          Keeper_tool_disclosure.unexpected_tool_names
            ~allowed_tool_names:all_tool_names
-           ~tool_names
+           ~tool_names:canonical_tool_names
        in
        (* Partial tolerance (#8471): when a turn mixes valid tool calls
           with unexpected ones (LLM hallucinating Claude Code built-ins
@@ -1975,7 +1988,7 @@ let run_turn
        let valid_tool_calls_present =
          Keeper_tool_disclosure.has_valid_tool_call
            ~unexpected_tool_names
-           ~tool_names
+           ~tool_names:canonical_tool_names
        in
        if unexpected_tool_names <> [] && not valid_tool_calls_present then
          let reason =

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -5,6 +5,7 @@
     (Phase A.2/A.3) can rely on stable contracts. *)
 
 module Alias = Masc_mcp.Keeper_tool_alias
+module Disclosure = Masc_mcp.Keeper_tool_disclosure
 
 let test_known_aliases_resolve () =
   Alcotest.(check (option string)) "Bash -> keeper_bash"
@@ -87,6 +88,67 @@ let test_alias_table_is_stable () =
          (Some internal) (Alias.to_internal public))
     pairs
 
+(* ── Phase A.3 integration: canonicalize before the disclosure check ─── *)
+
+(** Mirrors the call sequence in [keeper_agent_run.ml:1875] after
+    canonicalization is applied. Pins the contract: a turn whose only
+    tool calls are Anthropic Code aliases (Bash/Read/Edit/Grep/Write)
+    must NOT produce any unexpected names. *)
+let allowed_keeper_surface =
+  [ "keeper_bash"; "keeper_fs_read"; "keeper_fs_edit"; "keeper_shell";
+    "keeper_board_post"; "extend_turns" ]
+
+let test_pure_alias_turn_no_longer_unexpected () =
+  let observed = [ "Bash" ] in
+  let canonical = Alias.canonicalize_observed observed in
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:allowed_keeper_surface
+      ~tool_names:canonical
+  in
+  Alcotest.(check (list string))
+    "[Bash] only -> no unexpected (was the 18% nuke source)"
+    [] unexpected
+
+let test_mixed_alias_and_internal_no_unexpected () =
+  let observed = [ "Read"; "keeper_board_post"; "Edit" ] in
+  let canonical = Alias.canonicalize_observed observed in
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:allowed_keeper_surface
+      ~tool_names:canonical
+  in
+  Alcotest.(check (list string)) "mixed alias + internal -> no unexpected"
+    [] unexpected
+
+let test_hallucinated_builtin_still_unexpected () =
+  let observed = [ "Skill"; "Bash" ] in
+  let canonical = Alias.canonicalize_observed observed in
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:allowed_keeper_surface
+      ~tool_names:canonical
+  in
+  Alcotest.(check (list string))
+    "Skill remains unexpected (no cognate); Bash resolved"
+    [ "Skill" ] unexpected
+
+let test_partial_tolerance_still_works () =
+  let observed = [ "Skill"; "Bash" ] in
+  let canonical = Alias.canonicalize_observed observed in
+  let unexpected =
+    Disclosure.unexpected_tool_names
+      ~allowed_tool_names:allowed_keeper_surface
+      ~tool_names:canonical
+  in
+  let has_valid =
+    Disclosure.has_valid_tool_call
+      ~unexpected_tool_names:unexpected
+      ~tool_names:canonical
+  in
+  Alcotest.(check bool) "Bash counts as valid -> partial tolerance kicks in"
+    true has_valid
+
 let () =
   Alcotest.run "Keeper_tool_alias"
     [
@@ -100,5 +162,16 @@ let () =
           Alcotest.test_case "hallucinated builtins" `Quick test_hallucinated_builtins;
           Alcotest.test_case "no overlap" `Quick test_no_overlap_alias_and_hallucinated;
           Alcotest.test_case "table is stable" `Quick test_alias_table_is_stable;
+        ] );
+      ( "disclosure-integration",
+        [
+          Alcotest.test_case "pure alias turn no longer unexpected" `Quick
+            test_pure_alias_turn_no_longer_unexpected;
+          Alcotest.test_case "mixed alias + internal no unexpected" `Quick
+            test_mixed_alias_and_internal_no_unexpected;
+          Alcotest.test_case "hallucinated builtin still unexpected" `Quick
+            test_hallucinated_builtin_still_unexpected;
+          Alcotest.test_case "partial tolerance still works" `Quick
+            test_partial_tolerance_still_works;
         ] );
     ]


### PR DESCRIPTION
## Summary
Phase A.3 of RFC-0006. Wires \`Keeper_tool_alias.canonicalize_observed\` (landed in #8860) into the disclosure check at \`keeper_agent_run.ml:1875\` so when the LLM calls Anthropic Code built-in names (\`Bash\`/\`Read\`/\`Edit\`/\`Grep\`/\`Write\`) the surface check resolves them to their \`keeper_*\` cognates and **does not nuke the turn**.

This is the smallest change that recovers the 18% turn loss measured in #8778.

## Diff scope
- \`lib/keeper/keeper_agent_run.ml\`: insert one canonicalization step before \`unexpected_tool_names\` and reuse the canonical list in \`has_valid_tool_call\` so partial-tolerance (#8471) keeps working.
- \`test/test_keeper_tool_alias.ml\`: 4 new integration-style tests pinning the disclosure contract.

## What this PR does NOT do
The LLM's actual \`Bash\` / \`Read\` call still fails at OAS (\"tool not in registry\") because OAS only has \`keeper_*\` registered. The keeper just no longer fails the WHOLE turn over it. End-to-end success needs **Phase A.2** (OAS dual registration of the same handler under both public and internal names) — separate PR.

Immediate effect:
- decisions.jsonl: \"unexpected tool\" / Internal errors drop sharply.
- Keeper turn is preserved when the LLM mixes \`Bash\` with valid keeper_* calls; previously this still nuked when ALL calls were aliases.
- Dashboard \`fleet telemetry → Keeper Tool I/O\` should fill in for the affected turns instead of vanishing.

## Test plan
- [x] \`dune build @check\` passes.
- [x] \`dune runtest test/test_keeper_tool_alias.exe\`: 12 / 12 pass (8 alias-table + 4 disclosure-integration).
- [ ] CI required checks green.
- [ ] After merge: 24h replay metric — \`unexpected_tool_names\` for Bash/Read/Edit/Grep/Write should hit zero.

## Stack
- #8860 (Phase A.1: alias module — MERGED)
- **THIS PR** (Phase A.3: disclosure-side canonicalize)
- next: Phase A.2 (OAS dual registration so the LLM's call actually executes)
- next: Phase B-1 (minjae symmetric sandbox PoC)

## Refs
- RFC PR #8853
- Tracking issue #8854
- #8778 (the 18% loss)
- #8471 (partial-tolerance — predecessor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)