### PR TITLE
docs(logic): batch-7 .mli for dashboard_labels + worker_runtime_config (2 files)

### DIFF
--- a/lib/dashboard/dashboard_labels.mli
+++ b/lib/dashboard/dashboard_labels.mli
@@ -1,0 +1,57 @@
+(** Dashboard Labels — pure translation from raw states to operator-readable text.
+
+    No side effects, no IO. All functions take raw values and return
+    human-readable strings. This module has no dependency on Dashboard
+    to break circular deps; [Dashboard] and [Dashboard_attention]
+    both depend on it. *)
+
+(** {1 Shared types}
+
+    These break circular dependency between Dashboard subsystems. *)
+
+(** Coord snapshot shared between Dashboard and Dashboard_attention. *)
+type room_snapshot = {
+  room_id : string;
+  is_current : bool;
+  agents : Types.agent list;
+  tasks : Types.task list;
+  messages : Types.message list;
+  locks : int;
+}
+
+(** {1 Timestamp parsing}
+
+    Parses dashboard timestamps to Unix time. Accepts canonical UTC,
+    fractional-second RFC3339, numeric UTC offsets, and bare local
+    timestamps from older read models. Returns [None] on any parse
+    failure (empty / malformed / wrong-length). *)
+val parse_iso_timestamp : string -> float option
+
+(** [format_elapsed now timestamp fallback] renders the elapsed time
+    since [timestamp] as ["Ns ago"] (<60s), ["Nm ago"] (<1h), or
+    ["N.Nh ago"]. Returns [fallback] when parsing fails. *)
+val format_elapsed : float -> string -> string -> string
+
+(** {1 Agent status}
+
+    Thresholds come from {!Runtime_params} /
+    {!Governance_registry.dashboard_agent_quiet_threshold_sec} and
+    {!Governance_registry.dashboard_agent_stuck_threshold_sec}. *)
+
+(** Translate agent status + [last_seen_iso] into operator-readable text
+    like ["working"], ["quiet (Nm)"], ["STUCK (Nm, needs check)"], etc. *)
+val translate_agent_status :
+  now:float -> Types.agent_status -> string -> string
+
+(** Agent grouping for capacity / operator views.
+
+    [Offline] (Inactive) is distinct from [Idle] (Listening) so
+    downstream capacity logic does not treat offline agents as
+    available. *)
+type agent_group = Working | Stuck | Idle | Offline
+[@@deriving eq]
+
+(** Classify an agent using wall-clock [now] and the stuck threshold.
+    [Active]/[Busy] past the threshold → [Stuck]; otherwise → [Working].
+    [Listening] → [Idle]. [Inactive] → [Offline]. *)
+val classify_agent : now:float -> Types.agent -> agent_group

--- a/lib/worker_runtime_config.mli
+++ b/lib/worker_runtime_config.mli
@@ -1,0 +1,51 @@
+(** Worker runtime configuration — resolves [worker-runtime.json] plus
+    env overrides into a cached, effective config consulted by
+    [worker_runtime_*] modules at spawn time.
+
+    Config resolution order (first wins per field):
+
+    + [MASC_WORKER_RUNTIME_BACKEND]
+    + [MASC_WORKER_RUNTIME_DOCKER_IMAGE]
+    + [MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL]
+    + [<config_root>/worker-runtime.json]
+    + Built-in defaults ([Local] backend, ["masc-worker-runtime:dev"] image). *)
+
+(** {1 Types} *)
+
+type docker_config = {
+  image : string;
+  host_mcp_base_url : string option;
+}
+
+type worker_spawn = {
+  backend : Worker_execution_backend.t;
+  docker_scopes : Worker_types.execution_scope list;
+      (** Execution scopes routed through the Docker backend when
+          [backend = Docker]. Other scopes fall back to [Local]. *)
+  docker : docker_config;
+}
+
+type t = {
+  worker_spawn : worker_spawn;
+}
+
+(** {1 Public API} *)
+
+(** [backend_for_scope scope] returns the effective runtime backend
+    for [scope]:
+
+    - [Observe_only] → always [Local].
+    - Otherwise: [config.worker_spawn.backend]; [Docker] only when
+      [scope] is listed in [docker_scopes], else [Local]. *)
+val backend_for_scope :
+  Worker_types.execution_scope -> Worker_execution_backend.t
+
+(** Effective docker image, after file + env resolution. *)
+val docker_image : unit -> string
+
+(** Effective host MCP base URL override (if any). *)
+val host_mcp_base_url_opt : unit -> string option
+
+(** Invalidate the cached resolved config; next call re-reads disk
+    and env. Used by tests and by explicit reload paths. *)
+val reset : unit -> unit


### PR DESCRIPTION
## Summary

Wave 3 batch 7 — `.mli` 2 파일. 바디 무수정.

## 대상 파일 (2개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/dashboard/dashboard_labels.mli` | 196 | 55 | pure translation (timestamp + agent status + grouping) |
| `lib/worker_runtime_config.mli` | 192 | 47 | file+env resolver w/ cached state |

## 설계 노트

### dashboard_labels (circular-dep breaker)
- `Dashboard` 와 `Dashboard_attention` 양쪽이 의존 → 이 모듈이 중간 레이어. 순환 의존 방지용 `room_snapshot` shared type과 `parse_iso_timestamp` 파서가 여기 있음.
- `agent_group = Working | Stuck | Idle | Offline [@@deriving eq]` — Offline과 Idle 분리 이유 (Offline은 downstream capacity에서 available로 처리되면 안 됨) doc에 명시.
- `translate_agent_status` 의 quiet/stuck threshold가 `Runtime_params` + `Governance_registry` 를 통해 공급됨을 mli doc에 명시.

### worker_runtime_config (resolver w/ env precedence)
- **Resolution order** 4단계 모듈 doc에 명시 (env > file > defaults).
- 4 공개 val만 (backend_for_scope/docker_image/host_mcp_base_url_opt/reset). 내부 env 파서·파일 로더·캐시 ref 은닉.
- `reset` 공개 이유: 테스트 + 명시적 reload 경로. mli doc에 기록.

## 검증

- `dune build --root=.` → exit 0
- 외부 소비자 5개 (dashboard.ml, dashboard_attention.ml, worker_runtime_docker.ml, worker_container_runners.ml, test/test_worker_runtime.ml) 컴파일 유지

## 현재 누적 (세션)

8 PR merged + 이 PR = 9 PR, 22 파일 도달.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 310 | **312** |
| Wave 3 진행 | 21/113 (18.58%) | **23/113 (20.35%)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] resolution order doc 명시
- [x] cached ref 은닉 (내부 state 노출 X)
- [x] hype 금지

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)