### PR TITLE
chore(lint): remove stale coord.ml:88/109 allowlist entries (#8842 merged)

### DIFF
--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -12,9 +12,8 @@ lib/sdk_tool_contract.ml:377
 # activity_graph_types.ml:89 (span_status_of_string) eliminated by this PR --
 # strict _opt + warn-and-default wrapper template (mirrors #8779 node_status).
 # coord.ml:132 (observe_task_transition) eliminated by #8846.
-# coord.ml:88/109 (observe_agent_lifecycle) migration pending in #8842.
-lib/coord.ml:88
-lib/coord.ml:109
+# coord.ml:88/109 (observe_agent_lifecycle) eliminated by #8842
+# (agent_lifecycle_event variant: join/rejoin/leave).
 # eval_harness.ml:370 eliminated by lifting nested string match to outer
 # pattern (this PR — was a provably unreachable dead branch).
 lib/types/types_auth.ml:83


### PR DESCRIPTION
## Summary

Remove 2 stale entries from `scripts/lint/no-unknown-permissive-default.allowlist`:
- `lib/coord.ml:88`
- `lib/coord.ml:109`

The accompanying comment in the allowlist already states "migration pending in #8842" — but [#8842](https://github.com/jeong-sik/masc-mcp/pull/8842) is merged. `observe_agent_lifecycle` now dispatches on `agent_lifecycle_event` variant (`Lifecycle_join | Lifecycle_rejoin | Lifecycle_leave`) with no string wildcard, so these line refs are no longer #8605 family violations.

## Why this is purely cleanup

- Lint script (`scripts/lint/no-unknown-permissive-default.sh`) scans all `.ml` files at runtime; the awk logic doesn't cross-check allowlist entries against current violations. Dead entries are harmless but misleading.
- The comment now correctly reads: "coord.ml:88/109 (observe_agent_lifecycle) eliminated by #8842 (agent_lifecycle_event variant: join/rejoin/leave)."
- Follows the pattern set by #8846 cleanup (coord.ml:132) and the activity_graph_types cleanup comment.

## Verification

```
$ bash scripts/lint/no-unknown-permissive-default.sh
Scanned 684 .ml files.
No #8605 family violations found.
```

## Remaining allowlist (3 lines)

- `lib/sdk_tool_contract.ml:377` — umbrella #8605
- `lib/types/types_auth.ml:83` — will be updated to :91 by #8899 (adds 2 tool-match arms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)