### PR TITLE
fix(keeper): warn on unknown tool_preset in profile defaults (#8605 family)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -9,8 +9,23 @@ open Keeper_keepalive
 open Keeper_execution
 open Keeper_turn_up_args
 
+(* #8605 family: profile_defaults.tool_preset is a config-supplied string.
+   Option.bind silently absorbs unparseable values (e.g. config drift adds a
+   preset name the OCaml side does not yet know).  Warn before returning None
+   so the caller's `Option.value ~default:Research` fallback becomes visible
+   in operator logs instead of silently downgrading the preset. *)
 let preset_of_defaults defaults =
-  Option.bind defaults.tool_preset tool_preset_of_string
+  match defaults.tool_preset with
+  | None -> None
+  | Some raw ->
+      (match tool_preset_of_string raw with
+       | Some _ as v -> v
+       | None ->
+           Log.Keeper.warn
+             "preset_of_defaults: unknown tool_preset %S in profile defaults \
+              -> falling back to caller default (drift; see #8605)"
+             raw;
+           None)
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;


### PR DESCRIPTION
## Summary
- 14th fix in the #8605 family sweep — producer-side variant of the consumer-side fix in #8911.
- \`preset_of_defaults\` helper in \`keeper_turn_up_create.ml\` used \`Option.bind defaults.tool_preset tool_preset_of_string\` which silently absorbed unparseable preset strings (config drift would silently downgrade to \`Research\`).

## Behaviour
- **Known input**: identical (\`Some \"coding\"\` -> \`Some Coding\`).
- **No input** (\`defaults.tool_preset = None\`): identical (\`None\`).
- **Unknown input** (\`Some \"garbage\"\`): now logs \`Log.Keeper.warn\` then returns \`None\` (caller still defaults to \`Research\`, but the drift is no longer invisible).

## Why a producer-side fix here
- \`tool_preset_of_string\` (producer in \`keeper_types.ml:239\`) is already strict (\`_ -> None\`).
- \`preset_of_defaults\` (this helper) was the silent boundary — caller \`Option.value ~default:Research\` had no signal that the input was unparseable vs absent.
- Fixing in the helper means all downstream callers benefit without touching each \`Option.value\` site.

## Test plan
- [x] \`dune build @check\` green
- [ ] Behaviour: confirm Research default unchanged for known/None inputs (no test changes needed; bit-identical for those paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)