### PR TITLE
feat(bonsai-dashboard): tokenize swimlane palette (--t-*)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1480,11 +1480,11 @@ stylesheet
     border-radius: 1px;
   }
   .swim_frame:hover { border-color: var(--text-bright); z-index: 2; }
-  .swim_frame_llm  { background: #6a7a9c; }
-  .swim_frame_tool { background: #8a7a3a; }
-  .swim_frame_err  { background: var(--accent-blood); color: var(--text-bright); }
-  .swim_frame_wait { background: #2a2520; color: var(--text-dim); }
-  .swim_frame_think { background: #4a4a5a; color: var(--text-primary); }
+  .swim_frame_llm  { background: var(--t-llm); }
+  .swim_frame_tool { background: var(--t-tool); }
+  .swim_frame_err  { background: var(--t-err); color: var(--text-bright); }
+  .swim_frame_wait { background: var(--t-wait); color: var(--text-dim); }
+  .swim_frame_think { background: var(--t-think); color: var(--text-primary); }
 |}]
 
 let level_class level =

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -62,6 +62,13 @@
   --status-bad:   #a01818;       /* blood */
   --status-idle:  #4a3a32;       /* dried mold */
 
+  /* Trace frame palette — swimlane / flame / tool-category bars */
+  --t-llm:   #6a7a9c;            /* muted blue-gray — inference */
+  --t-tool:  #8a7a3a;            /* muted brass — tool call */
+  --t-think: #4a4a5a;            /* slate — reasoning */
+  --t-wait:  #2a2520;            /* deep dusk — idle */
+  --t-err:   var(--accent-blood);
+
   /* Type stacks */
   --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
   --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
@@ -123,6 +130,12 @@
   --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
   --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
   --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+  /* Trace frames — neon */
+  --t-llm:   #6a2fd6;
+  --t-tool:  #00ffcc;
+  --t-think: #3a2555;
+  --t-wait:  #0d0821;
+  --t-err:   #ff2266;
 }
 
 /* ── Terminal ──────────────────────────────────────────── */
@@ -151,6 +164,12 @@
   --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
   --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
   --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+  /* Trace frames — phosphor */
+  --t-llm:   #00aa00;
+  --t-tool:  #ffcc00;
+  --t-think: #006633;
+  --t-wait:  #000800;
+  --t-err:   #ff4400;
 }
 
 /* ── Parchment (in-app warm theme) ─────────────────────── */
@@ -170,6 +189,12 @@
   --accent-blood: #8b4513;
   --accent-ink:   #556b2f;
   --accent-glow:  rgba(196, 160, 80, 0.1);
+  /* Trace frames — warm parchment */
+  --t-llm:   #6a5d48;
+  --t-tool:  #c4a050;
+  --t-think: #4a3f30;
+  --t-wait:  #1a1610;
+  --t-err:   #8b4513;
 }
 
 /* ── Paper / Ink (docs + light-surface inversion) ──────── */
@@ -216,6 +241,12 @@
   --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
   --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
   --shadow-glow:  none;
+  /* Trace frames — ink on paper */
+  --t-llm:   var(--slate);
+  --t-tool:  var(--brass);
+  --t-think: var(--plum);
+  --t-wait:  var(--paper-3);
+  --t-err:   var(--brick);
 }
 
 /* ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

swimlane frame 4개 niche hex를 **DS token(`--t-*`)으로 추출**. 테마 전환 시 타임라인 팔레트가 자동으로 neon/phosphor/parchment/ink로 교체.

## 치환

| class | 기존 hex | 신규 token |
|---|---|---|
| `.swim_frame_llm` | `#6a7a9c` | `var(--t-llm)` |
| `.swim_frame_tool` | `#8a7a3a` | `var(--t-tool)` |
| `.swim_frame_think` | `#4a4a5a` | `var(--t-think)` |
| `.swim_frame_wait` | `#2a2520` | `var(--t-wait)` |
| `.swim_frame_err` | `var(--accent-blood)` | `var(--t-err)` (=blood alias) |

## 테마별 Trace Palette

| 테마 | llm | tool | think | wait | err |
|---|---|---|---|---|---|
| **dark-fantasy** | `#6a7a9c` muted blue-gray | `#8a7a3a` muted brass | `#4a4a5a` slate | `#2a2520` deep dusk | `--accent-blood` |
| **cyberpunk** | `#6a2fd6` violet | `#00ffcc` cyan | `#3a2555` twilight | `#0d0821` nightsky | `#ff2266` hot pink |
| **terminal** | `#00aa00` green | `#ffcc00` amber | `#006633` forest | `#000800` black | `#ff4400` fire |
| **parchment** | `#6a5d48` dust | `#c4a050` brass | `#4a3f30` umber | `#1a1610` char | `#8b4513` saddle |
| **paper** | `var(--slate)` | `var(--brass)` | `var(--plum)` | `var(--paper-3)` | `var(--brick)` |

## 왜

- `colors_and_type.css`는 `--accent-*`/`--status-*` 토큰 SSOT인데 swimlane만 ppx_css 블록에 하드코딩돼 테마 비반응.
- `--t-*` namespace 도입으로 "trace/flame/tool-category" visualization 전체에 재사용 가능 (추후 `view_flame_mini` 등).
- `--t-err`은 alias로만 두어 blood가 항상 theme의 blood를 따라감 (cyberpunk→hot pink, paper→brick).

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 기존 dark-fantasy에서 색 변화 없음 (일치 확인)
- [ ] `#cyberpunk` 전환 시 swimlane이 violet/cyan/hot-pink로 교체
- [ ] `#terminal`에서 green/amber phosphor로 교체
- [ ] `#paper`에서 light palette (slate/brass/plum)로 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)
