### PR TITLE
docs(logic): batch-8 .mli for keeper_tag_dispatch + autoresearch_metric

### DIFF
--- a/lib/autoresearch/autoresearch_metric.mli
+++ b/lib/autoresearch/autoresearch_metric.mli
@@ -1,0 +1,70 @@
+(** Autoresearch_metric — Metric measurement and retry logic.
+
+    Runs a shell command ([metric_fn]) via [Agent_sdk.Autonomy_exec]
+    (argv-only execution, no shell interpreter) and parses either a
+    strict metric-contract tag or the last non-empty stdout line as a
+    float score. Supports retry on transient errors (timeout,
+    connection).
+
+    @since 2.80.0 *)
+
+(** {1 Re-exports from [Agent_sdk.Metric_contract]}
+
+    Convenience bindings kept for callers that only depend on this
+    module. *)
+
+val default_metric_name : string
+
+val prompt_snippet : ?metric_name:string -> unit -> string
+
+(** {1 Re-exports from [String_util]} *)
+
+(** Substring containment check — re-exposed because
+    [Autoresearch_file] consumes it directly. *)
+val contains_substring : string -> string -> bool
+
+(** {1 [metric_fn] validation} *)
+
+(** Tokenise [metric_fn] into an [argv] list, rejecting shells
+    metacharacters outside quotes, unterminated quotes, and multi-line
+    input. *)
+val split_metric_fn_argv : string -> (string list, string) result
+
+(** [validate_metric_fn fn] returns [Ok fn] if tokenisation succeeds,
+    otherwise [Error reason]. Does not execute the command. *)
+val validate_metric_fn : string -> (string, string) result
+
+(** {1 Execution} *)
+
+(** [run_metric_argv ~workdir ~timeout_s argv] executes [argv] under
+    [Agent_sdk.Autonomy_exec.run] and returns
+    [(stdout, elapsed_ms)] on exit code 0, or an [Error] describing the
+    failure (including clock unavailability, non-zero exit, timeout,
+    signal). *)
+val run_metric_argv :
+  workdir:string ->
+  timeout_s:float ->
+  string list ->
+  (string * int, string) result
+
+(** [measure_metric ~workdir ~timeout_s metric_fn] tokenises, runs, and
+    parses [metric_fn]. On success returns [(score, elapsed_ms)];
+    [Error] on tokenisation failure, exec failure, or unparsable output
+    (neither a metric-contract tag nor a float on the last line). *)
+val measure_metric :
+  workdir:string ->
+  timeout_s:float ->
+  string ->
+  (float * int, string) result
+
+(** [measure_metric_with_retry ~workdir ~timeout_s ?max_retries metric_fn]
+    retries on transient errors (messages containing ["timeout"],
+    ["timed_out"], or ["connection"]) with a 1-second sleep between
+    attempts. [max_retries] defaults to [2] (up to 3 total attempts).
+    Non-transient errors return immediately. *)
+val measure_metric_with_retry :
+  workdir:string ->
+  timeout_s:float ->
+  ?max_retries:int ->
+  string ->
+  (float * int, string) result

--- a/lib/keeper/keeper_tag_dispatch.mli
+++ b/lib/keeper/keeper_tag_dispatch.mli
@@ -1,0 +1,34 @@
+(** Keeper_tag_dispatch — Tag-based tool dispatch for keeper context.
+
+    Bridges the gap between keeper's available context (config, agent_name,
+    Eio globals) and the module-specific contexts needed by [Tool_*.dispatch].
+
+    Callers must try {!Tool_dispatch.dispatch} (handler registry) first;
+    this module is the fallback for tools present only in [tag_registry].
+    See [mcp_server_eio_execute.ml] [dispatch_by_tag] for the MCP server
+    counterpart.
+
+    Issue: #4579 *)
+
+(** [dispatch ~config ~agent_name ~tag ~name ~args] routes [tag] to the
+    corresponding [Tool_*.dispatch] with a minimal keeper-shaped context.
+
+    Returns:
+    - [Some (true, msg)] on successful dispatch.
+    - [Some (false, msg)] when the tool is blocked in keeper context
+      ([Mod_control] mutators, [Mod_inline], [Mod_compact], [Mod_keeper],
+      [Mod_operator]) or when the underlying dispatch reports failure.
+    - [None] only if the selected module does not recognise [name] (does
+      not happen when [tag] was obtained via [Tool_dispatch.lookup_tag]).
+
+    Exceptions from inner dispatchers are caught and normalised into
+    [Some (false, "keeper dispatch error …")] with the exception type
+    stripped of internal paths to avoid leaking server internals.
+    [Eio.Cancel.Cancelled] is re-raised. *)
+val dispatch :
+  config:Coord.config ->
+  agent_name:string ->
+  tag:Tool_dispatch.module_tag ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  (bool * string) option


### PR DESCRIPTION
## Summary

Wave 3 batch 8 — `.mli` 2 파일. 바디 무수정.

## 대상 파일 (2개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/keeper/keeper_tag_dispatch.mli` | 194 | 27 | 1 external symbol (`dispatch`) |
| `lib/autoresearch/autoresearch_metric.mli` | 191 | 68 | 8 external symbol + 6 internal helper hide |

## 설계 노트

### keeper_tag_dispatch
- **external surface 1개**: `dispatch` 만 사용됨 (lib/mcp_server_eio.ml, lib/keeper/keeper_exec_tools.mli, test×2).
- 5 Eio-context helper (`require_sw`/`require_clock`/`get_proc_mgr_opt`/`require_net`/`get_net_opt`/`get_fs_opt`) 전부 internal hide.
- Exception taxonomy 명시: `Eio.Cancel.Cancelled` 재-raise + 나머지는 `(false, "keeper dispatch error …")` normalization.

### autoresearch_metric
- **Public surface 8개** (call-site verification 기반):
  - Primary API: `measure_metric`, `measure_metric_with_retry`, `validate_metric_fn` (autoresearch.ml, tool_autoresearch.ml)
  - Tool-cycle 용: `run_metric_argv`, `split_metric_fn_argv`, `default_metric_name`, `prompt_snippet` (tool_autoresearch_cycle.ml)
  - String util 재-export: `contains_substring` (autoresearch_file.ml)
- **Internal hide**: `quote_mode` 타입, `dangerous_shell_chars` 상수, `clip`, `is_blank`, `last_nonempty_line`, `parse_metric_output`.
- Transient retry keyword set (`timeout`/`timed_out`/`connection`) mli doc에 명시.

## 검증

- `dune build --root=.` → exit 0
- External consumer 4 파일 (autoresearch, autoresearch_file, tool_autoresearch, tool_autoresearch_cycle) + 3 caller site (mcp_server_eio, keeper_exec_tools.mli, 2 tests) 컴파일 유지.

## 현재 누적 (세션)

| # | PR | 파일 수 | 상태 |
|---|----|---------|------|
| 1 | #8821 | 1 | MERGED |
| 2 | #8847 | 1 | MERGED |
| 3 | #8859 | 6 | MERGED |
| 4 | #8865 | 3 | MERGED |
| 5 | #8877 | 3 | MERGED |
| 6 | #8886 | 3 | MERGED |
| 7 | #8898 | 2 | MERGED |
| 8 | #8908 | 2 | MERGED |
| 9 | #8913 | 2 | Open (auto-merge) |
| **10** | **이 PR** | **2** | Open |

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 312 | **314** |
| Wave 3 진행 | 21/113 (18.58%) | **23/113 (20.35%)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] Public surface을 grep 기반으로 검증
- [x] Re-export 유지 (contains_substring → String_util)
- [x] hype 금지 (정량치만)

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023 (Wave 3 `.mli` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)