### PR TITLE
fix(keeper): warn on unknown tool_preset in exec_persona path (#8605 family)

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -222,10 +222,25 @@ let resolved_keeper_args_from_persona args :
                      in
                      Ok (persona, resolved))
              | None ->
+                 (* #8605 family: defaults.tool_preset is a config-supplied
+                    string; Option.bind silently absorbs unparseable values
+                    (config drift adds an unknown preset name).  Warn before
+                    falling back so producer/consumer drift surfaces in
+                    operator logs.  Mirrors #8916 in keeper_turn_up_create.ml.
+                    Follow-up: lift to a shared helper to avoid divergence. *)
                  let tool_preset =
-                   match Option.bind defaults.tool_preset tool_preset_of_string with
-                   | Some preset -> preset
+                   match defaults.tool_preset with
                    | None -> Research
+                   | Some raw ->
+                       (match tool_preset_of_string raw with
+                        | Some preset -> preset
+                        | None ->
+                            Log.Keeper.warn
+                              "keeper_exec_persona: unknown tool_preset %S \
+                               in profile defaults -> Research (drift; \
+                               see #8605)"
+                              raw;
+                            Research)
                  in
                  let tool_also_allow =
                    match get_string_list args "tool_also_allow" with


### PR DESCRIPTION
## Summary
- 15th fix in the #8605 family sweep — second-site duplicate of #8916.
- \`keeper_exec_persona.ml:226\` had the same \`Option.bind defaults.tool_preset tool_preset_of_string\` silent fallback anti-pattern.

## Behaviour
- Known preset string: identical (parsed -> typed variant).
- Missing preset (\`None\`): identical (Research fallback).
- **Unknown preset string** (\`Some \"garbage\"\`): now warns then falls back to Research instead of silently downgrading.

## Follow-up
- File issue: lift \`preset_of_defaults\` to a shared helper (e.g. \`Keeper_types.tool_preset_resolve_with_warn\`) so both \`keeper_turn_up_create.ml\` and \`keeper_exec_persona.ml\` share one implementation.

## Test plan
- [x] \`dune build lib/keeper\` green
- Behaviour bit-identical for known/None inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)