### PR TITLE
docs(bonsai-dashboard): refresh README to current state (Phase 0→1)

### DIFF
--- a/dashboard_bonsai/README.md
+++ b/dashboard_bonsai/README.md
@@ -1,51 +1,121 @@
 # dashboard_bonsai
 
-Bonsai (Jane Street) implementation of the masc-mcp dashboard. Island migration
-target — coexists with the Preact SPA at `/dashboard` while this tree builds out
-`/dashboard/b/*`. See `planning/claude-plans/masc-mcp-eventual-parrot.md` for the
-full migration plan.
+Jane Street **Bonsai** (OCaml + js_of_ocaml) 기반 masc-mcp 대시보드 island.
+기존 Preact 대시보드(`../dashboard/`)와 URL prefix로 공존 — 점진 이전(lift-and-shift) 중.
+
+- **Preact**: `/dashboard/*` (기존)
+- **Bonsai**: `/dashboard/b/*` (이 디렉토리)
+
+## 현재 상태 (Phase 0 ~ 1 진행)
+
+- `/dashboard/b/hello` — Bonsai 부트 확인용 (logs_view 전체 렌더)
+- Mock 섹션: moonrise narrative · focus card · roster · cycle activity · context pressure
+- Live 섹션: 3s polling logs stream (`Logs_var` + `Logs_fetch`)
+- 5 테마: `dark-fantasy` (default) · `cyberpunk` · `terminal` · `parchment` · `paper`
 
 ## Toolchain
 
-- OCaml variant **`ocaml-variants.5.2.0+ox`** (OxCaml) in opam switch
-  `bonsai-dashboard`. The masc-mcp server switch (5.4.1, stock OCaml) is not
-  reused because Bonsai `v0.18~preview` requires `ppxlib < 0.36` (incompatible
-  with 5.4) and stock OCaml 5.3 fails to build Jane Street's `basement` C stubs
-  on macOS 26 due to a `fallthrough` macro collision with the system dispatch
-  headers.
-- Bonsai `v0.18~preview.130.83+317` from the OxCaml opam repository.
-- `ppx_css`, `virtual_dom`, `brr`, `ppx_yojson_conv`.
+OxCaml 기반 OCaml 5.2 + Jane Street v0.18 preview 패키지.
 
-## One-time switch setup
+- 컴파일러: `ocaml-variants.5.2.0+ox`
+- Bonsai: `v0.18~preview.130.83+317` (OxCaml repo)
+- stock OCaml 5.3/5.4 + janestreet-bleeding 조합은 macOS 26 SDK(`dispatch/base.h`
+  `fallthrough` 매크로 충돌)와 충돌 — OxCaml만 동작.
 
-    opam switch create bonsai-dashboard 5.2.0+ox \
-        --repos ox=git+https://github.com/oxcaml/opam-repository.git,default \
-        --no-install
-    opam install --switch=bonsai-dashboard \
-        bonsai ppx_css virtual_dom brr ppx_yojson_conv
+### 1회 switch 셋업
 
-If the OxCaml repo is not registered globally yet, the `--repos` flag above
-registers it only inside this switch, which is the recommended isolation.
+```bash
+opam switch create bonsai-dashboard 5.2.0+ox \
+    --repos ox=git+https://github.com/oxcaml/opam-repository.git,default \
+    --no-install
+opam install --switch=bonsai-dashboard \
+    bonsai ppx_css virtual_dom brr ppx_yojson_conv
+```
 
-## Build
+OxCaml 레포를 전역 등록하지 않고 switch 내부에만 두는 격리 설정.
 
-Build from this directory using the dedicated switch:
+## 빌드
 
-    eval $(opam env --switch=bonsai-dashboard)
-    dune build
+프로젝트 루트 Makefile에 통합:
 
-The compiled JS lands at `_build/default/bin/main.bc.js`. A production build
-step (not yet implemented) will copy that artifact into
-`../assets/dashboard_bonsai/` so the server can serve it via
-`/api/assets/dashboard_bonsai/main.bc.js`.
+```bash
+make bonsai-dashboard          # 전체: ml → main.bc.js + CSS 토큰
+make bonsai-dashboard-tokens   # CSS 토큰만 빠른 재배포
+```
 
-## Serving URL
+둘 다 결과를 `../assets/dashboard_bonsai/`에 복사 → 서버가 정적 서빙.
+수동 빌드는:
 
-- `/dashboard/b/hello` — Phase 0 smoke page (current).
-- `/dashboard/b/logs` — Phase 1 target (first real tab).
+```bash
+eval $(opam env --switch=bonsai-dashboard --set-switch)
+dune build --root .
+```
 
-## Directory layout
+컴파일 산출물: `_build/default/bin/main.bc.js` (~62MB debug 빌드, js_of_ocaml 통상적).
 
-    bin/main.ml            entry, mounts the Bonsai app on #app
-    src/hello_view.ml      placeholder component (ppx_css)
-    src/sse.ml             EventSource helper (Phase 0.4 spike)
+## 서빙
+
+- `lib/server/server_routes_http_pages.ml` — `/dashboard/b/*` 라우트 등록
+- `lib/server/server_routes_http_routes_frontend.ml` — `assets/dashboard_bonsai/*` 정적
+- 번들 캐시 버스트: `main.bc.js?v=<mtime>` · `colors_and_type.css?v=<mtime>`
+
+## 레이아웃
+
+```
+dashboard_bonsai/
+├── bin/
+│   ├── main.ml           # Bonsai entry, theme listener, moon clock tick
+│   └── dune
+├── src/
+│   ├── app.ml            # root component
+│   ├── logs_view.ml      # dashboard shell (ppx_css + view 함수)
+│   ├── logs_types.ml     # JSON response record + of_yojson
+│   ├── logs_var.ml       # Bonsai.Expert.Var for logs stream
+│   ├── logs_fetch.ml     # fetch + 3s polling
+│   ├── hello_view.ml     # legacy smoke page
+│   ├── sse.ml            # EventSource helper (Phase 0.4)
+│   └── dune
+├── static/
+│   └── colors_and_type.css   # DS token SSOT (5 테마)
+└── dune-project
+```
+
+## 스타일
+
+- **ppx_css 블록** inline (각 view 파일 내부)
+- **`static/colors_and_type.css`**: DS token SSOT — `--bg-*` / `--text-*` / `--accent-*` / `--status-*` / `--t-*`
+- Tailwind는 Preact 잔존 탭에서만 사용 (`../dashboard/`)
+
+테마 전환:
+- URL hash: `#cyberpunk` / `#terminal` / `#parchment` / `#paper`
+- localStorage: `masc.bonsai.theme` 키로 영속화
+- 하단 theme chip 클릭 → `<html data-theme>` 속성 교체
+
+## 아직 mock (pending 표시)
+
+| 섹션 | 필요한 endpoint |
+|------|----------------|
+| focus card (ctx / turn / mem / latency) | keeper status |
+| cycle activity swimlane | session tool-span trace |
+| context pressure chart | keeper status (per-cycle ctx %) |
+| roster 4 slot | keeper status |
+| moonrise `base=` / `operator` | server config + identity |
+| nav crumbs | router |
+
+## Phase 계획
+
+`~/me/planning/claude-plans/masc-mcp-eventual-parrot.md` 참조. 요약:
+
+- **Phase 0**: foundation (hello world, SSE helper 스파이크) — 완료
+- **Phase 1**: shared types + logs island — 진행 중 (3s polling 동작 중)
+- **Phase 2**: connectors / workspace (차트 없는 탭)
+- **Phase 3**: 차트 바인딩 (mermaid → d3 → vis-timeline → cytoscape → vis-network)
+- **Phase 4**: monitoring / command (차트 의존 탭)
+- **Phase N**: `/dashboard/b/*` → `/dashboard/*` 승격, Preact 폐기
+
+## 원칙
+
+- **Lift-and-shift, not redesign**: 레이아웃/IA 변경 금지. UI 개편은 Phase N+1.
+- **Pixel parity**: ±2px / hex 동일. 그 외는 버그.
+- **OAS 경계**: `agent_sdk` 무변경. 프론트-서버는 JSON over HTTP + SSE만.
+- **핸들러 JSON 계약 고정**: `lib/dashboard/*.ml`은 수정 금지, typed record로만 refactor.


### PR DESCRIPTION
## Summary

`dashboard_bonsai/README.md`를 현재 상태 기준으로 갱신. 기존 문서는 Phase 0 초기 스캐폴드 시점이라 `/dashboard/b/hello` 외의 진행을 반영하지 못했다.

## 갱신 포인트

- Phase 0 완료 / Phase 1 진행 중 (3s polling logs, 실데이터 렌더)
- Mock 섹션 리스트: moonrise narrative · focus card · roster · cycle activity · context pressure
- 5 테마 + hash URL (`#cyberpunk` 등) + localStorage 영속화
- Makefile 통합 — `make bonsai-dashboard` / `bonsai-dashboard-tokens`
- 번들 캐시 버스트: `?v=<mtime>` (mtime 기반)
- 레이아웃 최신화 — logs_view / logs_types / logs_var / logs_fetch
- 아직 mock 섹션별 필요 endpoint 매핑 테이블
- 원칙 재확인: lift-and-shift, pixel parity, OAS 경계, 핸들러 JSON 계약 고정

## Why

Phase 계획은 `planning/claude-plans/masc-mcp-eventual-parrot.md` SSOT를 참조로만 유지. README는 "이 디렉토리를 처음 보는 사람이 15초 안에 현재 어디까지 됐고 어디로 가는지 파악" 목적.

## Test plan

- [x] 문서만 수정 (코드 변경 없음)
- [ ] 렌더 결과 확인 후 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
