### PR TITLE
fix(auth): nickname prefix fallback for load_credential

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -107,12 +107,23 @@ let save_auth_config config (auth_cfg : auth_config) =
 let credential_file config agent_name =
   Filename.concat (agents_dir config) (agent_name ^ ".json")
 
-(** Load agent credential *)
-let load_credential config agent_name : agent_credential option =
-  let file = credential_file config agent_name in
-  if file_exists file then
+(* Inline copy of Nickname.is_generated_nickname / extract_agent_type.
+   Auth lives below masc_coord in the module graph and cannot depend on
+   it. The nickname pattern — three or more hyphen-separated segments,
+   first segment is the agent type — is small enough to duplicate here
+   without drift risk. Covered by the nickname fallback tests. *)
+let is_generated_nickname_shape name =
+  List.length (String.split_on_char '-' name) >= 3
+
+let extract_agent_type_prefix name =
+  match String.split_on_char '-' name with
+  | prefix :: _ when prefix <> "" -> Some prefix
+  | _ -> None
+
+let load_credential_from_path config agent_name path : agent_credential option =
+  if file_exists path then
     try
-      let content = read_text_file file in
+      let content = read_text_file path in
       let json = Yojson.Safe.from_string content in
       match agent_credential_of_yojson json with
       | Ok cred -> Some cred
@@ -122,6 +133,31 @@ let load_credential config agent_name : agent_credential option =
     with Sys_error _ | Yojson.Json_error _ -> None
   else
     None
+
+(** Load agent credential.
+
+    Tries an exact filename match first. If that misses and [agent_name]
+    looks like a generated nickname ({agent_type}-{adj}-{animal}[...]),
+    retry with just the agent_type prefix — shared-token aliases
+    provisioned for stable keeper names (e.g. [adversary.json]) then
+    cover every dynamically generated nickname in that family
+    (e.g. [adversary-fair-tapir]).
+
+    Without this fallback, Coord.join's nickname output caused a
+    chronic "No credential found for <type>-<adj>-<animal>" noise band
+    at ~0.3/min on the live fleet (2026-04-20). *)
+let load_credential config agent_name : agent_credential option =
+  let file = credential_file config agent_name in
+  match load_credential_from_path config agent_name file with
+  | Some _ as c -> c
+  | None ->
+    if is_generated_nickname_shape agent_name then
+      match extract_agent_type_prefix agent_name with
+      | Some prefix when prefix <> agent_name ->
+        let fallback = credential_file config prefix in
+        load_credential_from_path config prefix fallback
+      | _ -> None
+    else None
 
 (** Save agent credential *)
 let save_credential config (cred : agent_credential) =

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -225,6 +225,42 @@ let test_delete_credential () =
   cleanup_test_room dir;
   check int "0 credentials after delete" 0 (List.length creds)
 
+let test_load_credential_nickname_fallback () =
+  (* Exact-name misses fall through to the agent-type prefix so a single
+     credential (e.g. "adversary.json") covers dynamically generated
+     nicknames ("adversary-fair-tapir"). *)
+  let dir = setup_test_room () in
+  let _ = Auth.create_token dir ~agent_name:"adversary" ~role:Types.Worker in
+  let hit = Auth.load_credential dir "adversary-fair-tapir" in
+  let miss_non_nickname = Auth.load_credential dir "unknown_plain" in
+  let miss_different_family = Auth.load_credential dir "stranger-fair-tapir" in
+  cleanup_test_room dir;
+  (match hit with
+   | Some cred when cred.agent_name = "adversary" -> ()
+   | _ -> fail "nickname 'adversary-fair-tapir' should resolve via prefix");
+  (match miss_non_nickname with
+   | None -> ()
+   | Some _ -> fail "plain unknown names must not fall through");
+  (match miss_different_family with
+   | None -> ()
+   | Some _ -> fail "unrelated agent_type must not reuse another keeper's cred")
+
+let test_load_credential_exact_wins_over_fallback () =
+  (* If both the nickname file and the prefix file exist, the exact
+     match wins so a per-nickname override remains possible. *)
+  let dir = setup_test_room () in
+  let _ = Auth.create_token dir ~agent_name:"adversary" ~role:Types.Worker in
+  let _ = Auth.create_token dir ~agent_name:"adversary-fair-tapir" ~role:Types.Reader in
+  let resolved = Auth.load_credential dir "adversary-fair-tapir" in
+  cleanup_test_room dir;
+  match resolved with
+  | Some cred when cred.agent_name = "adversary-fair-tapir" && cred.role = Types.Reader -> ()
+  | Some cred ->
+      fail (Printf.sprintf "unexpected resolution: %s/%s" cred.agent_name
+              (match cred.role with Types.Reader -> "Reader" | Worker -> "Worker"
+               | Admin -> "Admin"))
+  | None -> fail "exact match should resolve"
+
 (* ============================================ *)
 (* Permission tests                             *)
 (* ============================================ *)
@@ -480,6 +516,10 @@ let () =
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;
       test_case "delete credential" `Quick test_delete_credential;
+      test_case "load_credential nickname prefix fallback" `Quick
+        test_load_credential_nickname_fallback;
+      test_case "load_credential exact match wins over fallback" `Quick
+        test_load_credential_exact_wins_over_fallback;
     ];
     "permissions", [
       test_case "reader permissions" `Quick test_reader_permissions;


### PR DESCRIPTION
## Summary

`Coord.join` 이 발급하는 generated nickname(`{agent_type}-{adj}-{animal}[-{hex4}]`, 예: `adversary-fair-tapir`)으로 MCP 호출이 들어올 때 `load_credential` exact filename match 가 실패하고 `No credential found` 반환. 에이전트 type 별 공유 credential alias 가 이미 있어도 dynamic nickname 에는 적용 못 함.

## Product impact

Fleet 로그 2026-04-20 17분 관찰창에서 `No credential found for <type>-<adj>-<animal>` 48건(분당 0.3건) — 전부 dynamic nickname 케이스. 16개 고정 keeper alias 로도 못 잡던 체급.

## Evidence

- `lib/coord/nickname.ml:58` nickname shape: `List.length (String.split_on_char '-' name) >= 3`
- `lib/auth.ml:111 load_credential`: `credential_file config agent_name` 는 `{dir}/{name}.json` exact match
- 실측 sample 이름: `adversary-fair-tapir`, `codex-task-claimer-20260419t102117z` 등
- `~/me/.masc/auth/agents/adversary.json` 은 이미 있음 (이번 세션 alias 작업의 결과)

## 변경

`lib/auth.ml`:
- `load_credential_from_path` helper 로 파일 로드 로직 분리
- 새 `load_credential`: exact match → None 이면 nickname shape 확인 → agent_type prefix 로 재시도
- Nickname 패턴 감지는 6-line inline copy (`lib/coord/` 의존성 추가 시 cycle 발생, auth ↔ coord)

## Review evidence

- `dune build --root . lib/auth.ml` 성공
- `dune exec --root . -- test/test_auth.exe` → **31/31 pass** (신규 fallback 2건 포함)
- 기존 credential 테스트 회귀 없음

## Linked issue

Refs MASC fleet log 2026-04-20 `No credential found for adversary-fair-tapir` 외 47건.

## Safety

Exact match 는 항상 우선. 공유 token alias 보안 경계는 기존과 동일 (이미 local-only auth 환경). Invariant: fallback 이 성공하려면 agent_type prefix 파일이 실제 존재해야 함 → unrelated family 는 여전히 거부 (test `stranger-fair-tapir` 로 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)