### PR TITLE
RFC-0006 Phase A.2: OAS dual registration of Bash/Read aliases

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1064,8 +1064,16 @@ let run_turn
      preset (e.g. social keeper seeing keeper_fs_edit) from reaching
      the LLM and triggering tool_not_allowed errors. *)
   let allowed_exec_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  (* RFC-0006 Phase A.2: extend the allowed-execution set with public
+     alias names (Bash/Read/...) whose internal target is already
+     allowed. Without this, the AllowList partition at line ~1476 drops
+     Bash/Read even though [Keeper_tools_oas.make_tools] now registers
+     them with OAS, defeating the dual registration. *)
+  let allowed_exec_names_with_aliases =
+    Keeper_tool_alias.expand_universe allowed_exec_names
+  in
   let allowed_exec_set =
-    let base = Keeper_tool_policy.tool_name_set allowed_exec_names in
+    let base = Keeper_tool_policy.tool_name_set allowed_exec_names_with_aliases in
     (* Core always-tools bypass candidate_set in can_execute, so they
        may be absent from keeper_allowed_tool_names.  Add them back to
        prevent the preset filter from dropping survival-critical tools. *)

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -11,9 +11,18 @@ let aliases : (string * string) list =
   [
     "Bash", "keeper_bash";
     "Edit", "keeper_fs_edit";
-    "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.2 *)
+    "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.4 *)
     "Read", "keeper_fs_read";
     "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
+  ]
+
+(* Subset of [aliases] safe for OAS dual registration in Phase A.2.
+   Edit/Write/Grep need nontrivial input shape adapters (string-replace
+   semantics, op=rg synthesis) — landing in Phase A.4. *)
+let oas_dual_register : (string * string) list =
+  [
+    "Bash", "keeper_bash";
+    "Read", "keeper_fs_read";
   ]
 
 (* Anthropic Code surface names without a keeper cognate. The disclosure
@@ -55,3 +64,122 @@ let hallucinated_set =
 let is_hallucinated_builtin name = Hashtbl.mem hallucinated_set name
 
 let all_aliases () = aliases
+
+(* ── Phase A.2 OAS dual registration ────────────────────────────── *)
+
+let oas_dual_register_aliases () = oas_dual_register
+
+(* Helpers for assembling JSON tool schemas. Kept local to avoid coupling
+   alias semantics with the broader Tool_shard helpers. *)
+let property name typ description =
+  ( name,
+    `Assoc
+      [ ("type", `String typ); ("description", `String description) ] )
+
+let object_schema ?(required = []) properties =
+  `Assoc
+    [
+      ("type", `String "object");
+      ("properties", `Assoc properties);
+      ("required", `List (List.map (fun n -> `String n) required));
+    ]
+
+(* Anthropic Code "Bash" tool schema, mirrored as closely as we can while
+   only exposing what keeper_bash actually supports. *)
+let bash_public_schema =
+  object_schema ~required:[ "command" ]
+    [
+      property "command" "string"
+        "The shell command to execute. Single command only. No chaining \
+         (&&, ||, ;), pipes (|), or redirects (>, >>). Example: 'dune \
+         build', 'rg pattern lib/'.";
+      property "description" "string"
+        "Optional short description of what the command does. Logged for \
+         observability.";
+      property "timeout" "number"
+        "Timeout in seconds (default 30, max 180). For \
+         run_in_background=true, 0 disables the timeout.";
+      property "run_in_background" "boolean"
+        "Default false. When true, returns immediately with \
+         background_task_id; poll output via keeper_bash_output, stop via \
+         keeper_bash_kill.";
+    ]
+
+(* Anthropic Code "Read" tool schema. We do not yet support offset/limit
+   in keeper_fs_read; declared here so the LLM can pass them but the
+   translator drops them. *)
+let read_public_schema =
+  object_schema ~required:[ "file_path" ]
+    [
+      property "file_path" "string"
+        "Absolute or playground-relative file path to read.";
+      property "limit" "integer"
+        "Approximate maximum bytes to return (mapped to keeper_fs_read \
+         max_bytes; line-based limit is not supported).";
+      property "offset" "integer"
+        "Currently ignored; reads from the start. Listed for compatibility \
+         with the Anthropic Read tool surface.";
+    ]
+
+let public_input_schema = function
+  | "Bash" -> Some bash_public_schema
+  | "Read" -> Some read_public_schema
+  | _ -> None
+
+(* Translate an LLM call payload from the public schema to the internal
+   tool's expected shape. Identity for unknown aliases.
+
+   Robust against malformed payloads: anything that isn't a JSON object
+   passes through unchanged so the downstream validator can produce the
+   normal structured error. *)
+let translate_bash_input input =
+  match input with
+  | `Assoc fields ->
+      let out = ref [] in
+      List.iter
+        (fun (k, v) ->
+          match k with
+          | "command" -> out := ("cmd", v) :: !out
+          | "timeout" -> out := ("timeout_sec", v) :: !out
+          | "description" -> ()  (* dropped; logged elsewhere *)
+          | _ -> out := (k, v) :: !out)
+        fields;
+      `Assoc (List.rev !out)
+  | _ -> input
+
+let translate_read_input input =
+  match input with
+  | `Assoc fields ->
+      let out = ref [] in
+      List.iter
+        (fun (k, v) ->
+          match k with
+          | "file_path" -> out := ("path", v) :: !out
+          | "limit" -> out := ("max_bytes", v) :: !out
+          | "offset" -> ()  (* keeper_fs_read does not support offsets *)
+          | _ -> out := (k, v) :: !out)
+        fields;
+      `Assoc (List.rev !out)
+  | _ -> input
+
+let translate_input ~public input =
+  match public with
+  | "Bash" -> translate_bash_input input
+  | "Read" -> translate_read_input input
+  | _ -> input
+
+let expand_universe internal_names =
+  let already = Hashtbl.create (List.length internal_names) in
+  List.iter (fun n -> Hashtbl.replace already n ()) internal_names;
+  let extras =
+    List.filter_map
+      (fun (public, internal) ->
+        if Hashtbl.mem already internal && not (Hashtbl.mem already public)
+        then begin
+          Hashtbl.replace already public ();
+          Some public
+        end
+        else None)
+      oas_dual_register
+  in
+  internal_names @ extras

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -2,24 +2,15 @@
     (Anthropic Code built-ins like [Bash], [Read]) and the internal
     keeper surface names ([keeper_bash], [keeper_fs_read], ...).
 
-    Phase A of RFC-0006. This module is data-only; no runtime path
-    consults it yet. Subsequent PRs will:
-
-    - register the public names with OAS so the LLM can call [Bash]
-      successfully (Phase A.2);
-    - canonicalize via [to_internal] before the disclosure check in
-      [keeper_agent_run.ml:1875] so [Bash] resolves to [keeper_bash]
-      and is not flagged unexpected (Phase A.3).
-
     The internal name remains the SSOT for metrics, decisions.jsonl,
-    audit logs and dashboards. *)
+    audit logs and dashboards. Aliases live alongside, not instead of,
+    the internal names. *)
 
 (** [to_internal public_name] returns the internal [keeper_*] name when
     [public_name] is a known alias. Returns [None] otherwise.
 
     Examples: [to_internal "Bash" = Some "keeper_bash"],
-    [to_internal "Skill" = None] (no cognate; surface should emit a
-    teaching error per RFC-0006 §3.1). *)
+    [to_internal "Skill" = None] (no cognate). *)
 val to_internal : string -> string option
 
 (** [to_public internal_name] returns the LLM-facing alias for an
@@ -47,3 +38,56 @@ val is_hallucinated_builtin : string -> bool
     [(public, internal)] pairs. Stable order; suitable for tests and
     documentation generation. *)
 val all_aliases : unit -> (string * string) list
+
+(** {1 OAS dual registration (Phase A.2)} *)
+
+(** [oas_dual_register_aliases ()] is the subset of [all_aliases ()]
+    that is currently safe to register with OAS as additional [Tool.t]
+    entries sharing the keeper handler.
+
+    Membership requires (a) a known input-shape translation back to the
+    internal tool's schema and (b) a tailored public input_schema so
+    the LLM sees the Anthropic-Code shape it expects.
+
+    Phase A.2: [Bash], [Read]. These two account for ~80% of the
+    hallucinated-builtin tool calls measured in #8778.
+
+    Excluded (deferred to Phase A.4): [Edit] (semantic mismatch:
+    Anthropic Edit does string-replace, keeper_fs_edit only overwrites);
+    [Write] (covered when [Edit] is); [Grep] (needs op=rg input
+    synthesis).
+
+    Excluded aliases remain in [all_aliases ()] / [to_internal] so the
+    disclosure-check canonicalization (Phase A.3) keeps treating
+    [Edit]/[Write]/[Grep] as known names — turns are no longer nuked
+    even though OAS still rejects the call. *)
+val oas_dual_register_aliases : unit -> (string * string) list
+
+(** [public_input_schema public_name] returns the LLM-facing JSON schema
+    for an aliased tool. [None] means there is no tailored schema yet
+    — callers should fall back to the internal tool's schema (which is
+    not ideal because the LLM expects the Anthropic-Code field names). *)
+val public_input_schema : string -> Yojson.Safe.t option
+
+(** [translate_input ~public input] reshapes an LLM call payload from
+    the public schema (Anthropic Code field names) to the internal
+    keeper tool's expected payload.
+
+    For unknown public names this is the identity. Defined for every
+    name in [oas_dual_register_aliases ()].
+
+    Examples:
+    - [translate_input ~public:"Bash" {| {"command":"ls","timeout":30} |}]
+      → [{| {"cmd":"ls","timeout_sec":30} |}]
+    - [translate_input ~public:"Read" {| {"file_path":"x"} |}]
+      → [{| {"path":"x"} |}] *)
+val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
+
+(** [expand_universe internal_names] returns [internal_names] with the
+    public-name aliases of every member of [oas_dual_register_aliases ()]
+    appended (deduplicated, original order preserved).
+
+    Callers building AllowList / universe / allowed_exec sets in
+    [keeper_agent_run.ml] must apply this so the public alias names are
+    not pruned before reaching the LLM-facing tool list. *)
+val expand_universe : string list -> string list

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -130,6 +130,242 @@ let normalize_tool_result ~(success : bool) (raw : string) : string =
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
 
+(** RFC-0006 Phase A.2: build the per-tool handler closure.
+
+    Extracted from the original anonymous closure inside [make_tools] so
+    that alias [Tool.t] entries (e.g. [Bash] -> [keeper_bash]) can reuse
+    the exact same telemetry/circuit-breaker/decision-log pipeline by
+    instantiating this helper with the INTERNAL name as [~name].
+
+    Telemetry SSOT contract: [~name] flows into every observability
+    sink (Keeper_registry.record_tool_use, SSE broadcast tool_name,
+    decision-log "tool" field, on_keeper_tool_call). The LLM-facing
+    public name (Bash/Read/...) only appears as the [Tool.schema.name]
+    set by [Tool_bridge.oas_tool_of_masc] above this helper.
+
+    [?translate_input] reshapes the incoming JSON from the public schema
+    to the internal tool's expected payload (e.g. [{command,timeout}] ->
+    [{cmd,timeout_sec}]). Identity by default. *)
+let make_keeper_tool_handler
+    ~(name : string)
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(ctx_snapshot : Keeper_types.working_context)
+    ?search_fn
+    ?on_tool_called
+    ?(translate_input = fun j -> j)
+    ~(failure_counts : (string, int) Hashtbl.t)
+    ()
+  : Yojson.Safe.t -> bool * string =
+  let args_key input =
+    let h = Hashtbl.hash (Yojson.Safe.to_string input) in
+    Printf.sprintf "%s:%d" name h
+  in
+  fun raw_input ->
+    let input = translate_input raw_input in
+    let key = args_key input in
+    let prior_fails =
+      (match Hashtbl.find_opt failure_counts key with
+        | Some n -> n | None -> 0)
+    in
+    if prior_fails >= max_consecutive_failures then begin
+      Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
+        name prior_fails;
+      let msg = Printf.sprintf
+        "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
+        prior_fails in
+      (false, normalize_tool_result ~success:false msg)
+    end else
+      let t0 = Time_compat.now () in
+      try
+        let (result, duration_ms) =
+          Inference_utils.timed (fun () ->
+            Keeper_exec_tools.execute_keeper_tool_call_with_outcome
+              ~config ~meta ~ctx_work:ctx_snapshot
+              ?search_fn
+              ~name ~input ())
+        in
+        let raw_result = result.raw_output in
+        let is_failure =
+          match result.outcome with
+          | `Failure -> true
+          | `Success -> false
+        in
+        if is_failure then begin
+          let count = prior_fails + 1 in
+          Hashtbl.replace failure_counts key count;
+          Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
+          !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
+          (* Tool-call observability flows through the OAS Event_bus
+             (ToolCalled + ToolCompleted). MASC-side observers removed
+             in refactor/tool-call-single-source. *)
+          (let tr = Tool_result.{ tool_name = name; success = false;
+              duration_ms = Float.of_int duration_ms; data = `Null } in
+           ignore (Tool_dispatch.run_post_hooks tr));
+          let detail =
+            let s = String.trim raw_result in
+            String_util.utf8_safe ~max_bytes:(sse_error_preview_max_chars + 3) ~suffix:"..." s |> String_util.to_string
+          in
+          let ts = Time_compat.now () in
+          (try Sse.broadcast
+            (`Assoc [
+              ("type", `String "keeper_tool_call");
+              ("name", `String meta.name);
+              ("tool_name", `String name);
+              ("duration_ms", `Int duration_ms);
+              ("success", `Bool false);
+              ("error_text", `String detail);
+              ("ts_unix", `Float ts);
+            ])
+           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          Log.Keeper.error
+            "tool %s returned error result (%d/%d): %s"
+            name count max_consecutive_failures detail;
+          let normalized_error =
+            normalize_tool_result ~success:false raw_result
+          in
+          (try
+            Keeper_types_support.append_jsonl_line
+              (Keeper_types_support.keeper_decision_log_path config meta.name)
+              (`Assoc [
+                "ts_unix", `Float ts;
+                "event", `String "tool_exec";
+                "keeper_name", `String meta.name;
+                "tool", `String name;
+                "duration_ms", `Int duration_ms;
+                "result_bytes", `Int (String.length normalized_error);
+                "ok", `Bool false;
+              ])
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          Keeper_tool_call_log.set_truncation_info
+            ~keeper_name:meta.name
+            ~original_bytes:(String.length normalized_error) ();
+          (false, Tool_output_validation.cap normalized_error)
+        end else begin
+          Hashtbl.remove failure_counts key;
+          Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
+          !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:true ~duration_ms;
+          (* Tool-call observability via OAS Event_bus. See above. *)
+          (let tr = Tool_result.{ tool_name = name; success = true;
+              duration_ms = Float.of_int duration_ms; data = `Null } in
+           ignore (Tool_dispatch.run_post_hooks tr));
+          let ts = Time_compat.now () in
+          (try Sse.broadcast
+            (`Assoc [
+              ("type", `String "keeper_tool_call");
+              ("name", `String meta.name);
+              ("tool_name", `String name);
+              ("duration_ms", `Int duration_ms);
+              ("success", `Bool true);
+              ("ts_unix", `Float ts);
+            ])
+           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          (* Notify session callback (e.g., mark_used for discovered tools) *)
+          (match on_tool_called with Some f -> f name | None -> ());
+          (* PR#814 Gap 1: Capture git status delta after successful tool execution.
+             If the working tree changed, log it so the keeper is aware of
+             file-system side effects from its tool calls. *)
+          let change_block =
+            Worktree_live_context.capture_change_block
+              ~base_path:config.base_path ~actor_key:meta.name
+          in
+          (match change_block with
+           | Some _cb ->
+               Log.Keeper.info "post-tool git delta detected for %s after %s"
+                 meta.name name
+           | None -> ());
+          let normalized =
+            normalize_tool_result ~success:true raw_result
+          in
+          let final_result =
+            match change_block with
+            | None -> normalized
+            | Some cb ->
+              (* Inject changes field into the normalized JSON envelope
+                 to preserve valid JSON structure. *)
+              (try
+                 let json = Yojson.Safe.from_string normalized in
+                 match json with
+                 | `Assoc fields ->
+                   Yojson.Safe.to_string
+                     (`Assoc (fields @ [("changes", `String cb)]))
+                 | _ -> normalized
+               with Yojson.Json_error _ -> normalized)
+          in
+          let original_len = String.length final_result in
+          let truncated_result = Tool_output_validation.cap final_result in
+          let was_truncated = original_len > Tool_output_validation.max_output_chars in
+          if was_truncated then
+            Log.Keeper.info "tool %s output truncated: %d -> %d chars"
+              name original_len (String.length truncated_result);
+          (try
+            Keeper_types_support.append_jsonl_line
+              (Keeper_types_support.keeper_decision_log_path config meta.name)
+              (`Assoc ([
+                "ts_unix", `Float ts;
+                "event", `String "tool_exec";
+                "keeper_name", `String meta.name;
+                "tool", `String name;
+                "duration_ms", `Int duration_ms;
+                "result_bytes", `Int original_len;
+                "ok", `Bool true;
+              ] @ (if was_truncated then
+                ["truncated_to", `Int (String.length truncated_result)]
+              else [])))
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+          (* Publish truncation info for OAS hook's tool_call_log *)
+          Keeper_tool_call_log.set_truncation_info
+            ~keeper_name:meta.name
+            ~original_bytes:original_len
+            ?truncated_to:(if was_truncated
+              then Some (String.length truncated_result) else None) ();
+          (true, truncated_result)
+        end
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        let ts = Time_compat.now () in
+        let duration_ms =
+          int_of_float ((ts -. t0) *. 1000.0) in
+        let count = prior_fails + 1 in
+        let error_text = Printexc.to_string exn in
+        Hashtbl.replace failure_counts key count;
+        Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
+        !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
+        (* Tool-call observability via OAS Event_bus. See above. *)
+        (try Sse.broadcast
+          (`Assoc [
+            ("type", `String "keeper_tool_call");
+            ("name", `String meta.name);
+            ("tool_name", `String name);
+            ("duration_ms", `Int duration_ms);
+            ("success", `Bool false);
+            ("error_text", `String error_text);
+            ("ts_unix", `Float ts);
+          ])
+         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
+          name count max_consecutive_failures
+          (Printexc.to_string exn) in
+        Log.Keeper.error "%s" msg;
+        let normalized_exn = normalize_tool_result ~success:false msg in
+        (try
+          Keeper_types_support.append_jsonl_line
+            (Keeper_types_support.keeper_decision_log_path config meta.name)
+            (`Assoc [
+              "ts_unix", `Float ts;
+              "event", `String "tool_exec";
+              "keeper_name", `String meta.name;
+              "tool", `String name;
+              "duration_ms", `Int duration_ms;
+              "result_bytes", `Int (String.length normalized_exn);
+              "ok", `Bool false;
+              "error", `String error_text;
+            ])
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        Keeper_tool_call_log.set_truncation_info
+          ~keeper_name:meta.name
+          ~original_bytes:(String.length normalized_exn) ();
+        (false, Tool_output_validation.cap normalized_exn)
+
 let make_tools
     ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -148,218 +384,48 @@ let make_tools
   in
   let failure_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
   (* No mutex: Hashtbl ops are non-yielding, single domain. *)
-  let args_key name input =
-    let h = Hashtbl.hash (Yojson.Safe.to_string input) in
-    Printf.sprintf "%s:%d" name h
+  (* Pass A: existing internal tools. Behavior unchanged from pre-A.2. *)
+  let internal_tools =
+    List.filter_map (fun (td : Types.tool_schema) ->
+      if List.mem td.name universe_names then
+        Some (Tool_bridge.oas_tool_of_masc
+          ~name:td.name
+          ~description:td.description
+          ~input_schema:td.input_schema
+          (make_keeper_tool_handler ~name:td.name ~config ~meta ~ctx_snapshot
+             ?search_fn ?on_tool_called ~failure_counts ()))
+      else None
+    ) tool_defs
   in
-  List.filter_map (fun (td : Types.tool_schema) ->
-    if List.mem td.name universe_names then
-      Some (Tool_bridge.oas_tool_of_masc
-        ~name:td.name
-        ~description:td.description
-        ~input_schema:td.input_schema
-        (fun input ->
-          let key = args_key td.name input in
-          let prior_fails =
-            (match Hashtbl.find_opt failure_counts key with
-              | Some n -> n | None -> 0)
+  (* Pass B: RFC-0006 Phase A.2 — register dual aliases so the LLM can
+     call Anthropic Code names (Bash/Read) successfully. The handler
+     dispatches with [~name:internal] so all telemetry SSOT remains
+     internal; only the Tool.schema.name (LLM-visible) is the public
+     alias. translate_input reshapes the LLM's payload before dispatch. *)
+  let alias_tools =
+    List.filter_map (fun (public, internal) ->
+      if not (List.mem internal universe_names) then None
+      else
+        match
+          List.find_opt (fun (td : Types.tool_schema) ->
+            String.equal td.name internal) tool_defs
+        with
+        | None -> None
+        | Some internal_def ->
+          let input_schema =
+            match Keeper_tool_alias.public_input_schema public with
+            | Some s -> s
+            | None -> internal_def.input_schema
           in
-          if prior_fails >= max_consecutive_failures then begin
-            Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
-              td.name prior_fails;
-            let msg = Printf.sprintf
-              "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
-              prior_fails in
-            (false, normalize_tool_result ~success:false msg)
-          end else
-            let t0 = Time_compat.now () in
-            try
-              let (result, duration_ms) =
-                Inference_utils.timed (fun () ->
-                  Keeper_exec_tools.execute_keeper_tool_call_with_outcome
-                    ~config ~meta ~ctx_work:ctx_snapshot
-                    ?search_fn
-                    ~name:td.name ~input ())
-              in
-              let raw_result = result.raw_output in
-              let is_failure =
-                match result.outcome with
-                | `Failure -> true
-                | `Success -> false
-              in
-              if is_failure then begin
-                let count = prior_fails + 1 in
-                Hashtbl.replace failure_counts key count;
-                Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
-                !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
-                (* Tool-call observability flows through the OAS Event_bus
-                   (ToolCalled + ToolCompleted). MASC-side observers removed
-                   in refactor/tool-call-single-source. *)
-                (let tr = Tool_result.{ tool_name = td.name; success = false;
-                    duration_ms = Float.of_int duration_ms; data = `Null } in
-                 ignore (Tool_dispatch.run_post_hooks tr));
-                let detail =
-                  let s = String.trim raw_result in
-                  String_util.utf8_safe ~max_bytes:(sse_error_preview_max_chars + 3) ~suffix:"..." s |> String_util.to_string
-                in
-                let ts = Time_compat.now () in
-                (try Sse.broadcast
-                  (`Assoc [
-                    ("type", `String "keeper_tool_call");
-                    ("name", `String meta.name);
-                    ("tool_name", `String td.name);
-                    ("duration_ms", `Int duration_ms);
-                    ("success", `Bool false);
-                    ("error_text", `String detail);
-                    ("ts_unix", `Float ts);
-                  ])
-                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                Log.Keeper.error
-                  "tool %s returned error result (%d/%d): %s"
-                  td.name count max_consecutive_failures detail;
-                let normalized_error =
-                  normalize_tool_result ~success:false raw_result
-                in
-                (try
-                  Keeper_types_support.append_jsonl_line
-                    (Keeper_types_support.keeper_decision_log_path config meta.name)
-                    (`Assoc [
-                      "ts_unix", `Float ts;
-                      "event", `String "tool_exec";
-                      "keeper_name", `String meta.name;
-                      "tool", `String td.name;
-                      "duration_ms", `Int duration_ms;
-                      "result_bytes", `Int (String.length normalized_error);
-                      "ok", `Bool false;
-                    ])
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                Keeper_tool_call_log.set_truncation_info
-                  ~keeper_name:meta.name
-                  ~original_bytes:(String.length normalized_error) ();
-                (false, Tool_output_validation.cap normalized_error)
-              end else begin
-                Hashtbl.remove failure_counts key;
-                Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
-                !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:true ~duration_ms;
-                (* Tool-call observability via OAS Event_bus. See above. *)
-                (let tr = Tool_result.{ tool_name = td.name; success = true;
-                    duration_ms = Float.of_int duration_ms; data = `Null } in
-                 ignore (Tool_dispatch.run_post_hooks tr));
-                let ts = Time_compat.now () in
-                (try Sse.broadcast
-                  (`Assoc [
-                    ("type", `String "keeper_tool_call");
-                    ("name", `String meta.name);
-                    ("tool_name", `String td.name);
-                    ("duration_ms", `Int duration_ms);
-                    ("success", `Bool true);
-                    ("ts_unix", `Float ts);
-                  ])
-                 with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                (* Notify session callback (e.g., mark_used for discovered tools) *)
-                (match on_tool_called with Some f -> f td.name | None -> ());
-                (* PR#814 Gap 1: Capture git status delta after successful tool execution.
-                   If the working tree changed, log it so the keeper is aware of
-                   file-system side effects from its tool calls. *)
-                let change_block =
-                  Worktree_live_context.capture_change_block
-                    ~base_path:config.base_path ~actor_key:meta.name
-                in
-                (match change_block with
-                 | Some _cb ->
-                     Log.Keeper.info "post-tool git delta detected for %s after %s"
-                       meta.name td.name
-                 | None -> ());
-                let normalized =
-                  normalize_tool_result ~success:true raw_result
-                in
-                let final_result =
-                  match change_block with
-                  | None -> normalized
-                  | Some cb ->
-                    (* Inject changes field into the normalized JSON envelope
-                       to preserve valid JSON structure. *)
-                    (try
-                       let json = Yojson.Safe.from_string normalized in
-                       match json with
-                       | `Assoc fields ->
-                         Yojson.Safe.to_string
-                           (`Assoc (fields @ [("changes", `String cb)]))
-                       | _ -> normalized
-                     with Yojson.Json_error _ -> normalized)
-                in
-                let original_len = String.length final_result in
-                let truncated_result = Tool_output_validation.cap final_result in
-                let was_truncated = original_len > Tool_output_validation.max_output_chars in
-                if was_truncated then
-                  Log.Keeper.info "tool %s output truncated: %d -> %d chars"
-                    td.name original_len (String.length truncated_result);
-                (try
-                  Keeper_types_support.append_jsonl_line
-                    (Keeper_types_support.keeper_decision_log_path config meta.name)
-                    (`Assoc ([
-                      "ts_unix", `Float ts;
-                      "event", `String "tool_exec";
-                      "keeper_name", `String meta.name;
-                      "tool", `String td.name;
-                      "duration_ms", `Int duration_ms;
-                      "result_bytes", `Int original_len;
-                      "ok", `Bool true;
-                    ] @ (if was_truncated then
-                      ["truncated_to", `Int (String.length truncated_result)]
-                    else [])))
-                with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                (* Publish truncation info for OAS hook's tool_call_log *)
-                Keeper_tool_call_log.set_truncation_info
-                  ~keeper_name:meta.name
-                  ~original_bytes:original_len
-                  ?truncated_to:(if was_truncated
-                    then Some (String.length truncated_result) else None) ();
-                (true, truncated_result)
-              end
-            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              let ts = Time_compat.now () in
-              let duration_ms =
-                int_of_float ((ts -. t0) *. 1000.0) in
-              let count = prior_fails + 1 in
-              let error_text = Printexc.to_string exn in
-              Hashtbl.replace failure_counts key count;
-              Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
-              !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
-              (* Tool-call observability via OAS Event_bus. See above. *)
-              (try Sse.broadcast
-                (`Assoc [
-                  ("type", `String "keeper_tool_call");
-                  ("name", `String meta.name);
-                  ("tool_name", `String td.name);
-                  ("duration_ms", `Int duration_ms);
-                  ("success", `Bool false);
-                  ("error_text", `String error_text);
-                  ("ts_unix", `Float ts);
-                ])
-               with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-              let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
-                td.name count max_consecutive_failures
-                (Printexc.to_string exn) in
-              Log.Keeper.error "%s" msg;
-              let normalized_exn = normalize_tool_result ~success:false msg in
-              (try
-                Keeper_types_support.append_jsonl_line
-                  (Keeper_types_support.keeper_decision_log_path config meta.name)
-                  (`Assoc [
-                    "ts_unix", `Float ts;
-                    "event", `String "tool_exec";
-                    "keeper_name", `String meta.name;
-                    "tool", `String td.name;
-                    "duration_ms", `Int duration_ms;
-                    "result_bytes", `Int (String.length normalized_exn);
-                    "ok", `Bool false;
-                    "error", `String error_text;
-                  ])
-              with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-              Keeper_tool_call_log.set_truncation_info
-                ~keeper_name:meta.name
-                ~original_bytes:(String.length normalized_exn) ();
-              (false, Tool_output_validation.cap normalized_exn)))
-    else None
-  ) tool_defs
+          Some (Tool_bridge.oas_tool_of_masc
+            ~name:public
+            ~description:internal_def.description
+            ~input_schema
+            (make_keeper_tool_handler ~name:internal ~config ~meta ~ctx_snapshot
+               ?search_fn ?on_tool_called
+               ~translate_input:(fun j ->
+                 Keeper_tool_alias.translate_input ~public j)
+               ~failure_counts ()))
+    ) (Keeper_tool_alias.oas_dual_register_aliases ())
+  in
+  internal_tools @ alias_tools

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -149,6 +149,148 @@ let test_partial_tolerance_still_works () =
   Alcotest.(check bool) "Bash counts as valid -> partial tolerance kicks in"
     true has_valid
 
+(* ── Phase A.2 OAS dual registration ─────────────────────────────── *)
+
+let yojson_field name j =
+  match j with
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let test_oas_dual_register_subset () =
+  let pairs = Alias.oas_dual_register_aliases () in
+  let names = List.map fst pairs in
+  Alcotest.(check (list string)) "Phase A.2 dual-reg subset"
+    [ "Bash"; "Read" ] names;
+  (* Every entry must also appear in the full alias table. *)
+  let full = List.map fst (Alias.all_aliases ()) in
+  List.iter
+    (fun (public, _) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s is in all_aliases" public)
+        true (List.mem public full))
+    pairs
+
+let test_public_input_schema_present () =
+  Alcotest.(check bool) "Bash has tailored schema"
+    true (Option.is_some (Alias.public_input_schema "Bash"));
+  Alcotest.(check bool) "Read has tailored schema"
+    true (Option.is_some (Alias.public_input_schema "Read"));
+  Alcotest.(check bool) "Edit (deferred) has no tailored schema"
+    true (Option.is_none (Alias.public_input_schema "Edit"));
+  Alcotest.(check bool) "unknown public name has no schema"
+    true (Option.is_none (Alias.public_input_schema "Nope"))
+
+let test_bash_schema_uses_command_field () =
+  let schema = Option.get (Alias.public_input_schema "Bash") in
+  let props = Option.get (yojson_field "properties" schema) in
+  Alcotest.(check bool) "Bash schema exposes 'command' (not 'cmd')"
+    true (Option.is_some (yojson_field "command" props));
+  Alcotest.(check bool) "Bash schema does not expose 'cmd' directly"
+    true (Option.is_none (yojson_field "cmd" props));
+  let required =
+    match yojson_field "required" schema with
+    | Some (`List items) ->
+        List.filter_map
+          (function `String s -> Some s | _ -> None) items
+    | _ -> []
+  in
+  Alcotest.(check (list string)) "Bash requires 'command'"
+    [ "command" ] required
+
+let test_read_schema_uses_file_path () =
+  let schema = Option.get (Alias.public_input_schema "Read") in
+  let props = Option.get (yojson_field "properties" schema) in
+  Alcotest.(check bool) "Read schema exposes 'file_path' (not 'path')"
+    true (Option.is_some (yojson_field "file_path" props));
+  Alcotest.(check bool) "Read schema does not expose 'path' directly"
+    true (Option.is_none (yojson_field "path" props))
+
+let test_translate_bash_input () =
+  let input = `Assoc
+    [ ("command", `String "ls -la");
+      ("timeout", `Int 60);
+      ("description", `String "list files");
+      ("run_in_background", `Bool false) ]
+  in
+  let translated = Alias.translate_input ~public:"Bash" input in
+  let cmd = yojson_field "cmd" translated in
+  let timeout_sec = yojson_field "timeout_sec" translated in
+  let bg = yojson_field "run_in_background" translated in
+  let desc = yojson_field "description" translated in
+  Alcotest.(check (option string)) "command -> cmd"
+    (Some "ls -la")
+    (Option.bind cmd (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option int)) "timeout -> timeout_sec"
+    (Some 60)
+    (Option.bind timeout_sec (function `Int i -> Some i | _ -> None));
+  Alcotest.(check bool) "run_in_background passes through"
+    true (Option.is_some bg);
+  Alcotest.(check bool) "description is dropped"
+    true (Option.is_none desc)
+
+let test_translate_read_input () =
+  let input = `Assoc
+    [ ("file_path", `String "/tmp/foo");
+      ("limit", `Int 4096);
+      ("offset", `Int 100) ]
+  in
+  let translated = Alias.translate_input ~public:"Read" input in
+  let path = yojson_field "path" translated in
+  let max_bytes = yojson_field "max_bytes" translated in
+  let offset = yojson_field "offset" translated in
+  Alcotest.(check (option string)) "file_path -> path"
+    (Some "/tmp/foo")
+    (Option.bind path (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option int)) "limit -> max_bytes"
+    (Some 4096)
+    (Option.bind max_bytes (function `Int i -> Some i | _ -> None));
+  Alcotest.(check bool) "offset is dropped (keeper_fs_read does not support it)"
+    true (Option.is_none offset)
+
+let test_translate_unknown_is_identity () =
+  let input = `Assoc [ ("foo", `String "bar") ] in
+  let translated = Alias.translate_input ~public:"NoSuchTool" input in
+  Alcotest.(check string) "identity for unknown public name"
+    (Yojson.Safe.to_string input) (Yojson.Safe.to_string translated)
+
+let test_translate_malformed_input_is_identity () =
+  let input = `String "not an object" in
+  let translated = Alias.translate_input ~public:"Bash" input in
+  Alcotest.(check string) "non-object payload passes through"
+    (Yojson.Safe.to_string input) (Yojson.Safe.to_string translated)
+
+let test_expand_universe_adds_aliases () =
+  let internal = [ "keeper_bash"; "keeper_fs_read"; "keeper_board_post" ] in
+  let expanded = Alias.expand_universe internal in
+  Alcotest.(check bool) "Bash appears after expansion"
+    true (List.mem "Bash" expanded);
+  Alcotest.(check bool) "Read appears after expansion"
+    true (List.mem "Read" expanded);
+  Alcotest.(check bool) "internal names preserved"
+    true (List.for_all (fun n -> List.mem n expanded) internal);
+  Alcotest.(check bool) "no duplicate Bash entries"
+    true
+    (List.length (List.filter (String.equal "Bash") expanded) = 1)
+
+let test_expand_universe_skips_when_internal_absent () =
+  let internal = [ "keeper_board_post"; "keeper_tasks_list" ] in
+  let expanded = Alias.expand_universe internal in
+  Alcotest.(check bool) "Bash NOT added when keeper_bash absent"
+    true (not (List.mem "Bash" expanded));
+  Alcotest.(check bool) "Read NOT added when keeper_fs_read absent"
+    true (not (List.mem "Read" expanded));
+  Alcotest.(check int) "expanded length unchanged"
+    (List.length internal) (List.length expanded)
+
+let test_expand_universe_dedup_existing_public () =
+  (* If a caller already has the public name in the input list, expand
+     must not duplicate it. *)
+  let internal = [ "keeper_bash"; "Bash"; "keeper_fs_read" ] in
+  let expanded = Alias.expand_universe internal in
+  Alcotest.(check int) "Bash appears exactly once"
+    1
+    (List.length (List.filter (String.equal "Bash") expanded))
+
 let () =
   Alcotest.run "Keeper_tool_alias"
     [
@@ -173,5 +315,19 @@ let () =
             test_hallucinated_builtin_still_unexpected;
           Alcotest.test_case "partial tolerance still works" `Quick
             test_partial_tolerance_still_works;
+        ] );
+      ( "oas-dual-register",
+        [
+          Alcotest.test_case "subset is Bash + Read only" `Quick test_oas_dual_register_subset;
+          Alcotest.test_case "tailored input schema present" `Quick test_public_input_schema_present;
+          Alcotest.test_case "Bash schema uses 'command' field" `Quick test_bash_schema_uses_command_field;
+          Alcotest.test_case "Read schema uses 'file_path' field" `Quick test_read_schema_uses_file_path;
+          Alcotest.test_case "translate Bash input shape" `Quick test_translate_bash_input;
+          Alcotest.test_case "translate Read input shape" `Quick test_translate_read_input;
+          Alcotest.test_case "translate unknown is identity" `Quick test_translate_unknown_is_identity;
+          Alcotest.test_case "translate malformed is identity" `Quick test_translate_malformed_input_is_identity;
+          Alcotest.test_case "expand_universe adds aliases" `Quick test_expand_universe_adds_aliases;
+          Alcotest.test_case "expand_universe skips when internal absent" `Quick test_expand_universe_skips_when_internal_absent;
+          Alcotest.test_case "expand_universe dedup existing public" `Quick test_expand_universe_dedup_existing_public;
         ] );
     ]

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -89,8 +89,18 @@ let test_tool_count_matches_allowed () =
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
       let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
-      check bool "all tools are in allowed list" true
-        (List.for_all (fun name -> List.mem name allowed) tool_names))
+      (* RFC-0006 Phase A.2: aliased Tool.t entries (Bash/Read) carry the
+         public name on Tool.schema.name even though their handler dispatches
+         the internal keeper_* name. Accept either: name in allowed OR the
+         alias's internal target in allowed. *)
+      check bool "all tools are in allowed list (or are an alias)" true
+        (List.for_all
+           (fun name ->
+              List.mem name allowed
+              || (match Keeper_tool_alias.to_internal name with
+                  | Some internal -> List.mem internal allowed
+                  | None -> false))
+           tool_names))
 
 let find_tool name tools =
   List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools


### PR DESCRIPTION
## Summary
Phase A.2 of RFC-0006. Registers the keeper Bash and Read tools with OAS under BOTH the public Anthropic-Code names (\`Bash\`, \`Read\`) AND the internal \`keeper_*\` names. The LLM can now actually call \`Bash\` end-to-end and the keeper handler runs for real — not just as a no-op canonicalization in the disclosure check (which was Phase A.3, #8912).

Together with A.3, this closes the loop for the two highest-volume hallucinated tool names. Per #8778: \`Bash\` 846 + \`Read\` 372 = **1218 / 1486** distinct hallucinated calls (~82% of the 18% nuke surface).

## Scope (intentional)

- **In scope**: \`Bash → keeper_bash\`, \`Read → keeper_fs_read\`. Highest impact, smallest input-shape gap.
- **Deferred to Phase A.4**: \`Edit\` (Anthropic Edit does string-replace; \`keeper_fs_edit\` only overwrites — needs read-replace-write adapter), \`Write\`, \`Grep\` (needs \`op=rg\` synthesis + flag mapping). They remain in the alias table so #8912 keeps canonicalizing them at the disclosure check (turns are not nuked even though OAS still rejects the call).

## Diff

| File | Change |
|---|---|
| \`lib/keeper/keeper_tool_alias.{ml,mli}\` | Add \`oas_dual_register_aliases\`, \`public_input_schema\`, \`translate_input\`, \`expand_universe\`. Bash/Read tailored schemas use Anthropic field names (\`command\`, \`file_path\`). |
| \`lib/keeper/keeper_tools_oas.ml\` | Extract the 210-line per-tool closure into \`make_keeper_tool_handler ~name\`. Behavior unchanged for internal tools. New alias pass instantiates the same helper with \`~name:internal\` (telemetry SSOT preserved) and the appropriate \`translate_input\`. \`Tool.schema.name\` carries the public alias. |
| \`lib/keeper/keeper_agent_run.ml\` | Apply \`Keeper_tool_alias.expand_universe\` when building \`allowed_exec_set\` so the AllowList partition at line ~1476 does not drop \`Bash\`/\`Read\` after they land in OAS. |
| \`test/test_keeper_tool_alias.ml\` | 11 new oas-dual-register cases pinning subset, schemas, translators, and \`expand_universe\`. |
| \`test/test_keeper_tools_oas.ml\` | Update \`test_tool_count_matches_allowed\` predicate to accept aliased Tool.t entries. |

## OAS boundary

OAS \`Tool_set\` has no alias concept — and we keep it that way. MASC simply hands OAS additional \`Tool.t\` values that happen to share a handler. From OAS's perspective they are N independent tools.

## Test plan
- [x] \`dune build --root . @check\` clean.
- [x] \`dune runtest test/test_keeper_tool_alias.exe\` — 19/19 pass.
- [x] \`dune runtest test/test_keeper_tools_oas.exe\` — 26/26 pass (including the updated predicate).
- [x] \`dune runtest test/test_keeper_tool_exposure.exe test/test_tool_exposure.exe test/test_tool_surface_ssot.exe\` — 59/59 pass (no regression).
- [ ] CI required checks green.
- [ ] After merge: 24h replay metric — \`unexpected tool name\` for \`Bash\`/\`Read\` should fall to zero AND \`keeper_bash\`/\`keeper_fs_read\` invocation count should rise correspondingly.

## Manual smoke (post-merge)
1. Spin up the local server.
2. Have a keeper (e.g. minjae) invoke \`Bash\` with \`{\"command\": \"ls\"}\`.
3. Confirm:
   - \`decisions.jsonl\` shows \`tool=\"keeper_bash\"\` (not \`Bash\`).
   - Dashboard \`Keeper Tool I/O\` increments \`keeper_bash\`.
   - No \`unexpected tool\` log.

## Stack
- #8853 RFC (MERGED)
- #8860 Phase A.1 alias data module (MERGED)
- #8912 Phase A.3 disclosure canonicalize (OPEN)
- **THIS PR** Phase A.2 OAS dual registration
- next: Phase A.4 — Edit/Write/Grep adapters
- next: Phase B-1 — minjae symmetric sandbox

## Risk register
- **AllowList drift**: load-bearing change is the \`expand_universe\` call at \`keeper_agent_run.ml:1067\`. Without it Phase A.2 silently no-ops at the disclosure layer. Pinned by the new \`expand_universe\` tests.
- **Auto-merge race** (memory: \`masc-mcp auto-merge overrides Draft\`): runner may flip Draft→Ready and merge before review. Body deliberately calls out the load-bearing wiring above.
- **Telemetry SSOT**: confirmed by extracting \`make_keeper_tool_handler\` and parameterizing on \`~name\`; alias pass uses \`~name:internal\` so every observability sink records the internal name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)