### PR TITLE
feat(keeper): add repo readiness preflight

### DIFF
--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -121,21 +121,38 @@ let origin_head_branch root =
       | branch :: _ -> Some branch
       | [] -> None)
 
+let unique_strings values =
+  List.fold_left
+    (fun acc value ->
+      let value = String.trim value in
+      if value = "" || List.mem value acc then acc else acc @ [ value ])
+    [] values
+
+let auto_base_branch_candidates root =
+  unique_strings
+    (match origin_head_branch root with
+     | Some head -> [ head; "main"; "master"; "develop" ]
+     | None -> [ "main"; "master"; "develop" ])
+
 let resolve_base_branch root base_branch =
-  if remote_branch_exists root base_branch then Ok (base_branch, None)
+  let base_branch = String.trim base_branch in
+  if base_branch = "" || String.equal base_branch "auto" then
+    match List.find_opt (remote_branch_exists root) (auto_base_branch_candidates root) with
+    | Some resolved -> Ok (resolved, None)
+    | None ->
+        Error
+          (IoError
+             "Base branch auto-detect failed: no origin/HEAD, origin/main, origin/master, or origin/develop found.")
+  else if remote_branch_exists root base_branch then Ok (base_branch, None)
   else
-    let candidates =
-      match origin_head_branch root with
-      | Some head -> [head; "main"; "master"]
-      | None -> ["main"; "master"]
-    in
-    match List.find_opt (remote_branch_exists root) candidates with
+    match List.find_opt (remote_branch_exists root) (auto_base_branch_candidates root) with
     | Some fallback -> Ok (fallback, Some base_branch)
     | None ->
         Error
           (IoError
              (Printf.sprintf
-                "Base branch origin/%s not found and no fallback branch detected." base_branch))
+                "Base branch origin/%s not found and no origin/HEAD, origin/main, origin/master, or origin/develop fallback detected."
+                base_branch))
 
 (* ============================================ *)
 (* Worktree Operations                          *)
@@ -162,9 +179,11 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
             (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
                worktree_path branch_name worktree_path)
         else (
-          (* Fetch origin first *)
-          let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
-          match resolve_base_branch root base_branch with
+          (* Fetch origin first; never create from a silently stale remote ref. *)
+          let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+          if fetch_exit <> 0 then
+            Error (IoError "Failed to fetch origin before worktree creation.")
+          else match resolve_base_branch root base_branch with
           | Error e -> Error e
           | Ok (resolved_base, fallback_from) ->
               let note =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -119,10 +119,10 @@ let link_worktree_to_task config ~task_id ~worktree_info =
 
 (** Create worktree for agent - Result version
     @param link_task If true, links worktree info to the task in backlog (default: true)
-    @param repo_name If set, target the keeper's playground clone at
+    @param repo_name If set, target the keeper's sandbox repo clone at
            [.masc/playground/<agent>/repos/<repo_name>/] directly. If
            unset, scan [repos/] and use the first git clone found
-           (alphabetical). A playground clone is required. *)
+           (alphabetical). A sandbox repo clone is required. *)
 let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
@@ -132,13 +132,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    (* Prefer a keeper's playground clone under
+    (* Prefer a keeper's sandbox repo clone under
        [.masc/playground/<agent>/repos/]. The layout is the SSOT in
        [Playground_paths] (masc_config). If [repo_name] is supplied,
        target that clone directly; otherwise scan the directory and
        pick the first git clone (alphabetical). Keepers may work on
        any repo their [tool_policy.toml] allows, but the worktree root
-       must come from a playground clone. *)
+       must come from a sandbox repo clone. *)
     let resolve_keeper_repo_root () =
       let repos_dir =
         Filename.concat config.base_path
@@ -218,7 +218,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
         Error
           (IoError
              (Printf.sprintf
-                "No playground git clone found under %s for agent %s. %s"
+                "No sandbox git clone found under %s for agent %s. %s"
                 repos_dir agent_name hint))
     in
     match resolve_keeper_repo_root () with
@@ -269,10 +269,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  Repo: %s%s\n\nNext: cd %s"
                 worktree_path branch_name repo_name link_note worktree_path)
           end else begin
-            (* Fetch origin first *)
-            let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
-
-            match Coord_git.resolve_base_branch root base_branch with
+            (* Fetch origin first; stale remotes must be explicit, not hidden. *)
+            let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+            if fetch_exit <> 0 then
+              Error
+                (IoError
+                   "Failed to fetch origin before worktree creation. Verify network/auth and retry so the task starts from the latest remote ref.")
+            else match Coord_git.resolve_base_branch root base_branch with
             | Error e -> Error e
             | Ok (resolved_base, fallback_from) ->
                 let note = match fallback_from with
@@ -379,7 +382,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
         Error
           (IoError
              (Printf.sprintf
-                "Worktree %s not found under playground clones in %s"
+                "Worktree %s not found under sandbox repo clones in %s"
                 worktree_name repos_dir))
     in
     match resolve_existing_worktree_root () with

--- a/lib/dune
+++ b/lib/dune
@@ -410,6 +410,7 @@
    keeper_memory_recall
    keeper_skill_routing
    keeper_sandbox
+   keeper_repo_readiness
    keeper_alerting
    keeper_alerting_path
    keeper_timing

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -89,14 +89,37 @@ let handle_keeper_preflight_check
     add_check "accountability_risk" (not accountability_risk)
       (if accountability_risk then "RISK_HIGH" else "ok")
   in
-  (* Check 6: playground clone target *)
-  let clone_target =
-    let repos_path = Keeper_alerting_path.playground_repos_path meta.name in
-    if repo <> "" then
-      Filename.concat repos_path (Filename.basename repo)
-    else
-      Filename.concat repos_path (Filename.basename root)
+  (* Check 6: sandbox clone target *)
+  let repo_name_arg =
+    Safe_ops.json_string ~default:"" "repo_name" args |> String.trim
   in
+  let clone_target =
+    let repo_name =
+      if repo_name_arg <> "" then repo_name_arg
+      else Keeper_repo_readiness.repo_name_of_repo_arg ~project_root:root repo
+    in
+    Filename.concat
+      (Keeper_alerting_path.playground_repos_path meta.name)
+      repo_name
+  in
+  (* Check 6: sandbox repo readiness *)
+  let repo_readiness =
+    Keeper_repo_readiness.inspect ~config ~keeper_name:meta.name
+      ?repo_name:(if repo_name_arg = "" then None else Some repo_name_arg)
+      ~repo ~default_branch:!default_branch ()
+  in
+  let repo_ready =
+    match repo_readiness with
+    | `Assoc fields -> (
+        match List.assoc_opt "ok" fields with
+        | Some (`Bool ok) -> ok
+        | _ -> false)
+    | _ -> false
+  in
+  let repo_state =
+    json_string_field "state" repo_readiness |> Option.value ~default:"unknown"
+  in
+  let () = add_check "repo_readiness" repo_ready repo_state in
   Yojson.Safe.to_string
     (`Assoc
         [ "ok", `Bool !all_ok
@@ -110,5 +133,6 @@ let handle_keeper_preflight_check
         ; "risk_band", `String risk_band
         ; "routing_hint", `String routing_hint
         ; "clone_target", `String clone_target
+        ; "repo_readiness", repo_readiness
         ; "keeper", `String meta.name
         ])

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -1,0 +1,203 @@
+(** Keeper repository readiness.
+
+    This is a read-only probe for the single keeper sandbox repo clone under
+    [.masc/playground/<keeper>/repos/<repo>/]. It gives preflight callers a
+    concrete answer about whether code work can safely start from that clone. *)
+
+type command_result =
+  { ok : bool
+  ; output : string
+  ; status : Unix.process_status
+  }
+
+let run_git ~timeout_sec ~clone_path args =
+  let argv = [ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args in
+  let status, output =
+    Process_eio.run_argv_with_status ~timeout_sec argv
+  in
+  { ok = status = Unix.WEXITED 0; output = String.trim output; status }
+
+let safe_is_dir path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let safe_repo_component s =
+  s <> "" && s <> "." && s <> ".."
+  && not (String.contains s '/')
+  && not (String.contains s '\\')
+  && not (String.contains s '\x00')
+  && String.for_all
+       (fun c ->
+         (c >= 'A' && c <= 'Z')
+         || (c >= 'a' && c <= 'z')
+         || (c >= '0' && c <= '9')
+         || c = '-'
+         || c = '_'
+         || c = '.')
+       s
+
+let repo_name_of_repo_arg ~project_root repo =
+  let trimmed = String.trim repo in
+  if trimmed = "" then Filename.basename project_root
+  else
+    let base = Filename.basename trimmed in
+    if Filename.check_suffix base ".git" then
+      String.sub base 0 (String.length base - 4)
+    else base
+
+let clone_path ~(config : Coord.config) ~keeper_name ~repo_name =
+  Filename.concat config.base_path
+    (Filename.concat (Playground_paths.repos_path keeper_name) repo_name)
+
+let first_line_opt s =
+  match
+    String.split_on_char '\n' s
+    |> List.map String.trim
+    |> List.filter (fun line -> line <> "")
+  with
+  | [] -> None
+  | line :: _ -> Some line
+
+let parse_ahead_behind output =
+  match String.split_on_char '\t' (String.trim output) with
+  | [ behind; ahead ] -> (
+      match int_of_string_opt behind, int_of_string_opt ahead with
+      | Some behind, Some ahead -> Some (ahead, behind)
+      | _ -> None)
+  | _ -> None
+
+let string_opt_field name = function
+  | None -> [ name, `Null ]
+  | Some value -> [ name, `String value ]
+
+let int_opt_field name = function
+  | None -> [ name, `Null ]
+  | Some value -> [ name, `Int value ]
+
+let inspect
+    ~(config : Coord.config)
+    ~keeper_name
+    ?repo_name
+    ?(repo = "")
+    ?(default_branch = "main")
+    ()
+  =
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  let derived_repo_name =
+    match repo_name with
+    | Some name when String.trim name <> "" -> String.trim name
+    | _ -> repo_name_of_repo_arg ~project_root repo
+  in
+  let clone_path = clone_path ~config ~keeper_name ~repo_name:derived_repo_name in
+  let common_fields state ok next_action extra =
+    `Assoc
+      ([
+         "ok", `Bool ok;
+         "state", `String state;
+         "keeper", `String keeper_name;
+         "repo", `String repo;
+         "repo_name", `String derived_repo_name;
+         "clone_path", `String clone_path;
+         "sandbox_repos", `String (Playground_paths.repos_path keeper_name);
+         "default_branch", `String default_branch;
+         "next_action", `String next_action;
+       ]
+      @ extra)
+  in
+  if not (safe_repo_component derived_repo_name) then
+    common_fields "invalid_repo_name" false
+      "Pass repo_name as a single directory name under repos/; no slashes or path traversal."
+      [
+        "exists", `Bool false;
+        "is_git_repo", `Bool false;
+        "has_origin", `Bool false;
+      ]
+  else if not (safe_is_dir clone_path) then
+    common_fields "missing_clone" false
+      "Clone the repo into sandbox repos/ first with keeper_shell op=git_clone, then create a worktree."
+      [
+        "exists", `Bool false;
+        "is_git_repo", `Bool false;
+        "has_origin", `Bool false;
+      ]
+  else
+    let inside =
+      run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
+    in
+    if not inside.ok then
+      common_fields "not_git_repo" false
+        "This sandbox repo directory is not a git clone; reclone it under repos/."
+        [
+          "exists", `Bool true;
+          "is_git_repo", `Bool false;
+          "has_origin", `Bool false;
+          "git_error", `String inside.output;
+        ]
+    else
+      let status =
+        run_git ~timeout_sec:10.0 ~clone_path [ "status"; "--porcelain" ]
+      in
+      let dirty = status.ok && String.trim status.output <> "" in
+      let branch =
+        run_git ~timeout_sec:5.0 ~clone_path [ "branch"; "--show-current" ]
+        |> fun r -> if r.ok then first_line_opt r.output else None
+      in
+      let head =
+        run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--short"; "HEAD" ]
+        |> fun r -> if r.ok then first_line_opt r.output else None
+      in
+      let upstream =
+        run_git ~timeout_sec:5.0 ~clone_path
+          [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
+      in
+      let upstream_name = if upstream.ok then first_line_opt upstream.output else None in
+      let ahead, behind =
+        match upstream_name with
+        | None -> None, None
+        | Some _ -> (
+            let counts =
+              run_git ~timeout_sec:10.0 ~clone_path
+                [ "rev-list"; "--left-right"; "--count"; "@{upstream}...HEAD" ]
+            in
+            if counts.ok then
+              match parse_ahead_behind counts.output with
+              | Some (ahead, behind) -> Some ahead, Some behind
+              | None -> None, None
+            else None, None)
+      in
+      let origin =
+        run_git ~timeout_sec:5.0 ~clone_path [ "remote"; "get-url"; "origin" ]
+      in
+      let has_origin = origin.ok && String.trim origin.output <> "" in
+      let state, ok, next_action =
+        if not status.ok then
+          "status_failed", false,
+          "Run keeper_shell op=git_status in this repo; repair git status before starting work."
+        else if not has_origin then
+          "missing_origin", false,
+          "Set or reclone origin before worktree creation; latest cannot be verified without origin."
+        else if dirty then
+          "dirty", false,
+          "Commit, stash, or move existing changes before creating a fresh task worktree."
+        else
+          match behind with
+          | Some n when n > 0 ->
+              "behind_upstream", false,
+              "Fetch/rebase the sandbox clone or create a new worktree from the fetched origin branch."
+          | _ -> "ready", true, "Create a task worktree from the fetched origin branch before editing."
+      in
+      common_fields state ok next_action
+        ([
+           "exists", `Bool true;
+           "is_git_repo", `Bool true;
+           "dirty", `Bool dirty;
+           "has_origin", `Bool has_origin;
+           "origin_url",
+           (if has_origin then `String origin.output else `Null);
+           "status_ok", `Bool status.ok;
+         ]
+        @ string_opt_field "branch" branch
+        @ string_opt_field "head" head
+        @ string_opt_field "upstream" upstream_name
+        @ int_opt_field "ahead" ahead
+        @ int_opt_field "behind" behind)

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -5,8 +5,8 @@ let schemas : tool_schema list = [
     name = "masc_worktree_create";
     description = "Create an isolated Git worktree for a task. \
 Requires task_id (REQUIRED). Example: task_id='fix-login', task_id='feature/auth'. \
-The worktree is rooted in your playground clone — typically at \
-.masc/playground/<your-name>/repos/<repo>/.worktrees/<agent>-<task_id>. \
+The worktree is rooted in your sandbox repo clone — typically at \
+repos/<repo>/.worktrees/<agent>-<task_id>. \
 Repo resolution: pass repo_name to target a specific clone, otherwise \
 the first git clone under your repos/ is used (alphabetical). Clone \
 the target repo first with keeper_shell op=git_clone if your repos/ \
@@ -25,12 +25,12 @@ masc_worktree_remove.";
         ]);
         ("base_branch", `Assoc [
           ("type", `String "string");
-          ("description", `String "Base branch (default: auto-detect). Rarely needed.");
-          ("default", `String "develop");
+          ("description", `String "Base branch (default: auto). Rarely needed. Auto resolves origin/HEAD, then origin/main, origin/master, origin/develop.");
+          ("default", `String "auto");
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Optional. Disambiguates which sandbox repo clone to use when you have multiple repos under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
           (* Negative lookahead is not supported by JSON Schema Draft 7
              (used by most MCP clients), so the pattern below only
              enforces the character class. The ".", ".." special cases

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -454,12 +454,13 @@ let keeper_preflight_tools : Types.tool_schema list = [
   {
     name = "keeper_preflight_check";
     description = "Validate prerequisites before starting autonomous work: \
-gh auth, repo access, keeper identity, preset level, clone target path. \
+gh auth, repo access, keeper identity, preset level, repo readiness. \
 Returns structured JSON with all check results. Read-only, no side effects.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name) to check access for")]);
+        ("repo_name", `Assoc [("type", `String "string"); ("description", `String "Optional sandbox repo directory name under repos/ when it differs from the GitHub repo basename")]);
       ]);
       ("required", `List [`String "repo"]);
     ];

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -10,6 +10,8 @@ type context = {
 
 type tool_result = bool * string
 
+let default_base_branch = "auto"
+
 (* Individual handlers *)
 let handle_worktree_create ctx args =
   (* LLM may omit agent_name in args; fall back to context agent_name.
@@ -48,7 +50,7 @@ let handle_worktree_create ctx args =
   | Error msg -> (false, msg)
   | Ok agent_name ->
   let raw_task_id = get_string args "task_id" "" in
-  let base_branch = get_string args "base_branch" "develop" in
+  let base_branch = get_string args "base_branch" default_base_branch in
   (* repo_name comes straight from MCP tool args. Reject anything that
      isn't a single safe directory component so it cannot escape
      [.masc/playground/<keeper>/repos/]. Coord.worktree_create_r also
@@ -72,7 +74,7 @@ let handle_worktree_create ctx args =
       ( None,
         Some (Printf.sprintf
           "repo_name %S is invalid. Use a single directory name \
-           under your playground repos/ (e.g. repo_name='masc-mcp'). \
+           under sandbox repos/ (e.g. repo_name='masc-mcp'). \
            Allowed characters: [A-Za-z0-9._-]. No slashes, no \
            path traversal, no '.'/'..' specials." bad) )
   in

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -7,6 +7,8 @@ type context = {
 
 type tool_result = bool * string
 
+val default_base_branch : string
+
 val handle_worktree_create : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_remove : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_list : context -> Yojson.Safe.t -> tool_result

--- a/test/dune
+++ b/test/dune
@@ -59,6 +59,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_repo_readiness
         test_keeper_tool_surface_guard
         test_keeper_pr_review
         test_keeper_execution_scope
@@ -168,6 +169,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_repo_readiness
           test_keeper_tool_surface_guard
           test_keeper_pr_review
           test_keeper_execution_scope

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -280,7 +280,14 @@ let test_preflight_exposes_routing_hint_for_high_risk_keeper () =
         (Yojson.Safe.Util.(result |> member "accountability_risk" |> to_bool));
       check string "risk band exposed" "high" (string_member "risk_band" result);
       check string "routing hint exposed" "manual_review_recommended"
-        (string_member "routing_hint" result))
+        (string_member "routing_hint" result);
+      let repo_readiness =
+        Yojson.Safe.Util.(result |> member "repo_readiness")
+      in
+      check string "repo readiness state exposed" "missing_clone"
+        (Yojson.Safe.Util.(repo_readiness |> member "state" |> to_string));
+      check bool "repo readiness blocks code start without clone" false
+        (Yojson.Safe.Util.(repo_readiness |> member "ok" |> to_bool)))
 
 let test_synthetic_claims_do_not_dilute_unsupported_rate () =
   (* Regression: synthetic completion claims (created by task_transition "done")

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -1,0 +1,83 @@
+(** Keeper_repo_readiness tests. *)
+
+open Alcotest
+
+let temp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec loop n =
+    let path =
+      Filename.concat base
+        (Printf.sprintf "%s-%d-%06d" prefix (Unix.getpid ()) n)
+    in
+    if Sys.file_exists path then loop (n + 1)
+    else (
+      Unix.mkdir path 0o755;
+      path)
+  in
+  loop (Random.int 1_000_000)
+
+let mkdir_p path =
+  let rec ensure dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    else (
+      ensure (Filename.dirname dir);
+      Unix.mkdir dir 0o755)
+  in
+  ensure path
+
+let json_bool key json =
+  Yojson.Safe.Util.(json |> member key |> to_bool)
+
+let json_string key json =
+  Yojson.Safe.Util.(json |> member key |> to_string)
+
+let test_missing_clone () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "missing_clone" (json_string "state" json);
+  check string "repo_name" "masc-mcp" (json_string "repo_name" json);
+  check bool "exists" false (json_bool "exists" json)
+
+let test_non_git_clone () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let clone_path =
+    Masc_mcp.Keeper_repo_readiness.clone_path ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp"
+  in
+  mkdir_p clone_path;
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "not_git_repo" (json_string "state" json);
+  check bool "exists" true (json_bool "exists" json);
+  check bool "is_git_repo" false (json_bool "is_git_repo" json)
+
+let test_invalid_repo_name () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"../escape" ()
+  in
+  check bool "not ok" false (json_bool "ok" json);
+  check string "state" "invalid_repo_name" (json_string "state" json)
+
+let () =
+  Random.self_init ();
+  run "Keeper_repo_readiness"
+    [
+      "inspect",
+      [
+        test_case "missing clone" `Quick test_missing_clone;
+        test_case "non-git clone" `Quick test_non_git_clone;
+        test_case "invalid repo_name" `Quick test_invalid_repo_name;
+      ];
+    ]

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -21,11 +21,13 @@ let test_get_string_missing () =
 
 let test_get_string_base_branch () =
   let args = `Assoc [("base_branch", `String "main")] in
-  check string "extracts branch" "main" (Tool_args.get_string args "base_branch" "develop")
+  check string "extracts branch" "main"
+    (Tool_args.get_string args "base_branch" Tool_worktree.default_base_branch)
 
 let test_get_string_base_branch_default () =
   let args = `Assoc [] in
-  check string "uses develop default" "develop" (Tool_args.get_string args "base_branch" "develop")
+  check string "uses auto default" "auto"
+    (Tool_args.get_string args "base_branch" Tool_worktree.default_base_branch)
 
 (* ============================================================
    Context Creation Tests


### PR DESCRIPTION
## Summary
- Add read-only keeper repo readiness inspection for the single sandbox repos clone path.
- Surface `repo_readiness` from `keeper_preflight_check`, including missing clone, invalid repo name, dirty tree, origin/upstream, ahead/behind, branch, and next action.
- Change worktree base selection to `auto` and fail fast when `git fetch origin` fails so keepers do not silently work from stale refs.
- Update worktree/preflight wording from playground clone to sandbox repos and add focused coverage.

## Verification
- `dune exec --root . ./test/test_keeper_repo_readiness.exe`
- `dune exec --root . ./test/test_tool_worktree_coverage.exe`
- `dune exec --root . ./test/test_room_git_coverage.exe`
- `dune exec --root . ./test/test_keeper_accountability.exe`
- `dune exec --root . ./test/test_tool_shard_coverage.exe`
- `dune exec --root . ./test/test_mcp_tool_matrix.exe`
- `dune build --root .`
- `git diff --check`