### PR TITLE
docs(logic): batch-9 .mli for feature_flag_registry + procedural_memory

### DIFF
--- a/lib/config/feature_flag_registry.mli
+++ b/lib/config/feature_flag_registry.mli
@@ -1,0 +1,75 @@
+(** Feature Flag Registry — single source of truth for all MASC boolean
+    feature flags.
+
+    Each flag has a canonical default, description, category, and
+    lifecycle state. The registry does not replace [env_config] modules
+    (they still read env vars). Instead it provides:
+
+    + Runtime enumeration for operators
+    + Consistency verification (CI lint: [check-feature-flag-consistency.sh])
+    + Lifecycle tracking: Active → Deprecated → (removed from registry)
+    + Machine-readable flag catalog
+
+    @since 2.162.0
+    @see <docs/design/inventory-gap-analysis-rfc.md> H5 Feature Flags *)
+
+(** {1 Types} *)
+
+(** Flag lifecycle state machine. *)
+type lifecycle =
+  | Active
+  | Deprecated of string  (** reason for deprecation *)
+  | Experimental          (** not yet stable, may change without notice *)
+
+type flag = {
+  env_name : string;      (** MASC_* environment variable name *)
+  description : string;
+  default : bool;
+  category : string;      (** Grouping: transport/tool/keeper/dashboard/inference/runtime *)
+  lifecycle : lifecycle;
+  since : string;
+}
+
+(** {1 Registry} *)
+
+(** The canonical registry. Alphabetically ordered within each
+    category. CI verifies that every [get_bool ... "MASC_*"] call in
+    [lib/config/] has a matching entry here with the same default. *)
+val all_flags : flag list
+
+(** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)
+val find_opt : string -> flag option
+
+(** {1 Runtime value} *)
+
+(** Read runtime value using the flag's canonical default. *)
+val runtime_value : flag -> bool
+
+(** Source of the active value: ["env"], ["boot_override"], or
+    ["default"]. *)
+val runtime_source : flag -> string
+
+(** [get_bool env_name] = registry-aware lookup. Falls back to
+    [Env_config_core.get_bool ~default:false] and logs a warning if
+    [env_name] is not registered. *)
+val get_bool : string -> bool
+
+(** {1 Serialisation} *)
+
+val lifecycle_to_string : lifecycle -> string
+
+(** JSON shape: [{env_name, description, canonical_default, runtime_value,
+    source, category, lifecycle, since}]. *)
+val flag_to_json : flag -> Yojson.Safe.t
+
+(** All flags grouped by category:
+    [{total_flags, categories:{transport:[...], tool:[...], ...}}]. *)
+val to_json : unit -> Yojson.Safe.t
+
+(** {1 Queries} *)
+
+(** Flags whose runtime value differs from the canonical default. *)
+val overridden_flags : unit -> flag list
+
+(** Flags currently in [Deprecated _] lifecycle state. *)
+val deprecated_flags : unit -> flag list

--- a/lib/procedural_memory.mli
+++ b/lib/procedural_memory.mli
@@ -1,0 +1,80 @@
+(** Procedural Memory — Patterns extracted from repeated agent behavior.
+
+    Crystallization uses adaptive thresholding:
+    - Standard: 3+ occurrences with 70%+ positive outcomes
+    - Rare-but-perfect: 2+ occurrences with 100% success rate
+
+    Thresholds are configurable via [MASC_PROC_MIN_EVIDENCE] and
+    [MASC_PROC_MIN_CONFIDENCE] environment variables.
+
+    Crystallized procedures are injected into successor agents via
+    capsule hydration.
+
+    Storage: [.masc/procedures/{agent}/procedures.jsonl]
+
+    @since 2.90.0 *)
+
+(** {1 Types} *)
+
+(** A learned procedure — "When X, do Y". *)
+type procedure = {
+  id : string;
+  agent_name : string;
+  pattern : string;            (** "When X, do Y" description *)
+  evidence : string list;      (** Decision IDs supporting this pattern *)
+  success_count : int;
+  failure_count : int;
+  confidence : float;          (** [success / (success + failure)] *)
+  created_at : float;
+  last_applied : float;
+}
+
+(** {1 Paths} *)
+
+(** [.masc/procedures/{agent_name}/procedures.jsonl] under
+    [Env_config.base_path ()]. *)
+val procedures_path : agent_name:string -> string
+
+(** {1 File I/O} *)
+
+(** Load all persisted procedures for [agent_name]. Malformed JSONL
+    lines are silently skipped (via [of_json]). Returns [[]] if the
+    file does not exist. *)
+val load_procedures : agent_name:string -> procedure list
+
+(** Append [p] to the agent's procedures file. Creates the directory
+    if it does not exist. *)
+val save_procedure : agent_name:string -> procedure -> unit
+
+(** Rewrite the full procedures file atomically. On write error,
+    logs via [Log.Config.warn] and returns [()]. *)
+val rewrite_procedures : agent_name:string -> procedure list -> unit
+
+(** {1 Outcomes} *)
+
+(** [record_outcome ~agent_name ~pattern ~evidence_id ~success] finds
+    an existing procedure with the same [pattern] and updates its
+    counts, or creates a new one. Persists the change and returns the
+    updated/new procedure. *)
+val record_outcome :
+  agent_name:string ->
+  pattern:string ->
+  evidence_id:string ->
+  success:bool ->
+  procedure
+
+(** {1 Crystallisation} *)
+
+(** Adaptive crystallisation check:
+    - Standard: [List.length p.evidence >= min_evidence ()]
+      AND [p.confidence >= min_confidence ()].
+    - Rare-but-perfect: [p.confidence >= 1.0] AND [List.length p.evidence >= 2]. *)
+val is_crystallized : procedure -> bool
+
+(** Top-N crystallised procedures sorted by confidence (descending). *)
+val top_procedures : agent_name:string -> limit:int -> procedure list
+
+(** Format top-N crystallised procedures as a capsule-injection
+    fragment: ["[PROCEDURES]\n- <pattern> (confidence: N%, evidence: N)\n…[/PROCEDURES]"].
+    Empty string when no procedures qualify. *)
+val format_for_dna : agent_name:string -> limit:int -> string


### PR DESCRIPTION
## Summary

Wave 3 batch 9 — `.mli` 2 파일. 바디 무수정.

## 대상 파일 (2개)

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/config/feature_flag_registry.mli` | 267 | 73 | 2 types (lifecycle/flag) + 10 vals |
| `lib/procedural_memory.mli` | 201 | 79 | procedure record + 8 vals |

## 설계 노트

### feature_flag_registry
- **Public surface 13개** (dashboard_feature_health, env_config_{governance,keeper,runtime}, tool_misc_admin, test_memory_hooks):
  - Constructors: `Active`, `Deprecated reason`, `Experimental`
  - Record accessor: `category`, `flag` 필드
  - Functions: `all_flags`, `find_opt`, `get_bool`, `runtime_value`, `runtime_source`, `flag_to_json`, `lifecycle_to_string`, `overridden_flags`, `deprecated_flags`
- CI consistency script (`check-feature-flag-consistency.sh`) 참조 명시.

### procedural_memory
- **Public surface 8개** (memory_oas_bridge + test_memory_oas_5tier):
  - `procedure` record full exposure (field access 필요)
  - `procedures_path`, `load_procedures`, `save_procedure`, `rewrite_procedures`
  - `record_outcome`, `is_crystallized`, `top_procedures`, `format_for_dna`
- Adaptive crystallisation threshold (standard 3+/0.7 vs rare-but-perfect 2+/1.0) mli doc에 수식 표기.

### 건너뛴 후보
- **Coord_state** (200 lines): `Coord`가 `include Coord_state` → narrowing .mli이 Coord 전체 API 침식. 별도 PR에서 Coord+Coord_state 동시 도입 필요.

## 검증

- `dune build --root=.` → exit 0
- 전체 external caller (13+8 symbols) 컴파일 유지.

## 현재 누적 (세션)

| # | PR | 파일 수 | 상태 |
|---|----|---------|------|
| 1-8 | (merged) | 21 | MERGED |
| 9 | #8913 | 2 | MERGED |
| 10 | #8920 | 2 | Open (auto-merge) |
| **11** | **이 PR** | **2** | Open |

## Metric 이전/이후 (main 실측)

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 319 | **321** |
| Wave 3 진행 | 20.35% | **~21% (7회 tick 누적)** |

## Anti-goal 자가 체크

- [x] ml 바디 수정 0
- [x] `include` umbrella 위험 회피 (Coord_state 보류)
- [x] Public surface을 grep 검증
- [x] hype 금지

## Epic / Milestone

- Epic: jeong-sik/me#1022
- Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)