### PR TITLE
Guard sidecar start on attempt metadata write failure

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -591,7 +591,7 @@ let reconcile_desired_once
     ?(now = isoish_now ())
     ?(next_retry_at = isoish_at (Unix.time () +. retry_backoff_seconds))
     ?previous_attempt
-    ?(write_attempt = fun (_ : attempt_record) -> ())
+    ?(write_attempt = fun (_ : attempt_record) -> Ok ())
     ~current_generation
     ~observed_state
     ~start_shell
@@ -610,9 +610,11 @@ let reconcile_desired_once
              let attempt =
                next_attempt_record ~now ~next_retry_at previous_attempt record
              in
-             write_attempt attempt;
-             start_shell ();
-             Reconcile_started)
+             (match write_attempt attempt with
+              | Ok () ->
+                  start_shell ();
+                  Reconcile_started
+              | Error _ -> Reconcile_noop "attempt_write_failed"))
     | Desired_running, Observed_available -> Reconcile_noop "already_available"
     | Desired_stopped, _ -> Reconcile_noop "desired_stopped"
 
@@ -1154,8 +1156,7 @@ let handle_start state request reqd =
                     ~current_generation:desired.generation
                     ?previous_attempt
                     ~observed_state
-                    ~write_attempt:(fun attempt ->
-                      ignore (write_attempt_record ~base_path ~id attempt))
+                    ~write_attempt:(write_attempt_record ~base_path ~id)
                     ~start_shell:(fun () -> ignore (Sys.command cmd))
                     desired
                 in

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -302,7 +302,9 @@ let test_reconcile_running_unavailable_starts_once () =
       ~next_retry_at:"2099-04-20T00:00:30Z"
       ~current_generation:3
       ~observed_state:Routes.Observed_unavailable
-      ~write_attempt:(fun attempt -> written_attempt := Some attempt)
+      ~write_attempt:(fun attempt ->
+        written_attempt := Some attempt;
+        Ok ())
       ~start_shell:(fun () -> incr shell_calls)
       desired
   in
@@ -317,7 +319,32 @@ let test_reconcile_running_unavailable_starts_once () =
        check string "next action recorded"
          "wait for observed status, or open logs if the sidecar remains offline after backoff"
          attempt.operator_next_action
-   | None -> failf "running reconcile should persist attempt metadata")
+  | None -> failf "running reconcile should persist attempt metadata")
+
+let test_reconcile_attempt_write_failure_does_not_start () =
+  let shell_calls = ref 0 in
+  let desired : Routes.desired_record =
+    {
+      Routes.connector_id = "discord";
+      desired_state = Routes.Desired_running;
+      generation = 3;
+      updated_by = "test";
+      updated_at = "2026-04-20T00:00:00Z";
+    }
+  in
+  let result =
+    Routes.reconcile_desired_once
+      ~now:"2026-04-20T00:00:00Z"
+      ~next_retry_at:"2099-04-20T00:00:30Z"
+      ~current_generation:3
+      ~observed_state:Routes.Observed_unavailable
+      ~write_attempt:(fun _ -> Error "disk full")
+      ~start_shell:(fun () -> incr shell_calls)
+      desired
+  in
+  check int "attempt write failure suppresses shell start" 0 !shell_calls;
+  check string "attempt write failure result" "noop:attempt_write_failed"
+    (Routes.reconcile_result_to_string result)
 
 let test_reconcile_running_unavailable_backoff_noops () =
   let shell_calls = ref 0 in
@@ -587,6 +614,8 @@ let () =
             test_reconcile_stale_generation_does_not_start;
           test_case "running + unavailable starts once" `Quick
             test_reconcile_running_unavailable_starts_once;
+          test_case "attempt write failure does not start" `Quick
+            test_reconcile_attempt_write_failure_does_not_start;
           test_case "running + unavailable backs off repeated same-generation start" `Quick
             test_reconcile_running_unavailable_backoff_noops;
           test_case "stopped desired no-ops" `Quick test_reconcile_stopped_noops;


### PR DESCRIPTION
## Product impact

Prevents a retry-storm hole in the #8905 sidecar reconcile backoff slice: if the attempt metadata cannot be persisted, the backend must not dispatch a shell start without durable backoff state.

## Summary

- Changes `reconcile_desired_once` so `write_attempt` returns a result.
- Suppresses shell start and returns `noop:attempt_write_failed` when `sidecar_lifecycle_attempt.json` cannot be written.
- Wires `/api/v1/sidecar/start` to respect `write_attempt_record` failures instead of ignoring them.
- Adds a route-level regression proving attempt-write failure does not shell-start.

## Evidence

- Local targeted build: `dune build --root . test/test_sidecar_lifecycle_routes.exe`
- Local targeted tests: `dune exec --root . test/test_sidecar_lifecycle_routes.exe` (35 tests pass)
- Follow-up commit: `91965a2b1`

## Review evidence

Review the two-file follow-up slice:

- `lib/server/server_routes_http_routes_sidecar.ml`
- `test/test_sidecar_lifecycle_routes.ml`

Check that a failed persisted attempt record cannot dispatch `sidecar_start_shell_command`, because the attempt record is the SSOT for retry/backoff safety.

## Linked issue

Refs #8905.

## Notes

This is a follow-up to #8919 after adversary identified that ignoring attempt write failures could allow repeated same-generation shell starts without durable backoff metadata. It does not add a scheduler/continuous loop and does not expand #8884 rendering work.