### PR TITLE
fix(reputation): inherit accountability penalties for generated aliases

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -185,6 +185,8 @@ let keeper_name_of_agent agent_name =
      && String.sub trimmed (len - suffix_len) suffix_len = suffix
   then
     String.sub trimmed 0 (len - suffix_len)
+  else if Nickname.is_generated_nickname trimmed then
+    Option.value (Nickname.extract_agent_type trimmed) ~default:trimmed
   else
     trimmed
 

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -674,23 +674,30 @@ let accountability_summary_lookup (config : Coord_query.config) =
   let now = Time_compat.now () in
   let cutoff = summary_cutoff now in
   let by_agent : (string, claim_snapshot list) Hashtbl.t = Hashtbl.create 32 in
+  let by_keeper : (string, claim_snapshot list) Hashtbl.t = Hashtbl.create 32 in
+  let add_snapshot table key snapshot =
+    let existing =
+      match Hashtbl.find_opt table key with
+      | Some items -> items
+      | None -> []
+    in
+    Hashtbl.replace table key (snapshot :: existing)
+  in
   (* Request-local pre-aggregation: the dashboard rebuilds this lookup per
      render, so the next request naturally refreshes the window contents. *)
   materialize_claims (read_window_entries config)
   |> List.iter (fun snapshot ->
-         if created_at_unix snapshot.claim >= cutoff then
-           let existing =
-             match Hashtbl.find_opt by_agent snapshot.claim.agent_name with
-             | Some items -> items
-             | None -> []
-           in
-           Hashtbl.replace by_agent snapshot.claim.agent_name
-             (snapshot :: existing));
+         if created_at_unix snapshot.claim >= cutoff then (
+           add_snapshot by_agent snapshot.claim.agent_name snapshot;
+           add_snapshot by_keeper snapshot.claim.keeper_name snapshot));
   fun ~keeper_name ~agent_name ->
     let snapshots =
       match Hashtbl.find_opt by_agent agent_name with
       | Some items -> items
-      | None -> []
+      | None -> (
+          match Hashtbl.find_opt by_keeper keeper_name with
+          | Some items -> items
+          | None -> [])
     in
     summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots
 

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -219,6 +219,44 @@ let test_agent_reputation_penalizes_unsupported_claims () =
       check bool "overall reputation penalized" true
         (rep.overall_score < unpenalized))
 
+let test_generated_alias_inherits_accountability_penalty () =
+  with_room ~agent_name:"adversary-eager-viper" (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-adversary-unsupported");
+             ("agent_name", `String "keeper-adversary-agent");
+             ("keeper_name", `String "adversary");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Unsupported canonical claim");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"adversary" ~agent_name:"adversary-eager-viper"
+      in
+      check string "alias summary inherits canonical keeper risk" "high"
+        (string_member "risk_band" summary);
+      check (float 0.0001) "alias summary inherits unsupported rate" 1.0
+        (float_member "unsupported_completion_rate" summary);
+      let rep =
+        Agent_reputation.compute_reputation config
+          ~agent_name:"adversary-eager-viper"
+      in
+      check string "generated alias risk band" "high"
+        rep.accountability_risk_band;
+      check (float 0.0001) "generated alias unsupported rate" 1.0
+        rep.accountability_unsupported_completion_rate;
+      check (float 0.0001) "generated alias accountability score" 0.0
+        rep.accountability_score)
+
 let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
   with_room (fun config ->
       let meta = make_test_meta () in
@@ -527,6 +565,8 @@ let () =
             test_stale_completion_claim_sets_high_risk;
           test_case "agent reputation penalizes unsupported claims" `Quick
             test_agent_reputation_penalizes_unsupported_claims;
+          test_case "generated alias inherits accountability penalty" `Quick
+            test_generated_alias_inherits_accountability_penalty;
           test_case "claim tool exposes routing warning for high risk keeper"
             `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
           test_case "preflight exposes routing hint for high risk keeper"


### PR DESCRIPTION
## Summary

Fixes the reputation/accountability identity gap from #8926.

Generated runtime aliases such as `adversary-eager-viper` now resolve their keeper type for reputation accountability lookup, and the accountability summary lookup falls back from exact `agent_name` to the canonical `keeper_name` ledger when the exact generated alias has no rows.

## Root Cause

`Agent_reputation.keeper_name_of_agent` only stripped the `-agent` suffix. For generated nicknames, reputation queried accountability using the generated alias as both the keeper identity and agent identity. Since the accountability ledger stores canonical keeper records, generated aliases could get default-safe accountability metrics and avoid prior unsupported-claim penalties.

## Changes

- Resolve generated nicknames to their `Nickname.extract_agent_type` keeper name in `Agent_reputation`.
- Build request-local accountability summary indexes by exact agent and canonical keeper.
- Preserve exact-agent lookup first, then fallback to keeper ledger only when no exact alias rows exist.
- Add a regression proving `adversary-eager-viper` inherits `adversary` unsupported-claim penalties.

## Verification

- `opam exec -- dune build --root "$PWD" test/test_keeper_accountability.exe`
- `opam exec -- _build/default/test/test_keeper_accountability.exe --color=never` -> 16 tests pass
- `git diff --check HEAD~1..HEAD`

Refs #8926