### PR TITLE
RFC-0006 Phase B-1: symmetric sandbox containment for hardened-keeper reads

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -601,6 +601,18 @@ module KeeperSandbox = struct
       with Not_found -> ""
     in
     get_string ~default "MASC_KEEPER_SANDBOX_GH_TOKEN"
+
+  (** RFC-0006 Phase B-1: when true, hardened keepers' read-side tools
+      (keeper_fs_read; later keeper_shell op=rg/ls/cat/find/...) are
+      restricted to the keeper's playground bundle on the host even
+      though the path resolver alone would have allowed broader access.
+
+      Closes the asymmetry where keeper_bash gates execution to docker
+      but keeper_fs_read still walks the host. Default off so existing
+      hardened keepers (analyst/janitor/poe/minjae) keep working until
+      operators flip the flag. *)
+  let symmetric_read_containment () =
+    get_bool ~default:false "MASC_KEEPER_SYMMETRIC_SANDBOX"
 end
 
 module DashboardHealth = struct

--- a/lib/dune
+++ b/lib/dune
@@ -411,6 +411,7 @@
    keeper_skill_routing
    keeper_alerting
    keeper_alerting_path
+   keeper_sandbox_containment
    keeper_timing
    keeper_tool_registry
    keeper_tool_diversity
@@ -664,6 +665,7 @@
   tool_autoresearch_cycle
   keeper_skill_routing
   keeper_alerting_path
+  keeper_sandbox_containment
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http
   tool_local_runtime_verify

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -65,6 +65,16 @@ let handle_keeper_fs_read
     missing_file_error_json ~config ~target ~fallback_dir ~error:e
   | Error e -> error_json e
   | Ok target ->
+    (* RFC-0006 Phase B-1: symmetric sandbox guard. For hardened keepers
+       (sandbox_profile=docker_hardened/docker_with_git) with
+       MASC_KEEPER_SYMMETRIC_SANDBOX=true, the resolver-level allowed_paths
+       check is augmented by a strict playground-bundle containment so the
+       host FS cannot leak through keeper_fs_read while keeper_bash is
+       container-isolated. No-op for legacy keepers and when the env flag
+       is off. *)
+    (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
+     | Error e -> error_json ~fields:[ "path", `String target ] e
+     | Ok () ->
     (match Safe_ops.read_file_safe target with
      | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
        missing_file_error_json ~config ~target ~fallback_dir ~error:e
@@ -80,7 +90,7 @@ let handle_keeper_fs_read
              ; "bytes", `Int total
              ; "truncated", `Bool truncated
              ; "content", `String body
-             ]))
+             ])))
 ;;
 
 let handle_keeper_fs_edit

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -1,0 +1,44 @@
+(** Keeper_sandbox_containment — see .mli for contract. *)
+
+let normalize p =
+  Keeper_alerting_path.normalize_path_for_check p
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let starts_with ~prefix s =
+  String.length s >= String.length prefix
+  && String.sub s 0 (String.length prefix) = prefix
+
+(** Build the absolute, normalized playground bundle root for [meta]
+    under [config.base_path]. *)
+let playground_root_abs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  let bundle_rel = Keeper_alerting_path.playground_path_of_keeper meta.name in
+  Filename.concat project_root bundle_rel |> normalize
+
+let target_is_inside_playground ~playground ~target =
+  let playground = playground in
+  target = playground || starts_with ~prefix:(playground ^ "/") target
+
+let is_hardened_profile = function
+  | Keeper_types.Docker_hardened
+  | Keeper_types.Docker_with_git -> true
+  | Keeper_types.Legacy_local -> false
+
+let check_read_target ~config ~meta ~target =
+  if not (is_hardened_profile meta.Keeper_types.sandbox_profile)
+     || not (Env_config_keeper.KeeperSandbox.symmetric_read_containment ())
+  then Ok ()
+  else
+    let playground = playground_root_abs ~config ~meta in
+    let target_norm = normalize target in
+    if target_is_inside_playground ~playground ~target:target_norm then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "symmetric_sandbox_blocked: target %s is outside keeper playground \
+            %s. Hardened keepers (sandbox_profile=docker_hardened or \
+            docker_with_git) with MASC_KEEPER_SYMMETRIC_SANDBOX=true may only \
+            read inside their playground. Clone the source into your \
+            playground via keeper_shell op=git_clone, or operate inside \
+            %s/repos/."
+           target_norm playground playground)

--- a/lib/keeper/keeper_sandbox_containment.mli
+++ b/lib/keeper/keeper_sandbox_containment.mli
@@ -1,0 +1,36 @@
+(** Keeper_sandbox_containment — symmetric host-FS guard for hardened
+    keepers (RFC-0006 Phase B-1).
+
+    The keeper sandbox boundary historically followed the tool name:
+    [keeper_bash] for [sandbox_profile=Docker_hardened] keepers ran in
+    a container, but [keeper_fs_read] / [keeper_shell] read directly
+    from the host. The result was a one-way leak — write was gated,
+    read was not.
+
+    This module enforces "whichever profile decides one tool, decides
+    every tool" on the host side without spinning up a per-call
+    container. When the symmetric-sandbox env flag is set
+    ([MASC_KEEPER_SYMMETRIC_SANDBOX=true]) AND the keeper's profile is
+    [Docker_hardened], read targets must lie within the keeper's
+    playground bundle ([.masc/playground/<keeper>/]).
+
+    Phase B-2 will route the same tools through [docker exec] so the
+    container's mount restrictions become the actual primary boundary;
+    this host-side guard remains as defense-in-depth. *)
+
+(** [check_read_target ~config ~meta ~target] returns [Ok ()] when the
+    resolved file path [target] is permitted under the keeper's
+    effective sandbox containment policy.
+
+    Returns [Error msg] only when ALL of the following hold:
+    - [meta.sandbox_profile = Docker_hardened]
+    - [Env_config_keeper.KeeperSandbox.symmetric_read_containment ()] is true
+    - [target] does NOT resolve under the keeper's playground bundle root
+
+    A no-op (always [Ok ()]) for legacy keepers and for hardened
+    keepers when the env flag is off. *)
+val check_read_target :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  target:string ->
+  (unit, string) result

--- a/test/dune
+++ b/test/dune
@@ -88,6 +88,7 @@
         test_keeper_discovered_tools
         test_keeper_tool_affinity
         test_keeper_tool_alias
+        test_keeper_sandbox_containment
         test_keeper_github_read_only
         test_worktree_live_context
         test_tool_input_validation
@@ -197,6 +198,7 @@
           test_keeper_discovered_tools
           test_keeper_tool_affinity
           test_keeper_tool_alias
+          test_keeper_sandbox_containment
           test_keeper_github_read_only
           test_worktree_live_context
           test_tool_input_validation

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -1,0 +1,181 @@
+(** Tests for Keeper_sandbox_containment.
+
+    RFC-0006 Phase B-1: pin the host-FS read guard for hardened keepers.
+    The containment is no-op for legacy keepers and for hardened keepers
+    when MASC_KEEPER_SYMMETRIC_SANDBOX is off. *)
+
+open Masc_mcp
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let with_env key value f =
+  let prior = try Some (Sys.getenv key) with Not_found -> None in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None ->
+          (* No "unset" in stdlib Unix; clear via empty value. The
+             containment module reads via env_config which treats empty
+             as "not set" for booleans. *)
+          Unix.putenv key "")
+    f
+
+let with_tmp_base f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_containment_%d_%d"
+         (Unix.getpid ()) (Random.int 1_000_000))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rmrf p =
+        match Unix.lstat p with
+        | { st_kind = Unix.S_DIR; _ } ->
+            Sys.readdir p
+            |> Array.iter (fun e -> rmrf (Filename.concat p e));
+            (try Unix.rmdir p with _ -> ())
+        | _ -> (try Unix.unlink p with _ -> ())
+        | exception Unix.Unix_error _ -> ()
+      in
+      rmrf dir)
+    (fun () -> f dir)
+
+let make_meta ~name ~sandbox =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String name);
+        ("trace_id", `String "test-trace-containment");
+        ("policy_voice_enabled", `Bool false);
+        ( "tool_access",
+          Keeper_types.tool_access_to_json
+            (Keeper_types.Preset
+               { preset = Keeper_types.Full; also_allow = [] }) );
+        ("sandbox_profile",
+         `String (Keeper_types.sandbox_profile_to_string sandbox));
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok m -> m
+  | Error e -> Alcotest.fail e
+
+(* ── Tests ───────────────────────────────────────────────────────── *)
+
+let test_legacy_keeper_always_allowed () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Legacy_local in
+  let outside = "/etc/passwd" in
+  Alcotest.(check bool)
+    "Legacy_local keeper bypasses containment even with flag on"
+    true
+    (Result.is_ok
+       (Keeper_sandbox_containment.check_read_target
+          ~config ~meta ~target:outside))
+
+let test_hardened_keeper_with_flag_off_is_passthrough () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "false" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened in
+  let outside = "/etc/passwd" in
+  Alcotest.(check bool)
+    "Docker_hardened with flag off allows host paths (legacy behavior)"
+    true
+    (Result.is_ok
+       (Keeper_sandbox_containment.check_read_target
+          ~config ~meta ~target:outside))
+
+let test_hardened_with_flag_on_blocks_outside () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened in
+  let outside = "/etc/passwd" in
+  match
+    Keeper_sandbox_containment.check_read_target ~config ~meta ~target:outside
+  with
+  | Ok () ->
+      Alcotest.fail "expected containment to block /etc/passwd for minjae"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions symmetric_sandbox_blocked"
+        true
+        (let needle = "symmetric_sandbox_blocked" in
+         let len = String.length needle in
+         String.length msg >= len
+         && String.sub msg 0 len = needle)
+
+let test_hardened_with_flag_on_allows_inside_playground () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened in
+  let bundle =
+    Filename.concat base
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  let inside = Filename.concat bundle "mind/scratch.md" in
+  Alcotest.(check bool) "playground-internal path is allowed"
+    true
+    (Result.is_ok
+       (Keeper_sandbox_containment.check_read_target
+          ~config ~meta ~target:inside))
+
+let test_docker_with_git_also_contained () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"poe" ~sandbox:Keeper_types.Docker_with_git in
+  let outside = "/etc/passwd" in
+  Alcotest.(check bool) "Docker_with_git is also subject to containment"
+    true
+    (Result.is_error
+       (Keeper_sandbox_containment.check_read_target
+          ~config ~meta ~target:outside))
+
+let test_path_just_outside_playground_blocked () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_tmp_base @@ fun base ->
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened in
+  (* Sibling directory with a name that LOOKS like a prefix of the playground
+     path; must still be blocked (prevents the classic prefix-without-slash
+     containment bypass). *)
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  let bundle = Keeper_alerting_path.playground_path_of_keeper meta.name in
+  let bundle_normalized =
+    Filename.concat project_root bundle
+    |> Keeper_alerting_path.normalize_path_for_check
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let sibling = bundle_normalized ^ "_evil/secret.txt" in
+  Alcotest.(check bool) "lookalike sibling path is blocked"
+    true
+    (Result.is_error
+       (Keeper_sandbox_containment.check_read_target
+          ~config ~meta ~target:sibling))
+
+let () =
+  Alcotest.run "Keeper_sandbox_containment"
+    [
+      ( "containment",
+        [
+          Alcotest.test_case "legacy keeper always allowed" `Quick
+            test_legacy_keeper_always_allowed;
+          Alcotest.test_case "hardened with flag off is passthrough" `Quick
+            test_hardened_keeper_with_flag_off_is_passthrough;
+          Alcotest.test_case "hardened with flag on blocks /etc/passwd" `Quick
+            test_hardened_with_flag_on_blocks_outside;
+          Alcotest.test_case "hardened with flag on allows inside playground"
+            `Quick test_hardened_with_flag_on_allows_inside_playground;
+          Alcotest.test_case "docker_with_git also contained" `Quick
+            test_docker_with_git_also_contained;
+          Alcotest.test_case "lookalike sibling path blocked" `Quick
+            test_path_just_outside_playground_blocked;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
Phase B-1 of RFC-0006. Closes the host-FS read leak for keepers with \`sandbox_profile=docker_hardened\` (or \`docker_with_git\`).

Today \`keeper_bash\` is gated to a docker container, but \`keeper_fs_read\` and \`keeper_shell\` execute as the host process. \`minjae\` (a docker_hardened keeper) was observed reading paths under \`/Users/dancer/...\` for that reason.

## Behavior

| Profile | Env flag | keeper_fs_read target outside playground |
|---------|----------|-----------------------------------------|
| Legacy_local | any | allowed (legacy semantics) |
| Docker_hardened / Docker_with_git | \`MASC_KEEPER_SYMMETRIC_SANDBOX=false\` (default) | allowed (legacy semantics) |
| Docker_hardened / Docker_with_git | \`MASC_KEEPER_SYMMETRIC_SANDBOX=true\` | **blocked** with \`symmetric_sandbox_blocked\` error pointing to \`keeper_shell op=git_clone\` |

Default off so existing hardened keepers keep working until operators opt in.

## Scope

In-scope: \`keeper_fs_read\` only.

Deferred:
- \`keeper_shell\` read-side ops (rg/ls/cat/find/...) → Phase B-1.5 (same containment, more wire points).
- Routing read through \`docker exec\` so the container's mount restrictions become the actual primary boundary → Phase B-2. This host-side guard remains as defense-in-depth.

## OAS boundary
Containment is a MASC-side decision. OAS sees the same tool surface either way; \`Tool.t\` definitions are unchanged.

## Files

| File | Change |
|---|---|
| \`lib/config/env_config_keeper.ml\` | New \`KeeperSandbox.symmetric_read_containment\` (env: \`MASC_KEEPER_SYMMETRIC_SANDBOX\`, default false). |
| \`lib/keeper/keeper_sandbox_containment.{ml,mli}\` | New module. Pure containment check; no-op when guard is inactive. |
| \`lib/keeper/keeper_exec_fs.ml\` | \`handle_keeper_fs_read\` invokes the check after path resolution and before file I/O. |
| \`test/test_keeper_sandbox_containment.ml\` | 6 tests pinning the behavior matrix. |

## Test plan
- [x] \`dune build --root . @check\` clean.
- [x] \`dune runtest test/test_keeper_sandbox_containment.exe\` — 6/6 pass.
- [x] \`dune runtest\` for adjacent suites (\`test_keeper_tool_alias\`, \`test_keeper_tools_oas\`, \`test_keeper_tool_exposure\`) — no regression.
- [ ] CI required checks green.
- [ ] Operator follow-up: opt minjae into the flag in production, monitor for \`symmetric_sandbox_blocked\` events to size the legitimate \`/Users/...\` reads it currently issues, then promote default to on.

## Manual smoke (post-merge)
1. \`MASC_KEEPER_SYMMETRIC_SANDBOX=true\` in the server env.
2. Have minjae issue \`Read /etc/passwd\` (via Bash alias if A.2 also merged, else \`keeper_fs_read path=/etc/passwd\`).
3. Confirm: tool result is structured error containing \`symmetric_sandbox_blocked\`; no host bytes returned.
4. Have minjae issue \`Read .masc/playground/minjae/mind/scratch.md\` (file may not exist; either way no containment error).

## Edge cases pinned by tests
- Legacy keeper bypass (Legacy_local profile).
- Flag-off passthrough.
- Block \`/etc/passwd\` for hardened keeper.
- Allow inside-playground path.
- \`Docker_with_git\` also contained (not just \`Docker_hardened\`).
- Lookalike sibling path \`<bundle>_evil/secret.txt\` blocked — defends against prefix-without-slash containment bypass.

## Stack
- #8853 RFC (MERGED)
- #8860 A.1 alias data module (MERGED)
- #8912 A.3 disclosure canonicalize (OPEN)
- #8929 A.2 OAS dual register (OPEN)
- **THIS PR** B-1 symmetric sandbox containment for fs_read

## Risk register
- **Default off**: PR ships disabled. Production behavior unchanged until \`MASC_KEEPER_SYMMETRIC_SANDBOX=true\` is set. Recommended rollout: enable on minjae's playground, observe one cycle, then promote.
- **Auto-merge race** (memory: \`masc-mcp auto-merge overrides Draft\`): runner may flip Draft→Ready and merge before review. The default-off design makes this acceptable.
- **Coverage gap**: \`keeper_shell\` read ops still walk the host. Phase B-1.5 follow-up tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)