### PR TITLE
docs(logic): batch-10 .mli for agent_health + masc_network_defaults

### DIFF
--- a/lib/agent_health.mli
+++ b/lib/agent_health.mli
@@ -1,0 +1,77 @@
+(** Agent Health — Autonomy-specific health gate over Circuit Breaker.
+
+    Wraps {!Circuit_breaker} with agent-name semantics for Keeper
+    Heartbeat. Agents with open breakers are skipped during tick
+    selection, preventing cascading failures from repeatedly invoking
+    failing agents.
+
+    Integration points:
+    - Pre-action: {!is_healthy} before [decide_agent_action]
+    - Post-action: {!record_success} / {!record_failure} after
+      [execute_agent_action]
+    - Statistics: {!get_summary} / {!get_all_summaries} for
+      dashboard/monitoring
+
+    @since 2.75.0 *)
+
+(** {1 Types} *)
+
+type health_status =
+  | Healthy
+  | Unhealthy of string  (** reason *)
+  | Recovering           (** half-open, testing *)
+  | Unknown of string
+      (** Issue #8607: unrecognised circuit-breaker state_name (carries
+          the raw value for diagnostics). Previously [_ -> Healthy]
+          silently masked future state additions and wire-format drift
+          as a green health signal. *)
+
+type agent_health_summary = {
+  agent_name : string;
+  status : health_status;
+  recent_failures : int;
+  cooldown_remaining_sec : int;
+}
+
+(** {1 Core API} *)
+
+(** [Healthy] / [Unhealthy reason] / [Recovering]. This function
+    currently never returns [Unknown] — that case is reserved for
+    {!get_summary} when [Circuit_breaker] exposes an unrecognised
+    [state_name]. *)
+val check_health : agent_name:string -> health_status
+
+(** Convenience predicate. Fail-closed: [Unhealthy] and [Unknown] map
+    to [false]; [Healthy] and [Recovering] map to [true]. *)
+val is_healthy : agent_name:string -> bool
+
+(** Record a successful action — clears half-open state. *)
+val record_success : agent_name:string -> unit
+
+(** Record a failed action — may open the breaker. *)
+val record_failure : agent_name:string -> reason:string -> unit
+
+(** {1 Batch Filtering} *)
+
+(** [filter_healthy agents] splits into [(healthy, skipped_with_reasons)].
+    [Unknown raw] is reported as ["unknown breaker state <raw>"]. *)
+val filter_healthy :
+  (string * 'a) list ->
+  (string * 'a) list * (string * string) list
+
+(** {1 Statistics} *)
+
+val get_summary : agent_name:string -> agent_health_summary
+
+val get_all_summaries : unit -> agent_health_summary list
+
+(** {1 JSON Serialization} *)
+
+(** Wire strings: ["healthy"] / ["unhealthy"] / ["recovering"] /
+    ["unknown"]. Issue #8607 introduced the dedicated ["unknown"] bucket
+    so dashboards can filter unrecognised states instead of mixing
+    them with green ones. *)
+val health_status_to_string : health_status -> string
+
+(** Shape: [{agent_name, status, recent_failures, cooldown_remaining_sec}]. *)
+val summary_to_json : agent_health_summary -> Yojson.Safe.t

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -1,0 +1,103 @@
+(** Network default constants — SSOT for ports and URLs.
+
+    All hardcoded network defaults live here. Other modules reference
+    these constants instead of inlining magic strings/numbers.
+
+    {!local_llm_default_url} follows the same env override chain that
+    OAS discovery uses before falling back to the current local runtime
+    URL.
+
+    @since 2.241.0 *)
+
+(** {1 Ollama defaults} *)
+
+(** Default port for Ollama (OpenAI-compatible at [/v1]). *)
+val ollama_default_port : int
+
+(** ["http://127.0.0.1:<ollama_default_port>"]. *)
+val ollama_default_url : string
+
+(** [":<ollama_default_port>"] — substring used by Ollama URL
+    heuristics. Anchored to {!ollama_default_port} so a port change
+    updates every classifier in one place. *)
+val ollama_port_needle : string
+
+(** Ollama native API path for the running-models ("process status")
+    endpoint. Used by {!Cascade_ollama_probe} and
+    {!Tool_local_runtime_probe}. *)
+val ollama_api_ps_path : string
+
+(** Ollama native API path for text generation. Used by the tool-level
+    probe path that exercises a model end-to-end. *)
+val ollama_api_generate_path : string
+
+(** Permissive substring check against {!ollama_port_needle}. Works
+    for [http://], [https://], [127.0.0.1], [localhost], or bare
+    [host:port]. *)
+val is_ollama_url : string -> bool
+
+(** {1 OpenAI-compatible API paths} *)
+
+(** [/v1/chat/completions]. *)
+val openai_chat_completions_path : string
+
+(** [/v1/models]. *)
+val openai_models_path : string
+
+(** {1 CLI sentinel transport} *)
+
+(** ["cli:"] — prefix marking a CLI-backed transport (e.g.
+    [cli:codex]). *)
+val cli_sentinel_prefix : string
+
+(** Strict prefix match for {!cli_sentinel_prefix}. *)
+val is_cli_sentinel_url : string -> bool
+
+(** {1 Local LLM URL} *)
+
+(** Override order:
+    [OAS_LOCAL_LLM_URL] → [OAS_LOCAL_QWEN_URL] → {!ollama_default_url}. *)
+val local_llm_default_url : string
+
+(** {1 MASC HTTP server} *)
+
+val masc_http_default_port : int
+
+(** String form of {!masc_http_default_port} for env-config fallback. *)
+val masc_http_default_port_s : string
+
+val masc_http_default_host : string
+
+(** {1 Loopback detection} *)
+
+(** Treats ["localhost"] (case-insensitive, trimmed) and any IPv4/IPv6
+    loopback literal as loopback. Unlike a prefix match, malformed
+    addresses return [false] (so ["127.invalid"] is rejected). *)
+val is_loopback_host : string -> bool
+
+(** Convenience for [Uri.host]-style inputs. [None] → [false]. *)
+val is_loopback_host_opt : string option -> bool
+
+(** {1 Vite dev frontend} *)
+
+val vite_dev_default_port : int
+
+(** Ordered [127.0.0.1 → localhost → [::1]] on {!vite_dev_default_port};
+    matches the historical CORS allowlist. *)
+val vite_dev_default_origins : string list
+
+(** {1 SearXNG & OpenTelemetry} *)
+
+val searxng_default_port : int
+
+val searxng_default_url : string
+
+val otel_default_port : int
+
+val otel_default_url : string
+
+(** {1 CORS / DNS rebinding allowlist} *)
+
+(** Allowed origins read by [server_routes_http_common.ml]. Update
+    here to add/remove CORS origins. *)
+val allowed_origins : string list


### PR DESCRIPTION
Wave 3 batch 10 — 2 pure .mli (agent_health / masc_network_defaults), body unchanged.

## 대상 파일

| 파일 | ml 줄수 | mli 줄수 | 성격 |
|------|---------|----------|------|
| `lib/agent_health.mli` | 158 | 76 | 2 types (health_status, agent_health_summary) + 9 vals |
| `lib/config/masc_network_defaults.mli` | 160 | 98 | 24 network default constants/helpers |

## 설계 노트

### agent_health
- Issue #8607 `Unknown` variant은 fail-closed semantic을 mli doc에 명시 (현재 `check_health`는 Unknown 안 내지만 `get_summary`가 냄).
- 내부 헬퍼 `health_status_of_breaker`, `cooldown_remaining_of` hide.
- 테스트 (test_agent_health.ml) 에서 4 constructor 전부 pattern match — variant 완전 노출 필수.

### masc_network_defaults
- SSOT 상수 24개 + 4 helper.
- Cascade / env_config / cli_sentinel 모듈 모두 이 SSOT 참조.
- `is_loopback_host`가 string prefix match 대신 `Ipaddr` 파싱으로 "127.invalid" 거부하는 안전성 doc 포함.

### 건너뛴 후보
- **autoresearch_codegen** (154): `include Autoresearch_types` → umbrella trap (Coord_state와 동일).

## 검증

- `dune build --root=.` → exit 0
- External consumer (agent_health: test/thompson_sampling; masc_network_defaults: cascade/env_config 다수) 컴파일 유지.

## Metric 이전/이후

| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` 파일 수 | 321 | **323** |
| Wave 3 진행 | ~21% | **+2 modules** |

## Anti-goal

- [x] ml 바디 수정 0
- [x] `include` umbrella 위험 회피
- [x] Public surface을 grep 기반으로 검증
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)