### PR TITLE
feat(legendary-bash): in-process shadow counters (Tick 25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ### Added
 
+- **Legendary Bash in-process shadow counters.**  New
+  `lib/legendary_counters.{ml,mli}` exposes `Atomic.t`-backed totals
+  for the P5 gate-diff observer (`total` + 4 buckets mirroring
+  `Worker_dev_tools.gate_diff` 1:1) and the P4 auto-background
+  observer (`observed` + `would_have_promoted`).  The counters are
+  incremented from the same sites that already emit
+  `gate_diff_shadow` / `auto_bg_would_have_promoted` log lines, so
+  the cost remains zero whenever the matching observer env flag is
+  off.  `snapshot_to_json` returns a stable field layout intended
+  for a later dashboard / HTTP endpoint.  5 unit tests
+  (`test_legendary_counters`).  No behavior change on the request
+  path.
+
 - **Legendary Bash operator runbook.**  New
   `docs/LEGENDARY-BASH-RUNBOOK.md` consolidates the P1–P6 rollout
   surface: current flag state table, authoritative opt-out tokens,

--- a/lib/dune
+++ b/lib/dune
@@ -186,6 +186,7 @@
    worker_container
    worker_container_runners
    worker_dev_tools
+   legendary_counters
    worker_tool_input
    worker_verification
    prompt_defaults

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -813,8 +813,18 @@ let handle_keeper_bash
        (Legacy_allow_shadow_deny) from real traffic without
        changing any behavior.  Flag-gated by
        [MASC_BASH_AST_SHADOW_LOG]; default off. *)
-    (if Worker_dev_tools.shadow_diff_log_enabled () then
+    (if Worker_dev_tools.shadow_diff_log_enabled () then begin
        let diff, legacy, shadow = Worker_dev_tools.diff_command cmd in
+       let counter_tag : Legendary_counters.gate_diff_tag =
+         match diff with
+         | Worker_dev_tools.Agree -> `Agree
+         | Worker_dev_tools.Legacy_allow_shadow_deny ->
+           `Legacy_allow_shadow_deny
+         | Worker_dev_tools.Legacy_deny_shadow_allow ->
+           `Legacy_deny_shadow_allow
+         | Worker_dev_tools.Shadow_cannot_parse -> `Shadow_cannot_parse
+       in
+       Legendary_counters.incr_gate_diff counter_tag;
        match diff with
        | Worker_dev_tools.Agree -> ()
        | _ ->
@@ -824,7 +834,8 @@ let handle_keeper_bash
            (Worker_dev_tools.cmd_hash_for_log cmd)
            (Worker_dev_tools.gate_diff_to_string diff)
            (Worker_dev_tools.legacy_verdict_to_tag legacy)
-           (Worker_dev_tools.shadow_verdict_to_tag shadow));
+           (Worker_dev_tools.shadow_verdict_to_tag shadow)
+     end);
     (* Resolve cwd early — needed for playground detection before validation. *)
     match resolve_keeper_shell_write_cwd ~config ~meta ~args with
     | Error e -> error_json e
@@ -1092,7 +1103,10 @@ let handle_keeper_bash
                       let budget_ms =
                         Masc_exec.Exec_run.default_budget_ms ()
                       in
-                      if duration_ms >= budget_ms then
+                      let promoted_candidate = duration_ms >= budget_ms in
+                      Legendary_counters.incr_auto_bg_observed
+                        ~promoted_candidate;
+                      if promoted_candidate then
                         Log.Keeper.info
                           "auto_bg_would_have_promoted keeper=%s \
                            cmd_hash=%s duration_ms=%d budget_ms=%d"

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -1,0 +1,75 @@
+type gate_diff_tag =
+  [ `Agree
+  | `Legacy_allow_shadow_deny
+  | `Legacy_deny_shadow_allow
+  | `Shadow_cannot_parse
+  ]
+
+let gate_diff_total = Atomic.make 0
+let gate_diff_agree = Atomic.make 0
+let gate_diff_legacy_allow_shadow_deny = Atomic.make 0
+let gate_diff_legacy_deny_shadow_allow = Atomic.make 0
+let gate_diff_shadow_cannot_parse = Atomic.make 0
+let auto_bg_observed = Atomic.make 0
+let auto_bg_would_have_promoted = Atomic.make 0
+
+let incr a = ignore (Atomic.fetch_and_add a 1)
+
+let incr_gate_diff tag =
+  incr gate_diff_total;
+  match tag with
+  | `Agree -> incr gate_diff_agree
+  | `Legacy_allow_shadow_deny -> incr gate_diff_legacy_allow_shadow_deny
+  | `Legacy_deny_shadow_allow -> incr gate_diff_legacy_deny_shadow_allow
+  | `Shadow_cannot_parse -> incr gate_diff_shadow_cannot_parse
+
+let incr_auto_bg_observed ~promoted_candidate =
+  incr auto_bg_observed;
+  if promoted_candidate then incr auto_bg_would_have_promoted
+
+let reset () =
+  Atomic.set gate_diff_total 0;
+  Atomic.set gate_diff_agree 0;
+  Atomic.set gate_diff_legacy_allow_shadow_deny 0;
+  Atomic.set gate_diff_legacy_deny_shadow_allow 0;
+  Atomic.set gate_diff_shadow_cannot_parse 0;
+  Atomic.set auto_bg_observed 0;
+  Atomic.set auto_bg_would_have_promoted 0
+
+type snapshot = {
+  gate_diff_total : int;
+  gate_diff_agree : int;
+  gate_diff_legacy_allow_shadow_deny : int;
+  gate_diff_legacy_deny_shadow_allow : int;
+  gate_diff_shadow_cannot_parse : int;
+  auto_bg_observed : int;
+  auto_bg_would_have_promoted : int;
+}
+
+let snapshot () =
+  {
+    gate_diff_total = Atomic.get gate_diff_total;
+    gate_diff_agree = Atomic.get gate_diff_agree;
+    gate_diff_legacy_allow_shadow_deny =
+      Atomic.get gate_diff_legacy_allow_shadow_deny;
+    gate_diff_legacy_deny_shadow_allow =
+      Atomic.get gate_diff_legacy_deny_shadow_allow;
+    gate_diff_shadow_cannot_parse =
+      Atomic.get gate_diff_shadow_cannot_parse;
+    auto_bg_observed = Atomic.get auto_bg_observed;
+    auto_bg_would_have_promoted = Atomic.get auto_bg_would_have_promoted;
+  }
+
+let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
+  `Assoc [
+    ("gate_diff_total", `Int s.gate_diff_total);
+    ("gate_diff_agree", `Int s.gate_diff_agree);
+    ("gate_diff_legacy_allow_shadow_deny",
+     `Int s.gate_diff_legacy_allow_shadow_deny);
+    ("gate_diff_legacy_deny_shadow_allow",
+     `Int s.gate_diff_legacy_deny_shadow_allow);
+    ("gate_diff_shadow_cannot_parse",
+     `Int s.gate_diff_shadow_cannot_parse);
+    ("auto_bg_observed", `Int s.auto_bg_observed);
+    ("auto_bg_would_have_promoted", `Int s.auto_bg_would_have_promoted);
+  ]

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -1,0 +1,51 @@
+(** In-process counters for the Legendary Bash dark-launch observers.
+
+    These counters are incremented only while the matching observer
+    env flag is enabled (see [Worker_dev_tools.shadow_diff_log_enabled]
+    and [MASC_BASH_AUTO_BG_OBSERVE] in [keeper_exec_shell]), so an
+    operator running with observers off pays zero cost.
+
+    All counters are [Atomic.t] and safe to increment from any fiber
+    or domain.  The module is a pure sidecar to the log-line stream:
+    flipping observers on produces both structured logs (for grep /
+    log aggregators) and in-memory totals (for dashboards / HTTP
+    snapshot endpoints). *)
+
+type gate_diff_tag =
+  [ `Agree
+  | `Legacy_allow_shadow_deny
+  | `Legacy_deny_shadow_allow
+  | `Shadow_cannot_parse
+  ]
+(** Categorical buckets mirroring [Worker_dev_tools.gate_diff] 1:1.
+    [`Agree] is recorded even though it is not logged, so the
+    denominator for "disagree rate" is observable. *)
+
+val incr_gate_diff : gate_diff_tag -> unit
+(** Record one P5 shadow-gate call under the given bucket.  Always
+    increments [gate_diff_total] in the snapshot. *)
+
+val incr_auto_bg_observed : promoted_candidate:bool -> unit
+(** Record one P4 foreground-only call that the observer inspected.
+    When [promoted_candidate] is [true] the elapsed duration would
+    have tripped [MASC_BLOCKING_BUDGET_MS]. *)
+
+val reset : unit -> unit
+(** Zero every counter.  Used by tests; operators should not rely on
+    this surface. *)
+
+type snapshot = {
+  gate_diff_total : int;
+  gate_diff_agree : int;
+  gate_diff_legacy_allow_shadow_deny : int;
+  gate_diff_legacy_deny_shadow_allow : int;
+  gate_diff_shadow_cannot_parse : int;
+  auto_bg_observed : int;
+  auto_bg_would_have_promoted : int;
+}
+
+val snapshot : unit -> snapshot
+
+val snapshot_to_json : snapshot -> Yojson.Safe.t
+(** Stable JSON shape for dashboard / HTTP consumers.  Field names
+    mirror the record labels exactly. *)

--- a/test/dune
+++ b/test/dune
@@ -321,6 +321,7 @@
         test_shadow_parse
         test_destructive_class
         test_gate_diff
+        test_legendary_counters
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge
@@ -482,6 +483,7 @@
         test_shadow_parse
         test_destructive_class
         test_gate_diff
+        test_legendary_counters
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge

--- a/test/test_legendary_counters.ml
+++ b/test/test_legendary_counters.ml
@@ -1,0 +1,88 @@
+open Masc_mcp
+
+let test_initial_zero () =
+  Legendary_counters.reset ();
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "gate_diff_total" 0 s.gate_diff_total;
+  Alcotest.(check int) "gate_diff_agree" 0 s.gate_diff_agree;
+  Alcotest.(check int)
+    "gate_diff_legacy_allow_shadow_deny" 0 s.gate_diff_legacy_allow_shadow_deny;
+  Alcotest.(check int)
+    "gate_diff_legacy_deny_shadow_allow" 0 s.gate_diff_legacy_deny_shadow_allow;
+  Alcotest.(check int)
+    "gate_diff_shadow_cannot_parse" 0 s.gate_diff_shadow_cannot_parse;
+  Alcotest.(check int) "auto_bg_observed" 0 s.auto_bg_observed;
+  Alcotest.(check int)
+    "auto_bg_would_have_promoted" 0 s.auto_bg_would_have_promoted
+
+let test_gate_diff_buckets () =
+  Legendary_counters.reset ();
+  Legendary_counters.incr_gate_diff `Agree;
+  Legendary_counters.incr_gate_diff `Agree;
+  Legendary_counters.incr_gate_diff `Legacy_allow_shadow_deny;
+  Legendary_counters.incr_gate_diff `Legacy_deny_shadow_allow;
+  Legendary_counters.incr_gate_diff `Shadow_cannot_parse;
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "total = 5" 5 s.gate_diff_total;
+  Alcotest.(check int) "agree = 2" 2 s.gate_diff_agree;
+  Alcotest.(check int)
+    "legacy_allow_shadow_deny = 1" 1 s.gate_diff_legacy_allow_shadow_deny;
+  Alcotest.(check int)
+    "legacy_deny_shadow_allow = 1" 1 s.gate_diff_legacy_deny_shadow_allow;
+  Alcotest.(check int)
+    "shadow_cannot_parse = 1" 1 s.gate_diff_shadow_cannot_parse
+
+let test_auto_bg_observed () =
+  Legendary_counters.reset ();
+  Legendary_counters.incr_auto_bg_observed ~promoted_candidate:false;
+  Legendary_counters.incr_auto_bg_observed ~promoted_candidate:false;
+  Legendary_counters.incr_auto_bg_observed ~promoted_candidate:true;
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "auto_bg_observed = 3" 3 s.auto_bg_observed;
+  Alcotest.(check int)
+    "auto_bg_would_have_promoted = 1" 1 s.auto_bg_would_have_promoted
+
+let test_snapshot_json_shape () =
+  Legendary_counters.reset ();
+  Legendary_counters.incr_gate_diff `Legacy_allow_shadow_deny;
+  Legendary_counters.incr_auto_bg_observed ~promoted_candidate:true;
+  let json =
+    Legendary_counters.snapshot_to_json (Legendary_counters.snapshot ())
+  in
+  (* Serialize and check stable field presence. *)
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "has gate_diff_total" true
+    (Astring.String.is_infix ~affix:"\"gate_diff_total\":1" s);
+  Alcotest.(check bool)
+    "has legacy_allow_shadow_deny" true
+    (Astring.String.is_infix
+       ~affix:"\"gate_diff_legacy_allow_shadow_deny\":1" s);
+  Alcotest.(check bool)
+    "has auto_bg_would_have_promoted" true
+    (Astring.String.is_infix
+       ~affix:"\"auto_bg_would_have_promoted\":1" s)
+
+let test_reset () =
+  Legendary_counters.incr_gate_diff `Agree;
+  Legendary_counters.incr_auto_bg_observed ~promoted_candidate:true;
+  Legendary_counters.reset ();
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "post-reset total" 0 s.gate_diff_total;
+  Alcotest.(check int) "post-reset auto_bg_observed" 0 s.auto_bg_observed;
+  Alcotest.(check int)
+    "post-reset would_have_promoted" 0 s.auto_bg_would_have_promoted
+
+let () =
+  Alcotest.run "legendary_counters"
+    [
+      ( "basic",
+        [
+          Alcotest.test_case "initial zero" `Quick test_initial_zero;
+          Alcotest.test_case "gate_diff buckets" `Quick test_gate_diff_buckets;
+          Alcotest.test_case "auto_bg observed" `Quick test_auto_bg_observed;
+          Alcotest.test_case "snapshot JSON shape" `Quick
+            test_snapshot_json_shape;
+          Alcotest.test_case "reset" `Quick test_reset;
+        ] );
+    ]


### PR DESCRIPTION
## Product impact

Operators running the Legendary Bash dark-launch observers (P5
`MASC_BASH_AST_SHADOW_LOG` and P4 `MASC_BASH_AUTO_BG_OBSERVE`) now have
in-memory counters alongside the existing structured log stream. This is
the data-layer prerequisite for a dashboard / HTTP snapshot endpoint
that removes the need to `grep` log files when deciding whether to flip
`MASC_BASH_AST_ONLY` / `MASC_BASH_AUTO_BG`. No route is exposed in this
PR — that split is intentional, per the RUNBOOK (#8918) "measurement
first, exposure later" rule.

## Evidence

- `lib/legendary_counters.{ml,mli}` (new, 107 lines) — `Atomic.t`
  counters + `snapshot` record + stable-shape `snapshot_to_json`.
- `lib/legendary_counters` added to `lib/dune`.
- `lib/keeper/keeper_exec_shell.ml` — increments inside the two
  existing observer branches; counters stay at zero when both observer
  env flags are unset (cost-free for operators who haven't turned
  observers on).
- `test/test_legendary_counters.ml` (new) — 5 tests: initial-zero,
  4-bucket gate_diff, auto_bg observed/promoted, snapshot JSON field
  shape, reset. Registered in `test/dune`.

Local `dune exec test/test_legendary_counters.exe --root .` → 5/5 OK
in 0.001s.

## Review evidence

- Counter tags mirror `Worker_dev_tools.gate_diff` variants 1:1
  (verified against `lib/worker_dev_tools.ml:1664` and
  `:1719`). No second mapping layer to drift.
- `Atomic.fetch_and_add` chosen over `ref + Mutex` because counters
  are hot-path side-effects from any fiber/domain. OCaml 5 `Atomic`
  primitive is lock-free and domain-safe.
- `reset ()` is test-only surface; unused in production.
- `snapshot_to_json` field names mirror the record labels, so a
  future HTTP consumer can deserialize via Yojson without a hand-
  rolled schema.

## Linked issue

Refs #8906 (P4 AUTO_BG observer), #8902 (P5 AST_SHADOW_LOG observer),
#8918 (runbook that describes both observers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)