### PR TITLE
docs(keeper_state_machine): correct derive_phase priority list (FSM doc drift)

### DIFF
--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -249,20 +249,32 @@ val transition_error_to_string : transition_error -> string
 (** Derive phase from conditions. Pure, priority-ordered.
     This is the SOLE function that determines keeper phase.
 
-    Priority (first match wins):
-    1.  Dead (terminal)
-    2.  Stopped (stop_requested + drain_complete)
-    3.  Offline (launch_pending before first fiber start)
-    4.  Restarting (fiber dead + budget + backoff elapsed)
-    5.  Crashed (fiber dead + budget remaining)
-    6.  Draining (stop_requested)
-    7.  Guardrail -> Failing
+    Priority (first match wins) — mirrors the [DerivePhase] action in
+    [specs/keeper-state-machine/KeeperStateMachine.tla]:
+    1.  Stopped (stop_requested + drain_complete + ~compaction_active +
+                 ~handoff_active)
+        -- Checked first because a clean drain wins even if the fiber
+        subsequently exits.  Buffer-state guards prevent a TLC deadlock
+        where Stopped is entered while compaction/handoff is still in
+        flight (see comment on [keeper_state_machine.ml:derive_phase]).
+    2.  Offline (launch_pending + ~fiber_alive) -- pre-start registration
+    3.  Dead (~fiber_alive + ~restart_budget_remaining) -- terminal
+    4.  Restarting (~fiber_alive + budget + backoff_elapsed)
+    5.  Crashed (~fiber_alive + budget remaining)
+    6.  Draining (stop_requested) -- in-progress stop
+    7.  Failing (guardrail_triggered)
     8.  Paused (operator_paused OR context_overflow + compact_retry_exhausted)
     9.  HandingOff (handoff_active)
     10. Compacting (compaction_active)
-    11. Overflowed (context_overflow AND NOT compaction_active)
-    12. Failing (heartbeat degraded, turn degraded, or manual reconcile required)
-    13. Running (fiber_alive) *)
+    11. Overflowed (context_overflow) -- transient, auto-compact pending
+    12. Failing (~heartbeat_healthy OR ~turn_healthy)
+    13. Running (fiber_alive)
+    14. Offline (default fallback for inconsistent zero-state)
+
+    Drift note: prior to this revision the docstring listed Dead as
+    priority 1; the actual implementation has always checked Stopped
+    first (the TLA+ spec agrees).  The order above is the ground truth
+    enforced by [keeper_state_machine.ml] and TLC. *)
 val derive_phase : conditions -> phase
 
 (** Pure condition updater: given current conditions and an event,


### PR DESCRIPTION
## Summary
- The \`keeper_state_machine.mli\` docstring for \`derive_phase\` listed phases in the **wrong priority order**.
- Caught while comparing OCaml implementation, .mli docstring, and TLA+ spec for #8605-family-adjacent drift.

## The drift
- **Docstring claimed**: \`1. Dead (terminal)\` first.
- **Actual implementation** (\`keeper_state_machine.ml:331\`): \`Stopped\` first (with \`~compaction_active && ~handoff_active\` guards).
- **TLA+ spec** (\`specs/keeper-state-machine/KeeperStateMachine.tla:DerivePhase\`): \`Stopped\` first, identical guards.
- TLA+ and OCaml impl agree; only the .mli was wrong.

## Why this matters
A reviewer reading the .mli to reason about phase transitions would build the wrong mental model — they would assume Dead is checked before Stopped, which would mislead any change to the lifecycle. The TLA+ spec found a real deadlock here in the past (the buffer-state guards on Stopped were added to resolve a TLC counterexample); having the docstring contradict that fix would cause the same bug to be re-introduced confidently.

## Changes
- Replace the priority list with the order actually enforced by the implementation.
- Add buffer-state guard documentation for Stopped (priority 1).
- Split Failing into the two priorities it actually occupies (guardrail vs. health).
- Add the default Offline fallback (priority 14).
- Cross-reference the TLA+ spec module.

## Test plan
- [x] Documentation only — no code, no test, no behaviour change.
- [x] \`dune build lib/keeper\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)