### PR TITLE
fix(cascade): resolve gemini_cli:auto → gemini-3-flash-preview

### DIFF
--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -63,13 +63,23 @@ let resolve_auto_model_id provider_name model_id =
     else model_id
   | "glm" -> resolve_glm_model_id model_id
   | "glm-coding" -> resolve_glm_coding_model_id model_id
-  | "gemini" ->
+  | "gemini" | "gemini_cli" ->
     (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview on
        2026-04-16 (PR C Cadd follow-up). Capabilities are inherited via
        the `starts_with "gemini-3"` prefix matcher in
        oas/lib/llm_provider/capabilities.ml:269 (1M context, tools,
        parallel tool calls). Override with GEMINI_DEFAULT_MODEL if you
-       still need the 2.5 line. *)
+       still need the 2.5 line.
+
+       2026-04-20: `gemini_cli` joined the same branch. Without this,
+       `gemini_cli:auto` fell through to the wildcard tail and was
+       forwarded as the literal string "auto" into OAS.
+       `oas/lib/llm_provider/transport_gemini_cli.build_args` then
+       omits `--model`, so the gemini CLI chose its internal default —
+       `gemini-3.1-pro-preview` — whose quota is small enough that every
+       fleet call 429'd with `MODEL_CAPACITY_EXHAUSTED`. Mapping to
+       `gemini-3-flash-preview` (higher quota, 1M context, tool calls)
+       restores throughput. *)
     if model_id = "auto" then env_or "gemini-3-flash-preview" "GEMINI_DEFAULT_MODEL"
     else model_id
   | "claude" ->

--- a/test/dune
+++ b/test/dune
@@ -693,6 +693,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_cascade_model_resolve)
+ (modules test_cascade_model_resolve)
+ (libraries masc_test_deps unix))
+
+(test
  (name test_dashboard_tla_specs)
  (modules test_dashboard_tla_specs)
  (libraries masc_test_deps))

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -1,0 +1,68 @@
+(** Unit tests for Cascade_model_resolve.resolve_auto_model_id.
+
+    Focus: "auto" → concrete model ID translation for cloud providers.
+    2026-04-20 regression guard — `gemini_cli:auto` used to fall
+    through to the wildcard tail and reach OAS as the literal string
+    "auto". OAS transport_gemini_cli.build_args then omits --model,
+    letting the Gemini CLI choose its own default (gemini-3.1-pro-preview)
+    whose quota 429'd the fleet. *)
+
+open Alcotest
+module R = Masc_mcp.Cascade_model_resolve
+
+let unset_env k =
+  try Unix.putenv k "" with _ -> ()
+
+let with_clean_env f =
+  List.iter unset_env [
+    "GEMINI_DEFAULT_MODEL";
+    "ANTHROPIC_DEFAULT_MODEL";
+    "OPENAI_DEFAULT_MODEL";
+    "OPENROUTER_DEFAULT_MODEL";
+    "OLLAMA_DEFAULT_MODEL";
+  ];
+  f ()
+
+let test_gemini_auto_maps_to_flash_preview () =
+  with_clean_env (fun () ->
+    let resolved = R.resolve_auto_model_id "gemini" "auto" in
+    check string "gemini:auto → gemini-3-flash-preview"
+      "gemini-3-flash-preview" resolved)
+
+let test_gemini_cli_auto_maps_to_flash_preview () =
+  with_clean_env (fun () ->
+    let resolved = R.resolve_auto_model_id "gemini_cli" "auto" in
+    check string "gemini_cli:auto → gemini-3-flash-preview"
+      "gemini-3-flash-preview" resolved)
+
+let test_gemini_cli_explicit_model_passthrough () =
+  with_clean_env (fun () ->
+    let resolved =
+      R.resolve_auto_model_id "gemini_cli" "gemini-2.5-flash"
+    in
+    check string "explicit model untouched"
+      "gemini-2.5-flash" resolved)
+
+let test_gemini_env_override () =
+  Unix.putenv "GEMINI_DEFAULT_MODEL" "gemini-2.5-flash";
+  let resolved_gemini = R.resolve_auto_model_id "gemini" "auto" in
+  let resolved_cli = R.resolve_auto_model_id "gemini_cli" "auto" in
+  Unix.putenv "GEMINI_DEFAULT_MODEL" "";
+  check string "gemini respects env override"
+    "gemini-2.5-flash" resolved_gemini;
+  check string "gemini_cli respects same env override"
+    "gemini-2.5-flash" resolved_cli
+
+let () =
+  run "Cascade_model_resolve" [
+    "gemini auto", [
+      test_case "gemini:auto"
+        `Quick test_gemini_auto_maps_to_flash_preview;
+      test_case "gemini_cli:auto (regression 2026-04-20)"
+        `Quick test_gemini_cli_auto_maps_to_flash_preview;
+      test_case "gemini_cli explicit"
+        `Quick test_gemini_cli_explicit_model_passthrough;
+      test_case "GEMINI_DEFAULT_MODEL env override"
+        `Quick test_gemini_env_override;
+    ];
+  ]


### PR DESCRIPTION
## Summary

`gemini_cli:auto` was not handled by `resolve_auto_model_id`'s provider-name match — it fell through the wildcard tail and reached OAS as the literal string `"auto"`. OAS `transport_gemini_cli.build_args` then omits `--model` entirely, letting the Gemini CLI pick its own default (`gemini-3.1-pro-preview`, tiny preview quota). Every fleet call via `gemini_cli:auto` 429'd with `MODEL_CAPACITY_EXHAUSTED`.

Widen the `"gemini"` arm to `"gemini" | "gemini_cli"` so both prefixes resolve `"auto"` → `gemini-3-flash-preview` (higher quota, 1M context, tool calls).

## Product impact

2026-04-20 12:14Z verdict keeper startup:

```
+[gemini stderr] Attempt 1 failed with status 429 ... gemini-3.1-pro-preview
+[gemini stderr] Attempt 2 failed with status 429 ... gemini-3.1-pro-preview
```

Single-provider retry loop — no fallback because the cascade had no flash inventory. Fix restores the intended 3-CLI diversity (claude_code / codex_cli / gemini_cli → flash).

## Evidence

- `lib/cascade/cascade_model_resolve.ml:66` — match arm widened
- `lib/cascade/cascade_config.ml:57` — `provider_name` is lowercase from `"gemini_cli:auto".split(":")[0]`, confirming the match targets the right string
- OAS `transport_gemini_cli.ml:103-107` omits `--model` when string is `"auto"` or empty — consumer side unchanged

## Review evidence

- `dune build --root . lib/cascade` — OK
- `dune exec --root . test/test_cascade_model_resolve.exe` — 4/4 pass
  - `gemini:auto` → `gemini-3-flash-preview` (existing behaviour guard)
  - `gemini_cli:auto` → `gemini-3-flash-preview` (regression guard, 2026-04-20)
  - `gemini_cli:gemini-2.5-flash` (explicit) → unchanged
  - `GEMINI_DEFAULT_MODEL` env override honoured for both prefixes

## Linked issue

Refs `~/me/.masc/logs/system_log_2026-04-20.jsonl` verdict keeper 429 trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)