### PR TITLE
feat(dashboard-bonsai): /dashboard/b/api/keepers/summary stub endpoint

### DIFF
--- a/lib/dashboard_api_types/dune
+++ b/lib/dashboard_api_types/dune
@@ -2,7 +2,6 @@
 (library
  (name masc_dashboard_api_types)
  (public_name masc_mcp.masc_dashboard_api_types)
- (wrapped false)
  (modules keepers)
  (libraries yojson)
  (preprocess (pps ppx_deriving_yojson)))

--- a/lib/dune
+++ b/lib/dune
@@ -812,6 +812,9 @@
    masc_mcp.config
    ;; Dashboard utilities (extracted sub-library)
    masc_mcp.dashboard_utils
+   ;; Dashboard API wire contracts (extracted sub-library)
+   ;; Shared typed JSON contracts between OCaml handlers and Bonsai island.
+   masc_mcp.masc_dashboard_api_types
    ;; Team session types removed (Epic #6107)
    ;; MCP tool schema cluster (extracted sub-library)
    masc_mcp.tool_schemas

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -331,6 +331,96 @@ let bonsai_index_html () =
 let serve_bonsai_index _request reqd =
   Http.Response.html (bonsai_index_html ()) reqd
 
+(** [GET /dashboard/b/api/keepers/summary] — projection consumed by
+    Bonsai focus card / roster / swimlane / context pressure chart.
+    Currently returns a static 4-keeper mock that mirrors what the
+    logs_view renders statically. Will be wired to Keeper_status_bridge
+    + cycle trace in a follow-up PR. *)
+let iso8601_utc_now () =
+  let open Unix in
+  let t = gmtime (gettimeofday ()) in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
+    t.tm_hour t.tm_min t.tm_sec
+
+let keepers_summary_mock () : Masc_dashboard_api_types.Keepers.response =
+  let module K = Masc_dashboard_api_types.Keepers in
+  let frames xs =
+    List.map (fun (kind, left, width, label) ->
+      K.{ kind; left; width; label }) xs
+  in
+  let ctx xs =
+    List.map (fun (t_minus_min, ctx_pct) ->
+      K.{ t_minus_min; ctx_pct }) xs
+  in
+  let luna = K.{
+    name = "luna";
+    stat = "reading";
+    status = Live;
+    ctx_pct = 38;
+    turn = 47;
+    turn_cap = 60;
+    mem_kb = 128;
+    latency_ms = 812;
+    last_tool = Some "llm";
+    lane_frames = frames [
+      ("llm",   5, 18, "llm");
+      ("tool", 28, 10, "read");
+      ("think",42,  8, "think");
+      ("llm",  54, 22, "llm");
+      ("tool", 80, 14, "edit");
+    ];
+    ctx_history = ctx [ (60, 38); (48, 40); (36, 37); (24, 40); (12, 42); (0, 38) ];
+  } in
+  let brass_owl = { luna with
+    K.name = "brass-owl"; stat = "retrying"; status = Warn;
+    ctx_pct = 67; turn = 39; mem_kb = 92; latency_ms = 1420;
+    last_tool = Some "fetch";
+    lane_frames = frames [
+      ("llm",   3, 20, "llm");
+      ("tool", 26, 12, "fetch");
+      ("wait", 40, 24, "wait");
+      ("tool", 66, 10, "fetch");
+    ];
+    ctx_history = ctx [ (60, 40); (48, 46); (36, 52); (24, 58); (12, 62); (0, 67) ];
+  } in
+  let moth = { luna with
+    K.name = "moth"; stat = "idle · listening"; status = Live;
+    ctx_pct = 12; turn = 8; mem_kb = 14; latency_ms = 220;
+    last_tool = Some "wait";
+    lane_frames = frames [
+      ("wait",  0, 40, "wait");
+      ("llm",  42, 14, "llm");
+      ("wait", 58, 40, "wait");
+    ];
+    ctx_history = ctx [ (60, 10); (48, 11); (36, 10); (24, 12); (12, 12); (0, 12) ];
+  } in
+  let ash_hound = { luna with
+    K.name = "ash-hound"; stat = "crashed t-34"; status = Dead;
+    ctx_pct = 95; turn = 22; mem_kb = 64; latency_ms = 0;
+    last_tool = Some "err";
+    lane_frames = frames [
+      ("llm",   2, 18, "llm");
+      ("tool", 22,  8, "exec");
+      ("err",  32,  6, "err");
+    ];
+    ctx_history = ctx [ (60, 45); (48, 65); (36, 85); (34, 95) ];
+  } in
+  K.{
+    keepers = [ luna; brass_owl; moth; ash_hound ];
+    cycle = 4;
+    room = Some "chronicle";
+    generated_at = iso8601_utc_now ();
+  }
+
+let bonsai_api_keepers_summary request reqd =
+  let resp = keepers_summary_mock () in
+  let body =
+    Yojson.Safe.to_string
+      (Masc_dashboard_api_types.Keepers.response_to_yojson resp)
+  in
+  respond_public_read_json request reqd body
+
 let serve_bonsai_static name request reqd =
   let path = Filename.concat (bonsai_asset_root ()) name in
   match read_file path with

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -122,6 +122,12 @@ let add_routes ~port ~host router =
            else
              Http.Response.not_found reqd
          ) request reqd)
+  (* Bonsai API — must precede the /dashboard/b/ SPA catchall. *)
+  |> Http.Router.get "/dashboard/b/api/keepers/summary"
+       (fun request reqd ->
+         with_public_read (fun _state req reqd ->
+           bonsai_api_keepers_summary req reqd
+         ) request reqd)
   |> Http.Router.get "/dashboard/b" (fun request reqd ->
        with_canonical_loopback_host ~port
          (fun request reqd ->


### PR DESCRIPTION
## Summary

`Keepers` 계약의 첫 소비자 — `GET /dashboard/b/api/keepers/summary`를 stub mock으로 노출. Bonsai 클라이언트(follow-up PR)가 **focus card · roster · swimlane · context pressure** 4개 view를 이 한 endpoint로 live 전환할 예정.

> **Stack base**: `feature/dashboard-api-types-keepers` (#8940). #8940 merge 시 자동 승격.

## 구현

### 신규 핸들러 (`server_routes_http_pages.ml`)

- `iso8601_utc_now ()` — `generated_at` 필드용
- `keepers_summary_mock ()` — 4 keeper static record (logs_view의 기존 mock과 동일 수치)
  - **luna** (Live, reading, 38% / 47t / 128kb / 812ms) — 5 lane frames, 6 ctx samples
  - **brass-owl** (Warn, retrying, 67% / 39t / 92kb / 1420ms) — 4 lane frames, ctx 상승 곡선
  - **moth** (Live, idle, 12% / 8t / 14kb / 220ms) — 3 lane frames, flat ctx
  - **ash-hound** (Dead, crashed t-34, 95% / 22t / 64kb / 0ms) — 3 frames ending in `err`
- `bonsai_api_keepers_summary` — `respond_public_read_json` 사용 (CORS + public read)

### 신규 라우트 (`server_routes_http_routes_frontend.ml`)

```ocaml
|> Http.Router.get "/dashboard/b/api/keepers/summary" (…)
(* 반드시 /dashboard/b/ prefix SPA catchall 앞에 위치 — 뒤에 오면 HTML 반환 *)
```

### `lib/dune` 변경

- `masc_mcp.masc_dashboard_api_types` 라이브러리 의존 추가 (wrapped=true default — `Masc_dashboard_api_types.Keepers` 접근)

## Follow-up

- **다음 PR**: `dashboard_bonsai/src/keepers_{types,var,fetch}.ml` + `logs_view.ml`의 focus card / swimlane / ctx chart / roster를 `Keepers` 데이터로 연결
- **그 다음**: mock → `Keeper_status_bridge` + cycle trace buffer 실 데이터 소스 연결

## Test plan

- [x] `dune build @check` — 타입체크 통과
- [ ] 머지 후 `curl -s http://localhost:<port>/dashboard/b/api/keepers/summary | jq '.keepers | length'` → `4`
- [ ] `jq '.keepers[0]'` → luna 전체 구조 (status=Live, lane_frames ≥1, ctx_history ≥1)
- [ ] `jq '.keepers[3].status'` → `"Dead"` (ash-hound)
- [ ] `generated_at` ISO-8601 UTC 포맷

🤖 Generated with [Claude Code](https://claude.com/claude-code)
