### PR TITLE
docs(spec): annotate Continuity_observed Escalated-path modelling gap (#8946)

### DIFF
--- a/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
@@ -36,6 +36,17 @@
 \* and lives in sibling specs (KeeperStateMachine, KeeperContextLifecycle).
 \* Adding a new keeper lifecycle phase does NOT require updating this
 \* spec; adding a new campaign phase DOES.
+\*
+\* Known modelling gap (issue #8946): [ContinuityObserved] models only the
+\* SUCCESS outcome.  The OCaml impl (apply_event at
+\* lib/keeper/keeper_campaign_fsm.ml:336-368) ALSO transitions to
+\* [Escalated] when goal_matches / task_matches / lifecycle_evidence /
+\* target_reached fail, with a textual reason.  TLC therefore cannot
+\* reach Escalated via the Continuity_observed path; only via
+\* [ErrorObserved].  Any safety/liveness property about the Escalated
+\* outcome from this entry point is currently unverified by the model.
+\* See issue #8946 for the proposed [ContinuityObservedInsufficientEvidence]
+\* sibling action and reason invariant.
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- Caught a real **TLA spec / OCaml impl drift** during the FSM cross-check sweep.
- Spec \`KeeperCampaignLifecycle.tla\`'s \`ContinuityObserved\` action models only the success transition; the OCaml impl has a parallel Escalated transition for the same event when payload predicates fail.
- Filed full proposed fix as **issue #8946** (sibling action + reason invariant + TLC re-verification).
- This PR is the minimal preamble-only ack so the gap is visible to future spec readers immediately.

## What this PR does
- Adds a 'Known modelling gap' note to the spec preamble pointing to issue #8946 and to the OCaml file/lines.
- No action change, no \`Next\` change, no \`.cfg\` change → no TLC re-run required.

## What this PR does NOT do
- Add the \`ContinuityObservedInsufficientEvidence\` action — that requires modelling \`goal_matches\` / \`task_matches\` as choosable variables and re-verifying both clean and \`-buggy\` cfgs. Tracked in #8946.

## Test plan
- [x] No code change — pure spec-comment edit.
- [x] No \`.cfg\` change — TLC behaviour identical.

## Refs
- #8946 (umbrella issue with full fix proposal)
- #8642 family (OCaml ↔ TLA mapping work)
- #8942 (sibling drift fix in the \`derive_phase\` priority docstring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)