### PR TITLE
feat(attempt_state): shared retry/attempt record (#8930 phase 1)

### DIFF
--- a/lib/attempt_state.ml
+++ b/lib/attempt_state.ml
@@ -1,0 +1,129 @@
+type result =
+  | Start_dispatched
+  | Failed of { reason : string }
+  | Timed_out
+
+let result_to_string = function
+  | Start_dispatched -> "start_dispatched"
+  | Failed _ -> "failed"
+  | Timed_out -> "timed_out"
+
+let result_of_string_opt = function
+  | "start_dispatched" -> Some Start_dispatched
+  | "failed" -> Some (Failed { reason = "" })
+  | "timed_out" -> Some Timed_out
+  | _ -> None
+
+type t = {
+  generation : int;
+  attempt_number : int;
+  attempt_id : string;
+  last_result : result;
+  next_retry_unix : float option;
+  updated_unix : float;
+}
+
+let make_next ~now ~backoff_seconds ~generation ~last_result ~previous =
+  let attempt_number =
+    match previous with
+    | Some p when p.generation = generation -> p.attempt_number + 1
+    | _ -> 1
+  in
+  {
+    generation;
+    attempt_number;
+    attempt_id = Printf.sprintf "%d:%d" generation attempt_number;
+    last_result;
+    next_retry_unix = Some (now +. backoff_seconds);
+    updated_unix = now;
+  }
+
+let is_backoff_active ~now t =
+  match t.next_retry_unix with
+  | Some deadline -> deadline > now
+  | None -> false
+
+let to_json t =
+  let failure_reason =
+    match t.last_result with
+    | Failed { reason } -> `String reason
+    | Start_dispatched | Timed_out -> `Null
+  in
+  let next_retry =
+    match t.next_retry_unix with
+    | Some v -> `Float v
+    | None -> `Null
+  in
+  `Assoc
+    [
+      ("generation", `Int t.generation);
+      ("attempt_number", `Int t.attempt_number);
+      ("attempt_id", `String t.attempt_id);
+      ("last_result", `String (result_to_string t.last_result));
+      ("failure_reason", failure_reason);
+      ("next_retry_unix", next_retry);
+      ("updated_unix", `Float t.updated_unix);
+    ]
+
+let int_of_json = function
+  | `Int n -> Some n
+  | _ -> None
+
+let string_of_json = function
+  | `String s -> Some s
+  | _ -> None
+
+let float_of_json = function
+  | `Float f -> Some f
+  | `Int n -> Some (float_of_int n)
+  | _ -> None
+
+let optional_float_of_json = function
+  | `Null -> Some None
+  | `Float f -> Some (Some f)
+  | `Int n -> Some (Some (float_of_int n))
+  | _ -> None
+
+let of_json = function
+  | `Assoc fields ->
+      let ( let* ) = Option.bind in
+      let* generation = List.assoc_opt "generation" fields |> Option.map int_of_json |> Option.join in
+      let* attempt_number =
+        List.assoc_opt "attempt_number" fields |> Option.map int_of_json |> Option.join
+      in
+      let* attempt_id =
+        List.assoc_opt "attempt_id" fields |> Option.map string_of_json |> Option.join
+      in
+      let* last_result_token =
+        List.assoc_opt "last_result" fields |> Option.map string_of_json |> Option.join
+      in
+      let* last_result_base = result_of_string_opt last_result_token in
+      let last_result =
+        match last_result_base with
+        | Failed _ ->
+            let reason =
+              match List.assoc_opt "failure_reason" fields with
+              | Some (`String s) -> s
+              | _ -> ""
+            in
+            Failed { reason }
+        | Start_dispatched | Timed_out -> last_result_base
+      in
+      let* next_retry_unix =
+        match List.assoc_opt "next_retry_unix" fields with
+        | Some v -> optional_float_of_json v
+        | None -> Some None
+      in
+      let* updated_unix =
+        List.assoc_opt "updated_unix" fields |> Option.map float_of_json |> Option.join
+      in
+      Some
+        {
+          generation;
+          attempt_number;
+          attempt_id;
+          last_result;
+          next_retry_unix;
+          updated_unix;
+        }
+  | _ -> None

--- a/lib/attempt_state.mli
+++ b/lib/attempt_state.mli
@@ -1,0 +1,54 @@
+(** Shared retry/attempt state for reconcile-style surfaces.
+
+    Purpose: a single record + backoff predicate reused by surfaces that
+    today reimplement their own [attempt_record] / [last_attempt_*] fields
+    (sidecar lifecycle routes, voice bridge, dashboard cache). See #8930
+    for the consolidation trail.
+
+    Boundary rules:
+    - Internal state is [float] (seconds-since-epoch). ISO serialization is
+      a boundary-only concern; callers must not compare wire strings.
+    - [result] is a closed variant, not a string. [result_of_string] is a
+      sound-partial parser (returns [None] on unknown input) to avoid the
+      #8605 family of silent-default decoders. *)
+
+type result =
+  | Start_dispatched
+  | Failed of { reason : string }
+  | Timed_out
+
+val result_to_string : result -> string
+(** Canonical wire token. Round-trips with [result_of_string_opt] for
+    known constructors. Unknown-result is impossible by construction. *)
+
+val result_of_string_opt : string -> result option
+(** Strict parser. Returns [None] for anything the wire-format does not
+    recognise. Callers that must keep going should warn + treat as a new
+    attempt rather than coercing to a concrete result. *)
+
+type t = {
+  generation : int;
+  attempt_number : int;
+  attempt_id : string;  (** [Printf.sprintf "%d:%d" generation attempt_number]. *)
+  last_result : result;
+  next_retry_unix : float option;
+  updated_unix : float;
+}
+
+val make_next :
+  now:float ->
+  backoff_seconds:float ->
+  generation:int ->
+  last_result:result ->
+  previous:t option ->
+  t
+(** Build the next attempt record. [attempt_number] continues from
+    [previous] when [generation] matches, else resets to 1. *)
+
+val is_backoff_active : now:float -> t -> bool
+(** Window test. False when [next_retry_unix] is [None] or in the past. *)
+
+val to_json : t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> t option
+(** [of_json] is strict: missing fields, wrong types, or unknown [last_result]
+    tokens all return [None]. *)

--- a/lib/dune
+++ b/lib/dune
@@ -7,6 +7,7 @@
    a2a_types
    a2a_tools
    admission_queue
+   attempt_state
    admission_queue_metrics
    agent_card
    agent_economy

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,7 @@
 ; ============================================================
 (tests
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+        test_attempt_state
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -137,6 +138,7 @@
         test_mid_turn_resume
         test_lockfree_atomic)
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+          test_attempt_state
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_attempt_state.ml
+++ b/test/test_attempt_state.ml
@@ -1,0 +1,120 @@
+(** Unit tests for Attempt_state — the shared retry/attempt record from #8930. *)
+
+open Masc_mcp.Attempt_state
+
+let test_make_next_resets_on_new_generation () =
+  let previous =
+    make_next ~now:100.0 ~backoff_seconds:30.0 ~generation:1
+      ~last_result:Start_dispatched ~previous:None
+  in
+  Alcotest.(check int) "initial attempt_number" 1 previous.attempt_number;
+  let next_same_gen =
+    make_next ~now:200.0 ~backoff_seconds:30.0 ~generation:1
+      ~last_result:Start_dispatched ~previous:(Some previous)
+  in
+  Alcotest.(check int) "continues within same generation" 2
+    next_same_gen.attempt_number;
+  let next_new_gen =
+    make_next ~now:300.0 ~backoff_seconds:30.0 ~generation:2
+      ~last_result:Start_dispatched ~previous:(Some next_same_gen)
+  in
+  Alcotest.(check int) "resets on new generation" 1 next_new_gen.attempt_number;
+  Alcotest.(check string)
+    "attempt_id format" "2:1" next_new_gen.attempt_id
+
+let test_backoff_window () =
+  let t =
+    make_next ~now:100.0 ~backoff_seconds:30.0 ~generation:1
+      ~last_result:Start_dispatched ~previous:None
+  in
+  Alcotest.(check bool)
+    "within window → active" true
+    (is_backoff_active ~now:120.0 t);
+  Alcotest.(check bool)
+    "at deadline → inactive" false
+    (is_backoff_active ~now:130.0 t);
+  Alcotest.(check bool)
+    "past deadline → inactive" false
+    (is_backoff_active ~now:131.0 t);
+  let never_retries = { t with next_retry_unix = None } in
+  Alcotest.(check bool)
+    "None → inactive" false
+    (is_backoff_active ~now:0.0 never_retries)
+
+let test_json_roundtrip_start_dispatched () =
+  let t =
+    make_next ~now:100.0 ~backoff_seconds:30.0 ~generation:7
+      ~last_result:Start_dispatched ~previous:None
+  in
+  match of_json (to_json t) with
+  | Some t' ->
+      Alcotest.(check int) "gen" t.generation t'.generation;
+      Alcotest.(check int) "num" t.attempt_number t'.attempt_number;
+      Alcotest.(check string) "id" t.attempt_id t'.attempt_id;
+      Alcotest.(check (option (float 0.001)))
+        "next_retry" t.next_retry_unix t'.next_retry_unix;
+      Alcotest.(check (float 0.001)) "updated" t.updated_unix t'.updated_unix
+  | None -> Alcotest.fail "json roundtrip returned None"
+
+let test_json_roundtrip_failed_preserves_reason () =
+  let t =
+    make_next ~now:100.0 ~backoff_seconds:30.0 ~generation:1
+      ~last_result:(Failed { reason = "shell exited 137" })
+      ~previous:None
+  in
+  match of_json (to_json t) with
+  | Some { last_result = Failed { reason }; _ } ->
+      Alcotest.(check string) "preserved reason" "shell exited 137" reason
+  | Some _ -> Alcotest.fail "last_result lost Failed constructor"
+  | None -> Alcotest.fail "json roundtrip returned None"
+
+let test_result_of_string_strict () =
+  Alcotest.(check bool) "known token → Some" true
+    (result_of_string_opt "start_dispatched" <> None);
+  Alcotest.(check bool) "unknown token → None" true
+    (result_of_string_opt "mystery_state" = None);
+  Alcotest.(check bool) "empty → None" true
+    (result_of_string_opt "" = None)
+
+let test_of_json_rejects_missing_fields () =
+  let half = `Assoc [ ("generation", `Int 1); ("attempt_number", `Int 1) ] in
+  Alcotest.(check bool) "missing fields → None" true
+    (of_json half = None);
+  let bad_result =
+    `Assoc
+      [
+        ("generation", `Int 1);
+        ("attempt_number", `Int 1);
+        ("attempt_id", `String "1:1");
+        ("last_result", `String "not_a_real_state");
+        ("next_retry_unix", `Null);
+        ("updated_unix", `Float 100.0);
+      ]
+  in
+  Alcotest.(check bool) "unknown last_result → None" true
+    (of_json bad_result = None)
+
+let () =
+  Alcotest.run "attempt_state"
+    [
+      ( "make_next",
+        [
+          Alcotest.test_case "resets on new generation" `Quick
+            test_make_next_resets_on_new_generation;
+        ] );
+      ( "backoff",
+        [ Alcotest.test_case "window semantics" `Quick test_backoff_window ] );
+      ( "json",
+        [
+          Alcotest.test_case "roundtrip start_dispatched" `Quick
+            test_json_roundtrip_start_dispatched;
+          Alcotest.test_case "roundtrip failed preserves reason" `Quick
+            test_json_roundtrip_failed_preserves_reason;
+          Alcotest.test_case "rejects missing fields and unknown tokens" `Quick
+            test_of_json_rejects_missing_fields;
+        ] );
+      ( "result_of_string_opt",
+        [
+          Alcotest.test_case "strict parse" `Quick test_result_of_string_strict;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Phase 1 of #8930: add a single `Attempt_state` module for retry/backoff metadata. No call sites migrated yet — this PR is intentionally narrow (module + unit tests only) so the design can be reviewed before any of the 4 reinvented surfaces (voice_bridge, dashboard_cache, sidecar #8919, ...) are rewired.

## Why a new module

Today the same-shaped state is reimplemented separately in:

| Site | What it owns |
|---|---|
| `lib/voice/voice_bridge_core.ml` | `initial_backoff_seconds=1.0`, `backoff_multiplier=2.0`, `max_retries=3` |
| `lib/voice/voice_bridge.ml:473` | per-op `backoff_sec` call arg |
| `lib/server/server_dashboard_http_cache.ml` | mutable `last_attempt_at`, `last_attempt_unix` |
| `lib/server/server_routes_http_routes_sidecar.ml` (#8919) | `attempt_record { generation; attempt_number; attempt_id; last_attempt_result; next_retry_at; ... }`, `retry_backoff_seconds = 30.0`, persisted JSON |

Each time a new connector/reconciler is added, a fifth variant shows up. Consolidating before the next surface is cheaper than consolidating after.

## Design decisions (evidence-gated)

1. **Internal state is `float` (seconds-since-epoch).** ISO serialization is a *boundary-only* concern. Avoids the bug latent in #8919 where `String.compare next_retry_at now > 0` would silently misbehave if either side grew a `+00:00` offset or `.NNN` milliseconds — memory rule `feedback_deterministic-nondeterministic-boundary`.
2. **`result` is a closed variant.** `Start_dispatched | Failed of { reason } | Timed_out`. `result_of_string_opt` is sound-partial (returns `None` on unknown). Starting with a variant prevents adopters from adding a `| _ -> Start_dispatched` once a second result value appears — that would reintroduce the #8605 family.
3. **`of_json` is strict.** Missing fields, wrong types, or unknown `last_result` tokens all return `None`. The adopter chooses the warn-and-fallback policy; the primitive does not silently default.
4. **No env plumbing yet.** `backoff_seconds` is a plain argument. A follow-up can route it through `Env_config_runtime` once 2+ adopters exist.

## Out of scope (intentional)

- Migrating #8919's `attempt_record` — that's phase 2 (will need to preserve the existing on-disk JSON shape with a translation wrapper, not just swap).
- Migrating `voice_bridge_core` — phase 3 (different semantics: exponential + max_retries; may not fit without extension).
- Migrating `server_dashboard_http_cache` — phase 4 (mutable in-memory, may not need persistence codec).

Each phase is its own PR linked to #8930.

## Verification

```
$ dune build --root . @check
(exit 0)
$ dune exec --root . test/test_attempt_state.exe
Testing `attempt_state'.
  [OK]  make_next                     0   resets on new generation.
  [OK]  backoff                       0   window semantics.
  [OK]  json                          0   roundtrip start_dispatched.
  [OK]  json                          1   roundtrip failed preserves reason.
  [OK]  json                          2   rejects missing fields and unknown tokens.
  [OK]  result_of_string_opt          0   strict parse.
Test Successful in 0.001s. 6 tests run.
```

## Files

- `lib/attempt_state.ml` / `lib/attempt_state.mli` — new module (+ dune entry)
- `test/test_attempt_state.ml` — 6 alcotest cases (+ dune entry)
- Total: 5 files, +306 LOC (pure additions)

Closes #8930 (phase 1 only — issue stays open until migrations land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)