### PR TITLE
docs(logic): batch-11 .mli for tempo + tool_schemas_agent

### DIFF
--- a/lib/tempo.mli
+++ b/lib/tempo.mli
@@ -1,0 +1,81 @@
+(** MASC Tempo Control — Dynamic Orchestrator Interval.
+
+    Cluster tempo control for adaptive orchestration:
+    - Urgent tasks (priority 1-2) → Fast tempo (min_interval_s)
+    - Normal tasks (priority 3) → Normal tempo (default_interval_s)
+    - Idle (no pending tasks) → Slow tempo (max_interval_s)
+
+    Storage: [.masc/tempo.json]. *)
+
+(** {1 Types} *)
+
+type tempo_config = {
+  min_interval_s : float;      (** Minimum interval (fast tempo) *)
+  max_interval_s : float;      (** Maximum interval (slow tempo) *)
+  default_interval_s : float;
+  adaptive : bool;             (** Enable adaptive tempo *)
+}
+
+type tempo_state = {
+  current_interval_s : float;
+  last_adjusted : float;
+  reason : string;
+}
+
+(** {1 Configuration} *)
+
+(** Loaded from [Env_config.Tempo.*_interval_seconds]. [adaptive = true]. *)
+val default_config : tempo_config
+
+(** [tempo_file config] = [<masc_dir(config)>/tempo.json]. *)
+val tempo_file : Coord_utils.config -> string
+
+(** {1 State serialisation} *)
+
+val state_to_json : tempo_state -> Yojson.Safe.t
+
+(** Returns [None] on [Yojson.Safe.Util.Type_error] (logged). *)
+val state_of_json : Yojson.Safe.t -> tempo_state option
+
+(** {1 State I/O} *)
+
+(** Reads [.masc/tempo.json]. On missing file or load/parse failure
+    returns a [default_config.default_interval_s] state with reason
+    ["default"]. *)
+val load_state : Coord_utils.config -> tempo_state
+
+(** Persists [state] to [tempo_file config] (creates parent dir). *)
+val save_state : Coord_utils.config -> tempo_state -> unit
+
+(** {1 Tempo adjustment} *)
+
+(** [set_tempo config ~interval_s ~reason] clamps [interval_s] to
+    [[min_interval_s; max_interval_s]], updates [last_adjusted], and
+    persists. *)
+val set_tempo :
+  Coord_utils.config -> interval_s:float -> reason:string -> tempo_state
+
+(** Alias for {!load_state}. *)
+val get_tempo : Coord_utils.config -> tempo_state
+
+val is_pending_task : Types.task -> bool
+
+(** [(interval, reason)] derived from priority mix:
+    - any task with [priority <= 2] → [min_interval_s]
+    - else any task with [priority = 3] → [default_interval_s]
+    - else → [max_interval_s]
+    - empty list → [max_interval_s] with ["idle - no pending tasks"]. *)
+val calculate_adaptive_tempo : Types.task list -> float * string
+
+(** Adjusts tempo from [Coord.get_tasks_raw config] via
+    {!calculate_adaptive_tempo} and persists. *)
+val adjust_tempo : Coord_utils.config -> tempo_state
+
+(** {1 Presentation} *)
+
+(** Human-readable status line:
+    ["⏱️ Tempo: <Ns|N.Nm> (<reason>, adjusted <just now|Nm ago|N.Nh ago>)"]. *)
+val format_state : tempo_state -> string
+
+(** Writes [default_interval_s] with reason ["reset to default"]. *)
+val reset_tempo : Coord_utils.config -> tempo_state

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -1,0 +1,24 @@
+(** Tool_schemas_agent — MCP tool schemas for [masc_agent*] family.
+
+    [masc_tool_schemas] only depends on [masc_types], so enum strings
+    that must stay in sync with {!Tool_agent} (which lives higher up
+    the dep tree) are hand-mirrored here. The
+    [test_types.ml :: agent_tool_variants_ssot] regression test catches
+    drift between the two sides.
+
+    Issues: #8501 (mirror pattern), #8372 (agent_status enum derivation),
+    #8467/#8480/#8484/#8490/#8493 (related mirror+sync pattern). *)
+
+(** Allowed values for [masc_agent_card] [action]: ["get" | "refresh"].
+    Mirror of [Tool_agent.valid_agent_card_action_strings]. *)
+val agent_card_action_enum_strings : string list
+
+(** Allowed values for [masc_collaboration_graph] [format]:
+    ["text" | "json"]. Mirror of
+    [Tool_agent.valid_collaboration_format_strings]. *)
+val collaboration_format_enum_strings : string list
+
+(** Tool schemas: [masc_agents], [masc_agent_update], [masc_agent_card],
+    [masc_agent_fitness], [masc_register_capabilities],
+    [masc_collaboration_graph], [masc_get_metrics]. *)
+val schemas : Types.tool_schema list


### PR DESCRIPTION
Wave 3 batch 11 — 2 pure .mli. Body unchanged.

| 파일 | ml 줄수 | mli 줄수 |
|------|---------|----------|
| `lib/tempo.mli` | 157 | 76 |
| `lib/tool_schemas/tool_schemas_agent.mli` | 154 | 19 |

## 설계 노트

- **tempo**: test_tempo_coverage.ml 에서 record 필드 + 9 val 접근 → 전체 surface 노출. 적응형 tempo 우선순위 규칙 mli doc에 명시.
- **tool_schemas_agent**: 3 val (schemas + 2 enum mirror). Tool_agent와의 drift는 test_types.ml agent_tool_variants_ssot 가 검증.

## 건너뛴 후보
- **coord_init** (161): `coord.ml: include Coord_init` + `coord.mli: include module type of Coord_init` → umbrella trap. Coord와 함께 한 PR로 도입 필요.

## 검증
- `dune build --root=.` → exit 0
- External caller 컴파일 유지.

## Metric
| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` | 325 | **327** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] umbrella-include 위험 회피
- [x] surface을 test + lib consumer에서 검증
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)