### PR TITLE
docs(spec): annotate Magentic ledger ClassifyEvent failure-topology drift (#8949)

### DIFF
--- a/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+++ b/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
@@ -9,6 +9,27 @@
 \*   - Make the "stalled stays stalled until a new delta arrives" rule explicit.
 \*   - Verify that progress evidence dominates other signals, reactive signals
 \*     dominate idle timeouts, and empty turns settle to Quiet.
+\*
+\* Known topology drift (issue #8949): this spec routes the failure signal
+\* through [ClassifyEvent] (where "failure dominates progress").  The OCaml
+\* impl splits this into two call paths instead:
+\*
+\*   1. Normal path: [classify_event] (no failure parameter)
+\*      handles progress / signals / idle / quiet.
+\*   2. Failure path: [derive_failure_state] in
+\*      [keeper_social_model_magentic_ledger_v1.ml:202] constructs the
+\*      [Failure_observed] event directly and bypasses [classify_event].
+\*
+\* Both topologies reach [Stalled] on failure, so end-state behaviour
+\* matches.  However, the spec's "failure dominates progress" property is
+\* trivially satisfied in OCaml because failure never reaches the
+\* dominance branch.  A future change that adds [has_failure] to the
+\* OCaml input record without re-checking dominance ordering would
+\* re-introduce the question with the OPPOSITE answer (OCaml's
+\* progress-first ordering would override failure).
+\*
+\* See issue #8949 for proposed alignment options
+\* (preferred: re-shape spec to mirror OCaml's two-path topology).
 
 EXTENDS TLC
 


### PR DESCRIPTION
## Summary
- 2nd FSM topology drift caught in this sweep (sibling: #8946 / #8948 for KeeperCampaignLifecycle).
- TLA spec routes failure through \`ClassifyEvent\` (with \"failure dominates progress\").
- OCaml impl uses TWO call paths: \`classify_event\` (no failure) + \`derive_failure_state\` direct emit.
- Behaviour-equivalent for now (both reach Stalled), but the dominance property is trivially satisfied for the wrong reason.
- Full proposed alignment tracked in **issue #8949**.

## What this PR does
- Adds a 'Known topology drift' note to the spec preamble.
- Cross-references OCaml file/line and the proposed fix in #8949.
- No action change, no \`Next\` change, no \`.cfg\` change → TLC behaviour identical.

## Why ship the doc note alone
- Spec re-shape (drop \`failure\` from \`ClassifyEvent\` + add \`FailureObservedAction\`) requires re-verifying every existing dominance/sticky/quiet property.  Tracked separately.
- Doc note is immediate visibility — future readers will know the spec topology does not match the code paths.

## Risk
- A future change adding \`has_failure\` to the OCaml \`input\` record would silently change semantics (OCaml's progress-first ordering would override failure, contradicting the spec).  This drift annotation makes that risk visible.

## Test plan
- [x] No code change.
- [x] No \`.cfg\` change — TLC behaviour identical.
- [x] Cross-link to issue #8949 verified.

## Refs
- #8949 (umbrella issue with full alignment proposal)
- #8946 / #8948 (sibling Campaign FSM drift annotation)
- #8642 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)