### PR TITLE
feat(bonsai-dashboard): focus card live from Keepers_var

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2069,7 +2069,28 @@ let view_hud (response : Logs_types.response) =
     ]
 ;;
 
-let render_response (response : Logs_types.response) : Node.t =
+(** Focus keeper — first entry of the live response, or [None] when empty
+    (triggers the legacy static fallback inside [focus_card_of]). *)
+let focus_keeper_of (k : Keepers_types.response) : Keepers_types.keeper option =
+  match k.keepers with
+  | [] -> None
+  | head :: _ -> Some head
+;;
+
+(** Display name — capitalize first character of the registry nickname. *)
+let display_name (s : string) : string =
+  if String.length s = 0
+  then s
+  else
+    let first = Char.to_string (Char.uppercase s.[0]) in
+    let rest = String.sub s ~pos:1 ~len:(String.length s - 1) in
+    first ^ rest
+;;
+
+let render_response
+      ?(keepers : Keepers_types.response = Keepers_types.fixture)
+      (response : Logs_types.response)
+    : Node.t =
   let tape =
     match response.entries with
     | [] ->
@@ -2257,18 +2278,44 @@ let render_response (response : Logs_types.response) : Node.t =
       ; Node.div ~attrs:[ Style.focus_stat_v ] [ Node.text v ]
       ]
   in
+  let focus_k = focus_keeper_of keepers in
+  let focus_name, focus_portrait, focus_role, focus_ctx_pct,
+      focus_turn, focus_mem, focus_latency =
+    match focus_k with
+    | None ->
+      ("Luna", "L", "dungeon master · alchemist", 64,
+       "47 / 60", "128k", "812ms")
+    | Some (k : Keepers_types.keeper) ->
+      let portrait =
+        if String.length k.name = 0
+        then "·"
+        else Char.to_string (Char.uppercase k.name.[0])
+      in
+      let role =
+        match k.last_tool with
+        | Some t -> Printf.sprintf "%s · %s" k.stat t
+        | None -> k.stat
+      in
+      (display_name k.name, portrait, role, k.ctx_pct,
+       Printf.sprintf "%d / %d" k.turn k.turn_cap,
+       Printf.sprintf "%dk" k.mem_kb,
+       Printf.sprintf "%dms" k.latency_ms)
+  in
+  let vial_style =
+    Attr.create "style" (Printf.sprintf "width:%d%%" focus_ctx_pct)
+  in
   let focus_card =
     Node.div
       ~attrs:[ Style.focus ]
       [ Node.div
           ~attrs:[ Style.focus_who ]
-          [ Node.div ~attrs:[ Style.focus_portrait ] [ Node.text "L" ]
+          [ Node.div ~attrs:[ Style.focus_portrait ] [ Node.text focus_portrait ]
           ; Node.div
               ~attrs:[ Style.focus_name_col ]
-              [ Node.div ~attrs:[ Style.focus_name ] [ Node.text "Luna" ]
+              [ Node.div ~attrs:[ Style.focus_name ] [ Node.text focus_name ]
               ; Node.div
                   ~attrs:[ Style.focus_role ]
-                  [ Node.text "dungeon master · alchemist" ]
+                  [ Node.text focus_role ]
               ]
           ]
       ; Node.div
@@ -2278,18 +2325,18 @@ let render_response (response : Logs_types.response) : Node.t =
               [ Node.span [ Node.text "context" ]
               ; Node.span
                   ~attrs:[ Style.ctx_lbl_v ]
-                  [ Node.text "64%" ]
+                  [ Node.text (Printf.sprintf "%d%%" focus_ctx_pct) ]
               ]
           ; Node.div
               ~attrs:[ Style.vial ]
-              [ Node.span ~attrs:[ Style.vial_fill ] [] ]
+              [ Node.span ~attrs:[ Style.vial_fill; vial_style ] [] ]
           ]
       ; Node.div
           ~attrs:[ Style.focus_stats ]
-          [ focus_stat "turn" "47 / 60"
+          [ focus_stat "turn" focus_turn
           ; focus_stat "heartbeat" "3s"
-          ; focus_stat "mem" "128k"
-          ; focus_stat "latency" "812ms"
+          ; focus_stat "mem" focus_mem
+          ; focus_stat "latency" focus_latency
           ]
       ]
   in
@@ -2371,7 +2418,9 @@ let render_response (response : Logs_types.response) : Node.t =
       ~attrs:[ Style.aside ]
       [ Node.div
           ~attrs:[]
-          [ aside_h ~tail:"ctx 64%" "focus · keeper"
+          [ aside_h
+              ~tail:(Printf.sprintf "ctx %d%%" focus_ctx_pct)
+              "focus · keeper"
           ; focus_card
           ]
       ; Node.div
@@ -2554,5 +2603,9 @@ let render_response (response : Logs_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Logs_var.var) ~f:render_response
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Logs_var.var)
+    (Bonsai.Expert.Var.value Keepers_var.var)
+    ~f:(fun logs_response keepers_response ->
+      render_response ~keepers:keepers_response logs_response)
 ;;


### PR DESCRIPTION
## Summary

**focus · keeper** 카드를 `Keepers_var`(#8947)로 라이브 바인딩. 3s polling에 맞춰 자동 갱신. 키퍼 데이터 파이프의 첫 consumer.

> **Stack base**: `feature/bonsai-keepers-client` (#8947).
> Stack chain: #8940 → #8945 → #8947 → **#8949 (this PR)**.

## 변경

- `render_response`에 `?keepers:Keepers_types.response` 매개변수 추가 (default fixture)
- `focus_keeper_of` / `display_name` helper 도입
- **focus_card 분기**:
  - `None` (fixture, empty keepers) → 기존 static "Luna 64%" 그대로 (pixel parity)
  - `Some k` → 라이브 렌더
    - 이름: `k.name` 첫 글자 대문자 (`luna` → `Luna`)
    - portrait: `k.name[0]` 대문자
    - role: `k.stat [· k.last_tool]`
    - ctx: `k.ctx_pct` %
    - turn: `k.turn / k.turn_cap`
    - mem: `k.mem_kb k`
    - latency: `k.latency_ms ms`
- `.vial_fill`의 하드코드 `width: 64%`를 inline `style="width:N%"`로 override
- `aside_h ~tail:"ctx 64%"` → `ctx <pct>%`
- `component`를 `Bonsai.map2` (logs_var × keepers_var) 합성으로 변경

## 왜 default fixture

Server stub(#8945)이 아직 merge 안 된 상태에서도 **기존 UI pixel parity 유지** 목적. `Keepers_types.fixture`는 빈 keepers — `focus_keeper_of`가 `None` → 기존 static block 사용. 머지 순서 무관하게 안전.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 `/dashboard/b/`에서 첫 렌더는 정적 Luna 64% (fetch 전)
- [ ] 3s 후 첫 polling 완료 시 focus card가 서버 응답 데이터로 교체
- [ ] 테마 전환 시 focus card는 변동 없음 (DS token으로 이미 처리됨)
- [ ] Network 탭에서 `/dashboard/b/api/keepers/summary` 3s 주기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
