### PR TITLE
feat(keeper): activate work_discovery_guidance dead schema (L4)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1154,7 +1154,24 @@ let run_turn
               | _ -> None)
             sources
         in
-        (match chunks with
+        (* L4 fix: meta.work_discovery_guidance was dead schema (declared
+           in 7 sites — types/json/toml/diff — but read by 0 consumers).
+           Inject as a persona-level operator hint that activates the
+           nudge even when [sources] is empty or yields no chunks. This
+           lets keepers like sangsu (local_only cascade, no sources
+           configured) receive directed guidance via the same Nudge
+           pipeline that L1+L2 already delivers to the LLM. *)
+        let guidance_section =
+          match meta.work_discovery_guidance with
+          | Some g when String.trim g <> "" ->
+            Some (Printf.sprintf "**Operator guidance:** %s" (String.trim g))
+          | _ -> None
+        in
+        let sections =
+          chunks
+          @ (match guidance_section with Some s -> [s] | None -> [])
+        in
+        (match sections with
          | [] -> None
          | _ ->
            Some (Printf.sprintf
@@ -1175,7 +1192,7 @@ let run_turn
               `keeper_*` names exactly as shown above.\n\n\
               Plain-text replies are ignored. Pick the smallest viable \
               action and emit it as a structured tool_call now."
-             interval (String.concat "\n\n" chunks)))
+             interval (String.concat "\n\n" sections)))
     | _ -> None
   in
   let base_hooks =


### PR DESCRIPTION
## Why

The \`work_discovery_guidance\` field is the **L4 layer** of the keeper-git-activity root chain investigated in #8773.

Schema declares it in 7 sites:
- \`lib/keeper/keeper_types.ml{,i}\` — record field
- \`lib/keeper/keeper_types.ml\` — JSON ser/de + storage list
- \`lib/keeper/keeper_types_profile.ml\` — TOML parser + profile_defaults + overlay merge + hot-reload
- \`lib/keeper/keeper_runtime.ml\` — apply_default + diff
- \`lib/keeper/keeper_turn_up_create.ml\` — bootstrap copy
- \`docs/KEEPER-FILE-MODEL.md\` — documented as \"Hint string fed into the work-discovery prompt\"

But \`grep work_discovery_guidance lib/keeper/\` shows **0 consumers** in nudge generation — the field is **dead schema**. Operators set it, hot-reload accepts it, but the LLM never sees it.

This PR wires the field into \`discover_work_nudge\` (\`lib/keeper/keeper_agent_run.ml:1107\`) so that:

1. Non-empty guidance is appended as an \`**Operator guidance:** ...\` section to the nudge text.
2. The nudge fires when \`sources\` is empty/zero-chunk (guidance becomes a **standalone trigger**), enabling persona-level direction for keepers like \`sangsu\` that run on \`local_only\` cascade with no sources configured.

## Layer context

| Layer | Status | PR |
|-------|--------|-----|
| L1 — OAS BeforeTurn Nudge handler | MERGED | oas#1065 |
| L2 — masc-mcp pin v0.163 | MERGED | #8844 |
| L4 — work_discovery_guidance inject | **THIS PR** | — |
| L5 — Docker_with_git sandbox profile | MERGED | #8838 |

L1+L2 deliver the nudge to the LLM. L4 lets the operator shape what the LLM hears without code changes — the dead field becomes the per-keeper steering knob.

## Behavior matrix

| chunks | guidance | before | after |
|--------|----------|--------|-------|
| 0 | None | None (no nudge) | None (no nudge) — unchanged |
| N | None | nudge with chunks | nudge with chunks — unchanged |
| 0 | non-empty | None (no nudge) | **nudge with guidance only — NEW** |
| N | non-empty | nudge with chunks | **nudge with chunks + guidance — NEW** |
| 0 | whitespace | None | None — whitespace trim guard |

## Verification plan

- [ ] CI build green (local build is blocked behind concurrent worktree opam contention; CI will re-verify)
- [ ] Live: set \`work_discovery_guidance = \"Pick a board comment and reply.\"\` on \`sangsu.toml\`, hot-reload, observe Nudge text in \`keeper:sangsu before_turn: injecting work_discovery nudge\` log includes the guidance string within 1 cycle
- [ ] Schema round-trip already covered by \`test/test_keeper_runtime_config_ssot.ml:572\`

## Out of scope

- L3 (additional \`work_discovery_sources\` types: github_issues, board_cleanup) — separate PR
- LLM tool selection drift (525/2906 hallucinated tool names from #8778) — separate axis

## Risk

Low. Only modifies the nudge text builder. \`work_discovery_enabled = Some true\` gate unchanged. Whitespace guard prevents accidental noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)