### PR TITLE
Fix no-owned status guidance

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -363,13 +363,26 @@ let status_summary_string (ctx : context) =
   in
   let suggested_next =
     guidance.next_steps
-    |> take_items 2
     |> List.map (fun (step : Workflow_guide.step) -> step.tool)
     |> fun tools ->
     if credential_blocked then
       List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
     else
-      tools
+      match binding.drift_reason with
+      | Some "no_owned" ->
+          let tools =
+            List.filter (fun tool -> not (String.equal tool "masc_transition"))
+              tools
+          in
+          let tools =
+            if todo_count > 0 then
+              "masc_claim_next" :: tools
+            else
+              tools
+          in
+          unique_strings tools
+      | Some _ | None -> tools
+    |> take_items 2
   in
   let attention_items =
     []

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -307,6 +307,25 @@ let () = test "dispatch_status_suppresses_lifecycle_guidance_without_credential"
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun () ->
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  ignore (Coord.add_task ctx.config ~title:"Unclaimed task" ~priority:3 ~description:"");
+  Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "owned=- | current=task-001");
+      assert (str_contains result "drift_reason=no_owned");
+      assert (str_contains result "claim_first_suppressed=no");
+      assert (str_contains result "💡 Suggested next: masc_claim_next -> masc_status");
+      assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
+  | None -> failwith "dispatch returned None"
+)
+
 let () = test "dispatch_check_project_ready_alias" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in


### PR DESCRIPTION
## Summary
- suppress unsafe `masc_transition` guidance when `planning_current` is set but no task is owned
- prefer `masc_claim_next` in that `no_owned` read-model state when unclaimed work exists
- add a regression for the `owned=- / current=task-* / drift_reason=no_owned` status output

## Evidence
- `dune build --root .`
- `dune build --root . test/test_tool_coord_coverage.exe`
- `./_build/default/test/test_tool_coord_coverage.exe test --compact '' 13`
- `./_build/default/test/test_tool_coord_coverage.exe test --compact '' 14`

Refs #8757
