### PR TITLE
docs(logic): batch-12 .mli for retrieval_projection + verifier_core

### DIFF
--- a/lib/retrieval_projection.mli
+++ b/lib/retrieval_projection.mli
@@ -1,0 +1,26 @@
+(** Retrieval_projection — Normalise heterogeneous search tool output
+    into a uniform [source/location: content] line format reminiscent
+    of [grep].
+
+    Accepts search output as either labelled chunks separated by
+    ["\n---\n"] or a raw JSON document, and renders a compact line
+    per result. Values that exceed the per-line cap are truncated
+    byte-safely. *)
+
+(** [grep_like_line ~source ~location ~content] renders a single line:
+    ["<source>/<location>: <content>"]. Empty fields fall back to
+    ["search"] / ["result"] / ["(no content)"]. [location] collapses
+    whitespace and truncates to 120 bytes; [content] collapses
+    whitespace and truncates to 300 bytes. *)
+val grep_like_line :
+  source:string -> location:string -> content:string -> string
+
+(** [lines_of_search_output ?max_lines input] splits [input] on
+    ["\n---\n"], parses each chunk as either a labelled payload
+    ([\[label\]: ...]) or raw JSON, and emits one
+    {!grep_like_line} per result. [max_lines] defaults to [20]. *)
+val lines_of_search_output : ?max_lines:int -> string -> string list
+
+(** [format_search_output] is {!lines_of_search_output} joined by
+    ["\n"]. *)
+val format_search_output : ?max_lines:int -> string -> string

--- a/lib/verifier_core.mli
+++ b/lib/verifier_core.mli
@@ -1,0 +1,65 @@
+(** Verifier_core — Pure verification types, parsing, and read-only
+    detection.
+
+    No [Agent_sdk] or OAS dependency. Extracted from [verifier_oas.ml]
+    to enforce the MASC-OAS boundary: core domain logic stays
+    OAS-free.
+
+    @since 2.61.0 (verifier core)
+    @since 2.223.0 (structured verdict via [report_verdict] tool)
+    @since 2.233.0 (extracted from [verifier_oas.ml]) *)
+
+(** {1 Types} *)
+
+type verification_request = {
+  action_description : string;
+  action_result : string;
+  goal : string;
+  context_summary : string;
+}
+
+type verdict =
+  | Pass
+  | Warn of string
+  | Fail of string
+
+(** {1 Read-Only Detection} *)
+
+(** [should_skip ~action_description] returns [true] when the
+    description text contains a word-boundary match for any
+    read-only keyword ([read], [glob], [grep], [search], [find],
+    [list], [ls], [cat], [head], [tail], [git status], [git log],
+    [git diff], [status], [view], [get], [fetch], [query]).
+    Case-insensitive, word-boundary aware. *)
+val should_skip : action_description:string -> bool
+
+(** {1 Verdict Parsing} *)
+
+(** ["PASS"] / ["WARN: <reason>"] / ["FAIL: <reason>"]. *)
+val verdict_to_string : verdict -> string
+
+(** Issue #8436: payload-free constructor names for schema enums:
+    ["PASS"] / ["WARN"] / ["FAIL"]. Adding a 4th variant fails
+    compilation here — the regression test [test_types.ml] asserts
+    every variant appears in {!valid_verdict_strings}. *)
+val verdict_constructor_name : verdict -> string
+
+val valid_verdict_strings : string list
+
+(** Parse a free-form verifier text line. Accepts [PASS | WARN | FAIL]
+    followed optionally by [:] or [-] and a reason. Returns [Error]
+    on empty input or unrecognised prefix; reason-less [Warn] /
+    [Fail] fill in a default reason. *)
+val parse_verdict : string -> (verdict, string) result
+
+(** {1 Structured Verdict — report_verdict tool} *)
+
+(** MCP tool schema for [report_verdict]: [verdict] (enum of
+    {!valid_verdict_strings}) + optional [reason]. *)
+val report_verdict_schema : Types.tool_schema
+
+(** Parse a [report_verdict] JSON arg payload. Empty/missing [reason]
+    on [Warn]/[Fail] fills in a default reason (same as
+    {!parse_verdict}). Errors on type mismatch or unknown [verdict]
+    values. *)
+val parse_verdict_from_json : Yojson.Safe.t -> (verdict, string) result


### PR DESCRIPTION
Wave 3 batch 12 — 2 pure .mli. Body unchanged.

| 파일 | ml 줄수 | mli 줄수 |
|------|---------|----------|
| `lib/retrieval_projection.mli` | 178 | 27 |
| `lib/verifier_core.mli` | 175 | 56 |

## 설계 노트

### retrieval_projection
- **External surface 1개만 확인** (auto_recall.ml: grep_like_line).
- 14 internal helper 전부 hide (collapse_whitespace, trim_to_option, split_chunks, parse_labeled_chunk, render_result_object, lines_of_json 등).
- `format_search_output`/`lines_of_search_output` proactive expose — 문서화된 high-level entry point.

### verifier_core
- MASC-OAS boundary 유지 (Agent_sdk 의존 없음) 명시.
- Issue #8436 enum SSOT 패턴: `verdict_constructor_name` + `valid_verdict_strings` + compile-time guard.
- 5 internal parser helper hide (has_pattern_with_word_boundary, has_keyword_boundary, extract_reason, is_word_char, read_only_patterns).

## 검증
- `dune build --root=.` → exit 0

## Metric
| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` | 327 | **329** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] surface 확인 (rg 기반 1/7 caller)
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)