### PR TITLE
docs(spec): correct stale 11-state/6-value phase counts in TLA preambles

### DIFF
--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -23,10 +23,14 @@
 \* Design intent
 \*   1. shared_measurement is the coordination hub (Context_measured event,
 \*      Keeper_state_machine.mli:131-136, auto_rules_summary).
-\*   2. The 11-state parent phase from RFC-0002 is projected to
+\*   2. The 12-state parent phase from RFC-0002 is projected to the
+\*      7-element set
 \*      {Running, Failing, Overflowed, Compacting, HandingOff, Draining,
 \*       Stable}
 \*      — exactly the phases that matter for cross-spec ordering.
+\*      (See Comment A for the explicit 12->7 mapping; the 6 phases that
+\*      collapse to "Stable" are out of scope for the joint invariants
+\*      because they sit outside the turn cycle.)
 \*   3. Parent-lifecycle recovery is modeled directly as Running/Failing
 \*      phase transitions; legacy two-store recovery placeholders are
 \*      intentionally excluded from this observer.
@@ -52,8 +56,9 @@ ASSUME MaxTurnTicks \in Nat /\ MaxTurnTicks >= 2
 
 VARIABLES
     ksm_phase,          \* KSM projection. KeeperStateMachine.tla phase
-                        \* Reduced to the 6 values that change cross-spec
-                        \* behavior. Mapping from 11-state is in Comment A.
+                        \* Reduced to the 7 values that change cross-spec
+                        \* behavior (6 active + Stable absorber).
+                        \* Mapping from 12-state OCaml phase is in Comment A.
 
     ktc_turn_phase,     \* KTC projection. KeeperTurnCycle.tla / unified turn
                         \* Values: idle, prompting, executing, compacting,

--- a/specs/keeper-state-machine/KeeperDwellMonotone.tla
+++ b/specs/keeper-state-machine/KeeperDwellMonotone.tla
@@ -68,7 +68,7 @@ VARIABLES
 
 vars == << phase, entered_at, now >>
 
-\* RFC-0002 11-phase FSM (keeper_state_machine.ml).
+\* RFC-0002 12-phase FSM (keeper_state_machine.ml: type phase, 12 constructors).
 PhaseSet == {
     "Offline",
     "Running",


### PR DESCRIPTION
## Summary
- Caught three small but stale phase-count comments in TLA preambles during the FSM drift sweep.
- OCaml \`keeper_state_machine.ml\` \`type phase\` has **12 constructors**; three preambles still cite the older **11-state** count.
- One additional drift: \`KeeperCompositeLifecycle\` says \"Reduced to the 6 values\" but its \`PhaseSet\` enumerates **7** (6 active + the Stable absorber).

## Locations fixed
| File | Line | Was | Is |
|------|------|-----|----|
| \`KeeperDwellMonotone.tla\` | 71 | \"RFC-0002 11-phase FSM\" | \"RFC-0002 12-phase FSM (12 constructors)\" |
| \`KeeperCompositeLifecycle.tla\` | 26 | \"11-state parent phase\" | \"12-state parent phase ... projected to the 7-element set\" |
| \`KeeperCompositeLifecycle.tla\` | 56 | \"Reduced to the 6 values ... Mapping from 11-state\" | \"Reduced to the 7 values (6 active + Stable absorber). Mapping from 12-state\" |

The KeeperCompositeLifecycle file was internally inconsistent: \`Comment A\` on line 85 already says \"12->7 phase projection\", contradicting line 26's \"11-state\".  KeeperDwellMonotone's \`PhaseSet\` already enumerates 12 phases, contradicting its own comment.

## Why ship this
- Doc-only — no \`.cfg\` change, no spec action change, TLC behaviour identical.
- Stale phase counts are exactly the kind of footgun that would let a future reviewer apply a \"fix\" based on a wrong mental model (cf. #8942 for the same class of drift in OCaml .mli docstring).

## Test plan
- [x] Pure documentation-comment edits.
- [x] No \`.cfg\` change.

## Refs
- #8942 (sibling: derive_phase priority docstring drift)
- #8948 / #8952 / #8959 (sibling FSM preamble drift annotations)
- #8642 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)