### PR TITLE
feat(legendary-bash): shadow counters HTTP endpoint (Tick 28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ### Added
 
+- **Legendary Bash shadow-counters HTTP endpoint.**  New
+  `GET /api/v1/legendary_bash/shadow_counters` returns the
+  `Legendary_counters.snapshot` as JSON.  Public-read (same auth
+  posture as `/api/v1/activity/*`), zero-cost when observers are
+  off (all counters stay at zero).  Wired behind
+  `Server_routes_http_routes_artifacts` in the route pipeline.
+  `LEGENDARY-BASH-RUNBOOK.md` now documents the endpoint and the
+  suggested `disagree_ratio` formula so operators can drive the
+  `MASC_BASH_AST_ONLY` flip decision from a dashboard instead of a
+  log grep pipeline.
+
 - **Legendary Bash in-process shadow counters.**  New
   `lib/legendary_counters.{ml,mli}` exposes `Atomic.t`-backed totals
   for the P5 gate-diff observer (`total` + 4 buckets mirroring

--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -181,6 +181,38 @@ justifies otherwise. Suggested gate:
 `MASC_BLOCKING_BUDGET_MS` tuning can precede the flip. Raising it
 reduces promotion frequency; lowering it accelerates it.
 
+## In-process Snapshot Endpoint
+
+Both observers also increment `Atomic.t` counters inside the process
+while enabled. The cumulative totals are exposed as a single public-
+read JSON endpoint for dashboards or flip-decision tooling that does
+not want to scan the keeper log stream:
+
+```
+GET /api/v1/legendary_bash/shadow_counters
+```
+
+Response shape (field names mirror `Legendary_counters.snapshot` 1:1):
+
+```json
+{
+  "gate_diff_total": 0,
+  "gate_diff_agree": 0,
+  "gate_diff_legacy_allow_shadow_deny": 0,
+  "gate_diff_legacy_deny_shadow_allow": 0,
+  "gate_diff_shadow_cannot_parse": 0,
+  "auto_bg_observed": 0,
+  "auto_bg_would_have_promoted": 0
+}
+```
+
+Every counter stays at `0` until the matching observer env flag is
+set, so the endpoint itself is cost-free under default posture. The
+log stream and the counter snapshot are redundant on purpose: logs
+for point-in-time diagnostics, counters for `disagree ratio =
+(legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total`
+trend math over a rolling window.
+
 ## Rollback
 
 Each Legendary flag has an inert opt-out path. No restart required.

--- a/lib/dune
+++ b/lib/dune
@@ -126,6 +126,7 @@
    server_routes_http_routes_attribution
    server_routes_http_routes_activity
    server_routes_http_routes_artifacts
+   server_routes_http_routes_legendary_bash
    server_routes_http_routes_channel_gate
    server_routes_http_routes_sidecar
    server_h2_gateway

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -20,5 +20,6 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_attribution.add_routes
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_artifacts.add_routes
+  |> Server_routes_http_routes_legendary_bash.add_routes
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_legendary_bash.ml
+++ b/lib/server/server_routes_http_routes_legendary_bash.ml
@@ -1,0 +1,33 @@
+(** Legendary Bash dark-launch observer HTTP surface.
+
+    Exposes the in-process [Legendary_counters] snapshot as a single
+    public-read JSON endpoint for dashboards and flip-decision tooling.
+    The counters themselves are incremented only while the matching
+    observer env flag is enabled (see [LEGENDARY-BASH-RUNBOOK.md]);
+    this endpoint is a zero-cost read.
+
+      GET /api/v1/legendary_bash/shadow_counters
+
+    Response (200): JSON shape mirrors [Legendary_counters.snapshot]
+    field-for-field. See [legendary_counters.mli] for the stable
+    contract. *)
+
+open Server_utils
+open Server_auth
+
+module Http = Http_server_eio
+
+let snapshot_response () : Yojson.Safe.t =
+  let snap = Legendary_counters.snapshot () in
+  Legendary_counters.snapshot_to_json snap
+
+let add_routes router =
+  router
+  |> Http.Router.get "/api/v1/legendary_bash/shadow_counters"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let json = snapshot_response () in
+             respond_public_read_json ~status:`OK request reqd
+               (Yojson.Safe.to_string json))
+           request reqd)


### PR DESCRIPTION
## Product impact

Follow-up to the counter module merged as #8941. Operators can now
poll `GET /api/v1/legendary_bash/shadow_counters` to get the current
P5 gate-diff and P4 AUTO_BG observer totals as JSON, so dashboards and
flip-decision tooling can compute trend metrics (e.g. the
`disagree_ratio = (legacy_allow_shadow_deny + legacy_deny_shadow_allow) /
gate_diff_total`) without scanning `gate_diff_shadow` /
`auto_bg_would_have_promoted` log lines.

## Evidence

- `lib/server/server_routes_http_routes_legendary_bash.ml` (new,
  ~35 LOC incl. header). Single `add_routes` binding GET
  `/api/v1/legendary_bash/shadow_counters` → public-read JSON of
  `Legendary_counters.snapshot_to_json`.
- `lib/dune` — module registered next to the other
  `server_routes_http_routes_*` modules.
- `lib/server/server_routes_http.ml` — wired into the pipeline
  between `artifacts` and `channel_gate` so ordering matches the
  manifest layout.
- `docs/LEGENDARY-BASH-RUNBOOK.md` — new "In-process Snapshot
  Endpoint" section documents the URL, response shape, and the
  `disagree_ratio` operator formula.
- `CHANGELOG.md [Unreleased] Added` entry.

Local `dune build --root . lib/` → clean build.

## Review evidence

- Public-read posture (`with_public_read`) matches the other
  observability endpoints under `/api/v1/activity/*` and
  `/api/v1/governance/*`. The counters contain no PII, no raw
  command strings, and no user-identifying data — they are pure
  aggregate totals.
- Zero-cost under default posture: every counter stays at its
  `Atomic.make 0` initial value until either
  `MASC_BASH_AST_SHADOW_LOG` or `MASC_BASH_AUTO_BG_OBSERVE` is set.
  No branch in the endpoint touches the keeper exec path.
- JSON field names are taken verbatim from
  `Legendary_counters.snapshot` record labels, so a future consumer
  can decode via Yojson without a hand-rolled schema. No new
  vocabulary.
- Runbook cross-link updated in the same PR (avoids docs-drift per
  masc-mcp#7481 lesson).

## Linked issue

Refs #8941 (counter module this PR exposes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)