### PR TITLE
feat(keeper): Edit/Write/Grep input adapters for OAS dual register (RFC-0006 Phase A.4)

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -12,10 +12,15 @@ open Keeper_exec_shared
 type fs_write_mode =
   | Overwrite
   | Append
+  | Patch
+    (** RFC-0006 Phase A.4: read-replace-write for the Anthropic Code
+        [Edit] cognate. Caller supplies [old_string] + [new_string]
+        (and optional [replace_all]) instead of [content]. *)
 
 let fs_write_mode_to_string = function
   | Overwrite -> "overwrite"
   | Append -> "append"
+  | Patch -> "patch"
 
 (* Sound partial parser: canonical strings AND the back-compat empty
    string both decode to a real Variant. Whitespace-only treated as
@@ -25,9 +30,10 @@ let fs_write_mode_of_string_opt raw =
   match String.trim (String.lowercase_ascii raw) with
   | "overwrite" | "" -> Some Overwrite
   | "append" -> Some Append
+  | "patch" -> Some Patch
   | _ -> None
 
-let all_fs_write_modes = [ Overwrite; Append ]
+let all_fs_write_modes = [ Overwrite; Append; Patch ]
 
 let valid_fs_write_mode_strings =
   List.map fs_write_mode_to_string all_fs_write_modes
@@ -93,6 +99,54 @@ let handle_keeper_fs_read
              ])))
 ;;
 
+(* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When
+   [replace_all=false], requires exactly one occurrence so accidental
+   multi-edits are rejected (mirrors Anthropic Edit semantics). *)
+let apply_patch ~old_string ~new_string ~replace_all text =
+  if old_string = "" then
+    Error "old_string must be non-empty for mode=patch."
+  else
+    let count_occurrences ~needle haystack =
+      let nlen = String.length needle in
+      if nlen = 0 then 0
+      else
+        let hlen = String.length haystack in
+        let rec loop i acc =
+          if i + nlen > hlen then acc
+          else if String.sub haystack i nlen = needle then
+            loop (i + nlen) (acc + 1)
+          else loop (i + 1) acc
+        in
+        loop 0 0
+    in
+    let occurrences = count_occurrences ~needle:old_string text in
+    if occurrences = 0 then
+      Error "old_string not found in file. Patch did not match anything."
+    else if (not replace_all) && occurrences > 1 then
+      Error
+        (Printf.sprintf
+           "old_string occurs %d times. Pass replace_all=true to apply to all, \
+            or supply a more specific old_string."
+           occurrences)
+    else
+      let buf = Buffer.create (String.length text) in
+      let nlen = String.length old_string in
+      let hlen = String.length text in
+      let rec loop i =
+        if i + nlen > hlen then Buffer.add_substring buf text i (hlen - i)
+        else if String.sub text i nlen = old_string then begin
+          Buffer.add_string buf new_string;
+          if replace_all then loop (i + nlen)
+          else Buffer.add_substring buf text (i + nlen) (hlen - i - nlen)
+        end
+        else begin
+          Buffer.add_char buf text.[i];
+          loop (i + 1)
+        end
+      in
+      loop 0;
+      Ok (Buffer.contents buf, occurrences)
+
 let handle_keeper_fs_edit
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -104,18 +158,69 @@ let handle_keeper_fs_edit
     Safe_ops.json_string ~default:"overwrite" "mode" args
   in
   let mode_opt = fs_write_mode_of_string_opt mode_raw in
-  (* Early validation for 9B models that send empty/missing params *)
+  (* Early validation: path is required for every mode. *)
   if String.trim path = "" then
     error_json "path is required. Good: path='lib/foo.ml'. Bad: path=''."
-  else if String.trim content = "" then
-    error_json "content is required (non-empty). Writing 0 bytes is usually unintended."
   else match mode_opt with
   | None ->
     error_json (Printf.sprintf
       "mode must be one of [%s], got %S."
       (String.concat ", " valid_fs_write_mode_strings) mode_raw)
-  | Some mode ->
+  | Some Patch ->
+    let old_string = Safe_ops.json_string ~default:"" "old_string" args in
+    let new_string = Safe_ops.json_string ~default:"" "new_string" args in
+    let replace_all = Safe_ops.json_bool ~default:false "replace_all" args in
+    if old_string = "" then
+      error_json
+        "mode=patch requires non-empty old_string. Good: \
+         old_string='let x = 1'."
+    else
+      (match resolve_keeper_path ~config ~meta ~raw_path:path with
+       | Error e -> error_json e
+       | Ok target ->
+         (try
+            let current =
+              try Fs_compat.load_file target
+              with _ -> ""
+            in
+            if current = "" then
+              error_json ~fields:[ "path", `String target ]
+                "patch target file does not exist or is empty. Use \
+                 mode=overwrite to create."
+            else
+              match
+                apply_patch ~old_string ~new_string ~replace_all current
+              with
+              | Error msg ->
+                error_json ~fields:[ "path", `String target ] msg
+              | Ok (updated, occurrences) ->
+                Fs_compat.save_file target updated;
+                Log.Keeper.info
+                  "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
+                   replace_all=%b occurrences=%d bytes=%d"
+                  meta.name target replace_all occurrences
+                  (String.length updated);
+                Yojson.Safe.to_string
+                  (`Assoc
+                      [ "ok", `Bool true
+                      ; "path", `String target
+                      ; "mode", `String "patch"
+                      ; "replace_all", `Bool replace_all
+                      ; "occurrences", `Int occurrences
+                      ; "bytes_written", `Int (String.length updated)
+                      ])
+          with
+          | Invalid_argument e ->
+            error_json ~fields:[ "path", `String target ] e
+          | Sys_error e -> error_json ~fields:[ "path", `String target ] e
+          | Unix.Unix_error (err, _, _) ->
+            error_json ~fields:[ "path", `String target ]
+              (Unix.error_message err)))
+  | Some ((Overwrite | Append) as mode) ->
   let mode_label = fs_write_mode_to_string mode in
+  if String.trim content = "" then
+    error_json "content is required (non-empty). Writing 0 bytes is usually unintended."
+  else
   match resolve_keeper_path ~config ~meta ~raw_path:path with
   | Error e -> error_json e
   | Ok target ->
@@ -124,7 +229,8 @@ let handle_keeper_fs_edit
        Fs_compat.mkdir_p parent;
        (match mode with
         | Append -> Fs_compat.append_file target content
-        | Overwrite -> Fs_compat.save_file target content);
+        | Overwrite -> Fs_compat.save_file target content
+        | Patch -> ()  (* unreachable: caught above *));
        Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
          meta.name target mode_label
          (String.length content);

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -3,7 +3,7 @@
 (** Issue #8490: Variant SSOT for fs write mode. Mirror in
     [Tool_shard.fs_write_mode_enum_strings] (cycle avoidance, sync
     regression test catches drift). *)
-type fs_write_mode = Overwrite | Append
+type fs_write_mode = Overwrite | Append | Patch
 
 val fs_write_mode_to_string : fs_write_mode -> string
 val fs_write_mode_of_string_opt : string -> fs_write_mode option

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -16,13 +16,18 @@ let aliases : (string * string) list =
     "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
   ]
 
-(* Subset of [aliases] safe for OAS dual registration in Phase A.2.
-   Edit/Write/Grep need nontrivial input shape adapters (string-replace
-   semantics, op=rg synthesis) — landing in Phase A.4. *)
+(* Subset of [aliases] safe for OAS dual registration. Phase A.4
+   (#8963 follow-up) added Edit/Write/Grep once their input adapters
+   landed: Edit goes through the new keeper_fs_edit mode=patch path,
+   Write maps cleanly to mode=overwrite, Grep synthesizes
+   keeper_shell op=rg. *)
 let oas_dual_register : (string * string) list =
   [
     "Bash", "keeper_bash";
+    "Edit", "keeper_fs_edit";
+    "Grep", "keeper_shell";
     "Read", "keeper_fs_read";
+    "Write", "keeper_fs_edit";
   ]
 
 (* Anthropic Code surface names without a keeper cognate. The disclosure
@@ -121,9 +126,68 @@ let read_public_schema =
          with the Anthropic Read tool surface.";
     ]
 
+(* Anthropic Code "Edit" tool schema. Patch semantics: in-place string
+   replacement. Maps to keeper_fs_edit mode=patch. *)
+let edit_public_schema =
+  object_schema ~required:[ "file_path"; "old_string"; "new_string" ]
+    [
+      property "file_path" "string"
+        "Absolute or playground-relative file path to edit. The file \
+         must exist.";
+      property "old_string" "string"
+        "Exact substring to replace. Must occur exactly once in the file \
+         unless replace_all=true.";
+      property "new_string" "string"
+        "Replacement substring. Pass an empty string to delete \
+         old_string.";
+      property "replace_all" "boolean"
+        "Default false. When true, replaces every occurrence of \
+         old_string.";
+    ]
+
+(* Anthropic Code "Write" tool schema. Maps to keeper_fs_edit
+   mode=overwrite (parent dirs created automatically). *)
+let write_public_schema =
+  object_schema ~required:[ "file_path"; "content" ]
+    [
+      property "file_path" "string"
+        "Absolute or playground-relative file path. Parent directories \
+         are created as needed.";
+      property "content" "string"
+        "Full file content. Overwrites the existing file.";
+    ]
+
+(* Anthropic Code "Grep" tool schema. Synthesized as keeper_shell op=rg
+   so the LLM does not need to learn keeper_shell's op enum. The
+   keeper_shell rg implementation already supports type/glob filters
+   used here. Anthropic-Code -i and -n flags are accepted as boolean
+   conveniences but currently dropped (rg always emits line numbers). *)
+let grep_public_schema =
+  object_schema ~required:[ "pattern" ]
+    [
+      property "pattern" "string"
+        "Regular expression to search for.";
+      property "path" "string"
+        "Directory or file to search in. Defaults to the keeper \
+         playground when omitted.";
+      property "glob" "string"
+        "Glob filter, e.g. '*.ml' or 'lib/**/*.ml'.";
+      property "type" "string"
+        "Ripgrep file-type filter, e.g. 'ml', 'py'.";
+      property "-i" "boolean"
+        "Case insensitive. Currently accepted but not yet routed; \
+         Anthropic-Code compatibility shim.";
+      property "-n" "boolean"
+        "Show line numbers. Always true under the hood; accepted for \
+         schema parity.";
+    ]
+
 let public_input_schema = function
   | "Bash" -> Some bash_public_schema
+  | "Edit" -> Some edit_public_schema
+  | "Grep" -> Some grep_public_schema
   | "Read" -> Some read_public_schema
+  | "Write" -> Some write_public_schema
   | _ -> None
 
 (* Translate an LLM call payload from the public schema to the internal
@@ -162,10 +226,70 @@ let translate_read_input input =
       `Assoc (List.rev !out)
   | _ -> input
 
+(* Anthropic Edit { file_path, old_string, new_string, replace_all? }
+   → keeper_fs_edit { path, mode=patch, old_string, new_string,
+                      replace_all }. The handler reads the current
+   file, replaces, and writes back. *)
+let translate_edit_input input =
+  match input with
+  | `Assoc fields ->
+      let out = ref [ ("mode", `String "patch") ] in
+      List.iter
+        (fun (k, v) ->
+          match k with
+          | "file_path" -> out := ("path", v) :: !out
+          | "old_string" | "new_string" | "replace_all" ->
+              out := (k, v) :: !out
+          | "mode" | "content" -> ()  (* ignore caller-supplied overrides *)
+          | _ -> out := (k, v) :: !out)
+        fields;
+      `Assoc (List.rev !out)
+  | _ -> input
+
+(* Anthropic Write { file_path, content } → keeper_fs_edit
+   { path, content, mode=overwrite }. *)
+let translate_write_input input =
+  match input with
+  | `Assoc fields ->
+      let out = ref [ ("mode", `String "overwrite") ] in
+      List.iter
+        (fun (k, v) ->
+          match k with
+          | "file_path" -> out := ("path", v) :: !out
+          | "content" -> out := ("content", v) :: !out
+          | "mode" -> ()  (* always overwrite via Write alias *)
+          | _ -> out := (k, v) :: !out)
+        fields;
+      `Assoc (List.rev !out)
+  | _ -> input
+
+(* Anthropic Grep { pattern, path?, glob?, type?, -i?, -n? } →
+   keeper_shell { op=rg, pattern, path?, glob?, type? }. The boolean
+   conveniences -i/-n are dropped; keeper_shell rg always emits line
+   numbers and case sensitivity is folded into the pattern itself. *)
+let translate_grep_input input =
+  match input with
+  | `Assoc fields ->
+      let out = ref [ ("op", `String "rg") ] in
+      List.iter
+        (fun (k, v) ->
+          match k with
+          | "pattern" | "path" | "glob" | "type" ->
+              out := (k, v) :: !out
+          | "op" -> ()  (* always rg via Grep alias *)
+          | "-i" | "-n" -> ()  (* shim accepted, not routed *)
+          | _ -> out := (k, v) :: !out)
+        fields;
+      `Assoc (List.rev !out)
+  | _ -> input
+
 let translate_input ~public input =
   match public with
   | "Bash" -> translate_bash_input input
+  | "Edit" -> translate_edit_input input
+  | "Grep" -> translate_grep_input input
   | "Read" -> translate_read_input input
+  | "Write" -> translate_write_input input
   | _ -> input
 
 let expand_universe internal_names =

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -42,25 +42,16 @@ val all_aliases : unit -> (string * string) list
 (** {1 OAS dual registration (Phase A.2)} *)
 
 (** [oas_dual_register_aliases ()] is the subset of [all_aliases ()]
-    that is currently safe to register with OAS as additional [Tool.t]
-    entries sharing the keeper handler.
+    safe to register with OAS as additional [Tool.t] entries sharing
+    the keeper handler.
 
     Membership requires (a) a known input-shape translation back to the
     internal tool's schema and (b) a tailored public input_schema so
     the LLM sees the Anthropic-Code shape it expects.
 
-    Phase A.2: [Bash], [Read]. These two account for ~80% of the
-    hallucinated-builtin tool calls measured in #8778.
-
-    Excluded (deferred to Phase A.4): [Edit] (semantic mismatch:
-    Anthropic Edit does string-replace, keeper_fs_edit only overwrites);
-    [Write] (covered when [Edit] is); [Grep] (needs op=rg input
-    synthesis).
-
-    Excluded aliases remain in [all_aliases ()] / [to_internal] so the
-    disclosure-check canonicalization (Phase A.3) keeps treating
-    [Edit]/[Write]/[Grep] as known names — turns are no longer nuked
-    even though OAS still rejects the call. *)
+    Phase A.2: [Bash], [Read].
+    Phase A.4: [Edit] (via new keeper_fs_edit mode=patch), [Write]
+    (via mode=overwrite), [Grep] (synthesized as keeper_shell op=rg). *)
 val oas_dual_register_aliases : unit -> (string * string) list
 
 (** [public_input_schema public_name] returns the LLM-facing JSON schema

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -39,7 +39,7 @@ let memory_kind_enum_strings =
     shape as #8467 / #8480 / #8484). Sync regression test in
     [test_types.ml :: fs_write_mode_ssot] catches drift. *)
 let fs_write_mode_enum_strings =
-  [ "overwrite"; "append" ]
+  [ "overwrite"; "append"; "patch" ]
 
 (** Issue #8513: hand-mirrored from
     [Board_dispatch.valid_sort_order_strings] (#8453 SSOT). Direct

--- a/test/dune
+++ b/test/dune
@@ -92,6 +92,7 @@
         test_keeper_tool_alias
         test_keeper_sandbox_containment
         test_keeper_shell_containment
+        test_keeper_fs_edit_patch
         test_keeper_github_read_only
         test_worktree_live_context
         test_tool_input_validation
@@ -205,6 +206,7 @@
           test_keeper_tool_alias
           test_keeper_sandbox_containment
           test_keeper_shell_containment
+          test_keeper_fs_edit_patch
           test_keeper_github_read_only
           test_worktree_live_context
           test_tool_input_validation

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -1,0 +1,279 @@
+(** Tests for [Keeper_exec_fs.handle_keeper_fs_edit] mode=patch.
+
+    RFC-0006 Phase A.4 — string-replace edit mode added so the
+    Anthropic Code [Edit] cognate can be wired through OAS dual
+    registration. *)
+
+module Coord = Masc_mcp.Coord
+module Keeper_exec_fs = Masc_mcp.Keeper_exec_fs
+module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
+module Fs_compat = Fs_compat
+module Json = Yojson.Safe.Util
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_fs_edit_patch_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun n -> rm (Filename.concat path n)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with _ -> ()
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let p = Filename.dirname path in
+    if p <> path then ensure_dir p;
+    Unix.mkdir path 0o755)
+
+let make_meta name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "patch test");
+        ("allowed_paths", `List [ `String "*" ]);
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok m -> m
+  | Error e -> Alcotest.fail e
+
+let with_eio_fs f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  f ()
+
+let setup f =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base ".masc");
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Keeper_registry.clear ();
+  let config = Coord.default_config base in
+  let meta = make_meta "tester" in
+  let playground =
+    Filename.concat base
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  ensure_dir playground;
+  f ~config ~meta ~playground
+
+let parse raw = Yojson.Safe.from_string raw
+
+let parse_ok raw =
+  parse raw |> Json.member "ok" |> Json.to_bool_option
+  |> Option.value ~default:false
+
+let parse_error raw =
+  parse raw |> Json.member "error" |> Json.to_string_option
+
+let parse_int raw field =
+  parse raw |> Json.member field |> Json.to_int_option
+
+(* ── Tests ───────────────────────────────────────────────────────── *)
+
+let test_patch_unique_match () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "let x = 1\nlet y = 2\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "let x = 1");
+            ("new_string", `String "let x = 42");
+          ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check (option int)) "occurrences=1" (Some 1)
+    (parse_int raw "occurrences");
+  let after = Fs_compat.load_file path in
+  Alcotest.(check string) "file content updated"
+    "let x = 42\nlet y = 2\n" after
+
+let test_patch_no_match_errors () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "let x = 1\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "let z = 99");
+            ("new_string", `String "let z = 100");
+          ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw);
+  match parse_error raw with
+  | None -> Alcotest.fail "expected error message"
+  | Some msg ->
+      Alcotest.(check bool) "error mentions not found" true
+        (let needle = "not found" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
+let test_patch_multiple_matches_without_replace_all_errors () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "x = 1");
+            ("new_string", `String "x = 2");
+          ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw);
+  let after = Fs_compat.load_file path in
+  Alcotest.(check string) "file unchanged on rejection"
+    "x = 1\nx = 1\nx = 1\n" after
+
+let test_patch_replace_all () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "x = 1");
+            ("new_string", `String "x = 2");
+            ("replace_all", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check (option int)) "occurrences=3" (Some 3)
+    (parse_int raw "occurrences");
+  Alcotest.(check string) "all replaced"
+    "x = 2\nx = 2\nx = 2\n" (Fs_compat.load_file path)
+
+let test_patch_empty_old_string_errors () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "let x = 1\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "");
+            ("new_string", `String "anything");
+          ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw);
+  Alcotest.(check bool) "error message present" true
+    (Option.is_some (parse_error raw))
+
+let test_patch_missing_file_errors () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "ghost.ml" in
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "x");
+            ("new_string", `String "y");
+          ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw)
+
+let test_patch_delete_via_empty_new_string () =
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "src.ml" in
+  Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "patch");
+            ("old_string", `String "DELETE_ME\n");
+            ("new_string", `String "");
+          ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check string) "deletion landed"
+    "keep me\nkeep me too\n" (Fs_compat.load_file path)
+
+let test_overwrite_unchanged_by_patch_addition () =
+  (* Regression: introducing Patch must not break existing overwrite. *)
+  setup @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "new.txt" in
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("path", `String path);
+            ("mode", `String "overwrite");
+            ("content", `String "fresh");
+          ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check string) "overwrite wrote bytes"
+    "fresh" (Fs_compat.load_file path)
+
+let () =
+  Alcotest.run "Keeper_fs_edit_patch"
+    [
+      ( "patch-mode",
+        [
+          Alcotest.test_case "unique match replaces" `Quick
+            test_patch_unique_match;
+          Alcotest.test_case "no match returns error" `Quick
+            test_patch_no_match_errors;
+          Alcotest.test_case "multi match without replace_all rejected"
+            `Quick test_patch_multiple_matches_without_replace_all_errors;
+          Alcotest.test_case "replace_all applies to every occurrence"
+            `Quick test_patch_replace_all;
+          Alcotest.test_case "empty old_string rejected" `Quick
+            test_patch_empty_old_string_errors;
+          Alcotest.test_case "missing file rejected" `Quick
+            test_patch_missing_file_errors;
+          Alcotest.test_case "empty new_string deletes substring" `Quick
+            test_patch_delete_via_empty_new_string;
+          Alcotest.test_case "overwrite mode regression" `Quick
+            test_overwrite_unchanged_by_patch_addition;
+        ] );
+    ]

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -159,8 +159,8 @@ let yojson_field name j =
 let test_oas_dual_register_subset () =
   let pairs = Alias.oas_dual_register_aliases () in
   let names = List.map fst pairs in
-  Alcotest.(check (list string)) "Phase A.2 dual-reg subset"
-    [ "Bash"; "Read" ] names;
+  Alcotest.(check (list string)) "Phase A.4 dual-reg covers Bash/Edit/Grep/Read/Write"
+    [ "Bash"; "Edit"; "Grep"; "Read"; "Write" ] names;
   (* Every entry must also appear in the full alias table. *)
   let full = List.map fst (Alias.all_aliases ()) in
   List.iter
@@ -171,12 +171,12 @@ let test_oas_dual_register_subset () =
     pairs
 
 let test_public_input_schema_present () =
-  Alcotest.(check bool) "Bash has tailored schema"
-    true (Option.is_some (Alias.public_input_schema "Bash"));
-  Alcotest.(check bool) "Read has tailored schema"
-    true (Option.is_some (Alias.public_input_schema "Read"));
-  Alcotest.(check bool) "Edit (deferred) has no tailored schema"
-    true (Option.is_none (Alias.public_input_schema "Edit"));
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s has tailored schema" name)
+        true (Option.is_some (Alias.public_input_schema name)))
+    [ "Bash"; "Edit"; "Grep"; "Read"; "Write" ];
   Alcotest.(check bool) "unknown public name has no schema"
     true (Option.is_none (Alias.public_input_schema "Nope"))
 
@@ -246,6 +246,141 @@ let test_translate_read_input () =
     (Option.bind max_bytes (function `Int i -> Some i | _ -> None));
   Alcotest.(check bool) "offset is dropped (keeper_fs_read does not support it)"
     true (Option.is_none offset)
+
+let test_edit_schema_uses_anthropic_fields () =
+  let schema = Option.get (Alias.public_input_schema "Edit") in
+  let props = Option.get (yojson_field "properties" schema) in
+  List.iter
+    (fun field ->
+      Alcotest.(check bool)
+        (Printf.sprintf "Edit schema exposes %S" field)
+        true (Option.is_some (yojson_field field props)))
+    [ "file_path"; "old_string"; "new_string"; "replace_all" ];
+  Alcotest.(check bool) "Edit schema does not expose internal 'mode' to LLM"
+    true (Option.is_none (yojson_field "mode" props))
+
+let test_write_schema_uses_anthropic_fields () =
+  let schema = Option.get (Alias.public_input_schema "Write") in
+  let props = Option.get (yojson_field "properties" schema) in
+  List.iter
+    (fun field ->
+      Alcotest.(check bool)
+        (Printf.sprintf "Write schema exposes %S" field)
+        true (Option.is_some (yojson_field field props)))
+    [ "file_path"; "content" ];
+  Alcotest.(check bool) "Write schema does not expose internal 'mode' to LLM"
+    true (Option.is_none (yojson_field "mode" props))
+
+let test_grep_schema_uses_anthropic_fields () =
+  let schema = Option.get (Alias.public_input_schema "Grep") in
+  let props = Option.get (yojson_field "properties" schema) in
+  Alcotest.(check bool) "Grep schema exposes 'pattern'"
+    true (Option.is_some (yojson_field "pattern" props));
+  Alcotest.(check bool) "Grep schema does not expose internal 'op' to LLM"
+    true (Option.is_none (yojson_field "op" props))
+
+let test_translate_edit_input () =
+  let input =
+    `Assoc
+      [
+        ("file_path", `String "/tmp/foo.ml");
+        ("old_string", `String "let x = 1");
+        ("new_string", `String "let x = 2");
+        ("replace_all", `Bool true);
+      ]
+  in
+  let translated = Alias.translate_input ~public:"Edit" input in
+  Alcotest.(check (option string)) "file_path -> path"
+    (Some "/tmp/foo.ml")
+    (Option.bind (yojson_field "path" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option string)) "mode injected as 'patch'"
+    (Some "patch")
+    (Option.bind (yojson_field "mode" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check bool) "old_string preserved" true
+    (Option.is_some (yojson_field "old_string" translated));
+  Alcotest.(check bool) "new_string preserved" true
+    (Option.is_some (yojson_field "new_string" translated));
+  Alcotest.(check (option bool)) "replace_all preserved"
+    (Some true)
+    (Option.bind (yojson_field "replace_all" translated)
+       (function `Bool b -> Some b | _ -> None))
+
+let test_translate_edit_drops_caller_supplied_mode () =
+  (* Defense-in-depth: even if the LLM tries to override mode the
+     translator must force mode=patch. *)
+  let input =
+    `Assoc
+      [
+        ("file_path", `String "/tmp/x");
+        ("old_string", `String "a");
+        ("new_string", `String "b");
+        ("mode", `String "overwrite");
+        ("content", `String "ignored");
+      ]
+  in
+  let translated = Alias.translate_input ~public:"Edit" input in
+  Alcotest.(check (option string)) "mode is forced to patch"
+    (Some "patch")
+    (Option.bind (yojson_field "mode" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check bool) "caller-supplied content dropped" true
+    (Option.is_none (yojson_field "content" translated))
+
+let test_translate_write_input () =
+  let input =
+    `Assoc
+      [
+        ("file_path", `String "/tmp/new.txt");
+        ("content", `String "hello world");
+      ]
+  in
+  let translated = Alias.translate_input ~public:"Write" input in
+  Alcotest.(check (option string)) "file_path -> path"
+    (Some "/tmp/new.txt")
+    (Option.bind (yojson_field "path" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option string)) "mode injected as 'overwrite'"
+    (Some "overwrite")
+    (Option.bind (yojson_field "mode" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option string)) "content preserved verbatim"
+    (Some "hello world")
+    (Option.bind (yojson_field "content" translated)
+       (function `String s -> Some s | _ -> None))
+
+let test_translate_grep_input () =
+  let input =
+    `Assoc
+      [
+        ("pattern", `String "TODO");
+        ("path", `String "lib/");
+        ("glob", `String "*.ml");
+        ("type", `String "ml");
+        ("-i", `Bool true);
+        ("-n", `Bool true);
+      ]
+  in
+  let translated = Alias.translate_input ~public:"Grep" input in
+  Alcotest.(check (option string)) "op injected as 'rg'"
+    (Some "rg")
+    (Option.bind (yojson_field "op" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check (option string)) "pattern preserved"
+    (Some "TODO")
+    (Option.bind (yojson_field "pattern" translated)
+       (function `String s -> Some s | _ -> None));
+  Alcotest.(check bool) "path preserved" true
+    (Option.is_some (yojson_field "path" translated));
+  Alcotest.(check bool) "glob preserved" true
+    (Option.is_some (yojson_field "glob" translated));
+  Alcotest.(check bool) "type preserved" true
+    (Option.is_some (yojson_field "type" translated));
+  Alcotest.(check bool) "-i shim dropped" true
+    (Option.is_none (yojson_field "-i" translated));
+  Alcotest.(check bool) "-n shim dropped" true
+    (Option.is_none (yojson_field "-n" translated))
 
 let test_translate_unknown_is_identity () =
   let input = `Assoc [ ("foo", `String "bar") ] in
@@ -322,8 +457,15 @@ let () =
           Alcotest.test_case "tailored input schema present" `Quick test_public_input_schema_present;
           Alcotest.test_case "Bash schema uses 'command' field" `Quick test_bash_schema_uses_command_field;
           Alcotest.test_case "Read schema uses 'file_path' field" `Quick test_read_schema_uses_file_path;
+          Alcotest.test_case "Edit schema uses Anthropic field names" `Quick test_edit_schema_uses_anthropic_fields;
+          Alcotest.test_case "Write schema uses Anthropic field names" `Quick test_write_schema_uses_anthropic_fields;
+          Alcotest.test_case "Grep schema uses Anthropic field names" `Quick test_grep_schema_uses_anthropic_fields;
           Alcotest.test_case "translate Bash input shape" `Quick test_translate_bash_input;
           Alcotest.test_case "translate Read input shape" `Quick test_translate_read_input;
+          Alcotest.test_case "translate Edit input shape" `Quick test_translate_edit_input;
+          Alcotest.test_case "translate Edit drops caller mode" `Quick test_translate_edit_drops_caller_supplied_mode;
+          Alcotest.test_case "translate Write input shape" `Quick test_translate_write_input;
+          Alcotest.test_case "translate Grep input shape" `Quick test_translate_grep_input;
           Alcotest.test_case "translate unknown is identity" `Quick test_translate_unknown_is_identity;
           Alcotest.test_case "translate malformed is identity" `Quick test_translate_malformed_input_is_identity;
           Alcotest.test_case "expand_universe adds aliases" `Quick test_expand_universe_adds_aliases;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -691,8 +691,8 @@ let () =
           if not (List.mem actual F.valid_fs_write_mode_strings) then
             Alcotest.failf "fs_write_mode_to_string %S not in valid_fs_write_mode_strings" actual
         in
-        witness F.Overwrite; witness F.Append;
-        Alcotest.(check int) "count" 2 (List.length F.valid_fs_write_mode_strings));
+        witness F.Overwrite; witness F.Append; witness F.Patch;
+        Alcotest.(check int) "count" 3 (List.length F.valid_fs_write_mode_strings));
       Alcotest.test_case "of_string_opt sound partial + empty back-compat" `Quick (fun () ->
         let module F = Masc_mcp.Keeper_exec_fs in
         Alcotest.(check bool) "overwrite" true (F.fs_write_mode_of_string_opt "overwrite" <> None);


### PR DESCRIPTION
## Summary

Extends Phase A.2 OAS dual registration from {Bash, Read} to the **full Anthropic Code core surface** {Bash, Edit, Grep, Read, Write}. The LLM can now call \`Edit\`/\`Write\`/\`Grep\` by their training-distribution names; routing + input translation happens in MASC.

| Public alias | Internal target | Translation |
|--------------|-----------------|-------------|
| \`Bash\` | \`keeper_bash\` | A.2 (existing) |
| \`Read\` | \`keeper_fs_read\` | A.2 (existing) |
| **\`Edit\`** | \`keeper_fs_edit\` | **patch mode (new)** |
| **\`Write\`** | \`keeper_fs_edit\` | **mode=overwrite** |
| **\`Grep\`** | \`keeper_shell\` | **op=rg synthesis** |

## Patch mode in keeper_fs_edit

Anthropic Edit is patch-style; \`keeper_fs_edit\` was overwrite-only. New \`mode=patch\` enforces Anthropic semantics:

- empty \`old_string\` → error
- \`old_string\` not in file → error
- multiple matches without \`replace_all=true\` → **rejected** (forces caller to disambiguate)
- \`replace_all=true\` → rewrites every occurrence

WRITE_AUDIT log includes \`mode\`, \`replace_all\`, \`occurrences\` for parity. SSOT mirror in \`tool_shard.ml\` updated; sync test in \`fs_write_mode_ssot\` covers the third constructor.

## Translator defense-in-depth

The Edit translator forces \`mode=patch\` and **drops caller-supplied \`content\`**, so a malformed LLM payload cannot accidentally route through overwrite. Tested.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`dune runtest test/test_keeper_fs_edit_patch.exe\` — 8/8 (new)
- [x] \`dune runtest test/test_keeper_tool_alias.exe\` — 30/30 (was 19, +11 new)
- [x] \`dune runtest test/test_types.exe\` — 117/117 (fs_write_mode_ssot extended)
- [x] \`dune runtest test/test_keeper_tools_oas.exe\` — 26/26
- [x] \`dune runtest test/test_tool_surface_ssot.exe\` — 12/12
- [x] \`dune runtest test/test_keeper_tool_exposure.exe\` — 25/25
- [x] \`dune runtest test/test_tool_registration_consistency.exe\` — 59/59
- [ ] CI green
- [ ] Operator: observe Edit/Write/Grep tool_exec entries with internal \`tool="keeper_fs_edit"\` etc. (telemetry SSOT preserved)
- [ ] After 24h: \`unexpected_tool_names\` for Edit/Write/Grep should drop to ~0

Refs: #8778, RFC-0006. Companion to #8929 (A.2 Bash/Read), #8912 (A.3 canonicalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)