### PR TITLE
feat(bonsai-dashboard): moonrise + page tag live from Keepers

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2214,6 +2214,40 @@ let view_hud (response : Logs_types.response) =
     ]
 ;;
 
+(** Roman numeral for cycle counters. Only small integers (≤ 39) are
+    expected for dashboard display; outside that range we fall back to the
+    decimal form so very large cycles still render. *)
+let roman_of_int (n : int) : string =
+  if n <= 0 || n > 39
+  then Printf.sprintf "%d" n
+  else
+    let pairs =
+      [ 10, "x"; 9, "ix"; 5, "v"; 4, "iv"; 1, "i" ]
+    in
+    let buf = Buffer.create 8 in
+    let rec go n = function
+      | [] -> ()
+      | (v, s) :: rest ->
+        if n >= v
+        then (Buffer.add_string buf s; go (n - v) ((v, s) :: rest))
+        else go n rest
+    in
+    go n pairs;
+    Buffer.contents buf
+;;
+
+(** Count keepers by status. *)
+type fleet_tally = { live : int; warn : int; dead : int }
+
+let tally_fleet (ks : Keepers_types.keeper list) : fleet_tally =
+  List.fold ks ~init:{ live = 0; warn = 0; dead = 0 }
+    ~f:(fun acc (k : Keepers_types.keeper) ->
+      match k.status with
+      | Live -> { acc with live = acc.live + 1 }
+      | Warn -> { acc with warn = acc.warn + 1 }
+      | Dead -> { acc with dead = acc.dead + 1 })
+;;
+
 (** Focus keeper — first entry of the live response, or [None] when empty
     (triggers the legacy static fallback inside [focus_card_of]). *)
 let focus_keeper_of (k : Keepers_types.response) : Keepers_types.keeper option =
@@ -2302,11 +2336,25 @@ let render_response
       ; Node.button ~attrs:[ Style.btn_ghost ] [ Node.text "refresh" ]
       ]
   in
+  let tally = tally_fleet keepers.keepers in
+  let moon_lead_text =
+    match tally with
+    | { live = 0; warn = 0; dead = 0 } -> "the watch is on"
+    | { dead; _ } when dead > 0 -> "the watch stands a casualty"
+    | { warn; _ } when warn > 0 -> "the watch holds uneasy"
+    | _ -> "the watch is on"
+  in
+  let fleet_mono_text =
+    match tally with
+    | { live = 0; warn = 0; dead = 0 } -> "fleet · —"
+    | t ->
+      Printf.sprintf "fleet · %dl / %dw / %dd" t.live t.warn t.dead
+  in
   let moonrise =
     Node.div
       ~attrs:[ Style.moonrise ]
       [ Node.span ~attrs:[ Style.moon_glyph ] []
-      ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text "the watch is on" ]
+      ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text moon_lead_text ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span [ Node.text "lit by a half moon" ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
@@ -2316,6 +2364,10 @@ let render_response
             ; Attr.create "data-moon-clock" ""
             ]
           [ Node.text "—:— local" ]
+      ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
+      ; Node.span
+          ~attrs:[ Style.moon_mono ]
+          [ Node.text fleet_mono_text ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span
           ~attrs:[ Style.moon_mono ]
@@ -2606,7 +2658,18 @@ let render_response
              ~attrs:[ Style.page_head_lead ]
              [ Node.div
                  ~attrs:[ Style.page_tag ]
-                 [ Node.text "chronicle · quiet fox · day iv" ]
+                 [ Node.text
+                     (let room =
+                        match keepers.room with
+                        | Some r when String.length r > 0 -> r
+                        | _ -> "chronicle"
+                      in
+                      let day =
+                        if keepers.cycle <= 0
+                        then "—"
+                        else roman_of_int keepers.cycle
+                      in
+                      Printf.sprintf "%s · quiet fox · day %s" room day) ]
              ; Node.h1
                  ~attrs:[ Style.page_h1 ]
                  [ Node.text "the watch "


### PR DESCRIPTION
## Summary

Dashboard 상단부의 2 narrative surface(moonrise narrative strip + page tag)를 `Keepers` response로 연결. **cycle·room·fleet tally**가 서버 데이터를 따라간다.

> **Stack base**: `feature/bonsai-keepers-client`.
> 이전: #8940(merged to main) → #8947(open, server+focus+swim+ctx+roster rolled up) → **this PR**.

## 새 helper

| helper | 역할 |
|---|---|
| `roman_of_int` | cycle 번호 → roman 소문자 (`i`..`xxxix`). 40+는 decimal fallback |
| `tally_fleet` | keeper list → `{ live; warn; dead }` 집계 |

## moonrise

- **moon_lead 문구**: fleet 상태별 동적
  - `dead > 0` → `"the watch stands a casualty"`
  - `warn > 0` → `"the watch holds uneasy"`
  - 그 외 → `"the watch is on"`
- **새 segment**: `"fleet · Nl / Ww / Dd"` (base= 앞에 추가)
  - 빈 응답 → `"fleet · —"`

## page_tag

- `"chronicle · quiet fox · day iv"` → `"{room} · quiet fox · day {roman}"`
- `room = None` → `"chronicle"`
- `cycle = 0` → `"day —"` (fixture 상태에서 의미있게 degrade)

## Fallback 동작

`Keepers_types.fixture` (빈 keepers, cycle=0, room=None):
- page_tag: `"chronicle · quiet fox · day —"` (기존 `day iv`와 다름 — 하드코드 의존 제거)
- moon_lead: `"the watch is on"` (기존과 동일)
- fleet_mono: `"fleet · —"` (신규 segment)

서버 stub이 cycle=4, room="chronicle", 4 keepers 반환 중이므로 polling 이후 `"chronicle · quiet fox · day iv"` 복원.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 첫 렌더: page_tag = `"chronicle · quiet fox · day —"`, moon_lead = `"the watch is on"`, fleet = `"fleet · —"`
- [ ] 3s 후 polling: page_tag = `"chronicle · quiet fox · day iv"`, moon_lead = `"the watch stands a casualty"` (ash-hound Dead), fleet = `"fleet · 2l / 1w / 1d"`
- [ ] cycle을 서버에서 14로 바꾸면 `"day xiv"`로 렌더 (roman 변환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
