### PR TITLE
docs(spec): resolve KeeperCoreTriad self-contradicting 12->6 phase mappings (#8970)

### DIFF
--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -23,20 +23,18 @@
 \*          lib/keeper/keeper_unified_turn.ml (turn lifecycle)
 \*
 \* OCaml mapping:
-\*   phase              <-> Keeper_state_machine.phase (simplified to 5)
+\*   phase              <-> Keeper_state_machine.phase (12-phase OCaml type
+\*                          projected to a 6-symbol triad alphabet; see the
+\*                          canonical mapping in the TypeOK preamble below)
 \*   effective_cascade  <-> Keeper_cascade_routing.select_cascade result
 \*   provider_ceiling   <-> Oas_model_resolve.resolve_max_cascade_context
 \*   requested_max_tokens <-> Cascade_inference.resolve_max_tokens
 \*
-\* Phase simplification (12 -> 6):
-\*   Running    = {Running}               -- healthy, can run turns
-\*   Failing    = {Failing}               -- degraded, needs cheap recovery
-\*   Overflowed = {Overflowed}            -- context overflow, no new turns
-\*                                           (added 2026-04, MASC-1)
-\*   Compacting = {Compacting, HandingOff} -- buffer ops, local sufficient
-\*   Draining   = {Draining, Paused}      -- winding down, complete in-progress
-\*   Terminal   = {Stopped, Dead, Offline, Crashed, Restarting}
-\*                                        -- no turns possible
+\* (The canonical 12->6 phase mapping lives next to TypeOK on line ~89.
+\*  An earlier version of this preamble carried a separate "Phase
+\*  simplification (12 -> 6)" mapping that classified HandingOff / Paused /
+\*  Restarting differently from the canonical one.  Removed in #8970 to
+\*  avoid the self-contradiction that TLC could not surface.)
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- Caught a **spec self-contradiction** during the FSM drift sweep: \`KeeperCoreTriad.tla\` had two phase-abstraction comments classifying the same 12 OCaml phases differently.
- Issue #8970 details the discrepancy.
- This PR resolves the contradiction by deleting the legacy preamble mapping and pointing at the canonical \`#8642/#8701\` mapping that already lives next to TypeOK.

## The two contradicting mappings (before)

| OCaml phase | Legacy preamble (lines 31-39) | Canonical TypeOK preamble (lines 89-104) |
|-------------|-------------------------------|------------------------------------------|
| HandingOff  | -> Compacting (collapsed)     | unmodelled (companion spec)              |
| Paused      | -> Draining (collapsed)       | unmodelled (companion spec)              |
| Restarting  | -> Terminal (collapsed)       | unmodelled (companion spec)              |

Both were documentation-only — TLC cannot surface the contradiction because no spec action references the disputed OCaml phases.  A future maintainer extending the triad would read whichever block they hit first and build the wrong mental model.

## Why the canonical mapping wins
- \`Restarting\` is **not terminal** in OCaml semantics (it transitions back to Running on supervisor backoff); putting it in "Terminal" was misleading.
- \`Paused\` is operator-paused, semantically distinct from \`Draining\` (completing current turn before stop); conflating them elided a real distinction.
- The canonical mapping honestly admits "unmodelled" for the 3 phases and points to companion specs (\`KeeperReconcileLiveness\`, \`KeeperGenerationLineage\`) that own them.

## Bonus drift fix
- The same preamble said \"phase ... (simplified to 5)\" but the actual set has **6** symbols.  Replaced the hard-coded count with a description that points at the canonical mapping (avoiding future count drift).

## Test plan
- [x] Pure documentation-comment edit.
- [x] No \`.cfg\` change — TLC behaviour identical.
- [x] No spec action change — \`Phases\` set unchanged.

## Refs
- #8970 (umbrella issue)
- #8942 (sibling: derive_phase docstring drift)
- #8948 / #8952 / #8959 / #8965 (sibling FSM preamble drift fixes)
- #8642 / #8701 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)