### PR TITLE
docs(logic): batch-13 .mli for supervisor + worktree_live_context

### DIFF
--- a/lib/supervisor.mli
+++ b/lib/supervisor.mli
@@ -1,0 +1,80 @@
+(** Supervisor — One-for-one Eio fiber supervisor.
+
+    Manages a set of named child fibers with restart policies.
+    When a child crashes, the supervisor decides whether to restart,
+    back off and retry, or escalate.
+
+    Erlang/OTP-inspired but adapted to Eio's cooperative model:
+    - Children are [(unit -> unit)] functions, not OS processes
+    - Restart uses [Eio.Fiber.fork], not process spawn
+    - Backoff uses [Eio.Time.sleep], not Erlang timers
+
+    @since 2.102.0 *)
+
+(** {1 Types} *)
+
+(** Restart policy for a child. *)
+type restart_strategy =
+  | Permanent  (** Always restart on failure *)
+  | Temporary  (** Never restart — failure is expected *)
+  | Transient  (** Restart only on abnormal exit (exception) *)
+
+(** Opaque child specification — construct via {!child}. *)
+type child_spec
+
+(** Opaque supervisor handle — construct via {!create}. *)
+type t
+
+(** Snapshot returned by {!status}. [strategy] is serialised as
+    one of ["permanent" | "temporary" | "transient"]. *)
+type child_status = {
+  name : string;
+  running : bool;
+  disabled : bool;
+  restart_count : int;
+  strategy : string;
+}
+
+(** {1 Construction} *)
+
+(** [child ~name ~start ?strategy ?max_restarts ?restart_window_s ()].
+    Defaults: [strategy = Permanent], [max_restarts = 5],
+    [restart_window_s = 60.0]. *)
+val child :
+  name:string ->
+  start:(unit -> unit) ->
+  ?strategy:restart_strategy ->
+  ?max_restarts:int ->
+  ?restart_window_s:float ->
+  unit ->
+  child_spec
+
+val create : child_spec list -> t
+
+(** {1 Lifecycle} *)
+
+(** Start all children. Must be called within an [Eio.Switch]
+    context. Idempotent — logs a warning and does nothing on a second
+    call. *)
+val start :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  t ->
+  unit
+
+(** Re-enable a child that was auto-disabled after exceeding
+    [max_restarts] in [restart_window_s]. Returns [true] when a
+    disabled child with [name] was re-enabled, [false] otherwise
+    (unknown name or already running). *)
+val reenable :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  t ->
+  string ->
+  bool
+
+(** {1 Observation} *)
+
+val status : t -> child_status list
+
+val status_to_json : child_status -> Yojson.Safe.t

--- a/lib/worktree_live_context.mli
+++ b/lib/worktree_live_context.mli
@@ -1,0 +1,47 @@
+(** Worktree_live_context — Capture per-keeper "has the working tree
+    changed since last turn?" signal for world-observation blocks.
+
+    On each call, runs [git status --porcelain] against the base_path
+    repo, compares a stable hash against the previous turn's hash for
+    the given [actor_key], and emits a formatted
+    [<git_status_change>] block only when the hash differs.
+
+    Cache state persists under
+    [<repo_root>/.masc/worktree-live-context/<actor_key>.hash].
+    Test hooks for injecting a deterministic git capture are kept
+    internal and not part of the public interface. *)
+
+(** [capture_change_block ~base_path ~actor_key] returns
+    - [Some block] — a [<git_status_change>] XML block with up to 20
+      visible lines, when the working tree has changed since the last
+      call for [actor_key].
+    - [None] — when the repo cannot be located, when no changes are
+      present, or when the hash matches the previous call. *)
+val capture_change_block :
+  base_path:string -> actor_key:string -> string option
+
+(** {1 Test hooks}
+
+    Production code should not call these. *)
+
+(** Capture hook signature: [~workdir args] → optional stdout lines
+    from the stubbed [git] invocation. *)
+type git_capture_hook =
+  workdir:string -> string list -> string list option
+
+(** Install a deterministic git capture used instead of spawning
+    [git] via {!Masc_exec.Exec_gate}. *)
+val set_git_capture_hook_for_tests : git_capture_hook -> unit
+
+(** Remove any previously installed {!set_git_capture_hook_for_tests}
+    hook. *)
+val clear_git_capture_hook_for_tests : unit -> unit
+
+(** Reset the in-memory per-repo status cache so tests observe a
+    deterministic "no previous hash" state. *)
+val clear_status_cache_for_tests : unit -> unit
+
+(** [current_status_lines ~repo_root] returns the cached
+    [git status --porcelain] lines for [repo_root], refreshing from
+    disk on cache miss. *)
+val current_status_lines : repo_root:string -> string list


### PR DESCRIPTION
Wave 3 batch 13. 바디 무수정.

| 파일 | ml 줄수 | mli 줄수 |
|------|---------|----------|
| `lib/supervisor.mli` | 174 | 70 |
| `lib/worktree_live_context.mli` | 170 | 38 |

## 설계 노트

### supervisor
- `child_spec` / `t` abstract (opaque type). `child_status`는 record expose (snapshot 용).
- `restart_strategy` variant 3개 (Permanent/Temporary/Transient) public.
- 4 internal (start_child 재귀 fiber spawn, prune_restarts, restart_limit_exceeded, find_child) hide.

### worktree_live_context
- Production API 1개 (`capture_change_block`). 4 test hook은 명시적으로 expose.
- 발견한 grep gap 2종:
  1. `open Dashboard_http_helpers` 패턴 → 모듈명 prefix 없이 사용되어 unqualified grep 필요.
  2. `module Wlc = Worktree_live_context` alias → test 파일은 alias로만 호출, 원 이름 grep이 miss.

### 건너뛴 후보
- **dashboard_http_helpers** (156): 5 파일이 `open` 으로 consume → narrow mli 불가. 전체 surface 조사 후 별도 PR.

## 검증
- `dune build --root=.` → exit 0 (iterative add 후)

## Metric
| 항목 | 이전 | 이후 |
|------|------|------|
| masc-mcp `.mli` | 329 | **331** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] open + alias grep trap 문서화
- [x] Abstract type 적극 활용 (supervisor child_spec/t)
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)