### PR TITLE
fix(auth): preserve explicit agent aliases on mutation paths

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -201,9 +201,15 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   let agent_name =
     match token with
-    (* Generated dashboard/session aliases should not outrank the
-       credential owner encoded by the bearer token. *)
-    | Some t when is_transient_agent_name agent_name ->
+    (* Explicit agent_name is the caller's SSOT for this request.
+       Rewriting an explicit generated alias to the bearer-token owner
+       makes mutation paths operate under a different identity than the
+       one shown in join/status/debug output, which is exactly the
+       #8892 joined/debug/credential-route drift. Keep the explicit
+       alias and let auth preflight reject it if the token does not
+       authorize that identity. We only fall back to token ownership
+       when the request did not explicitly name an agent. *)
+    | Some t when (not has_explicit_agent_name) && is_transient_agent_name agent_name ->
         (match Auth.resolve_agent_from_token config.base_path ~token:t with
          | Ok resolved -> resolved
          | Error _ -> agent_name)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1548,6 +1548,72 @@ let check_auth_preflight_result ~tool_name ok msg =
      || contains_substring msg "Unauthorized"
      || contains_substring msg "No credential")
 
+let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore
+    (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-claim-next"
+       ~priority:2 ~description:"");
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_claim_next"
+      ~arguments:(`Assoc [ ("agent_name", `String "dashboard-eager-manta") ])
+  in
+  check_auth_preflight_result ~tool_name:"masc_claim_next" ok msg;
+  check_task_still_todo state.room_config "task-001";
+  cleanup_dir base_path
+
+let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore
+    (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-transition"
+       ~priority:2 ~description:"");
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_transition"
+      ~arguments:
+        (`Assoc
+          [
+            ("agent_name", `String "dashboard-eager-manta");
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+  in
+  check_auth_preflight_result ~tool_name:"masc_transition" ok msg;
+  check_task_still_todo state.room_config "task-001";
+  cleanup_dir base_path
+
 let test_execute_tool_claim_next_requires_auth_before_mutation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2593,6 +2659,10 @@ let eio_tests = [
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "generated agent_name uses token identity", `Quick,
     test_execute_tool_generated_agent_name_uses_token_identity;
+  "explicit generated alias claim_next not rewritten by token", `Quick,
+    test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token;
+  "explicit generated alias transition not rewritten by token", `Quick,
+    test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token;
   "claim_next auth preflight blocks mutation", `Quick,
     test_execute_tool_claim_next_requires_auth_before_mutation;
   "transition auth preflight blocks mutation", `Quick,


### PR DESCRIPTION
## Summary
- preserve explicit generated `agent_name` on mutation paths instead of silently rewriting it to the bearer-token owner
- add regressions for `masc_claim_next` and `masc_transition` so explicit aliases fail auth preflight instead of mutating as the wrong identity
- keep this slice scoped to transport/auth identity resolution only

## Evidence
- `dune build --root . test/test_mcp_server_eio.exe`
- `./_build/default/test/test_mcp_server_eio.exe test --compact '' 45,46`
- `./_build/default/test/test_mcp_server_eio.exe test --compact '' 43-46`

## Out of scope
- live runtime/session identity selection for `masc_status`
- mutation-path preflight semantics beyond preserving explicit alias identity
- task-161 lifecycle cleanup itself

Refs #8892
