### PR TITLE
feat(bonsai-dashboard): filter chips active state via data-log-level

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -356,6 +356,19 @@ stylesheet
     box-shadow: inset 0 0 0 1px var(--accent-brass);
   }
 
+  /* Declarative active state for filter chips — theme chip 패턴과 동일.
+     <html data-log-level="X"> 가 set되면 매칭되는 chip만 active 스타일.
+     기본값 = info (data-log-level 속성 없는 초기 상태도 info chip이 활성). */
+  html[data-log-level="debug"] .chip[data-filter-level="debug"],
+  html[data-log-level="info"]  .chip[data-filter-level="info"],
+  html[data-log-level="warn"]  .chip[data-filter-level="warn"],
+  html[data-log-level="error"] .chip[data-filter-level="error"],
+  html:not([data-log-level])   .chip[data-filter-level="info"] {
+    color: var(--text-bright);
+    background: rgba(138, 106, 40, 0.14);
+    box-shadow: inset 0 0 0 1px var(--accent-brass);
+  }
+
   .input_shell {
     display: inline-flex;
     align-items: center;
@@ -2279,15 +2292,35 @@ let render_response
   let toolbar =
     Node.div
       ~attrs:[ Style.toolbar ]
-      [ Node.div
-          ~attrs:[ Style.chip_group ]
-          [ Node.span ~attrs:[ Style.chip ] [ Node.text "debug+" ]
-          ; Node.span
-              ~attrs:[ Style.chip; Style.chip_active ]
-              [ Node.text "info+" ]
-          ; Node.span ~attrs:[ Style.chip ] [ Node.text "warn+" ]
-          ; Node.span ~attrs:[ Style.chip ] [ Node.text "error" ]
-          ]
+      [ (let filter_chip ~level ~label =
+           let click =
+             Attr.on_click (fun _ev ->
+               let effect =
+                 Effect.of_sync_fun
+                   (fun () ->
+                     let doc = Js_of_ocaml.Dom_html.document in
+                     doc##.documentElement##setAttribute
+                       (Js_of_ocaml.Js.string "data-log-level")
+                       (Js_of_ocaml.Js.string level))
+                   ()
+               in
+               effect)
+           in
+           Node.span
+             ~attrs:
+               [ Style.chip
+               ; Attr.create "data-filter-level" level
+               ; click
+               ]
+             [ Node.text label ]
+         in
+         Node.div
+           ~attrs:[ Style.chip_group ]
+           [ filter_chip ~level:"debug" ~label:"debug+"
+           ; filter_chip ~level:"info" ~label:"info+"
+           ; filter_chip ~level:"warn" ~label:"warn+"
+           ; filter_chip ~level:"error" ~label:"error"
+           ])
       ; Node.div
           ~attrs:[ Style.input_shell ]
           [ Node.span ~attrs:[ Style.input_shell_label ] [ Node.text "module" ]


### PR DESCRIPTION
## Summary

toolbar의 filter chips (`debug+` · `info+` · `warn+` · `error`)를 **첫 인터랙티브 컴포넌트**로 전환. 클릭 시 해당 chip만 active 스타일. 실제 로그 필터링은 Phase 1c (List.filter + state machine); 이번 PR은 **시각 피드백만** — 대시보드가 처음으로 "눌리는" 반응을 준다.

> **Stack base**: `feature/bonsai-keepers-client`.

## 구현 (theme chip과 동일 declarative 패턴)

- `filter_chip ~level ~label` helper — `data-filter-level="X"` 속성 + `Attr.on_click`
- Click effect: `Effect.of_sync_fun`로 `document.documentElement.setAttribute("data-log-level", level)` 직접 변경
- Bonsai state 경유 안 함 — theme chip과 동일, render cycle 밖
- CSS: `html[data-log-level="X"] .chip[data-filter-level="X"] { ... }` — cascading selector가 active 자동 적용
- 초기 상태(속성 없음) → `html:not([data-log-level]) .chip[data-filter-level="info"]` 로 info 기본 활성

## 왜 Bonsai state 안 쓰나

- render cycle 밖 — 매번 virtual_dom diff 필요 없음 (theme chip과 같은 결정)
- cascading selector는 **브라우저가 O(1)**로 chip 하나만 재스타일 → 5 chip 중 1개만 dirty
- 추후 Phase 1c에서 실제 필터링 로직은 Bonsai state로 올릴 예정 (logs_var read → List.filter dispatch)

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 `info+` chip이 기본으로 brass outline (초기 상태)
- [ ] 다른 chip 클릭 → 해당 chip active / 이전 chip 해제 (즉시)
- [ ] `<html>` 요소에 `data-log-level="warn"` 등 속성 반영
- [ ] DevTools에서 수동으로 `data-log-level` 속성 바꿔도 같은 UX (declarative)
- [ ] `#cyberpunk` 테마 전환 후에도 active border가 해당 테마 brass로 (기존 `--accent-brass` 변수 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
