### PR TITLE
feat(keeper): docker-routed reads for hardened keepers (RFC-0006 Phase B-2)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -613,6 +613,20 @@ module KeeperSandbox = struct
       operators flip the flag. *)
   let symmetric_read_containment () =
     get_bool ~default:false "MASC_KEEPER_SYMMETRIC_SANDBOX"
+
+  (** RFC-0006 Phase B-2: when true (and symmetric_read_containment is
+      also on), hardened keeper read-side ops route through
+      [docker run --rm <image> cat <container_path>] so the
+      container's mount restrictions become the primary boundary.
+
+      The host-side containment check (B-1) remains as defense in
+      depth — if the docker route is misconfigured, the host check
+      still blocks. Default off because docker spawn per read is
+      slower (~hundreds of ms) and only worth it for deployments
+      that can absorb the latency in exchange for mount-level
+      isolation. *)
+  let docker_read_routing () =
+    get_bool ~default:false "MASC_KEEPER_DOCKER_READ"
 end
 
 module DashboardHealth = struct

--- a/lib/dune
+++ b/lib/dune
@@ -417,6 +417,7 @@
    keeper_alerting
    keeper_alerting_path
    keeper_sandbox_containment
+   keeper_docker_read
    keeper_timing
    keeper_tool_registry
    keeper_tool_diversity
@@ -672,6 +673,7 @@
   keeper_sandbox
   keeper_alerting_path
   keeper_sandbox_containment
+  keeper_docker_read
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http
   tool_local_runtime_verify

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -1,0 +1,139 @@
+(** See .mli for contract.
+
+    The docker invocation mirrors the hardened-keeper bash sandbox in
+    [keeper_exec_shell.ml] (read-only rootfs, no caps, no network)
+    with the playground mounted read-only and the program reduced to
+    a single [cat]. The argv assembly is duplicated rather than
+    shared so a future surgical change to either path does not need
+    to wade through the other's flags. *)
+
+open Keeper_types
+
+let is_hardened = function
+  | Docker_hardened | Docker_with_git -> true
+  | Legacy_local -> false
+
+let should_route_read ~(meta : keeper_meta) : bool =
+  is_hardened meta.sandbox_profile
+  && Env_config_keeper.KeeperSandbox.symmetric_read_containment ()
+  && Env_config_keeper.KeeperSandbox.docker_read_routing ()
+
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let host_playground_root ~config ~(meta : keeper_meta) =
+  Filename.concat
+    (Keeper_alerting_path.project_root_of_config config)
+    (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  |> Keeper_alerting_path.normalize_path_for_check
+  |> strip_trailing_slashes
+
+let container_root ~(meta : keeper_meta) =
+  Keeper_sandbox.container_root meta.name
+
+let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
+    : (string, string) result =
+  let host_root = host_playground_root ~config ~meta in
+  let host_norm =
+    Keeper_alerting_path.normalize_path_for_check host_path
+    |> strip_trailing_slashes
+  in
+  let croot = container_root ~meta in
+  if host_norm = host_root then Ok croot
+  else if String.starts_with ~prefix:(host_root ^ "/") host_norm then
+    let suffix =
+      String.sub host_norm
+        (String.length host_root + 1)
+        (String.length host_norm - String.length host_root - 1)
+    in
+    Ok (Filename.concat croot suffix)
+  else
+    Error
+      (Printf.sprintf
+         "container_path_of_host: %s is not inside playground %s"
+         host_norm host_root)
+
+(* Argv builder kept private — distinct from keeper_exec_shell's
+   bash argv to avoid coupling the two surfaces. *)
+let build_docker_argv ~image ~container_name ~host_root ~croot
+    ~container_path ~uid ~gid ~seccomp_args =
+  [
+    "docker";
+    "run";
+    "--rm";
+    "--name"; container_name;
+    "-i";
+    "--user"; Printf.sprintf "%d:%d" uid gid;
+    "--read-only";
+    "--tmpfs";
+    Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
+      (Env_config_keeper.KeeperSandbox.tmpfs_size ());
+    "--cap-drop=ALL";
+    "--security-opt"; "no-new-privileges";
+  ]
+  @ seccomp_args
+  @ [
+    "--pids-limit";
+    string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
+    "--memory"; Env_config_keeper.KeeperSandbox.memory ();
+    "-v"; host_root ^ ":" ^ croot ^ ":ro";
+    "--workdir"; croot;
+    "--network"; "none";
+    image;
+    "cat"; container_path;
+  ]
+
+let container_name_of meta =
+  Printf.sprintf "masc-keeper-read-%s-%d-%d"
+    (Coord_utils.safe_filename meta.name)
+    (Unix.getpid ())
+    (int_of_float (Unix.gettimeofday () *. 1000.0))
+
+let read_file_in_container ~config ~(meta : keeper_meta) ~host_path
+    ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =
+  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  if String.trim image = "" then
+    Error "keeper sandbox docker image is not configured"
+  else
+    match container_path_of_host ~config ~meta ~host_path with
+    | Error _ as e -> e
+    | Ok container_path ->
+      match
+        Keeper_exec_shell.ensure_keeper_sandbox_runtime ~timeout_sec
+      with
+      | Error err -> Error err
+      | Ok seccomp_args ->
+        let host_root = host_playground_root ~config ~meta in
+        let croot = container_root ~meta in
+        let container_name = container_name_of meta in
+        let uid = Unix.getuid () in
+        let gid = Unix.getgid () in
+        let argv =
+          build_docker_argv ~image ~container_name ~host_root ~croot
+            ~container_path ~uid ~gid ~seccomp_args
+        in
+        let st, out =
+          Process_eio.run_argv_with_status
+            ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+        in
+        match st with
+        | Unix.WEXITED 0 ->
+          let body =
+            if String.length out > max_bytes then String.sub out 0 max_bytes
+            else out
+          in
+          Ok body
+        | Unix.WEXITED code ->
+          Error
+            (Printf.sprintf
+               "docker_read_failed: exit=%d output=%s"
+               code
+               (Worker_dev_tools.truncate_for_log out))
+        | Unix.WSIGNALED n ->
+          Error (Printf.sprintf "docker_read_signaled: signal=%d" n)
+        | Unix.WSTOPPED n ->
+          Error (Printf.sprintf "docker_read_stopped: signal=%d" n)

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -1,0 +1,44 @@
+(** Keeper docker-routed read execution.
+
+    RFC-0006 Phase B-2: when [MASC_KEEPER_SYMMETRIC_SANDBOX] and
+    [MASC_KEEPER_DOCKER_READ] are both true and the keeper has a
+    hardened sandbox profile, read-side operations route through
+    [docker run --rm <image> cat <container_path>] so the container's
+    mount restrictions are the load-bearing boundary instead of a
+    host-side string check.
+
+    The host-side containment check from Phase B-1 remains as
+    defense in depth and is still applied before this module is
+    consulted. *)
+
+(** [should_route_read ~meta] is [true] iff this keeper's reads
+    should go through docker. Encapsulates the (sandbox_profile,
+    env flag) triplet so callers do not have to repeat it. *)
+val should_route_read : meta:Keeper_types.keeper_meta -> bool
+
+(** [container_path_of_host ~config ~meta ~host_path] maps a
+    host-side absolute playground path to its in-container
+    counterpart. Returns [Error _] when [host_path] is not inside the
+    keeper's playground bundle (programmer error — caller should have
+    run the containment check first). *)
+val container_path_of_host :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  host_path:string ->
+  (string, string) result
+
+(** [read_file_in_container ~config ~meta ~host_path ~max_bytes
+    ~timeout_sec ()] runs [docker run --rm <image> cat
+    <container_path>] with the keeper's playground mounted read-only
+    and returns the captured bytes (clamped to [max_bytes]).
+
+    Errors include image misconfiguration, docker exit non-zero, or
+    the input not being inside the playground. *)
+val read_file_in_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  host_path:string ->
+  max_bytes:int ->
+  timeout_sec:float ->
+  unit ->
+  (string, string) result

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -81,6 +81,33 @@ let handle_keeper_fs_read
     (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
      | Error e -> error_json ~fields:[ "path", `String target ] e
      | Ok () ->
+    (* RFC-0006 Phase B-2: when MASC_KEEPER_DOCKER_READ is on (and
+       symmetric_sandbox is also on, and the keeper is hardened),
+       route the actual byte read through [docker run --rm <image>
+       cat <container_path>] so the container's mount restrictions
+       are the load-bearing isolation. The host containment check
+       above remains as defense-in-depth. *)
+    if Keeper_docker_read.should_route_read ~meta then
+      let timeout_sec = 30.0 in
+      match
+        Keeper_docker_read.read_file_in_container ~config ~meta
+          ~host_path:target ~max_bytes ~timeout_sec ()
+      with
+      | Error msg ->
+        error_json ~fields:[ "path", `String target ] msg
+      | Ok body ->
+        let total = String.length body in
+        let truncated = total >= max_bytes in
+        Yojson.Safe.to_string
+          (`Assoc
+             [ "ok", `Bool true
+             ; "path", `String target
+             ; "bytes", `Int total
+             ; "truncated", `Bool truncated
+             ; "content", `String body
+             ; "via", `String "docker"
+             ])
+    else
     (match Safe_ops.read_file_safe target with
      | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
        missing_file_error_json ~config ~target ~fallback_dir ~error:e

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -60,3 +60,13 @@ val handle_keeper_shell :
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
   string
+
+(** [ensure_keeper_sandbox_runtime ~timeout_sec] preflights the host
+    Docker runtime against the configured hardening requirements
+    (seccomp profile present, optional rootless / userns checks).
+    Returns the [--security-opt seccomp=...] argv fragment when the
+    runtime passes; [Error _] when something is missing. Exposed for
+    [Keeper_docker_read] (RFC-0006 Phase B-2) which reuses the same
+    preflight before spawning a one-shot container for fs reads. *)
+val ensure_keeper_sandbox_runtime :
+  timeout_sec:float -> (string list, string) result

--- a/test/dune
+++ b/test/dune
@@ -93,6 +93,7 @@
         test_keeper_sandbox_containment
         test_keeper_shell_containment
         test_keeper_fs_edit_patch
+        test_keeper_docker_read
         test_keeper_github_read_only
         test_worktree_live_context
         test_tool_input_validation
@@ -207,6 +208,7 @@
           test_keeper_sandbox_containment
           test_keeper_shell_containment
           test_keeper_fs_edit_patch
+          test_keeper_docker_read
           test_keeper_github_read_only
           test_worktree_live_context
           test_tool_input_validation

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -1,0 +1,255 @@
+(** Tests for Keeper_docker_read.
+
+    RFC-0006 Phase B-2: docker-routed reads for hardened keepers.
+    These tests cover the pure path-mapping and flag-gating logic;
+    the actual [docker run] call is exercised only in environments
+    where docker is available, gated through env-set integration
+    tests. *)
+
+module Coord = Masc_mcp.Coord
+module Keeper_docker_read = Masc_mcp.Keeper_docker_read
+module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let with_env key value f =
+  let prior = try Some (Sys.getenv key) with Not_found -> None in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_docker_read_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun n -> rm (Filename.concat path n)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with _ -> ()
+
+let make_meta ~name ~sandbox =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "docker read test");
+        ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok m -> m
+  | Error e -> Alcotest.fail e
+
+(* ── should_route_read flag matrix ───────────────────────────────── *)
+
+let test_legacy_keeper_never_routes () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Legacy_local in
+  Alcotest.(check bool) "legacy keeper never routes through docker"
+    false
+    (Keeper_docker_read.should_route_read ~meta)
+
+let test_hardened_with_only_symmetric_does_not_route () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "false" @@ fun () ->
+  let meta =
+    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened
+  in
+  Alcotest.(check bool) "B-1 alone does not enable B-2 routing"
+    false
+    (Keeper_docker_read.should_route_read ~meta)
+
+let test_hardened_with_only_docker_read_does_not_route () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "false" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  let meta =
+    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened
+  in
+  Alcotest.(check bool)
+    "DOCKER_READ alone (without SYMMETRIC_SANDBOX) does not route"
+    false
+    (Keeper_docker_read.should_route_read ~meta)
+
+let test_hardened_with_both_flags_routes () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  let meta =
+    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker_hardened
+  in
+  Alcotest.(check bool) "hardened + both flags → docker route"
+    true
+    (Keeper_docker_read.should_route_read ~meta)
+
+let test_docker_with_git_also_routes () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  let meta =
+    make_meta ~name:"poe" ~sandbox:Keeper_types.Docker_with_git
+  in
+  Alcotest.(check bool) "docker_with_git also routes" true
+    (Keeper_docker_read.should_route_read ~meta)
+
+(* ── container_path_of_host pure mapping ─────────────────────────── *)
+
+let setup_config name =
+  let base = temp_dir () in
+  Unix.mkdir (Filename.concat base ".masc") 0o755;
+  let config = Coord.default_config base in
+  let meta =
+    make_meta ~name ~sandbox:Keeper_types.Docker_hardened
+  in
+  base, config, meta
+
+let test_container_path_root_maps () =
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let host_root =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  let croot = Keeper_sandbox.container_root meta.name in
+  match
+    Keeper_docker_read.container_path_of_host ~config ~meta
+      ~host_path:host_root
+  with
+  | Ok mapped ->
+      Alcotest.(check string) "host playground root maps to container root"
+        croot mapped
+  | Error e -> Alcotest.fail e
+
+let test_container_path_nested_maps_with_suffix () =
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let host_root =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  let host_path = Filename.concat host_root "mind/scratch.md" in
+  let croot = Keeper_sandbox.container_root meta.name in
+  match
+    Keeper_docker_read.container_path_of_host ~config ~meta ~host_path
+  with
+  | Ok mapped ->
+      Alcotest.(check string)
+        "host nested path maps with suffix"
+        (Filename.concat croot "mind/scratch.md")
+        mapped
+  | Error e -> Alcotest.fail e
+
+let test_container_path_outside_playground_errors () =
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let outside = "/etc/passwd" in
+  match
+    Keeper_docker_read.container_path_of_host ~config ~meta
+      ~host_path:outside
+  with
+  | Ok mapped ->
+      Alcotest.failf
+        "expected error for outside-playground path, got Ok %s" mapped
+  | Error _ -> ()
+
+(* ── Integration: read_file_in_container error paths
+   (exercised without invoking docker) ──────────────────────────── *)
+
+let test_read_outside_playground_returns_mapping_error () =
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.read_file_in_container ~config ~meta
+      ~host_path:"/etc/passwd" ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok _ -> Alcotest.fail "expected mapping error for /etc/passwd"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions playground" true
+        (let needle = "playground" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
+let test_read_empty_image_config_errors () =
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let host_root =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  let host_path = Filename.concat host_root "mind/x" in
+  match
+    Keeper_docker_read.read_file_in_container ~config ~meta ~host_path
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok _ -> Alcotest.fail "expected image-config error"
+  | Error msg ->
+      Alcotest.(check bool) "error mentions docker image" true
+        (let needle = "docker image" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
+let () =
+  Alcotest.run "Keeper_docker_read"
+    [
+      ( "should_route_read",
+        [
+          Alcotest.test_case "legacy never routes" `Quick
+            test_legacy_keeper_never_routes;
+          Alcotest.test_case "B-1 alone does not enable B-2" `Quick
+            test_hardened_with_only_symmetric_does_not_route;
+          Alcotest.test_case "DOCKER_READ alone does not route" `Quick
+            test_hardened_with_only_docker_read_does_not_route;
+          Alcotest.test_case "hardened + both flags routes" `Quick
+            test_hardened_with_both_flags_routes;
+          Alcotest.test_case "docker_with_git also routes" `Quick
+            test_docker_with_git_also_routes;
+        ] );
+      ( "container_path_of_host",
+        [
+          Alcotest.test_case "playground root maps to container root"
+            `Quick test_container_path_root_maps;
+          Alcotest.test_case "nested host path maps with suffix" `Quick
+            test_container_path_nested_maps_with_suffix;
+          Alcotest.test_case "outside playground errors" `Quick
+            test_container_path_outside_playground_errors;
+        ] );
+      ( "read_file_in_container",
+        [
+          Alcotest.test_case "outside playground returns mapping error"
+            `Quick test_read_outside_playground_returns_mapping_error;
+          Alcotest.test_case "empty image configuration errors" `Quick
+            test_read_empty_image_config_errors;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Routes hardened-keeper \`fs_read\` through \`docker run --rm <image> cat <container_path>\` so the **container's mount restrictions** are the load-bearing isolation, not a host-side string check. The Phase B-1 host containment guard remains as defense in depth.

## Behavior matrix

| Sandbox profile | \`MASC_KEEPER_SYMMETRIC_SANDBOX\` | \`MASC_KEEPER_DOCKER_READ\` | Read path |
|-----------------|-----------------------------------|------------------------------|-----------|
| \`legacy_local\` | any | any | host (no-op) |
| \`docker_*\` | off | any | host (no-op) |
| \`docker_*\` | on | off (default) | host containment check (B-1) |
| \`docker_*\` | on | **on** | **docker run cat (B-2)** + host check |

Both flags must be on. \`MASC_KEEPER_DOCKER_READ\` alone does nothing.

## Container hardening

Same flags as hardened-keeper bash (\`--read-only\`, \`--cap-drop=ALL\`, \`--security-opt no-new-privileges\`, optional seccomp, pids/memory caps, \`--network none\`) but with the playground mounted **read-only** and the program reduced to a single \`cat\`. Output byte-clamped to \`max_bytes\`.

## Why not extract a shared docker helper?

The bash and read invocations look similar but will evolve independently (read mounts \`:ro\`, never has network, no credential mounts). Premature extraction would couple them and have to be unraveled. Argv assembly is duplicated for now.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`dune runtest test/test_keeper_docker_read.exe\` — 10/10 (new)
  - Flag matrix (5)
  - \`container_path_of_host\` mapping (3)
  - Error paths exercised without docker (2)
- [x] \`dune runtest test/test_keeper_sandbox_containment.exe\` — 6/6 (B-1 regression)
- [ ] CI green
- [ ] Operator integration: opt minjae into both \`MASC_KEEPER_SYMMETRIC_SANDBOX=true\` AND \`MASC_KEEPER_DOCKER_READ=true\`. Verify fs_read response shows \`via: "docker"\` and reads still succeed for in-playground paths.
- [ ] Note pre-existing flaky test \`test_keeper_bash_safety :: doubled playground prefix auto-recovery\` is unrelated (fails on main too).

Refs: #8773, #8778. Companions: #8938 (B-1), #8963 (B-1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)