### PR TITLE
docs(spec): clarify abstract spec strings vs phase_to_string wire format (#8979)

### DIFF
--- a/specs/keeper-state-machine/KeeperContextLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperContextLifecycle.tla
@@ -58,15 +58,26 @@ vars == <<keeper_phase, turn_number, context_id, context_tokens, message_count,
 \* abstraction. SSOT for OCaml side is lib/keeper/keeper_state_machine.ml
 \* (12 phases). This spec intentionally collapses the 12 OCaml phases into
 \* a 7-symbol alphabet because the context-lifecycle invariants do not
-\* depend on transport/handoff details. Mapping:
+\* depend on transport/handoff details.
 \*
-\*   "idle"           ↔ Offline       (no fiber, no work)
-\*   "running"        ↔ Running       (active turn)
-\*   "compacting"     ↔ Compacting    (in-flight context compaction)
-\*   "overflow_retry" ↔ Overflowed    (next turn retries after compaction)
-\*   "done"           ↔ Stopped       (graceful shutdown)
-\*   "error"          ↔ Failing | Crashed   (recoverable | fatal)
-\*   "dead"           ↔ Dead          (terminal, no restart)
+\* Mapping (#8979: spec-internal abstract names — five of seven do NOT
+\* match phase_to_string output verbatim; two ("running", "compacting")
+\* coincide with the wire format):
+\*
+\*   spec name         ↔ OCaml constructor   (phase_to_string output)
+\*   ------------------+----------------------+----------------------
+\*   "idle"            ↔ Offline               ("offline")
+\*   "running"         ↔ Running               ("running")          *
+\*   "compacting"      ↔ Compacting            ("compacting")       *
+\*   "overflow_retry"  ↔ Overflowed            ("overflowed")
+\*   "done"            ↔ Stopped               ("stopped")
+\*   "error"           ↔ Failing | Crashed     ("failing"|"crashed")
+\*   "dead"            ↔ Dead                  ("dead")             *
+\*       * = spec name and wire format coincide.
+\*
+\* If trace-driven model checking is later added, the spec strings would
+\* need to be renamed to match the wire format.  Until then, treat the
+\* table above as the authoritative abstraction function.
 \*
 \* Unmodeled here (covered in companion specs):
 \*   HandingOff, Draining, Paused, Restarting

--- a/specs/keeper-state-machine/KeeperGenerationLineage.tla
+++ b/specs/keeper-state-machine/KeeperGenerationLineage.tla
@@ -45,11 +45,21 @@ vars ==
 \* spec uses the smallest possible alphabet (3 symbols) because the
 \* generation-lineage contract only inspects whether the keeper is
 \* idle, actively executing, or rolling over a generation handoff.
-\* Mapping (note: snake_case wire format from phase_to_string):
 \*
-\*   "idle"        ↔ Offline
-\*   "running"     ↔ Running
-\*   "handing_off" ↔ HandingOff
+\* Mapping (#8979: spec-internal abstract names — do NOT match
+\* phase_to_string output verbatim; "idle" is an abstraction over
+\* Offline, not the wire string "offline"):
+\*
+\*   spec name      ↔ OCaml constructor      (phase_to_string output)
+\*   ---------------+-------------------------+----------------------
+\*   "idle"         ↔ Offline                  ("offline")
+\*   "running"      ↔ Running                  ("running")
+\*   "handing_off"  ↔ HandingOff               ("handing_off")
+\*
+\* If trace-driven model checking is later added, the spec strings
+\* would need to be renamed to match the wire format ("offline" instead
+\* of "idle").  Until then, treat the table above as the authoritative
+\* abstraction function.
 \*
 \* Unmodeled here (covered in companion specs):
 \*   Failing, Overflowed, Compacting, Draining, Paused,


### PR DESCRIPTION
## Summary
- 6th FSM drift fix in this sweep — caught two TLA specs falsely claiming their lowercase phase strings are the wire format from \`phase_to_string\`.
- Five of the seven \`KeeperContextLifecycle\` strings and one of three \`KeeperGenerationLineage\` strings **do not match** the actual OCaml output.
- Issue **#8979** for full evidence and Option A vs B discussion.

## The drift

| spec name | OCaml constructor | phase_to_string output | match? |
|-----------|-------------------|------------------------|--------|
| \"idle\" | Offline | \"offline\" | ❌ |
| \"running\" | Running | \"running\" | ✓ |
| \"compacting\" | Compacting | \"compacting\" | ✓ |
| \"overflow_retry\" | Overflowed | \"overflowed\" | ❌ |
| \"done\" | Stopped | \"stopped\" | ❌ |
| \"error\" | Failing\|Crashed | \"failing\"\|\"crashed\" | ❌ + collapse |
| \"dead\" | Dead | \"dead\" | ✓ |
| \"handing_off\" | HandingOff | \"handing_off\" | ✓ |

KeeperGenerationLineage explicitly says \"snake_case wire format from phase_to_string\" — false for \`\"idle\"\`.

## What this PR does (Option B from #8979)

- Replaces both mapping tables with annotated versions that show the OCaml constructor AND the actual \`phase_to_string\` wire string, with a \`*\` mark for strings that coincide with wire format.
- Drops the false \"snake_case wire format from phase_to_string\" claim in GenerationLineage.
- Adds a note that trace-driven verification would require renaming the abstract strings (Option A from #8979, tracked separately).

## Test plan
- [x] Pure documentation edit in \`.tla\` preambles.
- [x] No \`Phases\` set change, no action change, no \`.cfg\` change.
- [x] TLC behaviour identical.

## Refs
- #8979 (umbrella issue with Option A renaming proposal)
- #8942 (sibling: derive_phase docstring drift)
- #8948 / #8952 / #8959 / #8965 / #8973 (sibling FSM drift fixes)
- #8642 / #8701 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)