### PR TITLE
docs(logic): batch-14 .mli for dashboard_attention + server_startup_state

### DIFF
--- a/lib/dashboard/dashboard_attention.mli
+++ b/lib/dashboard/dashboard_attention.mli
@@ -1,0 +1,45 @@
+(** Dashboard Attention — Collect actionable items that require
+    operator intervention.
+
+    Pure functions. Scans {!Dashboard_labels.room_snapshot} values
+    to produce a sorted list of items the operator should act on.
+    Each item includes a suggested MCP tool name. *)
+
+(** {1 Types} *)
+
+type severity = Critical | Warning | Info
+
+type attention_item = {
+  severity : severity;
+  category : string;
+  summary : string;
+  suggested_tool : string;
+}
+
+(** {1 Severity helpers} *)
+
+val severity_to_string : severity -> string
+
+val severity_icon : severity -> string
+
+(** Coerce to canonical {!Severity.t} for cross-module communication. *)
+val to_severity : severity -> Severity.t
+
+(** {1 Collection} *)
+
+(** [collect ~now snapshots] scans for stuck agents and idle-with-
+    pending-work situations, returning the items sorted by severity
+    (Critical first). *)
+val collect :
+  now:float ->
+  Dashboard_labels.room_snapshot list ->
+  attention_item list
+
+(** {1 Presentation} *)
+
+(** One rendered line per item, prefixed with {!severity_icon}. *)
+val format_items : attention_item list -> string list
+
+(** Compact single-line summary, e.g. ["[!] 2 critical, [~] 1 warning"].
+    Empty items list returns the empty string. *)
+val compact_summary : attention_item list -> string

--- a/lib/server_startup_state.mli
+++ b/lib/server_startup_state.mli
@@ -1,0 +1,102 @@
+(** Server_startup_state — In-memory singleton that tracks which
+    startup phase the server is in, plus backend identification,
+    pending lazy-task list, error/fallback notes, and path/config
+    resolution snapshots.
+
+    The state is a process-global mutable [ref]. All observers and
+    mutators go through this module so [to_yojson] can render a
+    consistent snapshot. *)
+
+(** {1 Types} *)
+
+type phase =
+  | Blocking    (** Bootstrapping — HTTP not serving yet *)
+  | Lazy        (** Serving, but some background tasks still pending *)
+  | Ready       (** Fully ready *)
+  | Degraded    (** A lazy task failed; serving with [last_error] set *)
+
+(** Wire string: ["blocking" | "lazy" | "ready" | "degraded"]. *)
+val phase_to_string : phase -> string
+
+(** Singleton record. Exposed because a handful of callers use
+    [Server_startup_state.((!state).state_ready)] etc. instead of
+    going through a getter. Prefer {!is_live} / {!to_yojson} /
+    {!elapsed_since_start} for new code. *)
+type t = {
+  phase : phase;
+  state_ready : bool;
+  backend_mode : string;
+  pending_lazy_tasks : string list;
+  last_error : string option;
+  fallback_reason : string option;
+  path_diagnostics : Yojson.Safe.t option;
+  config_resolution : Yojson.Safe.t option;
+  started_at : float;
+}
+
+(** Process-global state reference. Observers should prefer the
+    typed accessors above; [state] is exposed only to preserve the
+    existing [(!state)] call sites. *)
+val state : t ref
+
+(** {1 Observation} *)
+
+(** [true] once the HTTP accept loop can serve requests (always
+    [true] after socket bind). *)
+val is_live : unit -> bool
+
+val pending_lazy_tasks : unit -> string list
+
+(** [true] iff {!pending_lazy_tasks} is empty. *)
+val lazy_tasks_complete : unit -> bool
+
+(** Seconds elapsed since startup began. *)
+val elapsed_since_start : unit -> float
+
+(** Default startup watchdog timeout in seconds
+    ([MASC_STARTUP_WATCHDOG_SEC] default). *)
+val default_watchdog_timeout_sec : float
+
+(** Effective watchdog timeout from env, clamped to [[30, 600]]. *)
+val watchdog_timeout_sec : unit -> float
+
+(** Current snapshot as JSON:
+    [{phase, state_ready, backend_mode, pending_lazy_tasks,
+      last_error, fallback_reason, path_diagnostics,
+      config_resolution, elapsed_sec, watchdog_timeout_sec}]. *)
+val to_yojson : unit -> Yojson.Safe.t
+
+(** {1 Transitions} *)
+
+(** Reset to [Blocking] / not-ready. [backend_mode] defaults to
+    ["unknown"]. *)
+val reset : ?backend_mode:string -> unit -> unit
+
+val mark_blocking : backend_mode:string -> unit
+
+val mark_state_ready : backend_mode:string -> unit
+
+(** Transition to [Lazy] with [tasks] pending (or directly to
+    [Ready] when [tasks = []]). *)
+val activate_lazy : backend_mode:string -> tasks:string list -> unit
+
+(** Remove [task] from pending. When the list empties, transition
+    to [Ready] (unless already [Degraded], which is preserved). *)
+val finish_lazy_task : task:string -> unit
+
+(** Remove [task], set [phase = Degraded] and record [error] in
+    [last_error]. *)
+val fail_lazy_task : task:string -> error:string -> unit
+
+val mark_degraded : error:string -> unit
+
+(** Record the fallback reason (e.g. ["using filesystem backend
+    because PG unreachable"]). *)
+val note_fallback : string -> unit
+
+(** Persist path-diagnostics and config-resolution JSON snapshots
+    for the next {!to_yojson} call. *)
+val note_runtime_resolution :
+  path_diagnostics:Yojson.Safe.t ->
+  config_resolution:Yojson.Safe.t ->
+  unit


### PR DESCRIPTION
Wave 3 batch 14. 바디 무수정.

| 파일 | ml | mli |
|------|-----|-----|
| `lib/dashboard/dashboard_attention.mli` | 156 | 42 |
| `lib/server_startup_state.mli` | 166 | 80 |

## 설계 노트

### dashboard_attention
- severity 변환 heuristic과 attention_item 내부 detection rule (detect_stuck_agents/detect_idle_with_pending) 은 mli에서 hide.
- `Severity.t` cross-module coercion 공식화.

### server_startup_state
- Phase FSM (Blocking/Lazy/Ready/Degraded) + 17 vals.
- **3rd grep trap 문서화**: `Server_startup_state.(!state)` local-open deref 패턴이 `Module.\w+` grep에 안 잡힘. `t` record + `state : t ref` 추가 노출로 해결.

### 건너뛴 후보
- **meta_cognition_parse** (164): `include Meta_cognition_parse` in meta_cognition.ml → umbrella trap (5번째 사례).

## Session grep-trap Inventory (누적)

| # | 패턴 | 검출 방법 |
|---|------|-----------|
| 1 | `open Module` | `rg '^open Module' lib/ test/` |
| 2 | `module Alias = Module` | alias를 grep에 병합 |
| 3 | `Module.(!state)` local-open | `rg 'Module.\(\!' lib/` |
| 4 | `include Module` umbrella | `rg '^include Module' lib/` |

## 검증
- `dune build --root=.` → exit 0

## Metric
| | 이전 | 이후 |
|-|------|------|
| `.mli` | 331 | **333** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] grep trap inventory 문서화
- [x] umbrella-include 회피
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)