### PR TITLE
fix(worktree-live-context): raise git status timeout to 15s + env escape hatch

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -10,6 +10,29 @@ let set_git_capture_hook_for_tests hook =
 let clear_git_capture_hook_for_tests () =
   Atomic.set git_capture_hook_for_tests None
 
+(* `git status --porcelain` timeout budget.
+
+   The 5.0s default hit its ceiling 30x in a 45-minute fleet window on
+   2026-04-20 when the workdir was a Second Brain root with many
+   worktrees, thousands of untracked files, and concurrent indexer
+   activity. Each timeout falls through to stale cache (live context
+   goes quiet for the keeper) and emits a WARN.
+
+   15.0s covers p99 for large working trees without meaningfully
+   stretching keeper turn latency — the call is cached (see
+   [status_cache_ttl_sec] below) so the full budget is paid at most
+   once per TTL window per repo. Env var stays the escape hatch for
+   unusually slow hosts. *)
+let default_git_status_timeout_sec = 15.0
+
+let git_status_timeout_sec () =
+  match Sys.getenv_opt "MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC" with
+  | Some raw ->
+    (match float_of_string_opt (String.trim raw) with
+     | Some v when v > 0. -> v
+     | _ -> default_git_status_timeout_sec)
+  | None -> default_git_status_timeout_sec
+
 let run_git_capture_lines_once ~workdir args =
   try
     let argv = [ "git"; "-C"; workdir ] @ args in
@@ -19,7 +42,7 @@ let run_git_capture_lines_once ~workdir args =
         ~actor:"system/worktree_live_context"
         ~raw_source
         ~summary:"worktree live context git capture"
-        ~timeout_sec:5.0
+        ~timeout_sec:(git_status_timeout_sec ())
         argv
     with
     | Unix.WEXITED 0, output ->


### PR DESCRIPTION
## Summary

`run_git_capture_lines_once` ran `git status --porcelain` with a 5.0s hard timeout. Large working trees (many worktrees, thousands of untracked files) routinely hit that ceiling.

Raise default to 15.0s and expose `MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC` as a per-host escape hatch. The status-cache TTL still bounds how often the full budget can be paid, so keeper-turn latency is not meaningfully affected.

## Product impact

2026-04-20 /loop fleet triage (3000-log window):
- 30 × `[Process_eio] Timeout after 5s: 'git' '-C' '/Users/dancer/me' '--no-optional-locks' 'status' '--porcelain'`
- Always same workdir (Second Brain root with many worktrees + thousands of untracked files).
- Each miss silently falls back to stale cache (keeper live-context goes quiet for the TTL window) and pollutes the WARN channel.

## Evidence

- `lib/worktree_live_context.ml:22` hard-codes `~timeout_sec:5.0`
- Retry loop is 1-attempt — same timeout, same outcome
- Cache at `lib/worktree_live_context.ml:~60-85` is already present with TTL, so raising the ceiling does not multiply the cost

## Review evidence

- `dune build --root . lib` passes
- Config path: `default_git_status_timeout_sec = 15.0` with `MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC` env override (float seconds; invalid values fall back to default)
- No tests touch the timeout — behaviour is "ceiling not fuse"; the only observable change is fewer WARNs and fewer stale-cache fallbacks on slow hosts

## Linked

Top-3 triage item from 2026-04-20 fleet observation. Siblings:
- OAS #1082 (execve E2BIG on large prompts — 40 hits, same window)
- Eio.Stream backpressure (separate investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)