### PR TITLE
feat(bonsai-dashboard): page head hero reacts to fleet state

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -130,5 +130,7 @@ let () =
   Start.start ~bind_to_element_with_id:"app" Dashboard_bonsai_lib.App.root;
   Dashboard_bonsai_lib.Logs_fetch.run ();
   Dashboard_bonsai_lib.Logs_fetch.start_polling ();
+  Dashboard_bonsai_lib.Keepers_fetch.run ();
+  Dashboard_bonsai_lib.Keepers_fetch.start_polling ();
   install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/keepers_fetch.ml
+++ b/dashboard_bonsai/src/keepers_fetch.ml
@@ -1,0 +1,35 @@
+(** Single-shot fetch of [/dashboard/b/api/keepers/summary] + 3 s polling.
+
+    Mirrors [Logs_fetch] — same Fut-based Fetch API, same interval strategy.
+    Errors are currently dropped (the previous response stays in the Var so
+    views don't flicker). Phase 1c will surface a "stale" indicator when
+    multiple fetches in a row fail. *)
+
+open! Core
+open Brr_io
+
+let endpoint = "/dashboard/b/api/keepers/summary"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Keepers_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Keepers_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:3000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/keepers_types.ml
+++ b/dashboard_bonsai/src/keepers_types.ml
@@ -1,0 +1,134 @@
+(** Typed model of [/dashboard/b/api/keepers/summary] responses.
+
+    Mirror of [lib/dashboard_api_types/keepers.ml] (the server SSOT), parsed
+    manually with Yojson.Safe.Util to keep the client ppx surface small.
+    Server uses [ppx_deriving_yojson] — client does not carry that ppx into
+    js_of_ocaml compilation. Shape must stay in lock-step with the server
+    record. *)
+
+type keeper_status =
+  | Live
+  | Warn
+  | Dead
+
+type lane_frame =
+  { kind : string              (* "llm" | "tool" | "think" | "wait" | "err" *)
+  ; left : int                 (* left %, 0..100 *)
+  ; width : int                (* width %, 0..100 *)
+  ; label : string
+  }
+
+type ctx_sample =
+  { t_minus_min : int           (* minutes ago, 0..60 *)
+  ; ctx_pct : int               (* 0..100 *)
+  }
+
+type keeper =
+  { name : string
+  ; stat : string               (* human state: "reading", "retrying" *)
+  ; status : keeper_status
+  ; ctx_pct : int
+  ; turn : int
+  ; turn_cap : int
+  ; mem_kb : int
+  ; latency_ms : int
+  ; last_tool : string option
+  ; lane_frames : lane_frame list
+  ; ctx_history : ctx_sample list
+  }
+
+type response =
+  { keepers : keeper list
+  ; cycle : int
+  ; room : string option
+  ; generated_at : string        (* ISO-8601 UTC *)
+  }
+
+(* ---------- manual Yojson decoding ---------- *)
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let int_field ?(default = 0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> i
+  | `Intlit s -> (try int_of_string s with _ -> default)
+  | _ -> default
+;;
+
+let string_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> Some s
+  | _ -> None
+;;
+
+let status_of_string = function
+  | "Live" -> Live
+  | "Warn" -> Warn
+  | "Dead" -> Dead
+  | _ -> Live
+;;
+
+let status_of_yojson json =
+  match json with
+  | `String s -> status_of_string s
+  | `List [ `String s ] -> status_of_string s  (* ppx variant fallback *)
+  | _ -> Live
+;;
+
+let lane_frame_of_yojson json =
+  { kind = string_field json "kind"
+  ; left = int_field json "left"
+  ; width = int_field json "width"
+  ; label = string_field json "label"
+  }
+;;
+
+let ctx_sample_of_yojson json =
+  { t_minus_min = int_field json "t_minus_min"
+  ; ctx_pct = int_field json "ctx_pct"
+  }
+;;
+
+let list_field f json key =
+  match Yojson.Safe.Util.member key json with
+  | `List xs -> List.map f xs
+  | _ -> []
+;;
+
+let keeper_of_yojson json =
+  { name = string_field json "name"
+  ; stat = string_field json "stat"
+  ; status = status_of_yojson (Yojson.Safe.Util.member "status" json)
+  ; ctx_pct = int_field json "ctx_pct"
+  ; turn = int_field json "turn"
+  ; turn_cap = int_field ~default:60 json "turn_cap"
+  ; mem_kb = int_field json "mem_kb"
+  ; latency_ms = int_field json "latency_ms"
+  ; last_tool = string_opt_field json "last_tool"
+  ; lane_frames = list_field lane_frame_of_yojson json "lane_frames"
+  ; ctx_history = list_field ctx_sample_of_yojson json "ctx_history"
+  }
+;;
+
+let response_of_yojson json =
+  { keepers = list_field keeper_of_yojson json "keepers"
+  ; cycle = int_field json "cycle"
+  ; room = string_opt_field json "room"
+  ; generated_at = string_field json "generated_at"
+  }
+;;
+
+(** Initial placeholder — empty keepers list. Views should degrade gracefully
+    (show "— no data —" or fall back to the static mock) when rendered with
+    this fixture. *)
+let fixture : response =
+  { keepers = []
+  ; cycle = 0
+  ; room = None
+  ; generated_at = ""
+  }
+;;

--- a/dashboard_bonsai/src/keepers_var.ml
+++ b/dashboard_bonsai/src/keepers_var.ml
@@ -1,0 +1,11 @@
+(** Module-level Bonsai.Expert.Var holding the current keepers response.
+
+    Written externally by [Keepers_fetch.run]; read reactively by the four
+    views that depend on it (focus card, roster, swimlane, ctx pressure
+    chart). Using an [Expert.Var] for the same reason as [Logs_var] — it is
+    the documented escape hatch for driving incremental computation from a
+    [Fut]-based async source. *)
+
+let var : Keepers_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Keepers_types.fixture
+;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1271,6 +1271,14 @@ stylesheet
     color: var(--accent-blood);
     text-shadow: 0 0 18px rgba(201, 74, 58, 0.32);
   }
+  .page_h1_brass {
+    color: var(--accent-brass);
+    text-shadow: 0 0 18px rgba(138, 106, 40, 0.32);
+  }
+  .page_h1_bright {
+    color: var(--text-bright);
+    text-shadow: 0 0 18px rgba(216, 200, 160, 0.24);
+  }
   .page_sub {
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     font-style: italic;
@@ -2641,16 +2649,35 @@ let render_response
          List.count response.entries ~f:(fun e ->
            String.equal e.normalized_level "ERROR")
        in
+       let head_tally = tally_fleet keepers.keepers in
+       let keeper_count = List.length keepers.keepers in
        let sub_text =
-         match response.entries with
-         | [] ->
+         match response.entries, keeper_count with
+         | [], 0 ->
            "저택은 조용하다. 아무도 아직 말하지 않았고, 폭풍은 아직 문을 두드리지 않았다."
-         | _ ->
+         | [], n ->
            Printf.sprintf
-             "네 명의 키퍼가 홀을 지킨다. 마지막 %d행을 들었고, 경보 %d · 경고 %d이 울렸다."
-             response.total
-             err_n
-             warn_n
+             "%d명의 키퍼가 홀을 지킨다. 저널은 아직 비어 있다 — 폭풍 전의 숨."
+             n
+         | _, 0 ->
+           Printf.sprintf
+             "저널이 마지막 %d행을 기억한다. 경보 %d · 경고 %d이 울렸으나, 키퍼는 아직 도착하지 않았다."
+             response.total err_n warn_n
+         | _, n ->
+           Printf.sprintf
+             "%d명의 키퍼가 홀을 지킨다. 저널은 마지막 %d행을 들었고, 경보 %d · 경고 %d이 울렸다."
+             n response.total err_n warn_n
+       in
+       let h1_suffix, h1_suffix_class =
+         match head_tally with
+         | { dead; _ } when dead > 0 ->
+           "under storm", Style.page_h1_blood
+         | { warn; _ } when warn > 0 ->
+           "under watch", Style.page_h1_brass
+         | { live = 0; _ } ->
+           "before dawn", Style.page_h1_bright
+         | _ ->
+           "in vigil", Style.page_h1_bright
        in
        Node.div
          ~attrs:[ Style.page_head ]
@@ -2674,8 +2701,8 @@ let render_response
                  ~attrs:[ Style.page_h1 ]
                  [ Node.text "the watch "
                  ; Node.span
-                     ~attrs:[ Style.page_h1_blood ]
-                     [ Node.text "under storm" ]
+                     ~attrs:[ h1_suffix_class ]
+                     [ Node.text h1_suffix ]
                  ]
              ; Node.p ~attrs:[ Style.page_sub ] [ Node.text sub_text ]
              ]

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2069,7 +2069,28 @@ let view_hud (response : Logs_types.response) =
     ]
 ;;
 
-let render_response (response : Logs_types.response) : Node.t =
+(** Focus keeper — first entry of the live response, or [None] when empty
+    (triggers the legacy static fallback inside [focus_card_of]). *)
+let focus_keeper_of (k : Keepers_types.response) : Keepers_types.keeper option =
+  match k.keepers with
+  | [] -> None
+  | head :: _ -> Some head
+;;
+
+(** Display name — capitalize first character of the registry nickname. *)
+let display_name (s : string) : string =
+  if String.length s = 0
+  then s
+  else
+    let first = Char.to_string (Char.uppercase s.[0]) in
+    let rest = String.sub s ~pos:1 ~len:(String.length s - 1) in
+    first ^ rest
+;;
+
+let render_response
+      ?(keepers : Keepers_types.response = Keepers_types.fixture)
+      (response : Logs_types.response)
+    : Node.t =
   let tape =
     match response.entries with
     | [] ->
@@ -2257,18 +2278,44 @@ let render_response (response : Logs_types.response) : Node.t =
       ; Node.div ~attrs:[ Style.focus_stat_v ] [ Node.text v ]
       ]
   in
+  let focus_k = focus_keeper_of keepers in
+  let focus_name, focus_portrait, focus_role, focus_ctx_pct,
+      focus_turn, focus_mem, focus_latency =
+    match focus_k with
+    | None ->
+      ("Luna", "L", "dungeon master · alchemist", 64,
+       "47 / 60", "128k", "812ms")
+    | Some (k : Keepers_types.keeper) ->
+      let portrait =
+        if String.length k.name = 0
+        then "·"
+        else Char.to_string (Char.uppercase k.name.[0])
+      in
+      let role =
+        match k.last_tool with
+        | Some t -> Printf.sprintf "%s · %s" k.stat t
+        | None -> k.stat
+      in
+      (display_name k.name, portrait, role, k.ctx_pct,
+       Printf.sprintf "%d / %d" k.turn k.turn_cap,
+       Printf.sprintf "%dk" k.mem_kb,
+       Printf.sprintf "%dms" k.latency_ms)
+  in
+  let vial_style =
+    Attr.create "style" (Printf.sprintf "width:%d%%" focus_ctx_pct)
+  in
   let focus_card =
     Node.div
       ~attrs:[ Style.focus ]
       [ Node.div
           ~attrs:[ Style.focus_who ]
-          [ Node.div ~attrs:[ Style.focus_portrait ] [ Node.text "L" ]
+          [ Node.div ~attrs:[ Style.focus_portrait ] [ Node.text focus_portrait ]
           ; Node.div
               ~attrs:[ Style.focus_name_col ]
-              [ Node.div ~attrs:[ Style.focus_name ] [ Node.text "Luna" ]
+              [ Node.div ~attrs:[ Style.focus_name ] [ Node.text focus_name ]
               ; Node.div
                   ~attrs:[ Style.focus_role ]
-                  [ Node.text "dungeon master · alchemist" ]
+                  [ Node.text focus_role ]
               ]
           ]
       ; Node.div
@@ -2278,18 +2325,18 @@ let render_response (response : Logs_types.response) : Node.t =
               [ Node.span [ Node.text "context" ]
               ; Node.span
                   ~attrs:[ Style.ctx_lbl_v ]
-                  [ Node.text "64%" ]
+                  [ Node.text (Printf.sprintf "%d%%" focus_ctx_pct) ]
               ]
           ; Node.div
               ~attrs:[ Style.vial ]
-              [ Node.span ~attrs:[ Style.vial_fill ] [] ]
+              [ Node.span ~attrs:[ Style.vial_fill; vial_style ] [] ]
           ]
       ; Node.div
           ~attrs:[ Style.focus_stats ]
-          [ focus_stat "turn" "47 / 60"
+          [ focus_stat "turn" focus_turn
           ; focus_stat "heartbeat" "3s"
-          ; focus_stat "mem" "128k"
-          ; focus_stat "latency" "812ms"
+          ; focus_stat "mem" focus_mem
+          ; focus_stat "latency" focus_latency
           ]
       ]
   in
@@ -2371,7 +2418,9 @@ let render_response (response : Logs_types.response) : Node.t =
       ~attrs:[ Style.aside ]
       [ Node.div
           ~attrs:[]
-          [ aside_h ~tail:"ctx 64%" "focus · keeper"
+          [ aside_h
+              ~tail:(Printf.sprintf "ctx %d%%" focus_ctx_pct)
+              "focus · keeper"
           ; focus_card
           ]
       ; Node.div
@@ -2554,5 +2603,9 @@ let render_response (response : Logs_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Logs_var.var) ~f:render_response
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Logs_var.var)
+    (Bonsai.Expert.Var.value Keepers_var.var)
+    ~f:(fun logs_response keepers_response ->
+      render_response ~keepers:keepers_response logs_response)
 ;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1828,7 +1828,85 @@ let view_swim_lane ~name ~stat ~status ~frames =
     ]
 ;;
 
-let view_swimlanes () =
+(** Map JSON "kind" string to our [swim_frame_kind] variant. Unknown kinds
+    fall back to [`Wait] — neutral grey so unexpected telemetry renders
+    legibly instead of crashing the lane. *)
+let swim_frame_kind_of_string = function
+  | "llm" -> `Llm
+  | "tool" -> `Tool
+  | "think" -> `Think
+  | "err" -> `Err
+  | "wait" | _ -> `Wait
+;;
+
+let swim_lane_status_of (s : Keepers_types.keeper_status) : swim_lane_status =
+  match s with
+  | Live -> `Live
+  | Warn -> `Warn
+  | Dead -> `Dead
+;;
+
+(** Static fallback — matches the hand-coded mock before live wiring. *)
+let view_swim_lanes_static () =
+  [ view_swim_lane
+      ~name:"luna"
+      ~stat:"reading"
+      ~status:`Live
+      ~frames:
+        [ swim_frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
+        ; swim_frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
+        ; swim_frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
+        ; swim_frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
+        ; swim_frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
+        ]
+  ; view_swim_lane
+      ~name:"brass-owl"
+      ~stat:"retrying"
+      ~status:`Warn
+      ~frames:
+        [ swim_frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
+        ; swim_frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
+        ; swim_frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
+        ; swim_frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
+        ]
+  ; view_swim_lane
+      ~name:"moth"
+      ~stat:"idle · listening"
+      ~status:`Live
+      ~frames:
+        [ swim_frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
+        ; swim_frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
+        ; swim_frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
+        ]
+  ; view_swim_lane
+      ~name:"ash-hound"
+      ~stat:"crashed t-34"
+      ~status:`Dead
+      ~frames:
+        [ swim_frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
+        ; swim_frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
+        ; swim_frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
+        ]
+  ]
+;;
+
+let view_swim_lane_of_keeper (k : Keepers_types.keeper) =
+  let frames =
+    List.map k.lane_frames ~f:(fun (f : Keepers_types.lane_frame) ->
+      swim_frame
+        ~kind:(swim_frame_kind_of_string f.kind)
+        ~left:f.left
+        ~width:f.width
+        ~label:f.label)
+  in
+  view_swim_lane
+    ~name:k.name
+    ~stat:k.stat
+    ~status:(swim_lane_status_of k.status)
+    ~frames
+;;
+
+let view_swimlanes ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
   let axis_ticks =
     List.init 6 ~f:(fun i ->
       let left_pct = i * 20 in
@@ -1842,55 +1920,21 @@ let view_swimlanes () =
             [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
         ])
   in
+  let lanes =
+    match keepers.keepers with
+    | [] -> view_swim_lanes_static ()
+    | live_keepers -> List.map live_keepers ~f:view_swim_lane_of_keeper
+  in
   Node.div
     ~attrs:[ Style.swim ]
-    [ Node.div
-        ~attrs:[ Style.swim_axis ]
-        [ Node.div
-            ~attrs:[ Style.swim_axis_sp ]
-            [ Node.text "keeper · cycle" ]
-        ; Node.div ~attrs:[ Style.swim_axis_ax ] axis_ticks
-        ]
-    ; view_swim_lane
-        ~name:"luna"
-        ~stat:"reading"
-        ~status:`Live
-        ~frames:
-          [ swim_frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
-          ; swim_frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
-          ; swim_frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
-          ; swim_frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
-          ; swim_frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
-          ]
-    ; view_swim_lane
-        ~name:"brass-owl"
-        ~stat:"retrying"
-        ~status:`Warn
-        ~frames:
-          [ swim_frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
-          ; swim_frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
-          ; swim_frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
-          ; swim_frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
-          ]
-    ; view_swim_lane
-        ~name:"moth"
-        ~stat:"idle · listening"
-        ~status:`Live
-        ~frames:
-          [ swim_frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
-          ; swim_frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
-          ; swim_frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
-          ]
-    ; view_swim_lane
-        ~name:"ash-hound"
-        ~stat:"crashed t-34"
-        ~status:`Dead
-        ~frames:
-          [ swim_frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
-          ; swim_frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
-          ; swim_frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
-          ]
-    ]
+    ([ Node.div
+         ~attrs:[ Style.swim_axis ]
+         [ Node.div
+             ~attrs:[ Style.swim_axis_sp ]
+             [ Node.text "keeper · cycle" ]
+         ; Node.div ~attrs:[ Style.swim_axis_ax ] axis_ticks
+         ]
+     ] @ lanes)
 ;;
 
 let svg_a k v = Attr.create k v
@@ -2559,7 +2603,7 @@ let render_response
             ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
             ]
         ]
-    ; view_swimlanes ()
+    ; view_swimlanes ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
         [ Node.span ~attrs:[ Style.sec_glyph ] []

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2214,6 +2214,40 @@ let view_hud (response : Logs_types.response) =
     ]
 ;;
 
+(** Roman numeral for cycle counters. Only small integers (≤ 39) are
+    expected for dashboard display; outside that range we fall back to the
+    decimal form so very large cycles still render. *)
+let roman_of_int (n : int) : string =
+  if n <= 0 || n > 39
+  then Printf.sprintf "%d" n
+  else
+    let pairs =
+      [ 10, "x"; 9, "ix"; 5, "v"; 4, "iv"; 1, "i" ]
+    in
+    let buf = Buffer.create 8 in
+    let rec go n = function
+      | [] -> ()
+      | (v, s) :: rest ->
+        if n >= v
+        then (Buffer.add_string buf s; go (n - v) ((v, s) :: rest))
+        else go n rest
+    in
+    go n pairs;
+    Buffer.contents buf
+;;
+
+(** Count keepers by status. *)
+type fleet_tally = { live : int; warn : int; dead : int }
+
+let tally_fleet (ks : Keepers_types.keeper list) : fleet_tally =
+  List.fold ks ~init:{ live = 0; warn = 0; dead = 0 }
+    ~f:(fun acc (k : Keepers_types.keeper) ->
+      match k.status with
+      | Live -> { acc with live = acc.live + 1 }
+      | Warn -> { acc with warn = acc.warn + 1 }
+      | Dead -> { acc with dead = acc.dead + 1 })
+;;
+
 (** Focus keeper — first entry of the live response, or [None] when empty
     (triggers the legacy static fallback inside [focus_card_of]). *)
 let focus_keeper_of (k : Keepers_types.response) : Keepers_types.keeper option =
@@ -2302,11 +2336,25 @@ let render_response
       ; Node.button ~attrs:[ Style.btn_ghost ] [ Node.text "refresh" ]
       ]
   in
+  let tally = tally_fleet keepers.keepers in
+  let moon_lead_text =
+    match tally with
+    | { live = 0; warn = 0; dead = 0 } -> "the watch is on"
+    | { dead; _ } when dead > 0 -> "the watch stands a casualty"
+    | { warn; _ } when warn > 0 -> "the watch holds uneasy"
+    | _ -> "the watch is on"
+  in
+  let fleet_mono_text =
+    match tally with
+    | { live = 0; warn = 0; dead = 0 } -> "fleet · —"
+    | t ->
+      Printf.sprintf "fleet · %dl / %dw / %dd" t.live t.warn t.dead
+  in
   let moonrise =
     Node.div
       ~attrs:[ Style.moonrise ]
       [ Node.span ~attrs:[ Style.moon_glyph ] []
-      ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text "the watch is on" ]
+      ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text moon_lead_text ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span [ Node.text "lit by a half moon" ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
@@ -2316,6 +2364,10 @@ let render_response
             ; Attr.create "data-moon-clock" ""
             ]
           [ Node.text "—:— local" ]
+      ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
+      ; Node.span
+          ~attrs:[ Style.moon_mono ]
+          [ Node.text fleet_mono_text ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span
           ~attrs:[ Style.moon_mono ]
@@ -2606,7 +2658,18 @@ let render_response
              ~attrs:[ Style.page_head_lead ]
              [ Node.div
                  ~attrs:[ Style.page_tag ]
-                 [ Node.text "chronicle · quiet fox · day iv" ]
+                 [ Node.text
+                     (let room =
+                        match keepers.room with
+                        | Some r when String.length r > 0 -> r
+                        | _ -> "chronicle"
+                      in
+                      let day =
+                        if keepers.cycle <= 0
+                        then "—"
+                        else roman_of_int keepers.cycle
+                      in
+                      Printf.sprintf "%s · quiet fox · day %s" room day) ]
              ; Node.h1
                  ~attrs:[ Style.page_h1 ]
                  [ Node.text "the watch "

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1740,41 +1740,78 @@ let view_heartbeat () =
    state dot, last-heard timestamp, and presence reflect live telemetry. *)
 type keeper_state = [ `Live | `Thinking | `Idle | `Failed ]
 
-let view_roster () =
-  let slot ~sigil ~name ~(state : keeper_state) ~state_label ~when_ =
-    let dot_cls =
-      match state with
-      | `Live -> Style.roster_dot_live
-      | `Thinking -> Style.roster_dot_thinking
-      | `Idle -> Style.roster_dot_idle
-      | `Failed -> Style.roster_dot_failed
-    in
-    Node.div
-      ~attrs:[ Style.roster_slot ]
-      [ Node.div ~attrs:[ Style.roster_sigil ] [ Node.text sigil ]
-      ; Node.div
-          ~attrs:[ Style.roster_body ]
-          [ Node.span ~attrs:[ Style.roster_name ] [ Node.text name ]
-          ; Node.div
-              ~attrs:[ Style.roster_state ]
-              [ Node.span ~attrs:[ Style.roster_dot; dot_cls ] []
-              ; Node.text state_label
-              ]
-          ]
-      ; Node.span ~attrs:[ Style.roster_when ] [ Node.text when_ ]
-      ]
+(** Map live keeper status to the roster dot state. [Warn] → [`Thinking]
+    (something is happening but concerning), [Dead] → [`Failed]. *)
+let roster_state_of (s : Keepers_types.keeper_status) : keeper_state =
+  match s with
+  | Live -> `Live
+  | Warn -> `Thinking
+  | Dead -> `Failed
+;;
+
+let roster_slot_of ~(state : keeper_state) ~sigil ~name ~state_label ~when_ =
+  let dot_cls =
+    match state with
+    | `Live -> Style.roster_dot_live
+    | `Thinking -> Style.roster_dot_thinking
+    | `Idle -> Style.roster_dot_idle
+    | `Failed -> Style.roster_dot_failed
   in
   Node.div
-    ~attrs:[ Style.roster ]
-    [ slot ~sigil:"P" ~name:"keeper · poe" ~state:`Live
-        ~state_label:"speaking" ~when_:"3s"
-    ; slot ~sigil:"J" ~name:"janitor" ~state:`Thinking
-        ~state_label:"thinking" ~when_:"12s"
-    ; slot ~sigil:"G" ~name:"governance" ~state:`Idle
-        ~state_label:"idle · ok" ~when_:"2m"
-    ; slot ~sigil:"I" ~name:"improver" ~state:`Failed
-        ~state_label:"paused · auth" ~when_:"7m"
+    ~attrs:[ Style.roster_slot ]
+    [ Node.div ~attrs:[ Style.roster_sigil ] [ Node.text sigil ]
+    ; Node.div
+        ~attrs:[ Style.roster_body ]
+        [ Node.span ~attrs:[ Style.roster_name ] [ Node.text name ]
+        ; Node.div
+            ~attrs:[ Style.roster_state ]
+            [ Node.span ~attrs:[ Style.roster_dot; dot_cls ] []
+            ; Node.text state_label
+            ]
+        ]
+    ; Node.span ~attrs:[ Style.roster_when ] [ Node.text when_ ]
     ]
+;;
+
+let roster_slot_of_keeper (k : Keepers_types.keeper) =
+  let sigil =
+    if String.length k.name = 0
+    then "·"
+    else Char.to_string (Char.uppercase k.name.[0])
+  in
+  let when_ =
+    match k.latency_ms with
+    | 0 -> "×"
+    | n when n < 1000 -> Printf.sprintf "%dms" n
+    | n -> Printf.sprintf "%.1fs" (Float.of_int n /. 1000.0)
+  in
+  roster_slot_of
+    ~state:(roster_state_of k.status)
+    ~sigil
+    ~name:k.name
+    ~state_label:k.stat
+    ~when_
+;;
+
+let view_roster_static () =
+  [ roster_slot_of ~sigil:"P" ~name:"keeper · poe" ~state:`Live
+      ~state_label:"speaking" ~when_:"3s"
+  ; roster_slot_of ~sigil:"J" ~name:"janitor" ~state:`Thinking
+      ~state_label:"thinking" ~when_:"12s"
+  ; roster_slot_of ~sigil:"G" ~name:"governance" ~state:`Idle
+      ~state_label:"idle · ok" ~when_:"2m"
+  ; roster_slot_of ~sigil:"I" ~name:"improver" ~state:`Failed
+      ~state_label:"paused · auth" ~when_:"7m"
+  ]
+;;
+
+let view_roster ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
+  let slots =
+    match keepers.keepers with
+    | [] -> view_roster_static ()
+    | live -> List.map live ~f:roster_slot_of_keeper
+  in
+  Node.div ~attrs:[ Style.roster ] slots
 ;;
 
 (* ─── swimlane mock ───
@@ -1987,7 +2024,84 @@ let ctx_hairline ~x =
     []
 ;;
 
-let view_context_pressure () =
+(** Rotating palette for per-keeper ctx polylines. Dead keepers always use
+    [--t-err] regardless of index so crashed lanes stand out. *)
+let ctx_palette = [|
+  "var(--t-llm)";
+  "var(--t-tool)";
+  "var(--t-think)";
+  "var(--t-wait)";
+|]
+
+let ctx_stroke_of ~(index : int) ~(status : Keepers_types.keeper_status) =
+  match status with
+  | Dead -> "var(--t-err)"
+  | _ -> ctx_palette.(index mod Array.length ctx_palette)
+;;
+
+(** Build SVG [points] attribute from ctx_history. x = (60 - t_minus_min) * 10
+    (so t-60 → 0, t-0 → 600). y = 100 - pct (SVG origin at top). Samples
+    sorted by descending t_minus_min (older first). *)
+let ctx_points_of (samples : Keepers_types.ctx_sample list) : string =
+  let sorted =
+    List.sort samples ~compare:(fun (a : Keepers_types.ctx_sample)
+                                    (b : Keepers_types.ctx_sample) ->
+      Int.compare b.t_minus_min a.t_minus_min)
+  in
+  List.map sorted ~f:(fun (s : Keepers_types.ctx_sample) ->
+    Printf.sprintf "%d,%d"
+      ((60 - s.t_minus_min) * 10)
+      (100 - s.ctx_pct))
+  |> String.concat ~sep:" "
+;;
+
+(** Static fallback — mirrors the hand-coded 4 polyline mock. *)
+let ctx_polylines_static () =
+  [ ctx_polyline
+      ~points:"0,62 100,60 200,63 300,60 400,58 500,62 600,58"
+      ~stroke_var:"var(--t-llm)" ~dashed:false
+  ; ctx_polyline
+      ~points:"0,60 100,54 200,48 300,42 400,38 500,35 600,33"
+      ~stroke_var:"var(--t-tool)" ~dashed:false
+  ; ctx_polyline
+      ~points:"0,90 100,89 200,90 300,88 400,88 500,90 600,88"
+      ~stroke_var:"var(--t-wait)" ~dashed:false
+  ; ctx_polyline
+      ~points:"0,55 100,35 200,15 260,5"
+      ~stroke_var:"var(--t-err)" ~dashed:true
+  ]
+;;
+
+let ctx_polylines_of_keepers (ks : Keepers_types.keeper list) =
+  List.mapi ks ~f:(fun i (k : Keepers_types.keeper) ->
+    let dashed =
+      match k.status with
+      | Dead -> true
+      | _ -> false
+    in
+    ctx_polyline
+      ~points:(ctx_points_of k.ctx_history)
+      ~stroke_var:(ctx_stroke_of ~index:i ~status:k.status)
+      ~dashed)
+;;
+
+let ctx_meta_lines_of (ks : Keepers_types.keeper list) : string list =
+  let pair (k : Keepers_types.keeper) =
+    match k.status with
+    | Dead -> Printf.sprintf "%s ×" k.name
+    | _ -> Printf.sprintf "%s %d" k.name k.ctx_pct
+  in
+  (* group into 2 items per line for visual density *)
+  let rec chunks = function
+    | [] -> []
+    | [ a ] -> [ a ]
+    | a :: b :: rest -> (a ^ " · " ^ b) :: chunks rest
+  in
+  chunks (List.map ks ~f:pair)
+;;
+
+let view_context_pressure
+      ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
   let hairlines =
     List.init 7 ~f:(fun i -> ctx_hairline ~x:(i * 100))
   in
@@ -1996,27 +2110,10 @@ let view_context_pressure () =
     ; ctx_guide ~y:10 ~stroke_var:"var(--accent-blood)"      (* 90 % danger *)
     ]
   in
-  (* mock: 7 points over 60 min. y = 100 - pct. *)
-  let luna =
-    ctx_polyline
-      ~points:"0,62 100,60 200,63 300,60 400,58 500,62 600,58"
-      ~stroke_var:"var(--t-llm)" ~dashed:false
-  in
-  let brass_owl =
-    ctx_polyline
-      ~points:"0,60 100,54 200,48 300,42 400,38 500,35 600,33"
-      ~stroke_var:"var(--t-tool)" ~dashed:false
-  in
-  let moth =
-    ctx_polyline
-      ~points:"0,90 100,89 200,90 300,88 400,88 500,90 600,88"
-      ~stroke_var:"var(--t-wait)" ~dashed:false
-  in
-  let ash_hound =
-    (* crashes at t-34 (x=260). truncated polyline. *)
-    ctx_polyline
-      ~points:"0,55 100,35 200,15 260,5"
-      ~stroke_var:"var(--t-err)" ~dashed:true
+  let polylines =
+    match keepers.keepers with
+    | [] -> ctx_polylines_static ()
+    | live_keepers -> ctx_polylines_of_keepers live_keepers
   in
   let svg =
     Node.create_svg "svg"
@@ -2025,7 +2122,12 @@ let view_context_pressure () =
         svg_a "preserveAspectRatio" "none";
         Style.ctx_svg;
       ]
-      (hairlines @ guides @ [ luna; brass_owl; moth; ash_hound ])
+      (hairlines @ guides @ polylines)
+  in
+  let meta_lines =
+    match keepers.keepers with
+    | [] -> [ "luna 38 · brass-owl 67"; "moth 12 · ash ×" ]
+    | live -> ctx_meta_lines_of live
   in
   Node.div
     ~attrs:[ Style.swim ]
@@ -2050,10 +2152,9 @@ let view_context_pressure () =
         ~attrs:[ Style.ctx_chart ]
         [ Node.div
             ~attrs:[ Style.ctx_meta ]
-            [ Node.text "keepers · %"
-            ; Node.span ~attrs:[ Style.ctx_meta_v ] [ Node.text "luna 38 · brass-owl 67" ]
-            ; Node.span ~attrs:[ Style.ctx_meta_v ] [ Node.text "moth 12 · ash ×" ]
-            ]
+            (Node.text "keepers · %"
+             :: List.map meta_lines ~f:(fun line ->
+                  Node.span ~attrs:[ Style.ctx_meta_v ] [ Node.text line ]))
         ; Node.div
             ~attrs:[ Style.ctx_track ]
             [ svg
@@ -2588,7 +2689,7 @@ let render_response
             ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "iv" ]
             ]
         ]
-    ; view_roster ()
+    ; view_roster ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
         [ Node.span ~attrs:[ Style.sec_glyph ] []
@@ -2618,7 +2719,7 @@ let render_response
             ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
             ]
         ]
-    ; view_context_pressure ()
+    ; view_context_pressure ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
         [ Node.span ~attrs:[ Style.sec_glyph ] []


### PR DESCRIPTION
## Summary

"메인 화면"의 emotional weight 강화 — page_head의 h1 suffix와 sub_text가 fleet 상태와 keeper count를 반영해 동적으로 변한다. 사용자가 처음 마주치는 hero가 서술 화면으로 상승.

> **Stack base**: `feature/bonsai-keepers-client`.
> **주의**: 레이아웃/font-size/spacing은 변경 없음 — 색·문구만.

## h1 suffix · 색상

| 조건 | suffix | 색상 class |
|---|---|---|
| `dead > 0` | `"under storm"` | `page_h1_blood` (기존, 피) |
| `warn > 0` | `"under watch"` | `page_h1_brass` (신규, 놋쇠) |
| `live = 0` & empty | `"before dawn"` | `page_h1_bright` (신규, 뼈) |
| all live | `"in vigil"` | `page_h1_bright` |

## sub_text · 4-matrix 분기

| entries × keepers | 문구 |
|---|---|
| `[] × 0` | 저택은 조용하다... (기존 유지) |
| `[] × n` | N명의 키퍼가 홀을 지킨다. 저널은 아직 비어 있다 — 폭풍 전의 숨 |
| `entries × 0` | 저널이 마지막 X행을 기억한다 ... 키퍼는 아직 도착하지 않았다 |
| `entries × n` | N명의 키퍼가 홀을 지킨다. 저널은 마지막 X행을 들었고, 경보 Y · 경고 Z이 울렸다 |

기존 "네 명의 키퍼" 하드코드 제거 — 서버가 4 반환하면 복원, 5+면 자동 확장.

## 신규 CSS

- `.page_h1_brass` — amber variant (warn tier)
- `.page_h1_bright` — neutral variant (quiet tier)
- 기존 `.page_h1_blood` 유지 — dead 상태에서만 사용

## 왜 레이아웃 불변

Plan 원칙 "lift-and-shift, not redesign" 준수 — font-size 36px, letter-spacing 0.16em, padding 모두 동일. h1 span의 content/color와 sub p의 content만 데이터 기반.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] fixture (empty) → "before dawn" bright + "저택은 조용하다..."
- [ ] 서버 stub (ash-hound dead) → "under storm" blood + "네 명의 키퍼가 홀을 지킨다..."
- [ ] 서버에서 ash-hound를 warn으로 바꾸면 → "under watch" brass
- [ ] 전원 Live + entries 있음 → "in vigil" bright

🤖 Generated with [Claude Code](https://claude.com/claude-code)
