### PR TITLE
feat(cdal_judge): go test classifier + preface-anchored counts (Tick 29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ### Added
 
+- **`Cdal_judge` go test classifier.**  `of_exec_outcome` now emits
+  typed `Test_pass {count}` / `Test_fail {count}` markers for `go
+  test` output in addition to dune, cargo, alcotest, and pytest.
+  Detection anchors on the runner-specific `--- PASS:` / `--- FAIL:`
+  / `=== RUN` prefaces so that bare `PASS` / `FAIL` tokens elsewhere
+  in stdout (e.g. docstrings or user-visible prose) cannot
+  false-positive. Count is obtained by counting `--- PASS:` /
+  `--- FAIL:` occurrences — one per completed subtest. Banner-
+  required behavior is covered by a dedicated negative test
+  (`test_go_test_banner_required`). Verifier cascade now covers
+  dune + cargo + pytest + go test.
+
 - **Legendary Bash shadow-counters HTTP endpoint.**  New
   `GET /api/v1/legendary_bash/shadow_counters` returns the
   `Legendary_counters.snapshot` as JSON.  Public-read (same auth

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -306,6 +306,23 @@ let looks_like_pytest out =
   contains_sub out " pytest " ||
   contains_sub out "pytest "
 
+(* go test characteristic lines.  The `--- PASS:` / `--- FAIL:`
+   preface and the `=== RUN` banner are unique to the go test
+   runner — dune/cargo/pytest do not emit them.  We require at least
+   one of these signatures so that arbitrary prose containing
+   "PASS" or "FAIL" tokens cannot false-positive. *)
+let looks_like_go_test out =
+  contains_sub out "--- PASS:" ||
+  contains_sub out "--- FAIL:" ||
+  contains_sub out "=== RUN"
+
+(* Count "--- PASS:" or "--- FAIL:" preface lines.  Each line
+   corresponds to one completed subtest in the go test output stream,
+   so summing them gives the total pass/fail count for the invocation. *)
+let go_test_count ~tag out =
+  let needle = "--- " ^ tag ^ ":" in
+  count_sub out needle
+
 (* Test count extraction.  Alcotest / cargo-test lines commonly look
    like one of:
 
@@ -436,7 +453,10 @@ let of_exec_outcome ~semantic ~stdout ~stderr =
   match semantic with
   | `Git_not_a_repo -> [ Git_not_a_repo ]
   | `Ok ->
-      if looks_like_pytest out then
+      if looks_like_go_test out then
+        let n = go_test_count ~tag:"PASS" out in
+        [ Test_pass { count = n; confidence = `Heuristic } ]
+      else if looks_like_pytest out then
         let n = pytest_count_from_output ~tag:"passed" out in
         [ Test_pass { count = n; confidence = `Heuristic } ]
       else if looks_like_dune_runtest out then
@@ -462,7 +482,10 @@ let of_exec_outcome ~semantic ~stdout ~stderr =
       end
       else []
   | `Fail _ ->
-      if looks_like_pytest out then
+      if looks_like_go_test out then
+        let n = go_test_count ~tag:"FAIL" out in
+        [ Test_fail { count = n; confidence = `Heuristic } ]
+      else if looks_like_pytest out then
         let n = pytest_count_from_output ~tag:"failed" out in
         [ Test_fail { count = n; confidence = `Heuristic } ]
       else if looks_like_dune_runtest out then

--- a/test/test_cdal_verifiable_markers.ml
+++ b/test/test_cdal_verifiable_markers.ml
@@ -102,6 +102,56 @@ let test_pytest_banner_required () =
             ^ String.concat ","
                 (List.map Cdal_judge.marker_to_string markers))
 
+let test_go_test_pass_counts () =
+  let stdout =
+    "=== RUN   TestA\n\
+     --- PASS: TestA (0.00s)\n\
+     === RUN   TestB\n\
+     --- PASS: TestB (0.01s)\n\
+     === RUN   TestC\n\
+     --- PASS: TestC (0.00s)\n\
+     PASS\n\
+     ok   example.com/pkg    0.023s\n"
+  in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Test_pass { count = 3; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_pass { count; _ } ] ->
+      fail (Printf.sprintf "expected go test count=3, got %d" count)
+  | _ -> fail "expected Test_pass marker from go test output"
+
+let test_go_test_fail_counts () =
+  let stdout =
+    "=== RUN   TestA\n\
+     --- FAIL: TestA (0.00s)\n\
+         test_a.go:10: expected 1, got 2\n\
+     === RUN   TestB\n\
+     --- FAIL: TestB (0.00s)\n\
+     === RUN   TestC\n\
+     --- PASS: TestC (0.00s)\n\
+     FAIL\n\
+     exit status 1\n\
+     FAIL   example.com/pkg   0.012s\n"
+  in
+  match call ~stdout (`Fail 1) with
+  | [ Cdal_judge.Test_fail { count = 2; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_fail { count; _ } ] ->
+      fail (Printf.sprintf "expected go test failed=2, got %d" count)
+  | _ -> fail "expected Test_fail marker from go test output"
+
+let test_go_test_banner_required () =
+  (* Bare "PASS" / "FAIL" words in prose must NOT classify as go test —
+     the "--- PASS:" / "--- FAIL:" / "=== RUN" preface is required. *)
+  let stdout =
+    "doc: the test passed successfully\n\
+     user-visible result: PASS\n"
+  in
+  match call ~stdout `Ok with
+  | [] -> ()
+  | markers ->
+      fail ("expected [] without go test preface, got "
+            ^ String.concat ","
+                (List.map Cdal_judge.marker_to_string markers))
+
 let test_git_status_clean_exact () =
   let stdout = "On branch main\nnothing to commit, working tree clean\n" in
   match call ~stdout `Ok with
@@ -155,6 +205,9 @@ let () =
       test_case "pytest pass count" `Quick test_pytest_pass_counts;
       test_case "pytest fail count" `Quick test_pytest_fail_counts;
       test_case "pytest banner required" `Quick test_pytest_banner_required;
+      test_case "go test pass count" `Quick test_go_test_pass_counts;
+      test_case "go test fail count" `Quick test_go_test_fail_counts;
+      test_case "go test banner required" `Quick test_go_test_banner_required;
       test_case "git status clean" `Quick test_git_status_clean_exact;
       test_case "git status dirty" `Quick test_git_status_dirty_exact;
     ]);


### PR DESCRIPTION
## Product impact

Extends `Cdal_judge.of_exec_outcome` verifier-cascade coverage to Go
keepers. After this PR the coverage matrix is dune (alcotest + build)
+ cargo + pytest + go test. Any keeper that shells out to `go test`
now emits the same typed `Test_pass {count}` / `Test_fail {count}`
markers that the verifier cascade already consumes, so the verifier
path avoids falling back to generic regex scraping on Go output.

## Evidence

- `lib/cdal_judge.ml`:
  - `looks_like_go_test` classifier (three runner-specific prefaces).
  - `go_test_count ~tag` count helper that reuses the existing
    `count_sub` primitive.
  - `Ok` branch emits `Test_pass { count = N }` when prefaces
    found.
  - `Fail` branch emits `Test_fail { count = N }` analogously.
- `test/test_cdal_verifiable_markers.ml` — 3 new tests:
  - `test_go_test_pass_counts` (3 subtests, all PASS).
  - `test_go_test_fail_counts` (2 FAIL + 1 PASS, asserts count=2 on
    the fail arm).
  - `test_go_test_banner_required` — negative test proving bare
    `PASS` / `FAIL` prose without the `--- PASS:` / `--- FAIL:` /
    `=== RUN` preface does NOT classify, so doc strings and
    user-visible messages cannot mint fake markers.

Local `dune exec test/test_cdal_verifiable_markers.exe --root .` →
17/17 OK in 0.006s.

## Review evidence

- Preface anchor `"--- PASS:"` / `"--- FAIL:"` chosen over looser
  substrings like `"PASS"` so that benign prose mentioning PASS
  cannot false-positive. The `=== RUN` variant only appears in
  actual go test runs, so it's safe as an additional OR branch.
- Priority placement inside `of_exec_outcome` (go test checked
  BEFORE pytest / dune / cargo) is intentional: the go test prefaces
  are the most unambiguous anchor of the four, so putting it first
  minimises the false-positive-via-cross-runner risk.
- `go_test_count` reuses the existing `count_sub` primitive already
  proven by production traffic. No new low-level string logic.
- Follows the banner-anchored pattern established by the pytest
  classifier in #8944, including the dedicated negative test.

## Linked issue

Refs #8918 (operator runbook — additive marker coverage is the
rollout covenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)