### PR TITLE
docs(spec): KeeperReconcileLiveness rename RecoverablePhases -> StablePhases + clarify removed mechanism (#8987)

### DIFF
--- a/specs/keeper-state-machine/KeeperReconcileLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness.tla
@@ -29,7 +29,19 @@
 \*   Manual_reconcile_cleared and Fiber_started do), the flag stayed
 \*   TRUE forever, permanently trapping the keeper in Failing.
 \*
-\* IMPORTANT: The existing KeeperStateMachine.tla has a model-to-code
+\* HISTORICAL NOTE (#8987): The IMPORTANT block below references a
+\* discrepancy that no longer exists -- the manual_reconcile_required
+\* mechanism has been REMOVED ENTIRELY from both the canonical spec
+\* and the OCaml impl (verified: zero occurrences in
+\* specs/keeper-state-machine/KeeperStateMachine.tla and
+\* lib/keeper/keeper_state_machine.ml as of 2026-04-20).  The audit
+\* model is retained as a forensic record of the design lesson:
+\* recovery actions must clear ALL latches that block their target
+\* state, not just the most obvious one.  The named TurnSucceeded /
+\* manual_reconcile_required interaction is inactive.
+\*
+\* Original IMPORTANT (no longer applies to the current canonical spec):
+\* The existing KeeperStateMachine.tla has a model-to-code
 \* discrepancy: its TurnSucceeded action sets manual_reconcile_required'
 \* = FALSE, which masks this bug.  This spec models the OCaml behavior
 \* faithfully: TurnSucceeded does NOT clear manual_reconcile_required.
@@ -99,17 +111,17 @@ Phase == DerivePhase
 \*
 \*   "Stopped"  ↔ Stopped       \*  Terminal
 \*   "Dead"     ↔ Dead          \*  Terminal
-\*   "Running"  ↔ Running       \*  Recoverable
-\*   "Paused"   ↔ Paused        \*  Recoverable
-\*   "Crashed"  ↔ Crashed       \*  Recoverable
-\*   "Offline"  ↔ Offline       \*  Recoverable (cold)
+\*   "Running"  ↔ Running       \*  Stable (live)
+\*   "Paused"   ↔ Paused        \*  Stable (operator-held)
+\*   "Crashed"  ↔ Crashed       \*  Stable (awaiting supervisor)
+\*   "Offline"  ↔ Offline       \*  Stable (cold)
 \*
 \* Unmodeled here (covered in companion specs):
 \*   Failing, Overflowed, Compacting, HandingOff, Draining, Restarting
 \*   See KeeperCoreTriad.tla and KeeperContextLifecycle.tla.
 TerminalPhases == {"Stopped", "Dead"}
 NotTerminal == Phase \notin TerminalPhases
-RecoverablePhases == {"Running", "Paused", "Crashed", "Stopped", "Dead", "Offline"}
+StablePhases == {"Running", "Paused", "Crashed", "Stopped", "Dead", "Offline"}
 
 \* ── Initial State ─────────────────────────────────────────
 
@@ -440,13 +452,13 @@ FailingRecoveryLiveness ==
     (Phase = "Failing" /\ fiber_alive) ~> (Phase /= "Failing")
 
 \* L3: Compacting eventually exits (inherited from base spec)
-CompactingResolves == (Phase = "Compacting") ~> (Phase \in RecoverablePhases)
+CompactingResolves == (Phase = "Compacting") ~> (Phase \in StablePhases)
 
 \* L4: HandingOff eventually exits
-HandoffResolves == (Phase = "HandingOff") ~> (Phase \in RecoverablePhases)
+HandoffResolves == (Phase = "HandingOff") ~> (Phase \in StablePhases)
 
 \* L5: Draining eventually exits
-DrainingResolves == (Phase = "Draining") ~> (Phase \in RecoverablePhases)
+DrainingResolves == (Phase = "Draining") ~> (Phase \in StablePhases)
 
 \* ── Deadlock Freedom ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- 7th FSM drift fix in this sweep — caught two drifts in the HISTORICAL audit model.
- Issue **#8987** for full evidence.

## Drift 1 — set name contradicts members
- \`RecoverablePhases == {Running, Paused, Crashed, Stopped, Dead, Offline}\` includes Stopped/Dead.
- The header comment explicitly marked them \"Terminal\".  The name was a misnomer.
- Cross-spec evidence: \`KeeperStateMachine.tla\` defines the **same set** under the canonical name \`StablePhases\` (semantic: phases that don't transition autonomously).
- **Fix**: rename to \`StablePhases\` to match canonical.  Same set; same TLC behaviour; 4 use sites updated.

## Drift 2 — header references removed mechanism
- The header IMPORTANT block referenced a \"model-to-code discrepancy\" in \`KeeperStateMachine.tla\` involving \`manual_reconcile_required\`.
- The \`manual_reconcile_required\` mechanism has been **removed entirely**:
  - \`grep -c manual_reconcile specs/keeper-state-machine/KeeperStateMachine.tla\` -> 0
  - \`grep -c manual_reconcile lib/keeper/keeper_state_machine.ml\` -> 0
- **Fix**: add a HISTORICAL NOTE above the original IMPORTANT clarifying the named discrepancy is now inactive; keep the original text below as a forensic record of the design lesson.

## What this PR does NOT change
- No spec actions modified.
- No \`.cfg\` change.
- No invariant logic change — only the symbol name.

## Test plan
- [x] All 4 use sites of \`RecoverablePhases\` updated to \`StablePhases\`.
- [x] Cross-spec sweep: no external refs to old name (\`grep -rn RecoverablePhases specs/\` -> 0).
- [x] Pure documentation + identifier rename.

## Refs
- #8987 (umbrella issue)
- #8942 (sibling: derive_phase docstring drift)
- #8948 / #8952 / #8959 / #8965 / #8973 / #8980 (sibling FSM drift fixes)
- #8642 / #8701 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)