### PR TITLE
docs(logic): batch-15 .mli for cdal_verdict_gate + level4_config + tool_deep_review

### DIFF
--- a/lib/cdal_verdict_gate.mli
+++ b/lib/cdal_verdict_gate.mli
@@ -1,0 +1,47 @@
+(** Cdal_verdict_gate — Deterministic gate that blocks task completion
+    when the latest CDAL verdict is [Violated] or [Inconclusive] with
+    blocking completeness gaps.
+
+    Reads from [cdal_verdicts/*.jsonl] (produced by
+    [Cdal_eval_v1.persist]). Gate logic is pure:
+    - [Satisfied] → allow
+    - [Violated] → reject with findings summary
+    - [Inconclusive] with no blocking gaps → allow
+    - [Inconclusive] with blocking gaps → reject with gap summary
+    - No verdict available → allow (gate is opt-in per task) *)
+
+(** {1 Types} *)
+
+type gate_result =
+  | Allow
+  | Reject of string
+
+(** {1 Pure gate logic} *)
+
+(** Translate a verdict to [Allow] / [Reject reason] per the rules
+    documented above. Pure — no I/O. *)
+val check_verdict : Cdal_types.contract_verdict -> gate_result
+
+(** {1 Task completion gate} *)
+
+(** [gate_check ?base_dir ~task_id ()] looks up the latest verdict
+    for [task_id] under [base_dir] (default: CDAL verdict directory
+    resolved from MASC base path) and returns:
+
+    - [None] — completion is allowed.
+    - [Some reason] — completion must be rejected. *)
+val gate_check :
+  ?base_dir:string ->
+  task_id:string ->
+  unit ->
+  string option
+
+(** {1 Attribution wiring} *)
+
+(** [to_attribution v] maps [check_verdict v] to the matching
+    {!Attribution.t} — [Allow] → [passed], [Reject reason] →
+    [policy_failed]. *)
+val to_attribution : Cdal_types.contract_verdict -> Attribution.t
+
+(** Attribution used when no verdict exists for a task. *)
+val attribution_for_missing_verdict : task_id:string -> Attribution.t

--- a/lib/level4_config.mli
+++ b/lib/level4_config.mli
@@ -1,0 +1,32 @@
+(** MASC Level 4 Configuration — Shared numeric tuning helpers and
+    RNG wrappers.
+
+    All reads delegate to {!Env_config_core} so env-var semantics
+    (trim + malformed-value fallback) stay consistent with the rest
+    of the codebase.
+
+    @since MASC v3.1 (Level 4) *)
+
+(** {1 Environment helpers} *)
+
+(** [get_env_float name default] reads [name] as a float, falling
+    back to [default] on missing or malformed values. *)
+val get_env_float : string -> float -> float
+
+(** [get_env_int name default] reads [name] as an int, falling back
+    to [default] on missing or malformed values. *)
+val get_env_int : string -> int -> int
+
+(** {1 Random number generation}
+
+    RNG initialisation is lazy and idempotent. Seed defaults to
+    [int_of_float (Time_compat.now () *. 1000.0)] but can be
+    overridden via [MASC_RANDOM_SEED] for reproducibility. *)
+
+(** [random_float max] returns a value in [[0.0, max)]. Ensures RNG
+    is seeded before first call. *)
+val random_float : float -> float
+
+(** [random_int max] returns a value in [[0, max)]. Ensures RNG is
+    seeded before first call. *)
+val random_int : int -> int

--- a/lib/tool_deep_review.mli
+++ b/lib/tool_deep_review.mli
@@ -1,0 +1,26 @@
+(** Tool_deep_review — Adversarial code review with isolated context.
+
+    PR#814 Gap 2. Spawns a review pass via a different model
+    perspective. Context is deliberately stripped — only target file
+    contents and the reviewer's question are provided; no JIRA,
+    Slack, memory, or institutional knowledge.
+
+    This forces structural evaluation rather than relying on domain
+    context that might mask bugs. Uses the same
+    [Oas_worker.run_named] pattern as {!Verifier_oas}. *)
+
+(** [handle_deep_review config args] runs a deep review as described
+    by [args]. Returns [(success, message)] — [success = false] on
+    validation or dispatch failure with the failure reason in
+    [message], [success = true] with the review output otherwise. *)
+val handle_deep_review :
+  Coord.config -> Yojson.Safe.t -> bool * string
+
+(** Build the isolated review prompt. Returns [Ok prompt] or
+    [Error reason] when no target files could be read or inputs
+    fail {!Adversarial_eval.validate_inputs}. *)
+val build_prompt :
+  target_files:string list ->
+  question:string ->
+  base_path:string ->
+  (string, string) result


### PR DESCRIPTION
Wave 3 batch 15 — **3** pure .mli. 바디 무수정.

| 파일 | ml | mli |
|------|-----|-----|
| `lib/cdal_verdict_gate.mli` | 135 | 42 |
| `lib/level4_config.mli` | 145 | 32 |
| `lib/tool_deep_review.mli` | 146 | 21 |

## 설계 노트

세션 첫 3-파일 batch. Pre-scan으로 4종 grep trap(open/alias/deref/include) 사전 스크리닝 → 3개 모두 clean.

### cdal_verdict_gate
- gate_result variant + 5 val. Attribution wiring도 expose (test가 CVG alias로 접근).

### level4_config
- Env helper 2개 + RNG 2개. RNG lazy init 동작 mli에 명시.

### tool_deep_review
- handle_deep_review + build_prompt (test에서 build_prompt 호출).

## Session grep-trap Inventory (누적)

| # | 패턴 | 검출 명령 |
|---|------|-----------|
| 1 | `open Module` | `rg '^open Module' lib/ test/` |
| 2 | `module Alias = Module` | alias 파악 |
| 3 | `Module.(!state)` | `rg 'Module\.\(\!' lib/` |
| 4 | `include Module` umbrella | `rg '^include Module' lib/` |

## 검증
- `dune build --root=.` → exit 0

## Metric
| | 이전 | 이후 |
|-|------|------|
| `.mli` | 333 | **336** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] Pre-scan 적용으로 iterative build 최소화
- [x] 3 파일 병렬 처리
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)