### PR TITLE
feat(bonsai-dashboard): HUD gains Fleet + Synced cells (live from Keepers)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -251,6 +251,7 @@ stylesheet
 
   .hud_v_ok   { color: var(--status-ok); }
   .hud_v_warn { color: var(--status-warn); }
+  .hud_v_bad  { color: var(--status-bad); }
 
   /* Moonrise strip — narrative interlude between the HUD readout and
      the filter toolbar. Reads as a quiet status bar that names the
@@ -2223,7 +2224,42 @@ let view_flame_mini ~(segments : (flame_kind * int) list) =
   Node.div ~attrs:[ Style.flame ] [ bar; legend ]
 ;;
 
-let view_hud (response : Logs_types.response) =
+(** Extract "HH:MM:SS" from an ISO-8601 UTC timestamp
+    (e.g. "2026-04-20T04:02:07Z" → "04:02:07"). Falls back to the full
+    string if the shape doesn't match — never throws. *)
+let hhmmss_of_iso (s : string) : string =
+  if String.length s >= 19 && Char.equal s.[10] 'T'
+  then String.sub s ~pos:11 ~len:8
+  else s
+;;
+
+let view_hud
+      ?(keepers : Keepers_types.response = Keepers_types.fixture)
+      (response : Logs_types.response) =
+  let live_n, warn_n, dead_n =
+    List.fold keepers.keepers ~init:(0, 0, 0)
+      ~f:(fun (l, w, d) (k : Keepers_types.keeper) ->
+        match k.status with
+        | Live -> (l + 1, w, d)
+        | Warn -> (l, w + 1, d)
+        | Dead -> (l, w, d + 1))
+  in
+  let fleet_v, fleet_cls =
+    if live_n = 0 && warn_n = 0 && dead_n = 0
+    then "—", None
+    else if dead_n > 0
+    then
+      Printf.sprintf "%dl %dw %dd" live_n warn_n dead_n,
+      Some Style.hud_v_bad
+    else if warn_n > 0
+    then Printf.sprintf "%dl %dw" live_n warn_n, Some Style.hud_v_warn
+    else Printf.sprintf "%dl" live_n, Some Style.hud_v_ok
+  in
+  let sync_v =
+    match keepers.generated_at with
+    | "" -> "—"
+    | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
+  in
   Node.div
     ~attrs:[ Style.hud ]
     [ hud_cell ~k:"Source" ~v:"Log.Ring" ()
@@ -2232,6 +2268,8 @@ let view_hud (response : Logs_types.response) =
     ; hud_cell ~v_class:(Some Style.hud_v_ok) ~k:"Refresh" ~v:"poll · 3s" ()
     ; hud_cell ~k:"Limit" ~v:"200" ()
     ; hud_cell ~v_class:(Some Style.hud_v_ok) ~k:"Link" ~v:"fetch · ok" ()
+    ; hud_cell ~v_class:fleet_cls ~k:"Fleet" ~v:fleet_v ()
+    ; hud_cell ~k:"Synced" ~v:sync_v ()
     ]
 ;;
 
@@ -2673,7 +2711,7 @@ let render_response
     [ nav
     ; brand_row
     ; view_heartbeat ()
-    ; view_hud response
+    ; view_hud ~keepers response
     ; (let warn_n =
          List.count response.entries ~f:(fun e ->
            String.equal e.normalized_level "WARN")


### PR DESCRIPTION
## Summary

HUD 6 cell → 8 cell. **Fleet** (keeper status tally) + **Synced** (server timestamp) 추가. `keepers.generated_at` 과 tally가 마침내 UI에 반영되어 데이터의 "도착 시각"과 "지금 상태"가 한 줄에서 보인다.

> **Stack base**: `feature/bonsai-keepers-client`.

## 새 cells

| cell | 값 형식 | 색상 |
|---|---|---|
| **Fleet** | `"3l 1w 1d"` | `dead>0` → blood, `warn>0` → warn, else → ok |
|  | `"—"` (empty) | neutral |
| **Synced** | `"04:02:07 UTC"` | neutral |
|  | `"—"` (generated_at empty) | neutral |

fleet_v 포맷은 상황별 **verbosity 조절**:
- dead 있으면 3 slot 다 표시
- warn 있으면 live+warn 2 slot
- 전부 live면 live 하나만
- 응답 오기 전 fixture면 `"—"`

## 새 helper

- `hhmmss_of_iso`: `"2026-04-20T04:02:07Z"` → `"04:02:07"`. shape 불일치 시 원본 반환 (절대 throw 안 함)

## 새 CSS

- `.hud_v_bad { color: var(--status-bad); }` — 기존 hud_v_ok/warn 패턴 완성

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] fixture → Fleet `"—"` (neutral), Synced `"—"`
- [ ] 서버 stub → Fleet `"2l 1w 1d"` (blood, ash-hound dead), Synced `"HH:MM:SS UTC"`
- [ ] generated_at 갱신될 때마다 (3s 폴링) Synced cell 값 변화

🤖 Generated with [Claude Code](https://claude.com/claude-code)
