### PR TITLE
docs(logic): batch-16 .mli for tool_schemas_plan + tool_autoresearch_schemas

### DIFF
--- a/lib/tool_autoresearch_schemas.mli
+++ b/lib/tool_autoresearch_schemas.mli
@@ -1,0 +1,13 @@
+(** Tool_autoresearch_schemas — Autoresearch + swarm-facing synthesis
+    schema definitions.
+
+    Extracted from [tool_autoresearch.ml] to keep schema data
+    separate from logic.
+
+    @since 2.80.0 *)
+
+(** Autoresearch tool schemas: [masc_autoresearch_start],
+    [masc_autoresearch_status], [masc_autoresearch_stop],
+    [masc_autoresearch_history], [masc_autoresearch_insights], and
+    swarm synthesis entries. *)
+val schemas : Types.tool_schema list

--- a/lib/tool_schemas/tool_schemas_plan.mli
+++ b/lib/tool_schemas/tool_schemas_plan.mli
@@ -1,0 +1,10 @@
+(** Tool_schemas_plan — MCP tool schemas for [masc_plan_*] family.
+
+    Data-only module — separates schema definitions from dispatch
+    logic. *)
+
+(** Planning tool schemas: [masc_plan_init], [masc_plan_update],
+    [masc_plan_get], [masc_plan_delete], [masc_notes_append],
+    [masc_notes_get], [masc_deliverable_write],
+    [masc_deliverable_read]. *)
+val schemas : Types.tool_schema list


### PR DESCRIPTION
Wave 3 batch 16 — 2 schema-data .mli. 바디 무수정.

| 파일 | ml | mli |
|------|-----|-----|
| `lib/tool_schemas/tool_schemas_plan.mli` | 134 | 11 |
| `lib/tool_autoresearch_schemas.mli` | 144 | 13 |

## 설계 노트

Pre-scan 결과 4-trap clean (inc=0 opn=0) + surf ≤ 3 인 2 파일 선택. 세션 첫 **zero-rebuild batch** — 1차 빌드 통과.

### 건너뛴 후보
- **server_routes_http_routes_room** (135): `add_routes`의 반환 타입 `Http_server_eio.Router.t`가 명명되지 않아 mli 작성에 router 모듈의 mli 선행 필요. Router mli와 함께 별도 batch.

## 검증
- `dune build --root=.` → exit 0 (1차 시도)

## Metric
| | 이전 | 이후 |
|-|------|------|
| `.mli` | 336 | **338** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] Pre-scan 적용, 0 rebuild
- [x] 타입 명명 불명확 시 skip
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)