### PR TITLE
docs(spec): correct stale FSM cross-references in KeeperTaskInterlock

### DIFF
--- a/specs/bug-models/KeeperTaskInterlock.tla
+++ b/specs/bug-models/KeeperTaskInterlock.tla
@@ -10,18 +10,21 @@
 \* claimed task is making progress or is orphaned.
 \*
 \* masc-mcp reference:
-\*   lib/keeper/keeper_state_machine.ml (11-phase keeper FSM)
-\*   lib/types/types_core.ml:254-268    (5-state task FSM:
+\*   lib/keeper/keeper_state_machine.ml (12-phase keeper FSM:
+\*     Offline | Running | Failing | Overflowed | Compacting | HandingOff
+\*     | Draining | Paused | Stopped | Crashed | Restarting | Dead)
+\*   lib/types/types_core.ml:335        (6-state task FSM:
 \*     Todo | Claimed{assignee} | InProgress{assignee} |
+\*     AwaitingVerification{assignee, verification_id, ...} |
 \*     Done{assignee} | Cancelled{cancelled_by})
 \*
 \* A keeper going [Dead] while some task has [claimer = k] must not
-\* leave that task in Claimed / InProgress. Either the task is
-\* Released (back to Todo) or Cancelled as part of the Dead
-\* transition.
+\* leave that task in Claimed / InProgress / AwaitingVerification.
+\* Either the task is Released (back to Todo) or Cancelled as part of
+\* the Dead transition.
 \*
 \* ── Abstraction note ──
-\* The real keeper FSM has 11 phases; for this bug model we use
+\* The real keeper FSM has 12 phases; for this bug model we use
 \* three abstract phases:
 \*   Running       — representative of any dispatchable phase
 \*                   (Running, Paused-and-resumable).


### PR DESCRIPTION
## Summary
- 8th FSM drift fix in this sweep — caught **four** stale cross-references in a single comment block of \`specs/bug-models/KeeperTaskInterlock.tla\`.
- Bug-model preamble was tracking outdated counts and missing a real task variant.

## The four drifts

| # | Drift | Was | Is |
|---|-------|-----|-----|
| 1 | Keeper phase count | \"11-phase keeper FSM\" | 12-phase (Offline/Running/Failing/Overflowed/Compacting/HandingOff/Draining/Paused/Stopped/Crashed/Restarting/Dead) |
| 2 | Task FSM count | \"5-state task FSM\" | 6-state (AwaitingVerification added by #7531 CDAL Verdict Gate) |
| 3 | OCaml line ref | \`lib/types/types_core.ml:254-268\` | \`lib/types/types_core.ml:335\` (file shifted) |
| 4 | Constructor list | Todo \| Claimed \| InProgress \| Done \| Cancelled | Todo \| Claimed \| InProgress \| **AwaitingVerification** \| Done \| Cancelled |

## Why this matters
- A reviewer reading this bug-model would build the wrong mental model of the task FSM (missing the verifier-handoff state).
- The safety property \"Dead transition must not leave claimed task\" needs to extend to AwaitingVerification too — a verifier waiting on a Dead claimer must not block forever.  Updated the safety statement accordingly.

## What this PR does
- Updates the cross-reference block to enumerate all 12 keeper phases and all 6 task states.
- Fixes the stale OCaml line number.
- Adds AwaitingVerification to the safety statement.
- Pure documentation-comment edit — no spec actions, no \`.cfg\` change, TLC behaviour identical.

## Test plan
- [x] Comment-only change.
- [x] No \`.cfg\` modification.
- [x] Cross-checked OCaml at \`lib/types/types_core.ml:335\` and \`lib/keeper/keeper_state_machine.ml\`.

## Refs
- #8942 (sibling: derive_phase docstring drift)
- #8948 / #8952 / #8959 / #8965 / #8973 / #8980 / #8989 (sibling FSM drift fixes)
- #7531 (CDAL Verdict Gate — added AwaitingVerification)
- #8642 / #8701 family (OCaml ↔ TLA mapping work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)