### PR TITLE
feat(bonsai-dashboard): move flame mini into aside (design_v2 parity)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2701,6 +2701,18 @@ let render_response
           ]
       ; Node.div
           ~attrs:[]
+          [ aside_h ~tail:"mock · pending trace" "flame · last cycle"
+          ; view_flame_mini
+              ~segments:
+                [ `Llm, 42
+                ; `Tool, 18
+                ; `Think, 12
+                ; `Wait, 20
+                ; `Err, 8
+                ]
+          ]
+      ; Node.div
+          ~attrs:[]
           [ aside_h ~tail:evs_tail "chronicle · recent"
           ; evs_stream
           ]
@@ -2881,28 +2893,6 @@ let render_response
             ]
         ]
     ; view_context_pressure ~keepers ()
-    ; Node.div
-        ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
-        ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "flame · last cycle" ]
-        ; Node.span
-            ~attrs:[ Style.sec_sub ]
-            [ Node.text "tool category split · single bar + legend" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
-        ; Node.span
-            ~attrs:[ Style.sec_r ]
-            [ Node.text "mock · trace endpoint "
-            ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
-            ]
-        ]
-    ; view_flame_mini
-        ~segments:
-          [ `Llm, 42
-          ; `Tool, 18
-          ; `Think, 12
-          ; `Wait, 20
-          ; `Err, 8
-          ]
     ; Node.div ~attrs:[ Style.signet ] [ Node.text "M" ]
     ; aside
     ]


### PR DESCRIPTION
## Summary

`/Users/dancer/Downloads/MASC Design System/ui_kits/dashboard_v2/index.html` right aside는 **focus → flame → chronicle** 3-section canonical. 기존 구현은 flame이 main column에 있고 aside는 focus + chronicle 2-section이었음. Pure 위치 이동, 데이터/스타일 불변.

## Diff

| Before | After |
|---|---|
| main: context_pressure → **flame_sec + view_flame_mini** → signet → aside | main: context_pressure → signet → aside |
| aside: focus · chronicle | aside: **focus · flame · chronicle** |

## 왜 레이아웃 이동만

- 새 CSS 없음 — `aside_h`, `flame_*` 기존 class 재사용
- mock segments 동일 (`Llm 42 · Tool 18 · Think 12 · Wait 20 · Err 8`)
- `view_flame_mini` 시그니처 불변
- Net **-10 lines** (main sec header 제거가 add된 aside_h보다 큼)

## 왜 지금 옮기나

dashboard_v2 IA는 **right aside = "선택한 keeper의 현재 상태"** 도메인이다. focus(누구) + flame(방금 뭐 했나) + chronicle(최근 무엇이 있었나) 3축이 연속. main column은 fleet-wide (swim / ctx pressure / moonrise) 도메인. 지금이 둘의 경계를 맞출 시점.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 right aside가 focus → flame → chronicle 순서
- [ ] main column에 flame 사라짐, context pressure 바로 뒤 signet
- [ ] flame_mini 수치 그대로 (Llm 42 / Tool 18 / Think 12 / Wait 20 / Err 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)