### PR TITLE
docs(spec): correct stale "11 phases" + add Overflowed to KeepalivePhaseConsistency

### DIFF
--- a/specs/bug-models/KeepalivePhaseConsistency.tla
+++ b/specs/bug-models/KeepalivePhaseConsistency.tla
@@ -17,14 +17,21 @@
 \* of the non-dispatchable states.
 \*
 \* ── Abstraction note ──
-\* The real keeper_state_machine.ml has 11 phases:
-\*   Offline, Running, Failing, Compacting, HandingOff, Draining,
-\*   Paused, Stopped, Crashed, Restarting, Dead.
+\* The real keeper_state_machine.ml has 12 phases (lib/keeper/
+\* keeper_state_machine.ml:50, all_phases):
+\*   Offline, Running, Failing, Overflowed, Compacting, HandingOff,
+\*   Draining, Paused, Stopped, Crashed, Restarting, Dead.
 \* This model collapses them to 6 representative phases for the
 \* keepalive-dispatch invariant. The collapse:
 \*   - Failing/Crashed/Restarting -> not modeled (treated as Offline or
 \*     Running by the dispatcher; their invariants belong to
 \*     KeeperStateMachine.tla, not this spec).
+\*   - Overflowed -> collapsed into "compacting" for this contract.
+\*     Overflowed is the auto-compact entry signal in the real FSM
+\*     (keeper_state_machine.ml:212): Running -> Overflowed ->
+\*     Compacting on context overflow. Both phases are equally
+\*     non-dispatchable from keepalive's perspective; modeling them
+\*     separately would not add bug coverage.
 \*   - Draining -> not modeled (a variant of Stopped for the keepalive
 \*     contract; no dispatch allowed in either).
 \*   - Paused -> not modeled here. Paused is a caller-controlled soft


### PR DESCRIPTION
## Summary
- Spec said 11 phases (line 20). Real FSM has 12. Missing **Overflowed**.
- Same drift class as #8994 (KeeperTaskInterlock).
- Doc-only change. No spec semantics shift.

## Root cause
`Overflowed` was added to `lib/keeper/keeper_state_machine.ml:50` (`all_phases`) but the bug-model abstraction note in `specs/bug-models/KeepalivePhaseConsistency.tla:20` was not updated.

## Fix
Update the abstraction note to enumerate all 12 phases and document the collapse rule for `Overflowed` (collapses into modeled "compacting" — Running → Overflowed → Compacting is the auto-compact path documented at `keeper_state_machine.ml:212`, so both phases are equally non-dispatchable from keepalive's perspective).

## Verification
- `rg -n '\bOverflowed\b' lib/keeper/keeper_state_machine.ml` → confirms Overflowed in 5 sites
- `rg -n '\bOverflowed\b' specs/bug-models/KeepalivePhaseConsistency.tla` → 0 hits before fix

## Test plan
- [x] Doc-only change, no TLC re-run needed (NonDispatchable set unchanged)
- [x] Build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)