### PR TITLE
feat(bash-parser): single-quote string support (Tick 30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ### Added
 
+- **Bash parser single-quote string support (P5 parse-gap step).**
+  `lib/exec/parser/bash_lexer.mll` now recognises `'...'` literal
+  strings and emits them as a single `WORD` token with the surrounding
+  quotes stripped.  Lets the AST gate classify commands like
+  `git commit -m 'my message'` or `echo 'foo | bar'` without falling
+  back to `Shadow_cannot_parse`, narrowing the
+  `gate_diff_legacy_allow_shadow_deny` / `..._shadow_allow` signal
+  on the `MASC_BASH_AST_SHADOW_LOG` observer (feeds the
+  `MASC_BASH_AST_ONLY` flip decision per RUNBOOK §P5).  Five new
+  parser tests cover: basic quoted arg, empty `''`, multiple quoted
+  args in one command, pipe-metachar-as-literal-payload, and the
+  unterminated-quote negative.  No grammar change; no behaviour
+  change on commands without single quotes.
+
 - **`Cdal_judge` go test classifier.**  `of_exec_outcome` now emits
   typed `Test_pass {count}` / `Test_fail {count}` markers for `go
   test` output in addition to dune, cargo, alcotest, and pytest.

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -24,10 +24,20 @@ let word_char = [^ ' ' '\t' '\n' '\r' '|' '<' '>' '&' ';' '(' ')'
                    '\'' '"' '$' '`' '\\' '=' '{' '}' '!' '*' '?']
 let word = word_char+
 
+(* Single-quote string: literal, no escape processing, no nested
+   single quote allowed (bash semantics — there is no way to embed
+   a single quote inside a '...' string).  Matched content becomes
+   a single WORD token so the existing grammar accepts it in any
+   WORD position without change.  Spaces inside quotes are preserved
+   verbatim, so arguments like 'commit message' arrive at
+   [Bin.of_string] / args list as one element. *)
+let sq_body = [^ '\'' '\n']*
+
 rule token = parse
   | [' ' '\t']+    { token lexbuf }
   | '\n'           { incr_tokens (); Lexing.new_line lexbuf; token lexbuf }
   | '|'            { incr_tokens (); PIPE }
+  | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
   | word as w      { incr_tokens (); WORD w }
   | eof            { EOF }
   | _ as c         { raise (Failure (Printf.sprintf "unexpected char %c" c)) }

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -109,6 +109,61 @@ let test_whitespace_only_rejected () =
   (* "whitespace-only must Parse_error" *)
   | _ -> assert false
 
+let test_single_quoted_arg () =
+  (* Single-quoted args preserve internal spaces verbatim and arrive
+     as one Lit element (not split). *)
+  match Bash.parse_string "echo 'hello world'" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    (match s.args with
+     | [ Shell_ir.Lit "hello world" ] -> ()
+     (* "single-quoted content must land as one Lit" *)
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_single_quoted_empty () =
+  match Bash.parse_string "echo ''" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    (match s.args with
+     | [ Shell_ir.Lit "" ] -> ()
+     (* "empty single-quoted string must land as empty Lit" *)
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_multiple_single_quoted_args () =
+  match Bash.parse_string "git commit -m 'my message' --allow-empty" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "git");
+    (match s.args with
+     | [
+         Shell_ir.Lit "commit";
+         Shell_ir.Lit "-m";
+         Shell_ir.Lit "my message";
+         Shell_ir.Lit "--allow-empty";
+       ] -> ()
+     (* "commit message must preserve spaces as one Lit" *)
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_single_quote_with_pipe_metachar () =
+  (* Pipe inside single quotes is literal text, not a pipeline
+     separator — protects the gate from strings that look shell-like
+     but are actually inert literal payload. *)
+  match Bash.parse_string "echo 'foo | bar'" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    (match s.args with
+     | [ Shell_ir.Lit "foo | bar" ] -> ()
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_unterminated_single_quote_rejected () =
+  (* Missing closing quote must surface as Parse_error, not silently
+     consume to EOF. *)
+  match Bash.parse_string "echo 'unterminated" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
 let () =
   test_ls_single_command ();
   test_ls_with_args ();
@@ -121,4 +176,9 @@ let () =
   test_redirect_rejected_in_skeleton ();
   test_empty_input_rejected ();
   test_whitespace_only_rejected ();
+  test_single_quoted_arg ();
+  test_single_quoted_empty ();
+  test_multiple_single_quoted_args ();
+  test_single_quote_with_pipe_metachar ();
+  test_unterminated_single_quote_rejected ();
   print_endline "[test_bash_parser] all tests passed"


### PR DESCRIPTION
## Product impact

Narrows the P5 AST gate parse gap for a pervasive real-world pattern:
single-quoted literal strings. Today commands like `git commit -m 'my
message'` or `echo 'foo | bar'` surface as `Shadow_cannot_parse` on the
`MASC_BASH_AST_SHADOW_LOG` observer, inflating the parse-unsupported
bucket on the shadow-counters endpoint and delaying the
`MASC_BASH_AST_ONLY` flip decision. After this PR those commands
classify successfully — the AST gate produces a real Allow/Deny
verdict instead of a gate-bailout.

## Evidence

- `lib/exec/parser/bash_lexer.mll` — one new lexer rule (and a
  `sq_body` helper) that maps `'...'` to a single `WORD` token with
  the quotes stripped. No grammar change; the content arrives at the
  existing Menhir production as an ordinary WORD.
- `lib/exec/test/test_bash_parser.ml` — 5 new tests:
  - `test_single_quoted_arg` — basic `'hello world'` → single Lit.
  - `test_single_quoted_empty` — empty `''` → empty Lit.
  - `test_multiple_single_quoted_args` — realistic `git commit -m`
    pattern with surrounding flag args.
  - `test_single_quote_with_pipe_metachar` — `'foo | bar'` must
    remain a literal arg, not become a pipeline (critical gate
    guarantee).
  - `test_unterminated_single_quote_rejected` — missing closing
    quote must Parse_error, not silently consume to EOF.

Local `dune exec lib/exec/test/test_bash_parser.exe --root .` →
16/16 tests pass (11 existing + 5 new).

## Review evidence

- Single quotes in bash have no escape processing and cannot embed
  a literal single quote. The `sq_body = [^ '\'' '\n']*` regex
  captures that semantic exactly; the newline exclusion prevents
  multi-line sq strings which bash does support (this remains a
  known gap documented by its own negative test — no regression
  because the status quo already fails).
- The pipe-metachar test is the critical gate safety: without it a
  malicious payload containing an inner metacharacter could be
  misread after lex-level reordering. The test confirms the token
  is correctly recognised as WORD content and not split at the
  embedded metachar.
- Quote content passes through `Bin.of_string` for the bin
  position. An intentional quoted bin name (`'rg'`) would still
  need to be in the allowlist to Allow — quoting does not bypass
  any policy decision.
- Double-quote support is NOT added in this PR. Double quotes have
  escape processing (`\"`, `\\`, `\n`) and variable expansion
  (`\$FOO`), which need separate design work. A follow-up PR can
  address that using the same lexer-rule pattern.

## Linked issue

Refs #8918 (operator runbook §P5 — flip criteria that this narrows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)