### PR TITLE
docs(spec): correct stale line numbers + 4-of-7 abstraction note in MemoryCompaction

### DIFF
--- a/specs/bug-models/MemoryCompaction.tla
+++ b/specs/bug-models/MemoryCompaction.tla
@@ -2,13 +2,34 @@
 \* Bug Model: Memory bank compaction drops important notes.
 \*
 \* Models keeper_memory_bank.ml compact_memory_bank_if_needed.
-\* Correct code: selection respects kind caps (constraints:2,
-\* decision:2, long_term:4, ...) + recent floor (44 notes).
+\* Correct code: selection respects kind caps + recent floor.
 \* Bug: priority-only selection lets high-priority long_term notes
 \* fill all slots, starving constraints and other kinds.
 \*
-\* Reference: keeper_memory_bank.ml lines 292-448,
-\*            keeper_memory_policy.ml lines 131-148 (kind_caps).
+\* Reference (verified 2026-04-20):
+\*   lib/keeper/keeper_memory_bank.ml:346
+\*       compact_memory_bank_if_needed entry point
+\*   lib/keeper/keeper_memory_bank.ml:296
+\*       memory_kind_caps_for_compaction (per-target cap derivation)
+\*   lib/keeper/keeper_memory_policy.ml:806
+\*       kind_caps () : (string * int) list — SSOT
+\*
+\* ── Abstraction note ──
+\* The real kind_caps SSOT enumerates 7 kinds:
+\*   constraints:2, decision:2, next:2, goal:2, progress:2,
+\*   open_question:2, long_term:4
+\* This bug model collapses them to 4 representative kinds for the
+\* "starvation under priority-only selection" invariant:
+\*   constraint  — collapses {constraints} (note singular in spec
+\*                 vs plural "constraints" in source kind_caps)
+\*   decision    — collapses {decision}
+\*   progress    — collapses {next, goal, progress, open_question}
+\*                 (all per-cap=2 generic notes)
+\*   long_term   — collapses {long_term} (only kind with cap=4)
+\* Two abstract caps (ConstraintCap, LongTermCap) are sufficient to
+\* express the bug because the asymmetry that causes starvation is
+\* between "the high-priority kind" (long_term) and "the small-cap
+\* kinds" (everything else with cap=2).
 
 EXTENDS Naturals, Sequences, FiniteSets
 


### PR DESCRIPTION
## Summary
- Bug-model spec referenced stale line numbers + omitted abstraction note for 4-of-7 kind collapse.
- Doc-only change. No semantics shift.

## Drift

| Spec said | Actual code |
|---|---|
| \`keeper_memory_bank.ml lines 292-448\` | line 346 (\`compact_memory_bank_if_needed\`) + line 296 (\`memory_kind_caps_for_compaction\`) |
| \`keeper_memory_policy.ml lines 131-148\` | line 806 (\`kind_caps\`) — ~660 line shift |
| \`Kinds == {constraint, decision, progress, long_term}\` (4) | source has 7: \`constraints, decision, next, goal, progress, open_question, long_term\` |

## Abstraction note added

The 7→4 collapse:
- \`constraint\` ← \`{constraints}\` (note: spec singular vs source plural)
- \`decision\` ← \`{decision}\`
- \`progress\` ← \`{next, goal, progress, open_question}\` (all cap=2)
- \`long_term\` ← \`{long_term}\` (only kind with cap=4)

Two abstract caps (\`ConstraintCap\`, \`LongTermCap\`) suffice because the starvation asymmetry is between the cap=4 kind and the cap=2 kinds.

## Verification
\`\`\`
$ rg -n 'compact_memory_bank_if_needed|kind_caps' lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_policy.ml
lib/keeper/keeper_memory_bank.ml:346:let compact_memory_bank_if_needed
lib/keeper/keeper_memory_bank.ml:296:let memory_kind_caps_for_compaction
lib/keeper/keeper_memory_policy.ml:806:let kind_caps () : (string * int) list =
\`\`\`

## Test plan
- [x] Doc-only change in prelude comment block
- [x] Spec semantics, actions, invariants unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)