### PR TITLE
feat(bonsai-dashboard): nav tails live from Keepers (total + dead)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2572,7 +2572,12 @@ let render_response
       ; nav_link ~active:true "logs · journal"
       ; nav_link "goals"
       ; nav_section "runtime"
-      ; nav_link "keepers" ~tail:"04"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks -> Printf.sprintf "%02d" (List.length ks)
+         in
+         nav_link "keepers" ~tail)
       ; nav_link "observatory"
       ; nav_link "intervene"
       ; nav_section "lab"
@@ -2580,7 +2585,19 @@ let render_response
       ; nav_link "sessions"
       ; nav_link "social board"
       ; nav_section "crypt"
-      ; nav_link "dead keepers" ~tail:"00"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks ->
+             let dead_n =
+               List.count ks ~f:(fun (k : Keepers_types.keeper) ->
+                 match k.status with
+                 | Dead -> true
+                 | _ -> false)
+             in
+             Printf.sprintf "%02d" dead_n
+         in
+         nav_link "dead keepers" ~tail)
       ; nav_link "archive runs"
       ; (let chip name label =
            Node.div


### PR DESCRIPTION
## Summary

design_v2 nav는 `Dead keepers · 03` 처럼 sidebar 탭 끝에 count monospace tail을 보여준다. Bonsai 구현은 하드코드 `"04"` / `"00"` 였음. Keepers 응답에 따라 실시간으로 변하게 연결.

> **Stack base**: `feature/bonsai-tombstrip` (#9002).

## 변경

| nav item | before | after |
|---|---|---|
| Keepers | `04` (hardcoded) | `%02d` keepers.length 또는 `—` (empty) |
| Dead keepers | `00` (hardcoded) | `%02d` count of status=Dead 또는 `—` (empty) |

- `nav_link ~tail` 시그니처 불변, 계산 블록만 inline
- 새 CSS 없음, 새 Bonsai state 없음
- fixture(empty)는 `—` 로 "before data arrived" 시그널

## 왜 지금

nav tail은 "현재 fleet 규모"의 가장 작은 HUD. HUD section + tombstrip은 이미 실시간인데 nav tail만 정적이어서 시각적 drift가 있음. 이 PR로 모든 fleet-aware surface가 Keepers 폴링에 연결.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 서버 stub (4 keepers, ash-hound dead) → `Keepers 04` / `Dead keepers 01`
- [ ] fixture (empty) → `Keepers —` / `Dead keepers —`
- [ ] 3s 폴링마다 서버 응답에 따라 tail 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)