### PR TITLE
docs(logic): batch-17 .mli for backend_compression + channel_gate_discord_names + operator_review_state

### DIFF
--- a/lib/backend/backend_compression.mli
+++ b/lib/backend/backend_compression.mli
@@ -1,0 +1,49 @@
+(** Backend_compression — ZSTD header framing for the backend.
+
+    Currently a passthrough: compression is disabled because the
+    4TB SSD makes ZSTD savings negligible and corrupt ZSTD headers
+    in PG caused server-wide decompress storms (2026-03-28). The
+    public API is preserved so callers need no changes. *)
+
+(** {1 Constants} *)
+
+val min_size : int
+
+val default_level : int
+
+(** {1 Low-level primitives} *)
+
+(** [compress ?level data] returns [(compressed, used_dict, did_compress)].
+    When [did_compress = false] the returned [compressed] equals
+    [data] (input was below the compression threshold). *)
+val compress : ?level:int -> string -> string * bool * bool
+
+(** [decompress ~orig_size ~used_dict compressed] returns
+    [Some plaintext] on success, [None] on decompression error
+    (logged via [Log.Misc.error]). *)
+val decompress :
+  orig_size:int -> used_dict:bool -> string -> string option
+
+(** {1 Header framing}
+
+    Public because benchmarks / coverage tests assemble frames
+    manually. *)
+
+(** [encode_with_header ~used_dict orig_size compressed] prepends a
+    9-byte [ZSTD] / [ZSTDD] header to [compressed]. *)
+val encode_with_header : used_dict:bool -> int -> string -> string
+
+(** [decode_header data] returns [Some (orig_size, compressed, used_dict)]
+    when [data] starts with a recognised header, else [None]. *)
+val decode_header : string -> (int * string * bool) option
+
+(** {1 Framed entry points} *)
+
+(** Auto-decompress if a [ZSTD] / [ZSTDD] header is present; return
+    [data] unchanged otherwise. On decompression failure, returns
+    the original [data] (logged via [Log.Misc.error]). *)
+val decompress_auto : string -> string
+
+(** Compress and prepend a header if beneficial. Currently a
+    passthrough — returns [data] unchanged regardless of [level]. *)
+val compress_with_header : ?level:int -> string -> string

--- a/lib/gate/channel_gate_discord_names.mli
+++ b/lib/gate/channel_gate_discord_names.mli
@@ -1,0 +1,58 @@
+(** Discord name_map side-store.
+
+    Names (guild/channel id → human-readable names) are cosmetic
+    data owned by the sidecar: the bot enumerates guilds/channels
+    every heartbeat and atomically writes {!names_write_path}.
+    Bindings are immutable authority records; names can be renamed
+    at any time. The two concerns have separate lifecycles, so
+    they live in separate files. *)
+
+(** {1 Types} *)
+
+type name_map = {
+  guild_names : (string * string) list;
+  channel_names : (string * string) list;
+  channel_to_guild : (string * string) list;
+  updated_at : string;
+}
+
+(** {1 Path configuration} *)
+
+val default_names_path : string
+
+(** [configured_write_path env_name ~default] — env override
+    resolved against [Env_config_core.base_path ()] when relative. *)
+val configured_write_path : string -> default:string -> string
+
+(** [configured_read_path env_name ~default ~legacy] — env override,
+    else [default], else [legacy] fallback (for pre-v0.9.0 layout). *)
+val configured_read_path :
+  string -> default:string -> legacy:string -> string
+
+(** Default write path (env [MASC_DISCORD_NAMES_PATH] →
+    {!default_names_path}). *)
+val names_write_path : unit -> string
+
+(** Default read path with pre-v0.9.0 legacy fallback. *)
+val names_read_path : unit -> string
+
+(** {1 State I/O} *)
+
+(** Empty [name_map] with [updated_at = ""]. *)
+val empty : name_map
+
+(** Read {!names_read_path}. Missing file or malformed JSON returns
+    {!empty}. *)
+val read : unit -> name_map
+
+val save : name_map -> unit
+
+val to_json : name_map -> Yojson.Safe.t
+
+(** {1 Lookups} *)
+
+(** Return the guild id that owns [channel_id], using the cached
+    [channel_to_guild] map from {!read}. [None] when [channel_id]
+    is empty/whitespace or unknown. *)
+val resolve_guild_id_for_channel :
+  channel_id:string -> string option

--- a/lib/operator/operator_review_state.mli
+++ b/lib/operator/operator_review_state.mli
@@ -1,0 +1,64 @@
+(** Operator_review_state — Persisted log of operator review
+    decisions.
+
+    Records whether an operator has reviewed a particular target
+    (task, agent, etc.) and what action they recommended. Used by
+    {!Operator_digest} to surface recent operator decisions. *)
+
+(** {1 Types} *)
+
+type review_decision = {
+  item_id : string;
+  fingerprint : string;
+  decision : string;
+  actor : string;
+  reason : string;
+  at : string;
+  target_type : string;
+  target_id : string option;
+  recommended_action_type : string option;
+}
+
+(** {1 Path} *)
+
+val review_state_path : Coord_utils.config -> string
+
+(** {1 Serialisation} *)
+
+val review_decision_to_yojson : review_decision -> Yojson.Safe.t
+
+val review_decision_of_yojson :
+  Yojson.Safe.t -> (review_decision, string) result
+
+val compare_review_decision :
+  review_decision -> review_decision -> int
+
+(** {1 I/O} *)
+
+(** Read all stored review decisions (raw order, no filtering). *)
+val read_review_decisions :
+  Coord_utils.config -> review_decision list
+
+(** Atomically rewrite the full decision log. *)
+val write_review_decisions :
+  Coord_utils.config -> review_decision list -> unit
+
+(** {1 Queries} *)
+
+(** [recent_review_decisions ?limit ?target_type ?target_id config]
+    returns decisions matching the optional filters, most recent
+    first. Default [limit] is ["no cap"]. *)
+val recent_review_decisions :
+  ?limit:int ->
+  ?target_type:string ->
+  ?target_id:string ->
+  Coord_utils.config ->
+  review_decision list
+
+(** JSON array of {!recent_review_decisions}. *)
+val recent_review_decisions_json :
+  ?limit:int ->
+  ?target_type:string ->
+  ?target_id:string ->
+  Coord_utils.config ->
+  Yojson.Safe.t


### PR DESCRIPTION
Wave 3 batch 17 — **3** pure .mli. 바디 무수정.

| 파일 | ml | mli |
|------|-----|-----|
| `lib/backend/backend_compression.mli` | 121 | 45 |
| `lib/gate/channel_gate_discord_names.mli` | 123 | 60 |
| `lib/operator/operator_review_state.mli` | 100 | 62 |

## 설계 노트

### backend_compression
- 현재 passthrough (2026-03-28 decompress-storm 사고 이후 비활성) 사실 mli에 명시.
- Low-level(compress/decompress) + header framing(encode/decode_header) + auto entry(compress_with_header/decompress_auto) 3계층 문서화.

### channel_gate_discord_names
- name_map record + path config + state I/O + lookup.
- 5th grep trap: sibling module에서 `module Names = Channel_gate_discord_names` 별칭 — 이전엔 test만 alias trap 발견했으나 lib도 alias 사용함.

### operator_review_state
- review_decision record — 추측한 필드 목록이 실제와 달라 2차 iteration에서 수정.

## Session grep-trap Inventory (누적)

| # | 패턴 | 발견 위치 | 검출 명령 |
|---|------|-----------|-----------|
| 1 | `open Module` | lib | `rg '^open Module'` |
| 2 | `module Alias = Module` | test | `rg 'module .* = Module'` |
| 3 | `Module.(!state)` deref | lib | `rg 'Module\.\(\!'` |
| 4 | `include Module` umbrella | lib | `rg '^include Module'` |
| **5** | **Record field mismatch** | mli speculation | **타입 정의 실제 읽고 복사** |

## 검증
- `dune build --root=.` → exit 0 (3 iteration)

## Metric
| | 이전 | 이후 |
|-|------|------|
| `.mli` | 338 | **341** |

## Anti-goal
- [x] ml 바디 수정 0
- [x] Alias trap lib도 포함해서 pre-scan
- [x] Record signature는 speculation 대신 실제 읽기
- [x] hype 금지

Epic: jeong-sik/me#1022  Milestone: jeong-sik/me#1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)