### PR TITLE
feat(bonsai-dashboard): crumb row embeds live room name

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2572,7 +2572,12 @@ let render_response
       ; nav_link ~active:true "logs · journal"
       ; nav_link "goals"
       ; nav_section "runtime"
-      ; nav_link "keepers" ~tail:"04"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks -> Printf.sprintf "%02d" (List.length ks)
+         in
+         nav_link "keepers" ~tail)
       ; nav_link "observatory"
       ; nav_link "intervene"
       ; nav_section "lab"
@@ -2580,7 +2585,19 @@ let render_response
       ; nav_link "sessions"
       ; nav_link "social board"
       ; nav_section "crypt"
-      ; nav_link "dead keepers" ~tail:"00"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks ->
+             let dead_n =
+               List.count ks ~f:(fun (k : Keepers_types.keeper) ->
+                 match k.status with
+                 | Dead -> true
+                 | _ -> false)
+             in
+             Printf.sprintf "%02d" dead_n
+         in
+         nav_link "dead keepers" ~tail)
       ; nav_link "archive runs"
       ; (let chip name label =
            Node.div

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -104,6 +104,11 @@ stylesheet
 
   .crumbs_sep { color: var(--border-highlight); }
   .crumbs_cur { color: var(--text-bright); letter-spacing: 0.14em; }
+  .crumbs_room {
+    color: var(--accent-brass);
+    letter-spacing: 0.14em;
+    font-variant-numeric: tabular-nums;
+  }
 
   .pulse_slot { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 
@@ -2433,10 +2438,24 @@ let render_response
       ; Node.span ~attrs:[ Style.wordmark ] [ Node.text "masc" ]
       ; Node.div
           ~attrs:[ Style.crumbs ]
-          [ Node.span [ Node.text "observatory" ]
-          ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
-          ; Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "logs · 저널" ]
-          ]
+          (let head =
+             [ Node.span [ Node.text "observatory" ]
+             ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
+             ]
+           in
+           let room_seg =
+             match keepers.room with
+             | None | Some "" -> []
+             | Some name ->
+               [ Node.span ~attrs:[ Style.crumbs_room ] [ Node.text name ]
+               ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
+               ]
+           in
+           let tail =
+             [ Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "logs · 저널" ]
+             ]
+           in
+           head @ room_seg @ tail)
       ; Node.div
           ~attrs:[ Style.pulse_slot ]
           [ Node.span ~attrs:[ Style.pulse ] []


### PR DESCRIPTION
## Summary

design_v2 topbar crumbs는 `Chronicle · adventure-quiet-fox · Overview` 3단 구성: **section · room · page**. Bonsai 구현은 section · page 2단으로 room을 생략하고 있었음. Keepers 응답의 `room : string option` 이미 존재 — 소비만.

> **Stack base**: `feature/bonsai-tombstrip` (#9002, still open).
> **Original stack**: nav-tails(#9005 merged into tombstrip base) → crumbs-room(이 PR).

## 변경

| 조건 | crumbs |
|---|---|
| `room = Some "quiet-fox"` | `observatory › **QUIET-FOX** › logs · 저널` |
| `room = None` or `Some ""` | `observatory › logs · 저널` |

## 신규 CSS

```css
.crumbs_room {
  color: var(--accent-brass);
  letter-spacing: 0.14em;
  font-variant-numeric: tabular-nums;
}
```

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 서버 stub (room=Some "quiet-fox") → `observatory › QUIET-FOX › logs · 저널`
- [ ] fixture (room=None) → 기존 그대로
- [ ] 3s 폴링마다 room 값 변화 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)