### PR TITLE
docs(spec): correct stale cascade module paths in CascadeLiveness + cascade_config comment

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -519,7 +519,8 @@ let order_weighted_entries
     let health_adjusted = List.map
         (fun (e : Cascade_config_loader.weighted_entry) ->
            (* Extract model_id from "provider:model_id" to match the key
-              used by cascade_executor (cfg.model_id). *)
+              used by the cascade runtime (cfg.model_id; see
+              cascade_runtime.ml + cascade_strategy.ml). *)
            let provider_key = match String.split_on_char ':' e.model with
              | _ :: rest when rest <> [] -> String.concat ":" rest
              | _ -> e.model

--- a/specs/bug-models/CascadeLiveness.tla
+++ b/specs/bug-models/CascadeLiveness.tla
@@ -2,15 +2,26 @@
 \* Bug Model: Cascade liveness under concurrent keepers with slot contention.
 \*
 \* Models the interaction between:
-\*   - cascade_executor.ml: try_next with slot-aware fallthrough
-\*   - provider_throttle.ml: per-provider semaphore (non-blocking on non-last)
-\*   - admission_queue.ml: global MASC concurrency gate
-\*   - keeper_unified_turn.ml: MASC turn timeout (kills entire OAS cascade)
+\*   - lib/cascade/cascade_runtime.ml + cascade_strategy.ml + cascade_fsm.ml
+\*       (formerly a single `cascade_executor.ml`): try_next with
+\*       slot-aware fallthrough. The executor role was split into
+\*       runtime (orchestration), strategy (provider order), and fsm
+\*       (per-attempt state machine) under the lib/cascade/ subdir.
+\*   - lib/cascade/cascade_throttle.ml (formerly `provider_throttle.ml`):
+\*       per-provider semaphore (non-blocking on non-last)
+\*   - lib/admission_queue.ml: global MASC concurrency gate
+\*   - lib/keeper/keeper_unified_turn.ml: MASC turn timeout
+\*       (kills entire OAS cascade)
 \*
 \* Real-world evidence: 2026-04-08 logs show 7355 GLM calls, 54 Ollama calls,
 \* 1538 timeouts.  Ollama failover broken by parse error (Content-Length bug).
 \* This spec models the slot/timeout mechanics that determine whether Ollama
 \* is reachable at all, independent of the parse bug.
+\*
+\* (Path drift recorded 2026-04-20. The `cascade_executor` symbol no
+\* longer exists as a single module; `try_next` was distributed across
+\* the cascade_runtime + cascade_strategy + cascade_fsm trio when the
+\* lib/cascade/ subdir was extracted.)
 
 EXTENDS Naturals, FiniteSets
 


### PR DESCRIPTION
## Summary
- Bug-model spec + in-source comment referenced `cascade_executor.ml` and `provider_throttle.ml`, neither of which exist.
- Doc-only fix in two places (1 spec, 1 OCaml comment).

## Drift

| Spec said | Actual |
|---|---|
| `cascade_executor.ml: try_next` | role split across `lib/cascade/cascade_runtime.ml` + `cascade_strategy.ml` + `cascade_fsm.ml` when `lib/cascade/` subdir was extracted |
| `provider_throttle.ml` | `lib/cascade/cascade_throttle.ml` |

Same drift class as #8998 / #9000 / #9004 — module paths shifted by repo restructure, prelude not updated.

## Source comment also stale

`lib/cascade/cascade_config.ml:522` had `"used by cascade_executor (cfg.model_id)"` — same dead symbol. Replaced with reference to `cascade_runtime.ml + cascade_strategy.ml`.

## Verification
```
$ ls lib/cascade_executor.ml lib/provider_throttle.ml
ls: lib/cascade_executor.ml: No such file or directory
ls: lib/provider_throttle.ml: No such file or directory

$ ls lib/cascade/cascade_runtime.ml lib/cascade/cascade_strategy.ml lib/cascade/cascade_fsm.ml lib/cascade/cascade_throttle.ml
(all exist)
```

## Test plan
- [x] Doc/comment-only change, no behavior change
- [x] `try_next` behavior unchanged (no calls modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)