### PR TITLE
fix(bonsai-dashboard): page_tag room segment uses Keepers.room (no literal)

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2572,7 +2572,12 @@ let render_response
       ; nav_link ~active:true "logs · journal"
       ; nav_link "goals"
       ; nav_section "runtime"
-      ; nav_link "keepers" ~tail:"04"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks -> Printf.sprintf "%02d" (List.length ks)
+         in
+         nav_link "keepers" ~tail)
       ; nav_link "observatory"
       ; nav_link "intervene"
       ; nav_section "lab"
@@ -2580,7 +2585,19 @@ let render_response
       ; nav_link "sessions"
       ; nav_link "social board"
       ; nav_section "crypt"
-      ; nav_link "dead keepers" ~tail:"00"
+      ; (let tail =
+           match keepers.keepers with
+           | [] -> "—"
+           | ks ->
+             let dead_n =
+               List.count ks ~f:(fun (k : Keepers_types.keeper) ->
+                 match k.status with
+                 | Dead -> true
+                 | _ -> false)
+             in
+             Printf.sprintf "%02d" dead_n
+         in
+         nav_link "dead keepers" ~tail)
       ; nav_link "archive runs"
       ; (let chip name label =
            Node.div

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -104,6 +104,11 @@ stylesheet
 
   .crumbs_sep { color: var(--border-highlight); }
   .crumbs_cur { color: var(--text-bright); letter-spacing: 0.14em; }
+  .crumbs_room {
+    color: var(--accent-brass);
+    letter-spacing: 0.14em;
+    font-variant-numeric: tabular-nums;
+  }
 
   .pulse_slot { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 
@@ -2433,10 +2438,24 @@ let render_response
       ; Node.span ~attrs:[ Style.wordmark ] [ Node.text "masc" ]
       ; Node.div
           ~attrs:[ Style.crumbs ]
-          [ Node.span [ Node.text "observatory" ]
-          ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
-          ; Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "logs · 저널" ]
-          ]
+          (let head =
+             [ Node.span [ Node.text "observatory" ]
+             ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
+             ]
+           in
+           let room_seg =
+             match keepers.room with
+             | None | Some "" -> []
+             | Some name ->
+               [ Node.span ~attrs:[ Style.crumbs_room ] [ Node.text name ]
+               ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
+               ]
+           in
+           let tail =
+             [ Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "logs · 저널" ]
+             ]
+           in
+           head @ room_seg @ tail)
       ; Node.div
           ~attrs:[ Style.pulse_slot ]
           [ Node.span ~attrs:[ Style.pulse ] []

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2883,14 +2883,14 @@ let render_response
                      (let room =
                         match keepers.room with
                         | Some r when String.length r > 0 -> r
-                        | _ -> "chronicle"
+                        | _ -> "—"
                       in
                       let day =
                         if keepers.cycle <= 0
                         then "—"
                         else roman_of_int keepers.cycle
                       in
-                      Printf.sprintf "%s · quiet fox · day %s" room day) ]
+                      Printf.sprintf "chronicle · %s · day %s" room day) ]
              ; Node.h1
                  ~attrs:[ Style.page_h1 ]
                  [ Node.text "the watch "

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1597,6 +1597,43 @@ stylesheet
     color: var(--text-bright);
     font-variant-numeric: tabular-nums;
   }
+
+  /* ─── tombstrip — 12-state keeper FSM tiles ───
+     design_v2: Offline → Running → {Failing | Overflowed | Compacting |
+     HandingOff | Draining} → Paused / Stopped / Crashed → Restarting → Dead.
+     기본은 dim outline. active=brass glow, danger=blood(Crashed),
+     dead=strikethrough with blood decoration. */
+  .tombstrip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    padding: 6px 14px 12px;
+  }
+  .tomb {
+    padding: 5px 8px;
+    font-family: 'Cinzel', 'Cormorant SC', serif;
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    border: 1px solid var(--border-main);
+    background: #1a120c;
+  }
+  .tomb_active {
+    color: var(--accent-brass);
+    border-color: var(--accent-brass);
+    background: linear-gradient(180deg, #2a1f14, #14100a);
+  }
+  .tomb_danger {
+    color: var(--accent-blood);
+    border-color: color-mix(in oklab, var(--accent-blood) 50%, transparent);
+  }
+  .tomb_dead {
+    color: var(--text-dim);
+    opacity: 0.5;
+    text-decoration: line-through;
+    text-decoration-color: var(--accent-blood);
+  }
 |}]
 
 let level_class level =
@@ -2120,6 +2157,44 @@ let ctx_meta_lines_of (ks : Keepers_types.keeper list) : string list =
     | a :: b :: rest -> (a ^ " · " ^ b) :: chunks rest
   in
   chunks (List.map ks ~f:pair)
+;;
+
+type tomb_level = [ `Base | `Active | `Danger | `Dead ]
+
+let tomb_class = function
+  | `Base -> Style.tomb
+  | `Active -> Style.tomb_active
+  | `Danger -> Style.tomb_danger
+  | `Dead -> Style.tomb_dead
+;;
+
+(* 12-state keeper FSM per design_v2. active/danger/dead are mocked until
+   keeper phase is wired through Keepers_types. *)
+let keeper_fsm_states : (string * tomb_level) list =
+  [ "Offline",    `Base
+  ; "Running",    `Active
+  ; "Failing",    `Base
+  ; "Overflowed", `Base
+  ; "Compacting", `Active
+  ; "HandingOff", `Base
+  ; "Draining",   `Base
+  ; "Paused",     `Active
+  ; "Stopped",    `Base
+  ; "Crashed",    `Danger
+  ; "Restarting", `Base
+  ; "Dead",       `Dead
+  ]
+;;
+
+let view_tombstrip ?(states = keeper_fsm_states) () =
+  let tile (label, level) =
+    Node.span
+      ~attrs:[ Style.tomb; tomb_class level ]
+      [ Node.text label ]
+  in
+  Node.div
+    ~attrs:[ Style.tombstrip ]
+    (List.map states ~f:tile)
 ;;
 
 let view_context_pressure
@@ -2893,6 +2968,21 @@ let render_response
             ]
         ]
     ; view_context_pressure ~keepers ()
+    ; Node.div
+        ~attrs:[ Style.sec ]
+        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "keeper rites · 12 states" ]
+        ; Node.span
+            ~attrs:[ Style.sec_sub ]
+            [ Node.text "Offline → Running → {Failing · Overflowed · Compacting · Draining} → Paused / Stopped / Crashed → Restarting → Dead" ]
+        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span
+            ~attrs:[ Style.sec_r ]
+            [ Node.text "mock · keeper phase wire "
+            ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
+            ]
+        ]
+    ; view_tombstrip ()
     ; Node.div ~attrs:[ Style.signet ] [ Node.text "M" ]
     ; aside
     ]


### PR DESCRIPTION
## Summary

design_v2 hero tag는 `Chronicle · Quiet Fox · Day IV` 3단 구성 — **section · room · day**. 기존 구현은 literal `quiet fox` 가 중간에 **항상** 들어가서 Keepers.room 이 있어도 중복 표기되는 버그:

```
room=Some "quiet-fox"  →  "quiet-fox · quiet fox · day IV"   ❌ 중복
room=None              →  "chronicle · quiet fox · day —"    ❌ 없는 정보
```

## Fix

| before | after |
|---|---|
| `<room-or-'chronicle'> · quiet fox · day <roman>` | `chronicle · <room-or-'—'> · day <roman>` |

각 segment가 단일 역할을 갖도록 재배치:
- `chronicle` — 고정 section 레이블
- `<room>` — `Keepers.room` 소비 (empty → `—`)
- `day <roman>` — `Keepers.cycle` (0 → `—`)

> **Stack base**: `feature/bonsai-crumbs-room` (#9009).

## 왜 이 버그가 지금까지 남았나

- fixture (room=None) 기본값으로는 tag에 "chronicle · quiet fox · day —"처럼 literal이 자연스럽게 보임
- 서버 stub 붙이고 room=Some "quiet-fox" 실측 시 비로소 중복 노출
- #9009 (crumbs-room)에서 room segment 개념을 도입하면서 page_tag도 동일 규칙 적용 시점

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] fixture (room=None, cycle=0) → `chronicle · — · day —`
- [ ] 서버 stub (room=Some "quiet-fox", cycle=4) → `chronicle · quiet-fox · day IV`
- [ ] 3s 폴링마다 cycle 증가 시 roman 올바르게 (V, VI, ...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)