### PR TITLE
fix(status): surface missing planning for claimed tasks

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -210,6 +210,10 @@ type current_binding = {
   claim_first_suppressed : bool;
 }
 
+type planning_context_state = {
+  planning_missing_task : string option;
+}
+
 let resolve_current_binding ~assigned_task_ids ~planning_current =
   let primary_owned =
     match assigned_task_ids with
@@ -255,6 +259,17 @@ let resolve_current_binding ~assigned_task_ids ~planning_current =
     current_task_set;
     claim_first_suppressed = assigned_task_ids <> [];
   }
+
+let planning_context_state (ctx : context) (binding : current_binding) =
+  let planning_missing_task =
+    match binding.primary_owned with
+    | None -> None
+    | Some task_id -> (
+        match Planning_eio.load ctx.config ~task_id with
+        | Ok _ -> None
+        | Error _ -> Some task_id)
+  in
+  { planning_missing_task }
 
 let task_id_list_label = function
   | [] -> "[]"
@@ -353,6 +368,7 @@ let status_summary_string (ctx : context) =
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task
   in
+  let planning_state = planning_context_state ctx binding in
   let guidance =
     Workflow_guide.current_state_guidance
       ~room_set:true
@@ -362,27 +378,30 @@ let status_summary_string (ctx : context) =
       ~worktree_active ~session_active:false
   in
   let suggested_next =
-    guidance.next_steps
-    |> List.map (fun (step : Workflow_guide.step) -> step.tool)
-    |> fun tools ->
-    if credential_blocked then
-      List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
+    if Option.is_some planning_state.planning_missing_task then
+      [ "masc_plan_init"; "masc_status" ]
     else
-      match binding.drift_reason with
-      | Some "no_owned" ->
-          let tools =
-            List.filter (fun tool -> not (String.equal tool "masc_transition"))
-              tools
-          in
-          let tools =
-            if todo_count > 0 then
-              "masc_claim_next" :: tools
-            else
-              tools
-          in
-          unique_strings tools
-      | Some _ | None -> tools
-    |> take_items 2
+      guidance.next_steps
+      |> List.map (fun (step : Workflow_guide.step) -> step.tool)
+      |> fun tools ->
+      if credential_blocked then
+        List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
+      else
+        match binding.drift_reason with
+        | Some "no_owned" ->
+            let tools =
+              List.filter (fun tool -> not (String.equal tool "masc_transition"))
+                tools
+            in
+            let tools =
+              if todo_count > 0 then
+                "masc_claim_next" :: tools
+              else
+                tools
+            in
+            unique_strings tools
+        | Some _ | None -> tools
+      |> take_items 2
   in
   let attention_items =
     []
@@ -401,6 +420,16 @@ let status_summary_string (ctx : context) =
         ]
     else
       items
+    |> fun items ->
+    (match planning_state.planning_missing_task with
+    | Some task_id ->
+        items
+        @ [
+            Printf.sprintf
+              "Owned task %s has no planning context. Initialize or repair planning before continuing claimed work."
+              task_id;
+          ]
+    | None -> items)
     |> fun items ->
     if Option.is_some binding.primary_owned && not binding.current_task_set then
       items
@@ -469,6 +498,11 @@ let status_summary_string (ctx : context) =
        (option_or_dash binding.effective_current)
        (option_or_dash binding.drift_reason)
        (bool_flag binding.claim_first_suppressed));
+  (match planning_state.planning_missing_task with
+  | Some task_id ->
+      Buffer.add_string buf
+        (Printf.sprintf "📝 Planning: missing=yes | task=%s\n" task_id)
+  | None -> ());
   if credential_state.credential_required then
     Buffer.add_string buf
       (Printf.sprintf "🔐 Credential: required=yes | available=%s | candidates=%s\n"

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -326,6 +326,27 @@ let () = test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_status_surfaces_missing_planning_for_owned_task" (fun () ->
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  ignore (Coord.add_task ctx.config ~title:"Claimed without plan" ~priority:3 ~description:"");
+  ignore (Coord.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001");
+  Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "owned=task-001 | current=task-001");
+      assert (str_contains result "📝 Planning: missing=yes | task=task-001");
+      assert (str_contains result "Owned task task-001 has no planning context.");
+      assert (str_contains result "💡 Suggested next: masc_plan_init -> masc_status");
+      assert (not (str_contains result "💡 Suggested next: masc_heartbeat"));
+      assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
+  | None -> failwith "dispatch returned None"
+)
+
 let () = test "dispatch_check_project_ready_alias" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in


### PR DESCRIPTION
## Summary
- surface `planning missing` explicitly when a claimed/current task has no planning context
- suppress normal claimed-task guidance and point the operator at `masc_plan_init -> masc_status`
- add regression coverage for claimed/current tasks with missing planning context

## Evidence
- `dune build --root . test/test_tool_coord_coverage.exe`
- `./_build/default/test/test_tool_coord_coverage.exe test --compact '' 15`
- `./_build/default/test/test_tool_coord_coverage.exe test --compact '' 13`
- `./_build/default/test/test_tool_coord_coverage.exe test --compact '' 14`

## Review evidence
- issue: #8999
- scope: read-model/status only; does not change mutation reliability for `masc_plan_init`

## Linked issue
- Refs #8999
