### PR TITLE
feat(exec/parser): double-quote string literal support (P5 Tick 31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,31 @@
   unterminated-quote negative.  No grammar change; no behaviour
   change on commands without single quotes.
 
+- **Bash parser double-quote string support (P5 parse-gap step).**
+  `lib/exec/parser/bash_lexer.mll` now recognises `"..."` double-
+  quoted literals alongside unquoted `WORD` tokens.  The double-
+  quote body is matched by `dq_body = [^ '"' '\n' '\\' '$' '`']*`
+  and emitted as a single `WORD` with the surrounding quotes
+  stripped, so shapes like `rg "error pattern"` /
+  `git commit -m "some message"` / `echo "hello world"` round-trip
+  as one `Shell_ir.Lit` element — spaces preserved, pipe metachar
+  inside the body left literal.  Bash features that `"..."` would
+  otherwise interpret (backslash escapes `\"`/`\\`, variable
+  expansion `$FOO`, command substitution `` ` ``/`$(…)`, embedded
+  newlines) are subset-excluded at the A1 layer: their presence in
+  the body breaks the lex and surfaces as `Parse_error`, which is
+  fail-closed for the subset gate.  The grammar is unchanged
+  (`WORD` production already accepts the token in any argument
+  position).  Follow-up PRs will add an unescape sub-rule for `\"`
+  / `\\` / `\n` / `\$` to widen coverage.  Eight new parser tests
+  cover the happy paths (basic literal, empty string, pipe
+  metachar as literal, `rg "error pattern" src/`) and the four
+  fail-closed negatives (`$FOO`, `\"` escapes, backtick subst,
+  unterminated `"`).  19/19 parser tests green locally.  Narrows
+  the `Shadow_cannot_parse` bucket emitted by the AST gate shadow
+  observer, bringing the `MASC_BASH_AST_ONLY` flip criterion one
+  step closer.
+
 - **`Cdal_judge` go test classifier.**  `of_exec_outcome` now emits
   typed `Test_pass {count}` / `Test_fail {count}` markers for `go
   test` output in addition to dune, cargo, alcotest, and pytest.

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -33,11 +33,25 @@ let word = word_char+
    [Bin.of_string] / args list as one element. *)
 let sq_body = [^ '\'' '\n']*
 
+(* Double-quote string: A1 skeleton treats it as a literal whose body
+   excludes the four metachars bash would interpret inside "..." —
+   backslash escapes ('\"', '\\', '\$', '\`'), variable expansion ($FOO,
+   ${FOO}), command substitution (`cmd`, $(cmd)), and embedded newlines.
+   Any of those chars inside the body breaks the lex → Parse_error,
+   which is the correct fail-closed behavior for the subset.  The most
+   common caller shapes (rg "pattern", git commit -m "message",
+   echo "hello world") have none of those chars and land as one WORD
+   token, mirroring the single-quote rule's space-preservation guarantee.
+   Upgrade path: later PR widens dq_body to support escape sequences by
+   capturing in a sub-rule that unescapes into a Buffer. *)
+let dq_body = [^ '"' '\n' '\\' '$' '`']*
+
 rule token = parse
   | [' ' '\t']+    { token lexbuf }
   | '\n'           { incr_tokens (); Lexing.new_line lexbuf; token lexbuf }
   | '|'            { incr_tokens (); PIPE }
   | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
+  | '"' (dq_body as s) '"' { incr_tokens (); WORD s }
   | word as w      { incr_tokens (); WORD w }
   | eof            { EOF }
   | _ as c         { raise (Failure (Printf.sprintf "unexpected char %c" c)) }

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -164,6 +164,78 @@ let test_unterminated_single_quote_rejected () =
   | Parsed.Parse_error _ -> ()
   | _ -> assert false
 
+let test_double_quoted_arg () =
+  (* Double-quoted args with literal body (no $/\/backtick) preserve
+     internal spaces and arrive as one Lit element — mirrors the
+     common [rg "pattern"] shape.  The surrounding quotes are stripped
+     at lex time, so the Lit carries the payload only. *)
+  match Bash.parse_string "echo \"hello world\"" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    (match s.args with
+     | [ Shell_ir.Lit "hello world" ] -> ()
+     (* "double-quoted content must land as one Lit" *)
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_double_quoted_empty () =
+  match Bash.parse_string "echo \"\"" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    (match s.args with
+     | [ Shell_ir.Lit "" ] -> ()
+     (* "empty double-quoted string must land as empty Lit" *)
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_double_quote_with_pipe_metachar () =
+  (* Pipe inside double quotes is literal text, not a pipeline
+     separator — same safety invariant as single quotes. *)
+  match Bash.parse_string "echo \"foo | bar\"" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    (match s.args with
+     | [ Shell_ir.Lit "foo | bar" ] -> ()
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_double_quote_rg_pattern () =
+  (* The most common caller shape — [rg "error pattern"] style — must
+     round-trip through lex+parse untouched so the gate sees the
+     trusted argv the user intended. *)
+  match Bash.parse_string "rg \"error pattern\" src/" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "rg");
+    (match s.args with
+     | [ Shell_ir.Lit "error pattern"; Shell_ir.Lit "src/" ] -> ()
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_double_quote_with_dollar_rejected () =
+  (* Variable expansion is subset-excluded at the A1 layer — any '$'
+     inside "..." breaks the lex so Parse_error surfaces rather than
+     silently treating the literal as expanded. *)
+  match Bash.parse_string "echo \"value $FOO here\"" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
+let test_double_quote_with_backslash_rejected () =
+  (* Escape sequences ('\"', '\\') are subset-excluded at A1 — reject
+     until a later PR adds the unescape sub-rule. *)
+  match Bash.parse_string "echo \"he said \\\"hi\\\"\"" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
+let test_double_quote_with_backtick_rejected () =
+  (* Command substitution (`cmd`) is subset-excluded — reject. *)
+  match Bash.parse_string "echo \"now `date`\"" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
+let test_unterminated_double_quote_rejected () =
+  match Bash.parse_string "echo \"unterminated" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
 let () =
   test_ls_single_command ();
   test_ls_with_args ();
@@ -181,4 +253,12 @@ let () =
   test_multiple_single_quoted_args ();
   test_single_quote_with_pipe_metachar ();
   test_unterminated_single_quote_rejected ();
+  test_double_quoted_arg ();
+  test_double_quoted_empty ();
+  test_double_quote_with_pipe_metachar ();
+  test_double_quote_rg_pattern ();
+  test_double_quote_with_dollar_rejected ();
+  test_double_quote_with_backslash_rejected ();
+  test_double_quote_with_backtick_rejected ();
+  test_unterminated_double_quote_rejected ();
   print_endline "[test_bash_parser] all tests passed"


### PR DESCRIPTION
## Product impact

Extends the A1 bash subset parser to recognise `"..."` double-quoted strings as literal `WORD` tokens.  The most common CLI shapes that previously failed the AST gate — `rg "error pattern"`, `git commit -m "some message"`, `echo "hello world"` — now round-trip as a single `Shell_ir.Lit` argument with internal spaces preserved, matching the single-quote rule landed in #9003.

Bash features that `"..."` would otherwise interpret (backslash escapes `\"`/`\\`, variable expansion `$FOO`, command substitution `` ` ``/`$(…)`, embedded newlines) are subset-excluded at A1: their presence in the body breaks the lex and surfaces as `Parse_error`, which is fail-closed for the gate.  Later PRs will add an unescape sub-rule to widen coverage; for now the conservative body class protects against silent misinterpretation.

This narrows the `Shadow_cannot_parse` bucket emitted by the AST gate shadow observer, pulling the `MASC_BASH_AST_ONLY` flip criterion closer to zero-diff.

## Evidence

- `lib/exec/parser/bash_lexer.mll`: new `dq_body = [^ '"' '\n' '\\' '$' '`']*` helper + lexer rule `'"' (dq_body as s) '"' { incr_tokens (); WORD s }`.  No grammar change — the `WORD` production in `bash_subset.mly` already accepts the token.
- `lib/exec/test/test_bash_parser.ml`: 8 new tests.  Happy path: `test_double_quoted_arg`, `test_double_quoted_empty`, `test_double_quote_with_pipe_metachar`, `test_double_quote_rg_pattern`.  Fail-closed negatives: `test_double_quote_with_dollar_rejected`, `test_double_quote_with_backslash_rejected`, `test_double_quote_with_backtick_rejected`, `test_unterminated_double_quote_rejected`.
- Local `dune exec lib/exec/test/test_bash_parser.exe --root .` → 19/19 tests pass.

## Review evidence

Structural isolation — the change touches only the lex layer (one new rule + one regex helper) and one test file.  No behavior change for existing callers, no grammar diff, no dune-project bump.  The new rule composes with #9003's single-quote rule (orthogonal regex patterns, no overlap in match priority).

## Linked issue

N/A — P5 parse-gap narrowing per `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`.

## Runbook impact

None.  `LEGENDARY-BASH-RUNBOOK.md §P5` lists parse-gap narrowing as the gate to `MASC_BASH_AST_ONLY` flip; this PR chips at that gap without changing any flag semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)