### PR TITLE
fix(lint): symbol-anchor allowlist format — kill line-number DET drift class

### DIFF
--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -1,11 +1,20 @@
 # Allowlist for scripts/lint/no-unknown-permissive-default.sh
 #
-# Format: one `<path>:<line>` per line. Lines starting with `#` are ignored.
+# Entry formats (both accepted):
+#   path::symbol   — preferred. Stable across line drift; the entry stays
+#                    valid while the enclosing `let <symbol>` declaration
+#                    keeps its name. Rename/remove the symbol → entry goes
+#                    stale (exit 2) and must be cleaned up in the same PR.
+#   path:line      — legacy. Fragile: upstream insertion shifts the line
+#                    number and the entry goes stale even when the pattern
+#                    is still there. Prefer `path::symbol`.
 #
-# Entries below are pre-existing #8605 family instances that the CI gate
-# observed at install time (2026-04-20). They are NOT exonerations — each
-# should be migrated to sound-partial or Unknown variant in follow-up work.
-# File new instances as standalone bugs (see #8832 as an example).
+# Lines starting with `#` are ignored.
+#
+# Entries below (if any) are pre-existing #8605 family instances. They are
+# NOT exonerations — each should be migrated to sound-partial or Unknown
+# variant in follow-up work. File new instances as standalone bugs
+# (see #8832 as an example).
 
 # #8605 umbrella — tracked in https://github.com/jeong-sik/masc-mcp/issues/8605
 #

--- a/scripts/lint/no-unknown-permissive-default.sh
+++ b/scripts/lint/no-unknown-permissive-default.sh
@@ -8,10 +8,19 @@
 #      constructor (anything except None / Error / Some / Ok / Unknown / Other /
 #      Unspecified / Null / Nil / *_unknown / *_other / Module.lowercase_fn).
 #
+# Allowlist entry forms (both accepted):
+#   path:line        — legacy. Fragile under refactor: an upstream insertion
+#                      shifts the line number and the entry goes stale even
+#                      when the pattern is still there.
+#   path::symbol     — symbol-anchored. Stable across line drift. Resolves
+#                      to the enclosing top-level `let <symbol>` / `and
+#                      <symbol>` declaration at the violation site. Prefer
+#                      this form.
+#
 # Exit codes:
 #   0 — clean
 #   1 — new violations (not in allowlist)
-#   2 — stale allowlist entries (pattern no longer present at listed line)
+#   2 — stale allowlist entries (pattern no longer present at listed location)
 #
 # Reference: #8605 (family), #8832 (latest instance), event_kind.mli (fix template).
 
@@ -27,20 +36,36 @@ files_scanned=0
 detected_keys=()
 
 # awk scans each .ml file:
+#   - Tracks the enclosing top-level `let`/`and` symbol at each line.
 #   - Tracks whether the last ~40 lines contained a `| "literal" -> ...` arm.
 #   - When a `| _ -> Capital_Constructor` line appears AND the exclusion
-#     list doesn't match, emit `file:line:content`.
+#     list doesn't match, emit `file<TAB>line<TAB>symbol<TAB>content`.
+#
+# Using TAB as a field separator because OCaml `content` may embed `:` in
+# type annotations; `symbol` is always a plain identifier or `<top>`.
 scan_file() {
   awk '
     BEGIN {
       has_string_arm = 0
       arm_line = 0
+      current_symbol = "<top>"
+    }
+    function extract_symbol(s,    n, parts, idx, sym) {
+      n = split(s, parts, /[[:space:]]+/)
+      idx = 2
+      if (n >= 3 && parts[2] == "rec") idx = 3
+      sym = parts[idx]
+      # Strip anything after the identifier (args, type annotations, =, etc.).
+      gsub(/[^a-zA-Z0-9_'\''].*/, "", sym)
+      if (sym == "" || sym == "_") return "<top>"
+      return sym
     }
     {
       line = $0
 
-      # Reset tracker on function boundaries (let / and at column 0).
+      # Track the enclosing top-level let/and binding.
       if (line ~ /^(let|and)[[:space:]]/) {
+        current_symbol = extract_symbol(line)
         has_string_arm = 0
         arm_line = 0
       }
@@ -59,13 +84,12 @@ scan_file() {
       # Detect wildcard-to-constructor.
       if (has_string_arm && line ~ /^[[:space:]]*\|[[:space:]]*_[[:space:]]*->[[:space:]]*[A-Z][a-zA-Z_0-9]+/) {
         # Exclude Module.lowercase_fn (function application, not a constructor).
-        # Match any dotted chain where a lowercase segment appears after a dot.
         if (line ~ /->[[:space:]]*[A-Z][A-Za-z_0-9.]*\.[a-z]/) next
         # Exclude safe / explicit-failure constructors.
         if (line ~ /->[[:space:]]*([A-Z][A-Za-z_0-9]*\.)*(None|Error|Some|Ok|Unknown|Other|Unspecified|Null|Nil|Reject|Fail|Failure|Invalid|Missing|Denied|Skip|Skipped|Absent|NotFound|Not_found)([^A-Za-z0-9_]|$)/) next
         if (line ~ /(_unknown|_other|_unspecified|_invalid|_missing|_error)([^A-Za-z0-9_]|$)/) next
 
-        printf "%s:%d:%s\n", FILENAME, NR, line
+        printf "%s\t%d\t%s\t%s\n", FILENAME, NR, current_symbol, line
       }
     }
   ' "$1"
@@ -76,18 +100,20 @@ while IFS= read -r -d '' file; do
   findings=$(scan_file "$file" || true)
   [[ -z "$findings" ]] && continue
 
-  while IFS=: read -r _ linenum content; do
+  while IFS=$'\t' read -r _ linenum symbol content; do
     [[ -z "$linenum" ]] && continue
-    key="${file}:${linenum}"
-    detected_keys+=("$key")
+    line_key="${file}:${linenum}"
+    sym_key="${file}::${symbol}"
+    detected_keys+=("$line_key" "$sym_key")
 
-    if [[ -f "$ALLOWLIST_FILE" ]] && grep -qxF "$key" "$ALLOWLIST_FILE"; then
+    if [[ -f "$ALLOWLIST_FILE" ]] && \
+       { grep -qxF "$line_key" "$ALLOWLIST_FILE" || grep -qxF "$sym_key" "$ALLOWLIST_FILE"; }; then
       continue
     fi
 
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//')"
-    printf '::error file=%s,line=%d::#8605 family: permissive default in string-parsing match: %s\n' \
-      "$file" "$linenum" "$trimmed"
+    printf '::error file=%s,line=%d::#8605 family: permissive default in string-parsing match (symbol=%s): %s\n' \
+      "$file" "$linenum" "$symbol" "$trimmed"
     violations=$((violations + 1))
   done <<< "$findings"
 done < <(find lib -type f -name '*.ml' -print0)
@@ -113,21 +139,23 @@ Fix options:
      reference template.
   2. Explicit `Unknown of string` variant: preserves the wire string for
      diagnosis while making the unknown case visible to downstream matches.
-  3. If the coercion is intentional and well-documented, add the `file:line`
-     to scripts/lint/no-unknown-permissive-default.allowlist (one entry per
-     line). Prefer fixing.
+  3. If the coercion is intentional and well-documented, add one entry per
+     line to scripts/lint/no-unknown-permissive-default.allowlist:
+       path::symbol   (preferred — stable across line drift)
+       path:line      (legacy — fragile)
+     Prefer fixing.
 
 EOF
   exit 1
 fi
 
-# Self-verify: fail when an allowlist entry points to a line that no longer
-# matches the #8605 family pattern (upstream fix eliminated it, or the line
-# shifted). Keeps the allowlist an accurate debt ledger — merged fixes remove
-# their entry in the same PR, or the gate flags the drift.
+# Self-verify: fail when an allowlist entry no longer maps to a detected
+# violation (upstream fix eliminated it, or — with symbol anchors — the
+# symbol was renamed / removed). Symbol form eliminates the line-drift
+# false-stale class that the `path:line` form exhibits (cycle 26 / cycle 35).
 #
 # Opt out with SKIP_ALLOWLIST_VERIFY=1 during a transient in-flight migration
-# that lists lines before the fix lands.
+# that lists the location before the fix lands.
 stale=0
 if [[ -f "$ALLOWLIST_FILE" && "${SKIP_ALLOWLIST_VERIFY:-0}" != "1" ]]; then
   detected_set=$'\n'
@@ -142,7 +170,7 @@ if [[ -f "$ALLOWLIST_FILE" && "${SKIP_ALLOWLIST_VERIFY:-0}" != "1" ]]; then
     [[ -z "$entry" ]] && continue
 
     if [[ "$detected_set" != *$'\n'"$entry"$'\n'* ]]; then
-      printf '::error file=%s::stale allowlist entry: %s (no #8605 family pattern detected at this file:line; remove from allowlist)\n' \
+      printf '::error file=%s::stale allowlist entry: %s (no #8605 family pattern detected at this location; remove from allowlist)\n' \
         "$ALLOWLIST_FILE" "$entry"
       stale=$((stale + 1))
     fi
@@ -156,9 +184,10 @@ Stale allowlist entries detected.
 
 Why this fails CI:
   The allowlist is a debt ledger of pre-existing #8605 family sites. When
-  an upstream fix eliminates the pattern, the entry must be removed in the
-  same PR as the fix. Silently-stale entries turn the ledger into noise and
-  let new violations hide behind old listings (cycle 26 / cycle 35 drift
+  an upstream fix eliminates the pattern (or a symbol-anchored entry loses
+  its symbol via rename/removal), the entry must be removed in the same
+  PR. Silently-stale entries turn the ledger into noise and let new
+  violations hide behind old listings (cycle 26 / cycle 35 drift
   incidents).
 
 Fix: remove the listed entries from the allowlist file — mechanical edit,
@@ -173,9 +202,11 @@ fi
 
 echo "No #8605 family violations found."
 if [[ "${#detected_keys[@]}" -gt 0 ]]; then
-  if [[ "${#detected_keys[@]}" -eq 1 ]]; then
-    echo "Allowlist debt: 1 entry (allowlisted)."
+  # Each violation contributes 2 keys (line + symbol). Report unique sites.
+  site_count=$(( ${#detected_keys[@]} / 2 ))
+  if [[ "$site_count" -eq 1 ]]; then
+    echo "Allowlist debt: 1 site (allowlisted)."
   else
-    echo "Allowlist debt: ${#detected_keys[@]} entries (all allowlisted)."
+    echo "Allowlist debt: ${site_count} sites (all allowlisted)."
   fi
 fi


### PR DESCRIPTION
## Summary

Direct follow-up to #8937 self-verify. During review the patch was
critiqued as "not a root-cause fix" — correctly: it improved ledger
consistency but retained the underlying deterministic assumption
that `path:line` entries stay valid across refactors. That assumption
is the same failure mode that caused #8867 (cycle 26 drift incident).

This PR introduces `path::symbol` as the preferred allowlist anchor.

## The DET assumption being removed

Before: allowlist entry `lib/foo.ml:42` means "the pattern is at line 42".
An upstream PR inserts 3 comment lines above → pattern is now at line 45
→ entry is silently stale → cycle 26 replayed.

After: allowlist entry `lib/foo.ml::classify` means "the pattern is
somewhere inside `let classify`". Line drift is irrelevant. The entry
goes stale only when the function is renamed or removed — which is a
semantic change that deserves explicit review.

## Changes

- `scripts/lint/no-unknown-permissive-default.sh`:
  - awk scanner now tracks the enclosing top-level `let <sym>` / `and <sym>`
    binding at each line. Violations emit `file<TAB>line<TAB>symbol<TAB>content`.
  - Detection keys emitted per violation: `path:line` AND `path::symbol`.
  - Allowlist lookup accepts either form (backward compat).
  - Self-verify walks the allowlist and fails (exit 2) when neither form
    of the entry resolves to a detected violation.
  - Violation-fix hint and error messages call out `path::symbol` as
    preferred.
- `scripts/lint/no-unknown-permissive-default.allowlist`:
  - Header rewritten to document both forms side-by-side with explicit
    tradeoff notes. Body unchanged (0 entries).

## Why this matters (user frame)

> 결정론 가정 + 비결정론적 동작 못 살린 구현 = 버그. 수치화된 경험이
> 있다면 반복하지 않을 수 있다.

`path:line` was a DET assumption embedded in the prevention layer itself.
The previous self-verify patch assumed line numbers stayed fixed across
PRs — a non-deterministic reality (upstream refactors) that the ledger
couldn't accommodate. `path::symbol` removes that specific assumption.

This does NOT address the deepest root (language-level: wire parsing is
still unsafe-by-default at the OCaml type system layer). That would require
ppx or generated parsers, out of scope here. But within the lint gate,
this closes the specific DET failure mode that tripped cycle 26.

## Test plan

Synthetic fixture added temporarily under `lib/` then removed; five
scenarios verified locally (no fixture committed):

- [x] Clean scan, no allowlist entries → `EXIT=0`.
- [x] Violation + `path::symbol` allowlist entry → `EXIT=0` (suppressed).
- [x] Insert 3 comment lines above function, keep `path::symbol` entry
      → `EXIT=0` (symbol survives drift).
- [x] Same drift with legacy `path:line` entry → `EXIT=1` (legacy breaks,
      new violation at shifted line flagged — pushes migration toward symbol form).
- [x] Remove pattern entirely with `path::symbol` entry retained → `EXIT=2` (stale).

No `lib/` code changes. Existing allowlist body is empty, so there is no
migration burden — new entries added after this PR can adopt `path::symbol`
from the start.

## Scope

- Script: ~70 line diff (awk symbol-tracking, dual-key detection, exit
  code messaging).
- Allowlist: header rewrite only.
- Backward compat: legacy `path:line` entries still accepted.

## Risk

Low. The change is additive (new form accepted alongside the old).
Edge case: OCaml top-level `let () = ...` or `let _ = ...` resolves to
`<top>` symbol — intentional sentinel. Anonymous top-level bindings are
rare in the `match wire_string` contexts we care about (parsers tend to
be named functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)