### PR TITLE
docs(spec): correct stale paths/lines in FileLockStarvation + SSEBroadcastBlock

### DIFF
--- a/specs/bug-models/FileLockStarvation.tla
+++ b/specs/bug-models/FileLockStarvation.tla
@@ -1,16 +1,16 @@
 ---- MODULE FileLockStarvation ----
 \* Bug Model: File lock prune-while-held creates duplicate mutex.
 \*
-\* Models file_lock_eio.ml: get_lock + prune_stale_entries.
+\* Models lib/process/file_lock_eio.ml: get_entry + prune_stale_entries.
 \*
 \* Lock acquisition order: table_mu -> per-path Eio.Mutex -> Unix.flock
 \*
 \* Bug scenario:
-\*   1. Fiber A: get_lock("foo") returns mu1, acquires mu1, acquires flock
+\*   1. Fiber A: get_entry("foo") returns mu1, acquires mu1, acquires flock
 \*      (doing slow work, last_used becomes stale)
-\*   2. Fiber B: get_lock("bar") triggers prune_stale_entries,
+\*   2. Fiber B: get_entry("bar") triggers prune_stale_entries,
 \*      removes mu1 from table (last_used too old)
-\*   3. Fiber C: get_lock("foo") creates NEW mu2 for same path,
+\*   3. Fiber C: get_entry("foo") creates NEW mu2 for same path,
 \*      acquires mu2 (different mutex!), tries flock -> blocked by A
 \*
 \* After prune: two Eio.Mutexes exist for the same path.
@@ -19,10 +19,17 @@
 \*
 \* If flock is not used (with_mutex path only), data corruption is possible.
 \*
-\* Actual code:
-\*   file_lock_eio.ml:35-42  prune_stale_entries (under table_mu)
-\*   file_lock_eio.ml:47-59  get_lock (creates new entry if absent)
-\*   file_lock_eio.ml:144-146 with_mutex — uses Eio.Mutex ONLY, no flock
+\* Actual code (verified 2026-04-20):
+\*   lib/process/file_lock_eio.ml:52   prune_stale_entries (under table_mu)
+\*   lib/process/file_lock_eio.ml:68   get_entry (formerly get_lock; creates
+\*                                     new entry if absent)
+\*   lib/process/file_lock_eio.ml:84   release_entry (counterpart to get_entry)
+\*   lib/process/file_lock_eio.ml:170  with_mutex — uses Eio.Mutex ONLY, no flock
+\*   lib/process/file_lock_eio.ml:180  with_lock — Eio.Mutex + Unix flock
+\*
+\* (Path drift: lib/file_lock_eio.ml -> lib/process/file_lock_eio.ml.
+\*  Symbol drift: get_lock -> get_entry + release_entry pair.
+\*  Recorded for cross-reference.)
 
 EXTENDS Naturals
 

--- a/specs/bug-models/SSEBroadcastBlock.tla
+++ b/specs/bug-models/SSEBroadcastBlock.tla
@@ -9,12 +9,16 @@
 \* the stream fills up and Eio.Stream.add BLOCKS the broadcast fiber.
 \*
 \* Result: one dead client blocks event delivery to ALL other clients.
-\* The failed-list cleanup (line 483) only runs AFTER the iteration
-\* completes, but iteration is stuck on the blocking add.
+\* The failed-list cleanup runs AFTER the iteration completes, but
+\* iteration is stuck on the blocking add.
 \*
-\* Actual code:
-\*   sse.ml:471  Eio.Stream.add client.event_stream event (blocking!)
-\*   sse.ml:483  List.iter unregister !failed (too late)
+\* Actual code (verified 2026-04-20):
+\*   lib/sse.ml:608  let broadcast_impl target json
+\*   lib/sse.ml:637  Eio.Stream.add client.event_stream event (blocking!)
+\*   lib/sse.ml:649  List.iter unregister !failed (too late)
+\*
+\* (Line drift since spec authoring: previously cited :471 and :483.
+\*  ~165-line shift due to file growth. Recorded for cross-reference.)
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- Two bug-model specs had stale source references (path move, symbol rename, line shift).
- Doc-only change. No spec semantics modified.

## Drift

### FileLockStarvation.tla
| Spec said | Actual |
|---|---|
| `lib/file_lock_eio.ml` | `lib/process/file_lock_eio.ml` |
| `get_lock` (lines 47-59) | `get_entry` at :68 + `release_entry` at :84 |
| `prune_stale_entries` (lines 35-42) | line 52 |
| `with_mutex` (lines 144-146) | line 170 |
| (not mentioned) | `with_lock` at 180 — Eio.Mutex + Unix flock distinction worth recording |

### SSEBroadcastBlock.tla
| Spec said | Actual |
|---|---|
| `sse.ml:471 Eio.Stream.add` | `lib/sse.ml:637` |
| `sse.ml:483 List.iter unregister !failed` | `lib/sse.ml:649` |
| (not mentioned) | `broadcast_impl` entry at line 608 |

~165-line shift on sse.ml due to file growth.

## Verification
```
$ rg -n 'let prune_stale_entries|let get_entry|let with_mutex|let with_lock' lib/process/file_lock_eio.ml
52:let prune_stale_entries () =
68:let get_entry path =
170:let with_mutex path f =
180:let with_lock ?clock path f =

$ rg -n 'let broadcast_impl|Eio\.Stream\.add.*event_stream|List\.iter.*unregister.*failed' lib/sse.ml
608:let broadcast_impl target json =
637:           Eio.Stream.add client.event_stream event;
649:  List.iter (fun sid -> unregister sid) !failed;
```

## Test plan
- [x] Doc-only change in two prelude comment blocks
- [x] Spec actions/invariants unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)