### PR TITLE
feat(bonsai-dashboard): heartbeat bars live from Logs entries

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1749,7 +1749,37 @@ let heartbeat_bars : (int * [ `Info | `Warn | `Error | `Idle ]) list =
   ]
 ;;
 
-let view_heartbeat () =
+let heartbeat_bars_of_entries (entries : Logs_types.entry list)
+  : (int * [ `Info | `Warn | `Error | `Idle ]) list
+  =
+  let level_of (e : Logs_types.entry) =
+    match e.normalized_level with
+    | "ERROR" -> `Error
+    | "WARN" -> `Warn
+    | "DEBUG" -> `Idle
+    | _ -> `Info
+  in
+  let height_of (e : Logs_types.entry) =
+    Int.clamp_exn (String.length e.message / 2) ~min:6 ~max:72
+  in
+  let take_last n xs =
+    let total = List.length xs in
+    if total <= n then xs else List.drop xs (total - n)
+  in
+  let selected = take_last 60 entries in
+  let bars = List.map selected ~f:(fun e -> height_of e, level_of e) in
+  let n = List.length bars in
+  if n >= 60
+  then bars
+  else List.append (List.init (60 - n) ~f:(fun _ -> 6, `Idle)) bars
+;;
+
+let view_heartbeat ?(entries : Logs_types.entry list = []) () =
+  let bars =
+    match entries with
+    | [] -> heartbeat_bars
+    | _ -> heartbeat_bars_of_entries entries
+  in
   let bar i (height, level) =
     let cls =
       match level with
@@ -1765,7 +1795,7 @@ let view_heartbeat () =
       | `Idle -> "idle"
       | `Info -> "info"
     in
-    let total = List.length heartbeat_bars in
+    let total = List.length bars in
     let t_ago = total - 1 - i in
     let tip =
       Printf.sprintf "t-%d · %s · ticks %d" t_ago level_name height
@@ -1795,7 +1825,7 @@ let view_heartbeat () =
         ]
     ; Node.div
         ~attrs:[ Style.heartbeat_track ]
-        (List.mapi ~f:bar heartbeat_bars)
+        (List.mapi ~f:bar bars)
     ]
 ;;
 
@@ -2833,7 +2863,7 @@ let render_response
     ~attrs:[ Style.root ]
     [ nav
     ; brand_row
-    ; view_heartbeat ()
+    ; view_heartbeat ~entries:response.entries ()
     ; view_hud ~keepers response
     ; (let warn_n =
          List.count response.entries ~f:(fun e ->


### PR DESCRIPTION
## Summary

`view_heartbeat`는 60-sample hardcoded mock으로 정적이었음 → 실제 log entries에서 도출해 "cycle pulse"가 진짜 pulse를 반영하도록 전환. 관찰 대시보드 본래 역할(누가/어디서/**뭘**/왜) 중 "뭘"의 시각 대리자.

## 구현

```ocaml
val heartbeat_bars_of_entries
  : Logs_types.entry list
  -> (int * [ `Info | `Warn | `Error | `Idle ]) list
```

- **level**: `ERROR/WARN/INFO/DEBUG` → `` `Error / `Warn / `Info / `Idle ``
- **height**: `String.length msg / 2` clamp `[6, 72]`px — 메시지 정보 밀도 시각화
- **window**: last 60 entries
- **padding**: 60 미만이면 앞쪽을 `Idle height=6`으로 패딩 (왼쪽=과거, 오른쪽=현재)
- **fallback**: `entries=[]` (fixture) 시 기존 60 mock 유지 → 빈 응답에도 시각 끊김 없음

## API signature

| before | after |
|---|---|
| `view_heartbeat ()` | `view_heartbeat ?entries ()` |

Optional-arg injection 패턴(tombstrip과 동일): 기본값은 mock, 주입 시 live.

## 왜 지금

- #9002 stack 병합으로 main/aside canonical IA 완성
- 남은 정적 요소 중 heartbeat가 가장 "움직여 보이길 기대되는" 컴포넌트
- `response.entries`는 이미 3s 폴링으로 실시간 → 추가 endpoint 불필요

## 왜 mock fallback 유지

서버 이슈/초기 로드/빈 윈도우에서 빈 막대 strip은 "끊김" 신호로 오독. 60 mock pulse는 "정상 idle 상태의 시각 노이즈플로어" 역할.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] fixture (entries=[]) → 기존 60 mock pulse 그대로
- [ ] 서버 stub (entries<60) → 앞 idle 패딩, 뒤 실제 level 막대
- [ ] entries≥60 → 전체 실제 level 기반
- [ ] ERROR 많은 상황 → blood 막대 다수, 3s 폴링마다 변화

🤖 Generated with [Claude Code](https://claude.com/claude-code)