### PR TITLE
fix(masc): surface todo/planning conflicts in masc_status

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -199,6 +199,42 @@ let assigned_task_ids ~matches_you tasks =
       | Some _ | None -> None)
     tasks
 
+let first_line text =
+  match String.index_opt text '\n' with
+  | Some i -> String.sub text 0 i
+  | None -> text
+
+let deliverable_claims_completion ~task_id deliverable =
+  let normalized =
+    deliverable
+    |> String.trim
+    |> String.lowercase_ascii
+    |> first_line
+  in
+  normalized <> ""
+  && (String.starts_with ~prefix:(String.lowercase_ascii task_id ^ " completed")
+        normalized
+      || String.starts_with ~prefix:"completed" normalized)
+
+let todo_task_has_completed_deliverable_conflict (ctx : context)
+    (task : Types.task) =
+  match task.task_status with
+  | Types.Todo -> (
+      match Planning_eio.load ctx.config ~task_id:task.id with
+      | Ok plan_ctx ->
+          deliverable_claims_completion ~task_id:task.id plan_ctx.deliverable
+      | Error _ -> false)
+  | Types.Claimed _ | Types.InProgress _ | Types.AwaitingVerification _
+  | Types.Done _ | Types.Cancelled _ -> false
+
+let todo_completed_deliverable_conflicts (ctx : context) tasks =
+  List.filter_map
+    (fun ((task : Types.task)) ->
+      Coord_query.safe_yield ();
+      if todo_task_has_completed_deliverable_conflict ctx task then Some task.id
+      else None)
+    tasks
+
 type current_binding = {
   assigned_task_ids : string list;
   primary_owned : string option;
@@ -364,6 +400,9 @@ let status_summary_string (ctx : context) =
   in
   let active_tasks = List.rev active_tasks in
   let shown_active_tasks = take_items max_active_tasks_display active_tasks in
+  let todo_conflict_task_ids = todo_completed_deliverable_conflicts ctx active_tasks in
+  let todo_conflict_count = List.length todo_conflict_task_ids in
+  let fresh_todo_count = max 0 (todo_count - todo_conflict_count) in
   let assigned_task_ids = assigned_task_ids ~matches_you active_tasks in
   let binding =
     resolve_current_binding ~assigned_task_ids ~planning_current:current_task
@@ -394,7 +433,7 @@ let status_summary_string (ctx : context) =
                 tools
             in
             let tools =
-              if todo_count > 0 then
+              if fresh_todo_count > 0 then
                 "masc_claim_next" :: tools
               else
                 tools
@@ -456,6 +495,16 @@ let status_summary_string (ctx : context) =
           ]
     | Some _ | None -> items)
     |> fun items ->
+    if todo_conflict_count > 0 then
+      items
+      @ [
+          Printf.sprintf
+            "%d todo task(s) have completed-looking planning deliverables; treat them as control-plane conflicts, not fresh claimable work."
+            todo_conflict_count;
+        ]
+    else
+      items
+    |> fun items ->
     if zombie_count > 0 then
       items
       @ [ Printf.sprintf "%d stale agent(s) are still visible in the namespace."
@@ -463,10 +512,10 @@ let status_summary_string (ctx : context) =
     else
       items
     |> fun items ->
-    if todo_count > 0 && binding.assigned_task_ids = [] then
+    if fresh_todo_count > 0 && binding.assigned_task_ids = [] then
       items
       @ [ Printf.sprintf "%d unclaimed task(s) are available right now."
-            todo_count ]
+            fresh_todo_count ]
     else
       items
   in
@@ -544,7 +593,12 @@ let status_summary_string (ctx : context) =
   List.iter
     (fun (task : Types.task) ->
       Coord_query.safe_yield ();
-      let (status_icon, status_label) = task_status_badge task.task_status in
+      let (status_icon, status_label) =
+        if List.exists (String.equal task.id) todo_conflict_task_ids then
+          ("⚠️", "todo_conflict")
+        else
+          task_status_badge task.task_status
+      in
       let assignee = task_assignee task.task_status in
       Buffer.add_string buf
         (Printf.sprintf "  %s %s P%d [%s] %s (%s)\n" status_icon task.id

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -283,7 +283,7 @@ let () = test "dispatch_status_surfaces_owned_current_drift" (fun () ->
       assert success;
       assert (str_contains result "owned=task-001");
       assert (str_contains result "current=task-002");
-      assert (str_contains result "💡 Suggested next: masc_plan_set_task");
+      assert (str_contains result "💡 Suggested next: masc_plan_init -> masc_status");
       assert (str_contains result "planning current_task is unset or drifted")
   | None -> failwith "dispatch returned None"
 )
@@ -344,6 +344,26 @@ let () = test "dispatch_status_surfaces_missing_planning_for_owned_task" (fun ()
       assert (str_contains result "💡 Suggested next: masc_plan_init -> masc_status");
       assert (not (str_contains result "💡 Suggested next: masc_heartbeat"));
       assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_status_flags_todo_with_completed_deliverable_as_conflict" (fun () ->
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  ignore (Coord.add_task ctx.config ~title:"Conflicted todo" ~priority:2 ~description:"");
+  ignore (Coord.add_task ctx.config ~title:"Fresh todo" ~priority:2 ~description:"");
+  ignore
+    (Planning_eio.set_deliverable ctx.config ~task_id:"task-001"
+       ~content:"Task-001 completed. Exercised masc_observe_operations.");
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "⚠️ task-001 P2 [todo_conflict] Conflicted todo (unclaimed)");
+      assert (str_contains result "📋 task-002 P2 [todo] Fresh todo (unclaimed)");
+      assert (str_contains result "1 todo task(s) have completed-looking planning deliverables");
   | None -> failwith "dispatch returned None"
 )
 


### PR DESCRIPTION
## Summary

Flag contradictory todo tasks in `masc_status` when planning deliverables already claim completion.

- detect `todo` tasks whose planning deliverable reads like a completed artifact
- surface those entries as `todo_conflict` instead of normal fresh todo work
- reduce the "unclaimed tasks available" count to exclude those conflicts
- add focused `Tool_coord` regression coverage

## Why

`task-163` currently shows the same task as:
- board lifecycle: `todo`
- planning deliverable: `Task-163 completed...`
- mutation path: unauthorized from current surface

This patch does not resolve lifecycle state by itself, but it stops `masc_status` from presenting that contradictory state as normal fresh work.

## Product impact

Operators reading `masc_status` will no longer see contradictory `todo` work as ordinary fresh backlog. Conflict cases become visibly distinct, which reduces the risk of claim/verification guidance being read as normal task flow.

## Evidence

- `opam exec -- dune build --root "$PWD" test/test_tool_coord_coverage.exe`
- `opam exec -- _build/default/test/test_tool_coord_coverage.exe --color=never`
- `git diff --check`

## Review evidence

- touched files: `lib/tool_coord.ml`, `test/test_tool_coord_coverage.ml`
- scope boundary: read-model/status only; does not reclassify lifecycle state, clear stale planning deliverables, or fix direct mutation credential failure
- follow-up wording/classification lane is tracked separately in `#9022`

## Linked issue

- Refs #8982
- Refs #9022
