### PR TITLE
refactor(bonsai-dashboard): observation-first copy cleanup

### DIFF
--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2452,7 +2452,7 @@ let render_response
                ]
            in
            let tail =
-             [ Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "logs · 저널" ]
+             [ Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "저널" ]
              ]
            in
            head @ room_seg @ tail)
@@ -2965,12 +2965,18 @@ let render_response
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "keepers" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
-            [ Node.text "four hold the halls · one listens through the storm" ]
+            [ Node.text "sorted by heartbeat · ctx spark = last 10 min" ]
         ; Node.span ~attrs:[ Style.sec_hr ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "slot "
-            ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "iv" ]
+            ; Node.span
+                ~attrs:[ Style.sec_r_v ]
+                [ Node.text
+                    (match keepers.keepers with
+                     | [] -> "—"
+                     | ks -> String.lowercase (roman_of_int (List.length ks)))
+                ]
             ]
         ]
     ; view_roster ~keepers ()


### PR DESCRIPTION
## Summary

관찰 대시보드 3원칙 적용 (feedback memory `dashboard_observation-focus`):

1. **설명 최소화** — poetic sub-copy 제거
2. **영한혼용 금지**
3. **핵심은 누가 · 어디서 · 뭘 · 왜**

## 변경

| 위치 | before | after |
|---|---|---|
| `crumbs_cur` | `logs · 저널` | `저널` (영한혼용 제거) |
| keepers `sec_sub` | `four hold the halls · one listens through the storm` | `sorted by heartbeat · ctx spark = last 10 min` |
| keepers slot tail | `iv` (하드코드) | live `roman_of_int (len keepers)` 소문자 (empty → `—`) |

## 왜 이 문장

- poetic sub는 "네 명이 있다"는 중복 정보 + 아무것도 관찰 가능한 사실을 전달 안 함
- 새 문장은 design_v2 literal — **정렬 기준(heartbeat)** + **시각화 범위(10 min spark)** 두 가지 **관찰 가능한 구조**를 명시
- slot tail은 이미 보이는 keeper 행 개수와 중복이지만 "예상 slot 수"로 해석될 수 있어 로마 숫자로 구분 (4 = `iv`)

## 왜 "저널" 단독

- `crumbs_cur` 는 현재 페이지 제목 — mixing은 시각 잡음
- 대안 "logs" (영문 only)도 가능하지만, 사용자는 한국어 UX 선호
- 페이지 h1 이 이미 `THE WATCH · under vigil` 세리프 영문이므로 crumbs는 한글로 분담

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 crumbs 오른쪽 끝이 `저널` (이전 `logs · 저널`)
- [ ] keepers sec sub가 `sorted by heartbeat · ctx spark = last 10 min`
- [ ] 서버 stub (4 keepers) → slot `iv`
- [ ] fixture (empty) → slot `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)