### PR TITLE
docs(logic): batch-18 .mli for tool_local_runtime_status + keeper_chat_store + tool_unified

### DIFF
--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -1,0 +1,42 @@
+(** Keeper_chat_store — JSONL-based persistence for keeper direct
+    messages.
+
+    Each keeper owns an append-only file at
+    [<base_dir>/.masc/keeper_chat/<sanitized-name>.jsonl]. Lines are
+    JSON objects of the form
+    {v {"role":"user","content":"hello","ts":1774000000.0} v}
+
+    @since 2.145.0 *)
+
+(** {1 Types} *)
+
+type chat_message = {
+  role : string;
+  content : string;
+  ts : float option;
+}
+
+(** {1 I/O} *)
+
+(** [append_pair ~base_dir ~keeper_name ~user_content ~assistant_content]
+    appends two lines (user then assistant) sharing a single
+    timestamp. Failures are logged but never raised except for
+    {!Eio.Cancel.Cancelled}. *)
+val append_pair :
+  base_dir:string ->
+  keeper_name:string ->
+  user_content:string ->
+  assistant_content:string ->
+  unit
+
+(** [load ~base_dir ~keeper_name] returns the most recent
+    [max_history] messages in chronological order. Missing files
+    return [[]]. Unparseable lines are skipped. *)
+val load :
+  base_dir:string -> keeper_name:string -> chat_message list
+
+(** {1 Serialisation} *)
+
+(** JSON array of messages. Entries without a timestamp omit the
+    [ts] field. *)
+val to_json_array : chat_message list -> Yojson.Safe.t

--- a/lib/tool_local_runtime_status.mli
+++ b/lib/tool_local_runtime_status.mli
@@ -1,0 +1,13 @@
+(** Tool_local_runtime_status — Runtime pool status reporting.
+
+    Aggregates configured runtime snapshots, healthy counts, matching
+    processes, and optional model inventory into a single dashboard
+    payload. *)
+
+(** [runtime_status_json ?include_models ()] returns a JSON object
+    summarising the local llama runtime pool. When [include_models]
+    is [true] (default) each runtime fetches its model list and the
+    aggregate [models] field is populated. Observations include
+    warnings about misconfigured capacity, missing processes, or
+    runtime parse errors. *)
+val runtime_status_json : ?include_models:bool -> unit -> Yojson.Safe.t

--- a/lib/tool_unified.mli
+++ b/lib/tool_unified.mli
@@ -1,0 +1,33 @@
+(** Tool_unified — Unified query interface across catalog, registry,
+    and dispatch.
+
+    Combines:
+    - {!Tool_catalog}: visibility, lifecycle, metadata
+    - {!Tool_registry}: call statistics (count, success, failure, duration)
+    - {!Tool_dispatch}: registration status, read-only, join-required *)
+
+(** {1 Types} *)
+
+type tool_info = {
+  name : string;
+  visibility : Tool_catalog.visibility;
+  lifecycle : Tool_catalog.lifecycle;
+  is_registered : bool;
+  is_read_only : bool;
+  is_join_required : bool;
+  call_stats : Tool_registry.call_stats option;
+}
+
+(** {1 Per-tool lookup} *)
+
+(** [tool_info name] assembles the combined view for a single tool. *)
+val tool_info : string -> tool_info
+
+val tool_info_to_json : tool_info -> Yojson.Safe.t
+
+(** {1 Dashboard summary} *)
+
+(** [summary_report ()] aggregates total/top-20 call counts,
+    never-called tools, visibility distribution, dispatch registration
+    counts, and cascade metrics for the dashboard. *)
+val summary_report : unit -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/tool_local_runtime_status.mli` | 13 | `runtime_status_json` (1 caller: `lib/tool_local_runtime.ml`) |
| `lib/keeper/keeper_chat_store.mli` | 42 | `chat_message` + `append_pair` + `load` + `to_json_array` (2 callers in server layer) |
| `lib/tool_unified.mli` | 33 | `tool_info` record + `tool_info` / `tool_info_to_json` / `summary_report` (3 callers + test) |

Pre-scan trap filters: `include=0 open=0 alias=0 surf ≤ 5` for all three.

## Notes

- `tool_local_runtime_status` has `include Tool_local_runtime_core` internally. Verified no external caller reaches through — narrow mli is safe.
- `tool_unified.tool_info` record exposes `Tool_catalog.visibility / lifecycle / Tool_registry.call_stats` types. Those modules already have mli; no new cross-module surface.

## Metrics

- Files: 671 ml / 343+3 = **346 mli** (≈51.6% of ml, ↑ from ~51.1%).
- Build: `dune build @check` exit 0.
- Tests: `test_tool_unified.exe` (5 cases) pass.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)