### PR TITLE
feat(cdal_judge): jest / vitest classifier (P6 Tick 32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 
 ## Unreleased
 
+### Added
+
+- **`Cdal_judge` jest / vitest classifier.**  `of_exec_outcome`
+  now emits typed `Test_pass {count}` / `Test_fail {count}`
+  markers for jest and vitest runner output in addition to dune,
+  cargo, alcotest, pytest, and go test.  Detection anchors on the
+  runner-specific summary banners — `Test Suites:` for jest,
+  `Test Files ` for vitest — so bare prose or user-visible text
+  mentioning "Tests" or "passed" cannot false-positive.  Count is
+  extracted from the `Tests:` / `Tests` summary line by scanning
+  for " passed" / " failed" and reading the int immediately
+  before the tag.  This correctly handles vitest's pipe-delimited
+  failure lines (`Tests  2 failed | 3 passed (5)` →
+  `Test_fail {count=2}`).  Banner-required behaviour is covered
+  by a dedicated negative test (`test_jest_vitest_banner_
+  required`).  Verifier cascade now covers dune + cargo + pytest
+  + go test + jest + vitest, bringing JavaScript-ecosystem
+  runner output (Kidsnote FE repos, most npm projects) into the
+  same typed-marker surface the rest of the cascade consumes.
+
 ## [0.12.0] - 2026-04-20
 
 ### Added

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -323,6 +323,16 @@ let go_test_count ~tag out =
   let needle = "--- " ^ tag ^ ":" in
   count_sub out needle
 
+(* jest / vitest characteristic summary banners.  jest prints a
+   "Test Suites:" section header; vitest prints "Test Files" (no
+   colon, ASCII space follows).  Both tokens are runner-specific —
+   no other runner in this module's scope emits them — so arbitrary
+   stdout prose mentioning "Tests" or "passed" cannot false-positive
+   without at least one of these banners present. *)
+let looks_like_jest_vitest out =
+  contains_sub out "Test Suites:" ||
+  contains_sub out "Test Files "
+
 (* Test count extraction.  Alcotest / cargo-test lines commonly look
    like one of:
 
@@ -419,6 +429,43 @@ let pytest_count_from_output ~tag out =
   in
   per_line (split_lines out)
 
+(* jest / vitest count extraction.  Both runners emit a "Tests" line
+   in their final summary:
+
+     jest   — "Tests:       3 passed, 3 total"
+     jest   — "Tests:       2 failed, 1 passed, 3 total"
+     vitest — "     Tests  5 passed (5)"
+     vitest — "     Tests  2 failed | 3 passed (5)"
+
+   Strategy: per line, require the line to contain the literal
+   "Tests" (matches jest's "Tests:" and vitest's bare "Tests"),
+   locate " <tag>" (" passed" or " failed"), and read the int that
+   precedes it.  This correctly extracts per-tag counts from vitest's
+   pipe-delimited failure lines without double-counting the totals.
+   The banner check (`looks_like_jest_vitest`) has already gated the
+   caller so bare prose cannot reach this function. *)
+let jest_vitest_count ~tag out =
+  let rec per_line = function
+    | [] -> 0
+    | line :: rest ->
+        let is_tests_line =
+          match find_sub_in line "Tests" with
+          | Some _ -> true
+          | None -> false
+        in
+        if is_tests_line then begin
+          let needle = " " ^ tag in
+          match find_sub_in line needle with
+          | None -> per_line rest
+          | Some pos ->
+              (match first_int_before line pos with
+               | Some n -> n
+               | None -> per_line rest)
+        end
+        else per_line rest
+  in
+  per_line (split_lines out)
+
 let test_count_from_output out =
   let markers_before = [ "tests run"; "tests passed"; "test passed" ] in
   let markers_after = [ "test result: ok. "; "passed:" ] in
@@ -459,6 +506,9 @@ let of_exec_outcome ~semantic ~stdout ~stderr =
       else if looks_like_pytest out then
         let n = pytest_count_from_output ~tag:"passed" out in
         [ Test_pass { count = n; confidence = `Heuristic } ]
+      else if looks_like_jest_vitest out then
+        let n = jest_vitest_count ~tag:"passed" out in
+        [ Test_pass { count = n; confidence = `Heuristic } ]
       else if looks_like_dune_runtest out then
         let n = test_count_from_output out in
         [ Test_pass { count = n; confidence = `Heuristic } ]
@@ -487,6 +537,9 @@ let of_exec_outcome ~semantic ~stdout ~stderr =
         [ Test_fail { count = n; confidence = `Heuristic } ]
       else if looks_like_pytest out then
         let n = pytest_count_from_output ~tag:"failed" out in
+        [ Test_fail { count = n; confidence = `Heuristic } ]
+      else if looks_like_jest_vitest out then
+        let n = jest_vitest_count ~tag:"failed" out in
         [ Test_fail { count = n; confidence = `Heuristic } ]
       else if looks_like_dune_runtest out then
         let n = test_count_from_output out in

--- a/test/test_cdal_verifiable_markers.ml
+++ b/test/test_cdal_verifiable_markers.ml
@@ -152,6 +152,78 @@ let test_go_test_banner_required () =
             ^ String.concat ","
                 (List.map Cdal_judge.marker_to_string markers))
 
+let test_jest_pass_counts () =
+  let stdout =
+    "PASS src/component.test.ts\n\
+     PASS src/other.test.ts\n\n\
+     Test Suites: 2 passed, 2 total\n\
+     Tests:       7 passed, 7 total\n\
+     Snapshots:   0 total\n\
+     Time:        1.234 s\n"
+  in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Test_pass { count = 7; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_pass { count; _ } ] ->
+      fail (Printf.sprintf "expected jest count=7, got %d" count)
+  | _ -> fail "expected Test_pass marker from jest output"
+
+let test_jest_fail_counts () =
+  let stdout =
+    "FAIL src/component.test.ts\n\n\
+     Test Suites: 1 failed, 1 passed, 2 total\n\
+     Tests:       2 failed, 5 passed, 7 total\n\
+     Snapshots:   0 total\n"
+  in
+  match call ~stdout (`Fail 1) with
+  | [ Cdal_judge.Test_fail { count = 2; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_fail { count; _ } ] ->
+      fail (Printf.sprintf "expected jest failed=2, got %d" count)
+  | _ -> fail "expected Test_fail marker from jest output"
+
+let test_vitest_pass_counts () =
+  let stdout =
+    " \xe2\x9c\x93 src/foo.test.ts (3)\n\
+     \xe2\x9c\x93 src/bar.test.ts (2)\n\n\
+     Test Files  2 passed (2)\n\
+     \x20\x20    Tests  5 passed (5)\n\
+     \x20   Start at  10:00:00\n\
+     \x20Duration  0.50s\n"
+  in
+  match call ~stdout `Ok with
+  | [ Cdal_judge.Test_pass { count = 5; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_pass { count; _ } ] ->
+      fail (Printf.sprintf "expected vitest count=5, got %d" count)
+  | _ -> fail "expected Test_pass marker from vitest output"
+
+let test_vitest_fail_counts () =
+  let stdout =
+    " \xe2\x9d\xaf src/foo.test.ts (3)\n\
+     \x20\x20 \xc3\x97 test 1\n\n\
+     Test Files  1 failed | 1 passed (2)\n\
+     \x20    Tests  2 failed | 3 passed (5)\n\
+     \x20 Duration  0.50s\n"
+  in
+  match call ~stdout (`Fail 1) with
+  | [ Cdal_judge.Test_fail { count = 2; confidence = `Heuristic } ] -> ()
+  | [ Cdal_judge.Test_fail { count; _ } ] ->
+      fail (Printf.sprintf "expected vitest failed=2, got %d" count)
+  | _ -> fail "expected Test_fail marker from vitest output"
+
+let test_jest_vitest_banner_required () =
+  (* Bare prose containing "Tests" / "passed" without the "Test Suites:"
+     (jest) or "Test Files " (vitest) banner must NOT classify — the
+     banner is the runner-specific fingerprint. *)
+  let stdout =
+    "doc: the Tests passed successfully on all 12 runs\n\
+     user-visible result: Tests complete\n"
+  in
+  match call ~stdout `Ok with
+  | [] -> ()
+  | markers ->
+      fail ("expected [] without jest/vitest banner, got "
+            ^ String.concat ","
+                (List.map Cdal_judge.marker_to_string markers))
+
 let test_git_status_clean_exact () =
   let stdout = "On branch main\nnothing to commit, working tree clean\n" in
   match call ~stdout `Ok with
@@ -208,6 +280,12 @@ let () =
       test_case "go test pass count" `Quick test_go_test_pass_counts;
       test_case "go test fail count" `Quick test_go_test_fail_counts;
       test_case "go test banner required" `Quick test_go_test_banner_required;
+      test_case "jest pass count" `Quick test_jest_pass_counts;
+      test_case "jest fail count" `Quick test_jest_fail_counts;
+      test_case "vitest pass count" `Quick test_vitest_pass_counts;
+      test_case "vitest fail count" `Quick test_vitest_fail_counts;
+      test_case "jest/vitest banner required" `Quick
+        test_jest_vitest_banner_required;
       test_case "git status clean" `Quick test_git_status_clean_exact;
       test_case "git status dirty" `Quick test_git_status_dirty_exact;
     ]);


### PR DESCRIPTION
## Product impact

Extends the verifier cascade's typed-marker surface with jest and vitest detection.  Until now `Cdal_judge.of_exec_outcome` produced `Test_pass {count}` / `Test_fail {count}` for dune, cargo, pytest, and go test output; JavaScript runners fell through to `[]`, leaving Kidsnote FE repos and most npm projects without structured markers for the verifier cascade to consume.

With this PR the cascade now recognises:

- jest banner → `Test Suites:` header + `Tests: N passed, N total` summary
- vitest banner → `Test Files ` header + `Tests  N passed (N)` summary

Counts are extracted per-tag from the summary line, including vitest's pipe-delimited failure form `Tests  2 failed | 3 passed (5)`.

## Evidence

- `lib/cdal_judge.ml`:
  - `looks_like_jest_vitest` — banner-anchored detector (any of `Test Suites:` or `Test Files `)
  - `jest_vitest_count ~tag` — per-line extractor that requires a `Tests`-containing line and reads the int immediately before the ` <tag>` substring
  - `of_exec_outcome` — inserted jest/vitest branch after pytest and before dune_runtest in both `\`Ok` and `\`Fail _` arms
- `test/test_cdal_verifiable_markers.ml`: 5 new tests
  - `test_jest_pass_counts` (7 passed from jest banner)
  - `test_jest_fail_counts` (2 failed from jest failure summary)
  - `test_vitest_pass_counts` (5 passed from vitest banner)
  - `test_vitest_fail_counts` (2 failed from vitest pipe-delimited summary)
  - `test_jest_vitest_banner_required` — bare prose with "Tests" / "passed" but no banner must classify as `[]`
- Local `dune exec test/test_cdal_verifiable_markers.exe --root .` → 22/22 pass

## Review evidence

Banner-anchored detection keeps the existing false-positive defence the other classifiers already use.  The `Tests`-line requirement inside `jest_vitest_count` prevents the count function from reaching unrelated output — a doc line with "Tests complete" in prose will not produce a count because the banner gate is checked first.  No existing runner's detection changes — all prior tests still pass without modification.

## Linked issue

N/A — P6 runner-coverage extension per `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)