### PR TITLE
docs(spec): clarify HebbianLearning line + OllamaBodyIntegrity OAS cross-repo refs

### DIFF
--- a/specs/bug-models/HebbianLearning.tla
+++ b/specs/bug-models/HebbianLearning.tla
@@ -12,7 +12,12 @@
 \* Invariant: when an operation saves, no other write has happened
 \* since that operation loaded (graph_version == load_version + 1).
 \*
-\* Reference: hebbian_eio.ml lines 268-275 (docstring warning).
+\* Reference (verified 2026-04-20):
+\*   lib/hebbian_eio.ml:264  let strengthen — wraps body in
+\*                            with_graph_lock config (load -> compute -> save).
+\*   The lock-required pattern is enforced by call-site convention
+\*   (every public mutator calls with_graph_lock); there is no
+\*   inline docstring at lines 268-275.
 
 EXTENDS Naturals
 

--- a/specs/bug-models/OllamaBodyIntegrity.tla
+++ b/specs/bug-models/OllamaBodyIntegrity.tla
@@ -1,7 +1,14 @@
 ---- MODULE OllamaBodyIntegrity ----
 \* Bug Model: HTTP request body integrity for Ollama.
 \*
-\* Models complete.ml -> http_client.ml -> Ollama.
+\* Models the OAS-pinned LLM provider request flow:
+\*   complete.ml -> http_client.ml -> Ollama.
+\*
+\* Both files live in the pinned `agent_sdk.llm_provider` library
+\* (see lib/dune for the dependency), not in masc-mcp:
+\*   <oas>/lib/llm_provider/complete.ml
+\*   <oas>/lib/llm_provider/http_client.ml
+\*
 \* Yojson.Safe.to_string produces balanced JSON.
 \* Cohttp_eio transmits the body.
 \* Ollama's yyjson parser validates the received body.


### PR DESCRIPTION
## Summary
- 2 bug-model specs had inaccurate or ambiguous source references.
- Doc-only change. No semantics modified.

## Drift

### HebbianLearning.tla
- Spec said: `"hebbian_eio.ml lines 268-275 (docstring warning)"`
- Reality: lines 268-275 sit *inside* the `strengthen` function body, not in a docstring. There's no inline lock-warning docstring at that range.
- Fix: point at `let strengthen` entry (line 264) and explain the lock requirement is call-site convention (every public mutator wraps `with_graph_lock`), not an inline docstring.

### OllamaBodyIntegrity.tla
- Spec said: `"Models complete.ml -> http_client.ml -> Ollama"` without noting these files are not in masc-mcp.
- Reality: both files live in the pinned `agent_sdk.llm_provider` library (OAS), referenced via `lib/dune`:
  - `<oas>/lib/llm_provider/complete.ml`
  - `<oas>/lib/llm_provider/http_client.ml`
- Fix: prelude now makes the cross-repo dependency explicit so future readers look in OAS rather than `lib/`.

## Verification
```
$ rg -n 'let strengthen' lib/hebbian_eio.ml
264:let strengthen config ?params ~from_agent ~to_agent () : unit =

$ ls /Users/dancer/me/workspace/yousleepwhen/oas/lib/llm_provider/{complete,http_client}.ml
.../complete.ml
.../http_client.ml

$ rg 'agent_sdk.llm_provider' lib/dune
   agent_sdk.llm_provider
```

Note: DiscoveryCacheTTL.tla was also audited; all symbols (`cache_updated_at`, `cached_endpoints`, `get_cached_or_refresh`, `cache_mu`) match `lib/discovery_cache.ml` exactly. No fix needed there.

## Test plan
- [x] Doc-only change in two prelude comment blocks
- [x] Spec actions/invariants/safety properties unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)