### PR TITLE
feat(bonsai-dashboard): client-side routing · all nav links reachable

### DIFF
--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -3,7 +3,9 @@
     Server serves the same HTML shell (see
     [lib/server/server_routes_http_pages.ml:bonsai_index_html]) at every
     [/dashboard/b/*] URL, so route selection happens client-side. Static
-    read at mount time — no client-side history API yet. *)
+    read at mount time — no client-side history API yet.
+
+    Route SSOT: [route.ml]. Add a tab = add a variant + extend helpers. *)
 
 open! Core
 open! Bonsai_web
@@ -13,8 +15,8 @@ let current_path () =
 ;;
 
 let root (graph @ local) =
-  let path = current_path () in
-  if String.is_prefix path ~prefix:"/dashboard/b/logs"
-  then Logs_view.component graph
-  else Hello_view.component graph
+  match Route.of_path (current_path ()) with
+  | Logs -> Logs_view.component graph
+  | Hello -> Hello_view.component graph
+  | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -2551,21 +2551,25 @@ let render_response
   let nav_section label =
     Node.div ~attrs:[ Style.nav_section ] [ Node.text label ]
   in
-  let nav_link ?(active = false) ?tail label =
-    let attrs =
-      if active
-      then [ Style.nav_link; Style.nav_link_active ]
-      else [ Style.nav_link ]
+  let current_route =
+    let path =
+      Brr.Uri.path (Brr.Window.location Brr.G.window) |> Jstr.to_string
     in
+    Route.of_path path
+  in
+  let nav_link ?tail (route : Route.t) =
+    let active = Route.equal route current_route in
+    let base = [ Style.nav_link ] in
+    let base = if active then Style.nav_link_active :: base else base in
     let tail_node =
       match tail with
       | None -> []
       | Some t -> [ Node.span ~attrs:[ Style.nav_link_tail ] [ Node.text t ] ]
     in
-    Node.div
-      ~attrs
+    Node.a
+      ~attrs:(Attr.href (Route.path route) :: base)
       ([ Node.span ~attrs:[ Style.nav_link_glyph ] []
-       ; Node.text label
+       ; Node.text (Route.label route)
        ]
        @ tail_node)
   in
@@ -2587,22 +2591,22 @@ let render_response
               ]
           ]
       ; nav_section "chronicle"
-      ; nav_link "overview"
-      ; nav_link ~active:true "logs · journal"
-      ; nav_link "goals"
+      ; nav_link Overview
+      ; nav_link Logs
+      ; nav_link Goals
       ; nav_section "runtime"
       ; (let tail =
            match keepers.keepers with
            | [] -> "—"
            | ks -> Printf.sprintf "%02d" (List.length ks)
          in
-         nav_link "keepers" ~tail)
-      ; nav_link "observatory"
-      ; nav_link "intervene"
+         nav_link Keepers ~tail)
+      ; nav_link Observatory
+      ; nav_link Intervene
       ; nav_section "lab"
-      ; nav_link "tools"
-      ; nav_link "sessions"
-      ; nav_link "social board"
+      ; nav_link Tools
+      ; nav_link Sessions
+      ; nav_link Social_board
       ; nav_section "crypt"
       ; (let tail =
            match keepers.keepers with
@@ -2616,8 +2620,8 @@ let render_response
              in
              Printf.sprintf "%02d" dead_n
          in
-         nav_link "dead keepers" ~tail)
-      ; nav_link "archive runs"
+         nav_link Dead_keepers ~tail)
+      ; nav_link Archive_runs
       ; (let chip name label =
            Node.div
              ~attrs:

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -1,0 +1,248 @@
+(** Placeholder view for routes that haven't been migrated to Bonsai yet.
+
+    Renders the same dark-fantasy shell (brand + nav + centered card) but
+    the main content is a single "Phase 2" panel with a link back to the
+    Preact counterpart if applicable. Keeps the sidebar fully clickable so
+    the operator can keep exploring without a broken tab trap.
+
+    nav은 logs_view의 것과 구조가 거의 동일하지만 여기서는 단순화 —
+    theme chip이나 brand 상세는 생략. logs_view가 canonical, 여기는
+    "다른 탭이 있다" 사실만 표시하면 됨. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .nav {
+    background: linear-gradient(180deg, #18110c, #0e0806);
+    border-right: 1px solid var(--border-main);
+    padding: 24px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow: auto;
+  }
+  .nav_brand {
+    padding: 0 20px 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .nav_brand_rune {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--accent-brass-dim);
+    color: var(--accent-brass);
+    font-family: 'Cinzel', serif;
+    font-size: 15px;
+    letter-spacing: 0.08em;
+  }
+  .nav_brand_word {
+    font-family: 'Cinzel', serif;
+    font-size: 15px;
+    letter-spacing: 0.24em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+  }
+  .nav_brand_blood { color: var(--accent-blood); }
+
+  .nav_section {
+    padding: 14px 20px 6px;
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .nav_link {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding: 8px 20px;
+    color: var(--text-primary);
+    font-size: 11px;
+    text-decoration: none;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-left: 2px solid transparent;
+    transition: background 0.1s, color 0.1s;
+  }
+  .nav_link:hover {
+    color: var(--accent-brass);
+    background: rgba(212, 169, 64, 0.05);
+  }
+  .nav_link_active {
+    color: var(--accent-brass);
+    border-left-color: var(--accent-brass);
+    background: linear-gradient(90deg, rgba(212, 169, 64, 0.1), transparent 70%);
+  }
+  .nav_link_soon {
+    color: var(--text-dim);
+    opacity: 0.55;
+  }
+  .nav_link_soon:hover {
+    color: var(--accent-brass-dim);
+  }
+
+  .main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 3rem;
+  }
+  .card {
+    max-width: 560px;
+    border: 1px solid var(--border-highlight);
+    background:
+      linear-gradient(180deg, rgba(42, 30, 20, 0.4), rgba(20, 12, 8, 0.7));
+    padding: 2rem 2.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    box-shadow: 0 4px 22px rgba(0, 0, 0, 0.55);
+  }
+  .badge {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--accent-brass);
+    border: 1px solid var(--accent-brass-dim);
+    padding: 4px 10px;
+    align-self: flex-start;
+  }
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 28px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+  }
+  .link_row {
+    display: flex;
+    gap: 14px;
+    margin-top: 12px;
+  }
+  .link {
+    color: var(--accent-brass);
+    text-decoration: none;
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--accent-brass-dim);
+    padding-bottom: 2px;
+  }
+  .link:hover {
+    color: var(--text-bright);
+    border-bottom-color: var(--accent-brass);
+  }
+|}]
+
+let brand =
+  Node.div
+    ~attrs:[ Style.nav_brand ]
+    [ Node.div ~attrs:[ Style.nav_brand_rune ] [ Node.text "M" ]
+    ; Node.span
+        ~attrs:[ Style.nav_brand_word ]
+        [ Node.text "ma"
+        ; Node.span ~attrs:[ Style.nav_brand_blood ] [ Node.text "s" ]
+        ; Node.text "c"
+        ]
+    ]
+;;
+
+let nav_link ~active (route : Route.t) =
+  let classes =
+    let base = [ Style.nav_link ] in
+    let base = if active then Style.nav_link_active :: base else base in
+    if Route.is_implemented route then base else Style.nav_link_soon :: base
+  in
+  Node.a
+    ~attrs:(Attr.href (Route.path route) :: classes)
+    [ Node.text (Route.label route) ]
+;;
+
+let section label = Node.div ~attrs:[ Style.nav_section ] [ Node.text label ]
+
+let sidebar ~(active : Route.t) =
+  let lnk route = nav_link ~active:(Route.equal route active) route in
+  Node.div
+    ~attrs:[ Style.nav ]
+    [ brand
+    ; section "chronicle"
+    ; lnk Overview
+    ; lnk Logs
+    ; lnk Goals
+    ; section "runtime"
+    ; lnk Keepers
+    ; lnk Observatory
+    ; lnk Intervene
+    ; section "lab"
+    ; lnk Tools
+    ; lnk Sessions
+    ; lnk Social_board
+    ; section "crypt"
+    ; lnk Dead_keepers
+    ; lnk Archive_runs
+    ]
+;;
+
+let component ~(route : Route.t) (_graph @ local) =
+  Bonsai.return
+    (Node.div
+       ~attrs:[ Style.root ]
+       [ sidebar ~active:route
+       ; Node.div
+           ~attrs:[ Style.main ]
+           [ Node.div
+               ~attrs:[ Style.card ]
+               [ Node.span ~attrs:[ Style.badge ] [ Node.text "phase 2 · 작업 중" ]
+               ; Node.h1 ~attrs:[ Style.title ] [ Node.text (Route.label route) ]
+               ; Node.p
+                   ~attrs:[ Style.sub ]
+                   [ Node.text
+                       "이 탭은 아직 Bonsai로 이식되지 않았다. \
+                        logs · 저널이 유일한 이식 탭."
+                   ]
+               ; Node.div
+                   ~attrs:[ Style.link_row ]
+                   [ Node.a
+                       ~attrs:
+                         [ Attr.href (Route.path Logs); Style.link ]
+                       [ Node.text "← 저널로" ]
+                   ; Node.a
+                       ~attrs:
+                         [ Attr.href "/dashboard/"; Style.link ]
+                       [ Node.text "preact 대시보드 →" ]
+                   ]
+               ]
+           ]
+       ])
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -1,0 +1,115 @@
+(** Client-side route SSOT.
+
+    Server serves the same HTML shell at every [/dashboard/b/*] URL (catchall
+    [prefix_get] in [lib/server/server_routes_http_routes_frontend.ml]). The
+    Bonsai entry reads [window.location.pathname] and matches it against the
+    variants here to pick which view to mount.
+
+    Adding a tab = (1) add a variant, (2) extend [slug]/[label]/[path]/
+    [of_path], (3) add it to [all] so the nav renders it, (4) flip
+    [is_implemented] when the Bonsai view lands. *)
+
+open! Core
+
+type t =
+  | Overview
+  | Logs
+  | Goals
+  | Keepers
+  | Observatory
+  | Intervene
+  | Tools
+  | Sessions
+  | Social_board
+  | Dead_keepers
+  | Archive_runs
+  | Hello
+[@@deriving sexp, compare, equal]
+
+let slug = function
+  | Overview -> "overview"
+  | Logs -> "logs"
+  | Goals -> "goals"
+  | Keepers -> "keepers"
+  | Observatory -> "observatory"
+  | Intervene -> "intervene"
+  | Tools -> "tools"
+  | Sessions -> "sessions"
+  | Social_board -> "social-board"
+  | Dead_keepers -> "dead-keepers"
+  | Archive_runs -> "archive-runs"
+  | Hello -> "hello"
+;;
+
+(* User-facing short label. logs 탭은 한글 (h1은 영문 "THE WATCH"가 맡음). *)
+let label = function
+  | Overview -> "overview"
+  | Logs -> "저널"
+  | Goals -> "goals"
+  | Keepers -> "keepers"
+  | Observatory -> "observatory"
+  | Intervene -> "intervene"
+  | Tools -> "tools"
+  | Sessions -> "sessions"
+  | Social_board -> "social board"
+  | Dead_keepers -> "dead keepers"
+  | Archive_runs -> "archive runs"
+  | Hello -> "hello"
+;;
+
+let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
+
+(* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
+let is_implemented = function
+  | Logs | Hello -> true
+  | _ -> false
+;;
+
+(* 사이드바 렌더 순서. design_v2 IA와 동일. Hello는 legacy라 nav에 노출 안 함. *)
+let all : t list =
+  [ Overview
+  ; Logs
+  ; Goals
+  ; Keepers
+  ; Observatory
+  ; Intervene
+  ; Tools
+  ; Sessions
+  ; Social_board
+  ; Dead_keepers
+  ; Archive_runs
+  ]
+;;
+
+let of_path (path_str : string) : t =
+  let trimmed =
+    String.chop_prefix path_str ~prefix:"/dashboard/b/"
+    |> Option.value ~default:path_str
+  in
+  (* strip trailing slash / query string *)
+  let head =
+    match String.lsplit2 trimmed ~on:'/' with
+    | Some (h, _) -> h
+    | None -> trimmed
+  in
+  let head =
+    match String.lsplit2 head ~on:'?' with
+    | Some (h, _) -> h
+    | None -> head
+  in
+  match head with
+  | "logs" -> Logs
+  | "overview" -> Overview
+  | "goals" -> Goals
+  | "keepers" -> Keepers
+  | "observatory" -> Observatory
+  | "intervene" -> Intervene
+  | "tools" -> Tools
+  | "sessions" -> Sessions
+  | "social-board" -> Social_board
+  | "dead-keepers" -> Dead_keepers
+  | "archive-runs" -> Archive_runs
+  | "hello" -> Hello
+  | "" -> Overview (* /dashboard/b/ → Overview *)
+  | _ -> Overview (* unknown → Overview *)
+;;


### PR DESCRIPTION
## Summary

11개 nav 탭 중 **logs만 Bonsai 이식**된 상태였지만 나머지 10개는 `Node.div` + `href` 없음으로 **클릭 불가**. 사용자가 "메뉴 다 했나?" 라고 묻는 시점 — 본 PR로 **전체 nav가 navigable** 해지고, 아직 이식 안 된 탭은 단일 placeholder view에서 "phase 2 · 작업 중 + 저널로 / preact 링크" 로 안내.

> **시급성**: 스택 PR 아님, base=main 단독.

## 신규 모듈

### `dashboard_bonsai/src/route.ml` — SSOT

```ocaml
type t = Overview | Logs | Goals | Keepers | Observatory | Intervene
       | Tools | Sessions | Social_board | Dead_keepers | Archive_runs | Hello
[@@deriving sexp, compare, equal]

val slug : t -> string           (* "logs", "dead-keepers" *)
val label : t -> string          (* "저널", "dead keepers" *)
val path : t -> string           (* "/dashboard/b/logs" *)
val is_implemented : t -> bool   (* Logs/Hello = true *)
val all : t list                 (* 사이드바 렌더 순서 *)
val of_path : string -> t        (* fallback: Overview *)
```

### `dashboard_bonsai/src/placeholder_view.ml` — phase 2 안내

- sidebar: brand + 4 sections + 11 nav links, `Route.t` 기반 `<a href>`
- center card: phase 2 badge + 제목(route.label) + 안내문 + 2 링크
  - "← 저널로" → `/dashboard/b/logs`
  - "preact 대시보드 →" → `/dashboard/`
- 새 CSS scope (logs_view와 공유 X — Bonsai scoped class 기본 격리)

## 변경 모듈

### `app.ml` — Route dispatcher

```ocaml
let root graph =
  match Route.of_path (current_path ()) with
  | Logs -> Logs_view.component graph
  | Hello -> Hello_view.component graph
  | other -> Placeholder_view.component ~route:other graph
```

### `logs_view.ml:nav_link`

| | before | after |
|---|---|---|
| 시그니처 | `label:string` | `route:Route.t` |
| 태그 | `Node.div` | `Node.a` with `Attr.href` |
| active | 하드코드 `~active:true "logs · journal"` | `Route.equal route current_route` |

`current_route`는 render 시작 시 `Brr.Window.location` 1회 읽음 — 페이지 전환은 full reload이므로 mid-render 갱신 불필요.

## 서버 불변

`server_routes_http_routes_frontend.ml`의 `prefix_get "/dashboard/b/"` catchall이 **이미 동일 HTML shell을 모든 path에 서빙** → 서버 변경 0. 클라이언트 경로 추가만으로 11 탭 모두 도달 가능.

## 왜 Preact 링크도 같이 노출

현재 Preact 대시보드 `/dashboard/` 가 실제 작동하는 탭을 가짐. placeholder의 "preact 대시보드 →" 링크는 "이 Bonsai 탭이 phase 2 예정일 뿐, 탭 자체는 preact에서 동작 중"을 시각적으로 전달. 사용자 탭 trap 방지.

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] `/dashboard/b/logs` → logs 전체 렌더, nav "저널" 활성
- [ ] `/dashboard/b/overview` → placeholder "overview" 카드, nav "overview" 활성
- [ ] `/dashboard/b/` → placeholder "overview" (fallback)
- [ ] placeholder의 "← 저널로" 링크 → `/dashboard/b/logs` 이동
- [ ] placeholder의 "preact 대시보드 →" 링크 → `/dashboard/` 이동
- [ ] logs_view nav에서 다른 탭 클릭 시 placeholder 로 이동 (active 전환)
- [ ] 11 탭 모두 개별 URL 접근 확인

## 다음 단계 (별도 PR)

- Phase 2 탭 이전 시작 시 `Route.is_implemented` 를 해당 탭에서 `true`로 플립 + `app.ml` 에 dispatch 분기 1줄 추가
- 추후 client-side history (`pushState`) 도입하면 full reload 없이 탭 전환 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)