### PR TITLE
[codex] Fix operator CTX ratio for bare CLI providers

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -11,6 +11,49 @@ let active_model_of_meta (m : keeper_meta) : string =
     | model :: _ -> model
     | [] -> ""
 
+let model_id_of_label (label : string) : string =
+  match String.index_opt label ':' with
+  | Some idx when idx < String.length label - 1 ->
+      String.sub label (idx + 1) (String.length label - idx - 1) |> String.trim
+  | _ -> String.trim label
+
+let canonical_provider_of_label (label : string) : string option =
+  match String.index_opt label ':' with
+  | Some idx when idx > 0 ->
+      String.sub label 0 idx
+      |> String.trim
+      |> Provider_adapter.resolve_direct_canonical_name
+  | _ -> Provider_adapter.resolve_direct_canonical_name label
+
+let active_model_label_of_meta (m : keeper_meta) : string =
+  let active = String.trim (active_model_of_meta m) in
+  if active = "" then ""
+  else if String.contains active ':' then active
+  else
+    let configured = Keeper_model_labels.configured_model_labels_of_meta m in
+    let active_norm = String.lowercase_ascii active in
+    let matches_model_id label =
+      String.lowercase_ascii (model_id_of_label label) = active_norm
+    in
+    match List.find_opt matches_model_id configured with
+    | Some label -> label
+    | None -> (
+        match Provider_adapter.resolve_direct_adapter active with
+        | Some adapter ->
+            let matches_provider label =
+              canonical_provider_of_label label = Some adapter.canonical_name
+            in
+            (match List.find_opt matches_provider configured with
+             | Some label -> label
+             | None ->
+                 let model_id =
+                   match adapter.default_model_id with
+                   | Some value when String.trim value <> "" -> value
+                   | _ -> "auto"
+                 in
+                 adapter.cascade_prefix ^ ":" ^ model_id)
+        | None -> active)
+
 let next_model_hint_of_meta (m : keeper_meta) : string option =
   let active = active_model_of_meta m in
   let pool =

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -1,6 +1,7 @@
 open Keeper_types
 
 val active_model_of_meta : keeper_meta -> string
+val active_model_label_of_meta : keeper_meta -> string
 val next_model_hint_of_meta : keeper_meta -> string option
 val string_of_fiber_health : fiber_health -> string
 val agent_status_text : Yojson.Safe.t -> string

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -6,10 +6,10 @@ let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
   let input_tokens = meta.runtime.usage.last_input_tokens in
   if input_tokens = 0 then None
   else
-    let active_model = Keeper_exec_status.active_model_of_meta meta in
-    if active_model = "" then None
+    let active_model_label = Keeper_exec_status.active_model_label_of_meta meta in
+    if active_model_label = "" then None
     else
-      let max_ctx = Cascade_runtime.max_context_of_label active_model in
+      let max_ctx = Cascade_runtime.max_context_of_label active_model_label in
       if max_ctx = 0 then None
       else Some (float_of_int input_tokens /. float_of_int max_ctx)
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -17,6 +17,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_align_keeper_runtime_status_ignores_zombie_runtime_signal;
+          Alcotest.test_case "snapshot context ratio resolves cli provider budget"
+            `Quick
+            Test_operator_control_snapshot
+            .test_compute_context_ratio_uses_resolved_cli_context_budget;
           Alcotest.test_case "snapshot sections" `Quick
             Test_operator_control_snapshot.test_snapshot_has_expected_sections;
           Alcotest.test_case "snapshot pending confirm summary tracks actor scope"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -51,6 +51,45 @@ let test_align_keeper_runtime_status_ignores_zombie_runtime_signal () =
   Alcotest.(check string) "zombie runtime does not override inactive" "inactive"
     status
 
+let test_compute_context_ratio_uses_resolved_cli_context_budget () =
+  let base =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String "ctx-ratio-demo");
+            ("agent_name", `String "keeper-ctx-ratio-demo-agent");
+            ("trace_id", `String "trace-ctx-ratio-demo");
+            ("cascade_name", `String "keeper_unified");
+          ])
+    with
+    | Ok meta -> meta
+    | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+  in
+  let meta =
+    {
+      base with
+      models = [ "codex_cli:auto" ];
+      runtime =
+        {
+          base.runtime with
+          usage =
+            {
+              base.runtime.usage with
+              last_model_used = "codex";
+              last_input_tokens = 2_106_223;
+            };
+        };
+    }
+  in
+  let ratio =
+    match Operator_control_snapshot.compute_context_ratio meta with
+    | Some value -> value
+    | None -> Alcotest.fail "expected context ratio"
+  in
+  Alcotest.(check (float 0.0001)) "codex bare provider uses 1.05M context"
+    (2106223.0 /. 1050000.0) ratio
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary
- resolve bare `last_model_used` values like `codex` and `gemini` back to configured cascade labels before computing operator CTX ratio
- keep operator snapshot ratio math on the resolved label instead of the raw display name
- add an operator regression test that locks the Codex CLI context budget path

## Root Cause
Operator snapshot CTX ratio was dividing `last_input_tokens` by `Cascade_runtime.max_context_of_label active_model`, but `active_model` could be a bare provider string such as `codex` or `gemini`. Bare values do not include a `provider:model` prefix, so context resolution fell back to the default 128k window and inflated the displayed percentage far beyond the actual provider budget.

## Impact
- dashboard CTX percentages now use the correct provider context window for CLI-backed keepers
- extreme values like `2000%` caused by the 128k fallback path should no longer appear for Codex/Gemini CLI keepers
- genuine overflow signals can still exceed 100% when the prompt really is over budget

## Validation
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-ctx-ratio-bare-model/_build_ctxfix/default/test/test_keeper_exec_status.exe`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-ctx-ratio-bare-model/_build_ctxfix/default/test/test_operator_control.exe`