### PR TITLE
docs(spec): correct stale paths in CascadeExhaustion + DashboardCacheStampede

### DIFF
--- a/specs/bug-models/CascadeExhaustion.tla
+++ b/specs/bug-models/CascadeExhaustion.tla
@@ -1,14 +1,26 @@
 ---- MODULE CascadeExhaustion ----
 \* Bug Model: Cascade accept_on_exhaustion paradox.
 \*
-\* Models cascade_executor.ml:complete_cascade_with_accept.
-\* When accept_on_exhaustion=TRUE and ALL providers return Ok but are
+\* Models lib/cascade/cascade_fsm.ml:decide (formerly
+\* cascade_executor.ml:complete_cascade_with_accept). When
+\* accept_on_exhaustion=TRUE and ALL providers return Ok but are
 \* rejected by accept, the last provider's response should be accepted.
 \*
 \* Bug hypothesis: the last provider returns Error (not Ok), so
 \* accept_on_exhaustion never fires.  The error message says
 \* "rejected by accept validator" because the PREVIOUS Ok response
 \* was rejected, and that becomes last_err.
+\*
+\* Actual code (verified 2026-04-20):
+\*   lib/cascade/cascade_fsm.ml:21   let decide ~accept_on_exhaustion ~is_last
+\*   lib/cascade/cascade_fsm.ml:29   if is_last && accept_on_exhaustion then ...
+\*   lib/cascade/cascade_fsm.mli:37  accept_on_exhaustion:bool ->
+\*   lib/cascade/cascade_fsm.mli:45  Accept_rejected _ on last + accept_on_exhaustion -> Accept_on_exhaustion
+\*
+\* (Path/symbol drift: cascade_executor.ml:complete_cascade_with_accept
+\*  was extracted into the cascade FSM module + decide function when
+\*  the lib/cascade/ subdir was created. Recorded for cross-reference;
+\*  see also #9011.)
 
 EXTENDS Naturals, Sequences, FiniteSets
 

--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -1,15 +1,20 @@
 ---- MODULE DashboardCacheStampede ----
 \* Bug Model: Dashboard cache stale-while-revalidate zombie slot.
 \*
-\* Models dashboard_cache.ml:get_or_compute_eio.
+\* Models lib/dashboard/dashboard_cache.ml:get_or_compute_eio.
 \* When a background revalidation fiber is cancelled (Eio.Cancel.Cancelled),
 \* the Computing{stale=Some} slot is left orphaned:
 \*   - maybe_evict() only targets Ready entries, not Computing
 \*   - poll-retry only activates for Computing{stale=None}
 \*   - Result: permanent zombie slot returning stale data forever
 \*
-\* Actual code reference: dashboard_cache.ml line 265
-\*   Eio.Cancel.Cancelled _ as e -> raise e  (no cleanup)
+\* Actual code (verified 2026-04-20):
+\*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
+\*   lib/dashboard/dashboard_cache.ml:134  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:216  | Eio.Cancel.Cancelled _ as e -> ...
+\*
+\* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
+\*  Line drift: 265 -> 216. Recorded for cross-reference.)
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
- Two more bug-model specs had stale source references (path moves + symbol renames + line shift).
- Doc-only change. No semantics modified.

## Drift

### CascadeExhaustion.tla
| Spec said | Actual |
|---|---|
| `cascade_executor.ml:complete_cascade_with_accept` | `lib/cascade/cascade_fsm.ml:decide ~accept_on_exhaustion ~is_last` (line 21–29) |

Same drift class as #9011 (cascade_executor was distributed when `lib/cascade/` subdir was extracted).

### DashboardCacheStampede.tla
| Spec said | Actual |
|---|---|
| `dashboard_cache.ml line 265 Eio.Cancel.Cancelled` | `lib/dashboard/dashboard_cache.ml:216` |

Path move (`lib/dashboard_cache.ml` → `lib/dashboard/dashboard_cache.ml`) + ~50 line shift. Added new pointers for `maybe_evict` (:60) and `get_or_compute_eio` (:134).

## Verification
```
$ rg -n 'let decide|accept_on_exhaustion' lib/cascade/cascade_fsm.ml
21:let decide ~accept_on_exhaustion ~is_last outcome =
29:    if is_last && accept_on_exhaustion then

$ rg -n 'Eio\.Cancel\.Cancelled|maybe_evict|let get_or_compute_eio' lib/dashboard/dashboard_cache.ml
60:let maybe_evict map =
134:let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
216:              | Eio.Cancel.Cancelled _ as e ->
```

## Test plan
- [x] Doc-only change in two prelude comment blocks
- [x] Spec actions/invariants unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)