### PR TITLE
docs(logic): batch-19 .mli for tool_misc_transport + tool_schemas_inline_infra + dashboard_feature_health

### DIFF
--- a/lib/dashboard/dashboard_feature_health.mli
+++ b/lib/dashboard/dashboard_feature_health.mli
@@ -1,0 +1,61 @@
+(** Dashboard_feature_health — Read model for feature-flag health
+    monitoring.
+
+    Aggregates status, enablement source, and lifecycle buckets for
+    every flag in {!Feature_flag_registry.all_flags} to provide a
+    runtime view of which features are active, experimental, or
+    deprecated. *)
+
+(** {1 Types} *)
+
+type feature_status =
+  | Healthy
+  | Warning
+  | Inactive
+  | Deprecated
+
+type feature_health_item = {
+  env_name : string;
+  description : string;
+  category : string;
+  lifecycle : string;
+  is_enabled : bool;
+  source : string;  (** ["env"] when overridden, else ["default"]. *)
+  status : feature_status;
+  since : string;
+}
+
+(** {1 Enumeration} *)
+
+val status_to_string : feature_status -> string
+
+val lifecycle_to_status :
+  Feature_flag_registry.lifecycle -> feature_status
+
+val feature_to_health_item :
+  Feature_flag_registry.flag -> feature_health_item
+
+(** {1 Queries} *)
+
+val get_all_features : unit -> feature_health_item list
+
+val get_features_by_category : string -> feature_health_item list
+
+val get_feature_categories : unit -> string list
+
+val count_by_status :
+  feature_health_item list -> feature_status -> int
+
+(** {1 JSON output} *)
+
+val feature_health_item_to_json :
+  feature_health_item -> Yojson.Safe.t
+
+val overview_json : feature_health_item list -> Yojson.Safe.t
+
+val features_by_category_json :
+  feature_health_item list -> Yojson.Safe.t
+
+(** Full dashboard payload: [generated_at], [overview],
+    [features_by_category], [all_features]. *)
+val json : unit -> Yojson.Safe.t

--- a/lib/tool_misc_transport.mli
+++ b/lib/tool_misc_transport.mli
@@ -1,0 +1,27 @@
+(** Tool_misc_transport — Transport, WebSocket, and WebRTC tool
+    handlers.
+
+    Extracted from {!Tool_misc} to reduce the god-file footprint.
+    Contains HTTP/WS/gRPC/WebRTC discovery and status handlers.
+
+    @since 2.188.0 *)
+
+type tool_result = bool * string
+
+(** {1 Transport status} *)
+
+val handle_transport_status : Yojson.Safe.t -> tool_result
+
+val handle_websocket_discovery : Yojson.Safe.t -> tool_result
+
+(** {1 WebRTC handshake} *)
+
+(** [handle_webrtc_offer args] accepts [agent_name], [ice_candidates],
+    optional [dtls_fingerprint]. Returns an error result when WebRTC
+    transport is disabled or required fields are missing. *)
+val handle_webrtc_offer : Yojson.Safe.t -> tool_result
+
+(** [handle_webrtc_answer args] accepts [offer_id], [agent_name],
+    [ice_candidates]. Returns an error result when WebRTC transport
+    is disabled or required fields are missing. *)
+val handle_webrtc_answer : Yojson.Safe.t -> tool_result

--- a/lib/tool_schemas/tool_schemas_inline_infra.mli
+++ b/lib/tool_schemas/tool_schemas_inline_infra.mli
@@ -1,0 +1,14 @@
+(** Tool_schemas_inline_infra — Inline schemas for infra tool
+    surfaces (session, approval, spawn).
+
+    Issue #8520: [mcp_session_action_enum_strings] hand-mirrors
+    {!Mcp_session.valid_action_strings}. The sync regression test
+    [test_types.ml :: mcp_session_action_ssot] catches drift. *)
+
+(** Enum of valid [masc_mcp_session] action strings, mirrored from
+    {!Mcp_session.valid_action_strings}. *)
+val mcp_session_action_enum_strings : string list
+
+(** Tool schema list: [masc_mcp_session], [masc_approval_get],
+    [masc_spawn]. *)
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/tool_misc_transport.mli` | 27 | `tool_result` + 4 handlers (webrtc_offer/answer called from `Tool_misc`; transport_status/websocket_discovery kept to avoid unused-value warning) |
| `lib/tool_schemas/tool_schemas_inline_infra.mli` | 14 | `mcp_session_action_enum_strings` (SSOT test) + `schemas` (Types.tool_schema list) |
| `lib/dashboard/dashboard_feature_health.mli` | 61 | `feature_status` variant + `feature_health_item` record + 10 vals; callers in server layer |

Pre-scan: include=0 open=0 alias=0 surf ≤ 3 for all three.

## Notes

- `tool_schemas_inline_infra` qualified `Types.tool_schema` explicitly instead of `open Types` in the signature — avoids namespace pollution.
- `tool_misc_transport` exposes all four handlers because the ml defines them top-level; hiding two would trigger unused-value warnings.

## Metrics

- Files: 671 ml / ~349 mli (≈52% of ml).
- Build: `dune build @check` exit 0.
- Tests: `test_types.exe` (117 tests) pass.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)