### PR TITLE
refactor(sidecar): compare retry backoff in float seconds (#8930 phase 3)

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -566,11 +566,23 @@ let observed_state_of_status_json = function
 let retry_backoff_seconds () =
   Env_config_runtime.Sidecar.reconcile_backoff_sec
 
+(** Compare backoff deadline against [now] in unix-epoch seconds. Parses both
+    sides via [Types_core.parse_iso8601_opt] so that an ISO string that
+    serialises before-but-sorts-after (e.g. drift between timezones or a
+    clock skew) still resolves to the correct ordering. Fail-closed: if
+    either side fails to parse (malformed sidecar or boundary layer drift),
+    treat the backoff as inactive so reconcile retries instead of stalling.
+    See #8930 phase 3. *)
 let retry_backoff_active ~now attempt =
-  attempt.generation >= 0
-  && match attempt.next_retry_at with
-     | Some next_retry_at -> String.compare next_retry_at now > 0
-     | None -> false
+  match attempt.next_retry_at with
+  | None -> false
+  | Some next_retry_at ->
+      (match
+         ( Types_core.parse_iso8601_opt next_retry_at,
+           Types_core.parse_iso8601_opt now )
+       with
+      | Some next_unix, Some now_unix -> next_unix > now_unix
+      | _ -> false)
 
 let next_attempt_record ~now ~next_retry_at previous (record : desired_record) =
   let attempt_number =

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -602,6 +602,49 @@ let test_isoish_lexical_matches_chronological () =
   check int "equal timestamps compare zero" 0
     (String.compare earlier (Routes.isoish_at 1_000_000.0))
 
+(* ── retry_backoff_active (#8930 phase 3) ──────────────────────────────
+   After phase 3, [retry_backoff_active] parses both [next_retry_at] and
+   [now] via [Types_core.parse_iso8601_opt] and compares float unix-epoch
+   values. If either side is malformed the function returns false
+   (fail-closed) so a broken sidecar record retries instead of stalling. *)
+
+let make_attempt ~next_retry_at =
+  Routes.{
+    connector_id = "discord";
+    generation = 1;
+    attempt_id = "1:1";
+    attempt_number = 1;
+    last_attempt_result = "start_dispatched";
+    next_retry_at;
+    operator_next_action = "none";
+    updated_at = "2026-01-01T00:00:00Z";
+  }
+
+let test_retry_backoff_active_before_deadline () =
+  let attempt = make_attempt ~next_retry_at:(Some "2026-01-01T00:00:30Z") in
+  check bool "now < next_retry_at → backoff active" true
+    (Routes.retry_backoff_active ~now:"2026-01-01T00:00:00Z" attempt)
+
+let test_retry_backoff_inactive_after_deadline () =
+  let attempt = make_attempt ~next_retry_at:(Some "2026-01-01T00:00:00Z") in
+  check bool "now > next_retry_at → backoff expired" false
+    (Routes.retry_backoff_active ~now:"2026-01-01T00:00:30Z" attempt)
+
+let test_retry_backoff_inactive_when_no_deadline () =
+  let attempt = make_attempt ~next_retry_at:None in
+  check bool "next_retry_at=None → backoff inactive" false
+    (Routes.retry_backoff_active ~now:"2026-01-01T00:00:00Z" attempt)
+
+let test_retry_backoff_fail_closed_on_malformed_next () =
+  let attempt = make_attempt ~next_retry_at:(Some "not-an-iso-stamp") in
+  check bool "malformed next_retry_at → fail-closed" false
+    (Routes.retry_backoff_active ~now:"2026-01-01T00:00:00Z" attempt)
+
+let test_retry_backoff_fail_closed_on_malformed_now () =
+  let attempt = make_attempt ~next_retry_at:(Some "2026-01-01T00:00:30Z") in
+  check bool "malformed now → fail-closed" false
+    (Routes.retry_backoff_active ~now:"not-an-iso-stamp" attempt)
+
 let () =
   run "sidecar_lifecycle_routes"
     [
@@ -686,5 +729,18 @@ let () =
             test_isoish_at_epoch_round_trip;
           test_case "lexical compare matches chronological order" `Quick
             test_isoish_lexical_matches_chronological;
+        ] );
+      ( "retry_backoff_active (#8930 phase 3)",
+        [
+          test_case "now before deadline → active" `Quick
+            test_retry_backoff_active_before_deadline;
+          test_case "now after deadline → inactive" `Quick
+            test_retry_backoff_inactive_after_deadline;
+          test_case "no deadline → inactive" `Quick
+            test_retry_backoff_inactive_when_no_deadline;
+          test_case "malformed next_retry_at → fail-closed" `Quick
+            test_retry_backoff_fail_closed_on_malformed_next;
+          test_case "malformed now → fail-closed" `Quick
+            test_retry_backoff_fail_closed_on_malformed_now;
         ] );
     ]


### PR DESCRIPTION
## Summary
Migrates `retry_backoff_active` from lexical ISO string compare to float unix-epoch compare via the existing `Types_core.parse_iso8601_opt` helper. Removes the always-true `attempt.generation >= 0` dead gate. Wire format on disk is unchanged.

## Product impact
- **ops visibility** — sidecar reconcile behaviour stays observationally identical for the happy path (current 20-char `YYYY-MM-DDTHH:MM:SSZ` shape lexical-sort-equals chronological-sort). Removes the silent-drift risk: if a future refactor extends the ISO shape (offset, milliseconds, timezone), the backoff comparison keeps working instead of producing stale/duplicate retries.

## Evidence
- `dune build --root . @check` clean
- `dune exec --root . test/test_sidecar_lifecycle_routes.exe` → **43 tests pass** (38 existing + 5 new)
- No `.mli` changes; `retry_backoff_active` keeps the same `~now:string -> attempt_record -> bool` signature
- `Types_core.parse_iso8601_opt` is prior art with 3+ cross-module consumers (`resilience.ml`, `coord_task_schedule.ml`, `keeper_accountability.ml`)

Core change (`lib/server/server_routes_http_routes_sidecar.ml:569-582`):
```ocaml
let retry_backoff_active ~now attempt =
  match attempt.next_retry_at with
  | None -> false
  | Some next_retry_at ->
      (match
         ( Types_core.parse_iso8601_opt next_retry_at,
           Types_core.parse_iso8601_opt now )
       with
      | Some next_unix, Some now_unix -> next_unix > now_unix
      | _ -> false)  (* fail-closed *)
```

### Why fail-closed on parse drift
If either side fails to parse (malformed sidecar JSON, boundary layer drift), returning `false` treats the backoff as inactive so reconcile retries the connector instead of stalling on a broken record. Stuck-on-parse-error is the worst failure mode for a watchdog; noisy-retry is recoverable.

## Review evidence
Self-review only. 5 unit tests pin the semantics:
- `now before deadline → active`
- `now after deadline → inactive`
- `no deadline → inactive`
- `malformed next_retry_at → fail-closed`
- `malformed now → fail-closed`

## Linked issue
Refs #8930 — attempt_state SSOT consolidation, phase 3.

Prior phases in this track:
- #8950 — `lib/attempt_state.ml` SSOT module (MERGED)
- #8978 — `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` env knob (MERGED)
- #8992 — ISO format invariant tripwire tests (MERGED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)