### PR TITLE
fix(keeper): utf8_safe truncate for work_discovery nudge titles

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1146,11 +1146,17 @@ let run_turn
                      let preview =
                        List.filteri (fun i _ -> i < n) tasks
                        |> List.map (fun (t : Types.task) ->
+                            (* UTF-8 safe truncation: String.sub cuts on byte
+                               boundary and can split multi-byte codepoints,
+                               producing invalid UTF-8 that codex CLI rejects
+                               with "invalid UTF-8 was detected in one or
+                               more arguments" (fleet 2026-04-20). 83 bytes =
+                               80 byte prefix + 3 byte ellipsis (U+2026). *)
                             Printf.sprintf "  - %s (p%d): %s"
                               t.id t.priority
-                              (if String.length t.title > 80 then
-                                 String.sub t.title 0 80 ^ "…"
-                               else t.title))
+                              (String_util.utf8_safe
+                                 ~max_bytes:83 ~suffix:"…" t.title
+                               |> String_util.to_string))
                        |> String.concat "\n"
                      in
                      Some (Printf.sprintf


### PR DESCRIPTION
## Summary

Swap `String.sub` byte-level truncation for `String_util.utf8_safe` in
`discover_work_nudge` task title preview (`lib/keeper/keeper_agent_run.ml:1151`).
Residual drift — 15+ call sites already use the helper; this was the one
that slipped through.

## Symptom (fleet 2026-04-20, 45-min window)

4 × `codex exited with code 2: error: invalid UTF-8 was detected in one or more arguments`

- All immediately after `[Keeper] keeper:<X> before_turn: injecting work_discovery nudge (~1400 chars)`.
- Affected keepers: `masc-improver`, `verdict`. Cascade `vendor_mix_balanced`.
- Turn duration 0.2s = argv parse-time rejection, not runtime.
- Size is **not** the issue (1.4 KB ≪ ARG_MAX). Only the **bytes** are.

## Root cause

`String.sub t.title 0 80` cuts on a byte boundary. When `t.title` contains
multi-byte UTF-8 (Korean, emoji, etc.) and the 80-byte cut lands mid-codepoint,
the resulting nudge string contains an orphan continuation byte. OAS
`transport_codex_cli` passes the nudge as argv; the codex CLI validates argv
UTF-8 and rejects.

## Fix

`String_util.utf8_safe` already exists (`lib/core/string_util.ml`) and is the
established pattern in this codebase — `board_core_payload`, `dashboard`,
`audit_log`, `autoresearch_metric`, `mcp_server_eio_execute`, `metrics_store_eio`,
and more. This PR aligns the last remaining caller.

`max_bytes:83 ~suffix:"…"` preserves the prior byte budget:
80-byte prefix + 3-byte `U+2026` ellipsis = 83 total.

## Test plan

- [x] `dune build --root . lib/` — passes
- [ ] CI: `test_string_util.ml` already covers `utf8_safe` (ASCII in-bounds,
  Korean `나머지 리뷰` regression, emoji `😀😀😀`, invalid-UTF-8 best-effort).
  This PR is a single-expression swap to that helper, so the existing
  coverage is sufficient.

## Follow-ups (not in this PR)

- OAS `transport_codex_cli.ml` defensive pre-spawn argv `String.is_valid_utf_8`
  check. Would catch any future drift on *any* transport, and emit a cascadable
  error instead of letting codex fail at argv-parse time. Deferred to OAS PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
