### PR TITLE
test(matrix): add keeper_bash_kill / keeper_bash_output contracts (#9026)

### DIFF
--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -262,6 +262,17 @@ let keeper_arguments fixture (schema : Types.tool_schema) =
   | "keeper_shell" -> `Assoc [ ("op", `String "git_status") ]
   | "keeper_bash" ->
       `Assoc [ ("cmd", `String "pwd"); ("timeout_sec", `Float 5.0) ]
+  | "keeper_bash_output" ->
+      (* No live background task in test fixtures — handler returns
+         structured "no background task with id=..." error which the
+         expectation table accepts as a valid Bg_task surface. *)
+      `Assoc [ ("task_id", `String "bgt-matrix-fixture-0-0") ]
+  | "keeper_bash_kill" ->
+      `Assoc
+        [
+          ("task_id", `String "bgt-matrix-fixture-0-0");
+          ("grace_sec", `Float 0.5);
+        ]
   | "keeper_voice_speak" ->
       `Assoc [ ("message", `String "tool matrix hello") ]
   | "keeper_voice_listen" ->
@@ -354,6 +365,13 @@ let keeper_expectation_for_name name =
          the sample file is written at base_path. File-not-found in
          tests without a playground file is an acceptable outcome. *)
       Expect_success_or_guard [ "file not found" ]
+  | "keeper_bash_output" | "keeper_bash_kill" ->
+      (* Matrix fixtures never spawn a real background task, so the
+         only outcome is the handler's structured "no background task"
+         response. Bg_task.read returns Unknown_task; the keeper-side
+         handler maps it to error_json with this exact phrase. *)
+      Expect_success_or_guard
+        [ "no background task with id="; "already reaped" ]
   | _ -> Expect_success
 
 let extra_guard_fragments_for_name = function


### PR DESCRIPTION
## Summary
- `keeper_bash_kill`/`keeper_bash_output`이 universe에 등록되어 있는데(`lib/tool_shard.ml:419/435` + `lib/keeper/keeper_exec_tools.ml:249/252`) 매트릭스 contracts에는 빠져 있어 \`failwith "missing keeper arguments contract for ..."\` 로 3 failure 발생.
- 두 도구의 `arguments`/`expectation` 분기 추가. fictitious task_id로 호출하면 핸들러가 \`error_json "no background task with id=..."\` 를 반환하므로 그 phrase를 guard fragment에 등록.

## Test plan
- [x] \`dune build --root .\` 클린
- [x] \`dune test --root . test/test_keeper_tool_matrix.exe --force\` → **116 tests run, 1 failure** (\`028_keeper_task_done\` 25s timeout — pre-existing on main, unrelated). Pre-fix: 3 failures.
- [ ] CI green
- [ ] Required reviewers: -

Closes #9026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)