### PR TITLE
feat(server): legendary_bash bg_tasks/<keeper> endpoint (P2 Tick 33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ### Added
 
+- **Legendary Bash `bg_tasks/<keeper>` HTTP endpoint.**  New
+  `GET /api/v1/legendary_bash/bg_tasks/<keeper>` returns the
+  per-keeper background task roster as
+  `{"keeper": "<name>", "count": N, "tasks": ["<id>", …]}`.
+  Wraps `Bg_task.list ~keeper` under the same public-read posture
+  as `shadow_counters` (no auth on keeper identity, zero-cost when
+  quiet).  Unknown / quiet keepers return `{"count": 0, "tasks":
+  []}` — the endpoint mirrors the filesystem/PG lookup instead
+  of gating on keeper existence, so a dashboard can poll liberally.
+  Trailing-slash requests (`.../bg_tasks/`) return 400 with
+  `"keeper name is required"`.  Three new route tests cover empty
+  keeper, unusual-name echo (`my-keeper_01`), and stable
+  `keeper → count → tasks` field ordering.
+  `LEGENDARY-BASH-RUNBOOK.md` now documents the endpoint alongside
+  the existing `shadow_counters` snapshot endpoint so dashboards
+  and operator tooling have a single reference.
+
 - **`Cdal_judge` jest / vitest classifier.**  `of_exec_outcome`
   now emits typed `Test_pass {count}` / `Test_fail {count}`
   markers for jest and vitest runner output in addition to dune,

--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -213,6 +213,39 @@ for point-in-time diagnostics, counters for `disagree ratio =
 (legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total`
 trend math over a rolling window.
 
+## Background Task Roster Endpoint
+
+The `keeper_bash` P2 background task lifecycle tracks long-running
+shell tasks in an in-process registry (`Bg_task.list`). The roster is
+exposed for a given keeper through a second public-read endpoint so
+that dashboards can render "tasks currently owned by this keeper"
+without scraping logs:
+
+```
+GET /api/v1/legendary_bash/bg_tasks/<keeper>
+```
+
+Response shape:
+
+```json
+{
+  "keeper": "<name>",
+  "count": 2,
+  "tasks": ["<task_id_1>", "<task_id_2>"]
+}
+```
+
+Unknown or quiet keepers legitimately return `{"count": 0, "tasks": []}` —
+the endpoint does not gate on keeper existence, matching the
+`shadow_counters` "zero-cost public read" posture. The path param is
+required; a trailing-slash request (`.../bg_tasks/`) returns 400.
+
+Per-task snapshots (stdout drain, exit status, drop counters) are not
+surfaced by this endpoint — those require a stateful `since_*` offset
+and live inside the `keeper_bash_output` MCP tool. This endpoint is
+intentionally cheap and stateless so a dashboard can poll it on a
+short interval without coordinating cursors across callers.
+
 ## Rollback
 
 Each Legendary flag has an inert opt-out path. No restart required.

--- a/lib/server/server_routes_http_routes_legendary_bash.ml
+++ b/lib/server/server_routes_http_routes_legendary_bash.ml
@@ -1,16 +1,26 @@
 (** Legendary Bash dark-launch observer HTTP surface.
 
-    Exposes the in-process [Legendary_counters] snapshot as a single
-    public-read JSON endpoint for dashboards and flip-decision tooling.
-    The counters themselves are incremented only while the matching
-    observer env flag is enabled (see [LEGENDARY-BASH-RUNBOOK.md]);
-    this endpoint is a zero-cost read.
+    Exposes the in-process [Legendary_counters] snapshot and the
+    [Bg_task.list] per-keeper task roster as public-read JSON endpoints
+    for dashboards and flip-decision tooling.  The counters themselves
+    are incremented only while the matching observer env flag is
+    enabled (see [LEGENDARY-BASH-RUNBOOK.md]); this endpoint is a
+    zero-cost read.
 
       GET /api/v1/legendary_bash/shadow_counters
+      GET /api/v1/legendary_bash/bg_tasks/<keeper>
 
-    Response (200): JSON shape mirrors [Legendary_counters.snapshot]
-    field-for-field. See [legendary_counters.mli] for the stable
-    contract. *)
+    Response (200) for shadow_counters: JSON shape mirrors
+    [Legendary_counters.snapshot] field-for-field. See
+    [legendary_counters.mli] for the stable contract.
+
+    Response (200) for bg_tasks: JSON of shape
+      { "keeper": "<name>", "count": N, "tasks": [ "<task_id>", … ] }
+    where [tasks] is the list returned by [Bg_task.list ~keeper] at
+    the moment of the call.  Unknown / quiet keepers legitimately
+    return [count = 0, tasks = []] — the endpoint does not validate
+    keeper existence, mirroring [shadow_counters]' "zero-cost read"
+    posture. *)
 
 open Server_utils
 open Server_auth
@@ -21,6 +31,15 @@ let snapshot_response () : Yojson.Safe.t =
   let snap = Legendary_counters.snapshot () in
   Legendary_counters.snapshot_to_json snap
 
+let bg_tasks_response ~keeper : Yojson.Safe.t =
+  let ids = Bg_task.list ~keeper in
+  let as_strings = List.map Bg_task.task_id_to_string ids in
+  `Assoc [
+    ("keeper", `String keeper);
+    ("count", `Int (List.length ids));
+    ("tasks", `List (List.map (fun s -> `String s) as_strings));
+  ]
+
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/legendary_bash/shadow_counters"
@@ -30,4 +49,25 @@ let add_routes router =
              let json = snapshot_response () in
              respond_public_read_json ~status:`OK request reqd
                (Yojson.Safe.to_string json))
+           request reqd)
+  |> Http.Router.prefix_get "/api/v1/legendary_bash/bg_tasks/"
+       (fun request reqd ->
+         with_public_read
+           (fun _state _req reqd ->
+             let path = Http.Request.path request in
+             match
+               extract_path_param
+                 ~prefix:"/api/v1/legendary_bash/bg_tasks/" path
+             with
+             | None | Some "" ->
+                 Http.Response.json
+                   (Yojson.Safe.to_string
+                      (`Assoc [
+                         ("error", `String "keeper name is required");
+                       ]))
+                   ~status:`Bad_request reqd
+             | Some keeper ->
+                 let json = bg_tasks_response ~keeper in
+                 respond_public_read_json ~status:`OK request reqd
+                   (Yojson.Safe.to_string json))
            request reqd)

--- a/test/dune
+++ b/test/dune
@@ -334,6 +334,7 @@
         test_destructive_class
         test_gate_diff
         test_legendary_counters
+        test_legendary_bash_bg_tasks_route
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge
@@ -496,6 +497,7 @@
         test_destructive_class
         test_gate_diff
         test_legendary_counters
+        test_legendary_bash_bg_tasks_route
         test_oas_integration
         test_memory_oas_5tier
         test_verifier_oas_bridge

--- a/test/test_legendary_bash_bg_tasks_route.ml
+++ b/test/test_legendary_bash_bg_tasks_route.ml
@@ -1,0 +1,77 @@
+(* Legendary Bash bg_tasks route — JSON shape tests.
+
+   Exercises [Server_routes_http_routes_legendary_bash.bg_tasks_response]
+   directly as a pure function.  The live HTTP handler path and
+   extract_path_param wiring are covered by the route pipeline
+   integration suite; this file locks the serialisation contract that
+   dashboards will consume so it can't silently drift (field names,
+   empty-list encoding, keeper echo). *)
+
+open Masc_mcp
+
+let test_empty_keeper_shape () =
+  (* Quiet / unknown keeper legitimately returns count=0 and tasks=[].
+     The endpoint does not gate on keeper existence — mirrors the
+     shadow_counters "zero-cost public read" posture. *)
+  let json =
+    Server_routes_http_routes_legendary_bash.bg_tasks_response
+      ~keeper:"analyst"
+  in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "keeper echoed" true
+    (Astring.String.is_infix ~affix:"\"keeper\":\"analyst\"" s);
+  Alcotest.(check bool)
+    "count=0 when no tasks" true
+    (Astring.String.is_infix ~affix:"\"count\":0" s);
+  Alcotest.(check bool)
+    "tasks=[] when no tasks" true
+    (Astring.String.is_infix ~affix:"\"tasks\":[]" s)
+
+let test_keeper_with_unusual_name () =
+  (* Names can contain hyphens, underscores, digits — the endpoint
+     must echo the raw keeper string as-is without normalising. *)
+  let json =
+    Server_routes_http_routes_legendary_bash.bg_tasks_response
+      ~keeper:"my-keeper_01"
+  in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "unusual keeper name echoed" true
+    (Astring.String.is_infix ~affix:"\"keeper\":\"my-keeper_01\"" s)
+
+let test_field_ordering_stable () =
+  (* Dashboards depend on a stable JSON object key order ("keeper"
+     first, then "count", then "tasks") so that a human-readable curl
+     response mirrors the runbook's documented shape.  Yojson preserves
+     [`Assoc] order on serialisation. *)
+  let json =
+    Server_routes_http_routes_legendary_bash.bg_tasks_response
+      ~keeper:"x"
+  in
+  let s = Yojson.Safe.to_string json in
+  (* Locate positions of each key; keeper < count < tasks. *)
+  let find_key k =
+    match Astring.String.find_sub ~sub:("\"" ^ k ^ "\":") s with
+    | Some i -> i
+    | None -> -1
+  in
+  let i_keeper = find_key "keeper" in
+  let i_count = find_key "count" in
+  let i_tasks = find_key "tasks" in
+  Alcotest.(check bool) "keeper present" true (i_keeper >= 0);
+  Alcotest.(check bool) "count present" true (i_count > i_keeper);
+  Alcotest.(check bool) "tasks after count" true (i_tasks > i_count)
+
+let () =
+  Alcotest.run "legendary_bash_bg_tasks_route"
+    [
+      ( "shape",
+        [
+          Alcotest.test_case "empty keeper" `Quick test_empty_keeper_shape;
+          Alcotest.test_case "unusual keeper name" `Quick
+            test_keeper_with_unusual_name;
+          Alcotest.test_case "field ordering stable" `Quick
+            test_field_ordering_stable;
+        ] );
+    ]


### PR DESCRIPTION
## Product impact

Exposes the `Bg_task.list` per-keeper roster of long-running shell tasks as a public-read HTTP endpoint so dashboards and operator tooling can observe background task state without log grep or MCP round-trips.

```
GET /api/v1/legendary_bash/bg_tasks/<keeper>
```

Response shape:

```json
{"keeper": "<name>", "count": 2, "tasks": ["<id_1>", "<id_2>"]}
```

Pairs with the existing `shadow_counters` endpoint (#8967) to give the dashboard a complete Legendary Bash observation surface: counter trends + active bg tasks, both behind the same public-read posture.

## Evidence

- `lib/server/server_routes_http_routes_legendary_bash.ml`:
  - New `bg_tasks_response ~keeper` pure function that wraps `Bg_task.list ~keeper` and serialises to `{"keeper", "count", "tasks"}`.
  - New `Router.prefix_get "/api/v1/legendary_bash/bg_tasks/"` handler — uses the existing `extract_path_param` helper, returns 400 with `"keeper name is required"` on empty tail.
- `test/test_legendary_bash_bg_tasks_route.ml`: 3 new tests (empty keeper → count=0 + tasks=[]; unusual keeper name echoed verbatim; stable `keeper → count → tasks` field ordering for dashboard consumers).
- Registered in `test/dune` (both `names` and `modules` stanzas).
- `docs/LEGENDARY-BASH-RUNBOOK.md`: new "Background Task Roster Endpoint" section alongside the existing "In-process Snapshot Endpoint" so operators have one canonical reference.
- Local `dune exec test/test_legendary_bash_bg_tasks_route.exe --root .` → 3/3 pass.

## Review evidence

Endpoint follows the `shadow_counters` precedent (#8967) — same file, same auth posture (`with_public_read`), same response helper (`respond_public_read_json`).  The prefix_get path param extraction mirrors `/api/v1/governance/cases/:case_id` verbatim (`extract_path_param` + 400 on empty).  No behavioural change to `Bg_task` itself — this is strictly an additional read path.

Per-task snapshots (stdout drain, exit status, drop counters) remain in the `keeper_bash_output` MCP tool where stateful `since_*` offsets belong; exposing them in HTTP would force cursor coordination across callers.  This endpoint is deliberately cheap and stateless so a dashboard can poll on a short interval.

## Linked issue

N/A — plan candidate #3 (P2 observability enrichment) per `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)