### PR TITLE
refactor(bonsai-dashboard): extract flame_mini to shared Flame module

### DIFF
--- a/dashboard_bonsai/src/flame.ml
+++ b/dashboard_bonsai/src/flame.ml
@@ -1,0 +1,109 @@
+(** Flame mini — tool category stacked bar.
+
+    "Last cycle"의 시간 배분을 도구 카테고리로 나눈 단일 horizontal bar +
+    아래 legend (color chip + label + %). Phase 1 에서 logs_view.ml에
+    inline되어 있었으나 Phase 2 shell 추출에서 공용 모듈로 분리.
+
+    재사용 대상: Tools · Sessions · (차후) 도구 호출 분포를 그리고 싶은
+    모든 탭. 색 토큰은 `--t-*` namespace (colors_and_type.css).
+
+    CSS는 ppx_css로 scope 되므로 logs_view.ml 내 옛 블록과 클래스 충돌
+    없음. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type kind =
+  [ `Llm
+  | `Tool
+  | `Think
+  | `Wait
+  | `Err
+  ]
+
+module Style =
+[%css
+stylesheet
+  {|
+  .flame { padding: 10px 14px; }
+  .flame_bar {
+    display: flex;
+    height: 14px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-deep);
+    overflow: hidden;
+  }
+  .flame_seg {
+    height: 100%;
+    border-right: 1px solid rgba(0, 0, 0, 0.35);
+  }
+  .flame_seg:last-child { border-right: 0; }
+  .flame_seg_llm   { background: var(--t-llm); }
+  .flame_seg_tool  { background: var(--t-tool); }
+  .flame_seg_think { background: var(--t-think); }
+  .flame_seg_wait  { background: var(--t-wait); }
+  .flame_seg_err   { background: var(--t-err); }
+  .flame_legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 10px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+  }
+  .flame_item { display: inline-flex; align-items: center; gap: 6px; }
+  .flame_chip {
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+    border: 1px solid rgba(0, 0, 0, 0.45);
+  }
+  .flame_lbl { color: var(--text-primary); }
+  .flame_pct {
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+  }
+|}]
+
+let seg_class = function
+  | `Llm -> Style.flame_seg_llm
+  | `Tool -> Style.flame_seg_tool
+  | `Think -> Style.flame_seg_think
+  | `Wait -> Style.flame_seg_wait
+  | `Err -> Style.flame_seg_err
+;;
+
+let label = function
+  | `Llm -> "llm"
+  | `Tool -> "tool"
+  | `Think -> "think"
+  | `Wait -> "wait"
+  | `Err -> "err"
+;;
+
+let view_mini ~(segments : (kind * int) list) =
+  let bar =
+    Node.div
+      ~attrs:[ Style.flame_bar ]
+      (List.map segments ~f:(fun (kind, pct) ->
+         let style = Attr.create "style" (Printf.sprintf "width:%d%%" pct) in
+         Node.div ~attrs:[ Style.flame_seg; seg_class kind; style ] []))
+  in
+  let legend =
+    Node.div
+      ~attrs:[ Style.flame_legend ]
+      (List.map segments ~f:(fun (kind, pct) ->
+         Node.span
+           ~attrs:[ Style.flame_item ]
+           [ Node.span ~attrs:[ Style.flame_chip; seg_class kind ] []
+           ; Node.span ~attrs:[ Style.flame_lbl ] [ Node.text (label kind) ]
+           ; Node.span
+               ~attrs:[ Style.flame_pct ]
+               [ Node.text (Printf.sprintf "%d" pct) ]
+           ]))
+  in
+  Node.div ~attrs:[ Style.flame ] [ bar; legend ]
+;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1559,49 +1559,7 @@ stylesheet
   .ctx_lbl_warn { top: 22px; color: color-mix(in oklab, var(--accent-brass) 80%, var(--text-dim)); }
   .ctx_lbl_dang { top: 6px;  color: color-mix(in oklab, var(--accent-blood) 80%, var(--text-dim)); }
 
-  /* ─── flame mini — tool category stacked bar ───
-     last cycle의 시간 배분을 도구 카테고리로 나눈 단일 horizontal bar.
-     각 segment 색은 --t-*. 아래 legend는 color chip + label + %. */
-  .flame { padding: 10px 14px; }
-  .flame_bar {
-    display: flex;
-    height: 14px;
-    border: 1px solid var(--border-main);
-    background: var(--bg-deep);
-    overflow: hidden;
-  }
-  .flame_seg {
-    height: 100%;
-    border-right: 1px solid rgba(0, 0, 0, 0.35);
-  }
-  .flame_seg:last-child { border-right: 0; }
-  .flame_seg_llm   { background: var(--t-llm); }
-  .flame_seg_tool  { background: var(--t-tool); }
-  .flame_seg_think { background: var(--t-think); }
-  .flame_seg_wait  { background: var(--t-wait); }
-  .flame_seg_err   { background: var(--t-err); }
-  .flame_legend {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 14px;
-    margin-top: 10px;
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 10px;
-    color: var(--text-dim);
-    letter-spacing: 0.04em;
-  }
-  .flame_item { display: inline-flex; align-items: center; gap: 6px; }
-  .flame_chip {
-    width: 10px;
-    height: 10px;
-    display: inline-block;
-    border: 1px solid rgba(0, 0, 0, 0.45);
-  }
-  .flame_lbl { color: var(--text-primary); }
-  .flame_pct {
-    color: var(--text-bright);
-    font-variant-numeric: tabular-nums;
-  }
+  /* flame mini CSS → Flame 모듈로 이동 (shell 추출 Phase 2.A) */
 
   /* ─── tombstrip — 12-state keeper FSM tiles ───
      design_v2: Offline → Running → {Failing | Overflowed | Compacting |
@@ -2297,43 +2255,6 @@ let view_context_pressure
     ]
 ;;
 
-type flame_kind = [ `Llm | `Tool | `Think | `Wait | `Err ]
-
-let flame_seg_class = function
-  | `Llm   -> Style.flame_seg_llm
-  | `Tool  -> Style.flame_seg_tool
-  | `Think -> Style.flame_seg_think
-  | `Wait  -> Style.flame_seg_wait
-  | `Err   -> Style.flame_seg_err
-;;
-
-let flame_label = function
-  | `Llm -> "llm" | `Tool -> "tool" | `Think -> "think"
-  | `Wait -> "wait" | `Err -> "err"
-;;
-
-let view_flame_mini ~(segments : (flame_kind * int) list) =
-  let bar =
-    Node.div
-      ~attrs:[ Style.flame_bar ]
-      (List.map segments ~f:(fun (kind, pct) ->
-        let style = Attr.create "style" (Printf.sprintf "width:%d%%" pct) in
-        Node.div ~attrs:[ Style.flame_seg; flame_seg_class kind; style ] []))
-  in
-  let legend =
-    Node.div
-      ~attrs:[ Style.flame_legend ]
-      (List.map segments ~f:(fun (kind, pct) ->
-        Node.span
-          ~attrs:[ Style.flame_item ]
-          [ Node.span ~attrs:[ Style.flame_chip; flame_seg_class kind ] []
-          ; Node.span ~attrs:[ Style.flame_lbl ] [ Node.text (flame_label kind) ]
-          ; Node.span ~attrs:[ Style.flame_pct ] [ Node.text (Printf.sprintf "%d" pct) ]
-          ]))
-  in
-  Node.div ~attrs:[ Style.flame ] [ bar; legend ]
-;;
-
 (** Extract "HH:MM:SS" from an ISO-8601 UTC timestamp
     (e.g. "2026-04-20T04:02:07Z" → "04:02:07"). Falls back to the full
     string if the shape doesn't match — never throws. *)
@@ -2847,7 +2768,7 @@ let render_response
       ; Node.div
           ~attrs:[]
           [ aside_h ~tail:"mock · pending trace" "flame · last cycle"
-          ; view_flame_mini
+          ; Flame.view_mini
               ~segments:
                 [ `Llm, 42
                 ; `Tool, 18


### PR DESCRIPTION
## Summary

Phase 2.A 선행 PR — `logs_view.ml`(3069 LOC)의 공용 컴포넌트를 `dashboard_bonsai/src/` 공용 모듈로 하나씩 빼내는 **첫 단계**. 이번엔 **flame_mini 단독**.

> **Stack base**: main (독립 PR).
> **Phase**: 2.A (Shell 추출, 5개 타깃 중 1/5).

## 왜 flame_mini 먼저

- 가장 단순 (type + 2 helper + 1 view = 35 LOC + CSS)
- 외부 state 의존 無 (segments 인자만 받음)
- logs_view.ml 내 유일 call site (aside 내부)
- Shell 추출 pattern pilot — 이후 roster/swim/ctx_chart/hud 동일 방식

## 변경

### 신규 `dashboard_bonsai/src/flame.ml`

```ocaml
type kind = [ `Llm | `Tool | `Think | `Wait | `Err ]

val view_mini : segments:(kind * int) list -> Node.t
```

- 자체 `Style` 모듈 (ppx_css — scoped class, 원본 CSS 충돌 없음)
- 이전 logs_view.ml의 CSS 블록을 byte-for-byte 이동

### `logs_view.ml` 삭제분

- `type flame_kind` + `flame_seg_class` + `flame_label` + `view_flame_mini` (35 LOC)
- Style 블록의 `.flame*` CSS (46 LOC)

### Call site

| | before | after |
|---|---|---|
| aside 내부 | `view_flame_mini ~segments:[...]` | `Flame.view_mini ~segments:[...]` |

## 왜 이 변경

Phase 2.C 에서 **Tools / Sessions 탭이 flame_mini를 재사용 예정**. 기존엔 `logs_view.ml` 내부라서 외부 모듈이 쓸 수 없음. Shell 추출로 공개 API 확보.

## Pixel parity

ppx_css는 클래스를 hash-scope하므로 module 이관해도 렌더 결과 동일. CSS 내용 byte-for-byte 동일. Bundle 크기 **62MB 불변**.

## 왜 한 번에 5개 안 하나

Plan 은 shell/ 디렉토리에 5개 모듈을 한 번에 올리도록 제안했지만, 안전/리뷰 용이성 위해 **pilot + 후속 PR** 전략:

1. **이 PR** — flame (단순, 독립) → shell 추출 패턴 검증
2. 후속 — roster (type + SVG spark · 중간 규모)
3. 후속 — hud (HUD cell + KPI strip, API 일반화 포함)
4. 후속 — swim (최대 복잡도, helper 체인)
5. 후속 — ctx_chart (SVG math 포함)

각 PR은 logs 탭 pixel parity 유지 + 62MB 번들 변화 없어야 merge.

## Test plan

- [x] `dune build --root .` (dashboard_bonsai switch) — 62MB
- [ ] 머지 후 `/dashboard/b/logs` aside의 flame bar + legend 렌더 동일
- [ ] segments 하드코드 (Llm 42 / Tool 18 / Think 12 / Wait 20 / Err 8) 표시 그대로
- [ ] 다른 탭(placeholder)에는 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)