### PR TITLE
docs(changelog): record TLA+ specs migration (tla/ → specs/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 
 ## Unreleased
 
+### Changed
+
+- **TLA+ specs 이관 완결 (`tla/` → `specs/`).** 기존 top-level
+  `tla/` 디렉토리에 남아 있던 3개 스펙을 `specs/` 서브디렉토리
+  구조로 이동: `specs/task-lifecycle/TaskLifecycle.{tla,cfg,-buggy.cfg}`
+  (#8960), `specs/checkpoint-trim/CheckpointTrim.{tla,cfg,-buggy.cfg}`
+  (#9001), `specs/social-state-cap/SocialStateCap.{tla,cfg,-buggy.cfg}`
+  (#9020). 이관 이유: (1) `specs/Makefile` 의 `find . -name '*.cfg'`
+  auto-discovery 가 `specs/**` 하위만 탐색해 `tla/` 스펙은
+  `make -C specs check-all` 에서 제외되었고, (2) `ci.yml` 의
+  `tla-specs` job path filter (`^(specs/|lib/keeper/|lib/oas_.*\\.ml$
+  |Makefile$)`) 도 `tla/` 변경을 무시해 TaskLifecycle 이 PR #8437
+  merge 이후 로컬 only 로 남아 있었다. 이관 후 `scripts/tla-check.sh`
+  의 legacy `tla/` 루프 제거 및 `.gitignore` 의 `tla/` 전용 패턴
+  정리. `CheckpointTrim.cfg` / `-buggy.cfg` 에는 terminating spec
+  (`pc: "trim" → "done"`) 의 default deadlock 오탐을 막기 위해
+  `CHECK_DEADLOCK FALSE` 를 추가 — safety invariant 로만 검증.
+  CI `TLA+ Model Checking` job 은 SocialStateCap 11,665 distinct
+  states 포함 17 분 런타임에 pass.
+
 ### Added
 
 - **Legendary Bash `bg_tasks/<keeper>` HTTP endpoint.**  New


### PR DESCRIPTION
## Summary

This session's 3-PR TLA+ specs migration series (#8960, #9001, #9020) completed the retirement of the top-level `tla/` directory but did not add a `CHANGELOG.md` entry. This PR records the work under `## Unreleased / ### Changed`.

## What's recorded

- `tla/TaskLifecycle.*` → `specs/task-lifecycle/*` (#8960)
- `tla/CheckpointTrim.*` → `specs/checkpoint-trim/*` (#9001)
  - Plus `CHECK_DEADLOCK FALSE` for the terminating spec (`pc: "trim" → "done"`).
- `tla/SocialStateCap.*` → `specs/social-state-cap/*` (#9020)
  - Plus `scripts/tla-check.sh` legacy `tla/` loop removal and `.gitignore` cleanup.

## Why the move was needed

Captured in the entry itself:
- `specs/Makefile` auto-discovers `*.cfg` under `specs/**` — `tla/` invisible to `make -C specs check-all`.
- `ci.yml` `tla-specs` job path filter is `^(specs/|lib/keeper/|lib/oas_.*\.ml$|Makefile$)` — `tla/` changes never triggered the TLA+ Model Checking job.

Net effect: TaskLifecycle/CheckpointTrim/SocialStateCap are now exercised by CI on every relevant push (17 min total, SocialStateCap 11,665 distinct states is the long pole).

## Test plan

- [x] `scripts/check-doc-truth.sh` passes locally.
- [ ] Doc Truth CI step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)