### PR TITLE
docs(logic): batch-20 .mli for dashboard_agent_relations + server_dashboard_http_delete_actions + tool_schemas_coord_core

### DIFF
--- a/lib/dashboard/dashboard_agent_relations.mli
+++ b/lib/dashboard/dashboard_agent_relations.mli
@@ -1,0 +1,15 @@
+(** Dashboard_agent_relations — Proxy to GraphQL for agent
+    relationship data.
+
+    Fetches the [COLLABORATED_WITH] network and [TRUSTS] edges for an
+    agent from the Second Brain GraphQL server and assembles them
+    into a dashboard JSON payload.
+
+    @since 2.113.0 *)
+
+(** [json ~agent_name ()] queries the GraphQL server for [agent_name]'s
+    collaborators, interests, and outgoing relations (public-visibility,
+    first 20) with an 8-second per-query timeout. On GraphQL error the
+    affected section falls back to an empty list and the surrounding
+    payload is still returned. *)
+val json : agent_name:string -> unit -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -1,0 +1,15 @@
+(** Server_dashboard_http_delete_actions — POST handlers for
+    dashboard delete/sweep endpoints.
+
+    Extracted from {!Server_routes_http_routes_dashboard}. Registers
+    admin-only routes:
+    - [/api/v1/dashboard/board/delete] — delete one board post
+    - [/api/v1/dashboard/tasks/delete] — delete one task
+    - [/api/v1/dashboard/goals/delete] — delete one goal
+    - [/api/v1/dashboard/goals/sweep] — run {!Goal_janitor} *)
+
+(** [add_delete_action_routes router] returns [router] with the four
+    delete/sweep endpoints appended. Each route requires
+    {!Types.CanAdmin} via [Server_auth.with_token_permission_auth]. *)
+val add_delete_action_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t

--- a/lib/tool_schemas/tool_schemas_coord_core.mli
+++ b/lib/tool_schemas/tool_schemas_coord_core.mli
@@ -1,0 +1,18 @@
+(** Tool_schemas_coord_core — MCP tool schemas for room management
+    (core subset).
+
+    Only schemas dispatched by {!Tool_coord} live here. Other
+    schemas have been moved to their owning modules
+    ({!Tool_task}, {!Tool_control}, {!Tool_suspend}, {!Tool_plan},
+    {!Tool_portal}, {!Tool_inline_dispatch}).
+
+    Issue #8636: [assertion_kind_enum_strings] hand-mirrors
+    {!Tool_coord.valid_assertion_strings}; the sync regression test
+    [test_types.ml :: assertion_kind_ssot] catches drift. *)
+
+(** Enum of valid [masc_check] assertion strings. *)
+val assertion_kind_enum_strings : string list
+
+(** Tool schemas: [masc_status], [masc_reset], [masc_workflow_guide],
+    [masc_check], [masc_heartbeat]. *)
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/dashboard/dashboard_agent_relations.mli` | 15 | `json ~agent_name ()` (1 caller) |
| `lib/server/server_dashboard_http_delete_actions.mli` | 15 | `add_delete_action_routes : Router.t -> Router.t` (1 caller) |
| `lib/tool_schemas/tool_schemas_coord_core.mli` | 18 | `assertion_kind_enum_strings` (SSOT test) + `schemas` list |

Pre-scan trap filters: `include=0 open=0 alias=0 surf ≤ 4` for all three.

## Notes

- `tool_schemas_coord_core` uses qualified `Types.tool_schema` instead of `open Types` to keep the signature namespace clean.
- `server_dashboard_http_delete_actions` signature uses fully qualified `Http_server_eio.Router.t` (the ml aliases `module Http = Http_server_eio` internally).

## Metrics

- Files: 671 ml / ~352 mli (≈52.5% of ml).
- Build: `dune build @check` exit 0.
- Tests: `test_types.exe` (117 tests) pass.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)