### PR TITLE
docs(specs): fix KeeperCompositeLifecycle mli line drift

### DIFF
--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -22,7 +22,11 @@
 \*
 \* Design intent
 \*   1. shared_measurement is the coordination hub (Context_measured event,
-\*      Keeper_state_machine.mli:131-136, auto_rules_summary).
+\*      Keeper_state_machine.mli:139-144 [type event / Context_measured],
+\*      auto_rules_summary). Verified 2026-04-20: lines 131-136 reference
+\*      a NoDrainTransition / GhostDispatch *.mli docstring callout, not
+\*      the event type. Anchor here is the [type event] declaration that
+\*      starts at line 139 with [Context_measured] at line 144.
 \*   2. The 12-state parent phase from RFC-0002 is projected to the
 \*      7-element set
 \*      {Running, Failing, Overflowed, Compacting, HandingOff, Draining,


### PR DESCRIPTION
## Summary
- KeeperCompositeLifecycle.tla referenced `Keeper_state_machine.mli:131-136` for the `Context_measured` event anchor, but lines 131-136 contain a `NoDrainTransition` / `GhostDispatch` docstring callout — not the event type.
- Actual anchor: `type event` starts at line 139, `Context_measured` constructor lives at line 144.
- Doc-only fix (comment in spec preamble). No TLC behavior change.

## Verification
```
$ grep -n "type event\|Context_measured" lib/keeper/keeper_state_machine.mli | head -3
139:type event =
144:  | Context_measured of {
```

## Sweep context
Part of a TLA+ ↔ OCaml mapping drift sweep across `specs/keeper-state-machine/`. This is one of two findings — companion `KeeperWorkPipeline.tla` references a now-missing `lib/keeper/keeper_exec_github.ml` and will get a separate issue (mechanism review needed, not just a line bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)