### PR TITLE
docs(specs): fix KeeperContextLifecycle TokenBudgetExceeded line ref

### DIFF
--- a/specs/keeper-state-machine/KeeperContextLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperContextLifecycle.tla
@@ -147,7 +147,11 @@ TurnProducesOutput(k) ==
                    ckpt_turn, ckpt_valid, resume_ctx_id, fail_count, next_ctx_id>>
 
 \* 3. Token Budget Exceeded: running -> overflow_retry
-\*    Models TokenBudgetExceeded(Input) in keeper_unified_turn.ml:65
+\*    Models TokenBudgetExceeded(Input) recognised in
+\*    keeper_unified_turn.ml:318 (`is_input_overflow` pattern matcher)
+\*    and handled by the per-turn overflow path at line 455. Verified
+\*    2026-04-20: line 65 was a stale anchor predating the @since 2.256.0
+\*    extension that broadened TokenBudgetExceeded handling.
 TokenBudgetExceeded(k) ==
     /\ keeper_phase[k] = "running"
     /\ context_tokens[k] > MaxTokens


### PR DESCRIPTION
## Summary
- KeeperContextLifecycle.tla referenced \`keeper_unified_turn.ml:65\` for the \`TokenBudgetExceeded(Input)\` match anchor, but the actual \`is_input_overflow\` matcher lives at line 318 (with the per-turn overflow handler at line 455).
- Line 65 predates the \`@since 2.256.0\` extension that broadened TokenBudgetExceeded handling.
- Doc-only fix in spec comment. No TLC behavior change.

## Verification
\`\`\`
$ grep -n "TokenBudgetExceeded.*Input" lib/keeper/keeper_unified_turn.ml | head -3
318:  | Oas.Error.Agent (TokenBudgetExceeded { kind = "Input"; _ }) -> true
455:      | Oas.Error.Agent (TokenBudgetExceeded { kind = "Input"; used; limit }) ->
\`\`\`

## Sweep context
3rd doc-only line drift in the TLA+ ↔ OCaml mapping sweep across \`specs/keeper-state-machine/\`. Companion: PR #9043 (KeeperCompositeLifecycle), Issue #9044 (KeeperWorkPipeline aspirational mirrors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)