### PR TITLE
refactor(bootstrap): env-configurable janitor tick interval

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -616,6 +616,14 @@ module InternalTimers = struct
   (** Operator digest stalled session threshold (seconds). Default: 300 (5 min). *)
   let stalled_session_threshold_sec =
     get_float ~default:300.0 "MASC_STALLED_SESSION_THRESHOLD_SEC"
+
+  (** Bootstrap janitor tick interval (seconds). Drives the SSE/session/
+      rate-limit/webrtc reaper loop in [server_bootstrap_loops]. Default:
+      60 (1 min). Shorter interval reclaims stale connections faster at
+      the cost of more wake-ups; longer interval is fine if the process
+      is sized for the steady-state connection count. *)
+  let janitor_interval_sec =
+    get_float ~default:60.0 "MASC_JANITOR_INTERVAL_SEC"
 end
 
 (** {1 Sidecar reconcile loop}

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -486,7 +486,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Eio.Fiber.fork ~sw (fun () ->
       let last_prune = ref (Unix.gettimeofday ()) in
       let rec loop () =
-        Eio.Time.sleep clock 60.0;
+        Eio.Time.sleep clock
+          Env_config_runtime.InternalTimers.janitor_interval_sec;
         (try
           let stale_sids = Sse.cleanup_stale () in
           List.iter Server_routes_http_common.stop_sse_session stale_sids;


### PR DESCRIPTION
## Summary
Extract the hardcoded 60-second sleep in the SSE/session/rate-limit/webrtc reaper loop into \`Env_config_runtime.InternalTimers.janitor_interval_sec\` (env \`MASC_JANITOR_INTERVAL_SEC\`, default 60.0). Single literal, single call site, no behaviour change at the default.

## Product impact
- **ops visibility** — fleet operators can now stretch the interval (fewer wake-ups, lower idle CPU) or shorten it (faster socket reclaim under bursty connection load) without a recompile or fork. The call site is the catch-all janitor loop that reaps stale SSE connections, evicts SSE buffer events, reaps HTTP session guards, and drops dead external subscribers. Previously tuning required editing \`lib/server/server_bootstrap_loops.ml:489\`.

## Evidence
- \`dune build --root . @check\` clean
- Diff stat: +10/-1 across 2 files (env config + call site)
- New knob sits next to existing sibling timers (\`briefing_cache_ttl_sec\`, \`sse_buffer_ttl_sec\`, \`cancellation_cleanup_sec\`, \`provider_run_ttl_sec\`, \`stalled_session_threshold_sec\`) — follows the module convention
- No tests added: the change is a literal → env lookup; \`test_env_config_coverage.ml\` already validates \`get_float ~default\` baseline behaviour at the \`Env_config\` level

## Review evidence
Self-review only.

## Linked issue
None — incremental hardcoded-literal removal following the same pattern as #8978 (MASC_SIDECAR_RECONCILE_BACKOFF_SEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)