### PR TITLE
[codex] Restore goal tree front-door contract

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -372,7 +372,7 @@ export function GoalTree() {
       ${loading && !data ? html`
         <${LoadingState}>목표 트리 불러오는 중...<//>
       ` : data && data.tree.length === 0 ? html`
-        <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert 도구로 목표를 등록하세요." />
+        <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert로 목표를 등록하세요. 연결 태스크는 제목에 [goal:<id>]를 포함하면 Goal Tree에 반영됩니다." />
       ` : data && isFiltering && visibleTree.length === 0 ? html`
         <section class="py-4 text-center text-xs text-text-dim">
           필터 결과 없음 (${data.tree.length} 목표)

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -120,6 +120,7 @@ let public_mcp_surface_tools =
     "masc_add_task"; "masc_batch_add_tasks"; "masc_tasks";
     "masc_claim_next"; "masc_transition";
     (* Planning *)
+    "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
     "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
     (* Heartbeat *)
     "masc_heartbeat";
@@ -151,6 +152,7 @@ let spawned_agent_surface_tools =
     "masc_task_history"; "masc_broadcast"; "masc_join"; "masc_leave";
     "masc_who"; "masc_agent_update"; "masc_add_task"; "masc_heartbeat";
     "masc_messages";
+    "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
@@ -169,6 +171,7 @@ let local_worker_surface_tools =
   [
     "masc_status"; "masc_tasks"; "masc_claim_next"; "masc_transition";
     "masc_add_task"; "masc_heartbeat";
+    "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_search";
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
@@ -181,6 +184,7 @@ let session_min_surface_tools =
   [
     "masc_status"; "masc_tasks"; "masc_claim_next";
     "masc_plan_set_task"; "masc_transition"; "masc_add_task";
+    "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
     "masc_broadcast"; "masc_heartbeat";
   ]
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -836,10 +836,196 @@ let handle_heartbeat ctx _args =
     && Char.code result.[2] = 0xa0) in
   (success, result)
 
+let goal_horizon_strings = [ "short"; "mid"; "long" ]
+let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
+let goal_review_outcome_strings = [ "done"; "progress"; "blocked"; "dropped" ]
+
+let make_enum_field_error ~field ~allowed ~received =
+  {
+    field;
+    constraint_violated = One_of allowed;
+    message =
+      Printf.sprintf "%s must be one of: %s" field (String.concat ", " allowed);
+    expected = Some (String.concat "|" allowed);
+    received = Some received;
+  }
+
+let make_type_field_error ~field ~expected ~received =
+  {
+    field;
+    constraint_violated =
+      (match expected with
+       | "string" -> Type_string
+       | "integer" -> Type_int
+       | "number" -> Type_float
+       | "boolean" -> Type_bool
+       | _ -> Required);
+    message = Printf.sprintf "%s must be a %s" field expected;
+    expected = Some expected;
+    received = Some received;
+  }
+
+let parse_optional_horizon args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match Goal_store.parse_horizon (Some raw) with
+      | Some horizon -> Ok (Some horizon)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_horizon_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_goal_status args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match Goal_store.parse_goal_status (Some raw) with
+      | Some status -> Ok (Some status)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_status_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_review_outcome args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match Goal_store.parse_review_outcome raw with
+      | Some outcome -> Ok (Some outcome)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_review_outcome_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_priority args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `Int n ->
+      if n < 1 || n > 5 then
+        Error
+          {
+            field;
+            constraint_violated = Min_int 1;
+            message = "priority must be between 1 and 5";
+            expected = Some "1..5";
+            received = Some (string_of_int n);
+          }
+      else Ok (Some n)
+  | json ->
+      Error
+        (make_type_field_error ~field ~expected:"integer"
+           ~received:(Yojson.Safe.to_string json))
+
+let handle_goal_list (ctx : context) args =
+  match parse_optional_horizon args "horizon", parse_optional_goal_status args "status" with
+  | Error err, _
+  | _, Error err ->
+      validation_error_result [ err ]
+  | Ok horizon, Ok status ->
+      let goals = Goal_store.list_goals ctx.config ?horizon ?status () in
+      let rollup = Goal_store.compute_rollup goals in
+      ok_result
+        [
+          ("generated_at", `String (Types.now_iso ()));
+          ("count", `Int (List.length goals));
+          ("goals", `List (List.map Goal_store.goal_to_yojson goals));
+          ("rollup", Goal_store.rollup_to_yojson rollup);
+        ]
+
+let handle_goal_upsert (ctx : context) args =
+  match
+    parse_optional_horizon args "horizon",
+    parse_optional_goal_status args "status",
+    parse_optional_priority args "priority"
+  with
+  | Error err, _, _
+  | _, Error err, _
+  | _, _, Error err ->
+      validation_error_result [ err ]
+  | Ok horizon, Ok status, Ok priority ->
+      let id = get_string_opt args "id" in
+      let title = get_string_opt args "title" in
+      let metric = get_string_opt args "metric" in
+      let target_value = get_string_opt args "target_value" in
+      let due_date = get_string_opt args "due_date" in
+      let parent_goal_id = get_string_opt args "parent_goal_id" in
+      match
+        Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric
+          ?target_value ?due_date ?priority ?status ?parent_goal_id ()
+      with
+      | Error msg -> error_result_typed ~code:Validation_error msg
+      | Ok (goal, action) ->
+          let action_name =
+            match action with
+            | `created -> "created"
+            | `updated -> "updated"
+          in
+          let task_marker = Printf.sprintf "[goal:%s]" goal.id in
+          ok_result
+            [
+              ("action", `String action_name);
+              ("goal_id", `String goal.id);
+              ("goal", Goal_store.goal_to_yojson goal);
+              ("task_title_marker", `String task_marker);
+              ( "linked_task_title_example",
+                `String
+                  (Printf.sprintf "%s[child] %s" task_marker goal.title) );
+            ]
+
+let handle_goal_review (ctx : context) args =
+  match validate_string_required args "goal_id", parse_optional_review_outcome args "outcome",
+        parse_optional_horizon args "new_horizon" with
+  | Error err, _, _
+  | _, Error err, _
+  | _, _, Error err ->
+      validation_error_result [ err ]
+  | Ok goal_id, Ok (Some outcome), Ok new_horizon ->
+      let note = get_string_opt args "note" in
+      begin
+        match
+          Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon ?note ()
+        with
+        | Error msg ->
+            error_result_typed ~code:Not_found msg
+        | Ok goal ->
+            ok_result
+              [
+                ("goal_id", `String goal.id);
+                ("goal", Goal_store.goal_to_yojson goal);
+              ]
+      end
+  | Ok _, Ok None, _ ->
+      validation_error_result
+        [
+          {
+            field = "outcome";
+            constraint_violated = Required;
+            message = "outcome is required";
+            expected = Some "string";
+            received = None;
+          };
+        ]
+
 let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_status" -> Some (handle_status ctx args)
   | "masc_heartbeat" -> Some (handle_heartbeat ctx args)
+  | "masc_goal_list" -> Some (handle_goal_list ctx args)
+  | "masc_goal_upsert" -> Some (handle_goal_upsert ctx args)
+  | "masc_goal_review" -> Some (handle_goal_review ctx args)
   | "masc_reset" -> Some (handle_reset ctx args)
   | "masc_workflow_guide" -> Some (handle_workflow_guide ctx args)
   | "masc_check" -> Some (handle_check ctx args)
@@ -851,14 +1037,17 @@ let schemas = Tool_schemas_coord.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_status" ]
+let _tool_spec_read_only = [ "masc_status"; "masc_goal_list" ]
 let _tool_spec_system_internal = [ "masc_reset" ]
 
 let _tool_spec_requires_join = [ "masc_heartbeat" ]
 
 let tool_required_permission = function
-  | "masc_status" | "masc_workflow_guide" | "masc_check" ->
+  | "masc_status" | "masc_workflow_guide" | "masc_check"
+  | "masc_goal_list" ->
       Some Types.CanReadState
+  | "masc_goal_upsert" | "masc_goal_review" ->
+      Some Types.CanBroadcast
   | "masc_heartbeat" ->
       Some Types.CanBroadcast
   | "masc_reset" ->

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -194,6 +194,9 @@ module Masc = struct
     | Deliver
     | Dispatch_assign
     | Dispatch_plan
+    | Goal_list
+    | Goal_review
+    | Goal_upsert
     | Find_by_capability
     | Governance_feed
     | Governance_status
@@ -286,6 +289,9 @@ module Masc = struct
     | Deliver -> "masc_deliver"
     | Dispatch_assign -> "masc_dispatch_assign"
     | Dispatch_plan -> "masc_dispatch_plan"
+    | Goal_list -> "masc_goal_list"
+    | Goal_review -> "masc_goal_review"
+    | Goal_upsert -> "masc_goal_upsert"
     | Find_by_capability -> "masc_find_by_capability"
     | Governance_feed -> "masc_governance_feed"
     | Governance_status -> "masc_governance_status"
@@ -378,6 +384,9 @@ module Masc = struct
     | "masc_deliver" -> Some Deliver
     | "masc_dispatch_assign" -> Some Dispatch_assign
     | "masc_dispatch_plan" -> Some Dispatch_plan
+    | "masc_goal_list" -> Some Goal_list
+    | "masc_goal_review" -> Some Goal_review
+    | "masc_goal_upsert" -> Some Goal_upsert
     | "masc_find_by_capability" -> Some Find_by_capability
     | "masc_governance_feed" -> Some Governance_feed
     | "masc_governance_status" -> Some Governance_status

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -102,6 +102,9 @@ module Masc : sig
     | Deliver
     | Dispatch_assign
     | Dispatch_plan
+    | Goal_list
+    | Goal_review
+    | Goal_upsert
     | Find_by_capability
     | Governance_feed
     | Governance_status

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -2,4 +2,108 @@
 
 open Types
 
-let schemas : tool_schema list = []
+let goal_horizon_enum = [ "short"; "mid"; "long" ]
+let goal_status_enum = [ "active"; "paused"; "done"; "dropped" ]
+let goal_review_outcome_enum = [ "done"; "progress"; "blocked"; "dropped" ]
+
+let schemas : tool_schema list =
+  [
+    {
+      name = "masc_goal_list";
+      description =
+        "List shared planning goals from the Goal Store, optionally filtered by horizon or status. \
+Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
+The dashboard Goal Tree reads the same store. Linked tasks appear when task titles include [goal:<id>].";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ( "horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
+                        ("description", `String "Optional horizon filter: short | mid | long");
+                      ] );
+                  ( "status",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List (List.map (fun v -> `String v) goal_status_enum));
+                        ("description", `String "Optional status filter: active | paused | done | dropped");
+                      ] );
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_upsert";
+      description =
+        "Create or update a shared Goal Store entry used by Planning > Goal Tree. \
+For new goals, provide at least title; omitted horizon defaults to short. \
+After creation, link tasks into the tree by including [goal:<id>] in the task title.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("id", `Assoc [ ("type", `String "string") ]);
+                  ( "horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
+                      ] );
+                  ("title", `Assoc [ ("type", `String "string") ]);
+                  ("metric", `Assoc [ ("type", `String "string") ]);
+                  ("target_value", `Assoc [ ("type", `String "string") ]);
+                  ("due_date", `Assoc [ ("type", `String "string") ]);
+                  ("priority", `Assoc [ ("type", `String "integer") ]);
+                  ( "status",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List (List.map (fun v -> `String v) goal_status_enum));
+                      ] );
+                  ("parent_goal_id", `Assoc [ ("type", `String "string") ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_review";
+      description =
+        "Apply a review outcome to an existing shared goal. \
+Use to mark progress, completion, blockage, or drop decisions after evaluating sub-tasks. \
+Optionally move the goal to a new horizon and store a review note.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("goal_id", `Assoc [ ("type", `String "string") ]);
+                  ( "outcome",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            (List.map (fun v -> `String v) goal_review_outcome_enum) );
+                      ] );
+                  ( "new_horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
+                      ] );
+                  ("note", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "goal_id"; `String "outcome" ]);
+          ];
+    };
+  ]

--- a/test/dune
+++ b/test/dune
@@ -451,6 +451,7 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
+        test_goal_tools
         test_goal_store
         test_string_util
         test_board_core_payload
@@ -614,6 +615,7 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
+        test_goal_tools
         test_goal_store
         test_string_util
         test_board_core_payload

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1,0 +1,123 @@
+(** Goal tool coverage — shared Goal Store surface through Tool_coord. *)
+
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let path = Filename.temp_file "goal_tool_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let with_room f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
+    let config = Coord.default_config dir in
+    ignore (Coord.init config ~agent_name:(Some "planner"));
+    f config)
+
+let coord_ctx config : Tool_coord.context =
+  { Tool_coord.config; agent_name = "planner" }
+
+let parse_json_result = function
+  | true, body -> Yojson.Safe.from_string body
+  | false, body -> fail body
+
+let test_goal_upsert_and_list () =
+  with_room @@ fun config ->
+  let created =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_upsert"
+      ~args:
+        (`Assoc
+          [
+            ("title", `String "Ship Goal Surface");
+            ("horizon", `String "mid");
+            ("priority", `Int 2);
+          ])
+  in
+  let created_json =
+    match created with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_upsert not handled"
+  in
+  let goal_id =
+    match Yojson.Safe.Util.member "goal_id" created_json with
+    | `String id when id <> "" -> id
+    | _ -> fail "goal_id missing from upsert response"
+  in
+  let task_marker =
+    match Yojson.Safe.Util.member "task_title_marker" created_json with
+    | `String marker -> marker
+    | _ -> fail "task_title_marker missing from upsert response"
+  in
+  check bool "task marker embeds goal id" true
+    (String.equal task_marker (Printf.sprintf "[goal:%s]" goal_id));
+  let listed =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_list"
+      ~args:(`Assoc [ ("horizon", `String "mid") ])
+  in
+  let listed_json =
+    match listed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_list not handled"
+  in
+  let count =
+    match Yojson.Safe.Util.member "count" listed_json with
+    | `Int n -> n
+    | _ -> fail "count missing from goal list response"
+  in
+  check int "one listed goal" 1 count
+
+let test_goal_review_updates_status () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Review me" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let reviewed =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_review"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("outcome", `String "done");
+            ("note", `String "completed from test");
+          ])
+  in
+  let reviewed_json =
+    match reviewed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_review not handled"
+  in
+  let goal_json = Yojson.Safe.Util.member "goal" reviewed_json in
+  let status =
+    match Yojson.Safe.Util.member "status" goal_json with
+    | `String s -> s
+    | _ -> fail "status missing from goal review response"
+  in
+  check string "status updated to done" "done" status
+
+let () =
+  run "goal_tools"
+    [
+      ( "tool_coord",
+        [
+          test_case "upsert and list" `Quick test_goal_upsert_and_list;
+          test_case "review updates status" `Quick test_goal_review_updates_status;
+        ] );
+    ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -209,6 +209,50 @@ let test_masc_add_task_schema () =
           Alcotest.(check bool) "has contract" true (List.mem_assoc "contract" props)
       | None -> Alcotest.fail "masc_add_task missing properties"
 
+let test_masc_goal_list_schema () =
+  match find_tool "masc_goal_list" with
+  | None -> Alcotest.fail "masc_goal_list not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
+          Alcotest.(check bool) "has status" true (List.mem_assoc "status" props)
+      | None -> Alcotest.fail "masc_goal_list missing properties"
+
+let test_masc_goal_upsert_schema () =
+  match find_tool "masc_goal_upsert" with
+  | None -> Alcotest.fail "masc_goal_upsert not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has id" true (List.mem_assoc "id" props);
+          Alcotest.(check bool) "has title" true (List.mem_assoc "title" props);
+          Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
+          Alcotest.(check bool) "has parent_goal_id" true
+            (List.mem_assoc "parent_goal_id" props)
+      | None -> Alcotest.fail "masc_goal_upsert missing properties"
+
+let test_masc_goal_review_schema () =
+  match find_tool "masc_goal_review" with
+  | None -> Alcotest.fail "masc_goal_review not found"
+  | Some schema ->
+      (match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has goal_id" true
+            (List.mem_assoc "goal_id" props);
+          Alcotest.(check bool) "has outcome" true
+            (List.mem_assoc "outcome" props);
+          Alcotest.(check bool) "has new_horizon" true
+            (List.mem_assoc "new_horizon" props)
+      | None -> Alcotest.fail "masc_goal_review missing properties");
+      match get_json_list "required" schema.input_schema with
+      | Some reqs ->
+          Alcotest.(check bool) "goal_id required" true
+            (List.mem (`String "goal_id") reqs);
+          Alcotest.(check bool) "outcome required" true
+            (List.mem (`String "outcome") reqs)
+      | None -> Alcotest.fail "masc_goal_review missing required field"
+
 let test_remote_operator_action_schema_is_strict () =
   let schema =
     match List.find_opt (fun schema -> schema.name = "masc_operator_action")
@@ -733,6 +777,11 @@ let () =
       Alcotest.test_case "plan_update" `Quick test_masc_plan_update_schema;
       Alcotest.test_case "plan_get" `Quick test_masc_plan_get_schema;
       Alcotest.test_case "deliver" `Quick test_masc_deliver_schema;
+    ];
+    "goal_tools", [
+      Alcotest.test_case "goal_list" `Quick test_masc_goal_list_schema;
+      Alcotest.test_case "goal_upsert" `Quick test_masc_goal_upsert_schema;
+      Alcotest.test_case "goal_review" `Quick test_masc_goal_review_schema;
     ];
     "vote_tools", [
     ];


### PR DESCRIPTION
Superseded after the branch ref was recreated during CI-fix force-push. Reopening as a fresh draft PR from the current `goal-surface-align` head so checks attach to the right SHA.

Current head to use: `31087a80afebdfa257ec3925c6cb04aac774ce7f`.