### PR TITLE
fix(keeper): defensive UTF-8 gate at BeforeTurn hook

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -287,6 +287,20 @@ let make_hooks
          | None -> Agent_sdk.Hooks.Continue
          | Some text when String.trim text = "" ->
            Agent_sdk.Hooks.Continue
+         | Some text when not (String.is_valid_utf_8 text) ->
+           (* Defensive: nudge path producers (e.g. keeper_agent_run's
+              discover_work_nudge) source strings from external input
+              (task titles, operator guidance, board posts). A byte-
+              level truncation upstream can leave an orphan UTF-8
+              continuation byte, and codex CLI rejects the resulting
+              argv with "invalid UTF-8 was detected in one or more
+              arguments" at parse time (non-cascadable). This gate
+              prevents polluted nudges from ever reaching transport
+              argv, regardless of which producer introduced the
+              drift. See #9036 for the first observed producer fix. *)
+           Log.Keeper.warn "keeper:%s before_turn: dropped invalid UTF-8 nudge (%d bytes)"
+             (!meta_ref).name (String.length text);
+           Agent_sdk.Hooks.Continue
          | Some text ->
            Log.Keeper.info "keeper:%s before_turn: injecting work_discovery nudge (%d chars)"
              (!meta_ref).name (String.length text);


### PR DESCRIPTION
## Summary

Defense-in-depth for the UTF-8 argv corruption class fixed at its
first producer in #9036. Adds a hook-level gate so any *future*
producer drift cannot poison codex argv.

## Why a second layer

#9036 fixed one producer (`discover_work_nudge` task title preview
using `String.sub` on a byte boundary). But `BeforeTurn` `Nudge`
accepts arbitrary strings sourced from:

- Task titles (fixed in #9036).
- Operator guidance text (`work_discovery_guidance`) — still only `String.trim`, no UTF-8 check.
- Future producers added via the hook contract.

Any byte-level truncation anywhere upstream can land mid-codepoint
and emit an orphan UTF-8 continuation byte. The codex CLI then
rejects argv at parse time with exit 2 — non-cascadable.

## Change

`keeper_hooks_oas.ml` `BeforeTurn` hook gains one guard arm:

```ocaml
| Some text when not (String.is_valid_utf_8 text) ->
    Log.Keeper.warn "... dropped invalid UTF-8 nudge (%d bytes) ...";
    Agent_sdk.Hooks.Continue
```

Drop rather than sanitize. If a producer emits invalid UTF-8, that
is a bug to fix in the producer. The warn log tells triage which
keeper and how many bytes, so the drift is traceable.

## Observability

New signal to grep for during fleet triage:

```
[Keeper] keeper:<name> before_turn: dropped invalid UTF-8 nudge (N bytes)
```

## Test plan

- [x] `dune build --root . lib/` — passes
- `String.is_valid_utf_8` is OCaml 5.2+ stdlib; project is `>= 5.4`.
- Valid-UTF-8 path unchanged; existing keeper integration tests apply.
- No new unit tests: the guard is a one-line stdlib call with a
  log side effect; testing it would re-test `String.is_valid_utf_8`
  which is already stdlib-tested.

## Relation to #9036

- **#9036**: fixed the specific producer that leaked drift (title
  truncation → `utf8_safe`).
- **This PR**: adds the generic gate so the *class* of bug is
  contained even if a new producer introduces the same mistake.

Both layers are independently valuable. This PR does not depend on
#9036 at runtime — applying either alone fixes the observed symptom;
applying both prevents recurrence via a different path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
