### PR TITLE
refactor(bootstrap): env-configurable rate-limit bucket TTL

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -624,6 +624,13 @@ module InternalTimers = struct
       is sized for the steady-state connection count. *)
   let janitor_interval_sec =
     get_float ~default:60.0 "MASC_JANITOR_INTERVAL_SEC"
+
+  (** Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for
+      this long are reaped by the janitor loop. Default: 300 (5 min). Raise
+      for longer client quiet periods; lower to free memory faster under
+      churn. [Rate_limit.cleanup] takes an int, so this is int-typed. *)
+  let rate_limit_bucket_ttl_sec =
+    get_int ~default:300 "MASC_RATE_LIMIT_BUCKET_TTL_SEC"
 end
 
 (** {1 Sidecar reconcile loop}

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -535,9 +535,14 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
             if webrtc_expired > 0 then
               Log.Server.info "WebRTC: cleaned %d expired offers" webrtc_expired
           end;
-          (* Rate-limit buckets: evict keys unused for 5 minutes *)
+          (* Rate-limit buckets: evict keys unused for
+             [MASC_RATE_LIMIT_BUCKET_TTL_SEC] (default 5 minutes) *)
           let rl = Eio.Lazy.force Rate_limit.global in
-          let rl_reaped = Rate_limit.cleanup rl ~older_than_seconds:300 in
+          let rl_reaped =
+            Rate_limit.cleanup rl
+              ~older_than_seconds:
+                Env_config_runtime.InternalTimers.rate_limit_bucket_ttl_sec
+          in
           if rl_reaped > 0 then
             Log.Server.info "Reaped %d stale rate-limit buckets" rl_reaped;
           (* Agent registry: remove resolved-name cache for dead sessions *)


### PR DESCRIPTION
## Summary
Extract the hardcoded 300-second \`older_than_seconds:300\` on \`Rate_limit.cleanup\` into \`Env_config_runtime.InternalTimers.rate_limit_bucket_ttl_sec\` (env \`MASC_RATE_LIMIT_BUCKET_TTL_SEC\`, default 300). Same janitor loop as the sibling \`janitor_interval_sec\` from #9046.

## Product impact
- **ops visibility** — clients with long quiet gaps (keepers polling every 10 min, scheduled jobs) currently lose their rate-limit bucket every 5 minutes and pay the re-warm cost. Operators under bucket-churn memory pressure want the opposite trade. The previous literal forced a rebuild for either direction.

## Evidence
- \`dune build --root . @check\` clean
- Diff stat: +14/-2 across 2 files (env config + call site)
- New knob sits next to \`janitor_interval_sec\` and the other sibling timers
- Int-typed because \`Rate_limit.cleanup ~older_than_seconds\` takes \`int\`
- No behaviour change at the default

## Review evidence
Self-review only. This is the adjacent literal to #9046 in the same loop, applying the same \`Env_config_runtime.InternalTimers\` pattern.

## Linked issue
None — incremental hardcoded-literal removal. Follows #8978 (MASC_SIDECAR_RECONCILE_BACKOFF_SEC) and #9046 (MASC_JANITOR_INTERVAL_SEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)