### PR TITLE
fix(plan): sync structured deliverable on full-context updates

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -76,6 +76,64 @@ let write_file_content path content =
   ensure_dir (Filename.dirname path);
   Fs_compat.save_file path content
 
+let find_substring_from haystack ~needle ~from =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > haystack_len then None
+    else if String.sub haystack i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop from
+
+let normalize_placeholder value =
+  match String.trim value with
+  | "_No plan yet_" | "_No deliverable yet_" -> ""
+  | other -> other
+
+let extract_markdown_section content ~heading ~next_headings =
+  match find_substring_from content ~needle:heading ~from:0 with
+  | None -> None
+  | Some heading_idx ->
+      let body_start = heading_idx + String.length heading in
+      let body_end =
+        next_headings
+        |> List.filter_map (fun marker ->
+               find_substring_from content ~needle:marker ~from:body_start)
+        |> List.sort compare
+        |> function
+        | first :: _ -> first
+        | [] -> String.length content
+      in
+      let body =
+        String.sub content body_start (body_end - body_start)
+        |> String.trim
+        |> normalize_placeholder
+      in
+      Some body
+
+type parsed_full_context = {
+  task_plan: string;
+  deliverable: string option;
+}
+
+let parse_full_context_markdown content =
+  let task_heading = "## Task Plan (PDCA: Plan)" in
+  let notes_heading = "## Notes & Observations (PDCA: Do)" in
+  let errors_heading = "## Errors & Failures (PDCA: Check)" in
+  let deliverable_heading = "## Deliverable (PDCA: Act)" in
+  match
+    extract_markdown_section content ~heading:task_heading
+      ~next_headings:[ notes_heading; errors_heading; deliverable_heading ]
+  with
+  | None -> None
+  | Some task_plan ->
+      let deliverable =
+        extract_markdown_section content ~heading:deliverable_heading
+          ~next_headings:[ "\n---"; "\r\n---" ]
+      in
+      Some { task_plan; deliverable }
+
 (* ===== Core Operations (Pure Sync) ===== *)
 
 (** Initialize planning context for a task *)
@@ -120,8 +178,23 @@ let update_plan (config : Coord.config) ~task_id ~content : (planning_context, s
     match load config ~task_id with
     | Error e -> Error e
     | Ok ctx ->
-        let updated = { ctx with task_plan = content; updated_at = now_iso () } in
-        write_file_content (Filename.concat dir "task_plan.md") content;
+        let parsed = parse_full_context_markdown content in
+        let task_plan =
+          match parsed with
+          | Some p -> p.task_plan
+          | None -> content
+        in
+        let deliverable =
+          match parsed with
+          | Some { deliverable = Some value; _ } -> value
+          | _ -> ctx.deliverable
+        in
+        let updated = { ctx with task_plan; deliverable; updated_at = now_iso () } in
+        write_file_content (Filename.concat dir "task_plan.md") task_plan;
+        (match parsed with
+         | Some { deliverable = Some value; _ } ->
+             write_file_content (Filename.concat dir "deliverable.md") value
+         | _ -> ());
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
         Ok updated

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -146,6 +146,87 @@ let test_update_plan () =
   | Error e ->
       fail (Printf.sprintf "Update plan failed: %s" e)
 
+let test_update_plan_full_context_syncs_deliverable () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = make_config () in
+  (match Planning_eio.init config ~task_id:"update-plan-full-context" with
+   | Ok _ -> ()
+   | Error e -> fail (Printf.sprintf "Init failed: %s" e));
+  let stale_deliverable = "Task-163 completed. Stale deliverable." in
+  (match
+     Planning_eio.set_deliverable config ~task_id:"update-plan-full-context"
+       ~content:stale_deliverable
+   with
+   | Ok _ -> ()
+   | Error e -> fail (Printf.sprintf "Set deliverable failed: %s" e));
+  let full_context =
+    {|# Planning Context: update-plan-full-context
+
+## Task Plan (PDCA: Plan)
+- Fix owned/current drift in the MASC task control plane.
+
+## Notes & Observations (PDCA: Do)
+_No notes yet_
+
+## Errors & Failures (PDCA: Check)
+### Unresolved (0)
+_No unresolved errors_
+
+### Resolved (0)
+_No resolved errors_
+
+## Deliverable (PDCA: Act)
+In progress. Do not treat task-163 as completed.
+
+---
+*Created: 2026-04-20T00:00:00Z | Updated: 2026-04-20T00:00:01Z*
+|}
+  in
+  match
+    Planning_eio.update_plan config ~task_id:"update-plan-full-context"
+      ~content:full_context
+  with
+  | Error e -> fail (Printf.sprintf "Full context update failed: %s" e)
+  | Ok ctx ->
+      check string "task_plan extracted"
+        "- Fix owned/current drift in the MASC task control plane."
+        ctx.task_plan;
+      check string "deliverable synced"
+        "In progress. Do not treat task-163 as completed."
+        ctx.deliverable;
+      let deliverable_path =
+        Filename.concat !temp_dir
+          "planning/update-plan-full-context/deliverable.md"
+      in
+      let deliverable_file =
+        let ic = open_in deliverable_path in
+        Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+          really_input_string ic (in_channel_length ic))
+      in
+      check string "deliverable file synced"
+        "In progress. Do not treat task-163 as completed."
+        deliverable_file;
+      (match
+         Planning_eio.load config ~task_id:"update-plan-full-context"
+       with
+       | Error e -> fail (Printf.sprintf "Load after full context update failed: %s" e)
+       | Ok loaded ->
+           check string "loaded deliverable synced"
+             "In progress. Do not treat task-163 as completed."
+             loaded.deliverable;
+           let markdown = Planning_eio.get_context_markdown loaded in
+           let contains substr =
+             try
+               ignore (Str.search_forward (Str.regexp_string substr) markdown 0);
+               true
+             with Not_found -> false
+           in
+           check bool "markdown contains new deliverable" true
+             (contains "In progress. Do not treat task-163 as completed.");
+           check bool "markdown excludes stale deliverable" false
+             (contains stale_deliverable))
+
 let test_add_note () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -332,6 +413,8 @@ let () =
       test_case "load" `Quick test_load;
       test_case "load_nonexistent" `Quick test_load_nonexistent;
       test_case "update_plan" `Quick test_update_plan;
+      test_case "update_plan_full_context_syncs_deliverable" `Quick
+        test_update_plan_full_context_syncs_deliverable;
       test_case "add_note" `Quick test_add_note;
       test_case "set_deliverable" `Quick test_set_deliverable;
       test_case "set_deliverable_auto_init" `Quick test_set_deliverable_auto_init;


### PR DESCRIPTION
## Summary

Sync `planning_context.deliverable` when `masc_plan_update` receives a full planning-context markdown document.

## Why

`task-163` proved that owner-side `masc_plan_update` could succeed while `masc_plan_get` still returned a stale structured `deliverable` field (`Task-163 completed...`). The markdown view showed the new text, but the typed context stayed stale and kept the control-plane conflict alive.

## Changes

- detect full planning-context markdown in `Planning_eio.update_plan`
- extract the `Task Plan` and `Deliverable` sections instead of storing the whole document in `task_plan`
- sync `deliverable.md` and `context.json` when that full-context update path is used
- add a regression proving the stale deliverable is replaced and no longer appears in `masc_plan_get` markdown/context

## Scope

This is **not** a lifecycle reconciliation fix. It only removes the stale structured deliverable after a successful owner-side plan update.

## Verification

- `opam exec -- dune build --root "$PWD" test/test_planning_eio.exe test/test_tool_plan_coverage.exe`
- `opam exec -- _build/default/test/test_planning_eio.exe --color=never`
- `opam exec -- _build/default/test/test_tool_plan_coverage.exe --color=never`
- `git diff --check`

## Related

- Refs #8982
- Refs #9022
