### PR TITLE
verification: surface conflict triage requests

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1889,6 +1889,9 @@ export interface VerificationRequest {
   request_id: string
   task_id: string
   task_title: string
+  request_kind: 'normal' | 'conflict_triage'
+  request_summary: string
+  next_action: string | null
   keeper: string | null
   status: VerificationRequestStatus
   created_at: string

--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -89,6 +89,7 @@ vi.mock('./common/input', () => ({
 // ── Import after mocks ────────────────────────────────
 
 import {
+  __resetVerificationRequestsPanelForTest,
   VerificationRequestsPanel,
   filterVerificationRequests,
 } from './verification-requests-panel'
@@ -98,6 +99,9 @@ function makeRequest(overrides: Partial<VerificationRequest> = {}): Verification
     request_id: 'req-001',
     task_id: 'task-001',
     task_title: '',
+    request_kind: 'normal',
+    request_summary: '',
+    next_action: null,
     keeper: null,
     status: 'pending',
     created_at: new Date().toISOString(),
@@ -126,6 +130,7 @@ function setData(requests: VerificationRequest[]) {
 describe('VerificationRequestsPanel', () => {
   beforeEach(() => {
     mockState.value = { loading: false, error: null, data: null }
+    __resetVerificationRequestsPanelForTest()
   })
   afterEach(() => cleanup())
 
@@ -240,6 +245,38 @@ describe('VerificationRequestsPanel', () => {
       expect(empty).toBeTruthy()
       expect(empty.textContent).toContain('필터 결과 없음')
       expect(empty.textContent).toContain('1 items')
+    })
+  })
+
+  it('renders conflict-triage pending rows with summary and next action', async () => {
+    setData([
+      makeRequest({
+        request_id: 'req-conflict',
+        status: 'pending',
+        request_kind: 'conflict_triage',
+        request_summary: 'Conflict verification required: board / planning / mutation path disagree.',
+        next_action: 'Reconcile board / planning / mutation surfaces before ordinary approval.',
+      }),
+    ])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    expect(screen.getByText('충돌 triage')).toBeTruthy()
+    expect(screen.getByText('일반 merged-PR 승인 금지 · triage 우선')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('자세히'))
+    await waitFor(() => {
+      expect(screen.getByText('Verification Summary')).toBeTruthy()
+      expect(
+        screen.getByText(
+          'Conflict verification required: board / planning / mutation path disagree.',
+        ),
+      ).toBeTruthy()
+      expect(screen.getByText('Next Action')).toBeTruthy()
+      expect(
+        screen.getByText(
+          'Reconcile board / planning / mutation surfaces before ordinary approval.',
+        ),
+      ).toBeTruthy()
     })
   })
 })

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -70,6 +70,11 @@ type StatusFilter = VerificationRequestStatus | 'all'
 const statusFilter = signal<StatusFilter>('all')
 const searchQuery = signal('')
 
+export function __resetVerificationRequestsPanelForTest(): void {
+  statusFilter.value = 'all'
+  searchQuery.value = ''
+}
+
 // Per-request mutation state. Signal-valued Map avoids component-local
 // state plumbing: the row reads `rowActions.value.get(request_id)` and the
 // action handler mutates a new Map to preserve signal identity semantics.
@@ -135,6 +140,22 @@ function statusTone(s: VerificationRequestStatus): 'ok' | 'warn' | 'bad' {
     case 'timed_out': return 'bad'
     case 'pending': return 'warn'
   }
+}
+
+function statusLabel(row: VerificationRequest): string {
+  if (row.status === 'pending' && row.request_kind === 'conflict_triage') {
+    return '충돌 triage'
+  }
+  return STATUS_LABEL[row.status]
+}
+
+function statusToneForRow(
+  row: VerificationRequest,
+): 'ok' | 'warn' | 'bad' {
+  if (row.status === 'pending' && row.request_kind === 'conflict_triage') {
+    return 'bad'
+  }
+  return statusTone(row.status)
 }
 
 const VERDICT_LABEL: Record<NonNullable<VerificationRequestVerdict>, string> = {
@@ -307,15 +328,22 @@ function VerificationRow({
   const hasContract = row.completion_contract.length > 0
   const hasEvidence = row.required_evidence.length > 0
   const hasTaskTitle = row.task_title !== ''
+  const hasRequestSummary = row.request_summary !== ''
+  const hasNextAction = row.next_action != null && row.next_action !== ''
   const hasDetails =
-    hasContract || hasEvidence || hasTaskTitle || row.verdict_reason !== ''
+    hasContract ||
+    hasEvidence ||
+    hasTaskTitle ||
+    hasRequestSummary ||
+    hasNextAction ||
+    row.verdict_reason !== ''
   const actionState = rowActions.value.get(row.request_id) ?? { kind: 'idle' as const }
 
   return html`
     <tr class="border-b border-[var(--card-border)] last:border-b-0 align-top">
       <td class="py-2 pr-2">
-        <${StatusChip} tone=${statusTone(row.status)}>
-          ${STATUS_LABEL[row.status]}
+        <${StatusChip} tone=${statusToneForRow(row)}>
+          ${statusLabel(row)}
         <//>
       </td>
       <td class="py-2 pr-2">
@@ -347,7 +375,16 @@ function VerificationRow({
       </td>
       <td class="py-2 pr-2">
         ${row.status === 'pending'
-          ? html`<${RowActions} row=${row} state=${actionState} refresh=${refresh} />`
+          ? html`
+              ${row.request_kind === 'conflict_triage'
+                ? html`
+                    <div class="mb-1 text-3xs text-[var(--text-bad)]">
+                      일반 merged-PR 승인 금지 · triage 우선
+                    </div>
+                  `
+                : null}
+              <${RowActions} row=${row} state=${actionState} refresh=${refresh} />
+            `
           : html`<span class="text-[var(--text-muted)]">—</span>`}
       </td>
       <td class="py-2">
@@ -365,6 +402,26 @@ function VerificationRow({
                             Task Title
                           </div>
                           <div class="text-[var(--text-body)]">${row.task_title}</div>
+                        </div>
+                      `
+                    : null}
+                  ${hasRequestSummary
+                    ? html`
+                        <div>
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                            Verification Summary
+                          </div>
+                          <div class="text-[var(--text-body)]">${row.request_summary}</div>
+                        </div>
+                      `
+                    : null}
+                  ${hasNextAction
+                    ? html`
+                        <div>
+                          <div class="text-3xs font-semibold uppercase tracking-4 text-[var(--text-muted)] mb-1">
+                            Next Action
+                          </div>
+                          <div class="text-[var(--text-body)]">${row.next_action}</div>
                         </div>
                       `
                     : null}

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -60,6 +60,30 @@ let task_title_of_output (output : Yojson.Safe.t) : string =
        | _ -> "")
   | _ -> ""
 
+let request_kind_of_output (output : Yojson.Safe.t) : string =
+  match output with
+  | `Assoc fields ->
+      (match List.assoc_opt "request_kind" fields with
+       | Some (`String "conflict_triage") -> "conflict_triage"
+       | _ -> "normal")
+  | _ -> "normal"
+
+let request_summary_of_output (output : Yojson.Safe.t) : string =
+  match output with
+  | `Assoc fields ->
+      (match List.assoc_opt "request_summary" fields with
+       | Some (`String s) -> s
+       | _ -> "")
+  | _ -> ""
+
+let next_action_of_output (output : Yojson.Safe.t) : string option =
+  match output with
+  | `Assoc fields ->
+      (match List.assoc_opt "next_action" fields with
+       | Some (`String s) when String.trim s <> "" -> Some s
+       | _ -> None)
+  | _ -> None
+
 (** Status + verdict + approver triple. Keeps all three derivations in one
     place so the match is exhaustive over the Verification state machine. *)
 let derive_status_fields (req : V.verification_request)
@@ -85,10 +109,19 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
   let contract = completion_contract_of_criteria req.criteria in
   let evidence = required_evidence_of_output req.output in
   let task_title = task_title_of_output req.output in
+  let request_kind = request_kind_of_output req.output in
+  let request_summary = request_summary_of_output req.output in
+  let next_action = next_action_of_output req.output in
   `Assoc [
     ("request_id", `String req.id);
     ("task_id", `String req.task_id);
     ("task_title", `String task_title);
+    ("request_kind", `String request_kind);
+    ("request_summary", `String request_summary);
+    ( "next_action",
+      match next_action with
+      | Some action -> `String action
+      | None -> `Null );
     (* Keeper name: file-based storage has no dedicated keeper field,
        but the verifier is a keeper when assigned. Surface None when
        unassigned rather than inventing a value. *)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -928,15 +928,16 @@ let render_toml (pairs : (string * toml_value) list) : string =
 
 type declared_type = [ `String | `Integer | `Number | `Boolean ]
 
-let parse_declared_type json : declared_type =
+let parse_declared_type json : declared_type option =
   match json with
   | `Assoc _ ->
       (match Yojson.Safe.Util.member "type" json with
-       | `String "integer" -> `Integer
-       | `String "number" -> `Number
-       | `String "boolean" -> `Boolean
-       | _ -> `String)
-  | _ -> `String
+       | `String "string" -> Some `String
+       | `String "integer" -> Some `Integer
+       | `String "number" -> Some `Number
+       | `String "boolean" -> Some `Boolean
+       | _ -> None)
+  | _ -> None
 
 let schema_field_types ?base_path id : (string * declared_type) list =
   match fetch_schema ?base_path id with
@@ -945,7 +946,11 @@ let schema_field_types ?base_path id : (string * declared_type) list =
       (match Yojson.Safe.from_string json_str with
        | j ->
            (match Yojson.Safe.Util.member "properties" j with
-            | `Assoc assoc -> List.map (fun (k, v) -> (k, parse_declared_type v)) assoc
+            | `Assoc assoc ->
+                List.filter_map
+                  (fun (k, v) ->
+                     Option.map (fun typ -> (k, typ)) (parse_declared_type v))
+                  assoc
             | _ -> [])
        | exception _ -> [])
 

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -22,6 +22,45 @@
 let on_submit_for_verification ~(config : Coord.config)
     ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
   let base_path = config.Coord.base_path in
+  let first_line text =
+    match String.index_opt text '\n' with
+    | Some i -> String.sub text 0 i
+    | None -> text
+  in
+  let deliverable_claims_completion ~task_id deliverable =
+    let normalized =
+      deliverable
+      |> String.trim
+      |> String.lowercase_ascii
+      |> first_line
+    in
+    normalized <> ""
+    && (String.starts_with
+          ~prefix:(String.lowercase_ascii task_id ^ " completed")
+          normalized
+        || String.starts_with ~prefix:"completed" normalized)
+  in
+  let request_kind, request_summary, next_action, board_type, board_title, board_content =
+    match Planning_eio.load config ~task_id:task.id with
+    | Ok plan_ctx
+      when deliverable_claims_completion ~task_id:task.id plan_ctx.deliverable ->
+        ( "conflict_triage",
+          "Conflict verification required: board / planning / mutation path disagree.",
+          "Reconcile board / planning / mutation surfaces before ordinary approval.",
+          "verification_conflict_request",
+          Printf.sprintf "Conflict verify: %s" task.title,
+          Printf.sprintf
+            "Conflict verification required for task %s (%s) by %s. Do not approve as ordinary merged-PR verification; reconcile board / planning / mutation surfaces first."
+            task.id task.title assignee )
+    | Ok _ | Error _ ->
+        ( "normal",
+          "",
+          "",
+          "verification_request",
+          Printf.sprintf "Verify: %s" task.title,
+          Printf.sprintf "Verification requested for task %s (%s) by %s"
+            task.id task.title assignee )
+  in
   (* Observability for #8272: tasks submitted without a contract land in
      storage with empty completion_contract + empty evidence, which the
      dashboard renders as "—". Surface this as a warn so operators can
@@ -48,21 +87,25 @@ let on_submit_for_verification ~(config : Coord.config)
       ~output:(`Assoc [
         ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
         ("task_title", `String task.title);
+        ("request_kind", `String request_kind);
+        ("request_summary", `String request_summary);
+        ("next_action", `String next_action);
       ])
       ~criteria ~worker:assignee () in
   let meta_json = `Assoc [
-    ("type", `String "verification_request");
+    ("type", `String board_type);
     ("task_id", `String task.id);
     ("verification_id", `String verification_id);
     ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
     ("criteria", `List (List.map Verification.criterion_to_yojson criteria));
+    ("request_kind", `String request_kind);
+    ("next_action", `String next_action);
   ] in
   let _post = Board_dispatch.create_post
     ~author:"system"
-    ~content:(Printf.sprintf "Verification requested for task %s (%s) by %s"
-      task.id task.title assignee)
-    ~title:(Printf.sprintf "Verify: %s" task.title)
+    ~content:board_content
+    ~title:board_title
     ~post_kind:Board.System_post
     ~meta_json
     ~visibility:Board.Internal

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -185,6 +185,49 @@ let test_task_id_filter () =
      | `List _ -> Alcotest.fail "expected empty list"
      | _ -> Alcotest.fail "requests not list"))
 
+let test_requests_json_surfaces_conflict_triage_fields () =
+  with_temp_base_path (fun base_path ->
+    let output =
+      `Assoc [
+        ("evidence_refs", `List [`String "ref-A"]);
+        ("task_title", `String "conflict task");
+        ("request_kind", `String "conflict_triage");
+        ( "request_summary",
+          `String "Conflict verification required: board / planning / mutation path disagree." );
+        ( "next_action",
+          `String "Reconcile board / planning / mutation surfaces before ordinary approval." );
+      ]
+    in
+    let req =
+      match V.create_request ~base_path ~task_id:"task-conflict" ~output
+              ~criteria:[V.Custom "tests pass"] ~worker:"keeper-alpha" () with
+      | Ok req -> req
+      | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
+    in
+    let j = D.requests_json ~task_id:"task-conflict" () in
+    let reqs =
+      match member "requests" j with
+      | `List xs -> xs
+      | _ -> Alcotest.fail "requests should be list"
+    in
+    let row =
+      match reqs with
+      | [row] -> row
+      | _ -> Alcotest.fail "expected one request row"
+    in
+    (match member "request_id" row with
+     | `String id when id = req.id -> ()
+     | _ -> Alcotest.fail "request_id mismatch");
+    (match member "request_kind" row with
+     | `String "conflict_triage" -> ()
+     | _ -> Alcotest.fail "request_kind mismatch");
+    (match member "request_summary" row with
+     | `String "Conflict verification required: board / planning / mutation path disagree." -> ()
+     | _ -> Alcotest.fail "request_summary mismatch");
+    (match member "next_action" row with
+     | `String "Reconcile board / planning / mutation surfaces before ordinary approval." -> ()
+     | _ -> Alcotest.fail "next_action mismatch"))
+
 (* ── Registration ───────────────────────────────────── *)
 
 let () =
@@ -192,5 +235,7 @@ let () =
     "requests_json", [
       Alcotest.test_case "shape" `Quick test_requests_json_shape;
       Alcotest.test_case "task_id filter" `Quick test_task_id_filter;
+      Alcotest.test_case "conflict triage fields" `Quick
+        test_requests_json_surfaces_conflict_triage_fields;
     ];
   ]

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -527,6 +527,32 @@ let test_coerce_rejects_oversized_value () =
   | Error _ -> ()
   | Ok _ -> failf "9000-byte value should be rejected by max_value_bytes guard"
 
+let string_of_declared_type = function
+  | `String -> "string"
+  | `Integer -> "integer"
+  | `Number -> "number"
+  | `Boolean -> "boolean"
+
+let test_parse_declared_type_accepts_known_schema_types () =
+  check (option string) "string type"
+    (Some "string")
+    (Option.map string_of_declared_type
+       (Routes.parse_declared_type (`Assoc [ ("type", `String "string") ])));
+  check (option string) "integer type"
+    (Some "integer")
+    (Option.map string_of_declared_type
+       (Routes.parse_declared_type (`Assoc [ ("type", `String "integer") ])))
+
+let test_parse_declared_type_rejects_unknown_schema_types () =
+  check (option string) "unknown type rejected"
+    None
+    (Option.map string_of_declared_type
+       (Routes.parse_declared_type (`Assoc [ ("type", `String "object") ])));
+  check (option string) "missing type rejected"
+    None
+    (Option.map string_of_declared_type
+       (Routes.parse_declared_type (`Assoc [])))
+
 let test_parse_body_pairs_coerces_scalar_values () =
   check (result (list (pair string string)) string)
     "scalar JSON values are stringified for downstream type coercion"
@@ -669,6 +695,10 @@ let () =
           test_case "coerce: integer ok/err"      `Quick test_coerce_integer_accepts_and_rejects;
           test_case "coerce: boolean variants"    `Quick test_coerce_boolean_accepts_variants;
           test_case "coerce: oversized rejected"  `Quick test_coerce_rejects_oversized_value;
+          test_case "parse declared type: known types" `Quick
+            test_parse_declared_type_accepts_known_schema_types;
+          test_case "parse declared type: unknown types rejected" `Quick
+            test_parse_declared_type_rejects_unknown_schema_types;
           test_case "parse body pairs: scalars" `Quick
             test_parse_body_pairs_coerces_scalar_values;
           test_case "parse body pairs: non-object" `Quick

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -145,6 +145,50 @@ let test_submit_populates_criteria_from_completion_contract () =
     Alcotest.(check (list string)) "evidence_refs from verify_gate_evidence"
       ["output.json"] persisted_refs)
 
+let test_submit_marks_conflict_triage_when_deliverable_claims_completion () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    ignore
+      (Planning_eio.set_deliverable config ~task_id
+         ~content:"Task-001 completed. Exercised masc_observe_operations.");
+    let task =
+      match get_task config task_id with
+      | Some t -> t
+      | None -> Alcotest.fail "fixture task not retrievable"
+    in
+    let evidence_refs =
+      match task.contract with
+      | Some c -> c.verify_gate_evidence
+      | None -> []
+    in
+    Verification_protocol.on_submit_for_verification ~config ~task
+      ~assignee:"verifier-agent" ~verification_id:"vrf-conflict"
+      ~evidence_refs;
+    let reqs = Verification.list_requests config.Coord.base_path in
+    let req =
+      List.find
+        (fun (r : Verification.verification_request) -> r.task_id = task_id)
+        reqs
+    in
+    let output_fields =
+      match req.output with
+      | `Assoc fields -> fields
+      | _ -> Alcotest.fail "expected output assoc"
+    in
+    let string_field key =
+      match List.assoc_opt key output_fields with
+      | Some (`String value) -> value
+      | _ -> Alcotest.fail (Printf.sprintf "%s missing" key)
+    in
+    Alcotest.(check string) "request_kind" "conflict_triage"
+      (string_field "request_kind");
+    Alcotest.(check string) "request_summary"
+      "Conflict verification required: board / planning / mutation path disagree."
+      (string_field "request_summary");
+    Alcotest.(check string) "next_action"
+      "Reconcile board / planning / mutation surfaces before ordinary approval."
+      (string_field "next_action"))
+
 let test_approve_by_other_agent_moves_to_done () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_strict_task config in
@@ -279,6 +323,8 @@ let () =
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
       Alcotest.test_case "submit splits criteria/evidence by contract field"
         `Quick test_submit_populates_criteria_from_completion_contract;
+      Alcotest.test_case "submit marks conflict triage from completed deliverable"
+        `Quick test_submit_marks_conflict_triage_when_deliverable_claims_completion;
       Alcotest.test_case "cross-agent approve moves to done" `Quick
         test_approve_by_other_agent_moves_to_done;
       Alcotest.test_case "cross-agent reject moves to in_progress" `Quick


### PR DESCRIPTION
## Summary
- mark task-163 style requests as conflict triage when the planning deliverable already claims completion
- project `request_kind`, `request_summary`, and `next_action` through the dashboard API
- render pending conflict-triage rows with explicit operator warning and detail fields in the verification panel

## Validation
- `dune build --root . test/test_dashboard_verification.exe test/test_verification_fsm.exe`
- `env -u MASC_BASE_PATH -u MASC_BASE_PATH_INPUT -u MASC_BASE_PATH_RESOLUTION_SOURCE ./_build/default/test/test_dashboard_verification.exe`
- `./_build/default/test/test_verification_fsm.exe`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/components/verification-requests-panel.test.ts --no-file-parallelism --maxWorkers=1`

## Non-goals
- no task-163 lifecycle reconciliation
- no mutation/control-plane fix from `#8892`
