### PR TITLE
docs(specs): note stale module refs in KeeperRecoveryOrchestration

### DIFF
--- a/specs/boundary/KeeperRecoveryOrchestration.tla
+++ b/specs/boundary/KeeperRecoveryOrchestration.tla
@@ -7,20 +7,35 @@
 \*
 \* Cross-domain boundary spec: State (data layer) x FSM (condition layer).
 \*
-\* Models the maybe_recover_from_failing multi-event sequence in
-\* keeper_keepalive.ml:774-836. This function clears the filesystem
-\* reconcile record AND dispatches FSM events. Bug #1 (PR #6834) was
+\* Models the maybe_recover_from_failing multi-event sequence that USED
+\* to live around keeper_keepalive.ml:774-836. The runtime fix described
+\* below has since been generalized: the entire manual_reconcile mechanism
+\* (data record + FSM condition + Manual_reconcile_cleared event) was
+\* removed from both the canonical FSM and the OCaml impl (see #8987,
+\* sibling note in KeeperReconcileLiveness.tla). Bug #1 (PR #6834) was
 \* caused by clearing the data record without dispatching
 \* Manual_reconcile_cleared to the FSM, leaving the keeper stuck in
 \* Failing indefinitely.
 \*
+\* STALE REFERENCE NOTE (verified 2026-04-20):
+\*   - lib/keeper/keeper_manual_reconcile.ml was REMOVED entirely (no
+\*     such file in the tree). Searches for `manual_reconcile` in
+\*     lib/keeper/ return only one comment in keeper_keepalive.ml:398.
+\*   - keeper_keepalive.ml lines 774-836 today contain
+\*     Keeper_measurement.capture and unrelated turn-result wiring,
+\*     not the old maybe_recover_from_failing body.
+\* The spec is retained as a forensic record of the design lesson:
+\* recovery actions must clear ALL latches that block their target state.
+\*
 \* The spec captures the two-store consistency requirement: the data
 \* layer (filesystem JSON) and the FSM condition layer (in-memory
-\* conditions.manual_reconcile_required) must stay synchronized.
+\* conditions.manual_reconcile_required) had to stay synchronized.
 \*
-\* Domain boundary: lib/keeper/keeper_manual_reconcile.ml (data) x
-\*                  lib/keeper/keeper_state_machine.ml (FSM conditions)
-\* Orchestrator:    lib/keeper/keeper_keepalive.ml (recovery sequence)
+\* Domain boundary (HISTORICAL):
+\*   lib/keeper/keeper_manual_reconcile.ml (data — REMOVED) x
+\*   lib/keeper/keeper_state_machine.ml (FSM conditions — manual_reconcile_required REMOVED)
+\* Orchestrator (HISTORICAL):
+\*   lib/keeper/keeper_keepalive.ml (recovery sequence — replaced by KeeperContinueGate)
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary

\`specs/boundary/KeeperRecoveryOrchestration.tla\` already carries a HISTORICAL AUDIT MODEL banner pointing readers at \`KeeperContinueGate.tla\`, but the rest of the preamble still references two anchors that have been removed:

- \`lib/keeper/keeper_manual_reconcile.ml\` — file does not exist (\`find lib -name '*manual_reconcile*'\` → 0 hits except a single comment in \`keeper_keepalive.ml:398\`).
- \`keeper_keepalive.ml:774-836\` — that range now contains \`Keeper_measurement.capture\` and turn-result wiring, not \`maybe_recover_from_failing\`.

This PR adds an inline \`STALE REFERENCE NOTE\` block so a reader who follows the file/line refs is redirected without going hunting. Doc-only; no TLC behaviour change.

## Verification
\`\`\`
$ test -f lib/keeper/keeper_manual_reconcile.ml; echo \$?
1
$ grep -n "manual_reconcile" lib/keeper/keeper_keepalive.ml | head -2
398:(* Skip log throttle removed with manual_reconcile blocker — no more
$ sed -n '774,776p' lib/keeper/keeper_keepalive.ml
       (Printf.sprintf "msnap-%s-%Ld"
          meta_current.name
          (Int64.of_float (now_ts *. 1000.0)))
\`\`\`

## Sweep context
Part of a TLA+ ↔ OCaml mapping drift sweep. This is the second \`HISTORICAL\` boundary spec to get a stale-ref clarification (companion: \`KeeperReconcileLiveness.tla\` already disclosed the same removal in #8987). New finding from the same sweep: Issue #9056 (TaskLifecycle missing \`Claimed\` variant — a real coverage hole, not a doc fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)