### PR TITLE
[codex] Fix goal tool lint follow-up

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -850,16 +850,10 @@ let make_enum_field_error ~field ~allowed ~received =
     received = Some received;
   }
 
-let make_type_field_error ~field ~expected ~received =
+let make_type_field_error ~field ~constraint_violated ~expected ~received =
   {
     field;
-    constraint_violated =
-      (match expected with
-       | "string" -> Type_string
-       | "integer" -> Type_int
-       | "number" -> Type_float
-       | "boolean" -> Type_bool
-       | _ -> Required);
+    constraint_violated;
     message = Printf.sprintf "%s must be a %s" field expected;
     expected = Some expected;
     received = Some received;
@@ -877,7 +871,8 @@ let parse_optional_horizon args field =
                ~received:raw))
   | json ->
       Error
-        (make_type_field_error ~field ~expected:"string"
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
 let parse_optional_goal_status args field =
@@ -892,7 +887,8 @@ let parse_optional_goal_status args field =
                ~received:raw))
   | json ->
       Error
-        (make_type_field_error ~field ~expected:"string"
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
 let parse_optional_review_outcome args field =
@@ -907,7 +903,8 @@ let parse_optional_review_outcome args field =
                ~received:raw))
   | json ->
       Error
-        (make_type_field_error ~field ~expected:"string"
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
 let parse_optional_priority args field =
@@ -926,7 +923,8 @@ let parse_optional_priority args field =
       else Ok (Some n)
   | json ->
       Error
-        (make_type_field_error ~field ~expected:"integer"
+        (make_type_field_error ~field ~constraint_violated:Type_int
+           ~expected:"integer"
            ~received:(Yojson.Safe.to_string json))
 
 let handle_goal_list (ctx : context) args =


### PR DESCRIPTION
## What changed
- narrow `make_type_field_error` so it accepts an explicit `field_constraint` instead of parsing string labels and falling through to a default branch
- update the four local call-sites in `lib/tool_coord.ml` used by the new goal-tool validation path

## Why
PR #9047 restored the Goal Tree front-door contract, but the new helper triggered the `#8605` permissive-default lint family:
- it matched on string labels like `"string" | "integer"`
- and used a silent fallback branch for unknown values

That is exactly the class of contract drift the lint is meant to catch. This follow-up removes the permissive parse and makes the constraint explicit at each call-site.

## Contract angle
This is a small but important contract hardening step:
- error typing is now explicit rather than inferred from a wire-ish string
- the validation helper no longer encodes a hidden fallback path
- the goal-tool front door added in #9047 now satisfies the same stricter boundary discipline expected by CDAL/FSM-style contract checks

## Validation
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `git diff --check`

## Notes
- #9047 was already merged to `main`; this PR is the lint-only follow-up for that change
- I did not wait for a full fresh worktree build in the new follow-up worktree because this change is confined to one helper + four local call-sites, and CI will exercise the full matrix again