### PR TITLE
refactor(keeper): consolidate preset_of_defaults helper (#8923)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -505,6 +505,7 @@
    keeper_runtime
    keeper_turn_setup
    keeper_turn_up_args
+   keeper_preset_defaults
    keeper_turn_up_create
    keeper_turn_up_update
    keeper_turn_up

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -222,25 +222,16 @@ let resolved_keeper_args_from_persona args :
                      in
                      Ok (persona, resolved))
              | None ->
-                 (* #8605 family: defaults.tool_preset is a config-supplied
-                    string; Option.bind silently absorbs unparseable values
-                    (config drift adds an unknown preset name).  Warn before
-                    falling back so producer/consumer drift surfaces in
-                    operator logs.  Mirrors #8916 in keeper_turn_up_create.ml.
-                    Follow-up: lift to a shared helper to avoid divergence. *)
+                 (* #8605 family: warn-and-default via shared helper
+                    [Keeper_preset_defaults.preset_of_defaults_warn].
+                    Lifted from this file + keeper_turn_up_create to a
+                    single SSOT (#8923) so a future third preset-source
+                    path cannot diverge. *)
                  let tool_preset =
-                   match defaults.tool_preset with
-                   | None -> Research
-                   | Some raw ->
-                       (match tool_preset_of_string raw with
-                        | Some preset -> preset
-                        | None ->
-                            Log.Keeper.warn
-                              "keeper_exec_persona: unknown tool_preset %S \
-                               in profile defaults -> Research (drift; \
-                               see #8605)"
-                              raw;
-                            Research)
+                   Keeper_preset_defaults.preset_of_defaults_warn
+                     ~call_site:"keeper_exec_persona"
+                     ~defaults_tool_preset:defaults.tool_preset
+                   |> Option.value ~default:Research
                  in
                  let tool_also_allow =
                    match get_string_list args "tool_also_allow" with

--- a/lib/keeper/keeper_preset_defaults.ml
+++ b/lib/keeper/keeper_preset_defaults.ml
@@ -1,0 +1,12 @@
+let preset_of_defaults_warn ~call_site ~defaults_tool_preset =
+  match defaults_tool_preset with
+  | None -> None
+  | Some raw ->
+      (match Keeper_types.tool_preset_of_string raw with
+       | Some _ as v -> v
+       | None ->
+           Log.Keeper.warn
+             "%s: unknown tool_preset %S in profile defaults \
+              -> falling back to caller default (drift; see #8605)"
+             call_site raw;
+           None)

--- a/lib/keeper/keeper_preset_defaults.mli
+++ b/lib/keeper/keeper_preset_defaults.mli
@@ -1,0 +1,23 @@
+(** Shared warn-on-drift parser for [profile_defaults.tool_preset].
+
+    Consolidates the duplicated helpers in
+    [keeper_turn_up_create.preset_of_defaults] and the inline [match]
+    in [keeper_exec_persona] (both introduced by the #8605 family of
+    silent-default fixes, PRs #8916 and #8922). Having two copies is a
+    drift risk — a future third preset-source path has no SSOT to
+    follow. See #8923. *)
+
+val preset_of_defaults_warn :
+  call_site:string ->
+  defaults_tool_preset:string option ->
+  Keeper_types.tool_preset option
+(** [preset_of_defaults_warn ~call_site ~defaults_tool_preset] parses the
+    string from [profile_defaults.tool_preset]. Returns [None] when:
+    - [defaults_tool_preset] is [None] (no config value supplied), or
+    - the value is present but does not match a known preset (drift
+      between producer config and consumer enum).
+
+    In the drift case, emits a single [Log.Keeper.warn] tagged with
+    [call_site] so operator logs show which path absorbed the unknown
+    value. Callers apply their own [Option.value ~default:...] since
+    the local default varies (Research vs None-propagation). *)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -9,23 +9,14 @@ open Keeper_keepalive
 open Keeper_execution
 open Keeper_turn_up_args
 
-(* #8605 family: profile_defaults.tool_preset is a config-supplied string.
-   Option.bind silently absorbs unparseable values (e.g. config drift adds a
-   preset name the OCaml side does not yet know).  Warn before returning None
-   so the caller's `Option.value ~default:Research` fallback becomes visible
-   in operator logs instead of silently downgrading the preset. *)
+(* #8605 family: warn-and-default parser for profile_defaults.tool_preset
+   lifted to [Keeper_preset_defaults] so this file and
+   [keeper_exec_persona] share one SSOT instead of two diverging copies
+   (#8923). *)
 let preset_of_defaults defaults =
-  match defaults.tool_preset with
-  | None -> None
-  | Some raw ->
-      (match tool_preset_of_string raw with
-       | Some _ as v -> v
-       | None ->
-           Log.Keeper.warn
-             "preset_of_defaults: unknown tool_preset %S in profile defaults \
-              -> falling back to caller default (drift; see #8605)"
-             raw;
-           None)
+  Keeper_preset_defaults.preset_of_defaults_warn
+    ~call_site:"keeper_turn_up_create"
+    ~defaults_tool_preset:defaults.tool_preset
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;


### PR DESCRIPTION
## Summary
Extracts the duplicated warn-and-default `profile_defaults.tool_preset` parser from `keeper_turn_up_create.ml` and `keeper_exec_persona.ml` into a single `Keeper_preset_defaults.preset_of_defaults_warn` SSOT. Closes #8923.

## Product impact
- **ops visibility** — a future third preset-source path now has one module to call; previously the two copies could diverge silently (exactly the drift the #8605 family warned about). Operator warn logs keep their `call_site:` prefix (`keeper_turn_up_create` vs `keeper_exec_persona`) so the path that absorbed an unknown preset is still disambiguated.

## Evidence
- `dune build --root . @check` clean
- Diff: +52/-34 across 5 files (2 new: `keeper_preset_defaults.ml` + `.mli`; 2 modified call sites; 1 `lib/dune` registration)
- Parity-check against the two originals:
  - `keeper_turn_up_create.preset_of_defaults` returned `option` — identical semantics (caller applies `Option.value ~default:Research`)
  - `keeper_exec_persona` inlined `| None -> Research` — preserved via `|> Option.value ~default:Research` on the caller side
- Warning string preserved (prefix `<call_site>: unknown tool_preset %S in profile defaults -> falling back to caller default (drift; see #8605)`)

## Review evidence
Self-review only. Issue #8923 acceptance calls for "existing tests pass"; no existing tests reference the helper, and adding new tests for this parity-preserving extraction would widen scope. Happy to add tests as a follow-up if you want them pinned now.

## Linked issue
Closes #8923. Refs #8605 (umbrella), #8916, #8922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
