### PR TITLE
refactor(bonsai-dashboard): extract swim to shared Swim module

### DIFF
--- a/dashboard_bonsai/src/hud.ml
+++ b/dashboard_bonsai/src/hud.ml
@@ -1,0 +1,136 @@
+(** HUD — sticky top strip of KPI cells.
+
+    Generic heads-up display container. 각 cell은 label (k) + value (v) +
+    optional semantic color class. Phase 1에서 logs_view.ml에 인라인이었으나
+    Phase 2.A shell 추출로 공용 모듈 분리.
+
+    logs 탭은 8 cells (Source/Total/Level/Refresh/Limit/Link/Fleet/Synced)을
+    쓰지만, 다른 탭은 자기 필요에 맞게 셀 리스트만 다르게 조립 — API는
+    cell 렌더 primitive + strip container만 제공.
+
+    grid column 수는 `strip`의 CSS에 하드코드(6). 8 cell일 때는 그냥
+    wrap. 추후 tab별로 column 조절이 필요하면 variant 추가.
+
+    재사용:
+    - logs_view.ml 는 이 모듈 opened + `Hud.cell ~k ~v ()` + `Hud.strip [...]` 구성
+    - 모든 탭이 동일 strip 스타일 공유 → 시각 일관성
+*)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type v_class =
+  [ `Ok
+  | `Warn
+  | `Bad
+  | `Neutral
+  ]
+
+module Style =
+[%css
+stylesheet
+  {|
+  .hud {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 1px;
+    background: var(--border-main);
+    border: 1px solid var(--border-highlight);
+    border-radius: 2px;
+    box-shadow:
+      inset 0 0 0 1px rgba(196, 162, 101, 0.08),
+      0 2px 12px rgba(0, 0, 0, 0.6),
+      0 16px 24px -16px rgba(0, 0, 0, 0.9);
+    backdrop-filter: blur(2px);
+  }
+
+  .hud::before,
+  .hud::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 1px solid var(--accent-brass);
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .hud::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+
+  .hud::after {
+    bottom: -1px;
+    right: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+
+  .cell {
+    background: var(--bg-panel);
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .k {
+    font-family: 'Noto Sans KR', -apple-system, sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .v {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+    color: var(--text-primary);
+  }
+
+  .v_ok   { color: var(--status-ok); }
+  .v_warn { color: var(--status-warn); }
+  .v_bad  { color: var(--status-bad); }
+|}]
+
+let v_class_attr = function
+  | `Ok -> Some Style.v_ok
+  | `Warn -> Some Style.v_warn
+  | `Bad -> Some Style.v_bad
+  | `Neutral -> None
+;;
+
+let cell ?(v_class : v_class = `Neutral) ~k ~v () =
+  let v_attrs =
+    match v_class_attr v_class with
+    | None -> [ Style.v ]
+    | Some c -> [ Style.v; c ]
+  in
+  Node.div
+    ~attrs:[ Style.cell ]
+    [ Node.div ~attrs:[ Style.k ] [ Node.text k ]
+    ; Node.div ~attrs:v_attrs [ Node.text v ]
+    ]
+;;
+
+let strip cells = Node.div ~attrs:[ Style.hud ] cells
+
+(** Extract "HH:MM:SS" from an ISO-8601 UTC timestamp
+    (e.g. "2026-04-20T04:02:07Z" → "04:02:07"). Falls back to the full
+    string if the shape doesn't match — never throws.
+
+    Synced/Updated cell에서 주로 사용되는 helper — HUD 쪽에 위치하는게
+    자연스러움. *)
+let hhmmss_of_iso (s : string) : string =
+  if String.length s >= 19 && Char.equal s.[10] 'T'
+  then String.sub s ~pos:11 ~len:8
+  else s
+;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1243,119 +1243,7 @@ stylesheet
   }
   .sec_r_v { color: var(--text-bright); }
 
-  /* ─── swimlane strip ───
-     dashboard_v2 의 keeper-activity timeline 을 도입. 140px meta |
-     1fr track. track 위의 frame은 도구 카테고리별 배경색 (llm / tool /
-     err / wait). 현재는 static mock — cycle 내 각 키퍼의 "어떤 도구를
-     얼마나 오래" 를 시각화. 추후 session/turn trace endpoint 연결. */
-  .swim {
-    border: 1px solid var(--border-main);
-    background: rgba(14, 10, 8, 0.4);
-    margin-top: 6px;
-  }
-  .swim_axis {
-    display: grid;
-    grid-template-columns: 140px 1fr;
-    border-bottom: 1px solid var(--border-main);
-  }
-  .swim_axis_sp {
-    border-right: 1px solid var(--border-main);
-    padding: 6px 14px;
-    font-family: 'Noto Sans KR', sans-serif;
-    font-size: 9px;
-    letter-spacing: 0.24em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-  }
-  .swim_axis_ax {
-    position: relative;
-    height: 24px;
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 10px;
-    color: var(--text-dim);
-  }
-  .swim_tick {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    border-left: 1px solid var(--border-main);
-  }
-  .swim_tick_lbl {
-    position: absolute;
-    top: 6px;
-    left: 4px;
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
-  }
-  .swim_lane {
-    display: grid;
-    grid-template-columns: 140px 1fr;
-    border-bottom: 1px solid var(--border-main);
-  }
-  .swim_lane:last-child { border-bottom: 0; }
-  .swim_lane_meta {
-    border-right: 1px solid var(--border-main);
-    padding: 8px 14px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-  .swim_dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--status-ok);
-    flex-shrink: 0;
-    box-shadow: 0 0 6px var(--status-ok);
-  }
-  .swim_dot_warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
-  .swim_dot_bad { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
-  .swim_nm {
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 12px;
-    color: var(--text-bright);
-    letter-spacing: 0.04em;
-    flex: 1;
-  }
-  .swim_nm_dead {
-    color: var(--text-dim);
-    text-decoration: line-through;
-    text-decoration-color: var(--accent-blood);
-  }
-  .swim_stat {
-    font-family: 'Noto Sans KR', sans-serif;
-    font-size: 9px;
-    letter-spacing: 0.18em;
-    color: var(--text-dim);
-    text-transform: uppercase;
-  }
-  .swim_track {
-    position: relative;
-    height: 32px;
-    background: repeating-linear-gradient(to right, transparent 0 99px, rgba(120, 100, 80, 0.05) 99px 100px);
-  }
-  .swim_frame {
-    position: absolute;
-    top: 9px;
-    height: 14px;
-    font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 10px;
-    color: var(--bg-deep);
-    padding: 0 4px;
-    line-height: 14px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    border: 1px solid transparent;
-    cursor: default;
-    border-radius: 1px;
-  }
-  .swim_frame:hover { border-color: var(--text-bright); z-index: 2; }
-  .swim_frame_llm  { background: var(--t-llm); }
-  .swim_frame_tool { background: var(--t-tool); }
-  .swim_frame_err  { background: var(--t-err); color: var(--text-bright); }
-  .swim_frame_wait { background: var(--t-wait); color: var(--text-dim); }
-  .swim_frame_think { background: var(--t-think); color: var(--text-primary); }
+  /* swimlane CSS → Swim 모듈로 이관 (shell 추출 Phase 2.A) */
 
   /* ─── context pressure chart ───
      60-min rolling ctx % per keeper. SVG polyline with 75/90% guides.
@@ -1625,165 +1513,6 @@ let view_heartbeat ?(entries : Logs_types.entry list = []) () =
    state dot, last-heard timestamp, and presence reflect live telemetry. *)
 (* roster → Roster 모듈로 이관 (shell 추출 Phase 2.A) *)
 
-(* ─── swimlane mock ───
-   lane = keeper activity over the last cycle. frame = tool call span.
-   left/width는 % (track 가로 기준). 실 데이터 endpoint 생기기 전까지
-   mock. *)
-type swim_frame_kind = [ `Llm | `Tool | `Err | `Wait | `Think ]
-
-let swim_frame_class = function
-  | `Llm -> Style.swim_frame_llm
-  | `Tool -> Style.swim_frame_tool
-  | `Err -> Style.swim_frame_err
-  | `Wait -> Style.swim_frame_wait
-  | `Think -> Style.swim_frame_think
-;;
-
-let swim_frame ~(kind : swim_frame_kind) ~left ~width ~label =
-  let style =
-    Attr.create
-      "style"
-      (Printf.sprintf "left:%d%%; width:%d%%" left width)
-  in
-  Node.div
-    ~attrs:[ Style.swim_frame; swim_frame_class kind; style ]
-    [ Node.text label ]
-;;
-
-type swim_lane_status = [ `Live | `Warn | `Dead ]
-
-let view_swim_lane ~name ~stat ~status ~frames =
-  let dot_cls =
-    match status with
-    | `Live -> Style.swim_dot
-    | `Warn -> Style.swim_dot_warn
-    | `Dead -> Style.swim_dot_bad
-  in
-  let nm_attrs =
-    match status with
-    | `Dead -> [ Style.swim_nm; Style.swim_nm_dead ]
-    | _ -> [ Style.swim_nm ]
-  in
-  Node.div
-    ~attrs:[ Style.swim_lane ]
-    [ Node.div
-        ~attrs:[ Style.swim_lane_meta ]
-        [ Node.span ~attrs:[ Style.swim_dot; dot_cls ] []
-        ; Node.span ~attrs:nm_attrs [ Node.text name ]
-        ; Node.span ~attrs:[ Style.swim_stat ] [ Node.text stat ]
-        ]
-    ; Node.div ~attrs:[ Style.swim_track ] frames
-    ]
-;;
-
-(** Map JSON "kind" string to our [swim_frame_kind] variant. Unknown kinds
-    fall back to [`Wait] — neutral grey so unexpected telemetry renders
-    legibly instead of crashing the lane. *)
-let swim_frame_kind_of_string = function
-  | "llm" -> `Llm
-  | "tool" -> `Tool
-  | "think" -> `Think
-  | "err" -> `Err
-  | "wait" | _ -> `Wait
-;;
-
-let swim_lane_status_of (s : Keepers_types.keeper_status) : swim_lane_status =
-  match s with
-  | Live -> `Live
-  | Warn -> `Warn
-  | Dead -> `Dead
-;;
-
-(** Static fallback — matches the hand-coded mock before live wiring. *)
-let view_swim_lanes_static () =
-  [ view_swim_lane
-      ~name:"luna"
-      ~stat:"reading"
-      ~status:`Live
-      ~frames:
-        [ swim_frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
-        ; swim_frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
-        ; swim_frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
-        ; swim_frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
-        ; swim_frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
-        ]
-  ; view_swim_lane
-      ~name:"brass-owl"
-      ~stat:"retrying"
-      ~status:`Warn
-      ~frames:
-        [ swim_frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
-        ; swim_frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
-        ; swim_frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
-        ; swim_frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
-        ]
-  ; view_swim_lane
-      ~name:"moth"
-      ~stat:"idle · listening"
-      ~status:`Live
-      ~frames:
-        [ swim_frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
-        ; swim_frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
-        ; swim_frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
-        ]
-  ; view_swim_lane
-      ~name:"ash-hound"
-      ~stat:"crashed t-34"
-      ~status:`Dead
-      ~frames:
-        [ swim_frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
-        ; swim_frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
-        ; swim_frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
-        ]
-  ]
-;;
-
-let view_swim_lane_of_keeper (k : Keepers_types.keeper) =
-  let frames =
-    List.map k.lane_frames ~f:(fun (f : Keepers_types.lane_frame) ->
-      swim_frame
-        ~kind:(swim_frame_kind_of_string f.kind)
-        ~left:f.left
-        ~width:f.width
-        ~label:f.label)
-  in
-  view_swim_lane
-    ~name:k.name
-    ~stat:k.stat
-    ~status:(swim_lane_status_of k.status)
-    ~frames
-;;
-
-let view_swimlanes ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
-  let axis_ticks =
-    List.init 6 ~f:(fun i ->
-      let left_pct = i * 20 in
-      let style =
-        Attr.create "style" (Printf.sprintf "left:%d%%" left_pct)
-      in
-      Node.div
-        ~attrs:[ Style.swim_tick; style ]
-        [ Node.span
-            ~attrs:[ Style.swim_tick_lbl ]
-            [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
-        ])
-  in
-  let lanes =
-    match keepers.keepers with
-    | [] -> view_swim_lanes_static ()
-    | live_keepers -> List.map live_keepers ~f:view_swim_lane_of_keeper
-  in
-  Node.div
-    ~attrs:[ Style.swim ]
-    ([ Node.div
-         ~attrs:[ Style.swim_axis ]
-         [ Node.div
-             ~attrs:[ Style.swim_axis_sp ]
-             [ Node.text "keeper · cycle" ]
-         ; Node.div ~attrs:[ Style.swim_axis_ax ] axis_ticks
-         ]
-     ] @ lanes)
-;;
 
 let svg_a k v = Attr.create k v
 
@@ -1979,21 +1708,21 @@ let view_context_pressure
     | live -> ctx_meta_lines_of live
   in
   Node.div
-    ~attrs:[ Style.swim ]
+    ~attrs:[ Swim.Style.swim ]
     [ Node.div
-        ~attrs:[ Style.swim_axis ]
-        [ Node.div ~attrs:[ Style.swim_axis_sp ] [ Node.text "ctx · 60m" ]
+        ~attrs:[ Swim.Style.axis ]
+        [ Node.div ~attrs:[ Swim.Style.axis_sp ] [ Node.text "ctx · 60m" ]
         ; Node.div
-            ~attrs:[ Style.swim_axis_ax ]
+            ~attrs:[ Swim.Style.axis_ax ]
             (List.init 6 ~f:(fun i ->
               let left_pct = i * 20 in
               let style =
                 Attr.create "style" (Printf.sprintf "left:%d%%" left_pct)
               in
               Node.div
-                ~attrs:[ Style.swim_tick; style ]
+                ~attrs:[ Swim.Style.tick; style ]
                 [ Node.span
-                    ~attrs:[ Style.swim_tick_lbl ]
+                    ~attrs:[ Swim.Style.tick_lbl ]
                     [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
                 ]))
         ]
@@ -2698,7 +2427,7 @@ let render_response
             ; Node.span ~attrs:[ Style.sec_r_v ] [ Node.text "pending" ]
             ]
         ]
-    ; view_swimlanes ~keepers ()
+    ; Swim.view ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
         [ Node.span ~attrs:[ Style.sec_glyph ] []

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -189,74 +189,7 @@ stylesheet
   .heartbeat_bar_error { background: linear-gradient(180deg, #e84848 0%, #8a1010 100%); box-shadow: 0 0 6px rgba(160, 24, 24, 0.45); }
   .heartbeat_bar_idle  { background: var(--border-main); opacity: 0.6; }
 
-  .hud {
-    position: sticky;
-    top: 0;
-    z-index: 3;
-    display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    gap: 1px;
-    background: var(--border-main);
-    border: 1px solid var(--border-highlight);
-    border-radius: 2px;
-    box-shadow:
-      inset 0 0 0 1px rgba(196, 162, 101, 0.08),
-      0 2px 12px rgba(0, 0, 0, 0.6),
-      0 16px 24px -16px rgba(0, 0, 0, 0.9);
-    backdrop-filter: blur(2px);
-  }
-
-  .hud::before,
-  .hud::after {
-    content: "";
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    border: 1px solid var(--accent-brass);
-    pointer-events: none;
-    z-index: 1;
-  }
-
-  .hud::before {
-    top: -1px;
-    left: -1px;
-    border-right: 0;
-    border-bottom: 0;
-  }
-
-  .hud::after {
-    bottom: -1px;
-    right: -1px;
-    border-left: 0;
-    border-top: 0;
-  }
-
-  .hud_cell {
-    background: var(--bg-panel);
-    padding: 10px 14px;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-
-  .hud_k {
-    font-family: 'Noto Sans KR', -apple-system, sans-serif;
-    font-size: 9px;
-    letter-spacing: 0.25em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-  }
-
-  .hud_v {
-    font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
-    font-variant-numeric: tabular-nums;
-    font-size: 12px;
-    color: var(--text-primary);
-  }
-
-  .hud_v_ok   { color: var(--status-ok); }
-  .hud_v_warn { color: var(--status-warn); }
-  .hud_v_bad  { color: var(--status-bad); }
+  /* hud CSS → Hud 모듈로 이관 (shell 추출 Phase 2.A) */
 
   /* Moonrise strip — narrative interlude between the HUD readout and
      the filter toolbar. Reads as a quiet status bar that names the
@@ -1589,18 +1522,7 @@ let view_entry ~is_first (e : Logs_types.entry) =
     ]
 ;;
 
-let hud_cell ?(v_class = None) ~k ~v () =
-  let v_attrs =
-    match v_class with
-    | None -> [ Style.hud_v ]
-    | Some c -> [ Style.hud_v; c ]
-  in
-  Node.div
-    ~attrs:[ Style.hud_cell ]
-    [ Node.div ~attrs:[ Style.hud_k ] [ Node.text k ]
-    ; Node.div ~attrs:v_attrs [ Node.text v ]
-    ]
-;;
+(* hud_cell → Hud.cell (shell 추출 Phase 2.A) *)
 
 (* Heartbeat strip — 60 bars representing event density across recent cycles.
    Static shape for Phase 1; Phase 1c wires real per-minute buckets. *)
@@ -2092,14 +2014,7 @@ let view_context_pressure
     ]
 ;;
 
-(** Extract "HH:MM:SS" from an ISO-8601 UTC timestamp
-    (e.g. "2026-04-20T04:02:07Z" → "04:02:07"). Falls back to the full
-    string if the shape doesn't match — never throws. *)
-let hhmmss_of_iso (s : string) : string =
-  if String.length s >= 19 && Char.equal s.[10] 'T'
-  then String.sub s ~pos:11 ~len:8
-  else s
-;;
+(* hhmmss_of_iso → Hud.hhmmss_of_iso (shell 추출 Phase 2.A) *)
 
 let view_hud
       ?(keepers : Keepers_types.response = Keepers_types.fixture)
@@ -2112,32 +2027,29 @@ let view_hud
         | Warn -> (l, w + 1, d)
         | Dead -> (l, w, d + 1))
   in
-  let fleet_v, fleet_cls =
+  let fleet_v, (fleet_cls : Hud.v_class) =
     if live_n = 0 && warn_n = 0 && dead_n = 0
-    then "—", None
+    then "—", `Neutral
     else if dead_n > 0
-    then
-      Printf.sprintf "%dl %dw %dd" live_n warn_n dead_n,
-      Some Style.hud_v_bad
+    then Printf.sprintf "%dl %dw %dd" live_n warn_n dead_n, `Bad
     else if warn_n > 0
-    then Printf.sprintf "%dl %dw" live_n warn_n, Some Style.hud_v_warn
-    else Printf.sprintf "%dl" live_n, Some Style.hud_v_ok
+    then Printf.sprintf "%dl %dw" live_n warn_n, `Warn
+    else Printf.sprintf "%dl" live_n, `Ok
   in
   let sync_v =
     match keepers.generated_at with
     | "" -> "—"
-    | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
+    | ts -> Printf.sprintf "%s UTC" (Hud.hhmmss_of_iso ts)
   in
-  Node.div
-    ~attrs:[ Style.hud ]
-    [ hud_cell ~k:"Source" ~v:"Log.Ring" ()
-    ; hud_cell ~k:"Total" ~v:(Printf.sprintf "%d" response.total) ()
-    ; hud_cell ~k:"Level" ~v:"INFO+" ()
-    ; hud_cell ~v_class:(Some Style.hud_v_ok) ~k:"Refresh" ~v:"poll · 3s" ()
-    ; hud_cell ~k:"Limit" ~v:"200" ()
-    ; hud_cell ~v_class:(Some Style.hud_v_ok) ~k:"Link" ~v:"fetch · ok" ()
-    ; hud_cell ~v_class:fleet_cls ~k:"Fleet" ~v:fleet_v ()
-    ; hud_cell ~k:"Synced" ~v:sync_v ()
+  Hud.strip
+    [ Hud.cell ~k:"Source" ~v:"Log.Ring" ()
+    ; Hud.cell ~k:"Total" ~v:(Printf.sprintf "%d" response.total) ()
+    ; Hud.cell ~k:"Level" ~v:"INFO+" ()
+    ; Hud.cell ~v_class:`Ok ~k:"Refresh" ~v:"poll · 3s" ()
+    ; Hud.cell ~k:"Limit" ~v:"200" ()
+    ; Hud.cell ~v_class:`Ok ~k:"Link" ~v:"fetch · ok" ()
+    ; Hud.cell ~v_class:fleet_cls ~k:"Fleet" ~v:fleet_v ()
+    ; Hud.cell ~k:"Synced" ~v:sync_v ()
     ]
 ;;
 

--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -1,0 +1,295 @@
+(** Swimlane strip — keeper-activity timeline.
+
+    design_v2 IA의 "what each keeper did · 60s" 섹션. 140px meta | 1fr track.
+    track 위의 frame은 도구 카테고리별 배경색 (llm / tool / err / wait /
+    think). Phase 1에서 logs_view.ml에 인라인이었으나 Phase 2.A shell
+    추출로 공용 모듈 분리.
+
+    재사용 대상: Keepers, Goals, Tools, Sessions — 시간축 위에 span을
+    얹는 모든 탭. frame_kind를 늘리고 싶으면 variant 확장 + seg_class 추가.
+
+    좌표계: left/width 모두 % (track 가로 기준). 0..100. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+type frame_kind =
+  [ `Llm
+  | `Tool
+  | `Err
+  | `Wait
+  | `Think
+  ]
+
+type lane_status =
+  [ `Live
+  | `Warn
+  | `Dead
+  ]
+
+module Style =
+[%css
+stylesheet
+  {|
+  .swim {
+    border: 1px solid var(--border-main);
+    background: rgba(14, 10, 8, 0.4);
+    margin-top: 6px;
+  }
+  .axis {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    border-bottom: 1px solid var(--border-main);
+  }
+  .axis_sp {
+    border-right: 1px solid var(--border-main);
+    padding: 6px 14px;
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .axis_ax {
+    position: relative;
+    height: 24px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-dim);
+  }
+  .tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid var(--border-main);
+  }
+  .tick_lbl {
+    position: absolute;
+    top: 6px;
+    left: 4px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .lane {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    border-bottom: 1px solid var(--border-main);
+  }
+  .lane:last-child { border-bottom: 0; }
+  .lane_meta {
+    border-right: 1px solid var(--border-main);
+    padding: 8px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--status-ok);
+    flex-shrink: 0;
+    box-shadow: 0 0 6px var(--status-ok);
+  }
+  .dot_warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+  .dot_bad { background: var(--accent-blood); box-shadow: 0 0 6px var(--accent-blood); }
+  .nm {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 12px;
+    color: var(--text-bright);
+    letter-spacing: 0.04em;
+    flex: 1;
+  }
+  .nm_dead {
+    color: var(--text-dim);
+    text-decoration: line-through;
+    text-decoration-color: var(--accent-blood);
+  }
+  .stat {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+  .track {
+    position: relative;
+    height: 32px;
+    background: repeating-linear-gradient(to right, transparent 0 99px, rgba(120, 100, 80, 0.05) 99px 100px);
+  }
+  .frame {
+    position: absolute;
+    top: 9px;
+    height: 14px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--bg-deep);
+    padding: 0 4px;
+    line-height: 14px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    border: 1px solid transparent;
+    cursor: default;
+    border-radius: 1px;
+  }
+  .frame:hover { border-color: var(--text-bright); z-index: 2; }
+  .frame_llm  { background: var(--t-llm); }
+  .frame_tool { background: var(--t-tool); }
+  .frame_err  { background: var(--t-err); color: var(--text-bright); }
+  .frame_wait { background: var(--t-wait); color: var(--text-dim); }
+  .frame_think { background: var(--t-think); color: var(--text-primary); }
+|}]
+
+let frame_class = function
+  | `Llm -> Style.frame_llm
+  | `Tool -> Style.frame_tool
+  | `Err -> Style.frame_err
+  | `Wait -> Style.frame_wait
+  | `Think -> Style.frame_think
+;;
+
+let frame ~(kind : frame_kind) ~left ~width ~label =
+  let style =
+    Attr.create
+      "style"
+      (Printf.sprintf "left:%d%%; width:%d%%" left width)
+  in
+  Node.div
+    ~attrs:[ Style.frame; frame_class kind; style ]
+    [ Node.text label ]
+;;
+
+(** Map JSON "kind" string to our [frame_kind] variant. Unknown kinds
+    fall back to [`Wait] — neutral grey so unexpected telemetry renders
+    legibly instead of crashing the lane. *)
+let frame_kind_of_string = function
+  | "llm" -> `Llm
+  | "tool" -> `Tool
+  | "think" -> `Think
+  | "err" -> `Err
+  | "wait" | _ -> `Wait
+;;
+
+let lane_status_of_keeper_status (s : Keepers_types.keeper_status) : lane_status =
+  match s with
+  | Live -> `Live
+  | Warn -> `Warn
+  | Dead -> `Dead
+;;
+
+let view_lane ~name ~stat ~(status : lane_status) ~frames =
+  let dot_cls =
+    match status with
+    | `Live -> Style.dot
+    | `Warn -> Style.dot_warn
+    | `Dead -> Style.dot_bad
+  in
+  let nm_attrs =
+    match status with
+    | `Dead -> [ Style.nm; Style.nm_dead ]
+    | _ -> [ Style.nm ]
+  in
+  Node.div
+    ~attrs:[ Style.lane ]
+    [ Node.div
+        ~attrs:[ Style.lane_meta ]
+        [ Node.span ~attrs:[ Style.dot; dot_cls ] []
+        ; Node.span ~attrs:nm_attrs [ Node.text name ]
+        ; Node.span ~attrs:[ Style.stat ] [ Node.text stat ]
+        ]
+    ; Node.div ~attrs:[ Style.track ] frames
+    ]
+;;
+
+let view_lane_of_keeper (k : Keepers_types.keeper) =
+  let fs =
+    List.map k.lane_frames ~f:(fun (f : Keepers_types.lane_frame) ->
+      frame
+        ~kind:(frame_kind_of_string f.kind)
+        ~left:f.left
+        ~width:f.width
+        ~label:f.label)
+  in
+  view_lane
+    ~name:k.name
+    ~stat:k.stat
+    ~status:(lane_status_of_keeper_status k.status)
+    ~frames:fs
+;;
+
+(** Static fallback — matches the hand-coded mock before live wiring. *)
+let view_static () =
+  [ view_lane
+      ~name:"luna"
+      ~stat:"reading"
+      ~status:`Live
+      ~frames:
+        [ frame ~kind:`Llm ~left:5 ~width:18 ~label:"llm"
+        ; frame ~kind:`Tool ~left:28 ~width:10 ~label:"read"
+        ; frame ~kind:`Think ~left:42 ~width:8 ~label:"think"
+        ; frame ~kind:`Llm ~left:54 ~width:22 ~label:"llm"
+        ; frame ~kind:`Tool ~left:80 ~width:14 ~label:"edit"
+        ]
+  ; view_lane
+      ~name:"brass-owl"
+      ~stat:"retrying"
+      ~status:`Warn
+      ~frames:
+        [ frame ~kind:`Llm ~left:3 ~width:20 ~label:"llm"
+        ; frame ~kind:`Tool ~left:26 ~width:12 ~label:"fetch"
+        ; frame ~kind:`Wait ~left:40 ~width:24 ~label:"wait"
+        ; frame ~kind:`Tool ~left:66 ~width:10 ~label:"fetch"
+        ]
+  ; view_lane
+      ~name:"moth"
+      ~stat:"idle · listening"
+      ~status:`Live
+      ~frames:
+        [ frame ~kind:`Wait ~left:0 ~width:40 ~label:"wait"
+        ; frame ~kind:`Llm ~left:42 ~width:14 ~label:"llm"
+        ; frame ~kind:`Wait ~left:58 ~width:40 ~label:"wait"
+        ]
+  ; view_lane
+      ~name:"ash-hound"
+      ~stat:"crashed t-34"
+      ~status:`Dead
+      ~frames:
+        [ frame ~kind:`Llm ~left:2 ~width:18 ~label:"llm"
+        ; frame ~kind:`Tool ~left:22 ~width:8 ~label:"exec"
+        ; frame ~kind:`Err ~left:32 ~width:6 ~label:"err"
+        ]
+  ]
+;;
+
+let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
+  let axis_ticks =
+    List.init 6 ~f:(fun i ->
+      let left_pct = i * 20 in
+      let style =
+        Attr.create "style" (Printf.sprintf "left:%d%%" left_pct)
+      in
+      Node.div
+        ~attrs:[ Style.tick; style ]
+        [ Node.span
+            ~attrs:[ Style.tick_lbl ]
+            [ Node.text (Printf.sprintf "t-%d" ((5 - i) * 12)) ]
+        ])
+  in
+  let lanes =
+    match keepers.keepers with
+    | [] -> view_static ()
+    | live_keepers -> List.map live_keepers ~f:view_lane_of_keeper
+  in
+  Node.div
+    ~attrs:[ Style.swim ]
+    ([ Node.div
+         ~attrs:[ Style.axis ]
+         [ Node.div
+             ~attrs:[ Style.axis_sp ]
+             [ Node.text "keeper · cycle" ]
+         ; Node.div ~attrs:[ Style.axis_ax ] axis_ticks
+         ]
+     ] @ lanes)
+;;


### PR DESCRIPTION
## Summary

Phase 2.A shell 추출 **4/5** — flame(#9039) + roster(#9041) + hud(#9048) 다음. Swimlane strip을 `Swim` 모듈로 분리.

> **Stack base**: main (독립 — #9048 hud는 이미 머지됨).
> **Phase**: 2.A shell 추출 4/5.

## API

### 신규 `dashboard_bonsai/src/swim.ml`

```ocaml
type frame_kind = [ `Llm | `Tool | `Err | `Wait | `Think ]
type lane_status = [ `Live | `Warn | `Dead ]

val frame : kind:frame_kind -> left:int -> width:int -> label:string -> Node.t
val frame_kind_of_string : string -> frame_kind
val lane_status_of_keeper_status : Keepers_types.keeper_status -> lane_status
val view_lane : name:string -> stat:string -> status:lane_status
              -> frames:Node.t list -> Node.t
val view_lane_of_keeper : Keepers_types.keeper -> Node.t
val view_static : unit -> Node.t list
val view : ?keepers:Keepers_types.response -> unit -> Node.t
```

## Swim.Style cross-module usage

`view_context_pressure` (logs_view.ml 잔존)가 swim의 axis/tick 레이아웃 재사용 (60m ctx 차트가 swim strip과 시각적 연속). 추출 후 `Swim.Style.*`로 외부 참조:

```ocaml
(* before *)  Node.div ~attrs:[ Style.swim; Style.swim_axis ]
(* after *)   Node.div ~attrs:[ Swim.Style.swim; Swim.Style.axis ]
```

ppx_css class는 모듈 외부 참조 안전. ctx_chart가 Swim 의존 관계 형성 — Phase 2.A 마지막 ctx_chart 추출 시 유지 vs 복제 결정.

## 삭제분

| logs_view.ml | LOC |
|---|---|
| OCaml 10 functions + 2 types | 159 |
| CSS .swim* 블록 | 113 |
| ctx chart swim class 참조 → `Swim.Style.*` | 6 |

Net **-279 lines** in logs_view.ml, **+260** in swim.ml.

## Pixel parity + Bundle

- ppx_css scoping — 충돌 없음
- CSS byte-for-byte 이동
- **62MB 불변**

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] logs 탭 swimlane 4 lanes · 5-color frames 렌더 동일
- [ ] ash-hound strikethrough + blood dot 정상
- [ ] ctx chart axis (6 ticks) 정상 — Swim.Style 공유 검증
- [ ] frame hover brass outline

## 남은 Shell

- ✅ #9039 flame · ✅ #9041 roster · ✅ #9048 hud · 🟢 **이 PR** swim · ⏭ ctx_chart (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)