### PR TITLE
fix(keeper): separate effective and requested max-context budgets

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -133,6 +133,14 @@ type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
   turn_generation : int;
 }
 
+type max_context_resolution = {
+  requested_override : int option;
+  primary_budget : int;
+  cascade_budget : int;
+  turn_budget : int;
+  effective_budget : int;
+}
+
 let apply_post_turn_lifecycle = Keeper_post_turn.apply_post_turn_lifecycle
 let recover_latest_checkpoint_for_overflow_retry =
   Keeper_post_turn.recover_latest_checkpoint_for_overflow_retry
@@ -233,6 +241,39 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
       if model_allowed
       then dedupe_keep_order (model :: configured)
       else configured
+
+let resolve_max_context_resolution ~requested_override (labels : string list)
+    : max_context_resolution =
+  let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+  let clamp resolved =
+    let local_clamped =
+      Cascade_runtime.clamp_context_for_pure_local_labels
+        ~labels ~max_context:resolved
+    in
+    max min_keeper_context local_clamped
+  in
+  let primary_budget =
+    Cascade_runtime.resolve_primary_max_context labels
+    |> clamp
+  in
+  let cascade_budget =
+    Cascade_runtime.resolve_max_cascade_context labels
+    |> clamp
+  in
+  let turn_budget =
+    match requested_override with
+    | Some requested when requested > 0 ->
+      max min_keeper_context requested
+    | _ -> primary_budget
+  in
+  let effective_budget = min turn_budget primary_budget in
+  { requested_override; primary_budget; cascade_budget; turn_budget; effective_budget }
+
+let resolve_max_context_resolution_of_meta (m : keeper_meta)
+    : max_context_resolution =
+  let labels = effective_model_labels_for_turn m in
+  resolve_max_context_resolution
+    ~requested_override:m.max_context_override labels
 
 let room_cursor_for meta room_id =
   meta.last_seen_seq_by_room

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -123,6 +123,14 @@ type post_turn_lifecycle = {
   message_count : int;
 }
 
+type max_context_resolution = {
+  requested_override : int option;
+  primary_budget : int;
+  cascade_budget : int;
+  turn_budget : int;
+  effective_budget : int;
+}
+
 type overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
@@ -247,6 +255,14 @@ val keeper_action_kind_of_tool_names : string list -> string
 
 val effective_model_labels_for_turn :
   keeper_meta -> string list
+
+val resolve_max_context_resolution :
+  requested_override:int option ->
+  string list ->
+  max_context_resolution
+
+val resolve_max_context_resolution_of_meta :
+  keeper_meta -> max_context_resolution
 
 val room_cursor_for : keeper_meta -> string -> int
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -602,17 +602,12 @@ let write_heartbeat_snapshot
     Cascade_runtime.models_of_cascade_name meta_current.cascade_name
   in
   let max_cascade_context =
-    let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-    let raw = match meta_current.max_context_override with
-      | Some v -> v
-      | None ->
-          let resolved =
-            Cascade_runtime.resolve_max_cascade_context cascade_models
-          in
-          Cascade_runtime.clamp_context_for_pure_local_labels
-            ~labels:cascade_models ~max_context:resolved
+    let resolution =
+      Keeper_exec_context.resolve_max_context_resolution
+        ~requested_override:meta_current.max_context_override
+        cascade_models
     in
-    max min_keeper_context raw
+    resolution.effective_budget
   in
   let base_dir = session_base_dir ctx.config in
   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)));

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -476,20 +476,11 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = Keeper_model_labels.configured_model_labels_of_meta m in
-      let primary_max_context =
-        let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-        let raw =
-          match m.max_context_override with
-          | Some value -> value
-          | None ->
-              let resolved =
-                Cascade_runtime.resolve_max_cascade_context models
-              in
-              Cascade_runtime.clamp_context_for_pure_local_labels
-                ~labels:models ~max_context:resolved
-        in
-        max min_keeper_context raw
+      let max_context_resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:m.max_context_override models
       in
+      let primary_max_context = max_context_resolution.effective_budget in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
@@ -1119,6 +1110,13 @@ let handle_keeper_status ctx args : tool_result =
              ("include_history_tail", `Bool include_history_tail);
              ("include_compaction_history", `Bool include_compaction_history);
              ("tail_order", `String (tail_order_to_string tail_order));
+           ]);
+           ("context_budget", `Assoc [
+             ("requested_override", Json_util.int_opt_to_json max_context_resolution.requested_override);
+             ("primary_budget", `Int max_context_resolution.primary_budget);
+             ("cascade_budget", `Int max_context_resolution.cascade_budget);
+             ("turn_budget", `Int max_context_resolution.turn_budget);
+             ("effective_budget", `Int max_context_resolution.effective_budget);
            ]);
            ("models_resolved", models_resolved);
            ("model_observability", model_observability);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -185,24 +185,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Cascade_runtime.refresh_local_discovery_if_possible effective_models);
          let max_cascade_context =
-           let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-           let raw =
-             match meta.max_context_override with
-             | Some v ->
-                 Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
-                 v
-             | None ->
-                 let resolved =
-                   Cascade_runtime.resolve_max_cascade_context effective_models
-                 in
-                 Cascade_runtime.clamp_context_for_pure_local_labels
-                   ~labels:effective_models ~max_context:resolved
+           let resolution =
+             Keeper_exec_context.resolve_max_context_resolution
+               ~requested_override:meta.max_context_override effective_models
            in
-           if raw < min_keeper_context then begin
-             Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"
-               meta.name raw min_keeper_context;
-             min_keeper_context
-           end else raw
+           (match resolution.requested_override with
+            | Some requested ->
+              Log.Keeper.debug
+                "%s: using max_context_override=%d turn_budget=%d primary_budget=%d effective_budget=%d (manual turn)"
+                meta.name requested resolution.turn_budget resolution.primary_budget
+                resolution.effective_budget
+            | None -> ());
+           resolution.turn_budget
          in
             let base_dir =
               let root = session_base_dir ctx.config in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -623,43 +623,27 @@ let cascade_budget_logged : (string * int * int, unit) Hashtbl.t =
 let resolved_max_context_for_turn
     ~(meta : keeper_meta)
     (model_labels : string list) : int =
-  let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-  let raw =
-    match meta.max_context_override with
-    | Some v ->
-        Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
-        v
-    | None ->
-        let primary =
-          let resolved =
-            Cascade_runtime.resolve_primary_max_context model_labels
-          in
-          Cascade_runtime.clamp_context_for_pure_local_labels
-            ~labels:model_labels ~max_context:resolved
-        in
-        let cascade_max =
-          let resolved =
-            Cascade_runtime.resolve_max_cascade_context model_labels
-          in
-          Cascade_runtime.clamp_context_for_pure_local_labels
-            ~labels:model_labels ~max_context:resolved
-        in
-        if primary < cascade_max then begin
-          let key = (meta.name, primary, cascade_max) in
-          if not (Hashtbl.mem cascade_budget_logged key) then begin
-            Hashtbl.add cascade_budget_logged key ();
-            Log.Keeper.info
-              "%s: mixed cascade context budget primary=%d cascade_max=%d; using primary for initial turn budget"
-              meta.name primary cascade_max
-          end
-        end;
-        primary
+  let resolution =
+    Keeper_exec_context.resolve_max_context_resolution
+      ~requested_override:meta.max_context_override model_labels
   in
-  if raw < min_keeper_context then begin
-    Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"
-      meta.name raw min_keeper_context;
-    min_keeper_context
-  end else raw
+  if resolution.primary_budget < resolution.cascade_budget then begin
+    let key = (meta.name, resolution.primary_budget, resolution.cascade_budget) in
+    if not (Hashtbl.mem cascade_budget_logged key) then begin
+      Hashtbl.add cascade_budget_logged key ();
+      Log.Keeper.info
+        "%s: mixed cascade context budget primary=%d cascade_max=%d; using primary for initial turn budget"
+        meta.name resolution.primary_budget resolution.cascade_budget
+    end
+  end;
+  (match resolution.requested_override with
+   | Some requested ->
+     Log.Keeper.debug
+       "%s: using max_context_override=%d turn_budget=%d primary_budget=%d effective_budget=%d"
+       meta.name requested resolution.turn_budget resolution.primary_budget
+       resolution.effective_budget
+   | None -> ());
+  resolution.turn_budget
 
 let decision_channel_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
@@ -1661,6 +1645,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       match ensure_local_discovery_ready model_labels with
       | Error e -> Error (Oas.Error.Internal e)
       | Ok () ->
+      let max_context_resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:meta.max_context_override model_labels
+      in
       let max_context =
         resolved_max_context_for_turn ~meta model_labels
       in
@@ -2074,8 +2062,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                               && attempt <= max_transient_retries then begin
                   let delay = transient_backoff_sec attempt in
                   Log.Keeper.warn
-                    "%s: transient network error cascade=%s max_context=%d retry=%d/%d backoff=%.0fs: %s"
-                    meta.name effective_cascade_name max_context
+                    "%s: transient network error cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
+                    meta.name effective_cascade_name max_context_resolution.effective_budget
+                    max_context
+                    max_context_resolution.primary_budget
+                    (match max_context_resolution.requested_override with
+                     | Some requested -> string_of_int requested
+                     | None -> "none")
                     attempt max_transient_retries delay
                     (short_preview (Oas.Error.to_string err));
                   Eio.Time.sleep clock delay;
@@ -2262,8 +2255,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Prometheus.inc_counter Prometheus.metric_keeper_turns
             ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
           Log.Keeper.error
-            "%s: keeper cycle FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
-            meta.name effective_cascade_name max_context latency_ms
+            "%s: keeper cycle FAILED cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
+            meta.name effective_cascade_name max_context_resolution.effective_budget
+            max_context
+            max_context_resolution.primary_budget
+            (match max_context_resolution.requested_override with
+             | Some requested -> string_of_int requested
+             | None -> "none")
+            latency_ms
             (if is_ambiguous_partial then
                " (ambiguous partial commit)"
              else if is_server_parse_rejection then

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -324,18 +324,12 @@ let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
       Keeper_model_labels.configured_model_labels_of_meta meta
     in
     let primary_max_context =
-      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-      let raw =
-        match meta.max_context_override with
-        | Some value -> value
-        | None ->
-              let resolved =
-                Cascade_runtime.resolve_max_cascade_context cascade_models
-              in
-            Cascade_runtime.clamp_context_for_pure_local_labels
-              ~labels:cascade_models ~max_context:resolved
+      let resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:meta.max_context_override
+          cascade_models
       in
-      max min_keeper_context raw
+      resolution.effective_budget
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
@@ -363,18 +357,12 @@ let read_continuity_summary ~(config : Coord.config) ~(meta : keeper_meta)
       Keeper_model_labels.configured_model_labels_of_meta meta
     in
     let primary_max_context =
-      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-      let raw =
-        match meta.max_context_override with
-        | Some value -> value
-        | None ->
-              let resolved =
-                Cascade_runtime.resolve_max_cascade_context cascade_models
-              in
-            Cascade_runtime.clamp_context_for_pure_local_labels
-              ~labels:cascade_models ~max_context:resolved
+      let resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:meta.max_context_override
+          cascade_models
       in
-      max min_keeper_context raw
+      resolution.effective_budget
     in
     let base_dir = session_base_dir config in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -607,25 +607,18 @@ let handle_keeper_reset ctx args : tool_result =
 
 (** Resolve the primary model max context for a keeper.
 
-    Follows the same resolution order as
-    [Keeper_unified_turn.resolved_max_context_for_turn]:
-    max_context_override > cascade model resolution > min floor.
+    Returns the resolved primary provider/cascade budget, separate from any
+    requested [max_context_override] turn-budget widening.
     Returns [min_keeper_context_tokens] when meta is unavailable. *)
 let resolve_primary_max_context (meta : Keeper_types.keeper_meta option) : int =
   let min_ctx = Keeper_config.min_keeper_context_tokens in
   match meta with
   | None -> min_ctx
   | Some meta ->
-    let raw =
-      match meta.max_context_override with
-      | Some n when n > 0 -> n
-      | _ ->
-        let labels = Keeper_exec_context.effective_model_labels_for_turn meta in
-        let resolved = Cascade_runtime.resolve_max_cascade_context labels in
-        Cascade_runtime.clamp_context_for_pure_local_labels
-          ~labels ~max_context:resolved
+    let resolution =
+      Keeper_exec_context.resolve_max_context_resolution_of_meta meta
     in
-    max min_ctx raw
+    max min_ctx resolution.effective_budget
 
 (** Operator-initiated context compaction.
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2483,6 +2483,20 @@ let test_resolved_max_context_for_turn_uses_primary_budget () =
   check int "turn budget follows primary available model" expected
     (UT.resolved_max_context_for_turn ~meta:minimal_meta labels)
 
+let test_max_context_resolution_separates_override_and_effective_budget () =
+  let labels = [ "unknown:model" ] in
+  let resolution =
+    KEC.resolve_max_context_resolution
+      ~requested_override:(Some 1_000_000) labels
+  in
+  check int "primary budget uses fallback context window"
+    Masc_mcp.Cascade_runtime.fallback_context_window
+    resolution.primary_budget;
+  check int "turn budget preserves requested override" 1_000_000
+    resolution.turn_budget;
+  check int "effective budget caps to primary budget"
+    resolution.primary_budget resolution.effective_budget
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -3659,6 +3673,8 @@ let () =
             test_clamp_context_for_pure_local_labels;
           test_case "turn context budget uses primary model" `Quick
             test_resolved_max_context_for_turn_uses_primary_budget;
+          test_case "max_context resolution separates override and effective budget" `Quick
+            test_max_context_resolution_separates_override_and_effective_budget;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick


### PR DESCRIPTION
## Summary
- separate keeper turn-budget overrides from the effective provider context budget
- use the effective budget for keeper status, observation, and failure/transient logs
- add regression coverage for override vs effective-budget resolution

## Verification
- `DUNE_BUILD_DIR=/tmp/masc-effective-max-context-build dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-effective-max-context-ssot ./test/test_keeper_unified.exe`
- `DUNE_BUILD_DIR=/tmp/masc-effective-max-context-build dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-effective-max-context-ssot 2>&1`
