### PR TITLE
docs(logic): batch-21 .mli for autoresearch_file + tool_control + keeper_msg_async

### DIFF
--- a/lib/autoresearch/autoresearch_file.mli
+++ b/lib/autoresearch/autoresearch_file.mli
@@ -1,0 +1,41 @@
+(** Autoresearch_file — Target file validation and atomic code change
+    application.
+
+    Validates file paths (no [..] traversal, no symlink escape outside
+    [workdir]), reads file contents, and writes new content atomically
+    via temp-file rename.
+
+    @since 2.80.0 *)
+
+(** [has_path_traversal path] returns [true] when [path] is exactly
+    [..], contains [../], or ends with [/..]. *)
+val has_path_traversal : string -> bool
+
+(** [resolve_target_file_path ~workdir target_file] returns the
+    absolute path inside [workdir] without requiring the file to
+    exist. Existing parent directories are resolved via [realpath];
+    symlink escapes are rejected. Errors on empty / absolute /
+    traversal-containing [target_file]. *)
+val resolve_target_file_path :
+  workdir:string -> string -> (string, string) result
+
+(** [validate_target_file ~workdir target_file] resolves the path and
+    additionally requires the file to exist, be a regular file, and
+    stay inside [workdir] under [realpath]. Returns the resolved
+    absolute path. *)
+val validate_target_file :
+  workdir:string -> string -> (string, string) result
+
+(** Load a file in full. *)
+val read_file : string -> string
+
+(** [apply_code_change ~workdir ~target_file ~new_content] validates
+    the path, reads the original content, then atomically replaces
+    [target_file] with [new_content] via a same-directory temp file.
+    Returns [Ok original_content] on success (for rollback reference)
+    or [Error reason]. *)
+val apply_code_change :
+  workdir:string ->
+  target_file:string ->
+  new_content:string ->
+  (string, string) result

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -1,0 +1,50 @@
+(** Keeper_msg_async — Fire-and-forget keeper message execution.
+
+    Background fibers run [keeper_msg] turns. MCP tool returns
+    immediately with a [request_id]; clients poll via
+    [masc_keeper_msg_result] for completion. Entries auto-expire
+    after [max_age_sec] (1h) to prevent memory leaks. *)
+
+(** {1 Types} *)
+
+type request_status =
+  | Queued
+  | Running
+  | Done of { ok : bool; body : string }
+
+type entry = {
+  request_id : string;
+  keeper_name : string;
+  status : request_status;
+  submitted_at : float;
+  completed_at : float option;
+}
+
+(** {1 Submit and poll} *)
+
+(** [submit ~sw ~f ~keeper_name] forks a background daemon fiber on
+    [sw] that runs [f] and stores the result. Returns the fresh
+    [request_id] synchronously. Cancellation of [sw] cancels the
+    fiber. *)
+val submit :
+  sw:Eio.Switch.t ->
+  f:(unit -> Keeper_types.tool_result) ->
+  keeper_name:string ->
+  string
+
+(** [poll request_id] returns the current entry, or [None] when the
+    id is unknown or has expired. *)
+val poll : string -> entry option
+
+(** [list_for_keeper ~keeper_name] returns all entries for a keeper
+    sorted most-recent-first. *)
+val list_for_keeper : keeper_name:string -> entry list
+
+(** {1 JSON output} *)
+
+val status_to_string : request_status -> string
+
+(** JSON encoding with [request_id], [keeper_name], [status],
+    [submitted_at], and — depending on state — [completed_at] /
+    [elapsed_sec] / [ok] + [result]. *)
+val entry_to_json : entry -> Yojson.Safe.t

--- a/lib/tool_control.mli
+++ b/lib/tool_control.mli
@@ -1,0 +1,29 @@
+(** Tool_control — Flow control operations (pause / pause_status /
+    resume).
+
+    Dispatches [masc_pause], [masc_resume], [masc_pause_status]. *)
+
+type tool_result = bool * string
+
+type context = {
+  config : Coord.config;
+  agent_name : string;
+}
+
+(** {1 Handlers} *)
+
+val handle_pause : context -> Yojson.Safe.t -> tool_result
+
+val handle_resume : context -> Yojson.Safe.t -> tool_result
+
+val handle_pause_status : context -> Yojson.Safe.t -> tool_result
+
+(** {1 Dispatch} *)
+
+(** [dispatch ctx ~name ~args] returns [Some result] for
+    [masc_pause] / [masc_resume] / [masc_pause_status], else [None]. *)
+val dispatch :
+  context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/autoresearch/autoresearch_file.mli` | 41 | 5 vals (path validation + atomic file write); 1 caller in `autoresearch.ml` |
| `lib/tool_control.mli` | 29 | `tool_result` + `context` record + 3 handlers + `dispatch`; 4 callers |
| `lib/keeper/keeper_msg_async.mli` | 50 | `request_status` variant + `entry` record + 5 vals; 2 callers + 1 test module |

## Notes

- Private helpers stay hidden: `is_safe_subpath`/`nearest_existing_path`/`safe_realpath` (autoresearch), `Tool_spec.register` side-effect (tool_control), `Hashtbl`/`mu`/`gc_stale` (keeper_msg_async).
- `keeper_msg_async.submit`'s `f : unit -> Keeper_types.tool_result` signature qualified explicitly.

## Metrics

- Files: 671 ml / ~355 mli (≈52.9% of ml).
- Build: `dune @check` exit 0.
- Tests: `test_tool_control_coverage` (10) + `test_keeper_mutex_coverage` (1) pass.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)