### PR TITLE
docs(specs): add OCaml mapping table to SocialStateCap (#9065)

### DIFF
--- a/specs/social-state-cap/SocialStateCap.tla
+++ b/specs/social-state-cap/SocialStateCap.tla
@@ -33,7 +33,41 @@ VARIABLES
 vars == <<state, turn, pc>>
 
 \* ── Enum domains ────────────────────────────
-
+\*
+\* OCaml ↔ TLA+ mapping (verified 2026-04-20, see issue #9065):
+\*
+\*   spec name in Speeches  ↔ keeper_social_model_types.mli speech_act
+\*   ----------------------+----------------------------------------------
+\*   "stay_silent"          ↔ Stay_silent
+\*   "inform"               ↔ Inform
+\*   "request_help"         ↔ Request_help
+\*   "claim_task"           ↔ Claim_task
+\*   (NOT MODELLED)         ↔ Comment_board, Post_board, Broadcast, Defer
+\*
+\*   spec name in Surfaces  ↔ keeper_social_model_types.mli delivery_surface
+\*   ----------------------+----------------------------------------------
+\*   "silent"               ↔ Silent
+\*   "visible_reply"        ↔ Visible_reply
+\*   "board_post"           ↔ Board_post
+\*   "task_claim"           ↔ Task_claim_surface
+\*   (NOT MODELLED)         ↔ Board_comment, Broadcast_surface
+\*
+\* Sound partial coverage rationale:
+\*   The cap chain (PR #7692/#7704/#7709) is enforced at a SINGLE
+\*   emission point — `Types.cap_social_state` called from
+\*   keeper_social_model_magentic_ledger_v1.ml lines 200 and 220
+\*   (every emission path goes through it). Because that match is
+\*   exhaustive over the OCaml type, all 8 speech_act / 6 delivery_surface
+\*   constructors are capped uniformly regardless of which 4 the spec
+\*   chose to enumerate. The 4×4 projection here verifies the cap math
+\*   itself; unmodelled values are safe by construction (same emission
+\*   path, same cap_social_state call).
+\*
+\*   What this projection does NOT catch: a future change that adds
+\*   a new emission site that bypasses cap_social_state. If that happens
+\*   the spec must be extended to include the new constructors AND the
+\*   new emission action. See issue #9065 option 3 (witness pattern in
+\*   keeper_social_model_types.ml) for a compile-time guard.
 Speeches == {"stay_silent", "inform", "request_help", "claim_task"}
 Surfaces == {"silent", "visible_reply", "board_post", "task_claim"}
 


### PR DESCRIPTION
## Summary
Resolves the documentation half of #9065. The spec's 4-element \`Speeches\`/\`Surfaces\` enums modelled a partial projection of OCaml's 8 \`speech_act\` / 6 \`delivery_surface\` constructors without saying so.

Adds a \`#8642\`-style mapping table at the enum declaration site, plus a "sound partial coverage" rationale:
- \`cap_social_state\` at \`keeper_social_model_magentic_ledger_v1.ml:200,220\` is the single emission point.
- Its match is exhaustive over the OCaml type, so unmodelled variants (Comment_board, Post_board, Broadcast, Defer + Board_comment, Broadcast_surface) are safe by construction.
- The 4×4 spec projection verifies the cap math itself; the unmodelled values transit the same emission path with the same cap.

The note also calls out what this projection does NOT catch (a future emission site that bypasses \`cap_social_state\`) and points at #9065 option 3 (witness-pattern compile-time guard) for the gap.

## Verification
\`\`\`
$ grep -n "type speech_act\|type delivery_surface" lib/keeper/social_model/keeper_social_model_types.mli
1:type speech_act =      (* 8 constructors *)
11:type delivery_surface = (* 6 constructors *)
$ grep -n "cap_social_state" lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
200:  (routed_result, Types.cap_social_state state, transition_reason)
220:  ( Types.cap_social_state
\`\`\`

## Sweep context
First sweep finding to *resolve* an issue I previously filed (vs filing more).

5th doc-only PR in the TLA+ ↔ OCaml mapping sweep:
- PR #9043 — KeeperCompositeLifecycle line drift (MERGED)
- PR #9045 — KeeperContextLifecycle line drift (MERGED)
- PR #9058 — KeeperRecoveryOrchestration stale module note (MERGED)
- PR #9063 — ContractClosure plan path out-of-tree (OPEN)
- PR #THIS — SocialStateCap mapping table (this PR, OPEN)

Closes the documentation lane of #9065. The mechanical "compile-time witness" lane stays open as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)