### PR TITLE
docs(specs): add ASPIRATIONAL DESIGN banner to KeeperWorkPipeline (#9044)

### DIFF
--- a/specs/keeper-state-machine/KeeperWorkPipeline.tla
+++ b/specs/keeper-state-machine/KeeperWorkPipeline.tla
@@ -1,12 +1,29 @@
 ---- MODULE KeeperWorkPipeline ----
-\* Keeper Autonomous Work Pipeline — TLA+ Formal Specification
+\* ── STATUS: ASPIRATIONAL DESIGN INVARIANT (not wired to current runtime) ──
+\* This spec describes a future workspace/PR/commit pipeline. As of
+\* 2026-04-20:
+\*   - lib/keeper/keeper_exec_github.ml does NOT exist
+\*     (`find lib -name "*github*"` returns 0 hits in lib/keeper/)
+\*   - The primitives this spec models — `force_push_attempted`,
+\*     `workspace_init`, `workspace_cleaned`, `commit_identity`,
+\*     `submit_count` — have 0 hits in lib/keeper/
+\*   - This spec is NOT in scripts/tla-check.sh (TLC does not run it)
+\* The actual keeper exec surface is keeper_exec_board / _context / _fs /
+\* _masc / _memory + keeper_tool_pr_review, with a different state shape.
+\* See issue #9044 for the retire / re-target / banner trichotomy.
+\* This banner takes the "banner" option to make the aspirational nature
+\* explicit; treat the safety properties below as forward-looking design
+\* documentation, not runtime invariants.
+\* ──────────────────────────────────────────────────────────────────────
+\*
+\* Keeper Autonomous Work Pipeline — TLA+ Formal Specification (DESIGN)
 \*
 \* Models the deterministic core of a keeper's autonomous task execution:
 \* workspace lifecycle, file operations, commit safety, PR creation, review cycles.
 \*
 \* Complementary to KeeperStateMachine (lifecycle) and KeeperTurnCycle (turns).
 \* This spec models what happens WITHIN a Running phase when a keeper executes
-\* an autonomous coding task.
+\* an autonomous coding task — IF/WHEN such a runtime exists.
 \*
 \* Verifies properties that unit tests cannot:
 \*   - Path traversal safety (writes always inside workspace boundary)
@@ -15,7 +32,9 @@
 \*   - Review before submit (at least one review before PR creation)
 \*   - No orphan workspaces (initialized workspaces always cleaned up)
 \*
-\* Mirrors: lib/keeper/keeper_exec_github.ml, lib/tool_code_write.ml
+\* Mirrors (TARGET, not current):
+\*   lib/keeper/keeper_exec_github.ml — DOES NOT EXIST AS OF 2026-04-20
+\*   lib/tool_code_write.ml          — exists, partially relevant
 
 EXTENDS Naturals, FiniteSets
 


### PR DESCRIPTION
## Summary
Resolves the "banner" option of #9044's retire/banner/re-target trichotomy.

\`KeeperWorkPipeline.tla\` referenced \`lib/keeper/keeper_exec_github.ml\` (does not exist) and modelled primitives (\`force_push_attempted\`, \`workspace_init\`, \`commit_identity\`, ...) with 0 hits in \`lib/keeper/\`. It is also NOT in \`scripts/tla-check.sh\`, so TLC never runs it.

This PR adds a \`STATUS: ASPIRATIONAL DESIGN INVARIANT\` banner matching the \`KeeperReconcileLiveness.tla\` pattern so a reader doesn't assume the safety properties are runtime-enforced. The body stays intact — if an autonomous PR/commit pipeline is wired later, the spec stays as the design contract; until then it is forward-looking documentation.

## Verification
\`\`\`
$ test -f lib/keeper/keeper_exec_github.ml; echo \$?
1
$ grep "KeeperWorkPipeline" scripts/tla-check.sh
(no output)
$ grep -rn "force_push_attempted\|workspace_init" lib/keeper/
(no output)
\`\`\`

## Sweep context
6th doc-only PR + 2nd issue-resolving PR in the TLA+ ↔ OCaml mapping sweep:
- PR #9043 / #9045 / #9058 — line drift fixes (MERGED)
- PR #9063 — ContractClosure plan path (OPEN)
- PR #9068 — SocialStateCap mapping (OPEN, resolves doc half of #9056\* — actually #9065)
- PR #THIS — KeeperWorkPipeline banner (OPEN, resolves banner option of #9044)

Issues still open: #9006 (KeeperPhaseRace), #9032 (DispatchCoverage), #9044 (this PR closes one option), #9056 (TaskLifecycle Claimed variant), #9065 (witness-pattern half remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)