### PR TITLE
docs(spec): update DispatchCoverage line references (#9032)

### DIFF
--- a/specs/bug-models/DispatchCoverage.tla
+++ b/specs/bug-models/DispatchCoverage.tla
@@ -15,7 +15,7 @@
 \* keeper_status_detail.ml:118). This spec retains the bug class and the
 \* 4 other mapped blockers (turn, compact, handoff, guardrail) below, which
 \* continue to model live mechanisms. maybe_recover_from_failing() now lives
-\* at keeper_keepalive.ml:940.
+\* at keeper_keepalive.ml:935 and dispatches Turn_succeeded at :947.
 \*
 \* This spec models 5 blocking conditions from the keeper FSM
 \* (keeper_state_machine.ml). Each has a "data layer" boolean and an
@@ -24,13 +24,13 @@
 \*
 \* ── Mapped clearing actions (from OCaml code) ──
 \*
-\*  # | Data clear             | FSM event                  | OCaml location
+\*  # | Data clear             | FSM event                  | OCaml location (verified 2026-04-20)
 \*  --+------------------------+----------------------------+--------------------------------
 \*  1 | manual_reconcile file  | Manual_reconcile_cleared   | [REMOVED 2026-04-20, see #9032]
-\*  2 | turn_failures counter  | Turn_succeeded             | keeper_keepalive.ml (near recover)
-\*  3 | compaction_active flag  | Compaction_completed       | keeper_exec_context.ml
-\*  4 | handoff_active flag     | Handoff_completed          | keeper_exec_context.ml
-\*  5 | guardrail measurement  | Context_measured(stop=F)   | keeper_keepalive.ml
+\*  2 | turn_failures counter  | Turn_succeeded             | keeper_keepalive.ml:947 (inside maybe_recover_from_failing at :935)
+\*  3 | compaction_active flag | Compaction_completed       | keeper_exec_context.ml:174
+\*  4 | handoff_active flag    | Handoff_completed          | keeper_exec_context.ml:190
+\*  5 | guardrail measurement  | Context_measured(stop=F)   | keeper_keepalive.ml:807 (RFC-0002 dispatch)
 \*
 \* ── Abstraction ──
 \* Each blocking condition is modeled as a pair: (data_blocked, fsm_blocked).


### PR DESCRIPTION
## Summary
Comment-only follow-up to the earlier #9032 bug-#1 annotation. Verifies and pins the OCaml line numbers for the 4 live bug mappings in `DispatchCoverage.tla` so the spec's mapping table stays usable as a jump target.

## Product impact
- **none/internal** — TLC semantics unchanged (all edits are inside `\*` comments). Benefits land for spec readers only: next on-call looking at the `DispatchCoverage` bug class no longer has to re-grep to find the dispatch sites. Option C from the issue (annotate + line corrections), which matches the doc-only fixes shipped in #8998 / #9000 / #9004 / #9011 / #9017 / #9027 / #9031.

## Evidence
- Line numbers verified on `origin/main` at HEAD `e65e4b339` (2026-04-20):
  - Bug #2 `Turn_succeeded`: `keeper_keepalive.ml:947` inside `maybe_recover_from_failing` at `:935`
  - Bug #3 `Compaction_completed`: `keeper_exec_context.ml:174`
  - Bug #4 `Handoff_completed`: `keeper_exec_context.ml:190`
  - Bug #5 `Context_measured`: `keeper_keepalive.ml:807` (RFC-0002 dispatch)
- Preamble NOTE corrected: `maybe_recover_from_failing` is at `:935` (not `:940` as previously stated)
- Diff: +6/-6 across 1 file. No TLC re-run necessary — the spec model (`Init`, `Next`, `NextBuggy`, invariants) is byte-identical.

## Review evidence
Self-review only. This is the "cheapest path" option from #9032 (option C); options A (live replacement example) and B (retire spec) are intentionally deferred.

## Linked issue
Closes #9032. Refs #8989, #9006, #6801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
