### PR TITLE
feat(lint): spec-line-refs gate (#9052)

### DIFF
--- a/.github/workflows/lint-spec-line-refs.yml
+++ b/.github/workflows/lint-spec-line-refs.yml
@@ -1,0 +1,26 @@
+name: lint-spec-line-refs
+
+on:
+  pull_request:
+    paths:
+      - 'specs/**/*.tla'
+      - 'lib/**/*.ml'
+      - 'lib/**/*.mli'
+      - 'scripts/lint/spec-line-refs.sh'
+      - 'scripts/lint/spec-line-refs.allowlist'
+      - '.github/workflows/lint-spec-line-refs.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Validate (path:line snippet) references in specs/
+        run: bash scripts/lint/spec-line-refs.sh

--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -1,0 +1,47 @@
+# Allowlist for scripts/lint/spec-line-refs.sh
+#
+# Format: `<spec_path>  <source_path>:<line>` (two spaces between spec and
+# source ref). Lines starting with `#` and blank lines are ignored.
+#
+# Entries are baseline drift debt observed at install time (2026-04-20).
+# They are NOT exonerations — each represents a stale `(path:line snippet)`
+# comment in a spec file that should be re-anchored to the current source.
+#
+# A stale entry (drift no longer present, because someone re-anchored it)
+# surfaces as exit 2 via the self-verify step, so the ledger stays honest.
+#
+# To widen coverage: remove the matching entry after fixing the drift.
+#
+# File new drift as standalone work. Symbol-anchor form
+# (`path.ml:symbol_name`) sidesteps this drift class entirely — prefer it
+# when authoring new references.
+
+specs/bug-models/CascadeExhaustion.tla  lib/cascade/cascade_fsm.mli:45
+specs/bug-models/FileLockStarvation.tla  lib/process/file_lock_eio.ml:170
+specs/bug-models/FileLockStarvation.tla  lib/process/file_lock_eio.ml:180
+specs/bug-models/FileLockStarvation.tla  lib/process/file_lock_eio.ml:52
+specs/bug-models/FileLockStarvation.tla  lib/process/file_lock_eio.ml:68
+specs/bug-models/FileLockStarvation.tla  lib/process/file_lock_eio.ml:84
+specs/bug-models/HebbianLearning.tla  lib/hebbian_eio.ml:264
+specs/bug-models/KeeperTaskInterlock.tla  lib/types/types_core.ml:335
+specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:49
+specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:70
+specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
+specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:33
+specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:336
+specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:99
+specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:118
+specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:17
+specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:63
+specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:64
+specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:389
+specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:61
+specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:8
+specs/keeper-state-machine/KeeperCounterCausality.tla  lib/dashboard/dashboard_http_keeper.ml:763
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_bank.ml:550
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:159
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:164
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:166
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_recall.ml:104
+specs/keeper-state-machine/KeeperOutcomesConservation.tla  lib/dashboard/dashboard_http_keeper.ml:65
+specs/keeper-state-machine/KeeperReconcileLiveness.tla  lib/keeper/keeper_keepalive.ml:800

--- a/scripts/lint/spec-line-refs.sh
+++ b/scripts/lint/spec-line-refs.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# spec-line-refs.sh
+#
+# Validates (path:line  snippet) references embedded in TLA+ spec comments.
+#
+# The specs/ tree carries pointers into the OCaml codebase of the form:
+#
+#   (* lib/cascade/cascade_fsm.mli:37  accept_on_exhaustion:bool -> *)
+#
+# When upstream shifts line 37, the reference drifts silently. This gate
+# parses those tuples, reads the target source, and checks that the
+# referenced line still contains the recorded snippet.
+#
+# Exit codes:
+#   0 — all refs match (or no refs found)
+#   1 — at least one drift detected (line exists, snippet mismatch)
+#   2 — at least one dangling path (file missing, or line out of range)
+#
+# `path:SYMBOL` style references (where `:` is followed by a non-numeric
+# identifier, e.g. `cascade_fsm.ml:decide`) are symbol-anchored by design
+# and are resolved via `grep`, not line number. They are included in the
+# check but never trigger drift — only dangling-path.
+#
+# Invocation:
+#   bash scripts/lint/spec-line-refs.sh              # full repo scan
+#   SPEC_ROOT=specs bash scripts/lint/spec-line-refs.sh
+#
+# Opt-out for a single spec file:
+#   Add `# spec-line-refs: ignore` anywhere in the first 20 lines.
+
+set -u
+
+SPEC_ROOT="${SPEC_ROOT:-specs}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -d "$SPEC_ROOT" ]]; then
+  echo "spec-line-refs: no $SPEC_ROOT directory, nothing to check"
+  exit 0
+fi
+
+ALLOWLIST="${ALLOWLIST:-scripts/lint/spec-line-refs.allowlist}"
+
+drift_count=0
+dangle_count=0
+ok_count=0
+sym_count=0
+allowlisted_count=0
+# Track which allowlist entries were exercised this run so we can flag stale
+# entries that no longer correspond to a real drift.
+detected_keys_file="$(mktemp -t spec-line-refs.XXXXXX)"
+trap 'rm -f "$detected_keys_file"' EXIT
+
+in_allowlist() {
+  local key="$1"
+  [[ -f "$ALLOWLIST" ]] || return 1
+  grep -Fxq "$key" <(grep -v '^#' "$ALLOWLIST" | grep -v '^[[:space:]]*$') 2>/dev/null
+}
+
+# Iterate .tla files; portable across bash 3.2 (macOS) and 4+ (CI).
+while IFS= read -r -d '' f; do
+  if head -20 "$f" | grep -q 'spec-line-refs: ignore'; then
+    continue
+  fi
+
+  # Extract (path, line_or_sym, rest) tuples from every comment line.
+  # Match path like  lib/.../file.ml  or  lib/.../file.mli.
+  # Token after ':' is either digits (line) or identifier (symbol).
+  # Rest = everything after the ref, for snippet compare.
+  while IFS=$'\t' read -r lineno path ref rest; do
+    # Symbol-anchored reference — just check the file contains it.
+    if [[ "$ref" =~ ^[0-9]+$ ]]; then
+      line_num="$ref"
+    else
+      if [[ ! -f "$path" ]]; then
+        printf '::error file=%s,line=%s::dangling path: %s (file not found; ref :%s)\n' \
+          "$f" "$lineno" "$path" "$ref"
+        dangle_count=$((dangle_count + 1))
+        continue
+      fi
+      if ! grep -qE "(^|[^a-zA-Z0-9_])${ref}([^a-zA-Z0-9_]|$)" "$path"; then
+        printf '::error file=%s,line=%s::dangling symbol %s not found in %s\n' \
+          "$f" "$lineno" "$ref" "$path"
+        dangle_count=$((dangle_count + 1))
+        continue
+      fi
+      sym_count=$((sym_count + 1))
+      continue
+    fi
+
+    if [[ ! -f "$path" ]]; then
+      printf '::error file=%s,line=%s::dangling path: %s (ref %s:%s)\n' \
+        "$f" "$lineno" "$path" "$path" "$line_num"
+      dangle_count=$((dangle_count + 1))
+      continue
+    fi
+
+    total_lines=$(wc -l < "$path")
+    if (( line_num > total_lines )); then
+      printf '::error file=%s,line=%s::out-of-range: %s:%s (file has %d lines)\n' \
+        "$f" "$lineno" "$path" "$line_num" "$total_lines"
+      dangle_count=$((dangle_count + 1))
+      continue
+    fi
+
+    # Trim leading range-tail (e.g. "-68" from "N-M"), comment closer, and
+    # leading/trailing whitespace from the snippet text.
+    snippet=$(printf '%s' "$rest" | sed -E '
+      s/^-[0-9]+//
+      s/^[[:space:]]*\*\)?[[:space:]]*//
+      s/^[[:space:]]+//
+      s/[[:space:]]+$//
+    ')
+    if [[ -z "$snippet" ]]; then
+      # Bare ref with no snippet — nothing to check beyond path:line existence.
+      ok_count=$((ok_count + 1))
+      continue
+    fi
+
+    src_line=$(sed -n "${line_num}p" "$path")
+    # Take the first 24 chars of snippet as a signature — enough to identify,
+    # tolerant of trailing drift.
+    sig="${snippet:0:24}"
+    # Skip pure comment tokens that would false-negative (e.g. "*/").
+    if [[ "$sig" == "*/" || "$sig" == "*" ]]; then
+      ok_count=$((ok_count + 1))
+      continue
+    fi
+
+    if [[ "$src_line" == *"$sig"* ]]; then
+      ok_count=$((ok_count + 1))
+    else
+      key="$f  $path:$line_num"
+      printf '%s\n' "$key" >> "$detected_keys_file"
+      if in_allowlist "$key"; then
+        allowlisted_count=$((allowlisted_count + 1))
+        continue
+      fi
+      suggestion=$(grep -nF "$sig" "$path" 2>/dev/null | head -1 | cut -d: -f1)
+      if [[ -n "$suggestion" ]]; then
+        printf '::error file=%s,line=%s::drift: %s:%s expected %q; now at line %s\n' \
+          "$f" "$lineno" "$path" "$line_num" "$sig" "$suggestion"
+      else
+        printf '::error file=%s,line=%s::drift: %s:%s snippet %q not found in file\n' \
+          "$f" "$lineno" "$path" "$line_num" "$sig"
+      fi
+      drift_count=$((drift_count + 1))
+    fi
+  done < <(awk '
+    {
+      line = $0
+      while (match(line, /(lib|test|src|scripts|docs)\/[A-Za-z0-9_\/\-]+\.(ml|mli)\:/)) {
+        ref_start = RSTART
+        ref_end = RSTART + RLENGTH
+        path = substr(line, ref_start, RLENGTH - 1)
+        rest = substr(line, ref_end)
+        # Extract token after the colon.
+        # Forms: N (line), N-M (range — anchor at N), symbol (identifier).
+        if (match(rest, /^[0-9]+(-[0-9]+)?/)) {
+          tok = substr(rest, 1, RLENGTH)
+          after = substr(rest, RLENGTH + 1)
+          # For ranges, keep only the starting line as the anchor token.
+          dash = index(tok, "-")
+          if (dash > 0) {
+            tok = substr(tok, 1, dash - 1)
+          }
+        } else if (match(rest, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+          tok = substr(rest, 1, RLENGTH)
+          after = substr(rest, RLENGTH + 1)
+        } else {
+          line = substr(line, ref_end)
+          continue
+        }
+        print NR "\t" path "\t" tok "\t" after
+        line = substr(line, ref_end + length(tok))
+      }
+    }
+  ' "$f")
+done < <(find "$SPEC_ROOT" -name '*.tla' -type f -print0 | sort -z)
+
+total=$((ok_count + sym_count + drift_count + dangle_count + allowlisted_count))
+printf 'spec-line-refs: %d refs checked (%d line-anchored ok, %d symbol-anchored ok, %d drift, %d dangling, %d allowlisted)\n' \
+  "$total" "$ok_count" "$sym_count" "$drift_count" "$dangle_count" "$allowlisted_count"
+
+# Self-verify: allowlist entries that no drift matched this run are stale.
+stale_count=0
+if [[ "${SKIP_ALLOWLIST_VERIFY:-}" != "1" && -f "$ALLOWLIST" ]]; then
+  while IFS= read -r entry || [[ -n "$entry" ]]; do
+    [[ -z "$entry" || "$entry" =~ ^[[:space:]]*# ]] && continue
+    if ! grep -Fxq "$entry" "$detected_keys_file" 2>/dev/null; then
+      printf '::error file=%s::stale allowlist entry — no matching drift detected: %q\n' \
+        "$ALLOWLIST" "$entry"
+      stale_count=$((stale_count + 1))
+    fi
+  done < "$ALLOWLIST"
+fi
+
+if (( stale_count > 0 )); then
+  exit 2
+fi
+if (( dangle_count > 0 )); then
+  exit 2
+fi
+if (( drift_count > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #9052.

## Summary

CI gate that validates `(path:line snippet)` references embedded in TLA+ spec comments under `specs/`. Mirrors the #8605-family architecture (#8937 self-verify, #9016 symbol-anchor).

## Evidence / motivation

6+ drift-fix PRs in the last 2 days (#9000 #9004 #9011 #9017 #9027 #9031 #9043 #9045). 60+ live `path:line` refs across `specs/`. Each upstream `.mli` / `.ml` insertion silently invalidates some of them.

Same DET class the symbol-anchor migration closed in lint allowlists — now applied to a second surface (spec prose annotations).

## How the gate works

Parser (awk) extracts `(path, token, rest)` tuples from every line of every `.tla` file:

- `path:N` — line anchor. Validator reads source line N, requires the first 24 chars of the snippet to appear. On mismatch, suggests the current line via `grep -nF`.
- `path:N-M` — range. Anchored at N; the `-M *)` tail is stripped from the snippet before compare.
- `path:symbol` — symbol anchor (robust, no drift class). Validator greps the file for the symbol as a whole word. Only reports dangling (symbol not found anywhere).

## Allowlist

29 baseline entries cataloged from the current main state. Format: `<spec_path>  <source_path>:<line>` (two-space separator).

Philosophy: debt ledger, not exoneration. Each entry represents a stale `(path:line snippet)` comment that should be re-anchored. Self-verify surfaces entries that no longer match any detected drift as exit 2, so the ledger stays honest.

Migration target: replace `path:N snippet` with `path:symbol` where the snippet is a top-level identifier — same move the #9016 allowlist did.

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | All refs match or allowlisted |
| 1 | New drift detected (outside allowlist) |
| 2 | Dangling path, out-of-range line, or stale allowlist entry |

## Baseline on this PR

```
spec-line-refs: 72 refs checked (39 line-anchored ok, 3 symbol-anchored ok, 0 drift, 0 dangling, 30 allowlisted)
```

## Test plan

- [x] Baseline clean run on current main — exit 0.
- [x] Injected fake allowlist entry - self-verify reports stale - exit 2.
- [x] Range form `keeper_campaign_fsm.ml:71-93` parses as line 71, tail stripped from snippet.
- [x] Symbol-anchor refs (`cascade_fsm.ml:decide`) validated via grep.
- [ ] CI green on this PR - blocked until green.
- [ ] Observe: next drift-fix PR should pass through the gate.

## Out of scope / follow-ups

- Autofix codemod for the 29 allowlisted entries (replace `path:line` with `path:symbol` where the snippet is an identifier).
- Cross-repo refs into OAS (currently resolve to dangling path). Likely handled by skipping paths not starting with `lib/` / `test/` / `src/`.
