### PR TITLE
spec(task-lifecycle): extend to 6-state lifecycle with Claimed (#9056)

### DIFF
--- a/specs/task-lifecycle/TaskLifecycle-buggy.cfg
+++ b/specs/task-lifecycle/TaskLifecycle-buggy.cfg
@@ -1,6 +1,9 @@
-\* Buggy: BugSkipVerification MUST violate DoneRequiresApproval.
-\* If it passes the invariant is too weak and the spec is not checking
-\* the verification gate.
+\* Buggy: at least one of the two invariants MUST be violated.
+\*   - BugSkipVerification (InProgress -> Done) violates DoneRequiresApproval.
+\*   - BugSkipClaim (Todo -> InProgress) violates InProgressRequiresClaim.
+\* If both pass under SpecBuggy, the invariants are too weak and the
+\* spec is not actually checking either gate.
 SPECIFICATION SpecBuggy
 INVARIANT TypeOK
 INVARIANT DoneRequiresApproval
+INVARIANT InProgressRequiresClaim

--- a/specs/task-lifecycle/TaskLifecycle.cfg
+++ b/specs/task-lifecycle/TaskLifecycle.cfg
@@ -1,4 +1,7 @@
-\* Clean: DoneRequiresApproval must pass.
+\* Clean: both invariants must pass.
+\* DoneRequiresApproval guards the verification gate.
+\* InProgressRequiresClaim guards the new Claimed step (added in #9056).
 SPECIFICATION SpecClean
 INVARIANT TypeOK
 INVARIANT DoneRequiresApproval
+INVARIANT InProgressRequiresClaim

--- a/specs/task-lifecycle/TaskLifecycle.tla
+++ b/specs/task-lifecycle/TaskLifecycle.tla
@@ -1,62 +1,109 @@
 ------------------------------ MODULE TaskLifecycle ------------------------------
 (* TLA+ spec for the MASC task lifecycle and the AwaitingVerification gate.
 
-   Covers the Todo / InProgress / AwaitingVerification / Done / Cancelled
-   variants defined in Types_core.task_status. The central claim is that
-   state = "Done" is only reachable after an Approve_verification that flips
-   the "verified" ghost variable to TRUE.
+   Covers the 6-state lifecycle exposed by the OCaml [task_status] type
+   in `lib/types/types_core.ml:335-348`:
+
+     Todo / Claimed / InProgress / AwaitingVerification / Done / Cancelled
+
+   The OCaml comment at line 369 spells the canonical order as
+   "Todo -> Claimed -> InProgress -> AwaitingVerification -> Done | Cancelled".
+   Issue #9056 found that an earlier 5-state version of this spec
+   collapsed [Claim] into a Todo->InProgress shortcut, missing the
+   intermediate Claimed step where a worker has reserved the task but
+   not yet started it.
+
+   The central claim is that state = "Done" is only reachable after an
+   Approve_verification that flips the "verified" ghost variable to TRUE.
+   The Claimed extension preserves that invariant and adds a structural
+   gate: InProgress is only reachable via Claimed, not directly from Todo.
 
    Bug Model pattern (feedback_tla-spec-audit-outcome-trichotomy):
-     - Clean cfg: SpecClean + DoneRequiresApproval passes.
-     - Buggy cfg: SpecBuggy adds a direct InProgress -> Done skip which
-       MUST violate DoneRequiresApproval. If it passes the invariant is
-       too weak and the spec is not actually checking anything.
+     - Clean cfg: SpecClean + DoneRequiresApproval + InProgressRequiresClaim
+                  must all pass.
+     - Buggy cfg: SpecBuggy adds:
+                  * BugSkipVerification (InProgress -> Done) which MUST
+                    violate DoneRequiresApproval.
+                  * BugSkipClaim (Todo -> InProgress directly) which MUST
+                    violate InProgressRequiresClaim.
+                  If either invariant passes, it is too weak.
+
+   OCaml ↔ TLA+ mapping (#8642 family, #9056):
+     spec name              ↔ OCaml task_status constructor
+     ----------------------+---------------------------------------------
+     "Todo"                 ↔ Todo
+     "Claimed"              ↔ Claimed of { assignee; claimed_at }
+     "InProgress"           ↔ InProgress of { assignee; started_at }
+     "AwaitingVerification" ↔ AwaitingVerification of { assignee; ... }
+     "Done"                 ↔ Done of { assignee; completed_at; notes }
+     "Cancelled"            ↔ Cancelled of { cancelled_by; ... }
+
+   Adding a 7th constructor on the OCaml side would force a compile
+   error in [all_task_status_names] (witness pattern at types_core.ml:371)
+   AND should add the new value to [States] here. The witness function
+   is the cross-language drift gate.
 *)
 
 EXTENDS Integers
 
-VARIABLES state, verified
+VARIABLES state, verified, ever_claimed
 
-vars == <<state, verified>>
+vars == <<state, verified, ever_claimed>>
 
-States == { "Todo", "InProgress", "AwaitingVerification", "Done", "Cancelled" }
+States == { "Todo", "Claimed", "InProgress", "AwaitingVerification",
+            "Done", "Cancelled" }
 
 TypeOK ==
     /\ state \in States
     /\ verified \in BOOLEAN
+    /\ ever_claimed \in BOOLEAN
 
 \* ── Init ────────────────────────────────────
 
 Init ==
     /\ state = "Todo"
     /\ verified = FALSE
+    /\ ever_claimed = FALSE
 
 \* ── Clean transitions ───────────────────────
 
+\* Claim: Todo -> Claimed (worker reserves the task, has not started yet).
 Claim ==
     /\ state = "Todo"
-    /\ state' = "InProgress"
+    /\ state' = "Claimed"
+    /\ ever_claimed' = TRUE
     /\ UNCHANGED verified
+
+\* Start: Claimed -> InProgress (worker actually begins work).
+Start ==
+    /\ state = "Claimed"
+    /\ state' = "InProgress"
+    /\ UNCHANGED <<verified, ever_claimed>>
 
 Submit ==
     /\ state = "InProgress"
     /\ state' = "AwaitingVerification"
-    /\ UNCHANGED verified
+    /\ UNCHANGED <<verified, ever_claimed>>
 
 Approve ==
     /\ state = "AwaitingVerification"
     /\ state' = "Done"
     /\ verified' = TRUE
+    /\ UNCHANGED ever_claimed
 
+\* Reject: AwaitingVerification -> InProgress (worker has more to do).
+\* The Claimed prefix is preserved because [ever_claimed] is monotone.
 Reject ==
     /\ state = "AwaitingVerification"
     /\ state' = "InProgress"
-    /\ UNCHANGED verified
+    /\ UNCHANGED <<verified, ever_claimed>>
 
+\* Cancel: any non-terminal state -> Cancelled.
+\* OCaml allows cancellation from Claimed (worker abandons before starting).
 Cancel ==
-    /\ state \in { "Todo", "InProgress", "AwaitingVerification" }
+    /\ state \in { "Todo", "Claimed", "InProgress", "AwaitingVerification" }
     /\ state' = "Cancelled"
-    /\ UNCHANGED verified
+    /\ UNCHANGED <<verified, ever_claimed>>
 
 \* Terminal states stutter so TLC can close the model.
 Terminal ==
@@ -65,6 +112,7 @@ Terminal ==
 
 NextClean ==
     \/ Claim
+    \/ Start
     \/ Submit
     \/ Approve
     \/ Reject
@@ -79,11 +127,23 @@ NextClean ==
 BugSkipVerification ==
     /\ state = "InProgress"
     /\ state' = "Done"
-    /\ UNCHANGED verified
+    /\ UNCHANGED <<verified, ever_claimed>>
+
+\* ── Bug: skip claim step ────────────────────
+\* Models the OLD 5-state spec's shortcut where Todo went straight to
+\* InProgress, bypassing Claimed. Real OCaml runtime never does this
+\* (the [Claimed] constructor is the gate that records assignee +
+\* claimed_at), so InProgressRequiresClaim must catch this skip.
+
+BugSkipClaim ==
+    /\ state = "Todo"
+    /\ state' = "InProgress"
+    /\ UNCHANGED <<verified, ever_claimed>>
 
 NextBuggy ==
     \/ NextClean
     \/ BugSkipVerification
+    \/ BugSkipClaim
 
 \* ── Specs ───────────────────────────────────
 
@@ -100,5 +160,14 @@ DoneRequiresApproval ==
 \* class of refactor bugs where Done mutates verified post-hoc.)
 VerifiedMonotone ==
     state = "Done" => verified = TRUE
+
+\* InProgress (and any state past it) is reachable only after a Claim.
+\* Catches the BugSkipClaim shortcut. Mirrors the OCaml invariant that
+\* [InProgress { assignee; started_at }] cannot exist without a prior
+\* [Claimed { assignee; claimed_at }] step (or equivalent transition
+\* through the runtime task FSM).
+InProgressRequiresClaim ==
+    state \in { "InProgress", "AwaitingVerification", "Done" }
+        => ever_claimed = TRUE
 
 ================================================================================


### PR DESCRIPTION
## Summary
Resolves #9056. The TaskLifecycle.tla spec modelled a 5-state lifecycle while the OCaml \`task_status\` type at \`lib/types/types_core.ml:335-348\` carries 6 constructors with \`Claimed\` between Todo and InProgress.

This PR extends the spec to the canonical 6-state lifecycle from the OCaml comment:

> Todo -> Claimed -> InProgress -> AwaitingVerification -> Done | Cancelled

## Changes
- **Add \`"Claimed"\` to \`States\`**.
- **Introduce \`ever_claimed\` ghost variable** so the new invariant can witness the claim step.
- **Split old \`Claim\` action** into \`Claim\` (Todo → Claimed) and \`Start\` (Claimed → InProgress).
- **Allow Cancel from Claimed** (OCaml runtime allows abandon-after-claim).
- **New invariant \`InProgressRequiresClaim\`**: any state past InProgress requires a prior Claim.
- **New bug action \`BugSkipClaim\`** (Todo → InProgress directly, the OLD spec's behaviour) wired into \`NextBuggy\`.
- **Mapping table** at the spec preamble (\`#8642\` family) pointing at \`all_task_status_names\` witness function as the cross-language drift gate.
- **Both cfgs** updated with \`INVARIANT InProgressRequiresClaim\`.

## Bug-model contract (feedback_tla-spec-audit-outcome-trichotomy)

Clean cfg — both invariants must pass:
- \`DoneRequiresApproval\` ✓ (Done is only reachable via Approve)
- \`InProgressRequiresClaim\` ✓ (InProgress is only reachable via Start, which requires Claimed)

Buggy cfg — at least one invariant must fail:
- \`BugSkipVerification\` (InProgress → Done) violates \`DoneRequiresApproval\`
- \`BugSkipClaim\` (Todo → InProgress) violates \`InProgressRequiresClaim\`

If both pass under SpecBuggy, the invariants are too weak.

## Verification
\`\`\`
$ grep -nE "^\s*\|\s*(Todo|Claimed|InProgress|AwaitingVerification|Done|Cancelled)" lib/types/types_core.ml | head -6
336:  | Todo
337:  | Claimed of { assignee: string; claimed_at: string }
338:  | InProgress of { assignee: string; started_at: string }
339:  | AwaitingVerification of {
346:  | Done of { assignee: string; completed_at: string; notes: string option }
347:  | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
\$ sed -n '369,371p' lib/types/types_core.ml
    Order matches the FSM lifecycle (Todo -> Claimed -> InProgress ->
    AwaitingVerification -> Done | Cancelled) for readable schema docs. *)
\`\`\`

## Operator note
\`TaskLifecycle\` is **not** wired into \`scripts/tla-check.sh\` today, so CI does not run TLC on this spec automatically. Reviewer / merger should run TLC manually on both cfgs to confirm the contract:

\`\`\`
tlc -config TaskLifecycle.cfg TaskLifecycle.tla       # expect: no error
tlc -config TaskLifecycle-buggy.cfg TaskLifecycle.tla # expect: invariant violated
\`\`\`

I did not run TLC locally (no JVM toolchain ready in this worktree); the bug-model contract above is reasoned out by hand.

## Sweep context
3rd issue-resolving PR in the TLA+ ↔ OCaml mapping sweep. Closes #9056. Companion issues still open: #9006, #9032, #9044 (banner option in PR #9069), #9065 (doc half in PR #9068).

🤖 Generated with [Claude Code](https://claude.com/claude-code)