### PR TITLE
docs(spec): follow Room_gc -> Coord_gc rename in KeeperTaskInterlock

### DIFF
--- a/specs/bug-models/KeeperTaskInterlock.tla
+++ b/specs/bug-models/KeeperTaskInterlock.tla
@@ -53,11 +53,11 @@
 \*
 \* What actually restores the invariant:
 \*
-\*   Room_gc.cleanup_zombies (room/room_gc.ml:39-150) scans the
+\*   Coord_gc.cleanup_zombies (lib/coord/coord_gc.ml:39-190) scans the
 \*   agents directory on a periodic GC cycle, detects agents whose
 \*   last_seen is older than Env_config.Zombie.keeper_threshold_seconds
 \*   ("zombie" agents), and in Phase 3 iterates the backlog calling
-\*   Room_hooks.force_release_task_fn for every Claimed/InProgress
+\*   Coord_hooks.force_release_task_fn for every Claimed/InProgress
 \*   task whose assignee is a zombie. This is the **asynchronous,
 \*   heartbeat-timeout-driven** path that eventually restores the
 \*   NoDeadKeeperHoldsTask property.
@@ -306,8 +306,8 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 \*      update in keeper_registry.mark_dead leaves task_claimer
 \*      pointing at the dead keeper.
 \*
-\*   2. A separate asynchronous subsystem, Room_gc.cleanup_zombies
-\*      (lib/room/room_gc.ml), periodically scans agents by heartbeat
+\*   2. A separate asynchronous subsystem, Coord_gc.cleanup_zombies
+\*      (lib/coord/coord_gc.ml), periodically scans agents by heartbeat
 \*      last_seen and force-releases Claimed/InProgress tasks whose
 \*      assignee is a zombie agent. This is modelled below as
 \*      ReconcileByGC.
@@ -319,7 +319,7 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 \* it against the TLC runner in tla-check.sh / specs/Makefile.
 
 \* Zombie GC reconciliation: release an orphaned task whose claimer
-\* is dead. Mirrors room_gc.ml:118-132 Phase 3 cascade.
+\* is dead. Mirrors coord_gc.ml:128-146 Phase 3 cascade.
 ReconcileByGC(t) ==
     /\ Held(t)
     /\ keeper_phase[task_claimer[t]] = "dead"


### PR DESCRIPTION
## Summary
Fixes stale code references in `specs/bug-models/KeeperTaskInterlock.tla`. The spec pointed at `Room_gc` / `Room_hooks` / `room_gc.ml`, which no longer exist — these were renamed to `Coord_gc` / `Coord_hooks` / `lib/coord/coord_gc.ml` during the earlier `room` → `coord` consolidation.

## Product impact
- **none/internal** — TLC semantics unchanged; comment-only edits. Benefits land for spec readers only: the mapping table now points at a real file so the next reader can `sed -n '39,190p' lib/coord/coord_gc.ml` to see the implementation the spec is modelling.

## Evidence
- Verified no live occurrences of `Room_gc` / `Room_hooks` / `room_gc.ml` under `lib/`
- Verified the replacement targets exist:
  - `lib/coord/coord_gc.ml` (`cleanup_zombies` at line 39, spans through line 190)
  - `lib/coord/coord_hooks.ml` (`force_release_task_fn`)
  - Phase 3 cascade in `coord_gc.ml` at lines 128–146
- Diff: +5/-5 across 1 file, all inside `\*` comment blocks

## Review evidence
Self-review only. Sibling doc-only fix pattern from #9071 / #9069 and the earlier spec maintenance train (#8998 / #9000 / #9004 / #9011 / #9017 / #9027 / #9031).

## Linked issue
None — caught during audit of `specs/bug-models/` for broken code references (companion to #9032's DispatchCoverage fixes). No runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
