### PR TITLE
feat(bonsai-dashboard): Dead_keepers tab view (Phase 2.C first tab)

### DIFF
--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -18,5 +18,6 @@ let root (graph @ local) =
   match Route.of_path (current_path ()) with
   | Logs -> Logs_view.component graph
   | Hello -> Hello_view.component graph
+  | Dead_keepers -> Dead_keepers_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -1,0 +1,193 @@
+(** Dead keepers view — 추락한 키퍼 목록.
+
+    Phase 2.C 첫 탭 이식. 새 endpoint/fetch 없이 기존 [Keepers_var] 의
+    응답을 status=Dead 로 필터링만 한다. 4-파일 패턴 (types/fetch/var/view)
+    중 view 만 신규 — 가장 가벼운 탭.
+
+    design_v2 IA의 "crypt · dead keepers" 섹션. fleet에서 죽은 자들의
+    기록:
+    - 이름 · 마지막 상태(stat) · 지연시간(latency_ms가 × 로 표시)
+    - 경고 없음 상태(0명 Dead)는 조용한 배너
+    - 최근 crash timestamp는 keepers.generated_at 을 UTC 로
+
+    shell 재사용: [Placeholder_view.sidebar] (IA 일관성) + 자체 main. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .main {
+    padding: 3rem 3rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    overflow: auto;
+  }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .title_blood { color: var(--accent-blood); }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 620px;
+  }
+
+  .meta_strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    padding: 12px 16px;
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(42,20,14,0.35), rgba(20,12,8,0.65));
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+  .meta_item { display: flex; align-items: baseline; gap: 8px; }
+  .meta_k {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .meta_v {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-bright);
+  }
+  .meta_v_blood { color: var(--accent-blood); }
+
+  .quiet {
+    padding: 40px 20px;
+    text-align: center;
+    border: 1px dashed var(--border-main);
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-dim);
+  }
+|}]
+
+let hhmmss_of_iso (s : string) : string =
+  if String.length s >= 19 && Char.equal s.[10] 'T'
+  then String.sub s ~pos:11 ~len:8
+  else s
+;;
+
+let view_meta_strip ~(total : int) ~(dead : int) ~(synced : string) =
+  Node.div
+    ~attrs:[ Style.meta_strip ]
+    [ Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "fleet" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text (Printf.sprintf "%02d" total) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "dead" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v_blood ]
+            [ Node.text (Printf.sprintf "%02d" dead) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "synced" ]
+        ; Node.span ~attrs:[ Style.meta_v ] [ Node.text synced ]
+        ]
+    ]
+;;
+
+let view_dead_list (dead : Keepers_types.keeper list) =
+  match dead with
+  | [] ->
+    Node.div
+      ~attrs:[ Style.quiet ]
+      [ Node.text "fleet is whole — no keepers have fallen." ]
+  | ks ->
+    Node.div
+      ~attrs:[]
+      (List.map ks ~f:Roster.view_slot_of_keeper)
+;;
+
+let render (keepers : Keepers_types.response) : Node.t =
+  let total = List.length keepers.keepers in
+  let dead =
+    List.filter keepers.keepers ~f:(fun (k : Keepers_types.keeper) ->
+      match k.status with
+      | Dead -> true
+      | _ -> false)
+  in
+  let dead_n = List.length dead in
+  let synced =
+    match keepers.generated_at with
+    | "" -> "—"
+    | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
+  in
+  Node.div
+    ~attrs:[ Style.root ]
+    [ Placeholder_view.sidebar ~active:Dead_keepers
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "crypt · the fallen" ]
+        ; Node.h1
+            ~attrs:[ Style.title ]
+            [ Node.text "dead keepers "
+            ; Node.span
+                ~attrs:[ Style.title_blood ]
+                [ Node.text (Printf.sprintf "· %02d" dead_n) ]
+            ]
+        ; Node.p
+            ~attrs:[ Style.sub ]
+            [ Node.text
+                "fleet의 추락한 자들. 이 목록은 Keepers 엔드포인트의 status=Dead \
+                 필터링 — 별도 endpoint 없음. 각 slot은 마지막으로 관측된 \
+                 state와 latency를 기록한다."
+            ]
+        ; view_meta_strip ~total ~dead:dead_n ~synced
+        ; view_dead_list dead
+        ]
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Keepers_var.var) ~f:render
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -61,7 +61,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello -> true
+  | Logs | Hello | Dead_keepers -> true
   | _ -> false
 ;;
 


### PR DESCRIPTION
## Summary

Phase 2.A shell 추출 5/5 완료 후 **Phase 2.C 첫 탭 이식**. Dead_keepers는 새 endpoint/fetch 없이 기존 `Keepers_var`의 status=Dead 필터링만 — 가장 가벼운 탭 → shell/ 공용 모듈 조립 가치 실증.

> **Stack base**: main (독립).
> **Phase**: 2.C first tab · 4-파일 패턴 중 view만 신규.

## 신규 파일

`dashboard_bonsai/src/dead_keepers_view.ml` (~170 LOC)

### 재사용

| from | usage |
|---|---|
| `Placeholder_view.sidebar` | 좌측 nav (탭 간 IA 일관성) |
| `Roster.view_slot_of_keeper` | 각 dead keeper slot 렌더 |
| `Keepers_var.var` | 기존 3s 폴링 소스 |

### 자체 Style

hero(eyebrow/title/title_blood/sub) + meta_strip(fleet/dead/synced 3 KPI) + quiet(empty state 배너).

## Routing 변경

```ocaml
(* route.ml *)
let is_implemented = function
  | Logs | Hello | Dead_keepers -> true  (* Dead_keepers 추가 *)
  | _ -> false

(* app.ml *)
match Route.of_path (current_path ()) with
| Logs -> Logs_view.component graph
| Hello -> Hello_view.component graph
| Dead_keepers -> Dead_keepers_view.component graph  (* 신규 1줄 *)
| other -> Placeholder_view.component ~route:other graph
```

## 왜 Dead_keepers를 먼저

| 후보 | endpoint | types | 복잡도 |
|---|---|---|---|
| **Dead_keepers** | ✅ 기존 | ✅ 기존 | **1줄 필터** |
| Keepers | ✅ 기존 | ✅ 기존 | Roster + Ctx_chart + Swim 조립 |
| Overview | 신규 필요 | 신규 필요 | 서버 핸들러 touch |
| Archive runs | 신규 필요 | 신규 필요 | pagination 고려 |

가장 작은 diff로 **Phase 2.A shell 모듈 조립 패턴 검증**.

## Pixel parity

- fixture (empty) → "fleet is whole — no keepers have fallen." 배너
- 서버 stub (ash-hound dead) → 1 slot (blood dot · crashed stat · latency ×)
- Bundle **62MB 불변**

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 `/dashboard/b/dead-keepers` 탭 렌더
- [ ] fixture → "fleet is whole" 조용한 배너
- [ ] 서버 stub (dead 1명) → 1 slot + title "dead keepers · 01"
- [ ] nav "dead keepers" 활성 (brass + tail count 정상)
- [ ] 다른 탭 (logs/overview/hello) 영향 없음

## 다음 탭

- **Keepers** — Roster + Ctx_chart + Swim 조립 (중간 규모)
- **Overview** — 서버 shell 핸들러 typed + card KPI (큰 규모)
- **Archive runs** — autoresearch loop 리스트 (중간 규모)

🤖 Generated with [Claude Code](https://claude.com/claude-code)