### PR TITLE
docs(spec): finish Room -> Coord rename in bug-model specs

### DIFF
--- a/specs/bug-models/KeeperTaskInterlock.tla
+++ b/specs/bug-models/KeeperTaskInterlock.tla
@@ -70,7 +70,7 @@
 \*   without the GC window. Until that cascade exists, a Dead keeper
 \*   can hold a Claimed task for up to ~keeper_threshold_seconds —
 \*   the transient window is visible on the dashboard Keepers section
-\*   (#6556) and is safe because Room.claim_task_r rejects any
+\*   (#6556) and is safe because Coord_task.claim_task_r rejects any
 \*   attempt by another agent to re-claim the orphaned task
 \*   (TaskAlreadyClaimed), so no state corruption is possible.
 \*

--- a/specs/bug-models/SessionRegistryGhost.tla
+++ b/specs/bug-models/SessionRegistryGhost.tla
@@ -56,7 +56,7 @@ Init ==
 
 \* ── Leave flow (2 non-atomic steps) ─────────────
 
-\* Step 1: Room.leave — agent leaves room
+\* Step 1: Coord.leave — agent leaves room (Coord_lifecycle.leave)
 LeaveStep1_RoomLeave ==
     /\ leave_phase = "idle"
     /\ room_status = "joined"
@@ -73,7 +73,7 @@ LeaveStep2_Unregister ==
 
 \* ── Reconnect flow (atomic — under mutex) ───────
 
-\* Agent reconnects: Room.join + register (both succeed atomically)
+\* Agent reconnects: Coord.join + register (both succeed atomically)
 ReconnectJoinAndRegister ==
     /\ reconnect_phase = "idle"
     /\ room_status' = "joined"


### PR DESCRIPTION
## Summary
Follow-up to #9078. A wider spec-vs-lib audit caught three more stale `Room.*` references in `specs/bug-models/` that survived the earlier `room` → `coord` module consolidation. Comment-only; no TLC semantics change.

## Product impact
- **none/internal** — Same rationale as #9078: spec readers now point at the real module, so a future on-call can `grep "let claim_task_r"` in `lib/coord/coord_task.ml` instead of hunting for a `Room` module that was deleted.

## Evidence
- **Pre-fix scan** (`rg 'Room\.' specs/bug-models/`): 3 live matches
- **Post-fix scan**: 0 matches
- Live locations verified:
  - `Coord_task.claim_task_r` at `lib/coord/coord_task.ml:619`
  - `Coord.leave` re-exports `Coord_lifecycle.leave` at `lib/coord/coord_lifecycle.ml:192` (matches existing `Coord.leave` already in line 7 of the same spec)
  - `Coord.join` re-exports `Coord_lifecycle.join` at `lib/coord/coord_lifecycle.ml:32`
- Diff: +3/-3 across 2 files, all inside `\*` comments

## Review evidence
Self-review only. Same pattern as #9078 / #9071; no runtime effect.

## Linked issue
None — caught by structural audit (spec-references-existing-lib-modules) during #9078 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
