### PR TITLE
spec(bug-models): drop retired reconcile blocker from DispatchCoverage (#9032)

### DIFF
--- a/specs/bug-models/DispatchCoverage-buggy.cfg
+++ b/specs/bug-models/DispatchCoverage-buggy.cfg
@@ -1,7 +1,8 @@
 \* Buggy model: one clearing action omits the FSM event dispatch.
+\* "reconcile" was retired (see #9032 + spec preamble).
 \* Expected: DataFsmConsistent VIOLATED (and NeverStuckFailing VIOLATED).
 SPECIFICATION SpecBuggy
-CONSTANT Blockers = {reconcile, turn, compact, handoff, guardrail}
+CONSTANT Blockers = {turn, compact, handoff, guardrail}
 INVARIANT TypeOK
 INVARIANT DataFsmConsistent
 INVARIANT PhaseConsistent

--- a/specs/bug-models/DispatchCoverage.cfg
+++ b/specs/bug-models/DispatchCoverage.cfg
@@ -1,7 +1,8 @@
 \* Clean model: all clearing actions dispatch both data and FSM updates.
+\* "reconcile" was retired (see #9032 + spec preamble).
 \* Expected: no error.
 SPECIFICATION Spec
-CONSTANT Blockers = {reconcile, turn, compact, handoff, guardrail}
+CONSTANT Blockers = {turn, compact, handoff, guardrail}
 INVARIANT TypeOK
 INVARIANT DataFsmConsistent
 INVARIANT PhaseConsistent

--- a/specs/bug-models/DispatchCoverage.tla
+++ b/specs/bug-models/DispatchCoverage.tla
@@ -4,33 +4,40 @@
 \* Bug class: "Code clears a blocking condition at the data layer but
 \* forgets to dispatch the corresponding FSM event."
 \*
-\* Historical instance (Bug #1, #6801): maybe_recover_from_failing() in
-\* keeper_keepalive.ml called Keeper_manual_reconcile.clear (data) but did
-\* NOT dispatch Manual_reconcile_cleared to the FSM. Result: derive_phase()
-\* stayed in Failing because conditions.manual_reconcile_required was never
-\* set to FALSE, even though the blocking file was deleted.
+\* Headline live instance: keeper_exec_context.ml clears the data-layer
+\* compaction_active flag and MUST dispatch Compaction_completed to the
+\* FSM in the same step (line 174). If the dispatch is omitted,
+\* derive_phase keeps the keeper in Compacting forever even though the
+\* flag is cleared. Same shape applies to handoff_active +
+\* Handoff_completed (line 190), turn-failure counter + Turn_succeeded
+\* (keeper_keepalive.ml:947 inside maybe_recover_from_failing at :935),
+\* and the guardrail measurement carried by Context_measured (line 807).
 \*
-\* NOTE (2026-04-20, #9032): The Keeper_manual_reconcile mechanism has been
-\* removed from the runtime (only a gravestone comment remains at
-\* keeper_status_detail.ml:118). This spec retains the bug class and the
-\* 4 other mapped blockers (turn, compact, handoff, guardrail) below, which
-\* continue to model live mechanisms. maybe_recover_from_failing() now lives
-\* at keeper_keepalive.ml:935 and dispatches Turn_succeeded at :947.
+\* Historical instance (Bug #1, #6801): maybe_recover_from_failing()
+\* used to call Keeper_manual_reconcile.clear (data) without dispatching
+\* Manual_reconcile_cleared. The Keeper_manual_reconcile mechanism has
+\* been removed from the runtime (gravestone comment at
+\* keeper_status_detail.ml:118), so this spec drops "reconcile" from
+\* the modeled Blockers set and retains only the 4 live blockers
+\* (turn / compact / handoff / guardrail). See #9032.
 \*
-\* This spec models 5 blocking conditions from the keeper FSM
+\* This spec models 4 blocking conditions from the keeper FSM
 \* (keeper_state_machine.ml). Each has a "data layer" boolean and an
 \* "FSM condition" boolean. A clearing action MUST set both to FALSE
 \* atomically (within 1 step). The buggy variant omits the FSM dispatch.
 \*
-\* ── Mapped clearing actions (from OCaml code) ──
+\* ── Mapped clearing actions (from OCaml code, verified 2026-04-20) ──
 \*
-\*  # | Data clear             | FSM event                  | OCaml location (verified 2026-04-20)
+\*  # | Data clear             | FSM event                  | OCaml location
 \*  --+------------------------+----------------------------+--------------------------------
-\*  1 | manual_reconcile file  | Manual_reconcile_cleared   | [REMOVED 2026-04-20, see #9032]
-\*  2 | turn_failures counter  | Turn_succeeded             | keeper_keepalive.ml:947 (inside maybe_recover_from_failing at :935)
-\*  3 | compaction_active flag | Compaction_completed       | keeper_exec_context.ml:174
-\*  4 | handoff_active flag    | Handoff_completed          | keeper_exec_context.ml:190
-\*  5 | guardrail measurement  | Context_measured(stop=F)   | keeper_keepalive.ml:807 (RFC-0002 dispatch)
+\*  1 | turn_failures counter  | Turn_succeeded             | keeper_keepalive.ml:947 (inside maybe_recover_from_failing at :935)
+\*  2 | compaction_active flag | Compaction_completed       | keeper_exec_context.ml:174
+\*  3 | handoff_active flag    | Handoff_completed          | keeper_exec_context.ml:190
+\*  4 | guardrail measurement  | Context_measured(stop=F)   | keeper_keepalive.ml:807 (RFC-0002 dispatch)
+\*
+\*  RETIRED:
+\*    manual_reconcile file -> Manual_reconcile_cleared
+\*    [REMOVED, see #8987 / #9032 / KeeperReconcileLiveness.tla banner]
 \*
 \* ── Abstraction ──
 \* Each blocking condition is modeled as a pair: (data_blocked, fsm_blocked).
@@ -124,9 +131,11 @@ NeverStuckFailing ==
 
 \* ── Bug Model: one blocker omits FSM dispatch ──
 \* The buggy clear sets data_blocked=FALSE but does NOT touch fsm_blocked.
-\* Historical instance: keeper_keepalive.ml where Keeper_manual_reconcile.clear
-\* was called without Manual_reconcile_cleared. The mechanism has since been
-\* removed (see #9032), but the bug class generalizes to the 4 live blockers
+\* Live instance the spec now guards: a refactor in
+\* keeper_exec_context.ml that clears the compaction_active or
+\* handoff_active flag without dispatching the matching
+\* Compaction_completed / Handoff_completed event. Same shape as the
+\* historical reconcile bug (#6801) but applied to the 4 live blockers
 \* still mapped above.
 
 BuggyClear(b) ==


### PR DESCRIPTION
## Summary
Resolves #9032 via Option C (drop the dead headline + verify remaining cases).

The \`Keeper_manual_reconcile\` mechanism was removed from the runtime entirely (gravestone comment at \`keeper_status_detail.ml:118\`). The spec previously kept \`"reconcile"\` as one of 5 modeled \`Blockers\`, so TLC was exercising a dead code path on every cycle, and a reader scanning the headline mapping saw the historical bug as the canonical example.

## Changes
- **Drop \`"reconcile"\`** from \`Blockers\` in both \`.cfg\` files (\`{turn, compact, handoff, guardrail}\`).
- **Rewrite the preamble** to lead with the LIVE compaction/handoff blocker (\`keeper_exec_context.ml:174/190\`) as the headline example of the bug class, instead of the historical reconcile bug.
- **Move the historical reconcile note** to a \"RETIRED\" row at the bottom of the mapping table so a reader still sees the lineage without thinking it is a current blocker.
- **Update the \`BuggyClear\` comment** block to point at the live mechanisms.

## Verification (all 4 live FSM event refs)
\`\`\`
$ grep -nE "Turn_succeeded|Compaction_completed|Handoff_completed|Context_measured" lib/keeper/keeper_exec_context.ml lib/keeper/keeper_keepalive.ml | head -10
lib/keeper/keeper_exec_context.ml:174:        (Keeper_state_machine.Compaction_completed
lib/keeper/keeper_exec_context.ml:190:        (Keeper_state_machine.Handoff_completed
lib/keeper/keeper_keepalive.ml:799:    (* RFC-0002: dispatch Context_measured event through state machine *)
lib/keeper/keeper_keepalive.ml:807:        (Keeper_state_machine.Context_measured {
lib/keeper/keeper_keepalive.ml:947:      Keeper_state_machine.Turn_succeeded;
\`\`\`

## Spec semantics
For the 4 live blockers: unchanged.
- SpecBuggy still exercises \`DataFsmConsistent\` violation via \`BuggyClear\`.
- SpecClean still proves \`DataFsmConsistent\` / \`PhaseConsistent\` / \`NeverStuckFailing\`.

## Operator note
\`DispatchCoverage\` is not in \`scripts/tla-check.sh\`; CI does not run TLC on it. Reviewer / merger should verify both cfgs manually:
\`\`\`
tlc -config DispatchCoverage.cfg DispatchCoverage.tla        # expect: no error
tlc -config DispatchCoverage-buggy.cfg DispatchCoverage.tla  # expect: invariant violated
\`\`\`

I did not run TLC locally; reasoning is by hand against the bug-model contract.

## Sweep context
**5th** (and last) issue-resolving PR in the TLA+ ↔ OCaml mapping sweep. Closes #9032.

Cumulative tally — all 5 sweep issues now have an in-flight PR or are MERGED:
- #9006 → PR #9080 (KeeperPhaseRace cascade rescope, OPEN)
- #9032 → PR THIS (DispatchCoverage drop reconcile, OPEN)
- #9044 → PR #9069 (KeeperWorkPipeline ASPIRATIONAL banner, MERGED)
- #9056 → PR #9075 (TaskLifecycle 6-state extension, MERGED)
- #9065 → PR #9068 (SocialStateCap mapping table, MERGED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)