### PR TITLE
feat(legendary): per-reason too_complex_* counters (P5 Tick 35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 
 ## Unreleased
 
+### Added
+
+- **Legendary Bash shadow-counter per-reason `too_complex_*`
+  histogram.**  `Legendary_counters.snapshot` now includes fifteen
+  new fields — one per `Parsed.reason_too_complex` variant plus
+  dedicated `too_complex_parse_error`, `too_complex_parse_aborted`,
+  and `too_complex_other` buckets.  The shadow-observer in
+  `keeper_exec_shell.ml` feeds the `parse_tag` string (e.g.
+  `"too_complex:redirect"`) through the new
+  `Legendary_counters.incr_too_complex_by_tag` routing table
+  whenever `diff=Shadow_cannot_parse`; unknown tags collapse into
+  `too_complex_other` so the histogram sum always equals
+  `gate_diff_shadow_cannot_parse`.  Same zero-cost posture as the
+  other counters — nothing increments until
+  `MASC_BASH_AST_SHADOW_LOG` is on.  Exposed through the existing
+  `/api/v1/legendary_bash/shadow_counters` endpoint (additive
+  fields only, pre-existing consumers unaffected).  Six new unit
+  tests (prefixed / bare / parse_error / parse_aborted / unknown /
+  JSON shape).  `LEGENDARY-BASH-RUNBOOK.md` documents the new
+  buckets and the A1-PR-N prioritisation recipe ("top-N buckets
+  over observation window = next grammar expansion targets").
+
 ### Changed
 
 - **TLA+ specs 이관 완결 (`tla/` → `specs/`).** 기존 top-level

--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -202,7 +202,22 @@ Response shape (field names mirror `Legendary_counters.snapshot` 1:1):
   "gate_diff_legacy_deny_shadow_allow": 0,
   "gate_diff_shadow_cannot_parse": 0,
   "auto_bg_observed": 0,
-  "auto_bg_would_have_promoted": 0
+  "auto_bg_would_have_promoted": 0,
+  "too_complex_redirect": 0,
+  "too_complex_logic_op": 0,
+  "too_complex_heredoc": 0,
+  "too_complex_here_string": 0,
+  "too_complex_cmd_subst": 0,
+  "too_complex_proc_subst": 0,
+  "too_complex_subshell": 0,
+  "too_complex_arith_expansion": 0,
+  "too_complex_control_flow": 0,
+  "too_complex_function_def": 0,
+  "too_complex_glob_brace": 0,
+  "too_complex_background": 0,
+  "too_complex_parse_error": 0,
+  "too_complex_parse_aborted": 0,
+  "too_complex_other": 0
 }
 ```
 
@@ -212,6 +227,17 @@ log stream and the counter snapshot are redundant on purpose: logs
 for point-in-time diagnostics, counters for `disagree ratio =
 (legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total`
 trend math over a rolling window.
+
+The `too_complex_*` family is a histogram refinement of the single
+`gate_diff_shadow_cannot_parse` bucket: each subset-excluded bash
+feature gets its own counter, so operators can see which construct
+is driving the parse gap and prioritise future grammar expansion.
+The sum of all `too_complex_*` buckets equals
+`gate_diff_shadow_cannot_parse` — `too_complex_other` catches
+unknown reason strings so the invariant holds even if a future
+variant is added to `Parsed.reason_too_complex` without updating
+the counter routing table.  Top candidates for A1-PR-N grammar
+expansion are simply the top-N buckets over an observation window.
 
 ## Background Task Roster Endpoint
 

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -823,16 +823,35 @@ let handle_keeper_bash
          | Worker_dev_tools.Shadow_cannot_parse -> `Shadow_cannot_parse
        in
        Legendary_counters.incr_gate_diff counter_tag;
-       match diff with
-       | Worker_dev_tools.Agree -> ()
-       | _ ->
-         Log.Keeper.info
-           "gate_diff_shadow keeper=%s cmd_hash=%s diff=%s legacy=%s shadow=%s"
-           meta.name
-           (Worker_dev_tools.cmd_hash_for_log cmd)
-           (Worker_dev_tools.gate_diff_to_string diff)
-           (Worker_dev_tools.legacy_verdict_to_tag legacy)
-           (Worker_dev_tools.shadow_verdict_to_tag shadow)
+       (* Histogram refinement of the Shadow_cannot_parse bucket —
+          per-reason counters let operators prioritise A1-PR-N
+          grammar expansion by construct frequency.  Only increments
+          when diff=Shadow_cannot_parse; other diff variants do not
+          map to a parse-reason tag.  The parse_tag inside
+          Shadow_parse_unsupported carries the bare reason
+          (e.g. "too_complex:redirect") emitted by
+          Worker_dev_tools.shadow_parse_outcome. *)
+       (match diff, shadow with
+        | Worker_dev_tools.Shadow_cannot_parse,
+          Worker_dev_tools.Shadow_parse_unsupported { parse_tag } ->
+          Legendary_counters.incr_too_complex_by_tag parse_tag
+        | Worker_dev_tools.Shadow_cannot_parse, _ ->
+          (* Defensive: diff_of_verdicts only returns
+             Shadow_cannot_parse when shadow is
+             Shadow_parse_unsupported.  If that invariant changes,
+             the "other" bucket preserves the count. *)
+          Legendary_counters.incr_too_complex_by_tag "other"
+        | _ -> ());
+       (match diff with
+        | Worker_dev_tools.Agree -> ()
+        | _ ->
+          Log.Keeper.info
+            "gate_diff_shadow keeper=%s cmd_hash=%s diff=%s legacy=%s shadow=%s"
+            meta.name
+            (Worker_dev_tools.cmd_hash_for_log cmd)
+            (Worker_dev_tools.gate_diff_to_string diff)
+            (Worker_dev_tools.legacy_verdict_to_tag legacy)
+            (Worker_dev_tools.shadow_verdict_to_tag shadow))
      end);
     (* Resolve cwd early — needed for playground detection before validation. *)
     match resolve_keeper_shell_write_cwd ~config ~meta ~args with

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -13,6 +13,22 @@ let gate_diff_shadow_cannot_parse = Atomic.make 0
 let auto_bg_observed = Atomic.make 0
 let auto_bg_would_have_promoted = Atomic.make 0
 
+let too_complex_redirect = Atomic.make 0
+let too_complex_logic_op = Atomic.make 0
+let too_complex_heredoc = Atomic.make 0
+let too_complex_here_string = Atomic.make 0
+let too_complex_cmd_subst = Atomic.make 0
+let too_complex_proc_subst = Atomic.make 0
+let too_complex_subshell = Atomic.make 0
+let too_complex_arith_expansion = Atomic.make 0
+let too_complex_control_flow = Atomic.make 0
+let too_complex_function_def = Atomic.make 0
+let too_complex_glob_brace = Atomic.make 0
+let too_complex_background = Atomic.make 0
+let too_complex_parse_error = Atomic.make 0
+let too_complex_parse_aborted = Atomic.make 0
+let too_complex_other = Atomic.make 0
+
 let incr a = ignore (Atomic.fetch_and_add a 1)
 
 let incr_gate_diff tag =
@@ -27,6 +43,39 @@ let incr_auto_bg_observed ~promoted_candidate =
   incr auto_bg_observed;
   if promoted_candidate then incr auto_bg_would_have_promoted
 
+(* Strip the [too_complex:] / [parse_aborted:] prefix if present, so
+   callers can pass either the full [shadow_parse_outcome] tag or a
+   bare reason name. *)
+let bare_reason s =
+  let strip prefix =
+    let n = String.length prefix in
+    if String.length s >= n && String.sub s 0 n = prefix
+    then String.sub s n (String.length s - n)
+    else s
+  in
+  strip "too_complex:" |> fun s ->
+  if String.length s >= 14 && String.sub s 0 14 = "parse_aborted:"
+  then "__parse_aborted__"
+  else s
+
+let incr_too_complex_by_tag tag =
+  match bare_reason tag with
+  | "redirect" -> incr too_complex_redirect
+  | "logic_op" -> incr too_complex_logic_op
+  | "heredoc" -> incr too_complex_heredoc
+  | "here_string" -> incr too_complex_here_string
+  | "cmd_subst" -> incr too_complex_cmd_subst
+  | "proc_subst" -> incr too_complex_proc_subst
+  | "subshell" -> incr too_complex_subshell
+  | "arith_expansion" -> incr too_complex_arith_expansion
+  | "control_flow" -> incr too_complex_control_flow
+  | "function_def" -> incr too_complex_function_def
+  | "glob_brace" -> incr too_complex_glob_brace
+  | "background" -> incr too_complex_background
+  | "parse_error" -> incr too_complex_parse_error
+  | "__parse_aborted__" -> incr too_complex_parse_aborted
+  | _ -> incr too_complex_other
+
 let reset () =
   Atomic.set gate_diff_total 0;
   Atomic.set gate_diff_agree 0;
@@ -34,7 +83,22 @@ let reset () =
   Atomic.set gate_diff_legacy_deny_shadow_allow 0;
   Atomic.set gate_diff_shadow_cannot_parse 0;
   Atomic.set auto_bg_observed 0;
-  Atomic.set auto_bg_would_have_promoted 0
+  Atomic.set auto_bg_would_have_promoted 0;
+  Atomic.set too_complex_redirect 0;
+  Atomic.set too_complex_logic_op 0;
+  Atomic.set too_complex_heredoc 0;
+  Atomic.set too_complex_here_string 0;
+  Atomic.set too_complex_cmd_subst 0;
+  Atomic.set too_complex_proc_subst 0;
+  Atomic.set too_complex_subshell 0;
+  Atomic.set too_complex_arith_expansion 0;
+  Atomic.set too_complex_control_flow 0;
+  Atomic.set too_complex_function_def 0;
+  Atomic.set too_complex_glob_brace 0;
+  Atomic.set too_complex_background 0;
+  Atomic.set too_complex_parse_error 0;
+  Atomic.set too_complex_parse_aborted 0;
+  Atomic.set too_complex_other 0
 
 type snapshot = {
   gate_diff_total : int;
@@ -44,6 +108,21 @@ type snapshot = {
   gate_diff_shadow_cannot_parse : int;
   auto_bg_observed : int;
   auto_bg_would_have_promoted : int;
+  too_complex_redirect : int;
+  too_complex_logic_op : int;
+  too_complex_heredoc : int;
+  too_complex_here_string : int;
+  too_complex_cmd_subst : int;
+  too_complex_proc_subst : int;
+  too_complex_subshell : int;
+  too_complex_arith_expansion : int;
+  too_complex_control_flow : int;
+  too_complex_function_def : int;
+  too_complex_glob_brace : int;
+  too_complex_background : int;
+  too_complex_parse_error : int;
+  too_complex_parse_aborted : int;
+  too_complex_other : int;
 }
 
 let snapshot () =
@@ -58,6 +137,21 @@ let snapshot () =
       Atomic.get gate_diff_shadow_cannot_parse;
     auto_bg_observed = Atomic.get auto_bg_observed;
     auto_bg_would_have_promoted = Atomic.get auto_bg_would_have_promoted;
+    too_complex_redirect = Atomic.get too_complex_redirect;
+    too_complex_logic_op = Atomic.get too_complex_logic_op;
+    too_complex_heredoc = Atomic.get too_complex_heredoc;
+    too_complex_here_string = Atomic.get too_complex_here_string;
+    too_complex_cmd_subst = Atomic.get too_complex_cmd_subst;
+    too_complex_proc_subst = Atomic.get too_complex_proc_subst;
+    too_complex_subshell = Atomic.get too_complex_subshell;
+    too_complex_arith_expansion = Atomic.get too_complex_arith_expansion;
+    too_complex_control_flow = Atomic.get too_complex_control_flow;
+    too_complex_function_def = Atomic.get too_complex_function_def;
+    too_complex_glob_brace = Atomic.get too_complex_glob_brace;
+    too_complex_background = Atomic.get too_complex_background;
+    too_complex_parse_error = Atomic.get too_complex_parse_error;
+    too_complex_parse_aborted = Atomic.get too_complex_parse_aborted;
+    too_complex_other = Atomic.get too_complex_other;
   }
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
@@ -72,4 +166,19 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
      `Int s.gate_diff_shadow_cannot_parse);
     ("auto_bg_observed", `Int s.auto_bg_observed);
     ("auto_bg_would_have_promoted", `Int s.auto_bg_would_have_promoted);
+    ("too_complex_redirect", `Int s.too_complex_redirect);
+    ("too_complex_logic_op", `Int s.too_complex_logic_op);
+    ("too_complex_heredoc", `Int s.too_complex_heredoc);
+    ("too_complex_here_string", `Int s.too_complex_here_string);
+    ("too_complex_cmd_subst", `Int s.too_complex_cmd_subst);
+    ("too_complex_proc_subst", `Int s.too_complex_proc_subst);
+    ("too_complex_subshell", `Int s.too_complex_subshell);
+    ("too_complex_arith_expansion", `Int s.too_complex_arith_expansion);
+    ("too_complex_control_flow", `Int s.too_complex_control_flow);
+    ("too_complex_function_def", `Int s.too_complex_function_def);
+    ("too_complex_glob_brace", `Int s.too_complex_glob_brace);
+    ("too_complex_background", `Int s.too_complex_background);
+    ("too_complex_parse_error", `Int s.too_complex_parse_error);
+    ("too_complex_parse_aborted", `Int s.too_complex_parse_aborted);
+    ("too_complex_other", `Int s.too_complex_other);
   ]

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -30,6 +30,18 @@ val incr_auto_bg_observed : promoted_candidate:bool -> unit
     When [promoted_candidate] is [true] the elapsed duration would
     have tripped [MASC_BLOCKING_BUDGET_MS]. *)
 
+val incr_too_complex_by_tag : string -> unit
+(** Record one shadow rejection attributable to a subset-excluded
+    bash construct.  [tag] is the [parse_tag] string emitted by
+    [Worker_dev_tools.shadow_parse_outcome] — accepted forms are the
+    full [too_complex:<reason>] prefix or the bare [<reason>] suffix.
+    Unknown reasons are bucketed under [too_complex_other] so the
+    total is always consistent with [gate_diff_shadow_cannot_parse].
+
+    Callers should invoke this IN ADDITION to [incr_gate_diff
+    `Shadow_cannot_parse] — the per-reason buckets are a histogram
+    refinement of that single bucket, not a replacement. *)
+
 val reset : unit -> unit
 (** Zero every counter.  Used by tests; operators should not rely on
     this surface. *)
@@ -42,6 +54,27 @@ type snapshot = {
   gate_diff_shadow_cannot_parse : int;
   auto_bg_observed : int;
   auto_bg_would_have_promoted : int;
+  (* Per-reason histogram of the shadow_cannot_parse bucket.  Mirrors
+     [Parsed.reason_too_complex] 1:1 except for [Unknown_construct]
+     which collapses into [too_complex_other].  The sum of the
+     per-reason buckets plus [too_complex_parse_error] plus
+     [too_complex_parse_aborted] plus [too_complex_other] matches
+     [gate_diff_shadow_cannot_parse]. *)
+  too_complex_redirect : int;
+  too_complex_logic_op : int;
+  too_complex_heredoc : int;
+  too_complex_here_string : int;
+  too_complex_cmd_subst : int;
+  too_complex_proc_subst : int;
+  too_complex_subshell : int;
+  too_complex_arith_expansion : int;
+  too_complex_control_flow : int;
+  too_complex_function_def : int;
+  too_complex_glob_brace : int;
+  too_complex_background : int;
+  too_complex_parse_error : int;
+  too_complex_parse_aborted : int;
+  too_complex_other : int;
 }
 
 val snapshot : unit -> snapshot

--- a/test/test_legendary_counters.ml
+++ b/test/test_legendary_counters.ml
@@ -66,12 +66,81 @@ let test_snapshot_json_shape () =
 let test_reset () =
   Legendary_counters.incr_gate_diff `Agree;
   Legendary_counters.incr_auto_bg_observed ~promoted_candidate:true;
+  Legendary_counters.incr_too_complex_by_tag "too_complex:redirect";
   Legendary_counters.reset ();
   let s = Legendary_counters.snapshot () in
   Alcotest.(check int) "post-reset total" 0 s.gate_diff_total;
   Alcotest.(check int) "post-reset auto_bg_observed" 0 s.auto_bg_observed;
   Alcotest.(check int)
-    "post-reset would_have_promoted" 0 s.auto_bg_would_have_promoted
+    "post-reset would_have_promoted" 0 s.auto_bg_would_have_promoted;
+  Alcotest.(check int) "post-reset too_complex_redirect" 0 s.too_complex_redirect
+
+let test_too_complex_prefixed_tag () =
+  (* Shadow observer passes parse_tag strings straight through —
+     "too_complex:redirect" must route to the redirect bucket. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "too_complex:redirect";
+  Legendary_counters.incr_too_complex_by_tag "too_complex:redirect";
+  Legendary_counters.incr_too_complex_by_tag "too_complex:logic_op";
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "redirect = 2" 2 s.too_complex_redirect;
+  Alcotest.(check int) "logic_op = 1" 1 s.too_complex_logic_op;
+  Alcotest.(check int) "other untouched" 0 s.too_complex_other
+
+let test_too_complex_bare_tag () =
+  (* Callers may pass the bare reason name without the prefix. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "heredoc";
+  Legendary_counters.incr_too_complex_by_tag "here_string";
+  Legendary_counters.incr_too_complex_by_tag "cmd_subst";
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "heredoc = 1" 1 s.too_complex_heredoc;
+  Alcotest.(check int) "here_string = 1" 1 s.too_complex_here_string;
+  Alcotest.(check int) "cmd_subst = 1" 1 s.too_complex_cmd_subst
+
+let test_too_complex_parse_error () =
+  (* parse_error is a distinct bucket — unclassifiable input that
+     the post-hoc classifier could not attribute to a specific
+     construct.  Must not collapse into too_complex_other. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "parse_error";
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "parse_error = 1" 1 s.too_complex_parse_error;
+  Alcotest.(check int) "other still 0" 0 s.too_complex_other
+
+let test_too_complex_parse_aborted () =
+  (* parse_aborted:<reason> (timeout/depth/token limit) → dedicated
+     aborted bucket regardless of suffix. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "parse_aborted:timeout_50ms";
+  Legendary_counters.incr_too_complex_by_tag "parse_aborted:depth_limit";
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "parse_aborted = 2" 2 s.too_complex_parse_aborted
+
+let test_too_complex_unknown_tag () =
+  (* Unknown reason strings land in too_complex_other so the counter
+     family always sums to the Shadow_cannot_parse total. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "some_future_variant";
+  Legendary_counters.incr_too_complex_by_tag "";
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "other = 2" 2 s.too_complex_other
+
+let test_too_complex_json_shape () =
+  (* All 15 new fields must serialise under stable names. *)
+  Legendary_counters.reset ();
+  Legendary_counters.incr_too_complex_by_tag "redirect";
+  Legendary_counters.incr_too_complex_by_tag "arith_expansion";
+  let json =
+    Legendary_counters.snapshot_to_json (Legendary_counters.snapshot ())
+  in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool) "has redirect" true
+    (Astring.String.is_infix ~affix:"\"too_complex_redirect\":1" s);
+  Alcotest.(check bool) "has arith_expansion" true
+    (Astring.String.is_infix ~affix:"\"too_complex_arith_expansion\":1" s);
+  Alcotest.(check bool) "has other (=0)" true
+    (Astring.String.is_infix ~affix:"\"too_complex_other\":0" s)
 
 let () =
   Alcotest.run "legendary_counters"
@@ -84,5 +153,16 @@ let () =
           Alcotest.test_case "snapshot JSON shape" `Quick
             test_snapshot_json_shape;
           Alcotest.test_case "reset" `Quick test_reset;
+        ] );
+      ( "too_complex_histogram",
+        [
+          Alcotest.test_case "prefixed tag" `Quick test_too_complex_prefixed_tag;
+          Alcotest.test_case "bare tag" `Quick test_too_complex_bare_tag;
+          Alcotest.test_case "parse_error dedicated bucket" `Quick
+            test_too_complex_parse_error;
+          Alcotest.test_case "parse_aborted dedicated bucket" `Quick
+            test_too_complex_parse_aborted;
+          Alcotest.test_case "unknown → other" `Quick test_too_complex_unknown_tag;
+          Alcotest.test_case "JSON shape" `Quick test_too_complex_json_shape;
         ] );
     ]


### PR DESCRIPTION
## Product impact

Refines the single `gate_diff_shadow_cannot_parse` bucket into a fifteen-field histogram — one counter per `Parsed.reason_too_complex` variant, plus dedicated `too_complex_parse_error`, `too_complex_parse_aborted`, and `too_complex_other` buckets.

This is the observability counterpart to #9076 (post-hoc `Too_complex` classifier).  Tick 34 gave the parser finer-grained rejection reasons; this tick surfaces the distribution at `/api/v1/legendary_bash/shadow_counters` so the top-N buckets over an observation window directly answer "which shell feature should A1-PR-N support next" — replacing hunches with measured frequency.

## Evidence

**Counter module (`lib/legendary_counters.ml` + `.mli`)**

- 15 new `Atomic.t` buckets mirroring `Parsed.reason_too_complex` 1:1 (redirect, logic_op, heredoc, here_string, cmd_subst, proc_subst, subshell, arith_expansion, control_flow, function_def, glob_brace, background) plus `parse_error` / `parse_aborted` / `other`.
- `incr_too_complex_by_tag : string -> unit` — routes the `parse_tag` string (full `too_complex:<reason>` prefix or bare reason) to the right bucket.  Unknown tags fall through to `too_complex_other` so the sum invariant holds.
- `snapshot` + `snapshot_to_json` extended with all 15 fields.
- `reset` zeros all new fields (used by tests, not operators).

**Call site (`lib/keeper/keeper_exec_shell.ml`)**

Shadow observer — already behind `MASC_BASH_AST_SHADOW_LOG` — now routes through `incr_too_complex_by_tag` whenever `diff=Shadow_cannot_parse`, extracting the `parse_tag` from `Shadow_parse_unsupported { parse_tag }`.  Defensive `_` arm for the (unreachable today) case where another shadow variant maps to `Shadow_cannot_parse`.

**Tests (`test/test_legendary_counters.ml`)**

6 new cases:

- `test_too_complex_prefixed_tag` — `too_complex:redirect` → redirect bucket
- `test_too_complex_bare_tag` — `heredoc` (no prefix) → heredoc bucket
- `test_too_complex_parse_error` — `parse_error` routes to dedicated bucket, not `other`
- `test_too_complex_parse_aborted` — `parse_aborted:timeout_50ms` / `parse_aborted:depth_limit` → parse_aborted bucket
- `test_too_complex_unknown_tag` — future / empty variants → `other`
- `test_too_complex_json_shape` — stable field names at serialisation

Updated `test_reset` to cover the new fields.  11/11 pass locally (`dune exec test/test_legendary_counters.exe --root .`).

**Docs (`docs/LEGENDARY-BASH-RUNBOOK.md`)**

In-process snapshot endpoint example JSON shape extended with the 15 fields.  New prose explaining the histogram-of-bucket relationship and the A1-PR-N prioritisation recipe.

## Review evidence

Additive to the JSON shape — existing consumers of `/api/v1/legendary_bash/shadow_counters` see the same fields they already read.  The new shadow-observer branch is guarded by `diff=Shadow_cannot_parse`, so it runs only when `MASC_BASH_AST_SHADOW_LOG` is on AND the diff is actually parse-gap — no new cost path under default posture.

Sum invariant: `sum(too_complex_*) == gate_diff_shadow_cannot_parse` holds because `too_complex_other` absorbs unknown tags.  The unit tests exercise this explicitly (`test_too_complex_unknown_tag` + JSON shape assertions).

## Linked issue

N/A — follow-up to #9076 per plan candidate #2 (AST gate parse gap narrowing observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)