### PR TITLE
feat(bonsai-dashboard): Keepers tab view (Phase 2.C second tab)

### DIFF
--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -19,5 +19,6 @@ let root (graph @ local) =
   | Logs -> Logs_view.component graph
   | Hello -> Hello_view.component graph
   | Dead_keepers -> Dead_keepers_view.component graph
+  | Keepers -> Keepers_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -1,0 +1,207 @@
+(** Keepers view — fleet 전체 상태 대시보드.
+
+    Phase 2.C 두 번째 탭. Phase 2.A에서 추출된 shell 모듈 4개를 조립:
+    - [Hud]       : KPI strip (total / live / warn / dead / synced)
+    - [Roster]    : sticky bottom keeper slot 그리드
+    - [Swim]      : 60s per-keeper activity timeline
+    - [Ctx_chart] : 60m per-keeper context pressure
+
+    기존 `Keepers_var` 폴링 재사용 — 새 endpoint 無. Keepers 탭은 Dead_keepers
+    처럼 derived view가 아니라 fleet 전체를 **확대 투영**. logs 탭에서 보이던
+    HUD/Swim/Ctx/Roster를 독립 페이지로 끄집어낸 형태. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .main {
+    padding: 2.5rem 2.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    overflow: auto;
+  }
+
+  .hero { display: flex; flex-direction: column; gap: 6px; }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 30px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .title_tail {
+    color: var(--accent-brass);
+    font-size: 18px;
+    margin-left: 14px;
+  }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 640px;
+  }
+
+  .section_h {
+    font-family: 'Cinzel', serif;
+    font-size: 12px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 14px 0 4px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--border-main);
+  }
+
+  .quiet {
+    padding: 28px 20px;
+    text-align: center;
+    border: 1px dashed var(--border-main);
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    color: var(--text-dim);
+  }
+|}]
+
+let view_hero (keepers : Keepers_types.response) =
+  let live_n, warn_n, dead_n =
+    List.fold keepers.keepers ~init:(0, 0, 0)
+      ~f:(fun (l, w, d) (k : Keepers_types.keeper) ->
+        match k.status with
+        | Live -> l + 1, w, d
+        | Warn -> l, w + 1, d
+        | Dead -> l, w, d + 1)
+  in
+  let tail =
+    if live_n + warn_n + dead_n = 0
+    then "— offline"
+    else Printf.sprintf "· %d live · %d warn · %d dead" live_n warn_n dead_n
+  in
+  Node.div
+    ~attrs:[ Style.hero ]
+    [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "runtime · keepers" ]
+    ; Node.h1
+        ~attrs:[ Style.title ]
+        [ Node.text "fleet"
+        ; Node.span ~attrs:[ Style.title_tail ] [ Node.text tail ]
+        ]
+    ; Node.p
+        ~attrs:[ Style.sub ]
+        [ Node.text
+            "3s 폴링으로 본 fleet 전체. 아래 섹션은 roster(현재) · \
+             swim(60s 활동) · pressure(60m ctx)로 시간축이 짧아진다."
+        ]
+    ]
+;;
+
+let view_hud_strip (keepers : Keepers_types.response) =
+  let live_n, warn_n, dead_n =
+    List.fold keepers.keepers ~init:(0, 0, 0)
+      ~f:(fun (l, w, d) (k : Keepers_types.keeper) ->
+        match k.status with
+        | Live -> l + 1, w, d
+        | Warn -> l, w + 1, d
+        | Dead -> l, w, d + 1)
+  in
+  let total = live_n + warn_n + dead_n in
+  let synced =
+    match keepers.generated_at with
+    | "" -> "—"
+    | ts ->
+      if String.length ts >= 19 && Char.equal ts.[10] 'T'
+      then Printf.sprintf "%s UTC" (String.sub ts ~pos:11 ~len:8)
+      else ts
+  in
+  let dead_cls : Hud.v_class =
+    if dead_n > 0 then `Bad else `Neutral
+  in
+  let warn_cls : Hud.v_class =
+    if warn_n > 0 then `Warn else `Neutral
+  in
+  let live_cls : Hud.v_class =
+    if live_n > 0 then `Ok else `Neutral
+  in
+  Hud.strip
+    [ Hud.cell ~k:"Fleet" ~v:(Printf.sprintf "%02d" total) ()
+    ; Hud.cell ~v_class:live_cls ~k:"Live"
+        ~v:(Printf.sprintf "%02d" live_n) ()
+    ; Hud.cell ~v_class:warn_cls ~k:"Warn"
+        ~v:(Printf.sprintf "%02d" warn_n) ()
+    ; Hud.cell ~v_class:dead_cls ~k:"Dead"
+        ~v:(Printf.sprintf "%02d" dead_n) ()
+    ; Hud.cell
+        ~k:"Cycle"
+        ~v:(if keepers.cycle <= 0
+            then "—"
+            else Printf.sprintf "%d" keepers.cycle)
+        ()
+    ; Hud.cell ~k:"Synced" ~v:synced ()
+    ]
+;;
+
+let render (keepers : Keepers_types.response) : Node.t =
+  let has_fleet = not (List.is_empty keepers.keepers) in
+  Node.div
+    ~attrs:[ Style.root ]
+    [ Placeholder_view.sidebar ~active:Keepers
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ view_hero keepers
+        ; view_hud_strip keepers
+        ; (if has_fleet
+           then
+             Node.div
+               ~attrs:[]
+               [ Node.div ~attrs:[ Style.section_h ] [ Node.text "roster · 현재" ]
+               ; Roster.view ~keepers ()
+               ; Node.div ~attrs:[ Style.section_h ] [ Node.text "swim · 60s" ]
+               ; Swim.view ~keepers ()
+               ; Node.div
+                   ~attrs:[ Style.section_h ]
+                   [ Node.text "pressure · 60m" ]
+               ; Ctx_chart.view ~keepers ()
+               ]
+           else
+             Node.div
+               ~attrs:[ Style.quiet ]
+               [ Node.text
+                   "fleet endpoint is quiet — no keepers reported yet."
+               ])
+        ]
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Keepers_var.var) ~f:render
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -61,7 +61,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello | Dead_keepers -> true
+  | Logs | Hello | Dead_keepers | Keepers -> true
   | _ -> false
 ;;
 


### PR DESCRIPTION
## Summary

Phase 2.A shell 추출 완료 후 **Phase 2.C 두 번째 탭 이식**. Dead_keepers(#9079)에 이어 Keepers 탭 — shell 모듈 **4개 조립**으로 fleet 전체 상태 페이지.

> **Stack base**: `feature/bonsai-shell-ctx-chart` (#9077) — Ctx_chart 모듈 의존.

## 신규 `keepers_view.ml` (~230 LOC)

### shell 조립

| shell module | 사용 |
|---|---|
| `Placeholder_view.sidebar ~active:Keepers` | 좌측 nav IA |
| `Hud.strip + Hud.cell` | 6-cell KPI (`v_class` variant) |
| `Roster.view ~keepers` | 현재 상태 그리드 |
| `Swim.view ~keepers` | 60s 활동 timeline |
| `Ctx_chart.view ~keepers` | 60m context pressure SVG |

### Hud.v_class polymorphic variant 실사용

```ocaml
let live_cls : Hud.v_class = if live_n > 0 then `Ok else `Neutral in
let warn_cls : Hud.v_class = if warn_n > 0 then `Warn else `Neutral in
let dead_cls : Hud.v_class = if dead_n > 0 then `Bad else `Neutral in
```

Phase 2.A Hud 추출 시 도입한 variant 타입의 타입 안전성이 여기서 컴파일 타임 검증.

## 섹션 구조

```
hero       (title · "N live · M warn · K dead" · sub)
HUD strip  (Fleet · Live · Warn · Dead · Cycle · Synced — 6 cells)
─── roster · 현재 ───
Roster     (N-slot grid)
─── swim · 60s ───
Swim       (axis + per-keeper lanes)
─── pressure · 60m ───
Ctx_chart  (axis + 120px SVG)
```

empty fleet (fixture) → "fleet endpoint is quiet" 배너.

## Routing 변경

```ocaml
(* route.ml *)
let is_implemented = function
  | Logs | Hello | Keepers -> true    (* + Keepers *)
  | _ -> false

(* app.ml *)
| Keepers -> Keepers_view.component graph    (* 신규 1줄 *)
```

## Bundle

**62MB 불변** — shell 모듈 조립만으로 새 탭 완성 (Phase 1의 3069 LOC 단일 파일 반복 없음).

## Test plan

- [x] `dune build --root .` — 62MB
- [ ] 머지 후 `/dashboard/b/keepers` 탭 렌더
- [ ] fixture (empty) → "fleet is quiet" 배너
- [ ] 서버 stub → HUD 6 cell 정확 + 3 section (roster/swim/pressure) 정상
- [ ] nav "keepers" 활성 (brass) + tail count 정상

## Phase 2.C 진행률

- ✅ Dead_keepers (#9079)
- 🟢 **이 PR** Keepers
- ⏭ Overview · Archive_runs · Goals · Sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)