### PR TITLE
docs(specs): fix KeeperTaskInterlock room_gc module path drift

### DIFF
--- a/specs/bug-models/KeeperTaskInterlock.tla
+++ b/specs/bug-models/KeeperTaskInterlock.tla
@@ -306,8 +306,9 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 \*      update in keeper_registry.mark_dead leaves task_claimer
 \*      pointing at the dead keeper.
 \*
-\*   2. A separate asynchronous subsystem, Room_gc.cleanup_zombies
-\*      (lib/room/room_gc.ml), periodically scans agents by heartbeat
+\*   2. A separate asynchronous subsystem, Coord.cleanup_zombies
+\*      (lib/coord/coord_gc.ml — moved from the old lib/room/ namespace,
+\*      verified 2026-04-20), periodically scans agents by heartbeat
 \*      last_seen and force-releases Claimed/InProgress tasks whose
 \*      assignee is a zombie agent. This is modelled below as
 \*      ReconcileByGC.
@@ -319,7 +320,9 @@ SpecBuggy == Init /\ [][NextBuggy]_vars
 \* it against the TLC runner in tla-check.sh / specs/Makefile.
 
 \* Zombie GC reconciliation: release an orphaned task whose claimer
-\* is dead. Mirrors room_gc.ml:118-132 Phase 3 cascade.
+\* is dead. Mirrors lib/coord/coord_gc.ml:128 onward (the "Phase 3:
+\* Release tasks" cascade body, ~20 lines through line 147; verified
+\* 2026-04-20). Old "room_gc.ml:118-132" line range was stale.
 ReconcileByGC(t) ==
     /\ Held(t)
     /\ keeper_phase[task_claimer[t]] = "dead"


### PR DESCRIPTION
## Summary

\`specs/bug-models/KeeperTaskInterlock.tla\` referenced \`lib/room/room_gc.ml:118-132\` (and \`Room_gc.cleanup_zombies\`) for the zombie GC cascade, but:
1. \`lib/room/\` directory does not exist (verified 2026-04-20).
2. The module moved to \`lib/coord/coord_gc.ml\` during the room → coord namespace consolidation.
3. The "Phase 3: Release tasks" cascade body lives at line 128 onward (~20 lines through ~147), not 118-132.

This PR updates the two preamble references so a reader following the links lands on the live code. Module prefix renamed \`Room_gc\` → \`Coord\` to match the path. Doc-only; spec semantics unchanged.

## Verification
\`\`\`
$ test -d lib/room && echo exists   # no output (directory missing)
$ grep -n "let cleanup_zombies\\|Phase 3:" lib/coord/coord_gc.ml
39:let cleanup_zombies
128:      (* Phase 3: Release tasks — track failures per agent *)
\`\`\`

## Sweep context
**6th doc-only PR** in the TLA+ ↔ OCaml mapping sweep, found in a "second pass" after all 5 issues had PRs filed. Module-relocation drift escapes prior sweeps because \`grep "lib/foo/bar"\` only finds the spec; you have to test the path actually exists. New finding pattern to add to the methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)