### PR TITLE
docs(spec): add OCaml phase mapping block to StateProduct (#8642)

### DIFF
--- a/specs/state-product/StateProduct.tla
+++ b/specs/state-product/StateProduct.tla
@@ -14,11 +14,41 @@
 \*   - Deadlock freedom for non-terminal product states
 \*   - Liveness: validation eventually resolves
 \*
-\* Mirrors: lib/state_product.ml
+\* Mirrors: lib/state_product.ml (keeper via [Keeper_state_machine.phase])
 \*
 \* Two-config pattern (KeeperOASAdvanced precedent):
 \*   StateProduct.cfg     — clean spec, all invariants must hold
 \*   StateProduct-buggy.cfg — buggy spec, BoundaryViolated MUST be violated
+\*
+\* ── OCaml ↔ TLA+ KeeperPhases mapping (verified 2026-04-20, issue #8642) ──
+\*
+\* The OCaml [Keeper_state_machine.phase] type defines 12 variants; this
+\* spec projects to 6 to keep the product small (6 × 7 × 7 = 294 product
+\* states). Projection rationale: the invariants this spec verifies are
+\* all parameterised on three kinds of keeper state — (a) terminal, (b)
+\* draining / no-new-work, (c) suppresses-LLM. Each modelled phase stands
+\* in for a cluster of OCaml phases sharing that qualitative behaviour:
+\*
+\*   spec KeeperPhases  ↔ keeper_state_machine.ml phase (cluster)
+\*   ------------------+-------------------------------------------------
+\*   "Offline"          ↔ Offline
+\*   "Running"          ↔ Running, Failing, Restarting  (non-terminal active)
+\*   "Overflowed"       ↔ Overflowed                    (pre-compaction)
+\*   "Compacting"       ↔ Compacting                    (no LLM during compact)
+\*   "Draining"         ↔ Draining, HandingOff, Paused  (no-new-turn cluster)
+\*   "Stopped"          ↔ Stopped, Crashed, Dead        (terminal cluster)
+\*
+\* Sound-partial rationale: the product invariants (Terminal/Draining/
+\* Compacting LLM-gate boundaries) are preserved by each cluster's shared
+\* qualitative behaviour. What this projection does NOT catch: a future
+\* OCaml phase that belongs to a NEW cluster (e.g. a "ReadOnly" phase
+\* that permits some turn stages but not others) — that would need its
+\* own spec name. The OCaml witness [all_phases] in
+\* keeper_state_machine.ml already prevents silent variant addition; the
+\* spec reviewer's job when a new phase lands is to decide which cluster
+\* it joins (or introduce a new one).
+\*
+\* See issue #8642 for the full 12-phase enumeration.
 
 EXTENDS Naturals
 


### PR DESCRIPTION
## Summary
Adds an OCaml↔TLA+ `KeeperPhases` mapping block to `specs/state-product/StateProduct.tla`, following the #9068 `SocialStateCap` pattern. Closes #8642 via option-2 (documentation) path, not option-1 (full spec extension) which would require re-proving invariants over 294 product states.

## Product impact
- **none/internal** — Comment-only; TLC semantics unchanged. Reader benefit: the spec already said "6 key phases from 12-state FSM" in one line, but the reader had no way to see which 6 were modelled or where the other 6 landed. The new block:
  1. Names all 12 OCaml phases
  2. Clusters them into the 6 spec names by qualitative behaviour (terminal / draining-no-new-work / no-LLM / active)
  3. States the sound-partial rationale so a future reviewer can decide which cluster a new OCaml phase belongs to
  4. Points at `all_phases` witness in `keeper_state_machine.ml` for compile-time gate

## Evidence
- `lib/keeper/keeper_state_machine.ml:6-18` — 12-variant `type phase` verified
- `lib/keeper/keeper_state_machine.ml:49`, `.mli:41` — `all_phases : phase list` witness verified
- `lib/state_product.ml:5` — `module Keeper = Keeper_state_machine` confirms the OCaml side uses the full 12-phase type
- Diff: +31/-1 across 1 file, all inside `\*` comments

## Review evidence
Self-review only. Sibling pattern from #9068 (merged as `3b8d75183`) and #9069 (merged as `4bfc4067e`); same lowest-cost-fix shape as #9071 / #9078 / #9081.

## Linked issue
Closes #8642. Refs #9068 (SocialStateCap mapping precedent), #9056 (TaskLifecycle Claimed variant, separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
