### PR TITLE
docs(logic): batch-22 .mli for dashboard_governance + tool_schemas_inline_coord + keeper_sandbox

### DIFF
--- a/lib/dashboard/dashboard_governance.mli
+++ b/lib/dashboard/dashboard_governance.mli
@@ -1,0 +1,39 @@
+(** Dashboard_governance — Live governance judge status surface.
+
+    Case tracking has been retired; this module now returns judge
+    runtime telemetry, approval queue counts, and empty case lists
+    for backward-compat consumers. *)
+
+type detail_status = [ `OK | `Not_found ]
+
+(** {1 JSON surfaces} *)
+
+(** [factual_snapshot_json ~base_path] returns a minimal snapshot
+    used by the bootstrap loops. Items/activity lists are always
+    empty. *)
+val factual_snapshot_json : base_path:string -> Yojson.Safe.t
+
+(** Full dashboard payload with [summary], [judge], [judgments],
+    [approval_queue], and empty [items] / [activity] / [cases] /
+    [pending_actions] slots. *)
+val dashboard_json :
+  base_path:string ->
+  limit:int ->
+  offset:int ->
+  status_filter:'a ->
+  Yojson.Safe.t
+
+(** Legacy cases list (now always empty). *)
+val cases_json :
+  base_path:string ->
+  limit:int ->
+  offset:int ->
+  status_filter:'a ->
+  include_test:'b ->
+  Yojson.Safe.t
+
+(** Legacy case detail (now always [`Not_found]). *)
+val case_detail_json :
+  base_path:string ->
+  case_id:string ->
+  detail_status * Yojson.Safe.t

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -1,0 +1,67 @@
+(** Keeper_sandbox — Keeper-facing sandbox contract.
+
+    Keeper tools expose exactly one logical sandbox. The current
+    local-storage implementation lives at
+    [.masc/playground/<keeper>], but that path is an implementation
+    detail of the local / docker backends. *)
+
+(** {1 Types} *)
+
+type backend =
+  | Local
+  | Docker_hardened
+
+type t = {
+  keeper_name : string;
+  sandbox_id : string;
+  backend : backend;
+  sandbox_profile : string;
+  network_mode : string;
+  host_root_rel : string;
+  host_root_abs : string;
+  container_root : string option;
+  root_arg : string;
+  mind_arg : string;
+  repos_arg : string;
+  task_overlay_pattern : string;
+}
+
+(** {1 Backend helpers} *)
+
+val backend_to_string : backend -> string
+
+(** {1 Path resolution} *)
+
+(** [host_root_abs ~config name] returns the absolute host-side
+    sandbox root for [name] rooted at [config.base_path]. *)
+val host_root_abs : config:Coord.config -> string -> string
+
+(** [container_root name] returns the in-container path used by the
+    hardened Docker backend. *)
+val container_root : string -> string
+
+(** {1 Construction} *)
+
+(** [of_meta ~config ~meta] derives the full sandbox record from a
+    keeper meta entry. Backend is chosen from [meta.sandbox_profile]. *)
+val of_meta :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  t
+
+(** {1 Access control hints} *)
+
+(** Relative roots that tools may touch inside the keeper's
+    sandbox. Currently a single-element list. *)
+val allowed_path_roots : name:string -> string list
+
+(** Single relative root for [name] (convenience). *)
+val allowed_root_rel : name:string -> string
+
+(** {1 Dashboard / status output} *)
+
+(** Key-value fields describing the sandbox shape (id, backend,
+    profile, network mode, lifetime, root/mind/repos args, overlay
+    pattern). Suitable for splicing into a JSON [Assoc]. *)
+val context_status_fields :
+  t -> (string * Yojson.Safe.t) list

--- a/lib/tool_schemas/tool_schemas_inline_coord.mli
+++ b/lib/tool_schemas/tool_schemas_inline_coord.mli
@@ -1,0 +1,5 @@
+(** Tool_schemas_inline_coord — Inline schemas for coordination-layer
+    tool surfaces ([masc_start], [masc_join], [masc_leave],
+    [masc_broadcast], [masc_messages], [masc_who]). *)
+
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/dashboard/dashboard_governance.mli` | 39 | `detail_status` polyvariant + 4 vals; callers in `server_bootstrap_loops`, `server_dashboard_http`, `server_routes_http_runtime`, 1 test |
| `lib/tool_schemas/tool_schemas_inline_coord.mli` | 5 | `schemas` for `masc_start`/`join`/`leave`/`broadcast`/`messages`/`who`; 2 callers |
| `lib/keeper/keeper_sandbox.mli` | 67 | `backend` variant + `t` record + 7 vals; 8 callers across keeper layer |

Pre-scan: `include=0 open=0 alias=0`.

## Notes

- `dashboard_governance.case_detail_json` returns a pair `(detail_status * Yojson.Safe.t)` rather than a single tagged JSON; signature preserves that shape.
- `keeper_sandbox` internal helpers (`sandbox_id_of_name`, `host_root_rel`, `strip_trailing_slashes`, `backend_of_profile`, `storage_lifetime`) stay private — no call-site reaches them.

## Metrics

- Files: 671 ml / ~358 mli (≈53.4% of ml).
- Build: `dune @check` exit 0.
- Tests: `test_dashboard_governance` (9) + `test_keeper_docker_read` (10) + `test_tool_surface_ssot` (25) pass.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)