### PR TITLE
feat(keeper): expose run_command_in_container primitive (RFC-0006 Phase B-3a)

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -57,10 +57,12 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
          "container_path_of_host: %s is not inside playground %s"
          host_norm host_root)
 
-(* Argv builder kept private — distinct from keeper_exec_shell's
-   bash argv to avoid coupling the two surfaces. *)
+(* Argv prefix kept private — distinct from keeper_exec_shell's bash
+   argv to avoid coupling the two surfaces. The trailing
+   [program ; arg1 ; ... ] is appended by the caller via
+   [build_docker_argv ~command_argv]. *)
 let build_docker_argv ~image ~container_name ~host_root ~croot
-    ~container_path ~uid ~gid ~seccomp_args =
+    ~uid ~gid ~seccomp_args ~command_argv =
   [
     "docker";
     "run";
@@ -84,8 +86,8 @@ let build_docker_argv ~image ~container_name ~host_root ~croot
     "--workdir"; croot;
     "--network"; "none";
     image;
-    "cat"; container_path;
   ]
+  @ command_argv
 
 let container_name_of meta =
   Printf.sprintf "masc-keeper-read-%s-%d-%d"
@@ -93,47 +95,59 @@ let container_name_of meta =
     (Unix.getpid ())
     (int_of_float (Unix.gettimeofday () *. 1000.0))
 
-let read_file_in_container ~config ~(meta : keeper_meta) ~host_path
-    ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =
+let run_command_in_container ~config ~(meta : keeper_meta)
+    ~(command_argv : string list) ~(max_bytes : int)
+    ~(timeout_sec : float) () : (string, string) result =
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
+  else if command_argv = [] then
+    Error "run_command_in_container: command_argv is empty"
   else
-    match container_path_of_host ~config ~meta ~host_path with
-    | Error _ as e -> e
-    | Ok container_path ->
-      match
-        Keeper_exec_shell.ensure_keeper_sandbox_runtime ~timeout_sec
-      with
-      | Error err -> Error err
-      | Ok seccomp_args ->
-        let host_root = host_playground_root ~config ~meta in
-        let croot = container_root ~meta in
-        let container_name = container_name_of meta in
-        let uid = Unix.getuid () in
-        let gid = Unix.getgid () in
-        let argv =
-          build_docker_argv ~image ~container_name ~host_root ~croot
-            ~container_path ~uid ~gid ~seccomp_args
-        in
-        let st, out =
-          Process_eio.run_argv_with_status
-            ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-        in
-        match st with
-        | Unix.WEXITED 0 ->
-          let body =
-            if String.length out > max_bytes then String.sub out 0 max_bytes
-            else out
-          in
-          Ok body
-        | Unix.WEXITED code ->
-          Error
-            (Printf.sprintf
-               "docker_read_failed: exit=%d output=%s"
-               code
-               (Worker_dev_tools.truncate_for_log out))
-        | Unix.WSIGNALED n ->
-          Error (Printf.sprintf "docker_read_signaled: signal=%d" n)
-        | Unix.WSTOPPED n ->
-          Error (Printf.sprintf "docker_read_stopped: signal=%d" n)
+    match Keeper_exec_shell.ensure_keeper_sandbox_runtime ~timeout_sec with
+    | Error err -> Error err
+    | Ok seccomp_args ->
+      let host_root = host_playground_root ~config ~meta in
+      let croot = container_root ~meta in
+      let container_name = container_name_of meta in
+      let uid = Unix.getuid () in
+      let gid = Unix.getgid () in
+      let argv =
+        build_docker_argv ~image ~container_name ~host_root ~croot
+          ~uid ~gid ~seccomp_args ~command_argv
+      in
+      let st, out =
+        Process_eio.run_argv_with_status
+          ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+      in
+      let head_program =
+        match command_argv with prog :: _ -> prog | [] -> "?"
+      in
+      (match st with
+       | Unix.WEXITED 0 ->
+         let body =
+           if String.length out > max_bytes then String.sub out 0 max_bytes
+           else out
+         in
+         Ok body
+       | Unix.WEXITED code ->
+         Error
+           (Printf.sprintf
+              "docker_%s_failed: exit=%d output=%s"
+              head_program code
+              (Worker_dev_tools.truncate_for_log out))
+       | Unix.WSIGNALED n ->
+         Error
+           (Printf.sprintf "docker_%s_signaled: signal=%d" head_program n)
+       | Unix.WSTOPPED n ->
+         Error
+           (Printf.sprintf "docker_%s_stopped: signal=%d" head_program n))
+
+let read_file_in_container ~config ~(meta : keeper_meta) ~host_path
+    ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =
+  match container_path_of_host ~config ~meta ~host_path with
+  | Error _ as e -> e
+  | Ok container_path ->
+    run_command_in_container ~config ~meta
+      ~command_argv:[ "cat"; container_path ]
+      ~max_bytes ~timeout_sec ()

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -42,3 +42,30 @@ val read_file_in_container :
   timeout_sec:float ->
   unit ->
   (string, string) result
+
+(** [run_command_in_container ~config ~meta ~command_argv ~max_bytes
+    ~timeout_sec ()] is the general-purpose primitive that
+    [read_file_in_container] is built on. It runs the same hardened
+    docker prelude (read-only rootfs, no caps, no network, playground
+    mounted read-only at [Keeper_sandbox.container_root meta.name])
+    and appends [command_argv] as the program + arguments executed
+    inside the container.
+
+    The caller owns container-path translation: any path referenced
+    in [command_argv] must already be in container space (use
+    [container_path_of_host] to convert). The first element of
+    [command_argv] is the executable.
+
+    Returns the captured stdout bytes clamped to [max_bytes]. Errors
+    include image misconfiguration, empty [command_argv], runtime
+    preflight failure, and docker exit non-zero. The error tag uses
+    the program name (e.g. [docker_rg_failed], [docker_cat_failed])
+    for caller log forensics. *)
+val run_command_in_container :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  command_argv:string list ->
+  max_bytes:int ->
+  timeout_sec:float ->
+  unit ->
+  (string, string) result

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -220,6 +220,51 @@ let test_read_empty_image_config_errors () =
          in
          loop 0)
 
+(* ── run_command_in_container error paths
+   (exercised without invoking docker) ──────────────────────────── *)
+
+let test_run_command_empty_argv_errors () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.run_command_in_container ~config ~meta
+      ~command_argv:[] ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok _ -> Alcotest.fail "expected error for empty command_argv"
+  | Error msg ->
+      Alcotest.(check bool) "mentions empty command_argv" true
+        (let needle = "command_argv is empty" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
+let test_run_command_empty_image_errors () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.run_command_in_container ~config ~meta
+      ~command_argv:[ "ls"; "/" ] ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok _ -> Alcotest.fail "expected image-config error"
+  | Error msg ->
+      Alcotest.(check bool) "mentions docker image" true
+        (let needle = "docker image" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
 let () =
   Alcotest.run "Keeper_docker_read"
     [
@@ -251,5 +296,12 @@ let () =
             `Quick test_read_outside_playground_returns_mapping_error;
           Alcotest.test_case "empty image configuration errors" `Quick
             test_read_empty_image_config_errors;
+        ] );
+      ( "run_command_in_container",
+        [
+          Alcotest.test_case "empty command_argv errors" `Quick
+            test_run_command_empty_argv_errors;
+          Alcotest.test_case "empty image configuration errors" `Quick
+            test_run_command_empty_image_errors;
         ] );
     ]


### PR DESCRIPTION
## Summary
- B-2(#8977)는 keeper_fs_read만 docker 라우팅. keeper_shell read ops(rg/ls/cat/find/head/tail/wc/tree)는 여전히 host containment에 의존.
- 이 PR은 \`run_command_in_container\` primitive만 추가/노출. 동일 docker prelude(read-only rootfs, no caps, no network, playground :ro mount)를 \`cat\` 외 임의 프로그램에 재사용 가능.
- \`read_file_in_container\`은 \`run_command_in_container ~command_argv:[\"cat\"; container_path]\` 의 thin wrapper로 위임. 기존 행동 보존.

## Test plan
- [x] \`dune build --root .\` 클린
- [x] \`dune test --root . test/test_keeper_docker_read.exe --force\` → **12/12 pass** (10 → 12; 새 케이스: empty command_argv 거부, image config 부재 reuse)
- [ ] CI green
- [ ] No keeper_shell wiring (B-3b/c follow-up)

## Out of scope (intentional)
- \`should_route_read\` semantics 그대로
- 새 env flag 없음
- argv assembly는 keeper_exec_shell의 bash sandbox와 의도적으로 분리 (bash는 network/credential mount 필요, divergence 정당)

🤖 Generated with [Claude Code](https://claude.com/claude-code)