### PR TITLE
docs(spec): migrate KeeperCircuitBreaker refs to symbol anchors + fix drift

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -29,10 +29,6 @@ specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:33
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:336
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:99
-specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:118
-specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:17
-specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:63
-specs/keeper-state-machine/KeeperCircuitBreaker.tla  lib/keeper/keeper_failure_circuit_breaker.ml:64
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:389
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:61
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:8

--- a/specs/bug-models/KeeperTaskInterlock.tla
+++ b/specs/bug-models/KeeperTaskInterlock.tla
@@ -53,7 +53,7 @@
 \*
 \* What actually restores the invariant:
 \*
-\*   Coord_gc.cleanup_zombies (lib/coord/coord_gc.ml:39-190) scans the
+\*   Coord_gc.cleanup_zombies (lib/coord/coord_gc.ml:cleanup_zombies) scans the
 \*   agents directory on a periodic GC cycle, detects agents whose
 \*   last_seen is older than Env_config.Zombie.keeper_threshold_seconds
 \*   ("zombie" agents), and in Phase 3 iterates the backlog calling

--- a/specs/keeper-state-machine/KeeperCircuitBreaker.tla
+++ b/specs/keeper-state-machine/KeeperCircuitBreaker.tla
@@ -6,12 +6,11 @@
 \*
 \*   spec variable    | OCaml location                                          | semantic
 \*   -----------------+---------------------------------------------------------+---------
-\*   Threshold        | lib/keeper/keeper_failure_circuit_breaker.ml:118        | `let threshold = 3` (matches spec CONSTANT)
-\*   count            | lib/keeper/keeper_failure_circuit_breaker.ml:64         | `mutable consecutive_count : int`
-\*   currentClass     | lib/keeper/keeper_failure_circuit_breaker.ml:63         | `mutable consecutive_class : error_class`
-\*   tripped          | lib/keeper/keeper_failure_circuit_breaker.ml (record_   | `record_failure` returns whether hint was injected this step
-\*                    | failure return value)                                   |
-\*   ErrorClasses     | lib/keeper/keeper_failure_circuit_breaker.ml:17-22      | `type error_class = Path_not_found | Path_not_allowed | Cwd_not_directory | Shell_exit_nonzero | Other`
+\*   Threshold        | lib/keeper/keeper_failure_circuit_breaker.ml:threshold         | `let threshold = 3` (matches spec CONSTANT)
+\*   count            | lib/keeper/keeper_failure_circuit_breaker.ml:consecutive_count | `mutable consecutive_count : int`
+\*   currentClass     | lib/keeper/keeper_failure_circuit_breaker.ml:consecutive_class | `mutable consecutive_class : error_class`
+\*   tripped          | lib/keeper/keeper_failure_circuit_breaker.ml:record_failure    | `record_failure` returns whether hint was injected this step
+\*   ErrorClasses     | lib/keeper/keeper_failure_circuit_breaker.ml:error_class       | `type error_class = Path_not_found | Path_not_allowed | Cwd_not_directory | Shell_exit_nonzero | Other`
 \*
 \* Scope projection: spec models 3 error classes
 \* (path_not_found, path_not_allowed, other); OCaml has 5


### PR DESCRIPTION
## Summary
Follow-up to #9073 (spec-line-refs gate). Migrates 4 `KeeperCircuitBreaker.tla` refs from line-anchor to the drift-resistant symbol-anchor form, and fixes a latent drift from #9078 caught by running the gate locally.

## Product impact
- **none/internal** — Spec comments only, TLC behaviour unchanged.
- Durability: symbol-anchor refs survive upstream insertions; the 4 migrated entries no longer need allowlisting.
- Fixes an unintended drift class from #9078: the lint parses "prose after a range ref" as a snippet, so `...:39-190) scans the` made the gate report drift on `coord_gc.ml:39`. Switching to `:cleanup_zombies` sidesteps the range-tail parse entirely.

## Evidence
```
before: 73 refs, 29 allowlisted
after:  75 refs, 25 allowlisted, 11 symbol-anchored, 0 drift
```

Symbol-anchor target presence verified:
- `error_class` — type definition at `lib/keeper/keeper_failure_circuit_breaker.ml:17`
- `consecutive_class`, `consecutive_count` — record fields at `:63`, `:64`
- `threshold` — `let threshold = 3` at `:118`
- `cleanup_zombies` — function at `lib/coord/coord_gc.ml:39`

Diff: +6/-11 across 3 files (spec comment content unchanged, just ref form).

## Review evidence
Self-review only. Same lowest-cost pattern as #9071 / #9078 / #9081 / #9087. Matches the migration target stated in #9073 PR description: "replace `path:N snippet` with `path:symbol` where the snippet is a top-level identifier".

## Linked issue
None — this is the #9073 follow-up autofix path applied by hand in one batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
