### PR TITLE
ci(gate): downgrade build to advisory to restore signal-to-noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,24 +649,38 @@ jobs:
         run: |
           set -euo pipefail
           fail=0
+          # mode=required (default): fail → block merge
+          # mode=advisory: fail → log a WARN line, do not block
+          #
+          # Why `build` is advisory: of 80 PRs merged 2026-04-18..04-20,
+          # 22 (27%) landed with CI Gate FAILURE via manual admin merge,
+          # and 22/22 had Build and Test as the sole culprit (quick-suite
+          # Eio isolation flakes). CI Gate had stopped carrying signal.
+          # Advisory mode keeps the job running (result still on the PR)
+          # but lets the aggregator reflect deterministic checks only.
+          # When the flaky root cause is fixed, flip `build` back to
+          # required.
           check() {
             local name=$1
             local result=$2
+            local mode=${3:-required}
             if [[ "$result" == "success" || "$result" == "skipped" ]]; then
               printf 'PASS  %-20s %s\n' "$name" "$result"
+            elif [[ "$mode" == "advisory" ]]; then
+              printf 'WARN  %-20s %s (advisory, not blocking)\n' "$name" "$result"
             else
               printf 'FAIL  %-20s %s\n' "$name" "$result"
               fail=1
             fi
           }
-          check "pr-sync-check" "$PR_SYNC_RESULT"
-          check "changes"       "$CHANGES_RESULT"
-          check "build"         "$BUILD_RESULT"
-          check "lint"          "$LINT_RESULT"
-          check "dashboard"     "$DASHBOARD_RESULT"
+          check "pr-sync-check"   "$PR_SYNC_RESULT"
+          check "changes"         "$CHANGES_RESULT"
+          check "build"           "$BUILD_RESULT"           advisory
+          check "lint"            "$LINT_RESULT"
+          check "dashboard"       "$DASHBOARD_RESULT"
           check "dashboard-drift" "$DASHBOARD_DRIFT_RESULT"
-          check "health"        "$HEALTH_RESULT"
-          check "doc-truth"     "$DOC_TRUTH_RESULT"
-          check "oas-pin-check" "$OAS_PIN_RESULT"
-          check "tla-specs"     "$TLA_RESULT"
+          check "health"          "$HEALTH_RESULT"
+          check "doc-truth"       "$DOC_TRUTH_RESULT"
+          check "oas-pin-check"   "$OAS_PIN_RESULT"
+          check "tla-specs"       "$TLA_RESULT"
           [ "$fail" -eq 0 ]


### PR DESCRIPTION
## TL;DR

22 / 80 recent PRs (27%) landed with CI Gate FAILURE via manual admin merge. **22 / 22** of those had Build and Test as the sole culprit — every other required check was passing. CI Gate had stopped carrying signal; it was measuring flakiness, not correctness.

This PR makes `build` **advisory** inside the CI Gate aggregator. The job still runs, still shows on the PR, and still yields a visible WARN line when it fails — but a Build and Test flake no longer turns CI Gate red and forces an admin merge.

## Measurement

| Window | Merged PRs | CI Gate FAILURE at merge | Build and Test as culprit |
|--------|-----------:|-------------------------:|--------------------------:|
| 2026-04-18..04-20 | 80 | 22 (27%) | 22 (100%) |

All 22 were `auto_merge: null` — manual admin merges by `jeong-sik`. Pattern consistent with `memory/feedback_flaky-fleet-test-oscillation.md` (quick-suite Eio isolation flakes: `context_oas_sync`, `message_conversion`, `operator.NNN`).

## Diff

One-liner behaviour change inside `ci-gate` step:
- `check` helper gains an optional third arg `mode` (`required` default, `advisory`).
- `check "build" "$BUILD_RESULT" advisory` — the only call site that becomes advisory.
- Everything else (`lint`, `dashboard`, `dashboard-drift`, `health`, `doc-truth`, `oas-pin-check`, `tla-specs`, `pr-sync-check`, `changes`) remains required.

## What this PR does NOT do

- Does NOT remove Build and Test. Still runs, still shows, still carries the visible signal on the PR.
- Does NOT change branch protection rules. `required_status_checks` still lists only `CI Gate`.
- Does NOT fix the flaky root cause. A follow-up PR should fix the Eio fleet test isolation and flip `build` back to `required`.

## Rollback

Remove the `advisory` argument on the `build` line — one-token revert.

## Test plan

- [x] `bash -n` syntax check on the shell block.
- [ ] CI `Lint`, `Doc Truth`, `Dashboard Drift Gate`, `OAS Pin Consistency` pass.
- [ ] CI Gate ideally reports `WARN build …` on any PR where Build and Test is red this week.
- [ ] 7-day re-measurement: bypass rate should drop below 5%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)