### PR TITLE
docs(specs): fix KeeperContextLifecycle Compaction_failed handler line ref

### DIFF
--- a/specs/keeper-state-machine/KeeperContextLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperContextLifecycle.tla
@@ -191,8 +191,12 @@ CompactionCompletes(k) ==
 \* 5b. Compaction Failed: strategy returned an error — context_tokens
 \*     stay above budget, keeper transitions back to overflow_retry for
 \*     another compaction attempt.
-\*     Models keeper_state_machine.ml:383-389 Compaction_failed _ handler:
+\*     Models keeper_state_machine.ml:402-408 Compaction_failed _ handler:
 \*     clears compaction_active but leaves context_overflow=true.
+\*     (Verified 2026-04-20: lines 383-389 were a stale anchor; that
+\*     range now holds the Turn_failed + Context_measured branches.
+\*     The Compaction_failed handler shifted ~20 lines down as new
+\*     event variants were inserted above it.)
 \*     NOTE: the retry-exhaustion latch (compact_retry_exhausted → Paused)
 \*     lives in keeper_unified_turn and is not yet modelled here. Without
 \*     fairness on CompactionCompletes, TLC explores both retry and


### PR DESCRIPTION
## Summary

\`KeeperContextLifecycle.tla\` referenced \`keeper_state_machine.ml:383-389\` for the \`Compaction_failed _\` handler, but lines 383-389 today hold the \`Turn_failed\` + \`Context_measured\` branches of the event match. The \`Compaction_failed\` handler shifted to lines 402-408 as additional event variants were inserted above it. Doc-only fix; spec semantics unchanged.

## Verification
\`\`\`
$ grep -n "Compaction_failed" lib/keeper/keeper_state_machine.ml
118:  | Compaction_failed of { reason : string }
167:  | Compaction_failed r ->
402:  | Compaction_failed _ ->
\`\`\`

Line 402 is the actual handler body that the spec's \`CompactionFailed(k)\` action models.

## Sweep context

**8th doc-only PR** in the second-pass sweep (anchor verification methodology).

Companion second-pass PRs:
- #9086 — \`lib/room/\` → \`lib/coord/\` namespace move (OPEN)
- #9090 — KeeperTaskInterlock 2-anchor line drift (OPEN)
- #THIS — KeeperContextLifecycle Compaction_failed line drift (this PR)

Methodology yield so far this pass: ~3 anchor drifts among ~80 \`file:line\` refs scanned (~4%). Common pattern: handler line numbers drift downward as event variants are inserted above; type definitions drift downward as adjacent helper functions/witness enums are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)