### PR TITLE
feat(bonsai-dashboard): Archive runs tab view (Phase 2.C third tab)

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -132,5 +132,7 @@ let () =
   Dashboard_bonsai_lib.Logs_fetch.start_polling ();
   Dashboard_bonsai_lib.Keepers_fetch.run ();
   Dashboard_bonsai_lib.Keepers_fetch.start_polling ();
+  Dashboard_bonsai_lib.Archive_runs_fetch.run ();
+  Dashboard_bonsai_lib.Archive_runs_fetch.start_polling ();
   install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -20,5 +20,6 @@ let root (graph @ local) =
   | Hello -> Hello_view.component graph
   | Dead_keepers -> Dead_keepers_view.component graph
   | Keepers -> Keepers_view.component graph
+  | Archive_runs -> Archive_runs_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/archive_runs_fetch.ml
+++ b/dashboard_bonsai/src/archive_runs_fetch.ml
@@ -1,0 +1,34 @@
+(** Single-shot fetch of [/api/v1/autoresearch/loops] + 5 s polling.
+
+    Archive runs are not as time-sensitive as the logs tab, so polling is
+    slower (5 s vs 3 s). Errors are silently dropped; the previous response
+    remains in [Archive_runs_var] so the UI does not flicker. *)
+
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/autoresearch/loops?limit=200"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Archive_runs_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Archive_runs_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:5000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/archive_runs_types.ml
+++ b/dashboard_bonsai/src/archive_runs_types.ml
@@ -1,0 +1,126 @@
+(** Typed model of [/api/v1/autoresearch/loops] responses.
+
+    Manual Yojson.Safe.Util parsing to keep the client ppx surface small
+    (no [ppx_deriving_yojson] crossing into js_of_ocaml). Shape mirrors
+    [lib/dashboard/dashboard_http_autoresearch.ml:autoresearch_loops_json]. *)
+
+open! Core
+
+type status =
+  | Running
+  | Stopped
+  | Paused
+  | Failed
+  | Completed
+  | Unknown
+
+type loop =
+  { loop_id : string
+  ; goal : string
+  ; status : status
+  ; current_cycle : int
+  ; max_cycles : int
+  ; best_score : float
+  ; target_reached : bool
+  ; total_keeps : int
+  ; total_discards : int
+  ; elapsed_s : float
+  ; updated_at : float               (* unix seconds *)
+  ; live : bool
+  ; error : string option
+  ; target_file : string
+  }
+
+type response =
+  { loops : loop list
+  ; total : int
+  ; offset : int
+  ; limit : int
+  }
+
+let fixture : response = { loops = []; total = 0; offset = 0; limit = 100 }
+
+(* ---------- manual Yojson decoding ---------- *)
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let int_field ?(default = 0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> i
+  | `Intlit s -> (try Int.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let float_field ?(default = 0.0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> f
+  | `Int i -> Float.of_int i
+  | `Intlit s -> (try Float.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let bool_field ?(default = false) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> b
+  | _ -> default
+;;
+
+let string_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> Some s
+  | `Null -> None
+  | _ -> None
+;;
+
+let status_of_string = function
+  | "running" -> Running
+  | "stopped" -> Stopped
+  | "paused" -> Paused
+  | "failed" -> Failed
+  | "completed" -> Completed
+  | _ -> Unknown
+;;
+
+let loop_of_yojson json : loop =
+  { loop_id = string_field json "loop_id"
+  ; goal = string_field json "goal"
+  ; status = status_of_string (string_field ~default:"unknown" json "status")
+  ; current_cycle = int_field json "current_cycle"
+  ; max_cycles = int_field json "max_cycles"
+  ; best_score = float_field json "best_score"
+  ; target_reached = bool_field json "target_reached"
+  ; total_keeps = int_field json "total_keeps"
+  ; total_discards = int_field json "total_discards"
+  ; elapsed_s = float_field json "elapsed_s"
+  ; updated_at = float_field json "updated_at"
+  ; live = bool_field json "live"
+  ; error = string_opt_field json "error"
+  ; target_file = string_field json "target_file"
+  }
+;;
+
+let response_of_yojson json : response =
+  let loops =
+    match Yojson.Safe.Util.member "loops" json with
+    | `List xs -> List.map xs ~f:loop_of_yojson
+    | _ -> []
+  in
+  { loops
+  ; total = int_field json "total"
+  ; offset = int_field json "offset"
+  ; limit = int_field ~default:100 json "limit"
+  }
+;;
+
+let status_label = function
+  | Running -> "running"
+  | Stopped -> "stopped"
+  | Paused -> "paused"
+  | Failed -> "failed"
+  | Completed -> "completed"
+  | Unknown -> "—"
+;;

--- a/dashboard_bonsai/src/archive_runs_var.ml
+++ b/dashboard_bonsai/src/archive_runs_var.ml
@@ -1,0 +1,5 @@
+(** Bonsai.Expert.Var holding the current autoresearch loops response. *)
+
+let var : Archive_runs_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Archive_runs_types.fixture
+;;

--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -1,0 +1,405 @@
+(** Archive runs view — autoresearch loops list.
+
+    Phase 2.C second tab ported. Fetches [/api/v1/autoresearch/loops]
+    every 5 s. design_v2 IA의 "archive · autoresearch" 섹션. 각 row는
+    한 번의 reinforced-write loop — goal / status / cycle progress /
+    keeps·discards / elapsed. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.05), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(58,90,72,0.06), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .main {
+    padding: 3rem 3rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    overflow: auto;
+  }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .title_count { color: var(--accent-brass); }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 620px;
+  }
+
+  .meta_strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    padding: 12px 16px;
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(42,20,14,0.35), rgba(20,12,8,0.65));
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+  .meta_item { display: flex; align-items: baseline; gap: 8px; }
+  .meta_k {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .meta_v {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-bright);
+  }
+  .meta_v_live { color: var(--status-ok); }
+  .meta_v_fail { color: var(--accent-blood); }
+
+  .quiet {
+    padding: 40px 20px;
+    text-align: center;
+    border: 1px dashed var(--border-main);
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-dim);
+  }
+
+  .loop_list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .loop {
+    display: grid;
+    grid-template-columns: 90px 1fr 120px 140px 90px;
+    gap: 14px;
+    padding: 12px 16px;
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(28,18,14,0.7), rgba(14,10,8,0.85));
+    align-items: center;
+    transition: border-color 120ms ease, background 120ms ease;
+  }
+  .loop:hover {
+    border-color: var(--border-highlight);
+    background: linear-gradient(180deg, rgba(46,33,28,0.8), rgba(20,14,10,0.9));
+  }
+
+  .pill {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 4px 8px;
+    text-align: center;
+    border: 1px solid var(--border-main);
+    font-variant-numeric: tabular-nums;
+  }
+  .pill_running {
+    color: var(--status-ok);
+    border-color: var(--status-ok);
+    background: rgba(90,122,58,0.12);
+  }
+  .pill_completed {
+    color: var(--accent-brass);
+    border-color: var(--accent-brass);
+    background: rgba(138,106,40,0.12);
+  }
+  .pill_failed {
+    color: var(--accent-blood);
+    border-color: var(--accent-blood-dim);
+    background: rgba(160,24,24,0.14);
+  }
+  .pill_stopped {
+    color: var(--text-dim);
+    border-color: var(--border-main);
+  }
+  .pill_paused {
+    color: var(--status-warn);
+    border-color: var(--status-warn);
+    background: rgba(160,106,26,0.10);
+  }
+  .pill_unknown {
+    color: var(--text-dim);
+    border-color: var(--border-main);
+  }
+
+  .goal {
+    font-family: 'EB Garamond', serif;
+    font-size: 14px;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .goal_id {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.06em;
+    margin-right: 10px;
+  }
+  .goal_err {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--accent-viscera);
+    letter-spacing: 0.02em;
+    margin-left: 10px;
+  }
+
+  .cycle {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 12px;
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+  .cycle_dim { color: var(--text-dim); font-size: 10px; }
+
+  .kd {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    text-align: right;
+  }
+  .kd_keep { color: var(--status-ok); }
+  .kd_slash { color: var(--text-dim); margin: 0 4px; }
+  .kd_disc { color: var(--accent-viscera); }
+
+  .elapsed {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-dim);
+    text-align: right;
+  }
+|}]
+
+let pill_class : Archive_runs_types.status -> Attr.t = function
+  | Running -> Style.pill_running
+  | Completed -> Style.pill_completed
+  | Failed -> Style.pill_failed
+  | Stopped -> Style.pill_stopped
+  | Paused -> Style.pill_paused
+  | Unknown -> Style.pill_unknown
+;;
+
+let hhmmss_of_epoch (t : float) : string =
+  if Float.(t <= 0.0)
+  then "—"
+  else (
+    let seconds = Float.to_int t in
+    let s = Printf.sprintf "%d" (seconds mod 60) in
+    let m = Printf.sprintf "%d" (seconds / 60 mod 60) in
+    let h = seconds / 3600 in
+    if h > 0
+    then Printf.sprintf "%dh %sm" h m
+    else if (seconds / 60) > 0
+    then Printf.sprintf "%sm %ss" m s
+    else Printf.sprintf "%ss" s)
+;;
+
+let short_id (id : string) =
+  if String.length id > 11
+  then String.sub id ~pos:0 ~len:11
+  else id
+;;
+
+let truncate_goal ~(max_len : int) (s : string) =
+  if String.length s <= max_len
+  then s
+  else String.sub s ~pos:0 ~len:(max_len - 1) ^ "…"
+;;
+
+let view_loop (l : Archive_runs_types.loop) =
+  let goal_text = truncate_goal ~max_len:120 l.goal in
+  let cycle_str =
+    Printf.sprintf
+      "%d / %d"
+      l.current_cycle
+      (if l.max_cycles <= 0 then 0 else l.max_cycles)
+  in
+  let keeps = l.total_keeps in
+  let discards = l.total_discards in
+  Node.div
+    ~attrs:[ Style.loop ]
+    [ Node.span
+        ~attrs:[ Style.pill; pill_class l.status ]
+        [ Node.text (Archive_runs_types.status_label l.status) ]
+    ; Node.div
+        ~attrs:[ Style.goal ]
+        (List.concat
+           [ [ Node.span
+                 ~attrs:[ Style.goal_id ]
+                 [ Node.text (short_id l.loop_id) ]
+             ; Node.text goal_text
+             ]
+           ; (match l.error with
+              | Some e when String.length e > 0 ->
+                [ Node.span
+                    ~attrs:[ Style.goal_err ]
+                    [ Node.text (truncate_goal ~max_len:60 e) ]
+                ]
+              | _ -> [])
+           ])
+    ; Node.div
+        ~attrs:[ Style.cycle ]
+        [ Node.text cycle_str
+        ; Node.div
+            ~attrs:[ Style.cycle_dim ]
+            [ Node.text
+                (if l.target_reached then "target ✓" else "cycles")
+            ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.kd ]
+        [ Node.span
+            ~attrs:[ Style.kd_keep ]
+            [ Node.text (Printf.sprintf "+%d" keeps) ]
+        ; Node.span ~attrs:[ Style.kd_slash ] [ Node.text "·" ]
+        ; Node.span
+            ~attrs:[ Style.kd_disc ]
+            [ Node.text (Printf.sprintf "−%d" discards) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.elapsed ]
+        [ Node.text (hhmmss_of_epoch l.elapsed_s) ]
+    ]
+;;
+
+let view_meta_strip (r : Archive_runs_types.response) =
+  let running =
+    List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
+      match l.status with
+      | Running -> true
+      | _ -> false)
+  in
+  let completed =
+    List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
+      match l.status with
+      | Completed -> true
+      | _ -> false)
+  in
+  let failed =
+    List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
+      match l.status with
+      | Failed -> true
+      | _ -> false)
+  in
+  Node.div
+    ~attrs:[ Style.meta_strip ]
+    [ Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "total" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text (Printf.sprintf "%d" r.total) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "running" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v_live ]
+            [ Node.text (Printf.sprintf "%d" running) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "completed" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text (Printf.sprintf "%d" completed) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "failed" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v_fail ]
+            [ Node.text (Printf.sprintf "%d" failed) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "offset" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text (Printf.sprintf "%d" r.offset) ]
+        ]
+    ]
+;;
+
+let render (r : Archive_runs_types.response) : Node.t =
+  let total = r.total in
+  Node.div
+    ~attrs:[ Style.root ]
+    [ Placeholder_view.sidebar ~active:Archive_runs
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ Node.p
+            ~attrs:[ Style.eyebrow ]
+            [ Node.text "archive · autoresearch" ]
+        ; Node.h1
+            ~attrs:[ Style.title ]
+            [ Node.text "archive runs "
+            ; Node.span
+                ~attrs:[ Style.title_count ]
+                [ Node.text (Printf.sprintf "· %d" total) ]
+            ]
+        ; Node.p
+            ~attrs:[ Style.sub ]
+            [ Node.text
+                "autoresearch의 reinforced-write loop 기록. 각 row는 \
+                 목표 · cycle progress · keeps/discards 의 총합. 실패한 \
+                 run은 error 사유를 함께 남긴다."
+            ]
+        ; view_meta_strip r
+        ; (match r.loops with
+           | [] ->
+             Node.div
+               ~attrs:[ Style.quiet ]
+               [ Node.text "no runs recorded yet." ]
+           | loops ->
+             Node.div
+               ~attrs:[ Style.loop_list ]
+               (List.map loops ~f:view_loop))
+        ]
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Archive_runs_var.var) ~f:render
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -61,7 +61,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello | Dead_keepers | Keepers -> true
+  | Logs | Hello | Dead_keepers | Keepers | Archive_runs -> true
   | _ -> false
 ;;
 


### PR DESCRIPTION
## Summary

Phase 2.C 세 번째 탭 이식. 4-파일 패턴 (types/fetch/var/view) + app/route/main 와이어링.

## 신규

- \`archive_runs_types.ml\` — manual Yojson.Safe.Util 파서, 6 status variant
- \`archive_runs_fetch.ml\` — \`/api/v1/autoresearch/loops?limit=200\`, 5s polling
- \`archive_runs_var.ml\` — Bonsai.Expert.Var singleton
- \`archive_runs_view.ml\` — sidebar + hero + meta strip + loop list

## UI 스펙

- Status pill 색상: Running=ok/green · Completed=brass · Failed=blood · Stopped/Unknown=dim · Paused=warn
- Row grid: 90 pill | 1fr goal | 120 cycle | 140 keeps/discards | 90 elapsed
- Meta strip: total / running / completed / failed / offset

## 검증

- [x] \`dune build\` 통과 (bonsai-dashboard switch)
- [x] /api/v1/autoresearch/loops 샘플 응답으로 shape 검증
- [ ] 런타임 pixel 검증 필요

## Phase 2.C progress

- #9079 Dead_keepers ✅ merged
- #9084 Keepers (stacked on #9092)
- **#NEW Archive_runs** (this PR)
- 남은: Overview, Goals, Sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)