### PR TITLE
feat(legendary-bash): expose task_details with elapsed_ms on bg_tasks endpoint

### DIFF
--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -231,14 +231,35 @@ Response shape:
 {
   "keeper": "<name>",
   "count": 2,
-  "tasks": ["<task_id_1>", "<task_id_2>"]
+  "tasks": ["<task_id_1>", "<task_id_2>"],
+  "task_details": [
+    {
+      "task_id": "<task_id_1>",
+      "started_at_unix": 1730000000.123,
+      "elapsed_ms": 4821
+    },
+    {
+      "task_id": "<task_id_2>",
+      "started_at_unix": 1730000030.456,
+      "elapsed_ms": 15234
+    }
+  ]
 }
 ```
 
-Unknown or quiet keepers legitimately return `{"count": 0, "tasks": []}` —
-the endpoint does not gate on keeper existence, matching the
-`shadow_counters` "zero-cost public read" posture. The path param is
-required; a trailing-slash request (`.../bg_tasks/`) returns 400.
+Unknown or quiet keepers legitimately return
+`{"count": 0, "tasks": [], "task_details": []}` — the endpoint does
+not gate on keeper existence, matching the `shadow_counters`
+"zero-cost public read" posture. The path param is required; a
+trailing-slash request (`.../bg_tasks/`) returns 400.
+
+`task_details` mirrors `tasks` in order (`tasks[i]` equals
+`task_details[i].task_id`). `started_at_unix` is the fractional
+seconds-since-epoch captured at spawn and is immutable for a task's
+lifetime. `elapsed_ms` is computed server-side at response time so
+dashboards do not need to reconcile against their local clock — a
+subsequent poll returns a larger `elapsed_ms` for the same
+`started_at_unix` until the task exits (and leaves the roster).
 
 Per-task snapshots (stdout drain, exit status, drop counters) are not
 surfaced by this endpoint — those require a stateful `since_*` offset

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -263,6 +263,14 @@ let list ~keeper =
       (fun tid st acc -> if st.keeper = keeper then tid :: acc else acc)
       registry [])
 
+let list_with_started_at ~keeper =
+  with_reg (fun () ->
+    Hashtbl.fold
+      (fun tid st acc ->
+        if st.keeper = keeper then (tid, st.handle.started_at) :: acc
+        else acc)
+      registry [])
+
 (* Directory walk helpers — avoid Filename.Infix / extra deps. *)
 
 let safe_readdir dir =

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -105,6 +105,14 @@ val kill :
 val list : keeper:string -> task_id list
 (** All currently-tracked tasks owned by [keeper]. *)
 
+val list_with_started_at : keeper:string -> (task_id * float) list
+(** Same roster as {!list}, paired with the unix-timestamp at which
+    each task was spawned.  The timestamp is captured by
+    {!Process_eio.spawn_detached} before the child enters its session
+    and is immutable for the task's lifetime, so observers can compute
+    wall-clock elapsed time without consulting the child process or
+    reading the PID file. *)
+
 val reap_orphans : base_path:string -> int
 (** Startup hook: read PID files under \`.masc/keeper/*/bg/*.pid\`,
     SIGKILL any pgroup whose leader is no longer in the live task

--- a/lib/server/server_routes_http_routes_legendary_bash.ml
+++ b/lib/server/server_routes_http_routes_legendary_bash.ml
@@ -15,10 +15,20 @@
     [legendary_counters.mli] for the stable contract.
 
     Response (200) for bg_tasks: JSON of shape
-      { "keeper": "<name>", "count": N, "tasks": [ "<task_id>", … ] }
+      { "keeper": "<name>",
+        "count": N,
+        "tasks": [ "<task_id>", … ],
+        "task_details": [
+          { "task_id": "<id>",
+            "started_at_unix": 1.73e9,
+            "elapsed_ms": 1234 }, … ] }
     where [tasks] is the list returned by [Bg_task.list ~keeper] at
-    the moment of the call.  Unknown / quiet keepers legitimately
-    return [count = 0, tasks = []] — the endpoint does not validate
+    the moment of the call; [task_details] attaches [started_at] and
+    a server-computed [elapsed_ms] for observers that want wall-clock
+    age without a second round-trip.  Both arrays share the same
+    order, so [tasks.[i]] and [task_details.[i].task_id] agree.
+    Unknown / quiet keepers legitimately return [count = 0,
+    tasks = [], task_details = []] — the endpoint does not validate
     keeper existence, mirroring [shadow_counters]' "zero-cost read"
     posture. *)
 
@@ -31,13 +41,29 @@ let snapshot_response () : Yojson.Safe.t =
   let snap = Legendary_counters.snapshot () in
   Legendary_counters.snapshot_to_json snap
 
+let task_detail_json ~now (tid, started_at) : Yojson.Safe.t =
+  let elapsed_ms =
+    let seconds = max 0.0 (now -. started_at) in
+    int_of_float (seconds *. 1000.0)
+  in
+  `Assoc [
+    ("task_id", `String (Bg_task.task_id_to_string tid));
+    ("started_at_unix", `Float started_at);
+    ("elapsed_ms", `Int elapsed_ms);
+  ]
+
 let bg_tasks_response ~keeper : Yojson.Safe.t =
-  let ids = Bg_task.list ~keeper in
-  let as_strings = List.map Bg_task.task_id_to_string ids in
+  let rows = Bg_task.list_with_started_at ~keeper in
+  let now = Unix.gettimeofday () in
+  let ids_as_strings =
+    List.map (fun (tid, _) -> Bg_task.task_id_to_string tid) rows
+  in
   `Assoc [
     ("keeper", `String keeper);
-    ("count", `Int (List.length ids));
-    ("tasks", `List (List.map (fun s -> `String s) as_strings));
+    ("count", `Int (List.length rows));
+    ("tasks", `List (List.map (fun s -> `String s) ids_as_strings));
+    ("task_details",
+     `List (List.map (task_detail_json ~now) rows));
   ]
 
 let add_routes router =

--- a/test/test_legendary_bash_bg_tasks_route.ml
+++ b/test/test_legendary_bash_bg_tasks_route.ml
@@ -26,7 +26,10 @@ let test_empty_keeper_shape () =
     (Astring.String.is_infix ~affix:"\"count\":0" s);
   Alcotest.(check bool)
     "tasks=[] when no tasks" true
-    (Astring.String.is_infix ~affix:"\"tasks\":[]" s)
+    (Astring.String.is_infix ~affix:"\"tasks\":[]" s);
+  Alcotest.(check bool)
+    "task_details=[] when no tasks" true
+    (Astring.String.is_infix ~affix:"\"task_details\":[]" s)
 
 let test_keeper_with_unusual_name () =
   (* Names can contain hyphens, underscores, digits — the endpoint
@@ -59,9 +62,30 @@ let test_field_ordering_stable () =
   let i_keeper = find_key "keeper" in
   let i_count = find_key "count" in
   let i_tasks = find_key "tasks" in
+  let i_details = find_key "task_details" in
   Alcotest.(check bool) "keeper present" true (i_keeper >= 0);
   Alcotest.(check bool) "count present" true (i_count > i_keeper);
-  Alcotest.(check bool) "tasks after count" true (i_tasks > i_count)
+  Alcotest.(check bool) "tasks after count" true (i_tasks > i_count);
+  Alcotest.(check bool)
+    "task_details after tasks" true (i_details > i_tasks)
+
+let test_task_details_shape_on_empty () =
+  (* Even with no live tasks the empty task_details array must parse as
+     a JSON array of objects — dashboards that [].map over it without
+     a null guard would crash if it were serialised as null / missing. *)
+  let json =
+    Server_routes_http_routes_legendary_bash.bg_tasks_response
+      ~keeper:"x"
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "task_details" fields with
+     | Some (`List []) -> ()
+     | Some other ->
+       Alcotest.failf "expected `List [], got %s"
+         (Yojson.Safe.to_string other)
+     | None -> Alcotest.fail "task_details field missing")
+  | _ -> Alcotest.fail "response is not a JSON object"
 
 let () =
   Alcotest.run "legendary_bash_bg_tasks_route"
@@ -73,5 +97,7 @@ let () =
             test_keeper_with_unusual_name;
           Alcotest.test_case "field ordering stable" `Quick
             test_field_ordering_stable;
+          Alcotest.test_case "task_details empty shape" `Quick
+            test_task_details_shape_on_empty;
         ] );
     ]


### PR DESCRIPTION
## Summary

- New `Bg_task.list_with_started_at : keeper:string -> (task_id * float) list` exposes the immutable spawn timestamp already recorded by `Process_eio.spawn_detached` without widening the lifecycle contract.
- `/api/v1/legendary_bash/bg_tasks/<keeper>` now returns a `task_details` sibling array of `{ task_id, started_at_unix, elapsed_ms }` objects. `tasks` stays as the plain id list for simple consumers; the two arrays share the same order.
- `elapsed_ms` is server-computed at response time so dashboards don't have to reconcile their local clock with the keeper process — successive polls advance monotonically for the same `started_at_unix` until the task exits and leaves the roster.

## Why additive rather than replacing `tasks`

The Tick 33 bg_tasks endpoint has only existed for a few days but is already documented in the Legendary Bash runbook. Keeping `tasks: string[]` intact means the existing curl recipe and any early dashboard consumers keep working, and `task_details` is pure gravy for observers that want age.

## Test plan

- [x] `dune build --root .`
- [x] `test_legendary_bash_bg_tasks_route` 4/4 — adds `task_details` shape assertion + ordering check `keeper → count → tasks → task_details`
- [x] `test_bg_task_stub` 11/11 — lifecycle / signatures / persistence unchanged
- [x] `test_exec_run` 3/3 — race-budget path unaffected
- [x] Runbook `docs/LEGENDARY-BASH-RUNBOOK.md` updated with the new JSON shape, ordering invariant, and server-side elapsed contract

## Linked

Part of the Legendary Bash plan's "P2 observability enrichment" item (`~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-graceful-panda.md`). Independent of in-flight PRs #9076 (parser classifier) and #9083 (per-reason counters) — different files, different semantics.