### PR TITLE
feat(bonsai-dashboard): Goals tab view (Phase 2.C fourth tab)

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -136,5 +136,7 @@ let () =
   Dashboard_bonsai_lib.Archive_runs_fetch.start_polling ();
   Dashboard_bonsai_lib.Overview_fetch.run ();
   Dashboard_bonsai_lib.Overview_fetch.start_polling ();
+  Dashboard_bonsai_lib.Goals_fetch.run ();
+  Dashboard_bonsai_lib.Goals_fetch.start_polling ();
   install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -22,5 +22,6 @@ let root (graph @ local) =
   | Keepers -> Keepers_view.component graph
   | Archive_runs -> Archive_runs_view.component graph
   | Overview -> Overview_view.component graph
+  | Goals -> Goals_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/goals_fetch.ml
+++ b/dashboard_bonsai/src/goals_fetch.ml
@@ -1,0 +1,33 @@
+(** Single-shot fetch of [/api/v1/dashboard/goals] + 10 s polling.
+
+    Goals are config-driven — they change slowly. 10 s polling keeps the
+    tab fresh without hammering the endpoint. *)
+
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/dashboard/goals"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Goals_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Goals_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:10000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/goals_types.ml
+++ b/dashboard_bonsai/src/goals_types.ml
@@ -1,0 +1,158 @@
+(** Typed model of [/api/v1/dashboard/goals] responses.
+
+    Mirrors [lib/dashboard/dashboard_goals.ml:dashboard_goals_tree_json].
+    Recursive tree of goal nodes; each node carries its immediate task
+    list. *)
+
+open! Core
+
+type task =
+  { id : string
+  ; title : string
+  ; status : string         (* pending / claimed / in_progress / completed / cancelled *)
+  ; priority : int
+  ; assignee : string option
+  ; is_terminal : bool
+  }
+
+type node =
+  { id : string
+  ; title : string
+  ; horizon : string         (* "short" | "mid" | "long" | ... *)
+  ; status : string          (* active / paused / done / ... *)
+  ; priority : int
+  ; metric : string option
+  ; target_value : string option
+  ; due_date : string option
+  ; convergence : float
+  ; convergence_pct : int
+  ; tasks : task list
+  ; task_count : int
+  ; task_done_count : int
+  ; children : node list
+  ; child_count : int
+  }
+
+type summary =
+  { total_goals : int
+  ; active_goals : int
+  ; total_tasks : int
+  ; done_tasks : int
+  ; overall_convergence_pct : int
+  }
+
+type response =
+  { generated_at : string
+  ; tree : node list
+  ; summary : summary
+  }
+
+let fixture_summary : summary =
+  { total_goals = 0
+  ; active_goals = 0
+  ; total_tasks = 0
+  ; done_tasks = 0
+  ; overall_convergence_pct = 0
+  }
+;;
+
+let fixture : response =
+  { generated_at = ""; tree = []; summary = fixture_summary }
+;;
+
+(* ---------- manual Yojson decoding ---------- *)
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let int_field ?(default = 0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> i
+  | `Intlit s -> (try Int.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let float_field ?(default = 0.0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> f
+  | `Int i -> Float.of_int i
+  | `Intlit s -> (try Float.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let string_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> Some s
+  | _ -> None
+;;
+
+let bool_field ?(default = false) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> b
+  | _ -> default
+;;
+
+let task_of_yojson json : task =
+  { id = string_field json "id"
+  ; title = string_field json "title"
+  ; status = string_field json "status"
+  ; priority = int_field json "priority"
+  ; assignee = string_opt_field json "assignee"
+  ; is_terminal = bool_field json "is_terminal"
+  }
+;;
+
+let rec node_of_yojson json : node =
+  let tasks =
+    match Yojson.Safe.Util.member "tasks" json with
+    | `List xs -> List.map xs ~f:task_of_yojson
+    | _ -> []
+  in
+  let children =
+    match Yojson.Safe.Util.member "children" json with
+    | `List xs -> List.map xs ~f:node_of_yojson
+    | _ -> []
+  in
+  { id = string_field json "id"
+  ; title = string_field json "title"
+  ; horizon = string_field json "horizon"
+  ; status = string_field json "status"
+  ; priority = int_field json "priority"
+  ; metric = string_opt_field json "metric"
+  ; target_value = string_opt_field json "target_value"
+  ; due_date = string_opt_field json "due_date"
+  ; convergence = float_field json "convergence"
+  ; convergence_pct = int_field json "convergence_pct"
+  ; tasks
+  ; task_count = int_field json "task_count"
+  ; task_done_count = int_field json "task_done_count"
+  ; children
+  ; child_count = int_field json "child_count"
+  }
+;;
+
+let summary_of_yojson json : summary =
+  { total_goals = int_field json "total_goals"
+  ; active_goals = int_field json "active_goals"
+  ; total_tasks = int_field json "total_tasks"
+  ; done_tasks = int_field json "done_tasks"
+  ; overall_convergence_pct = int_field json "overall_convergence_pct"
+  }
+;;
+
+let response_of_yojson json : response =
+  let tree =
+    match Yojson.Safe.Util.member "tree" json with
+    | `List xs -> List.map xs ~f:node_of_yojson
+    | _ -> []
+  in
+  let summary =
+    match Yojson.Safe.Util.member "summary" json with
+    | `Assoc _ as s -> summary_of_yojson s
+    | _ -> fixture_summary
+  in
+  { generated_at = string_field json "generated_at"; tree; summary }
+;;

--- a/dashboard_bonsai/src/goals_var.ml
+++ b/dashboard_bonsai/src/goals_var.ml
@@ -1,0 +1,5 @@
+(** Bonsai.Expert.Var holding the current goals tree response. *)
+
+let var : Goals_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Goals_types.fixture
+;;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -1,0 +1,425 @@
+(** Goals view — config-driven goal tree.
+
+    Phase 2.C 네 번째 탭. design_v2 IA의 "goals · convergence" 섹션.
+    Recursive tree — 각 node는 goal + 직속 task list + child goals.
+
+    [`/api/v1/dashboard/goals`] 10s 폴링. Summary strip (total / active /
+    tasks done / convergence) + 접힌 tree. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(138,106,40,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(58,90,72,0.05), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .main {
+    padding: 3rem 3rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    overflow: auto;
+  }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .title_brass { color: var(--accent-brass); }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 620px;
+  }
+
+  .meta_strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    padding: 12px 16px;
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(42,20,14,0.35), rgba(20,12,8,0.65));
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+  .meta_item { display: flex; align-items: baseline; gap: 8px; }
+  .meta_k {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .meta_v { font-variant-numeric: tabular-nums; color: var(--text-bright); }
+  .meta_v_ok { color: var(--status-ok); }
+  .meta_v_brass { color: var(--accent-brass); }
+
+  .quiet {
+    padding: 40px 20px;
+    text-align: center;
+    border: 1px dashed var(--border-main);
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-dim);
+  }
+
+  .tree {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .goal {
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(28,18,14,0.7), rgba(14,10,8,0.85));
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .goal_indent { margin-left: 24px; border-left: 1px dashed var(--border-main); padding-left: 16px; }
+
+  .goal_head {
+    display: grid;
+    grid-template-columns: 1fr 160px 120px;
+    gap: 14px;
+    align-items: baseline;
+  }
+
+  .goal_title {
+    font-family: 'Cinzel', serif;
+    font-size: 16px;
+    letter-spacing: 0.08em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .goal_horizon {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  .goal_meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+  .goal_meta_v { color: var(--text-bright); font-variant-numeric: tabular-nums; }
+  .goal_meta_v_ok { color: var(--status-ok); font-variant-numeric: tabular-nums; }
+
+  .conv_bar_wrap {
+    text-align: right;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+  }
+  .conv_bar {
+    margin-top: 4px;
+    height: 4px;
+    background: rgba(58,90,72,0.12);
+    position: relative;
+  }
+  .conv_bar_fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    background: var(--status-ok);
+  }
+
+  .status_pill {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border: 1px solid var(--border-main);
+    text-align: center;
+    color: var(--text-dim);
+  }
+  .status_active { color: var(--status-ok); border-color: var(--status-ok); background: rgba(90,122,58,0.12); }
+  .status_paused { color: var(--status-warn); border-color: var(--status-warn); background: rgba(160,106,26,0.10); }
+  .status_done { color: var(--accent-brass); border-color: var(--accent-brass); background: rgba(138,106,40,0.12); }
+
+  .tasks {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--text-dim);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .task {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .task_dot { color: var(--text-dim); }
+  .task_dot_done { color: var(--status-ok); }
+  .task_dot_run { color: var(--status-warn); }
+  .task_title { color: var(--text-primary); }
+|}]
+
+let status_pill_class s =
+  match s with
+  | "active" -> Style.status_active
+  | "paused" -> Style.status_paused
+  | "done" | "completed" -> Style.status_done
+  | _ -> Style.status_pill
+;;
+
+let task_dot_class status =
+  match status with
+  | "completed" -> Style.task_dot_done
+  | "claimed" | "in_progress" -> Style.task_dot_run
+  | _ -> Style.task_dot
+;;
+
+let task_glyph status =
+  match status with
+  | "completed" -> "●"
+  | "claimed" | "in_progress" -> "◐"
+  | "cancelled" -> "×"
+  | _ -> "○"
+;;
+
+let view_task_chip (t : Goals_types.task) =
+  Node.div
+    ~attrs:[ Style.task ]
+    [ Node.span
+        ~attrs:[ Style.task_dot; task_dot_class t.status ]
+        [ Node.text (task_glyph t.status) ]
+    ; Node.span ~attrs:[ Style.task_title ] [ Node.text t.title ]
+    ]
+;;
+
+let truncate ~max_len s =
+  if String.length s <= max_len
+  then s
+  else String.sub s ~pos:0 ~len:(max_len - 1) ^ "…"
+;;
+
+let rec view_node ~(depth : int) (n : Goals_types.node) : Node.t =
+  let bar_fill_style =
+    Attr.create "style"
+      (Printf.sprintf "width:%d%%" (Int.clamp_exn n.convergence_pct ~min:0 ~max:100))
+  in
+  let horizon_text =
+    if String.is_empty n.horizon then "" else Printf.sprintf "%s · p%d" n.horizon n.priority
+  in
+  let indent_attr =
+    if depth > 0 then [ Style.goal_indent ] else []
+  in
+  let task_chips =
+    if List.is_empty n.tasks
+    then []
+    else
+      [ Node.div
+          ~attrs:[ Style.tasks ]
+          (List.map (List.take n.tasks 8) ~f:view_task_chip
+           @
+           if List.length n.tasks > 8
+           then
+             [ Node.div
+                 ~attrs:[ Style.task ]
+                 [ Node.span
+                     ~attrs:[ Style.task_dot ]
+                     [ Node.text
+                         (Printf.sprintf "+%d more" (List.length n.tasks - 8))
+                     ]
+                 ]
+             ]
+           else [])
+      ]
+  in
+  let children =
+    if List.is_empty n.children
+    then []
+    else List.map n.children ~f:(view_node ~depth:(depth + 1))
+  in
+  Node.div
+    ~attrs:(Style.goal :: indent_attr)
+    (List.concat
+       [ [ Node.div
+             ~attrs:[ Style.goal_head ]
+             [ Node.div
+                 ~attrs:[ Style.goal_title ]
+                 [ Node.text (truncate ~max_len:60 n.title) ]
+             ; Node.div
+                 ~attrs:[ Style.goal_horizon ]
+                 [ Node.text horizon_text ]
+             ; Node.div
+                 ~attrs:[ Style.conv_bar_wrap ]
+                 [ Node.text (Printf.sprintf "%d%%" n.convergence_pct)
+                 ; Node.div
+                     ~attrs:[ Style.conv_bar ]
+                     [ Node.div
+                         ~attrs:[ Style.conv_bar_fill; bar_fill_style ]
+                         []
+                     ]
+                 ]
+             ]
+         ; Node.div
+             ~attrs:[ Style.goal_meta ]
+             [ Node.span
+                 ~attrs:[ Style.status_pill; status_pill_class n.status ]
+                 [ Node.text (if String.is_empty n.status then "—" else n.status) ]
+             ; Node.span ~attrs:[]
+                 [ Node.text "tasks "
+                 ; Node.span
+                     ~attrs:[ Style.goal_meta_v ]
+                     [ Node.text (Printf.sprintf "%d" n.task_count) ]
+                 ]
+             ; Node.span ~attrs:[]
+                 [ Node.text "done "
+                 ; Node.span
+                     ~attrs:[ Style.goal_meta_v_ok ]
+                     [ Node.text (Printf.sprintf "%d" n.task_done_count) ]
+                 ]
+             ; (match n.metric with
+                | Some m when String.length m > 0 ->
+                  Node.span ~attrs:[]
+                    [ Node.text "metric "
+                    ; Node.span
+                        ~attrs:[ Style.goal_meta_v ]
+                        [ Node.text (truncate ~max_len:40 m) ]
+                    ]
+                | _ -> Node.none)
+             ; (match n.due_date with
+                | Some d when String.length d > 0 ->
+                  Node.span ~attrs:[]
+                    [ Node.text "due "
+                    ; Node.span
+                        ~attrs:[ Style.goal_meta_v ]
+                        [ Node.text d ]
+                    ]
+                | _ -> Node.none)
+             ]
+         ]
+       ; task_chips
+       ; children
+       ])
+;;
+
+let view_meta_strip (r : Goals_types.response) =
+  let s = r.summary in
+  Node.div
+    ~attrs:[ Style.meta_strip ]
+    [ Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "goals" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text (Printf.sprintf "%d" s.total_goals) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "active" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v_ok ]
+            [ Node.text (Printf.sprintf "%d" s.active_goals) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "tasks" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v ]
+            [ Node.text
+                (Printf.sprintf "%d / %d" s.done_tasks s.total_tasks)
+            ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.meta_item ]
+        [ Node.span ~attrs:[ Style.meta_k ] [ Node.text "convergence" ]
+        ; Node.span
+            ~attrs:[ Style.meta_v_brass ]
+            [ Node.text
+                (Printf.sprintf "%d%%" s.overall_convergence_pct)
+            ]
+        ]
+    ]
+;;
+
+let render (r : Goals_types.response) : Node.t =
+  Node.div
+    ~attrs:[ Style.root ]
+    [ Placeholder_view.sidebar ~active:Goals
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "goals · convergence" ]
+        ; Node.h1
+            ~attrs:[ Style.title ]
+            [ Node.text "goals "
+            ; Node.span
+                ~attrs:[ Style.title_brass ]
+                [ Node.text
+                    (Printf.sprintf "· %d" r.summary.total_goals)
+                ]
+            ]
+        ; Node.p
+            ~attrs:[ Style.sub ]
+            [ Node.text
+                "config-driven goal forest. 각 node는 goal 하나 + 직속 \
+                 task들 + 하위 goals. convergence는 child goals의 평균 \
+                 progress."
+            ]
+        ; view_meta_strip r
+        ; (match r.tree with
+           | [] ->
+             Node.div
+               ~attrs:[ Style.quiet ]
+               [ Node.text "goal tree is empty." ]
+           | nodes ->
+             Node.div
+               ~attrs:[ Style.tree ]
+               (List.map nodes ~f:(view_node ~depth:0)))
+        ]
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Goals_var.var) ~f:render
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -61,7 +61,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello | Dead_keepers | Keepers | Archive_runs | Overview -> true
+  | Logs | Hello | Dead_keepers | Keepers | Archive_runs | Overview | Goals -> true
   | _ -> false
 ;;
 


### PR DESCRIPTION
## Summary

Phase 2.C 네 번째 탭. config-driven goal forest를 Bonsai로 이식. 4-파일 패턴 (types/fetch/var/view) + app/route/main wiring.

## 신규 파일

- \`goals_types.ml\` — recursive node record + summary, manual Yojson 파서
- \`goals_fetch.ml\` — \`/api/v1/dashboard/goals\`, 10s polling
- \`goals_var.ml\` — Expert.Var singleton
- \`goals_view.ml\` — sidebar + hero + meta strip + recursive tree

## UI

- Meta strip: \`goals · active · tasks(done/total) · convergence %\`
- Goal card: title / horizon·priority / convergence bar (0-100%)
- Status pill (active/paused/done)
- 처음 8 task chip (glyph + title), 나머지 \`+N more\`
- depth>0 child는 left dashed border로 indent

## 검증

- [x] \`dune build\` 통과 (bonsai-dashboard switch)
- [x] \`/api/v1/dashboard/goals\` shape 확인 (빈 tree도 렌더 가능)
- [ ] 런타임 tree 렌더 확인 필요 (live goal 데이터 필요)

## Phase 2.C progress

- #9079 Dead_keepers ✅ merged
- #9084 Keepers ✅ merged
- #9098 Archive runs (pending checks)
- **#NEW Goals** (this PR)
- 남은: Overview, Sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)