### PR TITLE
docs(specs): fix KeeperConditionsGovernPhase json serializer line ref

### DIFF
--- a/specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
+++ b/specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
@@ -48,9 +48,12 @@
 \*     acknowledges the signal.
 \*
 \* Wire path to the dashboard banner consumer:
-\*   lib/keeper/keeper_state_machine.ml:620
+\*   lib/keeper/keeper_state_machine.ml:634
 \*     `"context_handoff_needed", \`Bool c.context_handoff_needed`
 \*     (json export — read by dashboard/src/components/keeper-conditions-divergent.ts).
+\*     Verified 2026-04-20: line 620 was a stale anchor; the json
+\*     serializer body shifted ~14 lines down as adjacent serializer
+\*     fields were inserted above it.
 \*
 \* Scope projection: spec models the 2-phase fragment (Running / HandingOff).
 \* The full 12-phase variant is out of scope here; sibling specs


### PR DESCRIPTION
## Summary

\`KeeperConditionsGovernPhase.tla\` referenced \`keeper_state_machine.ml:620\` for the \`context_handoff_needed\` json serializer line, but the field is actually emitted at line 634. The serializer body shifted ~14 lines down as adjacent serializer fields were inserted above it. Doc-only fix; spec semantics unchanged.

## Verification
\`\`\`
$ grep -n "context_handoff_needed.*Bool" lib/keeper/keeper_state_machine.ml
634:    "context_handoff_needed", `Bool c.context_handoff_needed;
\`\`\`

## Sweep context

**9th doc-only PR** in the second-pass sweep (anchor verification methodology). Pattern: serializer field line shifts as adjacent fields insert above. Same dominant drift class as #9090 (handler shift) and #9097 (event handler shift).

Companion second-pass PRs:
- #9086 — \`lib/room/\` → \`lib/coord/\` namespace move (MERGED)
- #9090 — KeeperTaskInterlock 2-anchor line drift (MERGED)
- #9097 — KeeperContextLifecycle Compaction_failed handler 383→402 (OPEN)
- #THIS — KeeperConditionsGovernPhase json line 620→634 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)