### PR TITLE
docs(logic): batch-23 .mli for goal_janitor + server_routes_http_routes_room + autoresearch_codegen

### DIFF
--- a/lib/autoresearch_codegen.mli
+++ b/lib/autoresearch_codegen.mli
@@ -1,0 +1,47 @@
+(** Autoresearch_codegen — LLM-based code change generation.
+
+    Builds prompts, parses MODEL responses as a strict JSON object,
+    and invokes the cascade for code generation.
+
+    @since 2.80.0 *)
+
+include module type of struct include Autoresearch_types end
+
+(** {1 Prompt construction (exposed for testing)} *)
+
+val build_code_change_prompt :
+  goal:string ->
+  baseline:float ->
+  lower_is_better:bool ->
+  history:cycle_record list ->
+  insights:string list ->
+  file_content:string ->
+  target_file:string ->
+  string
+
+(** {1 Response parsing} *)
+
+(** [parse_model_code_response raw] returns
+    [Ok (hypothesis, modified_code)] on success, [Error reason]
+    otherwise. Uses [Llm_provider.Lenient_json] for deterministic
+    recovery (strip markdown fences, unwrap double-stringify,
+    trailing commas, close brackets) before JSON parse. *)
+val parse_model_code_response :
+  string -> (string * string, string) result
+
+(** {1 Entry point} *)
+
+(** [generate_code_change ~goal ~baseline ~lower_is_better ~history
+    ~insights ~target_file ~file_content] invokes the
+    [autoresearch] cascade and returns [Ok (hypothesis, new_code)]
+    or [Error reason]. Backs off when local runtime slots are
+    saturated. *)
+val generate_code_change :
+  goal:string ->
+  baseline:float ->
+  lower_is_better:bool ->
+  history:cycle_record list ->
+  insights:string list ->
+  target_file:string ->
+  file_content:string ->
+  (string * string, string) result

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -1,0 +1,47 @@
+(** Goal_janitor — Periodic cleanup of stale and dropped goals.
+
+    Three sweep rules:
+    1. Purge: delete [Dropped] goals older than
+       [dropped_ttl_days] (default 7).
+    2. Stagnate: mark [Active] goals with no update for
+       [stagnant_days] (default 30) as [Dropped].
+    3. Orphan: remove [active_goal_ids] entries from each
+       [keeper_meta] that reference non-existent goals in the Goal
+       Store.
+
+    @since 2.236.0 *)
+
+(** {1 Configuration} *)
+
+type sweep_config = {
+  dropped_ttl_days : int;  (** Delete Dropped goals after this many days. *)
+  stagnant_days : int;     (** Drop Active goals with no update after this many days. *)
+}
+
+val default_config : sweep_config
+
+(** {1 Result} *)
+
+type sweep_result = {
+  purged : int;     (** Dropped goals deleted. *)
+  stagnated : int;  (** Active goals marked Dropped. *)
+  orphans : int;    (** Orphaned [active_goal_ids] cleaned. *)
+}
+
+val sweep_result_to_yojson : sweep_result -> Yojson.Safe.t
+
+(** {1 Helpers} *)
+
+(** [prune_active_goal_ids ~valid_goal_ids active_ids] keeps only
+    ids in [valid_goal_ids]. Returns the pruned list and the number
+    of removed ids. *)
+val prune_active_goal_ids :
+  valid_goal_ids:string list ->
+  string list ->
+  string list * int
+
+(** {1 Entry point} *)
+
+(** Run a full sweep: goal purge / stagnate, then keeper
+    [active_goal_ids] prune. Writes updated state to disk. *)
+val run : ?config:sweep_config -> Coord.config -> sweep_result

--- a/lib/server/server_routes_http_routes_room.mli
+++ b/lib/server/server_routes_http_routes_room.mli
@@ -1,0 +1,9 @@
+(** Server_routes_http_routes_room — Read-only HTTP routes for
+    project/room state.
+
+    Registers [GET /api/v1/status], [/tasks], [/agents],
+    [/messages]. All routes require read authentication via
+    {!Server_auth.with_read_auth}. *)
+
+val add_routes :
+  Http_server_eio.Router.t -> Http_server_eio.Router.t


### PR DESCRIPTION
## Summary

Wave 3 pure-types batch — 3 narrow `.mli` files added. Zero `.ml` changes.

| Module | Lines | External surface |
|---|---|---|
| `lib/goal/goal_janitor.mli` | 47 | `sweep_config` + `sweep_result` records + 4 vals; 2 callers + 1 test |
| `lib/server/server_routes_http_routes_room.mli` | 9 | `add_routes : Router.t -> Router.t`; 1 caller |
| `lib/autoresearch_codegen.mli` | 47 | 3 vals + re-export of `Autoresearch_types` via `include module type of struct include ... end` for cross-module type equality |

Pre-scan: `include=0 open=0 alias=0` (autoresearch_codegen has internal `include Autoresearch_types` but no external consumer uses its types directly; the `include module type of struct include ... end` form keeps `Autoresearch_codegen.cycle_record = Autoresearch.cycle_record` transparent).

## Notes

- First iteration used `include module type of Autoresearch_types` which made types abstract → `tool_autoresearch_registry.ml` broke on `Autoresearch.cycle_record ≠ Autoresearch_codegen.cycle_record`. Fixed with the `struct include` idiom.
- `goal_janitor` internal helpers (`parse_iso_ts`, `days_since_update`, `sweep_goals`) stay private — only `prune_active_goal_ids` exposed for the test.

## Metrics

- Files: 671 ml / ~361 mli (≈53.8% of ml).
- Build: `dune @check` exit 0.
- Tests: `test_goal_janitor` (4) passes.

## Milestone / Epic

- Milestone: #1023 (Wave 3 `.mli` coverage)
- Epic: #1022 (OCaml Best-of-Best North-Star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)