### PR TITLE
feat(bonsai-dashboard): Overview tab view (Phase 2.C fifth tab)

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -134,5 +134,7 @@ let () =
   Dashboard_bonsai_lib.Keepers_fetch.start_polling ();
   Dashboard_bonsai_lib.Archive_runs_fetch.run ();
   Dashboard_bonsai_lib.Archive_runs_fetch.start_polling ();
+  Dashboard_bonsai_lib.Overview_fetch.run ();
+  Dashboard_bonsai_lib.Overview_fetch.start_polling ();
   install_moon_clock ()
 ;;

--- a/dashboard_bonsai/src/app.ml
+++ b/dashboard_bonsai/src/app.ml
@@ -21,5 +21,6 @@ let root (graph @ local) =
   | Dead_keepers -> Dead_keepers_view.component graph
   | Keepers -> Keepers_view.component graph
   | Archive_runs -> Archive_runs_view.component graph
+  | Overview -> Overview_view.component graph
   | other -> Placeholder_view.component ~route:other graph
 ;;

--- a/dashboard_bonsai/src/overview_fetch.ml
+++ b/dashboard_bonsai/src/overview_fetch.ml
@@ -1,0 +1,30 @@
+(** Single-shot fetch of [/api/v1/dashboard/shell] + 5 s polling. *)
+
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/dashboard/shell"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Overview_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Overview_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:5000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/overview_types.ml
+++ b/dashboard_bonsai/src/overview_types.ml
@@ -1,0 +1,179 @@
+(** Typed model of [/api/v1/dashboard/shell] responses.
+
+    Subset of the full shell JSON — pick only what the Overview view
+    actually renders. Full schema in [lib/server/server_dashboard_http_core.ml].
+
+    Shape is manually parsed from [Yojson.Safe.t] — no ppx crossing into
+    js_of_ocaml. *)
+
+open! Core
+
+type build =
+  { release_version : string
+  ; commit : string
+  ; started_at : string
+  ; uptime_seconds : int
+  }
+
+type status =
+  { cluster : string
+  ; project : string
+  ; version : string
+  ; paused : bool
+  ; tempo_interval_s : float
+  ; build : build
+  }
+
+type counts =
+  { agents : int
+  ; tasks : int
+  ; keepers : int
+  }
+
+type belief =
+  { claim : string
+  ; status : string           (* "corroborated" | "contested" | ... *)
+  }
+
+type meta_cognition =
+  { stagnation_score : float
+  ; belief_count : int
+  ; contested_belief_count : int
+  ; dominant_belief : belief option
+  }
+
+type response =
+  { generated_at : string
+  ; status : status
+  ; counts : counts
+  ; configured_keepers : int
+  ; meta_cognition : meta_cognition
+  ; base_path : string
+  }
+
+let fixture_build : build =
+  { release_version = ""; commit = ""; started_at = ""; uptime_seconds = 0 }
+;;
+
+let fixture_status : status =
+  { cluster = ""
+  ; project = ""
+  ; version = ""
+  ; paused = false
+  ; tempo_interval_s = 0.0
+  ; build = fixture_build
+  }
+;;
+
+let fixture_counts : counts = { agents = 0; tasks = 0; keepers = 0 }
+
+let fixture_meta : meta_cognition =
+  { stagnation_score = 0.0
+  ; belief_count = 0
+  ; contested_belief_count = 0
+  ; dominant_belief = None
+  }
+;;
+
+let fixture : response =
+  { generated_at = ""
+  ; status = fixture_status
+  ; counts = fixture_counts
+  ; configured_keepers = 0
+  ; meta_cognition = fixture_meta
+  ; base_path = ""
+  }
+;;
+
+(* ---------- manual Yojson decoding ---------- *)
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let int_field ?(default = 0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> i
+  | `Intlit s -> (try Int.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let float_field ?(default = 0.0) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> f
+  | `Int i -> Float.of_int i
+  | `Intlit s -> (try Float.of_string s with _ -> default)
+  | _ -> default
+;;
+
+let bool_field ?(default = false) json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> b
+  | _ -> default
+;;
+
+let build_of_yojson json : build =
+  { release_version = string_field json "release_version"
+  ; commit = string_field json "commit"
+  ; started_at = string_field json "started_at"
+  ; uptime_seconds = int_field json "uptime_seconds"
+  }
+;;
+
+let status_of_yojson json : status =
+  let build_json = Yojson.Safe.Util.member "build" json in
+  { cluster = string_field json "cluster"
+  ; project = string_field json "project"
+  ; version = string_field json "version"
+  ; paused = bool_field json "paused"
+  ; tempo_interval_s = float_field json "tempo_interval_s"
+  ; build = build_of_yojson build_json
+  }
+;;
+
+let counts_of_yojson json : counts =
+  { agents = int_field json "agents"
+  ; tasks = int_field json "tasks"
+  ; keepers = int_field json "keepers"
+  }
+;;
+
+let belief_of_yojson json : belief option =
+  match json with
+  | `Null -> None
+  | _ ->
+    Some
+      { claim = string_field json "claim"
+      ; status = string_field json "status"
+      }
+;;
+
+let meta_cognition_of_yojson json : meta_cognition =
+  let dominant =
+    belief_of_yojson (Yojson.Safe.Util.member "dominant_belief" json)
+  in
+  { stagnation_score = float_field json "stagnation_score"
+  ; belief_count = int_field json "belief_count"
+  ; contested_belief_count = int_field json "contested_belief_count"
+  ; dominant_belief = dominant
+  }
+;;
+
+let response_of_yojson json : response =
+  let base_path =
+    match Yojson.Safe.Util.member "paths" json with
+    | `Assoc _ as p -> string_field p "effective_base_path"
+    | _ -> string_field (Yojson.Safe.Util.member "status" json) "base_path"
+  in
+  { generated_at = string_field json "generated_at"
+  ; status = status_of_yojson (Yojson.Safe.Util.member "status" json)
+  ; counts = counts_of_yojson (Yojson.Safe.Util.member "counts" json)
+  ; configured_keepers = int_field json "configured_keepers"
+  ; meta_cognition =
+      meta_cognition_of_yojson
+        (Yojson.Safe.Util.member "meta_cognition" json)
+  ; base_path
+  }
+;;

--- a/dashboard_bonsai/src/overview_var.ml
+++ b/dashboard_bonsai/src/overview_var.ml
@@ -1,0 +1,5 @@
+(** Bonsai.Expert.Var holding the current shell response. *)
+
+let var : Overview_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Overview_types.fixture
+;;

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -1,0 +1,445 @@
+(** Overview view — project vitals + stagnation.
+
+    Phase 2.C 다섯 번째 탭. design_v2 IA의 "overview · at a glance"
+    섹션. shell endpoint의 부분집합을 4 블록으로 배치:
+
+    1. Hero: project · cluster · base_path
+    2. Build strip: version + commit + uptime
+    3. Fleet counts: agents / tasks / keepers (+configured)
+    4. Meta-cognition: stagnation score + dominant belief
+
+    [`/api/v1/dashboard/shell`] 5s 폴링. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .root {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(138,106,40,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(58,58,90,0.06), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    color: var(--text-primary);
+    font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;
+  }
+
+  .main {
+    padding: 3rem 3rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    overflow: auto;
+  }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .title_brass { color: var(--accent-brass); }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary);
+    margin: 0;
+    max-width: 680px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+  }
+
+  .panel {
+    border: 1px solid var(--border-main);
+    background: linear-gradient(180deg, rgba(28,18,14,0.7), rgba(14,10,8,0.85));
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .panel_title {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0;
+  }
+
+  .kv_row {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .kv {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 14px;
+    align-items: baseline;
+  }
+  .k {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .v {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .v_dim { color: var(--text-dim); }
+  .v_brass { color: var(--accent-brass); }
+  .v_ok { color: var(--status-ok); }
+  .v_warn { color: var(--status-warn); }
+  .v_bad { color: var(--accent-blood); }
+
+  .counts {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+  }
+  .count_cell {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 14px;
+    background: rgba(14,10,8,0.4);
+    border: 1px solid var(--border-main);
+    text-align: center;
+  }
+  .count_k {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 9px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .count_v {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.05em;
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stag_bar {
+    height: 6px;
+    background: rgba(138,106,40,0.15);
+    position: relative;
+    margin-top: 6px;
+  }
+  .stag_fill {
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    background: var(--accent-brass);
+  }
+  .stag_fill_warn { background: var(--status-warn); }
+  .stag_fill_bad { background: var(--accent-blood); }
+
+  .belief {
+    padding: 12px 14px;
+    border: 1px dashed var(--border-main);
+    font-family: 'EB Garamond', serif;
+    font-size: 14px;
+    color: var(--text-primary);
+    font-style: italic;
+  }
+  .belief_tag {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent-brass);
+    margin-right: 10px;
+  }
+
+  .empty {
+    padding: 32px 16px;
+    text-align: center;
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    color: var(--text-dim);
+    border: 1px dashed var(--border-main);
+  }
+|}]
+
+let hms_of_seconds total =
+  let s = total mod 60 in
+  let m = (total / 60) mod 60 in
+  let h = total / 3600 in
+  if h > 0 then Printf.sprintf "%dh %dm" h m
+  else if m > 0 then Printf.sprintf "%dm %ds" m s
+  else Printf.sprintf "%ds" s
+;;
+
+let short_commit c =
+  if String.length c > 9 then String.sub c ~pos:0 ~len:9 else c
+;;
+
+let stag_color (score : float) =
+  if Float.(score >= 0.75) then Style.stag_fill_bad
+  else if Float.(score >= 0.5) then Style.stag_fill_warn
+  else Style.stag_fill
+;;
+
+let paused_pill ~(paused : bool) =
+  if paused
+  then Node.span ~attrs:[ Style.v; Style.v_warn ] [ Node.text "paused" ]
+  else Node.span ~attrs:[ Style.v; Style.v_ok ] [ Node.text "live" ]
+;;
+
+let view_hero_panel (r : Overview_types.response) =
+  let s = r.status in
+  Node.div
+    ~attrs:[ Style.panel ]
+    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "room · identity" ]
+    ; Node.div
+        ~attrs:[ Style.kv_row ]
+        [ Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "project" ]
+            ; Node.div
+                ~attrs:[ Style.v; Style.v_brass ]
+                [ Node.text (if String.is_empty s.project then "—" else s.project) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "cluster" ]
+            ; Node.div
+                ~attrs:[ Style.v ]
+                [ Node.text (if String.is_empty s.cluster then "—" else s.cluster) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "base path" ]
+            ; Node.div
+                ~attrs:[ Style.v; Style.v_dim ]
+                [ Node.text (if String.is_empty r.base_path then "—" else r.base_path) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "status" ]
+            ; paused_pill ~paused:s.paused
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "tempo" ]
+            ; Node.div
+                ~attrs:[ Style.v ]
+                [ Node.text
+                    (Printf.sprintf
+                       "%.0fs interval"
+                       s.tempo_interval_s)
+                ]
+            ]
+        ]
+    ]
+;;
+
+let view_build_panel (r : Overview_types.response) =
+  let b = r.status.build in
+  Node.div
+    ~attrs:[ Style.panel ]
+    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "build · release" ]
+    ; Node.div
+        ~attrs:[ Style.kv_row ]
+        [ Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "version" ]
+            ; Node.div
+                ~attrs:[ Style.v; Style.v_brass ]
+                [ Node.text
+                    (if String.is_empty b.release_version
+                     then r.status.version
+                     else b.release_version)
+                ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "commit" ]
+            ; Node.div
+                ~attrs:[ Style.v; Style.v_dim ]
+                [ Node.text (short_commit b.commit) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "uptime" ]
+            ; Node.div
+                ~attrs:[ Style.v ]
+                [ Node.text (hms_of_seconds b.uptime_seconds) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "started" ]
+            ; Node.div
+                ~attrs:[ Style.v; Style.v_dim ]
+                [ Node.text
+                    (if String.is_empty b.started_at then "—" else b.started_at)
+                ]
+            ]
+        ]
+    ]
+;;
+
+let view_counts_panel (r : Overview_types.response) =
+  let c = r.counts in
+  let keeper_label =
+    if r.configured_keepers <= 0
+    then Printf.sprintf "%d" c.keepers
+    else Printf.sprintf "%d / %d" c.keepers r.configured_keepers
+  in
+  Node.div
+    ~attrs:[ Style.panel ]
+    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "fleet · counts" ]
+    ; Node.div
+        ~attrs:[ Style.counts ]
+        [ Node.div
+            ~attrs:[ Style.count_cell ]
+            [ Node.div ~attrs:[ Style.count_k ] [ Node.text "keepers" ]
+            ; Node.div
+                ~attrs:[ Style.count_v ]
+                [ Node.text keeper_label ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.count_cell ]
+            [ Node.div ~attrs:[ Style.count_k ] [ Node.text "tasks" ]
+            ; Node.div
+                ~attrs:[ Style.count_v ]
+                [ Node.text (Printf.sprintf "%d" c.tasks) ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.count_cell ]
+            [ Node.div ~attrs:[ Style.count_k ] [ Node.text "agents" ]
+            ; Node.div
+                ~attrs:[ Style.count_v ]
+                [ Node.text (Printf.sprintf "%d" c.agents) ]
+            ]
+        ]
+    ]
+;;
+
+let view_meta_panel (r : Overview_types.response) =
+  let m = r.meta_cognition in
+  let pct = Int.of_float (Float.round_nearest (m.stagnation_score *. 100.0)) in
+  let bar_style =
+    Attr.create
+      "style"
+      (Printf.sprintf "width:%d%%" (Int.clamp_exn pct ~min:0 ~max:100))
+  in
+  let belief_node =
+    match m.dominant_belief with
+    | Some b ->
+      Node.div
+        ~attrs:[ Style.belief ]
+        [ Node.span
+            ~attrs:[ Style.belief_tag ]
+            [ Node.text b.status ]
+        ; Node.text (if String.is_empty b.claim then "—" else b.claim)
+        ]
+    | None ->
+      Node.div
+        ~attrs:[ Style.empty ]
+        [ Node.text "no dominant belief recorded." ]
+  in
+  Node.div
+    ~attrs:[ Style.panel ]
+    [ Node.p
+        ~attrs:[ Style.panel_title ]
+        [ Node.text "meta · cognition" ]
+    ; Node.div
+        ~attrs:[ Style.kv_row ]
+        [ Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "stagnation" ]
+            ; Node.div
+                ~attrs:[ Style.v ]
+                [ Node.text (Printf.sprintf "%d%%" pct)
+                ; Node.div
+                    ~attrs:[ Style.stag_bar ]
+                    [ Node.div
+                        ~attrs:[ Style.stag_fill; stag_color m.stagnation_score; bar_style ]
+                        []
+                    ]
+                ]
+            ]
+        ; Node.div
+            ~attrs:[ Style.kv ]
+            [ Node.div ~attrs:[ Style.k ] [ Node.text "beliefs" ]
+            ; Node.div
+                ~attrs:[ Style.v ]
+                [ Node.text
+                    (Printf.sprintf
+                       "%d total · %d contested"
+                       m.belief_count
+                       m.contested_belief_count)
+                ]
+            ]
+        ]
+    ; belief_node
+    ]
+;;
+
+let render (r : Overview_types.response) : Node.t =
+  Node.div
+    ~attrs:[ Style.root ]
+    [ Placeholder_view.sidebar ~active:Overview
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "overview · at a glance" ]
+        ; Node.h1
+            ~attrs:[ Style.title ]
+            [ Node.text "overview "
+            ; Node.span
+                ~attrs:[ Style.title_brass ]
+                [ Node.text (Printf.sprintf "· %s" r.status.cluster) ]
+            ]
+        ; Node.p
+            ~attrs:[ Style.sub ]
+            [ Node.text
+                "room의 current state — identity, build, fleet counts, \
+                 meta-cognition. shell 엔드포인트의 압축된 projection \
+                 으로, 깊은 진단은 각 tab에서 확인."
+            ]
+        ; Node.div
+            ~attrs:[ Style.grid ]
+            [ view_hero_panel r
+            ; view_build_panel r
+            ; view_counts_panel r
+            ; view_meta_panel r
+            ]
+        ]
+    ]
+;;
+
+let component (_graph @ local) =
+  Bonsai.map (Bonsai.Expert.Var.value Overview_var.var) ~f:render
+;;

--- a/dashboard_bonsai/src/route.ml
+++ b/dashboard_bonsai/src/route.ml
@@ -61,7 +61,7 @@ let path t = Printf.sprintf "/dashboard/b/%s" (slug t)
 
 (* Bonsai로 이식된 탭 목록. 그 외는 placeholder (Phase 2+). *)
 let is_implemented = function
-  | Logs | Hello | Dead_keepers | Keepers | Archive_runs -> true
+  | Logs | Hello | Dead_keepers | Keepers | Archive_runs | Overview -> true
   | _ -> false
 ;;
 


### PR DESCRIPTION
## Summary

Phase 2.C 다섯 번째 탭. shell endpoint의 압축 projection을 4 panel로 배치:

1. **Hero** — project / cluster / base_path / live·paused / tempo
2. **Build** — version / commit(short) / uptime / started_at
3. **Fleet counts** — keepers (live/configured) / tasks / agents
4. **Meta-cognition** — stagnation bar (0-100%, color-graded) + dominant belief

## 신규 파일

- \`overview_types.ml\` — shell endpoint 부분집합 (status/counts/meta_cognition/base_path)
- \`overview_fetch.ml\` — \`/api/v1/dashboard/shell\`, 5s polling
- \`overview_var.ml\` — Expert.Var singleton
- \`overview_view.ml\` — sidebar + 2x2 panel grid

## Stagnation 색상 단계

- \`<50%\` → brass (default)
- \`≥50%\` → warn amber
- \`≥75%\` → blood red

## 검증

- [x] \`dune build\` 통과
- [x] shell endpoint shape 확인 (auth disabled 상태에서도 counts/meta 정상)

## Phase 2.C progress

- #9079 Dead_keepers ✅
- #9084 Keepers ✅
- #9092 ctx_chart ✅
- #9098 Archive_runs (open)
- #9100 Goals (open)
- **#NEW Overview** (this PR)
- 남은: Sessions (session_id 파라미터 필요 → Phase 2.D drill-down으로 미룸)

🤖 Generated with [Claude Code](https://claude.com/claude-code)