### PR TITLE
feat(keeper): route keeper_shell cat/ls through docker (RFC-0006 Phase B-3b)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -417,6 +417,7 @@
    keeper_alerting
    keeper_alerting_path
    keeper_sandbox_containment
+   keeper_sandbox_runtime
    keeper_docker_read
    keeper_timing
    keeper_tool_registry
@@ -674,6 +675,7 @@
   keeper_sandbox
   keeper_alerting_path
   keeper_sandbox_containment
+  keeper_sandbox_runtime
   keeper_docker_read
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -104,7 +104,7 @@ let run_command_in_container ~config ~(meta : keeper_meta)
   else if command_argv = [] then
     Error "run_command_in_container: command_argv is empty"
   else
-    match Keeper_exec_shell.ensure_keeper_sandbox_runtime ~timeout_sec with
+    match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error err -> Error err
     | Ok seccomp_args ->
       let host_root = host_playground_root ~config ~meta in

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -491,74 +491,13 @@ let command_uses_nested_container_runtime cmd =
     lowered_words
   || List.exists (String_util.contains_substring lowered_cmd) sandbox_socket_markers
 
-let docker_info_security_options ~timeout_sec =
-  let st, out =
-    Process_eio.run_argv_with_status
-      ~cwd:(Sys.getcwd ())
-      ~timeout_sec
-      [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ]
-  in
-  if st <> Unix.WEXITED 0 then
-    Error
-      (Printf.sprintf "docker info failed while validating sandbox runtime: %s"
-         (Worker_dev_tools.truncate_for_log out))
-  else
-    try
-      match Yojson.Safe.from_string (String.trim out) with
-      | `List items ->
-          Ok
-            (List.filter_map Yojson.Safe.Util.to_string_option items
-            |> List.map String.lowercase_ascii)
-      | `Null -> Ok []
-      | _ ->
-          Error
-            "docker info returned unexpected SecurityOptions payload while validating sandbox runtime"
-    with
-    | Yojson.Json_error err ->
-        Error
-          (Printf.sprintf
-             "failed to parse docker info SecurityOptions JSON: %s"
-             err)
-
+(* Sandbox runtime preflight extracted to [Keeper_sandbox_runtime]
+   (RFC-0006 Phase B-3b) so [Keeper_docker_read] can call it without
+   forming a module cycle through this file. The helper below is the
+   call site retained for compatibility with this module's existing
+   callers. *)
 let ensure_keeper_sandbox_runtime ~timeout_sec =
-  let seccomp_profile =
-    String.trim (Env_config_keeper.KeeperSandbox.seccomp_profile ())
-  in
-  let require_rootless = Env_config_keeper.KeeperSandbox.require_rootless () in
-  let require_userns = Env_config_keeper.KeeperSandbox.require_userns () in
-  let seccomp_args =
-    if seccomp_profile = "" then
-      Ok []
-    else if Sys.file_exists seccomp_profile then
-      Ok [ "--security-opt"; "seccomp=" ^ seccomp_profile ]
-    else
-      Error
-        (Printf.sprintf
-           "sandbox seccomp profile not found: %s"
-           seccomp_profile)
-  in
-  match seccomp_args with
-  | Error _ as err -> err
-  | Ok seccomp_args ->
-      if not require_rootless && not require_userns then
-        Ok seccomp_args
-      else
-        match docker_info_security_options ~timeout_sec:(min 20.0 (max 5.0 timeout_sec)) with
-        | Error _ as err -> err
-        | Ok security_options ->
-            let has needle =
-              List.exists
-                (fun option_text -> String_util.contains_substring option_text needle)
-                security_options
-            in
-            if require_rootless && not (has "rootless") then
-              Error
-                "sandbox runtime requires Docker rootless mode (set MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS=false to disable this check)"
-            else if require_userns && not (has "userns") then
-              Error
-                "sandbox runtime requires Docker userns support (set MASC_KEEPER_SANDBOX_REQUIRE_USERNS=false to disable this check)"
-            else
-              Ok seccomp_args
+  Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec
 
 (* docker_with_git: leading-token check used by per-command dispatch.
    Returns true when the trimmed command's first whitespace-separated word
@@ -1423,38 +1362,98 @@ let handle_keeper_shell
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec [ "/bin/ls"; "-la"; target ]
-       in
        let limit = shell_readonly_limit args in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "path", `String target
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "entries", lines_to_json ~limit out
-             ]))
+       (* RFC-0006 Phase B-3b: when symmetric_sandbox+docker_read are
+          on for a hardened keeper, route ls through the same docker
+          prelude as keeper_fs_read so the container's mount is the
+          load-bearing isolation. The host-side containment guard
+          above remains as defense in depth. *)
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            Keeper_docker_read.container_path_of_host ~config ~meta
+              ~host_path:target
+          with
+          | Error e ->
+            error_json
+              ~fields:[ "op", `String op; "path", `String target ] e
+          | Ok cpath ->
+            (match
+               Keeper_docker_read.run_command_in_container ~config ~meta
+                 ~command_argv:[ "ls"; "-la"; cpath ]
+                 ~max_bytes:1_000_000
+                 ~timeout_sec:io_timeout_sec ()
+             with
+             | Error msg ->
+               error_json
+                 ~fields:[ "op", `String op; "path", `String target ] msg
+             | Ok out ->
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool true
+                     ; "op", `String op
+                     ; "path", `String target
+                     ; "via", `String "docker"
+                     ; "entries", lines_to_json ~limit out
+                     ])))
+       else
+         let st, out =
+           Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec [ "/bin/ls"; "-la"; target ]
+         in
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "op", `String op
+               ; "path", `String target
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "entries", lines_to_json ~limit out
+               ]))
   | "cat" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
        let max_bytes = shell_readonly_cat_max_bytes args in
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec [ "/bin/cat"; target ]
-       in
-       let body =
-         if String.length out > max_bytes then String.sub out 0 max_bytes else out
-       in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "path", `String target
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "truncated", `Bool (String.length out > max_bytes)
-             ; "content", `String body
-             ]))
+       (* RFC-0006 Phase B-3b: docker route via the existing
+          read_file_in_container helper (which is already a [cat]
+          wrapper around run_command_in_container). Symmetry with
+          keeper_fs_read's [via: "docker"] response field. *)
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            Keeper_docker_read.read_file_in_container ~config ~meta
+              ~host_path:target ~max_bytes
+              ~timeout_sec:read_timeout_sec ()
+          with
+          | Error msg ->
+            error_json
+              ~fields:[ "op", `String op; "path", `String target ] msg
+          | Ok body ->
+            let total = String.length body in
+            let truncated = total >= max_bytes in
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool true
+                  ; "op", `String op
+                  ; "path", `String target
+                  ; "via", `String "docker"
+                  ; "bytes", `Int total
+                  ; "truncated", `Bool truncated
+                  ; "content", `String body
+                  ]))
+       else
+         let st, out =
+           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec [ "/bin/cat"; target ]
+         in
+         let body =
+           if String.length out > max_bytes then String.sub out 0 max_bytes else out
+         in
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "op", `String op
+               ; "path", `String target
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "truncated", `Bool (String.length out > max_bytes)
+               ; "content", `String body
+               ]))
   | "rg" ->
     let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
     if pattern = ""

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -1,0 +1,76 @@
+(** See .mli for contract.
+
+    Extracted from [Keeper_exec_shell] (RFC-0006 Phase B-3b) so both
+    [Keeper_exec_shell] (bash sandbox) and [Keeper_docker_read] (read
+    sandbox) can preflight the host docker runtime against the
+    configured hardening requirements without forming a module
+    dependency cycle. *)
+
+let docker_info_security_options ~timeout_sec =
+  let st, out =
+    Process_eio.run_argv_with_status
+      ~cwd:(Sys.getcwd ())
+      ~timeout_sec
+      [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ]
+  in
+  if st <> Unix.WEXITED 0 then
+    Error
+      (Printf.sprintf "docker info failed while validating sandbox runtime: %s"
+         (Worker_dev_tools.truncate_for_log out))
+  else
+    try
+      match Yojson.Safe.from_string (String.trim out) with
+      | `List items ->
+          Ok
+            (List.filter_map Yojson.Safe.Util.to_string_option items
+            |> List.map String.lowercase_ascii)
+      | `Null -> Ok []
+      | _ ->
+          Error
+            "docker info returned unexpected SecurityOptions payload while validating sandbox runtime"
+    with
+    | Yojson.Json_error err ->
+        Error
+          (Printf.sprintf
+             "failed to parse docker info SecurityOptions JSON: %s"
+             err)
+
+let ensure_keeper_sandbox_runtime ~timeout_sec =
+  let seccomp_profile =
+    String.trim (Env_config_keeper.KeeperSandbox.seccomp_profile ())
+  in
+  let require_rootless = Env_config_keeper.KeeperSandbox.require_rootless () in
+  let require_userns = Env_config_keeper.KeeperSandbox.require_userns () in
+  let seccomp_args =
+    if seccomp_profile = "" then
+      Ok []
+    else if Sys.file_exists seccomp_profile then
+      Ok [ "--security-opt"; "seccomp=" ^ seccomp_profile ]
+    else
+      Error
+        (Printf.sprintf
+           "sandbox seccomp profile not found: %s"
+           seccomp_profile)
+  in
+  match seccomp_args with
+  | Error _ as err -> err
+  | Ok seccomp_args ->
+      if not require_rootless && not require_userns then
+        Ok seccomp_args
+      else
+        match docker_info_security_options ~timeout_sec:(min 20.0 (max 5.0 timeout_sec)) with
+        | Error _ as err -> err
+        | Ok security_options ->
+            let has needle =
+              List.exists
+                (fun option_text -> String_util.contains_substring option_text needle)
+                security_options
+            in
+            if require_rootless && not (has "rootless") then
+              Error
+                "sandbox runtime requires Docker rootless mode (set MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS=false to disable this check)"
+            else if require_userns && not (has "userns") then
+              Error
+                "sandbox runtime requires Docker userns support (set MASC_KEEPER_SANDBOX_REQUIRE_USERNS=false to disable this check)"
+            else
+              Ok seccomp_args

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -1,0 +1,18 @@
+(** Keeper sandbox runtime preflight.
+
+    Shared between [Keeper_exec_shell] (bash sandbox) and
+    [Keeper_docker_read] (read sandbox). Both surfaces need to verify
+    the host docker runtime satisfies the configured hardening
+    constraints (seccomp profile present, optional rootless / userns
+    enforcement) before launching any containerised work.
+
+    Pure leaf module — no upward dependencies on other [Keeper_*]
+    modules. *)
+
+val ensure_keeper_sandbox_runtime :
+  timeout_sec:float -> (string list, string) result
+(** Returns the [--security-opt seccomp=...] argv fragment when the
+    runtime passes; [Error _] when something is missing.
+
+    The fragment is empty when the env config has no seccomp profile
+    set; the caller should still concat it into the docker argv. *)

--- a/test/dune
+++ b/test/dune
@@ -92,6 +92,7 @@
         test_keeper_tool_alias
         test_keeper_sandbox_containment
         test_keeper_shell_containment
+        test_keeper_shell_docker_route
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -207,6 +208,7 @@
           test_keeper_tool_alias
           test_keeper_sandbox_containment
           test_keeper_shell_containment
+          test_keeper_shell_docker_route
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1,0 +1,202 @@
+(** Tests for keeper_shell docker routing (RFC-0006 Phase B-3b).
+
+    Verifies that the [should_route_read] branch fires for [cat] and
+    [ls] when symmetric_sandbox + docker_read are both on for a
+    hardened keeper. The docker process itself is not invoked because
+    the test environment sets [MASC_KEEPER_SANDBOX_DOCKER_IMAGE=""],
+    so the response must surface the structured "docker image is not
+    configured" error from [Keeper_docker_read] — proof that control
+    reached the docker route. *)
+
+module Coord = Masc_mcp.Coord
+module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
+module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
+module Fs_compat = Fs_compat
+module Json = Yojson.Safe.Util
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let with_env key value f =
+  let prior = try Some (Sys.getenv key) with Not_found -> None in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let temp_dir () =
+  let dir = Filename.temp_file "keeper_shell_docker_route_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter
+          (fun name -> rm (Filename.concat path name))
+          (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with _ -> ()
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let make_meta ~name ~sandbox =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "shell docker route test");
+        ("allowed_paths", `List [ `String "*" ]);
+        ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+let with_eio_fs f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  f ()
+
+let setup ~sandbox f =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base ".masc");
+  let config = Coord.default_config base in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_meta ~name:"minjae" ~sandbox in
+  let playground =
+    Filename.concat base
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  ensure_dir playground;
+  f ~config ~meta ~playground
+
+let parse_field raw field =
+  Yojson.Safe.from_string raw |> Json.member field
+
+let parse_string_field raw field =
+  parse_field raw field |> Json.to_string_option
+
+let response_mentions raw field needle =
+  match parse_string_field raw field with
+  | None -> false
+  | Some s ->
+      let len = String.length needle in
+      let n = String.length s in
+      let rec loop i =
+        if i + len > n then false
+        else if String.sub s i len = needle then true
+        else loop (i + 1)
+      in
+      loop 0
+
+(* ── Tests ───────────────────────────────────────────────────────── *)
+
+let test_cat_routes_through_docker () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker_hardened
+  @@ fun ~config ~meta ~playground ->
+  let host_path = Filename.concat playground "mind/x" in
+  ensure_dir (Filename.dirname host_path);
+  ignore (Fs_compat.save_file_atomic host_path "matrix");
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
+  in
+  Alcotest.(check bool)
+    "cat surfaces docker image config error (docker route fired)"
+    true
+    (response_mentions raw "error" "docker image")
+
+let test_ls_routes_through_docker () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker_hardened
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+      ~args:(`Assoc [ ("op", `String "ls"); ("path", `String playground) ])
+  in
+  Alcotest.(check bool)
+    "ls surfaces docker image config error (docker route fired)"
+    true
+    (response_mentions raw "error" "docker image")
+
+let test_cat_legacy_keeper_skips_docker () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Legacy_local
+  @@ fun ~config ~meta ~playground ->
+  let host_path = Filename.concat playground "mind/x" in
+  ensure_dir (Filename.dirname host_path);
+  ignore (Fs_compat.save_file_atomic host_path "matrix");
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
+  in
+  Alcotest.(check bool)
+    "legacy keeper does not surface docker image error"
+    false
+    (response_mentions raw "error" "docker image")
+
+let test_cat_flag_off_skips_docker () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker_hardened
+  @@ fun ~config ~meta ~playground ->
+  let host_path = Filename.concat playground "mind/x" in
+  ensure_dir (Filename.dirname host_path);
+  ignore (Fs_compat.save_file_atomic host_path "matrix");
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
+  in
+  Alcotest.(check bool)
+    "DOCKER_READ off → no docker route, no image error"
+    false
+    (response_mentions raw "error" "docker image")
+
+let () =
+  Alcotest.run "Keeper_shell_docker_route"
+    [
+      ( "docker_route_fires",
+        [
+          Alcotest.test_case "cat routes through docker for hardened+flags"
+            `Quick test_cat_routes_through_docker;
+          Alcotest.test_case "ls routes through docker for hardened+flags"
+            `Quick test_ls_routes_through_docker;
+        ] );
+      ( "docker_route_skipped",
+        [
+          Alcotest.test_case "legacy keeper skips docker route" `Quick
+            test_cat_legacy_keeper_skips_docker;
+          Alcotest.test_case "DOCKER_READ flag off skips docker route"
+            `Quick test_cat_flag_off_skips_docker;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Phase B-2(#8977)는 \`keeper_fs_read\`만 docker 라우팅. 본 PR은 \`keeper_shell\`의 \`cat\`/\`ls\` 두 op으로 확장.
- hardened keeper + \`MASC_KEEPER_SYMMETRIC_SANDBOX=true\` + \`MASC_KEEPER_DOCKER_READ=true\` 일 때 동일 docker prelude(read-only rootfs, no caps, no network, playground :ro mount) 통과. 호스트 측 B-1.5 containment는 defense-in-depth로 잔존.

## Module restructure
- \`ensure_keeper_sandbox_runtime\` + \`docker_info_security_options\`을 \`Keeper_exec_shell\` → 새 leaf \`Keeper_sandbox_runtime\` 모듈로 추출. \`Keeper_exec_shell ↔ Keeper_docker_read\` 잠재 cycle 제거.
- \`Keeper_exec_shell.ensure_keeper_sandbox_runtime\`은 thin wrapper로 보존(외부 호출자 무파괴).

## Response shape
- docker 경로: \`{ via: \"docker\", ... }\` (B-2 \`keeper_fs_read\` 일관성). \`status\` Unix.process_status 필드는 docker 경로에 의미 없어 제거.
- 로컬 경로: 변경 없음.

## Out of scope (B-3c 후속)
- \`rg/find/head/tail/wc/tree\`는 여전히 host 경로. argv에 host path를 컨테이너 path로 번역해야 해 별도 작업.

## Test plan
- [x] \`dune build --root .\` 클린
- [x] \`dune test --root . test/test_keeper_shell_docker_route.exe --force\` → **4/4 pass** (cat/ls fire docker route, legacy/flag-off skip)
- [x] 인접 슈트: \`test_keeper_shell_containment\` 8/8, \`test_keeper_docker_read\` 12/12, \`test_keeper_sandbox_containment\` 6/6
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)