### PR TITLE
feat(legendary-counters): add derived ratio helpers for flip decisions

### DIFF
--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -228,6 +228,25 @@ for point-in-time diagnostics, counters for `disagree ratio =
 (legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total`
 trend math over a rolling window.
 
+### Derived ratios (SSOT)
+
+Dashboards and flip-decision tooling should use the
+`Legendary_counters` helpers rather than re-deriving the math from
+raw fields — three different shell recipes and a UI drifted apart
+twice already. The helpers return `0.0` when their denominator is
+zero so the JSON output stays a finite float even with the observer
+off:
+
+| Helper | Formula | Flip criterion |
+| --- | --- | --- |
+| `disagree_ratio snap` | `(legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total` | `MASC_BASH_AST_ONLY` target: `0.0` over 7-day window |
+| `shadow_parse_coverage snap` | `1.0 - shadow_cannot_parse / gate_diff_total` | `MASC_BASH_AST_ONLY` target: `>= 0.99` (parse gap `< 1%`) |
+| `auto_bg_promotion_rate snap` | `would_have_promoted / auto_bg_observed` | Input to `MASC_BLOCKING_BUDGET_MS` tuning + `MASC_BASH_AUTO_BG` default-flip review |
+
+The signatures live in `lib/legendary_counters.mli`; reach for them
+from any new dashboard chip, Slack formatter, or CI gate before
+open-coding the ratio yourself.
+
 The `too_complex_*` family is a histogram refinement of the single
 `gate_diff_shadow_cannot_parse` bucket: each subset-excluded bash
 feature gets its own counter, so operators can see which construct

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -182,3 +182,26 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     ("too_complex_parse_aborted", `Int s.too_complex_parse_aborted);
     ("too_complex_other", `Int s.too_complex_other);
   ]
+
+let safe_ratio ~num ~den =
+  if den <= 0 then 0.0
+  else float_of_int num /. float_of_int den
+
+let disagree_ratio (s : snapshot) : float =
+  safe_ratio
+    ~num:(s.gate_diff_legacy_allow_shadow_deny
+          + s.gate_diff_legacy_deny_shadow_allow)
+    ~den:s.gate_diff_total
+
+let shadow_parse_coverage (s : snapshot) : float =
+  if s.gate_diff_total <= 0 then 0.0
+  else
+    1.0
+    -. safe_ratio
+         ~num:s.gate_diff_shadow_cannot_parse
+         ~den:s.gate_diff_total
+
+let auto_bg_promotion_rate (s : snapshot) : float =
+  safe_ratio
+    ~num:s.auto_bg_would_have_promoted
+    ~den:s.auto_bg_observed

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -82,3 +82,42 @@ val snapshot : unit -> snapshot
 val snapshot_to_json : snapshot -> Yojson.Safe.t
 (** Stable JSON shape for dashboard / HTTP consumers.  Field names
     mirror the record labels exactly. *)
+
+(** {2 Derived ratios}
+
+    Pure functions over [snapshot] that encapsulate the flip-decision
+    math documented in [LEGENDARY-BASH-RUNBOOK.md].  Dashboards, the
+    [/api/v1/legendary_bash/shadow_counters] JSON surface, and
+    operator shell recipes should prefer these helpers over
+    re-implementing the same numerator / denominator pairing.  All
+    functions return [0.0] when their denominator is zero — the
+    "observer off" read must be safely serialisable as a finite
+    float (no NaN / inf in the JSON output). *)
+
+val disagree_ratio : snapshot -> float
+(** [(gate_diff_legacy_allow_shadow_deny +
+        gate_diff_legacy_deny_shadow_allow)
+     / gate_diff_total].
+
+    Fraction of P5 gate calls where the legacy regex gate and the new
+    AST gate produced opposite verdicts, excluding [`Shadow_cannot_parse].
+    Drives the [MASC_BASH_AST_ONLY] flip criterion (target 0.0 over a
+    rolling 7-day window). *)
+
+val shadow_parse_coverage : snapshot -> float
+(** [1.0 - gate_diff_shadow_cannot_parse / gate_diff_total].
+
+    Fraction of observed P5 calls that the AST gate could fully parse
+    (i.e., the shadow verdict was either [`Agree] or an actual
+    disagreement, not a parser bailout).  Drives the "parse gap
+    < 1%" flip criterion in the runbook — a coverage of [0.99] or
+    higher is the flip target. *)
+
+val auto_bg_promotion_rate : snapshot -> float
+(** [auto_bg_would_have_promoted / auto_bg_observed].
+
+    Fraction of P4 observed foreground calls that exceeded
+    [MASC_BLOCKING_BUDGET_MS].  Guides both the [MASC_BLOCKING_BUDGET_MS]
+    tuning ("would promotion fire too often?") and the
+    [MASC_BASH_AUTO_BG] default-flip decision ("is promotion rare
+    enough to be tolerable?"). *)

--- a/test/test_legendary_counters.ml
+++ b/test/test_legendary_counters.ml
@@ -142,6 +142,80 @@ let test_too_complex_json_shape () =
   Alcotest.(check bool) "has other (=0)" true
     (Astring.String.is_infix ~affix:"\"too_complex_other\":0" s)
 
+let approx_eq ~eps a b = Float.abs (a -. b) <= eps
+
+let check_ratio name ~expected actual =
+  Alcotest.(check bool)
+    (Printf.sprintf "%s ≈ %.4f (got %.4f)" name expected actual)
+    true
+    (approx_eq ~eps:1e-9 expected actual)
+
+let test_ratios_zero_denominator () =
+  (* Observer off / fresh process: every ratio must return a finite 0.0,
+     not NaN / inf — shadow_counters JSON would fail to serialise
+     otherwise. *)
+  Legendary_counters.reset ();
+  let s = Legendary_counters.snapshot () in
+  check_ratio "disagree_ratio zero"
+    ~expected:0.0 (Legendary_counters.disagree_ratio s);
+  check_ratio "shadow_parse_coverage zero"
+    ~expected:0.0 (Legendary_counters.shadow_parse_coverage s);
+  check_ratio "auto_bg_promotion_rate zero"
+    ~expected:0.0 (Legendary_counters.auto_bg_promotion_rate s)
+
+let test_disagree_ratio_math () =
+  (* 10 total = 6 agree + 3 disagree (2 legacy_allow_shadow_deny +
+     1 legacy_deny_shadow_allow) + 1 shadow_cannot_parse.
+     disagree_ratio should count only the two *disagreement* buckets
+     — shadow_cannot_parse is its own category per the runbook. *)
+  Legendary_counters.reset ();
+  for _ = 1 to 6 do Legendary_counters.incr_gate_diff `Agree done;
+  for _ = 1 to 2 do
+    Legendary_counters.incr_gate_diff `Legacy_allow_shadow_deny
+  done;
+  Legendary_counters.incr_gate_diff `Legacy_deny_shadow_allow;
+  Legendary_counters.incr_gate_diff `Shadow_cannot_parse;
+  let s = Legendary_counters.snapshot () in
+  Alcotest.(check int) "total = 10" 10 s.gate_diff_total;
+  check_ratio "disagree_ratio = 3/10"
+    ~expected:0.3 (Legendary_counters.disagree_ratio s)
+
+let test_shadow_parse_coverage_math () =
+  (* 100 total, 3 shadow_cannot_parse → coverage 0.97.  Exactly the
+     runbook threshold for the MASC_BASH_AST_ONLY flip criterion. *)
+  Legendary_counters.reset ();
+  for _ = 1 to 97 do Legendary_counters.incr_gate_diff `Agree done;
+  for _ = 1 to 3 do
+    Legendary_counters.incr_gate_diff `Shadow_cannot_parse
+  done;
+  let s = Legendary_counters.snapshot () in
+  check_ratio "coverage = 0.97"
+    ~expected:0.97 (Legendary_counters.shadow_parse_coverage s)
+
+let test_shadow_parse_coverage_full () =
+  (* No parse failures → 1.0 (AST gate would parse everything
+     observed so far). *)
+  Legendary_counters.reset ();
+  for _ = 1 to 5 do Legendary_counters.incr_gate_diff `Agree done;
+  let s = Legendary_counters.snapshot () in
+  check_ratio "coverage = 1.0"
+    ~expected:1.0 (Legendary_counters.shadow_parse_coverage s)
+
+let test_auto_bg_promotion_rate_math () =
+  (* 10 observed, 4 would-have-promoted → 0.4.  Operator reads this
+     and decides whether raising MASC_BLOCKING_BUDGET_MS is warranted
+     before flipping MASC_BASH_AUTO_BG default. *)
+  Legendary_counters.reset ();
+  for _ = 1 to 6 do
+    Legendary_counters.incr_auto_bg_observed ~promoted_candidate:false
+  done;
+  for _ = 1 to 4 do
+    Legendary_counters.incr_auto_bg_observed ~promoted_candidate:true
+  done;
+  let s = Legendary_counters.snapshot () in
+  check_ratio "promotion_rate = 0.4"
+    ~expected:0.4 (Legendary_counters.auto_bg_promotion_rate s)
+
 let () =
   Alcotest.run "legendary_counters"
     [
@@ -164,5 +238,18 @@ let () =
             test_too_complex_parse_aborted;
           Alcotest.test_case "unknown → other" `Quick test_too_complex_unknown_tag;
           Alcotest.test_case "JSON shape" `Quick test_too_complex_json_shape;
+        ] );
+      ( "derived_ratios",
+        [
+          Alcotest.test_case "zero denominator returns 0.0" `Quick
+            test_ratios_zero_denominator;
+          Alcotest.test_case "disagree_ratio math" `Quick
+            test_disagree_ratio_math;
+          Alcotest.test_case "shadow_parse_coverage math" `Quick
+            test_shadow_parse_coverage_math;
+          Alcotest.test_case "shadow_parse_coverage full" `Quick
+            test_shadow_parse_coverage_full;
+          Alcotest.test_case "auto_bg_promotion_rate math" `Quick
+            test_auto_bg_promotion_rate_math;
         ] );
     ]


### PR DESCRIPTION
## Summary

- `disagree_ratio snap` — (legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total. AST_ONLY flip target: `0.0`.
- `shadow_parse_coverage snap` — `1.0 - shadow_cannot_parse / gate_diff_total`. AST_ONLY flip target: `>= 0.99`.
- `auto_bg_promotion_rate snap` — would_have_promoted / auto_bg_observed. Input to BLOCKING_BUDGET_MS tuning + AUTO_BG default-flip review.

Each returns `0.0` on zero denominator so the "observer off" snapshot stays a finite float through Yojson encoding.

## Why

The same ratio math lived in three shell recipes and the runbook prose, with two already-drifted definitions of "disagree" (one folded `shadow_cannot_parse` into the disagreement numerator, another kept it separate). Moving the math into typed helpers makes the runbook's definitions the single source of truth and lets future dashboards / CI gates call them directly instead of open-coding.

## Test plan

- [x] `test_legendary_counters` 16/16 — adds a `derived_ratios` suite with zero-denominator + exact-numeric cases (`0.3 / 0.97 / 1.0 / 0.4`, each drawn from a runbook flip threshold)
- [x] `dune build --root . lib test` clean

## Runbook

- New "Derived ratios (SSOT)" subsection in `docs/LEGENDARY-BASH-RUNBOOK.md` with the formulas, flip criteria, and an explicit "reach for these helpers before open-coding the ratio" directive.

Follow-up candidate: dashboard chip consumer + `/api/v1/legendary_bash/shadow_counters` could add a sibling `ratios` block so dashboards skip a client-side compute pass entirely. Deferred — that's a UI surface decision.