### PR TITLE
refactor(bonsai-dashboard): adopt Sec primitive in keepers_view

### DIFF
--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -73,17 +73,6 @@ stylesheet
     max-width: 640px;
   }
 
-  .section_h {
-    font-family: 'Cinzel', serif;
-    font-size: 12px;
-    letter-spacing: 0.28em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-    margin: 14px 0 4px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--border-main);
-  }
-
   .quiet {
     padding: 28px 20px;
     text-align: center;
@@ -183,13 +172,18 @@ let render (keepers : Keepers_types.response) : Node.t =
            then
              Node.div
                ~attrs:[]
-               [ Node.div ~attrs:[ Style.section_h ] [ Node.text "roster · 현재" ]
+               [ Sec.view ~title:"roster" ~sub:"현재"
+                   ~right:
+                     (Printf.sprintf
+                        "fleet %d"
+                        (List.length keepers.keepers))
+                   ()
                ; Roster.view ~keepers ()
-               ; Node.div ~attrs:[ Style.section_h ] [ Node.text "swim · 60s" ]
+               ; Sec.view ~title:"swim" ~sub:"60s"
+                   ~right:"lane · activity" ()
                ; Swim.view ~keepers ()
-               ; Node.div
-                   ~attrs:[ Style.section_h ]
-                   [ Node.text "pressure · 60m" ]
+               ; Sec.view ~title:"pressure" ~sub:"60m"
+                   ~right:"ctx %" ()
                ; Ctx_chart.view ~keepers ()
                ]
            else


### PR DESCRIPTION
## Stack

Base: \`feature/bonsai-design-sec-grain\` (#9109). #9109 머지 후 main으로 재정렬.

## Why

#9109에서 추가한 \`Sec.view\` primitive의 첫 consumer. Design System \`.sec\` 패턴을 실제 탭에 적용해서 구현 감을 확인.

## 변경

\`keepers_view.ml\`:

- \`.section_h\` 인라인 CSS 삭제 (border-bottom 방식)
- 3개 section header를 \`Sec.view\` 호출로 교체:

\`\`\`ocaml
Sec.view ~title:"roster" ~sub:"현재" ~right:(Printf.sprintf "fleet %d" n) ()
Sec.view ~title:"swim" ~sub:"60s" ~right:"lane · activity" ()
Sec.view ~title:"pressure" ~sub:"60m" ~right:"ctx %" ()
\`\`\`

## 시각 효과

**Before**: uppercase Cinzel title + border-bottom, 좌측 정렬
**After**: uppercase brass Cinzel title + italic EB Garamond sub + flex-grow hairline gradient + 우측 mono 메타

즉, MASC Design System dashboard_v2의 \`.sec\` 패턴 그대로.

## Follow-up

Overview/Goals/Archive_runs 탭도 같은 방식으로 수렴 예정. 각 PR은 1 file 만 touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)