### PR TITLE
chore(specs): prune stale allowlist entries (unblock detect)

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -39,6 +39,8 @@ specs/keeper-state-machine/KeeperReconcileLiveness.tla  lib/keeper/keeper_keepal
 # Added 2026-04-20: pre-existing drifts surfaced after refactors of
 # state machine / keepalive / coord_gc bodies. Non-blocking baseline,
 # spec text needs re-anchoring (issue: TBD).
-specs/bug-models/KeeperPhaseRace.tla  lib/keeper/keeper_state_machine.ml:311
-specs/bug-models/KeeperPhaseRace.tla  lib/keeper/keeper_keepalive.ml:1566
-specs/bug-models/KeeperTaskInterlock.tla  lib/coord/coord_gc.ml:39
+#
+# Pruned 2026-04-20: KeeperPhaseRace was repurposed in #9080 (no longer
+# references state_machine.ml:311 or keepalive.ml:1566). KeeperTaskInterlock
+# anchors were re-anchored in #9086/#9090 (coord_gc.ml:39 → :128 onward).
+# Removing the now-stale entries restores the self-verify ledger to honest.


### PR DESCRIPTION
## Summary

`scripts/lint/spec-line-refs.sh --self-verify` is now flagging 3 stale
allowlist entries (exit 2 in `detect` job, blocking spec PRs like
#9102):

- `KeeperPhaseRace.tla` → `keeper_state_machine.ml:311`
- `KeeperPhaseRace.tla` → `keeper_keepalive.ml:1566`
- `KeeperTaskInterlock.tla` → `coord_gc.ml:39`

Why stale: PRs #9080 (KeeperPhaseRace rewrite around keepalive crash
contract) and #9086/#9090 (KeeperTaskInterlock anchors moved to
`coord_gc.ml:128 onward`) re-anchored the spec text. The drift those
allowlist lines covered no longer exists.

This PR removes the 3 stale lines and adds a brief retrospective note
above the surviving baseline block so future readers can see why the
ledger shrunk.

## Verification

```
$ bash scripts/lint/spec-line-refs.sh
spec-line-refs: 81 refs checked (39 line-anchored ok, 22 symbol-anchored ok, 0 drift, 0 dangling, 20 allowlisted)
```

was 23 allowlisted, now 20. No new drift introduced.

## Risk

Doc-only. No code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)