### PR TITLE
docs(specs): symbol-anchor KeeperConditionsGovernPhase OCaml refs

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -24,9 +24,6 @@ specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:33
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:336
 specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:99
-specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:389
-specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:61
-specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:8
 specs/keeper-state-machine/KeeperCounterCausality.tla  lib/dashboard/dashboard_http_keeper.ml:763
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_bank.ml:550
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:159

--- a/specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
+++ b/specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
@@ -35,10 +35,10 @@
 \*
 \*   spec variable                | OCaml location                                    | semantic
 \*   -----------------------------+---------------------------------------------------+---------
-\*   phase \in {"Running", "HandingOff"} | lib/keeper/keeper_state_machine.ml:8,12     | type phase = ... | Running | ... | HandingOff | ...
+\*   phase \in {"Running", "HandingOff"} | lib/keeper/keeper_state_machine.ml:phase | type phase = ... | Running | ... | HandingOff | ...
 \*                                | (full 12-phase variant; this spec projects to 2)  |
-\*   handoff_needed (boolean)     | lib/keeper/keeper_state_machine.ml:61             | conditions.context_handoff_needed : bool
-\*                                | lib/keeper/keeper_state_machine.ml:389            | set from auto_rules.handoff at update_conditions
+\*   handoff_needed (boolean)     | lib/keeper/keeper_state_machine.ml:context_handoff_needed | conditions.context_handoff_needed : bool
+\*                                | lib/keeper/keeper_state_machine.ml:update_conditions | set from auto_rules.handoff at update_conditions
 \*
 \* Producer side (where conditions are stamped):
 \*   lib/keeper/keeper_state_machine.ml:351


### PR DESCRIPTION
## Summary

Three allowlist entries pointing at `KeeperConditionsGovernPhase.tla` were absorbed not because the line numbers were wrong but because the table-format snippet style does not match the validator's first-24-char signature rule:

```
| spec variable | OCaml location | semantic |
| phase ...     | ...:8,12       | type phase = ... |
```

The `, 12 | type phase = ` 24-char sig never appears in source line 8 (which is just `  | Running`).

Switching to symbol-anchor form (already the recommended pattern per the allowlist file's authoring note) sidesteps the drift class entirely:

| was | now |
|-----|-----|
| `state_machine.ml:8,12` | `state_machine.ml:phase` |
| `state_machine.ml:61` | `state_machine.ml:context_handoff_needed` |
| `state_machine.ml:389` | `state_machine.ml:update_conditions` |

Narrative text unchanged.

## Verification

```
$ bash scripts/lint/spec-line-refs.sh
spec-line-refs: 81 refs checked (39 line-anchored ok, 25 symbol-anchored ok, 0 drift, 0 dangling, 17 allowlisted)
```

Symbol-anchored: 22 → 25 (+3). Allowlisted: 20 → 17 (−3).

## Note on overlap with #9102

PR #9102 changes the `:620` json-serializer line ref (different anchor on the same file). No conflict expected — different lines, additive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)