### PR TITLE
docs(spec): symbol-anchor batch 6 (KeeperMemoryLifecycle, 5 entries)

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -26,7 +26,11 @@ specs/bug-models/HebbianLearning.tla  lib/hebbian_eio.ml:264
 specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:49
 specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:70
 specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
-specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_bank.ml:550
-specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:159
-specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:164
-specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:166
+# Added 2026-04-20: pre-existing drifts surfaced after refactors of
+# state machine / keepalive / coord_gc bodies. Non-blocking baseline,
+# spec text needs re-anchoring (issue: TBD).
+#
+# Pruned 2026-04-20: KeeperPhaseRace was repurposed in #9080 (no longer
+# references state_machine.ml:311 or keepalive.ml:1566). KeeperTaskInterlock
+# anchors were re-anchored in #9086/#9090 (coord_gc.ml:39 → :128 onward).
+# Removing the now-stale entries restores the self-verify ledger to honest.

--- a/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
@@ -31,18 +31,19 @@
 \*     `let long_term_horizon  = "long_term"`
 \*
 \* Producer (kind -> tier classification):
-\*   lib/keeper/keeper_memory_policy.ml:159-164  memory_horizon_of_kind
-\*   lib/keeper/keeper_memory_policy.ml:166-175  memory_horizon_of_json
+\*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind_opt  (strict)
+\*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind      (back-compat wrapper)
+\*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_json_opt  (JSON variant)
 \*
 \* Persistence / promotion sites:
-\*   lib/keeper/keeper_memory_bank.ml:550   `let horizon = memory_horizon_of_kind kind`
-\*   lib/keeper/keeper_memory_recall.ml:104 recall path uses same horizon function
+\*   lib/keeper/keeper_memory_bank.ml:append_memory_notes_from_reply   — writes via memory_horizon_of_kind
+\*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts       — recall path, same horizon fn
 \*   lib/keeper/keeper_compact_policy.ml    overflow + handoff scheduling
 \*   lib/keeper/keeper_compact_audit.ml     ledger trail (provenance source)
 \*
 \* SCOPE DRIFT (worth knowing, NOT a spec violation):
 \*   memory_horizon_of_kind silently routes unknown kinds to mid_term_horizon
-\*   (lib/keeper/keeper_memory_policy.ml:164  `| _ -> mid_term_horizon`).
+\*   (lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind  `| None -> mid_term_horizon`).
 \*   The spec invariants (ProvenanceRequired, RecoveryBounded, NoSilentLoss)
 \*   hold regardless of WHICH tier a note lands in -- the drift is UPSTREAM
 \*   of the spec vocabulary. A typo'd kind ("goalss") gets the wrong tier


### PR DESCRIPTION
## Summary
Largest single-spec batch so far — migrates all 5 `KeeperMemoryLifecycle.tla` line-anchor refs to symbol form. Follows the strict/wrapper split introduced by #8826 on the OCaml side.

## Product impact
- **none/internal** — TLA+ spec comments only.
- Spec now documents three distinct producers (`memory_horizon_of_kind_opt` strict, `memory_horizon_of_kind` wrapper, `memory_horizon_of_json_opt` JSON variant) instead of two line ranges that masked the split.

## Evidence
```
before: 82 refs, 20 allowlisted, 23 symbol-anchored, 0 drift
after:  82 refs, 15 allowlisted, 28 symbol-anchored, 0 drift
```

Migrations:
- `keeper_memory_policy.ml:159-164` → `:memory_horizon_of_kind_opt`
- `keeper_memory_policy.ml:166-175` → `:memory_horizon_of_json_opt`
- `keeper_memory_policy.ml:164` (SCOPE DRIFT block) → `:memory_horizon_of_kind` + updated prose to `| None -> mid_term_horizon` to reflect the post-#8826 cascade.
- `keeper_memory_bank.ml:550` → `:append_memory_notes_from_reply`
- `keeper_memory_recall.ml:104` → `:read_recent_memory_texts`

Symbol targets verified:
- `memory_horizon_of_kind_opt` at `lib/keeper/keeper_memory_policy.ml:161`
- `memory_horizon_of_kind` at `lib/keeper/keeper_memory_policy.ml:172`
- `memory_horizon_of_json_opt` at `lib/keeper/keeper_memory_policy.ml:184`
- `append_memory_notes_from_reply` at `lib/keeper/keeper_memory_bank.ml:513`
- `read_recent_memory_texts` at `lib/keeper/keeper_memory_recall.ml:86`

## Review evidence
Self-review only. Based on current `main` (post-#9111 stale cleanup).

## Linked issue
None. Burndown: #9091 (1), #9094 (2), #9101 (3), #9105 (4), #9106 (5), this (6). Remaining: CascadeExhaustion (1), HebbianLearning (1), SessionRegistryGhost (2), SSEBroadcastBlock (1) — 5 entries left across `specs/bug-models/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
