### PR TITLE
feat(cdal-gate): split advisory vs strict attribution buckets

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -105,31 +105,38 @@ let evidence_of_verdict (v : Cdal_types.contract_verdict) : Yojson.Safe.t =
     ("blocking_gaps_count", `Int (blocking_gap_count v));
   ]
 
-let to_attribution (v : Cdal_types.contract_verdict) : Attribution.t =
+let strict_gate_label = "cdal_verdict"
+let advisory_gate_label = "cdal_verdict_advisory"
+
+let to_attribution ?(gate_label = strict_gate_label)
+    (v : Cdal_types.contract_verdict) : Attribution.t =
   let evidence = evidence_of_verdict v in
   match check_verdict v with
   | Allow ->
-    Attribution.passed ~origin:Det ~gate:"cdal_verdict" ~evidence
+    Attribution.passed ~origin:Det ~gate:gate_label ~evidence
   | Reject reason ->
-    Attribution.policy_failed ~origin:Det ~gate:"cdal_verdict" ~evidence ~reason
+    Attribution.policy_failed ~origin:Det ~gate:gate_label ~evidence ~reason
 
-let attribution_for_missing_verdict ~task_id : Attribution.t =
+let attribution_for_missing_verdict ?(gate_label = strict_gate_label)
+    ~task_id () : Attribution.t =
   let evidence = `Assoc [ ("task_id", `String task_id) ] in
-  Attribution.policy_failed ~origin:Det ~gate:"cdal_verdict" ~evidence
+  Attribution.policy_failed ~origin:Det ~gate:gate_label ~evidence
     ~reason:
       (Printf.sprintf
          "No CDAL verdict found for task %s. Submit evidence before completing."
          task_id)
 
-let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
+let gate_check ?(base_dir = default_base_path)
+    ?(gate_label = strict_gate_label) ~task_id () : string option =
   match lookup_latest_verdict ~base_dir ~task_id () with
   | None ->
-    Dashboard_attribution.record (attribution_for_missing_verdict ~task_id);
+    Dashboard_attribution.record
+      (attribution_for_missing_verdict ~gate_label ~task_id ());
     Some (Printf.sprintf
       "No CDAL verdict found for task %s. Submit evidence before completing."
       task_id)
   | Some verdict ->
-    Dashboard_attribution.record (to_attribution verdict);
+    Dashboard_attribution.record (to_attribution ~gate_label verdict);
     match check_verdict verdict with
     | Allow -> None
     | Reject msg -> Some msg

--- a/lib/cdal_verdict_gate.mli
+++ b/lib/cdal_verdict_gate.mli
@@ -22,26 +22,51 @@ type gate_result =
     documented above. Pure — no I/O. *)
 val check_verdict : Cdal_types.contract_verdict -> gate_result
 
+(** {1 Gate labels for attribution recording}
+
+    Attribution ring-buffer entries are grouped by gate name. Two
+    labels are published so advisory vs. strict-enforced verdicts can
+    be counted separately in the dashboard. *)
+
+val strict_gate_label : string
+(** ["cdal_verdict"]. Used when a rejection actually blocks
+    completion. *)
+
+val advisory_gate_label : string
+(** ["cdal_verdict_advisory"]. Used when [contract.strict = false]
+    and the rejection is dropped — the audit trail is kept but the
+    task is allowed through. *)
+
 (** {1 Task completion gate} *)
 
-(** [gate_check ?base_dir ~task_id ()] looks up the latest verdict
-    for [task_id] under [base_dir] (default: CDAL verdict directory
-    resolved from MASC base path) and returns:
+(** [gate_check ?base_dir ?gate_label ~task_id ()] looks up the latest
+    verdict for [task_id] under [base_dir] (default: CDAL verdict
+    directory resolved from MASC base path) and returns:
 
     - [None] — completion is allowed.
-    - [Some reason] — completion must be rejected. *)
+    - [Some reason] — completion must be rejected.
+
+    [gate_label] controls the attribution-ring gate name (defaults to
+    {!strict_gate_label}). Callers operating on advisory contracts
+    should pass [~gate_label:advisory_gate_label] so the dashboard can
+    distinguish the two buckets. The return value is unaffected by
+    the label. *)
 val gate_check :
   ?base_dir:string ->
+  ?gate_label:string ->
   task_id:string ->
   unit ->
   string option
 
 (** {1 Attribution wiring} *)
 
-(** [to_attribution v] maps [check_verdict v] to the matching
-    {!Attribution.t} — [Allow] → [passed], [Reject reason] →
-    [policy_failed]. *)
-val to_attribution : Cdal_types.contract_verdict -> Attribution.t
+(** [to_attribution ?gate_label v] maps [check_verdict v] to the
+    matching {!Attribution.t} — [Allow] → [passed], [Reject reason] →
+    [policy_failed]. [gate_label] defaults to {!strict_gate_label}. *)
+val to_attribution : ?gate_label:string -> Cdal_types.contract_verdict -> Attribution.t
 
-(** Attribution used when no verdict exists for a task. *)
-val attribution_for_missing_verdict : task_id:string -> Attribution.t
+(** Attribution used when no verdict exists for a task.
+    [gate_label] defaults to {!strict_gate_label}. Trailing [unit]
+    is required so the optional argument can be erased. *)
+val attribution_for_missing_verdict :
+  ?gate_label:string -> task_id:string -> unit -> Attribution.t

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -136,6 +136,24 @@ let compute_outcomes_rollup
     | [] -> `Null
     | v :: _ -> `Float v.timestamp
   in
+  let cdal_bucket gate_name =
+    match
+      List.find_opt
+        (fun (s : Dashboard_attribution.gate_summary) ->
+          String.equal s.gate gate_name)
+        (Dashboard_attribution.summary ())
+    with
+    | None -> `Null
+    | Some s ->
+      `Assoc [
+        ("scope", `String "global");
+        ("passed", `Int s.passed);
+        ("policy_failed", `Int s.policy_failed);
+        ("transition_blocked", `Int s.transition_blocked);
+        ("partial_pass", `Int s.partial_pass);
+        ("total", `Int s.total);
+      ]
+  in
   `Assoc [
     ("window", `String "transition_ring_last_50");
     ("observed_turns", `Int observed_turns);
@@ -164,24 +182,15 @@ let compute_outcomes_rollup
       (* cdal_gate: populate from Dashboard_attribution ring.
          Scope is global (CDAL attribution is gate-keyed, not per-keeper),
          but visibility in the per-keeper diagnostic is still useful — it
-         confirms the verdict gate is live and surfaces recent outcomes. *)
-      ("cdal_gate",
-        (match
-           List.find_opt
-             (fun (s : Dashboard_attribution.gate_summary) ->
-               String.equal s.gate "cdal_verdict")
-             (Dashboard_attribution.summary ())
-         with
-         | None -> `Null
-         | Some s ->
-             `Assoc [
-               ("scope", `String "global");
-               ("passed", `Int s.passed);
-               ("policy_failed", `Int s.policy_failed);
-               ("transition_blocked", `Int s.transition_blocked);
-               ("partial_pass", `Int s.partial_pass);
-               ("total", `Int s.total);
-             ]));
+         confirms the verdict gate is live and surfaces recent outcomes.
+
+         Two buckets are exposed so consumers can tell "strict-enforced"
+         from "allowed through under advisory":
+         - [cdal_gate]            → gate="cdal_verdict"           (strict)
+         - [cdal_gate_advisory]   → gate="cdal_verdict_advisory"  (audit-only) *)
+      ("cdal_gate", cdal_bucket Cdal_verdict_gate.strict_gate_label);
+      ("cdal_gate_advisory",
+        cdal_bucket Cdal_verdict_gate.advisory_gate_label);
       ("last_verdict_at", last_verdict_at);
     ]);
   ]

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -317,11 +317,21 @@ let persisted_contract_rejection ~(ctx : context)
         (* Always run the verdict lookup so Dashboard_attribution records the
            outcome (pass / policy_failed / missing). strict=false stays
            advisory — we drop the rejection but keep the audit trail so the
-           dashboard shows a verification trace instead of nothing. *)
+           dashboard shows a verification trace instead of nothing.
+
+           Advisory recordings go into the [cdal_verdict_advisory] gate
+           bucket so the dashboard can distinguish "strict-enforced"
+           from "allowed through under advisory" without guessing. *)
+        let gate_label =
+          if contract.strict then Cdal_verdict_gate.strict_gate_label
+          else Cdal_verdict_gate.advisory_gate_label
+        in
         Log.Task.info
-          "[cdal-gate] checking verdict for task=%s agent=%s strict=%b"
-          task.id ctx.agent_name contract.strict;
-        let rejection = Cdal_verdict_gate.gate_check ~task_id:task.id () in
+          "[cdal-gate] checking verdict for task=%s agent=%s strict=%b gate=%s"
+          task.id ctx.agent_name contract.strict gate_label;
+        let rejection =
+          Cdal_verdict_gate.gate_check ~gate_label ~task_id:task.id ()
+        in
         if contract.strict then rejection
         else begin
           (match rejection with

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -288,7 +288,7 @@ let test_to_attribution_inconclusive_no_gaps_is_passed () =
     (match attr.outcome with A.Passed -> true | _ -> false)
 
 let test_attribution_missing_verdict () =
-  let attr = CVG.attribution_for_missing_verdict ~task_id:"T-999" in
+  let attr = CVG.attribution_for_missing_verdict ~task_id:"T-999" () in
   assert_gate_is_cdal_verdict attr;
   (match attr.outcome with
    | A.Policy_failed { reason } ->
@@ -299,6 +299,29 @@ let test_attribution_missing_verdict () =
   Alcotest.(check (option string))
     "evidence.task_id" (Some "T-999")
     (evidence_string_field attr "task_id")
+
+let test_to_attribution_honors_advisory_label () =
+  let v = make_verdict ~status:CT.Violated ~findings:[ make_finding () ] () in
+  let attr = CVG.to_attribution ~gate_label:CVG.advisory_gate_label v in
+  Alcotest.(check string) "gate" CVG.advisory_gate_label attr.A.gate;
+  Alcotest.(check bool) "still policy_failed" true
+    (match attr.outcome with A.Policy_failed _ -> true | _ -> false)
+
+let test_attribution_missing_verdict_honors_advisory_label () =
+  let attr =
+    CVG.attribution_for_missing_verdict
+      ~gate_label:CVG.advisory_gate_label
+      ~task_id:"T-advisory"
+      ()
+  in
+  Alcotest.(check string) "gate" CVG.advisory_gate_label attr.A.gate;
+  Alcotest.(check bool) "origin=Det" true (attr.origin = A.Det)
+
+let test_gate_labels_are_distinct () =
+  (* Guardrail so refactors cannot accidentally collapse the two
+     buckets into one: dashboards rely on the distinction. *)
+  Alcotest.(check bool) "labels differ" true
+    (not (String.equal CVG.strict_gate_label CVG.advisory_gate_label))
 
 let test_attribution_roundtrips_to_json () =
   (* Ensure the generated attribution serializes through Attribution.to_yojson
@@ -350,6 +373,12 @@ let () =
         test_to_attribution_inconclusive_no_gaps_is_passed;
       Alcotest.test_case "missing verdict envelope" `Quick
         test_attribution_missing_verdict;
+      Alcotest.test_case "advisory gate label on to_attribution" `Quick
+        test_to_attribution_honors_advisory_label;
+      Alcotest.test_case "advisory gate label on missing verdict" `Quick
+        test_attribution_missing_verdict_honors_advisory_label;
+      Alcotest.test_case "strict vs advisory labels are distinct" `Quick
+        test_gate_labels_are_distinct;
       Alcotest.test_case "yojson roundtrip" `Quick
         test_attribution_roundtrips_to_json;
     ]);

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -381,11 +381,25 @@ let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
   in
   if not success_done then
     failwith "advisory contract (strict=false) must not block handle_done";
-  let recent = Dashboard_attribution.recent ~gate:"cdal_verdict" ~limit:20 () in
-  if recent = [] then
+  (* Advisory contracts record under the dedicated advisory gate bucket so
+     dashboards can count "allowed through under advisory" separately from
+     strict-enforced verdicts. *)
+  let advisory_recent =
+    Dashboard_attribution.recent
+      ~gate:Cdal_verdict_gate.advisory_gate_label ~limit:20 ()
+  in
+  if advisory_recent = [] then
     failwith
-      "expected Dashboard_attribution to record a cdal_verdict entry for \
-       advisory contract (audit trail regression)"
+      "expected Dashboard_attribution to record a cdal_verdict_advisory \
+       entry for strict=false contract (audit trail regression)";
+  let strict_recent =
+    Dashboard_attribution.recent
+      ~gate:Cdal_verdict_gate.strict_gate_label ~limit:20 ()
+  in
+  if strict_recent <> [] then
+    failwith
+      "advisory recording must not leak into the strict cdal_verdict \
+       bucket"
 )
 
 let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun () ->


### PR DESCRIPTION
## 왜

사용자 지적: **\"CDAL 이 Task, 목표, Board, Keeper 등등 어디에도 검증 흔적이 없다\"** 문제의 세부 잔여 gap 해결.

Plan PR 1 의 핵심 요구(\"strict=false 여도 attribution 기록\")는 PR #8402 (2026-04-08) 에서 이미 머지됨. 그러나 advisory 경로와 strict 경로가 **같은 gate=\"cdal_verdict\" 버킷** 에 섞여 기록되어, 대시보드가 \"몇 건의 Violated contract 가 advisory 로 풀려 완료됐나?\" 를 구분해서 보여주지 못했음. 이 PR 은 두 경로를 분리한다.

## 무엇을

attribution ring buffer 의 gate 이름을 2개로 분리:

| Gate label | 경로 | 의미 |
|------------|------|------|
| `cdal_verdict`          | `contract.strict = true` + Approve/Reject_verification + Done_action | 실제로 완료를 막거나 확인한 verdict |
| `cdal_verdict_advisory` | `contract.strict = false` | audit-only, rejection 은 드롭되고 통과 |

### 공개 API (Cdal_verdict_gate)

- 추가: 상수 `strict_gate_label`, `advisory_gate_label`
- 추가: optional `?gate_label` on `gate_check`, `to_attribution`, `attribution_for_missing_verdict`
- default 는 `strict_gate_label` → 다운스트림 호출 사이트 변경 0건(테스트 1건만 assertion 업데이트)
- `attribution_for_missing_verdict` 에 trailing `unit` 추가 (optional erasure 요구)

### Keeper 진단 JSON

```
validation:
  cdal_gate:            { passed, policy_failed, ... }   (strict)
  cdal_gate_advisory:   { passed, policy_failed, ... }   (audit-only)
```

## 건드리지 않은 것

- `contract.strict` 기본값 (true) 의미론
- Gate 순서(4→5), FSM redirect 동작
- `Cdal_verdict_gate.check_verdict` 순수 로직
- Approve/Reject_verification, Done_action 후행 gate_check — 기본 `cdal_verdict` 유지

## 테스트

| 스위트 | 결과 | 비고 |
|--------|------|------|
| `test_cdal_verdict_gate` | 22/22 | 신규 3 (advisory to_attribution, advisory missing, guardrail distinct) |
| `test_tool_task_coverage` | 55/55 | 기존 advisory regression 에 \"strict 버킷 비어있어야 함\" 반대 assertion 추가 |
| `test_dashboard_attribution` | 11/11 | |
| `test_attribution` | 15/15 | |
| `test_attribution_tagged` | 9/9 | |
| `test_dashboard_http_core` | 6/6 | |
| `test_dashboard_keeper_routes` | 4/4 | |

## 후속 (이 PR 범위 밖)

1. Plan PR 2: Verifier keeper auto-claim affordance
2. Plan PR 4: Task lifecycle TLA+ spec + TLC CI target
3. Dashboard UI 에서 `cdal_gate_advisory.policy_failed` 를 시각적으로 강조 (advisory bypass rate 가시화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)