### PR TITLE
docs(specs): symbol-anchor KeeperCampaignLifecycle OCaml refs

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -21,9 +21,6 @@ specs/bug-models/HebbianLearning.tla  lib/hebbian_eio.ml:264
 specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:49
 specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:70
 specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
-specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:33
-specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:336
-specs/keeper-state-machine/KeeperCampaignLifecycle.tla  lib/keeper/keeper_campaign_fsm.ml:99
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:389
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:61
 specs/keeper-state-machine/KeeperConditionsGovernPhase.tla  lib/keeper/keeper_state_machine.ml:8

--- a/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
@@ -22,14 +22,14 @@
 \*   continuityGoal/Task  | snapshot.continuity_*                                  | snapshot record
 \*
 \* Verdict mapping ↔ OCaml: spec verdicts come from
-\* lib/keeper/keeper_campaign_fsm.ml:99 (`verdict_of_phase`) — confirms
+\* lib/keeper/keeper_campaign_fsm.ml:verdict_of_phase — confirms
 \* the spec's design goal that verdicts derive ONLY from the campaign FSM
 \* phase, never from the runtime keeper lifecycle phase (which lives in
 \* lib/keeper/keeper_state_machine.ml — orthogonal axis).
 \*
 \* Event mapping ↔ OCaml: spec actions correspond to
-\* lib/keeper/keeper_campaign_fsm.ml:33 (`type event`) — Task_bound_observed,
-\* etc. apply via `apply_event` at line 287.
+\* lib/keeper/keeper_campaign_fsm.ml:Task_bound_observed (and siblings in
+\* `type event`) — applied via lib/keeper/keeper_campaign_fsm.ml:apply_event.
 \*
 \* Scope: spec models the pure mission FSM. The runtime keeper lifecycle
 \* (Offline / Running / Crashed / etc.) is intentionally OUT OF SCOPE
@@ -38,8 +38,8 @@
 \* spec; adding a new campaign phase DOES.
 \*
 \* Known modelling gap (issue #8946): [ContinuityObserved] models only the
-\* SUCCESS outcome.  The OCaml impl (apply_event at
-\* lib/keeper/keeper_campaign_fsm.ml:336-368) ALSO transitions to
+\* SUCCESS outcome.  The OCaml impl
+\* (lib/keeper/keeper_campaign_fsm.ml:apply_event Pressure_testing arm) ALSO transitions to
 \* [Escalated] when goal_matches / task_matches / lifecycle_evidence /
 \* target_reached fail, with a textual reason.  TLC therefore cannot
 \* reach Escalated via the Continuity_observed path; only via


### PR DESCRIPTION
## Summary

Three allowlist entries pointing at `KeeperCampaignLifecycle.tla` (campaign_fsm.ml:33, :99, :336) were absorbed because the spec narrative cites lines with parenthetical context like ``(`verdict_of_phase`)`` that doesn't fit the validator's 24-char snippet signature.

Switching to the recommended symbol-anchor form:

| was | now |
|-----|-----|
| `campaign_fsm.ml:99` | `campaign_fsm.ml:verdict_of_phase` |
| `campaign_fsm.ml:33` | `campaign_fsm.ml:Task_bound_observed` |
| `campaign_fsm.ml:336` | `campaign_fsm.ml:apply_event` |

The narrative wording is preserved (verdict_of_phase, type event Task_bound_observed, apply_event Pressure_testing arm).

## Verification

```
$ bash scripts/lint/spec-line-refs.sh
spec-line-refs: 82 refs checked (39 line-anchored ok, 26 symbol-anchored ok, 0 drift, 0 dangling, 17 allowlisted)
```

Symbol-anchored: 22 → 26 (+4 refs added across two paragraphs). Allowlisted: 20 → 17 (−3).

## Series

- #9111 (MERGED) — pruned 3 stale allowlist entries
- #9112 (OPEN) — symbol-anchor KeeperConditionsGovernPhase (3 entries)
- this PR — symbol-anchor KeeperCampaignLifecycle (3 entries)

After all three merge, allowlist will be 14 (was 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)