### PR TITLE
docs(spec): symbol-anchor batch 7 (bug-models, 5 entries across 4 specs)

### DIFF
--- a/scripts/lint/spec-line-refs.allowlist
+++ b/scripts/lint/spec-line-refs.allowlist
@@ -21,11 +21,6 @@
 # distinguishes structured snippets (≥2 space / tab separator) from
 # continuation prose.
 
-specs/bug-models/CascadeExhaustion.tla  lib/cascade/cascade_fsm.mli:45
-specs/bug-models/HebbianLearning.tla  lib/hebbian_eio.ml:264
-specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:49
-specs/bug-models/SessionRegistryGhost.tla  lib/session.ml:70
-specs/bug-models/SSEBroadcastBlock.tla  lib/sse.ml:649
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_bank.ml:550
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:159
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla  lib/keeper/keeper_memory_policy.ml:164

--- a/specs/bug-models/CascadeExhaustion.tla
+++ b/specs/bug-models/CascadeExhaustion.tla
@@ -12,10 +12,10 @@
 \* was rejected, and that becomes last_err.
 \*
 \* Actual code (verified 2026-04-20):
-\*   lib/cascade/cascade_fsm.ml:21   let decide ~accept_on_exhaustion ~is_last
-\*   lib/cascade/cascade_fsm.ml:29   if is_last && accept_on_exhaustion then ...
-\*   lib/cascade/cascade_fsm.mli:37  accept_on_exhaustion:bool ->
-\*   lib/cascade/cascade_fsm.mli:45  Accept_rejected _ on last + accept_on_exhaustion -> Accept_on_exhaustion
+\*   lib/cascade/cascade_fsm.ml:decide   — accept_on_exhaustion/is_last guard
+\*     (if is_last && accept_on_exhaustion then Accept_on_exhaustion, else Exhausted)
+\*   lib/cascade/cascade_fsm.mli:decide  — signature + doc comment spelling out
+\*     "Accept_rejected on last + accept_on_exhaustion -> Accept_on_exhaustion"
 \*
 \* (Path/symbol drift: cascade_executor.ml:complete_cascade_with_accept
 \*  was extracted into the cascade FSM module + decide function when

--- a/specs/bug-models/HebbianLearning.tla
+++ b/specs/bug-models/HebbianLearning.tla
@@ -13,11 +13,11 @@
 \* since that operation loaded (graph_version == load_version + 1).
 \*
 \* Reference (verified 2026-04-20):
-\*   lib/hebbian_eio.ml:264  let strengthen — wraps body in
-\*                            with_graph_lock config (load -> compute -> save).
+\*   lib/hebbian_eio.ml:strengthen — wraps body in with_graph_lock config
+\*     (load -> compute -> save).
 \*   The lock-required pattern is enforced by call-site convention
-\*   (every public mutator calls with_graph_lock); there is no
-\*   inline docstring at lines 268-275.
+\*   (every public mutator calls with_graph_lock); there is no inline
+\*   docstring inside the strengthen body.
 
 EXTENDS Naturals
 

--- a/specs/bug-models/SSEBroadcastBlock.tla
+++ b/specs/bug-models/SSEBroadcastBlock.tla
@@ -13,9 +13,9 @@
 \* iteration is stuck on the blocking add.
 \*
 \* Actual code (verified 2026-04-20):
-\*   lib/sse.ml:608  let broadcast_impl target json
-\*   lib/sse.ml:637  Eio.Stream.add client.event_stream event (blocking!)
-\*   lib/sse.ml:649  List.iter unregister !failed (too late)
+\*   lib/sse.ml:broadcast_impl — target/json entry point
+\*     (inside) Eio.Stream.add client.event_stream event (blocking!)
+\*     (after loop) List.iter unregister !failed (too late)
 \*
 \* (Line drift since spec authoring: previously cited :471 and :483.
 \*  ~165-line shift due to file growth. Recorded for cross-reference.)

--- a/specs/bug-models/SessionRegistryGhost.tla
+++ b/specs/bug-models/SessionRegistryGhost.tla
@@ -19,13 +19,13 @@
 \* ── Status (2026-04-20) ──
 \* The historical bug class this spec models (no-mutex `unregister_sync`
 \* racing against mutex-guarded `register`) was fixed: `unregister` now
-\* takes the same `with_lock registry` as `register` (lib/session.ml:70).
+\* takes the same `with_lock registry` as `register` (lib/session.ml:unregister).
 \* The spec is retained as a regression-prevention contract: it will
 \* fail-fast if the lock is removed again.
 \*
 \* Actual code:
-\*   lib/session.ml:49-67    register   — Hashtbl.replace inside with_lock
-\*   lib/session.ml:70-76    unregister — Hashtbl.remove inside with_lock
+\*   lib/session.ml:register   — Hashtbl.replace inside with_lock
+\*   lib/session.ml:unregister — Hashtbl.remove inside with_lock
 \*   lib/tool_inline_dispatch_coord.ml:200-201
 \*                           Coord.leave then Session.unregister
 \* (Both formerly: `lib/session/session.ml` + `tool_inline_dispatch_room.ml`


### PR DESCRIPTION
## Summary
Closes out the `specs/bug-models/` side of the allowlist. 4 specs, 5 entries, all migrated to symbol form in one PR since each spec has only 1–2 refs.

## Product impact
- **none/internal** — TLA+ spec comments only.
- After this + #9101/#9105/#9106/#9113 land, the allowlist drops from 14 → 0 entries (not counting whatever new bug-model specs get added).

## Evidence
```
before: 82 refs, 20 allowlisted, 23 symbol-anchored, 0 drift
after:  77 refs, 14 allowlisted, 29 symbol-anchored, 0 drift
```

Migrations:
- `CascadeExhaustion` : `cascade_fsm.mli:45` → `:decide` (also rolled up `mli:37` and `ml:21/29` line refs into the single `:decide` anchor)
- `HebbianLearning` : `hebbian_eio.ml:264` → `:strengthen` (dropped stale "inline docstring at 268-275" claim — body has no docstring)
- `SessionRegistryGhost` : `session.ml:49` → `:register`, `:70` → `:unregister`
- `SSEBroadcastBlock` : `sse.ml:649` → `:broadcast_impl` (collapsed `:608/:637/:649` into a nested description under `:broadcast_impl`)

Symbol targets verified:
- `decide` at `lib/cascade/cascade_fsm.mli:36` + `.ml:21`
- `strengthen` at `lib/hebbian_eio.ml:264`
- `register` at `lib/session.ml:49`
- `unregister` at `lib/session.ml:70`
- `broadcast_impl` at `lib/sse.ml:608`

## Review evidence
Self-review only. Independent of all other open batch PRs — touches disjoint files.

## Linked issue
None. Burndown: #9091 (1), #9094 (2), #9101 (3 OPEN), #9105 (4 OPEN), #9106 (5 OPEN), #9113 (6 OPEN), this (7). After the open PRs land, remaining allowlist = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
