### PR TITLE
feat(bonsai-dashboard): add Hero primitive for tab page headers

### DIFF
--- a/dashboard_bonsai/src/hero.ml
+++ b/dashboard_bonsai/src/hero.ml
@@ -1,0 +1,93 @@
+(** Hero header primitive — MASC Design System 탭 페이지 상단의
+    eyebrow + title + tail + sub 3-element block.
+
+    탭별로 인라인 중복되어 있던 hero block을 한 API로 수렴. 각 탭은
+    [Hero.view ~eyebrow ~title ?tail ?sub ()] 한 번 호출로 같은 시각
+    구조 유지. tail은 선택적 brass/blood suffix. sub는 italic
+    EB Garamond 서브카피.
+
+    재사용: overview_view / goals_view / archive_runs_view /
+    dead_keepers_view / keepers_view 다섯 탭의 hero block 동일 패턴. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .hero { display: flex; flex-direction: column; gap: 6px; }
+
+  .eyebrow {
+    font-family: 'Noto Sans KR', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim, #6a5848);
+    margin: 0;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-size: 32px;
+    letter-spacing: 0.16em;
+    color: var(--text-bright, #e8d9b0);
+    text-transform: uppercase;
+    margin: 0;
+  }
+
+  .tail_brass {
+    color: var(--accent-brass, #8a6a28);
+    font-size: 18px;
+    margin-left: 14px;
+  }
+
+  .tail_blood {
+    color: var(--accent-blood, #a01818);
+    font-size: 18px;
+    margin-left: 14px;
+  }
+
+  .sub {
+    font-family: 'EB Garamond', serif;
+    font-style: italic;
+    font-size: 14px;
+    color: var(--text-primary, #c8b88c);
+    margin: 0;
+    max-width: 640px;
+  }
+|}]
+
+type tail_color = [ `Brass | `Blood ]
+
+let view
+      ?(sub : string option)
+      ?(tail : (string * tail_color) option)
+      ~(eyebrow : string)
+      ~(title : string)
+      ()
+  : Node.t
+  =
+  let title_children : Node.t list =
+    let head = [ Node.text (title ^ " ") ] in
+    match tail with
+    | None -> [ Node.text title ]
+    | Some (txt, `Brass) ->
+      head @ [ Node.span ~attrs:[ Style.tail_brass ] [ Node.text txt ] ]
+    | Some (txt, `Blood) ->
+      head @ [ Node.span ~attrs:[ Style.tail_blood ] [ Node.text txt ] ]
+  in
+  let sub_node : Node.t list =
+    match sub with
+    | Some s when String.length s > 0 ->
+      [ Node.p ~attrs:[ Style.sub ] [ Node.text s ] ]
+    | _ -> []
+  in
+  Node.div
+    ~attrs:[ Style.hero ]
+    ([ Node.p ~attrs:[ Style.eyebrow ] [ Node.text eyebrow ]
+     ; Node.h1 ~attrs:[ Style.title ] title_children
+     ]
+     @ sub_node)
+;;


### PR DESCRIPTION
## Summary
- Extract eyebrow + title + tail + sub hero block repeated across 5 tabs
- \`Hero.view ~eyebrow ~title ?tail ?sub ()\` API in \`dashboard_bonsai/src/hero.ml\`
- Tail color variants: \`\`Brass | \`Blood\` (covers all current usages)
- ppx_css hash-scoped classes with CSS variable fallbacks

## Context
5 탭(overview/goals/archive_runs/dead_keepers/keepers)이 같은 eyebrow+title+sub 구조를 탭마다 ~15 LOC로 독립 재현. Hero primitive 도입 후 탭당 ~5 LOC, 전역 typography 조정이 단일 지점에서 가능. Follow-up 5 adopter PR은 각 탭 hero block을 Hero.view 한 줄로 교체.

## Test plan
- [x] \`dune build --root .\` clean compile
- [x] \`dune build --root . bin/main.bc.js\` 63M bundle (dev mode)
- [ ] Follow-up adopter PR 머지 후 시각 parity 확인

## Metrics (Phase 2.E 3축)
- **Bundle**: primitive 모듈 추가, 크기 변화 미미 예상 (dead code elim 대상).
- **TTI**: 변화 없음(체인에 포함되지 않는 이상 load 안됨).
- **Interop**: 없음.

## Part of Phase 2.E — MASC Design System 흡수
- [x] 2.E.1 Sec primitive (#9109, CI 진행 중)
- [x] 2.E.2 Keepers Sec adopt (#9110 merged into #9109)
- [ ] **2.E.3 Hero primitive (본 PR)**
- [ ] 2.E.4 5 adopter PR (overview/goals/archive_runs/dead_keepers/keepers)