### PR TITLE
docs(logic): batch-24 .mli for worker_execution_spec + tool_schemas_coord_extra + briefing_compactors

### DIFF
--- a/lib/dashboard/briefing_compactors.mli
+++ b/lib/dashboard/briefing_compactors.mli
@@ -1,0 +1,21 @@
+(** Briefing_compactors — Reduce raw domain JSON into the shape the
+    mission-briefing dashboard consumes.
+
+    Each [compact_*] returns a [`Assoc _] with a fixed key set so
+    downstream renderers can treat the output as a stable contract. *)
+
+(** [relevant_sessions_for_briefing ~current_namespace ~now_ts
+    sessions] keeps sessions that either match [current_namespace]
+    (project/room id) and are in a live status, or have a
+    [recent_events] entry within the last hour of [now_ts]. *)
+val relevant_sessions_for_briefing :
+  current_namespace:string ->
+  now_ts:float ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t list
+
+val compact_session_json : Yojson.Safe.t -> Yojson.Safe.t
+
+val compact_keeper_json : Yojson.Safe.t -> Yojson.Safe.t
+
+val compact_agent_json : Types.agent -> Yojson.Safe.t

--- a/lib/tool_schemas/tool_schemas_coord_extra.mli
+++ b/lib/tool_schemas/tool_schemas_coord_extra.mli
@@ -1,0 +1,8 @@
+(** Tool_schemas_coord_extra — MCP tool schemas for shared Goal
+    Store operations (list / upsert / review).
+
+    Consumed by {!Tool_schemas_coord}, {!Tools}, and
+    {!Agent_tool_surfaces} to expose [masc_goal_*] on coordinating
+    surfaces. *)
+
+val schemas : Types.tool_schema list

--- a/lib/worker_execution_spec.mli
+++ b/lib/worker_execution_spec.mli
@@ -1,0 +1,31 @@
+(** Worker_execution_spec — JSON-addressable snapshot of a worker
+    invocation.
+
+    Carried across the local-worker boundary so runtime code
+    (docker/container runners, tests) can reconstruct a worker run
+    from stored state. *)
+
+type t = {
+  base_path : string;
+  worker_name : string;
+  model_label : string;
+  working_dir : string option;
+  worker_class : Worker_types.worker_class option;
+  execution_scope : Worker_types.execution_scope option;
+  thinking_enabled : bool option;
+  max_turns : int;
+  worker_run_id : string option;
+  role : string option;
+  selection_note : string option;
+  prompt : string;
+  allowed_tools : string list;
+  allowed_shell_tools : string list;
+  timeout_sec : int;
+}
+
+val to_yojson : t -> Yojson.Safe.t
+
+(** [of_yojson json] parses a previously serialized spec. Unknown
+    strings for [worker_class] / [execution_scope] surface as [None]
+    rather than a silent downgrade (issue #8605). *)
+val of_yojson : Yojson.Safe.t -> (t, string) result


### PR DESCRIPTION
Wave 3 .mli coverage (Milestone #1023).

3 narrow .mli:
- `lib/worker_execution_spec.mli` — record `t` exposed (consumers do field access on `base_path` / `model_label`) + `to_yojson` / `of_yojson`.
- `lib/tool_schemas/tool_schemas_coord_extra.mli` — single `val schemas : Types.tool_schema list`.
- `lib/dashboard/briefing_compactors.mli` — 4 compaction fns (`relevant_sessions_for_briefing`, `compact_session_json`, `compact_keeper_json`, `compact_agent_json`).

4-trap pre-scan: `open` in `.ml` does not leak; qualified refs used in mli (`Worker_types.worker_class`, `Types.tool_schema`, `Types.agent`).

`dune build @check`: exit 0.

Refs #1023.
