### PR TITLE
fix(telemetry): classify keeper-internal vs external_mcp tool calls (#8915)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -290,6 +290,18 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       (Printf.sprintf "tool call failed: %s — %s" name
          (Option.value ~default:"(no detail)" error_detail));
 
+  (* Classify call source: Keeper_internal if the resolved agent_name matches
+     a registered keeper (keeper-internal dispatch via cli_agent runtime),
+     otherwise External_mcp (true external MCP client).  Sound partial:
+     missing identity falls through to External_mcp.  Issue #8915. *)
+  let source : Tool_registry.call_source =
+    if String.length agent_name = 0 then External_mcp
+    else
+      match Keeper_registry.find_by_agent_name agent_name with
+      | Some _ -> Keeper_internal
+      | None -> External_mcp
+  in
+
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled = Env_config_core.telemetry_enabled () in
   if telemetry_enabled then
@@ -297,7 +309,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      | Some fs ->
          (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
-                ~source:(Tool_registry.string_of_source External_mcp) ()
+                ~source:(Tool_registry.string_of_source source) ()
           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             log_mcp_exn ~label:"telemetry tracking failed" exn)
      | None -> ());
@@ -307,7 +319,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     Prometheus.record_error ~error_type:name ();
 
   (* Track in-memory call counter for all declared tool names (including hidden). *)
-  Tool_registry.record_call_if_known ~source:External_mcp ~tool_name:name ~success ~duration_ms ();
+  Tool_registry.record_call_if_known ~source ~tool_name:name ~success ~duration_ms ();
 
   let tool_args_preview =
     Observability_redact.redact_tool_input ~tool_name:name arguments
@@ -329,7 +341,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
          ("tool_name", `String name);
          ("success", `Bool success);
          ("duration_ms", `Int duration_ms);
-         ("source", `String (Tool_registry.string_of_source External_mcp));
+         ("source", `String (Tool_registry.string_of_source source));
          ("error", match error_detail with Some e -> `String e | None -> `Null);
          ( "tool_args_preview",
            match tool_args_preview with


### PR DESCRIPTION
## Summary

Closes #8915.

Three callsites in `lib/mcp_server_eio_call_tool.ml` (telemetry track, in-memory record, activity payload) hardcoded `External_mcp` as the call source. For CLI-agent runtime keepers (claude_code / codex_cli / gemini_cli), the OAS spawns a child process that re-enters the MCP server through a separate connection — looking external but actually keeper-internal. The `Keeper_internal` variant in `Tool_registry.call_source` was defined precisely for this case but never reached.

This is the **unknown → permissive default** anti-pattern from `CLAUDE.md` AI-codegen rule #2 — the wildcard branch trades precision for convenience.

## Fix

Classify the source once before the telemetry block by looking up the resolved `agent_name` in `Keeper_registry.find_by_agent_name`:

```ocaml
let source : Tool_registry.call_source =
  if String.length agent_name = 0 then External_mcp
  else
    match Keeper_registry.find_by_agent_name agent_name with
    | Some _ -> Keeper_internal
    | None -> External_mcp
in
```

Sound partial: empty or unknown `agent_name` → `External_mcp` (existing behaviour, no regression for true external clients).

The 3 hardcoded callsites then consume `source` instead of `External_mcp`.

## Verification

```
$ dune build @check
(no output, exit 0)
```

Existing telemetry tests are unaffected — they use empty `agent_id`, so the lookup short-circuits to External_mcp.

## Risk

- **Behaviour change for keeper-internal dispatch**: previously logged as External_mcp, now Keeper_internal. Dashboards that aggregate `external_mcp_count` will see a drop and `keeper_internal_count` will start populating (was permanently 0). This is the desired correction.
- **No external-client regression**: lookup miss preserves External_mcp.
- **Cost**: one `StringMap.fold` over the keeper registry per tool call — same shape as existing dashboard reads, dwarfed by the telemetry write that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)