### PR TITLE
feat(legendary-bash): surface derived ratios on shadow_counters endpoint

### DIFF
--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -217,16 +217,25 @@ Response shape (field names mirror `Legendary_counters.snapshot` 1:1):
   "too_complex_background": 0,
   "too_complex_parse_error": 0,
   "too_complex_parse_aborted": 0,
-  "too_complex_other": 0
+  "too_complex_other": 0,
+  "ratios": {
+    "disagree_ratio": 0.0,
+    "shadow_parse_coverage": 0.0,
+    "auto_bg_promotion_rate": 0.0
+  }
 }
 ```
 
 Every counter stays at `0` until the matching observer env flag is
 set, so the endpoint itself is cost-free under default posture. The
-log stream and the counter snapshot are redundant on purpose: logs
-for point-in-time diagnostics, counters for `disagree ratio =
-(legacy_allow_shadow_deny + legacy_deny_shadow_allow) / gate_diff_total`
-trend math over a rolling window.
+`ratios` sibling surfaces the three flip-decision ratios server-side
+so dashboards and shell recipes do not have to re-derive them (and
+can no longer drift from the
+[`Legendary_counters` SSOT helpers](#derived-ratios-ssot)). All three
+values are finite floats — the endpoint never emits `NaN` / `inf`,
+even when every counter is `0`. The log stream and the counter
+snapshot remain redundant on purpose: logs for point-in-time
+diagnostics, counters for trend math over a rolling window.
 
 ### Derived ratios (SSOT)
 

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -205,3 +205,16 @@ let auto_bg_promotion_rate (s : snapshot) : float =
   safe_ratio
     ~num:s.auto_bg_would_have_promoted
     ~den:s.auto_bg_observed
+
+let snapshot_to_json_with_ratios (s : snapshot) : Yojson.Safe.t =
+  match snapshot_to_json s with
+  | `Assoc fields ->
+      `Assoc (fields @ [
+        ("ratios",
+         `Assoc [
+           ("disagree_ratio", `Float (disagree_ratio s));
+           ("shadow_parse_coverage", `Float (shadow_parse_coverage s));
+           ("auto_bg_promotion_rate", `Float (auto_bg_promotion_rate s));
+         ]);
+      ])
+  | other -> other

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -121,3 +121,14 @@ val auto_bg_promotion_rate : snapshot -> float
     tuning ("would promotion fire too often?") and the
     [MASC_BASH_AUTO_BG] default-flip decision ("is promotion rare
     enough to be tolerable?"). *)
+
+val snapshot_to_json_with_ratios : snapshot -> Yojson.Safe.t
+(** Same flat field set as {!snapshot_to_json}, with an additional
+    ["ratios"] sibling object containing the three derived ratios
+    ({!disagree_ratio}, {!shadow_parse_coverage},
+    {!auto_bg_promotion_rate}).  Consumers that prefer server-computed
+    flip-decision math over client-side arithmetic should call this
+    helper; the flat fields remain a 1:1 mirror of {!snapshot} so
+    existing dashboards keep working.  All ratio values are finite
+    ([0.0] when the denominator is zero), so the output remains a
+    valid JSON document regardless of observer state. *)

--- a/lib/server/server_routes_http_routes_legendary_bash.ml
+++ b/lib/server/server_routes_http_routes_legendary_bash.ml
@@ -11,8 +11,13 @@
       GET /api/v1/legendary_bash/bg_tasks/<keeper>
 
     Response (200) for shadow_counters: JSON shape mirrors
-    [Legendary_counters.snapshot] field-for-field. See
-    [legendary_counters.mli] for the stable contract.
+    [Legendary_counters.snapshot] field-for-field, plus a [ratios]
+    sibling object carrying the three derived flip-decision ratios
+    ([disagree_ratio], [shadow_parse_coverage],
+    [auto_bg_promotion_rate]) so consumers do not have to re-derive
+    them client-side.  See [legendary_counters.mli] for the stable
+    contract and the [Derived ratios (SSOT)] runbook section for the
+    operator interpretation.
 
     Response (200) for bg_tasks: JSON of shape
       { "keeper": "<name>",
@@ -39,7 +44,7 @@ module Http = Http_server_eio
 
 let snapshot_response () : Yojson.Safe.t =
   let snap = Legendary_counters.snapshot () in
-  Legendary_counters.snapshot_to_json snap
+  Legendary_counters.snapshot_to_json_with_ratios snap
 
 let task_detail_json ~now (tid, started_at) : Yojson.Safe.t =
   let elapsed_ms =

--- a/test/test_legendary_counters.ml
+++ b/test/test_legendary_counters.ml
@@ -201,6 +201,66 @@ let test_shadow_parse_coverage_full () =
   check_ratio "coverage = 1.0"
     ~expected:1.0 (Legendary_counters.shadow_parse_coverage s)
 
+let test_snapshot_to_json_with_ratios_shape () =
+  (* Even with observers idle (all counters zero) the helper must
+     still produce a JSON object that round-trips as a string.  The
+     [ratios] sibling exists and carries three finite [0.0] entries,
+     so dashboards can blind-read without NaN/inf handling. *)
+  Legendary_counters.reset ();
+  let json =
+    Legendary_counters.snapshot_to_json_with_ratios
+      (Legendary_counters.snapshot ())
+  in
+  let s = Yojson.Safe.to_string json in
+  Alcotest.(check bool)
+    "flat field preserved"
+    true
+    (Astring.String.is_infix ~affix:"\"gate_diff_total\":0" s);
+  Alcotest.(check bool)
+    "ratios sibling present"
+    true
+    (Astring.String.is_infix ~affix:"\"ratios\":{" s);
+  Alcotest.(check bool)
+    "disagree_ratio finite 0.0"
+    true
+    (Astring.String.is_infix ~affix:"\"disagree_ratio\":0.0" s);
+  Alcotest.(check bool)
+    "shadow_parse_coverage finite 0.0"
+    true
+    (Astring.String.is_infix ~affix:"\"shadow_parse_coverage\":0.0" s);
+  Alcotest.(check bool)
+    "auto_bg_promotion_rate finite 0.0"
+    true
+    (Astring.String.is_infix ~affix:"\"auto_bg_promotion_rate\":0.0" s)
+
+let test_snapshot_to_json_with_ratios_populated () =
+  Legendary_counters.reset ();
+  (* 10 observations with 3 disagreements + 1 parse-bailout. *)
+  for _ = 1 to 6 do Legendary_counters.incr_gate_diff `Agree done;
+  for _ = 1 to 2 do
+    Legendary_counters.incr_gate_diff `Legacy_allow_shadow_deny
+  done;
+  Legendary_counters.incr_gate_diff `Legacy_deny_shadow_allow;
+  Legendary_counters.incr_gate_diff `Shadow_cannot_parse;
+  let json =
+    Legendary_counters.snapshot_to_json_with_ratios
+      (Legendary_counters.snapshot ())
+  in
+  let s = Yojson.Safe.to_string json in
+  (* disagree_ratio = 3/10 = 0.3.  Assert the exact float repr that
+     Yojson emits for 0.3 so regressions in the serializer are
+     caught.  The double-quoted affix also guards against accidental
+     string-vs-number type changes. *)
+  Alcotest.(check bool)
+    "disagree_ratio carries populated value"
+    true
+    (Astring.String.is_infix ~affix:"\"disagree_ratio\":0.3" s);
+  (* shadow_parse_coverage = 1 - 1/10 = 0.9 *)
+  Alcotest.(check bool)
+    "shadow_parse_coverage carries populated value"
+    true
+    (Astring.String.is_infix ~affix:"\"shadow_parse_coverage\":0.9" s)
+
 let test_auto_bg_promotion_rate_math () =
   (* 10 observed, 4 would-have-promoted → 0.4.  Operator reads this
      and decides whether raising MASC_BLOCKING_BUDGET_MS is warranted
@@ -251,5 +311,9 @@ let () =
             test_shadow_parse_coverage_full;
           Alcotest.test_case "auto_bg_promotion_rate math" `Quick
             test_auto_bg_promotion_rate_math;
+          Alcotest.test_case "JSON with ratios sibling (zero)" `Quick
+            test_snapshot_to_json_with_ratios_shape;
+          Alcotest.test_case "JSON with ratios sibling (populated)" `Quick
+            test_snapshot_to_json_with_ratios_populated;
         ] );
     ]


### PR DESCRIPTION
## Summary

Extends `/api/v1/legendary_bash/shadow_counters` with a `ratios` sibling
object carrying the three flip-decision ratios server-side. Dashboards
and operator recipes no longer need to re-derive them client-side, and
the [`Legendary_counters` SSOT helpers](../blob/main/lib/legendary_counters.mli)
become the single source of flip-decision math.

Additive: all existing flat fields are preserved 1:1 with
`Legendary_counters.snapshot`. The new `ratios` key is appended to the
same top-level object, so any existing consumer keeps working.

## Changes

- `lib/legendary_counters.{ml,mli}`: add `snapshot_to_json_with_ratios`
  that wraps `snapshot_to_json` and appends the three derived ratios
  (`disagree_ratio`, `shadow_parse_coverage`, `auto_bg_promotion_rate`)
  as a `ratios` sibling. All three values are finite floats —
  `safe_ratio` returns `0.0` when the denominator is `<= 0`, so the
  observer-off path emits a valid JSON document.
- `lib/server/server_routes_http_routes_legendary_bash.ml`: route the
  endpoint response through the new helper. The module doc comment
  updates to describe the new shape and links back to the runbook.
- `test/test_legendary_counters.ml`: two new cases covering the JSON
  shape — the all-zero observer-off path (every ratio must round-trip
  as `0.0`) and a populated path with counters matching the helper
  math (`disagree_ratio=0.3`, `shadow_parse_coverage=0.9`). String-
  based `is_infix` guards against accidental string/number drift in
  the serializer.
- `docs/LEGENDARY-BASH-RUNBOOK.md`: the `shadow_counters` JSON example
  gains the `ratios` sibling with a short note linking to the Derived
  ratios (SSOT) section.

## Why

Two prior PRs laid the groundwork:

- #9108 introduced the derived ratio helpers as pure functions over
  `snapshot`, with the flip-decision math expressed once.
- The runbook documents the flip criteria that reference those ratios.

Dashboards still had to compute the ratios client-side from the flat
fields, which re-introduces the drift this refactor was trying to
eliminate. Surfacing the ratios on the endpoint collapses that path.

## Test plan

- [x] `dune build @check` clean
- [x] `./_build/default/test/test_legendary_counters.exe` — 18/18 green
  including the two new `derived_ratios` JSON shape cases
- [x] `./_build/default/test/test_legendary_bash_bg_tasks_route.exe` —
  4/4 green (sibling endpoint unaffected)