### PR TITLE
fix(keeper): reconcile meta.social_model on TOML hot-reload

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -78,6 +78,9 @@ let ensure_keeper_meta config name =
     in
     let target_denylist = apply_default defaults.tool_denylist meta.tool_denylist in
     let target_models = apply_default defaults.models meta.models in
+    let target_social_model =
+      apply_default defaults.social_model meta.social_model
+      |> Keeper_social_model.normalize_social_model in
     let target_cascade_name =
       effective_declarative_cascade_name defaults meta
     in
@@ -134,6 +137,7 @@ let ensure_keeper_meta config name =
       meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled in
     let denylist_changed = meta.tool_denylist <> target_denylist in
     let models_changed = meta.models <> target_models in
+    let social_model_changed = meta.social_model <> target_social_model in
     (* [meta.cascade_name] may be a raw TOML/JSON value while
        [target_cascade_name] is already canonicalized; canonicalize both
        sides so a reload that only normalizes the spelling (e.g.
@@ -171,6 +175,7 @@ let ensure_keeper_meta config name =
       || meta.telemetry_feedback_window_hours <> target_tf_window in
     let any_changed =
       proactive_changed || signal_changed || denylist_changed || models_changed
+      || social_model_changed
       || cascade_changed
       || personality_changed || policy_changed || discovery_changed
       || telemetry_changed in
@@ -181,6 +186,7 @@ let ensure_keeper_meta config name =
         (if signal_changed then Some "signal" else None);
         (if denylist_changed then Some "denylist" else None);
         (if models_changed then Some "models" else None);
+        (if social_model_changed then Some "social_model" else None);
         (if cascade_changed then Some "cascade" else None);
         (if personality_changed then Some "personality" else None);
         (if policy_changed then Some "policy" else None);
@@ -200,6 +206,7 @@ let ensure_keeper_meta config name =
         room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
         models = target_models;
+        social_model = target_social_model;
         (* Preserve raw [meta.cascade_name] when the cascade itself did
            not change, even if another field (personality, policy, ...)
            triggered a re-sync.  Otherwise a reconcile caused by an


### PR DESCRIPTION
## Summary
- Same drift class as #9126 (models). `defaults.social_model : string option` flows to `meta.social_model : string` at keeper_up materialization (`keeper_turn_up_create.ml:172-176` via `Keeper_social_model.normalize_social_model`), but `ensure_keeper_meta` reconcile sweep omits it.
- **Symptom**: TOML edits to `[keeper.social_model]` have no runtime effect during hot-reload; keeper retains previously-materialized value until a full restart or `keeper_up`.
- **Root cause (evidence-first)**: grep of \`defaults\.social_model\` in lib/ → single hit (`keeper_turn_up_create.ml:173`), zero hits in `keeper_runtime.ml`. Parallel structure to models field (#8709/#9126).

## Fix scope
Surgical +6/-1 mirror of the #9126 models pattern, one file: \`lib/keeper/keeper_runtime.ml\`.

1. \`target_social_model\` via \`apply_default defaults.social_model meta.social_model |> Keeper_social_model.normalize_social_model\` — stickiness + normalization consistent with materialization.
2. \`social_model_changed = meta.social_model <> target_social_model\`.
3. Added to \`any_changed\` disjunction.
4. Added to \`cats\` label list (\"social_model\").
5. \`social_model = target_social_model\` in \`updated\` record.

## Non-goals
- Does NOT touch other reconcile branches (denylist/cascade/policy/etc already covered).
- Does NOT change keeper_up materialization (`keeper_turn_up_create.ml` unchanged).

## Verification
- \`dune build @check\` passes cleanly.
- Normalization mirrors materialization path — no silent round-trip drift.

## Residual reconcile gaps — none found
Other \`defaults\` fields not in reconcile (\`max_turns_per_call\`, \`max_turns_per_call_scheduled_autonomous\`, \`oas_env\`, \`shards\`) are config-layer only — they do NOT have corresponding \`keeper_meta\` fields, so reconcile N/A.

## Test plan
- [ ] Full CI green
- [ ] Manual: edit `config/keepers/<name>.toml` `[keeper].social_model`, wait for hot-reload tick, confirm `ensure_keeper_meta: re-syncing [social_model]` in logs

---
Pattern lineage: #8707 → #8709 → #9126 → this.
Feedback memory: \`feedback_record-update-bypass-builder-drift.md\` (no Builder in play here; direct grep audit found the gap).