### PR TITLE
feat(reputation): expose accountability provenance

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -22,6 +22,9 @@ type agent_reputation = {
   accountability_evidence_coverage: float; [@default 1.0]
   accountability_unsupported_completion_rate: float; [@default 0.0]
   accountability_open_overdue_commitments: int; [@default 0]
+  accountability_keeper_name: string; [@default ""]
+  accountability_source: string; [@default "none"]
+  accountability_source_label: string; [@default "No accountability history"]
   overall_score: float; [@default 0.0]
 } [@@deriving yojson { strict = false }]
 
@@ -42,6 +45,9 @@ let default_reputation ~(agent_name : string) : agent_reputation =
     accountability_evidence_coverage = 1.0;
     accountability_unsupported_completion_rate = 0.0;
     accountability_open_overdue_commitments = 0;
+    accountability_keeper_name = agent_name;
+    accountability_source = "none";
+    accountability_source_label = "No accountability history";
     overall_score = 0.0;
   }
 
@@ -191,9 +197,10 @@ let keeper_name_of_agent agent_name =
     trimmed
 
 let accountability_metrics (config : Coord.config) ~(agent_name : string) =
+  let keeper_name = keeper_name_of_agent agent_name in
   let summary =
     Keeper_accountability.accountability_summary_json config
-      ~keeper_name:(keeper_name_of_agent agent_name) ~agent_name
+      ~keeper_name ~agent_name
   in
   let evidence_coverage =
     Safe_ops.json_float ~default:1.0 "evidence_coverage" summary
@@ -207,12 +214,19 @@ let accountability_metrics (config : Coord.config) ~(agent_name : string) =
   let risk_band =
     Safe_ops.json_string ~default:"low" "risk_band" summary
   in
+  let source =
+    Safe_ops.json_string ~default:"none" "source" summary
+  in
+  let source_label =
+    Safe_ops.json_string ~default:"No accountability history" "source_label"
+      summary
+  in
   let score =
     compute_accountability_score ~evidence_coverage
       ~unsupported_completion_rate ~open_overdue_commitments
   in
   (score, risk_band, evidence_coverage, unsupported_completion_rate,
-   open_overdue_commitments)
+   open_overdue_commitments, keeper_name, source, source_label)
 
 (** {1 Main Computation} *)
 
@@ -238,7 +252,10 @@ let compute_reputation (config : Coord.config) ~(agent_name : string)
   let (accountability_score, accountability_risk_band,
        accountability_evidence_coverage,
        accountability_unsupported_completion_rate,
-       accountability_open_overdue_commitments) =
+       accountability_open_overdue_commitments,
+       accountability_keeper_name,
+       accountability_source,
+       accountability_source_label) =
     accountability_metrics config ~agent_name
   in
   let overall_score =
@@ -255,5 +272,8 @@ let compute_reputation (config : Coord.config) ~(agent_name : string)
     accountability_evidence_coverage;
     accountability_unsupported_completion_rate;
     accountability_open_overdue_commitments;
+    accountability_keeper_name;
+    accountability_source;
+    accountability_source_label;
     overall_score;
   }

--- a/lib/agent_reputation.mli
+++ b/lib/agent_reputation.mli
@@ -23,6 +23,9 @@ type agent_reputation = {
   accountability_evidence_coverage: float;
   accountability_unsupported_completion_rate: float;
   accountability_open_overdue_commitments: int;
+  accountability_keeper_name: string; (** Keeper identity used for accountability lookup. *)
+  accountability_source: string; (** direct_agent | canonical_keeper_fallback | none *)
+  accountability_source_label: string; (** Operator-facing provenance label. *)
   overall_score: float;       (** Weighted composite after accountability penalty, 0.0-1.0 *)
 }
 

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -670,6 +670,24 @@ let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
       ("history", `List history);
     ]
 
+let source_label ~source ~keeper_name =
+  match source with
+  | "direct_agent" -> "Direct runtime alias history"
+  | "canonical_keeper_fallback" ->
+      Printf.sprintf "Inherited from canonical identity: %s" keeper_name
+  | _ -> "No accountability history"
+
+let with_accountability_source ~source ~keeper_name json =
+  match json with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+         @ [
+             ("source", `String source);
+             ("source_label", `String (source_label ~source ~keeper_name));
+           ])
+  | other -> other
+
 let accountability_summary_lookup (config : Coord_query.config) =
   let now = Time_compat.now () in
   let cutoff = summary_cutoff now in
@@ -691,15 +709,16 @@ let accountability_summary_lookup (config : Coord_query.config) =
            add_snapshot by_agent snapshot.claim.agent_name snapshot;
            add_snapshot by_keeper snapshot.claim.keeper_name snapshot));
   fun ~keeper_name ~agent_name ->
-    let snapshots =
+    let source, snapshots =
       match Hashtbl.find_opt by_agent agent_name with
-      | Some items -> items
+      | Some items -> ("direct_agent", items)
       | None -> (
           match Hashtbl.find_opt by_keeper keeper_name with
-          | Some items -> items
-          | None -> [])
+          | Some items -> ("canonical_keeper_fallback", items)
+          | None -> ("none", []))
     in
     summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots
+    |> with_accountability_source ~source ~keeper_name
 
 let accountability_summary_json (config : Coord_query.config) ~keeper_name
     ~agent_name =

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -244,6 +244,11 @@ let test_generated_alias_inherits_accountability_penalty () =
       in
       check string "alias summary inherits canonical keeper risk" "high"
         (string_member "risk_band" summary);
+      check string "alias summary source" "canonical_keeper_fallback"
+        (string_member "source" summary);
+      check string "alias summary source label"
+        "Inherited from canonical identity: adversary"
+        (string_member "source_label" summary);
       check (float 0.0001) "alias summary inherits unsupported rate" 1.0
         (float_member "unsupported_completion_rate" summary);
       let rep =
@@ -255,7 +260,14 @@ let test_generated_alias_inherits_accountability_penalty () =
       check (float 0.0001) "generated alias unsupported rate" 1.0
         rep.accountability_unsupported_completion_rate;
       check (float 0.0001) "generated alias accountability score" 0.0
-        rep.accountability_score)
+        rep.accountability_score;
+      check string "generated alias keeper provenance" "adversary"
+        rep.accountability_keeper_name;
+      check string "generated alias reputation source"
+        "canonical_keeper_fallback" rep.accountability_source;
+      check string "generated alias reputation source label"
+        "Inherited from canonical identity: adversary"
+        rep.accountability_source_label)
 
 let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
   with_room (fun config ->


### PR DESCRIPTION
## Summary

- expose accountability lookup provenance on accountability summaries (`source`, `source_label`)
- include reputation JSON fields for the keeper identity and provenance label used by operator surfaces
- extend the generated-alias regression so canonical fallback provenance is pinned in the display contract

## Product impact

Operator-facing reputation/accountability surfaces can now tell whether a displayed runtime alias score comes from direct alias history, inherited canonical keeper fallback, or no accountability record. This prevents generated aliases from looking like independent direct history when the value is inherited.

## Evidence

- `opam exec -- dune build --root "$PWD" test/test_keeper_accountability.exe`
- `opam exec -- _build/default/test/test_keeper_accountability.exe --color=never` -> 16 tests pass
- `git diff --check`
- GitHub PR #9136, head `1dc75834b43ee45f399ca02b71fabbe28dbb4d3e`: `lint-permissive-defaults` success; main `CI` still in progress at last check

## Review evidence

- Focused test pins generated alias `adversary-eager-viper` to `canonical_keeper_fallback`.
- Expected operator copy is pinned as `Inherited from canonical identity: adversary`.
- PR hygiene warning from `github-actions[bot]` was addressed by adding the required sections to this PR body.

## Linked issue

Refs #8988