### PR TITLE
add cli auto model rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ### Added
 
+- **CLI auto-model rotation for cascade specs.** `gemini_cli:auto` now
+  expands into a quota-aware concrete Gemini CLI candidate list
+  (Flash/Lite first, Pro last), and `codex_cli:auto` expands through a
+  light-to-heavy Codex order from `gpt-5.1-codex-mini` up to `gpt-5.4`,
+  including `gpt-5.4-mini` and `gpt-5.3-codex-spark`.
+  `claude_code:auto` remains single-entry by default but can be expanded via
+  `MASC_CLAUDE_CODE_AUTO_MODELS`. This lets existing cascade
+  failover/round-robin/cooldown machinery rotate CLI models without
+  relying on interactive `/model` state.
+
 - **Legendary Bash shadow-counter per-reason `too_complex_*`
   histogram.**  `Legendary_counters.snapshot` now includes fifteen
   new fields — one per `Parsed.reason_too_complex` variant plus

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -154,6 +154,9 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `ZAI_DEFAULT_MODEL` | string | `"glm-5.1"` | `glm` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:38) |
 | `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
 | `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
+| `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"gemini-3-flash-preview,gemini-3.1-flash-lite-preview,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-3.1-pro-preview,gemini-2.5-pro"` | `gemini_cli:auto`를 여러 concrete model 후보로 확장하는 순서. 설정 시 `GEMINI_DEFAULT_MODEL`보다 우선 |
+| `MASC_CODEX_CLI_AUTO_MODELS` | csv string | `"gpt-5.1-codex-mini,gpt-5.1-codex-max,gpt-5.2,gpt-5.2-codex,gpt-5.3-codex-spark,gpt-5.3-codex,gpt-5.4-mini,gpt-5.4"` | `codex_cli:auto` 확장 순서. 기본은 5.1→5.4 세대 오름차순이며 mini/spark 후보를 먼저 포함 |
+| `MASC_CLAUDE_CODE_AUTO_MODELS` | csv string | `"auto"` | `claude_code:auto` 확장 순서. 기본은 Claude Code의 사용자 기본 모델에 위임 |
 | `ANTHROPIC_DEFAULT_MODEL` | string | `"claude-sonnet-4-6-20250514"` | `claude` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:70) |
 | `OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | `openai` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:73) |
 | `OLLAMA_DEFAULT_MODEL` | string | `""` | `ollama` provider `auto` 기본 모델 (lib/config/env_config_runtime.ml:181) |
@@ -344,6 +347,9 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 | `glm` | `Glm` | `ZAI_DEFAULT_MODEL` |
 | `glm-coding` | `Glm` | `ZAI_CODING_DEFAULT_MODEL` |
 | `gemini` | `Gemini` | `GEMINI_DEFAULT_MODEL` |
+| `gemini_cli` | CLI transport | `MASC_GEMINI_CLI_AUTO_MODELS` when model is `auto` |
+| `codex_cli` | CLI transport | `MASC_CODEX_CLI_AUTO_MODELS` when model is `auto` |
+| `claude_code` | CLI transport | `MASC_CLAUDE_CODE_AUTO_MODELS` when model is `auto` |
 | `claude` | `Claude` | `ANTHROPIC_DEFAULT_MODEL` |
 | `openai` | `OpenAI` | `OPENAI_DEFAULT_MODEL` |
 | `openrouter` | `OpenRouter` | `OPENROUTER_DEFAULT_MODEL` |
@@ -392,6 +398,10 @@ ollama HTTP 및 CLI provider(Claude_code / Gemini_cli / Codex_cli)는 endpoint s
 우선순위: per-cascade 키 > env var > 1 (min clamp 1).
 
 CLI sentinel key는 내부적으로 `cli:claude_code` / `cli:gemini_cli` / `cli:codex_cli` 형태로 registry에 등록된다. 대시보드 `/api/v1/cascade/client_capacity`에서 현재 이용률 확인 가능.
+
+`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 cascade 파싱 시 concrete 후보 목록으로 확장된다. Gemini CLI는 기본적으로 Flash/Lite 우선, Pro 후순위의 quota-aware 순서를 사용한다. Codex CLI는 `gpt-5.1-codex-mini`에서 시작해 `gpt-5.4`로 올라가는 세대 오름차순을 기본으로 사용하며, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.1-codex-mini` 같은 mini/spark 후보를 로테이션에 포함한다. Claude Code는 비용과 조직별 model policy 차이가 커서 기본값을 `auto` 1개로 유지하며, 운영자가 `MASC_CLAUDE_CODE_AUTO_MODELS`를 설정할 때만 여러 후보로 로테이션한다.
+
+Codex 후보 목록은 2026-04-20 로컬 Codex CLI model picker 기준이고, 기본 순서는 5.1→5.4로 재정렬되어 있다. hosted model menu가 바뀌면 `MASC_CODEX_CLI_AUTO_MODELS`로 즉시 override하고, 코드 기본값은 별도 PR로 갱신한다.
 
 ### 7.6 Ollama HTTP Probe (Phase C2, #7619)
 

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -257,6 +257,48 @@ let parse_weighted_entry_diag
             ?supports_tool_choice_override:entry.supports_tool_choice
             ~provider_name ~model_id reg_entry)
 
+(** Expand provider:auto specs that map to multiple models.
+    "glm:auto" expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
+    CLI-backed transports expand too, so a single [gemini_cli:auto] can
+    cascade through concrete CLI model overrides instead of delegating to
+    the CLI's interactive/default model picker. Other specs pass through
+    as-is. *)
+let expand_auto_model_string (s : string) : string list =
+  let trimmed = String.trim s in
+  match split_provider_model trimmed with
+  | Some ("glm", model_id)
+    when String.lowercase_ascii model_id = "auto" ->
+    Cascade_model_resolve.glm_auto_models ()
+    |> List.map (fun m -> "glm:" ^ m)
+  | Some ("glm-coding", model_id)
+    when String.lowercase_ascii model_id = "auto" ->
+    Cascade_model_resolve.glm_coding_auto_models ()
+    |> List.map (fun m -> "glm-coding:" ^ m)
+  | Some ("gemini_cli", model_id)
+    when String.lowercase_ascii model_id = "auto" ->
+    Cascade_model_resolve.gemini_cli_auto_models ()
+    |> List.map (fun m -> "gemini_cli:" ^ m)
+  | Some ("codex_cli", model_id)
+    when String.lowercase_ascii model_id = "auto" ->
+    Cascade_model_resolve.codex_cli_auto_models ()
+    |> List.map (fun m -> "codex_cli:" ^ m)
+  | Some ("claude_code", model_id)
+    when String.lowercase_ascii model_id = "auto" ->
+    Cascade_model_resolve.claude_code_auto_models ()
+    |> List.map (fun m -> "claude_code:" ^ m)
+  | _ -> [ trimmed ]
+
+let expand_auto_models (strs : string list) : string list =
+  List.concat_map expand_auto_model_string strs
+
+let expand_weighted_auto_entries
+    (entries : Cascade_config_loader.weighted_entry list) =
+  List.concat_map
+    (fun (entry : Cascade_config_loader.weighted_entry) ->
+       expand_auto_model_string entry.model
+       |> List.map (fun model -> { entry with model }))
+    entries
+
 (** Parse a list of weighted entries, dropping ones that cannot produce a
     provider config. Load-time drops are logged once per call with
     categorised reasons so upstream drift (e.g. a cascade.json entry
@@ -271,6 +313,7 @@ let parse_weighted_entries
     ?(cascade_name = "")
     (entries : Cascade_config_loader.weighted_entry list)
   : Llm_provider.Provider_config.t list =
+  let entries = expand_weighted_auto_entries entries in
   let parsed, unregistered, unavailable, invalid =
     List.fold_left
       (fun (acc, unr, unv, inv) entry ->
@@ -338,24 +381,6 @@ let parse_model_string_exn
     | Some entry ->
       Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
             ~provider_name ~model_id entry)
-
-(** Expand provider:auto specs that map to multiple models.
-    "glm:auto" expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
-    Other specs pass through as-is. *)
-let expand_auto_models (strs : string list) : string list =
-  List.concat_map (fun s ->
-    let trimmed = String.trim s in
-    match split_provider_model trimmed with
-    | Some ("glm", model_id)
-      when String.lowercase_ascii model_id = "auto" ->
-      Cascade_model_resolve.glm_auto_models ()
-      |> List.map (fun m -> "glm:" ^ m)
-    | Some ("glm-coding", model_id)
-      when String.lowercase_ascii model_id = "auto" ->
-      Cascade_model_resolve.glm_coding_auto_models ()
-      |> List.map (fun m -> "glm-coding:" ^ m)
-    | _ -> [ trimmed ]
-  ) strs
 
 let parse_model_strings
     ?(temperature = Llm_provider.Constants.Inference.default_temperature)
@@ -509,6 +534,7 @@ let weighted_shuffle
 let order_weighted_entries
     ?(rand_int = weighted_random_int)
     (entries : Cascade_config_loader.weighted_entry list) =
+  let entries = expand_weighted_auto_entries entries in
   let has_weights = List.exists
       (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
       entries

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -111,7 +111,9 @@ val parse_model_string_exn :
 
 (** Expand provider:auto specs that map to multiple models.
     ["glm:auto"] expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
-    Other specs pass through unchanged. *)
+    CLI specs such as ["gemini_cli:auto"], ["codex_cli:auto"], and
+    ["claude_code:auto"] expand through their provider-specific
+    auto-model lists. Other specs pass through unchanged. *)
 val expand_auto_models : string list -> string list
 
 (** Parse multiple model strings, skipping unavailable ones.

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -26,12 +26,67 @@ let env_or default var =
   | Some v when String.trim v <> "" -> String.trim v
   | _ -> default
 
+let csv_items raw =
+  raw
+  |> String.split_on_char ','
+  |> List.filter_map (fun item ->
+         let item = String.trim item in
+         if item = "" then None else Some item)
+
+let env_csv_or default var =
+  match Sys.getenv_opt var with
+  | Some raw -> (
+      match csv_items raw with
+      | [] -> default
+      | items -> items)
+  | None -> default
+
 (** Default GLM auto-cascade order: quality-first, then speed.
     glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
     glm-4.7 = stable general, glm-4.7-flashx = fastest/cheapest.
     Configurable via ZAI_AUTO_MODELS env var (comma-separated). *)
 let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
 let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
+
+let gemini_cli_default_auto_models = [
+  "gemini-3-flash-preview";
+  "gemini-3.1-flash-lite-preview";
+  "gemini-2.5-flash";
+  "gemini-2.5-flash-lite";
+  "gemini-3.1-pro-preview";
+  "gemini-2.5-pro";
+]
+
+let gemini_cli_auto_models () =
+  match Sys.getenv_opt "MASC_GEMINI_CLI_AUTO_MODELS" with
+  | Some raw -> (
+      match csv_items raw with
+      | [] -> gemini_cli_default_auto_models
+      | items -> items)
+  | None -> (
+      match Sys.getenv_opt "GEMINI_DEFAULT_MODEL" with
+      | Some model when String.trim model <> "" -> [ String.trim model ]
+      | _ -> gemini_cli_default_auto_models)
+
+(* Mirrors the Codex CLI models observed locally on 2026-04-20, reordered
+   light-to-heavy by generation (5.1 -> 5.4). Keep this operator-tunable
+   because hosted model menus drift. *)
+let codex_cli_default_auto_models = [
+  "gpt-5.1-codex-mini";
+  "gpt-5.1-codex-max";
+  "gpt-5.2";
+  "gpt-5.2-codex";
+  "gpt-5.3-codex-spark";
+  "gpt-5.3-codex";
+  "gpt-5.4-mini";
+  "gpt-5.4";
+]
+
+let codex_cli_auto_models () =
+  env_csv_or codex_cli_default_auto_models "MASC_CODEX_CLI_AUTO_MODELS"
+
+let claude_code_auto_models () =
+  env_csv_or [ "auto" ] "MASC_CLAUDE_CODE_AUTO_MODELS"
 
 let resolve_glm_model_id model_id =
   Llm_provider.Zai_catalog.resolve_glm_alias

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -14,6 +14,24 @@
 val glm_auto_models : unit -> string list
 val glm_coding_auto_models : unit -> string list
 
+(** Ordered Gemini CLI candidates for [gemini_cli:auto].
+    Configurable via [MASC_GEMINI_CLI_AUTO_MODELS] (comma-separated).
+    When unset, [GEMINI_DEFAULT_MODEL] narrows the list to that single
+    model for backward-compatible explicit override semantics. *)
+val gemini_cli_auto_models : unit -> string list
+
+(** Ordered Codex CLI candidates for [codex_cli:auto].
+    Configurable via [MASC_CODEX_CLI_AUTO_MODELS] (comma-separated).
+    Defaults to a light-to-heavy generation order (5.1 -> 5.4),
+    including mini/spark variants. *)
+val codex_cli_auto_models : unit -> string list
+
+(** Ordered Claude Code candidates for [claude_code:auto].
+    Configurable via [MASC_CLAUDE_CODE_AUTO_MODELS] (comma-separated).
+    Defaults to [["auto"]] so the user's Claude Code default remains in
+    control unless an operator opts into model rotation. *)
+val claude_code_auto_models : unit -> string list
+
 (** Resolve a GLM model alias to the concrete API model ID.
     - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5"]
     - ["flash"] -> ["glm-4.7-flashx"]

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -9,6 +9,7 @@
 
 open Alcotest
 module R = Masc_mcp.Cascade_model_resolve
+module C = Masc_mcp.Cascade_config
 
 let unset_env k =
   try Unix.putenv k "" with _ -> ()
@@ -20,6 +21,9 @@ let with_clean_env f =
     "OPENAI_DEFAULT_MODEL";
     "OPENROUTER_DEFAULT_MODEL";
     "OLLAMA_DEFAULT_MODEL";
+    "MASC_GEMINI_CLI_AUTO_MODELS";
+    "MASC_CODEX_CLI_AUTO_MODELS";
+    "MASC_CLAUDE_CODE_AUTO_MODELS";
   ];
   f ()
 
@@ -53,6 +57,80 @@ let test_gemini_env_override () =
   check string "gemini_cli respects same env override"
     "gemini-2.5-flash" resolved_cli
 
+let test_gemini_cli_auto_models_default_rotation_order () =
+  with_clean_env (fun () ->
+    check (list string) "gemini_cli:auto expands to quota-aware rotation"
+      [
+        "gemini-3-flash-preview";
+        "gemini-3.1-flash-lite-preview";
+        "gemini-2.5-flash";
+        "gemini-2.5-flash-lite";
+        "gemini-3.1-pro-preview";
+        "gemini-2.5-pro";
+      ]
+      (R.gemini_cli_auto_models ()))
+
+let test_gemini_cli_auto_models_env_override () =
+  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS"
+    "gemini-a, gemini-b,, gemini-c ";
+  let models = R.gemini_cli_auto_models () in
+  Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "";
+  check (list string) "operator override trims blanks"
+    [ "gemini-a"; "gemini-b"; "gemini-c" ] models
+
+let test_codex_and_claude_cli_auto_models_env_override () =
+  with_clean_env (fun () ->
+    check (list string) "codex default follows 5.1-to-5.4 order"
+      [
+        "gpt-5.1-codex-mini";
+        "gpt-5.1-codex-max";
+        "gpt-5.2";
+        "gpt-5.2-codex";
+        "gpt-5.3-codex-spark";
+        "gpt-5.3-codex";
+        "gpt-5.4-mini";
+        "gpt-5.4";
+      ]
+      (R.codex_cli_auto_models ());
+    check (list string) "claude default delegates to CLI"
+      [ "auto" ] (R.claude_code_auto_models ());
+    Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "gpt-a,gpt-b";
+    Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "sonnet,opus";
+    let codex = R.codex_cli_auto_models () in
+    let claude = R.claude_code_auto_models () in
+    Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "";
+    Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "";
+    check (list string) "codex operator rotation"
+      [ "gpt-a"; "gpt-b" ] codex;
+    check (list string) "claude operator rotation"
+      [ "sonnet"; "opus" ] claude)
+
+let test_expand_auto_models_includes_cli_auto_specs () =
+  with_clean_env (fun () ->
+    let expanded =
+      C.expand_auto_models
+        [ "gemini_cli:auto"; "codex_cli:auto"; "claude_code:auto" ]
+    in
+    check (list string) "CLI auto specs expand in-place"
+      [
+        "gemini_cli:gemini-3-flash-preview";
+        "gemini_cli:gemini-3.1-flash-lite-preview";
+        "gemini_cli:gemini-2.5-flash";
+        "gemini_cli:gemini-2.5-flash-lite";
+        "gemini_cli:gemini-3.1-pro-preview";
+        "gemini_cli:gemini-2.5-pro";
+        "codex_cli:gpt-5.1-codex-mini";
+        "codex_cli:gpt-5.1-codex-max";
+        "codex_cli:gpt-5.2";
+        "codex_cli:gpt-5.2-codex";
+        "codex_cli:gpt-5.3-codex-spark";
+        "codex_cli:gpt-5.3-codex";
+        "codex_cli:gpt-5.4-mini";
+        "codex_cli:gpt-5.4";
+        "claude_code:auto";
+      ]
+      expanded)
+
 let () =
   run "Cascade_model_resolve" [
     "gemini auto", [
@@ -64,5 +142,13 @@ let () =
         `Quick test_gemini_cli_explicit_model_passthrough;
       test_case "GEMINI_DEFAULT_MODEL env override"
         `Quick test_gemini_env_override;
+      test_case "gemini_cli:auto model list"
+        `Quick test_gemini_cli_auto_models_default_rotation_order;
+      test_case "gemini_cli:auto env list override"
+        `Quick test_gemini_cli_auto_models_env_override;
+      test_case "codex/claude cli auto env list override"
+        `Quick test_codex_and_claude_cli_auto_models_env_override;
+      test_case "expand_auto_models covers CLI auto"
+        `Quick test_expand_auto_models_includes_cli_auto_specs;
     ];
   ]


### PR DESCRIPTION
## Summary
- Expand `gemini_cli:auto` into a concrete Flash/Lite-first Gemini CLI rotation list.
- Expand `codex_cli:auto` into a 5.1-to-5.4 light-to-heavy Codex rotation list, including mini/spark candidates.
- Keep `claude_code:auto` as a single default entry, with `MASC_CLAUDE_CODE_AUTO_MODELS` available for operator-managed rotation.
- Document the new env overrides and add coverage for CLI `auto` expansion.

## Dependency
- Codex CLI model rotation depends on OAS passing request model IDs to `codex exec --model`: https://github.com/jeong-sik/oas/pull/1098
- This PR does not bump the OAS pin yet. After the OAS PR is merged/released or pinned, update MASC's OAS dependency separately.

## Verification
- `dune exec --root . ./test/test_cascade_model_resolve.exe`
- `git diff --check`

## Notes
- Full cascade-targeted `dune build` was not used for final verification because local Dune jobs were hanging silently in this workspace; the dedicated cascade model-resolve test passed.