### PR TITLE
[codex] Absorb dashboard v2 shell into Bonsai

### DIFF
--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -334,31 +334,27 @@ let view_meta_strip (r : Archive_runs_types.response) =
 
 let render (r : Archive_runs_types.response) : Node.t =
   let total = r.total in
-  Node.div
-    ~attrs:[ Style.root ]
-    [ Placeholder_view.sidebar ~active:Archive_runs
-    ; Node.div
-        ~attrs:[ Style.main ]
-        [ Hero.view
-            ~eyebrow:"archive · autoresearch"
-            ~title:"archive runs"
-            ~tail:(Printf.sprintf "· %d" total, `Brass)
-            ~sub:
-              "autoresearch의 reinforced-write loop 기록. 각 row는 \
-               목표 · cycle progress · keeps/discards 의 총합. 실패한 \
-               run은 error 사유를 함께 남긴다."
-            ()
-        ; view_meta_strip r
-        ; (match r.loops with
-           | [] ->
-             Node.div
-               ~attrs:[ Style.quiet ]
-               [ Node.text "no runs recorded yet." ]
-           | loops ->
-             Node.div
-               ~attrs:[ Style.loop_list ]
-               (List.map loops ~f:view_loop))
-        ]
+  Shell_view.view
+    ~active:Archive_runs
+    [ Hero.view
+        ~eyebrow:"archive · autoresearch"
+        ~title:"archive runs"
+        ~tail:(Printf.sprintf "· %d" total, `Brass)
+        ~sub:
+          "autoresearch의 reinforced-write loop 기록. 각 row는 \
+           목표 · cycle progress · keeps/discards 의 총합. 실패한 \
+           run은 error 사유를 함께 남긴다."
+        ()
+    ; view_meta_strip r
+    ; (match r.loops with
+       | [] ->
+         Node.div
+           ~attrs:[ Style.quiet ]
+           [ Node.text "no runs recorded yet." ]
+       | loops ->
+         Node.div
+           ~attrs:[ Style.loop_list ]
+           (List.map loops ~f:view_loop))
     ]
 ;;
 

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -145,23 +145,19 @@ let render (keepers : Keepers_types.response) : Node.t =
     | "" -> "—"
     | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
   in
-  Node.div
-    ~attrs:[ Style.root ]
-    [ Placeholder_view.sidebar ~active:Dead_keepers
-    ; Node.div
-        ~attrs:[ Style.main ]
-        [ Hero.view
-            ~eyebrow:"crypt · the fallen"
-            ~title:"dead keepers"
-            ~tail:(Printf.sprintf "· %02d" dead_n, `Blood)
-            ~sub:
-              "fleet의 추락한 자들. 이 목록은 Keepers 엔드포인트의 status=Dead \
-               필터링 — 별도 endpoint 없음. 각 slot은 마지막으로 관측된 \
-               state와 latency를 기록한다."
-            ()
-        ; view_meta_strip ~total ~dead:dead_n ~synced
-        ; view_dead_list dead
-        ]
+  Shell_view.view
+    ~active:Dead_keepers
+    [ Hero.view
+        ~eyebrow:"crypt · the fallen"
+        ~title:"dead keepers"
+        ~tail:(Printf.sprintf "· %02d" dead_n, `Blood)
+        ~sub:
+          "fleet의 추락한 자들. 이 목록은 Keepers 엔드포인트의 status=Dead \
+           필터링 — 별도 endpoint 없음. 각 slot은 마지막으로 관측된 \
+           state와 latency를 기록한다."
+        ()
+    ; view_meta_strip ~total ~dead:dead_n ~synced
+    ; view_dead_list dead
     ]
 ;;
 

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -359,31 +359,27 @@ let view_meta_strip (r : Goals_types.response) =
 ;;
 
 let render (r : Goals_types.response) : Node.t =
-  Node.div
-    ~attrs:[ Style.root ]
-    [ Placeholder_view.sidebar ~active:Goals
-    ; Node.div
-        ~attrs:[ Style.main ]
-        [ Hero.view
-            ~eyebrow:"goals · convergence"
-            ~title:"goals"
-            ~tail:(Printf.sprintf "· %d" r.summary.total_goals, `Brass)
-            ~sub:
-              "config-driven goal forest. 각 node는 goal 하나 + 직속 \
-               task들 + 하위 goals. convergence는 child goals의 평균 \
-               progress."
-            ()
-        ; view_meta_strip r
-        ; (match r.tree with
-           | [] ->
-             Node.div
-               ~attrs:[ Style.quiet ]
-               [ Node.text "goal tree is empty." ]
-           | nodes ->
-             Node.div
-               ~attrs:[ Style.tree ]
-               (List.map nodes ~f:(view_node ~depth:0)))
-        ]
+  Shell_view.view
+    ~active:Goals
+    [ Hero.view
+        ~eyebrow:"goals · convergence"
+        ~title:"goals"
+        ~tail:(Printf.sprintf "· %d" r.summary.total_goals, `Brass)
+        ~sub:
+          "config-driven goal forest. 각 node는 goal 하나 + 직속 \
+           task들 + 하위 goals. convergence는 child goals의 평균 \
+           progress."
+        ()
+    ; view_meta_strip r
+    ; (match r.tree with
+       | [] ->
+         Node.div
+           ~attrs:[ Style.quiet ]
+           [ Node.text "goal tree is empty." ]
+       | nodes ->
+         Node.div
+           ~attrs:[ Style.tree ]
+           (List.map nodes ~f:(view_node ~depth:0)))
     ]
 ;;
 

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -154,38 +154,34 @@ let view_hud_strip (keepers : Keepers_types.response) =
 
 let render (keepers : Keepers_types.response) : Node.t =
   let has_fleet = not (List.is_empty keepers.keepers) in
-  Node.div
-    ~attrs:[ Style.root ]
-    [ Placeholder_view.sidebar ~active:Keepers
-    ; Node.div
-        ~attrs:[ Style.main ]
-        [ view_hero keepers
-        ; view_hud_strip keepers
-        ; (if has_fleet
-           then
-             Node.div
-               ~attrs:[]
-               [ Sec.view ~title:"roster" ~sub:"현재"
-                   ~right:
-                     (Printf.sprintf
-                        "fleet %d"
-                        (List.length keepers.keepers))
-                   ()
-               ; Roster.view ~keepers ()
-               ; Sec.view ~title:"swim" ~sub:"60s"
-                   ~right:"lane · activity" ()
-               ; Swim.view ~keepers ()
-               ; Sec.view ~title:"pressure" ~sub:"60m"
-                   ~right:"ctx %" ()
-               ; Ctx_chart.view ~keepers ()
-               ]
-           else
-             Node.div
-               ~attrs:[ Style.quiet ]
-               [ Node.text
-                   "fleet endpoint is quiet — no keepers reported yet."
-               ])
-        ]
+  Shell_view.view
+    ~active:Keepers
+    [ view_hero keepers
+    ; view_hud_strip keepers
+    ; (if has_fleet
+       then
+         Node.div
+           ~attrs:[]
+           [ Sec.view ~title:"roster" ~sub:"현재"
+               ~right:
+                 (Printf.sprintf
+                    "fleet %d"
+                    (List.length keepers.keepers))
+               ()
+           ; Roster.view ~keepers ()
+           ; Sec.view ~title:"swim" ~sub:"60s"
+               ~right:"lane · activity" ()
+           ; Swim.view ~keepers ()
+           ; Sec.view ~title:"pressure" ~sub:"60m"
+               ~right:"ctx %" ()
+           ; Ctx_chart.view ~keepers ()
+           ]
+       else
+         Node.div
+           ~attrs:[ Style.quiet ]
+           [ Node.text
+               "fleet endpoint is quiet — no keepers reported yet."
+           ])
     ]
 ;;
 

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -409,27 +409,23 @@ let view_meta_panel (r : Overview_types.response) =
 ;;
 
 let render (r : Overview_types.response) : Node.t =
-  Node.div
-    ~attrs:[ Style.root ]
-    [ Placeholder_view.sidebar ~active:Overview
+  Shell_view.view
+    ~active:Overview
+    [ Hero.view
+        ~eyebrow:"overview · at a glance"
+        ~title:"overview"
+        ~tail:(Printf.sprintf "· %s" r.status.cluster, `Brass)
+        ~sub:
+          "room의 current state — identity, build, fleet counts, \
+           meta-cognition. shell 엔드포인트의 압축된 projection \
+           으로, 깊은 진단은 각 tab에서 확인."
+        ()
     ; Node.div
-        ~attrs:[ Style.main ]
-        [ Hero.view
-            ~eyebrow:"overview · at a glance"
-            ~title:"overview"
-            ~tail:(Printf.sprintf "· %s" r.status.cluster, `Brass)
-            ~sub:
-              "room의 current state — identity, build, fleet counts, \
-               meta-cognition. shell 엔드포인트의 압축된 projection \
-               으로, 깊은 진단은 각 tab에서 확인."
-            ()
-        ; Node.div
-            ~attrs:[ Style.grid ]
-            [ view_hero_panel r
-            ; view_build_panel r
-            ; view_counts_panel r
-            ; view_meta_panel r
-            ]
+        ~attrs:[ Style.grid ]
+        [ view_hero_panel r
+        ; view_build_panel r
+        ; view_counts_panel r
+        ; view_meta_panel r
         ]
     ]
 ;;

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -216,32 +216,28 @@ let sidebar ~(active : Route.t) =
 
 let component ~(route : Route.t) (_graph @ local) =
   Bonsai.return
-    (Node.div
-       ~attrs:[ Style.root ]
-       [ sidebar ~active:route
-       ; Node.div
-           ~attrs:[ Style.main ]
-           [ Node.div
-               ~attrs:[ Style.card ]
-               [ Node.span ~attrs:[ Style.badge ] [ Node.text "phase 2 · 작업 중" ]
-               ; Node.h1 ~attrs:[ Style.title ] [ Node.text (Route.label route) ]
-               ; Node.p
-                   ~attrs:[ Style.sub ]
-                   [ Node.text
-                       "이 탭은 아직 Bonsai로 이식되지 않았다. \
-                        logs · 저널이 유일한 이식 탭."
-                   ]
-               ; Node.div
-                   ~attrs:[ Style.link_row ]
-                   [ Node.a
-                       ~attrs:
-                         [ Attr.href (Route.path Logs); Style.link ]
-                       [ Node.text "← 저널로" ]
-                   ; Node.a
-                       ~attrs:
-                         [ Attr.href "/dashboard/"; Style.link ]
-                       [ Node.text "preact 대시보드 →" ]
-                   ]
+    (Shell_view.view
+       ~active:route
+       [ Node.div
+           ~attrs:[ Style.card ]
+           [ Node.span ~attrs:[ Style.badge ] [ Node.text "phase 2 · 작업 중" ]
+           ; Node.h1 ~attrs:[ Style.title ] [ Node.text (Route.label route) ]
+           ; Node.p
+               ~attrs:[ Style.sub ]
+               [ Node.text
+                   "이 탭은 아직 Bonsai로 완전히 이식되지 않았다. \
+                    그래도 chrome은 dashboard_v2 shell을 공유한다."
+               ]
+           ; Node.div
+               ~attrs:[ Style.link_row ]
+               [ Node.a
+                   ~attrs:
+                     [ Attr.href (Route.path Logs); Style.link ]
+                   [ Node.text "저널로" ]
+               ; Node.a
+                   ~attrs:
+                     [ Attr.href "/dashboard/"; Style.link ]
+                   [ Node.text "preact 대시보드" ]
                ]
            ]
        ])

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -1,0 +1,902 @@
+(** Shared Bonsai shell for [/dashboard/b/*].
+
+    This ports the Dashboard v2 design-system chrome into one Bonsai
+    component: topbar, glyph-lit nav, HUD strip, main scroll area, and right
+    observatory aside. Route views should provide only their page body. *)
+
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+module Style =
+[%css
+stylesheet
+  {|
+  .shell {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr) 340px;
+    grid-template-rows: 52px 1fr;
+    min-height: 100vh;
+    color: var(--text-primary);
+    background:
+      radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+  }
+
+  .topbar {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 0 22px;
+    background: linear-gradient(180deg, #1a140e, #120b08);
+    border-bottom: 1px solid var(--border-highlight);
+    box-shadow: 0 2px 0 rgba(0,0,0,0.4), inset 0 -1px 0 rgba(212,169,64,0.12);
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+  }
+
+  .brand_mark {
+    width: 22px;
+    height: 22px;
+    border: 1px solid var(--accent-brass-dim);
+    color: var(--accent-brass);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 12px;
+    line-height: 1;
+    transform: rotate(45deg);
+  }
+
+  .brand_mark > span { transform: rotate(-45deg); }
+
+  .wordmark {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 14px;
+    letter-spacing: 0.28em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+  }
+
+  .blood {
+    color: var(--accent-blood);
+    text-shadow: 0 0 18px var(--accent-blood-glow);
+  }
+
+  .crumbs {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-dim);
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 10px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .crumbs_current {
+    color: var(--accent-brass);
+  }
+
+  .sep { color: var(--border-highlight); }
+
+  .top_right {
+    margin-left: auto;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .clock {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.08em;
+  }
+
+  .clock b {
+    color: var(--text-bright);
+    font-weight: 400;
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    padding: 4px 8px;
+    border: 1px solid var(--border-main);
+    color: var(--text-primary);
+    background: #14100a;
+    white-space: nowrap;
+  }
+
+  .pill_ok {
+    color: var(--status-ok);
+    border-color: color-mix(in oklab, var(--status-ok) 40%, transparent);
+  }
+
+  .pill_warn {
+    color: var(--accent-brass);
+    border-color: color-mix(in oklab, var(--accent-brass) 40%, transparent);
+  }
+
+  .pill_bad {
+    color: var(--accent-blood);
+    border-color: color-mix(in oklab, var(--accent-blood) 50%, transparent);
+  }
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 6px currentColor;
+  }
+
+  .nav {
+    background: linear-gradient(180deg, #18110c, #0e0806);
+    border-right: 1px solid var(--border-main);
+    padding: 16px 0;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
+
+  .nav_section {
+    padding: 14px 18px 6px;
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .nav_section::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, var(--border-highlight), transparent);
+  }
+
+  .nav_link {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    padding: 8px 18px;
+    color: var(--text-primary);
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 11px;
+    text-decoration: none;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-left: 2px solid transparent;
+    position: relative;
+  }
+
+  .nav_link:hover {
+    color: var(--accent-brass);
+    background: rgba(212,169,64,0.05);
+  }
+
+  .nav_link_active {
+    color: var(--accent-brass);
+    border-left-color: var(--accent-brass);
+    background: linear-gradient(90deg, rgba(212,169,64,0.1), transparent 70%);
+  }
+
+  .nav_link_active::after {
+    content: "";
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--accent-brass);
+    box-shadow: 0 0 8px var(--accent-brass);
+    transform: translateY(-50%);
+  }
+
+  .nav_link_soon {
+    color: var(--text-dim);
+    opacity: 0.62;
+  }
+
+  .nav_glyph {
+    width: 14px;
+    height: 14px;
+    border: 1px solid currentColor;
+    opacity: 0.55;
+    transform: rotate(45deg);
+    flex-shrink: 0;
+  }
+
+  .nav_link_active .nav_glyph {
+    opacity: 1;
+    box-shadow: 0 0 8px var(--accent-glow);
+  }
+
+  .tail {
+    margin-left: auto;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--accent-blood);
+  }
+
+  .main {
+    min-width: 0;
+    overflow: auto;
+  }
+
+  .hud {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    background: linear-gradient(180deg, #1a140e, #140d08);
+    border-bottom: 1px solid var(--border-highlight);
+  }
+
+  .hud_cell {
+    padding: 10px 14px;
+    border-right: 1px solid var(--border-main);
+    position: relative;
+    min-width: 0;
+  }
+
+  .hud_cell:last-child { border-right: 0; }
+
+  .hud_k {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .hud_v {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 13px;
+    letter-spacing: 0.14em;
+    color: var(--text-bright);
+    margin-top: 3px;
+    text-transform: uppercase;
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .hud_ok { color: var(--status-ok); }
+  .hud_warn { color: var(--accent-brass); }
+  .hud_bad { color: var(--accent-blood); }
+
+  .page {
+    padding: 22px 28px 60px;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+
+  .aside {
+    background: linear-gradient(180deg, #16100a, #0e0806);
+    border-left: 1px solid var(--border-main);
+    padding: 18px 18px 30px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+
+  .aside_title {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 11px;
+    letter-spacing: 0.28em;
+    color: var(--accent-brass);
+    text-transform: uppercase;
+    margin: 0 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .aside_title::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, var(--border-highlight), transparent);
+  }
+
+  .aside_title .r {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--text-dim);
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+    text-transform: none;
+  }
+
+  .focus {
+    position: relative;
+    padding: 16px 16px 14px;
+    background: linear-gradient(180deg, #241a12, #14100a);
+    border: 1px solid var(--accent-brass-dim);
+  }
+
+  .focus::before {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    border: 1px solid var(--border-highlight);
+    pointer-events: none;
+  }
+
+  .focus_inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .focus_row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .portrait {
+    width: 46px;
+    height: 46px;
+    border: 1px solid var(--accent-brass);
+    display: grid;
+    place-items: center;
+    color: var(--accent-brass);
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 20px;
+    background:
+      radial-gradient(circle at 35% 25%, rgba(212,169,64,0.16), transparent 38%),
+      linear-gradient(180deg, #241a12, #100a07);
+  }
+
+  .focus_name {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 16px;
+    color: var(--accent-brass);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .focus_role {
+    font-family: var(--font-body, 'EB Garamond', serif);
+    font-style: italic;
+    font-size: 11px;
+    color: var(--text-dim);
+    margin-top: 2px;
+  }
+
+  .vial_lbl {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--text-dim);
+    margin-bottom: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .vial_lbl b {
+    color: var(--text-bright);
+    font-weight: 400;
+  }
+
+  .vial {
+    height: 8px;
+    background: #0a0604;
+    border: 1px solid var(--border-main);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .vial > span {
+    display: block;
+    height: 100%;
+    width: 62%;
+    background: linear-gradient(90deg, #3d6a28, #6a9a44);
+    box-shadow: 0 0 6px rgba(106,154,68,0.35);
+  }
+
+  .vial::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(90deg, transparent 0 19px, rgba(0,0,0,0.5) 19px 20px);
+    pointer-events: none;
+  }
+
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px 14px;
+  }
+
+  .stat_l {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+  }
+
+  .stat_v {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    color: var(--text-bright);
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .flame {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--text-bright);
+    border: 1px solid rgba(120,100,80,0.14);
+    background: #0c0806;
+    padding: 1px;
+  }
+
+  .flame_row {
+    display: flex;
+    height: 16px;
+    gap: 1px;
+    margin-bottom: 1px;
+  }
+
+  .flame_row:last-child { margin-bottom: 0; }
+
+  .flame_block {
+    padding: 0 5px;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    background: #2a2838;
+    color: #b8c0e0;
+  }
+
+  .flame_plan { background: #2a3a2a; color: #c4dcb0; }
+  .flame_exec { background: #3a2a2a; color: #e4b8b0; }
+  .flame_wait { background: #1a1410; color: var(--text-dim); }
+  .flame_err { background: #3a1010; color: #e0b8a8; }
+
+  .events {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .event {
+    display: grid;
+    grid-template-columns: 56px 14px 1fr;
+    gap: 10px;
+    padding: 8px 0;
+    border-bottom: 1px dashed var(--border-main);
+    align-items: baseline;
+  }
+
+  .event:last-child { border-bottom: 0; }
+
+  .event_time {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .event_mark {
+    width: 10px;
+    height: 10px;
+    border: 1px solid var(--accent-brass-dim);
+    transform: rotate(45deg);
+  }
+
+  .event_bad { border-color: var(--accent-blood); box-shadow: 0 0 5px var(--accent-blood-glow); }
+  .event_ok { border-color: var(--status-ok); }
+
+  .event_body {
+    font-family: var(--font-body, 'EB Garamond', serif);
+    font-size: 12px;
+    color: var(--text-primary);
+    line-height: 1.45;
+  }
+
+  .event_body code {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--accent-brass);
+    background: rgba(212,169,64,0.08);
+    padding: 0 5px;
+    border: 1px solid var(--border-main);
+  }
+
+  @media (max-width: 1180px) {
+    .shell {
+      grid-template-columns: 200px minmax(0, 1fr);
+    }
+    .aside {
+      display: none;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .shell {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto 1fr;
+    }
+    .topbar {
+      min-height: 52px;
+      flex-wrap: wrap;
+      padding: 10px 14px;
+    }
+    .nav {
+      grid-row: 2;
+      flex-direction: row;
+      overflow-x: auto;
+      border-right: 0;
+      border-bottom: 1px solid var(--border-main);
+      padding: 6px 0;
+    }
+    .nav_section {
+      display: none;
+    }
+    .nav_link {
+      flex: 0 0 auto;
+      border-left: 0;
+      border-bottom: 2px solid transparent;
+      padding: 8px 12px;
+    }
+    .nav_link_active {
+      border-bottom-color: var(--accent-brass);
+    }
+    .nav_link_active::after {
+      display: none;
+    }
+    .main {
+      grid-row: 3;
+    }
+    .hud {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .page {
+      padding: 18px 16px 44px;
+    }
+  }
+|}]
+
+type tone =
+  [ `Neutral
+  | `Ok
+  | `Warn
+  | `Bad
+  ]
+
+let label (route : Route.t) = Route.label route
+
+let section text =
+  Node.div ~attrs:[ Style.nav_section ] [ Node.text text ]
+;;
+
+let route_tail = function
+  | Route.Dead_keepers -> Some "03"
+  | Keepers -> Some "IV"
+  | Goals -> Some "07"
+  | _ -> None
+;;
+
+let nav_link ~(active : Route.t) (route : Route.t) =
+  let attrs =
+    let base = [ Style.nav_link ] in
+    let base = if Route.equal active route then Style.nav_link_active :: base else base in
+    let base =
+      if Route.is_implemented route then base else Style.nav_link_soon :: base
+    in
+    Attr.href (Route.path route) :: base
+  in
+  let tail =
+    match route_tail route with
+    | Some text -> [ Node.span ~attrs:[ Style.tail ] [ Node.text text ] ]
+    | None -> []
+  in
+  Node.a
+    ~attrs
+    ([ Node.span ~attrs:[ Style.nav_glyph ] []
+     ; Node.text (label route)
+     ]
+     @ tail)
+;;
+
+let nav ~(active : Route.t) =
+  let lnk = nav_link ~active in
+  Node.div
+    ~attrs:[ Style.nav ]
+    [ section "chronicle"
+    ; lnk Overview
+    ; lnk Logs
+    ; lnk Goals
+    ; section "runtime"
+    ; lnk Keepers
+    ; lnk Observatory
+    ; lnk Intervene
+    ; section "lab"
+    ; lnk Tools
+    ; lnk Sessions
+    ; lnk Social_board
+    ; section "crypt"
+    ; lnk Dead_keepers
+    ; lnk Archive_runs
+    ]
+;;
+
+let pill ?(tone : tone = `Neutral) text =
+  let attrs =
+    match tone with
+    | `Neutral -> [ Style.pill ]
+    | `Ok -> [ Style.pill; Style.pill_ok ]
+    | `Warn -> [ Style.pill; Style.pill_warn ]
+    | `Bad -> [ Style.pill; Style.pill_bad ]
+  in
+  Node.span
+    ~attrs
+    [ Node.span ~attrs:[ Style.dot ] []
+    ; Node.text text
+    ]
+;;
+
+let topbar ~(active : Route.t) =
+  Node.div
+    ~attrs:[ Style.topbar ]
+    [ Node.div
+        ~attrs:[ Style.brand ]
+        [ Node.div ~attrs:[ Style.brand_mark ] [ Node.span [ Node.text "M" ] ]
+        ; Node.span
+            ~attrs:[ Style.wordmark ]
+            [ Node.text "MA"
+            ; Node.span ~attrs:[ Style.blood ] [ Node.text "S" ]
+            ; Node.text "C"
+            ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.crumbs ]
+        [ Node.span [ Node.text "Chronicle" ]
+        ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
+        ; Node.span [ Node.text "dashboard bonsai" ]
+        ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
+        ; Node.strong ~attrs:[ Style.crumbs_current ] [ Node.text (label active) ]
+        ]
+    ; Node.div
+        ~attrs:[ Style.top_right ]
+        [ Node.span
+            ~attrs:[ Style.clock ]
+            [ Node.text "Bonsai "
+            ; Node.b [ Node.text "v0.18" ]
+            ]
+        ; pill ~tone:`Ok "sse live"
+        ; pill "operator"
+        ]
+    ]
+;;
+
+let hud_cell ?(tone : tone = `Neutral) ~k ~v () =
+  let v_attrs =
+    match tone with
+    | `Neutral -> [ Style.hud_v ]
+    | `Ok -> [ Style.hud_v; Style.hud_ok ]
+    | `Warn -> [ Style.hud_v; Style.hud_warn ]
+    | `Bad -> [ Style.hud_v; Style.hud_bad ]
+  in
+  Node.div
+    ~attrs:[ Style.hud_cell ]
+    [ Node.div ~attrs:[ Style.hud_k ] [ Node.text k ]
+    ; Node.div ~attrs:v_attrs [ Node.text v ]
+    ]
+;;
+
+let default_hud ~(active : Route.t) =
+  [ hud_cell ~k:"Room" ~v:"local" ()
+  ; hud_cell ~tone:`Ok ~k:"Session" ~v:"running" ()
+  ; hud_cell ~k:"Surface" ~v:"bonsai" ()
+  ; hud_cell ~tone:`Warn ~k:"Route" ~v:(label active) ()
+  ; hud_cell ~k:"Prefix" ~v:"/dashboard/b" ()
+  ; hud_cell ~tone:`Ok ~k:"Build" ~v:"js_of_ocaml" ()
+  ]
+;;
+
+let aside_title ?right text =
+  Node.h4
+    ~attrs:[ Style.aside_title ]
+    ([ Node.text text ]
+     @
+     match right with
+     | Some r -> [ Node.span ~attrs:[ Style.r ] [ Node.text r ] ]
+     | None -> [])
+;;
+
+let focus_card ~(active : Route.t) =
+  Node.div
+    [ aside_title ~right:"shared shell" "Focus"
+    ; Node.div
+        ~attrs:[ Style.focus ]
+        [ Node.div
+            ~attrs:[ Style.focus_inner ]
+            [ Node.div
+                ~attrs:[ Style.focus_row ]
+                [ Node.div ~attrs:[ Style.portrait ] [ Node.text "M" ]
+                ; Node.div
+                    [ Node.div ~attrs:[ Style.focus_name ] [ Node.text (label active) ]
+                    ; Node.div
+                        ~attrs:[ Style.focus_role ]
+                        [ Node.text "Dashboard v2 chrome absorbed into Bonsai" ]
+                    ]
+                ]
+            ; Node.div
+                [ Node.div
+                    ~attrs:[ Style.vial_lbl ]
+                    [ Node.span [ Node.text "Context" ]
+                    ; Node.span
+                        [ Node.b [ Node.text "62%" ]
+                        ; Node.text " . compact @ 85%"
+                        ]
+                    ]
+                ; Node.div ~attrs:[ Style.vial ] [ Node.span [] ]
+                ]
+            ; Node.div
+                ~attrs:[ Style.stats ]
+                [ Node.div
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Turns" ]
+                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "7 / 15" ]
+                    ]
+                ; Node.div
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Route" ]
+                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text (label active) ]
+                    ]
+                ; Node.div
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Shell" ]
+                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "v2" ]
+                    ]
+                ; Node.div
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Prefix" ]
+                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "b" ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+;;
+
+let flame_block ?(cls = Style.flame_block) ~flex text =
+  Node.div
+    ~attrs:
+      [ cls
+      ; Attr.style
+          (Css_gen.create
+             ~field:"flex-grow"
+             ~value:(Float.to_string flex))
+      ]
+    [ Node.text text ]
+;;
+
+let flame () =
+  Node.div
+    [ aside_title ~right:"2.40s" "Last turn"
+    ; Node.div
+        ~attrs:[ Style.flame ]
+        [ Node.div
+            ~attrs:[ Style.flame_row ]
+            [ flame_block ~flex:240. "bonsai.shell()" ]
+        ; Node.div
+            ~attrs:[ Style.flame_row ]
+            [ flame_block ~cls:Style.flame_plan ~flex:40. "plan"
+            ; flame_block ~cls:Style.flame_exec ~flex:160. "absorb"
+            ; flame_block ~flex:40. "reflect"
+            ]
+        ; Node.div
+            ~attrs:[ Style.flame_row ]
+            [ flame_block ~cls:Style.flame_wait ~flex:40. "route"
+            ; flame_block ~flex:70. "topbar"
+            ; flame_block ~cls:Style.flame_exec ~flex:60. "nav"
+            ; flame_block ~cls:Style.flame_err ~flex:30. "aside"
+            ; flame_block ~cls:Style.flame_wait ~flex:40. "hud"
+            ]
+        ]
+    ]
+;;
+
+let chronicle () =
+  let event ?(tone : tone = `Neutral) time body =
+    let mark_attrs =
+      match tone with
+      | `Ok -> [ Style.event_mark; Style.event_ok ]
+      | `Bad -> [ Style.event_mark; Style.event_bad ]
+      | _ -> [ Style.event_mark ]
+    in
+    Node.div
+      ~attrs:[ Style.event ]
+      [ Node.span ~attrs:[ Style.event_time ] [ Node.text time ]
+      ; Node.span ~attrs:mark_attrs []
+      ; Node.span ~attrs:[ Style.event_body ] body
+      ]
+  in
+  Node.div
+    [ aside_title ~right:"live" "Chronicle"
+    ; Node.div
+        ~attrs:[ Style.events ]
+        [ event ~tone:`Ok "now"
+            [ Node.code [ Node.text "shell" ]
+            ; Node.text " . dashboard_v2 chrome mounted."
+            ]
+        ; event "t-01"
+            [ Node.text "Route body keeps its own projection and data fetch." ]
+        ; event ~tone:`Bad "t-02"
+            [ Node.text "Old two-column placeholder shell retired from active tabs." ]
+        ; event "t-03"
+            [ Node.text "Design tokens loaded from "
+            ; Node.code [ Node.text "colors_and_type.css" ]
+            ; Node.text "."
+            ]
+        ]
+    ]
+;;
+
+let default_aside ~(active : Route.t) =
+  Node.div
+    ~attrs:[ Style.aside ]
+    [ focus_card ~active
+    ; flame ()
+    ; chronicle ()
+    ]
+;;
+
+let view ?hud ?aside ~(active : Route.t) (children : Node.t list) =
+  let hud_nodes =
+    match hud with
+    | Some nodes -> nodes
+    | None -> default_hud ~active
+  in
+  let aside_node =
+    match aside with
+    | Some node -> node
+    | None -> default_aside ~active
+  in
+  Node.div
+    ~attrs:[ Style.shell ]
+    [ topbar ~active
+    ; nav ~active
+    ; Node.div
+        ~attrs:[ Style.main ]
+        [ Node.div ~attrs:[ Style.hud ] hud_nodes
+        ; Node.div ~attrs:[ Style.page ] children
+        ]
+    ; aside_node
+    ]
+;;

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Share+Tech+Mono&display=swap');
+
 /* ══════════════════════════════════════════════════════════════
    MASC — Colors & Type
    The brand runs across 4 themes (Dark Fantasy / Cyberpunk /
@@ -7,21 +9,8 @@
    Paper/Ink dashboard inversion (used as the docs/light surface).
    ══════════════════════════════════════════════════════════════ */
 
-/* Local fonts — copied from viewer/assets/fonts */
-@font-face {
-  font-family: 'Cinzel';
-  src: url('fonts/Cinzel-Regular.ttf') format('truetype');
-  font-weight: 400 700;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Noto Sans KR';
-  src: url('fonts/NotoSansKR-Regular.ttf') format('truetype');
-  font-weight: 300 700;
-  font-display: swap;
-}
-/* Webfonts the viewer also uses — fetched from Google when available */
-@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Share+Tech+Mono&display=swap');
+/* Bonsai shell loads Cinzel and Noto Sans KR from its HTML prelude. Keep this
+   token file free of local font URLs so /dashboard/b/assets stays self-contained. */
 
 /* ── Dark Fantasy (default) — Visceral · decay-forward ── */
 :root,


### PR DESCRIPTION
## What changed

- Added a shared Bonsai `Shell_view` for `/dashboard/b/*` based on the MASC Design System dashboard v2 chrome.
- Wired overview, goals, keepers, dead keepers, archive runs, and placeholder routes into the shared shell.
- Cleaned Bonsai design token CSS so `/dashboard/b/assets` no longer requests missing local font files.

## Why

The Bonsai migration had route-level content, but most routes did not share the dashboard v2 topbar/nav/HUD/right-aside structure, so `/dashboard/b/logs` looked much more complete than the other pages. This brings the migrated routes under the same visual frame.

## Validation

- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root .`
- `make bonsai-dashboard`
- Browser smoke on `http://127.0.0.1:8935/dashboard/b/overview`, `/goals`, and `/keepers`
- DevTools network/console check: Bonsai JS/CSS/API requests returned 200; only Bonsai's standard debug console groups remained.