### PR TITLE
[codex] Harden dashboard execution status JSON handling

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -156,22 +156,17 @@ let parse_agent_status (config : Coord.config) ~(agent_name : string) : Yojson.S
               ]))
 
 let json_string_opt key json =
-  match Yojson.Safe.Util.member key json with
-  | `String s ->
+  match Safe_ops.json_string_opt key json with
+  | Some s ->
       let trimmed = String.trim s in
       if trimmed = "" then None else Some trimmed
-  | _ -> None
+  | None -> None
 
 let json_bool key json default =
-  match Yojson.Safe.Util.member key json with
-  | `Bool value -> value
-  | _ -> default
+  Safe_ops.json_bool ~default key json
 
 let json_float_opt key json =
-  match Yojson.Safe.Util.member key json with
-  | `Float value -> Some value
-  | `Int value -> Some (float_of_int value)
-  | _ -> None
+  Safe_ops.json_float_opt key json
 
 let agent_status_text agent_status =
   json_string_opt "status" agent_status

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -80,9 +80,7 @@ let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
     Keeper_exec_status.agent_runtime_has_live_signal agent_status_json
   in
   let is_zombie =
-    match U.member "is_zombie" agent_status_json with
-    | `Bool value -> value
-    | _ -> false
+    Safe_ops.json_bool ~default:false "is_zombie" agent_status_json
   in
   match (runtime_status, has_live_signal, is_zombie) with
   | Some status, true, false -> Some status
@@ -90,9 +88,8 @@ let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
 
 let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
   let kh =
-    match U.member "health_state" diagnostic with
-    | `String s -> Keeper_exec_status.keeper_health_of_string s
-    | _ -> Keeper_types.KH_offline
+    Safe_ops.json_string ~default:"offline" "health_state" diagnostic
+    |> Keeper_exec_status.keeper_health_of_string
   in
   match kh with
   | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false
@@ -424,9 +421,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    Keeper_status_bridge.runtime_keepalive_running config meta
                  in
                  let agent_exists =
-                   match agent_json |> U.member "exists" with
-                   | `Bool value -> value
-                   | _ -> false
+                   Safe_ops.json_bool ~default:false "exists" agent_json
                  in
                  let now_ts = Time_compat.now () in
                  let keepalive_started_at =

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -84,6 +84,13 @@ let test_keeper_surface_status_maps_dead_to_inactive () =
   in
   check string "dead keeper is not surfaced as busy" "inactive" status
 
+let test_keeper_status_helpers_tolerate_null_status_json () =
+  check string "null agent status is unknown" "unknown" (ES.agent_status_text `Null);
+  check bool "null agent status has no live signal" false
+    (ES.agent_runtime_has_live_signal `Null);
+  check string "null surface inputs fall back offline" "offline"
+    (ES.keeper_surface_status ~agent_status:`Null ~diagnostic:`Null)
+
 (* --- keeper_health_state tests (online/offline mismatch fix) --- *)
 
 let make_agent_status ?(exists = true) ?(status = "active")
@@ -95,6 +102,18 @@ let make_agent_status ?(exists = true) ?(status = "active")
     ("last_seen_ago_s", `Float last_seen_ago_s);
     ("is_zombie", `Bool is_zombie);
   ]
+
+let test_keeper_diagnostic_tolerates_null_agent_status () =
+  let meta = make_meta ~name:"keeper-null-agent-status-test" () in
+  let diagnostic =
+    ES.keeper_diagnostic_json ~meta ~agent_status:`Null ~keepalive_running:true
+      ~history_items:[] ~now_ts:(Time_compat.now ())
+  in
+  let open Yojson.Safe.Util in
+  check string "null agent status maps diagnostic offline" "offline"
+    (diagnostic |> member "health_state" |> to_string);
+  check string "null agent status maps quiet reason" "agent_missing"
+    (diagnostic |> member "quiet_reason" |> to_string)
 
 let test_health_keepalive_running_overrides_stale_last_seen () =
   let meta = make_meta () in
@@ -449,6 +468,8 @@ let () =
             test_health_keepalive_not_running_not_stale_is_offline;
           test_case "fresh live signal suppresses stale error degradation" `Quick
             test_diagnostic_ignores_stale_error_when_live_signal_is_newer;
+          test_case "diagnostic tolerates null agent status json" `Quick
+            test_keeper_diagnostic_tolerates_null_agent_status;
         ] );
       ( "surface_status",
         [
@@ -462,6 +483,8 @@ let () =
             test_keeper_surface_status_maps_zombie_to_inactive;
           test_case "maps dead to inactive" `Quick
             test_keeper_surface_status_maps_dead_to_inactive;
+          test_case "status helpers tolerate null status json" `Quick
+            test_keeper_status_helpers_tolerate_null_status_json;
           test_case "runtime surface derives slot wait timeout blocker" `Quick
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
           test_case "runtime surface derives continue-gate blocker" `Quick

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -17,6 +17,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_align_keeper_runtime_status_ignores_zombie_runtime_signal;
+          Alcotest.test_case "snapshot runtime alignment tolerates null status json"
+            `Quick
+            Test_operator_control_snapshot
+            .test_align_keeper_runtime_status_tolerates_null_status_json;
           Alcotest.test_case "snapshot context ratio resolves cli provider budget"
             `Quick
             Test_operator_control_snapshot

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -51,6 +51,15 @@ let test_align_keeper_runtime_status_ignores_zombie_runtime_signal () =
   Alcotest.(check string) "zombie runtime does not override inactive" "inactive"
     status
 
+let test_align_keeper_runtime_status_tolerates_null_status_json () =
+  let status =
+    Operator_control_snapshot.align_keeper_runtime_status
+      ~surface_status:"inactive" ~diagnostic:`Null ~agent_status_json:`Null
+      ~keepalive_running:true
+  in
+  Alcotest.(check string) "null runtime status keeps surface status" "inactive"
+    status
+
 let test_compute_context_ratio_uses_resolved_cli_context_budget () =
   let base =
     match


### PR DESCRIPTION
## Summary

- Hardened dashboard/operator keeper status projections so `null` or otherwise non-object JSON falls back to safe defaults instead of raising `Yojson__Safe.Util.Type_error`.
- Reused `Safe_ops` in keeper status helpers for string/bool/float extraction, preserving blank-string trimming for status strings.
- Added regression coverage for null agent status JSON in keeper diagnostics and dashboard runtime status alignment.

## Root Cause

`/api/v1/dashboard/execution` can project keeper/agent status JSON from live runtime state. One path assumed the value was always an object and called `Yojson.Safe.Util.member "exists"` directly. If the value was `null`, Yojson raised `Type_error("Can't get member 'exists' of non-object type null", ...)`, which escaped as HTTP 500.

## Validation

- `dune build --root .`
- `dune exec --root . ./test/test_operator_control.exe`
- `dune exec --root . ./test/test_keeper_exec_status.exe -- test --quick-tests`
- `dune exec --root . ./test/test_keeper_exec_status.exe -- test health_state 10`
- `dune exec --root . ./test/test_keeper_exec_status.exe -- test surface_status 5`
- `git diff --check`

Note: `dune build --root . @fmt` still fails on existing repo-wide formatting drift in unrelated dune/OCaml files, so it was not used as a gating signal for this narrow patch.