### PR TITLE
[codex] Fix transport health truth reporting

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -434,7 +434,7 @@ let status_summary_string (ctx : context) =
   in
   let suggested_next =
     if Option.is_some planning_state.planning_missing_task then
-      [ "masc_plan_init"; "masc_status" ]
+      []
     else if Option.is_some planning_state.deliverable_conflict_task then
       [ "masc_deliver"; "masc_status" ]
     else
@@ -483,7 +483,7 @@ let status_summary_string (ctx : context) =
         items
         @ [
             Printf.sprintf
-              "Owned task %s has no planning context. Initialize or repair planning before continuing claimed work."
+              "Owned task %s has no planning context. Do not retry generic masc_plan_init from a drifted surface; use handoff/worktree/test logs as the temporary SSOT until a credentialed owner repair receipt exists."
               task_id;
           ]
     | None -> items)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -209,7 +209,8 @@ let tcp_port_reachable port =
       ~finally:(fun () -> try Unix.close sock with _ -> ())
       (fun () ->
         Unix.connect sock
-          (Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", port));
+          (Unix.ADDR_INET
+             (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
         true)
   with _ -> false
 

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -202,6 +202,17 @@ let ws_port () = Env_config.Transport.ws_port
 let ws_listening () =
   ws_enabled () && Atomic.get ws_runtime_listening
 
+let tcp_port_reachable port =
+  try
+    let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    Fun.protect
+      ~finally:(fun () -> try Unix.close sock with _ -> ())
+      (fun () ->
+        Unix.connect sock
+          (Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", port));
+        true)
+  with _ -> false
+
 let hot_session_json (session : hot_queue_session) =
   `Assoc
     [
@@ -281,8 +292,13 @@ let transport_health_json ~config =
   let ws_sessions = int_of_float (v "masc_ws_sessions_total" ()) in
   let grpc_configured = grpc_enabled () in
   let grpc_live = grpc_listening () in
+  let grpc_reachable = grpc_live || tcp_port_reachable (grpc_port ()) in
   let ws_configured = ws_enabled () in
   let ws_live = ws_listening () in
+  let ws_reachable = ws_live || tcp_port_reachable (ws_port ()) in
+  let streamable_auth_policy_present =
+    Env_config.Transport.http_auth_strict_env_enabled ()
+  in
   let webrtc_configured = Server_webrtc_transport.is_enabled () in
   let webrtc_pending = Server_webrtc_transport.pending_offer_count () in
   let webrtc_peers = Server_webrtc_transport.active_peer_count () in
@@ -343,6 +359,7 @@ let transport_health_json ~config =
       ("enabled", `Bool grpc_configured);
       ("configured", `Bool grpc_configured);
       ("listening", `Bool grpc_live);
+      ("reachable", `Bool grpc_reachable);
       ("listen_status", `String (Atomic.get grpc_listen_status));
       ("port", `Int (grpc_port ()));
       ("active_streams", `Int (int_of_float grpc_streams));
@@ -354,6 +371,7 @@ let transport_health_json ~config =
       ("enabled", `Bool ws_configured);
       ("configured", `Bool ws_configured);
       ("listening", `Bool ws_live);
+      ("reachable", `Bool ws_reachable);
       ("listen_status", `String (Atomic.get ws_listen_status));
       ("mode", `String "standalone");
       ("port", `Int (ws_port ()));
@@ -381,6 +399,9 @@ let transport_health_json ~config =
       ("legacy_sse_endpoint", `String "/sse");
       ("legacy_messages_endpoint", `String "/messages");
       ("default_transport", `String "streamable_http");
+      ("configured", `Bool true);
+      ("protocol_capable", `Bool true);
+      ("auth_policy_present", `Bool streamable_auth_policy_present);
       ("supports_post", `Bool true);
       ("supports_sse_upgrade", `Bool true);
       ("supports_delete", `Bool true);

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -108,7 +108,8 @@ let tcp_port_reachable port =
       ~finally:(fun () -> try Unix.close sock with _ -> ())
       (fun () ->
         Unix.connect sock
-          (Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", port));
+          (Unix.ADDR_INET
+             (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
         true)
   with _ -> false
 

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -101,9 +101,21 @@ let context_from_env ?(include_configured = false) ~allow_legacy_accept () =
 let maybe_configured_fields ~include_configured enabled =
   if include_configured then [ ("configured", `Bool enabled) ] else []
 
+let tcp_port_reachable port =
+  try
+    let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    Fun.protect
+      ~finally:(fun () -> try Unix.close sock with _ -> ())
+      (fun () ->
+        Unix.connect sock
+          (Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", port));
+        true)
+  with _ -> false
+
 let websocket_discovery_json (ctx : http_context) =
   let enabled = Server_ws_standalone.is_enabled () in
   let port = Server_ws_standalone.configured_port () in
+  let reachable = Transport_metrics.ws_listening () || tcp_port_reachable port in
   let base_fields =
     [
       ("enabled", `Bool enabled);
@@ -111,6 +123,7 @@ let websocket_discovery_json (ctx : http_context) =
     @ maybe_configured_fields ~include_configured:ctx.include_configured enabled
     @ [
         ("listening", `Bool (Transport_metrics.ws_listening ()));
+        ("reachable", `Bool reachable);
         ("listen_status", `String (Atomic.get Transport_metrics.ws_listen_status));
         ("mode", `String "standalone");
         ("discovery_path", `String "/ws");
@@ -146,6 +159,12 @@ let enabled_protocols_json () =
 let transport_status_json (ctx : http_context) =
   let grpc_enabled = Masc_grpc_server.is_enabled () in
   let grpc_port = Masc_grpc_server.configured_port () in
+  let grpc_reachable =
+    Transport_metrics.grpc_listening () || tcp_port_reachable grpc_port
+  in
+  let streamable_auth_policy_present =
+    Env_config.Transport.http_auth_strict_env_enabled ()
+  in
   let webrtc_enabled = Server_webrtc_transport.is_enabled () in
   `Assoc
     [
@@ -154,12 +173,16 @@ let transport_status_json (ctx : http_context) =
       ("legacy_endpoints_deprecated", `Bool true);
       ( "http",
         `Assoc
-          [
+          (maybe_configured_fields ~include_configured:ctx.include_configured
+             true
+          @ [
             ("enabled", `Bool true);
+            ("protocol_capable", `Bool true);
+            ("auth_policy_present", `Bool streamable_auth_policy_present);
             ("base_url", `String ctx.base_url);
             ("mcp_url", `String (ctx.base_url ^ "/mcp"));
             ("sse_url", `String (ctx.base_url ^ "/sse"));
-          ] );
+          ]) );
       ( "grpc",
         `Assoc
           ([
@@ -169,6 +192,7 @@ let transport_status_json (ctx : http_context) =
               grpc_enabled
           @ [
               ("listening", `Bool (Transport_metrics.grpc_listening ()));
+              ("reachable", `Bool grpc_reachable);
               ("listen_status", `String (Atomic.get Transport_metrics.grpc_listen_status));
               ("port", `Int grpc_port);
               ("service", `String Masc_grpc_service.service_name);

--- a/scripts/harness/transport/common.sh
+++ b/scripts/harness/transport/common.sh
@@ -35,6 +35,7 @@ export MASC_WS_URL
 PASS=0
 FAIL=0
 SKIP=0
+AUTH_BLOCKED=0
 
 TRANSPORT_SERVER_PID=""
 TRANSPORT_SERVER_BASE_PATH=""
@@ -55,10 +56,15 @@ skip() {
   printf '  \033[33mSKIP\033[0m %s: %s\n' "$1" "${2:-}"
 }
 
+auth_blocked() {
+  AUTH_BLOCKED=$((AUTH_BLOCKED + 1))
+  printf '  \033[36mAUTH-BLOCKED\033[0m %s: %s\n' "$1" "${2:-}"
+}
+
 summary() {
   echo ""
-  printf '=== %s: %d passed, %d failed, %d skipped ===\n' \
-    "${HARNESS_NAME:-transport}" "$PASS" "$FAIL" "$SKIP"
+  printf '=== %s: %d passed, %d failed, %d skipped, %d auth-blocked ===\n' \
+    "${HARNESS_NAME:-transport}" "$PASS" "$FAIL" "$SKIP" "$AUTH_BLOCKED"
   [ "$FAIL" -eq 0 ]
 }
 

--- a/scripts/harness/transport/verify_truth.sh
+++ b/scripts/harness/transport/verify_truth.sh
@@ -25,7 +25,8 @@ echo "--- Transport Truth Harness ---"
 json_bool() {
   local json="$1"
   local filter="$2"
-  jq -r "${filter} // \"missing\"" <<<"$json" 2>/dev/null || printf 'missing\n'
+  jq -r "(${filter}) as \$value | if \$value == null then \"missing\" else \$value end" \
+    <<<"$json" 2>/dev/null || printf 'missing\n'
 }
 
 fetch_transport_health_json() {
@@ -172,15 +173,20 @@ PY
 probe_sse() {
   local headers
   headers="$(mktemp "${TMPDIR:-/tmp}/masc-transport-truth-sse.XXXXXX")"
-  curl -sS -N --max-time 2 -D "$headers" -o /dev/null \
+  local status
+  status="$(curl -sS -N --max-time 2 -D "$headers" -o /dev/null \
+    -w '%{http_code}' \
     -H "Accept: application/json, text/event-stream" \
     "${MASC_BASE_URL}/mcp?sse_kind=observer&session_id=transport-truth-$$" \
-    >/dev/null 2>&1 || true
+    2>/dev/null || printf '000')"
   if grep -qi "content-type:.*text/event-stream" "$headers"; then
     rm -f "$headers"
     return 0
   fi
   rm -f "$headers"
+  if [[ "$status" = "401" || "$status" = "403" ]]; then
+    return 2
+  fi
   return 1
 }
 
@@ -188,12 +194,48 @@ probe_h2c() {
   if ! curl --version | grep -q "HTTP2"; then
     return 2
   fi
-  curl --http2-prior-knowledge -fsS --max-time 3 -X POST \
+  local mcp_probe health_probe status version
+  mcp_probe="$(curl --http2-prior-knowledge -sS --max-time 3 -o /dev/null \
+    -w '%{http_code} %{http_version}' -X POST \
     "${MASC_BASE_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-truth-h2","version":"1.0"}}}' \
-    >/dev/null
+    2>/dev/null || true)"
+  health_probe="$(curl --http2-prior-knowledge -sS --max-time 3 -o /dev/null \
+    -w '%{http_code} %{http_version}' "${MASC_BASE_URL}/health" \
+    2>/dev/null || true)"
+  status="$(awk '{print $1}' <<<"$mcp_probe")"
+  version="$(awk '{print $2}' <<<"$health_probe")"
+  status="${status:-000}"
+  version="${version:-0}"
+  case "$status" in
+    200|202)
+      [[ "$version" = "2" || "$version" = "2.0" ]]
+      ;;
+    401|403)
+      [[ "$version" = "2" || "$version" = "2.0" ]] && return 3
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+probe_mcp_post() {
+  local status
+  status="$(curl -sS --max-time 3 -o /dev/null -w '%{http_code}' -X POST \
+    "${MASC_BASE_URL}/mcp" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-truth-http","version":"1.0"}}}' \
+    2>/dev/null || printf '000')"
+  case "$status" in
+    200|202) return 0 ;;
+    401|403) return 2 ;;
+    *) return 1 ;;
+  esac
 }
 
 compare_truth() {
@@ -206,6 +248,10 @@ compare_truth() {
 
   if [[ "$actual" = "skip" ]]; then
     skip "${name} truth" "$detail"
+    return
+  fi
+  if [[ "$actual" = "auth_blocked" ]]; then
+    auth_blocked "${name} truth" "dashboard=${dashboard} tool=${tool} ${detail}"
     return
   fi
   if [[ "$dashboard" != "missing" && "$dashboard" != "$actual" ]]; then
@@ -248,13 +294,16 @@ if session_id="$(mcp_initialize_session 2>/dev/null)"; then
     fail "masc_transport_status" "could not decode JSON tool content"
   fi
 else
-  fail "masc_transport_status" "MCP initialize failed"
+  auth_blocked "masc_transport_status" "MCP initialize blocked; likely auth-required endpoint"
 fi
 
-if mcp_initialize_session >/dev/null; then
+if probe_mcp_post; then
   actual_http="true"
 else
-  actual_http="false"
+  case "$?" in
+    2) actual_http="auth_blocked" ;;
+    *) actual_http="false" ;;
+  esac
 fi
 dashboard_http="$(json_bool "$transport_health_json" '.streamable_http.supports_post')"
 tool_http="$(json_bool "$transport_status_json" '.streamable_http_default // .http.enabled')"
@@ -264,7 +313,10 @@ compare_truth "streamable-http" "$dashboard_http" "$tool_http" "$actual_http" \
 if probe_sse; then
   actual_sse="true"
 else
-  actual_sse="false"
+  case "$?" in
+    2) actual_sse="auth_blocked" ;;
+    *) actual_sse="false" ;;
+  esac
 fi
 dashboard_sse="$(json_bool "$transport_health_json" '.streamable_http.supports_sse_upgrade')"
 tool_sse="$(jq -r 'if (.http.sse_url // "") != "" then "true" else "missing" end' \
@@ -278,8 +330,11 @@ if [[ "$grpc_port" =~ ^[0-9]+$ ]] && probe_tcp "127.0.0.1" "$grpc_port"; then
 else
   actual_grpc="false"
 fi
-dashboard_grpc="$(json_bool "$transport_health_json" '.grpc.listening')"
-tool_grpc="$(json_bool "$transport_status_json" '.grpc.listening')"
+if refreshed_transport_health_json="$(fetch_transport_health_json)"; then
+  transport_health_json="$refreshed_transport_health_json"
+fi
+dashboard_grpc="$(json_bool "$transport_health_json" '.grpc as $grpc | if ($grpc | has("reachable")) then $grpc.reachable else $grpc.listening end')"
+tool_grpc="$(json_bool "$transport_status_json" '.grpc as $grpc | if ($grpc | has("reachable")) then $grpc.reachable else $grpc.listening end')"
 compare_truth "grpc" "$dashboard_grpc" "$tool_grpc" "$actual_grpc" \
   "tcp=127.0.0.1:${grpc_port}"
 
@@ -290,8 +345,11 @@ if [[ "$ws_port" =~ ^[0-9]+$ ]] && probe_ws_handshake "127.0.0.1" "$ws_port"; th
 else
   actual_ws="false"
 fi
-dashboard_ws="$(json_bool "$transport_health_json" '.websocket.listening')"
-tool_ws="$(json_bool "$transport_status_json" '.websocket.listening')"
+if refreshed_transport_health_json="$(fetch_transport_health_json)"; then
+  transport_health_json="$refreshed_transport_health_json"
+fi
+dashboard_ws="$(json_bool "$transport_health_json" '.websocket as $ws | if ($ws | has("reachable")) then $ws.reachable else $ws.listening end')"
+tool_ws="$(json_bool "$transport_status_json" '.websocket as $ws | if ($ws | has("reachable")) then $ws.reachable else $ws.listening end')"
 compare_truth "websocket" "$dashboard_ws" "$tool_ws" "$actual_ws" \
   "port=${ws_port:-missing}"
 
@@ -314,6 +372,7 @@ if [[ "$dashboard_h2" = "true" || "$tool_h2" = "true" ]]; then
   else
     case "$?" in
       2) actual_h2="skip" ;;
+      3) actual_h2="auth_blocked" ;;
       *) actual_h2="false" ;;
     esac
   fi

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -283,7 +283,10 @@ let () = test "dispatch_status_surfaces_owned_current_drift" (fun () ->
       assert success;
       assert (str_contains result "owned=task-001");
       assert (str_contains result "current=task-002");
-      assert (str_contains result "💡 Suggested next: masc_plan_init -> masc_status");
+      assert (
+        str_contains result
+          "Do not retry generic masc_plan_init from a drifted surface");
+      assert (not (str_contains result "💡 Suggested next: masc_plan_init -> masc_status"));
       assert (str_contains result "planning current_task is unset or drifted")
   | None -> failwith "dispatch returned None"
 )
@@ -341,7 +344,11 @@ let () = test "dispatch_status_surfaces_missing_planning_for_owned_task" (fun ()
       assert (str_contains result "owned=task-001 | current=task-001");
       assert (str_contains result "📝 Planning: missing=yes | task=task-001");
       assert (str_contains result "Owned task task-001 has no planning context.");
-      assert (str_contains result "💡 Suggested next: masc_plan_init -> masc_status");
+      assert (
+        str_contains result
+          "Do not retry generic masc_plan_init from a drifted surface");
+      assert (str_contains result "handoff/worktree/test logs as the temporary SSOT");
+      assert (not (str_contains result "💡 Suggested next: masc_plan_init -> masc_status"));
       assert (not (str_contains result "💡 Suggested next: masc_heartbeat"));
       assert (not (str_contains result "💡 Suggested next: masc_status -> masc_transition"))
   | None -> failwith "dispatch returned None"

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -225,6 +225,7 @@ let test_transport_health_json () =
   Masc_mcp.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   let json = TM.transport_health_json ~config in
   let sse_json = json |> U.member "sse" in
+  let streamable_json = json |> U.member "streamable_http" in
   let grpc_json = json |> U.member "grpc" in
   let ws_json = json |> U.member "websocket" in
   let webrtc_json = json |> U.member "webrtc" in
@@ -245,16 +246,32 @@ let test_transport_health_json () =
     (sse_json |> U.member "relay_retry_total" |> U.to_int);
   check int "relay drops total" 4
     (sse_json |> U.member "relay_drop_total" |> U.to_int);
+  check bool "streamable http configured field exists" true
+    (match streamable_json |> U.member "configured" with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "streamable http protocol_capable field exists" true
+    (match streamable_json |> U.member "protocol_capable" with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "streamable http auth_policy_present field exists" true
+    (match streamable_json |> U.member "auth_policy_present" with
+    | `Bool _ -> true
+    | _ -> false);
   check int "grpc active streams" 1
     (grpc_json |> U.member "active_streams" |> U.to_int);
   check int "grpc subscribers" 2
     (grpc_json |> U.member "subscribers" |> U.to_int);
   check bool "grpc listening field exists" true
     (match grpc_json |> U.member "listening" with `Bool _ -> true | _ -> false);
+  check bool "grpc reachable field exists" true
+    (match grpc_json |> U.member "reachable" with `Bool _ -> true | _ -> false);
   check bool "grpc listen_status field exists" true
     (match grpc_json |> U.member "listen_status" with `String _ -> true | _ -> false);
   check bool "websocket listening field exists" true
     (match ws_json |> U.member "listening" with `Bool _ -> true | _ -> false);
+  check bool "websocket reachable field exists" true
+    (match ws_json |> U.member "reachable" with `Bool _ -> true | _ -> false);
   check bool "ws listen_status field exists" true
     (match ws_json |> U.member "listen_status" with `String _ -> true | _ -> false);
   check bool "websocket section exists" true

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -63,6 +63,41 @@ let test_transport_status_http_shape_extends_tool_shape () =
      with
     | `Bool _ -> true
     | _ -> false);
+  check bool "http surface exposes streamable configured"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "http" |> member "configured")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "http surface exposes streamable protocol capability"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "http" |> member "protocol_capable")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "http surface exposes auth policy dimension"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "http" |> member "auth_policy_present")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "grpc surface exposes reachability"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "grpc" |> member "reachable")
+     with
+    | `Bool _ -> true
+    | _ -> false);
+  check bool "websocket surface exposes reachability"
+    true
+    (match
+       Yojson.Safe.Util.(http_json |> member "websocket" |> member "reachable")
+     with
+    | `Bool _ -> true
+    | _ -> false);
   check bool "webrtc surface exposes signaling availability"
     true
     (match


### PR DESCRIPTION
## Summary

- Splits transport health/read-model output into explicit configured/protocol/auth/reachable dimensions so auth-blocked probes are not collapsed into a false pass/fail boolean.
- Updates the transport truth harness and focused tests to preserve `auth_blocked` as an operator-visible outcome.
- Changes `masc_status` planning-missing guidance so it no longer suggests generic `masc_plan_init -> masc_status`; it tells operators to use handoff/worktree/test logs as temporary SSOT until a credentialed owner repair receipt exists.
- Replaces new loopback reachability literals with `Masc_network_defaults.masc_http_default_host` so the SSOT bypass ratchet stays within baseline.

## Task Scope

MASC task: `task-050` (`Transport health truth drift 수정`).

This PR addresses the current scoped close gate:

- transport/auth-blocked patch evidence should be testable and operator-visible
- stale planning context must not be presented as plan-backed evidence
- task closure still requires non-self verification; this PR does not claim that unrelated planning FK issues are solved globally

## Validation

- `scripts/check-ssot.sh`
- `dune exec --root . ./test/test_tool_coord_coverage.exe`
- `./_build/default/test/test_transport_read_model.exe --color=never`
- `./_build/default/test/test_transport_metrics.exe --color=never`
- `git diff --check`
- `dune build --root .`

## Evidence

Branch commits:
- `7225321e6` — transport truth/status-source-boundary implementation
- `ae46f205d` — SSOT loopback literal fix for CI lint ratchet
