### PR TITLE
[codex] Reject staged changes before PR submit

### DIFF
--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -60,6 +60,14 @@ validate_pr_body_file() {
   fi
 }
 
+validate_no_staged_changes() {
+  if ! git diff --cached --quiet --exit-code; then
+    echo "staged changes detected; commit or unstage them before opening a PR" >&2
+    git diff --cached --name-only >&2
+    exit 1
+  fi
+}
+
 is_doc_path() {
   case "$1" in
     docs/*|examples/trpg-mvp/*|README.md|*.md) return 0 ;;
@@ -105,6 +113,8 @@ if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "refusing to open PR from branch '$branch'" >&2
   exit 1
 fi
+
+validate_no_staged_changes
 
 if [[ -n "$body_file" ]]; then
   validate_pr_body_file "$body_file"

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -242,6 +242,45 @@ let test_script_rejects_body_missing_required_sections () =
       check bool "gh never invoked before validation" false
         (Sys.file_exists gh_log))
 
+let test_script_rejects_staged_changes_before_push () =
+  with_temp_dir "pr-open-script-staged-changes" (fun dir ->
+      init_repo_with_remote dir;
+      let fake_gh_dir = make_fake_gh dir in
+      let gh_log = Filename.concat dir "gh.log" in
+      let gh_labels = Filename.concat dir "gh-labels.json" in
+      let body_file = Filename.concat dir "body.md" in
+      write_file body_file
+        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
+      write_file (Filename.concat dir "lib/staged.ml") "let staged = true\n";
+      ignore (run_shell_ok ~cwd:dir "git add lib/staged.ml");
+      let path =
+        Printf.sprintf "%s:%s" fake_gh_dir
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_GH_LOG", gh_log);
+          ("FAKE_GH_LABELS", gh_labels);
+        ]
+      in
+      let cmd =
+        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
+          (quote (script_path ()))
+          (quote "example/test")
+          (quote "fix: reject staged changes")
+          (quote body_file)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
+      check bool "command fails" true (code <> 0);
+      check bool "stdout empty" true (String.trim stdout = "");
+      check bool "mentions staged changes" true
+        (contains_substring stderr "staged changes detected");
+      check bool "mentions staged path" true
+        (contains_substring stderr "lib/staged.ml");
+      check bool "gh never invoked before staged validation" false
+        (Sys.file_exists gh_log))
+
 let () =
   run "pr_open_script"
     [
@@ -253,5 +292,7 @@ let () =
             test_script_runs_under_system_bash_without_watch;
           test_case "rejects body missing required sections" `Quick
             test_script_rejects_body_missing_required_sections;
+          test_case "rejects staged changes before push" `Quick
+            test_script_rejects_staged_changes_before_push;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Add a pre-push staged-change guard to `scripts/pr-open.sh`.
- Fail fast with the staged file list before draft PR creation when the index contains uncommitted changes.
- Add a focused regression test that verifies `gh` is not invoked when staged changes are present.

## Product impact
- Promise affected: internal keeper PR submission hygiene.
- User-visible change: `scripts/pr-open.sh` now tells keepers to commit or unstage indexed changes before opening a draft PR, preventing accidental PRs that omit staged work.

## Evidence
- `git diff --check` exit 0
- `dune exec --root . ./test/test_pr_open_script.exe` exit 0, 4 tests
- `bash -n scripts/pr-open.sh` exit 0
- `dune build --root .` exit 0

## Review evidence
- Recent open PR/CI sweep before implementation: #9155, #9154, #9153, #9152 were open/draft; exposed checks were green or skipped by routing, with no red blocker found for this task.
- Focused regression: `rejects staged changes before push` creates an indexed file and asserts the script exits before any fake `gh` call.

## Linked issue
- Refs task-019
