### PR TITLE
[codex] Align Bonsai shell runtime terminology

### DIFF
--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -190,6 +190,15 @@ stylesheet
     color: var(--text-dim);
     border: 1px dashed var(--border-main);
   }
+
+  @media (max-width: 920px) {
+    .grid { grid-template-columns: 1fr; }
+    .panel { min-width: 0; }
+    .kv { grid-template-columns: 96px minmax(0, 1fr); }
+    .counts { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .count_cell { padding: 12px 8px; }
+    .count_v { font-size: 28px; }
+  }
 |}]
 
 let hms_of_seconds total =
@@ -221,7 +230,7 @@ let view_hero_panel (r : Overview_types.response) =
   let s = r.status in
   Node.div
     ~attrs:[ Style.panel ]
-    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "room · identity" ]
+    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "runtime · identity" ]
     ; Node.div
         ~attrs:[ Style.kv_row ]
         [ Node.div
@@ -416,9 +425,9 @@ let render (r : Overview_types.response) : Node.t =
         ~title:"overview"
         ~tail:(Printf.sprintf "· %s" r.status.cluster, `Brass)
         ~sub:
-          "room의 current state — identity, build, fleet counts, \
-           meta-cognition. shell 엔드포인트의 압축된 projection \
-           으로, 깊은 진단은 각 tab에서 확인."
+          "runtime snapshot — identity, build, fleet counts, \
+           meta-cognition. shell endpoint의 압축 projection으로, \
+           깊은 진단은 각 tab에서 확인."
         ()
     ; Node.div
         ~attrs:[ Style.grid ]

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -245,7 +245,7 @@ let component ~(route : Route.t) (_graph @ local) =
            ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
            ; panel
                ~title:"fallback"
-               ~text:"The journal remains the live room witness while this lane gathers signal."
+               ~text:"The journal remains the live runtime witness while this lane gathers signal."
                ~code:(Route.path Logs)
            ]
        ; Node.div

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -690,7 +690,7 @@ let topbar ~(active : Route.t) =
         ~attrs:[ Style.crumbs ]
         [ Node.span [ Node.text "Chronicle" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
-        ; Node.span [ Node.text "dashboard bonsai" ]
+        ; Node.span [ Node.text "runtime bonsai" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
         ; Node.strong ~attrs:[ Style.crumbs_current ] [ Node.text (label active) ]
         ]
@@ -723,11 +723,11 @@ let hud_cell ?(tone : tone = `Neutral) ~k ~v () =
 ;;
 
 let default_hud ~(active : Route.t) =
-  [ hud_cell ~k:"Room" ~v:"local" ()
-  ; hud_cell ~tone:`Ok ~k:"Session" ~v:"running" ()
+  [ hud_cell ~k:"Runtime" ~v:"local" ()
+  ; hud_cell ~tone:`Ok ~k:"Snapshot" ~v:"running" ()
   ; hud_cell ~k:"Surface" ~v:"bonsai" ()
   ; hud_cell ~tone:`Warn ~k:"Route" ~v:(label active) ()
-  ; hud_cell ~k:"Prefix" ~v:"/dashboard/b" ()
+  ; hud_cell ~k:"Base" ~v:"/dashboard/b" ()
   ; hud_cell ~tone:`Ok ~k:"Build" ~v:"js_of_ocaml" ()
   ]
 ;;
@@ -785,7 +785,7 @@ let focus_card ~(active : Route.t) =
                     ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "v2" ]
                     ]
                 ; Node.div
-                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Prefix" ]
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Base" ]
                     ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "b" ]
                     ]
                 ]


### PR DESCRIPTION
## What changed

- Renamed Bonsai shell chrome from legacy room/session language toward runtime/snapshot language.
- Updated the shell HUD labels: `Room` -> `Runtime`, `Session` -> `Snapshot`, `Prefix` -> `Base`.
- Updated the overview hero/panel copy to say `runtime snapshot` and `runtime · identity`.
- Updated staged route fallback copy to refer to a live runtime witness.
- Added a mobile breakpoint for the overview card grid so the 2-column layout collapses to one column on narrow screens.

## Why

This is the next small #9149 slice after the dashboard v2 shell work: the Bonsai shell should use the runtime/snapshot terminology instead of carrying old room/namespace phrasing into the new UI.

The mobile breakpoint came from visual verification: the overview cards still overflowed horizontally at a 390px viewport.

## Validation

- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root .`
- `make bonsai-dashboard`
- `opam exec -- dune build --root . ./bin/main_eio.exe`
- Served the worktree on `http://127.0.0.1:18937` with keeper bootstrap disabled.
- Verified:
  - `GET /dashboard/b/overview` returns `200 text/html`
  - `GET /dashboard/b/assets/main.bc.js` returns `200 application/javascript`
  - Browser snapshot shows `runtime bonsai`, `Runtime`, `Snapshot`, `runtime · identity`, and `runtime snapshot`.
  - Desktop screenshot reviewed.
  - Mobile screenshot reviewed after fixing overview grid collapse.
  - `agent-browser errors` returned no page errors.
