### PR TITLE
Report SCC deltas in lib dependency summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
       dashboard: ${{ steps.scope.outputs.dashboard }}
       health: ${{ steps.scope.outputs.health }}
       health_snapshot: ${{ steps.scope.outputs.health_snapshot }}
+      lib_deps: ${{ steps.scope.outputs.lib_deps }}
       doc_truth: ${{ steps.scope.outputs.doc_truth }}
       tla: ${{ steps.scope.outputs.tla }}
       oas_pin: ${{ steps.scope.outputs.oas_pin }}
@@ -98,7 +99,7 @@ jobs:
           set -euo pipefail
 
           emit_all_true() {
-            for key in build lint dashboard health health_snapshot doc_truth tla oas_pin spec_refs; do
+            for key in build lint dashboard health health_snapshot lib_deps doc_truth tla oas_pin spec_refs; do
               echo "${key}=true" >> "$GITHUB_OUTPUT"
             done
           }
@@ -144,6 +145,7 @@ jobs:
           dashboard=false
           health=false
           health_snapshot=false
+          lib_deps=false
           doc_truth=false
           tla=false
           oas_pin=false
@@ -173,6 +175,10 @@ jobs:
             health_snapshot=true
           fi
 
+          if has_match '^(\.github/workflows/ci\.yml|lib/|dune-project$|dune-workspace$|.*\.opam$|scripts/analyze_lib_deps\.py$|scripts/lib_dep_report\.py$|scripts/lib_dep_delta_ci\.sh$)'; then
+            lib_deps=true
+          fi
+
           if has_match '^(docs/|README\.md$|ROADMAP\.md$|CHANGELOG\.md$|dune-project$|.*\.opam$|scripts/check-doc-truth\.sh$|scripts/check-version-truth\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$)'; then
             doc_truth=true
           fi
@@ -195,6 +201,7 @@ jobs:
             dashboard=true
             health=true
             health_snapshot=true
+            lib_deps=true
             doc_truth=true
             oas_pin=true
             spec_refs=true
@@ -211,13 +218,14 @@ jobs:
           echo "dashboard=${dashboard}" >> "$GITHUB_OUTPUT"
           echo "health=${health}" >> "$GITHUB_OUTPUT"
           echo "health_snapshot=${health_snapshot}" >> "$GITHUB_OUTPUT"
+          echo "lib_deps=${lib_deps}" >> "$GITHUB_OUTPUT"
           echo "doc_truth=${doc_truth}" >> "$GITHUB_OUTPUT"
           echo "tla=${tla}" >> "$GITHUB_OUTPUT"
           echo "oas_pin=${oas_pin}" >> "$GITHUB_OUTPUT"
           echo "spec_refs=${spec_refs}" >> "$GITHUB_OUTPUT"
 
-          printf 'CI scope => build=%s lint=%s dashboard=%s health=%s health_snapshot=%s doc_truth=%s tla=%s oas_pin=%s\n' \
-            "${build}" "${lint}" "${dashboard}" "${health}" "${health_snapshot}" "${doc_truth}" "${tla}" "${oas_pin}"
+          printf 'CI scope => build=%s lint=%s dashboard=%s health=%s health_snapshot=%s lib_deps=%s doc_truth=%s tla=%s oas_pin=%s\n' \
+            "${build}" "${lint}" "${dashboard}" "${health}" "${health_snapshot}" "${lib_deps}" "${doc_truth}" "${tla}" "${oas_pin}"
 
   health:
     name: Health
@@ -310,6 +318,35 @@ jobs:
           scripts/check-doc-truth.sh
           scripts/check-version-truth.sh
           scripts/sync-oas-pin-docs.sh --check
+
+  lib-dependency-delta:
+    name: Lib Dependency Delta
+    runs-on: ubuntu-latest
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.lib_deps == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run report self-test
+        run: python3 scripts/lib_dep_report.py --self-test
+
+      - name: Generate lib dependency delta
+        run: bash scripts/lib_dep_delta_ci.sh
+
+      - name: Upload lib dependency reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: lib-dependency-delta
+          path: |
+            reports/lib-dependency-graph.json
+            reports/lib-dependency-graph.baseline.json
+            reports/lib-dependency-summary.md
+            reports/lib-dependency-summary.json
 
   oas-pin-check:
     name: OAS Pin Consistency
@@ -651,7 +688,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check, changes, build, lint, dashboard, dashboard-drift, health, doc-truth, oas-pin-check, tla-specs, spec-line-refs]
+    needs: [pr-sync-check, changes, build, lint, dashboard, dashboard-drift, health, lib-dependency-delta, doc-truth, oas-pin-check, tla-specs, spec-line-refs]
     if: ${{ !cancelled() }}
     timeout-minutes: 2
 
@@ -665,6 +702,7 @@ jobs:
           DASHBOARD_RESULT: ${{ needs.dashboard.result }}
           DASHBOARD_DRIFT_RESULT: ${{ needs.dashboard-drift.result }}
           HEALTH_RESULT: ${{ needs.health.result }}
+          LIB_DEPENDENCY_DELTA_RESULT: ${{ needs.lib-dependency-delta.result }}
           DOC_TRUTH_RESULT: ${{ needs.doc-truth.result }}
           OAS_PIN_RESULT: ${{ needs.oas-pin-check.result }}
           TLA_RESULT: ${{ needs.tla-specs.result }}
@@ -703,6 +741,7 @@ jobs:
           check "dashboard"       "$DASHBOARD_RESULT"
           check "dashboard-drift" "$DASHBOARD_DRIFT_RESULT"
           check "health"          "$HEALTH_RESULT"
+          check "lib-dep-delta"   "$LIB_DEPENDENCY_DELTA_RESULT"
           check "doc-truth"       "$DOC_TRUTH_RESULT"
           check "oas-pin-check"   "$OAS_PIN_RESULT"
           check "tla-specs"       "$TLA_RESULT"

--- a/docs/lib-dependency-delta-report.md
+++ b/docs/lib-dependency-delta-report.md
@@ -10,6 +10,12 @@ python3 scripts/analyze_lib_deps.py --json
 
 This writes `reports/lib-dependency-graph.json`.
 
+CI uses the same analyzer and summary generator through:
+
+```sh
+bash scripts/lib_dep_delta_ci.sh
+```
+
 ## Generate The Summary
 
 ```sh
@@ -53,3 +59,18 @@ python3 scripts/lib_dep_report.py \
 The JSON shape is stable enough for CI checks to read `scc_count_delta`,
 `largest_scc_size`, `largest_scc_delta`, `scc_delta`,
 `room_coordination_dependents`, and `batch2_candidate_delta`.
+
+## CI Report
+
+The `Lib Dependency Delta` CI job runs automatically when PRs touch `lib/`,
+the dependency-report scripts, or core build metadata. It writes the Markdown
+summary to the GitHub Actions step summary and uploads:
+
+- `reports/lib-dependency-graph.json`
+- `reports/lib-dependency-graph.baseline.json`
+- `reports/lib-dependency-summary.md`
+- `reports/lib-dependency-summary.json`
+
+On pull requests, the baseline graph is generated from the base branch so SCC
+count, largest SCC size, room/coordination dependents, and extraction candidate
+deltas are visible without a manual local compare.

--- a/docs/lib-dependency-delta-report.md
+++ b/docs/lib-dependency-delta-report.md
@@ -21,6 +21,7 @@ python3 scripts/lib_dep_report.py \
 The summary includes:
 
 - SCC count and largest SCC size
+- SCC count delta and added/removed SCC member sets when a baseline is provided
 - Room/coordination dependent counts
 - Top hub modules by dependent count
 - Heaviest importers by dependency count
@@ -49,5 +50,6 @@ python3 scripts/lib_dep_report.py \
   --output reports/lib-dependency-summary.json
 ```
 
-The JSON shape is stable enough for CI checks to read `largest_scc_size`,
+The JSON shape is stable enough for CI checks to read `scc_count_delta`,
+`largest_scc_size`, `largest_scc_delta`, `scc_delta`,
 `room_coordination_dependents`, and `batch2_candidate_delta`.

--- a/scripts/lib_dep_delta_ci.sh
+++ b/scripts/lib_dep_delta_ci.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_graph=${LIB_DEP_CURRENT_GRAPH:-reports/lib-dependency-graph.json}
+baseline_graph=${LIB_DEP_BASELINE_GRAPH:-reports/lib-dependency-graph.baseline.json}
+summary_md=${LIB_DEP_SUMMARY_MD:-reports/lib-dependency-summary.md}
+summary_json=${LIB_DEP_SUMMARY_JSON:-reports/lib-dependency-summary.json}
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+mkdir -p "$(dirname "$current_graph")"
+
+python3 scripts/analyze_lib_deps.py --json
+
+baseline_args=()
+baseline_tree=""
+if [[ -n "${GITHUB_BASE_REF:-}" && "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+  baseline_tree=$(mktemp -d)
+  rm -rf "$baseline_tree"
+  git fetch origin "$GITHUB_BASE_REF" --depth=200
+  base_ref="origin/$GITHUB_BASE_REF"
+  if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    base_ref="FETCH_HEAD"
+  fi
+  git worktree add --detach "$baseline_tree" "$base_ref" >/dev/null
+  cleanup() {
+    git worktree remove --force "$baseline_tree" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  (
+    cd "$baseline_tree"
+    python3 scripts/analyze_lib_deps.py --json
+  )
+  cp "$baseline_tree/reports/lib-dependency-graph.json" "$baseline_graph"
+  baseline_args=(--baseline "$baseline_graph")
+elif [[ -f "$baseline_graph" ]]; then
+  baseline_args=(--baseline "$baseline_graph")
+fi
+
+summary_args=(--graph "$current_graph")
+if [[ ${#baseline_args[@]} -gt 0 ]]; then
+  summary_args+=("${baseline_args[@]}")
+fi
+
+python3 scripts/lib_dep_report.py \
+  "${summary_args[@]}" \
+  --output "$summary_md"
+
+python3 scripts/lib_dep_report.py \
+  "${summary_args[@]}" \
+  --format json \
+  --output "$summary_json"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Lib Dependency Delta"
+    echo
+    cat "$summary_md"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/lib_dep_report.py
+++ b/scripts/lib_dep_report.py
@@ -123,6 +123,29 @@ def largest_scc(raw: Json) -> int:
     return max((len(component) for component in cycles(raw)), default=0)
 
 
+def scc_key(component: list[str]) -> tuple[str, ...]:
+    return tuple(sorted(component))
+
+
+def scc_delta(current: Json, baseline: Json, *, limit: int) -> list[Json]:
+    current_sccs = {scc_key(component) for component in cycles(current)}
+    baseline_sccs = {scc_key(component) for component in cycles(baseline)}
+    changes: list[Json] = []
+    for status, components in (
+        ("added", current_sccs - baseline_sccs),
+        ("removed", baseline_sccs - current_sccs),
+    ):
+        for component in sorted(components, key=lambda item: (-len(item), item)):
+            changes.append(
+                {
+                    "status": status,
+                    "size": len(component),
+                    "members": list(component),
+                }
+            )
+    return changes[:limit]
+
+
 def room_dependents(raw: Json) -> list[Pair]:
     reverse: dict[str, set[str]] = {}
     for node, deps in graph(raw).items():
@@ -231,8 +254,14 @@ def build_report(
         if baseline is not None
         else None,
         "scc_count": len(cycles(current)),
+        "scc_count_delta": len(cycles(current)) - len(cycles(baseline))
+        if baseline is not None
+        else None,
         "largest_scc_size": largest_scc(current),
         "largest_scc_delta": largest_scc(current) - largest_scc(baseline)
+        if baseline is not None
+        else None,
+        "scc_delta": scc_delta(current, baseline, limit=limit)
         if baseline is not None
         else None,
         "room_coordination_dependents": current_room,
@@ -283,7 +312,11 @@ def render_markdown(report: Json) -> str:
             for name in ("total_modules", "total_edges", "avg_out_degree")
         ]
         + [
-            ["scc_count", str(report["scc_count"]), "-"],
+            [
+                "scc_count",
+                str(report["scc_count"]),
+                fmt_delta(report["scc_count_delta"]),
+            ],
             [
                 "largest_scc_size",
                 str(report["largest_scc_size"]),
@@ -363,6 +396,24 @@ def render_markdown(report: Json) -> str:
         "",
         candidates,
     ]
+    if report["scc_delta"] is not None:
+        scc_delta_rows = [
+            [
+                str(item["status"]),
+                str(item["size"]),
+                ", ".join(str(member) for member in item["members"][:12])
+                + ("..." if len(item["members"]) > 12 else ""),
+            ]
+            for item in report["scc_delta"]
+        ]
+        sections += [
+            "",
+            "## SCC Delta",
+            "",
+            table(["Status", "Size", "Members"], scc_delta_rows)
+            if scc_delta_rows
+            else "No SCC changes.",
+        ]
     if report["batch2_candidate_delta"] is not None:
         delta_rows = [
             [
@@ -455,6 +506,11 @@ def self_test() -> None:
         "total_modules": -1,
     }
     assert report["largest_scc_delta"] == -1
+    assert report["scc_count_delta"] == 0
+    assert report["scc_delta"] == [
+        {"status": "added", "size": 3, "members": ["A", "B", "C"]},
+        {"status": "removed", "size": 4, "members": ["A", "B", "C", "D"]},
+    ]
     assert report["room_coordination_dependents_delta"] == [
         {"module": "Coord", "count": -1}
     ]


### PR DESCRIPTION
## Summary
- add explicit `scc_count_delta` and `scc_delta` fields to `scripts/lib_dep_report.py` JSON output when a baseline is provided
- render an `SCC Delta` markdown section showing added/removed SCC member sets
- add `scripts/lib_dep_delta_ci.sh` to generate graph, baseline graph, markdown summary, and JSON summary in CI
- add a `Lib Dependency Delta` CI job and wire it into the CI gate when lib dependency surfaces change
- document the new stable JSON fields and CI helper path

## Product impact
Dependency graph extraction work can now see SCC regressions or improvements directly in the generated before/after report instead of inferring them from largest SCC size only. PRs that touch lib dependency surfaces now publish the report as a CI artifact and step summary.

## Evidence
- PR branch: `task-055-lib-dep-scc-delta`
- Head commit: `b46df9c86a94349b1c0dcae5cbc3bd8b0247ab07`
- Changed files: `.github/workflows/ci.yml`, `docs/lib-dependency-delta-report.md`, `scripts/lib_dep_delta_ci.sh`, plus the SCC-delta report script changes already present on the branch
- Local CI-driver smoke emitted `reports/lib-dependency-graph.json`, `reports/lib-dependency-summary.md`, and `reports/lib-dependency-summary.json`; generated report artifacts were not committed

## Review evidence
- `python3 scripts/lib_dep_report.py --self-test` -> pass
- `ruff check scripts/lib_dep_report.py` -> pass
- `ruff format --check scripts/lib_dep_report.py` -> pass
- `python3 -m py_compile scripts/lib_dep_report.py` -> pass
- `bash -n scripts/lib_dep_delta_ci.sh` -> pass
- workflow YAML parse via `python3` + `yaml.safe_load` -> pass
- `bash scripts/lib_dep_delta_ci.sh` -> pass after fixing empty-baseline array handling
- baseline JSON smoke: `scc_count`, `scc_count_delta`, `largest_scc_size`, `largest_scc_delta`, `scc_delta` emitted as expected

## Linked issue
Refs #3593

## Known limitation
- `pyright --outputjson scripts/lib_dep_report.py` could not run because `pyright` is not installed in this environment (`zsh:1: command not found: pyright`).

## Scope boundary
This PR changes reporting and CI automation only. It does not commit regenerated `reports/lib-dependency-graph.json` / summary artifacts and does not change the dependency analyzer graph construction.