### PR TITLE
[codex] Polish Bonsai runtime terminology

### DIFF
--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -73,7 +73,7 @@ let component (_graph @ local) =
   Bonsai.return
     (Node.div
        ~attrs:[ Style.root ]
-       [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "masc · observatory" ]
+       [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "masc · runtime" ]
        ; Node.h1 ~attrs:[ Style.title ] [ Node.text "dark manor · bonsai" ]
        ; Node.p
            ~attrs:[ Style.sub ]

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1604,6 +1604,11 @@ let render_response
       ?(keepers : Keepers_types.response = Keepers_types.fixture)
       (response : Logs_types.response)
     : Node.t =
+  let runtime_name =
+    match keepers.room with
+    | Some name when String.length name > 0 -> name
+    | _ -> "local"
+  in
   let tape =
     match response.entries with
     | [] ->
@@ -1634,23 +1639,20 @@ let render_response
       ; Node.div
           ~attrs:[ Style.crumbs ]
           (let head =
-             [ Node.span [ Node.text "observatory" ]
+             [ Node.span [ Node.text "runtime" ]
              ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
              ]
            in
-           let room_seg =
-             match keepers.room with
-             | None | Some "" -> []
-             | Some name ->
-               [ Node.span ~attrs:[ Style.crumbs_room ] [ Node.text name ]
-               ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
-               ]
+           let runtime_seg =
+             [ Node.span ~attrs:[ Style.crumbs_room ] [ Node.text runtime_name ]
+             ; Node.span ~attrs:[ Style.crumbs_sep ] [ Node.text "›" ]
+             ]
            in
            let tail =
              [ Node.span ~attrs:[ Style.crumbs_cur ] [ Node.text "저널" ]
              ]
            in
-           head @ room_seg @ tail)
+           head @ runtime_seg @ tail)
       ; Node.div
           ~attrs:[ Style.pulse_slot ]
           [ Node.span ~attrs:[ Style.pulse ] []
@@ -2079,17 +2081,12 @@ let render_response
              [ Node.div
                  ~attrs:[ Style.page_tag ]
                  [ Node.text
-                     (let room =
-                        match keepers.room with
-                        | Some r when String.length r > 0 -> r
-                        | _ -> "—"
-                      in
-                      let day =
+                     (let cycle =
                         if keepers.cycle <= 0
                         then "—"
                         else roman_of_int keepers.cycle
                       in
-                      Printf.sprintf "chronicle · %s · day %s" room day) ]
+                      Printf.sprintf "runtime · %s · cycle %s" runtime_name cycle) ]
              ; Node.h1
                  ~attrs:[ Style.page_h1 ]
                  [ Node.text "the watch "

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -190,6 +190,15 @@ stylesheet
     color: var(--text-dim);
     border: 1px dashed var(--border-main);
   }
+
+  @media (max-width: 920px) {
+    .grid { grid-template-columns: 1fr; }
+    .panel { min-width: 0; }
+    .kv { grid-template-columns: 96px minmax(0, 1fr); }
+    .counts { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .count_cell { padding: 12px 8px; }
+    .count_v { font-size: 28px; }
+  }
 |}]
 
 let hms_of_seconds total =
@@ -221,7 +230,7 @@ let view_hero_panel (r : Overview_types.response) =
   let s = r.status in
   Node.div
     ~attrs:[ Style.panel ]
-    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "room · identity" ]
+    [ Node.p ~attrs:[ Style.panel_title ] [ Node.text "runtime · identity" ]
     ; Node.div
         ~attrs:[ Style.kv_row ]
         [ Node.div
@@ -416,9 +425,9 @@ let render (r : Overview_types.response) : Node.t =
         ~title:"overview"
         ~tail:(Printf.sprintf "· %s" r.status.cluster, `Brass)
         ~sub:
-          "room의 current state — identity, build, fleet counts, \
-           meta-cognition. shell 엔드포인트의 압축된 projection \
-           으로, 깊은 진단은 각 tab에서 확인."
+          "runtime snapshot — identity, build, fleet counts, \
+           meta-cognition. shell endpoint의 압축 projection으로, \
+           깊은 진단은 각 tab에서 확인."
         ()
     ; Node.div
         ~attrs:[ Style.grid ]

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -245,7 +245,7 @@ let component ~(route : Route.t) (_graph @ local) =
            ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
            ; panel
                ~title:"fallback"
-               ~text:"The journal remains the live room witness while this lane gathers signal."
+               ~text:"The journal remains the live runtime witness while this lane gathers signal."
                ~code:(Route.path Logs)
            ]
        ; Node.div

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -200,7 +200,7 @@ let blueprint_of_route : Route.t -> blueprint = function
     }
   | route ->
     {
-      eyebrow = "chronicle · route";
+      eyebrow = "runtime · route";
       title = Route.label route;
       tail = "· staged";
       signal = "pending";

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -690,7 +690,7 @@ let topbar ~(active : Route.t) =
         ~attrs:[ Style.crumbs ]
         [ Node.span [ Node.text "Runtime" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
-        ; Node.span [ Node.text "dashboard bonsai" ]
+        ; Node.span [ Node.text "runtime bonsai" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
         ; Node.strong ~attrs:[ Style.crumbs_current ] [ Node.text (label active) ]
         ]
@@ -723,11 +723,11 @@ let hud_cell ?(tone : tone = `Neutral) ~k ~v () =
 ;;
 
 let default_hud ~(active : Route.t) =
-  [ hud_cell ~k:"Room" ~v:"local" ()
-  ; hud_cell ~tone:`Ok ~k:"Session" ~v:"running" ()
+  [ hud_cell ~k:"Runtime" ~v:"local" ()
+  ; hud_cell ~tone:`Ok ~k:"Snapshot" ~v:"running" ()
   ; hud_cell ~k:"Surface" ~v:"bonsai" ()
   ; hud_cell ~tone:`Warn ~k:"Route" ~v:(label active) ()
-  ; hud_cell ~k:"Prefix" ~v:"/dashboard/b" ()
+  ; hud_cell ~k:"Base" ~v:"/dashboard/b" ()
   ; hud_cell ~tone:`Ok ~k:"Build" ~v:"js_of_ocaml" ()
   ]
 ;;
@@ -785,7 +785,7 @@ let focus_card ~(active : Route.t) =
                     ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "v2" ]
                     ]
                 ; Node.div
-                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Prefix" ]
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Base" ]
                     ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "b" ]
                     ]
                 ]

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -688,7 +688,7 @@ let topbar ~(active : Route.t) =
         ]
     ; Node.div
         ~attrs:[ Style.crumbs ]
-        [ Node.span [ Node.text "Chronicle" ]
+        [ Node.span [ Node.text "Runtime" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]
         ; Node.span [ Node.text "dashboard bonsai" ]
         ; Node.span ~attrs:[ Style.sep ] [ Node.text "." ]


### PR DESCRIPTION
## Summary
- align the Bonsai shell chrome with the runtime/snapshot/base terminology
- carry the same runtime wording into logs breadcrumbs, page tags, hello, and placeholder copy
- keep the overview panel responsive on narrow mobile widths

## Verification
- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root .`
- `make bonsai-dashboard`
- temporary server on `127.0.0.1:18937` with keeper bootstrap disabled
- `agent-browser` snapshots for `/dashboard/b/overview`, `/dashboard/b/hello`, `/dashboard/b/logs`
- `agent-browser errors`
