### PR TITLE
[codex] Expose config source provenance details

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -34,52 +34,107 @@ type source_provenance = {
   kind : string;
   detail : string;
   derived_from : string list;
+  env_name : string;
+  raw_source : string;
+  raw_env_present : bool;
+  raw_env_blank : bool;
+  default_display : string;
+  sensitive : bool;
+  value_redacted : bool;
 }
 
 let entry ?(sensitive = false) ~default env_name description =
   let sensitive = sensitive || is_sensitive_name env_name in
   { env_name; description; default_display = default; sensitive }
 
-let default_provenance e =
+let default_provenance (e : entry) =
   match e.default_display with
   | "(derived)" ->
       {
         kind = "derived";
         detail = "computed by runtime config helpers from related settings";
         derived_from = [];
+        env_name = e.env_name;
+        raw_source = "derived_runtime";
+        raw_env_present = false;
+        raw_env_blank = false;
+        default_display = e.default_display;
+        sensitive = e.sensitive;
+        value_redacted = false;
       }
   | "(cwd)" ->
       {
         kind = "runtime";
         detail = "resolved from the process working directory or base path";
         derived_from = [];
+        env_name = e.env_name;
+        raw_source = "runtime";
+        raw_env_present = false;
+        raw_env_blank = false;
+        default_display = e.default_display;
+        sensitive = e.sensitive;
+        value_redacted = false;
       }
   | _ ->
-      { kind = "default"; detail = "compiled default value"; derived_from = [] }
+      {
+        kind = "default";
+        detail = "compiled default value";
+        derived_from = [];
+        env_name = e.env_name;
+        raw_source = "compiled_default";
+        raw_env_present = false;
+        raw_env_blank = false;
+        default_display = e.default_display;
+        sensitive = e.sensitive;
+        value_redacted = false;
+      }
 
-let source_provenance e raw =
+let source_provenance (e : entry) ~raw_env raw =
+  let raw_env_present = Option.is_some raw_env in
+  let raw_env_blank =
+    match raw_env with
+    | Some value -> String.trim value = ""
+    | None -> false
+  in
   match raw with
   | Some _ ->
       {
         kind = "env";
         detail = "environment variable " ^ e.env_name;
         derived_from = [];
+        env_name = e.env_name;
+        raw_source = "environment";
+        raw_env_present;
+        raw_env_blank;
+        default_display = e.default_display;
+        sensitive = e.sensitive;
+        value_redacted = e.sensitive;
       }
-  | None -> default_provenance e
+  | None ->
+      let provenance = default_provenance e in
+      { provenance with raw_env_present; raw_env_blank }
 
 let provenance_to_json p =
   `Assoc
     ([
        ("kind", `String p.kind);
        ("detail", `String p.detail);
+       ("env", `String p.env_name);
+       ("raw_source", `String p.raw_source);
+       ("raw_env_present", `Bool p.raw_env_present);
+       ("raw_env_blank", `Bool p.raw_env_blank);
+       ("default", `String p.default_display);
+       ("sensitive", `Bool p.sensitive);
+       ("value_redacted", `Bool p.value_redacted);
      ]
     @
     if p.derived_from = [] then []
     else [ ("derived_from", `List (List.map (fun v -> `String v) p.derived_from)) ])
 
-let read_entry e =
-  let raw = Env_config_core.trim_opt (Sys.getenv_opt e.env_name) in
-  let provenance = source_provenance e raw in
+let read_entry (e : entry) =
+  let raw_env = Sys.getenv_opt e.env_name in
+  let raw = Env_config_core.trim_opt raw_env in
+  let provenance = source_provenance e ~raw_env raw in
   let display_value =
     match raw with
     | None -> None

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -39,61 +39,94 @@ let effective_declarative_cascade_name
   | None, Some _ -> Keeper_config.default_cascade_name
   | None, None -> Keeper_cascade_profile.canonicalize meta.cascade_name
 
-let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_defaults) :
-    string list =
+type override_field_detail = {
+  field : string;
+  default_value : Yojson.Safe.t;
+  live_value : Yojson.Safe.t;
+}
+
+let override_field field ~default_value ~live_value =
+  { field; default_value; live_value }
+
+let maybe_string_override field ?(normalize = fun value -> value) default live
+    acc =
+  let default = Option.map normalize default in
+  match default with
+  | Some value when value <> live ->
+      override_field field ~default_value:(`String value) ~live_value:(`String live)
+      :: acc
+  | _ -> acc
+
+let maybe_bool_override field default live acc =
+  match default with
+  | Some value when value <> live ->
+      override_field field ~default_value:(`Bool value) ~live_value:(`Bool live)
+      :: acc
+  | _ -> acc
+
+let maybe_string_list_override field default live acc =
+  match default with
+  | Some authored when authored <> live ->
+      override_field field ~default_value:(string_list_to_json authored)
+        ~live_value:(string_list_to_json live)
+      :: acc
+  | _ -> acc
+
+let nonempty_string_list_override field default live acc =
+  if default <> [] && default <> live then
+    override_field field ~default_value:(string_list_to_json default)
+      ~live_value:(string_list_to_json live)
+    :: acc
+  else acc
+
+let maybe_string_option_override field default live acc =
+  match default, live with
+  | Some authored, Some active when authored <> active ->
+      override_field field ~default_value:(`String authored)
+        ~live_value:(`String active)
+      :: acc
+  | _ -> acc
+
+let live_override_details (meta : keeper_meta)
+    (defaults : keeper_profile_defaults) : override_field_detail list =
   let effective_cascade_name =
     effective_declarative_cascade_name defaults meta
   in
-  let add_if label cond acc = if cond then label :: acc else acc in
   []
-  |> add_if "prompt.goal"
-       (match defaults.goal with
-        | Some value -> normalize_goal_horizon_text value <> meta.goal
-        | None -> false)
-  |> add_if "prompt.short_goal"
-       (match defaults.short_goal with
-        | Some value -> value <> meta.short_goal
-        | None -> false)
-  |> add_if "prompt.mid_goal"
-       (match defaults.mid_goal with
-        | Some value -> value <> meta.mid_goal
-        | None -> false)
-  |> add_if "prompt.long_goal"
-       (match defaults.long_goal with
-        | Some value -> value <> meta.long_goal
-        | None -> false)
-  |> add_if "prompt.will"
-       (match defaults.will with Some value -> value <> meta.will | None -> false)
-  |> add_if "prompt.needs"
-       (match defaults.needs with Some value -> value <> meta.needs | None -> false)
-  |> add_if "prompt.desires"
-       (match defaults.desires with Some value -> value <> meta.desires | None -> false)
-  |> add_if "prompt.instructions"
-       (match defaults.instructions with
-        | Some value -> value <> meta.instructions
-        | None -> false)
-  |> add_if "coordination.mention_targets"
-       (defaults.mention_targets <> [] && defaults.mention_targets <> meta.mention_targets)
-  |> add_if "tools.tool_preset"
-       (match defaults.tool_preset, Keeper_types.tool_access_preset meta.tool_access with
-        | Some authored, Some active -> authored <> Keeper_types.tool_preset_to_string active
-        | _ -> false)
-  |> add_if "tools.tool_also_allow"
-       (match defaults.tool_also_allow with
-        | Some authored ->
-            authored <> Keeper_types.tool_access_also_allowlist meta.tool_access
-        | None -> false)
-  |> add_if "tools.tool_denylist"
-       (match defaults.tool_denylist with
-        | Some authored -> authored <> meta.tool_denylist
-        | None -> false)
-  |> add_if "model.cascade_name"
-       (effective_cascade_name <> meta.cascade_name)
-  |> add_if "proactive.enabled"
-       (match defaults.proactive_enabled with
-        | Some value -> value <> meta.proactive.enabled
-        | None -> false)
+  |> maybe_string_override "prompt.goal"
+       ~normalize:normalize_goal_horizon_text defaults.goal meta.goal
+  |> maybe_string_override "prompt.short_goal" defaults.short_goal meta.short_goal
+  |> maybe_string_override "prompt.mid_goal" defaults.mid_goal meta.mid_goal
+  |> maybe_string_override "prompt.long_goal" defaults.long_goal meta.long_goal
+  |> maybe_string_override "prompt.will" defaults.will meta.will
+  |> maybe_string_override "prompt.needs" defaults.needs meta.needs
+  |> maybe_string_override "prompt.desires" defaults.desires meta.desires
+  |> maybe_string_override "prompt.instructions" defaults.instructions
+       meta.instructions
+  |> nonempty_string_list_override "coordination.mention_targets"
+       defaults.mention_targets meta.mention_targets
+  |> maybe_string_option_override "tools.tool_preset" defaults.tool_preset
+       (Keeper_types.tool_access_preset meta.tool_access
+        |> Option.map Keeper_types.tool_preset_to_string)
+  |> maybe_string_list_override "tools.tool_also_allow"
+       defaults.tool_also_allow
+       (Keeper_types.tool_access_also_allowlist meta.tool_access)
+  |> maybe_string_list_override "tools.tool_denylist" defaults.tool_denylist
+       meta.tool_denylist
+  |> (fun acc ->
+       if effective_cascade_name <> meta.cascade_name then
+         override_field "model.cascade_name"
+           ~default_value:(`String effective_cascade_name)
+           ~live_value:(`String meta.cascade_name)
+         :: acc
+       else acc)
+  |> maybe_bool_override "proactive.enabled" defaults.proactive_enabled
+       meta.proactive.enabled
   |> List.rev
+
+let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_defaults) :
+    string list =
+  live_override_details meta defaults |> List.map (fun detail -> detail.field)
 
 let runtime_registry_entry (config : Coord_utils.config) name =
   Keeper_registry.get ~base_path:config.base_path name
@@ -309,18 +342,35 @@ let optional_existing_path_json ?source = function
   | Some path -> existing_path_json ?source path
   | None -> `Null
 
-let override_field_source_json ~default_source_kind ~default_manifest_path field =
+let override_field_source_json ~default_source_kind ~default_manifest_path detail =
+  let default_missing =
+    match detail.default_value with
+    | `Null -> true
+    | _ -> false
+  in
+  let default_manifest_exists =
+    match default_manifest_path with
+    | Some path -> Fs_compat.file_exists path
+    | None -> false
+  in
   `Assoc
     [
-      ("field", `String field);
+      ("field", `String detail.field);
       ("source", `String "live_meta");
+      ("live_source", `String "runtime_overlay");
+      ("default_source", Json_util.string_opt_to_json default_source_kind);
       ("default_source_kind", Json_util.string_opt_to_json default_source_kind);
       ("default_manifest_path", Json_util.string_opt_to_json default_manifest_path);
+      ("default_manifest_exists", `Bool default_manifest_exists);
+      ("default_missing", `Bool default_missing);
+      ("default_value", detail.default_value);
+      ("live_value", detail.live_value);
     ]
 
 let source_provenance_json config (meta : keeper_meta) =
   let snapshot = keeper_default_source_snapshot meta.name in
-  let override_fields = live_override_fields meta snapshot.defaults in
+  let override_details = live_override_details meta snapshot.defaults in
+  let override_fields = List.map (fun detail -> detail.field) override_details in
   let resolution = Config_dir_resolver.resolve () in
   let live_meta_path = keeper_meta_path config meta.name in
   let default_manifest_path = snapshot.defaults.manifest_path in
@@ -344,5 +394,5 @@ let source_provenance_json config (meta : keeper_meta) =
         `List
           (List.map
              (override_field_source_json ~default_source_kind ~default_manifest_path)
-             override_fields) );
+             override_details) );
     ]

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -263,6 +263,16 @@ let test_to_json_masks_sensitive_values_and_tracks_sources () =
         (entry |> member "source_detail" |> to_string);
       check string "provenance kind is env" "env"
         (entry |> member "provenance" |> member "kind" |> to_string);
+      check string "provenance env names source var" "MASC_ADMIN_TOKEN"
+        (entry |> member "provenance" |> member "env" |> to_string);
+      check string "provenance raw source is environment" "environment"
+        (entry |> member "provenance" |> member "raw_source" |> to_string);
+      check bool "provenance notes env presence" true
+        (entry |> member "provenance" |> member "raw_env_present" |> to_bool);
+      check bool "provenance notes env is not blank" false
+        (entry |> member "provenance" |> member "raw_env_blank" |> to_bool);
+      check bool "provenance notes redaction" true
+        (entry |> member "provenance" |> member "value_redacted" |> to_bool);
       check bool "marked sensitive" true (entry |> member "sensitive" |> to_bool);
       check string "masked token" "supe***"
         (entry |> member "value" |> to_string))
@@ -274,6 +284,12 @@ let test_to_json_treats_blank_env_as_default () =
       let open Yojson.Safe.Util in
       check string "blank source is default" "default"
         (entry |> member "source" |> to_string);
+      check bool "blank provenance preserves env presence" true
+        (entry |> member "provenance" |> member "raw_env_present" |> to_bool);
+      check bool "blank provenance marks blank env" true
+        (entry |> member "provenance" |> member "raw_env_blank" |> to_bool);
+      check string "blank provenance raw source falls back" "compiled_default"
+        (entry |> member "provenance" |> member "raw_source" |> to_string);
       check bool "blank value omitted" true (entry |> member "value" = `Null))
 
 let test_to_json_exposes_derived_and_runtime_provenance () =
@@ -287,10 +303,14 @@ let test_to_json_exposes_derived_and_runtime_provenance () =
             (base_url |> member "source" |> to_string);
           check string "derived provenance kind" "derived"
             (base_url |> member "provenance" |> member "kind" |> to_string);
+          check string "derived provenance raw source" "derived_runtime"
+            (base_url |> member "provenance" |> member "raw_source" |> to_string);
           check string "runtime source" "runtime"
             (base_path |> member "source" |> to_string);
           check string "runtime provenance kind" "runtime"
-            (base_path |> member "provenance" |> member "kind" |> to_string)))
+            (base_path |> member "provenance" |> member "kind" |> to_string);
+          check string "runtime provenance raw source" "runtime"
+            (base_path |> member "provenance" |> member "raw_source" |> to_string)))
 
 (* ============================================================
    print_summary Tests

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -984,21 +984,38 @@ proactive_enabled = true
       in
       Alcotest.(check bool) "override field proactive" true
         (List.mem "proactive.enabled" override_fields);
-      let override_field_sources =
-        json |> member "sources" |> member "override_field_sources" |> to_list
-      in
-      Alcotest.(check bool) "override field source proactive" true
-        (List.exists
-           (fun item ->
-              String.equal
-                (item |> member "field" |> to_string)
-                "proactive.enabled"
-              && String.equal
-                   (item |> member "source" |> to_string)
-                   "live_meta")
-           override_field_sources);
-      Alcotest.(check bool) "initiative surface removed" true
-        (json |> member "initiative" = `Null);
+	      let override_field_sources =
+	        json |> member "sources" |> member "override_field_sources" |> to_list
+	      in
+	      let proactive_source =
+	        List.find_opt
+	          (fun item ->
+	             String.equal
+	               (item |> member "field" |> to_string)
+	               "proactive.enabled")
+	          override_field_sources
+	      in
+	      let proactive_source =
+	        match proactive_source with
+	        | Some item -> item
+	        | None -> Alcotest.fail "missing proactive override source"
+	      in
+	      Alcotest.(check string) "override field source proactive" "live_meta"
+	        (proactive_source |> member "source" |> to_string);
+	      Alcotest.(check string) "override field live source" "runtime_overlay"
+	        (proactive_source |> member "live_source" |> to_string);
+	      Alcotest.(check string) "override field default source" "toml"
+	        (proactive_source |> member "default_source" |> to_string);
+	      Alcotest.(check bool) "override field default manifest exists" true
+	        (proactive_source |> member "default_manifest_exists" |> to_bool);
+	      Alcotest.(check bool) "override field default present" false
+	        (proactive_source |> member "default_missing" |> to_bool);
+	      Alcotest.(check bool) "override field default value" true
+	        (proactive_source |> member "default_value" |> to_bool);
+	      Alcotest.(check bool) "override field live value" false
+	        (proactive_source |> member "live_value" |> to_bool);
+	      Alcotest.(check bool) "initiative surface removed" true
+	        (json |> member "initiative" = `Null);
       Alcotest.(check int) "total input tokens surfaced" 1200
         (json |> member "metrics" |> member "total_input_tokens" |> to_int);
       Alcotest.(check int) "last latency surfaced" 4000


### PR DESCRIPTION
## Summary

- enrich env config snapshot provenance with explicit source metadata such as env name, raw-source classification, env presence/blank state, redaction flag, and default display
- expand keeper config override provenance to include both default and live values plus default-manifest availability, instead of only listing field names
- add regression coverage for the new provenance fields in env-config and operator keeper config tests

## Why

The existing config introspection surface showed only coarse provenance. That made it hard to tell whether a value came from a present-but-blank env var, a compiled default, runtime-derived logic, or a live keeper override. This patch makes the provenance payload directly inspectable by dashboards and operators.

## Impact

- env config snapshot JSON now carries richer provenance details per entry
- keeper config source provenance now includes structured override detail rather than a field-only marker
- tests now pin the new provenance contract so future drift is visible

## Validation

- `git diff --check`
- `dune build --root .`
- `dune exec --root . ./test/test_env_config_coverage.exe`
- `dune exec --root . ./test/test_operator_control.exe -- test operator 34`

## Notes

- `test_operator_control_keeper.ml` is covered through the `test_operator_control.exe` bundle; the targeted keeper-config case is `operator 34`
- this PR was prepared from worktree `masc-mcp/.worktrees/task-056-config-introspection-provenance`