### PR TITLE
[codex] Retire Bonsai chronicle labels

### DIFF
--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -79,12 +79,12 @@ let component (_graph @ local) =
            ~attrs:[ Style.sub ]
            [ Node.text
                "네 명의 키퍼, 폭풍 속의 저택. Bonsai 섬은 조용히 숨쉬는 \
-                관찰자이다. 이 페이지는 phase 0 의 자리를 지킬 뿐, 곧 관조 \
+                관찰자이다. 이 페이지는 런타임 입구를 지킬 뿐, 곧 관조 \
                 판이 들어설 예정."
            ]
        ; Node.hr ~attrs:[ Style.divider ] ()
        ; Node.div
            ~attrs:[ Style.meta ]
-           [ Node.text "phase 0 · /dashboard/b · bonsai v0.18~preview" ]
+           [ Node.text "preview · /dashboard/b · runtime shell" ]
        ])
 ;;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -891,7 +891,7 @@ stylesheet
   }
 
   /* ─── right aside (340px, fixed) ───
-     dashboard_v2 aside: focus card + chronicle evs stream.
+     dashboard_v2 aside: focus card + watch evs stream.
      현재는 static skeleton. 추후 Var 연결. */
   .aside {
     position: fixed;
@@ -1040,7 +1040,7 @@ stylesheet
     font-variant-numeric: tabular-nums;
   }
 
-  /* ─── chronicle evs stream ─── */
+  /* ─── watch evs stream ─── */
   .evs { display: flex; flex-direction: column; }
   .evrow {
     display: grid;
@@ -1793,7 +1793,7 @@ let render_response
               ; Node.text "c"
               ]
           ]
-      ; nav_section "chronicle"
+      ; nav_section "watch"
       ; nav_link Overview
       ; nav_link Logs
       ; nav_link Goals

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1849,10 +1849,10 @@ let render_response
            ])
       ; Node.div
           ~attrs:[ Style.nav_foot ]
-          [ Node.text "phase 0 · /b/ · "
+          [ Node.text "preview · /b/ · "
           ; Node.span
               ~attrs:[ Style.nav_foot_v ]
-              [ Node.text "v0.18-pre" ]
+              [ Node.text "runtime shell" ]
           ]
       ]
   in

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -135,7 +135,7 @@ let blueprint_of_route : Route.t -> blueprint = function
         "A single sightline for runtime pressure, missing telemetry, and keeper \
          stall signatures.";
       measure = "Dropped spans, stale heartbeat windows, and blocked capability claims.";
-      next_step = "Bind span summaries to the pressure and chronicle lanes.";
+      next_step = "Bind span summaries to the pressure and journal lanes.";
       endpoint = "/api/v1/dashboard/*";
     }
   | Intervene ->

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -699,7 +699,7 @@ let topbar ~(active : Route.t) =
         [ Node.span
             ~attrs:[ Style.clock ]
             [ Node.text "Bonsai "
-            ; Node.b [ Node.text "v0.18" ]
+            ; Node.b [ Node.text "preview" ]
             ]
         ; pill ~tone:`Ok "sse live"
         ; pill "operator"

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -640,7 +640,7 @@ let nav ~(active : Route.t) =
   let lnk = nav_link ~active in
   Node.div
     ~attrs:[ Style.nav ]
-    [ section "chronicle"
+    [ section "watch"
     ; lnk Overview
     ; lnk Logs
     ; lnk Goals
@@ -832,7 +832,7 @@ let flame () =
     ]
 ;;
 
-let chronicle () =
+let watch_feed () =
   let event ?(tone : tone = `Neutral) time body =
     let mark_attrs =
       match tone with
@@ -848,7 +848,7 @@ let chronicle () =
       ]
   in
   Node.div
-    [ aside_title ~right:"live" "Chronicle"
+    [ aside_title ~right:"live" "Watch"
     ; Node.div
         ~attrs:[ Style.events ]
         [ event ~tone:`Ok "now"
@@ -873,7 +873,7 @@ let default_aside ~(active : Route.t) =
     ~attrs:[ Style.aside ]
     [ focus_card ~active
     ; flame ()
-    ; chronicle ()
+    ; watch_feed ()
     ]
 ;;
 

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -431,7 +431,7 @@ let keepers_summary_mock () : Masc_dashboard_api_types.Keepers.response =
   K.{
     keepers = [ luna; brass_owl; moth; ash_hound ];
     cycle = 4;
-    room = Some "chronicle";
+    room = Some "local";
     generated_at = iso8601_utc_now ();
   }
 


### PR DESCRIPTION
## Summary
- replace the remaining Bonsai shell/logs "chronicle" section labels with "watch"
- stop the mock keepers summary from surfacing the legacy `chronicle` room name in breadcrumbs and badges
- align the observatory placeholder follow-up copy with the journal wording already used elsewhere

## Verification
- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root .`
- `make bonsai-dashboard`
- `opam exec -- dune build --root . ./bin/main_eio.exe`
- temporary server on `127.0.0.1:18937` with keeper bootstrap disabled
- `agent-browser` snapshots for `/dashboard/b/overview`, `/dashboard/b/logs`, `/dashboard/b/observatory`
- `agent-browser errors`
