### PR TITLE
[codex] Improve TLA CI observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,8 +672,17 @@ jobs:
           curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
-      - name: Run TLA+ model checking
-        run: make -C specs ${{ matrix.suite }}
+      - name: List TLA+ plan
+        run: make -C specs list
+
+      - name: Run keeper-state-machine TLA checks
+        run: make -C specs check-keeper
+
+      - name: Run supporting TLA checks
+        run: make -C specs check-supporting
+
+      - name: Run bug-model TLA checks
+        run: make -C specs check-bug-models
 
   spec-line-refs:
     name: Spec Line Refs

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -122,12 +122,12 @@ check-bug-models:
 
 check-keeper:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)" \
 	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy*.cfg' | sort)" check-all
 
 check-supporting:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  CLEAN_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)" \
 	  BUGGY_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*-buggy*.cfg' | sort)" check-all
 
 check-ecosystem:

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -52,8 +52,8 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 	-DTLA2-Library="$(SPEC_DIRS)" \
 	-cp $(TLA2TOOLS) tlc2.TLC $(TLC_FLAGS)
 
-CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)
-BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
+CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort | tr '\n' ' ')
+BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort | tr '\n' ' ')
 SUPPORTING_SPEC_DIRS := boundary checkpoint-trim closure masc-ecosystem social-state-cap state-product task-lifecycle
 
 .PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-supporting check-ecosystem check-boundary check-closure list clean clean-artefacts
@@ -68,10 +68,10 @@ check-all: check-clean check-buggy
 
 check-clean:
 	@echo "=== Running clean specs (expect no errors) ==="; \
-	set -- $(CLEAN_CFGS); \
-	if [ $$# -eq 0 ]; then echo "(none)"; exit 0; fi; \
 	fail=0; \
-	for cfg in "$$@"; do \
+	cfgs="$(CLEAN_CFGS)"; \
+	if [ -z "$$cfgs" ]; then echo "(none)"; exit 0; fi; \
+	for cfg in $$cfgs; do \
 	  dir=$$(dirname "$$cfg"); \
 	  base=$$(basename "$$cfg" .cfg); \
 	  tla="$$dir/$$base.tla"; \
@@ -91,10 +91,10 @@ check-clean:
 
 check-buggy:
 	@echo "=== Running buggy specs (expect violations) ==="; \
-	set -- $(BUGGY_CFGS); \
-	if [ $$# -eq 0 ]; then echo "(none)"; exit 0; fi; \
 	fail=0; \
-	for cfg in "$$@"; do \
+	cfgs="$(BUGGY_CFGS)"; \
+	if [ -z "$$cfgs" ]; then echo "(none)"; exit 0; fi; \
+	for cfg in $$cfgs; do \
 	  dir=$$(dirname "$$cfg"); \
 	  stripped=$${cfg%%-buggy*}; \
 	  bugbase=$$(basename "$$stripped"); \
@@ -117,33 +117,33 @@ check-buggy:
 
 check-bug-models:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find bug-models/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find bug-models/ -name '*-buggy*.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find bug-models/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort | tr '\n' ' ')" \
+	  BUGGY_CFGS="$$(find bug-models/ -name '*-buggy*.cfg' | sort | tr '\n' ' ')" check-all
 
 check-keeper:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy*.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort | tr '\n' ' ')" \
+	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy*.cfg' | sort | tr '\n' ' ')" check-all
 
 check-supporting:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*-buggy*.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort | tr '\n' ' ')" \
+	  BUGGY_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*-buggy*.cfg' | sort | tr '\n' ' ')" check-all
 
 check-ecosystem:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find masc-ecosystem/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  CLEAN_CFGS="$$(find masc-ecosystem/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort | tr '\n' ' ')" \
 	  BUGGY_CFGS="" check-all
 
 check-boundary:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy*.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort | tr '\n' ' ')" \
+	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy*.cfg' | sort | tr '\n' ' ')" check-all
 
 check-closure:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find closure/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find closure/ -name '*-buggy*.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find closure/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort | tr '\n' ' ')" \
+	  BUGGY_CFGS="$$(find closure/ -name '*-buggy*.cfg' | sort | tr '\n' ' ')" check-all
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -68,33 +68,33 @@ check-all: check-clean check-buggy
 
 check-clean:
 	@echo "=== Running clean specs (expect no errors) ==="; \
+	set -- $(CLEAN_CFGS); \
+	if [ $$# -eq 0 ]; then echo "(none)"; exit 0; fi; \
 	fail=0; \
-	cfgs="$(CLEAN_CFGS)"; \
-	if [ -z "$$cfgs" ]; then echo "(none)"; exit 0; fi; \
-	for cfg in $$cfgs; do \
+	for cfg in "$$@"; do \
 	  dir=$$(dirname "$$cfg"); \
 	  base=$$(basename "$$cfg" .cfg); \
 	  tla="$$dir/$$base.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kf in $(KNOWN_FAILURES); do [ "$$base" = "$$kf" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_FAILURES)\n" "$$base"; continue; fi; \
+	  if [ $$skip -eq 1 ]; then printf 'SKIP %-40s (KNOWN_FAILURES)\n' "$$base"; continue; fi; \
 	  start=$$(date +%s); \
-	  printf "CHECK %-40s START cfg=%s\n" "$$base" "$$cfg"; \
+	  printf 'CHECK %-40s START cfg=%s\n' "$$base" "$$cfg"; \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$base.log 2>&1; \
 	  rc=$$?; \
 	  end=$$(date +%s); \
 	  elapsed=$$((end - start)); \
-	  if [ $$rc -eq 0 ]; then printf "CHECK %-40s OK (%ss)\n" "$$base" "$$elapsed"; \
-	  else printf "CHECK %-40s FAIL (exit $$rc, %ss)\n" "$$base" "$$elapsed"; tail -5 /tmp/tlc-$$base.log; fail=1; fi; \
+	  if [ $$rc -eq 0 ]; then printf 'CHECK %-40s OK (%ss)\n' "$$base" "$$elapsed"; \
+	  else printf 'CHECK %-40s FAIL (exit %s, %ss)\n' "$$base" "$$rc" "$$elapsed"; tail -5 /tmp/tlc-$$base.log; fail=1; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 
 check-buggy:
 	@echo "=== Running buggy specs (expect violations) ==="; \
+	set -- $(BUGGY_CFGS); \
+	if [ $$# -eq 0 ]; then echo "(none)"; exit 0; fi; \
 	fail=0; \
-	cfgs="$(BUGGY_CFGS)"; \
-	if [ -z "$$cfgs" ]; then echo "(none)"; exit 0; fi; \
-	for cfg in $$cfgs; do \
+	for cfg in "$$@"; do \
 	  dir=$$(dirname "$$cfg"); \
 	  stripped=$${cfg%%-buggy*}; \
 	  bugbase=$$(basename "$$stripped"); \
@@ -102,16 +102,16 @@ check-buggy:
 	  tla="$$dir/$$bugbase.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kb in $(KNOWN_BUGGY_NO_VIOLATION); do [ "$$bugbase" = "$$kb" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
+	  if [ $$skip -eq 1 ]; then printf 'SKIP %-40s (KNOWN_BUGGY_NO_VIOLATION)\n' "$$bugbase (buggy)"; continue; fi; \
 	  start=$$(date +%s); \
-	  printf "CHECK %-40s START cfg=%s\n" "$$cfgtag (buggy)" "$$cfg"; \
+	  printf 'CHECK %-40s START cfg=%s\n' "$$cfgtag (buggy)" "$$cfg"; \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$cfgtag.log 2>&1; \
 	  rc=$$?; \
 	  end=$$(date +%s); \
 	  elapsed=$$((end - start)); \
-	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then printf "CHECK %-40s OK (violation exit $$rc, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; \
-	  elif [ $$rc -eq 0 ]; then printf "CHECK %-40s FAIL (no violation, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; fail=1; \
-	  else printf "CHECK %-40s WARN (exit $$rc, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; fi; \
+	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then printf 'CHECK %-40s OK (violation exit %s, %ss)\n' "$$cfgtag (buggy)" "$$rc" "$$elapsed"; \
+	  elif [ $$rc -eq 0 ]; then printf 'CHECK %-40s FAIL (no violation, %ss)\n' "$$cfgtag (buggy)" "$$elapsed"; fail=1; \
+	  else printf 'CHECK %-40s WARN (exit %s, %ss)\n' "$$cfgtag (buggy)" "$$rc" "$$elapsed"; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -5,6 +5,7 @@
 #   make check-all          Run all specs (clean + buggy)
 #   make check-bug-models   Bug models only
 #   make check-keeper       Keeper state machine only
+#   make check-supporting   Boundary + closure + small domain specs
 #   make check-ecosystem    MASC ecosystem only
 #   make check-boundary     Cross-domain boundary specs only
 #   make check-closure      Contract-closure specs (autoresearch<->verification<->FSM)
@@ -53,8 +54,9 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 
 CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)
 BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
+SUPPORTING_SPEC_DIRS := boundary checkpoint-trim closure masc-ecosystem social-state-cap state-product task-lifecycle
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure list clean clean-artefacts
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-supporting check-ecosystem check-boundary check-closure list clean clean-artefacts
 
 clean: clean-artefacts
 
@@ -75,15 +77,15 @@ check-clean:
 	  tla="$$dir/$$base.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kf in $(KNOWN_FAILURES); do [ "$$base" = "$$kf" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP  %-40s (KNOWN_FAILURES)\n" "$$base"; continue; fi; \
-	  printf "CHECK %-40s ...\n" "$$base"; \
-	  start_ts=$$(date +%s); \
+	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_FAILURES)\n" "$$base"; continue; fi; \
+	  start=$$(date +%s); \
+	  printf "CHECK %-40s START cfg=%s\n" "$$base" "$$cfg"; \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$base.log 2>&1; \
 	  rc=$$?; \
-	  end_ts=$$(date +%s); \
-	  duration=$$((end_ts - start_ts)); \
-	  if [ $$rc -eq 0 ]; then printf "OK    %-40s (%3ds)\n" "$$base" "$$duration"; \
-	  else printf "FAIL  %-40s (exit $$rc, %3ds)\n" "$$base" "$$duration"; tail -15 /tmp/tlc-$$base.log; fail=1; fi; \
+	  end=$$(date +%s); \
+	  elapsed=$$((end - start)); \
+	  if [ $$rc -eq 0 ]; then printf "CHECK %-40s OK (%ss)\n" "$$base" "$$elapsed"; \
+	  else printf "CHECK %-40s FAIL (exit $$rc, %ss)\n" "$$base" "$$elapsed"; tail -5 /tmp/tlc-$$base.log; fail=1; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 
@@ -100,16 +102,16 @@ check-buggy:
 	  tla="$$dir/$$bugbase.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kb in $(KNOWN_BUGGY_NO_VIOLATION); do [ "$$bugbase" = "$$kb" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP  %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
-	  printf "CHECK %-40s ...\n" "$$cfgtag (buggy)"; \
-	  start_ts=$$(date +%s); \
+	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
+	  start=$$(date +%s); \
+	  printf "CHECK %-40s START cfg=%s\n" "$$cfgtag (buggy)" "$$cfg"; \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$cfgtag.log 2>&1; \
 	  rc=$$?; \
-	  end_ts=$$(date +%s); \
-	  duration=$$((end_ts - start_ts)); \
-	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then printf "OK    %-40s (violation exit $$rc, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; \
-	  elif [ $$rc -eq 0 ]; then printf "FAIL  %-40s (no violation, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; fail=1; \
-	  else printf "WARN  %-40s (exit $$rc, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; fi; \
+	  end=$$(date +%s); \
+	  elapsed=$$((end - start)); \
+	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then printf "CHECK %-40s OK (violation exit $$rc, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; \
+	  elif [ $$rc -eq 0 ]; then printf "CHECK %-40s FAIL (no violation, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; fail=1; \
+	  else printf "CHECK %-40s WARN (exit $$rc, %ss)\n" "$$cfgtag (buggy)" "$$elapsed"; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 
@@ -122,6 +124,11 @@ check-keeper:
 	@$(MAKE) --no-print-directory \
 	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
 	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy*.cfg' | sort)" check-all
+
+check-supporting:
+	@$(MAKE) --no-print-directory \
+	  CLEAN_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find $(SUPPORTING_SPEC_DIRS) -name '*-buggy*.cfg' | sort)" check-all
 
 check-ecosystem:
 	@$(MAKE) --no-print-directory \


### PR DESCRIPTION
## Summary

- split the CI TLA lane into visible buckets: keeper-state-machine, supporting specs, and bug-models
- make `specs/Makefile` print per-spec START/OK/FAIL lines with elapsed seconds so the active spec is visible in logs
- add a supporting-spec target that covers the non-keeper, non-bug-model directories without changing the overall spec coverage

## Why

PR CI currently exposes `TLA+ Model Checking` as one long opaque required step. When TLC is healthy but slow, operators cannot tell which spec family is active or whether the lane is still making progress. This patch addresses issue #9167 by surfacing both the active bucket in GitHub Actions and the active spec inside each bucket.

## What changed

- `.github/workflows/ci.yml`
  - replaced the single `make -C specs check-all` step with:
    - `make -C specs list`
    - `make -C specs check-keeper`
    - `make -C specs check-supporting`
    - `make -C specs check-bug-models`
- `specs/Makefile`
  - added `check-supporting` to cover `boundary`, `checkpoint-trim`, `closure`, `masc-ecosystem`, `social-state-cap`, `state-product`, and `task-lifecycle`
  - changed clean/buggy spec loops to emit START and completion lines with elapsed time per spec

## Validation

- `make -C specs list`
- `make -C specs -n check-keeper check-supporting check-bug-models`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`

## Issue

Closes #9167
