### PR TITLE
[codex] fix keeper gate_rejected outcomes rollup

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -49,8 +49,10 @@ let compute_health_score
 (** Outcomes rollup: aggregate successes / failures / validation for a keeper.
 
     Data sources (all already in-process, zero new schema):
-    - [Keeper_transition_audit.recent_transitions] (50-entry ring) → turn,
-      compaction, handoff outcomes classified by [selected_event].
+    - [Keeper_transition_audit.recent_completed_turns] (50-entry ring) →
+      turn outcomes classified after [mark_turn_finished].
+    - [Keeper_transition_audit.recent_transitions] (50-entry ring) →
+      compaction / handoff outcomes classified by [selected_event].
     - [registry_entry] crash_log / restart_count / turn_consecutive_failures
       → resilience counters.
     - [Dashboard_harness_health.read_recent_verdicts] → OAS verdict pass/fail
@@ -59,9 +61,8 @@ let compute_health_score
     Conservation law (spec {!KeeperOutcomesConservation.tla}):
       successes.substantive_turns + failures.turn_failed + failures.gate_rejected
         = observed_turns
-    holds by construction only for buckets backed by the transition ring pass.
-    Historical [gate_rejected] counts are not yet persisted in the same read
-    model, so the field remains 0 until a keeper-turn source is added. *)
+    holds by construction because all three turn buckets now come from the
+    same completed-turn ring. *)
 let compute_outcomes_rollup
     ~keeper_name
     ~agent_name
@@ -71,22 +72,31 @@ let compute_outcomes_rollup
   let succ_compactions = ref 0 in
   let succ_handoffs = ref 0 in
   let fail_turn = ref 0 in
+  let fail_gate_rejected = ref 0 in
   let fail_compaction = ref 0 in
   let fail_handoff = ref 0 in
+  let completed_turns =
+    Keeper_transition_audit.recent_completed_turns ~keeper_name ~limit:50
+  in
+  List.iter
+    (fun (turn : Keeper_transition_audit.completed_turn_record) ->
+      match turn.outcome with
+      | Keeper_transition_audit.Turn_substantive -> incr succ_turns
+      | Keeper_transition_audit.Turn_failed -> incr fail_turn
+      | Keeper_transition_audit.Turn_gate_rejected -> incr fail_gate_rejected)
+    completed_turns;
   let transitions =
     Keeper_transition_audit.recent_transitions ~keeper_name ~limit:50
   in
   List.iter (fun (tr : Keeper_transition_audit.transition_record) ->
     match tr.selected_event with
-    | Keeper_state_machine.Turn_succeeded -> incr succ_turns
-    | Turn_failed _ -> incr fail_turn
-    | Compaction_completed _ -> incr succ_compactions
+    | Keeper_state_machine.Compaction_completed _ -> incr succ_compactions
     | Compaction_failed _ -> incr fail_compaction
     | Handoff_completed _ -> incr succ_handoffs
     | Handoff_failed _ -> incr fail_handoff
     | _ -> ()
   ) transitions;
-  let observed_turns = !succ_turns + !fail_turn in
+  let observed_turns = List.length completed_turns in
   let restarts, consecutive_fail =
     match registry_entry with
     | Some (e : Keeper_registry.registry_entry) ->
@@ -164,8 +174,7 @@ let compute_outcomes_rollup
     ]);
     ("failures", `Assoc [
       ("turn_failed", `Int !fail_turn);
-      (* Historical gate_rejected counts are not persisted yet. *)
-      ("gate_rejected", `Int 0);
+      ("gate_rejected", `Int !fail_gate_rejected);
       ("compaction_failed", `Int !fail_compaction);
       ("handoff_failed", `Int !fail_handoff);
       ("crashes", `Int recent_crash_count);

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -375,6 +375,13 @@ let turn_phase_of_cascade_state = function
   | Cascade_trying -> Turn_executing
   | Cascade_done | Cascade_exhausted -> Turn_finalizing
 
+let completed_turn_outcome_of_observation
+    (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =
+  match obs.decision_stage, obs.cascade_state with
+  | Decision_gate_rejected, _ -> Keeper_transition_audit.Turn_gate_rejected
+  | _, Cascade_done -> Keeper_transition_audit.Turn_substantive
+  | _ -> Keeper_transition_audit.Turn_failed
+
 let update_current_turn e f =
   let current_turn_observation =
     match e.current_turn_observation with
@@ -470,23 +477,37 @@ let mark_turn_gate_rejected_by_name name =
           }))
 
 let mark_turn_finished ~base_path name =
+  let completed_turn_to_record = ref None in
   update_entry ~base_path name (fun e ->
     let last_completed_turn =
       match e.current_turn_observation with
       | Some obs ->
-        Some {
-          ct_turn_id = obs.turn_id;
-          ct_started_at = obs.started_at;
-          ct_ended_at = Time_compat.now ();
-          ct_decision_stage = obs.decision_stage;
-          ct_cascade_state = obs.cascade_state;
-          ct_selected_model = obs.selected_model;
-        }
+          let ended_at = Time_compat.now () in
+          completed_turn_to_record :=
+            Some
+              {
+                Keeper_transition_audit.turn_id = obs.turn_id;
+                started_at = obs.started_at;
+                ended_at;
+                outcome = completed_turn_outcome_of_observation obs;
+              };
+          Some
+            {
+              ct_turn_id = obs.turn_id;
+              ct_started_at = obs.started_at;
+              ct_ended_at = ended_at;
+              ct_decision_stage = obs.decision_stage;
+              ct_cascade_state = obs.cascade_state;
+              ct_selected_model = obs.selected_model;
+            }
       | None -> e.last_completed_turn  (* no live turn → preserve previous *)
     in
     { e with
       current_turn_observation = None;
-      last_completed_turn })
+      last_completed_turn });
+  Option.iter
+    (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
+    !completed_turn_to_record
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -24,6 +24,32 @@ let to_json (r : transition_record) : Yojson.Safe.t =
     "wall_clock_at_decision", `Float r.wall_clock_at_decision;
   ]
 
+type completed_turn_outcome =
+  | Turn_substantive
+  | Turn_failed
+  | Turn_gate_rejected
+
+type completed_turn_record = {
+  turn_id : int;
+  started_at : float;
+  ended_at : float;
+  outcome : completed_turn_outcome;
+}
+
+let completed_turn_outcome_to_json = function
+  | Turn_substantive -> `String "substantive"
+  | Turn_failed -> `String "failed"
+  | Turn_gate_rejected -> `String "gate_rejected"
+
+let completed_turn_to_json (r : completed_turn_record) : Yojson.Safe.t =
+  `Assoc
+    [
+      "turn_id", `Int r.turn_id;
+      "started_at", `Float r.started_at;
+      "ended_at", `Float r.ended_at;
+      "outcome", completed_turn_outcome_to_json r.outcome;
+    ]
+
 (* ================================================================ *)
 (* In-memory ring buffer for recent transitions                     *)
 (* ================================================================ *)
@@ -41,12 +67,33 @@ let ring_capacity = 50
 
 let rings : (string, ring) Hashtbl.t = Hashtbl.create 16
 
+type completed_turn_ring = {
+  buf : completed_turn_record option array;
+  mutable pos : int;
+  mutable count : int;
+}
+
+let completed_turn_rings : (string, completed_turn_ring) Hashtbl.t =
+  Hashtbl.create 16
+
 let get_or_create_ring name =
   match Hashtbl.find_opt rings name with
   | Some r -> r
   | None ->
-    let r = { buf = Array.make ring_capacity None; pos = 0; count = 0 } in
+    let r : ring =
+      { buf = Array.make ring_capacity None; pos = 0; count = 0 }
+    in
     Hashtbl.replace rings name r;
+    r
+
+let get_or_create_completed_turn_ring name =
+  match Hashtbl.find_opt completed_turn_rings name with
+  | Some r -> r
+  | None ->
+    let r : completed_turn_ring =
+      { buf = Array.make ring_capacity None; pos = 0; count = 0 }
+    in
+    Hashtbl.replace completed_turn_rings name r;
     r
 
 (* ================================================================ *)
@@ -108,3 +155,42 @@ let recent_transitions ~keeper_name ~limit : transition_record list =
 
 let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
   `List (List.map to_json (recent_transitions ~keeper_name ~limit))
+
+let record_completed_turn ~keeper_name (rec_ : completed_turn_record) =
+  let ring = get_or_create_completed_turn_ring keeper_name in
+  ring.buf.(ring.pos) <- Some rec_;
+  ring.pos <- (ring.pos + 1) mod ring_capacity;
+  ring.count <- ring.count + 1;
+  match sink_path () with
+  | None -> ()
+  | Some path ->
+      Safe_ops.protect ~default:() (fun () ->
+          let line =
+            Yojson.Safe.to_string
+              (`Assoc
+                [
+                  "keeper", `String keeper_name;
+                  "completed_turn", completed_turn_to_json rec_;
+                ])
+          in
+          let oc =
+            open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
+          in
+          Fun.protect
+            ~finally:(fun () ->
+              Safe_ops.protect ~default:() (fun () -> close_out oc))
+            (fun () -> output_string oc (line ^ "\n")))
+
+let recent_completed_turns ~keeper_name ~limit : completed_turn_record list =
+  match Hashtbl.find_opt completed_turn_rings keeper_name with
+  | None -> []
+  | Some ring ->
+      let n = min limit (min ring.count ring_capacity) in
+      let result = ref [] in
+      for i = 0 to n - 1 do
+        let idx = (ring.pos - 1 - i + ring_capacity) mod ring_capacity in
+        match ring.buf.(idx) with
+        | Some r -> result := r :: !result
+        | None -> ()
+      done;
+      !result

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -16,6 +16,22 @@ type transition_record = {
 (** Serialize a transition record for JSONL storage. *)
 val to_json : transition_record -> Yojson.Safe.t
 
+(** Historical keeper-turn outcome buckets for dashboard outcomes rollups.
+    This stays separate from [transition_record] because a keeper turn can be
+    [Turn_succeeded] at the state-machine layer while still ending in a
+    [gate_rejected] decision_stage at the turn observer layer. *)
+type completed_turn_outcome =
+  | Turn_substantive
+  | Turn_failed
+  | Turn_gate_rejected
+
+type completed_turn_record = {
+  turn_id : int;
+  started_at : float;
+  ended_at : float;
+  outcome : completed_turn_outcome;
+}
+
 (** {1 In-memory Ring Buffer} *)
 
 (** Record a transition in the per-keeper ring buffer (last 50). *)
@@ -29,3 +45,11 @@ val recent_transitions :
 (** JSON array of recent transitions. *)
 val recent_transitions_json :
   keeper_name:string -> limit:int -> Yojson.Safe.t
+
+(** Record a completed keeper turn in the per-keeper ring buffer (last 50). *)
+val record_completed_turn :
+  keeper_name:string -> completed_turn_record -> unit
+
+(** Retrieve recent completed keeper turns for a keeper, newest first. *)
+val recent_completed_turns :
+  keeper_name:string -> limit:int -> completed_turn_record list

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -4,6 +4,7 @@ module Harness = Masc_mcp.Dashboard_harness_health
 module Cal = Masc_mcp.Eval_calibration
 module AR = Masc_mcp.Anti_rationalization
 module Coord = Masc_mcp.Coord
+module Reg = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
 
 let test_counter = ref 0
@@ -334,6 +335,45 @@ let test_agent_scoped_verdicts_filter_before_limit () =
   check (option (float 0.000_001)) "last verdict timestamp preserved" (Some 101.0)
     Yojson.Safe.Util.(outcomes |> member "validation" |> member "last_verdict_at" |> to_float_option)
 
+let test_outcomes_rollup_counts_gate_rejected_from_completed_turns () =
+  with_test_stores @@ fun config ->
+  let keeper_name = "keeper-outcomes-gate" in
+  let meta = make_keeper_meta ~name:keeper_name () in
+  Reg.clear ();
+  ignore (Reg.register ~base_path:config.base_path keeper_name meta);
+  Reg.mark_turn_started ~base_path:config.base_path keeper_name;
+  Reg.set_turn_decision_stage
+    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+  Reg.mark_turn_gate_rejected_by_name keeper_name;
+  Reg.mark_turn_finished ~base_path:config.base_path keeper_name;
+  Reg.mark_turn_started ~base_path:config.base_path keeper_name;
+  Reg.set_turn_decision_stage
+    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+  Reg.set_turn_cascade_state
+    ~base_path:config.base_path keeper_name Reg.Cascade_done;
+  Reg.mark_turn_finished ~base_path:config.base_path keeper_name;
+  Reg.mark_turn_started ~base_path:config.base_path keeper_name;
+  Reg.set_turn_decision_stage
+    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+  Reg.set_turn_cascade_state
+    ~base_path:config.base_path keeper_name Reg.Cascade_exhausted;
+  Reg.mark_turn_finished ~base_path:config.base_path keeper_name;
+  let outcomes =
+    Masc_mcp.Dashboard_http_keeper.compute_outcomes_rollup
+      ~keeper_name
+      ~agent_name:keeper_name
+      ~recent_crash_count:0
+      ~registry_entry:(Reg.get ~base_path:config.base_path keeper_name)
+  in
+  check int "observed turns comes from completed turn ring" 3
+    Yojson.Safe.Util.(outcomes |> member "observed_turns" |> to_int);
+  check int "gate_rejected bucket populated" 1
+    Yojson.Safe.Util.(outcomes |> member "failures" |> member "gate_rejected" |> to_int);
+  check int "substantive turns exclude gate_rejected" 1
+    Yojson.Safe.Util.(outcomes |> member "successes" |> member "substantive_turns" |> to_int);
+  check int "turn_failed bucket keeps non-gate failures" 1
+    Yojson.Safe.Util.(outcomes |> member "failures" |> member "turn_failed" |> to_int)
+
 let () =
   run "Dashboard_harness_health"
     [
@@ -353,5 +393,7 @@ let () =
             test_overview_warns_when_evaluator_falls_back;
           test_case "agent-scoped verdicts filter before limit" `Quick
             test_agent_scoped_verdicts_filter_before_limit;
+          test_case "outcomes rollup counts gate_rejected from completed turns"
+            `Quick test_outcomes_rollup_counts_gate_rejected_from_completed_turns;
         ] );
     ]

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -189,6 +189,30 @@ let test_dispatch_event_with_audit_preserves_snapshot () =
       check string "new phase" "failing" (KSM.phase_to_string audit.new_phase)
   | _ -> fail "expected exactly one transition audit entry"
 
+let test_mark_turn_finished_records_completed_turn_outcome_once () =
+  R.clear ();
+  let keeper_name = "k-completed-turn-audit" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.set_turn_decision_stage
+    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+  R.mark_turn_gate_rejected_by_name keeper_name;
+  R.mark_turn_finished ~base_path:bp keeper_name;
+  R.mark_turn_finished ~base_path:bp keeper_name;
+  match Audit.recent_completed_turns ~keeper_name ~limit:5 with
+  | [ turn ] ->
+      check int "turn_id recorded" 1 turn.turn_id;
+      check bool "started_at recorded" true (turn.started_at > 0.0);
+      check bool "ended_at recorded" true (turn.ended_at >= turn.started_at);
+      check bool "gate_rejected outcome recorded" true
+        (match turn.outcome with
+         | Audit.Turn_gate_rejected -> true
+         | _ -> false)
+  | turns ->
+      fail
+        (Printf.sprintf "expected exactly one completed turn, got %d"
+           (List.length turns))
+
 let test_unregister () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k2" (make_meta "k2") in
@@ -737,6 +761,8 @@ let () =
           eio_test "register restarting and start" test_register_restarting_and_start;
           eio_test "dispatch event with audit preserves snapshot"
             test_dispatch_event_with_audit_preserves_snapshot;
+          eio_test "mark_turn_finished records completed turn outcome once"
+            test_mark_turn_finished_records_completed_turn_outcome_once;
           eio_test "unregister" test_unregister;
           eio_test "all" test_all;
           eio_test "update meta" test_update_meta;


### PR DESCRIPTION
## Summary

Fixes #7950 by persisting historical keeper turn outcomes so `/api/v1/keepers[*].outcomes.failures.gate_rejected` is backed by a real read model instead of being hard-coded to `0`.

## What changed

- Added a `completed_turn_record` ring to `Keeper_transition_audit` for the last 50 finished turns per keeper.
- Recorded a completed-turn outcome from `Keeper_registry.mark_turn_finished`, classifying each turn as:
  - `substantive`
  - `failed`
  - `gate_rejected`
- Updated `Dashboard_http_keeper.compute_outcomes_rollup` to compute turn buckets from completed-turn history instead of inferring them from lifecycle transitions.
- Left compaction and handoff counters on the existing transition audit ring.
- Added regression tests for:
  - recording gate-rejected completed turns exactly once
  - counting `gate_rejected` correctly in the dashboard outcomes rollup

## Root cause

`gate_rejected` lived only in the live registry decision stage (`Keeper_registry.mark_turn_gate_rejected_by_name`) and never entered the historical source used by the dashboard rollup. The rollup therefore always emitted `0`, and `turn_succeeded` lifecycle events could still make a gate-rejected turn look substantive.

## Impact

- `/api/v1/keepers` now reports historical `gate_rejected` counts from a stable source.
- `observed_turns = substantive_turns + turn_failed + gate_rejected` holds within the completed-turn window.
- Gate-rejected turns no longer get folded into `substantive_turns`.

## Validation

- `dune build --root . -j 1 test/test_keeper_registry.exe test/test_dashboard_harness_health.exe`
- `dune exec --root . ./test/test_keeper_registry.exe`
- `dune exec --root . ./test/test_dashboard_harness_health.exe`

## Notes

A full `dune build --root .` was attempted first, but this workspace has long-lived concurrent dune processes and the full build did not complete reliably in this environment, so validation was narrowed to the affected targets and regression tests.