### PR TITLE
fix(keeper): prevent parameter loss in Edit and Grep tool aliases

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -233,14 +233,16 @@ let translate_read_input input =
 let translate_edit_input input =
   match input with
   | `Assoc fields ->
-      let out = ref [ ("mode", `String "patch") ] in
+      let has_content = List.exists (fun (k, _) -> k = "content") fields in
+      let mode = if has_content then "overwrite" else "patch" in
+      let out = ref [ ("mode", `String mode) ] in
       List.iter
         (fun (k, v) ->
           match k with
           | "file_path" -> out := ("path", v) :: !out
-          | "old_string" | "new_string" | "replace_all" ->
+          | "old_string" | "new_string" | "replace_all" | "content" ->
               out := (k, v) :: !out
-          | "mode" | "content" -> ()  (* ignore caller-supplied overrides *)
+          | "mode" -> ()  (* ignore caller-supplied overrides *)
           | _ -> out := (k, v) :: !out)
         fields;
       `Assoc (List.rev !out)
@@ -271,10 +273,23 @@ let translate_grep_input input =
   match input with
   | `Assoc fields ->
       let out = ref [ ("op", `String "rg") ] in
+      let is_case_insensitive =
+        match List.assoc_opt "-i" fields with
+        | Some (`Bool true) -> true
+        | _ -> false
+      in
       List.iter
         (fun (k, v) ->
           match k with
-          | "pattern" | "path" | "glob" | "type" ->
+          | "pattern" ->
+              let v' = if is_case_insensitive then
+                match v with
+                | `String s -> `String ("(?i)" ^ s)
+                | _ -> v
+              else v
+              in
+              out := (k, v') :: !out
+          | "path" | "glob" | "type" ->
               out := (k, v) :: !out
           | "op" -> ()  (* always rg via Grep alias *)
           | "-i" | "-n" -> ()  (* shim accepted, not routed *)

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -308,25 +308,25 @@ let test_translate_edit_input () =
        (function `Bool b -> Some b | _ -> None))
 
 let test_translate_edit_drops_caller_supplied_mode () =
-  (* Defense-in-depth: even if the LLM tries to override mode the
-     translator must force mode=patch. *)
+  (* Defense-in-depth: if the LLM tries to write via Edit by providing 'content',
+     fallback to mode=overwrite instead of silently dropping it. *)
   let input =
     `Assoc
       [
         ("file_path", `String "/tmp/x");
-        ("old_string", `String "a");
-        ("new_string", `String "b");
-        ("mode", `String "overwrite");
-        ("content", `String "ignored");
+        ("mode", `String "patch");
+        ("content", `String "fallback");
       ]
   in
   let translated = Alias.translate_input ~public:"Edit" input in
-  Alcotest.(check (option string)) "mode is forced to patch"
-    (Some "patch")
+  Alcotest.(check (option string)) "mode is fallback to overwrite"
+    (Some "overwrite")
     (Option.bind (yojson_field "mode" translated)
        (function `String s -> Some s | _ -> None));
-  Alcotest.(check bool) "caller-supplied content dropped" true
-    (Option.is_none (yojson_field "content" translated))
+  Alcotest.(check (option string)) "caller-supplied content preserved"
+    (Some "fallback")
+    (Option.bind (yojson_field "content" translated)
+       (function `String s -> Some s | _ -> None))
 
 let test_translate_write_input () =
   let input =
@@ -367,8 +367,8 @@ let test_translate_grep_input () =
     (Some "rg")
     (Option.bind (yojson_field "op" translated)
        (function `String s -> Some s | _ -> None));
-  Alcotest.(check (option string)) "pattern preserved"
-    (Some "TODO")
+  Alcotest.(check (option string)) "pattern preserved and prefix added"
+    (Some "(?i)TODO")
     (Option.bind (yojson_field "pattern" translated)
        (function `String s -> Some s | _ -> None));
   Alcotest.(check bool) "path preserved" true


### PR DESCRIPTION
This PR addresses silent parameter drops in the OAS dual registration aliases for `Grep` and `Edit` tools.

- **Grep**: When `-i` (case-insensitive) is passed by the LLM, the alias translator now prepends `(?i)` to the search pattern instead of silently dropping the flag. This prevents hallucination loops where the LLM thinks a case-insensitive search yielded no results.
- **Edit**: When the LLM attempts to rewrite a file completely by providing a `content` field, the alias translator now dynamically falls back to `mode="overwrite"` and passes the content through, instead of forcing `mode="patch"` and silently discarding the content.

These changes ensure the LLM's intended behavior matches the actual execution, reducing thrashing and improving reliability.

Tests have been updated to verify these translation rules.