### PR TITLE
[codex] fix dashboard observer mcp sse auth

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -33,7 +33,7 @@ let devTokenBootstrapPromise: Promise<void> | null = null
     only exposes `/api/v1/dashboard/dev-token` when bound to loopback with
     strict-auth overrides disabled; in every other case this quietly no-ops
     and existing flows (URL `?token=…`, manual paste) continue to work. */
-async function ensureDevToken(): Promise<void> {
+export async function ensureDevToken(): Promise<void> {
   if (getStoredToken()) return
   if (devTokenBootstrapPromise) return devTokenBootstrapPromise
   devTokenBootstrapPromise = (async () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -18,6 +18,7 @@ import { refreshForRoute } from './tab-refresh'
 import { refreshMissionSnapshot } from './mission-store'
 import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 import { refreshShell } from './store'
+import { ensureDevToken } from './api/mcp'
 import {
   BuildIdentityBadge,
   ConnectionStatus,
@@ -64,8 +65,15 @@ export function App() {
       })
       .finally(() => {
         if (cancelled) return
-        connectSSE()
-        resumeQueuedOasRuntimeIngress()
+        void ensureDevToken()
+          .catch(err => {
+            console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
+          })
+          .finally(() => {
+            if (cancelled) return
+            connectSSE()
+            resumeQueuedOasRuntimeIngress()
+          })
       })
 
     // Register mission refresh for periodic recovery from transient failures.

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -76,6 +76,26 @@ let auth_token_from_request request =
     (Httpun.Headers.get request.Httpun.Request.headers "authorization")
     bearer_token_from_header
 
+let observer_sse_query_token_from_request request =
+  let path = Http_server_eio.Request.path request in
+  let observer_stream_requested =
+    match query_param request "sse_kind" with
+    | Some raw ->
+        String.equal "observer" (String.lowercase_ascii (String.trim raw))
+    | None -> false
+  in
+  match request.Httpun.Request.meth with
+  | `GET
+    when observer_stream_requested
+         && (String.equal path "/mcp" || String.equal path "/sse") ->
+      trim_opt (query_param request "token")
+  | _ -> None
+
+let observer_sse_auth_token_from_request request =
+  match auth_token_from_request request with
+  | Some _ as token -> token
+  | None -> observer_sse_query_token_from_request request
+
 (** Verify Bearer token for MCP endpoints *)
 let verify_mcp_auth ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
@@ -91,6 +111,26 @@ let verify_mcp_auth ~base_path request =
         | None ->
             Error
               "Authentication required. Use 'Authorization: Bearer <token>' header."
+        | Some token -> (
+            match Auth.find_credential_by_token base_path ~token with
+            | Ok cred -> Ok (Some cred)
+            | Error err -> Error (Types.masc_error_to_string err))
+
+let verify_mcp_observer_stream_auth ~base_path request =
+  let auth_config = Auth.load_auth_config base_path in
+  match ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config with
+  | Error msg -> Error msg
+  | Ok auth_config ->
+      if not auth_config.Types.enabled then
+        Ok None
+      else
+        match observer_sse_auth_token_from_request request with
+        | None when not auth_config.require_token ->
+            Ok None
+        | None ->
+            Error
+              "Authentication required. Use 'Authorization: Bearer <token>' header \
+               or 'token' query param for the observer SSE stream."
         | Some token -> (
             match Auth.find_credential_by_token base_path ~token with
             | Ok cred -> Ok (Some cred)

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -470,7 +470,11 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
   let auth_result =
     match profile with
     | Full | Managed_agent ->
-        deps.verify_mcp_auth ~base_path request
+        (match sse_kind with
+         | Sse.Observer ->
+             deps.verify_mcp_observer_stream_auth ~base_path request
+         | Sse.Coordinator ->
+             deps.verify_mcp_auth ~base_path request)
     | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -24,6 +24,8 @@ type deps = {
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
   verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_observer_stream_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
   verify_operator_mcp_auth :
     base_path:string -> Httpun.Request.t -> (unit, string) result;
 }

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -19,6 +19,8 @@ type deps = Server_mcp_transport_http_types.deps = {
     unit -> (Server_mcp_transport_http_types.runtime, string) result;
   get_base_path : unit -> string;
   verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_observer_stream_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
   verify_operator_mcp_auth :
     base_path:string -> Httpun.Request.t -> (unit, string) result;
 }

--- a/lib/server/server_mcp_transport_http_types.ml
+++ b/lib/server/server_mcp_transport_http_types.ml
@@ -24,6 +24,8 @@ type deps = {
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
   verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_observer_stream_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
   verify_operator_mcp_auth :
     base_path:string -> Httpun.Request.t -> (unit, string) result;
 }

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -24,6 +24,8 @@ type deps = {
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
   verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_observer_stream_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
   verify_operator_mcp_auth :
     base_path:string -> Httpun.Request.t -> (unit, string) result;
 }

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -233,6 +233,9 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
     verify_mcp_auth =
       (fun ~base_path request ->
         Result.map (fun _ -> ()) (verify_mcp_auth ~base_path request));
+    verify_mcp_observer_stream_auth =
+      (fun ~base_path request ->
+        Result.map (fun _ -> ()) (verify_mcp_observer_stream_auth ~base_path request));
     verify_operator_mcp_auth =
       (fun ~base_path request ->
         Result.map (fun _ -> ()) (verify_operator_mcp_auth ~base_path request));

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -429,6 +429,51 @@ let test_http_auth_rejects_query_token_fallback () =
   check (option string) "query token ignored" None
     (Server_auth.auth_token_from_request request)
 
+let test_observer_sse_auth_accepts_query_token_fallback () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let request =
+        Httpun.Request.create `GET
+          ("/mcp?sse_kind=observer&session_id=dash_test&token=" ^ raw_token)
+      in
+      match Server_auth.verify_mcp_observer_stream_auth ~base_path:dir request with
+      | Ok (Some cred) ->
+          check string "observer query token resolves credential" "stable-admin"
+            cred.Types.agent_name
+      | Ok None -> fail "expected observer SSE auth credential"
+      | Error e -> fail e)
+
+let test_observer_sse_auth_rejects_query_token_on_non_observer_path () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let request =
+        Httpun.Request.create `GET
+          ("/mcp?session_id=dash_test&token=" ^ raw_token)
+      in
+      match Server_auth.verify_mcp_observer_stream_auth ~base_path:dir request with
+      | Ok _ -> fail "expected non-observer query token to be rejected"
+      | Error msg ->
+          check bool "non-observer path still requires header" true
+            (String.starts_with ~prefix:"Authentication required." msg))
+
 let test_permission_for_tool_approve () =
   match Auth.permission_for_tool "masc_approve" with
   | None -> ()
@@ -828,6 +873,10 @@ let () =
       test_case "header token only" `Quick test_http_auth_token_from_header_only;
       test_case "reject query token fallback" `Quick
         test_http_auth_rejects_query_token_fallback;
+      test_case "observer sse accepts query token fallback" `Quick
+        test_observer_sse_auth_accepts_query_token_fallback;
+      test_case "observer sse rejects query token on non-observer path" `Quick
+        test_observer_sse_auth_rejects_query_token_on_non_observer_path;
       test_case "generated actor prefers token subject" `Quick
         test_resolve_agent_name_prefers_token_for_generated_actor;
       test_case "stable actor preserved" `Quick


### PR DESCRIPTION
## Summary
Fix dashboard observer SSE auth drift so a fresh dashboard tab does not show `신호 없음` just because the observer stream opened before auth was available.

## What changed
- allow dashboard observer SSE on `/mcp?sse_kind=observer` to authenticate with the existing `token` query param contract, without widening header-free auth for other MCP paths
- bootstrap the dashboard dev token before opening the observer SSE stream on first page load
- add auth coverage tests for observer-stream query token acceptance and non-observer rejection

## Why
The dashboard health chip could show `신호 없음` even while the server was healthy because the page opened the observer SSE stream before the dashboard had a bearer token available, and the server-side `/mcp` observer GET path only accepted `Authorization` headers.

`EventSource` cannot send custom auth headers, so the dashboard and server contracts had drifted: the client used `/mcp?...&token=...`, but the server ignored the query token for observer SSE auth.

## Product impact
- first-load dashboard tabs should connect their observer SSE stream reliably in loopback/dev-token flows
- the fix stays scoped to observer SSE and does not relax auth for general MCP, POST, or mutation routes
- deprecated `/sse` is not used by the dashboard path; the canonical `/mcp` observer stream now matches the dashboard contract

## Evidence
- local reproduction showed `/mcp` observer SSE failed auth when opened without a bearer header even though the dashboard client used the query-token contract
- server auth path now has observer-SSE-specific coverage and non-observer rejection coverage in `test_auth_coverage`
- dashboard bootstrap now requests the dev token before opening the observer SSE tail on initial load

## Review evidence
- `dune exec --root . ./test/test_auth_coverage.exe`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/api/mcp.test.ts src/sse.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`

## Linked issue
Fixes #9174
