### PR TITLE
Unify keeper GitHub guidance and status observability

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1190,16 +1190,24 @@ let run_turn
          | _ ->
            Some (Printf.sprintf
              "## Discovered Work (auto, %ds interval)\n\n%s\n\n\
-              ### Required: use ONE structured keeper tool if available\n\
-              Valid keeper tools (copy the name and schema verbatim):\n\
+              ### Use the smallest real action now\n\
+              Preferred keeper tools (copy the name and schema verbatim):\n\
              \  - `keeper_task_claim` {} \
               — reserve the next eligible task\n\
+             \  - `keeper_shell` { op: \"gh\", cmd: \"pr list --state open\" } \
+              — inspect GitHub PRs/issues/checks\n\
              \  - `keeper_bash` { cmd: \"<single shell command>\" } \
-              — execute shell (sandboxed)\n\
+              — run one shell command, including raw git in a worktree\n\
+             \  - `masc_worktree_create` { repo_name: \"masc-mcp\", branch_name: \"<branch>\" } \
+              — create a worktree before editing code\n\
              \  - `keeper_board_post` { content: \"<note>\" } \
               — coordinate via board\n\
              \  - `keeper_stay_silent` {} \
               — none of the above fit my role\n\n\
+              GitHub/code workflow: inspect with `keeper_shell op=gh`; \
+              if code change is needed, `masc_worktree_create` -> edit -> \
+              `keeper_bash` for `git add` / `git commit` / `git push` -> \
+              `keeper_shell op=gh` with `cmd=\"pr create --draft ...\"`.\n\n\
               Anti-pattern: `Bash`, `Read`, `Skill`, `Agent` are NOT \
               registered tools. Calling them is a hallucination — the \
               call fails silently and the turn is wasted. Use the \
@@ -1208,7 +1216,7 @@ let run_turn
               expose a structured tool channel, return exactly \
               `NO_TOOL_CHANNEL: <brief reason>` instead of pretending a \
               tool ran. Otherwise pick the smallest viable action and emit \
-              it as a structured tool_call now."
+              one or more structured tool calls now."
              interval (String.concat "\n\n" sections)))
     | _ -> None
   in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -156,6 +156,11 @@ let assoc_bool_opt key fields =
   | Some (`Bool value) -> Some value
   | _ -> None
 
+let json_string_opt_member json key =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> nonempty_trimmed value
+  | _ -> None
+
 let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =
   let lines =
     let dated = Dated_jsonl.read_recent_lines metrics_store 8 in
@@ -319,7 +324,9 @@ let attempt_summary_json ~configured_labels ~resolved_candidates ~selected_model
   | None ->
       `Assoc
         [
-          ("summary", `String "No recent cascade observation. Showing configured labels only.");
+          ( "summary",
+            `String
+              "No recent cascade observation for current keeper config. Showing configured labels only." );
           ("attempts_observed", `Null);
           ("selected_index", `Null);
           ("fallback_hops", `Null);
@@ -381,8 +388,8 @@ let attempt_summary_json ~configured_labels ~resolved_candidates ~selected_model
           ("fallback_applied", `Bool fallback_applied);
         ]
 
-let model_observability_json ~configured_labels ~active_model
-    ~runtime_blocker_fields latest_metrics =
+let latest_cascade_for_current_config ~current_cascade_name ~configured_labels
+    latest_metrics =
   let latest_cascade =
     match latest_metrics with
     | Some metrics -> (
@@ -391,24 +398,35 @@ let model_observability_json ~configured_labels ~active_model
         | _ -> None)
     | None -> None
   in
+  match latest_cascade with
+  | None -> None
+  | Some cascade ->
+      let cascade_name_matches =
+        match json_string_opt_member cascade "cascade_name" with
+        | Some observed_name -> String.equal observed_name current_cascade_name
+        | None -> true
+      in
+      let configured_labels_match =
+        match json_string_list_member cascade "configured_labels" with
+        | [] -> true
+        | observed_labels -> observed_labels = configured_labels
+      in
+      if cascade_name_matches && configured_labels_match then Some cascade
+      else None
+
+let model_observability_json ~current_cascade_name ~configured_labels ~active_model
+    ~runtime_blocker_fields latest_metrics =
+  let latest_cascade =
+    latest_cascade_for_current_config ~current_cascade_name ~configured_labels
+      latest_metrics
+  in
   let runtime_blocker_class =
     assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
   in
   let cascade_name =
-    match latest_cascade with
-    | Some cascade -> (
-        match Yojson.Safe.Util.member "cascade_name" cascade with
-        | `String value when String.trim value <> "" -> value
-        | _ -> "")
-    | None -> ""
+    Option.value ~default:"" (nonempty_trimmed current_cascade_name)
   in
-  let configured_labels_surface =
-    match latest_cascade with
-    | Some cascade ->
-        let labels = json_string_list_member cascade "configured_labels" in
-        if labels <> [] then labels else configured_labels
-    | None -> configured_labels
-  in
+  let configured_labels_surface = configured_labels in
   let resolved_candidates =
     match latest_cascade with
     | Some cascade ->
@@ -416,13 +434,18 @@ let model_observability_json ~configured_labels ~active_model
         if labels <> [] then labels else configured_labels_surface
     | None -> configured_labels_surface
   in
+  let fallback_selected_model =
+    match configured_labels_surface with
+    | model :: _ -> Some model
+    | [] -> nonempty_trimmed active_model
+  in
   let selected_model =
     match latest_cascade with
     | Some cascade -> (
-        match Yojson.Safe.Util.member "selected_model" cascade with
-        | `String value -> nonempty_trimmed value
-        | _ -> nonempty_trimmed active_model)
-    | None -> nonempty_trimmed active_model
+        match json_string_opt_member cascade "selected_model" with
+        | Some _ as model -> model
+        | None -> fallback_selected_model)
+    | None -> fallback_selected_model
   in
   `Assoc
     [
@@ -439,7 +462,7 @@ let model_observability_json ~configured_labels ~active_model
           ~resolved_candidates ~selected_model latest_cascade );
       ( "runtime_contract",
         lightweight_runtime_contract_json ~selected_model
-          ~runtime_blocker_class );
+         ~runtime_blocker_class );
     ]
 
 let handle_keeper_status ctx args : tool_result =
@@ -929,7 +952,8 @@ let handle_keeper_status ctx args : tool_result =
            latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes
          in
          let model_observability =
-           model_observability_json ~configured_labels:models
+           model_observability_json ~current_cascade_name:m.cascade_name
+             ~configured_labels:models
              ~active_model ~runtime_blocker_fields latest_metrics
          in
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -105,6 +105,11 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_status_exposes_model_observability;
+          Alcotest.test_case
+            "keeper status ignores stale cascade observation"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_status_ignores_stale_cascade_observation;
           Alcotest.test_case "keeper down accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_down_accepts_agent_name_alias;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -419,6 +419,116 @@ let test_keeper_status_exposes_model_observability () =
         (observability |> member "runtime_contract"
          |> member "chat_completion_compatible" = `Null))
 
+let test_keeper_status_ignores_stale_cascade_observation () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "stale-observation-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Ignore stale keeper metrics");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing after up"
+        | Error err -> Alcotest.fail ("meta read failed: " ^ err)
+      in
+      let current_labels =
+        Keeper_model_labels.configured_model_labels_of_meta meta
+      in
+      let stale_selected_model = "stale:old-path" in
+      Dated_jsonl.append
+        (Keeper_types.keeper_metrics_store config keeper_name)
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
+            ("model_used", `String stale_selected_model);
+            ( "cascade",
+              `Assoc
+                [
+                  ("cascade_name", `String "stale-cascade");
+                  ( "configured_labels",
+                    `List [ `String "stale:old-path"; `String "stale:fallback" ] );
+                  ( "candidate_models",
+                    `List [ `String "stale:old-path"; `String "stale:fallback" ] );
+                  ("selected_model", `String stale_selected_model);
+                  ("selected_index", `Int 0);
+                  ("fallback_hops", `Int 0);
+                  ("fallback_applied", `Bool false);
+                  ( "attempts",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ("attempt_index", `Int 0);
+                            ("model_id", `String "old-path");
+                            ("model_label", `String stale_selected_model);
+                            ("latency_ms", `Int 52);
+                            ("error", `Null);
+                          ];
+                      ] );
+                ] );
+          ]);
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ])
+      in
+      Alcotest.(check bool) "status ok" true ok;
+      let status_json = parse_json_exn body in
+      let open Yojson.Safe.Util in
+      let observability = status_json |> member "model_observability" in
+      let status_dump = Yojson.Safe.pretty_to_string status_json in
+      Alcotest.(check (option string))
+        ("current cascade name wins over stale metrics\n" ^ status_dump)
+        (Some meta.cascade_name)
+        (observability |> member "cascade_name" |> to_string_option);
+      Alcotest.(check bool) "stale observation ignored" false
+        (observability |> member "recent_turn_observation" |> to_bool);
+      Alcotest.(check (list string)) "configured labels come from current meta"
+        current_labels
+        (observability |> member "configured_labels" |> to_list
+       |> List.map to_string);
+      Alcotest.(check (list string)) "resolved candidates fall back to current config"
+        current_labels
+        (observability |> member "resolved_candidates" |> to_list
+       |> List.map to_string);
+      Alcotest.(check bool) "stale selected model not surfaced" true
+        (observability |> member "selected_model" |> to_string_option
+       <> Some stale_selected_model);
+      Alcotest.(check string) "attempt summary resets to current config"
+        "No recent cascade observation for current keeper config. Showing configured labels only."
+        (observability |> member "attempt_summary" |> member "summary"
+       |> to_string))
+
 let test_keeper_down_accepts_agent_name_alias () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary
- tighten discovered-work guidance so keepers follow one GitHub/code path: inspect with `keeper_shell op=gh`, create a worktree before edits, then use raw git in the worktree and open a draft PR through `gh`
- make `masc_keeper_status` treat the current keeper config as the SSOT for cascade/model observability instead of letting stale turn telemetry override it
- add a regression test that proves stale cascade observations no longer leak into the current status surface

## Verification
- `./_build/default/test/test_operator_control.exe`

## Notes
- I also tried a full `dune build @default --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-confusion-cleanup`, but stopped it after the targeted test pass because the branch only touches keeper guidance/status code and the relevant operator-control suite already passed.