### PR TITLE
[codex] Improve auth mismatch credential errors

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -238,10 +238,19 @@ let create_token config ~agent_name ~role : (string * agent_credential, masc_err
      Log.Auth.error "%s" msg;
      Error (IoError msg))
 
+let missing_credential_error config ~agent_name ~token : masc_error =
+  match find_credential_by_token config ~token with
+  | Ok owner when owner.agent_name <> agent_name ->
+      Unauthorized
+        (Printf.sprintf
+           "No credential found for %s (bearer token belongs to %s)"
+           agent_name owner.agent_name)
+  | _ -> Unauthorized ("No credential found for " ^ agent_name)
+
 (** Verify a token *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
   match load_credential config agent_name with
-  | None -> Error (Unauthorized ("No credential found for " ^ agent_name))
+  | None -> Error (missing_credential_error config ~agent_name ~token)
   | Some cred ->
       let token_hash = sha256_hash token in
       if cred.token <> token_hash then

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -195,6 +195,29 @@ let test_verify_wrong_token () =
   | Error _, _ ->
       fail "create_token should succeed"
 
+let test_verify_token_reports_token_owner_on_agent_mismatch () =
+  let dir = setup_test_room () in
+  let create_result = Auth.create_token dir ~agent_name:"codex" ~role:Types.Worker in
+  let verify_result =
+    match create_result with
+    | Ok (raw_token, _) -> Auth.verify_token dir ~agent_name:"gemini" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match create_result, verify_result with
+  | Ok _, Error (Types.Unauthorized msg) ->
+      check string "mismatch message"
+        "🔐 Unauthorized: No credential found for gemini (bearer token belongs to codex)"
+        (Types.masc_error_to_string (Types.Unauthorized msg))
+  | Ok _, Ok _ ->
+      fail "verify_token should fail when token owner and requested agent differ"
+  | Ok _, Error e ->
+      fail
+        (Printf.sprintf "wrong error type for mismatch: %s"
+           (Types.masc_error_to_string e))
+  | Error _, _ ->
+      fail "create_token should succeed"
+
 let test_resolve_agent_from_token () =
   let dir = setup_test_room () in
   let create_result = Auth.create_token dir ~agent_name:"resolver" ~role:Types.Worker in
@@ -513,6 +536,8 @@ let () =
         test_credential_saved_private;
       test_case "verify token" `Quick test_verify_token;
       test_case "verify wrong token" `Quick test_verify_wrong_token;
+      test_case "verify token reports token owner on agent mismatch" `Quick
+        test_verify_token_reports_token_owner_on_agent_mismatch;
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;
       test_case "delete credential" `Quick test_delete_credential;


### PR DESCRIPTION
## Summary
This change improves MASC auth mismatch errors when a request explicitly targets an agent name that does not match the presented bearer token owner.

## What Changed
- include the bearer token owner in the missing-credential auth error when the token belongs to a different registered agent
- add a regression test covering the explicit agent/token mismatch case

## Why
The previous `No credential found for <agent>` error hid the real failure mode during room-auth debugging. In the observed failure, the request targeted `gemini` while the bearer token belonged to `codex-mcp-client`, so the old message made it look like a missing Gemini setup issue instead of an identity mismatch.

## Impact
Auth failures caused by explicit agent/header/query mismatches are now diagnosable from the server error alone.

## Validation
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-auth-mismatch-msg test/test_auth.exe`
- `opam exec -- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-auth-mismatch-msg/_build/default/test/test_auth.exe`
- `test_auth`: 32 tests passed