### PR TITLE
[codex] Wire Bonsai focus card to shell snapshot

### DIFF
--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -332,9 +332,10 @@ let view_meta_strip (r : Archive_runs_types.response) =
     ]
 ;;
 
-let render (r : Archive_runs_types.response) : Node.t =
+let render ~(shell : Overview_types.response) (r : Archive_runs_types.response) : Node.t =
   let total = r.total in
   Shell_view.view
+    ~shell
     ~active:Archive_runs
     [ Hero.view
         ~eyebrow:"archive · autoresearch"
@@ -359,5 +360,8 @@ let render (r : Archive_runs_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Archive_runs_var.var) ~f:render
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Archive_runs_var.var)
+    (Bonsai.Expert.Var.value Overview_var.var)
+    ~f:(fun runs shell -> render ~shell runs)
 ;;

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -131,7 +131,7 @@ let view_dead_list (dead : Keepers_types.keeper list) =
       (List.map ks ~f:Roster.view_slot_of_keeper)
 ;;
 
-let render (keepers : Keepers_types.response) : Node.t =
+let render ~(shell : Overview_types.response) (keepers : Keepers_types.response) : Node.t =
   let total = List.length keepers.keepers in
   let dead =
     List.filter keepers.keepers ~f:(fun (k : Keepers_types.keeper) ->
@@ -146,6 +146,7 @@ let render (keepers : Keepers_types.response) : Node.t =
     | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
   in
   Shell_view.view
+    ~shell
     ~active:Dead_keepers
     [ Hero.view
         ~eyebrow:"crypt · the fallen"
@@ -162,5 +163,8 @@ let render (keepers : Keepers_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Keepers_var.var) ~f:render
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Keepers_var.var)
+    (Bonsai.Expert.Var.value Overview_var.var)
+    ~f:(fun keepers shell -> render ~shell keepers)
 ;;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -358,8 +358,9 @@ let view_meta_strip (r : Goals_types.response) =
     ]
 ;;
 
-let render (r : Goals_types.response) : Node.t =
+let render ~(shell : Overview_types.response) (r : Goals_types.response) : Node.t =
   Shell_view.view
+    ~shell
     ~active:Goals
     [ Hero.view
         ~eyebrow:"goals · convergence"
@@ -384,5 +385,8 @@ let render (r : Goals_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Goals_var.var) ~f:render
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Goals_var.var)
+    (Bonsai.Expert.Var.value Overview_var.var)
+    ~f:(fun goals shell -> render ~shell goals)
 ;;

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -152,9 +152,10 @@ let view_hud_strip (keepers : Keepers_types.response) =
     ]
 ;;
 
-let render (keepers : Keepers_types.response) : Node.t =
+let render ~(shell : Overview_types.response) (keepers : Keepers_types.response) : Node.t =
   let has_fleet = not (List.is_empty keepers.keepers) in
   Shell_view.view
+    ~shell
     ~active:Keepers
     [ view_hero keepers
     ; view_hud_strip keepers
@@ -186,5 +187,8 @@ let render (keepers : Keepers_types.response) : Node.t =
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map (Bonsai.Expert.Var.value Keepers_var.var) ~f:render
+  Bonsai.map2
+    (Bonsai.Expert.Var.value Keepers_var.var)
+    (Bonsai.Expert.Var.value Overview_var.var)
+    ~f:(fun keepers shell -> render ~shell keepers)
 ;;

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -419,6 +419,7 @@ let view_meta_panel (r : Overview_types.response) =
 
 let render (r : Overview_types.response) : Node.t =
   Shell_view.view
+    ~shell:r
     ~active:Overview
     [ Hero.view
         ~eyebrow:"overview · at a glance"

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -224,41 +224,42 @@ let panel ~title ~text ~code =
 
 let component ~(route : Route.t) (_graph @ local) =
   let bp = blueprint_of_route route in
-  Bonsai.return
-    (Shell_view.view
-       ~active:route
-       [ Hero.view
-           ~eyebrow:bp.eyebrow
-           ~title:bp.title
-           ~tail:(bp.tail, `Brass)
-           ~sub:bp.vow
-           ()
-       ; Meta.strip
-           [ Meta.cell ~color:`Brass ~k:"signal" ~v:bp.signal ()
-           ; Meta.cell ~k:"source" ~v:bp.source ()
-           ; Meta.cell ~k:"cadence" ~v:bp.cadence ()
-           ]
-       ; Sec.view ~title:"operator contract" ~sub:"target · measure · next" ()
-       ; Node.div
-           ~attrs:[ Style.grid ]
-           [ panel ~title:"measure" ~text:bp.measure ~code:"what must stay visible"
-           ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
-           ; panel
-               ~title:"fallback"
-               ~text:"The journal remains the live runtime witness while this lane gathers signal."
-               ~code:(Route.path Logs)
-           ]
-       ; Node.div
-           ~attrs:[ Style.cta ]
-           [ Node.a
-               ~attrs:[ Attr.href (Route.path Logs); Style.btn; Style.btn_primary ]
-               [ Node.text "journal" ]
-           ; Node.a
-               ~attrs:[ Attr.href "/dashboard/"; Style.btn ]
-               [ Node.text "legacy" ]
-           ; Node.span
-               ~attrs:[ Style.cta_note ]
-               [ Node.text (Route.path route) ]
-           ]
-       ])
+  Bonsai.map (Bonsai.Expert.Var.value Overview_var.var) ~f:(fun shell ->
+    Shell_view.view
+      ~shell
+      ~active:route
+      [ Hero.view
+          ~eyebrow:bp.eyebrow
+          ~title:bp.title
+          ~tail:(bp.tail, `Brass)
+          ~sub:bp.vow
+          ()
+      ; Meta.strip
+          [ Meta.cell ~color:`Brass ~k:"signal" ~v:bp.signal ()
+          ; Meta.cell ~k:"source" ~v:bp.source ()
+          ; Meta.cell ~k:"cadence" ~v:bp.cadence ()
+          ]
+      ; Sec.view ~title:"operator contract" ~sub:"target · measure · next" ()
+      ; Node.div
+          ~attrs:[ Style.grid ]
+          [ panel ~title:"measure" ~text:bp.measure ~code:"what must stay visible"
+          ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
+          ; panel
+              ~title:"fallback"
+              ~text:"The journal remains the live runtime witness while this lane gathers signal."
+              ~code:(Route.path Logs)
+          ]
+      ; Node.div
+          ~attrs:[ Style.cta ]
+          [ Node.a
+              ~attrs:[ Attr.href (Route.path Logs); Style.btn; Style.btn_primary ]
+              [ Node.text "journal" ]
+          ; Node.a
+              ~attrs:[ Attr.href "/dashboard/"; Style.btn ]
+              [ Node.text "legacy" ]
+          ; Node.span
+              ~attrs:[ Style.cta_note ]
+              [ Node.text (Route.path route) ]
+          ]
+      ])
 ;;

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -732,6 +732,18 @@ let default_hud ~(active : Route.t) =
   ]
 ;;
 
+let hhmmss_of_iso ts =
+  if String.length ts >= 19 then String.sub ts ~pos:11 ~len:8 else ts
+;;
+
+let short_commit c =
+  if String.length c > 9 then String.sub c ~pos:0 ~len:9 else c
+;;
+
+let short_base path =
+  if String.is_empty path then "—" else Filename.basename path
+;;
+
 let aside_title ?right text =
   Node.h4
     ~attrs:[ Style.aside_title ]
@@ -742,51 +754,101 @@ let aside_title ?right text =
      | None -> [])
 ;;
 
-let focus_card ~(active : Route.t) =
+let focus_card ~(shell : Overview_types.response) ~(active : Route.t) =
+  let project =
+    if String.is_empty shell.status.project then "runtime" else shell.status.project
+  in
+  let cluster =
+    if String.is_empty shell.status.cluster then "default" else shell.status.cluster
+  in
+  let portrait =
+    let seed =
+      if String.is_empty project then label active else project
+    in
+    Char.to_string (Char.uppercase seed.[0])
+  in
+  let snapshot_right =
+    match shell.generated_at with
+    | "" -> "shell pending"
+    | ts -> Printf.sprintf "%s UTC" (hhmmss_of_iso ts)
+  in
+  let focus_role = Printf.sprintf "%s · %s" project cluster in
+  let focus_meter_label, focus_pct, focus_detail =
+    if shell.configured_keepers > 0
+    then
+      ( "Fleet"
+      , Int.min 100 ((shell.counts.keepers * 100) / shell.configured_keepers)
+      , Printf.sprintf
+          " . %d / %d keepers"
+          shell.counts.keepers
+          shell.configured_keepers )
+    else if String.is_empty shell.generated_at
+    then "Snapshot", 0, " . pending"
+    else "Snapshot", 100, " . ready"
+  in
+  let vial_style =
+    Attr.style
+      (Css_gen.create
+         ~field:"width"
+         ~value:(Printf.sprintf "%d%%" focus_pct))
+  in
+  let build_v =
+    if not (String.is_empty shell.status.build.release_version)
+    then shell.status.build.release_version
+    else if not (String.is_empty shell.status.build.commit)
+    then short_commit shell.status.build.commit
+    else "—"
+  in
   Node.div
-    [ aside_title ~right:"shared shell" "Focus"
+    [ aside_title ~right:snapshot_right "Focus"
     ; Node.div
         ~attrs:[ Style.focus ]
         [ Node.div
             ~attrs:[ Style.focus_inner ]
             [ Node.div
                 ~attrs:[ Style.focus_row ]
-                [ Node.div ~attrs:[ Style.portrait ] [ Node.text "M" ]
+                [ Node.div ~attrs:[ Style.portrait ] [ Node.text portrait ]
                 ; Node.div
                     [ Node.div ~attrs:[ Style.focus_name ] [ Node.text (label active) ]
                     ; Node.div
                         ~attrs:[ Style.focus_role ]
-                        [ Node.text "Dashboard v2 chrome absorbed into Bonsai" ]
+                        [ Node.text focus_role ]
                     ]
                 ]
             ; Node.div
                 [ Node.div
                     ~attrs:[ Style.vial_lbl ]
-                    [ Node.span [ Node.text "Context" ]
+                    [ Node.span [ Node.text focus_meter_label ]
                     ; Node.span
-                        [ Node.b [ Node.text "62%" ]
-                        ; Node.text " . compact @ 85%"
+                        [ Node.b [ Node.text (Printf.sprintf "%d%%" focus_pct) ]
+                        ; Node.text focus_detail
                         ]
                     ]
-                ; Node.div ~attrs:[ Style.vial ] [ Node.span [] ]
+                ; Node.div ~attrs:[ Style.vial ] [ Node.span ~attrs:[ vial_style ] [] ]
                 ]
             ; Node.div
                 ~attrs:[ Style.stats ]
                 [ Node.div
-                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Turns" ]
-                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "7 / 15" ]
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Agents" ]
+                    ; Node.div
+                        ~attrs:[ Style.stat_v ]
+                        [ Node.text (Printf.sprintf "%d" shell.counts.agents) ]
                     ]
                 ; Node.div
-                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Route" ]
-                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text (label active) ]
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Tasks" ]
+                    ; Node.div
+                        ~attrs:[ Style.stat_v ]
+                        [ Node.text (Printf.sprintf "%d" shell.counts.tasks) ]
                     ]
                 ; Node.div
-                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Shell" ]
-                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "v2" ]
+                    [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Build" ]
+                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text build_v ]
                     ]
                 ; Node.div
                     [ Node.div ~attrs:[ Style.stat_l ] [ Node.text "Base" ]
-                    ; Node.div ~attrs:[ Style.stat_v ] [ Node.text "b" ]
+                    ; Node.div
+                        ~attrs:[ Style.stat_v ]
+                        [ Node.text (short_base shell.base_path) ]
                     ]
                 ]
             ]
@@ -868,16 +930,16 @@ let watch_feed () =
     ]
 ;;
 
-let default_aside ~(active : Route.t) =
+let default_aside ~(shell : Overview_types.response) ~(active : Route.t) =
   Node.div
     ~attrs:[ Style.aside ]
-    [ focus_card ~active
+    [ focus_card ~shell ~active
     ; flame ()
     ; watch_feed ()
     ]
 ;;
 
-let view ?hud ?aside ~(active : Route.t) (children : Node.t list) =
+let view ?(shell = Overview_types.fixture) ?hud ?aside ~(active : Route.t) (children : Node.t list) =
   let hud_nodes =
     match hud with
     | Some nodes -> nodes
@@ -886,7 +948,7 @@ let view ?hud ?aside ~(active : Route.t) (children : Node.t list) =
   let aside_node =
     match aside with
     | Some node -> node
-    | None -> default_aside ~active
+    | None -> default_aside ~shell ~active
   in
   Node.div
     ~attrs:[ Style.shell ]


### PR DESCRIPTION
## Summary
- wire the shared Bonsai focus card to the live `/api/v1/dashboard/shell` snapshot instead of static placeholder values
- feed that shell snapshot into every route that uses `Shell_view`, including keepers/goals/archive/dead-keepers/placeholder surfaces
- replace the old fake focus stats with real project, cluster, build, base, agent/task, and keeper readiness values

## Verification
- `OPAMSWITCH=bonsai-dashboard opam exec -- dune build --root .`
- `make bonsai-dashboard`
- temporary server on `127.0.0.1:18937` with keeper bootstrap disabled
- `agent-browser` snapshots for `/dashboard/b/overview`, `/dashboard/b/keepers`, `/dashboard/b/observatory`
- `agent-browser errors`
