### PR TITLE
[codex] surface runtime cascade catalog drift

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -804,6 +804,17 @@ let warn_unknown_strategy ~name ~raw ~msg =
       "[warn] cascade %s: %s; falling back to failover\n%!" name msg
   end
 
+let invalid_priority_tier_warned : (string * string, unit) Hashtbl.t =
+  Hashtbl.create 4
+
+let warn_invalid_priority_tier ~name ~msg =
+  let key = (name, msg) in
+  if not (Hashtbl.mem invalid_priority_tier_warned key) then begin
+    Hashtbl.add invalid_priority_tier_warned key ();
+    Printf.eprintf
+      "[warn] cascade %s: %s; falling back to failover\n%!" name msg
+  end
+
 let parse_kind_or_default ~name = function
   | None -> Cascade_strategy.Failover
   | Some raw ->
@@ -830,19 +841,65 @@ let cycle_policy_from_loader (cfg : Cascade_config_loader.strategy_config) =
   in
   { Cascade_strategy.max_cycles; backoff_base_ms; backoff_cap_ms }
 
+let model_ids_of_specs (specs : string list) : string list =
+  specs
+  |> List.concat_map expand_auto_model_string
+  |> List.filter_map (fun spec ->
+         match split_provider_model spec with
+         | Some (_, model_id) when model_id <> "" -> Some model_id
+         | _ -> None)
+  |> List.sort_uniq String.compare
+
+let normalize_priority_tiers ~config_path ~name raw_tiers =
+  let configured_model_ids =
+    Cascade_config_loader.load_profile_weighted ~config_path ~name
+    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)
+    |> model_ids_of_specs
+  in
+  if configured_model_ids = [] then
+    Error "priority_tier has no configured models to validate against"
+  else
+    let normalized =
+      raw_tiers
+      |> List.filter_map (fun tier ->
+             let tier_model_ids =
+               model_ids_of_specs tier
+               |> List.filter (fun model_id ->
+                      List.mem model_id configured_model_ids)
+             in
+             if tier_model_ids = [] then None else Some tier_model_ids)
+    in
+    if normalized = [] then
+      Error
+        "priority_tier tiers did not match any configured candidate model ids"
+    else
+      Ok normalized
+
 let resolve_strategy ?config_path ~name () =
   match config_path with
   | None -> Cascade_strategy.failover
   | Some path ->
     let cfg = Cascade_config_loader.resolve_strategy_config
                 ~config_path:path ~name in
-    let kind = parse_kind_or_default ~name cfg.kind in
+    let parsed_kind = parse_kind_or_default ~name cfg.kind in
     let cycle = cycle_policy_from_loader cfg in
-    let tiers =
-      match kind, cfg.tiers with
-      | Cascade_strategy.Priority_tier, Some t -> t
-      | Cascade_strategy.Priority_tier, None -> []  (* misconfig → empty tier *)
-      | _, _ -> []
+    let kind, tiers =
+      match parsed_kind with
+      | Cascade_strategy.Priority_tier ->
+          let result =
+            match cfg.tiers with
+            | Some raw_tiers ->
+                normalize_priority_tiers ~config_path:path ~name raw_tiers
+            | None ->
+                Error
+                  "priority_tier requires a non-empty <name>_tiers configuration"
+          in
+          (match result with
+           | Ok tiers -> (parsed_kind, tiers)
+           | Error msg ->
+               warn_invalid_priority_tier ~name ~msg;
+               (Cascade_strategy.Failover, []))
+      | _ -> (parsed_kind, [])
     in
     let sticky_ttl_ms =
       match kind, cfg.sticky_ttl_ms with

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -39,6 +39,15 @@ type t = {
   next_actions : string list;
 }
 
+type catalog_issue_severity =
+  | Catalog_warn
+  | Catalog_error
+
+type catalog_issue = {
+  severity : catalog_issue_severity;
+  message : string;
+}
+
 let trim_opt = Env_config_core.trim_opt
 
 let init_state_to_string = function
@@ -62,6 +71,48 @@ let dedupe_keep_order values =
         Hashtbl.replace seen value ();
         true))
     values
+
+let contains_substring ~needle s =
+  let needle_len = String.length needle in
+  let s_len = String.length s in
+  if needle_len = 0 || needle_len > s_len then
+    false
+  else
+    let limit = s_len - needle_len in
+    let rec loop i =
+      if i > limit then
+        false
+      else if String.sub s i needle_len = needle then
+        true
+      else
+        loop (i + 1)
+    in
+    loop 0
+
+let has_suffix ~suffix s =
+  let suffix_len = String.length suffix in
+  let s_len = String.length s in
+  s_len > suffix_len
+  && String.sub s (s_len - suffix_len) suffix_len = suffix
+
+let is_provider_unavailable_error msg =
+  contains_substring ~needle:"unavailable" msg
+
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+      if idx = 0 || idx >= String.length s - 1 then
+        None
+      else
+        let provider_name =
+          String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+        in
+        let model_id =
+          String.sub s (idx + 1) (String.length s - idx - 1)
+          |> String.trim
+        in
+        if model_id = "" then None else Some (provider_name, model_id)
 
 let canonicalize_path ~cwd path =
   let absolute =
@@ -94,6 +145,217 @@ let repo_config_seed_path (inputs : inputs) =
 let option_field name = function
   | Some value -> (name, `String value)
   | None -> (name, `Null)
+
+let discover_cascade_profiles = function
+  | `Assoc fields ->
+      fields
+      |> List.filter_map (fun (key, value) ->
+             match value with
+             | `List _ when has_suffix ~suffix:"_models" key ->
+                 let suffix_len = String.length "_models" in
+                 Some (String.sub key 0 (String.length key - suffix_len))
+             | _ -> None)
+      |> List.sort_uniq String.compare
+  | _ -> []
+
+let model_ids_of_specs (specs : string list) : string list =
+  specs
+  |> Cascade_config.expand_auto_models
+  |> List.filter_map (fun spec ->
+         match split_provider_model spec with
+         | Some (_, model_id) when model_id <> "" -> Some model_id
+         | _ -> None)
+  |> List.sort_uniq String.compare
+
+let format_spec_errors specs =
+  specs
+  |> List.map (fun (spec, msg) -> Printf.sprintf "%S (%s)" spec msg)
+  |> String.concat ", "
+
+let priority_tier_issue ~profile configured_specs raw_tiers =
+  let configured_model_ids = model_ids_of_specs configured_specs in
+  if configured_model_ids = [] then
+    Some
+      {
+        severity = Catalog_error;
+        message =
+          Printf.sprintf
+            "Cascade preset %s uses priority_tier but has no configured \
+             models to validate."
+            profile;
+      }
+  else
+    let normalized =
+      raw_tiers
+      |> List.filter_map (fun tier ->
+             let tier_model_ids =
+               model_ids_of_specs tier
+               |> List.filter (fun model_id ->
+                      List.mem model_id configured_model_ids)
+             in
+             if tier_model_ids = [] then None else Some tier_model_ids)
+    in
+    if normalized = [] then
+      Some
+        {
+          severity = Catalog_error;
+          message =
+            Printf.sprintf
+              "Cascade preset %s uses priority_tier, but every tier \
+               collapses after model-id normalization; runtime will fall \
+               back to failover."
+              profile;
+        }
+    else if List.length normalized < List.length raw_tiers then
+      Some
+        {
+          severity = Catalog_warn;
+          message =
+            Printf.sprintf
+              "Cascade preset %s uses priority_tier, but %d/%d tier(s) \
+               collapse after model-id normalization."
+              profile
+              (List.length raw_tiers - List.length normalized)
+              (List.length raw_tiers);
+        }
+    else
+      None
+
+let diagnose_cascade_profile ~config_path ~profile =
+  let model_specs =
+    Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
+    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
+           entry.model)
+  in
+  let invalid_specs =
+    model_specs
+    |> Cascade_config.expand_auto_models
+    |> List.filter_map (fun spec ->
+           match Cascade_config.parse_model_string_exn spec with
+           | Ok _ -> None
+           | Error msg when is_provider_unavailable_error msg -> None
+           | Error msg -> Some (spec, msg))
+  in
+  let invalid_model_issue =
+    if invalid_specs = [] then
+      None
+    else
+      Some
+        {
+          severity = Catalog_error;
+          message =
+            Printf.sprintf
+              "Cascade preset %s has %d hard-invalid model spec(s): %s"
+              profile
+              (List.length invalid_specs)
+              (format_spec_errors invalid_specs);
+        }
+  in
+  let strategy_cfg =
+    Cascade_config_loader.resolve_strategy_config ~config_path ~name:profile
+  in
+  let strategy_issue =
+    match strategy_cfg.kind with
+    | None -> None
+    | Some raw_kind -> (
+        match Cascade_strategy.parse_kind raw_kind with
+        | Error msg ->
+            Some
+              {
+                severity = Catalog_error;
+                message =
+                  Printf.sprintf
+                    "Cascade preset %s has unknown strategy %S: %s"
+                    profile raw_kind msg;
+              }
+        | Ok Cascade_strategy.Priority_tier -> (
+            match strategy_cfg.tiers with
+            | None ->
+                Some
+                  {
+                    severity = Catalog_error;
+                    message =
+                      Printf.sprintf
+                        "Cascade preset %s uses priority_tier without a \
+                         valid non-empty <name>_tiers configuration."
+                        profile;
+                  }
+            | Some raw_tiers ->
+                priority_tier_issue ~profile model_specs raw_tiers)
+        | Ok _ -> None)
+  in
+  [ invalid_model_issue; strategy_issue ]
+  |> List.filter_map (fun issue -> issue)
+
+let diagnose_cascade_catalog ~active_config_root =
+  let config_path =
+    Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
+  in
+  if not (Env_config_core.existing_file config_path) then
+    []
+  else
+    match Cascade_config_loader.load_json config_path with
+    | Error msg ->
+        [
+          {
+            severity = Catalog_error;
+            message =
+              Printf.sprintf
+                "Cascade catalog %s could not be loaded: %s"
+                config_path msg;
+          };
+        ]
+    | Ok json ->
+        let profiles = discover_cascade_profiles json in
+        let issues =
+          profiles
+          |> List.concat_map (fun profile ->
+                 diagnose_cascade_profile ~config_path ~profile)
+        in
+        if issues = [] then
+          []
+        else
+          let error_count =
+            issues
+            |> List.filter (fun issue -> issue.severity = Catalog_error)
+            |> List.length
+          in
+          let warn_count = List.length issues - error_count in
+          {
+            severity = if error_count > 0 then Catalog_error else Catalog_warn;
+            message =
+              Printf.sprintf
+                "Cascade catalog check scanned %d preset(s): %d error, %d \
+                 warn."
+                (List.length profiles)
+                error_count
+                warn_count;
+          }
+          :: issues
+
+let cascade_catalog_next_actions ~config_path issues =
+  if issues = [] then
+    []
+  else
+    let has_errors =
+      List.exists (fun issue -> issue.severity = Catalog_error) issues
+    in
+    let primary_action =
+      if has_errors then
+        Printf.sprintf
+          "Fix or disable the broken cascade preset entries in %s before \
+           assigning keepers to them."
+          config_path
+      else
+        Printf.sprintf
+          "Clean up the degraded cascade preset metadata in %s so doctor \
+           and runtime see the same routing intent."
+          config_path
+    in
+    [
+      primary_action;
+      "Rerun `masc-mcp doctor config` after editing cascade.json.";
+    ]
 
 let current_inputs ~base_path_input ~default_base_path () =
   let normalized_base_path =
@@ -222,6 +484,12 @@ let analyze_with (inputs : inputs) =
       ~effective_masc_root:runtime_data_root
       ()
   in
+  let cascade_catalog_issues =
+    diagnose_cascade_catalog ~active_config_root
+  in
+  let cascade_config_path =
+    Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
+  in
   let warnings =
     [
       (if explicit_config_invalid then
@@ -274,7 +542,15 @@ let analyze_with (inputs : inputs) =
       path_diag.warning;
     ]
     |> List.filter_map (fun warning -> warning)
+    |> fun base_warnings ->
+    base_warnings
+    @ List.map (fun issue -> issue.message) cascade_catalog_issues
     |> dedupe_keep_order
+  in
+  let cascade_actions =
+    cascade_catalog_next_actions
+      ~config_path:cascade_config_path
+      cascade_catalog_issues
   in
   let next_actions =
     match init_state with
@@ -344,13 +620,21 @@ let analyze_with (inputs : inputs) =
            | _ ->
                "No further action needed.");
         ]
+    |> fun base_actions -> base_actions @ cascade_actions
+    |> dedupe_keep_order
+  in
+  let has_catalog_errors =
+    List.exists
+      (fun issue -> issue.severity = Catalog_error)
+      cascade_catalog_issues
   in
   let status =
     match init_state with
     | Invalid_env | Missing_init -> Error
     | Shadowed -> Warn
     | Initialized ->
-        if warnings = [] then Ok else Warn
+        if has_catalog_errors then Error
+        else if warnings = [] then Ok else Warn
   in
   {
     status;

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -180,6 +180,66 @@ let test_unknown_provider_is_dropped () =
         true
         (List.length parsed < List.length strings))
 
+let with_temp_cascade_json body =
+  let tmp = Filename.temp_file "cascade-strategy-" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove tmp with _ -> ())
+    (fun () -> body tmp)
+
+let test_priority_tier_label_tiers_normalize_to_model_ids () =
+  with_temp_cascade_json @@ fun tmp ->
+  let oc = open_out tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        {|{
+  "regression_models": [
+    "claude_code:claude-haiku-4-5-20251001",
+    "gemini_cli:gemini-3-flash-preview"
+  ],
+  "regression_strategy": "priority_tier",
+  "regression_tiers": [
+    ["claude_code:claude-haiku-4-5-20251001"],
+    ["gemini_cli:gemini-3-flash-preview"]
+  ]
+}|});
+  let strategy =
+    Masc_mcp.Cascade_config.resolve_strategy
+      ~config_path:tmp ~name:"regression" ()
+  in
+  check string "priority_tier preserved"
+    "priority_tier"
+    (Masc_mcp.Cascade_strategy.kind_to_string strategy.kind);
+  check (list (list string)) "tiers normalized to model ids"
+    [ [ "claude-haiku-4-5-20251001" ]; [ "gemini-3-flash-preview" ] ]
+    strategy.tiers
+
+let test_priority_tier_invalid_tiers_fall_back_to_failover () =
+  with_temp_cascade_json @@ fun tmp ->
+  let oc = open_out tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        {|{
+  "regression_models": [
+    "claude_code:claude-haiku-4-5-20251001"
+  ],
+  "regression_strategy": "priority_tier",
+  "regression_tiers": [
+    ["codex_cli:auto"]
+  ]
+}|});
+  let strategy =
+    Masc_mcp.Cascade_config.resolve_strategy
+      ~config_path:tmp ~name:"regression" ()
+  in
+  check string "invalid tiers demote to failover"
+    "failover"
+    (Masc_mcp.Cascade_strategy.kind_to_string strategy.kind);
+  check (list (list string)) "failover carries no tiers" [] strategy.tiers
+
 let () =
   let path = cascade_path () in
   let profiles = discover_profiles path in
@@ -201,5 +261,13 @@ let () =
             "unknown provider dropped (meta-guard)"
             `Quick
             test_unknown_provider_is_dropped;
+          test_case
+            "priority_tier label tiers normalize to model ids"
+            `Quick
+            test_priority_tier_label_tiers_normalize_to_model_ids;
+          test_case
+            "priority_tier invalid tiers fall back to failover"
+            `Quick
+            test_priority_tier_invalid_tiers_fall_back_to_failover;
         ] );
     ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -220,10 +220,18 @@ let test_route_auth_contracts () =
        {|Http.Router.post "/api/v1/gate/connector/unbind"|})
 
 let test_http_write_auth_contracts () =
-  check bool "server auth no longer accepts query token fallback" true
-    (not
-       (file_contains_pattern "lib/server/server_auth.ml"
-          {|query_param request "token"|}));
+  check bool "server auth scopes query token fallback to observer SSE helper" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "let observer_sse_query_token_from_request");
+  check bool "observer SSE helper still gates query token on sse_kind" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|match query_param request "sse_kind" with|});
+  check bool "observer SSE helper still reads token query param" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|trim_opt (query_param request "token")|});
+  check bool "observer SSE auth error documents scoped query token contract" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|or 'token' query param for the observer SSE stream.|});
   check bool "server auth defines token-bound permission helper" true
     (file_contains_pattern "lib/server/server_auth.ml"
        "let authorize_token_bound_permission_request");

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -45,6 +45,22 @@ let status = function
   | Config_doctor.Warn -> "warn"
   | Config_doctor.Error -> "error"
 
+let contains_substring ~needle s =
+  let nl = String.length needle in
+  let sl = String.length s in
+  if nl = 0 || nl > sl then false
+  else
+    let limit = sl - nl in
+    let rec loop i =
+      if i > limit then false
+      else if String.sub s i nl = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let list_contains_substring ~needle values =
+  List.exists (contains_substring ~needle) values
+
 let make_inputs ?env_config_dir ?env_personas_dir ~cwd ~base_path_input () =
   Config_doctor.
     {
@@ -58,8 +74,8 @@ let make_inputs ?env_config_dir ?env_personas_dir ~cwd ~base_path_input () =
       repo_config_fallback_enabled = false;
     }
 
-let initialize_config_root root =
-  write_file (Filename.concat root "cascade.json") "{}";
+let initialize_config_root ?(cascade_json="{}") root =
+  write_file (Filename.concat root "cascade.json") cascade_json;
   mkdir_p (Filename.concat root "personas")
 
 let test_invalid_explicit_config_dir () =
@@ -106,7 +122,8 @@ let test_initialized_local_base_config () =
     (init_state report.init_state);
   check string "status" "ok" (status report.status);
   check string "source" "local_masc" report.config_root_source;
-  check bool "keeper runtime optional" false report.keeper_runtime_toml_present
+  check bool "keeper runtime optional" false report.keeper_runtime_toml_present;
+  check (list string) "no warnings" [] report.warnings
 
 let test_shadowed_explicit_config_dir () =
   with_temp_dir "config-doctor-shadowed" @@ fun dir ->
@@ -126,6 +143,47 @@ let test_shadowed_explicit_config_dir () =
   check string "active root" (canonical_path explicit_root) report.active_config_root;
   check bool "local base initialized" true report.local_base_config_initialized
 
+let test_broken_cascade_catalog_surfaces_errors () =
+  with_temp_dir "config-doctor-cascade-bad" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_config_root
+    ~cascade_json:{|{
+  "bad_provider_models": [
+    "__nonexistent_provider_sentinel__:fake-model"
+  ],
+  "bad_strategy_models": [
+    "claude_code:claude-haiku-4-5-20251001"
+  ],
+  "bad_strategy_strategy": "priority_tier",
+  "bad_strategy_tiers": [
+    ["codex_cli:auto"]
+  ]
+}|}
+    config_root;
+  let report =
+    Config_doctor.analyze_with
+      (make_inputs ~cwd:dir ~base_path_input:base_path ())
+  in
+  check string "status escalates to error" "error" (status report.status);
+  check bool "catalog summary warning present" true
+    (list_contains_substring
+       ~needle:"Cascade catalog check scanned 2 preset(s): 2 error, 0 warn."
+       report.warnings);
+  check bool "invalid provider warning present" true
+    (list_contains_substring
+       ~needle:"Cascade preset bad_provider has 1 hard-invalid model spec"
+       report.warnings);
+  check bool "priority_tier collapse warning present" true
+    (list_contains_substring
+       ~needle:
+         "Cascade preset bad_strategy uses priority_tier, but every tier collapses after model-id normalization"
+       report.warnings);
+  check bool "next action mentions doctor rerun" true
+    (list_contains_substring
+       ~needle:"Rerun `masc-mcp doctor config` after editing cascade.json."
+       report.next_actions)
+
 let () =
   run "config_doctor"
     [
@@ -138,5 +196,7 @@ let () =
              test_initialized_local_base_config;
            test_case "shadowed explicit config dir" `Quick
              test_shadowed_explicit_config_dir;
+           test_case "broken cascade catalog surfaces errors" `Quick
+             test_broken_cascade_catalog_surfaces_errors;
          ]);
     ]


### PR DESCRIPTION
## Summary

Stacked on top of #9170.

This PR addresses the still-live structural part of #7872 in two places:

- normalize `priority_tier` tier selectors from `provider:model` labels into the runtime `model_id` key space
- surface broken or degraded cascade presets from the active runtime `cascade.json` through `masc-mcp doctor config`

## Product impact

Operators can now see broken cascade catalog entries before they strand keepers behind a silently degraded preset. In particular, `doctor config` will now flag:

- hard-invalid model specs in the active cascade catalog
- unknown cascade strategies
- `priority_tier` presets whose tiers collapse after runtime model-id normalization

If the active catalog contains structural preset errors, Config Doctor now exits as `error` instead of looking healthy.

## Problem

`priority_tier` tiers in runtime `cascade.json` are authored as `provider:model` selectors, but the runtime strategy compares against candidate `model_id` keys.

That mismatch means a config like:

- models: `claude_code:claude-haiku-4-5-20251001`
- tiers: `claude_code:claude-haiku-4-5-20251001`

can still filter out every candidate, because the strategy sees only `claude-haiku-4-5-20251001` at comparison time.

Separately, operator tooling did not surface when the active runtime catalog already contained invalid provider specs or degraded `priority_tier` metadata. That left `cascade.json` drift visible only through downstream keeper failures.

## What changed

- Added normalization for `priority_tier` tier selectors in `Cascade_config.resolve_strategy`:
  - expand `provider:auto` selectors first
  - convert label selectors to runtime `model_id` keys
  - intersect tiers with the configured candidate model set for that cascade
- If a `priority_tier` config has no usable tier after normalization, log a one-time warning and fall back to `failover` instead of producing an empty tier set.
- Added active-catalog diagnostics to `Config_doctor`:
  - discover presets from the active `cascade.json`
  - flag hard-invalid model specs that fail structural parse
  - flag unknown strategy names
  - flag `priority_tier` presets that fully collapse, or partially collapse, after model-id normalization
  - append those findings to existing `warnings` / `next_actions`
  - escalate doctor status to `error` when the active catalog has structural preset errors
- Added regression tests for:
  - label-based tiers normalizing to `model_id` values
  - invalid tiers demoting safely to `failover`
  - broken active catalog entries surfacing through Config Doctor

## Why this is safe

- Non-`priority_tier` runtime routing is unchanged.
- Valid `priority_tier` configs keep their semantics, but now match the key space used by runtime candidate comparison.
- Invalid `priority_tier` configs degrade to `failover`, which is safer than silently filtering every candidate and idling the keeper.
- Doctor reads the active catalog and reports structural drift without mutating runtime config.

## Evidence

- `dune build --root . -j 1 lib/cascade/cascade_config.ml test/test_cascade_config_validity.exe`
- `env MASC_CASCADE_JSON_PATH=$PWD/config/cascade.json _build/default/test/test_cascade_config_validity.exe`
- `dune build --root . -j 1 lib/config_doctor.ml test/test_config_doctor.exe`
- `dune exec --root . ./test/test_config_doctor.exe`

## Review evidence

I checked the current live runtime config at `/Users/dancer/me/.masc/config/cascade.json` before scoping this work. The broader #7872 issue is partially stale now, so this PR is intentionally limited to the still-live `priority_tier` selector drift plus operator-visible runtime catalog diagnostics.

## Linked issue

Refs #7872