### PR TITLE
[codex] Gate tool-required keeper turns on provider capabilities

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -248,6 +248,41 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
            (String.concat ", " labels)
            (String.concat ", " missing))
 
+let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
+  let registry = Llm_provider.Provider_registry.default () in
+  let provider_name = Provider_adapter.string_of_provider_kind cfg.kind in
+  let caps =
+    match Llm_provider.Provider_registry.find registry provider_name with
+    | Some entry -> entry.capabilities
+    | None -> Llm_provider.Capabilities.default_capabilities
+  in
+  match cfg.supports_tool_choice_override with
+  | Some supports_tool_choice -> { caps with supports_tool_choice }
+  | None -> caps
+
+let apply_required_tool_choice_filter ~require_tool_choice_support ~label
+    (providers : Llm_provider.Provider_config.t list) =
+  if not require_tool_choice_support then
+    providers
+  else
+    let supports_required_tool_use cfg =
+      let caps = provider_capabilities_of_config cfg in
+      caps.supports_tools && caps.supports_tool_choice
+    in
+    let filtered = List.filter supports_required_tool_use providers in
+    if filtered = [] && providers <> [] then
+      Log.Misc.warn
+        "cascade %s: required tool-use gate removed all providers (providers=[%s])"
+        label
+        (String.concat ", "
+           (List.map
+              (fun (cfg : Llm_provider.Provider_config.t) ->
+                Printf.sprintf "%s:%s"
+                  (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
+                  cfg.model_id)
+              providers));
+    filtered
+
 let cascade_config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"CascadeRuntime" ();
   Config_dir_resolver.cascade_path_opt ()
@@ -267,6 +302,7 @@ let models_of_cascade_name (cascade_name : string) : string list =
       defaults
 
 let resolve_providers_from_model_strings ?provider_filter
+    ?(require_tool_choice_support = false)
     (model_strings : string list)
     : Llm_provider.Provider_config.t list =
   let specs = Cascade_config.parse_model_strings model_strings in
@@ -275,6 +311,8 @@ let resolve_providers_from_model_strings ?provider_filter
       ~provider_filter
       ~label:"direct_model_strings"
       specs
+    |> apply_required_tool_choice_filter ~require_tool_choice_support
+         ~label:"direct_model_strings"
   in
   if filtered <> [] then filtered
   else (
@@ -282,7 +320,8 @@ let resolve_providers_from_model_strings ?provider_filter
       (List.length model_strings);
     [])
 
-let resolve_named_providers ?provider_filter ~cascade_name ()
+let resolve_named_providers ?provider_filter
+    ?(require_tool_choice_support = false) ~cascade_name ()
     : Llm_provider.Provider_config.t list =
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let defaults = default_model_strings ~cascade_name in
@@ -301,6 +340,8 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
        Cascade_config.parse_model_strings
          (models_of_cascade_name cascade_name))
     |> Cascade_config.apply_provider_filter ~provider_filter ~label:cascade_name
+    |> apply_required_tool_choice_filter ~require_tool_choice_support
+         ~label:cascade_name
   in
   if specs <> [] then specs
   else if models_of_cascade_name cascade_name = defaults then (
@@ -311,4 +352,5 @@ let resolve_named_providers ?provider_filter ~cascade_name ()
     Log.Misc.warn
       "cascade %s: configured models unavailable — retrying built-in defaults"
       cascade_name;
-    resolve_providers_from_model_strings ?provider_filter defaults)
+    resolve_providers_from_model_strings ?provider_filter
+      ~require_tool_choice_support defaults)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -34,7 +34,9 @@ val default_model_strings : cascade_name:string -> string list
 val models_of_cascade_name : string -> string list
 val resolve_named_providers :
   ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
   cascade_name:string -> unit -> Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
   ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
   string list -> Llm_provider.Provider_config.t list

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1848,6 +1848,7 @@ let run_turn
   with
   | Error e -> Error (Oas.Error.Internal e)
   | Ok oas_allowed_paths ->
+    let require_tool_choice_support = tools <> [] && max_turns > 1 in
     let timeout_s =
       match oas_timeout_s with
       | Some value -> value
@@ -1860,6 +1861,7 @@ let run_turn
            ~cascade_name
            ~model_strings:meta.models
            ?provider_filter
+           ~require_tool_choice_support
            ~goal:user_message
            ~priority
            ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
@@ -2057,48 +2059,41 @@ let run_turn
              ~history_messages
              ~actual_input_tokens:usage.input_tokens
          in
-         (* Text-response trap tolerance: when tool_choice=Any is set but
-            the provider ignores it (e.g. Ollama #14493), the model returns
-            text-only on non-last turns. Instead of hard-failing the turn
-            (which wastes the entire OAS run), log a warning and treat the
-            text response as valid. The turn is counted as text_response
-            in telemetry via keeper_unified_turn. See #5566. *)
-         let text =
+         (* Required-tool turns are filtered onto providers that declare
+            tool support plus tool_choice support. If a text-only response
+            still reaches this point, treat it as a contract failure. *)
+         let text_result =
            match
              Keeper_tool_disclosure.validate_completion_contract
                ~contract:!completion_contract_ref
                ~tool_names
                ()
            with
-           | Ok () -> text
+           | Ok () -> Ok text
            | Error reason ->
              let contract_str =
                match !completion_contract_ref with
                | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
                | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
              in
-             Log.Keeper.warn
-               "keeper:%s text_response trap: tool contract violated \
-                (turn=%d, tools=0, contract=%s). \
-                Provider likely ignored tool_choice=Any. Tolerating text-only \
-                response to avoid wasting OAS run. Reason: %s"
-               meta.name result.turns contract_str reason;
-             (* When both text and tool_names are empty, normalize_response_text
-                would hard-fail. Synthesize minimal text so the turn survives. *)
-             if String.trim text = "" && tool_names = []
-             then "[no output]"
-             else text
+             Log.Keeper.error
+               "keeper:%s required tool contract violated \
+                (turn=%d, tools=%d, contract=%s). \
+                Rejecting text-only response. Reason: %s"
+               meta.name result.turns (List.length tool_names) contract_str reason;
+             Error
+               (Oas.Error.Agent
+                  (Oas.Error.CompletionContractViolation
+                     { contract = "require_tool_use"; reason }))
          in
-         match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
-         | Error e -> Error (Oas.Error.Internal e)
-         | Ok response_text ->
-          (* Ensure every generation has a [STATE] block for continuity.
-             If the model omitted it, synthesize one deterministically
-             from tool usage and stop reason. *)
-          let response_text =
-            match Keeper_memory_policy.find_state_block response_text with
-               | Some _ -> response_text
-               | None ->
+         let finalize_response_text response_text =
+           (* Ensure every generation has a [STATE] block for continuity.
+              If the model omitted it, synthesize one deterministically
+              from tool usage and stop reason. *)
+           let response_text =
+             match Keeper_memory_policy.find_state_block response_text with
+             | Some _ -> response_text
+             | None ->
                  let stop_reason_str =
                    match result.stop_reason with
                    | Oas_worker.Completed -> "completed"
@@ -2122,288 +2117,295 @@ let run_turn
                    (List.length tool_names)
                    stop_reason_str;
                  response_text ^ "\n" ^ block
-             in
-             let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
-             Keeper_exec_context.persist_message
-               ~source:history_assistant_source
-               session
-               assistant_msg;
-          (* ctx_snapshot is immutable — assistant message is persisted
-                via checkpoint (OAS) and persist_message (history file).
-                No in-memory mutation needed; next turn reconstructs
-                context from checkpoint. *)
-          (* Save checkpoint AFTER [STATE] synthesis.  Patch the last
-                assistant message in the OAS checkpoint so that the persisted
-                checkpoint contains the [STATE] block.  Without this patch,
-                read_continuity_summary would find no [STATE] in checkpoint
-                messages and return empty, causing context loss.  #5431 *)
-          let saved_checkpoint =
-            match result.checkpoint with
-            | Some checkpoint ->
-              let patched =
-                Keeper_context_core.patch_checkpoint_last_assistant
-                  checkpoint
-                  ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                  ~response_text
-              in
-              (match
-                 Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir patched
-               with
-               | Ok () -> ()
-               | Error e ->
-                 Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s" meta.name e);
-              Some patched
-            | None ->
-              Log.Keeper.error "keeper:%s missing OAS checkpoint after run" meta.name;
-              None
-          in
-          (match result.proof with
-           | Some p ->
-             Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
-             let store = Agent_sdk.Proof_store.default_config in
-             let outcome = Cdal_eval_v1.evaluate ~store p in
-             let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
-             let task_subject =
-               Option.map
-                 (fun task_id ->
-                   Coord_hooks.
-                     { kind = "task"; id = Keeper_id.Task_id.to_string task_id })
-                 meta.current_task_id
-             in
-             let emit_keeper_activity ~kind ~payload ~tags =
-               try
-                 (Atomic.get Coord_hooks.activity_emit_fn) config
-                   ~actor:Coord_hooks.{ kind = "agent"; id = meta.agent_name }
-                   ?subject:task_subject
-                   ~kind ~payload ~tags ()
-               with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn ->
-                 Log.Keeper.warn
-                   "keeper:%s activity emit failed (%s): %s"
-                   meta.name
-                   kind
-                   (Printexc.to_string exn)
-             in
-             let task_id = Option.map Keeper_id.Task_id.to_string meta.current_task_id in
-             Cdal_eval_v1.persist ?task_id verdict;
-             Keeper_turn_telemetry.log_keeper_contract_verdict ~keeper_name:meta.name verdict;
-             emit_keeper_activity
-               ~kind:"keeper.contract_verdict"
-               ~payload:
-                 (Keeper_turn_telemetry.contract_verdict_activity_payload
-                    ~keeper_name:meta.name verdict)
-               ~tags:
-                 ([ "keeper"; "cdal"; "contract_verdict";
-                    Cdal_types.contract_status_to_string verdict.status ]
-                  @
-                  if List.exists
-                       (fun (gap : Cdal_types.completeness_gap) ->
-                         String.equal gap.artifact "evidence/review_warning.json")
-                       verdict.completeness_gaps
-                  then [ "review_requirement" ]
-                  else []);
-             (match outcome with
-              | Cdal_eval_v1.Load_failure (err, _) ->
-                Log.Keeper.warn
-                  "keeper:%s contract_verdict load failure: %s"
-                  meta.name
-                  (Cdal_loader.load_error_to_string err)
-              | Cdal_eval_v1.Verdict (_, _) -> ());
-             (match Cdal_eval_v1.friction_of_outcome outcome with
-              | Some fp ->
-                Keeper_turn_telemetry.log_keeper_friction ~keeper_name:meta.name fp;
-                emit_keeper_activity
-                  ~kind:"keeper.friction"
-                  ~payload:
-                    (Keeper_turn_telemetry.friction_activity_payload
-                       ~keeper_name:meta.name fp)
-                  ~tags:
-                    ([ "keeper"; "cdal"; "friction" ]
-                     @ if fp.review_tripwires <> [] then [ "tripwire" ] else [])
-              | None -> ())
-           | None -> ());
-          (* Post-turn deterministic memory write.
-            Uses meta-based fallback when [STATE] parsing fails.
-            See RFC #3646 Section 3: Det/NonDet boundary. *)
-          (try
-             let notes_written, kinds_written =
-               Keeper_memory_bank.append_memory_notes_from_reply
-                 config
-                 meta
-                 ~turn:result.turns
-                 ~reply:response_text
-             in
-             if notes_written > 0
-             then
-               Keeper_turn_telemetry.log_keeper_memory_write
-                 ~keeper_name:meta.name
-                 ~notes_written
-                 ~kinds_written
-           with
-           | exn ->
-             Log.Keeper.error
-               "keeper:%s memory_write failed: %s"
-               meta.name
-               (Printexc.to_string exn));
-          (* Episodic memory: create OAS episode from [STATE] snapshot.
-             store_episode adds to Memory.t, then flush_incremental
-             persists to institution_episodes.jsonl. The explicit flush
-             is required because this runs AFTER Agent.run returns, so
-             the AfterTurn hook has already fired for the last turn.
-             Collaboration learning (Hebbian strengthen/weaken) is not
-             recorded here; it is owned by the task lifecycle path. *)
-          (try
-             (match
-                Keeper_memory_policy.parse_state_snapshot_from_reply
-                  response_text
-              with
-             | Some snap ->
-               Memory_oas_bridge.store_episode_from_snapshot ~memory
-                 ~keeper_name:meta.name ~turn:result.turns
-                 ~trace_id:
-                   (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 snap;
-               let ep, pr =
-                 Memory_oas_bridge.flush_incremental ~memory
-                   ~agent_name:meta.name
+           in
+           let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
+           Keeper_exec_context.persist_message
+             ~source:history_assistant_source
+             session
+             assistant_msg;
+           (* ctx_snapshot is immutable — assistant message is persisted
+                 via checkpoint (OAS) and persist_message (history file).
+                 No in-memory mutation needed; next turn reconstructs
+                 context from checkpoint. *)
+           (* Save checkpoint AFTER [STATE] synthesis.  Patch the last
+                 assistant message in the OAS checkpoint so that the persisted
+                 checkpoint contains the [STATE] block.  Without this patch,
+                 read_continuity_summary would find no [STATE] in checkpoint
+                 messages and return empty, causing context loss.  #5431 *)
+           let saved_checkpoint =
+             match result.checkpoint with
+             | Some checkpoint ->
+               let patched =
+                 Keeper_context_core.patch_checkpoint_last_assistant
+                   checkpoint
+                   ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                   ~response_text
                in
-               if ep > 0 || pr > 0 then begin
-                 Log.Keeper.debug
-                   "keeper:%s post-run flush episodes=%d procedures=%d"
-                   meta.name ep pr;
-                 (* Emit activity event so episode flushes appear in
-                    the activity graph / telemetry surface. *)
-                 (try
-                    (Atomic.get Coord_hooks.activity_emit_fn) config
-                      ~actor:Coord_hooks.{ kind = "keeper"; id = meta.name }
-                      ~kind:"episode.flush"
-                      ~payload:(`Assoc [
-                        ("keeper", `String meta.name);
-                        ("episodes", `Int ep);
-                        ("procedures", `Int pr);
-                        ("turn", `Int result.turns);
-                      ])
-                      ~tags:[ "memory"; "episode"; "flush" ]
-                      ()
-                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
-               end
-             | None -> ())
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               Log.Keeper.error "keeper:%s episode_create failed: %s"
-                 meta.name (Printexc.to_string exn));
-          (* Memory bank compaction: dedup + consolidate if over threshold. *)
-          (try
-             let compaction =
-               Keeper_memory_bank.compact_memory_bank_if_needed config meta
-             in
-             if compaction.performed then
-               Log.Keeper.info
-                 "keeper:%s memory_compacted before=%d after=%d dropped=%d"
-                 meta.name compaction.before_notes compaction.after_notes
-                 compaction.dropped_notes
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
-                 (Printexc.to_string exn));
-          (* Post-turn quality metrics — goal alignment + memory recall.
-            Logged to decisions.jsonl for feedback loop analysis. *)
-          (try
-             let goal_score =
-               Keeper_memory_recall.goal_alignment_score
-                 ~meta
-                 ~user_message:None
-                 ~assistant_reply:(Some response_text)
-             in
-             let used_search =
-               List.exists (fun t -> t = "keeper_memory_search") tool_names
-             in
-             let recall_eval =
-               if used_search
-               then (
-                 let bank_path =
-                   Keeper_types_support.keeper_memory_bank_path config meta.name
-                 in
-                 let candidates =
-                   try
-                     Keeper_memory_recall.load_history_user_messages
-                       ~path:bank_path
-                       ~max_n:50
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | exn ->
-                     Log.Keeper.warn
-                       "keeper:%s memory recall history load failed: %s"
-                       meta.name
-                       (Printexc.to_string exn);
-                     []
-                 in
-                 Some
-                   (Keeper_memory_recall.evaluate_memory_recall
-                      ~user_message:""
-                      ~assistant_reply:response_text
-                      ~candidates))
-               else None
-             in
-             let post_turn_ms =
-               Keeper_timing.round1 ((Time_compat.now () -. post_turn_t0) *. 1000.0)
-             in
-             let eval_json =
-               `Assoc
-                 ([ "ts_unix", `Float (Time_compat.now ())
-                  ; "event", `String "post_turn_eval"
-                  ; "keeper_name", `String meta.name
-                  ; "turn", `Int result.turns
-                  ; "goal_alignment", `Float goal_score
-                  ; "tools_used_count", `Int (List.length tool_names)
-                  ; "used_memory_search", `Bool used_search
-                  ; "post_turn_ms", `Float post_turn_ms
-                  ]
-                  @ (match result.response.telemetry with
-                     | Some t ->
-                       [ ( "inference_telemetry"
-                         , Agent_sdk.Types.inference_telemetry_to_yojson t )
-                       ]
-                     | None -> [])
-                  @
-                  match recall_eval with
-                  | Some e ->
-                    [ "memory_recall_performed", `Bool e.performed
-                    ; "memory_recall_passed", `Bool e.passed
-                    ; "memory_recall_score", `Float e.final_score
-                    ; "memory_recall_candidates", `Int e.candidate_count
-                    ]
-                  | None -> [])
-             in
-             Keeper_types_support.append_jsonl_line
-               (Keeper_types_support.keeper_decision_log_path config meta.name)
-               eval_json
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Keeper.warn
-               "keeper:%s post_turn_eval jsonl append failed: %s"
-               meta.name
-               (Printexc.to_string exn));
-             Ok
-               { response_text
-               ; model_used = model
-               ; prompt_metrics
-               ; ctx_composition
-               ; cascade_observation = result.cascade_observation
-               ; turn_count = result.turns
-               ; tool_calls_made = List.length tool_names
-               ; usage
-               ; tools_used = tool_names
-               ; checkpoint = saved_checkpoint
-	               ; proof = result.proof
-	               ; trace_ref = result.trace_ref
-	               ; run_validation = result.run_validation
-	               ; stop_reason = result.stop_reason
-	               ; inference_telemetry = result.response.telemetry
-	               })
-	       )
+               (match
+                  Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir patched
+                with
+                | Ok () -> ()
+                | Error e ->
+                  Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s" meta.name e);
+               Some patched
+             | None ->
+               Log.Keeper.error "keeper:%s missing OAS checkpoint after run" meta.name;
+               None
+           in
+           (match result.proof with
+            | Some p ->
+              Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
+              let store = Agent_sdk.Proof_store.default_config in
+              let outcome = Cdal_eval_v1.evaluate ~store p in
+              let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
+              let task_subject =
+                Option.map
+                  (fun task_id ->
+                    Coord_hooks.
+                      { kind = "task"; id = Keeper_id.Task_id.to_string task_id })
+                  meta.current_task_id
+              in
+              let emit_keeper_activity ~kind ~payload ~tags =
+                try
+                  (Atomic.get Coord_hooks.activity_emit_fn) config
+                    ~actor:Coord_hooks.{ kind = "agent"; id = meta.agent_name }
+                    ?subject:task_subject
+                    ~kind ~payload ~tags ()
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Keeper.warn
+                    "keeper:%s activity emit failed (%s): %s"
+                    meta.name
+                    kind
+                    (Printexc.to_string exn)
+              in
+              let task_id = Option.map Keeper_id.Task_id.to_string meta.current_task_id in
+              Cdal_eval_v1.persist ?task_id verdict;
+              Keeper_turn_telemetry.log_keeper_contract_verdict ~keeper_name:meta.name verdict;
+              emit_keeper_activity
+                ~kind:"keeper.contract_verdict"
+                ~payload:
+                  (Keeper_turn_telemetry.contract_verdict_activity_payload
+                     ~keeper_name:meta.name verdict)
+                ~tags:
+                  ([ "keeper"; "cdal"; "contract_verdict";
+                     Cdal_types.contract_status_to_string verdict.status ]
+                   @
+                   if List.exists
+                        (fun (gap : Cdal_types.completeness_gap) ->
+                          String.equal gap.artifact "evidence/review_warning.json")
+                        verdict.completeness_gaps
+                   then [ "review_requirement" ]
+                   else []);
+              (match outcome with
+               | Cdal_eval_v1.Load_failure (err, _) ->
+                 Log.Keeper.warn
+                   "keeper:%s contract_verdict load failure: %s"
+                   meta.name
+                   (Cdal_loader.load_error_to_string err)
+               | Cdal_eval_v1.Verdict (_, _) -> ());
+              (match Cdal_eval_v1.friction_of_outcome outcome with
+               | Some fp ->
+                 Keeper_turn_telemetry.log_keeper_friction ~keeper_name:meta.name fp;
+                 emit_keeper_activity
+                   ~kind:"keeper.friction"
+                   ~payload:
+                     (Keeper_turn_telemetry.friction_activity_payload
+                        ~keeper_name:meta.name fp)
+                   ~tags:
+                     ([ "keeper"; "cdal"; "friction" ]
+                      @ if fp.review_tripwires <> [] then [ "tripwire" ] else [])
+               | None -> ())
+            | None -> ());
+           (* Post-turn deterministic memory write.
+             Uses meta-based fallback when [STATE] parsing fails.
+             See RFC #3646 Section 3: Det/NonDet boundary. *)
+           (try
+              let notes_written, kinds_written =
+                Keeper_memory_bank.append_memory_notes_from_reply
+                  config
+                  meta
+                  ~turn:result.turns
+                  ~reply:response_text
+              in
+              if notes_written > 0
+              then
+                Keeper_turn_telemetry.log_keeper_memory_write
+                  ~keeper_name:meta.name
+                  ~notes_written
+                  ~kinds_written
+            with
+            | exn ->
+              Log.Keeper.error
+                "keeper:%s memory_write failed: %s"
+                meta.name
+                (Printexc.to_string exn));
+           (* Episodic memory: create OAS episode from [STATE] snapshot.
+              store_episode adds to Memory.t, then flush_incremental
+              persists to institution_episodes.jsonl. The explicit flush
+              is required because this runs AFTER Agent.run returns, so
+              the AfterTurn hook has already fired for the last turn.
+              Collaboration learning (Hebbian strengthen/weaken) is not
+              recorded here; it is owned by the task lifecycle path. *)
+           (try
+              (match
+                 Keeper_memory_policy.parse_state_snapshot_from_reply
+                   response_text
+               with
+              | Some snap ->
+                Memory_oas_bridge.store_episode_from_snapshot ~memory
+                  ~keeper_name:meta.name ~turn:result.turns
+                  ~trace_id:
+                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                  snap;
+                let ep, pr =
+                  Memory_oas_bridge.flush_incremental ~memory
+                    ~agent_name:meta.name
+                in
+                if ep > 0 || pr > 0 then begin
+                  Log.Keeper.debug
+                    "keeper:%s post-run flush episodes=%d procedures=%d"
+                    meta.name ep pr;
+                  (* Emit activity event so episode flushes appear in
+                     the activity graph / telemetry surface. *)
+                  (try
+                     (Atomic.get Coord_hooks.activity_emit_fn) config
+                       ~actor:Coord_hooks.{ kind = "keeper"; id = meta.name }
+                       ~kind:"episode.flush"
+                       ~payload:(`Assoc [
+                         ("keeper", `String meta.name);
+                         ("episodes", `Int ep);
+                         ("procedures", `Int pr);
+                         ("turn", `Int result.turns);
+                       ])
+                       ~tags:[ "memory"; "episode"; "flush" ]
+                       ()
+                   with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
+                end
+              | None -> ())
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Keeper.error "keeper:%s episode_create failed: %s"
+                  meta.name (Printexc.to_string exn));
+           (* Memory bank compaction: dedup + consolidate if over threshold. *)
+           (try
+              let compaction =
+                Keeper_memory_bank.compact_memory_bank_if_needed config meta
+              in
+              if compaction.performed then
+                Log.Keeper.info
+                  "keeper:%s memory_compacted before=%d after=%d dropped=%d"
+                  meta.name compaction.before_notes compaction.after_notes
+                  compaction.dropped_notes
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
+                  (Printexc.to_string exn));
+           (* Post-turn quality metrics — goal alignment + memory recall.
+             Logged to decisions.jsonl for feedback loop analysis. *)
+           (try
+              let goal_score =
+                Keeper_memory_recall.goal_alignment_score
+                  ~meta
+                  ~user_message:None
+                  ~assistant_reply:(Some response_text)
+              in
+              let used_search =
+                List.exists (fun t -> t = "keeper_memory_search") tool_names
+              in
+              let recall_eval =
+                if used_search
+                then (
+                  let bank_path =
+                    Keeper_types_support.keeper_memory_bank_path config meta.name
+                  in
+                  let candidates =
+                    try
+                      Keeper_memory_recall.load_history_user_messages
+                        ~path:bank_path
+                        ~max_n:50
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                      Log.Keeper.warn
+                        "keeper:%s memory recall history load failed: %s"
+                        meta.name
+                        (Printexc.to_string exn);
+                      []
+                  in
+                  Some
+                    (Keeper_memory_recall.evaluate_memory_recall
+                       ~user_message:""
+                       ~assistant_reply:response_text
+                       ~candidates))
+                else None
+              in
+              let post_turn_ms =
+                Keeper_timing.round1 ((Time_compat.now () -. post_turn_t0) *. 1000.0)
+              in
+              let eval_json =
+                `Assoc
+                  ([ "ts_unix", `Float (Time_compat.now ())
+                   ; "event", `String "post_turn_eval"
+                   ; "keeper_name", `String meta.name
+                   ; "turn", `Int result.turns
+                   ; "goal_alignment", `Float goal_score
+                   ; "tools_used_count", `Int (List.length tool_names)
+                   ; "used_memory_search", `Bool used_search
+                   ; "post_turn_ms", `Float post_turn_ms
+                   ]
+                   @ (match result.response.telemetry with
+                      | Some t ->
+                        [ ( "inference_telemetry"
+                          , Agent_sdk.Types.inference_telemetry_to_yojson t )
+                        ]
+                      | None -> [])
+                   @
+                   match recall_eval with
+                   | Some e ->
+                     [ "memory_recall_performed", `Bool e.performed
+                     ; "memory_recall_passed", `Bool e.passed
+                     ; "memory_recall_score", `Float e.final_score
+                     ; "memory_recall_candidates", `Int e.candidate_count
+                     ]
+                   | None -> [])
+              in
+              Keeper_types_support.append_jsonl_line
+                (Keeper_types_support.keeper_decision_log_path config meta.name)
+                eval_json
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Keeper.warn
+                "keeper:%s post_turn_eval jsonl append failed: %s"
+                meta.name
+                (Printexc.to_string exn));
+           Ok
+             { response_text
+             ; model_used = model
+             ; prompt_metrics
+             ; ctx_composition
+             ; cascade_observation = result.cascade_observation
+             ; turn_count = result.turns
+             ; tool_calls_made = List.length tool_names
+             ; usage
+             ; tools_used = tool_names
+             ; checkpoint = saved_checkpoint
+             ; proof = result.proof
+             ; trace_ref = result.trace_ref
+             ; run_validation = result.run_validation
+             ; stop_reason = result.stop_reason
+             ; inference_telemetry = result.response.telemetry
+             }
+         in
+         match text_result with
+         | Error e -> Error e
+         | Ok text -> (
+             match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
+             | Error e -> Error (Oas.Error.Internal e)
+             | Ok response_text -> finalize_response_text response_text))
+    )
 ;;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -178,13 +178,8 @@ let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
 
 let is_required_tool_contract_violation (err : Oas.Error.sdk_error) : bool =
   match err with
-  | Oas.Error.Agent (Oas.Error.CompletionContractViolation { contract; reason }) ->
+  | Oas.Error.Agent (Oas.Error.CompletionContractViolation { contract; _ }) ->
       String.equal contract "require_tool_use"
-      || let lower = String.lowercase_ascii reason in
-         string_contains_substring
-           ~needle:"tool_choice requested tool use"
-           lower
-         && string_contains_substring ~needle:"no tooluse block" lower
   | _ -> false
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -82,6 +82,7 @@ val run_named :
   ?model_strings:string list ->
   goal:string ->
   ?provider_filter:string list ->
+  ?require_tool_choice_support:bool ->
   ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -50,15 +50,18 @@ let eio_context_error_to_sdk_error detail =
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
-let resolve_cascade_providers ?provider_filter ~cascade_name () =
-  Cascade_runtime.resolve_named_providers ?provider_filter ~cascade_name ()
+let resolve_cascade_providers ?provider_filter
+    ?(require_tool_choice_support = false) ~cascade_name () =
+  Cascade_runtime.resolve_named_providers ?provider_filter
+    ~require_tool_choice_support ~cascade_name ()
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
     resulting provider configs into OAS execution. *)
-let resolve_providers_from_model_strings ?provider_filter model_strings =
+let resolve_providers_from_model_strings ?provider_filter
+    ?(require_tool_choice_support = false) model_strings =
   Cascade_runtime.resolve_providers_from_model_strings ?provider_filter
-    model_strings
+    ~require_tool_choice_support model_strings
 
 type masc_internal_error =
   | Cascade_exhausted of {
@@ -357,6 +360,7 @@ let run_named
     ?model_strings
     ~goal
     ?provider_filter
+    ?(require_tool_choice_support = false)
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -412,10 +416,14 @@ let run_named
     | Some ms when ms <> [] ->
       (* Direct model strings from keeper TOML — skip named preset lookup.
          MASC passes these strings through without interpretation. *)
-      (ms, resolve_providers_from_model_strings ?provider_filter ms)
+      ( ms,
+        resolve_providers_from_model_strings ?provider_filter
+          ~require_tool_choice_support ms )
     | _ ->
       let labels = Cascade_runtime.models_of_cascade_name cascade_name in
-      (labels, resolve_cascade_providers ?provider_filter ~cascade_name ())
+      ( labels,
+        resolve_cascade_providers ?provider_filter
+          ~require_tool_choice_support ~cascade_name () )
   in
   let capture, _metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
   let name = Printf.sprintf "oas-%s" cascade_name in
@@ -427,7 +435,12 @@ let run_named
          (Cascade_exhausted
             {
               cascade_name;
-              detail = Some "no callable models available";
+              detail =
+                Some
+                  (if require_tool_choice_support then
+                     "no callable models support required tool use"
+                   else
+                     "no callable models available");
             }))
   | _ ->
   let transport_resolved = match transport with

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -6,6 +6,29 @@ let provider_kinds providers =
       Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
     providers
 
+let provider_kind_models providers =
+  List.map
+    (fun (cfg : Llm_provider.Provider_config.t) ->
+      Printf.sprintf "%s:%s"
+        (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
+        cfg.model_id)
+    providers
+
+let provider_supports_required_tool_use (cfg : Llm_provider.Provider_config.t) =
+  let registry = Llm_provider.Provider_registry.default () in
+  let provider_name = Masc_mcp.Provider_adapter.string_of_provider_kind cfg.kind in
+  let caps =
+    match Llm_provider.Provider_registry.find registry provider_name with
+    | Some entry -> entry.capabilities
+    | None -> Llm_provider.Capabilities.default_capabilities
+  in
+  let caps =
+    match cfg.supports_tool_choice_override with
+    | Some supports_tool_choice -> { caps with supports_tool_choice }
+    | None -> caps
+  in
+  caps.supports_tools && caps.supports_tool_choice
+
 let direct_model_strings =
   [ "ollama:local-model"
   ; "custom:remote-model@http://127.0.0.1:18080/v1"
@@ -29,6 +52,33 @@ let test_provider_filter_falls_back_to_unfiltered_when_no_match () =
   check (list string) "no-match filter falls back to unfiltered providers"
     [ "ollama"; "openai_compat" ] (provider_kinds providers)
 
+let tool_required_model_strings =
+  [ "codex_cli:auto"
+  ; "gemini_cli:auto"
+  ; "ollama:local-model"
+  ; "llama:qwen3.5-3b-a3b-ud-q8-xl"
+  ]
+
+let test_required_tool_choice_filter_keeps_only_supported_providers () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~require_tool_choice_support:true
+      tool_required_model_strings
+  in
+  check bool "tool-required path keeps at least one callable provider" true
+    (providers <> []);
+  check bool "every surviving provider satisfies required tool-use capabilities" true
+    (List.for_all provider_supports_required_tool_use providers)
+
+let test_required_tool_choice_filter_can_exhaust_candidates () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~require_tool_choice_support:true
+      [ "ollama:local-model" ]
+  in
+  check (list string) "unsupported-only candidate set becomes empty" []
+    (provider_kind_models providers)
+
 let () =
   run "Cascade_runtime"
     [
@@ -38,5 +88,9 @@ let () =
             test_provider_filter_is_applied_to_direct_model_strings;
           test_case "falls back when filter matches nothing" `Quick
             test_provider_filter_falls_back_to_unfiltered_when_no_match;
+          test_case "required tool choice keeps only supported providers" `Quick
+            test_required_tool_choice_filter_keeps_only_supported_providers;
+          test_case "required tool choice can exhaust candidates" `Quick
+            test_required_tool_choice_filter_can_exhaust_candidates;
         ] );
     ]


### PR DESCRIPTION
## Summary
- gate `tool_required` keeper turns so only providers that support both tools and `tool_choice` are eligible
- thread that requirement through named-cascade resolution and return an explicit exhaustion reason when no candidate survives
- treat text-only responses on required-tool turns as `CompletionContractViolation(require_tool_use)` instead of tolerating them
- add cascade runtime regression tests for provider pruning and empty-candidate behavior

## Why
Keeper turns that required tool use could still route through providers that do not honor `tool_choice`. Those runs then fell back to text-only responses, which looked like progress but left keepers doing no work.

## Impact
This makes the runtime contract single-path for tool-required turns: either a capable provider is selected, or the run fails explicitly before pretending the turn succeeded.

## Validation
- `git diff --check`
- `dune exec ./test/test_cascade_runtime.exe --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-tool-required-gate`
- `dune build test/test_keeper_unified.exe --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-tool-required-gate`