### PR TITLE
ci: improve TLA+ model checking observability and duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,11 +647,15 @@ jobs:
         run: scripts/dashboard-drift-check.sh
 
   tla-specs:
-    name: TLA+ Model Checking
+    name: TLA+ Model Checking (${{ matrix.suite }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     needs: [pr-sync-check, changes]
     if: ${{ !cancelled() && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [check-clean, check-buggy]
 
     steps:
       - name: Checkout
@@ -669,7 +673,7 @@ jobs:
             https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
       - name: Run TLA+ model checking
-        run: make -C specs check-all
+        run: make -C specs ${{ matrix.suite }}
 
   spec-line-refs:
     name: Spec Line Refs

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -75,12 +75,15 @@ check-clean:
 	  tla="$$dir/$$base.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kf in $(KNOWN_FAILURES); do [ "$$base" = "$$kf" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_FAILURES)\n" "$$base"; continue; fi; \
-	  printf "CHECK %-40s " "$$base"; \
+	  if [ $$skip -eq 1 ]; then printf "SKIP  %-40s (KNOWN_FAILURES)\n" "$$base"; continue; fi; \
+	  printf "CHECK %-40s ...\n" "$$base"; \
+	  start_ts=$$(date +%s); \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$base.log 2>&1; \
 	  rc=$$?; \
-	  if [ $$rc -eq 0 ]; then echo "OK"; \
-	  else echo "FAIL (exit $$rc)"; tail -5 /tmp/tlc-$$base.log; fail=1; fi; \
+	  end_ts=$$(date +%s); \
+	  duration=$$((end_ts - start_ts)); \
+	  if [ $$rc -eq 0 ]; then printf "OK    %-40s (%3ds)\n" "$$base" "$$duration"; \
+	  else printf "FAIL  %-40s (exit $$rc, %3ds)\n" "$$base" "$$duration"; tail -15 /tmp/tlc-$$base.log; fail=1; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 
@@ -97,13 +100,16 @@ check-buggy:
 	  tla="$$dir/$$bugbase.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kb in $(KNOWN_BUGGY_NO_VIOLATION); do [ "$$bugbase" = "$$kb" ] && skip=1; done; \
-	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
-	  printf "CHECK %-40s " "$$cfgtag (buggy)"; \
+	  if [ $$skip -eq 1 ]; then printf "SKIP  %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
+	  printf "CHECK %-40s ...\n" "$$cfgtag (buggy)"; \
+	  start_ts=$$(date +%s); \
 	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$cfgtag.log 2>&1; \
 	  rc=$$?; \
-	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then echo "OK (violation exit $$rc)"; \
-	  elif [ $$rc -eq 0 ]; then echo "FAIL (no violation)"; fail=1; \
-	  else echo "WARN (exit $$rc)"; fi; \
+	  end_ts=$$(date +%s); \
+	  duration=$$((end_ts - start_ts)); \
+	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then printf "OK    %-40s (violation exit $$rc, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; \
+	  elif [ $$rc -eq 0 ]; then printf "FAIL  %-40s (no violation, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; fail=1; \
+	  else printf "WARN  %-40s (exit $$rc, %3ds)\n" "$$cfgtag (buggy)" "$$duration"; fi; \
 	done; \
 	if [ $$fail -eq 1 ]; then exit 1; fi
 


### PR DESCRIPTION
Closes #9167

This PR addresses the silent long-running TLA+ Model Checking step in CI:
1. **Matrix parallelization**: Split `check-clean` and `check-buggy` into separate matrix jobs to run in parallel and isolate failures.
2. **Progress & Timings**: The Makefile now explicitly logs `CHECK <spec> ...` before starting, and calculates `duration` to print `OK <spec> (<duration>s)` or `FAIL` right after the check completes. This gives immediate feedback in GitHub Actions logs without buffering.
3. **Reduced timeout**: Timeout for each TLA+ job is tightened from 30 to 15 minutes since they run in parallel now.