### PR TITLE
[codex] canonicalize dashboard project snapshot naming

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -187,7 +187,7 @@ describe('get bootstrap warm-up mapping', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const controller = new AbortController()
-    const request = get('/api/v1/dashboard/namespace-truth', { signal: controller.signal })
+    const request = get('/api/v1/dashboard/project-snapshot', { signal: controller.signal })
     controller.abort()
 
     await expect(request).rejects.toMatchObject({
@@ -195,7 +195,7 @@ describe('get bootstrap warm-up mapping', () => {
     })
   })
 
-  it('maps dashboard namespace-truth not-initialized errors to initializing payloads', async () => {
+  it('maps dashboard project-snapshot not-initialized errors to initializing payloads', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"error":"not initialized"}', {
         status: 500,
@@ -204,7 +204,7 @@ describe('get bootstrap warm-up mapping', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/namespace-truth')
+    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/project-snapshot')
 
     expect(data.status).toBe('initializing')
     expect(data.message).toContain('warming up')
@@ -272,10 +272,10 @@ describe('get bootstrap warm-up mapping', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(get('/api/v1/dashboard/namespace-truth')).rejects.toMatchObject({
+    await expect(get('/api/v1/dashboard/project-snapshot')).rejects.toMatchObject({
       name: 'ApiRequestError',
       status: 401,
-      path: '/api/v1/dashboard/namespace-truth',
+      path: '/api/v1/dashboard/project-snapshot',
     })
   })
 
@@ -288,23 +288,31 @@ describe('get bootstrap warm-up mapping', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/namespace-truth')
+    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/project-snapshot')
 
     expect(data.status).toBe('initializing')
     expect(data.message).toContain('warming up')
   })
 
-  it('remaps room-truth alias the same as namespace-truth', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response('{"error":"not initialized"}', {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+  it('remaps namespace/room-truth aliases the same as project-snapshot', async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('{"error":"not initialized"}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ))
     vi.stubGlobal('fetch', fetchMock)
 
-    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/room-truth')
+    const canonical = await get<{ status?: string; message?: string }>('/api/v1/dashboard/project-snapshot')
+    expect(canonical.status).toBe('initializing')
+    expect(canonical.message).toContain('warming up')
 
+    const legacyNamespace = await get<{ status?: string; message?: string }>('/api/v1/dashboard/namespace-truth')
+    expect(legacyNamespace.status).toBe('initializing')
+    expect(legacyNamespace.message).toContain('warming up')
+
+    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/room-truth')
     expect(data.status).toBe('initializing')
     expect(data.message).toContain('warming up')
   })

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -198,6 +198,7 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
 
 const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
   '/api/v1/dashboard/shell',
+  '/api/v1/dashboard/project-snapshot',
   '/api/v1/dashboard/namespace-truth',
   '/api/v1/dashboard/room-truth',
   '/api/v1/dashboard/execution',
@@ -330,6 +331,7 @@ function bootstrapInitializingPayload(path: string): unknown | null {
         config_resolution: null,
         runtime_resolution: null,
       }
+    case '/api/v1/dashboard/project-snapshot':
     case '/api/v1/dashboard/namespace-truth':
     case '/api/v1/dashboard/room-truth':
       return {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -163,7 +163,7 @@ export function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
 }
 
 export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions): Promise<DashboardNamespaceTruthResponse> {
-  return get('/api/v1/dashboard/namespace-truth', {
+  return get('/api/v1/dashboard/project-snapshot', {
     timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
     signal: opts?.signal,
   })

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -53,7 +53,7 @@ export function App() {
     initRouter()
 
     // Prime the lightweight shell status first so build/version metadata lands
-    // while namespace-truth warms heavier execution/command projections.
+    // while the project snapshot warms heavier execution/command projections.
     void refreshShell()
     requestNamespaceTruthNow()
 

--- a/dashboard/src/components/flow-control/flow-control-state.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.test.ts
@@ -42,7 +42,7 @@ describe('flow-control-state', () => {
     flowState.value = 'unknown'
   }, 120_000)
 
-  it('reuses namespace truth pause state before calling MCP', async () => {
+  it('reuses project snapshot pause state before calling MCP', async () => {
     namespaceTruth.value = {
       root: {
         status: {
@@ -58,7 +58,7 @@ describe('flow-control-state', () => {
     expect(callMcpTool).not.toHaveBeenCalled()
   })
 
-  it('treats namespace truth warm-up as initializing before calling MCP', async () => {
+  it('treats project snapshot warm-up as initializing before calling MCP', async () => {
     namespaceTruthInitializing.value = true
 
     const { fetchPauseStatus, flowState } = await import('./flow-control-state')
@@ -112,7 +112,7 @@ describe('flow-control-state', () => {
     expect(flowState.value).toBe('unknown')
   })
 
-  it('reacts to namespace-truth signal changes after mount', async () => {
+  it('reacts to project-snapshot signal changes after mount', async () => {
     const { flowState } = await import('./flow-control-state')
 
     namespaceTruthInitializing.value = true

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -29,7 +29,7 @@ async function doFetchNamespaceTruth(): Promise<void> {
       isRecord(raw)
       && asString((raw as Record<string, unknown>).status) === 'initializing'
     if (isInitializing) {
-      console.debug('[namespace-truth] server initializing, scheduling warm-up retry')
+      console.debug('[project-snapshot] server initializing, scheduling warm-up retry')
       namespaceTruthInitializing.value = true
       scheduleNamespaceWarmRetry()
       return
@@ -43,8 +43,8 @@ async function doFetchNamespaceTruth(): Promise<void> {
       normalized.root.status ?? null,
     )
   } catch (err) {
-    const detail = err instanceof Error ? err.message : 'Failed to load project truth'
-    console.warn('[namespace-truth] fetch failed:', detail)
+    const detail = err instanceof Error ? err.message : 'Failed to load project snapshot'
+    console.warn('[project-snapshot] fetch failed:', detail)
     namespaceTruthError.value = detail
   } finally {
     namespaceTruthLoading.value = false
@@ -53,7 +53,7 @@ async function doFetchNamespaceTruth(): Promise<void> {
 
 function scheduleNamespaceWarmRetry(): void {
   warmRetryAttempt++
-  console.debug(`[namespace-truth] warm-up retry ${warmRetryAttempt}/${WARM_MAX_RETRIES}`)
+  console.debug(`[project-snapshot] warm-up retry ${warmRetryAttempt}/${WARM_MAX_RETRIES}`)
   if (warmRetryAttempt > WARM_MAX_RETRIES) {
     namespaceTruthInitializing.value = false
     namespaceTruthError.value = 'Server warm-up timed out. Try refreshing.'
@@ -77,12 +77,12 @@ const namespaceTruthScheduler = new FetchScheduler(doFetchNamespaceTruth, {
 
 // --- Public API ---
 
-/** Request a namespace-truth refresh (debounced, cooldown-enforced). */
+/** Request a project-snapshot refresh (debounced, cooldown-enforced). */
 export function requestNamespaceTruth(): void {
   namespaceTruthScheduler.request()
 }
 
-/** Request an immediate namespace-truth refresh (deduped with inflight). */
+/** Request an immediate project-snapshot refresh (deduped with inflight). */
 export function requestNamespaceTruthNow(): void {
   namespaceTruthScheduler.requestNow()
 }

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -64,6 +64,72 @@ describe('normalizeNamespaceTruth', () => {
     expect(status!.version).toBe('1.0.0')
   })
 
+  it('reuses the shared server-status normalizer for shell-derived truth fields', () => {
+    const result = normalizeNamespaceTruth({
+      root: {
+        status: {
+          coordination_root: '/path/to/root',
+          workspace_path: '/path/to/ws',
+          version: '1.0.0',
+          generated_at: '2026-04-17T10:00:00Z',
+          build: {
+            release_version: '1.0.0',
+            commit: '2897da06',
+            started_at: '2026-04-17T09:50:00Z',
+            uptime_seconds: 600,
+          },
+          tempo: 'steady',
+          tool_call_health: {
+            window_hours: 6,
+            tool_calls: 42,
+            failures: 3,
+            failure_rate: 0.071,
+            since_epoch: 1775000000,
+            distinct_tools: 8,
+          },
+          alert_thresholds: {
+            proactive_fallback_warn: 0.15,
+            proactive_fallback_bad: 0.3,
+            proactive_similarity_warn: 0.25,
+            proactive_similarity_bad: 0.5,
+            toast_cooldown_sec: 120,
+          },
+          monitoring: {
+            board: {
+              stale_posts: 2,
+            },
+          },
+          data_quality: {
+            board_contract_ok: true,
+            governance_feed_ok: false,
+            last_sync_at: '2026-04-17T09:55:00Z',
+          },
+        },
+      },
+    })
+
+    expect(result.root.status).toMatchObject({
+      tempo: 'steady',
+      tool_call_health: {
+        tool_calls: 42,
+        distinct_tools: 8,
+      },
+      alert_thresholds: {
+        toast_cooldown_sec: 120,
+      },
+      monitoring: {
+        board: {
+          stale_posts: 2,
+        },
+      },
+      data_quality: {
+        board_contract_ok: true,
+        governance_feed_ok: false,
+        last_sync_at: '2026-04-17T09:55:00Z',
+      },
+    })
+  })
+
   it('extracts root.counts', () => {
     const result = normalizeNamespaceTruth({
       root: {
@@ -354,7 +420,7 @@ describe('normalizeNamespaceTruth', () => {
 
   // ── full integration ──
 
-  it('parses a full namespace truth response', () => {
+  it('parses a full project snapshot response', () => {
     const result = normalizeNamespaceTruth({
       generated_at: '2026-04-17T12:00:00Z',
       root: {

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -1,6 +1,6 @@
 import { asBoolean, asNumber, asString, asStringArray, isRecord, extractArray } from './components/common/normalize'
 import {
-  normalizeBuildIdentity,
+  normalizeServerStatus,
   normalizeExecutionSummary,
   normalizeExecutionQueueItem,
   normalizeAttentionItem,
@@ -14,24 +14,7 @@ import type {
   DashboardNamespaceTruthRecommendationSummary,
   DashboardNamespaceTruthResponse,
   PendingConfirmSummary,
-  ServerStatus,
 } from './types'
-
-function normalizeServerStatus(raw: unknown): ServerStatus | null {
-  if (!isRecord(raw)) return null
-  return {
-    coordination_root: asString(raw.coordination_root),
-    workspace_path: asString(raw.workspace_path),
-    workspace_differs: asBoolean(raw.workspace_differs),
-    cluster: asString(raw.cluster),
-    project: asString(raw.project),
-    paused: asBoolean(raw.paused),
-    version: asString(raw.version),
-    generated_at: asString(raw.generated_at),
-    build: normalizeBuildIdentity(raw.build),
-    tempo_interval_s: asNumber(raw.tempo_interval_s),
-  }
-}
 
 function normalizePendingConfirmSummary(raw: unknown): PendingConfirmSummary | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/namespace-truth-store.test.ts
+++ b/dashboard/src/namespace-truth-store.test.ts
@@ -9,6 +9,9 @@ const apiMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./api', () => apiMocks)
+vi.mock('./api/dashboard', () => ({
+  fetchDashboardNamespaceTruth: apiMocks.fetchDashboardNamespaceTruth,
+}))
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -16,7 +19,7 @@ afterEach(() => {
 })
 
 describe('refreshNamespaceTruth', () => {
-  it('hydrates build identity into serverStatus from namespace truth', async () => {
+  it('hydrates build identity into serverStatus from project snapshot', async () => {
     apiMocks.fetchDashboardNamespaceTruth.mockResolvedValue({
       generated_at: '2026-03-25T08:16:21Z',
       root: {
@@ -67,7 +70,7 @@ describe('refreshNamespaceTruth', () => {
     })
   }, 20000)
 
-  it('normalizes latest meta-cognition digest from namespace truth', async () => {
+  it('normalizes latest meta-cognition digest from project snapshot', async () => {
     apiMocks.fetchDashboardNamespaceTruth.mockResolvedValue({
       generated_at: '2026-03-25T08:16:21Z',
       root: {

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -6,7 +6,7 @@ import {
 } from './runtime-counts'
 
 describe('resolveRuntimeCounts', () => {
-  it('uses namespace-truth counts while execution is still warming', () => {
+  it('uses project-snapshot counts while execution is still warming', () => {
     expect(resolveRuntimeCounts({
       executionLoaded: false,
       agentsCount: 0,
@@ -20,11 +20,11 @@ describe('resolveRuntimeCounts', () => {
       tasks: 12,
       totalRuntimes: 5,
       configuredKeepers: 5,
-      source: 'namespace-truth',
+      source: 'project-snapshot',
     })
   })
 
-  it('falls back to shell counts when namespace-truth is unavailable', () => {
+  it('falls back to shell counts when project-snapshot is unavailable', () => {
     expect(resolveRuntimeCounts({
       executionLoaded: false,
       agentsCount: 0,
@@ -72,7 +72,7 @@ describe('resolveRuntimeCounts', () => {
       tasks: 12,
       totalRuntimes: 5,
       configuredKeepers: 4,
-      source: 'namespace-truth',
+      source: 'project-snapshot',
     })
   })
 })
@@ -80,7 +80,7 @@ describe('resolveRuntimeCounts', () => {
 describe('runtimeCountSourceLabel', () => {
   it('maps count source ids to user-facing labels', () => {
     expect(runtimeCountSourceLabel('execution')).toBe('execution 상세')
-    expect(runtimeCountSourceLabel('namespace-truth')).toBe('namespace-truth')
+    expect(runtimeCountSourceLabel('project-snapshot')).toBe('project snapshot')
     expect(runtimeCountSourceLabel('shell')).toBe('shell')
   })
 })

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -2,7 +2,7 @@ import type { DashboardNamespaceTruthResponse, DashboardShellResponse } from './
 
 type RuntimeCountSource =
   | 'execution'
-  | 'namespace-truth'
+  | 'project-snapshot'
   | 'shell'
   | 'partial'
   | 'unknown'
@@ -89,7 +89,7 @@ export function resolveRuntimeCounts({
       ...namespace!,
       totalRuntimes: namespaceTotalRuntimes,
       configuredKeepers,
-      source: 'namespace-truth',
+      source: 'project-snapshot',
     }
   }
 
@@ -123,8 +123,8 @@ export function runtimeCountSourceLabel(source: RuntimeCountSource): string {
   switch (source) {
     case 'execution':
       return 'execution 상세'
-    case 'namespace-truth':
-      return 'namespace-truth'
+    case 'project-snapshot':
+      return 'project snapshot'
     case 'shell':
       return 'shell'
     case 'partial':

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -53,6 +53,7 @@ const FixedSSEEventTypeSchema = z.enum([
   'governance_param_changed',
   'approval:pending',
   'approval:resolved',
+  'project_snapshot',
   'room_truth_snapshot',
   'namespace_truth_snapshot',
   'execution_snapshot',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -120,4 +120,32 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.clearAllTimers()
     cleanup()
   })
+
+  it('hydrates the canonical project_snapshot SSE event without an HTTP fetch', async () => {
+    const { sseStore, sse } = await loadSseStore()
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.lastEvent.value = {
+      type: 'project_snapshot',
+      payload: {
+        root: {
+          status: {
+            project: 'default',
+          },
+        },
+      },
+    }
+    await flushAsyncWork()
+
+    expect(namespaceTruth.value).toEqual({
+      root: {
+        status: {
+          project: 'default',
+        },
+      },
+    })
+    expect(requestNamespaceTruthNow).not.toHaveBeenCalled()
+
+    cleanup()
+  })
 })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -159,7 +159,7 @@ const AUTORESEARCH_EVENTS = new Set([
   'autoresearch_stopped',
 ])
 
-/** Hydrate namespace-truth signals directly from SSE payload — zero HTTP fetch. */
+/** Hydrate project-snapshot signals directly from SSE payload — zero HTTP fetch. */
 function handleNamespaceTruthSnapshot(payload: unknown): void {
   try {
     const normalized = normalizeNamespaceTruth(payload)
@@ -169,7 +169,7 @@ function handleNamespaceTruthSnapshot(payload: unknown): void {
       normalized.root.status ?? null,
     )
   } catch (err) {
-    console.debug('[SSE] namespace-truth snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
+    console.debug('[SSE] project-snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
   }
 }
 
@@ -289,7 +289,7 @@ async function hydrateAfterReconnect(): Promise<void> {
   void refreshActiveRoute().catch(err =>
     console.warn('[SSE] reconnect route refresh failed', err instanceof Error ? err.message : err),
   )
-  // Safety-net retry: if namespace-truth fetch failed (e.g. server warm-up),
+  // Safety-net retry: if project-snapshot fetch failed (e.g. server warm-up),
   // the scheduler's error signal will be set. Retry once after delay.
   setTimeout(() => {
     if (namespaceTruthError.value) {
@@ -352,8 +352,8 @@ export function setupSSEReaction(): () => void {
   const unsubscribe = lastEvent.subscribe((event) => {
     if (!event) return
 
-    // 0. Namespace-truth snapshot — server push, no HTTP fetch needed
-    if ((event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
+    // 0. Project snapshot — server push, no HTTP fetch needed
+    if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
       handleNamespaceTruthSnapshot(event.payload)
       return
     }

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -1,5 +1,5 @@
 /* UI — toast animation, markdown content, think block, SPA refresh tabs, button.agent,
-   namespace-truth-card, monitor buttons, agent-event-badge variants. Extracted from global.css for #3915. */
+   project-snapshot card, monitor buttons, agent-event-badge variants. Extracted from global.css for #3915. */
 
 /* ═══ UI ═══ */
 

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -52,7 +52,7 @@ describe('refreshPlanForRoute', () => {
     vi.clearAllMocks()
   })
 
-  it('hydrates overview from namespace truth and mission snapshot', () => {
+  it('hydrates overview from project snapshot and mission snapshot', () => {
     expect(refreshPlanForRoute({
       tab: 'overview',
       params: {},

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -64,6 +64,7 @@ export type SSEEventType =
   // newer runtime bridges do not get dropped at the schema boundary.
   | `oas:${string}`
   // Server-push snapshot events (proactive cache broadcasts)
+  | 'project_snapshot'
   | 'room_truth_snapshot'
   | 'namespace_truth_snapshot'
   | 'execution_snapshot'

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -75,7 +75,7 @@ let all_entries =
       hidden_from_nav = false;
       meets_main_gate = true;
       rationale =
-        "오버뷰는 shell/mission/namespace truth를 묶는 front-door 브리핑 surface라 메인에서 유지합니다.";
+        "오버뷰는 shell/mission/project snapshot을 묶는 front-door 브리핑 surface라 메인에서 유지합니다.";
       route_hash = Some "#overview";
       refs =
         {

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -47,7 +47,7 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let started_at = Unix.gettimeofday () in
         let t0 = Time_compat.now () in
         (* Staged fetch: shell may still need a guarded refresh, while execution
-           stays on the proactive cache to keep namespace-truth off the cold path. *)
+           stays on the proactive cache to keep project-snapshot off the cold path. *)
         let shell_ref = ref (`Assoc []) in
         let execution_ref = ref (`Assoc []) in
         let command_ref = ref (`Assoc []) in
@@ -72,13 +72,13 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
             match Eio.Time.with_timeout clock timeout_s (fun () -> Ok (f ())) with
             | Ok v -> v
             | Error `Timeout ->
-                Log.Dashboard.warn "namespace-truth fiber %s timed out (%.0fs)" label
+                Log.Dashboard.warn "project-snapshot fiber %s timed out (%.0fs)" label
                   timeout_s;
                 fallback
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
-              Log.Dashboard.warn "namespace-truth fiber %s failed: %s" label
+              Log.Dashboard.warn "project-snapshot fiber %s failed: %s" label
                 (Printexc.to_string exn);
               fallback
         in
@@ -119,9 +119,9 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let command_summary_json = !command_ref in
         let parallel_ms = (Time_compat.now () -. t0) *. 1000.0 in
         if parallel_ms >= 100.0 then
-          Log.Dashboard.info "namespace-truth fetch: %.0fms" parallel_ms
+          Log.Dashboard.info "project-snapshot fetch: %.0fms" parallel_ms
         else
-          Log.Dashboard.debug "namespace-truth fetch: %.0fms" parallel_ms;
+          Log.Dashboard.debug "project-snapshot fetch: %.0fms" parallel_ms;
         let execution_cache_state =
           json_assoc_field "projection_diagnostics" execution_json
           |> json_string_field_opt "cache_state"
@@ -208,6 +208,14 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
       let namespace_sse_json =
         `Assoc
           [
+            ("type", `String "project_snapshot");
+            ("payload", snapshot);
+            ("ts_unix", `Float (Time_compat.now ()));
+          ]
+      in
+      let namespace_alias_sse_json =
+        `Assoc
+          [
             ("type", `String "namespace_truth_snapshot");
             ("payload", snapshot);
             ("ts_unix", `Float (Time_compat.now ()));
@@ -222,22 +230,23 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
           ]
       in
       Sse.broadcast_to Observers namespace_sse_json;
+      Sse.broadcast_to Observers namespace_alias_sse_json;
       Sse.broadcast_to Observers legacy_sse_json;
       (* Demote the "pushed via SSE" log to DEBUG when no SSE client is
          connected. With zero observers, the broadcast still runs (for
          the replay buffer and external subscribers) but the log line
          is pure housekeeping noise — once per minute for 96 minutes
          straight in a fresh masc-server.log when nothing is tailing
-         /namespace-truth. Operators only care about this signal when
+         /project-snapshot. Operators only care about this signal when
          there is an actual client on the wire. *)
       let log_fn =
         if Sse.client_count () > 0
         then Log.Dashboard.info
         else Log.Dashboard.debug
       in
-      log_fn "namespace-truth snapshot pushed via SSE"
+      log_fn "project-snapshot pushed via SSE"
   | Some _ ->
-      Log.Dashboard.debug "namespace-truth snapshot unchanged, skipping SSE broadcast"
+      Log.Dashboard.debug "project-snapshot unchanged, skipping SSE broadcast"
 
 let () =
   Execution_surfaces._broadcast_namespace_truth_ref :=

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -182,7 +182,7 @@ let dashboard_namespace_truth_focus_json ~initialized ~runtime_count
           | _ ->
               let label, reason, source, provenance =
                 if not initialized then
-                  ( "초기 namespace truth",
+                  ( "초기 project snapshot",
                     "조율 namespace가 아직 초기화되지 않았습니다. 기본 namespace 상태부터 확인하세요.",
                     "orchestra",
                     "derived" )
@@ -374,7 +374,7 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
         (Some summary_input, Some (Meta_cognition.interpret summary_input))
     | Error err ->
         Log.Dashboard.debug
-          "namespace-truth meta-cognition summary parse skipped: %s" err;
+          "project-snapshot meta-cognition summary parse skipped: %s" err;
         (None, None)
   in
   let meta_cognition_latest_digest =

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -547,6 +547,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                  ~status:`Bad_request ~extra_headers:cors
           )
 
+      | `GET, "/api/v1/dashboard/project-snapshot"
       | `GET, "/api/v1/dashboard/namespace-truth"
       | `GET, "/api/v1/dashboard/room-truth" ->
           let state = get_server_state () in

--- a/lib/server/server_meta_cognition_feedback.ml
+++ b/lib/server/server_meta_cognition_feedback.ml
@@ -76,7 +76,7 @@ let body_of_snapshot snapshot (summary : Meta_cognition.summary_input)
   let evidence_refs = String.concat ", " interpretation.evidence_refs in
   let lines =
     [
-      Some "namespace-truth promoted a meta-cognition signal into shared attention.";
+      Some "project snapshot promoted a meta-cognition signal into shared attention.";
       json_string_field_opt "reason" focus;
       Some
         (Printf.sprintf "primary signal: %s"

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -302,6 +302,11 @@ let rec add_routes ~sw ~clock router =
                  (Yojson.Safe.to_string (`Assoc [("ok", `Bool false); ("error", `String "Invalid JSON body")])) reqd
            )
          ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/project-snapshot" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -232,6 +232,18 @@ let test_http_write_auth_contracts () =
   check bool "observer SSE auth error documents scoped query token contract" true
     (file_contains_pattern "lib/server/server_auth.ml"
        {|or 'token' query param for the observer SSE stream.|});
+  check bool "server auth keeps general MCP auth header-only" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|match auth_token_from_request request with|});
+  check bool "observer SSE query token fallback stays scoped" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|let observer_sse_query_token_from_request request =|});
+  check bool "observer SSE fallback reads token query param explicitly" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|query_param request "token"|});
+  check bool "observer SSE auth has dedicated verifier" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       {|let verify_mcp_observer_stream_auth ~base_path request =|});
   check bool "server auth defines token-bound permission helper" true
     (file_contains_pattern "lib/server/server_auth.ml"
        "let authorize_token_bound_permission_request");
@@ -413,7 +425,10 @@ let test_input_validation_contracts () =
 let test_room_current_validation_contracts () =
   (* H2 gateway serves canonical namespace routes and keeps temporary room
      aliases so mixed dashboard/backend deployments do not break during rollout. *)
-  check bool "h2 gateway serves namespace-truth endpoint" true
+  check bool "h2 gateway serves project-snapshot endpoint" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|"/api/v1/dashboard/project-snapshot"|});
+  check bool "h2 gateway serves namespace-truth endpoint alias" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|"/api/v1/dashboard/namespace-truth"|});
   check bool "h2 gateway keeps room-truth alias endpoint during rollout" true


### PR DESCRIPTION
## Summary
Canonicalize the dashboard read-model naming to `project snapshot` while preserving the legacy `namespace-truth` / `room-truth` aliases for compatibility.

## What changed
- switched the dashboard frontend to use `/api/v1/dashboard/project-snapshot` as the canonical bootstrap/read-model route
- added `/api/v1/dashboard/project-snapshot` on the server and kept `/api/v1/dashboard/namespace-truth` plus `/api/v1/dashboard/room-truth` as aliases
- emitted `project_snapshot` as the canonical SSE event while still broadcasting the legacy alias events
- aligned runtime source labels, warm-up logs, and overview/readiness copy with `project snapshot`
- removed the duplicate frontend `ServerStatus` normalization path so project-snapshot hydration reuses the shared status SSOT
- updated the source-guard contract to allow the intentional observer-SSE query-token fallback while keeping general MCP auth header-only

## Why
The product/operator terminology had already moved away from `namespace-truth`, but the dashboard contract still surfaced that older name in routes, SSE event types, labels, and logs. That left the UI and protocol language out of sync with the intended SSOT.

At the same time, the project-snapshot path was still normalizing server-status data through a separate frontend path, which risked display drift when shell/status payloads gained new fields.

## Product impact
- dashboard clients and logs now prefer `project snapshot`
- existing consumers using the old `namespace-truth` / `room-truth` paths or SSE events keep working
- server status shown through the project snapshot now preserves the same fields as the shared shell/status normalization path

## Evidence
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard test src/api/core.test.ts src/runtime-counts.test.ts src/namespace-truth-normalizers.test.ts src/namespace-truth-store.test.ts src/components/flow-control/flow-control-state.test.ts src/tab-refresh.test.ts src/sse-store.test.ts`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pr-9184-conflict-fix`
- `gh pr checks 9184 --repo jeong-sik/masc-mcp`

## Review evidence
- Reviewer: not run in this follow-up
- Fallback reason: scope was limited to rebase/conflict cleanup plus targeted validation, and no unresolved review threads remained on 2026-04-21.

## Linked issue
- Fixes #9183
