### PR TITLE
Clarify agent roster runtime surfaces

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1026,6 +1026,7 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'turn_timeout_after_queue_wait':
     case 'turn_timeout':
     case 'completion_contract_violation':
+    case 'cascade_exhausted':
       return blockerClass
     default:
       return null
@@ -1100,6 +1101,8 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     execution: {
       models: normalizeStringList(execution.models),
       active_model: asNullableString(execution.active_model) ?? '',
+      active_model_label: asNullableString(execution.active_model_label),
+      last_model_used_label: asNullableString(execution.last_model_used_label),
       verify: asLooseBoolean(execution.verify),
     },
     compaction: {
@@ -1152,6 +1155,8 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       presence_keepalive: asLooseBoolean(runtime.presence_keepalive),
       presence_keepalive_sec: asInt(runtime.presence_keepalive_sec) ?? 0,
       runtime_blocker_class: normalizeRuntimeBlockerClass(runtime.runtime_blocker_class),
+      active_model_label: asNullableString(runtime.active_model_label),
+      last_model_used_label: asNullableString(runtime.last_model_used_label),
       runtime_blocker_summary: asNullableString(runtime.runtime_blocker_summary),
       runtime_blocker_continue_gate:
         typeof runtime.runtime_blocker_continue_gate === 'boolean'

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -95,7 +95,7 @@ describe('compactModelLabel', () => {
     expect(compactModelLabel('   ')).toBeNull()
   })
 
-  it('returns last segment for colon-separated string', () => {
+  it('drops the provider prefix for provider:model labels', () => {
     expect(compactModelLabel('provider:model-name')).toBe('model-name')
   })
 
@@ -103,8 +103,12 @@ describe('compactModelLabel', () => {
     expect(compactModelLabel('claude-sonnet')).toBe('claude-sonnet')
   })
 
-  it('returns last segment for multi-segment', () => {
-    expect(compactModelLabel('a:b:c')).toBe('c')
+  it('keeps model family and variant after the first colon', () => {
+    expect(compactModelLabel('ollama:qwen3.6:35b-a3b-mlx-bf16')).toBe('qwen3.6:35b-a3b-mlx-bf16')
+  })
+
+  it('falls back to the provider label when the resolved model is auto', () => {
+    expect(compactModelLabel('codex_cli:auto')).toBe('codex')
   })
 
   it('handles spaces around segments', () => {
@@ -113,6 +117,17 @@ describe('compactModelLabel', () => {
 })
 
 describe('rosterModelMeta', () => {
+  it('prefers last_model_used_label when backend provides a display label', () => {
+    expect(
+      rosterModelMeta({
+        last_model_used_label: 'qwen3.6:35b-a3b-mlx-bf16',
+        last_model_used: 'ollama:qwen3.6:35b-a3b-mlx-bf16',
+        active_model_label: 'codex_cli:auto',
+        active_model: 'codex',
+      } as Keeper),
+    ).toEqual({ label: '최근 모델', value: 'qwen3.6:35b-a3b-mlx-bf16' })
+  })
+
   it('prefers last_model_used as recent model', () => {
     expect(
       rosterModelMeta({
@@ -121,6 +136,16 @@ describe('rosterModelMeta', () => {
         model: 'fallback-model',
       } as Keeper),
     ).toEqual({ label: '최근 모델', value: 'openai:gpt-5.4' })
+  })
+
+  it('falls back to active_model_label when last model is absent', () => {
+    expect(
+      rosterModelMeta({
+        active_model_label: 'codex_cli:auto',
+        active_model: 'codex',
+        model: 'fallback-model',
+      } as Keeper),
+    ).toEqual({ label: '현재 모델', value: 'codex_cli:auto' })
   })
 
   it('falls back to active_model when last model is absent', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — Unified Agent Roster
 // All entities are agents. Keeper = agent with persistent runtime.
-// Keeper state (CTX gauge, generation, autonomy) shown inline on the card.
+// Keeper state (CTX gauge, autonomy) shown inline on the card.
 
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
@@ -69,20 +69,34 @@ export function stageBadgeClass(stageKey: string): string {
 export function compactModelLabel(model: string | null | undefined): string | null {
   const value = model?.trim()
   if (!value) return null
-  const parts = value.split(':').map(part => part.trim()).filter(Boolean)
-  if (parts.length >= 2) return parts[parts.length - 1] ?? value
+  const separator = value.indexOf(':')
+  if (separator >= 0 && separator < value.length - 1) {
+    const provider = value.slice(0, separator).trim()
+    const suffix = value.slice(separator + 1).trim()
+    if (!suffix) return value
+    if (suffix === 'auto') return provider.replace(/(?:[_-](?:cli|code))$/i, '')
+    return suffix
+  }
   return value
 }
 
 export function rosterModelMeta(
   source: {
+    last_model_used_label?: string | null
     last_model_used?: string | null
+    active_model_label?: string | null
     active_model?: string | null
     model?: string | null
   } | null | undefined,
 ): { label: string; value: string } | null {
+  const lastModelLabel = source?.last_model_used_label?.trim()
+  if (lastModelLabel) return { label: '최근 모델', value: lastModelLabel }
+
   const lastModel = source?.last_model_used?.trim()
   if (lastModel) return { label: '최근 모델', value: lastModel }
+
+  const activeModelLabel = source?.active_model_label?.trim()
+  if (activeModelLabel) return { label: '현재 모델', value: activeModelLabel }
 
   const activeModel = source?.active_model?.trim()
   if (activeModel) return { label: '현재 모델', value: activeModel }
@@ -706,7 +720,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ?? agent.name
           const modelMeta = rosterModelMeta(keeperRuntime ?? keeper ?? null)
           const compactModel = compactModelLabel(modelMeta?.value)
-          const generation = keeperRuntime?.generation ?? keeper?.generation ?? null
           const fsmPhaseKey =
             keeperMonitoring?.phase.key && keeperMonitoring.phase.key !== 'unknown'
               ? keeperMonitoring.phase.key
@@ -752,14 +765,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                         </span>
                       ` : null}
                     </div>
-
-                    ${isKeeper && generation != null && generation > 0 ? html`
-                      <div class="mt-1 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--text-muted)]">
-                        <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-3xs">
-                          세대 ${generation}
-                        </span>
-                      </div>
-                    ` : null}
                   </div>
                 </div>
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -168,6 +168,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         turn_timeout_after_queue_wait: 'Turn timeout after queue wait',
         turn_timeout: 'Turn timeout',
         completion_contract_violation: 'Completion contract violation',
+        cascade_exhausted: 'Cascade exhausted',
       }[runtimeBlockerClass]
     : null
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -376,7 +376,9 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         model,
         primary_model: asString(row.primary_model),
         active_model: asString(row.active_model),
+        active_model_label: asString(row.active_model_label) ?? null,
         last_model_used: asString(row.last_model_used),
+        last_model_used_label: asString(row.last_model_used_label) ?? null,
         next_model_hint: asString(row.next_model_hint) ?? null,
         status: normalizeKeeperAgentStatus(statusRaw),
         presence_keepalive:

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -515,7 +515,9 @@ export interface Keeper {
   model?: string
   primary_model?: string
   active_model?: string
+  active_model_label?: string | null
   last_model_used?: string
+  last_model_used_label?: string | null
   next_model_hint?: string | null
   cascade_name?: string
   status: string
@@ -535,6 +537,7 @@ export interface Keeper {
     | 'turn_timeout_after_queue_wait'
     | 'turn_timeout'
     | 'completion_contract_violation'
+    | 'cascade_exhausted'
     | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null
@@ -766,6 +769,8 @@ interface KeeperConfigPrompt {
 interface KeeperConfigExecution {
   models: string[]
   active_model: string
+  active_model_label?: string | null
+  last_model_used_label?: string | null
   verify: boolean
 }
 
@@ -815,7 +820,10 @@ interface KeeperConfigRuntime {
     | 'turn_timeout_after_queue_wait'
     | 'turn_timeout'
     | 'completion_contract_violation'
+    | 'cascade_exhausted'
     | null
+  active_model_label?: string | null
+  last_model_used_label?: string | null
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null
 }

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -391,7 +391,9 @@ export interface OperatorKeeperSnapshot {
   autonomous_text_turn_count?: number
   autonomous_tool_turn_count?: number
   last_model_used?: string
+  last_model_used_label?: string | null
   active_model?: string
+  active_model_label?: string | null
   diagnostic?: Record<string, unknown>
   recent_activity?: Record<string, unknown>[]
 }

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -969,6 +969,14 @@ let keeper_config_json (config : Coord.config) (name : string)
       (* bootstrap_runtime is called at server startup — skip here to
          avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
       let active_model = Keeper_exec_status.active_model_of_meta m in
+      let active_model_label =
+        let value = Keeper_exec_status.active_model_label_of_meta m |> String.trim in
+        if value = "" then None else Some value
+      in
+      let last_model_used_label =
+        if String.trim m.runtime.usage.last_model_used = "" then None
+        else active_model_label
+      in
       let defaults = Keeper_types_profile.load_keeper_profile_defaults m.name in
       let persona_extended =
         Keeper_types_profile.resolved_persona_name ~keeper_name:m.name defaults
@@ -1012,6 +1020,8 @@ let keeper_config_json (config : Coord.config) (name : string)
               (List.map (fun s -> `String s)
                  (Cascade_runtime.models_of_cascade_name m.cascade_name)) );
           ("active_model", `String active_model);
+          ("active_model_label", Json_util.string_opt_to_json active_model_label);
+          ("last_model_used_label", Json_util.string_opt_to_json last_model_used_label);
           ("verify", `Bool false);
         ]
       in

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -180,6 +180,27 @@ let runtime_blocker_surface_of_reason (reason : string) =
         summary = trimmed;
         continue_gate = true;
       }
+  else if String_util.contains_substring_ci trimmed "cascade_exhausted"
+  then
+    Some
+      {
+        blocker_class = "cascade_exhausted";
+        summary =
+          (if String_util.contains_substring_ci trimmed "connection refused" then
+             "Cascade exhausted after provider failures; local runtime connection refused."
+           else if
+             String_util.contains_substring_ci trimmed
+               "no providers available"
+           then
+             "Cascade exhausted; no providers were available."
+           else if
+             String_util.contains_substring_ci trimmed "all providers failed"
+           then
+             "Cascade exhausted after all configured providers failed."
+           else
+             "Cascade exhausted after provider failures.");
+        continue_gate = false;
+      }
   else if String_util.contains_substring_ci trimmed "autonomous turn slot wait timeout"
   then
     Some
@@ -263,6 +284,17 @@ let trimmed_string_json value =
   let trimmed = String.trim value in
   if trimmed = "" then `Null else `String trimmed
 
+let non_empty_string_opt value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let active_model_label_opt_of_meta (meta : keeper_meta) =
+  Keeper_exec_status.active_model_label_of_meta meta |> non_empty_string_opt
+
+let last_model_used_label_opt_of_meta (meta : keeper_meta) =
+  if String.trim meta.runtime.usage.last_model_used = "" then None
+  else active_model_label_opt_of_meta meta
+
 let social_model_resolution_fields_json (meta : keeper_meta) =
   let resolved = Keeper_social_model.normalize_social_model meta.social_model in
   let recognized = Keeper_social_model.is_known_social_model meta.social_model in
@@ -286,6 +318,10 @@ let social_runtime_fields_json (meta : keeper_meta) =
   in
   social_model_resolution_fields_json meta
   @ [
+      ( "active_model_label",
+        Json_util.string_opt_to_json (active_model_label_opt_of_meta meta) );
+      ( "last_model_used_label",
+        Json_util.string_opt_to_json (last_model_used_label_opt_of_meta meta) );
       ("last_speech_act", trimmed_string_json meta.runtime.last_speech_act);
       ("delivery_surface_view", Json_util.string_opt_to_json delivery_surface_view);
       ( "delivery_surface_view_source",

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -299,6 +299,37 @@ let test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta () =
     false
     (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
 
+let test_runtime_surface_derives_cascade_exhausted_from_meta () =
+  KR.clear ();
+  let base = make_meta ~name:"runtime-cascade-exhausted-test" () in
+  let reason =
+    "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"keeper_unified\",\"detail\":\"all providers failed: Connection refused\"}"
+  in
+  let meta =
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          last_blocker = reason;
+        };
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-cascade-exhausted"
+  in
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "runtime blocker class"
+    "cascade_exhausted"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  check string "runtime blocker summary"
+    "Cascade exhausted after provider failures; local runtime connection refused."
+    (runtime |> member "runtime_blocker_summary" |> to_string);
+  check bool "runtime blocker continue gate stays false"
+    false
+    (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
+
 let test_runtime_surface_derives_continue_gate_from_ambiguous_partial_commit () =
   KR.clear ();
   let meta = make_meta ~name:"runtime-continue-gate-test" () in
@@ -412,6 +443,35 @@ let test_runtime_surface_exposes_social_model_resolution_fields () =
   check (option string) "blank last_need omitted" None
     (runtime |> member "last_need" |> to_string_option)
 
+let test_runtime_surface_exposes_model_display_labels () =
+  KR.clear ();
+  let base = make_meta ~name:"runtime-model-label-test" () in
+  let meta =
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          usage =
+            {
+              base.runtime.usage with
+              last_model_used = "codex";
+            };
+        };
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-model-display-labels"
+  in
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "active model label"
+    "codex_cli:auto"
+    (runtime |> member "active_model_label" |> to_string);
+  check string "last model used label"
+    "codex_cli:auto"
+    (runtime |> member "last_model_used_label" |> to_string)
+
 (* Issue #8670: parser must round-trip every constructor and reject
    unknown strings. The previous catch-all silently mapped typos to
    KH_offline, masking drift between dashboard producers and consumers. *)
@@ -487,6 +547,8 @@ let () =
             test_keeper_status_helpers_tolerate_null_status_json;
           test_case "runtime surface derives slot wait timeout blocker" `Quick
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
+          test_case "runtime surface derives cascade exhausted blocker" `Quick
+            test_runtime_surface_derives_cascade_exhausted_from_meta;
           test_case "runtime surface derives continue-gate blocker" `Quick
             test_runtime_surface_derives_continue_gate_from_ambiguous_partial_commit;
           test_case "runtime surface derives persisted continue-gate blocker"
@@ -494,5 +556,7 @@ let () =
             test_runtime_surface_derives_continue_gate_from_persisted_ambiguous_blocker;
           test_case "runtime surface exposes social model fields" `Quick
             test_runtime_surface_exposes_social_model_resolution_fields;
+          test_case "runtime surface exposes model display labels" `Quick
+            test_runtime_surface_exposes_model_display_labels;
         ] );
     ]


### PR DESCRIPTION
## Summary
- clarify the agent roster by hiding lineage generation, preferring display-safe model labels, and fixing provider/model truncation
- surface friendly `cascade_exhausted` blocker summaries plus display model labels from keeper runtime/config read models
- extend frontend/backend tests for the new roster and runtime blocker semantics

## Product impact
- Promise affected: `ops visibility`
- User-visible change: dashboard roster/runtime surfaces now show cleaner model labels and friendlier cascade-exhausted blocker summaries.

## Evidence
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard test src/components/agent-roster.test.ts`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pr-9187-conflict-fix`
- `gh pr checks 9187 --repo jeong-sik/masc-mcp`

## Review evidence
- Reviewer: not run in this follow-up
- Fallback reason: scope was limited to rebase/conflict cleanup plus targeted validation, and no unresolved review threads remained on 2026-04-21.

## Linked issue
- No linked issue was recorded in the original PR body.
