### PR TITLE
[codex] Suppress stale proactive blockers in keeper status

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -225,6 +225,12 @@ let runtime_blocker_surface_of_reason (reason : string) =
   else
     None
 
+let proactive_runtime_reason_is_current (meta : keeper_meta) =
+  let proactive_ts = meta.runtime.proactive_rt.last_ts in
+  let last_turn_ts = meta.runtime.usage.last_turn_ts in
+  proactive_ts > 0.0
+  && (last_turn_ts <= 0.0 || proactive_ts >= last_turn_ts)
+
 let runtime_blocker_fields_json (config : Coord_utils.config)
     (meta : keeper_meta) =
   let derived =
@@ -238,12 +244,14 @@ let runtime_blocker_fields_json (config : Coord_utils.config)
   let derived =
     match derived with
     | Some blocker -> Some blocker
-    | None ->
-        (match runtime_blocker_surface_of_reason meta.runtime.last_blocker with
-         | Some blocker -> Some blocker
-         | None ->
-             runtime_blocker_surface_of_reason
-               meta.runtime.proactive_rt.last_reason)
+    | None -> (
+        match runtime_blocker_surface_of_reason meta.runtime.last_blocker with
+        | Some blocker -> Some blocker
+        | None
+          when proactive_runtime_reason_is_current meta ->
+            runtime_blocker_surface_of_reason
+              meta.runtime.proactive_rt.last_reason
+        | None -> None)
   in
   match derived with
   | Some blocker ->

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -360,6 +360,51 @@ let test_runtime_surface_derives_continue_gate_from_persisted_ambiguous_blocker 
     true
     (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
 
+let test_runtime_surface_suppresses_stale_proactive_timeout_reason () =
+  KR.clear ();
+  let now_ts = Time_compat.now () in
+  let base = make_meta ~name:"runtime-stale-proactive-timeout-test" () in
+  let meta =
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          usage =
+            {
+              base.runtime.usage with
+              total_turns = 3;
+              last_turn_ts = now_ts;
+            };
+          proactive_rt =
+            {
+              base.runtime.proactive_rt with
+              last_ts = now_ts -. 600.0;
+              last_outcome = KT.Proactive_error;
+              last_reason =
+                "unified:error:Internal error: Turn wall-clock timeout after 1200s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
+              last_preview =
+                "Internal error: Turn wall-clock timeout after 1200s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
+            };
+        };
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-stale-proactive-timeout"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  let json_string_opt = function
+    | `Null -> None
+    | `String value -> Some value
+    | _ -> fail "expected string-or-null runtime blocker field"
+  in
+  check (option string) "stale proactive timeout suppressed" None
+    (runtime |> member "runtime_blocker_summary" |> json_string_opt);
+  check (option string) "stale proactive blocker class suppressed" None
+    (runtime |> member "runtime_blocker_class" |> json_string_opt)
+
 let test_runtime_surface_exposes_social_model_resolution_fields () =
   KR.clear ();
   let base = make_meta ~name:"runtime-social-model-test" () in
@@ -492,6 +537,9 @@ let () =
           test_case "runtime surface derives persisted continue-gate blocker"
             `Quick
             test_runtime_surface_derives_continue_gate_from_persisted_ambiguous_blocker;
+          test_case "runtime surface suppresses stale proactive timeout blocker"
+            `Quick
+            test_runtime_surface_suppresses_stale_proactive_timeout_reason;
           test_case "runtime surface exposes social model fields" `Quick
             test_runtime_surface_exposes_social_model_resolution_fields;
         ] );


### PR DESCRIPTION
## What changed
- ignore `runtime.proactive_rt.last_reason` when it predates the most recent keeper turn
- keep deriving blocker fields from current persisted runtime blockers and failure reasons
- add regression coverage for stale proactive timeout reasons in `test_keeper_exec_status`

## Why
A stale proactive timeout could continue to appear in keeper status even after newer turns had completed. That produced a false proactive blocker surface for agents that were no longer blocked.

## Impact
Keeper status now only surfaces proactive runtime blockers when the proactive signal is current, which reduces false blocker warnings without hiding real active blockers.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-status-stale-blocker test/test_keeper_exec_status.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-status-stale-blocker/_build/default/test/test_keeper_exec_status.exe`