### PR TITLE
[codex] Drive cascade manager from live catalog

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Known cascade profiles (SSOT: lib/keeper/keeper_cascade_profile.ml). Every <name>_models key here must correspond to a known cascade in that module, and vice versa. Personal/playground-only cascades belong in $MASC_BASE_PATH/.masc/playground/<persona>/.../cascade.json, not in this repo config.",
+  "_comment": "Known keeper-facing cascade profiles remain typed in lib/keeper/keeper_cascade_profile.ml. Live catalog discovery is schema-driven via lib/cascade/cascade_config_loader.ml: any recognized {name}_* cascade key participates in the catalog, and optional {name}_keeper_assignable=false marks system-only profiles that stay visible/editable but must not be assignable to keepers. Personal/playground-only cascades belong in $MASC_BASE_PATH/.masc/playground/<persona>/.../cascade.json, not in this repo config.",
   "default_models": [
     {"model": "glm-coding:glm-5.1", "weight": 50},
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30},
@@ -35,6 +35,7 @@
   "_comment_tool_rerank": "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here. Short responses for rerank scoring.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
+  "tool_rerank_keeper_assignable": false,
 
   "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls.  Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle.  Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04.  Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama).",
   "sangsu_models": [

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -320,7 +320,11 @@ Tier는 mode/category와 독립적으로 적용되는 추가 필터 레이어다
 
 ### 7.1 config/cascade.json 구조
 
-JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_name}_models`.
+JSON 파일로 cascade별 설정을 정의한다. 기본 키 패턴은
+`{cascade_name}_models`이며, catalog discovery는
+`Cascade_config_loader`가 알고 있는 recognized per-cascade 키 집합
+(`_models`, `_temperature`, `_max_tokens`, `_strategy`, ...)을 기준으로
+이뤄진다.
 
 ```json
 {
@@ -357,6 +361,16 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 ### 7.3 Per-cascade 추론 파라미터
 
 `{cascade_name}_temperature`, `{cascade_name}_max_tokens` 키로 cascade별 온도와 토큰 수를 오버라이드할 수 있다. 미설정 시 호출자 기본값 사용.
+
+### 7.3.1 Keeper assignability metadata
+
+`{cascade_name}_keeper_assignable`는 dashboard/cascade manager가 keeper에
+할당 가능한 profile인지 명시하는 bool metadata다. 기본값은 `true`.
+
+- `true` 또는 미설정: keeper assignment dropdown에 노출 가능
+- `false`: system-only profile. cascade manager에는 보이지만 keeper에는 할당 불가
+
+예: `tool_rerank_keeper_assignable = false`
 
 ### 7.4 Pluggable Strategy (Phase A~B, #7606/#7611)
 

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -123,6 +123,103 @@ let parse_weighted_item = function
      | _ -> None)
   | _ -> None
 
+type catalog_entry = {
+  name : string;
+  keeper_assignable : bool;
+}
+
+module StringMap = Map.Make (String)
+
+type catalog_field =
+  | Schema_field
+  | Keeper_assignable_field
+
+let catalog_key_specs =
+  [
+    ("_models", Schema_field);
+    ("_temperature", Schema_field);
+    ("_max_tokens", Schema_field);
+    ("_api_key_env", Schema_field);
+    ("_strategy", Schema_field);
+    ("_max_cycles", Schema_field);
+    ("_backoff_base_ms", Schema_field);
+    ("_backoff_cap_ms", Schema_field);
+    ("_ollama_max_concurrent", Schema_field);
+    ("_cli_max_concurrent", Schema_field);
+    ("_tiers", Schema_field);
+    ("_sticky_ttl_ms", Schema_field);
+    ("_keeper_assignable", Keeper_assignable_field);
+  ]
+
+let split_catalog_key key =
+  let key_len = String.length key in
+  if key_len = 0 || key.[0] = '_' then None
+  else
+    List.find_map
+      (fun (suffix, field) ->
+        let suffix_len = String.length suffix in
+        if key_len > suffix_len
+           && String.sub key (key_len - suffix_len) suffix_len = suffix
+        then Some (String.sub key 0 (key_len - suffix_len), field)
+        else None)
+      catalog_key_specs
+
+type catalog_builder = {
+  has_schema_field : bool;
+  keeper_assignable : bool option;
+}
+
+let empty_catalog_builder = {
+  has_schema_field = false;
+  keeper_assignable = None;
+}
+
+let update_catalog_builder builder field value =
+  match field with
+  | Schema_field -> { builder with has_schema_field = true }
+  | Keeper_assignable_field ->
+      let keeper_assignable =
+        match value with
+        | `Bool b -> Some b
+        | _ -> builder.keeper_assignable
+      in
+      { builder with keeper_assignable }
+
+let load_catalog ~config_path =
+  match load_json config_path with
+  | Error _ as err -> err
+  | Ok (`Assoc fields) ->
+      let builders =
+        List.fold_left
+          (fun acc (key, value) ->
+            match split_catalog_key key with
+            | None -> acc
+            | Some (name, field) ->
+                let prior =
+                  match StringMap.find_opt name acc with
+                  | Some builder -> builder
+                  | None -> empty_catalog_builder
+                in
+                StringMap.add name (update_catalog_builder prior field value) acc)
+          StringMap.empty
+          fields
+      in
+      let entries =
+        builders
+        |> StringMap.bindings
+        |> List.filter_map (fun (name, builder) ->
+               if not builder.has_schema_field then None
+               else
+                 Some
+                   {
+                     name;
+                     keeper_assignable =
+                       Option.value builder.keeper_assignable ~default:true;
+                   })
+      in
+      Ok entries
+  | Ok _ -> Ok []
+
 let load_profile_weighted ~config_path ~name =
   let key = name ^ "_models" in
   match load_json config_path with

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -26,6 +26,34 @@ type weighted_entry = {
       pattern-matching on [model_id]. *)
 }
 
+(** Catalog metadata for one named cascade profile discovered from
+    [cascade.json].
+
+    A profile enters the catalog when it declares at least one
+    recognized cascade schema key such as ["{name}_models"],
+    ["{name}_temperature"], ["{name}_strategy"], etc. This keeps
+    profile discovery aligned with the loader's typed schema instead of
+    duplicating ad-hoc JSON-key parsing at call sites. *)
+type catalog_entry = {
+  name : string;
+  keeper_assignable : bool;
+  (** Whether the profile may be assigned to keepers. Defaults to [true]
+      when ["{name}_keeper_assignable"] is absent. *)
+}
+
+(** Load the cascade catalog from [config_path].
+
+    Discovery is schema-driven: a profile is included when the JSON
+    contains at least one recognized per-cascade key for that [name].
+    The optional metadata key ["{name}_keeper_assignable"] marks
+    system-only profiles that should remain editable/visible but must
+    not appear in keeper-assignment UIs.
+
+    Returns [Error _] when the file cannot be read or parsed. *)
+val load_catalog :
+  config_path:string ->
+  (catalog_entry list, string) result
+
 (** Load a named model list from a JSON config file.
 
     The JSON file maps ["{name}_models"] keys to string arrays.

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -26,15 +26,13 @@ let source_to_string = function
 
 (** Profiles to surface in the dashboard.
 
-    We don't try to enumerate every possible profile name the loader might
-    accept — the dashboard cares about the profiles that keepers actively use,
-    plus a few standard ones. Listing them explicitly avoids loading the raw
-    JSON and reimplementing key-name heuristics.
-
-    Keepers run through [Keeper_cascade_profile.canonicalize], so any unknown
-    keeper [cascade_name] from the registry also shows up below by virtue of
-    being included in [keeper_profiles]. *)
-let standard_profiles = Keeper_cascade_profile.known_cascades
+    The cascade manager needs the live catalog from the active
+    [cascade.json], not just the built-in enum. That keeps repo-local
+    or operator-added profiles visible without duplicating the JSON key
+    scan here. Keepers still round-trip their raw [cascade_name], so
+    runtime drift can be shown alongside the live catalog. *)
+let live_profiles ?config_path () =
+  Keeper_cascade_profile.catalog_names ?config_path ()
 
 let profile_json ~config_path name =
   let defaults = Cascade_runtime.default_model_strings ~cascade_name:name in
@@ -85,9 +83,9 @@ let config_json () =
       profile_json ~config_path canonical :: acc
     end
   in
-  (* Start with the standard profiles, then append any runtime-drifted
-     keeper cascade_name values (e.g. a keeper TOML pointing at a
-     non-standard profile). Both paths go through [add_profile] so
+  (* Start with the live config catalog, then append any runtime-drifted
+     keeper cascade_name values (e.g. a keeper TOML pointing at an
+     alias or stale profile). Both paths go through [add_profile] so
      duplicates are filtered by canonical name. *)
   let keeper_entries =
     (* Issue #8619: was [with _ -> []] which silently swallowed
@@ -100,7 +98,7 @@ let config_json () =
     | _ -> []
   in
   let acc_after_standard =
-    List.fold_left add_profile [] standard_profiles
+    List.fold_left add_profile [] (live_profiles ?config_path ())
   in
   let acc_after_keepers =
     List.fold_left

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -81,12 +81,70 @@ let canonical (raw : string) : t =
   | Some t -> t
   | None -> default
 
-let canonicalize (raw : string) : string = to_string (canonical raw)
+let catalog_entries ?config_path () =
+  let path_opt =
+    match config_path with
+    | Some path -> Some path
+    | None -> Config_dir_resolver.cascade_path_opt ()
+  in
+  match path_opt with
+  | None -> None
+  | Some path -> (
+      match Cascade_config_loader.load_catalog ~config_path:path with
+      | Ok entries -> Some entries
+      | Error _ -> None)
+
+let catalog_names ?config_path () =
+  match catalog_entries ?config_path () with
+  | Some entries ->
+      List.map (fun (entry : Cascade_config_loader.catalog_entry) -> entry.name)
+        entries
+  | None -> []
+
+let is_system_only_cascade raw =
+  let name = String.trim raw in
+  match catalog_entries () with
+  | None -> false
+  | Some entries ->
+      List.exists
+        (fun (entry : Cascade_config_loader.catalog_entry) ->
+          String.equal entry.name name && not entry.keeper_assignable)
+        entries
+
+let keeper_catalog_names ?config_path () =
+  match catalog_entries ?config_path () with
+  | Some entries ->
+      entries
+      |> List.filter_map
+           (fun (entry : Cascade_config_loader.catalog_entry) ->
+             if entry.keeper_assignable then Some entry.name else None)
+  | None -> []
+
+let system_catalog_names ?config_path () =
+  match catalog_entries ?config_path () with
+  | Some entries ->
+      entries
+      |> List.filter_map
+           (fun (entry : Cascade_config_loader.catalog_entry) ->
+             if entry.keeper_assignable then None else Some entry.name)
+  | None -> []
+
+let canonicalize_with_catalog ~catalog raw =
+  match String.trim raw with
+  | "" -> default_name
+  | trimmed -> (
+      match of_string_opt trimmed with
+      | Some profile -> to_string profile
+      | None ->
+          if List.mem trimmed catalog then trimmed else default_name)
+
+let canonicalize (raw : string) : string =
+  canonicalize_with_catalog ~catalog:(catalog_names ()) raw
 
 let models_key_t t = to_string t ^ "_models"
 let temperature_key_t t = to_string t ^ "_temperature"
 let max_tokens_key_t t = to_string t ^ "_max_tokens"
 
-let models_key name = models_key_t (canonical name)
-let temperature_key name = temperature_key_t (canonical name)
-let max_tokens_key name = max_tokens_key_t (canonical name)
+let models_key name = canonicalize name ^ "_models"
+let temperature_key name = canonicalize name ^ "_temperature"
+let max_tokens_key name = canonicalize name ^ "_max_tokens"

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -63,11 +63,38 @@ val known_cascades : string list
     that still operate on strings (cascade.json key prefixes, metric
     label allow-list); new code should take {!t} directly. *)
 
+val catalog_names : ?config_path:string -> unit -> string list
+(** Live profile catalog discovered from the active [cascade.json].
+    Discovery is delegated to {!Cascade_config_loader.load_catalog}, so
+    profiles are surfaced from recognized cascade schema keys
+    (for example [{name}_models], [{name}_temperature],
+    [{name}_strategy], ...). When the file cannot be read, returns [[]]
+    rather than synthesizing a hardcoded catalog. *)
+
+val keeper_catalog_names : ?config_path:string -> unit -> string list
+(** Assignable live profile names from {!catalog_names}, filtered by
+    explicit [{name}_keeper_assignable = false] metadata in
+    [cascade.json]. Read failures return [[]]. *)
+
+val system_catalog_names : ?config_path:string -> unit -> string list
+(** Live system-only profile names present in [cascade.json], selected
+    by explicit [{name}_keeper_assignable = false] metadata. Read
+    failures return [[]]. *)
+
+val is_system_only_cascade : string -> bool
+(** Exact-name membership check against the active config's
+    {!system_catalog_names}. *)
+
+val canonicalize_with_catalog : catalog:string list -> string -> string
+(** Like {!canonicalize}, but resolves dynamic profiles against an explicit
+    live catalog instead of the active config path. Intended for tests and
+    server-side validation flows that already loaded the catalog. *)
+
 val canonicalize : string -> string
 (** [canonicalize raw = to_string (canonical raw)]. Existing
-    string-based call sites continue to work; unknown names now fall
-    back to {!default_name} (previously they passed through unchanged,
-    letting typos and dead profile names create ghost metric labels). *)
+    string-based call sites continue to work; legacy aliases collapse to
+    their canonical built-in name, live catalog names pass through, and
+    unknown values fall back to {!default_name}. *)
 
 (** {1 cascade.json key helpers} *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -14,31 +14,8 @@ module Keeper_api = Server_dashboard_http_keeper_api
 
 let available_cascade_profiles () : string list =
   let config_path = Cascade_runtime.cascade_config_path () in
-  match config_path with
-  | None -> ["default"]
-  | Some path ->
-    (match Yojson.Safe.from_file path with
-     | `Assoc fields ->
-       let from_keys =
-         List.filter_map (fun (k, _) ->
-           if String.length k > 7
-              && String.sub k (String.length k - 7) 7 = "_models"
-           then Some (String.sub k 0 (String.length k - 7))
-           else None
-         ) fields
-       in
-       let with_default =
-         if List.mem "default" from_keys then from_keys
-         else "default" :: from_keys
-       in
-       List.sort_uniq String.compare with_default
-     | _ -> ["default"]
-     | exception Yojson.Json_error msg ->
-       Log.Keeper.warn "cascade config parse error: %s" msg;
-       ["default"]
-     | exception Sys_error msg ->
-       Log.Keeper.warn "cascade config read error: %s" msg;
-       ["default"])
+  Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+  |> List.sort_uniq String.compare
 
 (** Broadcast handler: parse JSON body, extract "message" string field, and
     relay via Coord.broadcast.  Error responses are encoded through Yojson so

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -18,6 +18,43 @@ let to_list_opt = function
   | `List xs -> Some xs
   | _ -> None
 
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let with_temp_config_root contents f =
+  let dir = Filename.temp_file "dashboard-cascade-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let cascade_path = Filename.concat dir "cascade.json" in
+  write_file cascade_path contents;
+  let prev_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev_config_dir with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Masc_mcp.Config_dir_resolver.reset ();
+      (try Sys.remove cascade_path with _ -> ());
+      try Unix.rmdir dir with _ -> ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" dir;
+      Masc_mcp.Config_dir_resolver.reset ();
+      f cascade_path)
+
+let profile_names json =
+  match member "profiles" json with
+  | `List profiles ->
+    List.filter_map
+      (fun profile ->
+        match member "name" profile with
+        | `String name -> Some name
+        | _ -> None)
+      profiles
+  | _ -> []
+
 (* ── config_json ───────────────────────────────────── *)
 
 let test_config_shape () =
@@ -68,6 +105,32 @@ let test_config_candidate_shape () =
          match member k c with
          | `Null -> fail (Printf.sprintf "candidate.%s missing" k)
          | _ -> ()) fields)
+
+let test_config_uses_live_catalog () =
+  with_temp_config_root
+    {|
+      {
+        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "custom_live_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "governance_judge_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "governance_judge_keeper_assignable": false,
+        "tool_rerank_temperature": 0.0,
+        "tool_rerank_max_tokens": 200,
+        "tool_rerank_keeper_assignable": false
+      }
+    |}
+    (fun cascade_path ->
+      let j = Masc_mcp.Dashboard_cascade.config_json () in
+      let names = profile_names j in
+      check bool "includes dynamic live profile" true
+        (List.mem "custom_live" names);
+      check bool "includes system-only live profile" true
+        (List.mem "governance_judge" names);
+      check bool "includes profiles declared by non-model schema keys" true
+        (List.mem "tool_rerank" names);
+      check (option string) "config_path reflects active root"
+        (Some cascade_path)
+        Yojson.Safe.Util.(j |> member "config_path" |> to_string_option))
 
 (* ── health_json ───────────────────────────────────── *)
 
@@ -269,6 +332,7 @@ let () =
       test_case "top-level shape" `Quick test_config_shape;
       test_case "profile shape" `Quick test_config_profile_shape;
       test_case "candidate shape" `Quick test_config_candidate_shape;
+      test_case "uses live config catalog" `Quick test_config_uses_live_catalog;
     ];
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -22,6 +22,24 @@ let active_names =
     "tool_use_strict";
     "resilient_breaker" ]
 
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let with_temp_config contents f =
+  let dir = Filename.temp_file "keeper-cascade-profile-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let path = Filename.concat dir "cascade.json" in
+  write_file path contents;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove path with _ -> ());
+      try Unix.rmdir dir with _ -> ())
+    (fun () -> f path)
+
 let test_round_trip () =
   List.iter
     (fun name ->
@@ -54,11 +72,60 @@ let test_unknown_falls_back_to_default () =
     "keeper_unified"
     (Profile.canonicalize "definitely_not_a_real_cascade_xyz")
 
+let test_catalog_names_follow_live_config () =
+  with_temp_config
+    {|
+      {
+        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "custom_live_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "tool_rerank_temperature": 0.0,
+        "tool_rerank_max_tokens": 200,
+        "tool_rerank_keeper_assignable": false,
+        "governance_judge_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "governance_judge_keeper_assignable": false
+      }
+    |}
+    (fun path ->
+      let catalog = Profile.catalog_names ~config_path:path () in
+      check (list string) "catalog_names follows cascade schema keys"
+        [ "custom_live"; "default"; "governance_judge"; "tool_rerank" ]
+        catalog;
+      check (list string) "keeper catalog excludes system-only cascades"
+        [ "custom_live"; "default" ]
+        (Profile.keeper_catalog_names ~config_path:path ());
+      check (list string) "system catalog follows explicit metadata"
+        [ "governance_judge"; "tool_rerank" ]
+        (Profile.system_catalog_names ~config_path:path ());
+      check string "dynamic live profile survives canonicalization"
+        "custom_live"
+        (Profile.canonicalize_with_catalog ~catalog "custom_live");
+      check string "dynamic live profile requires exact match"
+        "keeper_unified"
+        (Profile.canonicalize_with_catalog ~catalog "Custom_Live");
+      check string "unknown live profile still falls back"
+        "keeper_unified"
+        (Profile.canonicalize_with_catalog ~catalog "missing_profile"))
+
+let test_catalog_read_failures_do_not_fallback_to_hardcoded_names () =
+  let missing = Filename.concat (Filename.get_temp_dir_name ()) "missing-cascade.json" in
+  check (list string) "catalog_names stays empty on read failure"
+    []
+    (Profile.catalog_names ~config_path:missing ());
+  check (list string) "keeper catalog stays empty on read failure"
+    []
+    (Profile.keeper_catalog_names ~config_path:missing ());
+  check (list string) "system catalog stays empty on read failure"
+    []
+    (Profile.system_catalog_names ~config_path:missing ())
+
 let () =
   run "keeper_cascade_profile"
     [ ( "ssot",
         [ test_case "active names round-trip" `Quick test_round_trip;
           test_case "known_cascades covers active" `Quick test_known_cascades_covers_active;
           test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_keeper_unified;
-          test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default ] )
+          test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default;
+          test_case "catalog_names follow live config" `Quick test_catalog_names_follow_live_config;
+          test_case "catalog read failures stay empty" `Quick
+            test_catalog_read_failures_do_not_fallback_to_hardcoded_names ] )
     ]


### PR DESCRIPTION
## What changed
- added a schema-driven cascade catalog loader so live profiles come from recognized `cascade.json` keys instead of ad-hoc dashboard or route parsing
- switched the cascade manager dashboard to render from the active live catalog, including dynamic and system-only profiles
- switched keeper cascade assignment options to use explicit `{name}_keeper_assignable=false` metadata so system-only profiles stay visible but are not assignable
- added regression coverage for live catalog discovery, exact-match canonicalization, and read-failure behavior

## Why
The previous dashboard and keeper API paths inferred profile names from partial `_models` scanning and hardcoded fallbacks. That made dynamic profiles invisible, let system-only profiles leak into keeper assignment, and left room for heuristic string handling.

## Impact
- cascade manager now reflects the active `cascade.json` catalog instead of a baked-in enum
- keeper dropdowns only expose assignable profiles from config metadata
- live catalog discovery no longer synthesizes a hardcoded catalog on read failure

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature-cascade-manager-ui`
- `_build/default/test/test_keeper_cascade_profile.exe`
- `_build/default/test/test_dashboard_cascade.exe`
