### PR TITLE
[codex] Validate cascade catalog before keeper assignment

### DIFF
--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -1,0 +1,251 @@
+type severity =
+  | Catalog_warn
+  | Catalog_error
+
+type issue = {
+  profile : string option;
+  severity : severity;
+  message : string;
+}
+
+module StringMap = Map.Make (String)
+
+let contains_substring ~needle s =
+  let needle_len = String.length needle in
+  let s_len = String.length s in
+  if needle_len = 0 || needle_len > s_len then
+    false
+  else
+    let limit = s_len - needle_len in
+    let rec loop i =
+      if i > limit then
+        false
+      else if String.sub s i needle_len = needle then
+        true
+      else
+        loop (i + 1)
+    in
+    loop 0
+
+let has_suffix ~suffix s =
+  let suffix_len = String.length suffix in
+  let s_len = String.length s in
+  s_len > suffix_len
+  && String.sub s (s_len - suffix_len) suffix_len = suffix
+
+let is_provider_unavailable_error msg =
+  contains_substring ~needle:"unavailable" msg
+
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+      if idx = 0 || idx >= String.length s - 1 then
+        None
+      else
+        let provider_name =
+          String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+        in
+        let model_id =
+          String.sub s (idx + 1) (String.length s - idx - 1)
+          |> String.trim
+        in
+        if model_id = "" then None else Some (provider_name, model_id)
+
+let discover_profiles_in_json = function
+  | `Assoc fields ->
+      fields
+      |> List.filter_map (fun (key, value) ->
+             match value with
+             | `List _ when has_suffix ~suffix:"_models" key ->
+                 let suffix_len = String.length "_models" in
+                 Some (String.sub key 0 (String.length key - suffix_len))
+             | _ -> None)
+      |> List.sort_uniq String.compare
+  | _ -> []
+
+let discover_profiles ~config_path =
+  match Cascade_config_loader.load_json config_path with
+  | Ok json -> discover_profiles_in_json json
+  | Error _ -> []
+
+let model_ids_of_specs (specs : string list) : string list =
+  specs
+  |> Cascade_config.expand_auto_models
+  |> List.filter_map (fun spec ->
+         match split_provider_model spec with
+         | Some (_, model_id) when model_id <> "" -> Some model_id
+         | _ -> None)
+  |> List.sort_uniq String.compare
+
+let format_spec_errors specs =
+  specs
+  |> List.map (fun (spec, msg) -> Printf.sprintf "%S (%s)" spec msg)
+  |> String.concat ", "
+
+let priority_tier_issue ~profile configured_specs raw_tiers =
+  let configured_model_ids = model_ids_of_specs configured_specs in
+  if configured_model_ids = [] then
+    Some
+      {
+        profile = Some profile;
+        severity = Catalog_error;
+        message =
+          Printf.sprintf
+            "Cascade preset %s uses priority_tier but has no configured \
+             models to validate."
+            profile;
+      }
+  else
+    let normalized =
+      raw_tiers
+      |> List.filter_map (fun tier ->
+             let tier_model_ids =
+               model_ids_of_specs tier
+               |> List.filter (fun model_id ->
+                      List.mem model_id configured_model_ids)
+             in
+             if tier_model_ids = [] then None else Some tier_model_ids)
+    in
+    if normalized = [] then
+      Some
+        {
+          profile = Some profile;
+          severity = Catalog_error;
+          message =
+            Printf.sprintf
+              "Cascade preset %s uses priority_tier, but every tier \
+               collapses after model-id normalization; runtime will fall \
+               back to failover."
+              profile;
+        }
+    else if List.length normalized < List.length raw_tiers then
+      Some
+        {
+          profile = Some profile;
+          severity = Catalog_warn;
+          message =
+            Printf.sprintf
+              "Cascade preset %s uses priority_tier, but %d/%d tier(s) \
+               collapse after model-id normalization."
+              profile
+              (List.length raw_tiers - List.length normalized)
+              (List.length raw_tiers);
+        }
+    else
+      None
+
+let diagnose_profile ~config_path ~profile =
+  let model_specs =
+    Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
+    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
+           entry.model)
+  in
+  let invalid_specs =
+    model_specs
+    |> Cascade_config.expand_auto_models
+    |> List.filter_map (fun spec ->
+           match Cascade_config.parse_model_string_exn spec with
+           | Ok _ -> None
+           | Error msg when is_provider_unavailable_error msg -> None
+           | Error msg -> Some (spec, msg))
+  in
+  let invalid_model_issue =
+    if invalid_specs = [] then
+      None
+    else
+      Some
+        {
+          profile = Some profile;
+          severity = Catalog_error;
+          message =
+            Printf.sprintf
+              "Cascade preset %s has %d hard-invalid model spec(s): %s"
+              profile
+              (List.length invalid_specs)
+              (format_spec_errors invalid_specs);
+        }
+  in
+  let strategy_cfg =
+    Cascade_config_loader.resolve_strategy_config ~config_path ~name:profile
+  in
+  let strategy_issue =
+    match strategy_cfg.kind with
+    | None -> None
+    | Some raw_kind -> (
+        match Cascade_strategy.parse_kind raw_kind with
+        | Error msg ->
+            Some
+              {
+                profile = Some profile;
+                severity = Catalog_error;
+                message =
+                  Printf.sprintf
+                    "Cascade preset %s has unknown strategy %S: %s"
+                    profile raw_kind msg;
+              }
+        | Ok Cascade_strategy.Priority_tier -> (
+            match strategy_cfg.tiers with
+            | None ->
+                Some
+                  {
+                    profile = Some profile;
+                    severity = Catalog_error;
+                    message =
+                      Printf.sprintf
+                        "Cascade preset %s uses priority_tier without a \
+                         valid non-empty <name>_tiers configuration."
+                        profile;
+                  }
+            | Some raw_tiers ->
+                priority_tier_issue ~profile model_specs raw_tiers)
+        | Ok _ -> None)
+  in
+  [ invalid_model_issue; strategy_issue ]
+  |> List.filter_map (fun issue -> issue)
+
+let diagnose_catalog ~config_path =
+  match Cascade_config_loader.load_json config_path with
+  | Error msg ->
+      [
+        {
+          profile = None;
+          severity = Catalog_error;
+          message =
+            Printf.sprintf
+              "Cascade catalog %s could not be loaded: %s"
+              config_path msg;
+        };
+      ]
+  | Ok json ->
+      discover_profiles_in_json json
+      |> List.concat_map (fun profile -> diagnose_profile ~config_path ~profile)
+
+let dedupe_keep_order values =
+  let seen = Hashtbl.create (List.length values) in
+  List.filter
+    (fun value ->
+      if value = "" || Hashtbl.mem seen value then
+        false
+      else (
+        Hashtbl.replace seen value ();
+        true))
+    values
+
+let error_messages_by_profile ~config_path =
+  diagnose_catalog ~config_path
+  |> List.fold_left
+       (fun acc (issue : issue) ->
+          match issue.profile, issue.severity with
+          | Some profile, Catalog_error ->
+              let prior =
+                match StringMap.find_opt profile acc with
+                | Some messages -> messages
+                | None -> []
+              in
+              StringMap.add profile (prior @ [ issue.message ]) acc
+          | _ -> acc)
+       StringMap.empty
+  |> StringMap.bindings
+  |> List.map (fun (profile, messages) ->
+         (profile, dedupe_keep_order messages))

--- a/lib/cascade_catalog_validator.mli
+++ b/lib/cascade_catalog_validator.mli
@@ -1,0 +1,36 @@
+(** Structured validation for cascade.json preset entries.
+
+    This module lifts the existing static cascade catalog checks out of
+    {!Config_doctor} so server routes and other runtime surfaces can
+    reject invalid presets before they are assigned to keepers. *)
+
+type severity =
+  | Catalog_warn
+  | Catalog_error
+
+type issue = {
+  profile : string option;
+  severity : severity;
+  message : string;
+}
+
+val discover_profiles : config_path:string -> string list
+(** Discover named cascade presets from ["{name}_models"] keys. Returns
+    [[]] when the config cannot be loaded. *)
+
+val diagnose_catalog : config_path:string -> issue list
+(** Validate every discovered preset in [config_path].
+
+    - hard-invalid model specs (unknown provider / invalid syntax)
+    - unknown strategy names
+    - [priority_tier] presets whose tiers collapse structurally
+
+    Provider-unavailable entries are not treated as hard failures here:
+    the validator is intended to catch broken catalog structure, not
+    environment-specific credential state. *)
+
+val error_messages_by_profile :
+  config_path:string ->
+  (string * string list) list
+(** Group only [Catalog_error] diagnostics by profile name. Config-wide
+    load errors without a concrete profile are omitted from the grouping. *)

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -39,11 +39,12 @@ type t = {
   next_actions : string list;
 }
 
-type catalog_issue_severity =
+type catalog_issue_severity = Cascade_catalog_validator.severity =
   | Catalog_warn
   | Catalog_error
 
-type catalog_issue = {
+type catalog_issue = Cascade_catalog_validator.issue = {
+  profile : string option;
   severity : catalog_issue_severity;
   message : string;
 }
@@ -71,48 +72,6 @@ let dedupe_keep_order values =
         Hashtbl.replace seen value ();
         true))
     values
-
-let contains_substring ~needle s =
-  let needle_len = String.length needle in
-  let s_len = String.length s in
-  if needle_len = 0 || needle_len > s_len then
-    false
-  else
-    let limit = s_len - needle_len in
-    let rec loop i =
-      if i > limit then
-        false
-      else if String.sub s i needle_len = needle then
-        true
-      else
-        loop (i + 1)
-    in
-    loop 0
-
-let has_suffix ~suffix s =
-  let suffix_len = String.length suffix in
-  let s_len = String.length s in
-  s_len > suffix_len
-  && String.sub s (s_len - suffix_len) suffix_len = suffix
-
-let is_provider_unavailable_error msg =
-  contains_substring ~needle:"unavailable" msg
-
-let split_provider_model (s : string) : (string * string) option =
-  match String.index_opt s ':' with
-  | None -> None
-  | Some idx ->
-      if idx = 0 || idx >= String.length s - 1 then
-        None
-      else
-        let provider_name =
-          String.sub s 0 idx |> String.trim |> String.lowercase_ascii
-        in
-        let model_id =
-          String.sub s (idx + 1) (String.length s - idx - 1)
-          |> String.trim
-        in
-        if model_id = "" then None else Some (provider_name, model_id)
 
 let canonicalize_path ~cwd path =
   let absolute =
@@ -146,147 +105,6 @@ let option_field name = function
   | Some value -> (name, `String value)
   | None -> (name, `Null)
 
-let discover_cascade_profiles = function
-  | `Assoc fields ->
-      fields
-      |> List.filter_map (fun (key, value) ->
-             match value with
-             | `List _ when has_suffix ~suffix:"_models" key ->
-                 let suffix_len = String.length "_models" in
-                 Some (String.sub key 0 (String.length key - suffix_len))
-             | _ -> None)
-      |> List.sort_uniq String.compare
-  | _ -> []
-
-let model_ids_of_specs (specs : string list) : string list =
-  specs
-  |> Cascade_config.expand_auto_models
-  |> List.filter_map (fun spec ->
-         match split_provider_model spec with
-         | Some (_, model_id) when model_id <> "" -> Some model_id
-         | _ -> None)
-  |> List.sort_uniq String.compare
-
-let format_spec_errors specs =
-  specs
-  |> List.map (fun (spec, msg) -> Printf.sprintf "%S (%s)" spec msg)
-  |> String.concat ", "
-
-let priority_tier_issue ~profile configured_specs raw_tiers =
-  let configured_model_ids = model_ids_of_specs configured_specs in
-  if configured_model_ids = [] then
-    Some
-      {
-        severity = Catalog_error;
-        message =
-          Printf.sprintf
-            "Cascade preset %s uses priority_tier but has no configured \
-             models to validate."
-            profile;
-      }
-  else
-    let normalized =
-      raw_tiers
-      |> List.filter_map (fun tier ->
-             let tier_model_ids =
-               model_ids_of_specs tier
-               |> List.filter (fun model_id ->
-                      List.mem model_id configured_model_ids)
-             in
-             if tier_model_ids = [] then None else Some tier_model_ids)
-    in
-    if normalized = [] then
-      Some
-        {
-          severity = Catalog_error;
-          message =
-            Printf.sprintf
-              "Cascade preset %s uses priority_tier, but every tier \
-               collapses after model-id normalization; runtime will fall \
-               back to failover."
-              profile;
-        }
-    else if List.length normalized < List.length raw_tiers then
-      Some
-        {
-          severity = Catalog_warn;
-          message =
-            Printf.sprintf
-              "Cascade preset %s uses priority_tier, but %d/%d tier(s) \
-               collapse after model-id normalization."
-              profile
-              (List.length raw_tiers - List.length normalized)
-              (List.length raw_tiers);
-        }
-    else
-      None
-
-let diagnose_cascade_profile ~config_path ~profile =
-  let model_specs =
-    Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
-    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
-           entry.model)
-  in
-  let invalid_specs =
-    model_specs
-    |> Cascade_config.expand_auto_models
-    |> List.filter_map (fun spec ->
-           match Cascade_config.parse_model_string_exn spec with
-           | Ok _ -> None
-           | Error msg when is_provider_unavailable_error msg -> None
-           | Error msg -> Some (spec, msg))
-  in
-  let invalid_model_issue =
-    if invalid_specs = [] then
-      None
-    else
-      Some
-        {
-          severity = Catalog_error;
-          message =
-            Printf.sprintf
-              "Cascade preset %s has %d hard-invalid model spec(s): %s"
-              profile
-              (List.length invalid_specs)
-              (format_spec_errors invalid_specs);
-        }
-  in
-  let strategy_cfg =
-    Cascade_config_loader.resolve_strategy_config ~config_path ~name:profile
-  in
-  let strategy_issue =
-    match strategy_cfg.kind with
-    | None -> None
-    | Some raw_kind -> (
-        match Cascade_strategy.parse_kind raw_kind with
-        | Error msg ->
-            Some
-              {
-                severity = Catalog_error;
-                message =
-                  Printf.sprintf
-                    "Cascade preset %s has unknown strategy %S: %s"
-                    profile raw_kind msg;
-              }
-        | Ok Cascade_strategy.Priority_tier -> (
-            match strategy_cfg.tiers with
-            | None ->
-                Some
-                  {
-                    severity = Catalog_error;
-                    message =
-                      Printf.sprintf
-                        "Cascade preset %s uses priority_tier without a \
-                         valid non-empty <name>_tiers configuration."
-                        profile;
-                  }
-            | Some raw_tiers ->
-                priority_tier_issue ~profile model_specs raw_tiers)
-        | Ok _ -> None)
-  in
-  [ invalid_model_issue; strategy_issue ]
-  |> List.filter_map (fun issue -> issue)
-
 let diagnose_cascade_catalog ~active_config_root =
   let config_path =
     Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
@@ -294,44 +112,29 @@ let diagnose_cascade_catalog ~active_config_root =
   if not (Env_config_core.existing_file config_path) then
     []
   else
-    match Cascade_config_loader.load_json config_path with
-    | Error msg ->
-        [
-          {
-            severity = Catalog_error;
-            message =
-              Printf.sprintf
-                "Cascade catalog %s could not be loaded: %s"
-                config_path msg;
-          };
-        ]
-    | Ok json ->
-        let profiles = discover_cascade_profiles json in
-        let issues =
-          profiles
-          |> List.concat_map (fun profile ->
-                 diagnose_cascade_profile ~config_path ~profile)
-        in
-        if issues = [] then
-          []
-        else
-          let error_count =
-            issues
-            |> List.filter (fun issue -> issue.severity = Catalog_error)
-            |> List.length
-          in
-          let warn_count = List.length issues - error_count in
-          {
-            severity = if error_count > 0 then Catalog_error else Catalog_warn;
-            message =
-              Printf.sprintf
-                "Cascade catalog check scanned %d preset(s): %d error, %d \
-                 warn."
-                (List.length profiles)
-                error_count
-                warn_count;
-          }
-          :: issues
+    let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
+    let issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
+    if issues = [] then
+      []
+    else
+      let error_count =
+        issues
+        |> List.filter (fun issue -> issue.severity = Catalog_error)
+        |> List.length
+      in
+      let warn_count = List.length issues - error_count in
+      {
+        profile = None;
+        severity = if error_count > 0 then Catalog_error else Catalog_warn;
+        message =
+          Printf.sprintf
+            "Cascade catalog check scanned %d preset(s): %d error, %d \
+             warn."
+            (List.length profiles)
+            error_count
+            warn_count;
+      }
+      :: issues
 
 let cascade_catalog_next_actions ~config_path issues =
   if issues = [] then

--- a/lib/dune
+++ b/lib/dune
@@ -34,6 +34,7 @@
    cascade_inference
    cascade_client_capacity
    cascade_client_capacity_history
+   cascade_catalog_validator
    cascade_config
    cascade_config_loader
    cascade_fsm

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -12,10 +12,36 @@ module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
 
-let available_cascade_profiles () : string list =
+type cascade_profile_gate = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+}
+
+let cascade_profile_gate () : cascade_profile_gate =
   let config_path = Cascade_runtime.cascade_config_path () in
-  Keeper_cascade_profile.keeper_catalog_names ?config_path ()
-  |> List.sort_uniq String.compare
+  let keeper_profiles =
+    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> List.sort_uniq String.compare
+  in
+  match config_path with
+  | None -> { valid_profiles = keeper_profiles; invalid_profiles = [] }
+  | Some path ->
+      let invalid_profiles =
+        Cascade_catalog_validator.error_messages_by_profile
+          ~config_path:path
+      in
+      let invalid_names = List.map fst invalid_profiles in
+      let valid_profiles =
+        keeper_profiles
+        |> List.filter (fun profile -> not (List.mem profile invalid_names))
+      in
+      { valid_profiles; invalid_profiles }
+
+let available_cascade_profiles () : string list =
+  (cascade_profile_gate ()).valid_profiles
+
+let invalid_cascade_profiles () : (string * string list) list =
+  (cascade_profile_gate ()).invalid_profiles
 
 (** Broadcast handler: parse JSON body, extract "message" string field, and
     relay via Coord.broadcast.  Error responses are encoded through Yojson so
@@ -952,6 +978,16 @@ and add_autoresearch_routes router =
                  reqd
              | Some name, Some cascade ->
                let known = available_cascade_profiles () in
+               let invalid = invalid_cascade_profiles () in
+               (match List.assoc_opt cascade invalid with
+                | Some reasons ->
+                  Http.Response.json ~status:`Conflict ~request:req
+                    (Printf.sprintf
+                       {|{"ok":false,"error":"cascade %s is invalid in active cascade.json: %s"}|}
+                       (String.escaped cascade)
+                       (String.escaped (String.concat " | " reasons)))
+                    reqd
+                | None ->
                if not (List.mem cascade known) then
                  Http.Response.json ~status:`Bad_request ~request:req
                    (Printf.sprintf
@@ -980,6 +1016,6 @@ and add_autoresearch_routes router =
                      (Printf.sprintf
                        {|{"ok":true,"keeper":"%s","cascade_name":"%s","source":"toml"}|}
                        (String.escaped name) (String.escaped cascade))
-                     reqd
+                     reqd)
          )
        ) request reqd)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -34,6 +34,16 @@ let write_file path content =
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 ;;
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/"
+  then ()
+  else if Sys.file_exists path
+  then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755)
+;;
+
 let rec rm_rf path =
   if Sys.file_exists path
   then
@@ -207,6 +217,36 @@ let merge_env_overrides overrides =
   Array.of_list (base @ injected)
 ;;
 
+let with_temp_config_root cascade_json f =
+  let root = Filename.temp_file "dashboard-keeper-config-" "" in
+  (try Sys.remove root with
+   | _ -> ());
+  Unix.mkdir root 0o755;
+  let cleanup () = rm_rf root in
+  Fun.protect
+    ~finally:cleanup
+    (fun () ->
+       mkdir_p (Filename.concat root "personas");
+       mkdir_p (Filename.concat root "keepers");
+       mkdir_p (Filename.concat root "prompts");
+       write_file (Filename.concat root "cascade.json") cascade_json;
+       f root)
+;;
+
+let with_config_dir config_root f =
+  let prev = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+       (match prev with
+        | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+        | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+       Masc_mcp.Config_dir_resolver.reset ())
+    (fun () ->
+       Unix.putenv "MASC_CONFIG_DIR" config_root;
+       Masc_mcp.Config_dir_resolver.reset ();
+       f ())
+;;
+
 let run_curl_post ?body ?token ~port ~path () =
   let header_file = Filename.temp_file "dashboard-keeper-post-" ".hdr" in
   let body_file = Filename.temp_file "dashboard-keeper-post-" ".body" in
@@ -336,6 +376,19 @@ let execution_keeper_paused body keeper_name =
   | None -> fail ("keeper missing from execution payload: " ^ keeper_name)
 ;;
 
+let profile_names body =
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  match json |> member "profiles" with
+  | `List items ->
+      List.filter_map
+        (function
+          | `String value -> Some value
+          | _ -> None)
+        items
+  | _ -> []
+;;
+
 let make_keeper_meta_json ?(name = "route-shadow-demo") () =
   match
     Masc_mcp.Keeper_types.meta_of_json
@@ -375,7 +428,7 @@ let seed_auth_and_keeper ~base_path ~keeper_name =
   config, admin_token
 ;;
 
-let with_seeded_server f =
+let with_seeded_server ?(env_overrides = []) f =
   let exe = find_main_eio_exe () in
   let port =
     match find_free_port () with
@@ -394,16 +447,17 @@ let with_seeded_server f =
   in
   let env =
     merge_env_overrides
-      [ "MASC_AUTONOMY_ENABLED", "0"
-      ; "GRAPHQL_API_KEY", ""
-      ; "GRAPHQL_URL", "http://127.0.0.1:9/graphql"
-      ; "MASC_BASE_PATH", base_path
-      ; "MASC_POSTGRES_URL", ""
-      ; "DATABASE_URL", ""
-      ; "SUPABASE_DB_URL", ""
-      ; "SB_PG_URL", ""
-      ; "MASC_BOARD_BACKEND", "jsonl"
-      ]
+      ([ "MASC_AUTONOMY_ENABLED", "0"
+       ; "GRAPHQL_API_KEY", ""
+       ; "GRAPHQL_URL", "http://127.0.0.1:9/graphql"
+       ; "MASC_BASE_PATH", base_path
+       ; "MASC_POSTGRES_URL", ""
+       ; "DATABASE_URL", ""
+       ; "SUPABASE_DB_URL", ""
+       ; "SB_PG_URL", ""
+       ; "MASC_BOARD_BACKEND", "jsonl"
+       ]
+       @ env_overrides)
   in
   let argv =
     [| exe
@@ -616,6 +670,64 @@ let test_keeper_directive_resume_updates_paused_meta () =
       fail ("failed to read keeper meta after directive resume: " ^ err)
 ;;
 
+let test_available_cascade_profiles_filter_invalid_catalog_entries () =
+  with_temp_config_root
+    {|
+      {
+        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "good_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "broken_models": ["__nonexistent_provider_sentinel__:fake-model"]
+      }
+    |}
+  @@ fun config_root ->
+  with_config_dir config_root @@ fun () ->
+  check
+    (list string)
+    "assignable cascades exclude invalid presets"
+    [ "default"; "good" ]
+    (Routes.available_cascade_profiles ());
+  let invalid = Routes.invalid_cascade_profiles () in
+  check bool "invalid preset is surfaced separately" true
+    (List.mem_assoc "broken" invalid)
+;;
+
+let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
+  with_temp_config_root
+    {|
+      {
+        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "good_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "broken_models": ["__nonexistent_provider_sentinel__:fake-model"]
+      }
+    |}
+  @@ fun config_root ->
+  with_seeded_server
+    ~env_overrides:[ "MASC_CONFIG_DIR", config_root ]
+  @@ fun ~port ~config:_ ~admin_token ~keeper_name ->
+  let list_result =
+    run_curl_get ~port ~path:"/api/v1/keeper/cascades" ()
+  in
+  require_status "keeper cascades GET returns 200" 200 list_result;
+  let profiles = profile_names list_result.body in
+  check bool "valid profile remains assignable" true (List.mem "good" profiles);
+  check bool "invalid profile omitted from assignable list" false
+    (List.mem "broken" profiles);
+  let assign_invalid_result =
+    run_curl_post
+      ~body:
+        (Printf.sprintf
+           {|{"keeper":"%s","cascade_name":"broken"}|}
+           keeper_name)
+      ~token:admin_token
+      ~port
+      ~path:"/api/v1/keeper/cascade"
+      ()
+  in
+  require_status "invalid cascade assignment returns 409" 409 assign_invalid_result;
+  check bool "invalid cascade rejection explains config error" true
+    (contains_substr "invalid in active cascade.json" assign_invalid_result.body)
+;;
+
 let test_merge_keeper_trace_lines_includes_internal_history () =
   let base_path = Filename.temp_file "dashboard-keeper-trajectory-" "" in
   (try Sys.remove base_path with
@@ -702,6 +814,14 @@ let () =
             "directive resume updates paused meta"
             `Slow
             test_keeper_directive_resume_updates_paused_meta
+        ; test_case
+            "available cascade profiles filter invalid catalog entries"
+            `Quick
+            test_available_cascade_profiles_filter_invalid_catalog_entries
+        ; test_case
+            "keeper cascade routes filter invalid catalog entries"
+            `Slow
+            test_keeper_cascade_routes_filter_invalid_catalog_entries
         ; test_case
             "merge keeper trace lines includes internal history"
             `Quick


### PR DESCRIPTION
## Summary
- extract reusable cascade catalog validation into `Cascade_catalog_validator`
- reuse that validator in `Config_doctor` instead of keeping a separate validation path
- hide structurally invalid presets from keeper cascade assignment surfaces and reject direct invalid assignment with `409 Conflict`
- add regression coverage for invalid catalog entries in dashboard keeper route tests

## Why
Issue #7872 showed that cascade presets could remain assignable even when the active `cascade.json` contained structurally broken entries. The validation logic existed only inside doctor output, so runtime assignment surfaces still exposed bad presets.

## Impact
- invalid presets are filtered out of `/api/v1/keeper/cascades`
- direct assignment of an invalid preset through `/api/v1/keeper/cascade` now fails with an explicit config error
- doctor and runtime surfaces now share the same catalog validation logic instead of drifting separately

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-7872-cascade-catalog-validation`
- `_build/default/test/test_config_doctor.exe`
- `_build/default/test/test_dashboard_keeper_routes.exe`
- `env MASC_CASCADE_JSON_PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-7872-cascade-catalog-validation/config/cascade.json _build/default/test/test_cascade_config_validity.exe`

Refs #7872