### PR TITLE
[codex] fix masc-mcp compatibility with agent_sdk 0.163

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2267,7 +2267,10 @@ let run_turn
              Error
                (Oas.Error.Agent
                   (Oas.Error.CompletionContractViolation
-                     { contract = "require_tool_use"; reason }))
+                     {
+                       contract = Oas.Completion_contract_id.Require_tool_use;
+                       reason;
+                     }))
          in
          let finalize_response_text response_text =
            (* Ensure every generation has a [STATE] block for continuity.

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -127,7 +127,7 @@ let empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens
     top_k = None;
     min_p = None;
     enable_thinking = None;
-    response_format_json = false;
+    response_format = Agent_sdk.Types.Off;
     thinking_budget = None;
     cache_system_prompt = false;
     max_input_tokens = None;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -179,7 +179,7 @@ let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
 let is_required_tool_contract_violation (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Agent (Oas.Error.CompletionContractViolation { contract; _ }) ->
-      String.equal contract "require_tool_use"
+      contract = Oas.Completion_contract_id.Require_tool_use
   | _ -> false
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -208,6 +208,7 @@ let make_pre_tool_hook
     | Agent_sdk.Hooks.PostToolUseFailure _
     | Agent_sdk.Hooks.OnStop _
     | Agent_sdk.Hooks.OnIdle _
+    | Agent_sdk.Hooks.OnIdleEscalated _
     | Agent_sdk.Hooks.OnError _
     | Agent_sdk.Hooks.OnToolError _
     | Agent_sdk.Hooks.PreCompact _


### PR DESCRIPTION
## Summary
- update keeper checkpoint construction to use typed response_format
- handle the new on_idle_escalated hook event in verifier pass-through logic
- compare completion contract violations against typed contract IDs in keeper error handling

## Why
- after merging oas main and repinning agent_sdk, masc-mcp main no longer compiled against agent_sdk 0.163.0

## Validation
- env DUNE_CACHE=disabled dune build --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-0163-compat @install
- env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-0163-compat/_build/default/test/test_keeper_tool_surface_guard.exe
- env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-0163-compat/_build/default/test/test_tool_surface_ssot.exe
- env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-0163-compat/_build/default/test/test_keeper_agent_isolation.exe