### PR TITLE
refactor(keeper): Tool_name.Keeper variant phase 2 — 4 files

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -148,7 +148,7 @@ let suggest_alternatives ~(allowed_tools : string list)
   allowed_tools
   |> List.filter (fun t ->
        not (SS.mem t repeated_set)
-       && t <> "keeper_stay_silent")
+       && t <> Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent)
   |> fun candidates ->
      let len = List.length candidates in
      if len <= max_suggestions then candidates

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -101,7 +101,7 @@ let compute_diversity ~(available_tools : string list)
   let threshold = max 1 (total_calls / 100) in
   let underused = available_tools
     |> List.filter (fun tool ->
-      not (String.equal tool "keeper_stay_silent")
+      not (String.equal tool (Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent))
       && (not (SS.mem tool used_set)
           || List.exists (fun s -> s.name = tool && s.count < threshold) stats))
   in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -466,14 +466,14 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     |> List.exists (fun tool_name ->
                            let trimmed = String.trim tool_name in
                            trimmed <> ""
-                           && not (String.equal trimmed "keeper_stay_silent"))
+                           && not (String.equal trimmed (Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent)))
                   in
                   let tool_refs =
                     result.tools_used
                     |> List.filter_map (fun tool_name ->
                            let trimmed = String.trim tool_name in
                            if trimmed = ""
-                              || String.equal trimmed "keeper_stay_silent"
+                              || String.equal trimmed (Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent)
                            then None
                            else Some ("tool:" ^ trimmed))
                   in

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -144,7 +144,7 @@ let inferred_text_reply_state ~(meta : keeper_meta)
     { speech_act = Types.Inform; delivery_surface = Types.Visible_reply } )
 
 let inferred_tool_surface tools =
-  if tools = [ "keeper_stay_silent" ] then
+  if tools = [ Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent ] then
     Some
       ( { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
       , Types.Tool_only_stay_silent )


### PR DESCRIPTION
## Summary
- Replace 5 `"keeper_stay_silent"` raw string literals with `Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent` across 4 files
- Completes the comparison-site coverage started in #9198 (phase 1)

## Files changed
- `keeper_tool_diversity.ml` — underused tool filter
- `keeper_hooks_oas.ml` — tool suggestion filter  
- `social_model/keeper_social_model_bdi_speech_v1.ml` — silent-turn detection
- `keeper_turn.ml` — evidence tool-ref filter (2 sites)

## What's NOT changed
- `keeper_exec_tools.ml` dispatch match — single case change would be inconsistent with 50+ other raw tool names in same function; needs full dispatch refactor

## Test plan
- [ ] CI build passes (no new compilation errors from these changes)
- [ ] grep confirms zero remaining `"keeper_stay_silent"` in comparison sites (excluding dispatch and schema definitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)