### PR TITLE
refactor(keeper): deduplicate is_scheduled_autonomous_channel

### DIFF
--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -95,8 +95,8 @@ let empty_tool_audit_snapshot =
     tool_audit_at = None;
   }
 
-let is_scheduled_autonomous_channel (channel : string) : bool =
-  channel = "scheduled_autonomous" || channel = "proactive"
+let is_scheduled_autonomous_channel =
+  Keeper_world_observation.is_autonomous_channel
 
 let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
   let interaction_points = s.turn_points + s.proactive_points in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -651,9 +651,8 @@ let decision_channel_of_observation
   else
     "scheduled_autonomous"
 
-let is_scheduled_autonomous_channel (channel : string) : bool =
-  String.equal channel "scheduled_autonomous"
-  || String.equal channel "proactive"
+let is_scheduled_autonomous_channel =
+  Keeper_world_observation.is_autonomous_channel
 
 let is_scheduled_autonomous_cycle_of_observation
     (observation : Keeper_world_observation.world_observation) : bool =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -99,6 +99,10 @@ let channel_to_string = function
   | Reactive -> "reactive"
   | Scheduled_autonomous -> "scheduled_autonomous"
 
+let is_autonomous_channel (channel : string) : bool =
+  String.equal channel "scheduled_autonomous"
+  || String.equal channel "proactive"
+
 let verdict_reasons_to_strings = function
   | Run { reasons = (first, rest) } ->
       List.map turn_reason_to_string (first :: rest)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -134,6 +134,10 @@ val skip_reason_to_string : skip_reason -> string
 (** Convert channel to string tag. *)
 val channel_to_string : keeper_cycle_channel -> string
 
+(** Check if a string channel tag represents an autonomous cycle
+    (scheduled_autonomous or proactive). *)
+val is_autonomous_channel : string -> bool
+
 (** Extract all reasons as flat string tags from a verdict.
     Tags map 1:1 to the typed reasons carried by the verdict and do not
     include variant payloads. *)


### PR DESCRIPTION
## Summary
- Deduplicate `is_scheduled_autonomous_channel` — was defined identically in both `keeper_unified_turn.ml` and `keeper_exec_status_metrics.ml`
- Canonical location: `keeper_world_observation.ml` (where `keeper_cycle_channel` variant is defined) as `is_autonomous_channel`
- Both callers delegate via alias, preserving existing public API

## Files changed
- `keeper_world_observation.ml/.mli` — add `is_autonomous_channel : string -> bool`
- `keeper_unified_turn.ml` — replace local def with alias
- `keeper_exec_status_metrics.ml` — replace local def with alias

## Test plan
- [ ] CI build passes (no new compilation errors)
- [ ] grep confirms zero duplicate definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)