### PR TITLE
[codex] route public masc tools through the runtime MCP lane

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -250,7 +250,10 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
 
 let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   let registry = Llm_provider.Provider_registry.default () in
-  let provider_name = Provider_adapter.string_of_provider_kind cfg.kind in
+  (* Use the exact OAS provider kind name here. Provider_adapter collapses
+     CLI kinds onto shared canonical families ("gemini", "codex"), which
+     makes Gemini_cli incorrectly inherit direct-API capabilities. *)
+  let provider_name = Llm_provider.Provider_config.string_of_provider_kind cfg.kind in
   let caps =
     match Llm_provider.Provider_registry.find registry provider_name with
     | Some entry -> entry.capabilities
@@ -260,14 +263,24 @@ let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   | Some supports_tool_choice -> { caps with supports_tool_choice }
   | None -> caps
 
-let apply_required_tool_choice_filter ~require_tool_choice_support ~label
+let apply_required_tool_choice_filter ~require_tool_choice_support
+    ~require_tool_support ~label
     (providers : Llm_provider.Provider_config.t list) =
-  if not require_tool_choice_support then
+  if not require_tool_choice_support && not require_tool_support then
     providers
   else
     let supports_required_tool_use cfg =
       let caps = provider_capabilities_of_config cfg in
-      caps.supports_tools && caps.supports_tool_choice
+      let inline_tools = caps.supports_tools in
+      let inline_tool_choice = inline_tools && caps.supports_tool_choice in
+      let runtime_mcp =
+        caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events
+      in
+      match require_tool_choice_support, require_tool_support with
+      | true, true -> inline_tool_choice || runtime_mcp
+      | true, false -> inline_tool_choice
+      | false, true -> inline_tools || runtime_mcp
+      | false, false -> true
     in
     let filtered = List.filter supports_required_tool_use providers in
     if filtered = [] && providers <> [] then
@@ -303,6 +316,7 @@ let models_of_cascade_name (cascade_name : string) : string list =
 
 let resolve_providers_from_model_strings ?provider_filter
     ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
     (model_strings : string list)
     : Llm_provider.Provider_config.t list =
   let specs = Cascade_config.parse_model_strings model_strings in
@@ -312,6 +326,7 @@ let resolve_providers_from_model_strings ?provider_filter
       ~label:"direct_model_strings"
       specs
     |> apply_required_tool_choice_filter ~require_tool_choice_support
+         ~require_tool_support
          ~label:"direct_model_strings"
   in
   if filtered <> [] then filtered
@@ -321,7 +336,9 @@ let resolve_providers_from_model_strings ?provider_filter
     [])
 
 let resolve_named_providers ?provider_filter
-    ?(require_tool_choice_support = false) ~cascade_name ()
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ~cascade_name ()
     : Llm_provider.Provider_config.t list =
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let defaults = default_model_strings ~cascade_name in
@@ -341,6 +358,7 @@ let resolve_named_providers ?provider_filter
          (models_of_cascade_name cascade_name))
     |> Cascade_config.apply_provider_filter ~provider_filter ~label:cascade_name
     |> apply_required_tool_choice_filter ~require_tool_choice_support
+         ~require_tool_support
          ~label:cascade_name
   in
   if specs <> [] then specs
@@ -353,4 +371,4 @@ let resolve_named_providers ?provider_filter
       "cascade %s: configured models unavailable — retrying built-in defaults"
       cascade_name;
     resolve_providers_from_model_strings ?provider_filter
-      ~require_tool_choice_support defaults)
+      ~require_tool_choice_support ~require_tool_support defaults)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -35,8 +35,10 @@ val models_of_cascade_name : string -> string list
 val resolve_named_providers :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   cascade_name:string -> unit -> Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   string list -> Llm_provider.Provider_config.t list

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -83,6 +83,7 @@ val run_named :
   goal:string ->
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -23,6 +23,8 @@ type config = {
   priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Oas.Tool.t list;
+  runtime_mcp_policy :
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
   max_turns : int;
   max_idle_turns : int;
   max_tokens : int;
@@ -69,6 +71,7 @@ let default_config
   let provider = Oas.Provider.config_of_provider_config provider_cfg in
   { name; provider_cfg; provider; model_id = provider_cfg.model_id;
     priority = None; system_prompt; tools;
+    runtime_mcp_policy = None;
     max_turns = 20;
     max_idle_turns = 3;
     max_tokens = Oas_worker_cascade.default_max_tokens;
@@ -169,6 +172,115 @@ let cli_model_override model_id =
   match String.lowercase_ascii (String.trim model_id) with
   | "" | "auto" -> None
   | _ -> Some (String.trim model_id)
+
+let provider_caps_of_config (provider_cfg : Llm_provider.Provider_config.t) =
+  let base_caps =
+    match provider_cfg.kind with
+    | Llm_provider.Provider_config.Ollama ->
+        Llm_provider.Capabilities.ollama_capabilities
+    | Anthropic -> Llm_provider.Capabilities.anthropic_capabilities
+    | Glm -> Llm_provider.Capabilities.glm_capabilities
+    | Gemini -> Llm_provider.Capabilities.gemini_capabilities
+    | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+    | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
+    | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
+    | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+  in
+  let caps =
+    match provider_cfg.kind with
+    | Llm_provider.Provider_config.Claude_code
+    | Gemini_cli
+    | Codex_cli -> base_caps
+    | _ ->
+        (match Llm_provider.Capabilities.for_model_id provider_cfg.model_id with
+         | Some caps -> caps
+         | None -> base_caps)
+  in
+  match provider_cfg.supports_tool_choice_override with
+  | Some supports_tool_choice -> { caps with supports_tool_choice }
+  | None -> caps
+
+let provider_supports_inline_tools (provider_cfg : Llm_provider.Provider_config.t) =
+  (provider_caps_of_config provider_cfg).supports_tools
+
+let provider_supports_runtime_mcp_lane
+    (provider_cfg : Llm_provider.Provider_config.t) =
+  let caps = provider_caps_of_config provider_cfg in
+  caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events
+
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then
+        false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let public_mcp_tool_names_of_oas_tools (tools : Oas.Tool.t list) =
+  List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
+
+let tool_names_are_public_mcp (tool_names : string list) =
+  tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
+
+let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
+    Llm_provider.Llm_transport.runtime_mcp_policy option =
+  let tool_names = dedupe_preserve_order tool_names in
+  if not (tool_names_are_public_mcp tool_names) then
+    None
+  else
+    Some
+      {
+        Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+        servers =
+          [
+            Llm_provider.Llm_transport.Http_server
+              {
+                name = "masc";
+                url = Env_config_runtime.Local_runtime.mcp_url ();
+                headers = [];
+              };
+          ];
+        allowed_server_names = [ "masc" ];
+        allowed_tool_names = tool_names;
+        strict = true;
+        disable_builtin_tools = true;
+      }
+
+let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf "%s:%s"
+    (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
+    provider_cfg.model_id
+
+let resolve_tool_lane_for_oas_tools
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    ~(tools : Oas.Tool.t list)
+  : (Oas.Tool.t list
+     * Llm_provider.Llm_transport.runtime_mcp_policy option,
+     Oas.Error.sdk_error)
+    result =
+  let tool_names = public_mcp_tool_names_of_oas_tools tools in
+  match public_mcp_runtime_policy_of_tool_names tool_names with
+  | Some runtime_mcp_policy
+    when provider_supports_runtime_mcp_lane provider_cfg ->
+      Ok ([], Some runtime_mcp_policy)
+  | _ when tools = [] ->
+      Ok (tools, None)
+  | _ when provider_supports_inline_tools provider_cfg ->
+      Ok (tools, None)
+  | _ ->
+      let detail =
+        if tool_names_are_public_mcp tool_names then
+          Printf.sprintf
+            "%s does not support inline tools or request-scoped runtime MCP tools"
+            (provider_label provider_cfg)
+        else
+          Printf.sprintf "%s does not support inline tools"
+            (provider_label provider_cfg)
+      in
+      Error (invalid_runtime_config "tool_support" detail)
 
 (** Wrap CLI transports in a per-call sub-switch.
 
@@ -382,6 +494,11 @@ let build
     | None -> builder
   in
   let builder =
+    match config.runtime_mcp_policy with
+    | Some policy -> Oas.Builder.with_runtime_mcp_policy policy builder
+    | None -> builder
+  in
+  let builder =
     if config.cache_system_prompt then
       Oas.Builder.with_cache_system_prompt true builder
     else builder
@@ -575,6 +692,7 @@ let resume_from_checkpoint
     description = config.description;
     approval = config.approval;
     slot_id = config.slot_id;
+    runtime_mcp_policy = config.runtime_mcp_policy;
     summarizer = config.summarizer;
     priority = config.priority;
   } in
@@ -795,12 +913,32 @@ let run_with_masc_tools
     ?on_resume
     (goal : string)
   : (run_result, Oas.Error.sdk_error) result =
-  let oas_tools = List.map (fun (td : Types.tool_schema) ->
-    Tool_bridge.oas_tool_of_masc
-      ~name:td.name
-      ~description:td.description
-      ~input_schema:td.input_schema
-      (fun input -> dispatch ~name:td.name ~args:input)
-  ) masc_tools in
-  let config = { config with tools = oas_tools @ config.tools } in
-  run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  match
+    public_mcp_runtime_policy_of_tool_names
+      (List.map (fun (td : Types.tool_schema) -> td.name) masc_tools)
+  with
+  | Some runtime_mcp_policy
+    when provider_supports_runtime_mcp_lane config.provider_cfg ->
+      let config = { config with runtime_mcp_policy = Some runtime_mcp_policy } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ when masc_tools = [] ->
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ when provider_supports_inline_tools config.provider_cfg ->
+      let oas_tools =
+        List.map
+          (fun (td : Types.tool_schema) ->
+            Tool_bridge.oas_tool_of_masc
+              ~name:td.name
+              ~description:td.description
+              ~input_schema:td.input_schema
+              (fun input -> dispatch ~name:td.name ~args:input))
+          masc_tools
+      in
+      let config = { config with tools = oas_tools @ config.tools } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ ->
+      Error
+        (invalid_runtime_config "tool_support"
+           (Printf.sprintf
+              "%s does not support inline tools or request-scoped runtime MCP tools"
+              (provider_label config.provider_cfg)))

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -51,17 +51,21 @@ let eio_context_error_to_sdk_error detail =
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
 let resolve_cascade_providers ?provider_filter
-    ?(require_tool_choice_support = false) ~cascade_name () =
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ~cascade_name () =
   Cascade_runtime.resolve_named_providers ?provider_filter
-    ~require_tool_choice_support ~cascade_name ()
+    ~require_tool_choice_support ~require_tool_support ~cascade_name ()
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
     resulting provider configs into OAS execution. *)
 let resolve_providers_from_model_strings ?provider_filter
-    ?(require_tool_choice_support = false) model_strings =
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    model_strings =
   Cascade_runtime.resolve_providers_from_model_strings ?provider_filter
-    ~require_tool_choice_support model_strings
+    ~require_tool_choice_support ~require_tool_support model_strings
 
 type masc_internal_error =
   | Cascade_exhausted of {
@@ -361,6 +365,7 @@ let run_named
     ~goal
     ?provider_filter
     ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -418,12 +423,13 @@ let run_named
          MASC passes these strings through without interpretation. *)
       ( ms,
         resolve_providers_from_model_strings ?provider_filter
-          ~require_tool_choice_support ms )
+          ~require_tool_choice_support ~require_tool_support ms )
     | _ ->
       let labels = Cascade_runtime.models_of_cascade_name cascade_name in
       ( labels,
         resolve_cascade_providers ?provider_filter
-          ~require_tool_choice_support ~cascade_name () )
+          ~require_tool_choice_support ~require_tool_support ~cascade_name ()
+      )
   in
   let capture, _metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
   let name = Printf.sprintf "oas-%s" cascade_name in
@@ -439,6 +445,8 @@ let run_named
                 Some
                   (if require_tool_choice_support then
                      "no callable models support required tool use"
+                   else if require_tool_support then
+                     "no callable models support inline or runtime MCP tool use"
                    else
                      "no callable models available");
             }))
@@ -459,49 +467,74 @@ let run_named
      and the agent's checkpoint (if progress was made). try_cascade
      threads this checkpoint to the next provider without mutable state. *)
   let try_provider ?resume_checkpoint (provider_cfg : Llm_provider.Provider_config.t) =
-    let config : Oas_worker_exec.config =
-      { (Oas_worker_exec.default_config ~name ~provider_cfg
-        ~system_prompt ~tools)
-      with
-        priority;
-        max_turns; max_tokens; max_input_tokens; max_cost_usd; temperature; max_idle_turns;
-        guardrails; hooks; context_reducer; memory; tool_retry_policy;
-        description = Some (Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id);
-        transport = transport_resolved;
-        allowed_paths;
-        checkpoint_sidecar;
-        session_id;
-        cache_system_prompt;
-        compact_ratio;
-        contract;
-        checkpoint_dir;
-        context_injector;
-        context;
-        slot_id;
-        enable_thinking;
-        event_bus;
-        approval;
-        exit_condition;
-        exit_condition_result;
-        summarizer;
-        initial_messages; raw_trace; yield_on_tool;
-      }
+    let config_result =
+      Oas_worker_exec.resolve_tool_lane_for_oas_tools ~provider_cfg ~tools
+      |> Result.map
+           (fun (effective_tools, runtime_mcp_policy) ->
+             {
+               (Oas_worker_exec.default_config ~name ~provider_cfg
+                  ~system_prompt ~tools:effective_tools)
+               with
+                 priority;
+                 max_turns;
+                 max_tokens;
+                 max_input_tokens;
+                 max_cost_usd;
+                 temperature;
+                 max_idle_turns;
+                 guardrails;
+                 hooks;
+                 context_reducer;
+                 memory;
+                 tool_retry_policy;
+                 description =
+                   Some
+                     (Printf.sprintf "cascade:%s/%s" cascade_name
+                        provider_cfg.model_id);
+                 transport = transport_resolved;
+                 allowed_paths;
+                 checkpoint_sidecar;
+                 session_id;
+                 cache_system_prompt;
+                 compact_ratio;
+                 contract;
+                 checkpoint_dir;
+                 context_injector;
+                 context;
+                 slot_id;
+                 enable_thinking;
+                 event_bus;
+                 approval;
+                 exit_condition;
+                 exit_condition_result;
+                 summarizer;
+                 initial_messages;
+                 raw_trace;
+                 yield_on_tool;
+                 runtime_mcp_policy;
+             })
     in
     let local_agent_ref : Oas.Agent.t option ref = ref None in
-    match
-      with_codex_cli_preflight
-        ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
-        ~config ~goal
-        (fun () ->
-          let effective_checkpoint = match resume_checkpoint with
-            | Some _ -> resume_checkpoint
-            | None -> oas_checkpoint
-          in
-          let result =
-            Oas_worker_exec.run ~sw ~net ~config ?oas_checkpoint:effective_checkpoint ?on_event
-              ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref ?contract goal
-          in
-          Ok result)
+    match config_result with
+    | Error err ->
+      (Error err, None)
+    | Ok config ->
+      match
+        with_codex_cli_preflight
+          ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
+          ~config ~goal
+          (fun () ->
+            let effective_checkpoint = match resume_checkpoint with
+              | Some _ -> resume_checkpoint
+              | None -> oas_checkpoint
+            in
+            let result =
+              Oas_worker_exec.run ~sw ~net ~config
+                ?oas_checkpoint:effective_checkpoint ?on_event
+                ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
+                ?contract goal
+            in
+            Ok result)
     with
     | Error err ->
       (Error err, None)
@@ -975,6 +1008,7 @@ let run_named_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
+    ~require_tool_support:(masc_tools <> [])
     ~max_turns ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
     ?wait_timeout_sec ?guardrails ?hooks ?memory
     ?tool_retry_policy

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -16,7 +16,9 @@ let provider_kind_models providers =
 
 let provider_supports_required_tool_use (cfg : Llm_provider.Provider_config.t) =
   let registry = Llm_provider.Provider_registry.default () in
-  let provider_name = Masc_mcp.Provider_adapter.string_of_provider_kind cfg.kind in
+  let provider_name =
+    Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+  in
   let caps =
     match Llm_provider.Provider_registry.find registry provider_name with
     | Some entry -> entry.capabilities
@@ -28,6 +30,19 @@ let provider_supports_required_tool_use (cfg : Llm_provider.Provider_config.t) =
     | None -> caps
   in
   caps.supports_tools && caps.supports_tool_choice
+
+let provider_supports_callable_tool_use (cfg : Llm_provider.Provider_config.t) =
+  let registry = Llm_provider.Provider_registry.default () in
+  let provider_name =
+    Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+  in
+  let caps =
+    match Llm_provider.Provider_registry.find registry provider_name with
+    | Some entry -> entry.capabilities
+    | None -> Llm_provider.Capabilities.default_capabilities
+  in
+  caps.supports_tools
+  || (caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events)
 
 let direct_model_strings =
   [ "ollama:local-model"
@@ -53,10 +68,18 @@ let test_provider_filter_falls_back_to_unfiltered_when_no_match () =
     [ "ollama"; "openai_compat" ] (provider_kinds providers)
 
 let tool_required_model_strings =
-  [ "codex_cli:auto"
+  [ "custom:remote-model@http://127.0.0.1:18080/v1"
+  ; "codex_cli:auto"
   ; "gemini_cli:auto"
   ; "ollama:local-model"
-  ; "llama:qwen3.5-3b-a3b-ud-q8-xl"
+  ]
+
+let callable_tool_required_model_strings =
+  [ "custom:remote-model@http://127.0.0.1:18080/v1"
+  ; "claude_code:auto"
+  ; "codex_cli:auto"
+  ; "gemini_cli:auto"
+  ; "ollama:local-model"
   ]
 
 let test_required_tool_choice_filter_keeps_only_supported_providers () =
@@ -65,10 +88,12 @@ let test_required_tool_choice_filter_keeps_only_supported_providers () =
       ~require_tool_choice_support:true
       tool_required_model_strings
   in
-  check bool "tool-required path keeps at least one callable provider" true
-    (providers <> []);
   check bool "every surviving provider satisfies required tool-use capabilities" true
-    (List.for_all provider_supports_required_tool_use providers)
+    (List.for_all provider_supports_required_tool_use providers);
+  check bool "drops codex_cli without inline tool choice" false
+    (List.mem "codex_cli" (provider_kinds providers));
+  check bool "drops gemini_cli without inline tool choice" false
+    (List.mem "gemini_cli" (provider_kinds providers))
 
 let test_required_tool_choice_filter_can_exhaust_candidates () =
   let providers =
@@ -78,6 +103,19 @@ let test_required_tool_choice_filter_can_exhaust_candidates () =
   in
   check (list string) "unsupported-only candidate set becomes empty" []
     (provider_kind_models providers)
+
+let test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~require_tool_support:true
+      callable_tool_required_model_strings
+  in
+  check bool "tool-support path keeps at least one callable provider" true
+    (providers <> []);
+  check bool "every surviving provider supports inline or runtime MCP tools" true
+    (List.for_all provider_supports_callable_tool_use providers);
+  check bool "drops gemini_cli without runtime MCP lane" false
+    (List.mem "gemini_cli" (provider_kinds providers))
 
 let () =
   run "Cascade_runtime"
@@ -92,5 +130,8 @@ let () =
             test_required_tool_choice_filter_keeps_only_supported_providers;
           test_case "required tool choice can exhaust candidates" `Quick
             test_required_tool_choice_filter_can_exhaust_candidates;
+          test_case "required tool support keeps inline or runtime-capable providers"
+            `Quick
+            test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers;
         ] );
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -76,6 +76,23 @@ let make_noop_tool () =
     ~parameters:[]
     (fun _ -> Ok Oas.Types.{ content = "ok" })
 
+let make_named_noop_tool name =
+  Oas.Tool.create
+    ~name
+    ~description:"No-op test tool"
+    ~parameters:[]
+    (fun _ -> Ok Oas.Types.{ content = "ok" })
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let openai_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
@@ -874,6 +891,7 @@ let mock_completion_request () : Llm_provider.Llm_transport.completion_request =
         ();
     messages = [];
     tools = [];
+    runtime_mcp_policy = None;
   }
 
 let mock_api_response () : Oas.Types.api_response =
@@ -977,6 +995,68 @@ let make_codex_cli_provider_cfg ?(model_id = "codex") () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Codex_cli
     ~model_id ~base_url:"" ()
+
+let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id ~base_url:"http://127.0.0.1:18080/v1" ()
+
+let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, Some policy) ->
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "allowed tool names preserve public MCP set"
+        [ "masc_status"; "masc_tasks" ] policy.allowed_tool_names;
+      Alcotest.(check (list string)) "allowed server names"
+        [ "masc" ] policy.allowed_server_names;
+      Alcotest.(check (list string)) "runtime server name"
+        [ "masc" ]
+        (List.map Llm_provider.Llm_transport.runtime_mcp_server_name policy.servers);
+      Alcotest.(check bool) "strict runtime policy" true policy.strict;
+      Alcotest.(check bool) "builtins disabled" true policy.disable_builtin_tools
+  | Ok (_, None) ->
+      Alcotest.fail "expected codex_cli public MCP tools to use runtime MCP lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_openai_compat_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, None) ->
+      Alcotest.(check int) "inline lane keeps requested tools"
+        (List.length tools) (List.length effective_tools)
+  | Ok (_, Some _) ->
+      Alcotest.fail "expected openai_compat public tools to stay on inline lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_codex_cli_internal_tools_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_board_get" ]
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected codex_cli to reject keeper-internal tools without inline tool support"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
+      Alcotest.(check string) "field" "tool_support" field
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
@@ -2202,6 +2282,12 @@ let () =
         test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback;
       Alcotest.test_case "codex preflight scales retry limit for argv overflow" `Quick
         test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow;
+      Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
+        test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
+      Alcotest.test_case "public MCP tools on openai_compat stay inline" `Quick
+        test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools;
+      Alcotest.test_case "keeper-internal tools on codex_cli are rejected" `Quick
+        test_resolve_tool_lane_for_codex_cli_internal_tools_rejects;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## What changed
Route public `masc_*` tools through the new runtime MCP lane for supported CLI providers.

- resolve tool execution lane per provider instead of assuming inline tool support
- build request-scoped runtime MCP policy for the public MASC HTTP server and public tool allowlist
- keep internal `keeper_*` tools on the inline bridge path only
- extend cascade provider filtering with `require_tool_support` so runtime-MCP-capable providers remain eligible
- fix provider capability lookup so CLI provider kinds are not flattened into the wrong capability family
- add worker and cascade tests covering Codex CLI runtime MCP selection and inline/runtime filtering behavior

## Why
Public MASC tools and internal keeper tools have different execution contracts. CLI providers need the public MCP surface, while internal keeper tools still require the inline bridge.

## Impact
`claude_code` and `codex_cli` can now use public `masc_*` tools through OAS request-scoped MCP wiring, while unsupported combinations fail cleanly.

## Validation
- `env OCAMLPATH=/Users/dancer/me/.local-oas/lib dune build --root .`
- `env OCAMLPATH=/Users/dancer/me/.local-oas/lib dune exec --root . ./test/test_cascade_runtime.exe`
- `env OCAMLPATH=/Users/dancer/me/.local-oas/lib dune exec --root . ./test/test_oas_worker.exe`

## Notes
`masc_mcp.opam` had an unrelated local version bump and was intentionally left out of this PR.