### PR TITLE
[codex] Follow up runtime cascade snapshot gate after #9200

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -152,6 +152,13 @@ let normalize_declared_name (raw : string) : string =
   | None when trimmed = "" -> default_name
   | None -> trimmed
 
+let normalize_declared_name (raw : string) : string =
+  let trimmed = String.trim raw in
+  match of_string_opt trimmed with
+  | Some t -> to_string t
+  | None when trimmed = "" -> default_name
+  | None -> trimmed
+
 let models_key_t t = to_string t ^ "_models"
 let temperature_key_t t = to_string t ^ "_temperature"
 let max_tokens_key_t t = to_string t ^ "_max_tokens"

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -108,6 +108,17 @@ val normalize_declared_name : string -> string
     This lets runtime-authoritative catalogs accept dynamic profile names
     without using the compile-time variant inventory as the source of truth. *)
 
+val normalize_declared_name : string -> string
+(** Normalizes only the keeper-side implicit default and legacy aliases.
+
+    Semantics:
+    - blank/whitespace -> {!default_name}
+    - known legacy alias -> canonical known name
+    - unknown nonblank name -> preserved (trimmed)
+
+    This lets runtime-authoritative catalogs accept dynamic profile names
+    without using the compile-time variant inventory as the source of truth. *)
+
 (** {1 cascade.json key helpers} *)
 
 val models_key_t : t -> string


### PR DESCRIPTION
## Summary
- preserve validated runtime snapshot as the only dashboard-visible cascade catalog after #9200
- keep TopK rerank provider selection behind the validated runtime catalog gate
- retain typed SDK compatibility fixes needed after latest main drift

## Why
- #9200 merged while the branch was being rebased onto newer main commits
- after replaying the merge against current main, 12 files still differed in behavior from main
- the remaining delta is not merge noise: it restores runtime-authoritative snapshot behavior and related keeper/dashboard guards

## Validation
- dune build --root . @install
- dune exec --root . ./test/test_cascade_catalog_runtime.exe
- dune exec --root . ./test/test_dashboard_cascade.exe
- dune exec --root . ./test/test_keeper_runtime_config_ssot.exe
- dune exec --root . ./test/test_oas_worker.exe
- dune exec --root . ./test/test_keeper_topk_llm.exe
- dune exec --root . ./test/test_keeper_unified.exe

Refs #7872
Follow-up to #9200