### PR TITLE
refactor(types): delegate scattered task_status match to canonical helpers

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -17,12 +17,7 @@ let task_is_linked_to_goal (task : Types.task) goal_id =
   with Not_found -> false
 
 let task_assignee (task : Types.task) : string option =
-  match task.task_status with
-  | Types.Claimed { assignee; _ } -> Some assignee
-  | Types.InProgress { assignee; _ } -> Some assignee
-  | Types.AwaitingVerification { assignee; _ } -> Some assignee
-  | Types.Done { assignee; _ } -> Some assignee
-  | Types.Todo | Types.Cancelled _ -> None
+  Types.task_assignee_of_status task.task_status
 
 let task_status_label (task : Types.task) : string =
   match task.task_status with
@@ -34,10 +29,7 @@ let task_status_label (task : Types.task) : string =
   | Types.Cancelled _ -> "cancelled"
 
 let task_is_terminal (task : Types.task) : bool =
-  match task.task_status with
-  | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _
-  | Types.AwaitingVerification _ -> false
+  Types.task_status_is_terminal task.task_status
 
 let task_is_done (task : Types.task) : bool =
   match task.task_status with

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -49,14 +49,9 @@ let task_matches_goal ~goal_id (task : Types.task) =
     done;
     !found
 
-(** A task is in a terminal state (completed or cancelled). *)
 let is_terminal (task : Types.task) =
-  match task.task_status with
-  | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _
-  | Types.AwaitingVerification _ -> false
+  Types.task_status_is_terminal task.task_status
 
-(** A task counts as completed (not merely cancelled). *)
 let is_completed (task : Types.task) =
   match task.task_status with
   | Types.Done _ -> true

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -380,14 +380,10 @@ let social_edges_json ~limit sources =
 (* ================================================================ *)
 
 let active_task_count tasks =
-  tasks
-  |> List.fold_left
-       (fun acc (task : Types.task) ->
-         match task.task_status with
-         | Types.Done _ | Types.Cancelled _ -> acc
-         | Types.Todo | Types.Claimed _ | Types.InProgress _
-         | Types.AwaitingVerification _ -> acc + 1)
-       0
+  List.length (List.filter
+    (fun (task : Types.task) ->
+       not (Types.task_status_is_terminal task.task_status))
+    tasks)
 
 let stagnation_score ~active_agents ~active_tasks ~idle_signal_count
     ~heartbeat_count ~blocker_count =

--- a/lib/room_protocol.ml
+++ b/lib/room_protocol.ml
@@ -41,12 +41,7 @@ let tasks ?status_filter ?(include_done = false) ?(include_cancelled = false)
              | `Active -> true))
 
 let task_assignee (task : Types.task) =
-  match task.task_status with
-  | Claimed { assignee; _ }
-  | InProgress { assignee; _ }
-  | Done { assignee; _ } ->
-      Some assignee
-  | _ -> None
+  Types.task_assignee_of_status task.task_status
 
 let agents ?status_filter config =
   let agents =

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -99,15 +99,8 @@ let set_tempo (config : Coord_utils.config) ~interval_s ~reason : tempo_state =
 let get_tempo (config : Coord_utils.config) : tempo_state =
   load_state config
 
-(** Check if task is pending (not done/cancelled) *)
 let is_pending_task (task : Types.task) : bool =
-  match task.task_status with
-  | Types.Todo -> true
-  | Types.Claimed _ -> true
-  | Types.InProgress _ -> true
-  | Types.AwaitingVerification _ -> true
-  | Types.Done _ -> false
-  | Types.Cancelled _ -> false
+  not (Types.task_status_is_terminal task.task_status)
 
 (** Calculate adaptive tempo based on task urgency *)
 let calculate_adaptive_tempo (tasks : Types.task list) : float * string =


### PR DESCRIPTION
## Summary
- Delegate 5 files' inline task_status match patterns to canonical helpers from #9209
- 38 lines removed, 9 added — net 29-line reduction in scattered match duplication

## Files changed
| File | Before | After |
|------|--------|-------|
| dashboard/dashboard_goals.ml | 7-line match for assignee + 5-line match for terminal | Delegation via Types.* |
| meta_cognition_snapshot.ml | active_task_count fold_left with inline status check | not (Types.task_status_is_terminal ...) |
| goal/convergence.ml | is_terminal 6-case match | Delegation; is_completed kept (no canonical is_done) |
| tempo.ml | is_pending_task 6-case inverse match | not (Types.task_status_is_terminal ...) |
| room_protocol.ml | task_assignee 5-line match | Delegation via Types.task_assignee_of_status |

## Design notes
- is_completed in convergence.ml kept as direct match (no canonical task_status_is_done yet)
- is_terminal_task in room_protocol.ml returns polymorphic variant, different semantics from bool, not replaced
- Follows Alexis King Parse dont validate: variant-derived logic lives next to type definition

## Test plan
- [x] dune build --root . passes
- [ ] CI green (awaiting)

Depends on: #9209 (canonical helper extraction, already merged)
