### PR TITLE
refactor(types): add task_status_is_done canonical helper

### DIFF
--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -214,7 +214,7 @@ let gc config ?(days=7) () =
   let stale_count = ref 0 in
   let archived_tasks = ref [] in
   let kept_tasks = List.filter (fun task ->
-    let is_done = match task.task_status with Done _ -> true | _ -> false in
+    let is_done = Types.task_status_is_done task.task_status in
     let is_old = task.created_at < cutoff_iso in
     if is_old && not is_done then begin
       incr stale_count;
@@ -244,9 +244,8 @@ let gc config ?(days=7) () =
   (* Get open task IDs (not Done or Cancelled) *)
   let open_task_ids =
     List.filter_map (fun task ->
-      match task.task_status with
-      | Done _ | Cancelled _ -> None
-      | _ -> Some task.id
+      if Types.task_status_is_terminal task.task_status then None
+      else Some task.id
     ) backlog.tasks
   in
 

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -34,16 +34,10 @@ let task_status_label (task : Types.task) : string =
   | Types.Cancelled _ -> "cancelled"
 
 let task_is_terminal (task : Types.task) : bool =
-  match task.task_status with
-  | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _
-  | Types.AwaitingVerification _ -> false
+  Types.task_status_is_terminal task.task_status
 
 let task_is_done (task : Types.task) : bool =
-  match task.task_status with
-  | Types.Done _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _
-  | Types.AwaitingVerification _ | Types.Cancelled _ -> false
+  Types.task_status_is_done task.task_status
 
 let compute_convergence (goal : Goal_store.goal) linked_tasks children =
   (* Convergence = weighted average of own task completion + child convergence.

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -51,16 +51,11 @@ let task_matches_goal ~goal_id (task : Types.task) =
 
 (** A task is in a terminal state (completed or cancelled). *)
 let is_terminal (task : Types.task) =
-  match task.task_status with
-  | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _
-  | Types.AwaitingVerification _ -> false
+  Types.task_status_is_terminal task.task_status
 
 (** A task counts as completed (not merely cancelled). *)
 let is_completed (task : Types.task) =
-  match task.task_status with
-  | Types.Done _ -> true
-  | _ -> false
+  Types.task_status_is_done task.task_status
 
 let check_convergence ~goal_id ~tasks ?(stagnation_threshold = 5)
     ~iterations_without_progress () =

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -390,6 +390,13 @@ let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
   | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
 
+(** Completed state: [Done]. Distinct from [task_status_is_terminal] which
+    also includes [Cancelled]. Use this when only successful completion
+    matters (e.g. convergence ratios, reputation counting). *)
+let task_status_is_done = function
+  | Done _ -> true
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+
 (** Issue #8354: schema enums for [task_status] used to be hand-rolled in
     [tool_shard.ml] and [mcp_server.ml], dropping [awaiting_verification].
     [task_status] carries record payloads so we cannot enumerate dummy


### PR DESCRIPTION
## Summary
- Add `Types.task_status_is_done` canonical helper (distinct from `task_status_is_terminal` which also includes Cancelled)
- Delegate 3 files' hand-rolled `Done _ -> true | _ -> false` patterns to canonical helpers
- 4 files changed, +14/-19 lines

## Files changed
| File | Change |
|------|--------|
| `types/types_core.ml` | Add `task_status_is_done` with doc comment |
| `coord/coord_gc.ml` | `is_done` + `is_terminal` filter → delegation |
| `goal/convergence.ml` | `is_completed` + `is_terminal` → delegation |
| `dashboard/dashboard_goals.ml` | `task_is_done` + `task_is_terminal` → delegation |

## Why separate from is_terminal
`is_terminal = Done | Cancelled` counts abandonment as terminal. `is_done = Done only` counts only successful completion. Different semantics for:
- Convergence ratios (done vs total, not cancelled vs total)
- Reputation scoring (completed tasks should count, cancelled should not)
- GC stale detection (done tasks should be kept, cancelled reaped differently)

## Test plan
- [x] dune build passes for affected compilation units
- [ ] CI full build (pre-existing OAS pin errors in main are unrelated)
- [x] Exhaustive match: new constructor would force compiler errors at all 4 sites
