### PR TITLE
[codex] route public masc tools through the runtime MCP lane

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -250,7 +250,10 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
 
 let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   let registry = Llm_provider.Provider_registry.default () in
-  let provider_name = Provider_adapter.string_of_provider_kind cfg.kind in
+  (* Use the exact OAS provider kind name here. Provider_adapter collapses
+     CLI kinds onto shared canonical families ("gemini", "codex"), which
+     makes Gemini_cli incorrectly inherit direct-API capabilities. *)
+  let provider_name = Llm_provider.Provider_config.string_of_provider_kind cfg.kind in
   let caps =
     match Llm_provider.Provider_registry.find registry provider_name with
     | Some entry -> entry.capabilities
@@ -260,14 +263,24 @@ let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   | Some supports_tool_choice -> { caps with supports_tool_choice }
   | None -> caps
 
-let apply_required_tool_choice_filter ~require_tool_choice_support ~label
+let apply_required_tool_choice_filter ~require_tool_choice_support
+    ~require_tool_support ~label
     (providers : Llm_provider.Provider_config.t list) =
-  if not require_tool_choice_support then
+  if not require_tool_choice_support && not require_tool_support then
     providers
   else
     let supports_required_tool_use cfg =
       let caps = provider_capabilities_of_config cfg in
-      caps.supports_tools && caps.supports_tool_choice
+      let inline_tools = caps.supports_tools in
+      let inline_tool_choice = inline_tools && caps.supports_tool_choice in
+      let runtime_mcp =
+        caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events
+      in
+      match require_tool_choice_support, require_tool_support with
+      | true, true -> inline_tool_choice || runtime_mcp
+      | true, false -> inline_tool_choice
+      | false, true -> inline_tools || runtime_mcp
+      | false, false -> true
     in
     let filtered = List.filter supports_required_tool_use providers in
     if filtered = [] && providers <> [] then
@@ -305,6 +318,7 @@ let models_of_cascade_name (cascade_name : string) : string list =
 
 let resolve_providers_from_model_strings ?provider_filter
     ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
     (model_strings : string list)
     : Llm_provider.Provider_config.t list =
   let specs = Cascade_config.parse_model_strings model_strings in
@@ -314,6 +328,7 @@ let resolve_providers_from_model_strings ?provider_filter
       ~label:"direct_model_strings"
       specs
     |> apply_required_tool_choice_filter ~require_tool_choice_support
+         ~require_tool_support
          ~label:"direct_model_strings"
   in
   if filtered <> [] then filtered
@@ -323,17 +338,29 @@ let resolve_providers_from_model_strings ?provider_filter
     [])
 
 let resolve_named_providers_result ?provider_filter
-    ?(require_tool_choice_support = false) ~cascade_name ()
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ~cascade_name ()
     : (Llm_provider.Provider_config.t list, string) result =
-  Cascade_catalog_runtime.resolve_named_providers ?provider_filter
-    ~require_tool_choice_support ~cascade_name ()
+  let label = Keeper_cascade_profile.normalize_declared_name cascade_name in
+  match
+    Cascade_catalog_runtime.resolve_named_providers ?provider_filter
+      ~require_tool_choice_support:false ~cascade_name ()
+  with
+  | Error _ as e -> e
+  | Ok providers ->
+      Ok
+        (apply_required_tool_choice_filter ~require_tool_choice_support
+           ~require_tool_support ~label providers)
 
 let resolve_named_providers ?provider_filter
-    ?(require_tool_choice_support = false) ~cascade_name ()
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ~cascade_name ()
     : Llm_provider.Provider_config.t list =
   match
     resolve_named_providers_result ?provider_filter
-      ~require_tool_choice_support ~cascade_name ()
+      ~require_tool_choice_support ~require_tool_support ~cascade_name ()
   with
   | Ok providers -> providers
   | Error detail ->

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -36,12 +36,15 @@ val models_of_cascade_name : string -> string list
 val resolve_named_providers_result :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   cascade_name:string -> unit -> (Llm_provider.Provider_config.t list, string) result
 val resolve_named_providers :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   cascade_name:string -> unit -> Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   string list -> Llm_provider.Provider_config.t list

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -83,6 +83,7 @@ val run_named :
   goal:string ->
   ?provider_filter:string list ->
   ?require_tool_choice_support:bool ->
+  ?require_tool_support:bool ->
   ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -154,7 +154,7 @@ let reset_cascade_counters_for_test () =
     Uses OAS provider resolution so endpoint-distinct providers such as
     [glm] and [glm-coding] remain distinguishable. *)
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  Llm_provider.Provider_registry.provider_name_of_config cfg
+  Llm_provider.Provider_config.string_of_provider_kind cfg.kind
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   Provider_adapter.display_provider_name (provider_name_of_config cfg)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -23,6 +23,8 @@ type config = {
   priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Oas.Tool.t list;
+  runtime_mcp_policy :
+    Llm_provider.Llm_transport.runtime_mcp_policy option;
   max_turns : int;
   max_idle_turns : int;
   max_tokens : int;
@@ -69,6 +71,7 @@ let default_config
   let provider = Oas.Provider.config_of_provider_config provider_cfg in
   { name; provider_cfg; provider; model_id = provider_cfg.model_id;
     priority = None; system_prompt; tools;
+    runtime_mcp_policy = None;
     max_turns = 20;
     max_idle_turns = 3;
     max_tokens = Oas_worker_cascade.default_max_tokens;
@@ -169,6 +172,115 @@ let cli_model_override model_id =
   match String.lowercase_ascii (String.trim model_id) with
   | "" | "auto" -> None
   | _ -> Some (String.trim model_id)
+
+let provider_caps_of_config (provider_cfg : Llm_provider.Provider_config.t) =
+  let base_caps =
+    match provider_cfg.kind with
+    | Llm_provider.Provider_config.Ollama ->
+        Llm_provider.Capabilities.ollama_capabilities
+    | Anthropic -> Llm_provider.Capabilities.anthropic_capabilities
+    | Glm -> Llm_provider.Capabilities.glm_capabilities
+    | Gemini -> Llm_provider.Capabilities.gemini_capabilities
+    | OpenAI_compat -> Llm_provider.Capabilities.openai_chat_capabilities
+    | Claude_code -> Llm_provider.Capabilities.claude_code_capabilities
+    | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
+    | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
+  in
+  let caps =
+    match provider_cfg.kind with
+    | Llm_provider.Provider_config.Claude_code
+    | Gemini_cli
+    | Codex_cli -> base_caps
+    | _ ->
+        (match Llm_provider.Capabilities.for_model_id provider_cfg.model_id with
+         | Some caps -> caps
+         | None -> base_caps)
+  in
+  match provider_cfg.supports_tool_choice_override with
+  | Some supports_tool_choice -> { caps with supports_tool_choice }
+  | None -> caps
+
+let provider_supports_inline_tools (provider_cfg : Llm_provider.Provider_config.t) =
+  (provider_caps_of_config provider_cfg).supports_tools
+
+let provider_supports_runtime_mcp_lane
+    (provider_cfg : Llm_provider.Provider_config.t) =
+  let caps = provider_caps_of_config provider_cfg in
+  caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events
+
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then
+        false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let public_mcp_tool_names_of_oas_tools (tools : Oas.Tool.t list) =
+  List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
+
+let tool_names_are_public_mcp (tool_names : string list) =
+  tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
+
+let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
+    Llm_provider.Llm_transport.runtime_mcp_policy option =
+  let tool_names = dedupe_preserve_order tool_names in
+  if not (tool_names_are_public_mcp tool_names) then
+    None
+  else
+    Some
+      {
+        Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+        servers =
+          [
+            Llm_provider.Llm_transport.Http_server
+              {
+                name = "masc";
+                url = Env_config_runtime.Local_runtime.mcp_url ();
+                headers = [];
+              };
+          ];
+        allowed_server_names = [ "masc" ];
+        allowed_tool_names = tool_names;
+        strict = true;
+        disable_builtin_tools = true;
+      }
+
+let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf "%s:%s"
+    (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
+    provider_cfg.model_id
+
+let resolve_tool_lane_for_oas_tools
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    ~(tools : Oas.Tool.t list)
+  : (Oas.Tool.t list
+     * Llm_provider.Llm_transport.runtime_mcp_policy option,
+     Oas.Error.sdk_error)
+    result =
+  let tool_names = public_mcp_tool_names_of_oas_tools tools in
+  match public_mcp_runtime_policy_of_tool_names tool_names with
+  | Some runtime_mcp_policy
+    when provider_supports_runtime_mcp_lane provider_cfg ->
+      Ok ([], Some runtime_mcp_policy)
+  | _ when tools = [] ->
+      Ok (tools, None)
+  | _ when provider_supports_inline_tools provider_cfg ->
+      Ok (tools, None)
+  | _ ->
+      let detail =
+        if tool_names_are_public_mcp tool_names then
+          Printf.sprintf
+            "%s does not support inline tools or request-scoped runtime MCP tools"
+            (provider_label provider_cfg)
+        else
+          Printf.sprintf "%s does not support inline tools"
+            (provider_label provider_cfg)
+      in
+      Error (invalid_runtime_config "tool_support" detail)
 
 (** Wrap CLI transports in a per-call sub-switch.
 
@@ -382,6 +494,11 @@ let build
     | None -> builder
   in
   let builder =
+    match config.runtime_mcp_policy with
+    | Some policy -> Oas.Builder.with_runtime_mcp_policy policy builder
+    | None -> builder
+  in
+  let builder =
     if config.cache_system_prompt then
       Oas.Builder.with_cache_system_prompt true builder
     else builder
@@ -575,6 +692,7 @@ let resume_from_checkpoint
     description = config.description;
     approval = config.approval;
     slot_id = config.slot_id;
+    runtime_mcp_policy = config.runtime_mcp_policy;
     summarizer = config.summarizer;
     priority = config.priority;
   } in
@@ -795,12 +913,32 @@ let run_with_masc_tools
     ?on_resume
     (goal : string)
   : (run_result, Oas.Error.sdk_error) result =
-  let oas_tools = List.map (fun (td : Types.tool_schema) ->
-    Tool_bridge.oas_tool_of_masc
-      ~name:td.name
-      ~description:td.description
-      ~input_schema:td.input_schema
-      (fun input -> dispatch ~name:td.name ~args:input)
-  ) masc_tools in
-  let config = { config with tools = oas_tools @ config.tools } in
-  run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  match
+    public_mcp_runtime_policy_of_tool_names
+      (List.map (fun (td : Types.tool_schema) -> td.name) masc_tools)
+  with
+  | Some runtime_mcp_policy
+    when provider_supports_runtime_mcp_lane config.provider_cfg ->
+      let config = { config with runtime_mcp_policy = Some runtime_mcp_policy } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ when masc_tools = [] ->
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ when provider_supports_inline_tools config.provider_cfg ->
+      let oas_tools =
+        List.map
+          (fun (td : Types.tool_schema) ->
+            Tool_bridge.oas_tool_of_masc
+              ~name:td.name
+              ~description:td.description
+              ~input_schema:td.input_schema
+              (fun input -> dispatch ~name:td.name ~args:input))
+          masc_tools
+      in
+      let config = { config with tools = oas_tools @ config.tools } in
+      run ~sw ~net ~config ?on_event ?on_yield ?on_resume ?contract goal
+  | _ ->
+      Error
+        (invalid_runtime_config "tool_support"
+           (Printf.sprintf
+              "%s does not support inline tools or request-scoped runtime MCP tools"
+              (provider_label config.provider_cfg)))

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -55,17 +55,21 @@ let cascade_catalog_error_to_sdk_error detail =
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
 let resolve_cascade_providers ?provider_filter
-    ?(require_tool_choice_support = false) ~cascade_name () =
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    ~cascade_name () =
   Cascade_runtime.resolve_named_providers_result ?provider_filter
-    ~require_tool_choice_support ~cascade_name ()
+    ~require_tool_choice_support ~require_tool_support ~cascade_name ()
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
     resulting provider configs into OAS execution. *)
 let resolve_providers_from_model_strings ?provider_filter
-    ?(require_tool_choice_support = false) model_strings =
+    ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
+    model_strings =
   Cascade_runtime.resolve_providers_from_model_strings ?provider_filter
-    ~require_tool_choice_support model_strings
+    ~require_tool_choice_support ~require_tool_support model_strings
 
 type masc_internal_error =
   | Cascade_exhausted of {
@@ -429,6 +433,7 @@ let run_named
     ~goal
     ?provider_filter
     ?(require_tool_choice_support = false)
+    ?(require_tool_support = false)
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -489,11 +494,12 @@ let run_named
       ( Ok ms,
         Ok
           (resolve_providers_from_model_strings ?provider_filter
-             ~require_tool_choice_support ms) )
+             ~require_tool_choice_support ~require_tool_support ms) )
     | _ ->
       ( Cascade_runtime.models_of_cascade_name_result cascade_name,
         resolve_cascade_providers ?provider_filter
-          ~require_tool_choice_support ~cascade_name () )
+          ~require_tool_choice_support ~require_tool_support ~cascade_name ()
+      )
   in
   (match configured_labels_result, candidate_cfgs_result with
    | Error detail, _ | _, Error detail ->
@@ -517,7 +523,12 @@ let run_named
             Cascade_exhausted
               {
                 cascade_name;
-                detail = Some "no callable models available";
+                detail =
+                  Some
+                    (if require_tool_support then
+                       "no callable models support inline or runtime MCP tool use"
+                     else
+                       "no callable models available");
               }))
   | _ ->
   let transport_resolved = match transport with
@@ -536,49 +547,74 @@ let run_named
      and the agent's checkpoint (if progress was made). try_cascade
      threads this checkpoint to the next provider without mutable state. *)
   let try_provider ?resume_checkpoint (provider_cfg : Llm_provider.Provider_config.t) =
-    let config : Oas_worker_exec.config =
-      { (Oas_worker_exec.default_config ~name ~provider_cfg
-        ~system_prompt ~tools)
-      with
-        priority;
-        max_turns; max_tokens; max_input_tokens; max_cost_usd; temperature; max_idle_turns;
-        guardrails; hooks; context_reducer; memory; tool_retry_policy;
-        description = Some (Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id);
-        transport = transport_resolved;
-        allowed_paths;
-        checkpoint_sidecar;
-        session_id;
-        cache_system_prompt;
-        compact_ratio;
-        contract;
-        checkpoint_dir;
-        context_injector;
-        context;
-        slot_id;
-        enable_thinking;
-        event_bus;
-        approval;
-        exit_condition;
-        exit_condition_result;
-        summarizer;
-        initial_messages; raw_trace; yield_on_tool;
-      }
+    let config_result =
+      Oas_worker_exec.resolve_tool_lane_for_oas_tools ~provider_cfg ~tools
+      |> Result.map
+           (fun (effective_tools, runtime_mcp_policy) ->
+             {
+               (Oas_worker_exec.default_config ~name ~provider_cfg
+                  ~system_prompt ~tools:effective_tools)
+               with
+                 priority;
+                 max_turns;
+                 max_tokens;
+                 max_input_tokens;
+                 max_cost_usd;
+                 temperature;
+                 max_idle_turns;
+                 guardrails;
+                 hooks;
+                 context_reducer;
+                 memory;
+                 tool_retry_policy;
+                 description =
+                   Some
+                     (Printf.sprintf "cascade:%s/%s" cascade_name
+                        provider_cfg.model_id);
+                 transport = transport_resolved;
+                 allowed_paths;
+                 checkpoint_sidecar;
+                 session_id;
+                 cache_system_prompt;
+                 compact_ratio;
+                 contract;
+                 checkpoint_dir;
+                 context_injector;
+                 context;
+                 slot_id;
+                 enable_thinking;
+                 event_bus;
+                 approval;
+                 exit_condition;
+                 exit_condition_result;
+                 summarizer;
+                 initial_messages;
+                 raw_trace;
+                 yield_on_tool;
+                 runtime_mcp_policy;
+             })
     in
     let local_agent_ref : Oas.Agent.t option ref = ref None in
-    match
-      with_codex_cli_preflight
-        ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
-        ~config ~goal
-        (fun () ->
-          let effective_checkpoint = match resume_checkpoint with
-            | Some _ -> resume_checkpoint
-            | None -> oas_checkpoint
-          in
-          let result =
-            Oas_worker_exec.run ~sw ~net ~config ?oas_checkpoint:effective_checkpoint ?on_event
-              ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref ?contract goal
-          in
-          Ok result)
+    match config_result with
+    | Error err ->
+      (Error err, None)
+    | Ok config ->
+      match
+        with_codex_cli_preflight
+          ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
+          ~config ~goal
+          (fun () ->
+            let effective_checkpoint = match resume_checkpoint with
+              | Some _ -> resume_checkpoint
+              | None -> oas_checkpoint
+            in
+            let result =
+              Oas_worker_exec.run ~sw ~net ~config
+                ?oas_checkpoint:effective_checkpoint ?on_event
+                ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
+                ?contract goal
+            in
+            Ok result)
     with
     | Error err ->
       (Error err, None)
@@ -1056,6 +1092,7 @@ let run_named_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
+    ~require_tool_support:(masc_tools <> [])
     ~max_turns ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
     ?wait_timeout_sec ?guardrails ?hooks ?memory
     ?tool_retry_policy

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,14 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.164.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
+<<<<<<< HEAD
 readonly OAS_AGENT_SDK_SHA="3dabe7a88bc549b164a455f478396e53e9202ff9"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.164.0"
+||||||| parent of ca0aea311 (fix duplicate oas pin declaration)
+readonly OAS_AGENT_SDK_TRACK_REF="main"
+readonly OAS_AGENT_SDK_SHA="0358649897de3420fba2044cdccb47390f8655ab"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.163.0"
+=======
+readonly OAS_AGENT_SDK_SHA="0358649897de3420fba2044cdccb47390f8655ab"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.163.0"
+>>>>>>> ca0aea311 (fix duplicate oas pin declaration)

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,14 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.164.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-<<<<<<< HEAD
 readonly OAS_AGENT_SDK_SHA="3dabe7a88bc549b164a455f478396e53e9202ff9"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.164.0"
-||||||| parent of ca0aea311 (fix duplicate oas pin declaration)
-readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="0358649897de3420fba2044cdccb47390f8655ab"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.163.0"
-=======
-readonly OAS_AGENT_SDK_SHA="0358649897de3420fba2044cdccb47390f8655ab"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.163.0"
->>>>>>> ca0aea311 (fix duplicate oas pin declaration)

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -16,7 +16,9 @@ let provider_kind_models providers =
 
 let provider_supports_required_tool_use (cfg : Llm_provider.Provider_config.t) =
   let registry = Llm_provider.Provider_registry.default () in
-  let provider_name = Masc_mcp.Provider_adapter.string_of_provider_kind cfg.kind in
+  let provider_name =
+    Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+  in
   let caps =
     match Llm_provider.Provider_registry.find registry provider_name with
     | Some entry -> entry.capabilities
@@ -28,6 +30,19 @@ let provider_supports_required_tool_use (cfg : Llm_provider.Provider_config.t) =
     | None -> caps
   in
   caps.supports_tools && caps.supports_tool_choice
+
+let provider_supports_callable_tool_use (cfg : Llm_provider.Provider_config.t) =
+  let registry = Llm_provider.Provider_registry.default () in
+  let provider_name =
+    Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+  in
+  let caps =
+    match Llm_provider.Provider_registry.find registry provider_name with
+    | Some entry -> entry.capabilities
+    | None -> Llm_provider.Capabilities.default_capabilities
+  in
+  caps.supports_tools
+  || (caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events)
 
 let direct_model_strings =
   [ "ollama:local-model"
@@ -53,10 +68,18 @@ let test_provider_filter_falls_back_to_unfiltered_when_no_match () =
     [ "ollama"; "openai_compat" ] (provider_kinds providers)
 
 let tool_required_model_strings =
-  [ "codex_cli:auto"
+  [ "custom:remote-model@http://127.0.0.1:18080/v1"
+  ; "codex_cli:auto"
   ; "gemini_cli:auto"
   ; "ollama:local-model"
-  ; "llama:qwen3.5-3b-a3b-ud-q8-xl"
+  ]
+
+let callable_tool_required_model_strings =
+  [ "custom:remote-model@http://127.0.0.1:18080/v1"
+  ; "claude_code:auto"
+  ; "codex_cli:auto"
+  ; "gemini_cli:auto"
+  ; "ollama:local-model"
   ]
 
 let test_required_tool_choice_filter_keeps_only_supported_providers () =
@@ -65,10 +88,12 @@ let test_required_tool_choice_filter_keeps_only_supported_providers () =
       ~require_tool_choice_support:true
       tool_required_model_strings
   in
-  check bool "tool-required path keeps at least one callable provider" true
-    (providers <> []);
   check bool "every surviving provider satisfies required tool-use capabilities" true
-    (List.for_all provider_supports_required_tool_use providers)
+    (List.for_all provider_supports_required_tool_use providers);
+  check bool "drops codex_cli without inline tool choice" false
+    (List.mem "codex_cli" (provider_kinds providers));
+  check bool "drops gemini_cli without inline tool choice" false
+    (List.mem "gemini_cli" (provider_kinds providers))
 
 let test_required_tool_choice_filter_can_exhaust_candidates () =
   let providers =
@@ -78,6 +103,19 @@ let test_required_tool_choice_filter_can_exhaust_candidates () =
   in
   check (list string) "unsupported-only candidate set becomes empty" []
     (provider_kind_models providers)
+
+let test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~require_tool_support:true
+      callable_tool_required_model_strings
+  in
+  check bool "tool-support path keeps at least one callable provider" true
+    (providers <> []);
+  check bool "every surviving provider supports inline or runtime MCP tools" true
+    (List.for_all provider_supports_callable_tool_use providers);
+  check bool "drops gemini_cli without runtime MCP lane" false
+    (List.mem "gemini_cli" (provider_kinds providers))
 
 let () =
   run "Cascade_runtime"
@@ -92,5 +130,8 @@ let () =
             test_required_tool_choice_filter_keeps_only_supported_providers;
           test_case "required tool choice can exhaust candidates" `Quick
             test_required_tool_choice_filter_can_exhaust_candidates;
+          test_case "required tool support keeps inline or runtime-capable providers"
+            `Quick
+            test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers;
         ] );
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -76,6 +76,23 @@ let make_noop_tool () =
     ~parameters:[]
     (fun _ -> Ok Oas.Types.{ content = "ok" })
 
+let make_named_noop_tool name =
+  Oas.Tool.create
+    ~name
+    ~description:"No-op test tool"
+    ~parameters:[]
+    (fun _ -> Ok Oas.Types.{ content = "ok" })
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let openai_text_response ?(id = "chatcmpl-1") text =
   Printf.sprintf
     {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}|}
@@ -1010,6 +1027,68 @@ let make_codex_cli_provider_cfg ?(model_id = "codex") () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Codex_cli
     ~model_id ~base_url:"" ()
+
+let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id ~base_url:"http://127.0.0.1:18080/v1" ()
+
+let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, Some policy) ->
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "allowed tool names preserve public MCP set"
+        [ "masc_status"; "masc_tasks" ] policy.allowed_tool_names;
+      Alcotest.(check (list string)) "allowed server names"
+        [ "masc" ] policy.allowed_server_names;
+      Alcotest.(check (list string)) "runtime server name"
+        [ "masc" ]
+        (List.map Llm_provider.Llm_transport.runtime_mcp_server_name policy.servers);
+      Alcotest.(check bool) "strict runtime policy" true policy.strict;
+      Alcotest.(check bool) "builtins disabled" true policy.disable_builtin_tools
+  | Ok (_, None) ->
+      Alcotest.fail "expected codex_cli public MCP tools to use runtime MCP lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_openai_compat_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, None) ->
+      Alcotest.(check int) "inline lane keeps requested tools"
+        (List.length tools) (List.length effective_tools)
+  | Ok (_, Some _) ->
+      Alcotest.fail "expected openai_compat public tools to stay on inline lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_codex_cli_internal_tools_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_board_get" ]
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected codex_cli to reject keeper-internal tools without inline tool support"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
+      Alcotest.(check string) "field" "tool_support" field
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
@@ -2241,6 +2320,12 @@ let () =
         test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback;
       Alcotest.test_case "codex preflight scales retry limit for argv overflow" `Quick
         test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow;
+      Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
+        test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
+      Alcotest.test_case "public MCP tools on openai_compat stay inline" `Quick
+        test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools;
+      Alcotest.test_case "keeper-internal tools on codex_cli are rejected" `Quick
+        test_resolve_tool_lane_for_codex_cli_internal_tools_rejects;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## Summary
- route public  tools for CLI providers through the runtime MCP lane
- keep keeper-internal tools on the inline lane and preserve structured OAS tool events
- bump the pinned OAS SDK metadata to merged main 

## Validation
- 
- Testing `Cascade_runtime'.
This run has ID `PCTSRAM2'.

  [OK]          provider_filter          0   applies direct model string filter.
  [OK]          provider_filter          1   falls back when filter matches n...
  [OK]          provider_filter          2   required tool choice keeps only ...
  [OK]          provider_filter          3   required tool choice can exhaust...
  [OK]          provider_filter          4   required tool support keeps inli...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/Cascade_runtime'.
Test Successful in 0.003s. 5 tests run.
- Testing `OAS Worker'.
This run has ID `VBVF6B1W'.

  [OK]          sse_event_bridge                      0   text delta extraction.
  [OK]          sse_event_bridge                      1   non-text events ign...
  [OK]          sse_event_bridge                      2   mixed event stream.
  [OK]          sse_event_bridge                      3   empty text deltas t...
  [OK]          sse_event_bridge                      4   SSE error event ign...
  [OK]          cascade_config                        0   keeper_turn default...
  [OK]          cascade_config                        1   heartbeat default m...
  [OK]          cascade_config                        2   local_only defaults...
  [OK]          cascade_config                        3   unknown cascade fal...
  [OK]          cascade_config                        4   default_config_path.
  [OK]          cascade_config                        5   all cascade names p...
  [OK]          cascade_config                        6   cascade inference n...
  [OK]          cascade_config                        7   cascade observation...
  [OK]          cascade_config                        8   cascade metrics con...
  [OK]          cascade_config                        9   cascade metrics evi...
  [OK]          cascade_config                       10   cascade audit persi...
  [OK]          resume_config                         0   checkpoint model wins.
  [OK]          resume_config                         1   meta model fallback.
  [OK]          resume_config                         2   oas_worker default ...
  [OK]          resume_config                         3   oas_worker opt-in a...
  [OK]          resume_config                         4   oas_worker default ...
  [OK]          resume_config                         5   oas_worker applies ...
  [OK]          resume_config                         6   resume propagates a...
  [OK]          resume_config                         7   resume propagates s...
  [OK]          resume_config                         8   resume propagates s...
  [OK]          resume_config                         9   resume propagates p...
  [OK]          resume_config                        10   CLI transports rele...
  [OK]          resume_config                        11   invalid explicit mo...
  [OK]          resume_config                        12   run_model_with_masc...
  [OK]          resume_config                        13   structured MASC int...
  [OK]          resume_config                        14   codex preflight use...
  [OK]          resume_config                        15   codex preflight sca...
  [OK]          resume_config                        16   public MCP tools on...
  [OK]          resume_config                        17   public MCP tools on...
  [OK]          resume_config                        18   keeper-internal too...
  [OK]          resume_config                        19   worker build_agent ...
  [OK]          resume_config                        20   resume config propa...
  [OK]          resume_config                        21   worker build_agent ...
  [OK]          resume_config                        22   worker build_agent ...
  [OK]          resume_config                        23   exit_condition_resu...
  [OK]          keeper_checkpoint_boundary            0   prefers OAS checkpo...
  [OK]          keeper_checkpoint_boundary            1   legacy fallback sti...
  [OK]          keeper_checkpoint_boundary            2   legacy checkpoint r...
  [OK]          keeper_checkpoint_boundary            3   legacy old tool mes...
  [OK]          keeper_checkpoint_boundary            4   OAS handoff rollove...
  [OK]          keeper_checkpoint_boundary            5   OAS handoff rollove...
  [OK]          keeper_checkpoint_boundary            6   overflow retry fall...
  [OK]          keeper_checkpoint_boundary            7   overflow retry skip...
  [OK]          keeper_checkpoint_boundary            8   overflow retry requ...
  [OK]          keeper_checkpoint_boundary            9   overflow retry save...
  [OK]          keeper_checkpoint_store               0   OAS store roundtrip.
  [OK]          keeper_checkpoint_store               1   OAS store writes hi...
  [OK]          keeper_checkpoint_store               2   OAS store missing r...
  [OK]          keeper_checkpoint_store               3   prefers OAS checkpo...
  [OK]          keeper_checkpoint_store               4   legacy fallback sti...
  [OK]          keeper_checkpoint_store               5   legacy checkpoint r...
  [OK]          keeper_checkpoint_store               6   legacy old tool mes...
  [OK]          keeper_checkpoint_store               7   prefers newer legac...
  [OK]          keeper_checkpoint_store               8   OAS handoff rollove...
  [OK]          keeper_checkpoint_store               9   OAS handoff rollove...
  [OK]          keeper_checkpoint_continuity          0   same-trace multi-tu...
  [OK]          keeper_checkpoint_continuity          1   restart continuity ...
  [OK]          idle_detail_enrichment                0   idle error with too...
  [OK]          idle_detail_enrichment                1   idle error with no ...
  [OK]          idle_detail_enrichment                2   idle error with emp...
  [OK]          idle_detail_enrichment                3   non-idle error is n...
  [OK]          idle_detail_enrichment                4   last tool name wins...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/OAS Worker'.
Test Successful in 1.536s. 67 tests run.
- Testing `Keeper Cycle'.
This run has ID `WN1I07T5'.

  [OK]          world_observation                0   defaults.
  [OK]          world_observation                1   with mentions.
  [OK]          world_observation                2   uses precollected board ...
  [OK]          world_observation                3   keeps non-mention board ...
  [OK]          world_observation                4   keeps external replies a...
  [OK]          world_observation                5   scheduled turn uses cool...
  [OK]          world_observation                6   scheduled turn skips wit...
  [OK]          world_observation                7   scheduled turn respects ...
  [OK]          world_observation                8   scheduled turn requires ...
  [OK]          world_observation                9   idle decay: no decay wit...
  [OK]          world_observation               10   idle decay: at boundary.
  [OK]          world_observation               11   idle decay: first decay.
  [OK]          world_observation               12   idle decay: second decay.
  [OK]          world_observation               13   idle decay: floor.
  [OK]          world_observation               14   idle decay: max_int.
  [OK]          world_observation               15   noop backoff: doubles co...
  [OK]          world_observation               16   noop backoff: quadruples...
  [OK]          world_observation               17   noop backoff: caps at 8x.
  [OK]          world_observation               18   noop backoff: zero noops...
  [OK]          world_observation               19   idle decay: triggers turn.
  [OK]          world_observation               20   scheduled decision uses ...
  [OK]          world_observation               21   verdict reasons use stru...
  [OK]          world_observation               22   verdict reasons use stru...
  [OK]          world_observation               23   paused keeper blocks turns.
  [OK]          world_observation               24   pending approval blocks ...
  [OK]          world_observation               25   task reactive cooldown f...
  [OK]          world_observation               26   with goals.
  [OK]          world_observation               27   economic modes.
  [OK]          unified_prompt                   0   contains identity.
  [OK]          unified_prompt                   1   contains goal.
  [OK]          unified_prompt                   2   mentions extend_turns gu...
  [OK]          unified_prompt                   3   includes operational too...
  [OK]          unified_prompt                   4   distinguishes sandbox an...
  [OK]          unified_prompt                   5   world prompt distinguish...
  [OK]          unified_prompt                   6   prefers submit over lega...
  [OK]          unified_prompt                   7   includes autonomous trig...
  [OK]          unified_prompt                   8   omits autonomous trigger...
  [OK]          unified_prompt                   9   omits empty sections.
  [OK]          unified_prompt                  10   continuity drops inert i...
  [OK]          unified_prompt                  11   includes mentions.
  [OK]          unified_prompt                  12   includes board activity.
  [OK]          unified_prompt                  13   includes goals.
  [OK]          unified_prompt                  14   includes context ratio.
  [OK]          unified_prompt                  15   includes idle.
  [OK]          unified_prompt                  16   frugal economy.
  [OK]          unified_prompt                  17   hustle economy.
  [OK]          unified_prompt                  18   includes worktree delta.
  [OK]          unified_prompt                  19   room state section.
  [OK]          unified_prompt                  20   claim first guidance.
  [OK]          unified_prompt                  21   claim first guidance omi...
  [OK]          unified_prompt                  22   claim first guidance omi...
  [OK]          unified_prompt                  23   claim first guidance omi...
  [OK]          unified_prompt                  24   work discovery nudge use...
  [OK]          unified_prompt                  25   prefers silence guidance.
  [OK]          unified_prompt                  26   sanitize_text_utf8 repla...
  [OK]          unified_prompt                  27   prompt sanitizes control...
  [OK]          unified_prompt                  28   sanitize_messages_utf8 c...
  [OK]          unified_prompt                  29   sanitize_messages_utf8 r...
  [OK]          metacognition                    0   on_idle nudge at first i...
  [OK]          metacognition                    1   on_idle final warning be...
  [OK]          metacognition                    2   on_idle skip at repeated...
  [OK]          metacognition                    3   on_idle skip with custom...
  [OK]          metacognition                    4   recent tool streak count...
  [OK]          metacognition                    5   recent tool streak ignor...
  [OK]          config                           0   default social model.
  [OK]          config                           1   unified runtime defaults.
  [OK]          metrics_observation              0   prompt metrics fingerprint.
  [OK]          metrics_observation              1   text response.
  [OK]          metrics_observation              2   surface model prefers su...
  [OK]          metrics_observation              3   tool response.
  [OK]          metrics_observation              4   noop response.
  [OK]          metrics_observation              5   validated evidence count...
  [OK]          metrics_observation              6   failed validation does n...
  [OK]          metrics_observation              7   file write evidence coun...
  [OK]          metrics_observation              8   heartbeat-only tool resp...
  [OK]          metrics_observation              9   reactive turn leaves pro...
  [OK]          metrics_observation             10   silent proactive cycle a...
  [OK]          metrics_observation             11   reactive failure leaves ...
  [OK]          metrics_observation             12   legacy migration does no...
  [OK]          metrics_observation             13   snapshot includes cascad...
  [OK]          metrics_observation             14   snapshot treats validate...
  [OK]          metrics_observation             15   social fields.
  [OK]          metrics_observation             16   failure response.
  [OK]          metrics_observation             17   mixed response.
  [OK]          metrics_observation             18   normalize passthrough.
  [OK]          metrics_observation             19   normalize tool only synt...
  [OK]          metrics_observation             20   normalize empty without ...
  [OK]          metrics_observation             21   completion contract allo...
  [OK]          metrics_observation             22   completion contract requ...
  [OK]          metrics_observation             23   completion contract acce...
  [OK]          metrics_observation             24   unexpected tool names ac...
  [OK]          metrics_observation             25   unexpected tool names re...
  [OK]          metrics_observation             26   completion contract mapp...
  [OK]          metrics_observation             27   completion contract mapp...
  [OK]          metrics_observation             28   run completion contract ...
  [OK]          metrics_observation             29   completion contract pres...
  [OK]          metrics_observation             30   tool usage delta uses re...
  [OK]          metrics_observation             31   tool usage delta ignores...
  [OK]          metrics_observation             32   merge observed and synth...
  [OK]          metrics_observation             33   tool query strips contin...
  [OK]          metrics_observation             34   tool query keeps counted...
  [OK]          metrics_observation             35   social model registry ro...
  [OK]          metrics_observation             36   social model silences sk...
  [OK]          metrics_observation             37   social model unknown met...
  [OK]          metrics_observation             38   social model unknown hea...
  [OK]          metrics_observation             39   social model infers visi...
  [OK]          metrics_observation             40   social model empty text ...
  [OK]          metrics_observation             41   social model state-only ...
  [OK]          metrics_observation             42   social model strips stat...
  [OK]          metrics_observation             43   social model routes bloc...
  [OK]          metrics_observation             44   social model tool-only t...
  [OK]          metrics_observation             45   social model restores pr...
  [OK]          metrics_observation             46   social model tool-only t...
  [OK]          metrics_observation             47   social model infers boar...
  [OK]          metrics_observation             48   magentic ledger silences...
  [OK]          metrics_observation             49   magentic ledger hides no...
  [OK]          metrics_observation             50   magentic ledger restores...
  [OK]          metrics_observation             51   social model previous st...
  [OK]          metrics_observation             52   magentic ledger stalled ...
  [OK]          metrics_observation             53   render_inline deny.
  [OK]          metrics_observation             54   render_inline cost.
  [OK]          metrics_observation             55   render_inline destructive.
  [OK]          metrics_observation             56   normalize override passt...
  [OK]          metrics_observation             57   escape edge cases.
  [OK]          metrics_observation             58   render_inline with repla...
  [OK]          transient_network_error          0   NetworkError detected.
  [OK]          transient_network_error          1   Timeout detected.
  [OK]          transient_network_error          2   Overloaded detected.
  [OK]          transient_network_error          3   ServerError 503 detected.
  [OK]          transient_network_error          4   ServerError 500 not tran...
  [OK]          transient_network_error          5   AuthError not transient.
  [OK]          transient_network_error          6   RateLimited not transient.
  [OK]          transient_network_error          7   ContextOverflow not tran...
  [OK]          transient_network_error          8   Internal error not trans...
  [OK]          transient_network_error          9   timeout after mutating t...
  [OK]          transient_network_error         10   reclassification require...
  [OK]          transient_network_error         11   read-only tool timeouts ...
  [OK]          transient_network_error         12   any post-commit error be...
  [OK]          transient_network_error         13   timeout classified as po...
  [OK]          transient_network_error         14   non-timeout classified a...
  [OK]          transient_network_error         15   ollama closing brace det...
  [OK]          transient_network_error         16   unterminated JSON detect...
  [OK]          transient_network_error         17   unexpected character in ...
  [OK]          transient_network_error         18   parse error detected.
  [OK]          transient_network_error         19   case insensitive detection.
  [OK]          transient_network_error         20   generic InvalidRequest i...
  [OK]          transient_network_error         21   generic 'closing' is NOT...
  [OK]          transient_network_error         22   generic 'can't find' is ...
  [OK]          transient_network_error         23   network error is NOT ser...
  [OK]          transient_network_error         24   auto-recoverable include...
  [OK]          transient_network_error         25   auto-recoverable include...
  [OK]          transient_network_error         26   required tool contract v...
  [OK]          transient_network_error         27   legacy internal contract...
  [OK]          transient_network_error         28   structured cascade exhau...
  [OK]          transient_network_error         29   legacy internal cascade ...
  [OK]          transient_network_error         30   auto-recoverable exclude...
  [OK]          transient_network_error         31   auto-recoverable exclude...
  [OK]          transient_network_error         32   bounded OAS timeout keep...
  [OK]          transient_network_error         33   bounded OAS timeout caps...
  [OK]          transient_network_error         34   bounded OAS timeout resp...
  [OK]          transient_network_error         35   bounded OAS timeout refu...
  [OK]          transient_network_error         36   pure local label detection.
  [OK]          transient_network_error         37   pure local context clamp.
  [OK]          transient_network_error         38   turn context budget uses...
  [OK]          transient_network_error         39   max_context resolution s...
  [OK]          transient_network_error         40   read-only keeper tools d...
  [OK]          transient_network_error         41   mixed tool sets only kee...
  [OK]          transient_network_error         42   overflow detection and l...
  [OK]          context_overflow                 0   parses common OAS overfl...
  [OK]          context_overflow                 1   is_context_overflow only...
  [OK]          context_overflow                 2   summarize_turn_event_bus...
  [OK]          context_overflow                 3   context_overflow_event p...
  [OK]          context_overflow                 4   context_overflow_event f...
  [OK]          phase_gate                       0   run_keeper_cycle skips p...
  [OK]          phase_gate                       1   run_keeper_cycle records...
  [OK]          phase_gate                       2   run_keeper_cycle surface...
  [OK]          phase_gate                       3   paused-state sync surfac...
  [OK]          phase_gate                       4   local discovery guard su...
  [OK]          tool_classification              0   keeper allowed tools exc...
  [OK]          verifier_role                    0   is_verifier_role_keeper ...
  [OK]          verifier_role                    1   is_verifier_role_keeper ...
  [OK]          verifier_role                    2   is_verifier_role_keeper ...
  [OK]          verifier_role                    3   is_verifier_role_keeper ...
  [OK]          verifier_role                    4   affordance: verifier see...
  [OK]          verifier_role                    5   affordance: non-verifier...
  [OK]          verifier_role                    6   affordance: no meta keep...
  [OK]          verifier_role                    7   trigger: non-verifier ga...
  [OK]          verifier_role                    8   trigger: verifier sees p...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/Keeper Cycle'.
Test Successful in 0.106s. 188 tests run.
- Testing `keeper_lifecycle'.
This run has ID `PCE6MSBK'.

  [OK]          post_turn_lifecycle          0   no checkpoint records skip s...
  [OK]          post_turn_lifecycle          1   restore prefers live primary...
  [OK]          post_turn_lifecycle          2   compaction persists checkpoi...
  [OK]          post_turn_lifecycle          3   skip compaction keeps checkp...
  [OK]          post_turn_lifecycle          4   handoff runs after compaction.
  [OK]          post_turn_lifecycle          5   handoff runs on current-turn...
  [OK]          post_turn_lifecycle          6   rollover aborts on save fail...
  [OK]          post_turn_lifecycle          7   overflow retry compacts OAS ...
  [OK]          post_turn_lifecycle          8   overflow retry falls back to...
  [OK]          post_turn_lifecycle          9   overflow retry history budge...
  [OK]          post_turn_lifecycle         10   overflow retry repairs orpha...
  [OK]          post_turn_lifecycle         11   rollover repairs orphan tool...
  [OK]          checkpoint_patch             0   persist_message drops world ...
  [OK]          checkpoint_patch             1   migrate_session_history_logs...
  [OK]          checkpoint_patch             2   save strips ephemeral world ...
  [OK]          checkpoint_patch             3   save caps oversized text.
  [OK]          checkpoint_patch             4   save caps oversized tool res...
  [OK]          checkpoint_patch             5   save caps aggregate tool res...
  [OK]          checkpoint_patch             6   save stubs old tool results.
  [OK]          checkpoint_patch             7   save repairs orphaned tool r...
  [OK]          checkpoint_patch             8   save strips summarized world...
  [OK]          checkpoint_patch             9   patch replaces last assistan...
  [OK]          checkpoint_patch            10   patch preserves non-assistan...
  [OK]          checkpoint_patch            11   patch updates session_id.
  [OK]          checkpoint_patch            12   patch with no assistant is n...
  [OK]          checkpoint_patch            13   patch strips ephemeral world...
  [OK]          checkpoint_patch            14   load migrates ephemeral worl...
  [OK]          checkpoint_patch            15   load migrates oversized text...
  [OK]          checkpoint_patch            16   load migrates summarized wor...
  [OK]          checkpoint_patch            17   load repairs orphaned tool r...
  [OK]          checkpoint_patch            18   deserialize repairs orphaned...
  [OK]          checkpoint_patch            19   deserialize preserves valid ...
  [OK]          checkpoint_patch            20   deserialize repairs dangling...
  [OK]          checkpoint_patch            21   load repairs dangling tool u...
  [OK]          compact_policy               0   ts=0.0 bypasses cooldown gate.
  [OK]          compact_policy               1   emergency ratio bypasses coo...
  [OK]          compact_policy               2   compaction records saved tok...
  [OK]          registry_dispatch            0   phase event uses room base_p...
  [OK]          registry_dispatch            1   post-turn lifecycle events u...
  [OK]          registry_dispatch            2   phase event rejection increm...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/keeper_lifecycle'.
Test Successful in 0.065s. 40 tests run.
- Testing `Keeper github read-only boundary'.
This run has ID `1PQ3TRNO'.

  [OK]          read_only_cmd           0   read-only cmd prefixes.
  [OK]          read_only_cmd           1   case insensitive.
  [OK]          read_only_cmd           2   prefixed gh command normalization.
  [OK]          read_only_args          0   read-only via args field.
  [OK]          read_only_args          1   cmd takes precedence over args.
  [OK]          mutating_cmds           0   mutating cmds not read-only.
  [OK]          gh_api                  0   api GET default is read-only.
  [OK]          gh_api                  1   api with -X method is mutating.
  [OK]          gh_api                  2   api with -f/-F is mutating.
  [OK]          gh_api                  3   api graphql is mutating.
  [OK]          edge_cases              0   empty input not read-only.
  [OK]          edge_cases              1   non-gh tool.
  [OK]          edge_cases              2   api via args.
  [OK]          edge_cases              3   input-aware mutation detection.
  [OK]          edge_cases              4   dangerous gh classifier.
  [OK]          edge_cases              5   tool observer via OAS event bus.
  [OK]          edge_cases              6   side-effect tracking via OAS even...
  [OK]          edge_cases              7   task claim mutating but boundary ...
  [OK]          edge_cases              8   masc_code_git write actions bypas...
  [OK]          edge_cases              9   keeper_bash still opens boundary.
  [OK]          edge_cases             10   masc_* coordination aliases bypas...
  [OK]          edge_cases             11   keeper_board_delete and cleanup b...
  [OK]          repo_context            0   current task worktree resolves re...
  [OK]          repo_context            1   missing worktree is structured er...
  [OK]          repo_context            2   non-github origin is structured e...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/Keeper github read-only boundary'.
Test Successful in 0.165s. 25 tests run.
- Testing `Masc_context_injector'.
This run has ID `F6L7QU1P'.

  [OK]          injector                  0   returns Some on success.
  [OK]          injector                  1   returns Some on error.
  [OK]          injector                  2   increments counts.
  [OK]          context                   0   populated after injection.
  [OK]          temporal_summary          0   empty context.
  [OK]          temporal_summary          1   populated context.
  [OK]          iso8601                   0   format.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/Masc_context_injector'.
Test Successful in 0.001s. 7 tests run.
- Testing `Keeper_adaptive_thinking'.
This run has ID `WCECIEO3'.

  [OK]          budget_logic          0   disabled.
  [OK]          budget_logic          1   error_or_retry.
  [OK]          budget_logic          2   complex_task.
  [OK]          budget_logic          3   fallback.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/Keeper_adaptive_thinking'.
Test Successful in 0.000s. 4 tests run.
- Testing `keeper_state_snapshot_json'.
This run has ID `ZINU1ZAS'.

  [OK]          round_trip                   0   full snapshot.
  [OK]          round_trip                   1   minimal snapshot.
  [OK]          round_trip                   2   empty -> None.
  [OK]          round_trip                   3   malformed -> None.
  [OK]          round_trip                   4   null -> None.
  [OK]          structured_envelope          0   envelope round-trip.
  [OK]          structured_envelope          1   wrong version -> None.
  [OK]          structured_envelope          2   missing version -> None.
  [OK]          structured_envelope          3   empty in envelope -> None.
  [OK]          patch_checkpoint             0   flag off preserves wc.
  [OK]          patch_checkpoint             1   flag on stores structured.
  [OK]          patch_checkpoint             2   flag on no [STATE] preserves.
  [OK]          dual_source                  0   text matches json.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/cli-mcp-parity/_build/_tests/keeper_state_snapshot_json'.
Test Successful in 0.001s. 13 tests run.
- OAS pin verified: main@0358649897de3420fba2044cdccb47390f8655ab (base version v0.163.0)
OAS API surface: ✓ matches fingerprint