### PR TITLE
[codex] fix cascade CLI quota cooldown and auto rotation

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -742,7 +742,9 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
   | Error _ as e -> e
   | Ok (_snapshot, normalized, profile) ->
       let providers =
-        Cascade_config.order_weighted_entries profile.weighted_entries
+        Cascade_config.order_weighted_entries
+          ~rotation_scope:normalized
+          profile.weighted_entries
         |> Cascade_config.parse_weighted_entries
              ~api_key_env_overrides:profile.api_key_env_overrides
              ~cascade_name:normalized

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -263,39 +263,67 @@ let parse_weighted_entry_diag
     cascade through concrete CLI model overrides instead of delegating to
     the CLI's interactive/default model picker. Other specs pass through
     as-is. *)
-let expand_auto_model_string (s : string) : string list =
+let rotate_list_by offset items =
+  if offset <= 0 then items
+  else
+    let rec split i acc = function
+      | xs when i <= 0 -> (List.rev acc, xs)
+      | [] -> (List.rev acc, [])
+      | x :: rest -> split (i - 1) (x :: acc) rest
+    in
+    let head, tail = split offset [] items in
+    tail @ head
+
+let maybe_rotate_auto_models ?rotation_scope ~spec models =
+  match rotation_scope, models with
+  | Some scope, _ :: _ :: _ ->
+    let cursor =
+      Cascade_state.rotate_round_robin
+        ~cascade:(Printf.sprintf "auto-expand:%s:%s"
+                    scope (String.lowercase_ascii spec))
+        ~bound:(List.length models)
+    in
+    rotate_list_by cursor models
+  | _ -> models
+
+let expand_provider_auto ?rotation_scope ~spec provider models =
+  maybe_rotate_auto_models ?rotation_scope ~spec models
+  |> List.map (fun model -> provider ^ ":" ^ model)
+
+let expand_auto_model_string ?rotation_scope (s : string) : string list =
   let trimmed = String.trim s in
   match split_provider_model trimmed with
   | Some ("glm", model_id)
     when String.lowercase_ascii model_id = "auto" ->
-    Cascade_model_resolve.glm_auto_models ()
-    |> List.map (fun m -> "glm:" ^ m)
+    expand_provider_auto ?rotation_scope ~spec:trimmed "glm"
+      (Cascade_model_resolve.glm_auto_models ())
   | Some ("glm-coding", model_id)
     when String.lowercase_ascii model_id = "auto" ->
-    Cascade_model_resolve.glm_coding_auto_models ()
-    |> List.map (fun m -> "glm-coding:" ^ m)
+    expand_provider_auto ?rotation_scope ~spec:trimmed "glm-coding"
+      (Cascade_model_resolve.glm_coding_auto_models ())
   | Some ("gemini_cli", model_id)
     when String.lowercase_ascii model_id = "auto" ->
-    Cascade_model_resolve.gemini_cli_auto_models ()
-    |> List.map (fun m -> "gemini_cli:" ^ m)
+    expand_provider_auto ?rotation_scope ~spec:trimmed "gemini_cli"
+      (Cascade_model_resolve.gemini_cli_auto_models ())
   | Some ("codex_cli", model_id)
     when String.lowercase_ascii model_id = "auto" ->
-    Cascade_model_resolve.codex_cli_auto_models ()
-    |> List.map (fun m -> "codex_cli:" ^ m)
+    expand_provider_auto ?rotation_scope ~spec:trimmed "codex_cli"
+      (Cascade_model_resolve.codex_cli_auto_models ())
   | Some ("claude_code", model_id)
     when String.lowercase_ascii model_id = "auto" ->
-    Cascade_model_resolve.claude_code_auto_models ()
-    |> List.map (fun m -> "claude_code:" ^ m)
+    expand_provider_auto ?rotation_scope ~spec:trimmed "claude_code"
+      (Cascade_model_resolve.claude_code_auto_models ())
   | _ -> [ trimmed ]
 
 let expand_auto_models (strs : string list) : string list =
   List.concat_map expand_auto_model_string strs
 
 let expand_weighted_auto_entries
+    ?rotation_scope
     (entries : Cascade_config_loader.weighted_entry list) =
   List.concat_map
     (fun (entry : Cascade_config_loader.weighted_entry) ->
-       expand_auto_model_string entry.model
+       expand_auto_model_string ?rotation_scope entry.model
        |> List.map (fun model -> { entry with model }))
     entries
 
@@ -533,8 +561,9 @@ let weighted_shuffle
 
 let order_weighted_entries
     ?(rand_int = weighted_random_int)
+    ?rotation_scope
     (entries : Cascade_config_loader.weighted_entry list) =
-  let entries = expand_weighted_auto_entries entries in
+  let entries = expand_weighted_auto_entries ?rotation_scope entries in
   let has_weights = List.exists
       (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
       entries
@@ -758,9 +787,9 @@ let dedupe_stable (items : string list) =
   in
   loop [] [] items
 
-let expand_model_strings_for_execution (items : string list) =
+let expand_model_strings_for_execution ?rotation_scope (items : string list) =
   items
-  |> List.concat_map expand_auto_model_string
+  |> List.concat_map (expand_auto_model_string ?rotation_scope)
   |> dedupe_stable
 
 (* Filter providers by kind name (exact, case-insensitive).

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -99,12 +99,17 @@ val parse_weighted_entries :
 
 val order_weighted_entries :
   ?rand_int:(int -> int) ->
+  ?rotation_scope:string ->
   Cascade_config_loader.weighted_entry list ->
   Cascade_config_loader.weighted_entry list
 (** Order weighted entries using the same health-adjusted runtime logic as
     {!resolve_model_strings}. Exposed so runtime-authoritative catalog
     snapshots can preserve dynamic health ordering without rereading raw
-    [cascade.json]. *)
+    [cascade.json].
+
+    When [rotation_scope] is provided, each [provider:auto] expansion is
+    round-robined independently within that scope before the usual
+    weight/health ordering is applied. *)
 
 (** Like {!parse_model_string} but returns a [Result] with a diagnostic
     error message explaining why parsing failed (unknown provider, missing
@@ -184,14 +189,21 @@ val resolve_model_strings :
 
     Uses the same provider:auto expansion as {!expand_auto_models}, so
     CLI and GLM family entries execute in the same concrete order the
-    dashboard shows.
+    dashboard shows by default.
+
+    When [rotation_scope] is provided, each [provider:auto] entry is
+    rotated independently within that scope so repeated execution calls
+    do not always start from the same concrete model.
 
     Duplicate entries are removed after expansion, keeping the first
     appearance. This lets callers keep config concise while still
     getting automatic provider-internal failover at execution time.
 
     @since 0.116.2 *)
-val expand_model_strings_for_execution : string list -> string list
+val expand_model_strings_for_execution :
+  ?rotation_scope:string ->
+  string list ->
+  string list
 
 (** Like {!resolve_model_strings} but also returns which resolution
     path was taken. Use this to detect typos: if [source <> Named]

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -382,6 +382,36 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
       (Llm_provider.Http_client.AcceptRejected { reason }))
   | _ -> None
 
+let cli_wrapped_hard_quota_indicators = [
+  "terminalquotaerror";
+  "quota_exhausted";
+  "exhausted your capacity on this model";
+  "quota will reset after";
+]
+
+let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
+  List.exists
+    (String_util.contains_substring_ci message)
+    cli_wrapped_hard_quota_indicators
+
+let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
+  match err with
+  | Oas.Error.Api api_err ->
+    Llm_provider.Retry.is_hard_quota api_err
+    ||
+    (match api_err with
+     | Llm_provider.Retry.NetworkError { message }
+     | Llm_provider.Retry.Overloaded { message }
+     | Llm_provider.Retry.ServerError { message; _ } ->
+       message_looks_like_cli_wrapped_hard_quota message
+     | Llm_provider.Retry.RateLimited _
+     | Llm_provider.Retry.AuthError _
+     | Llm_provider.Retry.InvalidRequest _
+     | Llm_provider.Retry.ContextOverflow _
+     | Llm_provider.Retry.Timeout _ ->
+       false)
+  | _ -> false
+
 (** Run a single Agent.run() call with MASC-driven cascade model fallback.
 
     MASC drives the cascade FSM directly:
@@ -688,11 +718,10 @@ let run_named
            ([hard_quota_cooldown_sec], default 1h) so weighted_random
            re-selection doesn't waste cascade turns on a provider that
            is terminally unavailable. *)
-        (match sdk_err with
-         | Oas.Error.Api api_err when Llm_provider.Retry.is_hard_quota api_err ->
-           Cascade_health_tracker.(record_hard_quota global ~provider_key:provider_cfg.model_id)
-         | _ ->
-           Cascade_health_tracker.(record_failure global ~provider_key:provider_cfg.model_id));
+        if sdk_error_is_hard_quota sdk_err then
+          Cascade_health_tracker.(record_hard_quota global ~provider_key:provider_cfg.model_id)
+        else
+          Cascade_health_tracker.(record_failure global ~provider_key:provider_cfg.model_id);
         (* FSM: Call_err → decide *)
         (match sdk_error_to_cascade_outcome sdk_err with
          | Some outcome ->

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -10,6 +10,7 @@
 open Alcotest
 module R = Masc_mcp.Cascade_model_resolve
 module C = Masc_mcp.Cascade_config
+module State = Masc_mcp.Cascade_state
 
 let unset_env k =
   try Unix.putenv k "" with _ -> ()
@@ -158,6 +159,75 @@ let test_expand_model_strings_for_execution_matches_auto_expansion () =
       (C.expand_auto_models items)
       (C.expand_model_strings_for_execution items))
 
+let test_expand_model_strings_for_execution_rotation_scope_rotates () =
+  with_clean_env (fun () ->
+    State.clear_all ();
+    let first =
+      C.expand_model_strings_for_execution
+        ~rotation_scope:"keeper_unified"
+        [ "gemini_cli:auto" ]
+    in
+    let second =
+      C.expand_model_strings_for_execution
+        ~rotation_scope:"keeper_unified"
+        [ "gemini_cli:auto" ]
+    in
+    let other_scope =
+      C.expand_model_strings_for_execution
+        ~rotation_scope:"tool_rerank"
+        [ "gemini_cli:auto" ]
+    in
+    check string "first scoped call starts at default head"
+      "gemini_cli:gemini-3-flash-preview"
+      (List.hd first);
+    check string "second scoped call advances head"
+      "gemini_cli:gemini-3.1-flash-lite-preview"
+      (List.hd second);
+    check string "different scope has its own cursor"
+      "gemini_cli:gemini-3-flash-preview"
+      (List.hd other_scope))
+
+let test_order_weighted_entries_rotation_scope_rotates_generically () =
+  with_clean_env (fun () ->
+    State.clear_all ();
+    let entry model =
+      {
+        Masc_mcp.Cascade_config_loader.model = model;
+        weight = 1;
+        supports_tool_choice = None;
+      }
+    in
+    let first =
+      C.order_weighted_entries
+        ~rotation_scope:"keeper_unified"
+        [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    let second =
+      C.order_weighted_entries
+        ~rotation_scope:"keeper_unified"
+        [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    let other_scope =
+      C.order_weighted_entries
+        ~rotation_scope:"tool_rerank"
+        [ entry "codex_cli:auto" ]
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    check string "weighted first call keeps default head"
+      "codex_cli:gpt-5.1-codex-mini"
+      (List.hd first);
+    check string "weighted second call advances head"
+      "codex_cli:gpt-5.1-codex-max"
+      (List.hd second);
+    check string "weighted rotation is scoped"
+      "codex_cli:gpt-5.1-codex-mini"
+      (List.hd other_scope))
+
 let () =
   run "Cascade_model_resolve" [
     "gemini auto", [
@@ -183,5 +253,9 @@ let () =
         `Quick test_expand_auto_models_includes_cli_auto_specs;
       test_case "execution expansion matches auto expansion"
         `Quick test_expand_model_strings_for_execution_matches_auto_expansion;
+      test_case "execution expansion can rotate by scope"
+        `Quick test_expand_model_strings_for_execution_rotation_scope_rotates;
+      test_case "weighted ordering rotates auto by scope"
+        `Quick test_order_weighted_entries_rotation_scope_rotates_generically;
     ];
   ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -572,6 +572,38 @@ let test_cascade_audit_persists_observation () =
       | _ ->
           Alcotest.fail "expected one cascade audit record")
 
+let test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.NetworkError
+         {
+           message =
+             "gemini exited with code 1: TerminalQuotaError: You have exhausted \
+              your capacity on this model. Your quota will reset after 4h41m7s. \
+              reason=QUOTA_EXHAUSTED";
+         })
+  in
+  Alcotest.(check bool) "Gemini CLI quota wrapper counts as hard quota" true
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
+let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.NetworkError
+         { message = "gemini exited with code 1: connection reset by peer" })
+  in
+  Alcotest.(check bool) "transient network error stays transient" false
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
+let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.RateLimited
+         { retry_after = None; message = "resource exhausted" })
+  in
+  Alcotest.(check bool) "existing RateLimited hard quota still works" true
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
 let make_worker_meta ?(effective_model = "local-qwen") () :
     Worker_container_types.worker_container_meta =
   {
@@ -2168,6 +2200,12 @@ let () =
         test_cascade_metrics_evicts_lowest_call_key;
       Alcotest.test_case "cascade audit persists observation" `Quick
         test_cascade_audit_persists_observation;
+      Alcotest.test_case "sdk_error_is_hard_quota detects Gemini CLI wrapper" `Quick
+        test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper;
+      Alcotest.test_case "sdk_error_is_hard_quota keeps transient network errors false" `Quick
+        test_sdk_error_is_hard_quota_keeps_transient_network_errors_false;
+      Alcotest.test_case "sdk_error_is_hard_quota preserves RateLimited detection" `Quick
+        test_sdk_error_is_hard_quota_preserves_rate_limited_detection;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick


### PR DESCRIPTION
## Summary
- classify CLI-wrapped quota exhaustion as hard quota so exhausted models get long cooldown instead of immediate reselection
- rotate `provider:auto` expansions per named cascade scope during execution instead of always starting from the same first concrete model
- add regression tests for CLI hard quota detection and scoped auto-model rotation

## Root cause
- Gemini CLI quota exhaustion surfaced as a wrapped `NetworkError` (`TerminalQuotaError` / `QUOTA_EXHAUSTED`), so the hard-quota cooldown path was skipped
- named cascades expanding `*:auto` always started from a fixed head candidate, so repeated turns kept biasing the same model

## Impact
- cascades back off exhausted CLI-backed models more intelligently
- auto-model cascades spread attempts across candidates without provider-specific hardcoding

## Validation
- `git diff --check`
- attempted targeted `dune` execution with an isolated build dir, but the repo is currently blocked by pre-existing compile errors in `lib/tool_bridge.ml:88` and `lib/worker_dev_tools.ml:1218`
