### PR TITLE
[codex] fail open routed local_only when ollama is unavailable

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -131,6 +131,55 @@ let ensure_local_discovery_ready
              (String.concat ", " labels)
              (Printexc.to_string exn))
 
+let fail_open_local_only_when_unavailable
+    ?resolve_label
+    ?probe_ollama_base_url
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    (labels : string list) : string =
+  let resolve_label =
+    match resolve_label with
+    | Some resolve_label -> resolve_label
+    | None -> fun label -> Cascade_config.parse_model_string label
+  in
+  let normalized_base =
+    Keeper_cascade_profile.normalize_declared_name base_cascade
+  in
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name effective_cascade
+  in
+  if not (String.equal normalized_effective Keeper_config.local_only_cascade_name)
+     || String.equal normalized_base Keeper_config.local_only_cascade_name
+  then normalized_effective
+  else
+    let ollama_urls =
+      labels
+      |> List.filter_map resolve_label
+      |> List.filter_map (fun (cfg : Llm_provider.Provider_config.t) ->
+             if Cascade_ollama_probe.is_ollama_url cfg.base_url then
+               Some cfg.base_url
+             else None)
+      |> dedupe_keep_order
+    in
+    match ollama_urls with
+    | [] -> normalized_effective
+    | _ ->
+      let probe_ollama_base_url =
+        match probe_ollama_base_url with
+        | Some probe -> Some probe
+        | None ->
+          (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+           | Some sw, Some net ->
+             Some (fun base_url ->
+               Option.is_some (Cascade_ollama_probe.try_probe ~sw ~net base_url))
+           | _ -> None)
+      in
+      (match probe_ollama_base_url with
+       | None -> normalized_effective
+       | Some probe ->
+         if List.exists probe ollama_urls then normalized_effective
+         else normalized_base)
+
 (** {1 Retry & Side-Effect Safety}
 
     @boundary-contract
@@ -1649,9 +1698,23 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         let routing = Keeper_cascade_routing.select_cascade
           ~base_cascade:meta.cascade_name ~phase
         in
+        let routed_meta = { meta with cascade_name = routing.effective_cascade } in
+        let routed_labels =
+          Keeper_model_labels.configured_model_labels_of_meta routed_meta
+        in
+        let resolved_cascade =
+          fail_open_local_only_when_unavailable
+            ~base_cascade:meta.cascade_name
+            ~effective_cascade:routing.effective_cascade
+            routed_labels
+        in
         Log.Keeper.debug "%s: cascade routing: %s -> %s (reason: %s)"
           meta.name meta.cascade_name routing.effective_cascade routing.reason;
-        routing.effective_cascade
+        if not (String.equal resolved_cascade routing.effective_cascade) then
+          Log.Keeper.warn
+            "%s: local_only unavailable for labels [%s]; falling back to base cascade %s"
+            meta.name (String.concat ", " routed_labels) resolved_cascade;
+        resolved_cascade
       in
       (* 1. Check API keys *)
       let meta_for_cascade = { meta with cascade_name = effective_cascade_name } in

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -205,6 +205,18 @@ val ensure_local_discovery_ready :
   string list ->
   (unit, string) result
 
+(** When phase routing temporarily forces [local_only], fail open to the
+    keeper's configured base cascade if the local Ollama endpoint is
+    unavailable. Explicit [local_only] keepers are preserved. Exposed for
+    targeted tests. *)
+val fail_open_local_only_when_unavailable :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  ?probe_ollama_base_url:(string -> bool) ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  string list ->
+  string
+
 val run_keeper_cycle :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1897,6 +1897,37 @@ let test_ensure_local_discovery_ready_surfaces_refresh_failure () =
       check int "refresh called once" 1 !refresh_calls;
       check bool "error includes label" true
         (contains_substring msg "llama:auto")
+
+let test_fail_open_local_only_when_probe_fails () =
+  let cascade =
+    UT.fail_open_local_only_when_unavailable
+      ~probe_ollama_base_url:(fun _ -> false)
+      ~base_cascade:"keeper_unified"
+      ~effective_cascade:"local_only"
+      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
+  in
+  check string "falls back to base cascade" "keeper_unified" cascade
+
+let test_fail_open_local_only_preserves_explicit_local_only_base () =
+  let cascade =
+    UT.fail_open_local_only_when_unavailable
+      ~probe_ollama_base_url:(fun _ -> false)
+      ~base_cascade:"local_only"
+      ~effective_cascade:"local_only"
+      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
+  in
+  check string "explicit local_only stays local_only" "local_only" cascade
+
+let test_fail_open_local_only_preserves_healthy_local_only () =
+  let cascade =
+    UT.fail_open_local_only_when_unavailable
+      ~probe_ollama_base_url:(fun _ -> true)
+      ~base_cascade:"keeper_unified"
+      ~effective_cascade:"local_only"
+      [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
+  in
+  check string "healthy ollama keeps local_only" "local_only" cascade
+
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
 let test_context_overflow_limit_parses_common_oas_errors () =
@@ -3802,6 +3833,12 @@ let () =
             test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry;
           test_case "local discovery guard surfaces refresh failure" `Quick
             test_ensure_local_discovery_ready_surfaces_refresh_failure;
+          test_case "local_only fail-open falls back when ollama is down" `Quick
+            test_fail_open_local_only_when_probe_fails;
+          test_case "explicit local_only does not fail-open" `Quick
+            test_fail_open_local_only_preserves_explicit_local_only_base;
+          test_case "healthy local_only stays selected" `Quick
+            test_fail_open_local_only_preserves_healthy_local_only;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## What changed
- add a keeper-side fail-open guard for phase-routed `local_only`
- if `local_only` was selected only as a temporary routing override and the local Ollama endpoint is unavailable, fall back to the keeper's configured base cascade
- preserve explicit `local_only` keepers and preserve healthy local Ollama routing
- add focused unit coverage for the fallback and preservation cases

## Why
A keeper could be phase-routed into `local_only` during compacting / handoff style phases. When Ollama was not running, the effective cascade had only one local candidate, so the turn died immediately on `127.0.0.1:11434` connection refusal instead of returning to the keeper's normal cascade.

## Impact
- temporary `local_only` routing is now fail-open instead of fail-stop when Ollama is down
- keepers explicitly configured to use `local_only` are unchanged
- healthy local routing is unchanged

## Validation
- added targeted tests in `test/test_keeper_unified.ml`
- attempted local rebuild with:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-glm-coding-plan-cascade test/test_keeper_unified.exe`
- current full rebuild is blocked by unrelated existing drift:
  - `lib/worker_dev_tools.ml`: missing record field `error_class`
  - `lib/tool_bridge.ml`: missing record field `error_class`
