### PR TITLE
[codex] match OAS tool error shape in tests

### DIFF
--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -101,7 +101,7 @@ let test_to_oas_error_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   match B.to_oas_tool_result (false, "fail") with
   | Ok _ -> Alcotest.fail "expected Error"
-  | Error { message; recoverable } ->
+  | Error { message; recoverable; _ } ->
       Alcotest.(check string) "message" "fail" message;
       Alcotest.(check bool) "default recoverable=false" false recoverable
 


### PR DESCRIPTION
## What Changed
- updated `test_tool_bridge_externalize` to match the expanded OAS tool error record shape by ignoring the extra field in the error pattern

## Why
`masc-mcp` was built against a newer OAS surface where tool errors now carry an extra `error_class` field. After rebasing onto the latest `main`, most fixture updates were already present upstream, but this remaining test still matched the old 2-field record shape and broke the build.

## Impact
- restores compatibility with the current OAS type surface in `masc-mcp` tests
- no runtime behavior change; test-only fix

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-type-fixtures`
- `./_build/default/test/test_tool_bridge_externalize.exe`
- `git diff --check`
