### PR TITLE
[codex] restore agent_sdk compat on current oas pin

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -60,6 +60,9 @@ let worker_raw_trace_path ~base_path ~worker_name =
     (worker_container_dir ~base_path ~worker_name)
     "raw-trace.jsonl"
 
+let oas_tool_error ?(recoverable = false) message : Oas.Types.tool_result =
+  Error { Oas.Types.message; recoverable; error_class = None }
+
 let oas_trace_session_root ~base_path =
   Filename.concat (Filename.concat base_path ".masc") "oas-runtime"
 
@@ -349,17 +352,11 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name ~prompt:_
                    ~args
                with
                | Ok result when result.is_error ->
-                 Error
-                   {
-                     Oas.Types.message = result.text;
-                     recoverable = false;
-                     error_class = None;
-                   }
+                 oas_tool_error result.text
                | Ok result ->
                  Ok { Oas.Types.content = result.text }
                | Error e ->
-                 Error
-                   { Oas.Types.message = e; recoverable = false; error_class = None }
+                 oas_tool_error e
              in
              Oas.Mcp.mcp_tool_to_sdk_tool ~call_fn
                {

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -153,6 +153,7 @@ let reset_cascade_counters_for_test () =
 (** Map provider_kind to cascade-label prefix (e.g. "claude", "gemini").
     Uses OAS provider resolution so endpoint-distinct providers such as
     [glm] and [glm-coding] remain distinguishable. *)
+
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   Llm_provider.Provider_config.string_of_provider_kind cfg.kind
 

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -82,16 +82,13 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
 
 (** {1 Result Conversion} *)
 
+let make_tool_error ?(recoverable = false) message : Agent_sdk.Types.tool_result =
+  Error { Agent_sdk.Types.message; recoverable; error_class = None }
+
 let to_oas_tool_result ?(recoverable = false) (success, msg)
   : Agent_sdk.Types.tool_result =
   if success then Ok { Agent_sdk.Types.content = maybe_externalize msg }
-  else
-    Error
-      {
-        Agent_sdk.Types.message = maybe_externalize msg;
-        recoverable;
-        error_class = None;
-      }
+  else make_tool_error ~recoverable (maybe_externalize msg)
 
 let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
   | Ok { content } -> (true, content)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1422,7 +1422,8 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
                  | `Exited 0 ->
                    Ok { Agent_sdk.Types.content = output }
                  | `Exited code ->
-                   tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
+                   tool_error
+                     (Printf.sprintf "Exit code %d:\n%s" code output)
                  | `Signaled sig_num ->
                    tool_error
                      ~recoverable:(sig_num = Sys.sigterm)

--- a/test/test_keeper_adaptive_thinking.ml
+++ b/test/test_keeper_adaptive_thinking.ml
@@ -15,12 +15,7 @@ let test_adaptive_thinking_disabled () =
 
 let test_adaptive_thinking_error_or_retry () =
   let err_res : Agent_sdk.Types.tool_result =
-    Error
-      {
-        Agent_sdk.Types.message = "fail";
-        recoverable = true;
-        error_class = None;
-      }
+    Error { Agent_sdk.Types.message = "fail"; recoverable = true; error_class = None }
   in
   let result1 =
     Masc_mcp.Keeper_agent_run.adaptive_thinking_budget

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -598,13 +598,8 @@ let test_side_effect_tracking_via_event_bus () =
     (Agent_sdk.Event_bus.mk_event
        (Agent_sdk.Event_bus.ToolCompleted
           { agent_name = "keeper-a"; tool_name = "keeper_shell";
-            output =
-              Error
-                {
-                  Agent_sdk.Types.message = "boom";
-                  recoverable = false;
-                  error_class = None;
-                } }));
+            output = Error { Agent_sdk.Types.message = "boom";
+                             recoverable = false; error_class = None } }));
   let events = Agent_sdk.Event_bus.drain sub in
   Agent_sdk.Event_bus.unsubscribe bus sub;
   process events;

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -9,12 +9,7 @@ let ok_output content : Agent_sdk.Types.tool_result =
   Ok { Agent_sdk.Types.content }
 
 let err_output message : Agent_sdk.Types.tool_result =
-  Error
-    {
-      Agent_sdk.Types.message;
-      recoverable = true;
-      error_class = None;
-    }
+  Error { Agent_sdk.Types.message; recoverable = true; error_class = None }
 
 (* ── Unit tests: injector function ──────────────────── *)
 


### PR DESCRIPTION
## Summary
- restore error_class=None compat for tool-result error constructors used by the current pinned agent_sdk
- keep tool_bridge and local worker MCP error wrapping on the compat path instead of stale record layouts
- update affected keeper/context tests to match the current tool-result shape

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-glm-coding-plan-cascade test/test_keeper_unified.exe test/test_keeper_adaptive_thinking.exe test/test_keeper_github_read_only.exe test/test_masc_context_injector.exe
- ./_build/default/test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_adaptive_thinking.exe
- ./_build/default/test/test_keeper_github_read_only.exe
- ./_build/default/test/test_masc_context_injector.exe