### PR TITLE
[codex] degrade startup when cascade catalog validation fails

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -718,31 +718,40 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let state =
         create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
       in
-      let raise_catalog_validation_failure label rejection =
-        raise
-          (Invalid_argument
-             (Printf.sprintf
-                "%s: %s"
-                label
-                (Yojson.Safe.to_string
-                   (Cascade_catalog_runtime.rejection_to_yojson rejection))))
+      let format_catalog_validation_error label rejection =
+        Printf.sprintf
+          "%s: %s"
+          label
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
       in
-      (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-       | Ok (Cascade_catalog_runtime.Validated snapshot) ->
-           Log.Server.info
-             "Validated active cascade catalog: %s"
-             (Yojson.Safe.to_string
-                (Cascade_catalog_runtime.snapshot_to_yojson snapshot))
-       | Ok
-           (Cascade_catalog_runtime.Serving_last_known_good
-              { rejected_update; _ }) ->
-           raise_catalog_validation_failure
-             "startup rejected active cascade catalog"
-             rejected_update
-       | Error rejection ->
-           raise_catalog_validation_failure
-             "startup catalog validation failed"
-             rejection);
+      let catalog_validation_error =
+        match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+        | Ok (Cascade_catalog_runtime.Validated snapshot) ->
+            Log.Server.info
+              "Validated active cascade catalog: %s"
+              (Yojson.Safe.to_string
+                 (Cascade_catalog_runtime.snapshot_to_yojson snapshot));
+            None
+        | Ok
+            (Cascade_catalog_runtime.Serving_last_known_good
+               { rejected_update; _ }) ->
+            Some
+              (format_catalog_validation_error
+                 "startup rejected active cascade catalog"
+                 rejected_update)
+        | Error rejection ->
+            Some
+              (format_catalog_validation_error
+                 "startup catalog validation failed"
+                 rejection)
+      in
+      (match catalog_validation_error with
+       | Some detail ->
+           Log.Server.error
+             "Startup continuing in degraded mode because cascade catalog validation failed: %s"
+             detail
+       | None -> ());
       let t1 = Eio.Time.now clock in
       Log.Server.info "State created (PG pool) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
@@ -765,7 +774,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       Server_bootstrap_loops.install_tooling ~governance_level state;
       Log.Server.info "Tooling + schemas in %.1fs" (Eio.Time.now clock -. t2);
-      (state, path_diagnostics)
+      (state, path_diagnostics, catalog_validation_error)
     in
     let run_lazy_task (task_name, task_fn) =
       Log.Server.info "lazy_task: starting %s" task_name;
@@ -827,7 +836,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     in
     try
       Server_startup_state.mark_blocking ~backend_mode:initial_backend_mode;
-      let state, path_diagnostics = init_state_blocking () in
+      let state, path_diagnostics, catalog_validation_error =
+        init_state_blocking ()
+      in
       server_state := Some state;
       Server_startup_state.mark_state_ready
         ~backend_mode:(Coord.backend_name state.room_config);
@@ -1001,6 +1012,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
            Log.Dashboard.warn "shell cache pre-warm failed: %s"
              (Printexc.to_string exn)));
       start_lazy_startup state;
+      (match catalog_validation_error with
+       | Some detail -> Server_startup_state.mark_degraded ~error:detail
+       | None -> ());
       Server_bootstrap_loops.start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -355,6 +355,15 @@ let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
   in
   loop ()
 
+let write_invalid_local_only_cascade base_path =
+  let config_root = Filename.concat base_path ".masc/config" in
+  mkdir_p config_root;
+  write_file
+    (Filename.concat config_root "cascade.json")
+    {|{
+  "local_only_models": ["ollama:qwen3.6:35b-a3b-mlx-bf16"]
+}|}
+
 let stop_process pid =
   (try Unix.kill pid Sys.sigterm with _ -> ());
   ignore
@@ -1335,6 +1344,87 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
           Alcotest.(check bool) "canonical tool present" true
             (List.mem "masc_status" tool_names)))
 
+let test_main_eio_invalid_cascade_stays_degraded_but_serves_dashboard () =
+  with_temp_dir "startup-invalid-cascade" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_invalid_local_only_cascade dir;
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () -> stop_process pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "degraded") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio invalid cascade did not reach startup.phase=degraded within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir ~name:"health-invalid" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup = Yojson.Safe.Util.member "startup" health_json in
+          Alcotest.(check string) "startup phase degraded" "degraded"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check bool) "startup remains ready" true
+            Yojson.Safe.Util.(startup |> member "state_ready" |> to_bool);
+          let startup_error =
+            Yojson.Safe.Util.(startup |> member "last_error" |> to_string)
+          in
+          Alcotest.(check bool) "last error mentions catalog validation" true
+            (String.starts_with ~prefix:"startup catalog validation failed:" startup_error);
+          let config_headers, config_body =
+            curl_request_capture ~output_dir:dir ~name:"cascade-config-invalid"
+              ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/api/v1/cascade/config" port)
+              ()
+          in
+          Alcotest.(check (option int)) "cascade config http 200" (Some 200)
+            (http_status_from_headers config_headers);
+          let config_json = parse_json_response_file config_body in
+          Alcotest.(check string) "dashboard cascade surface is live"
+            (Filename.concat dir ".masc/config/cascade.json")
+            Yojson.Safe.Util.(
+              config_json |> member "config_path" |> to_string)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1453,5 +1543,9 @@ let () =
           Alcotest.test_case
             "main_eio fresh bootstrap and MCP handshake"
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
+          Alcotest.test_case
+            "main_eio invalid cascade stays degraded but serves dashboard"
+            `Slow
+            test_main_eio_invalid_cascade_stays_degraded_but_serves_dashboard;
         ] );
     ]


### PR DESCRIPTION
## Summary
- stop treating active cascade catalog validation failures as fatal during blocking startup
- continue serving in degraded mode with startup.last_error populated from the catalog rejection
- add a bootstrap integration test covering invalid cascade startup while /health and /api/v1/cascade/config stay live

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-startup-catalog-probe-degrade ./bin/main_eio.exe ./test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe