### PR TITLE
fix: accept file:// agent_sdk pins in check-oas-pin

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -132,6 +132,36 @@ normalize_version_triplet() {
   fi
 }
 
+extract_opam_pin_source() {
+  local pin_line="$1"
+  local token
+  for token in ${pin_line}; do
+    case "${token}" in
+      git+*|file://*)
+        printf '%s' "${token}"
+        return 0
+        ;;
+    esac
+  done
+}
+
+local_pin_path_from_source() {
+  local pin_source="$1"
+  local local_pin_path
+  case "${pin_source}" in
+    git+file://*)
+      local_pin_path="${pin_source#git+file://}"
+      ;;
+    file://*)
+      local_pin_path="${pin_source#file://}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  printf '%s' "${local_pin_path%%#*}"
+}
+
 version_gte() {
   local lhs rhs
   lhs="$(normalize_version_triplet "$1")"
@@ -180,13 +210,12 @@ if command -v opam >/dev/null 2>&1; then
   pin_list_output="$(OPAMCOLOR=never opam pin list 2>/dev/null || true)"
   pin_line="$(awk '$1 ~ /^agent_sdk\./ { print }' <<<"${pin_list_output}")"
   if [[ -n "${pin_line}" ]]; then
-    installed_pin_source="$(sed -nE 's/.*(git\+[^[:space:]]+).*/\1/p' <<<"${pin_line}")"
+    installed_pin_source="$(extract_opam_pin_source "${pin_line}")"
     case "${installed_pin_source}" in
       "${expected_opam_pin_source}")
         ;;
-      git+file://*)
-        local_pin_path="${installed_pin_source#git+file://}"
-        local_pin_path="${local_pin_path%%#*}"
+      git+file://*|file://*)
+        local_pin_path="$(local_pin_path_from_source "${installed_pin_source}")"
         local_pin_head="$(git -C "${local_pin_path}" rev-parse HEAD 2>/dev/null || true)"
         if [[ "${local_pin_head}" != "${OAS_AGENT_SDK_SHA}" ]]; then
           echo "local agent_sdk pin points to ${local_pin_path}@${local_pin_head:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -136,6 +136,19 @@ let test_release_truth_contracts () =
   check bool "make release evidence target exists" true
     (file_contains_pattern "Makefile" "release-evidence:")
 
+let test_oas_pin_source_contracts () =
+  check bool "oas pin check parses local file pins from opam output" true
+    (file_contains_pattern "scripts/check-oas-pin.sh"
+       "extract_opam_pin_source()");
+  check bool "oas pin check accepts rsync-style file pins" true
+    (file_contains_pattern "scripts/check-oas-pin.sh" "git+*|file://*)");
+  check bool "oas pin check normalizes local pin path helper" true
+    (file_contains_pattern "scripts/check-oas-pin.sh"
+       "local_pin_path_from_source()");
+  check bool "oas pin check accepts both git file pins and plain file pins" true
+    (file_contains_pattern "scripts/check-oas-pin.sh"
+       "git+file://*|file://*)")
+
 let test_doc_truth_guard_contracts () =
   check bool "doc truth script protects spec index front door wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
@@ -803,6 +816,7 @@ let () =
              test_contract_harness_and_execution_session_authz_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "release truth contracts" `Quick test_release_truth_contracts;
+           test_case "oas pin source contracts" `Quick test_oas_pin_source_contracts;
            test_case "doc truth guard contracts" `Quick test_doc_truth_guard_contracts;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;


### PR DESCRIPTION
## Summary
- accept plain `file://...` opam pin sources in `scripts/check-oas-pin.sh`
- reuse a helper that normalizes local pin paths for both `git+file://` and `file://` sources
- add source-guard coverage for the local pin parsing contract

## Testing
- dune build --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-check-oas-pin-file-url test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe
- bash scripts/check-oas-pin.sh --local-only
- git diff --check

Refs #9212