### PR TITLE
fix(oas): delegate cascade provider labels to registry helper

### DIFF
--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -151,48 +151,11 @@ let reset_cascade_counters_for_test () =
 (* ================================================================ *)
 
 (** Map provider_kind to cascade-label prefix (e.g. "claude", "gemini").
-    Uses OAS provider resolution so endpoint-distinct providers such as
-    [glm] and [glm-coding] remain distinguishable. *)
-let normalize_url value =
-  let trimmed = String.trim value in
-  if trimmed = "" then trimmed
-  else
-    let rec strip_trailing_slash s =
-      let len = String.length s in
-      if len > 1 && s.[len - 1] = '/' then
-        strip_trailing_slash (String.sub s 0 (len - 1))
-      else
-        s
-    in
-    strip_trailing_slash trimmed
+    Delegates to the current OAS registry helper so endpoint-distinct
+    providers such as [glm], [glm-coding], and [openrouter] track the
+    pinned agent_sdk behavior exactly. *)
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  match cfg.kind with
-  | Anthropic -> "claude"
-  | Gemini -> "gemini"
-  | Glm ->
-      if Llm_provider.Zai_catalog.is_coding_base_url cfg.base_url then
-        "glm-coding"
-      else "glm"
-  | Claude_code -> "claude_code"
-  | Gemini_cli -> "gemini_cli"
-  | Codex_cli -> "codex_cli"
-  | Ollama -> "ollama"
-  | OpenAI_compat ->
-      if Llm_provider.Provider_config.is_local cfg then
-        "llama"
-      else
-        let request_path = String.trim cfg.request_path in
-        let base_url = normalize_url cfg.base_url in
-        let registry = Llm_provider.Provider_registry.default () in
-        match
-          Llm_provider.Provider_registry.all registry
-          |> List.find_opt (fun (entry : Llm_provider.Provider_registry.entry) ->
-                 entry.defaults.kind = cfg.kind
-                 && String.equal (normalize_url entry.defaults.base_url) base_url
-                 && String.equal (String.trim entry.defaults.request_path) request_path)
-        with
-        | Some entry -> entry.name
-        | None -> "openai"
+  Llm_provider.Provider_registry.provider_name_of_config cfg
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   Provider_adapter.display_provider_name (provider_name_of_config cfg)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1033,6 +1033,44 @@ let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
     ~kind:Llm_provider.Provider_config.OpenAI_compat
     ~model_id ~base_url:"http://127.0.0.1:18080/v1" ()
 
+let make_glm_provider_cfg ?(base_url = Llm_provider.Zai_catalog.general_base_url)
+    ?(model_id = "glm-5.1") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Glm
+    ~model_id ~base_url ()
+
+let provider_registry_entry_exn name =
+  let registry = Llm_provider.Provider_registry.default () in
+  match Llm_provider.Provider_registry.find registry name with
+  | Some entry -> entry
+  | None -> Alcotest.failf "expected provider registry entry %S" name
+
+let make_openrouter_provider_cfg ?(model_id = "anthropic/claude-3.5") () =
+  let entry = provider_registry_entry_exn "openrouter" in
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id
+    ~base_url:entry.defaults.base_url
+    ~request_path:entry.defaults.request_path
+    ()
+
+let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
+  let glm = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+      (make_glm_provider_cfg ()) in
+  let glm_coding = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+      (make_glm_provider_cfg ~base_url:Llm_provider.Zai_catalog.coding_base_url ()) in
+  Alcotest.(check string) "general GLM label" "glm" glm;
+  Alcotest.(check string) "coding GLM label" "glm-coding" glm_coding
+
+let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
+  let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+      (make_openrouter_provider_cfg ()) in
+  let model_label = Masc_mcp.Oas_worker_cascade.model_label_of_config
+      (make_openrouter_provider_cfg ()) in
+  Alcotest.(check string) "openrouter provider name" "openrouter" provider_name;
+  Alcotest.(check string) "openrouter model label"
+    "openrouter:anthropic/claude-3.5" model_label
+
 let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   let tools =
@@ -2280,6 +2318,10 @@ let () =
         test_cascade_metrics_evicts_lowest_call_key;
       Alcotest.test_case "cascade audit persists observation" `Quick
         test_cascade_audit_persists_observation;
+      Alcotest.test_case "cascade provider labels keep glm and glm-coding distinct" `Quick
+        test_cascade_provider_labels_keep_glm_and_glm_coding_distinct;
+      Alcotest.test_case "cascade provider labels preserve registered openai_compat family" `Quick
+        test_cascade_provider_labels_preserve_registered_openai_compat_family;
       Alcotest.test_case "sdk_error_is_hard_quota detects Gemini CLI wrapper" `Quick
         test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper;
       Alcotest.test_case "sdk_error_is_hard_quota keeps transient network errors false" `Quick


### PR DESCRIPTION
## Summary
- delegate cascade provider label derivation to the pinned OAS 
- add regression tests that keep  vs  distinct and preserve registered OpenAI-compatible endpoint families such as 

## Context
-  merged while this follow-up was in progress
- the merged PR restored endpoint-aware provider labels, but this follow-up removes local duplication and locks the behavior to the pinned agent_sdk helper

## Validation
- 
- 
- Testing `OAS Worker'.
This run has ID `N2UYV95N'.

  [SKIP]        sse_event_bridge                      0   text delta extraction.
  [SKIP]        sse_event_bridge                      1   non-text events ign...
  [SKIP]        sse_event_bridge                      2   mixed event stream.
  [SKIP]        sse_event_bridge                      3   empty text deltas t...
  [SKIP]        sse_event_bridge                      4   SSE error event ign...
  [SKIP]        cascade_config                        0   keeper_turn default...
  [SKIP]        cascade_config                        1   heartbeat default m...
  [SKIP]        cascade_config                        2   local_only defaults...
  [SKIP]        cascade_config                        3   unknown cascade fal...
  [SKIP]        cascade_config                        4   default_config_path.
  [SKIP]        cascade_config                        5   all cascade names p...
  [SKIP]        cascade_config                        6   cascade inference n...
  [SKIP]        cascade_config                        7   cascade observation...
  [SKIP]        cascade_config                        8   cascade metrics con...
  [SKIP]        cascade_config                        9   cascade metrics evi...
  [SKIP]        cascade_config                       10   cascade audit persi...
  [OK]          cascade_config                       11   cascade provider la...
  [OK]          cascade_config                       12   cascade provider la...
  [SKIP]        cascade_config                       13   sdk_error_is_hard_q...
  [SKIP]        cascade_config                       14   sdk_error_is_hard_q...
  [SKIP]        cascade_config                       15   sdk_error_is_hard_q...
  [SKIP]        resume_config                         0   checkpoint model wins.
  [SKIP]        resume_config                         1   meta model fallback.
  [SKIP]        resume_config                         2   oas_worker default ...
  [SKIP]        resume_config                         3   oas_worker opt-in a...
  [SKIP]        resume_config                         4   oas_worker default ...
  [SKIP]        resume_config                         5   oas_worker applies ...
  [SKIP]        resume_config                         6   resume propagates a...
  [SKIP]        resume_config                         7   resume propagates s...
  [SKIP]        resume_config                         8   resume propagates s...
  [SKIP]        resume_config                         9   resume propagates p...
  [SKIP]        resume_config                        10   CLI transports rele...
  [SKIP]        resume_config                        11   invalid explicit mo...
  [SKIP]        resume_config                        12   run_model_with_masc...
  [SKIP]        resume_config                        13   structured MASC int...
  [SKIP]        resume_config                        14   codex preflight use...
  [SKIP]        resume_config                        15   codex preflight sca...
  [SKIP]        resume_config                        16   public MCP tools on...
  [SKIP]        resume_config                        17   public MCP tools on...
  [SKIP]        resume_config                        18   keeper-internal too...
  [SKIP]        resume_config                        19   worker build_agent ...
  [SKIP]        resume_config                        20   resume config propa...
  [SKIP]        resume_config                        21   worker build_agent ...
  [SKIP]        resume_config                        22   worker build_agent ...
  [SKIP]        resume_config                        23   exit_condition_resu...
  [SKIP]        keeper_checkpoint_boundary            0   prefers OAS checkpo...
  [SKIP]        keeper_checkpoint_boundary            1   legacy fallback sti...
  [SKIP]        keeper_checkpoint_boundary            2   legacy checkpoint r...
  [SKIP]        keeper_checkpoint_boundary            3   legacy old tool mes...
  [SKIP]        keeper_checkpoint_boundary            4   OAS handoff rollove...
  [SKIP]        keeper_checkpoint_boundary            5   OAS handoff rollove...
  [SKIP]        keeper_checkpoint_boundary            6   overflow retry fall...
  [SKIP]        keeper_checkpoint_boundary            7   overflow retry skip...
  [SKIP]        keeper_checkpoint_boundary            8   overflow retry requ...
  [SKIP]        keeper_checkpoint_boundary            9   overflow retry save...
  [SKIP]        keeper_checkpoint_store               0   OAS store roundtrip.
  [SKIP]        keeper_checkpoint_store               1   OAS store writes hi...
  [SKIP]        keeper_checkpoint_store               2   OAS store missing r...
  [SKIP]        keeper_checkpoint_store               3   prefers OAS checkpo...
  [SKIP]        keeper_checkpoint_store               4   legacy fallback sti...
  [SKIP]        keeper_checkpoint_store               5   legacy checkpoint r...
  [SKIP]        keeper_checkpoint_store               6   legacy old tool mes...
  [SKIP]        keeper_checkpoint_store               7   prefers newer legac...
  [SKIP]        keeper_checkpoint_store               8   OAS handoff rollove...
  [SKIP]        keeper_checkpoint_store               9   OAS handoff rollove...
  [SKIP]        keeper_checkpoint_continuity          0   same-trace multi-tu...
  [SKIP]        keeper_checkpoint_continuity          1   restart continuity ...
  [SKIP]        idle_detail_enrichment                0   idle error with too...
  [SKIP]        idle_detail_enrichment                1   idle error with no ...
  [SKIP]        idle_detail_enrichment                2   idle error with emp...
  [SKIP]        idle_detail_enrichment                3   non-idle error is n...
  [SKIP]        idle_detail_enrichment                4   last tool name wins...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-surface-post-9218/_build/_tests/OAS Worker'.
Test Successful in 0.001s. 2 tests run.
- full  still hits pre-existing keeper checkpoint boundary failures unrelated to this change