### PR TITLE
fix(room-protocol): remove non-exhaustive task_status wildcard

### DIFF
--- a/lib/room_protocol.ml
+++ b/lib/room_protocol.ml
@@ -21,12 +21,6 @@ let task_status_matches status_filter (task : Types.task) =
   | Some status ->
       String.equal status (Types.string_of_task_status task.task_status)
 
-let is_terminal_task (task : Types.task) =
-  match task.task_status with
-  | Types.Done _ -> `Done
-  | Types.Cancelled _ -> `Cancelled
-  | _ -> `Active
-
 let tasks ?status_filter ?(include_done = false) ?(include_cancelled = false)
     config =
   Coord.get_tasks_raw config
@@ -34,11 +28,11 @@ let tasks ?status_filter ?(include_done = false) ?(include_cancelled = false)
   |> List.filter (fun task ->
          match status_filter with
          | Some _ -> true
-         | None -> (
-             match is_terminal_task task with
-             | `Done -> include_done
-             | `Cancelled -> include_cancelled
-             | `Active -> true))
+         | None ->
+             let s = task.task_status in
+             if Types.task_status_is_done s then include_done
+             else if Types.task_status_is_terminal s then include_cancelled
+             else true)
 
 let task_assignee (task : Types.task) =
   Types.task_assignee_of_status task.task_status

--- a/lib/room_protocol.ml
+++ b/lib/room_protocol.ml
@@ -25,7 +25,7 @@ let tasks ?status_filter ?(include_done = false) ?(include_cancelled = false)
     config =
   Coord.get_tasks_raw config
   |> List.filter (task_status_matches status_filter)
-  |> List.filter (fun task ->
+  |> List.filter (fun (task : Types.task) ->
          match status_filter with
          | Some _ -> true
          | None ->


### PR DESCRIPTION
## Summary
- Remove `is_terminal_task` function which used `| _ -> \`Active` wildcard on `task_status` match
- Replace with canonical helpers `Types.task_status_is_done` and `Types.task_status_is_terminal` from `types_core.ml`
- Zero behavior change — compiler will now error if a new `task_status` variant is added

## Test plan
- [x] `dune build --root .` passes with zero errors
- [ ] CI Build and Test passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>