### PR TITLE
fix(coord-status): remove non-exhaustive task_status wildcard

### DIFF
--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -79,10 +79,10 @@ let status config =
   let active_tasks, done_count, cancelled_count =
     List.fold_left
       (fun (active, done_cnt, cancelled_cnt) task ->
-        match task.task_status with
-        | Done _ -> (active, done_cnt + 1, cancelled_cnt)
-        | Cancelled _ -> (active, done_cnt, cancelled_cnt + 1)
-        | _ -> (task :: active, done_cnt, cancelled_cnt))
+        let s = task.task_status in
+        if Types.task_status_is_done s then (active, done_cnt + 1, cancelled_cnt)
+        else if Types.task_status_is_terminal s then (active, done_cnt, cancelled_cnt + 1)
+        else (task :: active, done_cnt, cancelled_cnt))
       ([], 0, 0) sorted_tasks
   in
   let active_tasks = List.rev active_tasks in


### PR DESCRIPTION
## Summary
- Replace `| _ ->` catch-all in task bucketing fold with canonical helpers
- `Types.task_status_is_done` and `Types.task_status_is_terminal` from types_core.ml
- Zero behavior change — new task_status variants will be correctly classified as active

## Test plan
- [x] `dune build --root .` passes with zero errors
- [ ] CI Build and Test passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>