### PR TITLE
fix(tool-task): make task_status match exhaustive in can_review_completion

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -155,7 +155,10 @@ let can_review_completion ~(task_opt : Types.task option) ~(agent_name : string)
        | Types.Claimed { assignee; _ }
        | Types.InProgress { assignee; _ } ->
            String.equal assignee agent_name
-       | _ -> false)
+       | Types.Todo
+       | Types.AwaitingVerification _
+       | Types.Done _
+       | Types.Cancelled _ -> false)
   | None -> false
 
 (* Concrete example handed to the keeper when the anti-rationalization


### PR DESCRIPTION
## Summary
- Replace `| _ -> false` wildcard in `can_review_completion` with explicit constructors
- Todo, AwaitingVerification, Done, Cancelled now explicitly return false
- Zero behavior change — compiler will error if a new task_status variant is added

## Test plan
- [x] `dune build --root .` passes with zero errors
- [ ] CI Build and Test passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>