### PR TITLE
fix(grpc): make task_status match exhaustive in unclaimed filter

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -265,7 +265,8 @@ let compute_directives
       |> List.filter_map (fun (task : Types.task) ->
            match task.task_status with
            | Types.Todo -> Some task.id
-           | _ -> None)
+           | Types.Claimed _ | Types.InProgress _ | Types.AwaitingVerification _
+           | Types.Done _ | Types.Cancelled _ -> None)
     in
     match unclaimed with
     | task_id :: _ -> directives := ("claim:" ^ task_id) :: !directives


### PR DESCRIPTION
## Summary
- Replace `| _ -> None` wildcard with explicit constructors for all non-Todo variants
- Zero behavior change — compiler will error if a new task_status variant is added

## Test plan
- [x] `dune build --root .` passes with zero errors
- [ ] CI Build and Test passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>