### PR TITLE
fix(server-dashboard): make task_status match exhaustive in task filter

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -187,7 +187,9 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
            match t.task_status with
            | Types.Cancelled _ -> false
            | Types.Done _ -> not compact
-           | _ -> true)
+           | Types.Todo -> true
+           | Types.Claimed _ | Types.InProgress _ -> true
+           | Types.AwaitingVerification _ -> true)
          tasks)
   in
   let agents_json =


### PR DESCRIPTION
## Summary
- Replace `| _ -> true` wildcard with explicit Todo, Claimed, InProgress, AwaitingVerification
- Cancelled and Done already had explicit handling above the wildcard
- Zero behavior change — compiler will error if a new task_status variant is added

## Test plan
- [x] `dune build --root .` passes with zero errors
- [ ] CI Build and Test passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>