### PR TITLE
docs(compression): freeze public API surface with .mli files

### DIFF
--- a/lib/compression/compression_codec.mli
+++ b/lib/compression/compression_codec.mli
@@ -1,0 +1,61 @@
+(** Shared compression codec surface.
+
+    This module owns the raw zstd compression/decompression policy so transport
+    and backend layers depend on a neutral codec rather than backend-local
+    helpers. *)
+
+(** {1 Types} *)
+
+type encoding =
+  | Standard
+  | Dictionary
+
+type compressed = {
+  payload : string;
+  encoding : encoding;
+}
+
+type compress_result =
+  | Unchanged of string
+  | Compressed of compressed
+
+(** {1 Thresholds} *)
+
+val min_size : int
+(** Minimum payload size (bytes) below which compression is skipped. *)
+
+val max_dict_size : int
+(** Upper bound reserved for dictionary payloads. *)
+
+(** {1 Encoding helpers} *)
+
+val should_use_dict : int -> bool
+(** [should_use_dict size] returns whether a payload of [size] bytes should be
+    routed through the dictionary-aware path. Currently a simple size floor. *)
+
+val get_dict : unit -> string
+(** Current dictionary bytes. Empty string when no dictionary is loaded. *)
+
+val has_dict : unit -> bool
+
+val uses_dict : encoding -> bool
+val of_used_dict : bool -> encoding
+
+val content_encoding : encoding -> string
+(** HTTP [Content-Encoding] header value for an [encoding]. *)
+
+(** {1 Compression} *)
+
+val compress : ?level:int -> string -> compress_result
+(** [compress ?level data] compresses [data] with zstd at [level] (default 3).
+    Returns [Unchanged] when the payload is smaller than {!min_size} or when
+    compression does not reduce the size. Zstd failures are logged and
+    surfaced as [Unchanged]. *)
+
+val decompress :
+  orig_size:int ->
+  encoding:encoding ->
+  string ->
+  (string, string) Stdlib.result
+(** [decompress ~orig_size ~encoding data] attempts to decompress [data] into a
+    buffer of [orig_size] bytes. Returns [Error msg] on zstd failure. *)

--- a/lib/compression/compression_dict.mli
+++ b/lib/compression/compression_dict.mli
@@ -1,0 +1,45 @@
+(** Compatibility facade for callers that still expect [Compression_dict].
+
+    The actual codec lives in {!Compression_codec}; this module re-exports the
+    subset of the codec surface used by legacy transport code. *)
+
+(** {1 Size Thresholds} *)
+
+val min_dict_size : int
+val max_dict_size : int
+val should_use_dict : int -> bool
+
+(** {1 Dictionary Stubs} *)
+
+val get_dict : unit -> string
+val has_dict : unit -> bool
+
+(** {1 Compression} *)
+
+val compress : ?level:int -> string -> string * bool * bool
+(** [compress ?level data] returns [(payload, used_dict, changed)].
+
+    - [payload] is either the compressed bytes or the input [data] unchanged.
+    - [used_dict] is [true] when the dictionary-aware encoding was applied.
+    - [changed] is [true] when the payload actually differs from [data]
+      (i.e. compression succeeded and reduced the size).
+
+    Any codec failure is logged and surfaced as [(data, false, false)]. *)
+
+val decompress : orig_size:int -> used_dict:bool -> string -> string
+(** [decompress ~orig_size ~used_dict data] is the inverse of {!compress}.
+    Returns the input [data] unchanged when decompression fails (the error is
+    logged). *)
+
+(** {1 Content-Encoding Headers} *)
+
+val encoding_with_dict : string
+(** HTTP [Content-Encoding] header value used when [used_dict] is [true]. *)
+
+val encoding_standard : string
+(** HTTP [Content-Encoding] header value used when [used_dict] is [false]. *)
+
+(** {1 Version Info} *)
+
+val version : string
+val version_string : string


### PR DESCRIPTION
## Summary

Adds `.mli` files for `lib/compression/compression_codec.ml` and `lib/compression/compression_dict.ml`, freezing the currently intended public surface of the compression subsystem.

## Why

Part of the lib/ `.mli` coverage sweep. Current masc-mcp state:

- 699 `.ml`, 372 `.mli` → 53% coverage (vs. oas's 95%).
- `lib/compression/` was 0% covered — both files exposed every top-level binding as implicitly public.

With an explicit `.mli`, AI-assisted refactoring inside either file can move freely without accidentally leaking or breaking caller-visible identifiers. The compiler now enforces the intended surface.

See `~/me/planning/ocaml-best-of-best/g2-mli-audit.md` for the full subsystem coverage audit and wave-1 plan.

## Scope

- **No behaviour change.** Both `.mli` mirror the existing `.ml` surface exactly (sum types stay concrete, values keep their current types).
- Narrowing / `private` types are deferred to later passes; this PR is pure externalisation.

## Verification

- `dune build --root .` succeeds on the worktree.
- Existing callers (`lib/http_server_eio.ml`, `lib/backend/backend_compression.ml`) recompile cleanly against the new signatures (new `.cmi` artefacts produced under `_build/default/lib/.masc_mcp.objs/public_cmi/`).
- Public surface:
  - `Compression_codec`: `encoding`, `compressed`, `compress_result`, `min_size`, `max_dict_size`, `should_use_dict`, `get_dict`, `has_dict`, `uses_dict`, `of_used_dict`, `content_encoding`, `compress`, `decompress`.
  - `Compression_dict`: `min_dict_size`, `max_dict_size`, `should_use_dict`, `get_dict`, `has_dict`, `compress`, `decompress`, `encoding_with_dict`, `encoding_standard`, `version`, `version_string`.

## Test plan

- [x] `dune build --root .` (clean, full library)
- [ ] CI runs (see checks below)
- [ ] No callers need changes (verified locally; confirm CI)

Generated with Claude Code.
