### PR TITLE
fix(keeper): exhaustive task_status matches in world observation

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -221,7 +221,10 @@ let read_backlog_counts ~(config : Coord.config) : int * int * int =
       List.length
         (List.filter
            (fun (t : Types.task) ->
-             match t.task_status with Types.Cancelled _ -> true | _ -> false)
+             match t.task_status with
+             | Types.Cancelled _ -> true
+             | Types.Todo | Types.Claimed _ | Types.InProgress _
+             | Types.AwaitingVerification _ | Types.Done _ -> false)
            backlog.tasks)
     in
     let pending_verification =
@@ -229,7 +232,9 @@ let read_backlog_counts ~(config : Coord.config) : int * int * int =
         (List.filter
            (fun (t : Types.task) ->
              match t.task_status with
-             | Types.AwaitingVerification _ -> true | _ -> false)
+             | Types.AwaitingVerification _ -> true
+             | Types.Todo | Types.Claimed _ | Types.InProgress _
+             | Types.Done _ | Types.Cancelled _ -> false)
            backlog.tasks)
     in
     (unclaimed, failed, pending_verification)


### PR DESCRIPTION
## Summary
- Replace two `_ -> false` wildcard matches in `keeper_world_observation.ml` task counting predicates with explicit constructors
- Line 224: `Cancelled _ -> true | _ -> false` → explicit 5-branch match
- Line 232: `AwaitingVerification _ -> true | _ -> false` → explicit 5-branch match

## Why
Wildcard `_` catches any new `task_status` variant silently. Exhaustive matches force the compiler to flag additions, making the type system work for us.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)