### PR TITLE
fix(keeper): exhaustive fiber_health match in exec status

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -372,7 +372,7 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
   match fiber_health with
   | Fiber_zombie -> KH_zombie
   | Fiber_dead -> KH_dead
-  | _ ->
+  | Fiber_alive | Fiber_unknown ->
   let agent_exists = json_bool "exists" agent_status false in
   let agent_status_text =
     json_string_opt "status" agent_status


### PR DESCRIPTION
## Summary
- Replace `_ ->` wildcard on `fiber_health` variant match in `keeper_exec_status.ml:375`
- Explicit `Fiber_alive | Fiber_unknown` branches ensure compiler flags new variants

## Why
`fiber_health` has 4 constructors. The wildcard silently accepted any future additions.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)