### PR TITLE
fix(coord): use canonical helpers for task_status in query filter

### DIFF
--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -298,8 +298,12 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
     | None ->
         List.filter (fun (task : task) ->
           let status = task.task_status in
-          let is_done = match status with Done _ -> true | _ -> false in
-          let is_cancelled = match status with Cancelled _ -> true | _ -> false in
+          let is_done = Types.task_status_is_done status in
+          let is_cancelled = match status with
+            | Types.Cancelled _ -> true
+            | Types.Todo | Types.Claimed _ | Types.InProgress _
+            | Types.AwaitingVerification _ | Types.Done _ -> false
+          in
           (include_done || not is_done) &&
           (include_cancelled || not is_cancelled)
         ) backlog.tasks


### PR DESCRIPTION
## Summary
- Replace `Done _ -> true | _ -> false` with `Types.task_status_is_done`
- Replace `Cancelled _ -> true | _ -> false` with exhaustive 5-branch match
- Both in `coord_query.ml:301-302` task filtering predicate

## Why
Canonical helpers are the SSOT for status classification. Explicit match on cancelled ensures compiler coverage.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)