### PR TITLE
fix(server): keep dashboard alive on invalid cascade

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1799,9 +1799,19 @@ export interface CascadeKeeperProfile {
   canonical: string
 }
 
+export type CascadeValidationStatus = 'validated' | 'serving_last_known_good' | 'invalid'
+
+export interface CascadeInvalidProfile {
+  name: string
+  errors: string[]
+}
+
 export interface CascadeConfigResponse {
   updated_at: string
   config_path: string | null
+  validation_status: CascadeValidationStatus
+  validation_errors: string[]
+  invalid_profiles: CascadeInvalidProfile[]
   profiles: CascadeProfile[]
   keeper_profiles: CascadeKeeperProfile[]
 }

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -26,6 +26,7 @@ import {
   type CascadeConfigResponse,
   type CascadeHealthProvider,
   type CascadeHealthResponse,
+  type CascadeInvalidProfile,
   type CascadeKeeperProfile,
   type CascadeProfile,
   type CascadeStrategyTraceEvent,
@@ -33,6 +34,7 @@ import {
   type CascadeStrategyTraceResponse,
   type CascadeSloResponse,
   type CascadeSloStatus,
+  type CascadeValidationStatus,
 } from '../api/dashboard'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -91,6 +93,33 @@ export function sourceTone(source: CascadeProfile['source']): string {
     case 'named': return 'ok'
     case 'default_fallback': return 'warn'
     case 'hardcoded_defaults': return 'warn'
+  }
+}
+
+function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
+  switch (status) {
+    case 'validated': return 'ok'
+    case 'serving_last_known_good': return 'warn'
+    case 'invalid': return 'bad'
+  }
+}
+
+function validationLabel(status: CascadeValidationStatus): string {
+  switch (status) {
+    case 'validated': return 'validated'
+    case 'serving_last_known_good': return 'last known good'
+    case 'invalid': return 'invalid'
+  }
+}
+
+function validationDescription(status: CascadeValidationStatus): string {
+  switch (status) {
+    case 'validated':
+      return '현재 cascade catalog 이 정상 검증되었습니다.'
+    case 'serving_last_known_good':
+      return '새 cascade.json 업데이트가 검증에 실패해 마지막 검증 성공 snapshot 을 계속 서빙 중입니다.'
+    case 'invalid':
+      return '현재 cascade.json 검증에 실패했습니다. 서버와 dashboard 는 degraded 로 계속 동작하지만 유효하지 않은 profile 은 라우팅에서 제외될 수 있습니다.'
   }
 }
 
@@ -278,6 +307,70 @@ function OrphanKeeperList({ orphans }: { orphans: readonly CascadeKeeperProfile[
           </li>
         `)}
       </ul>
+    </div>
+  `
+}
+
+function InvalidProfileSummary({
+  invalidProfile,
+}: { invalidProfile: CascadeInvalidProfile }) {
+  const firstError = invalidProfile.errors[0] ?? 'validation rejected'
+  const extraErrors = Math.max(0, invalidProfile.errors.length - 1)
+  return html`
+    <li class="flex flex-wrap items-start gap-2">
+      <code class="text-[var(--text-strong)]">${invalidProfile.name}</code>
+      <span class="text-[var(--text-muted)]">${firstError}</span>
+      ${extraErrors > 0
+        ? html`<span class="text-[var(--text-muted)]">+${extraErrors} more</span>`
+        : null}
+    </li>
+  `
+}
+
+function CascadeValidationBanner({ config }: { config: CascadeConfigResponse }) {
+  if (config.validation_status === 'validated') return null
+  const tone = validationTone(config.validation_status)
+  const boxTone = tone === 'bad'
+    ? 'border-[var(--bad)]/40 bg-[var(--bad)]/10'
+    : 'border-[var(--warn)]/40 bg-[var(--warn)]/10'
+  const visibleErrors = config.validation_errors.slice(0, 3)
+  const visibleProfiles = config.invalid_profiles.slice(0, 4)
+  return html`
+    <div class=${`rounded border ${boxTone} p-3 text-xs mb-3`}>
+      <div class="flex items-center gap-2 flex-wrap mb-2">
+        <${StatusChip} tone=${tone}>${validationLabel(config.validation_status)}<//>
+        <span class="text-[var(--text-muted)]">
+          ${config.invalid_profiles.length} invalid profile${config.invalid_profiles.length === 1 ? '' : 's'}
+          · ${config.validation_errors.length} error${config.validation_errors.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div class="text-[var(--text-strong)] mb-2">
+        ${validationDescription(config.validation_status)}
+      </div>
+      ${visibleErrors.length > 0
+        ? html`
+          <ul class="flex flex-col gap-1 mb-2 text-[var(--text-muted)]">
+            ${visibleErrors.map(error => html`<li>${error}</li>`)}
+          </ul>
+        `
+        : null}
+      ${visibleProfiles.length > 0
+        ? html`
+          <div class="text-[var(--text-strong)] mb-1">Rejected Profiles</div>
+          <ul class="flex flex-col gap-1 text-[var(--text-muted)]">
+            ${visibleProfiles.map(invalidProfile => html`
+              <${InvalidProfileSummary} invalidProfile=${invalidProfile} />
+            `)}
+          </ul>
+        `
+        : null}
+      ${config.invalid_profiles.length > visibleProfiles.length
+        ? html`
+          <div class="mt-2 text-[var(--text-muted)]">
+            + ${config.invalid_profiles.length - visibleProfiles.length} more invalid profiles
+          </div>
+        `
+        : null}
     </div>
   `
 }
@@ -679,6 +772,7 @@ export function CascadeConfigPanel() {
                 0,
               )
               return html`
+                <${CascadeValidationBanner} config=${config} />
                 <div class="grid grid-cols-3 gap-3 mb-3">
                   <${StatCell}
                     label="Profiles"
@@ -696,11 +790,15 @@ export function CascadeConfigPanel() {
                     detail="raw ≠ canonical"
                   />
                 </div>
-                <div class="grid gap-3 md:grid-cols-2 mb-3">
-                  ${config.profiles.map(p => html`
-                    <${ProfileCard} profile=${p} keepers=${keeperGroups.get(p.name) ?? []} />
-                  `)}
-                </div>
+                ${config.profiles.length === 0
+                  ? html`<${EmptyState}>표시할 유효 cascade profile 이 없습니다.<//>`
+                  : html`
+                    <div class="grid gap-3 md:grid-cols-2 mb-3">
+                      ${config.profiles.map(p => html`
+                        <${ProfileCard} profile=${p} keepers=${keeperGroups.get(p.name) ?? []} />
+                      `)}
+                    </div>
+                  `}
                 <${OrphanKeeperList} orphans=${orphans} />
               `
             })()

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -27,6 +27,41 @@ let source_to_string = function
   | CC.Default_fallback -> "default_fallback"
   | CC.Hardcoded_defaults -> "hardcoded_defaults"
 
+let string_list_to_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let invalid_profile_to_json (name, errors : string * string list) =
+  `Assoc
+    [
+      ("name", `String name);
+      ("errors", string_list_to_json errors);
+    ]
+
+let json_assoc_member key = function
+  | `Assoc fields -> Option.value (List.assoc_opt key fields) ~default:`Null
+  | _ -> `Null
+
+let json_string_list = function
+  | `List values ->
+      List.filter_map
+        (function
+          | `String value -> Some value
+          | _ -> None)
+        values
+  | _ -> []
+
+let invalid_profiles_of_rejection_json rejection_json =
+  match json_assoc_member "profiles" rejection_json with
+  | `List profiles ->
+      List.filter_map
+        (fun profile_json ->
+           match json_assoc_member "name" profile_json with
+           | `String name ->
+               Some (name, json_string_list (json_assoc_member "errors" profile_json))
+           | _ -> None)
+        profiles
+  | _ -> []
+
 (* ── Config projection ──────────────────────────────── *)
 
 (** Profiles to surface in the dashboard.
@@ -96,6 +131,40 @@ let invalid_name_set = function
            (fun acc (name, _reasons) -> StringSet.add name acc)
            StringSet.empty
 
+let invalid_profiles_of_config_path = function
+  | None -> []
+  | Some path -> Cascade_catalog_validator.error_messages_by_profile ~config_path:path
+
+let validation_summary_json ?config_path () =
+  let fallback_invalid_profiles = invalid_profiles_of_config_path config_path in
+  let of_rejection ~status rejection =
+    let rejection_json = Cascade_catalog_runtime.rejection_to_yojson rejection in
+    let invalid_profiles =
+      match invalid_profiles_of_rejection_json rejection_json with
+      | [] -> fallback_invalid_profiles
+      | profiles -> profiles
+    in
+    [
+      ("validation_status", `String status);
+      ("validation_errors",
+       string_list_to_json (json_string_list (json_assoc_member "errors" rejection_json)));
+      ("invalid_profiles", `List (List.map invalid_profile_to_json invalid_profiles));
+    ]
+  in
+  match Cascade_catalog_runtime.inspect_active () with
+  | Ok (Cascade_catalog_runtime.Validated _) ->
+      [
+        ("validation_status", `String "validated");
+        ("validation_errors", `List []);
+        ("invalid_profiles", `List []);
+      ]
+  | Ok
+      (Cascade_catalog_runtime.Serving_last_known_good
+         { rejected_update; _ }) ->
+      of_rejection ~status:"serving_last_known_good" rejected_update
+  | Error rejection ->
+      of_rejection ~status:"invalid" rejection
+
 let config_json () =
   let config_path = Cascade_runtime.cascade_config_path () in
   let keeper_entries =
@@ -138,15 +207,21 @@ let config_json () =
         in
         List.map (profile_json_raw ~config_path) names
   in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("config_path",
-     match config_path with
-     | Some p -> `String p
-     | None -> `Null);
-    ("profiles", `List profiles);
-    ("keeper_profiles", `List (List.map keeper_profile_json keeper_entries));
-  ]
+  let fields =
+    [
+      ("updated_at", `String (now_iso ()));
+      ("config_path",
+       match config_path with
+       | Some p -> `String p
+       | None -> `Null);
+    ]
+    @ validation_summary_json ?config_path ()
+    @ [
+        ("profiles", `List profiles);
+        ("keeper_profiles", `List (List.map keeper_profile_json keeper_entries));
+      ]
+  in
+  `Assoc fields
 
 (* ── Health projection ──────────────────────────────── *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1009,7 +1009,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-           Log.Dashboard.warn "shell cache pre-warm failed: %s"
+             Log.Dashboard.warn "shell cache pre-warm failed: %s"
              (Printexc.to_string exn)));
       start_lazy_startup state;
       (match catalog_validation_error with

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -18,6 +18,21 @@ let to_list_opt = function
   | `List xs -> Some xs
   | _ -> None
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then
+      true
+    else if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
 let write_file path contents =
   let oc = open_out path in
   Fun.protect
@@ -74,10 +89,42 @@ let test_config_shape () =
   (match member "config_path" j with
    | `String _ | `Null -> ()
    | _ -> fail "config_path should be string or null");
+  (match member "validation_status" j with
+   | `String ("validated" | "serving_last_known_good" | "invalid") -> ()
+   | _ -> fail "validation_status should be known string");
+  (match member "validation_errors" j with
+   | `List _ -> ()
+   | _ -> fail "validation_errors should be list");
+  (match member "invalid_profiles" j with
+   | `List _ -> ()
+   | _ -> fail "invalid_profiles should be list");
   (match member "profiles" j with
    | `List _ -> () | _ -> fail "profiles should be list");
   (match member "keeper_profiles" j with
    | `List _ -> () | _ -> fail "keeper_profiles should be list")
+
+let test_config_validated_status () =
+  with_temp_config_root
+    {|
+      {
+        "keeper_unified_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+      }
+    |}
+    (fun cascade_path ->
+      Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+      Masc_mcp.Cascade_catalog_runtime.install_snapshot_for_tests
+        ~source_path:cascade_path
+        ~profile_names:[ Masc_mcp.Keeper_config.default_cascade_name ];
+      Fun.protect
+        ~finally:Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests
+        (fun () ->
+           let j = Masc_mcp.Dashboard_cascade.config_json () in
+           check string "validated status" "validated"
+             Yojson.Safe.Util.(j |> member "validation_status" |> to_string);
+           check int "validation errors empty" 0
+             Yojson.Safe.Util.(j |> member "validation_errors" |> to_list |> List.length);
+           check int "invalid profiles empty" 0
+             Yojson.Safe.Util.(j |> member "invalid_profiles" |> to_list |> List.length)))
 
 let test_config_profile_shape () =
   with_dashboard_snapshot @@ fun () ->
@@ -142,6 +189,31 @@ let test_config_uses_live_catalog () =
       check (option string) "config_path reflects active root"
         (Some cascade_path)
         Yojson.Safe.Util.(j |> member "config_path" |> to_string_option))
+
+let test_config_invalid_catalog_surfaces_validation_metadata () =
+  with_temp_config_root
+    {|
+      {
+        "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+      }
+    |}
+    (fun _cascade_path ->
+      Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
+      Fun.protect
+        ~finally:Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests
+        (fun () ->
+           let j = Masc_mcp.Dashboard_cascade.config_json () in
+           check string "invalid status" "invalid"
+             Yojson.Safe.Util.(j |> member "validation_status" |> to_string);
+           check bool "invalid provider surfaced in metadata" true
+             (contains_substring (Yojson.Safe.to_string j)
+                "__nonexistent_provider_sentinel__");
+           check bool "broken profile listed" true
+             (Yojson.Safe.Util.(j |> member "invalid_profiles" |> to_list)
+              |> List.exists (fun profile ->
+                     match member "name" profile with
+                     | `String "broken_profile" -> true
+                     | _ -> false))))
 
 (* ── health_json ───────────────────────────────────── *)
 
@@ -341,9 +413,12 @@ let () =
   run "dashboard_cascade" [
     "config_json", [
       test_case "top-level shape" `Quick test_config_shape;
+      test_case "validated status when snapshot exists" `Quick test_config_validated_status;
       test_case "profile shape" `Quick test_config_profile_shape;
       test_case "candidate shape" `Quick test_config_candidate_shape;
       test_case "uses live config catalog" `Quick test_config_uses_live_catalog;
+      test_case "invalid catalog surfaces validation metadata" `Quick
+        test_config_invalid_catalog_surfaces_validation_metadata;
     ];
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -905,6 +905,25 @@ let test_startup_state_json () =
   Alcotest.(check string) "last error recorded" "keeper failed"
     (json_string_field "last_error" json)
 
+let test_startup_state_catalog_degraded_survives_lazy_activation () =
+  Server_startup_state.reset ~backend_mode:"filesystem" ();
+  Server_startup_state.mark_state_ready ~backend_mode:"filesystem";
+  Server_startup_state.activate_lazy ~backend_mode:"filesystem"
+    ~tasks:[ "restore_sessions" ];
+  Server_startup_state.mark_degraded
+    ~error:"startup catalog validation failed: synthetic";
+  Server_startup_state.finish_lazy_task ~task:"restore_sessions";
+  let current = Server_startup_state.(!state) in
+  Alcotest.(check string) "phase stays degraded after lazy task completes"
+    "degraded"
+    (Server_startup_state.phase_to_string current.phase);
+  Alcotest.(check bool) "ready flag stays true after degradation" true
+    current.state_ready;
+  Alcotest.(check (option string))
+    "catalog validation error is preserved"
+    (Some "startup catalog validation failed: synthetic")
+    current.last_error
+
 let test_startup_state_liveness () =
   Server_startup_state.reset ~backend_mode:"unknown" ();
   Alcotest.(check bool) "is_live returns true even during init" true
@@ -1506,6 +1525,10 @@ let () =
             test_blocking_bootstrap_ignores_whitespace_legacy_room_dirs;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
+          Alcotest.test_case
+            "startup catalog degradation survives lazy activation"
+            `Quick
+            test_startup_state_catalog_degraded_survives_lazy_activation;
           Alcotest.test_case "liveness probe is always true" `Quick
             test_startup_state_liveness;
           Alcotest.test_case "readiness false before init" `Quick


### PR DESCRIPTION
Summary:
- keep server and dashboard alive when startup cascade validation fails
- expose cascade validation status and rejected profiles in the dashboard
- add bootstrap and dashboard regression coverage

Verification:
- dune build --root . bin/main_eio.exe test/test_server_runtime_bootstrap.exe test/test_dashboard_cascade.exe
- ./_build/default/test/test_dashboard_cascade.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe --quick-tests

Notes:
- dashboard pnpm typecheck was not run here because dashboard/node_modules is missing