### PR TITLE
fix: exhaustive variant matches for verdict and audit_log outcome

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -264,4 +264,4 @@ let overridden_flags () =
 
 (** Flags in deprecated lifecycle state. *)
 let deprecated_flags () =
-  List.filter (fun f -> match f.lifecycle with Deprecated _ -> true | _ -> false) all_flags
+  List.filter (fun f -> match f.lifecycle with Deprecated _ -> true | Active | Experimental -> false) all_flags

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -29,7 +29,7 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Coord.confi
         match e.action with
         | Audit_log.ToolCall tool_name when e.timestamp >= since ->
           let is_fail =
-            match e.outcome with Audit_log.Failure _ -> true | _ -> false
+            match e.outcome with Audit_log.Failure _ -> true | Audit_log.Success -> false
           in
           let calls, fails =
             match SMap.find_opt tool_name m with

--- a/lib/post_verifier.ml
+++ b/lib/post_verifier.ml
@@ -219,7 +219,7 @@ let verify ~content =
     Heuristic_metrics.record {
       module_name = "post_verifier"; site = "verify";
       raw_value = verdict_score v; threshold = 0.5;
-      triggered = (match v with Fail _ -> true | _ -> false);
+      triggered = (match v with Fail _ -> true | Pass | Warn _ -> false);
       provenance = Post_verifier (match dim with Relevance -> "relevance" | Quality -> "quality" | Safety -> "safety");
       timestamp = Unix.gettimeofday ();
     }) [(Relevance, relevance); (Quality, quality); (Safety, safety)];


### PR DESCRIPTION
## Summary
- `post_verifier.ml:222`: `verdict` type wildcard `_ -> false` → explicit `Pass | Warn _ -> false`
- `dashboard_http_monitoring.ml:32`: `outcome` type wildcard `_ -> false` → explicit `Success -> false`

## Why
Both types have few constructors (3 and 2). Wildcards silently accept future additions.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)