### PR TITLE
docs(mli): freeze time_compat + dashboard_api_types + mcp_session surfaces

### DIFF
--- a/lib/dashboard_api_types/keepers.mli
+++ b/lib/dashboard_api_types/keepers.mli
@@ -1,0 +1,65 @@
+(** Dashboard API types — [GET /dashboard/b/api/keepers/summary] response.
+
+    Single-endpoint projection consumed by four Bonsai visualisations:
+    focus card, roster grid, cycle-activity swimlane, context-pressure chart.
+
+    SSOT for the JSON wire contract — any change here must be reflected in
+    [dashboard_bonsai/src/keepers_fetch.ml]. *)
+
+type keeper_status =
+  | Live
+  | Warn
+  | Dead
+
+val keeper_status_of_yojson : Yojson.Safe.t -> keeper_status Ppx_deriving_yojson_runtime.error_or
+val keeper_status_to_yojson : keeper_status -> Yojson.Safe.t
+
+(** One tool-span in a keeper's cycle, positioned as a percentage of the
+    last-60-min window. *)
+type keeper_lane_frame = {
+  kind : string;   (** ["llm" | "tool" | "think" | "wait" | "err"] *)
+  left : int;      (** left %, 0..100 *)
+  width : int;     (** width %, 0..100 *)
+  label : string;
+}
+
+val keeper_lane_frame_of_yojson : Yojson.Safe.t -> keeper_lane_frame Ppx_deriving_yojson_runtime.error_or
+val keeper_lane_frame_to_yojson : keeper_lane_frame -> Yojson.Safe.t
+
+(** One sample on the 60-min context-pressure polyline. *)
+type keeper_ctx_sample = {
+  t_minus_min : int;   (** minutes ago, 0..60 *)
+  ctx_pct : int;       (** 0..100 *)
+}
+
+val keeper_ctx_sample_of_yojson : Yojson.Safe.t -> keeper_ctx_sample Ppx_deriving_yojson_runtime.error_or
+val keeper_ctx_sample_to_yojson : keeper_ctx_sample -> Yojson.Safe.t
+
+(** Per-keeper summary. *)
+type keeper = {
+  name : string;
+  stat : string;               (** short human state, e.g. "reading", "retrying" *)
+  status : keeper_status;
+  ctx_pct : int;               (** current context utilisation, 0..100 *)
+  turn : int;
+  turn_cap : int;
+  mem_kb : int;
+  latency_ms : int;
+  last_tool : string option;
+  lane_frames : keeper_lane_frame list;
+  ctx_history : keeper_ctx_sample list;
+}
+
+val keeper_of_yojson : Yojson.Safe.t -> keeper Ppx_deriving_yojson_runtime.error_or
+val keeper_to_yojson : keeper -> Yojson.Safe.t
+
+(** Top-level response. *)
+type response = {
+  keepers : keeper list;
+  cycle : int;                 (** current cycle number *)
+  room : string option;
+  generated_at : string;       (** ISO-8601 UTC *)
+}
+
+val response_of_yojson : Yojson.Safe.t -> response Ppx_deriving_yojson_runtime.error_or
+val response_to_yojson : response -> Yojson.Safe.t

--- a/lib/mcp_session/mcp_session.mli
+++ b/lib/mcp_session/mcp_session.mli
@@ -1,0 +1,57 @@
+(** MCP HTTP Session ID management.
+
+    MCP Spec 2025-03-26: session IDs must be visible ASCII (0x21–0x7E). *)
+
+(** {1 Session action variant}
+
+    Variant SSOT for the [masc_mcp_session] tool action. Adding a constructor
+    forces recompilation of [action_to_string] and extends
+    [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml] and
+    the dispatcher in [tool_inline_dispatch.ml] both consume this type via
+    {!action_of_string_opt}. *)
+
+type action =
+  | Get
+  | Create
+  | List
+  | Cleanup
+  | Remove
+
+val action_to_string : action -> string
+
+val action_of_string_opt : string -> action option
+(** Case-insensitive, trimmed lookup. Returns [None] for unknown input. *)
+
+val all_actions : action list
+
+val valid_action_strings : string list
+(** [List.map action_to_string all_actions]. Useful for schema enums. *)
+
+(** {1 Session IDs (MCP spec)} *)
+
+val is_valid : string -> bool
+(** [is_valid id] checks that [id] is non-empty and contains only visible
+    ASCII (0x21–0x7E), per the MCP spec. *)
+
+val generate : unit -> string
+(** Generate a fresh session ID of the form [mcp_<ts>_<pid>_<rand>] (base62
+    parts). The resulting string always satisfies {!is_valid}. *)
+
+val get_or_generate : string option -> string
+(** [get_or_generate hdr] returns [hdr] unchanged when it is already a valid
+    session ID, otherwise generates a fresh one via {!generate}. *)
+
+(** {1 Internal building blocks (exposed for tests)}
+
+    These identifiers are implementation details of {!generate}; they are
+    exposed only so that [test/test_mcp_session_coverage.ml] can verify the
+    encoding table and base-62 helper. Do not depend on them in production
+    code. *)
+
+val base62_chars : string
+(** The 62-character alphabet used by {!encode_base62}:
+    [0-9A-Za-z]. *)
+
+val encode_base62 : int -> string
+(** [encode_base62 n] returns the base-62 representation of a non-negative
+    integer using {!base62_chars} as the alphabet. *)

--- a/lib/time_compat/time_compat.mli
+++ b/lib/time_compat/time_compat.mli
@@ -1,0 +1,9 @@
+(** Time compatibility layer — transparent re-export of
+    {!Mcp_protocol_eio.Time_compat}.
+
+    All existing [Time_compat.now ()], [Time_compat.sleep], etc. calls continue
+    to work unchanged.
+
+    @since 2.103.0 — migrated to the mcp-protocol-sdk shared module. *)
+
+include module type of Mcp_protocol_eio.Time_compat


### PR DESCRIPTION
## Summary

Adds `.mli` files for three single-file subsystems that had no interface declarations: `lib/time_compat/`, `lib/dashboard_api_types/`, and `lib/mcp_session/`. Each subsystem moves from 0 % to 100 % `.mli` coverage.

## Why

Follow-up to #9238 (compression). Current masc-mcp state is 53 % `.mli` coverage (vs. oas's 95 %). Without `.mli`, every top-level `let` in a `.ml` is implicitly public — AI-assisted refactoring cannot tell which identifiers are load-bearing to callers.

See `~/me/planning/ocaml-best-of-best/g2-mli-audit.md` for the full audit.

## Scope

- **Zero behaviour change.** Each `.mli` mirrors the current public surface.
- `Mcp_session.base62_chars` and `Mcp_session.encode_base62` are exposed
  because `test/test_mcp_session_coverage.ml` exercises the encoding table
  directly. They are documented as internal implementation details — future
  passes may lift the tests to the public API and narrow the interface.
- `Time_compat` uses `include module type of Mcp_protocol_eio.Time_compat`,
  which is the idiomatic way to mirror an `include M` body into an interface.

## Verification

- `dune build --root .` green (full library).
- `dune build --root . @test/runtest` green.
- Callers checked: all refs to `Time_compat.*`, `Mcp_session.*`, `Keepers.*` recompile cleanly against the new signatures (new `.cmi` artefacts under `_build/default/lib/`).

## Test plan

- [x] `dune build --root .`
- [x] `dune build --root . @test/runtest`
- [ ] CI runs (see checks below)
- [ ] No caller needs changes (verified locally; confirm CI)
