### PR TITLE
fix(match): exhaust pulse/adversarial/sdk wildcard matches

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -322,7 +322,9 @@ let evaluate ctx =
   let diff_findings =
     List.filter_map
       (fun input ->
-        match input with Diff content -> check_diff_size content | _ -> None)
+        match input with
+        | Diff content -> check_diff_size content
+        | Changed_file _ | Type_signature _ | Interface_contract _ -> None)
       ctx.inputs
   in
   let interface_findings = check_missing_interface ctx.inputs in

--- a/lib/pulse/pulse.ml
+++ b/lib/pulse/pulse.ml
@@ -198,7 +198,7 @@ let tick t trigger =
     trigger;
   } in
   t.last_beat_v <- Some beat;
-  (match trigger with Nudge _ -> t.total_nudges <- t.total_nudges + 1 | _ -> ());
+  (match trigger with Nudge _ -> t.total_nudges <- t.total_nudges + 1 | Rhythm | Demand -> ());
   Log.Pulse.debug "beat #%d trigger=%s" beat.seq (trigger_to_string trigger);
   dispatch_consumers_with_recovery t beat;
   (* Check bounded lifecycle *)

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -459,7 +459,7 @@ let sdk_alias_json binding =
   let inject_agent_name =
     List.exists
       (fun (_target, source) ->
-        match source with Agent_name -> true | _ -> false)
+        match source with Agent_name -> true | Input_field _ | Static _ -> false)
       binding.arg_bindings
   in
   `Assoc


### PR DESCRIPTION
## Summary
- Replace `_` wildcards with explicit variant constructors in 3 modules
- `pulse.ml`: `trigger` type — Rhythm, Demand explicit
- `adversarial_eval.ml`: `allowed_input` type — Changed_file, Type_signature, Interface_contract explicit
- `sdk_tool_contract.ml`: `arg_source` type — Input_field, Static explicit

## Test plan
- [x] `dune build` passes
- [ ] CI green
- [ ] Zero behavior change (exhaustive match is refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)