### PR TITLE
ci: raise tla-specs timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,7 @@ jobs:
   tla-specs:
     name: TLA+ Model Checking (${{ matrix.suite }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [pr-sync-check, changes]
     if: ${{ !cancelled() && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     strategy:


### PR DESCRIPTION
## Summary
- raise `tla-specs` job timeout from 15 to 25 minutes
- stop `check-clean` from being cancelled mid-run and poisoning `CI Gate`

## Why
- PR #9232 hit `CI Gate` failures because `TLA+ Model Checking (check-clean)` was cancelled at the workflow timeout instead of failing on a spec error
- GitHub Actions logs for runs `24708645306` and `24708645572` show the job being cancelled at the 15 minute mark
- local reproduction completed successfully in `1383.42s` (~23m 3s), so 15 minutes is no longer enough headroom

## Validation
- `git diff --check`
- `/usr/bin/time -p make -C specs check-clean`
