### PR TITLE
fix(match): exhaust autoresearch/keeper/snapshot wildcard matches

### DIFF
--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -135,7 +135,7 @@ let safe_active_entry_json ~(base_path : string)
       {
         live_rank = 0;
         status_rank =
-          (match state.status with Running -> 0 | _ -> 1);
+          (match state.status with Running -> 0 | Completed | Stopped | Error -> 1);
         neg_updated_at = -. state.updated_at;
       }
     in
@@ -156,7 +156,7 @@ let safe_persisted_entry_json ~(base_path : string)
       {
         live_rank = 1;
         status_rank =
-          (match summary.status with Running -> 0 | _ -> 1);
+          (match summary.status with Running -> 0 | Completed | Stopped | Error -> 1);
         neg_updated_at =
           -. Option.value ~default:0.0 summary.updated_at;
       }

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -469,7 +469,7 @@ let keeper_continuity_state
     ~(now_ts : float) : keeper_continuity =
   let _ = meta in
   let healthy_like =
-    match health_state with KH_healthy | KH_idle -> true | _ -> false
+    match health_state with KH_healthy | KH_idle -> true | KH_offline | KH_stale | KH_degraded | KH_zombie | KH_dead -> false
   in
   let recently_started =
     match keepalive_started_at with

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1056,7 +1056,7 @@ let invalidate_snapshot_cache () =
     let conds =
       Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
         let cs = Hashtbl.fold (fun _key slot acc ->
-          match slot with Computing { cond } -> cond :: acc | _ -> acc
+          match slot with Computing { cond } -> cond :: acc | Cached _ -> acc
         ) _snapshot_table [] in
         Hashtbl.clear _snapshot_table;
         cs)
@@ -1192,7 +1192,7 @@ let snapshot_json ?actor ?view ?(include_messages = true)
   let summary_fields = timed "summary_fields" (fun () ->
     if include_summary_fields
        && initialized
-       && (match view with Summary | Full -> true | _ -> false)
+       && (match view with Summary | Full -> true | Sessions | Keepers | Messages -> false)
     then
       let room_attention =
         build_room_attention_items config


### PR DESCRIPTION
## Summary
- Replace `_` wildcards with explicit variant constructors in 3 modules
- `dashboard_http_autoresearch.ml`: `status = Running | Completed | Stopped | Error`
- `keeper_exec_status.ml`: `keeper_health` (7 constructors, 5 non-healthy explicit)
- `operator_control_snapshot.ml`: `snapshot_slot` (Cached|Computing), `snapshot_view` (5 constructors)

## Test plan
- [x] `dune build` passes
- [ ] CI green
- [ ] Zero behavior change (exhaustive match is refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)