### PR TITLE
[codex] add cascade profile display helpers

### DIFF
--- a/dashboard/src/lib/cascade-profile-display.test.ts
+++ b/dashboard/src/lib/cascade-profile-display.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cascadeProfileDescription,
+  cascadeProfileDisplay,
+  cascadeProfileLabel,
+  cascadeProfileOptionLabel,
+  cascadeProfileSearchText,
+} from './cascade-profile-display'
+
+describe('cascade-profile-display', () => {
+  it('maps keeper_unified to a friendly balanced label', () => {
+    expect(cascadeProfileDisplay('keeper_unified')).toEqual({
+      label: 'Balanced',
+      description: '기본 멀티-CLI 균형형. 대부분 keeper용.',
+    })
+  })
+
+  it('builds option labels that preserve the internal id', () => {
+    expect(cascadeProfileOptionLabel('tool_use_strict')).toBe('Tool Required (tool_use_strict)')
+  })
+
+  it('falls back to the raw name for unknown profiles', () => {
+    expect(cascadeProfileLabel('custom_live')).toBe('custom_live')
+    expect(cascadeProfileDescription('custom_live')).toBe('Custom/internal cascade profile.')
+  })
+
+  it('includes raw id and friendly text in search text', () => {
+    const text = cascadeProfileSearchText('resilient_breaker')
+    expect(text).toContain('resilient_breaker')
+    expect(text).toContain('resilient')
+  })
+})

--- a/dashboard/src/lib/cascade-profile-display.ts
+++ b/dashboard/src/lib/cascade-profile-display.ts
@@ -1,0 +1,66 @@
+export interface CascadeProfileDisplay {
+  label: string
+  description: string
+}
+
+const DISPLAY: Record<string, CascadeProfileDisplay> = {
+  default: {
+    label: 'Single',
+    description: '단일 Claude baseline. 문맥 일관성이 중요한 keeper용.',
+  },
+  keeper_unified: {
+    label: 'Balanced',
+    description: '기본 멀티-CLI 균형형. 대부분 keeper용.',
+  },
+  tool_use_strict: {
+    label: 'Tool Required',
+    description: '툴 호출 강제가 필요한 keeper용.',
+  },
+  resilient_breaker: {
+    label: 'Resilient',
+    description: '장애 격리와 backoff가 필요한 keeper용.',
+  },
+  local_only: {
+    label: 'Local Fallback',
+    description: '3-CLI가 모두 불가할 때만 쓰는 로컬 fallback.',
+  },
+  tool_rerank: {
+    label: 'Tool Rerank',
+    description: '짧은 rerank scoring 전용 system profile.',
+  },
+  governance_judge: {
+    label: 'Governance Judge',
+    description: 'Dashboard governance judge 전용 system profile.',
+  },
+  operator_judge: {
+    label: 'Operator Judge',
+    description: 'Operator judge 전용 system profile.',
+  },
+}
+
+const fallbackDisplay = (name: string): CascadeProfileDisplay => ({
+  label: name,
+  description: 'Custom/internal cascade profile.',
+})
+
+export function cascadeProfileDisplay(name: string): CascadeProfileDisplay {
+  return DISPLAY[name] ?? fallbackDisplay(name)
+}
+
+export function cascadeProfileLabel(name: string): string {
+  return cascadeProfileDisplay(name).label
+}
+
+export function cascadeProfileDescription(name: string): string {
+  return cascadeProfileDisplay(name).description
+}
+
+export function cascadeProfileOptionLabel(name: string): string {
+  const display = cascadeProfileDisplay(name)
+  return display.label === name ? name : `${display.label} (${name})`
+}
+
+export function cascadeProfileSearchText(name: string): string {
+  const display = cascadeProfileDisplay(name)
+  return `${name} ${display.label} ${display.description}`.toLowerCase()
+}


### PR DESCRIPTION
## Summary
- add a shared dashboard helper for human-friendly cascade profile labels and descriptions
- add option-label and search-text helpers so UI components can reuse one source of truth
- add focused Vitest coverage for known and fallback profile names

## Why
The dashboard currently needs a small display mapping layer for internal cascade profile ids. Keeping that logic in one module avoids repeating labels and fallback behavior across components.

## Impact
This is groundwork only. It adds the helper module and tests but does not yet wire the helper into an existing panel.

## Validation
- `pnpm test src/lib/cascade-profile-display.test.ts`
- `pnpm typecheck`
- `pnpm lint`
