### PR TITLE
[codex] fix persistence read drop observability

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -115,6 +115,21 @@ let read_json_file_logged ~label path : Yojson.Safe.t option =
     Log.Misc.warn "[%s] failed to read JSON from %s: %s" label path msg;
     None
 
+let persistence_read_drop_reason_list_dir_error = "list_dir_error"
+let persistence_read_drop_reason_entry_load_error = "entry_load_error"
+let persistence_read_drop_reason_invalid_payload = "invalid_payload"
+
+let report_persistence_read_drop ~on_drop ~surface ~reason ~path ~detail =
+  Log.Misc.warn "[%s] persistence read drop (%s) path=%s: %s"
+    surface reason path detail;
+  on_drop ()
+
+let result_to_option_logged ~on_drop ~surface ~reason ~path = function
+  | Ok value -> Some value
+  | Error detail ->
+    report_persistence_read_drop ~on_drop ~surface ~reason ~path ~detail;
+    None
+
 (** Read JSON file via Eio-native I/O (Fs_compat).
     Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts.
     Falls back to blocking I/O when Eio fs is not set. *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -43,6 +43,29 @@ val read_json_file_logged : label:string -> string -> Yojson.Safe.t option
 (** Read JSON file safely, logging errors instead of silently discarding them.
     Returns [Some json] on success, [None] on failure with a warning log. *)
 
+val persistence_read_drop_reason_list_dir_error : string
+val persistence_read_drop_reason_entry_load_error : string
+val persistence_read_drop_reason_invalid_payload : string
+
+val report_persistence_read_drop :
+  on_drop:(unit -> unit) ->
+  surface:string ->
+  reason:string ->
+  path:string ->
+  detail:string ->
+  unit
+(** Report a persisted read-model drop via WARN log + Prometheus counter. *)
+
+val result_to_option_logged :
+  on_drop:(unit -> unit) ->
+  surface:string ->
+  reason:string ->
+  path:string ->
+  ('a, string) result ->
+  'a option
+(** Convert a [Result] into an option while reporting [Error] as an
+    observable persisted-read drop. *)
+
 val read_json_eio : string -> Yojson.Safe.t
 (** Read JSON file via Eio-native I/O (Fs_compat).
     Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts. *)

--- a/lib/governance_cases_snapshot.ml
+++ b/lib/governance_cases_snapshot.ml
@@ -16,12 +16,32 @@ type case = {
   created_at : float;
 }
 
+let persistence_surface = "governance_cases_snapshot"
+
+let observe_drop ~reason =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)] ()
+
+let report_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () -> observe_drop ~reason)
+    ~surface:persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 let cases_dir ~base_path =
   Filename.concat base_path (Filename.concat ".masc" "governance_v2/cases")
 
-let parse_case (json : Yojson.Safe.t) : case option =
+let parse_case ~path (json : Yojson.Safe.t) : case option =
   let id = Safe_ops.json_string ~default:"" "id" json in
-  if id = "" then None
+  if id = "" then (
+    report_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+      ~path
+      ~detail:"missing required id";
+    None
+  )
   else
     let title = Safe_ops.json_string ~default:"" "title" json in
     let status = Safe_ops.json_string ~default:"" "status" json in
@@ -36,17 +56,31 @@ let parse_case (json : Yojson.Safe.t) : case option =
 
 let load_all ~base_path : case list =
   let dir = cases_dir ~base_path in
-  match Safe_ops.list_dir_safe dir with
-  | Error _ -> []
-  | Ok names ->
-    names
-    |> List.filter (fun name ->
-      Filename.check_suffix name ".json"
-      && not (String.starts_with ~prefix:"_" name))
-    |> List.filter_map (fun name ->
-      match Safe_ops.read_json_file_safe (Filename.concat dir name) with
-      | Error _ -> None
-      | Ok json -> parse_case json)
+  if not (Sys.file_exists dir) then
+    []
+  else
+    match Safe_ops.list_dir_safe dir with
+    | Error detail ->
+      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+      []
+    | Ok names ->
+      names
+      |> List.filter (fun name ->
+        Filename.check_suffix name ".json"
+        && not (String.starts_with ~prefix:"_" name))
+      |> List.filter_map (fun name ->
+        let path = Filename.concat dir name in
+        match
+          Safe_ops.result_to_option_logged
+            ~on_drop:(fun () ->
+              observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
+            ~surface:persistence_surface
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+            ~path
+            (Safe_ops.read_json_file_safe path)
+        with
+        | None -> None
+        | Some json -> parse_case ~path json)
 
 let count_by_status ~base_path ~status =
   load_all ~base_path

--- a/lib/governance_cases_snapshot.mli
+++ b/lib/governance_cases_snapshot.mli
@@ -15,8 +15,8 @@ val cases_dir : base_path:string -> string
 
 (** Load every case in [base_path/.masc/governance_v2/cases/*.json] whose
     name does not start with ["_"] (reserved for markers).  Unreadable
-    or malformed files are skipped silently; the caller gets an empty
-    list when the directory does not exist. *)
+    or malformed files are skipped with WARN+metric observability; the
+    caller still gets an empty list when the directory does not exist. *)
 val load_all : base_path:string -> case list
 
 (** Count of cases whose [status] equals the given string. *)

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -181,19 +181,42 @@ let load_handover ~fs config handover_id : (handover_record, string) result =
 
 (** List all handovers *)
 let list_handovers ~fs config : handover_record list =
+  let surface = "handover_eio" in
+  let observe_drop ~reason =
+    Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+      ~labels:[("surface", surface); ("reason", reason)] ()
+  in
+  let report_drop ~reason ~path ~detail =
+    Safe_ops.report_persistence_read_drop
+      ~on_drop:(fun () -> observe_drop ~reason)
+      ~surface
+      ~reason
+      ~path
+      ~detail
+  in
   let dir = handover_dir_path config in
-  let path = Eio.Path.(fs / dir) in
-  try
-    let files = Eio.Path.read_dir path in
-    let json_files = List.filter (fun f ->
-      Filename.check_suffix f ".json" && f <> "pending.json"
-    ) files in
-    let handovers = List.filter_map (fun f ->
-      let id = Filename.chop_suffix f ".json" in
-      match load_handover ~fs config id with Ok h -> Some h | Error _ -> None
-    ) json_files in
-    List.sort (fun a b -> compare b.created_at a.created_at) handovers
-  with Eio.Io _ | Yojson.Json_error _ -> []
+  if not (Sys.file_exists dir) then
+    []
+  else
+    match Safe_ops.list_dir_safe dir with
+    | Error detail ->
+      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+      []
+    | Ok files ->
+      let json_files = List.filter (fun f ->
+        Filename.check_suffix f ".json" && f <> "pending.json"
+      ) files in
+      let handovers = List.filter_map (fun f ->
+        let id = Filename.chop_suffix f ".json" in
+        Safe_ops.result_to_option_logged
+          ~on_drop:(fun () ->
+            observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
+          ~surface
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path:(Filename.concat dir f)
+          (load_handover ~fs config id)
+      ) json_files in
+      List.sort (fun a b -> compare b.created_at a.created_at) handovers
 
 (** Get pending handovers *)
 let get_pending_handovers ~fs config : handover_record list =
@@ -277,5 +300,3 @@ let format_as_markdown (h : handover_record) : string =
   end;
 
   Buffer.contents buf
-
-

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -40,23 +40,56 @@ let load_board_vote_count config =
   List.length (load_jsonl_safe path)
 
 let load_governance_cases config =
+  let surface = "meta_cognition_snapshot" in
+  let observe_drop ~reason =
+    Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+      ~labels:[("surface", surface); ("reason", reason)] ()
+  in
+  let report_drop ~reason ~path ~detail =
+    Safe_ops.report_persistence_read_drop
+      ~on_drop:(fun () -> observe_drop ~reason)
+      ~surface
+      ~reason
+      ~path
+      ~detail
+  in
   let dir = Filename.concat (Coord.masc_dir config) "governance_v2/cases" in
-  match Safe_ops.list_dir_safe dir with
-  | Error _ -> []
-  | Ok names ->
-      names
-      |> List.filter (fun name ->
-             Filename.check_suffix name ".json"
-             && not (String.starts_with ~prefix:"_" name))
-      |> List.filter_map (fun name ->
-             let path = Filename.concat dir name in
-             match Safe_ops.read_json_file_safe path with
-             | Error _ -> None
-             | Ok json ->
-                 let id = Safe_ops.json_string ~default:"" "id" json in
-                 let title = Safe_ops.json_string ~default:"" "title" json in
-                 let status = Safe_ops.json_string ~default:"" "status" json in
-                 if id = "" then None else Some { id; title; status })
+  if not (Sys.file_exists dir) then
+    []
+  else
+    match Safe_ops.list_dir_safe dir with
+    | Error detail ->
+      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+      []
+    | Ok names ->
+        names
+        |> List.filter (fun name ->
+               Filename.check_suffix name ".json"
+               && not (String.starts_with ~prefix:"_" name))
+        |> List.filter_map (fun name ->
+               let path = Filename.concat dir name in
+               match
+                 Safe_ops.result_to_option_logged
+                   ~on_drop:(fun () ->
+                     observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
+                   ~surface
+                   ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                   ~path
+                   (Safe_ops.read_json_file_safe path)
+               with
+               | None -> None
+               | Some json ->
+                   let id = Safe_ops.json_string ~default:"" "id" json in
+                   if id = "" then (
+                     report_drop
+                       ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                       ~path
+                       ~detail:"missing required id";
+                     None
+                   ) else
+                     let title = Safe_ops.json_string ~default:"" "title" json in
+                     let status = Safe_ops.json_string ~default:"" "status" json in
+                     Some { id; title; status })
 
 (* ================================================================ *)
 (* Source extraction                                                *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -205,6 +205,8 @@ let metric_keeper_lifecycle_dispatch_rejections =
   "masc_keeper_lifecycle_dispatch_rejections_total"
 let metric_keeper_paused_state_persist_errors =
   "masc_keeper_paused_state_persist_errors_total"
+let metric_persistence_read_drops =
+  "masc_persistence_read_drops_total"
 
 (* OAS SSE relay (oas_sse_bridge.ml). *)
 let metric_oas_sse_relay_retries =
@@ -308,6 +310,10 @@ let init () =
   add metric_keeper_paused_state_persist_errors
     "Total keeper paused-state persistence failures, labeled by phase \
      (boot_resume_check|boot_resume_persist) and reason (read_meta_error|meta_missing)"
+    Counter;
+  add metric_persistence_read_drops
+    "Total persisted read-model entries dropped during filesystem scans, \
+     labeled by surface and reason"
     Counter;
   add metric_oas_sse_relay_retries
     "Total OAS SSE relay retry attempts, labeled by failed stage"

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -294,18 +294,39 @@ let load_request base_path req_id =
     Error (Printf.sprintf "Verification %s not found" req_id)
 
 let list_requests base_path =
+  let surface = "verification" in
+  let observe_drop ~reason =
+    Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+      ~labels:[("surface", surface); ("reason", reason)] ()
+  in
+  let report_drop ~reason ~path ~detail =
+    Safe_ops.report_persistence_read_drop
+      ~on_drop:(fun () -> observe_drop ~reason)
+      ~surface
+      ~reason
+      ~path
+      ~detail
+  in
   let dir = verifications_dir base_path in
-  if Sys.file_exists dir then
-    let files = Sys.readdir dir in
-    Array.to_list files
-    |> List.filter (fun f -> Filename.check_suffix f ".json")
-    |> List.filter_map (fun f ->
-        let id = Filename.chop_suffix f ".json" in
-        match load_request base_path id with
-        | Ok req -> Some req
-        | Error _ -> None)
-  else
+  if not (Sys.file_exists dir) then
     []
+  else
+    match Safe_ops.list_dir_safe dir with
+    | Error detail ->
+      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+      []
+    | Ok files ->
+      files
+      |> List.filter (fun f -> Filename.check_suffix f ".json")
+      |> List.filter_map (fun f ->
+          let id = Filename.chop_suffix f ".json" in
+          Safe_ops.result_to_option_logged
+            ~on_drop:(fun () ->
+              observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
+            ~surface
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+            ~path:(Filename.concat dir f)
+            (load_request base_path id))
 
 (** High-level API *)
 

--- a/test/dune
+++ b/test/dune
@@ -281,6 +281,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_governance_cases_snapshot)
+ (modules test_governance_cases_snapshot)
+ (libraries masc_test_deps))
+
+(test
  (name test_meta_cognition_feedback)
  (modules test_meta_cognition_feedback)
  (libraries masc_test_deps))

--- a/test/test_governance_cases_snapshot.ml
+++ b/test/test_governance_cases_snapshot.ml
@@ -1,0 +1,107 @@
+open Alcotest
+
+module G = Masc_mcp.Governance_cases_snapshot
+module P = Masc_mcp.Prometheus
+
+let persistence_surface = "governance_cases_snapshot"
+
+let counter_value reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)] ()
+
+let with_temp_dir f =
+  let dir = Filename.temp_dir "masc_governance_cases" "" in
+  let rec cleanup path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name ->
+          cleanup (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Unix.unlink path
+  in
+  Fun.protect
+    ~finally:(fun () -> try cleanup dir with _ -> ())
+    (fun () -> f dir)
+
+let write_file path body =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc body)
+
+let test_missing_dir_stays_quiet () =
+  with_temp_dir @@ fun base_path ->
+  let before_list_dir =
+    counter_value Safe_ops.persistence_read_drop_reason_list_dir_error
+  in
+  let before_entry =
+    counter_value Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let before_invalid =
+    counter_value Safe_ops.persistence_read_drop_reason_invalid_payload
+  in
+  let cases = G.load_all ~base_path in
+  check int "no cases" 0 (List.length cases);
+  check (float 0.1) "missing dir does not increment list_dir_error"
+    before_list_dir
+    (counter_value Safe_ops.persistence_read_drop_reason_list_dir_error);
+  check (float 0.1) "missing dir does not increment entry_load_error"
+    before_entry
+    (counter_value Safe_ops.persistence_read_drop_reason_entry_load_error);
+  check (float 0.1) "missing dir does not increment invalid_payload"
+    before_invalid
+    (counter_value Safe_ops.persistence_read_drop_reason_invalid_payload)
+
+let test_load_all_skips_bad_entries_with_metric () =
+  with_temp_dir @@ fun base_path ->
+  let dir = G.cases_dir ~base_path in
+  Fs_compat.mkdir_p dir;
+  Fs_compat.save_file (Filename.concat dir "good.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "case-1");
+           ("title", `String "case title");
+           ("status", `String "pending_ruling");
+           ("risk_class", `String "high");
+           ("created_at", `Float 1000.0);
+         ]));
+  write_file (Filename.concat dir "broken.json") "{not-json";
+  Fs_compat.save_file (Filename.concat dir "missing-id.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("title", `String "missing id");
+           ("status", `String "pending_ruling");
+           ("risk_class", `String "low");
+         ]));
+  let before_entry =
+    counter_value Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let before_invalid =
+    counter_value Safe_ops.persistence_read_drop_reason_invalid_payload
+  in
+  let cases = G.load_all ~base_path in
+  check int "only valid case loaded" 1 (List.length cases);
+  let case = List.hd cases in
+  check string "case id" "case-1" case.id;
+  check string "case status" "pending_ruling" case.status;
+  check (float 0.1) "broken file increments entry_load_error" 1.0
+    (counter_value Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before_entry);
+  check (float 0.1) "missing id increments invalid_payload" 1.0
+    (counter_value Safe_ops.persistence_read_drop_reason_invalid_payload
+     -. before_invalid)
+
+let () =
+  run "Governance_cases_snapshot"
+    [
+      ( "load_all",
+        [
+          test_case "missing dir stays quiet" `Quick
+            test_missing_dir_stays_quiet;
+          test_case "skips bad entries with metric" `Quick
+            test_load_all_skips_bad_entries_with_metric;
+        ] );
+    ]

--- a/test/test_handover_eio_coverage.ml
+++ b/test/test_handover_eio_coverage.ml
@@ -10,6 +10,13 @@
 open Alcotest
 
 module Handover_eio = Masc_mcp.Handover_eio
+module Prometheus = Masc_mcp.Prometheus
+
+let persistence_surface = "handover_eio"
+
+let persistence_counter reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)] ()
 
 (* ============================================================
    handover_record Type Tests
@@ -292,8 +299,14 @@ let test_load_nonexistent () =
 
 let test_list_handovers_empty () =
   with_eio_env @@ fun ~fs config ->
+  let before =
+    persistence_counter Safe_ops.persistence_read_drop_reason_list_dir_error
+  in
   let handovers = Handover_eio.list_handovers ~fs config in
-  check int "empty list" 0 (List.length handovers)
+  check int "empty list" 0 (List.length handovers);
+  check (float 0.1) "missing dir does not increment metric"
+    before
+    (persistence_counter Safe_ops.persistence_read_drop_reason_list_dir_error)
 
 let test_list_handovers_multiple () =
   with_eio_env @@ fun ~fs config ->
@@ -305,6 +318,26 @@ let test_list_handovers_multiple () =
   ignore (Handover_eio.save_handover ~fs config h2);
   let handovers = Handover_eio.list_handovers ~fs config in
   check int "two handovers" 2 (List.length handovers)
+
+let test_list_handovers_skips_bad_entries_with_metric () =
+  with_eio_env @@ fun ~fs config ->
+  let h = Handover_eio.create_handover
+    ~from_agent:"a1" ~task_id:"t1" ~session_id:"s1" ~reason:Handover_eio.Explicit in
+  ignore (Handover_eio.save_handover ~fs config h);
+  let dir = Filename.concat config.base_path ".masc/handovers" in
+  let broken = Filename.concat dir "broken.json" in
+  let oc = open_out broken in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc "{not-json");
+  let before =
+    persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let handovers = Handover_eio.list_handovers ~fs config in
+  check int "only valid handover returned" 1 (List.length handovers);
+  check (float 0.1) "broken file increments metric" 1.0
+    (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before)
 
 (* ============================================================
    Eio IO Tests: get_pending_handovers
@@ -397,6 +430,8 @@ let () =
     "eio_list", [
       test_case "empty" `Quick test_list_handovers_empty;
       test_case "multiple" `Quick test_list_handovers_multiple;
+      test_case "skips bad entries with metric" `Quick
+        test_list_handovers_skips_bad_entries_with_metric;
     ];
     "eio_pending", [
       test_case "get pending" `Quick test_get_pending_handovers;

--- a/test/test_meta_cognition_snapshot.ml
+++ b/test/test_meta_cognition_snapshot.ml
@@ -1,8 +1,10 @@
 module Tool_agent = Masc_mcp.Tool_agent
 module Coord = Masc_mcp.Coord
 module Meta_cognition = Masc_mcp.Meta_cognition
+module Prometheus = Masc_mcp.Prometheus
 
 let counter = ref 0
+let persistence_surface = "meta_cognition_snapshot"
 
 let temp_dir () =
   incr counter;
@@ -92,6 +94,10 @@ let json_list_ids key json =
          match item |> member "id" with
          | `String value -> Some value
          | _ -> None)
+
+let persistence_counter reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)] ()
 
 let test_snapshot_detects_signals () =
   with_ctx @@ fun ctx ->
@@ -248,6 +254,43 @@ let test_parse_summary_preserves_refs_and_secondary_signals () =
         [ "comment:c-1"; "post:p-root" ]
         (interpretation.evidence_refs |> List.sort String.compare)
 
+let test_snapshot_governance_cases_skip_bad_entries_with_metric () =
+  with_ctx @@ fun ctx ->
+  let cases_dir = Filename.concat (Coord.masc_dir ctx.config) "governance_v2/cases" in
+  Fs_compat.mkdir_p cases_dir;
+  Fs_compat.save_file (Filename.concat cases_dir "good.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "case-1");
+           ("title", `String "good governance case");
+           ("status", `String "pending_ruling");
+         ]));
+  Fs_compat.save_file (Filename.concat cases_dir "missing-id.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("title", `String "bad governance case");
+           ("status", `String "pending_ruling");
+         ]));
+  Fs_compat.save_file (Filename.concat cases_dir "broken.json") "{not-json";
+  let before_entry =
+    persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let before_invalid =
+    persistence_counter Safe_ops.persistence_read_drop_reason_invalid_payload
+  in
+  let json = Meta_cognition.snapshot_json ~limit:5 ctx.config in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "valid governance case still counted" 1
+    (json |> member "room_state" |> member "governance_case_count" |> to_int);
+  Alcotest.(check (float 0.1)) "broken file increments entry_load_error" 1.0
+    (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before_entry);
+  Alcotest.(check (float 0.1)) "missing id increments invalid_payload" 1.0
+    (persistence_counter Safe_ops.persistence_read_drop_reason_invalid_payload
+     -. before_invalid)
+
 let () =
   Alcotest.run "Meta_cognition_snapshot"
     [
@@ -259,5 +302,7 @@ let () =
             test_snapshot_marks_contested_belief;
           Alcotest.test_case "parses summary refs and secondary signals" `Quick
             test_parse_summary_preserves_refs_and_secondary_signals;
+          Alcotest.test_case "governance cases skip bad entries with metric"
+            `Quick test_snapshot_governance_cases_skip_bad_entries_with_metric;
         ] );
     ]

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -4,6 +4,13 @@
 let () = Mirage_crypto_rng_unix.use_default ()
 
 module V = Masc_mcp.Verification
+module P = Masc_mcp.Prometheus
+
+let persistence_surface = "verification"
+
+let persistence_counter reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)] ()
 
 (* Initialize mirage-crypto-rng once (needed by Verification.generate_id). *)
 let () = Mirage_crypto_rng_unix.use_default ()
@@ -152,6 +159,32 @@ let test_list_requests () =
         ~output:`Null ~criteria:[] ~worker:"b" () in
     let reqs = V.list_requests base_path in
     Alcotest.(check int) "two requests" 2 (List.length reqs))
+
+let test_list_requests_missing_dir_stays_quiet () =
+  with_temp_dir (fun base_path ->
+    let before =
+      persistence_counter Safe_ops.persistence_read_drop_reason_list_dir_error
+    in
+    let reqs = V.list_requests base_path in
+    Alcotest.(check int) "no requests" 0 (List.length reqs);
+    Alcotest.(check (float 0.1)) "missing dir does not increment metric"
+      before
+      (persistence_counter Safe_ops.persistence_read_drop_reason_list_dir_error))
+
+let test_list_requests_skips_bad_entries_with_metric () =
+  with_temp_dir (fun base_path ->
+    let _ = V.create_request ~base_path ~task_id:"t1"
+        ~output:`Null ~criteria:[] ~worker:"a" () in
+    let dir = Filename.concat base_path "verifications" in
+    Fs_compat.save_file (Filename.concat dir "broken.json") "{not-json";
+    let before =
+      persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+    in
+    let reqs = V.list_requests base_path in
+    Alcotest.(check int) "only valid request returned" 1 (List.length reqs);
+    Alcotest.(check (float 0.1)) "broken file increments metric" 1.0
+      (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+       -. before))
 
 let test_assign_verifier () =
   with_temp_dir (fun base_path ->
@@ -361,6 +394,10 @@ let () =
     "storage", [
       Alcotest.test_case "create and load" `Quick test_create_and_load;
       Alcotest.test_case "list requests" `Quick test_list_requests;
+      Alcotest.test_case "list requests missing dir stays quiet" `Quick
+        test_list_requests_missing_dir_stays_quiet;
+      Alcotest.test_case "list requests skips bad entries with metric" `Quick
+        test_list_requests_skips_bad_entries_with_metric;
       Alcotest.test_case "assign verifier" `Quick test_assign_verifier;
       Alcotest.test_case "cross-agent assign fail" `Quick test_assign_verifier_cross_agent_fail;
       Alcotest.test_case "submit verdict" `Quick test_submit_verdict;


### PR DESCRIPTION
## What changed
- made the remaining #8391 Cluster A persisted-read surfaces observable instead of silently dropping read/load failures
- added `masc_persistence_read_drops_total` and shared drop-report helpers
- updated governance case, meta-cognition, handover, and verification filesystem readers to preserve partial success while logging/counting real drops
- added focused regression coverage for each touched surface

## Why
Several read-model surfaces still collapsed `Error _ -> []` or `Error _ -> None`, which made malformed or unreadable persisted records disappear without any operational signal.

## Impact
- operators still get the same list/count shapes for missing directories and partial-success reads
- real scan/load/payload drops now emit WARN logs and Prometheus metrics
- dashboards and snapshot consumers no longer fail open silently when neighboring persisted files are broken

## Root cause
The read paths were still using silent fallback patterns in a few remaining Cluster A readers, so broken JSON or per-entry load failures looked identical to empty state.

## SSOT cleanup
I found one SSOT drift in the first implementation pass: persistence-drop reason labels were repeated as raw strings across code and tests. Those reason values are now centralized in `Safe_ops` constants before publishing the PR.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-8391-cluster-a --build-dir /tmp/issue-8391-dune ./test/test_governance_cases_snapshot.exe ./test/test_meta_cognition_snapshot.exe ./test/test_verification.exe ./test/test_handover_eio_coverage.exe`
- `/tmp/issue-8391-dune/default/test/test_governance_cases_snapshot.exe`
- `/tmp/issue-8391-dune/default/test/test_meta_cognition_snapshot.exe`
- `/tmp/issue-8391-dune/default/test/test_verification.exe`
- `/tmp/issue-8391-dune/default/test/test_handover_eio_coverage.exe`

Refs #8391
