### PR TITLE
[codex] fallback to static catalog for keeper lookups

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -434,6 +434,87 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               candidates;
             }
 
+let load_static_snapshot ~config_path : (snapshot, rejection) result =
+  let checked_at = Unix.gettimeofday () in
+  let attempted_mtime =
+    try Some (Unix.stat config_path).Unix.st_mtime
+    with
+    | Unix.Unix_error _ | Sys_error _ -> None
+  in
+  if not (Env_config_core.existing_file config_path) then
+    Error
+      (rejection_of_path ~config_path ~attempted_mtime ~checked_at
+         ~errors:[ Printf.sprintf "active cascade catalog is missing: %s" config_path ]
+         ~profiles:[])
+  else
+    match Cascade_config_loader.load_json config_path with
+    | Error msg ->
+        Error
+          (rejection_of_path ~config_path ~attempted_mtime ~checked_at
+             ~errors:
+               [
+                 Printf.sprintf
+                   "active cascade catalog could not be loaded: %s"
+                   msg;
+               ]
+             ~profiles:[])
+    | Ok json ->
+        let profiles = discover_profiles json in
+        let top_errors =
+          let base =
+            if profiles = [] then
+              [ "active cascade catalog has no <name>_models profiles" ]
+            else
+              []
+          in
+          if List.mem Keeper_config.default_cascade_name profiles then
+            base
+          else
+            base
+            @
+            [
+              Printf.sprintf
+                "required default profile %S is missing"
+                Keeper_config.default_cascade_name;
+            ]
+        in
+        let built_profiles, rejected_profiles =
+          List.fold_left
+            (fun (ok_acc, err_acc) name ->
+              match validate_profile_static ~config_path name with
+              | Ok profile -> (profile :: ok_acc, err_acc)
+              | Error rejection -> (ok_acc, rejection :: err_acc))
+            ([], [])
+            profiles
+        in
+        let built_profiles = List.rev built_profiles in
+        let rejected_profiles = List.rev rejected_profiles in
+        if top_errors <> [] || rejected_profiles <> [] then
+          Error
+            (rejection_of_path ~config_path ~attempted_mtime ~checked_at
+               ~errors:top_errors ~profiles:rejected_profiles)
+        else
+          Ok
+            {
+              source_path = config_path;
+              mtime = Option.value attempted_mtime ~default:0.0;
+              validated_at = checked_at;
+              profiles =
+                List.map
+                  (fun (profile : profile_build) ->
+                    {
+                      name = profile.name;
+                      weighted_entries = profile.weighted_entries;
+                      inference_params = profile.inference_params;
+                      api_key_env_overrides = profile.api_key_env_overrides;
+                      strategy = profile.strategy;
+                      ollama_max_concurrent = profile.ollama_max_concurrent;
+                      cli_max_concurrent = profile.cli_max_concurrent;
+                      probes = [];
+                    })
+                  built_profiles;
+            }
+
 let validate_path ~sw ~net ~clock ~config_path =
   let checked_at = Unix.gettimeofday () in
   let attempted_mtime =
@@ -711,7 +792,21 @@ let normalize_declared_name raw =
 let lookup_active_profile ?sw ?net ?clock raw_name =
   let normalized = normalize_declared_name raw_name in
   match require_snapshot ?sw ?net ?clock () with
-  | Error _ as e -> e
+  | Error active_detail -> (
+      match config_path_opt () with
+      | None -> Error active_detail
+      | Some config_path -> (
+          match load_static_snapshot ~config_path with
+          | Error _ -> Error active_detail
+          | Ok snapshot -> (
+              match profile_lookup snapshot.profiles normalized with
+              | Some profile -> Ok (snapshot, normalized, profile)
+              | None ->
+                  let known = profile_names_of_snapshot snapshot |> String.concat ", " in
+                  Error
+                    (Printf.sprintf
+                       "unknown cascade_name %S (active profiles: %s)"
+                       normalized known))))
   | Ok snapshot -> (
       match profile_lookup snapshot.profiles normalized with
       | Some profile -> Ok (snapshot, normalized, profile)

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -301,6 +301,50 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
     []
     (Cascade_runtime.models_of_cascade_name "missing_profile")
 
+let test_static_profile_lookup_survives_probe_rejection_without_snapshot () =
+  with_temp_dir "cascade-static-fallback" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
+  let port = find_free_port () in
+  let refused_model = Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" port in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "keeper_unified_models": ["%s"],
+  "tool_rerank_models": ["%s"]
+}|}
+          refused_model refused_model));
+  (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+   | Ok _ -> fail "expected probe rejection without a last-known-good snapshot"
+   | Error rejection ->
+       let rejection_json =
+         Cascade_catalog_runtime.rejection_to_yojson rejection
+         |> Yojson.Safe.to_string
+       in
+       check bool "probe rejection is surfaced" true
+         (contains_substring rejection_json "probe failed"));
+  let resolved_name =
+    require_ok
+      (Cascade_catalog_runtime.resolve_declared_name
+         ~sw ~net ~clock ~raw_name:"" ())
+  in
+  check string "default cascade still resolves statically"
+    Keeper_config.default_cascade_name resolved_name;
+  check (list string) "model strings still resolve statically"
+    [ refused_model ]
+    (require_ok
+       (Cascade_catalog_runtime.models_of_cascade_name
+          ~sw ~net ~clock "keeper_unified"));
+  let providers =
+    require_ok
+      (Cascade_catalog_runtime.resolve_named_providers
+         ~sw ~net ~clock ~cascade_name:"keeper_unified" ())
+  in
+  check int "static provider fallback keeps one provider" 1 (List.length providers)
+
 let test_dashboard_available_profiles_use_validated_snapshot_only () =
   with_temp_dir "dashboard-cascade-profiles" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
@@ -397,6 +441,10 @@ let () =
             "legacy runtime wrapper does not fallback to defaults"
             `Quick
             test_legacy_runtime_wrapper_does_not_fallback_to_defaults;
+          test_case
+            "static profile lookup survives probe rejection without snapshot"
+            `Quick
+            test_static_profile_lookup_survives_probe_rejection_without_snapshot;
           test_case
             "dashboard available profiles use validated snapshot only"
             `Quick


### PR DESCRIPTION
## Summary
- fallback to statically validated cascade profiles when live catalog probes reject every profile and no last-known-good snapshot exists
- keep dashboard and doctor surfaces on validated-only behavior by limiting the fallback to keeper profile lookups
- add a regression test covering probe rejection without a cached snapshot

## Root Cause
Keeper cascade resolution depended on the active validated snapshot. When live provider probes rejected all profiles before any snapshot had been cached, `resolve_declared_name` and related lookups failed with `Invalid config "cascade_name"` even though `cascade.json` itself was still statically valid.

## Validation
- `dune build --root .`
- `./_build/default/test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_cascade_runtime.exe`
