### PR TITLE
[codex] Fix operator keeper context snapshot truth

### DIFF
--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -235,6 +235,28 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers[0]!.generation).toBe(10)
   })
 
+  it('preserves keeper context fields from nested context payloads', () => {
+    const result = normalizeOperatorSnapshot({
+      keepers: [
+        {
+          name: 'sojin',
+          context: {
+            source: 'keeper_context_status',
+            context_ratio: 0.1274375,
+            context_tokens: 16312,
+            context_max: 128000,
+          },
+        },
+      ],
+    })
+    expect(result.keepers).toHaveLength(1)
+    expect(result.keepers[0]!.context_ratio).toBe(0.1274375)
+    expect(result.keepers[0]!.context_tokens).toBe(16312)
+    expect(result.keepers[0]!.context_max).toBe(128000)
+    expect(result.keepers[0]!.context_source).toBe('keeper_context_status')
+    expect(result.keepers[0]!.context?.source).toBe('keeper_context_status')
+  })
+
   it('filters keepers without name', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -279,6 +279,19 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     agent_name: asString(raw.agent_name),
     status: asString(raw.status),
     context_ratio: asNumber(raw.context_ratio) ?? asNumber(contextRaw?.context_ratio),
+    context_tokens: asNumber(raw.context_tokens) ?? asNumber(contextRaw?.context_tokens),
+    context_max: asNumber(raw.context_max) ?? asNumber(contextRaw?.context_max),
+    context_source: asString(raw.context_source) ?? asString(contextRaw?.source),
+    context: contextRaw
+      ? {
+          source: asString(contextRaw.source),
+          context_ratio: asNumber(contextRaw.context_ratio),
+          context_tokens: asNumber(contextRaw.context_tokens),
+          context_max: asNumber(contextRaw.context_max),
+          message_count: asNumber(contextRaw.message_count),
+          has_checkpoint: asBoolean(contextRaw.has_checkpoint),
+        }
+      : undefined,
     generation: asNumber(raw.generation),
     active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -385,6 +385,16 @@ export interface OperatorKeeperSnapshot {
   short_goal?: string
   turn_count?: number
   context_tokens?: number
+  context_max?: number
+  context_source?: string
+  context?: {
+    source?: string
+    context_ratio?: number
+    context_tokens?: number
+    context_max?: number
+    message_count?: number
+    has_checkpoint?: boolean
+  }
   keepalive_running?: boolean
   autonomous_action_count?: number
   autonomous_turn_count?: number

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -2,16 +2,126 @@ module U = Yojson.Safe.Util
 include Operator_pending_confirm
 include Operator_digest
 
+let resolved_context_budget_of_meta (meta : Keeper_types.keeper_meta) : int option =
+  let active_model_label = Keeper_exec_status.active_model_label_of_meta meta in
+  if active_model_label = "" then None
+  else
+    let max_ctx = Cascade_runtime.max_context_of_label active_model_label in
+    if max_ctx = 0 then None else Some max_ctx
+
 let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
   let input_tokens = meta.runtime.usage.last_input_tokens in
   if input_tokens = 0 then None
   else
-    let active_model_label = Keeper_exec_status.active_model_label_of_meta meta in
-    if active_model_label = "" then None
+    match resolved_context_budget_of_meta meta with
+    | Some max_ctx -> Some (float_of_int input_tokens /. float_of_int max_ctx)
+    | None -> None
+
+type keeper_context_snapshot = {
+  context_ratio : float option;
+  context_tokens : int option;
+  context_max : int option;
+  context_source : string option;
+}
+
+let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
+  snapshot.context_ratio = None
+  && snapshot.context_tokens = None
+  && snapshot.context_max = None
+  && snapshot.context_source = None
+
+let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
+  let snapshot =
+    {
+      context_ratio = Safe_ops.json_float_opt "context_ratio" json;
+      context_tokens = Safe_ops.json_int_opt "context_tokens" json;
+      context_max = Safe_ops.json_int_opt "context_max" json;
+      context_source =
+        (match Safe_ops.json_string_opt "snapshot_source" json with
+        | Some source when String.trim source <> "" -> Some source
+        | _ -> (
+            match Safe_ops.json_string_opt "channel" json with
+            | Some channel when String.trim channel <> "" ->
+                Some ("metrics_" ^ String.trim channel)
+            | _ -> Some "metrics_log"));
+    }
+  in
+  if keeper_context_snapshot_is_empty snapshot then None else Some snapshot
+
+let latest_keeper_context_snapshot_from_files config keeper_name =
+  let metrics_lines =
+    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let dated = Dated_jsonl.read_recent_lines store 32 in
+    if dated <> [] then dated
     else
-      let max_ctx = Cascade_runtime.max_context_of_label active_model_label in
-      if max_ctx = 0 then None
-      else Some (float_of_int input_tokens /. float_of_int max_ctx)
+      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      Keeper_memory.read_file_tail_lines path ~max_bytes:32000 ~max_lines:32
+  in
+  let snapshots =
+    List.rev metrics_lines
+    |> List.filter_map (fun line ->
+           try
+             let json = Yojson.Safe.from_string line in
+             keeper_context_snapshot_from_metrics_json json
+           with Yojson.Json_error _ -> None)
+  in
+  match
+    List.find_opt
+      (fun snapshot ->
+        snapshot.context_source = Some "keeper_context_status")
+      snapshots
+  with
+  | Some snapshot -> Some snapshot
+  | None -> (
+      match snapshots with
+      | snapshot :: _ -> Some snapshot
+      | [] -> None)
+
+let fallback_keeper_context_snapshot (meta : Keeper_types.keeper_meta) =
+  {
+    context_ratio = compute_context_ratio meta;
+    context_tokens =
+      (match meta.runtime.usage.last_input_tokens with
+      | n when n > 0 -> Some n
+      | _ -> None);
+    context_max = resolved_context_budget_of_meta meta;
+    context_source =
+      (match meta.runtime.usage.last_input_tokens, resolved_context_budget_of_meta meta with
+      | n, Some _ when n > 0 -> Some "usage_last_input_tokens"
+      | _ -> None);
+  }
+
+let keeper_context_snapshot_of_meta config (meta : Keeper_types.keeper_meta) =
+  match latest_keeper_context_snapshot_from_files config meta.name with
+  | Some snapshot -> snapshot
+  | None -> fallback_keeper_context_snapshot meta
+
+let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
+  let context_json =
+    if keeper_context_snapshot_is_empty snapshot then
+      `Null
+    else
+      `Assoc
+        [
+          ("source", string_option_to_json snapshot.context_source);
+          ("context_ratio",
+            option_to_json (fun value -> `Float value) snapshot.context_ratio);
+          ("context_tokens",
+            option_to_json (fun value -> `Int value) snapshot.context_tokens);
+          ("context_max",
+            option_to_json (fun value -> `Int value) snapshot.context_max);
+        ]
+  in
+  [
+    ("context_ratio",
+      option_to_json (fun value -> `Float value) snapshot.context_ratio);
+    ("context_tokens",
+      option_to_json (fun value -> `Int value) snapshot.context_tokens);
+    ("context_max",
+      option_to_json (fun value -> `Int value) snapshot.context_max);
+    ("context_source", string_option_to_json snapshot.context_source);
+    ("context", context_json);
+  ]
 
 type action_result_status = ActionOk | ActionError
 
@@ -599,6 +709,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    | Some p -> `String (Keeper_state_machine.phase_to_string p)
                    | None -> `Null
                  in
+                 let context_snapshot = keeper_context_snapshot_of_meta config meta in
                  emit_timing_log (Time_compat.now () -. t_work_start);
                  Some
                    (`Assoc
@@ -617,11 +728,6 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("agent", agent_json);
                        ("generation", `Int meta.runtime.generation);
                        ("turn_count", `Int meta.runtime.usage.total_turns);
-                       ("context_ratio",
-                         (match compute_context_ratio meta with
-                          | Some r -> `Float r
-                          | None -> `Null));
-                       ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
                        ("last_turn_ago_s", `Float last_turn_ago_s);
                        ("last_handoff_ago_s", `Float last_handoff_ago_s);
                        ("last_compaction_ago_s", `Float last_compaction_ago_s);
@@ -789,6 +895,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                           dt_activity := Time_compat.now () -. t_act;
                           result));
                      ]
+                     @ keeper_context_snapshot_fields context_snapshot
                      @ Keeper_status_bridge.runtime_blocker_fields_json config meta))
                  end
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -830,6 +937,9 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                        ("turn_count", field_or_null "turn_count");
                        ("context_ratio", field_or_null "context_ratio");
                        ("context_tokens", field_or_null "context_tokens");
+                       ("context_max", field_or_null "context_max");
+                       ("context_source", field_or_null "context_source");
+                       ("context", field_or_null "context");
                        ("last_model_used", field_or_null "last_model_used");
                        ("active_model", field_or_null "active_model");
                        ("next_model_hint", field_or_null "next_model_hint");
@@ -875,9 +985,10 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                       | _ -> "unknown")
                   | _ -> "unknown"
                 in
+                let context_snapshot = keeper_context_snapshot_of_meta config meta in
                 Some
                   (`Assoc
-                    [
+                    ([
                       ("runtime_class", `String "keeper");
                       ("name", `String meta.name);
                       ("agent_name", `String meta.agent_name);
@@ -889,11 +1000,6 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                       ("status", `String agent_status);
                       ("generation", `Int meta.runtime.generation);
                       ("turn_count", `Int meta.runtime.usage.total_turns);
-                      ("context_ratio",
-                        (match compute_context_ratio meta with
-                         | Some r -> `Float r
-                         | None -> `Null));
-                      ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
                       ("last_model_used", `String meta.runtime.usage.last_model_used);
                       ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
                       ("next_model_hint", string_option_to_json (Keeper_exec_status.next_model_hint_of_meta meta));
@@ -903,7 +1009,8 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                       ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
                       ("updated_at", `String meta.updated_at);
                       ("created_at", `String meta.created_at);
-                    ]))
+                    ]
+                    @ keeper_context_snapshot_fields context_snapshot)))
           names
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -25,6 +25,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_compute_context_ratio_uses_resolved_cli_context_budget;
+          Alcotest.test_case "snapshot prefers metrics context truth over usage counters"
+            `Quick
+            Test_operator_control_snapshot
+            .test_snapshot_prefers_metrics_context_truth_over_usage_counters;
           Alcotest.test_case "snapshot sections" `Quick
             Test_operator_control_snapshot.test_snapshot_has_expected_sections;
           Alcotest.test_case "snapshot pending confirm summary tracks actor scope"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -99,6 +99,103 @@ let test_compute_context_ratio_uses_resolved_cli_context_budget () =
   Alcotest.(check (float 0.0001)) "codex bare provider uses 1.05M context"
     (2106223.0 /. 1050000.0) ratio
 
+let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "owner"));
+      ignore (Coord.join config ~agent_name:"owner" ~capabilities:[] ());
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "owner";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let keeper_name = "ctx-truth" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Prefer metrics context truth");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      let updated_meta =
+        {
+          meta with
+          models = [ "codex_cli:auto" ];
+          runtime =
+            {
+              meta.runtime with
+              usage =
+                {
+                  meta.runtime.usage with
+                  last_model_used = "codex";
+                  last_input_tokens = 6_637_033;
+                  last_total_tokens = 6_670_646;
+                };
+            };
+        }
+      in
+      (match Keeper_types.write_meta config updated_meta with
+      | Ok () -> ()
+      | Error err -> Alcotest.fail err);
+      let metrics_store = Keeper_types.keeper_metrics_store config keeper_name in
+      Dated_jsonl.append metrics_store
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
+            ("channel", `String "heartbeat");
+            ("snapshot_source", `String "keeper_context_status");
+            ("context_ratio", `Float 0.1274375);
+            ("context_tokens", `Int 16312);
+            ("context_max", `Int 128000);
+          ]);
+      Operator_control.invalidate_snapshot_cache ();
+      let json =
+        Operator_control.snapshot_json ~view:"summary"
+          ~include_keepers:true ~include_messages:false
+          ~lightweight_summary:true
+          (operator_ctx env sw config "owner")
+      in
+      let keeper =
+        match
+          Yojson.Safe.Util.(json |> member "keepers" |> member "items" |> to_list)
+          |> List.find_opt (fun row ->
+                 Yojson.Safe.Util.(row |> member "name" |> to_string) = keeper_name)
+        with
+        | Some keeper -> keeper
+        | None -> Alcotest.fail "expected keeper in snapshot"
+      in
+      Alcotest.(check (float 0.000001)) "metrics ratio wins over usage fallback"
+        0.1274375 Yojson.Safe.Util.(keeper |> member "context_ratio" |> to_float);
+      Alcotest.(check int) "metrics tokens retained" 16312
+        Yojson.Safe.Util.(keeper |> member "context_tokens" |> to_int);
+      Alcotest.(check int) "metrics max retained" 128000
+        Yojson.Safe.Util.(keeper |> member "context_max" |> to_int);
+      Alcotest.(check string) "metrics source retained" "keeper_context_status"
+        Yojson.Safe.Util.(keeper |> member "context_source" |> to_string))
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## Summary
- make operator keeper snapshots prefer authoritative `keeper_context_status` metrics over raw usage counters for CTX reporting
- preserve `context_tokens`, `context_max`, `context_source`, and nested `context` through the dashboard operator normalizer
- add regression coverage for backend snapshot sourcing and frontend normalization

## Root Cause
- the operator roster path was deriving CTX from `last_input_tokens / resolved max_context`, which reflects request usage rather than live working-context pressure
- the dashboard operator normalizer was also dropping the richer context fields even when they were present

## Validation
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-operator-ctx-truth ./test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe`
  - new regression passes
  - one pre-existing unrelated baseline failure remains: `keeper status exposes model observability`

## Notes
- dashboard TypeScript verification was not runnable in this worktree because `dashboard/node_modules` is missing, so `tsc` was unavailable
