### PR TITLE
fix: keep active catalog alive when optional cascades are invalid

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1799,7 +1799,11 @@ export interface CascadeKeeperProfile {
   canonical: string
 }
 
-export type CascadeValidationStatus = 'validated' | 'serving_last_known_good' | 'invalid'
+export type CascadeValidationStatus =
+  | 'validated'
+  | 'serving_valid_subset'
+  | 'serving_last_known_good'
+  | 'invalid'
 
 export interface CascadeInvalidProfile {
   name: string

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -104,6 +104,7 @@ export function sourceTone(source: CascadeProfile['source']): string {
 function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
   switch (status) {
     case 'validated': return 'ok'
+    case 'serving_valid_subset': return 'warn'
     case 'serving_last_known_good': return 'warn'
     case 'invalid': return 'bad'
   }
@@ -112,6 +113,7 @@ function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' 
 function validationLabel(status: CascadeValidationStatus): string {
   switch (status) {
     case 'validated': return 'validated'
+    case 'serving_valid_subset': return 'valid subset'
     case 'serving_last_known_good': return 'last known good'
     case 'invalid': return 'invalid'
   }
@@ -121,6 +123,8 @@ function validationDescription(status: CascadeValidationStatus): string {
   switch (status) {
     case 'validated':
       return '현재 cascade catalog 이 정상 검증되었습니다.'
+    case 'serving_valid_subset':
+      return '현재 cascade.json 일부 profile 이 검증에 실패해 invalid profile 은 제외하고 유효한 subset 만 계속 서빙 중입니다.'
     case 'serving_last_known_good':
       return '새 cascade.json 업데이트가 검증에 실패해 마지막 검증 성공 snapshot 을 계속 서빙 중입니다.'
     case 'invalid':

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -44,10 +44,18 @@ type rejection = {
 
 type state =
   | Validated of snapshot
+  | Serving_valid_subset of {
+      snapshot : snapshot;
+      rejected_update : rejection;
+    }
   | Serving_last_known_good of {
       snapshot : snapshot;
       rejected_update : rejection;
     }
+
+type rejected_mode =
+  | Rejected_valid_subset
+  | Rejected_last_known_good
 
 type candidate_runtime = {
   model_string : string;
@@ -68,9 +76,16 @@ type profile_build = {
 type cache = {
   active_snapshot : snapshot option;
   rejected_update : rejection option;
+  rejected_mode : rejected_mode option;
 }
 
-let cache = ref { active_snapshot = None; rejected_update = None }
+let cache =
+  ref
+    {
+      active_snapshot = None;
+      rejected_update = None;
+      rejected_mode = None;
+    }
 let cache_mu = Mutex.create ()
 
 let with_cache_lock f =
@@ -78,7 +93,13 @@ let with_cache_lock f =
   Fun.protect ~finally:(fun () -> Mutex.unlock cache_mu) f
 
 let reset_cache_for_tests () =
-  with_cache_lock (fun () -> cache := { active_snapshot = None; rejected_update = None })
+  with_cache_lock (fun () ->
+      cache :=
+        {
+          active_snapshot = None;
+          rejected_update = None;
+          rejected_mode = None;
+        })
 
 let invalidate_path config_path =
   let keep_snapshot = function
@@ -130,6 +151,7 @@ let install_snapshot_for_tests ~source_path ~profile_names =
         {
           active_snapshot = Some snapshot;
           rejected_update = None;
+          rejected_mode = None;
         })
 
 let has_suffix ~suffix s =
@@ -224,14 +246,25 @@ let state_to_yojson = function
         [
           ("status", `String "validated");
           ("serving_last_known_good", `Bool false);
+          ("serving_valid_subset", `Bool false);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", `Null);
+        ]
+  | Serving_valid_subset { snapshot; rejected_update } ->
+      `Assoc
+        [
+          ("status", `String "serving_valid_subset");
+          ("serving_last_known_good", `Bool false);
+          ("serving_valid_subset", `Bool true);
+          ("snapshot", snapshot_to_yojson snapshot);
+          ("rejected_update", rejection_to_yojson rejected_update);
         ]
   | Serving_last_known_good { snapshot; rejected_update } ->
       `Assoc
         [
           ("status", `String "serving_last_known_good");
           ("serving_last_known_good", `Bool true);
+          ("serving_valid_subset", `Bool false);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", rejection_to_yojson rejected_update);
         ]
@@ -262,8 +295,23 @@ let expand_weighted_entries
 let profile_lookup profiles name =
   List.find_opt (fun (profile : profile_snapshot) -> String.equal profile.name name) profiles
 
+let profile_rejection_lookup profiles name =
+  List.find_opt (fun (profile : profile_rejection) -> String.equal profile.name name) profiles
+
 let profile_names_of_snapshot (snapshot : snapshot) =
   List.map (fun (profile : profile_snapshot) -> profile.name) snapshot.profiles
+
+let snapshot_of_state = function
+  | Validated snapshot
+  | Serving_valid_subset { snapshot; _ }
+  | Serving_last_known_good { snapshot; _ } ->
+      snapshot
+
+let rejected_update_of_state = function
+  | Validated _ -> None
+  | Serving_valid_subset { rejected_update; _ }
+  | Serving_last_known_good { rejected_update; _ } ->
+      Some rejected_update
 
 let eio_caps ?sw ?net ?clock () =
   let sw =
@@ -532,7 +580,53 @@ let load_static_snapshot ~config_path : (snapshot, rejection) result =
                   built_profiles;
             }
 
-let validate_path ~sw ~net ~clock ~config_path =
+let runtime_required_profiles ~config_path =
+  let keepers_from_catalog =
+    match Cascade_config_loader.load_catalog ~config_path with
+    | Ok entries ->
+        List.filter_map
+          (fun (entry : Cascade_config_loader.catalog_entry) ->
+            if entry.keeper_assignable then Some entry.name else None)
+          entries
+    | Error _ -> []
+  in
+  List.sort_uniq String.compare
+    (Keeper_cascade_profile.known_cascades
+    @ keepers_from_catalog
+    @ [ "governance_judge"; "operator_judge" ])
+
+let runtime_required_profile_names ?config_path () =
+  let config_path =
+    match config_path with
+    | Some path -> path
+    | None -> (
+        match config_path_opt () with
+        | Some path -> path
+        | None -> "")
+  in
+  if String.equal config_path "" then
+    Keeper_cascade_profile.known_cascades
+    @ [ "governance_judge"; "operator_judge" ]
+    |> List.sort_uniq String.compare
+  else
+    runtime_required_profiles ~config_path
+
+let partition_profile_rejections ~required_profiles rejected_profiles =
+  List.partition
+    (fun (rejection : profile_rejection) ->
+      List.mem rejection.name required_profiles)
+    rejected_profiles
+
+let validated_snapshot_of_profiles ~config_path ~attempted_mtime ~checked_at
+    profile_snapshots =
+  {
+    source_path = config_path;
+    mtime = Option.value attempted_mtime ~default:0.0;
+    validated_at = checked_at;
+    profiles = profile_snapshots;
+  }
+
+let validate_path_state ~sw ~net ~clock ~config_path =
   let checked_at = Unix.gettimeofday () in
   let attempted_mtime =
     try Some (Unix.stat config_path).Unix.st_mtime
@@ -558,6 +652,7 @@ let validate_path ~sw ~net ~clock ~config_path =
              ~profiles:[])
     | Ok json ->
         let profiles = discover_profiles json in
+        let required_profiles = runtime_required_profiles ~config_path in
         let top_errors =
           let base =
             if profiles = [] then
@@ -587,10 +682,14 @@ let validate_path ~sw ~net ~clock ~config_path =
         in
         let built_profiles = List.rev built_profiles in
         let rejected_profiles = List.rev rejected_profiles in
-        if top_errors <> [] || rejected_profiles <> [] then
+        let required_rejections, optional_rejections =
+          partition_profile_rejections ~required_profiles rejected_profiles
+        in
+        if top_errors <> [] || required_rejections <> [] then
           Error
             (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-               ~errors:top_errors ~profiles:rejected_profiles)
+               ~errors:top_errors
+               ~profiles:(required_rejections @ optional_rejections))
         else
           let unique_candidates = Hashtbl.create 16 in
           List.iter
@@ -660,25 +759,52 @@ let validate_path ~sw ~net ~clock ~config_path =
           in
           let profile_snapshots = List.rev profile_snapshots in
           let rejected_profiles = List.rev rejected_profiles in
-          if rejected_profiles <> [] then
+          let required_probe_rejections, optional_probe_rejections =
+            partition_profile_rejections ~required_profiles rejected_profiles
+          in
+          if required_probe_rejections <> [] then
             Error
               (rejection_of_path ~config_path ~attempted_mtime ~checked_at
                  ~errors:
                    [
                      Printf.sprintf
-                       "catalog validation rejected %d/%d profile(s)"
-                       (List.length rejected_profiles)
+                       "catalog validation rejected %d/%d runtime-required profile(s)"
+                       (List.length required_probe_rejections)
                        (List.length built_profiles);
                    ]
-                 ~profiles:rejected_profiles)
+                 ~profiles:
+                   (optional_rejections @ required_probe_rejections
+                  @ optional_probe_rejections))
+          else if optional_rejections <> [] || optional_probe_rejections <> [] then
+            let snapshot =
+              validated_snapshot_of_profiles ~config_path ~attempted_mtime
+                ~checked_at profile_snapshots
+            in
+            let rejected_update =
+              rejection_of_path ~config_path ~attempted_mtime ~checked_at
+                ~errors:
+                  [
+                    Printf.sprintf
+                      "catalog validation rejected %d non-runtime-required profile(s); runtime is serving the validated subset"
+                      (List.length optional_rejections
+                     + List.length optional_probe_rejections);
+                  ]
+                ~profiles:(optional_rejections @ optional_probe_rejections)
+            in
+            Ok (Serving_valid_subset { snapshot; rejected_update })
           else
             Ok
-              {
-                source_path = config_path;
-                mtime = Option.value attempted_mtime ~default:0.0;
-                validated_at = checked_at;
-                profiles = profile_snapshots;
-              }
+              (Validated
+                 (validated_snapshot_of_profiles ~config_path ~attempted_mtime
+                    ~checked_at profile_snapshots))
+
+let validate_path ~sw ~net ~clock ~config_path =
+  match validate_path_state ~sw ~net ~clock ~config_path with
+  | Ok (Validated snapshot)
+  | Ok (Serving_valid_subset { snapshot; _ })
+  | Ok (Serving_last_known_good { snapshot; _ }) ->
+      Ok snapshot
+  | Error rejection -> Error rejection
 
 let same_snapshot_key (snapshot : snapshot) ~path ~mtime =
   String.equal snapshot.source_path path && Float.equal snapshot.mtime mtime
@@ -710,6 +836,7 @@ let inspect_active ?sw ?net ?clock () =
                  {
                    active_snapshot = Some snapshot;
                    rejected_update = Some rejection;
+                   rejected_mode = Some Rejected_last_known_good;
                  });
            Ok (Serving_last_known_good { snapshot; rejected_update = rejection })
        | None -> Error rejection)
@@ -721,14 +848,23 @@ let inspect_active ?sw ?net ?clock () =
       in
       let cached_result =
         with_cache_lock (fun () ->
-            match !cache.active_snapshot, !cache.rejected_update, current_mtime with
-            | Some snapshot, _, Some mtime
-              when same_snapshot_key snapshot ~path:config_path ~mtime ->
-                Some (Ok (Validated snapshot))
-            | Some snapshot, Some rejection, Some mtime
+            match
+              !cache.active_snapshot,
+              !cache.rejected_update,
+              !cache.rejected_mode,
+              current_mtime
+            with
+            | Some snapshot, Some rejection, Some Rejected_valid_subset, Some mtime
+              when same_rejection_key rejection ~path:config_path ~mtime ->
+                Some
+                  (Ok (Serving_valid_subset { snapshot; rejected_update = rejection }))
+            | Some snapshot, Some rejection, Some Rejected_last_known_good, Some mtime
               when same_rejection_key rejection ~path:config_path ~mtime ->
                 Some (Ok (Serving_last_known_good { snapshot; rejected_update = rejection }))
-            | None, Some rejection, Some mtime
+            | Some snapshot, _, _, Some mtime
+              when same_snapshot_key snapshot ~path:config_path ~mtime ->
+                Some (Ok (Validated snapshot))
+            | None, Some rejection, _, Some mtime
               when same_rejection_key rejection ~path:config_path ~mtime ->
                 Some (Error rejection)
             | _ -> None)
@@ -754,21 +890,33 @@ let inspect_active ?sw ?net ?clock () =
                          {
                            active_snapshot = Some snapshot;
                            rejected_update = Some rejection;
+                           rejected_mode = Some Rejected_last_known_good;
                          });
                    Ok
                      (Serving_last_known_good
                         { snapshot; rejected_update = rejection })
                | None -> Error rejection)
           | Ok (sw, net, clock) -> (
-              match validate_path ~sw ~net ~clock ~config_path with
-              | Ok snapshot ->
+              match validate_path_state ~sw ~net ~clock ~config_path with
+              | Ok (Validated snapshot as state) ->
                   with_cache_lock (fun () ->
                       cache :=
                         {
                           active_snapshot = Some snapshot;
                           rejected_update = None;
+                          rejected_mode = None;
                         });
-                  Ok (Validated snapshot)
+                  Ok state
+              | Ok (Serving_valid_subset { snapshot; rejected_update } as state) ->
+                  with_cache_lock (fun () ->
+                      cache :=
+                        {
+                          active_snapshot = Some snapshot;
+                          rejected_update = Some rejected_update;
+                          rejected_mode = Some Rejected_valid_subset;
+                        });
+                  Ok state
+              | Ok (Serving_last_known_good _) -> assert false
               | Error rejection ->
                   (match with_cache_lock (fun () -> !cache.active_snapshot) with
                    | Some snapshot ->
@@ -777,6 +925,7 @@ let inspect_active ?sw ?net ?clock () =
                              {
                                active_snapshot = Some snapshot;
                                rejected_update = Some rejection;
+                               rejected_mode = Some Rejected_last_known_good;
                              });
                        Ok
                          (Serving_last_known_good
@@ -787,12 +936,14 @@ let inspect_active ?sw ?net ?clock () =
                              {
                                active_snapshot = None;
                                rejected_update = Some rejection;
+                               rejected_mode = None;
                              });
                        Error rejection)))
 
 let require_snapshot ?sw ?net ?clock () =
   match inspect_active ?sw ?net ?clock () with
   | Ok (Validated snapshot) -> Ok snapshot
+  | Ok (Serving_valid_subset { snapshot; _ }) -> Ok snapshot
   | Ok (Serving_last_known_good { snapshot; _ }) -> Ok snapshot
   | Error rejection ->
       let detail =
@@ -808,31 +959,56 @@ let normalize_declared_name raw =
 
 let lookup_active_profile ?sw ?net ?clock raw_name =
   let normalized = normalize_declared_name raw_name in
-  match require_snapshot ?sw ?net ?clock () with
-  | Error active_detail -> (
-      match config_path_opt () with
-      | None -> Error active_detail
-      | Some config_path -> (
-          match load_static_snapshot ~config_path with
-          | Error _ -> Error active_detail
-          | Ok snapshot -> (
-              match profile_lookup snapshot.profiles normalized with
-              | Some profile -> Ok (snapshot, normalized, profile)
-              | None ->
-                  let known = profile_names_of_snapshot snapshot |> String.concat ", " in
-                  Error
-                    (Printf.sprintf
-                       "unknown cascade_name %S (active profiles: %s)"
-                       normalized known))))
-  | Ok snapshot -> (
+  match inspect_active ?sw ?net ?clock () with
+  | Error active_rejection ->
+      let active_detail =
+        if active_rejection.errors = [] then
+          "active catalog validation failed"
+        else
+          String.concat "; " active_rejection.errors
+      in
+      (match config_path_opt () with
+       | None -> Error active_detail
+       | Some config_path -> (
+           match load_static_snapshot ~config_path with
+           | Error _ -> Error active_detail
+           | Ok snapshot -> (
+               match profile_lookup snapshot.profiles normalized with
+               | Some profile -> Ok (snapshot, normalized, profile)
+               | None ->
+                   let known = profile_names_of_snapshot snapshot |> String.concat ", " in
+                   Error
+                     (Printf.sprintf
+                        "unknown cascade_name %S (active profiles: %s)"
+                        normalized known))))
+  | Ok state ->
+      let snapshot = snapshot_of_state state in
+      let unknown_cascade () =
+        let known = profile_names_of_snapshot snapshot |> String.concat ", " in
+        Error
+          (Printf.sprintf
+             "unknown cascade_name %S (active profiles: %s)"
+             normalized known)
+      in
       match profile_lookup snapshot.profiles normalized with
       | Some profile -> Ok (snapshot, normalized, profile)
       | None ->
-          let known = profile_names_of_snapshot snapshot |> String.concat ", " in
-          Error
-            (Printf.sprintf
-               "unknown cascade_name %S (active profiles: %s)"
-               normalized known))
+          (match rejected_update_of_state state with
+           | Some rejected_update -> (
+               match
+                 profile_rejection_lookup rejected_update.profiles normalized
+               with
+               | Some rejected_profile ->
+                   let detail =
+                     match rejected_profile.errors with
+                     | [] -> "profile validation rejected"
+                     | errors -> String.concat "; " errors
+                   in
+                   Error
+                     (Printf.sprintf "invalid cascade_name %S: %s"
+                        normalized detail)
+               | None -> unknown_cascade ())
+           | None -> unknown_cascade ())
 
 let resolve_declared_name ?sw ?net ?clock ~raw_name () =
   match lookup_active_profile ?sw ?net ?clock raw_name with

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -112,10 +112,16 @@ let invalidate_path config_path =
   in
   with_cache_lock (fun () ->
       let current = !cache in
+      let active_snapshot = keep_snapshot current.active_snapshot in
+      let rejected_update = keep_rejection current.rejected_update in
       cache :=
         {
-          active_snapshot = keep_snapshot current.active_snapshot;
-          rejected_update = keep_rejection current.rejected_update;
+          active_snapshot;
+          rejected_update;
+          rejected_mode =
+            (match rejected_update with
+            | Some _ -> current.rejected_mode
+            | None -> None);
         })
 
 let install_snapshot_for_tests ~source_path ~profile_names =

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -25,6 +25,10 @@ type rejection
 
 type state =
   | Validated of snapshot
+  | Serving_valid_subset of {
+      snapshot : snapshot;
+      rejected_update : rejection;
+    }
   | Serving_last_known_good of {
       snapshot : snapshot;
       rejected_update : rejection;
@@ -128,6 +132,10 @@ val state_to_yojson : state -> Yojson.Safe.t
     @since 0.160.1 *)
 val invalidate_path : string -> unit
 
+val runtime_required_profile_names :
+  ?config_path:string ->
+  unit ->
+  string list
 val install_snapshot_for_tests :
   source_path:string ->
   profile_names:string list ->

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -136,6 +136,7 @@ val runtime_required_profile_names :
   ?config_path:string ->
   unit ->
   string list
+
 val install_snapshot_for_tests :
   source_path:string ->
   profile_names:string list ->

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -114,7 +114,26 @@ let diagnose_cascade_catalog ~active_config_root =
     []
   else
     let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
-    let issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
+    let runtime_required_profiles =
+      Cascade_catalog_runtime.runtime_required_profile_names ~config_path ()
+    in
+    let issues =
+      Cascade_catalog_validator.diagnose_catalog ~config_path
+      |> List.map (fun (issue : catalog_issue) ->
+             match issue.profile, issue.severity with
+             | Some profile, Catalog_error
+               when not (List.mem profile runtime_required_profiles) ->
+                 {
+                   issue with
+                   severity = Catalog_warn;
+                   message =
+                     Printf.sprintf
+                       "%s (non-runtime-required profile; runtime can serve \
+                        a validated subset)"
+                       issue.message;
+                 }
+             | _ -> issue)
+    in
     if issues = [] then
       []
     else
@@ -464,18 +483,27 @@ let analyze ~base_path_input ~default_base_path () =
   current_inputs ~base_path_input ~default_base_path ()
   |> analyze_with
 
+type live_catalog_status =
+  | Live_ok
+  | Live_warn
+  | Live_error
+
 let live_catalog_summary = function
   | Stdlib.Ok (Cascade_catalog_runtime.Validated snapshot) ->
-      ( false,
+      ( Live_ok,
         "Live cascade catalog validation passed.",
         Cascade_catalog_runtime.state_to_yojson
           (Cascade_catalog_runtime.Validated snapshot) )
+  | Stdlib.Ok (Cascade_catalog_runtime.Serving_valid_subset _ as state) ->
+      ( Live_warn,
+        "Live cascade catalog validation rejected non-runtime-required profiles; runtime is serving the validated subset.",
+        Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Ok (Cascade_catalog_runtime.Serving_last_known_good _ as state) ->
-      ( true,
+      ( Live_error,
         "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Error rejection ->
-      ( true,
+      ( Live_error,
         "Live cascade catalog validation failed; no validated snapshot is available.",
         `Assoc
           [
@@ -491,33 +519,33 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   let report = analyze ~base_path_input ~default_base_path () in
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
-  let live_failed, live_warning, catalog_validation =
+  let live_status, live_warning, catalog_validation =
     match
       Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
       |> live_catalog_summary
     with
-    | failed, warning, validation -> (failed, warning, validation)
+    | status, warning, validation -> (status, warning, validation)
   in
   let warnings =
     if live_warning = "" then report.warnings
     else report.warnings @ [ live_warning ]
   in
   let next_actions =
-    if live_failed then
+    if live_status = Live_ok then
+      report.next_actions
+    else
       report.next_actions
       @
       [
         "Fix the active cascade catalog candidates/strategy and rerun `masc-mcp doctor config`.";
       ]
-    else
-      report.next_actions
   in
   let status =
-    match report.status, live_failed with
+    match report.status, live_status with
     | Error, _ -> Error
-    | _, true -> Error
-    | Ok, false -> Ok
-    | Warn, false -> Warn
+    | _, Live_error -> Error
+    | Warn, _ | _, Live_warn -> Warn
+    | Ok, Live_ok -> Ok
   in
   {
     report with

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -159,6 +159,10 @@ let validation_summary_json ?config_path () =
         ("invalid_profiles", `List []);
       ]
   | Ok
+      (Cascade_catalog_runtime.Serving_valid_subset
+         { rejected_update; _ }) ->
+      of_rejection ~status:"serving_valid_subset" rejected_update
+  | Ok
       (Cascade_catalog_runtime.Serving_last_known_good
          { rejected_update; _ }) ->
       of_rejection ~status:"serving_last_known_good" rejected_update

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -734,6 +734,13 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                  (Cascade_catalog_runtime.snapshot_to_yojson snapshot));
             None
         | Ok
+            (Cascade_catalog_runtime.Serving_valid_subset
+               { rejected_update; _ }) ->
+            Some
+              (format_catalog_validation_error
+                 "startup accepted active cascade catalog with invalid extra profiles"
+                 rejected_update)
+        | Ok
             (Cascade_catalog_runtime.Serving_last_known_good
                { rejected_update; _ }) ->
             Some

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -184,6 +184,8 @@ let test_valid_catalog_dedupes_shared_live_probes () =
   let snapshot =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
     | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
+    | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
+        fail "expected a freshly validated snapshot"
     | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
         fail "expected a freshly validated snapshot"
     | Error rejection ->
@@ -235,6 +237,8 @@ let test_invalid_hot_reload_preserves_last_known_good () =
   in
   (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
    | Ok (Cascade_catalog_runtime.Validated _) -> ()
+   | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
+       fail "expected the initial snapshot to validate cleanly"
    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
        fail "expected the initial snapshot to validate cleanly"
    | Error rejection ->
@@ -269,6 +273,8 @@ let test_invalid_hot_reload_preserves_last_known_good () =
         (contains_substring rejection_json "__nonexistent_provider_sentinel__")
   | Ok (Cascade_catalog_runtime.Validated _) ->
       fail "expected invalid hot reload to be rejected"
+  | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
+      fail "expected invalid hot reload to fall back to last-known-good"
   | Error rejection ->
       failf "expected last-known-good fallback, got hard error: %s"
         (Yojson.Safe.to_string
@@ -368,6 +374,8 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
           valid_model valid_model));
   let _ =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+    | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
+        fail "expected invalid raw file to be rejected before snapshot priming"
     | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
         fail "expected direct validation, not last-known-good"
     | Ok (Cascade_catalog_runtime.Validated _) ->
@@ -388,6 +396,94 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
   check (list string) "dashboard config_json only renders validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
     profile_names
+
+let test_invalid_extra_profile_serves_valid_subset () =
+  with_temp_dir "cascade-valid-subset" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
+  let port = find_free_port () in
+  let base_url, _request_count =
+    start_counting_mock ~sw ~net ~port
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "default_models": ["%s"],
+  "keeper_unified_models": ["%s"],
+  "manual_trial_models": ["__nonexistent_provider_sentinel__:fake"],
+  "manual_trial_keeper_assignable": false
+}|}
+          valid_model valid_model));
+  match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+  | Ok
+      (Cascade_catalog_runtime.Serving_valid_subset
+         { snapshot; rejected_update }) ->
+      let snapshot_json =
+        Cascade_catalog_runtime.snapshot_to_yojson snapshot
+      in
+      let profile_names =
+        json_list_field "profiles" snapshot_json
+        |> List.map (json_string_field "name")
+      in
+      check bool "default remains routable" true
+        (List.mem Keeper_config.default_cascade_name profile_names);
+      check bool "keeper_unified remains routable" true
+        (List.mem "keeper_unified" profile_names);
+      check bool "invalid extra profile omitted from active snapshot" false
+        (List.mem "manual_trial" profile_names);
+      check (list string) "keeper_unified models still resolve"
+        [ valid_model ]
+        (require_ok
+           (Cascade_catalog_runtime.models_of_cascade_name
+              ~sw ~net ~clock "keeper_unified"));
+      (match
+         Cascade_catalog_runtime.models_of_cascade_name
+           ~sw ~net ~clock "manual_trial"
+       with
+       | Ok labels ->
+           failf "expected invalid extra profile to be rejected, got %s"
+             (String.concat ", " labels)
+       | Error detail ->
+           check bool "invalid extra profile detail is surfaced" true
+             (contains_substring detail "manual_trial"));
+      let rejected_json =
+        Cascade_catalog_runtime.rejection_to_yojson rejected_update
+        |> Yojson.Safe.to_string
+      in
+      check bool "rejected_update lists invalid extra profile" true
+        (contains_substring rejected_json "manual_trial");
+      let dashboard_json = Masc_mcp.Dashboard_cascade.config_json () in
+      check string "dashboard reports valid subset status"
+        "serving_valid_subset"
+        (json_string_field "validation_status" dashboard_json);
+      let report =
+        Config_doctor.analyze_live
+          ~sw ~net ~clock ~fs ~proc_mgr
+          ~base_path_input:dir
+          ~default_base_path:dir
+          ()
+      in
+      check string "live doctor status degrades to warn" "warn"
+        (Config_doctor.status_to_string report.status);
+      (match report.catalog_validation with
+       | None -> fail "expected catalog_validation output from analyze_live"
+       | Some json ->
+           check string "doctor reports valid subset status"
+             "serving_valid_subset"
+             (json_string_field "status" json))
+  | Ok (Cascade_catalog_runtime.Validated _) ->
+      fail "expected invalid extra profile to downgrade into serving_valid_subset"
+  | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+      fail "expected current validated subset, not last-known-good"
+  | Error rejection ->
+      failf "expected serving_valid_subset, got hard rejection: %s"
+        (Yojson.Safe.to_string
+           (Cascade_catalog_runtime.rejection_to_yojson rejection))
 
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
@@ -449,6 +545,10 @@ let () =
             "dashboard available profiles use validated snapshot only"
             `Quick
             test_dashboard_available_profiles_use_validated_snapshot_only;
+          test_case
+            "invalid extra profile serves validated subset"
+            `Quick
+            test_invalid_extra_profile_serves_valid_subset;
           test_case
             "config doctor live reports catalog validation"
             `Quick

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -184,6 +184,35 @@ let test_broken_cascade_catalog_surfaces_errors () =
        ~needle:"Rerun `masc-mcp doctor config` after editing cascade.json."
        report.next_actions)
 
+let test_non_runtime_required_cascade_catalog_warns () =
+  with_temp_dir "config-doctor-cascade-warn" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_config_root
+    ~cascade_json:{|{
+  "default_models": [
+    "claude_code:claude-haiku-4-5-20251001"
+  ],
+  "manual_trial_models": [
+    "__nonexistent_provider_sentinel__:fake-model"
+  ],
+  "manual_trial_keeper_assignable": false
+}|}
+    config_root;
+  let report =
+    Config_doctor.analyze_with
+      (make_inputs ~cwd:dir ~base_path_input:base_path ())
+  in
+  check string "status downgrades to warn" "warn" (status report.status);
+  check bool "catalog summary warning present" true
+    (list_contains_substring
+       ~needle:"Cascade catalog check scanned 2 preset(s): 0 error, 1 warn."
+       report.warnings);
+  check bool "non-runtime-required detail surfaced" true
+    (list_contains_substring
+       ~needle:"non-runtime-required profile; runtime can serve a validated subset"
+       report.warnings)
+
 let () =
   run "config_doctor"
     [
@@ -198,5 +227,7 @@ let () =
              test_shadowed_explicit_config_dir;
            test_case "broken cascade catalog surfaces errors" `Quick
              test_broken_cascade_catalog_surfaces_errors;
+           test_case "non-runtime-required cascade catalog warns" `Quick
+             test_non_runtime_required_cascade_catalog_warns;
          ]);
     ]

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -98,7 +98,7 @@ let test_config_shape () =
    | `String _ | `Null -> ()
    | _ -> fail "config_path should be string or null");
   (match member "validation_status" j with
-   | `String ("validated" | "serving_last_known_good" | "invalid") -> ()
+   | `String ("validated" | "serving_valid_subset" | "serving_last_known_good" | "invalid") -> ()
    | _ -> fail "validation_status should be known string");
   (match member "validation_errors" j with
    | `List _ -> ()


### PR DESCRIPTION
## Summary

- stop optional invalid cascade profiles from poisoning the active runtime catalog
- keep serving a validated subset when only non-runtime-required profiles fail validation
- surface the degraded `serving_valid_subset` state in doctor and dashboard

## Product impact

- Promise affected: `ops visibility`
- User-visible change:
  invalid extra profiles in `cascade.json` still show up as degraded, but they no longer take down unrelated keepers or collapse the whole active catalog

## Evidence

- `dune build --root . bin/main_eio.exe test/test_cascade_catalog_runtime.exe test/test_dashboard_cascade.exe test/test_config_doctor.exe`
- `./_build/default/test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_dashboard_cascade.exe`
- `./_build/default/test/test_config_doctor.exe`
- `pnpm typecheck`
- `pnpm lint`

## Review evidence

- Local code review completed in worktree after focused runtime/doctor/dashboard regression coverage updates.

## Linked issue

- Closes #
- Relates #
