### PR TITLE
[codex] Add raw cascade editor to dashboard

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1816,6 +1816,12 @@ export interface CascadeConfigResponse {
   keeper_profiles: CascadeKeeperProfile[]
 }
 
+export interface CascadeRawConfigResponse {
+  updated_at: string
+  config_path: string | null
+  raw_json: string
+}
+
 export interface CascadeHealthProvider {
   provider_key: string
   success_rate: number
@@ -1841,6 +1847,18 @@ export interface CascadeHealthResponse {
 
 export function fetchCascadeConfig(opts?: AbortableRequestOptions): Promise<CascadeConfigResponse> {
   return get<CascadeConfigResponse>('/api/v1/cascade/config', { signal: opts?.signal })
+}
+
+export function fetchCascadeConfigRaw(
+  opts?: AbortableRequestOptions,
+): Promise<CascadeRawConfigResponse> {
+  return get<CascadeRawConfigResponse>('/api/v1/cascade/config/raw', {
+    signal: opts?.signal,
+  })
+}
+
+export function updateCascadeConfigRaw(raw_json: string): Promise<CascadeConfigResponse> {
+  return post<CascadeConfigResponse>('/api/v1/cascade/config/raw', { raw_json })
 }
 
 export function fetchCascadeHealth(opts?: AbortableRequestOptions): Promise<CascadeHealthResponse> {

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -16,7 +16,9 @@ import {
   fetchCascadeStrategyTrace,
   fetchCascadeSlo,
   fetchCascadeConfig,
+  fetchCascadeConfigRaw,
   fetchCascadeHealth,
+  updateCascadeConfigRaw,
   type CascadeCandidate,
   type CascadeCapacityEventKind,
   type CascadeClientCapacityEntry,
@@ -29,6 +31,7 @@ import {
   type CascadeInvalidProfile,
   type CascadeKeeperProfile,
   type CascadeProfile,
+  type CascadeRawConfigResponse,
   type CascadeStrategyTraceEvent,
   type CascadeStrategyTraceKind,
   type CascadeStrategyTraceResponse,
@@ -46,6 +49,7 @@ import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/as
 
 interface CascadeData {
   config: CascadeConfigResponse | null
+  rawConfig: CascadeRawConfigResponse | null
   health: CascadeHealthResponse | null
   capacity: CascadeClientCapacityResponse | null
   history: CascadeClientCapacityHistoryResponse | null
@@ -55,15 +59,16 @@ interface CascadeData {
 
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
-    const [config, health, capacity, history, trace, slo] = await Promise.all([
+    const [config, rawConfig, health, capacity, history, trace, slo] = await Promise.all([
       fetchCascadeConfig({ signal }),
+      fetchCascadeConfigRaw({ signal }),
       fetchCascadeHealth({ signal }),
       fetchCascadeClientCapacity({ signal }),
       fetchCascadeClientCapacityHistory({ limit: 50, signal }),
       fetchCascadeStrategyTrace({ limit: 50, signal }),
       fetchCascadeSlo({ signal }),
     ])
-    return { config, health, capacity, history, trace, slo }
+    return { config, rawConfig, health, capacity, history, trace, slo }
   })
 }
 
@@ -718,6 +723,153 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
   `
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function validateJsonText(raw: string): string | null {
+  try {
+    JSON.parse(raw)
+    return null
+  } catch (error) {
+    return errorMessage(error)
+  }
+}
+
+function CascadeRawConfigEditor({
+  raw,
+  onRefresh,
+}: {
+  raw: CascadeRawConfigResponse | null
+  onRefresh: () => Promise<void>
+}) {
+  const editorText = useSignal(raw?.raw_json ?? '')
+  const editorDirty = useSignal(false)
+  const saving = useSignal(false)
+  const saveMessage = useSignal<string | null>(null)
+
+  useEffect(() => {
+    if (!raw || editorDirty.value) return
+    editorText.value = raw.raw_json
+  }, [raw?.config_path, raw?.updated_at, raw?.raw_json])
+
+  const syntaxError = validateJsonText(editorText.value)
+  const saveDisabled = saving.value
+    || !editorDirty.value
+    || raw?.config_path == null
+    || syntaxError != null
+
+  const handleReset = () => {
+    editorText.value = raw?.raw_json ?? ''
+    editorDirty.value = false
+    saveMessage.value = 'Latest disk snapshot restored in the editor.'
+  }
+
+  const handleSave = async (event: Event) => {
+    event.preventDefault()
+    const currentSyntaxError = validateJsonText(editorText.value)
+    if (currentSyntaxError) {
+      saveMessage.value = `Invalid JSON: ${currentSyntaxError}`
+      return
+    }
+    if (raw?.config_path == null) {
+      saveMessage.value = 'Resolved cascade config path is unavailable.'
+      return
+    }
+    saving.value = true
+    saveMessage.value = null
+    try {
+      await updateCascadeConfigRaw(editorText.value)
+      editorDirty.value = false
+      saveMessage.value = 'Saved. Refreshing cascade snapshot...'
+      try {
+        await onRefresh()
+        saveMessage.value = 'Saved successfully.'
+      } catch (error) {
+        saveMessage.value = `Saved, but refresh failed: ${errorMessage(error)}`
+      }
+    } catch (error) {
+      saveMessage.value = `Failed to save: ${errorMessage(error)}`
+    } finally {
+      saving.value = false
+    }
+  }
+
+  return html`
+    <${Card} title="Raw cascade.json Editor">
+      <div class="flex flex-col gap-3 p-4">
+        <p class="text-sm text-[var(--text-muted)]">
+          dashboard에서 바로 <code>cascade.json</code> 을 수정합니다.
+          저장 경로는
+          <code>${raw?.config_path ?? 'unresolved'}</code>
+          이고, 저장 후 current cascade snapshot 을 다시 읽습니다.
+        </p>
+        <p class="text-xs text-[var(--text-muted)]">
+          semantics invalid profile 도 저장은 허용됩니다. 저장 후 위의 validation banner 에서 invalid/last-known-good 상태를 바로 확인하면 됩니다.
+        </p>
+
+        <form class="flex flex-col gap-3" onSubmit=${handleSave}>
+          <textarea
+            class="h-96 w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+            spellcheck="false"
+            value=${editorText.value}
+            onInput=${(event: Event) => {
+              editorText.value = (event.target as HTMLTextAreaElement).value
+              editorDirty.value = true
+              saveMessage.value = null
+            }}
+          />
+
+          <div class="flex items-center gap-3 flex-wrap text-xs">
+            <span class=${editorDirty.value ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'}>
+              ${editorDirty.value ? 'unsaved changes' : 'in sync with disk'}
+            </span>
+            ${syntaxError
+              ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
+              : html`<span class="text-[var(--ok)]">syntax: valid JSON</span>`}
+            ${saveMessage.value
+              ? html`
+                <span class=${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid')
+                  ? 'text-[var(--bad-light)]'
+                  : 'text-[var(--text-muted)]'}
+                >
+                  ${saveMessage.value}
+                </span>
+              `
+              : null}
+          </div>
+
+          <div class="flex items-center gap-3 flex-wrap">
+            <button
+              type="submit"
+              class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+              disabled=${saveDisabled}
+            >
+              ${saving.value ? 'Saving...' : 'Save cascade.json'}
+            </button>
+            <button
+              type="button"
+              class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              onClick=${handleReset}
+              disabled=${saving.value || !editorDirty.value}
+            >
+              Reset to disk
+            </button>
+            <button
+              type="button"
+              class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)] disabled:opacity-50"
+              onClick=${() => void onRefresh()}
+              disabled=${saving.value}
+            >
+              Reload snapshot
+            </button>
+          </div>
+        </form>
+      </div>
+    <//>
+  `
+}
+
 export function CascadeConfigPanel() {
   const traceSearch = useSignal('')
   const healthSearch = useSignal('')
@@ -735,6 +887,7 @@ export function CascadeConfigPanel() {
 
   const current = resource.state.value
   const config = current.data?.config ?? null
+  const rawConfig = current.data?.rawConfig ?? null
   const health = current.data?.health ?? null
   const capacity = current.data?.capacity ?? null
   const history = current.data?.history ?? null
@@ -758,7 +911,7 @@ export function CascadeConfigPanel() {
 
       ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
 
-      ${current.loading && !config && !health
+      ${current.loading && !config && !rawConfig && !health
         ? html`<${LoadingState}>cascade snapshot 불러오는 중...<//>`
         : null}
 
@@ -804,6 +957,11 @@ export function CascadeConfigPanel() {
             })()
           : null}
       <//>
+
+      <${CascadeRawConfigEditor}
+        raw=${rawConfig}
+        onRefresh=${() => loadCascadeData(resource)}
+      />
 
       <${Card} title="Health Tracker">
         ${health

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -80,6 +80,23 @@ let with_cache_lock f =
 let reset_cache_for_tests () =
   with_cache_lock (fun () -> cache := { active_snapshot = None; rejected_update = None })
 
+let invalidate_path config_path =
+  let keep_snapshot = function
+    | Some (snapshot : snapshot) when String.equal snapshot.source_path config_path -> None
+    | other -> other
+  in
+  let keep_rejection = function
+    | Some (rejection : rejection) when String.equal rejection.source_path config_path -> None
+    | other -> other
+  in
+  with_cache_lock (fun () ->
+      let current = !cache in
+      cache :=
+        {
+          active_snapshot = keep_snapshot current.active_snapshot;
+          rejected_update = keep_rejection current.rejected_update;
+        })
+
 let install_snapshot_for_tests ~source_path ~profile_names =
   let mtime =
     try (Unix.stat source_path).Unix.st_mtime with

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -120,6 +120,14 @@ val snapshot_to_yojson : snapshot -> Yojson.Safe.t
 val rejection_to_yojson : rejection -> Yojson.Safe.t
 val state_to_yojson : state -> Yojson.Safe.t
 
+(** Drop any cached runtime snapshot/rejection derived from [config_path].
+
+    Used by in-process editors/tests after overwriting [cascade.json] so the
+    next {!inspect_active} call revalidates from disk immediately.
+
+    @since 0.160.1 *)
+val invalidate_path : string -> unit
+
 val install_snapshot_for_tests :
   source_path:string ->
   profile_names:string list ->

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -18,6 +18,9 @@ let with_cache_lock f =
   Mutex.lock config_cache_mu;
   Fun.protect ~finally:(fun () -> Mutex.unlock config_cache_mu) f
 
+let invalidate_cache_entry path =
+  with_cache_lock (fun () -> Hashtbl.remove config_cache path)
+
 let read_json_file path =
   let ic = open_in path in
   let content =

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -10,6 +10,14 @@
     Cached with mtime-based hot-reload. *)
 val load_json : string -> (Yojson.Safe.t, string) result
 
+(** Drop the cached JSON entry for one [cascade.json] path.
+
+    Intended for in-process editors/tests that overwrite the file and need
+    the next read to bypass the previous mtime cache entry immediately.
+
+    @since 0.160.1 *)
+val invalidate_cache_entry : string -> unit
+
 (** A model entry with an optional weight for weighted cascade selection.
     Weight defaults to 1 when not specified.
     @since 0.137.0

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -341,6 +341,9 @@ let cascade_path_opt () =
   let resolution = resolve () in
   if resolution.cascade.exists then Some resolution.cascade.path else None
 
+let cascade_path_candidate () =
+  (resolve ()).cascade.path
+
 let prompts_dir () =
   (resolve ()).prompts.path
 

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -223,6 +223,64 @@ let config_json () =
   in
   `Assoc fields
 
+let default_raw_config_json = "{}\n"
+
+let load_raw_config_string path =
+  if Fs_compat.file_exists path then
+    Fs_compat.load_file path
+  else
+    default_raw_config_json
+
+let raw_config_json () =
+  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
+  let config_path = Some (Config_dir_resolver.cascade_path_candidate ()) in
+  let raw_json =
+    match config_path with
+    | None -> ""
+    | Some path -> (
+        try load_raw_config_string path with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | Sys_error msg ->
+            Log.Keeper.warn
+              "dashboard cascade raw config: failed to read %s: %s"
+              path msg;
+            "")
+  in
+  `Assoc
+    [
+      ("updated_at", `String (now_iso ()));
+      ("config_path", Json_util.string_opt_to_json config_path);
+      ("raw_json", `String raw_json);
+    ]
+
+let save_raw_config_json raw_json =
+  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
+  let config_path = Config_dir_resolver.cascade_path_candidate () in
+      let parse_result =
+        try
+          ignore (Yojson.Safe.from_string raw_json);
+          Ok ()
+        with
+        | Yojson.Json_error msg ->
+            Error (Printf.sprintf "invalid JSON: %s" msg)
+        | exn ->
+            Error (Printf.sprintf "failed to parse JSON: %s" (Printexc.to_string exn))
+      in
+      match parse_result with
+      | Error _ as err -> err
+      | Ok () -> (
+          try
+            Fs_compat.mkdir_p (Filename.dirname config_path);
+            match Fs_compat.save_file_atomic config_path raw_json with
+            | Error msg -> Error msg
+            | Ok () ->
+                Cascade_config_loader.invalidate_cache_entry config_path;
+                Cascade_catalog_runtime.invalidate_path config_path;
+                Ok (config_json ())
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Sys_error msg -> Error msg)
+
 (* ── Health projection ──────────────────────────────── *)
 
 let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -43,6 +43,38 @@
     @since 0.6.0 *)
 val config_json : unit -> Yojson.Safe.t
 
+(** Raw [cascade.json] payload from the active resolved config root.
+
+    Shape:
+    {[
+      {
+        "updated_at": "2026-04-21T08:15:00Z",
+        "config_path": "/path/to/cascade.json" | null,
+        "raw_json": "{ ... }\n"
+      }
+    ]}
+
+    [config_path] is the resolver's candidate [cascade.json] path under the
+    active config root, even when the file does not exist yet. In that missing
+    file case, [raw_json] defaults to ["{}\n"] so operators can bootstrap a
+    config from the dashboard editor.
+
+    @since 0.160.1 *)
+val raw_config_json : unit -> Yojson.Safe.t
+
+(** Validate and persist a raw [cascade.json] payload to the resolved config
+    root, then return the refreshed {!config_json} snapshot.
+
+    The input must be syntactically valid JSON. Semantic validation is not a
+    hard gate here: invalid cascades are still written and surfaced through the
+    returned validation metadata so the runtime can continue serving the last
+    known good snapshot. Missing parent directories are created on demand under
+    the active config root.
+
+    @since 0.160.1 *)
+val save_raw_config_json :
+  string -> (Yojson.Safe.t, string) result
+
 (** Build the per-keeper row of [keeper_profiles] without a full
     {!Keeper_registry.registry_entry}. Exposed so the raw-vs-canonical
     contract can be exercised in tests directly.

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -21,6 +21,14 @@ let parse_history_since request =
   | None -> None
   | Some s -> float_of_string_opt (String.trim s)
 
+let raw_json_of_body body_str =
+  match Yojson.Safe.from_string body_str with
+  | `Assoc fields -> (
+      match List.assoc_opt "raw_json" fields with
+      | Some (`String raw_json) -> Ok raw_json
+      | _ -> Error "expected JSON body with string field raw_json")
+  | _ -> Error "expected JSON object body"
+
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/cascade/config" (fun request reqd ->
@@ -29,6 +37,35 @@ let add_routes router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/config/raw" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Dashboard_cascade.raw_config_json () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.post "/api/v1/cascade/config/raw" (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun _state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             let response status message =
+               Http.Response.json ~status ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+                 reqd
+             in
+             match raw_json_of_body body_str with
+             | exception Yojson.Json_error msg ->
+                 response `Bad_request ("invalid JSON body: " ^ msg)
+             | Error msg ->
+                 response `Bad_request msg
+             | Ok raw_json -> (
+                 match Dashboard_cascade.save_raw_config_json raw_json with
+                 | Ok json ->
+                     Http.Response.json ~request:req
+                       (Yojson.Safe.to_string json) reqd
+                 | Error msg ->
+                     response `Bad_request msg))
+         ) request reqd)
   |> Http.Router.get "/api/v1/cascade/health" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cascade.health_json () in

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -39,6 +39,14 @@ let write_file path contents =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc contents)
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len)
+
 let with_temp_config_root contents f =
   let dir = Filename.temp_file "dashboard-cascade-" "" in
   Sys.remove dir;
@@ -214,6 +222,77 @@ let test_config_invalid_catalog_surfaces_validation_metadata () =
                      match member "name" profile with
                      | `String "broken_profile" -> true
                      | _ -> false))))
+
+(* ── raw_config_json / save_raw_config_json ───────────────────── *)
+
+let test_raw_config_shape () =
+  with_temp_config_root
+    {|
+      {
+        "keeper_unified_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+      }
+    |}
+    (fun cascade_path ->
+      let j = Masc_mcp.Dashboard_cascade.raw_config_json () in
+      let raw_json = Yojson.Safe.Util.(j |> member "raw_json" |> to_string) in
+      (match member "updated_at" j with
+       | `String _ -> ()
+       | _ -> fail "updated_at should be string");
+      check (option string) "config_path reflects active root"
+        (Some cascade_path)
+        Yojson.Safe.Util.(j |> member "config_path" |> to_string_option);
+      check bool "raw_json includes current file contents" true
+        (contains_substring raw_json "keeper_unified_models"))
+
+let test_raw_config_defaults_when_file_missing () =
+  with_temp_config_root "{}\n"
+    (fun cascade_path ->
+      Sys.remove cascade_path;
+      let j = Masc_mcp.Dashboard_cascade.raw_config_json () in
+      check (option string) "config_path still known"
+        (Some cascade_path)
+        Yojson.Safe.Util.(j |> member "config_path" |> to_string_option);
+      check string "missing file seeds default object"
+        "{}\n"
+        Yojson.Safe.Util.(j |> member "raw_json" |> to_string))
+
+let test_save_raw_config_json_rejects_invalid_json () =
+  with_temp_config_root "{}\n"
+    (fun _cascade_path ->
+      match Masc_mcp.Dashboard_cascade.save_raw_config_json "{ invalid" with
+      | Ok _ -> fail "invalid JSON should be rejected"
+      | Error msg ->
+          check bool "error mentions invalid JSON" true
+            (contains_substring msg "invalid JSON"))
+
+let test_save_raw_config_json_persists_and_refreshes_projection () =
+  with_temp_config_root
+    {|
+      {
+        "alpha_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+      }
+    |}
+    (fun cascade_path ->
+      let before = Masc_mcp.Dashboard_cascade.config_json () in
+      check bool "old profile visible before save" true
+        (List.mem "alpha" (profile_names before));
+      let next_raw =
+        {|
+          {
+            "beta_editor_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+          }
+        |}
+      in
+      match Masc_mcp.Dashboard_cascade.save_raw_config_json next_raw with
+      | Error msg -> fail ("save_raw_config_json failed: " ^ msg)
+      | Ok saved_config ->
+          check bool "new profile visible immediately after save" true
+            (List.mem "beta_editor" (profile_names saved_config));
+          check bool "old profile removed after save" false
+            (List.mem "alpha" (profile_names saved_config));
+          check string "file persisted verbatim"
+            next_raw
+            (read_file cascade_path))
 
 (* ── health_json ───────────────────────────────────── *)
 
@@ -419,6 +498,15 @@ let () =
       test_case "uses live config catalog" `Quick test_config_uses_live_catalog;
       test_case "invalid catalog surfaces validation metadata" `Quick
         test_config_invalid_catalog_surfaces_validation_metadata;
+    ];
+    "raw_config_json", [
+      test_case "top-level shape" `Quick test_raw_config_shape;
+      test_case "missing file seeds default object" `Quick
+        test_raw_config_defaults_when_file_missing;
+      test_case "invalid JSON is rejected" `Quick
+        test_save_raw_config_json_rejects_invalid_json;
+      test_case "save persists and refreshes config projection" `Quick
+        test_save_raw_config_json_persists_and_refreshes_projection;
     ];
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;


### PR DESCRIPTION
## Summary
- add a raw `cascade.json` editor to the dashboard cascade panel
- expose read/write dashboard endpoints for the resolved cascade config path
- invalidate in-process cascade caches after save so the refreshed snapshot reflects the new file immediately

## Why
The cascade panel was read-only, so operators had to leave the dashboard and edit the live config by hand. This adds the missing raw editor while keeping the existing validation banner and runtime snapshot as the source of truth for semantic validity.

## What changed
- added `GET/POST /api/v1/cascade/config/raw`
- added dashboard API bindings and a textarea editor with dirty-state protection against auto-refresh
- taught the resolver/dashboard raw path flow to expose the candidate `cascade.json` path even when the file does not exist yet
- added cache invalidation hooks and regression coverage for raw read/save behavior

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature-cascade-raw-editor lib/masc_mcp.cmxa test/test_dashboard_cascade.exe`
- `./_build/default/test/test_dashboard_cascade.exe`
- `./node_modules/.bin/tsc --noEmit --pretty false`
