### PR TITLE
[codex] Trim operator context payload surface

### DIFF
--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -254,7 +254,6 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers[0]!.context_tokens).toBe(16312)
     expect(result.keepers[0]!.context_max).toBe(128000)
     expect(result.keepers[0]!.context_source).toBe('keeper_context_status')
-    expect(result.keepers[0]!.context?.source).toBe('keeper_context_status')
   })
 
   it('filters keepers without name', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -282,16 +282,6 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     context_tokens: asNumber(raw.context_tokens) ?? asNumber(contextRaw?.context_tokens),
     context_max: asNumber(raw.context_max) ?? asNumber(contextRaw?.context_max),
     context_source: asString(raw.context_source) ?? asString(contextRaw?.source),
-    context: contextRaw
-      ? {
-          source: asString(contextRaw.source),
-          context_ratio: asNumber(contextRaw.context_ratio),
-          context_tokens: asNumber(contextRaw.context_tokens),
-          context_max: asNumber(contextRaw.context_max),
-          message_count: asNumber(contextRaw.message_count),
-          has_checkpoint: asBoolean(contextRaw.has_checkpoint),
-        }
-      : undefined,
     generation: asNumber(raw.generation),
     active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -387,14 +387,6 @@ export interface OperatorKeeperSnapshot {
   context_tokens?: number
   context_max?: number
   context_source?: string
-  context?: {
-    source?: string
-    context_ratio?: number
-    context_tokens?: number
-    context_max?: number
-    message_count?: number
-    has_checkpoint?: boolean
-  }
   keepalive_running?: boolean
   autonomous_action_count?: number
   autonomous_turn_count?: number

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -97,21 +97,6 @@ let keeper_context_snapshot_of_meta config (meta : Keeper_types.keeper_meta) =
   | None -> fallback_keeper_context_snapshot meta
 
 let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
-  let context_json =
-    if keeper_context_snapshot_is_empty snapshot then
-      `Null
-    else
-      `Assoc
-        [
-          ("source", string_option_to_json snapshot.context_source);
-          ("context_ratio",
-            option_to_json (fun value -> `Float value) snapshot.context_ratio);
-          ("context_tokens",
-            option_to_json (fun value -> `Int value) snapshot.context_tokens);
-          ("context_max",
-            option_to_json (fun value -> `Int value) snapshot.context_max);
-        ]
-  in
   [
     ("context_ratio",
       option_to_json (fun value -> `Float value) snapshot.context_ratio);
@@ -120,7 +105,6 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
     ("context_max",
       option_to_json (fun value -> `Int value) snapshot.context_max);
     ("context_source", string_option_to_json snapshot.context_source);
-    ("context", context_json);
   ]
 
 type action_result_status = ActionOk | ActionError
@@ -939,7 +923,6 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                        ("context_tokens", field_or_null "context_tokens");
                        ("context_max", field_or_null "context_max");
                        ("context_source", field_or_null "context_source");
-                       ("context", field_or_null "context");
                        ("last_model_used", field_or_null "last_model_used");
                        ("active_model", field_or_null "active_model");
                        ("next_model_hint", field_or_null "next_model_hint");

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -194,7 +194,9 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       Alcotest.(check int) "metrics max retained" 128000
         Yojson.Safe.Util.(keeper |> member "context_max" |> to_int);
       Alcotest.(check string) "metrics source retained" "keeper_context_status"
-        Yojson.Safe.Util.(keeper |> member "context_source" |> to_string))
+        Yojson.Safe.Util.(keeper |> member "context_source" |> to_string);
+      Alcotest.(check bool) "nested context payload omitted" true
+        (Yojson.Safe.Util.member "context" keeper = `Null))
 
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- remove the nested `context` mirror from operator keeper snapshots
- keep the operator CTX fix on the top-level fields only: `context_ratio`, `context_tokens`, `context_max`, `context_source`
- retain normalizer compatibility for nested input payloads without expanding the public operator snapshot surface

## Why
- the original CTX-truth fix was correct, but it widened the operator payload surface more than necessary
- this follow-up keeps the bug fix while avoiding an ambiguous partial `context` object in the operator snapshot contract

## Validation
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-operator-ctx-truth ./test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe`
  - follow-up regression passes
  - one pre-existing unrelated baseline failure remains: `keeper status exposes model observability`
