### PR TITLE
[codex] route hardened keeper shell readonly ops via docker

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -95,14 +95,15 @@ let container_name_of meta =
     (Unix.getpid ())
     (int_of_float (Unix.gettimeofday () *. 1000.0))
 
-let run_command_in_container ~config ~(meta : keeper_meta)
+let run_command_in_container_with_status ?(ok_exit_codes = [ 0 ])
+    ~config ~(meta : keeper_meta)
     ~(command_argv : string list) ~(max_bytes : int)
-    ~(timeout_sec : float) () : (string, string) result =
+    ~(timeout_sec : float) () : (Unix.process_status * string, string) result =
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else if command_argv = [] then
-    Error "run_command_in_container: command_argv is empty"
+    Error "run_command_in_container_with_status: command_argv is empty"
   else
     match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error err -> Error err
@@ -124,12 +125,13 @@ let run_command_in_container ~config ~(meta : keeper_meta)
         match command_argv with prog :: _ -> prog | [] -> "?"
       in
       (match st with
-       | Unix.WEXITED 0 ->
+       | Unix.WEXITED code
+         when List.exists (fun ok_code -> ok_code = code) ok_exit_codes ->
          let body =
            if String.length out > max_bytes then String.sub out 0 max_bytes
            else out
          in
-         Ok body
+         Ok (st, body)
        | Unix.WEXITED code ->
          Error
            (Printf.sprintf
@@ -142,6 +144,15 @@ let run_command_in_container ~config ~(meta : keeper_meta)
        | Unix.WSTOPPED n ->
          Error
            (Printf.sprintf "docker_%s_stopped: signal=%d" head_program n))
+
+let run_command_in_container ?(ok_exit_codes = [ 0 ]) ~config ~meta
+    ~command_argv ~max_bytes ~timeout_sec () =
+  match
+    run_command_in_container_with_status ~ok_exit_codes ~config ~meta
+      ~command_argv ~max_bytes ~timeout_sec ()
+  with
+  | Error _ as err -> err
+  | Ok (_st, out) -> Ok out
 
 let read_file_in_container ~config ~(meta : keeper_meta) ~host_path
     ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -61,7 +61,22 @@ val read_file_in_container :
     preflight failure, and docker exit non-zero. The error tag uses
     the program name (e.g. [docker_rg_failed], [docker_cat_failed])
     for caller log forensics. *)
+val run_command_in_container_with_status :
+  ?ok_exit_codes:int list ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  command_argv:string list ->
+  max_bytes:int ->
+  timeout_sec:float ->
+  unit ->
+  (Unix.process_status * string, string) result
+
+(** [run_command_in_container ?ok_exit_codes ~config ~meta ~command_argv
+    ~max_bytes ~timeout_sec ()] is a convenience wrapper around
+    [run_command_in_container_with_status] that drops the returned
+    process status and keeps only the captured stdout bytes. *)
 val run_command_in_container :
+  ?ok_exit_codes:int list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   command_argv:string list ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1462,18 +1462,20 @@ let handle_keeper_shell
   let docker_read_error ~target msg =
     error_json ~fields:[ "op", `String op; "path", `String target ] msg
   in
-  let run_readonly_in_docker ~target ~command_argv ~max_bytes ~timeout_sec =
+  let run_readonly_in_docker ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
+      ~max_bytes ~timeout_sec () =
     match
       Keeper_docker_read.container_path_of_host ~config ~meta ~host_path:target
     with
     | Error e -> Error (docker_read_error ~target e)
     | Ok cpath -> (
         match
-          Keeper_docker_read.run_command_in_container ~config ~meta
-            ~command_argv:(command_argv cpath) ~max_bytes ~timeout_sec ()
+          Keeper_docker_read.run_command_in_container_with_status
+            ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
+            ~max_bytes ~timeout_sec ()
         with
         | Error msg -> Error (docker_read_error ~target msg)
-        | Ok out -> Ok out)
+        | Ok payload -> Ok payload)
   in
   match op with
   | "pwd" ->
@@ -1627,11 +1629,13 @@ let handle_keeper_shell
              run_readonly_in_docker ~target
                ~command_argv:(fun cpath ->
                  base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
+               ~ok_exit_codes:[ 0; 1 ]
                ~max_bytes:1_000_000
                ~timeout_sec:read_timeout_sec
+               ()
            with
            | Error response -> response
-           | Ok out ->
+           | Ok (st, out) ->
              Yojson.Safe.to_string
                (`Assoc
                    [ "ok", `Bool true
@@ -1639,9 +1643,7 @@ let handle_keeper_shell
                    ; "path", `String target
                    ; "pattern", `String pattern
                    ; "via", `String "docker"
-                   ; "status",
-                     Keeper_alerting_path.process_status_to_json
-                       (Unix.WEXITED 0)
+                   ; "status", Keeper_alerting_path.process_status_to_json st
                    ; "matches", lines_to_json ~limit out
                    ]))
         else
@@ -1704,9 +1706,10 @@ let handle_keeper_shell
                    "-not"; "-path"; "*/.masc/*" ])
                ~max_bytes:1_000_000
                ~timeout_sec:read_timeout_sec
+               ()
            with
            | Error response -> response
-           | Ok out ->
+           | Ok (st, out) ->
              Yojson.Safe.to_string
                (`Assoc
                    [ "ok", `Bool true
@@ -1714,9 +1717,7 @@ let handle_keeper_shell
                    ; "path", `String target
                    ; "name", `String name_pattern
                    ; "via", `String "docker"
-                   ; "status",
-                     Keeper_alerting_path.process_status_to_json
-                       (Unix.WEXITED 0)
+                   ; "status", Keeper_alerting_path.process_status_to_json st
                    ; "files", lines_to_json ~limit out
                    ]))
         else
@@ -1745,12 +1746,13 @@ let handle_keeper_shell
          (match
             run_readonly_in_docker ~target
               ~command_argv:(fun cpath ->
-                [ "/usr/bin/head"; "-n"; string_of_int n; cpath ])
+                [ "head"; "-n"; string_of_int n; cpath ])
               ~max_bytes:1_000_000
               ~timeout_sec:read_timeout_sec
+              ()
           with
           | Error response -> response
-          | Ok out ->
+          | Ok (st, out) ->
             Yojson.Safe.to_string
               (`Assoc
                   [ "ok", `Bool true
@@ -1758,9 +1760,7 @@ let handle_keeper_shell
                   ; "path", `String target
                   ; "lines", `Int n
                   ; "via", `String "docker"
-                  ; "status",
-                    Keeper_alerting_path.process_status_to_json
-                      (Unix.WEXITED 0)
+                  ; "status", Keeper_alerting_path.process_status_to_json st
                   ; "content", `String out
                   ]))
        else
@@ -1786,12 +1786,13 @@ let handle_keeper_shell
          (match
             run_readonly_in_docker ~target
               ~command_argv:(fun cpath ->
-                [ "/usr/bin/tail"; "-n"; string_of_int n; cpath ])
+                [ "tail"; "-n"; string_of_int n; cpath ])
               ~max_bytes:1_000_000
               ~timeout_sec:read_timeout_sec
+              ()
           with
           | Error response -> response
-          | Ok out ->
+          | Ok (st, out) ->
             Yojson.Safe.to_string
               (`Assoc
                   [ "ok", `Bool true
@@ -1799,9 +1800,7 @@ let handle_keeper_shell
                   ; "path", `String target
                   ; "lines", `Int n
                   ; "via", `String "docker"
-                  ; "status",
-                    Keeper_alerting_path.process_status_to_json
-                      (Unix.WEXITED 0)
+                  ; "status", Keeper_alerting_path.process_status_to_json st
                   ; "content", `String out
                   ]))
        else
@@ -1825,12 +1824,13 @@ let handle_keeper_shell
        if Keeper_docker_read.should_route_read ~meta then
          (match
             run_readonly_in_docker ~target
-              ~command_argv:(fun cpath -> [ "/usr/bin/wc"; "-l"; cpath ])
+              ~command_argv:(fun cpath -> [ "wc"; "-l"; cpath ])
               ~max_bytes:4096
               ~timeout_sec:read_timeout_sec
+              ()
           with
           | Error response -> response
-          | Ok out ->
+          | Ok (st, out) ->
             Yojson.Safe.to_string
               (Exec_core.process_result_json
                  ~artifact_policy:Exec_core.Inline_only
@@ -1845,7 +1845,7 @@ let handle_keeper_shell
                      "path", `String target;
                      "via", `String "docker";
                    ]
-                 ~status:(Unix.WEXITED 0)
+                 ~status:st
                  ~output:out
                  ()))
        else
@@ -1864,20 +1864,19 @@ let handle_keeper_shell
                   "-not"; "-path"; "*/_build/*" ])
               ~max_bytes:1_000_000
               ~timeout_sec:read_timeout_sec
+              ()
           with
-          | Error response -> response
-          | Ok out ->
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool true
-                  ; "op", `String op
-                  ; "path", `String target
-                  ; "via", `String "docker"
-                  ; "status",
-                    Keeper_alerting_path.process_status_to_json
-                      (Unix.WEXITED 0)
-                  ; "entries", lines_to_json ~limit out
-                  ]))
+           | Error response -> response
+           | Ok (st, out) ->
+             Yojson.Safe.to_string
+               (`Assoc
+                   [ "ok", `Bool true
+                   ; "op", `String op
+                   ; "path", `String target
+                   ; "via", `String "docker"
+                   ; "status", Keeper_alerting_path.process_status_to_json st
+                   ; "entries", lines_to_json ~limit out
+                   ]))
        else
          let st, out =
            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1459,6 +1459,22 @@ let handle_keeper_shell
          ~output:out
          ())
   in
+  let docker_read_error ~target msg =
+    error_json ~fields:[ "op", `String op; "path", `String target ] msg
+  in
+  let run_readonly_in_docker ~target ~command_argv ~max_bytes ~timeout_sec =
+    match
+      Keeper_docker_read.container_path_of_host ~config ~meta ~host_path:target
+    with
+    | Error e -> Error (docker_read_error ~target e)
+    | Ok cpath -> (
+        match
+          Keeper_docker_read.run_command_in_container ~config ~meta
+            ~command_argv:(command_argv cpath) ~max_bytes ~timeout_sec ()
+        with
+        | Error msg -> Error (docker_read_error ~target msg)
+        | Ok out -> Ok out)
+  in
   match op with
   | "pwd" ->
     (match cwd_target () with
@@ -1494,7 +1510,8 @@ let handle_keeper_shell
                Keeper_docker_read.run_command_in_container ~config ~meta
                  ~command_argv:[ "ls"; "-la"; cpath ]
                  ~max_bytes:1_000_000
-                 ~timeout_sec:io_timeout_sec ()
+                 ~timeout_sec:io_timeout_sec
+                 ()
              with
              | Error msg ->
                error_json
@@ -1533,7 +1550,8 @@ let handle_keeper_shell
          (match
             Keeper_docker_read.read_file_in_container ~config ~meta
               ~host_path:target ~max_bytes
-              ~timeout_sec:read_timeout_sec ()
+              ~timeout_sec:read_timeout_sec
+              ()
           with
           | Error msg ->
             error_json
@@ -1601,21 +1619,47 @@ let handle_keeper_shell
         match argv with
         | Error e -> path_error e
         | Ok argv ->
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
-        in
-        (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
-           Treat exit 1 as success with empty results — "no match" is a valid answer. *)
-        let is_ok = st = Unix.WEXITED 0 || st = Unix.WEXITED 1 in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool is_ok
-              ; "op", `String op
-              ; "path", `String target
-              ; "pattern", `String pattern
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "matches", lines_to_json ~limit out
-              ]))
+        if Keeper_docker_read.should_route_read ~meta then
+          let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
+          let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
+          let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
+          (match
+             run_readonly_in_docker ~target
+               ~command_argv:(fun cpath ->
+                 base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
+               ~max_bytes:1_000_000
+               ~timeout_sec:read_timeout_sec
+           with
+           | Error response -> response
+           | Ok out ->
+             Yojson.Safe.to_string
+               (`Assoc
+                   [ "ok", `Bool true
+                   ; "op", `String op
+                   ; "path", `String target
+                   ; "pattern", `String pattern
+                   ; "via", `String "docker"
+                   ; "status",
+                     Keeper_alerting_path.process_status_to_json
+                       (Unix.WEXITED 0)
+                   ; "matches", lines_to_json ~limit out
+                   ]))
+        else
+          let st, out =
+            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
+          in
+          (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
+             Treat exit 1 as success with empty results — "no match" is a valid answer. *)
+          let is_ok = st = Unix.WEXITED 0 || st = Unix.WEXITED 1 in
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool is_ok
+                ; "op", `String op
+                ; "path", `String target
+                ; "pattern", `String pattern
+                ; "status", Keeper_alerting_path.process_status_to_json st
+                ; "matches", lines_to_json ~limit out
+                ]))
   | "git_log" ->
     (match cwd_target () with
      | Error e -> path_error e
@@ -1650,82 +1694,205 @@ let handle_keeper_shell
       | Error e -> path_error e
       | Ok target ->
         let limit = shell_readonly_limit args in
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
-            [ "find"; target; "-maxdepth"; "5"; "-name"; name_pattern;
-              "-not"; "-path"; "*/.git/*";
-              "-not"; "-path"; "*/_build/*";
-              "-not"; "-path"; "*/.masc/*" ]
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
-              ; "op", `String op
-              ; "path", `String target
-              ; "name", `String name_pattern
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "files", lines_to_json ~limit out
-              ]))
+        if Keeper_docker_read.should_route_read ~meta then
+          (match
+             run_readonly_in_docker ~target
+               ~command_argv:(fun cpath ->
+                 [ "find"; cpath; "-maxdepth"; "5"; "-name"; name_pattern;
+                   "-not"; "-path"; "*/.git/*";
+                   "-not"; "-path"; "*/_build/*";
+                   "-not"; "-path"; "*/.masc/*" ])
+               ~max_bytes:1_000_000
+               ~timeout_sec:read_timeout_sec
+           with
+           | Error response -> response
+           | Ok out ->
+             Yojson.Safe.to_string
+               (`Assoc
+                   [ "ok", `Bool true
+                   ; "op", `String op
+                   ; "path", `String target
+                   ; "name", `String name_pattern
+                   ; "via", `String "docker"
+                   ; "status",
+                     Keeper_alerting_path.process_status_to_json
+                       (Unix.WEXITED 0)
+                   ; "files", lines_to_json ~limit out
+                   ]))
+        else
+          let st, out =
+            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+              [ "find"; target; "-maxdepth"; "5"; "-name"; name_pattern;
+                "-not"; "-path"; "*/.git/*";
+                "-not"; "-path"; "*/_build/*";
+                "-not"; "-path"; "*/.masc/*" ]
+          in
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool (st = Unix.WEXITED 0)
+                ; "op", `String op
+                ; "path", `String target
+                ; "name", `String name_pattern
+                ; "status", Keeper_alerting_path.process_status_to_json st
+                ; "files", lines_to_json ~limit out
+                ]))
   | "head" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
-           [ "/usr/bin/head"; "-n"; string_of_int n; target ]
-       in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "path", `String target
-             ; "lines", `Int n
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "content", `String out
-             ]))
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            run_readonly_in_docker ~target
+              ~command_argv:(fun cpath ->
+                [ "/usr/bin/head"; "-n"; string_of_int n; cpath ])
+              ~max_bytes:1_000_000
+              ~timeout_sec:read_timeout_sec
+          with
+          | Error response -> response
+          | Ok out ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool true
+                  ; "op", `String op
+                  ; "path", `String target
+                  ; "lines", `Int n
+                  ; "via", `String "docker"
+                  ; "status",
+                    Keeper_alerting_path.process_status_to_json
+                      (Unix.WEXITED 0)
+                  ; "content", `String out
+                  ]))
+       else
+         let st, out =
+           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+             [ "/usr/bin/head"; "-n"; string_of_int n; target ]
+         in
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "op", `String op
+               ; "path", `String target
+               ; "lines", `Int n
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "content", `String out
+               ]))
   | "tail" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
-           [ "/usr/bin/tail"; "-n"; string_of_int n; target ]
-       in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "path", `String target
-             ; "lines", `Int n
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "content", `String out
-             ]))
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            run_readonly_in_docker ~target
+              ~command_argv:(fun cpath ->
+                [ "/usr/bin/tail"; "-n"; string_of_int n; cpath ])
+              ~max_bytes:1_000_000
+              ~timeout_sec:read_timeout_sec
+          with
+          | Error response -> response
+          | Ok out ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool true
+                  ; "op", `String op
+                  ; "path", `String target
+                  ; "lines", `Int n
+                  ; "via", `String "docker"
+                  ; "status",
+                    Keeper_alerting_path.process_status_to_json
+                      (Unix.WEXITED 0)
+                  ; "content", `String out
+                  ]))
+       else
+         let st, out =
+           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+             [ "/usr/bin/tail"; "-n"; string_of_int n; target ]
+         in
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "op", `String op
+               ; "path", `String target
+               ; "lines", `Int n
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "content", `String out
+               ]))
   | "wc" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
-       render_process_result ~cmd:"wc" [ "/usr/bin/wc"; "-l"; target ])
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            run_readonly_in_docker ~target
+              ~command_argv:(fun cpath -> [ "/usr/bin/wc"; "-l"; cpath ])
+              ~max_bytes:4096
+              ~timeout_sec:read_timeout_sec
+          with
+          | Error response -> response
+          | Ok out ->
+            Yojson.Safe.to_string
+              (Exec_core.process_result_json
+                 ~artifact_policy:Exec_core.Inline_only
+                 ~base_path:root
+                 ~keeper_name:meta.name
+                 ~cmd:"wc"
+                 ~extra:
+                   [
+                     "op", `String op;
+                     "cmd", `String "wc";
+                     "cwd", `Null;
+                     "path", `String target;
+                     "via", `String "docker";
+                   ]
+                 ~status:(Unix.WEXITED 0)
+                 ~output:out
+                 ()))
+       else
+         render_process_result ~cmd:"wc" [ "/usr/bin/wc"; "-l"; target ])
   | "tree" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
-           [ "find"; target; "-maxdepth"; "3"; "-print";
-             "-not"; "-path"; "*/.git/*";
-             "-not"; "-path"; "*/_build/*" ]
-       in
        let limit = shell_readonly_limit args in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "path", `String target
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "entries", lines_to_json ~limit out
-             ]))
+       if Keeper_docker_read.should_route_read ~meta then
+         (match
+            run_readonly_in_docker ~target
+              ~command_argv:(fun cpath ->
+                [ "find"; cpath; "-maxdepth"; "3"; "-print";
+                  "-not"; "-path"; "*/.git/*";
+                  "-not"; "-path"; "*/_build/*" ])
+              ~max_bytes:1_000_000
+              ~timeout_sec:read_timeout_sec
+          with
+          | Error response -> response
+          | Ok out ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool true
+                  ; "op", `String op
+                  ; "path", `String target
+                  ; "via", `String "docker"
+                  ; "status",
+                    Keeper_alerting_path.process_status_to_json
+                      (Unix.WEXITED 0)
+                  ; "entries", lines_to_json ~limit out
+                  ]))
+       else
+         let st, out =
+           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+             [ "find"; target; "-maxdepth"; "3"; "-print";
+               "-not"; "-path"; "*/.git/*";
+               "-not"; "-path"; "*/_build/*" ]
+         in
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "op", `String op
+               ; "path", `String target
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "entries", lines_to_json ~limit out
+               ]))
   | "git_diff" ->
     (match cwd_target () with
      | Error e -> path_error e

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -41,6 +41,11 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
 let make_meta ~name ~sandbox =
   let json =
     `Assoc
@@ -117,6 +122,19 @@ let setup_config name =
     make_meta ~name ~sandbox:Keeper_types.Docker_hardened
   in
   base, config, meta
+
+let with_fake_docker script f =
+  let dir = temp_dir () in
+  let docker_path = Filename.concat dir "docker" in
+  write_file docker_path script;
+  Unix.chmod docker_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "PATH" path f
 
 let test_container_path_root_maps () =
   let base, config, meta = setup_config "minjae" in
@@ -265,6 +283,110 @@ let test_run_command_empty_image_errors () =
          in
          loop 0)
 
+let fake_docker_exit_1_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"run\" ]; then\n\
+  printf 'no matches\\n'\n\
+  exit 1\n\
+fi\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let fake_docker_echo_command_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" != \"run\" ]; then\n\
+  printf 'unexpected docker invocation\\n' >&2\n\
+  exit 2\n\
+fi\n\
+shift\n\
+while [ \"$#\" -gt 0 ]; do\n\
+  if [ \"$1\" = \"alpine:test\" ]; then\n\
+    shift\n\
+    break\n\
+  fi\n\
+  shift\n\
+done\n\
+printf '%s\\n' \"$*\"\n\
+exit 0\n"
+
+let test_run_command_nonzero_exit_errors_by_default () =
+  with_fake_docker fake_docker_exit_1_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.run_command_in_container_with_status ~config ~meta
+      ~command_argv:[ "rg"; "needle"; "/home/keeper/playground/demo.txt" ]
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok (_st, _out) ->
+      Alcotest.fail "expected exit=1 docker command to error by default"
+  | Error msg ->
+      Alcotest.(check bool) "error preserves exit code" true
+        (let needle = "exit=1" in
+         let nlen = String.length needle in
+         let mlen = String.length msg in
+         let rec loop i =
+           if i + nlen > mlen then false
+           else if String.sub msg i nlen = needle then true
+           else loop (i + 1)
+         in
+         loop 0)
+
+let test_run_command_allows_configured_nonzero_exit () =
+  with_fake_docker fake_docker_exit_1_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.run_command_in_container_with_status
+      ~ok_exit_codes:[ 0; 1 ] ~config ~meta
+      ~command_argv:[ "rg"; "needle"; "/home/keeper/playground/demo.txt" ]
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Error msg ->
+      Alcotest.failf "expected exit=1 to be allowed for rg, got %s" msg
+  | Ok (st, out) ->
+      Alcotest.(check (pair string int)) "preserves rg no-match status"
+        ("exit", 1)
+        (match st with
+         | Unix.WEXITED code -> ("exit", code)
+         | Unix.WSIGNALED code -> ("signaled", code)
+         | Unix.WSTOPPED code -> ("stopped", code));
+      Alcotest.(check string) "preserves stdout on allowed exit"
+        "no matches\n" out
+
+let test_run_command_preserves_bare_command_argv () =
+  with_fake_docker fake_docker_echo_command_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  match
+    Keeper_docker_read.run_command_in_container_with_status ~config ~meta
+      ~command_argv:
+        [ "head"; "-n"; "1"; "/home/keeper/playground/minjae/mind/demo.txt" ]
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Error msg ->
+      Alcotest.failf "expected bare command argv echo, got %s" msg
+  | Ok (st, out) ->
+      Alcotest.(check (pair string int)) "echo script exits cleanly"
+        ("exit", 0)
+        (match st with
+         | Unix.WEXITED code -> ("exit", code)
+         | Unix.WSIGNALED code -> ("signaled", code)
+         | Unix.WSTOPPED code -> ("stopped", code));
+      Alcotest.(check string) "preserves bare head argv"
+        "head -n 1 /home/keeper/playground/minjae/mind/demo.txt\n" out
+
 let () =
   Alcotest.run "Keeper_docker_read"
     [
@@ -303,5 +425,11 @@ let () =
             test_run_command_empty_argv_errors;
           Alcotest.test_case "empty image configuration errors" `Quick
             test_run_command_empty_image_errors;
+          Alcotest.test_case "nonzero exit errors by default" `Quick
+            test_run_command_nonzero_exit_errors_by_default;
+          Alcotest.test_case "configured nonzero exit is allowed" `Quick
+            test_run_command_allows_configured_nonzero_exit;
+          Alcotest.test_case "preserves bare command argv" `Quick
+            test_run_command_preserves_bare_command_argv;
         ] );
     ]

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -48,6 +48,11 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
   else if Sys.file_exists path then ()
@@ -93,6 +98,19 @@ let setup ~sandbox f =
   ensure_dir playground;
   f ~config ~meta ~playground
 
+let with_fake_docker script f =
+  let dir = temp_dir () in
+  let docker_path = Filename.concat dir "docker" in
+  write_file docker_path script;
+  Unix.chmod docker_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "PATH" path f
+
 let parse_field raw field =
   Yojson.Safe.from_string raw |> Json.member field
 
@@ -111,6 +129,14 @@ let response_mentions raw field needle =
         else loop (i + 1)
       in
       loop 0
+
+let parse_bool_field raw field =
+  parse_field raw field |> Json.to_bool_option
+
+let parse_status_exit_code raw =
+  match parse_field raw "status" |> Json.member "code" |> Json.to_int_option with
+  | Some code -> code
+  | None -> Alcotest.failf "missing status.code in %s" raw
 
 let assert_docker_route_fires ~config ~meta ~playground =
   let host_path = Filename.concat playground "mind/demo.txt" in
@@ -209,6 +235,57 @@ let test_cat_flag_off_skips_docker () =
     false
     (response_mentions raw "error" "docker image")
 
+let fake_docker_rg_no_match_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" != \"run\" ]; then\n\
+  printf 'unexpected docker invocation\\n' >&2\n\
+  exit 2\n\
+fi\n\
+shift\n\
+while [ \"$#\" -gt 0 ]; do\n\
+  if [ \"$1\" = \"alpine:test\" ]; then\n\
+    shift\n\
+    break\n\
+  fi\n\
+  shift\n\
+done\n\
+if [ \"$1\" = \"rg\" ]; then\n\
+  exit 1\n\
+fi\n\
+printf '%s\\n' \"$*\"\n\
+exit 0\n"
+
+let test_rg_no_match_remains_successful_in_docker_route () =
+  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_rg_no_match_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker_hardened
+  @@ fun ~config ~meta ~playground ->
+  let host_path = Filename.concat playground "mind/demo.txt" in
+  ensure_dir (Filename.dirname host_path);
+  ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+      ~args:
+        (`Assoc
+            [
+              ("op", `String "rg");
+              ("pattern", `String "missing");
+              ("path", `String playground);
+            ])
+  in
+  Alcotest.(check (option bool)) "rg no-match stays ok" (Some true)
+    (parse_bool_field raw "ok");
+  Alcotest.(check int) "rg keeps exit=1 status" 1
+    (parse_status_exit_code raw);
+  Alcotest.(check int) "rg no-match returns empty matches" 0
+    (parse_field raw "matches" |> Json.to_list |> List.length)
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -224,5 +301,10 @@ let () =
             test_cat_legacy_keeper_skips_docker;
           Alcotest.test_case "DOCKER_READ flag off skips docker route"
             `Quick test_cat_flag_off_skips_docker;
+        ] );
+      ( "docker_route_contract",
+        [
+          Alcotest.test_case "rg no-match remains successful" `Quick
+            test_rg_no_match_remains_successful_in_docker_route;
         ] );
     ]

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1,12 +1,13 @@
-(** Tests for keeper_shell docker routing (RFC-0006 Phase B-3b).
+(** Tests for keeper_shell docker routing (RFC-0006 Phase B-3b+).
 
-    Verifies that the [should_route_read] branch fires for [cat] and
-    [ls] when symmetric_sandbox + docker_read are both on for a
-    hardened keeper. The docker process itself is not invoked because
-    the test environment sets [MASC_KEEPER_SANDBOX_DOCKER_IMAGE=""],
-    so the response must surface the structured "docker image is not
-    configured" error from [Keeper_docker_read] — proof that control
-    reached the docker route. *)
+    Verifies that the [should_route_read] branch fires for path-based
+    readonly keeper_shell ops when symmetric_sandbox + docker_read are
+    both on for a hardened keeper. The docker process itself is not
+    invoked because the test environment sets
+    [MASC_KEEPER_SANDBOX_DOCKER_IMAGE=""], so the response must
+    surface the structured "docker image is not configured" error from
+    [Keeper_docker_read] — proof that control reached the docker
+    route. *)
 
 module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
@@ -111,40 +112,66 @@ let response_mentions raw field needle =
       in
       loop 0
 
+let assert_docker_route_fires ~config ~meta ~playground =
+  let host_path = Filename.concat playground "mind/demo.txt" in
+  ensure_dir (Filename.dirname host_path);
+  ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
+  let cases =
+    [
+      ("cat", `Assoc [ ("op", `String "cat"); ("path", `String host_path) ]);
+      ("ls", `Assoc [ ("op", `String "ls"); ("path", `String playground) ]);
+      ( "rg",
+        `Assoc
+          [
+            ("op", `String "rg");
+            ("pattern", `String "alpha");
+            ("path", `String playground);
+          ] );
+      ( "find",
+        `Assoc
+          [
+            ("op", `String "find");
+            ("pattern", `String "*.txt");
+            ("path", `String playground);
+          ] );
+      ( "head",
+        `Assoc
+          [
+            ("op", `String "head");
+            ("lines", `Int 1);
+            ("path", `String host_path);
+          ] );
+      ( "tail",
+        `Assoc
+          [
+            ("op", `String "tail");
+            ("lines", `Int 1);
+            ("path", `String host_path);
+          ] );
+      ("wc", `Assoc [ ("op", `String "wc"); ("path", `String host_path) ]);
+      ("tree", `Assoc [ ("op", `String "tree"); ("path", `String playground) ]);
+    ]
+  in
+  List.iter
+    (fun (op, args) ->
+      let raw =
+        Keeper_exec_shell.handle_keeper_shell ~config ~meta ~args
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s surfaces docker image config error (docker route fired)" op)
+        true
+        (response_mentions raw "error" "docker image"))
+    cases
+
 (* ── Tests ───────────────────────────────────────────────────────── *)
 
-let test_cat_routes_through_docker () =
+let test_readonly_ops_route_through_docker () =
   with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup ~sandbox:Keeper_types.Docker_hardened
   @@ fun ~config ~meta ~playground ->
-  let host_path = Filename.concat playground "mind/x" in
-  ensure_dir (Filename.dirname host_path);
-  ignore (Fs_compat.save_file_atomic host_path "matrix");
-  let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
-      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
-  in
-  Alcotest.(check bool)
-    "cat surfaces docker image config error (docker route fired)"
-    true
-    (response_mentions raw "error" "docker image")
-
-let test_ls_routes_through_docker () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker_hardened
-  @@ fun ~config ~meta ~playground ->
-  let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
-      ~args:(`Assoc [ ("op", `String "ls"); ("path", `String playground) ])
-  in
-  Alcotest.(check bool)
-    "ls surfaces docker image config error (docker route fired)"
-    true
-    (response_mentions raw "error" "docker image")
+  assert_docker_route_fires ~config ~meta ~playground
 
 let test_cat_legacy_keeper_skips_docker () =
   with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
@@ -187,10 +214,9 @@ let () =
     [
       ( "docker_route_fires",
         [
-          Alcotest.test_case "cat routes through docker for hardened+flags"
-            `Quick test_cat_routes_through_docker;
-          Alcotest.test_case "ls routes through docker for hardened+flags"
-            `Quick test_ls_routes_through_docker;
+          Alcotest.test_case
+            "path-based readonly ops route through docker for hardened+flags"
+            `Quick test_readonly_ops_route_through_docker;
         ] );
       ( "docker_route_skipped",
         [


### PR DESCRIPTION
## Summary
- route the remaining path-based readonly `keeper_shell` ops through `Keeper_docker_read` when `docker_hardened` keepers have both symmetric sandboxing and docker read enabled
- cover `rg`, `find`, `head`, `tail`, `wc`, and `tree` in the same docker-contained path already used by `ls` and `cat`
- extend the focused docker-route test to assert all of these ops hit the docker path

## Why
`keeper_shell` still had a split execution model under RFC-0006: `ls` and `cat` used the docker-mounted containment path, but the other readonly file/path inspection ops still executed on the host. That left the symmetric sandbox incomplete for hardened keepers.

## Impact
- hardened keepers with `MASC_KEEPER_SYMMETRIC_SANDBOX=true` and `MASC_KEEPER_DOCKER_READ=true` now resolve all supported path-based readonly shell reads through the container mount
- responses keep their existing shapes and now include `via: "docker"` for the newly routed docker cases
- legacy keepers and flag-off paths remain unchanged

## Root Cause
RFC-0006 docker read routing had only been wired into part of the readonly `keeper_shell` surface, so host-side execution still leaked through for several file/path read commands.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-8854-rfc-0006-slice --build-dir /tmp/issue-8854-dune ./test/test_keeper_shell_docker_route.exe ./test/test_keeper_shell_containment.exe ./test/test_keeper_docker_read.exe`
- `/tmp/issue-8854-dune/default/test/test_keeper_shell_docker_route.exe`
- `/tmp/issue-8854-dune/default/test/test_keeper_docker_read.exe`
- `/tmp/issue-8854-dune/default/test/test_keeper_shell_containment.exe` still has a pre-existing failure in `gh binds repo from active task worktree`; the same failure reproduces on `main` with `/tmp/issue-8854-main-dune/default/test/test_keeper_shell_containment.exe` and is tracked separately in #9263
