### PR TITLE
[codex] keep cascade catalog usable on partial validation

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -44,7 +44,7 @@ type rejection = {
 
 type state =
   | Validated of snapshot
-  | Serving_valid_subset of {
+  | Validated_with_rejections of {
       snapshot : snapshot;
       rejected_update : rejection;
     }
@@ -53,9 +53,10 @@ type state =
       rejected_update : rejection;
     }
 
-type rejected_mode =
-  | Rejected_valid_subset
-  | Rejected_last_known_good
+type validation_result = {
+  snapshot : snapshot;
+  rejected_update : rejection option;
+}
 
 type candidate_runtime = {
   model_string : string;
@@ -76,16 +77,9 @@ type profile_build = {
 type cache = {
   active_snapshot : snapshot option;
   rejected_update : rejection option;
-  rejected_mode : rejected_mode option;
 }
 
-let cache =
-  ref
-    {
-      active_snapshot = None;
-      rejected_update = None;
-      rejected_mode = None;
-    }
+let cache = ref { active_snapshot = None; rejected_update = None }
 let cache_mu = Mutex.create ()
 
 let with_cache_lock f =
@@ -93,36 +87,7 @@ let with_cache_lock f =
   Fun.protect ~finally:(fun () -> Mutex.unlock cache_mu) f
 
 let reset_cache_for_tests () =
-  with_cache_lock (fun () ->
-      cache :=
-        {
-          active_snapshot = None;
-          rejected_update = None;
-          rejected_mode = None;
-        })
-
-let invalidate_path config_path =
-  let keep_snapshot = function
-    | Some (snapshot : snapshot) when String.equal snapshot.source_path config_path -> None
-    | other -> other
-  in
-  let keep_rejection = function
-    | Some (rejection : rejection) when String.equal rejection.source_path config_path -> None
-    | other -> other
-  in
-  with_cache_lock (fun () ->
-      let current = !cache in
-      let active_snapshot = keep_snapshot current.active_snapshot in
-      let rejected_update = keep_rejection current.rejected_update in
-      cache :=
-        {
-          active_snapshot;
-          rejected_update;
-          rejected_mode =
-            (match rejected_update with
-            | Some _ -> current.rejected_mode
-            | None -> None);
-        })
+  with_cache_lock (fun () -> cache := { active_snapshot = None; rejected_update = None })
 
 let install_snapshot_for_tests ~source_path ~profile_names =
   let mtime =
@@ -157,7 +122,6 @@ let install_snapshot_for_tests ~source_path ~profile_names =
         {
           active_snapshot = Some snapshot;
           rejected_update = None;
-          rejected_mode = None;
         })
 
 let has_suffix ~suffix s =
@@ -252,16 +216,14 @@ let state_to_yojson = function
         [
           ("status", `String "validated");
           ("serving_last_known_good", `Bool false);
-          ("serving_valid_subset", `Bool false);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", `Null);
         ]
-  | Serving_valid_subset { snapshot; rejected_update } ->
+  | Validated_with_rejections { snapshot; rejected_update } ->
       `Assoc
         [
-          ("status", `String "serving_valid_subset");
+          ("status", `String "validated");
           ("serving_last_known_good", `Bool false);
-          ("serving_valid_subset", `Bool true);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", rejection_to_yojson rejected_update);
         ]
@@ -270,7 +232,6 @@ let state_to_yojson = function
         [
           ("status", `String "serving_last_known_good");
           ("serving_last_known_good", `Bool true);
-          ("serving_valid_subset", `Bool false);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", rejection_to_yojson rejected_update);
         ]
@@ -301,23 +262,8 @@ let expand_weighted_entries
 let profile_lookup profiles name =
   List.find_opt (fun (profile : profile_snapshot) -> String.equal profile.name name) profiles
 
-let profile_rejection_lookup profiles name =
-  List.find_opt (fun (profile : profile_rejection) -> String.equal profile.name name) profiles
-
 let profile_names_of_snapshot (snapshot : snapshot) =
   List.map (fun (profile : profile_snapshot) -> profile.name) snapshot.profiles
-
-let snapshot_of_state = function
-  | Validated snapshot
-  | Serving_valid_subset { snapshot; _ }
-  | Serving_last_known_good { snapshot; _ } ->
-      snapshot
-
-let rejected_update_of_state = function
-  | Validated _ -> None
-  | Serving_valid_subset { rejected_update; _ }
-  | Serving_last_known_good { rejected_update; _ } ->
-      Some rejected_update
 
 let eio_caps ?sw ?net ?clock () =
   let sw =
@@ -505,7 +451,7 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               candidates;
             }
 
-let load_static_snapshot ~config_path : (snapshot, rejection) result =
+let validate_path_result ~sw ~net ~clock ~config_path =
   let checked_at = Unix.gettimeofday () in
   let attempted_mtime =
     try Some (Unix.stat config_path).Unix.st_mtime
@@ -549,7 +495,7 @@ let load_static_snapshot ~config_path : (snapshot, rejection) result =
                 Keeper_config.default_cascade_name;
             ]
         in
-        let built_profiles, rejected_profiles =
+        let built_profiles, statically_rejected_profiles =
           List.fold_left
             (fun (ok_acc, err_acc) name ->
               match validate_profile_static ~config_path name with
@@ -559,143 +505,11 @@ let load_static_snapshot ~config_path : (snapshot, rejection) result =
             profiles
         in
         let built_profiles = List.rev built_profiles in
-        let rejected_profiles = List.rev rejected_profiles in
-        if top_errors <> [] || rejected_profiles <> [] then
+        let statically_rejected_profiles = List.rev statically_rejected_profiles in
+        if top_errors <> [] || built_profiles = [] then
           Error
             (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-               ~errors:top_errors ~profiles:rejected_profiles)
-        else
-          Ok
-            {
-              source_path = config_path;
-              mtime = Option.value attempted_mtime ~default:0.0;
-              validated_at = checked_at;
-              profiles =
-                List.map
-                  (fun (profile : profile_build) ->
-                    {
-                      name = profile.name;
-                      weighted_entries = profile.weighted_entries;
-                      inference_params = profile.inference_params;
-                      api_key_env_overrides = profile.api_key_env_overrides;
-                      strategy = profile.strategy;
-                      ollama_max_concurrent = profile.ollama_max_concurrent;
-                      cli_max_concurrent = profile.cli_max_concurrent;
-                      probes = [];
-                    })
-                  built_profiles;
-            }
-
-let runtime_required_profiles ~config_path =
-  let keepers_from_catalog =
-    match Cascade_config_loader.load_catalog ~config_path with
-    | Ok entries ->
-        List.filter_map
-          (fun (entry : Cascade_config_loader.catalog_entry) ->
-            if entry.keeper_assignable then Some entry.name else None)
-          entries
-    | Error _ -> []
-  in
-  List.sort_uniq String.compare
-    (Keeper_cascade_profile.known_cascades
-    @ keepers_from_catalog
-    @ [ "governance_judge"; "operator_judge" ])
-
-let runtime_required_profile_names ?config_path () =
-  let config_path =
-    match config_path with
-    | Some path -> path
-    | None -> (
-        match config_path_opt () with
-        | Some path -> path
-        | None -> "")
-  in
-  if String.equal config_path "" then
-    Keeper_cascade_profile.known_cascades
-    @ [ "governance_judge"; "operator_judge" ]
-    |> List.sort_uniq String.compare
-  else
-    runtime_required_profiles ~config_path
-
-let partition_profile_rejections ~required_profiles rejected_profiles =
-  List.partition
-    (fun (rejection : profile_rejection) ->
-      List.mem rejection.name required_profiles)
-    rejected_profiles
-
-let validated_snapshot_of_profiles ~config_path ~attempted_mtime ~checked_at
-    profile_snapshots =
-  {
-    source_path = config_path;
-    mtime = Option.value attempted_mtime ~default:0.0;
-    validated_at = checked_at;
-    profiles = profile_snapshots;
-  }
-
-let validate_path_state ~sw ~net ~clock ~config_path =
-  let checked_at = Unix.gettimeofday () in
-  let attempted_mtime =
-    try Some (Unix.stat config_path).Unix.st_mtime
-    with
-    | Unix.Unix_error _ | Sys_error _ -> None
-  in
-  if not (Env_config_core.existing_file config_path) then
-    Error
-      (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-         ~errors:[ Printf.sprintf "active cascade catalog is missing: %s" config_path ]
-         ~profiles:[])
-  else
-    match Cascade_config_loader.load_json config_path with
-    | Error msg ->
-        Error
-          (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-             ~errors:
-               [
-                 Printf.sprintf
-                   "active cascade catalog could not be loaded: %s"
-                   msg;
-               ]
-             ~profiles:[])
-    | Ok json ->
-        let profiles = discover_profiles json in
-        let required_profiles = runtime_required_profiles ~config_path in
-        let top_errors =
-          let base =
-            if profiles = [] then
-              [ "active cascade catalog has no <name>_models profiles" ]
-            else
-              []
-          in
-          if List.mem Keeper_config.default_cascade_name profiles then
-            base
-          else
-            base
-            @
-            [
-              Printf.sprintf
-                "required default profile %S is missing"
-                Keeper_config.default_cascade_name;
-            ]
-        in
-        let built_profiles, rejected_profiles =
-          List.fold_left
-            (fun (ok_acc, err_acc) name ->
-              match validate_profile_static ~config_path name with
-              | Ok profile -> (profile :: ok_acc, err_acc)
-              | Error rejection -> (ok_acc, rejection :: err_acc))
-            ([], [])
-            profiles
-        in
-        let built_profiles = List.rev built_profiles in
-        let rejected_profiles = List.rev rejected_profiles in
-        let required_rejections, optional_rejections =
-          partition_profile_rejections ~required_profiles rejected_profiles
-        in
-        if top_errors <> [] || required_rejections <> [] then
-          Error
-            (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-               ~errors:top_errors
-               ~profiles:(required_rejections @ optional_rejections))
+               ~errors:top_errors ~profiles:statically_rejected_profiles)
         else
           let unique_candidates = Hashtbl.create 16 in
           List.iter
@@ -718,7 +532,7 @@ let validate_path_state ~sw ~net ~clock ~config_path =
           List.iter
             (fun (key, probe) -> Hashtbl.replace probe_table key probe)
             probe_results;
-          let profile_snapshots, rejected_profiles =
+          let profile_snapshots, probe_rejected_profiles =
             List.fold_left
               (fun (ok_acc, err_acc) (profile : profile_build) ->
                 let probes =
@@ -764,53 +578,40 @@ let validate_path_state ~sw ~net ~clock ~config_path =
               built_profiles
           in
           let profile_snapshots = List.rev profile_snapshots in
-          let rejected_profiles = List.rev rejected_profiles in
-          let required_probe_rejections, optional_probe_rejections =
-            partition_profile_rejections ~required_profiles rejected_profiles
+          let rejected_profiles =
+            statically_rejected_profiles @ List.rev probe_rejected_profiles
           in
-          if required_probe_rejections <> [] then
-            Error
-              (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-                 ~errors:
-                   [
-                     Printf.sprintf
-                       "catalog validation rejected %d/%d runtime-required profile(s)"
-                       (List.length required_probe_rejections)
-                       (List.length built_profiles);
-                   ]
-                 ~profiles:
-                   (optional_rejections @ required_probe_rejections
-                  @ optional_probe_rejections))
-          else if optional_rejections <> [] || optional_probe_rejections <> [] then
-            let snapshot =
-              validated_snapshot_of_profiles ~config_path ~attempted_mtime
-                ~checked_at profile_snapshots
-            in
-            let rejected_update =
+          let snapshot =
+            {
+              source_path = config_path;
+              mtime = Option.value attempted_mtime ~default:0.0;
+              validated_at = checked_at;
+              profiles = profile_snapshots;
+            }
+          in
+          if rejected_profiles = [] then
+            Ok { snapshot; rejected_update = None }
+          else
+            let rejection =
               rejection_of_path ~config_path ~attempted_mtime ~checked_at
                 ~errors:
                   [
                     Printf.sprintf
-                      "catalog validation rejected %d non-runtime-required profile(s); runtime is serving the validated subset"
-                      (List.length optional_rejections
-                     + List.length optional_probe_rejections);
+                      "catalog validation rejected %d/%d profile(s)"
+                      (List.length rejected_profiles)
+                      (List.length profiles);
                   ]
-                ~profiles:(optional_rejections @ optional_probe_rejections)
+                ~profiles:rejected_profiles
             in
-            Ok (Serving_valid_subset { snapshot; rejected_update })
-          else
-            Ok
-              (Validated
-                 (validated_snapshot_of_profiles ~config_path ~attempted_mtime
-                    ~checked_at profile_snapshots))
+            if profile_snapshots = [] then
+              Error rejection
+            else
+              Ok { snapshot; rejected_update = Some rejection }
 
 let validate_path ~sw ~net ~clock ~config_path =
-  match validate_path_state ~sw ~net ~clock ~config_path with
-  | Ok (Validated snapshot)
-  | Ok (Serving_valid_subset { snapshot; _ })
-  | Ok (Serving_last_known_good { snapshot; _ }) ->
-      Ok snapshot
-  | Error rejection -> Error rejection
+  match validate_path_result ~sw ~net ~clock ~config_path with
+  | Ok result -> Ok result.snapshot
+  | Error _ as e -> e
 
 let same_snapshot_key (snapshot : snapshot) ~path ~mtime =
   String.equal snapshot.source_path path && Float.equal snapshot.mtime mtime
@@ -842,7 +643,6 @@ let inspect_active ?sw ?net ?clock () =
                  {
                    active_snapshot = Some snapshot;
                    rejected_update = Some rejection;
-                   rejected_mode = Some Rejected_last_known_good;
                  });
            Ok (Serving_last_known_good { snapshot; rejected_update = rejection })
        | None -> Error rejection)
@@ -854,23 +654,21 @@ let inspect_active ?sw ?net ?clock () =
       in
       let cached_result =
         with_cache_lock (fun () ->
-            match
-              !cache.active_snapshot,
-              !cache.rejected_update,
-              !cache.rejected_mode,
-              current_mtime
-            with
-            | Some snapshot, Some rejection, Some Rejected_valid_subset, Some mtime
-              when same_rejection_key rejection ~path:config_path ~mtime ->
+            match !cache.active_snapshot, !cache.rejected_update, current_mtime with
+            | Some snapshot, Some rejection, Some mtime
+              when same_snapshot_key snapshot ~path:config_path ~mtime
+                   && same_rejection_key rejection ~path:config_path ~mtime ->
                 Some
-                  (Ok (Serving_valid_subset { snapshot; rejected_update = rejection }))
-            | Some snapshot, Some rejection, Some Rejected_last_known_good, Some mtime
-              when same_rejection_key rejection ~path:config_path ~mtime ->
-                Some (Ok (Serving_last_known_good { snapshot; rejected_update = rejection }))
-            | Some snapshot, _, _, Some mtime
+                  (Ok
+                     (Validated_with_rejections
+                        { snapshot; rejected_update = rejection }))
+            | Some snapshot, _, Some mtime
               when same_snapshot_key snapshot ~path:config_path ~mtime ->
                 Some (Ok (Validated snapshot))
-            | None, Some rejection, _, Some mtime
+            | Some snapshot, Some rejection, Some mtime
+              when same_rejection_key rejection ~path:config_path ~mtime ->
+                Some (Ok (Serving_last_known_good { snapshot; rejected_update = rejection }))
+            | None, Some rejection, Some mtime
               when same_rejection_key rejection ~path:config_path ~mtime ->
                 Some (Error rejection)
             | _ -> None)
@@ -896,33 +694,31 @@ let inspect_active ?sw ?net ?clock () =
                          {
                            active_snapshot = Some snapshot;
                            rejected_update = Some rejection;
-                           rejected_mode = Some Rejected_last_known_good;
                          });
                    Ok
                      (Serving_last_known_good
                         { snapshot; rejected_update = rejection })
                | None -> Error rejection)
           | Ok (sw, net, clock) -> (
-              match validate_path_state ~sw ~net ~clock ~config_path with
-              | Ok (Validated snapshot as state) ->
+              match validate_path_result ~sw ~net ~clock ~config_path with
+              | Ok { snapshot; rejected_update = None } ->
                   with_cache_lock (fun () ->
                       cache :=
                         {
                           active_snapshot = Some snapshot;
                           rejected_update = None;
-                          rejected_mode = None;
                         });
-                  Ok state
-              | Ok (Serving_valid_subset { snapshot; rejected_update } as state) ->
+                  Ok (Validated snapshot)
+              | Ok { snapshot; rejected_update = Some rejection } ->
                   with_cache_lock (fun () ->
                       cache :=
                         {
                           active_snapshot = Some snapshot;
-                          rejected_update = Some rejected_update;
-                          rejected_mode = Some Rejected_valid_subset;
+                          rejected_update = Some rejection;
                         });
-                  Ok state
-              | Ok (Serving_last_known_good _) -> assert false
+                  Ok
+                    (Validated_with_rejections
+                       { snapshot; rejected_update = rejection })
               | Error rejection ->
                   (match with_cache_lock (fun () -> !cache.active_snapshot) with
                    | Some snapshot ->
@@ -931,7 +727,6 @@ let inspect_active ?sw ?net ?clock () =
                              {
                                active_snapshot = Some snapshot;
                                rejected_update = Some rejection;
-                               rejected_mode = Some Rejected_last_known_good;
                              });
                        Ok
                          (Serving_last_known_good
@@ -942,14 +737,13 @@ let inspect_active ?sw ?net ?clock () =
                              {
                                active_snapshot = None;
                                rejected_update = Some rejection;
-                               rejected_mode = None;
                              });
                        Error rejection)))
 
 let require_snapshot ?sw ?net ?clock () =
   match inspect_active ?sw ?net ?clock () with
   | Ok (Validated snapshot) -> Ok snapshot
-  | Ok (Serving_valid_subset { snapshot; _ }) -> Ok snapshot
+  | Ok (Validated_with_rejections { snapshot; _ }) -> Ok snapshot
   | Ok (Serving_last_known_good { snapshot; _ }) -> Ok snapshot
   | Error rejection ->
       let detail =
@@ -965,56 +759,17 @@ let normalize_declared_name raw =
 
 let lookup_active_profile ?sw ?net ?clock raw_name =
   let normalized = normalize_declared_name raw_name in
-  match inspect_active ?sw ?net ?clock () with
-  | Error active_rejection ->
-      let active_detail =
-        if active_rejection.errors = [] then
-          "active catalog validation failed"
-        else
-          String.concat "; " active_rejection.errors
-      in
-      (match config_path_opt () with
-       | None -> Error active_detail
-       | Some config_path -> (
-           match load_static_snapshot ~config_path with
-           | Error _ -> Error active_detail
-           | Ok snapshot -> (
-               match profile_lookup snapshot.profiles normalized with
-               | Some profile -> Ok (snapshot, normalized, profile)
-               | None ->
-                   let known = profile_names_of_snapshot snapshot |> String.concat ", " in
-                   Error
-                     (Printf.sprintf
-                        "unknown cascade_name %S (active profiles: %s)"
-                        normalized known))))
-  | Ok state ->
-      let snapshot = snapshot_of_state state in
-      let unknown_cascade () =
-        let known = profile_names_of_snapshot snapshot |> String.concat ", " in
-        Error
-          (Printf.sprintf
-             "unknown cascade_name %S (active profiles: %s)"
-             normalized known)
-      in
+  match require_snapshot ?sw ?net ?clock () with
+  | Error _ as e -> e
+  | Ok snapshot -> (
       match profile_lookup snapshot.profiles normalized with
       | Some profile -> Ok (snapshot, normalized, profile)
       | None ->
-          (match rejected_update_of_state state with
-           | Some rejected_update -> (
-               match
-                 profile_rejection_lookup rejected_update.profiles normalized
-               with
-               | Some rejected_profile ->
-                   let detail =
-                     match rejected_profile.errors with
-                     | [] -> "profile validation rejected"
-                     | errors -> String.concat "; " errors
-                   in
-                   Error
-                     (Printf.sprintf "invalid cascade_name %S: %s"
-                        normalized detail)
-               | None -> unknown_cascade ())
-           | None -> unknown_cascade ())
+          let known = profile_names_of_snapshot snapshot |> String.concat ", " in
+          Error
+            (Printf.sprintf
+               "unknown cascade_name %S (active profiles: %s)"
+               normalized known))
 
 let resolve_declared_name ?sw ?net ?clock ~raw_name () =
   match lookup_active_profile ?sw ?net ?clock raw_name with

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -89,6 +89,23 @@ let with_cache_lock f =
 let reset_cache_for_tests () =
   with_cache_lock (fun () -> cache := { active_snapshot = None; rejected_update = None })
 
+let invalidate_path config_path =
+  let keep_snapshot = function
+    | Some (snapshot : snapshot) when String.equal snapshot.source_path config_path -> None
+    | other -> other
+  in
+  let keep_rejection = function
+    | Some (rejection : rejection) when String.equal rejection.source_path config_path -> None
+    | other -> other
+  in
+  with_cache_lock (fun () ->
+      let current = !cache in
+      cache :=
+        {
+          active_snapshot = keep_snapshot current.active_snapshot;
+          rejected_update = keep_rejection current.rejected_update;
+        })
+
 let install_snapshot_for_tests ~source_path ~profile_names =
   let mtime =
     try (Unix.stat source_path).Unix.st_mtime with
@@ -450,6 +467,37 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               cli_max_concurrent;
               candidates;
             }
+
+let runtime_required_profiles ~config_path =
+  let keepers_from_catalog =
+    match Cascade_config_loader.load_catalog ~config_path with
+    | Ok entries ->
+        List.filter_map
+          (fun (entry : Cascade_config_loader.catalog_entry) ->
+            if entry.keeper_assignable then Some entry.name else None)
+          entries
+    | Error _ -> []
+  in
+  List.sort_uniq String.compare
+    (Keeper_cascade_profile.known_cascades
+    @ keepers_from_catalog
+    @ [ "governance_judge"; "operator_judge" ])
+
+let runtime_required_profile_names ?config_path () =
+  let config_path =
+    match config_path with
+    | Some path -> path
+    | None -> (
+        match config_path_opt () with
+        | Some path -> path
+        | None -> "")
+  in
+  if String.equal config_path "" then
+    Keeper_cascade_profile.known_cascades
+    @ [ "governance_judge"; "operator_judge" ]
+    |> List.sort_uniq String.compare
+  else
+    runtime_required_profiles ~config_path
 
 let validate_path_result ~sw ~net ~clock ~config_path =
   let checked_at = Unix.gettimeofday () in

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -581,6 +581,12 @@ let validate_path_result ~sw ~net ~clock ~config_path =
           let rejected_profiles =
             statically_rejected_profiles @ List.rev probe_rejected_profiles
           in
+          let default_profile_validated =
+            List.exists
+              (fun (profile : profile_snapshot) ->
+                String.equal profile.name Keeper_config.default_cascade_name)
+              profile_snapshots
+          in
           let snapshot =
             {
               source_path = config_path;
@@ -595,15 +601,24 @@ let validate_path_result ~sw ~net ~clock ~config_path =
             let rejection =
               rejection_of_path ~config_path ~attempted_mtime ~checked_at
                 ~errors:
-                  [
-                    Printf.sprintf
-                      "catalog validation rejected %d/%d profile(s)"
-                      (List.length rejected_profiles)
-                      (List.length profiles);
-                  ]
+                  ((if default_profile_validated then
+                      []
+                    else
+                      [
+                        Printf.sprintf
+                          "required default profile %S failed validation"
+                          Keeper_config.default_cascade_name;
+                      ])
+                   @
+                   [
+                     Printf.sprintf
+                       "catalog validation rejected %d/%d profile(s)"
+                       (List.length rejected_profiles)
+                       (List.length profiles);
+                   ])
                 ~profiles:rejected_profiles
             in
-            if profile_snapshots = [] then
+            if profile_snapshots = [] || not default_profile_validated then
               Error rejection
             else
               Ok { snapshot; rejected_update = Some rejection }

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -25,7 +25,7 @@ type rejection
 
 type state =
   | Validated of snapshot
-  | Serving_valid_subset of {
+  | Validated_with_rejections of {
       snapshot : snapshot;
       rejected_update : rejection;
     }
@@ -47,6 +47,9 @@ val validate_path :
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config_path:string ->
   (snapshot, rejection) result
+(** Returns the validated subset of profiles when the catalog is partly
+    usable but some presets are rejected at runtime. Inspect
+    {!inspect_active} when the caller needs the rejected-profile detail. *)
 
 val resolve_declared_name :
   ?sw:Eio.Switch.t ->
@@ -123,19 +126,6 @@ val resolve_selection_trace :
 val snapshot_to_yojson : snapshot -> Yojson.Safe.t
 val rejection_to_yojson : rejection -> Yojson.Safe.t
 val state_to_yojson : state -> Yojson.Safe.t
-
-(** Drop any cached runtime snapshot/rejection derived from [config_path].
-
-    Used by in-process editors/tests after overwriting [cascade.json] so the
-    next {!inspect_active} call revalidates from disk immediately.
-
-    @since 0.160.1 *)
-val invalidate_path : string -> unit
-
-val runtime_required_profile_names :
-  ?config_path:string ->
-  unit ->
-  string list
 
 val install_snapshot_for_tests :
   source_path:string ->

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -127,6 +127,13 @@ val snapshot_to_yojson : snapshot -> Yojson.Safe.t
 val rejection_to_yojson : rejection -> Yojson.Safe.t
 val state_to_yojson : state -> Yojson.Safe.t
 
+val invalidate_path : string -> unit
+
+val runtime_required_profile_names :
+  ?config_path:string ->
+  unit ->
+  string list
+
 val install_snapshot_for_tests :
   source_path:string ->
   profile_names:string list ->

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -114,26 +114,7 @@ let diagnose_cascade_catalog ~active_config_root =
     []
   else
     let profiles = Cascade_catalog_validator.discover_profiles ~config_path in
-    let runtime_required_profiles =
-      Cascade_catalog_runtime.runtime_required_profile_names ~config_path ()
-    in
-    let issues =
-      Cascade_catalog_validator.diagnose_catalog ~config_path
-      |> List.map (fun (issue : catalog_issue) ->
-             match issue.profile, issue.severity with
-             | Some profile, Catalog_error
-               when not (List.mem profile runtime_required_profiles) ->
-                 {
-                   issue with
-                   severity = Catalog_warn;
-                   message =
-                     Printf.sprintf
-                       "%s (non-runtime-required profile; runtime can serve \
-                        a validated subset)"
-                       issue.message;
-                 }
-             | _ -> issue)
-    in
+    let issues = Cascade_catalog_validator.diagnose_catalog ~config_path in
     if issues = [] then
       []
     else
@@ -483,27 +464,23 @@ let analyze ~base_path_input ~default_base_path () =
   current_inputs ~base_path_input ~default_base_path ()
   |> analyze_with
 
-type live_catalog_status =
-  | Live_ok
-  | Live_warn
-  | Live_error
-
 let live_catalog_summary = function
   | Stdlib.Ok (Cascade_catalog_runtime.Validated snapshot) ->
-      ( Live_ok,
+      ( false,
         "Live cascade catalog validation passed.",
         Cascade_catalog_runtime.state_to_yojson
           (Cascade_catalog_runtime.Validated snapshot) )
-  | Stdlib.Ok (Cascade_catalog_runtime.Serving_valid_subset _ as state) ->
-      ( Live_warn,
-        "Live cascade catalog validation rejected non-runtime-required profiles; runtime is serving the validated subset.",
+  | Stdlib.Ok
+      (Cascade_catalog_runtime.Validated_with_rejections _ as state) ->
+      ( false,
+        "Live cascade catalog validation kept the usable profile subset and rejected some presets.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Ok (Cascade_catalog_runtime.Serving_last_known_good _ as state) ->
-      ( Live_error,
+      ( true,
         "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Error rejection ->
-      ( Live_error,
+      ( true,
         "Live cascade catalog validation failed; no validated snapshot is available.",
         `Assoc
           [
@@ -519,33 +496,34 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   let report = analyze ~base_path_input ~default_base_path () in
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
-  let live_status, live_warning, catalog_validation =
+  let live_failed, live_warning, catalog_validation =
     match
       Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
       |> live_catalog_summary
     with
-    | status, warning, validation -> (status, warning, validation)
+    | failed, warning, validation -> (failed, warning, validation)
   in
   let warnings =
     if live_warning = "" then report.warnings
     else report.warnings @ [ live_warning ]
   in
   let next_actions =
-    if live_status = Live_ok then
-      report.next_actions
-    else
+    if live_failed then
       report.next_actions
       @
       [
         "Fix the active cascade catalog candidates/strategy and rerun `masc-mcp doctor config`.";
       ]
+    else
+      report.next_actions
   in
   let status =
-    match report.status, live_status with
-    | Error, _ -> Error
-    | _, Live_error -> Error
-    | Warn, _ | _, Live_warn -> Warn
-    | Ok, Live_ok -> Ok
+    match report.status, live_failed, live_warning <> "" with
+    | Error, _, _ -> Error
+    | _, true, _ -> Error
+    | Warn, false, _ -> Warn
+    | Ok, false, true -> Warn
+    | Ok, false, false -> Ok
   in
   {
     report with

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -227,6 +227,64 @@ let config_json () =
   in
   `Assoc fields
 
+let default_raw_config_json = "{}\n"
+
+let load_raw_config_string path =
+  if Fs_compat.file_exists path then
+    Fs_compat.load_file path
+  else
+    default_raw_config_json
+
+let raw_config_json () =
+  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
+  let config_path = Some (Config_dir_resolver.cascade_path_candidate ()) in
+  let raw_json =
+    match config_path with
+    | None -> ""
+    | Some path -> (
+        try load_raw_config_string path with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | Sys_error msg ->
+            Log.Keeper.warn
+              "dashboard cascade raw config: failed to read %s: %s"
+              path msg;
+            "")
+  in
+  `Assoc
+    [
+      ("updated_at", `String (now_iso ()));
+      ("config_path", Json_util.string_opt_to_json config_path);
+      ("raw_json", `String raw_json);
+    ]
+
+let save_raw_config_json raw_json =
+  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
+  let config_path = Config_dir_resolver.cascade_path_candidate () in
+  let parse_result =
+    try
+      ignore (Yojson.Safe.from_string raw_json);
+      Ok ()
+    with
+    | Yojson.Json_error msg ->
+        Error (Printf.sprintf "invalid JSON: %s" msg)
+    | exn ->
+        Error (Printf.sprintf "failed to parse JSON: %s" (Printexc.to_string exn))
+  in
+  match parse_result with
+  | Error _ as err -> err
+  | Ok () -> (
+      try
+        Fs_compat.mkdir_p (Filename.dirname config_path);
+        match Fs_compat.save_file_atomic config_path raw_json with
+        | Error msg -> Error msg
+        | Ok () ->
+            Cascade_config_loader.invalidate_cache_entry config_path;
+            Cascade_catalog_runtime.invalidate_path config_path;
+            Ok (config_json ())
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | Sys_error msg -> Error msg)
+
 (* ── Health projection ──────────────────────────────── *)
 
 let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -159,9 +159,9 @@ let validation_summary_json ?config_path () =
         ("invalid_profiles", `List []);
       ]
   | Ok
-      (Cascade_catalog_runtime.Serving_valid_subset
+      (Cascade_catalog_runtime.Validated_with_rejections
          { rejected_update; _ }) ->
-      of_rejection ~status:"serving_valid_subset" rejected_update
+      of_rejection ~status:"validated" rejected_update
   | Ok
       (Cascade_catalog_runtime.Serving_last_known_good
          { rejected_update; _ }) ->
@@ -226,64 +226,6 @@ let config_json () =
       ]
   in
   `Assoc fields
-
-let default_raw_config_json = "{}\n"
-
-let load_raw_config_string path =
-  if Fs_compat.file_exists path then
-    Fs_compat.load_file path
-  else
-    default_raw_config_json
-
-let raw_config_json () =
-  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
-  let config_path = Some (Config_dir_resolver.cascade_path_candidate ()) in
-  let raw_json =
-    match config_path with
-    | None -> ""
-    | Some path -> (
-        try load_raw_config_string path with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | Sys_error msg ->
-            Log.Keeper.warn
-              "dashboard cascade raw config: failed to read %s: %s"
-              path msg;
-            "")
-  in
-  `Assoc
-    [
-      ("updated_at", `String (now_iso ()));
-      ("config_path", Json_util.string_opt_to_json config_path);
-      ("raw_json", `String raw_json);
-    ]
-
-let save_raw_config_json raw_json =
-  Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
-  let config_path = Config_dir_resolver.cascade_path_candidate () in
-      let parse_result =
-        try
-          ignore (Yojson.Safe.from_string raw_json);
-          Ok ()
-        with
-        | Yojson.Json_error msg ->
-            Error (Printf.sprintf "invalid JSON: %s" msg)
-        | exn ->
-            Error (Printf.sprintf "failed to parse JSON: %s" (Printexc.to_string exn))
-      in
-      match parse_result with
-      | Error _ as err -> err
-      | Ok () -> (
-          try
-            Fs_compat.mkdir_p (Filename.dirname config_path);
-            match Fs_compat.save_file_atomic config_path raw_json with
-            | Error msg -> Error msg
-            | Ok () ->
-                Cascade_config_loader.invalidate_cache_entry config_path;
-                Cascade_catalog_runtime.invalidate_path config_path;
-                Ok (config_json ())
-          with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | Sys_error msg -> Error msg)
 
 (* ── Health projection ──────────────────────────────── *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -734,12 +734,15 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                  (Cascade_catalog_runtime.snapshot_to_yojson snapshot));
             None
         | Ok
-            (Cascade_catalog_runtime.Serving_valid_subset
-               { rejected_update; _ }) ->
-            Some
-              (format_catalog_validation_error
-                 "startup accepted active cascade catalog with invalid extra profiles"
-                 rejected_update)
+            (Cascade_catalog_runtime.Validated_with_rejections
+               { snapshot; rejected_update }) ->
+            Log.Server.warn
+              "Validated active cascade catalog with rejected profiles: snapshot=%s rejected_update=%s"
+              (Yojson.Safe.to_string
+                 (Cascade_catalog_runtime.snapshot_to_yojson snapshot))
+              (Yojson.Safe.to_string
+                 (Cascade_catalog_runtime.rejection_to_yojson rejected_update));
+            None
         | Ok
             (Cascade_catalog_runtime.Serving_last_known_good
                { rejected_update; _ }) ->

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -184,8 +184,8 @@ let test_valid_catalog_dedupes_shared_live_probes () =
   let snapshot =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
     | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
-    | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
-        fail "expected a freshly validated snapshot"
+    | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+        fail "expected fully validated snapshot without rejected profiles"
     | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
         fail "expected a freshly validated snapshot"
     | Error rejection ->
@@ -237,7 +237,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
   in
   (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
    | Ok (Cascade_catalog_runtime.Validated _) -> ()
-   | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
+   | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
        fail "expected the initial snapshot to validate cleanly"
    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
        fail "expected the initial snapshot to validate cleanly"
@@ -273,8 +273,8 @@ let test_invalid_hot_reload_preserves_last_known_good () =
         (contains_substring rejection_json "__nonexistent_provider_sentinel__")
   | Ok (Cascade_catalog_runtime.Validated _) ->
       fail "expected invalid hot reload to be rejected"
-  | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
-      fail "expected invalid hot reload to fall back to last-known-good"
+  | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+      fail "expected invalid hot reload to use last-known-good"
   | Error rejection ->
       failf "expected last-known-good fallback, got hard error: %s"
         (Yojson.Safe.to_string
@@ -307,51 +307,7 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
     []
     (Cascade_runtime.models_of_cascade_name "missing_profile")
 
-let test_static_profile_lookup_survives_probe_rejection_without_snapshot () =
-  with_temp_dir "cascade-static-fallback" @@ fun dir ->
-  let config_dir = Filename.concat dir "config" in
-  init_config_root config_dir;
-  with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let refused_model = Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" port in
-  ignore
-    (write_cascade_json config_dir
-       (Printf.sprintf
-          {|{
-  "keeper_unified_models": ["%s"],
-  "tool_rerank_models": ["%s"]
-}|}
-          refused_model refused_model));
-  (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-   | Ok _ -> fail "expected probe rejection without a last-known-good snapshot"
-   | Error rejection ->
-       let rejection_json =
-         Cascade_catalog_runtime.rejection_to_yojson rejection
-         |> Yojson.Safe.to_string
-       in
-       check bool "probe rejection is surfaced" true
-         (contains_substring rejection_json "probe failed"));
-  let resolved_name =
-    require_ok
-      (Cascade_catalog_runtime.resolve_declared_name
-         ~sw ~net ~clock ~raw_name:"" ())
-  in
-  check string "default cascade still resolves statically"
-    Keeper_config.default_cascade_name resolved_name;
-  check (list string) "model strings still resolve statically"
-    [ refused_model ]
-    (require_ok
-       (Cascade_catalog_runtime.models_of_cascade_name
-          ~sw ~net ~clock "keeper_unified"));
-  let providers =
-    require_ok
-      (Cascade_catalog_runtime.resolve_named_providers
-         ~sw ~net ~clock ~cascade_name:"keeper_unified" ())
-  in
-  check int "static provider fallback keeps one provider" 1 (List.length providers)
-
-let test_dashboard_available_profiles_use_validated_snapshot_only () =
+let test_partial_catalog_keeps_validated_subset_available () =
   with_temp_dir "dashboard-cascade-profiles" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
@@ -369,22 +325,28 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
           {|{
   "keeper_unified_models": ["%s"],
   "tool_rerank_models": ["%s"],
-  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
 }|}
           valid_model valid_model));
-  let _ =
+  let rejection_json =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-    | Ok (Cascade_catalog_runtime.Serving_valid_subset _) ->
-        fail "expected invalid raw file to be rejected before snapshot priming"
-    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
-        fail "expected direct validation, not last-known-good"
+    | Ok
+        (Cascade_catalog_runtime.Validated_with_rejections
+           { rejected_update; _ }) ->
+        Cascade_catalog_runtime.rejection_to_yojson rejected_update
+        |> Yojson.Safe.to_string
     | Ok (Cascade_catalog_runtime.Validated _) ->
-        fail "expected invalid raw file to be rejected before snapshot priming"
-    | Error _ -> ()
+        fail "expected mixed catalog to keep only the validated subset"
+    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+        fail "expected direct validation against the current file"
+    | Error rejection ->
+        failf "expected partial validation, got hard error: %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
   in
-  Cascade_catalog_runtime.install_snapshot_for_tests
-    ~source_path:(Filename.concat config_dir "cascade.json")
-    ~profile_names:[ Keeper_config.default_cascade_name; "tool_rerank" ];
+  check bool "rejected runtime probe is surfaced" true
+    (contains_substring rejection_json
+       "custom:flaky@http://127.0.0.1:9/v1");
   check (list string) "dashboard only advertises validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
     (Masc_mcp.Server_routes_http_routes_dashboard.available_cascade_profiles ());
@@ -395,95 +357,9 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
   in
   check (list string) "dashboard config_json only renders validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
-    profile_names
-
-let test_invalid_extra_profile_serves_valid_subset () =
-  with_temp_dir "cascade-valid-subset" @@ fun dir ->
-  let config_dir = Filename.concat dir "config" in
-  init_config_root config_dir;
-  with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
-  let port = find_free_port () in
-  let base_url, _request_count =
-    start_counting_mock ~sw ~net ~port
-      ~response:(openai_text_response "pong")
-  in
-  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
-  ignore
-    (write_cascade_json config_dir
-       (Printf.sprintf
-          {|{
-  "default_models": ["%s"],
-  "keeper_unified_models": ["%s"],
-  "manual_trial_models": ["__nonexistent_provider_sentinel__:fake"],
-  "manual_trial_keeper_assignable": false
-}|}
-          valid_model valid_model));
-  match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-  | Ok
-      (Cascade_catalog_runtime.Serving_valid_subset
-         { snapshot; rejected_update }) ->
-      let snapshot_json =
-        Cascade_catalog_runtime.snapshot_to_yojson snapshot
-      in
-      let profile_names =
-        json_list_field "profiles" snapshot_json
-        |> List.map (json_string_field "name")
-      in
-      check bool "default remains routable" true
-        (List.mem Keeper_config.default_cascade_name profile_names);
-      check bool "keeper_unified remains routable" true
-        (List.mem "keeper_unified" profile_names);
-      check bool "invalid extra profile omitted from active snapshot" false
-        (List.mem "manual_trial" profile_names);
-      check (list string) "keeper_unified models still resolve"
-        [ valid_model ]
-        (require_ok
-           (Cascade_catalog_runtime.models_of_cascade_name
-              ~sw ~net ~clock "keeper_unified"));
-      (match
-         Cascade_catalog_runtime.models_of_cascade_name
-           ~sw ~net ~clock "manual_trial"
-       with
-       | Ok labels ->
-           failf "expected invalid extra profile to be rejected, got %s"
-             (String.concat ", " labels)
-       | Error detail ->
-           check bool "invalid extra profile detail is surfaced" true
-             (contains_substring detail "manual_trial"));
-      let rejected_json =
-        Cascade_catalog_runtime.rejection_to_yojson rejected_update
-        |> Yojson.Safe.to_string
-      in
-      check bool "rejected_update lists invalid extra profile" true
-        (contains_substring rejected_json "manual_trial");
-      let dashboard_json = Masc_mcp.Dashboard_cascade.config_json () in
-      check string "dashboard reports valid subset status"
-        "serving_valid_subset"
-        (json_string_field "validation_status" dashboard_json);
-      let report =
-        Config_doctor.analyze_live
-          ~sw ~net ~clock ~fs ~proc_mgr
-          ~base_path_input:dir
-          ~default_base_path:dir
-          ()
-      in
-      check string "live doctor status degrades to warn" "warn"
-        (Config_doctor.status_to_string report.status);
-      (match report.catalog_validation with
-       | None -> fail "expected catalog_validation output from analyze_live"
-       | Some json ->
-           check string "doctor reports valid subset status"
-             "serving_valid_subset"
-             (json_string_field "status" json))
-  | Ok (Cascade_catalog_runtime.Validated _) ->
-      fail "expected invalid extra profile to downgrade into serving_valid_subset"
-  | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
-      fail "expected current validated subset, not last-known-good"
-  | Error rejection ->
-      failf "expected serving_valid_subset, got hard rejection: %s"
-        (Yojson.Safe.to_string
-           (Cascade_catalog_runtime.rejection_to_yojson rejection))
+    profile_names;
+  check bool "dashboard config_json keeps rejected profile metadata" true
+    (contains_substring (Yojson.Safe.to_string config_json) "broken_profile")
 
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
@@ -520,6 +396,51 @@ let test_config_doctor_live_reports_catalog_validation () =
         (contains_substring (Yojson.Safe.to_string json)
            "__nonexistent_provider_sentinel__")
 
+let test_config_doctor_live_warns_on_partial_catalog_validation () =
+  with_temp_dir "cascade-doctor-live-partial" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_dir = Filename.concat base_path ".masc/config" in
+  init_config_root config_dir;
+  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
+  let port = find_free_port () in
+  let base_url, _request_count =
+    start_counting_mock ~sw ~net ~port
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "keeper_unified_models": ["%s"],
+  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
+}|}
+          valid_model));
+  with_config_dir config_dir @@ fun () ->
+  let report =
+    Config_doctor.analyze_live
+      ~sw ~net ~clock ~fs ~proc_mgr
+      ~base_path_input:base_path
+      ~default_base_path:base_path
+      ()
+  in
+  check string "live doctor partial status" "warn"
+    (Config_doctor.status_to_string report.status);
+  check bool "live partial warning present" true
+    (List.exists
+       (fun warning ->
+          contains_substring warning
+            "kept the usable profile subset and rejected some presets")
+       report.warnings);
+  match report.catalog_validation with
+  | None -> fail "expected catalog_validation output from analyze_live"
+  | Some json ->
+      check string "partial catalog validation status" "validated"
+        (json_string_field "status" json);
+      check bool "rejected profile is surfaced in live doctor json" true
+        (contains_substring (Yojson.Safe.to_string json)
+           "custom:flaky@http://127.0.0.1:9/v1")
+
 let () =
   run "cascade_catalog_runtime"
     [
@@ -538,20 +459,16 @@ let () =
             `Quick
             test_legacy_runtime_wrapper_does_not_fallback_to_defaults;
           test_case
-            "static profile lookup survives probe rejection without snapshot"
+            "partial catalog keeps validated subset available"
             `Quick
-            test_static_profile_lookup_survives_probe_rejection_without_snapshot;
-          test_case
-            "dashboard available profiles use validated snapshot only"
-            `Quick
-            test_dashboard_available_profiles_use_validated_snapshot_only;
-          test_case
-            "invalid extra profile serves validated subset"
-            `Quick
-            test_invalid_extra_profile_serves_valid_subset;
+            test_partial_catalog_keeps_validated_subset_available;
           test_case
             "config doctor live reports catalog validation"
             `Quick
             test_config_doctor_live_reports_catalog_validation;
+          test_case
+            "config doctor live warns on partial catalog validation"
+            `Quick
+            test_config_doctor_live_warns_on_partial_catalog_validation;
         ] );
     ]

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -361,6 +361,47 @@ let test_partial_catalog_keeps_validated_subset_available () =
   check bool "dashboard config_json keeps rejected profile metadata" true
     (contains_substring (Yojson.Safe.to_string config_json) "broken_profile")
 
+let test_partial_catalog_rejects_invalid_default_profile () =
+  with_temp_dir "dashboard-cascade-default-gate" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
+  let port = find_free_port () in
+  let base_url, _request_count =
+    start_counting_mock ~sw ~net ~port
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  match
+    ignore
+      (write_cascade_json config_dir
+         (Printf.sprintf
+            {|{
+  "keeper_unified_models": ["custom:flaky@http://127.0.0.1:9/v1"],
+  "tool_rerank_models": ["%s"]
+}|}
+            valid_model));
+    Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
+  with
+  | Error rejection ->
+      let rejection_json =
+        Cascade_catalog_runtime.rejection_to_yojson rejection
+        |> Yojson.Safe.to_string
+      in
+      check bool "default-profile gate is surfaced" true
+        (contains_substring rejection_json
+           "required default profile \"keeper_unified\" failed validation");
+      check bool "rejected default profile probe is surfaced" true
+        (contains_substring rejection_json
+           "custom:flaky@http://127.0.0.1:9/v1")
+  | Ok (Cascade_catalog_runtime.Validated _) ->
+      fail "expected invalid default profile to hard-fail validation"
+  | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+      fail "expected invalid default profile to be rejected, not partially validated"
+  | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+      fail "expected direct validation against the current file"
+
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -462,6 +503,10 @@ let () =
             "partial catalog keeps validated subset available"
             `Quick
             test_partial_catalog_keeps_validated_subset_available;
+          test_case
+            "partial catalog rejects invalid default profile"
+            `Quick
+            test_partial_catalog_rejects_invalid_default_profile;
           test_case
             "config doctor live reports catalog validation"
             `Quick

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -387,13 +387,18 @@ let test_partial_catalog_rejects_invalid_default_profile () =
   | Error rejection ->
       let rejection_json =
         Cascade_catalog_runtime.rejection_to_yojson rejection
-        |> Yojson.Safe.to_string
       in
+      let errors = json_list_field "errors" rejection_json in
       check bool "default-profile gate is surfaced" true
-        (contains_substring rejection_json
-           "required default profile \"keeper_unified\" failed validation");
+        (List.exists
+           (function
+             | `String value ->
+                 contains_substring value
+                   "required default profile \"keeper_unified\" failed validation"
+             | _ -> false)
+           errors);
       check bool "rejected default profile probe is surfaced" true
-        (contains_substring rejection_json
+        (contains_substring (Yojson.Safe.to_string rejection_json)
            "custom:flaky@http://127.0.0.1:9/v1")
   | Ok (Cascade_catalog_runtime.Validated _) ->
       fail "expected invalid default profile to hard-fail validation"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -96,8 +96,7 @@ goal = "example"
 room_scope = "current"
 proactive_enabled = false
 |}
-let find_free_port () =
-  let start = 9200 + (Unix.getpid () mod 1000) in
+let find_free_port_from start =
   let rec loop attempts port =
     if attempts <= 0 then
       Alcotest.skip ()
@@ -117,6 +116,43 @@ let find_free_port () =
                 (Unix.error_message err) fn arg)
   in
   loop 2048 start
+
+let find_free_port () =
+  find_free_port_from (9200 + (Unix.getpid () mod 1000))
+
+let openai_text_response ?(id = "chatcmpl-1") text =
+  Printf.sprintf
+    {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}|}
+    id text
+
+let start_mock_openai_server ~port ~response =
+  match Unix.fork () with
+  | 0 ->
+      let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, port));
+      Unix.listen socket 16;
+      let payload =
+        Printf.sprintf
+          "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+          (String.length response) response
+      in
+      let buffer = Bytes.create 4096 in
+      let rec loop () =
+        let client, _ = Unix.accept socket in
+        Fun.protect
+          ~finally:(fun () -> Unix.close client)
+          (fun () ->
+            ignore
+              (try Unix.read client buffer 0 (Bytes.length buffer)
+               with Unix.Unix_error _ -> 0);
+            ignore (Unix.write_substring client payload 0 (String.length payload)));
+        loop ()
+      in
+      loop ()
+  | pid ->
+      Unix.sleepf 0.1;
+      pid
 
 let merge_env_overrides overrides =
   let override_keys = List.map fst overrides in
@@ -329,8 +365,10 @@ let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
     match curl_health_json ~port with
     | Some json -> (
         let phase =
-          Yojson.Safe.Util.(
-            json |> member "startup" |> member "phase" |> to_string_option)
+          match Yojson.Safe.Util.member "startup" json with
+          | `Assoc _ as startup ->
+              Yojson.Safe.Util.(startup |> member "phase" |> to_string_option)
+          | _ -> None
         in
         match phase with
         | Some phase when String.equal phase expected_phase -> true
@@ -363,6 +401,18 @@ let write_invalid_local_only_cascade base_path =
     {|{
   "local_only_models": ["ollama:qwen3.6:35b-a3b-mlx-bf16"]
 }|}
+
+let write_partially_invalid_cascade ~base_path ~valid_model =
+  let config_root = Filename.concat base_path ".masc/config" in
+  mkdir_p config_root;
+  write_file
+    (Filename.concat config_root "cascade.json")
+    (Printf.sprintf
+       {|{
+  "keeper_unified_models": ["%s"],
+  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+}|}
+       valid_model)
 
 let stop_process pid =
   (try Unix.kill pid Sys.sigterm with _ -> ());
@@ -1444,6 +1494,95 @@ let test_main_eio_invalid_cascade_stays_degraded_but_serves_dashboard () =
             Yojson.Safe.Util.(
               config_json |> member "config_path" |> to_string)))
 
+let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
+  with_temp_dir "startup-partial-cascade" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let mock_port = find_free_port_from (port + 1) in
+      let mock_pid =
+        start_mock_openai_server ~port:mock_port
+          ~response:(openai_text_response "ok")
+      in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_partially_invalid_cascade ~base_path:dir
+        ~valid_model:(Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" mock_port);
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () ->
+          stop_process pid;
+          stop_process mock_pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "ready") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio partial catalog did not reach startup.phase=ready within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir ~name:"health-partial" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup = Yojson.Safe.Util.member "startup" health_json in
+          Alcotest.(check string) "startup phase stays ready" "ready"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check bool) "startup remains ready" true
+            Yojson.Safe.Util.(startup |> member "state_ready" |> to_bool);
+          Alcotest.(check bool) "last error remains unset" true
+            Yojson.Safe.Util.(startup |> member "last_error" |> to_string_option = None);
+          let config_headers, config_body =
+            curl_request_capture ~output_dir:dir ~name:"cascade-config-partial"
+              ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/api/v1/cascade/config" port)
+              ()
+          in
+          Alcotest.(check (option int)) "cascade config http 200" (Some 200)
+            (http_status_from_headers config_headers);
+          let config_json = parse_json_response_file config_body in
+          Alcotest.(check string) "partial validation stays validated"
+            "validated"
+            Yojson.Safe.Util.(
+              config_json |> member "validation_status" |> to_string);
+          Alcotest.(check int) "one invalid profile is surfaced" 1
+            Yojson.Safe.Util.(
+              config_json |> member "invalid_profiles" |> to_list |> List.length)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1566,6 +1705,10 @@ let () =
           Alcotest.test_case
             "main_eio fresh bootstrap and MCP handshake"
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
+          Alcotest.test_case
+            "main_eio partial catalog stays ready and surfaces rejections"
+            `Slow
+            test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections;
           Alcotest.test_case
             "main_eio invalid cascade stays degraded but serves dashboard"
             `Slow

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -22,6 +22,21 @@ let write_file path content =
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then
+      true
+    else if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
 let canonical_path path =
   try Unix.realpath path with Unix.Unix_error _ -> path
 
@@ -411,6 +426,18 @@ let write_partially_invalid_cascade ~base_path ~valid_model =
        {|{
   "keeper_unified_models": ["%s"],
   "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+}|}
+       valid_model)
+
+let write_partially_invalid_default_cascade ~base_path ~valid_model =
+  let config_root = Filename.concat base_path ".masc/config" in
+  mkdir_p config_root;
+  write_file
+    (Filename.concat config_root "cascade.json")
+    (Printf.sprintf
+       {|{
+  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"],
+  "tool_rerank_models": ["%s"]
 }|}
        valid_model)
 
@@ -1583,6 +1610,101 @@ let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
             Yojson.Safe.Util.(
               config_json |> member "invalid_profiles" |> to_list |> List.length)))
 
+let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
+  with_temp_dir "startup-default-invalid-partial-cascade" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let mock_port = find_free_port_from (port + 1) in
+      let mock_pid =
+        start_mock_openai_server ~port:mock_port
+          ~response:(openai_text_response "ok")
+      in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_partially_invalid_default_cascade ~base_path:dir
+        ~valid_model:(Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" mock_port);
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () ->
+          stop_process pid;
+          stop_process mock_pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "degraded") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio default-invalid partial catalog did not reach startup.phase=degraded within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir ~name:"health-default-invalid"
+              ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup = Yojson.Safe.Util.member "startup" health_json in
+          Alcotest.(check string) "startup phase degraded" "degraded"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          let startup_error =
+            Yojson.Safe.Util.(startup |> member "last_error" |> to_string)
+          in
+          Alcotest.(check bool) "last error mentions default-profile gate" true
+            (contains_substring startup_error
+               "startup catalog validation failed:"
+             &&
+             contains_substring startup_error
+               "required default profile \"keeper_unified\" failed validation");
+          let config_headers, config_body =
+            curl_request_capture ~output_dir:dir ~name:"cascade-config-default-invalid"
+              ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/api/v1/cascade/config" port)
+              ()
+          in
+          Alcotest.(check (option int)) "cascade config http 200" (Some 200)
+            (http_status_from_headers config_headers);
+          let config_json = parse_json_response_file config_body in
+          Alcotest.(check string) "default-invalid partial catalog is invalid"
+            "invalid"
+            Yojson.Safe.Util.(
+              config_json |> member "validation_status" |> to_string);
+          Alcotest.(check int) "default-invalid profile is surfaced" 1
+            Yojson.Safe.Util.(
+              config_json |> member "invalid_profiles" |> to_list |> List.length)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1709,6 +1831,10 @@ let () =
             "main_eio partial catalog stays ready and surfaces rejections"
             `Slow
             test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections;
+          Alcotest.test_case
+            "main_eio invalid default partial catalog stays degraded"
+            `Slow
+            test_main_eio_invalid_default_partial_catalog_stays_degraded;
           Alcotest.test_case
             "main_eio invalid cascade stays degraded but serves dashboard"
             `Slow


### PR DESCRIPTION
## What changed
This keeps the active cascade catalog usable when only some profiles fail validation.

Instead of rejecting the whole catalog, runtime validation now preserves the validated subset and carries rejected profile details separately. Config doctor, dashboard cascade JSON, and server startup all treat that state as `validated` with surfaced rejection metadata instead of a fatal startup degradation.

## Why
A single bad profile could previously poison the entire active catalog. That made healthy cascades like `keeper_unified` fall back to `[]` and produced warnings such as `catalog validation rejected 8/8 profile(s)` even when only part of the catalog was actually bad.

## Impact
Healthy profiles remain routable.
Invalid profiles still appear in doctor/dashboard output so the bad entries are visible and actionable.
Startup no longer marks the server degraded just because a subset of profiles was rejected.

## Validation
- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cascade-partial-validation`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cascade-partial-validation ./test/test_cascade_catalog_runtime.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cascade-partial-validation ./test/test_dashboard_cascade.exe -- test config_json 1,5`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cascade-partial-validation ./test/test_server_runtime_bootstrap.exe -- test bootstrap 40`
