### PR TITLE
fix(coord): exhaustive match in audit_orphan_tasks

### DIFF
--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -139,10 +139,11 @@ let audit_orphan_tasks config : (Types.task * string) list =
     List.filter_map (fun (task : Types.task) ->
       match task.task_status with
       | Types.Claimed { assignee; _ }
-      | Types.InProgress { assignee; _ } ->
+      | Types.InProgress { assignee; _ }
+      | Types.AwaitingVerification { assignee; _ } ->
           if is_active_agent assignee then None
           else Some (task, assignee)
-      | _ -> None
+      | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
     ) backlog.tasks
 
 let is_agent_active_at_path config path =


### PR DESCRIPTION
## Summary
- Replace `_ -> None` wildcard in `audit_orphan_tasks` with explicit `task_status` constructors (Todo, Done, Cancelled)
- Promote `AwaitingVerification` to orphan-candidate branch — tasks whose assignee went inactive while awaiting verification are now surfaced instead of silently skipped

## Why
Exhaustive pattern matching ensures the compiler rejects this code if a new `task_status` constructor is added. The `AwaitingVerification` inclusion is a latent bug fix: verification-pending tasks with inactive assignees should be caught by orphan audits.

## Test plan
- [x] `dune build` passes
- [ ] CI green (Build and Test, Lint, Meta Guards)
- [ ] Zero behavior change for existing constructors

🤖 Generated with [Claude Code](https://claude.com/claude-code)