### PR TITLE
[codex] Harden keeper runtime and cascade health surfaces

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1,5 +1,6 @@
 type candidate_probe_status =
   | Probe_ok
+  | Probe_skipped of string
   | Probe_error of string
 
 let probe_timeout_sec = 5.0
@@ -173,11 +174,13 @@ let candidate_probe_to_yojson (probe : candidate_probe) =
       ( "status",
         match probe.status with
         | Probe_ok -> `String "ok"
+        | Probe_skipped _ -> `String "skipped"
         | Probe_error message ->
             `String "error" );
       ( "error",
         match probe.status with
         | Probe_ok -> `Null
+        | Probe_skipped message -> `String message
         | Probe_error message -> `String message );
     ]
 
@@ -324,6 +327,15 @@ let candidate_probe_ok (candidate : candidate_runtime) =
     status = Probe_ok;
   }
 
+let candidate_probe_skipped (candidate : candidate_runtime) reason =
+  {
+    model_string = candidate.model_string;
+    provider_kind = provider_kind_string candidate.provider_cfg;
+    model_id = candidate.provider_cfg.model_id;
+    base_url = candidate.provider_cfg.base_url;
+    status = Probe_skipped reason;
+  }
+
 let validate_strategy ~config_path ~name =
   let cfg =
     Cascade_config_loader.resolve_strategy_config ~config_path ~name
@@ -363,40 +375,6 @@ let validate_strategy ~config_path ~name =
       ( Cascade_config.resolve_strategy ~config_path ~name (),
         Cascade_config.resolve_ollama_max_concurrent ~config_path ~name (),
         Cascade_config.resolve_cli_max_concurrent ~config_path ~name () )
-
-let probe_provider ~sw ~net ~clock (candidate : candidate_runtime) =
-  let provider_cfg = candidate.provider_cfg in
-  let config =
-    Oas_worker_exec.default_config
-      ~name:"catalog_probe"
-      ~provider_cfg
-      ~system_prompt:"Reply with one short token."
-      ~tools:[]
-    |> fun config ->
-    {
-      config with
-      max_turns = 1;
-      max_idle_turns = 1;
-      max_tokens = 1;
-      temperature = 0.0;
-      description =
-        Some
-          (Printf.sprintf "catalog-probe:%s/%s"
-             (provider_kind_string provider_cfg)
-             provider_cfg.model_id);
-      transport = Masc_grpc_transport.Local;
-    }
-  in
-  let run () = Oas_worker_exec.run ~sw ~net ~config "ping" in
-  try
-    match Eio.Time.with_timeout_exn clock probe_timeout_sec run with
-    | Ok _ -> candidate_probe_ok candidate
-    | Error sdk_err ->
-        candidate_probe_error candidate (Oas.Error.to_string sdk_err)
-  with
-  | Eio.Time.Timeout ->
-      candidate_probe_error candidate
-        (Printf.sprintf "probe timeout after %.0fs" probe_timeout_sec)
 
 let rejection_of_path ~config_path ~attempted_mtime ~checked_at
     ~(errors : string list) ~(profiles : profile_rejection list) =
@@ -496,7 +474,7 @@ let runtime_required_profile_names ?config_path () =
   else
     runtime_required_profiles ~config_path
 
-let validate_path_result ~sw ~net ~clock ~config_path =
+let validate_path_result ~config_path =
   let checked_at = Unix.gettimeofday () in
   let attempted_mtime =
     try Some (Unix.stat config_path).Unix.st_mtime
@@ -556,76 +534,27 @@ let validate_path_result ~sw ~net ~clock ~config_path =
             (rejection_of_path ~config_path ~attempted_mtime ~checked_at
                ~errors:top_errors ~profiles:statically_rejected_profiles)
         else
-          let unique_candidates = Hashtbl.create 16 in
-          List.iter
-            (fun (profile : profile_build) ->
-              List.iter
-                (fun (candidate : candidate_runtime) ->
-                  Hashtbl.replace unique_candidates
-                    (candidate_key_of_cfg candidate.provider_cfg)
-                    candidate)
-                profile.candidates)
-            built_profiles;
-          let probe_results =
-            Hashtbl.to_seq_values unique_candidates
-            |> List.of_seq
-            |> List.map (fun candidate ->
-                   (candidate_key_of_cfg candidate.provider_cfg,
-                    probe_provider ~sw ~net ~clock candidate))
-          in
-          let probe_table = Hashtbl.create (List.length probe_results) in
-          List.iter
-            (fun (key, probe) -> Hashtbl.replace probe_table key probe)
-            probe_results;
-          let profile_snapshots, probe_rejected_profiles =
-            List.fold_left
-              (fun (ok_acc, err_acc) (profile : profile_build) ->
-                let probes =
-                  List.map
-                    (fun (candidate : candidate_runtime) ->
-                      Hashtbl.find probe_table
-                        (candidate_key_of_cfg candidate.provider_cfg))
-                    profile.candidates
-                in
-                let probe_errors =
-                  probes
-                  |> List.filter_map (fun probe ->
-                         match probe.status with
-                         | Probe_ok -> None
-                         | Probe_error message ->
-                             Some
-                               (Printf.sprintf
-                                  "candidate %S probe failed: %s"
-                                  probe.model_string message))
-                in
-                if probe_errors <> [] then
-                  ( ok_acc,
-                    {
-                      name = profile.name;
-                      errors = probe_errors;
-                      probes;
-                    }
-                    :: err_acc )
-                else
-                  ( {
-                      name = profile.name;
-                      weighted_entries = profile.weighted_entries;
-                      inference_params = profile.inference_params;
-                      api_key_env_overrides = profile.api_key_env_overrides;
-                      strategy = profile.strategy;
-                      ollama_max_concurrent = profile.ollama_max_concurrent;
-                      cli_max_concurrent = profile.cli_max_concurrent;
-                      probes;
-                    }
-                    :: ok_acc,
-                    err_acc ))
-              ([], [])
+          let profile_snapshots =
+            List.map
+              (fun (profile : profile_build) ->
+                {
+                  name = profile.name;
+                  weighted_entries = profile.weighted_entries;
+                  inference_params = profile.inference_params;
+                  api_key_env_overrides = profile.api_key_env_overrides;
+                  strategy = profile.strategy;
+                  ollama_max_concurrent = profile.ollama_max_concurrent;
+                  cli_max_concurrent = profile.cli_max_concurrent;
+                  probes =
+                    List.map
+                      (fun (candidate : candidate_runtime) ->
+                        candidate_probe_skipped candidate
+                          "runtime provider health is advisory; bootstrap skips live probe")
+                      profile.candidates;
+                })
               built_profiles
           in
-          let profile_snapshots = List.rev profile_snapshots in
-          let rejected_profiles =
-            statically_rejected_profiles @ List.rev probe_rejected_profiles
-          in
+          let rejected_profiles = statically_rejected_profiles in
           let default_profile_validated =
             List.exists
               (fun (profile : profile_snapshot) ->
@@ -668,8 +597,11 @@ let validate_path_result ~sw ~net ~clock ~config_path =
             else
               Ok { snapshot; rejected_update = Some rejection }
 
-let validate_path ~sw ~net ~clock ~config_path =
-  match validate_path_result ~sw ~net ~clock ~config_path with
+let validate_path ?sw ?net ?clock ~config_path () =
+  let (_ : Eio.Switch.t option) = sw in
+  let (_ : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option) = net in
+  let (_ : float Eio.Time.clock_ty Eio.Resource.t option) = clock in
+  match validate_path_result ~config_path with
   | Ok result -> Ok result.snapshot
   | Error _ as e -> e
 
@@ -736,17 +668,26 @@ let inspect_active ?sw ?net ?clock () =
       match cached_result with
       | Some result -> result
       | None -> (
-          match eio_caps ?sw ?net ?clock () with
-          | Error detail ->
-              let rejection =
-                {
-                  source_path = config_path;
-                  attempted_mtime = current_mtime;
-                  checked_at = Unix.gettimeofday ();
-                  errors = [ detail ];
-                  profiles = [];
-                }
-              in
+          match validate_path_result ~config_path with
+          | Ok { snapshot; rejected_update = None } ->
+              with_cache_lock (fun () ->
+                  cache :=
+                    {
+                      active_snapshot = Some snapshot;
+                      rejected_update = None;
+                    });
+              Ok (Validated snapshot)
+          | Ok { snapshot; rejected_update = Some rejection } ->
+              with_cache_lock (fun () ->
+                  cache :=
+                    {
+                      active_snapshot = Some snapshot;
+                      rejected_update = Some rejection;
+                    });
+              Ok
+                (Validated_with_rejections
+                   { snapshot; rejected_update = rejection })
+          | Error rejection ->
               (match with_cache_lock (fun () -> !cache.active_snapshot) with
                | Some snapshot ->
                    with_cache_lock (fun () ->
@@ -758,47 +699,14 @@ let inspect_active ?sw ?net ?clock () =
                    Ok
                      (Serving_last_known_good
                         { snapshot; rejected_update = rejection })
-               | None -> Error rejection)
-          | Ok (sw, net, clock) -> (
-              match validate_path_result ~sw ~net ~clock ~config_path with
-              | Ok { snapshot; rejected_update = None } ->
-                  with_cache_lock (fun () ->
-                      cache :=
-                        {
-                          active_snapshot = Some snapshot;
-                          rejected_update = None;
-                        });
-                  Ok (Validated snapshot)
-              | Ok { snapshot; rejected_update = Some rejection } ->
-                  with_cache_lock (fun () ->
-                      cache :=
-                        {
-                          active_snapshot = Some snapshot;
-                          rejected_update = Some rejection;
-                        });
-                  Ok
-                    (Validated_with_rejections
-                       { snapshot; rejected_update = rejection })
-              | Error rejection ->
-                  (match with_cache_lock (fun () -> !cache.active_snapshot) with
-                   | Some snapshot ->
-                       with_cache_lock (fun () ->
-                           cache :=
-                             {
-                               active_snapshot = Some snapshot;
-                               rejected_update = Some rejection;
-                             });
-                       Ok
-                         (Serving_last_known_good
-                            { snapshot; rejected_update = rejection })
-                   | None ->
-                       with_cache_lock (fun () ->
-                           cache :=
-                             {
-                               active_snapshot = None;
-                               rejected_update = Some rejection;
-                             });
-                       Error rejection)))
+               | None ->
+                   with_cache_lock (fun () ->
+                       cache :=
+                         {
+                           active_snapshot = None;
+                           rejected_update = Some rejection;
+                         });
+                   Error rejection))
 
 let require_snapshot ?sw ?net ?clock () =
   match inspect_active ?sw ?net ?clock () with

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -1,15 +1,16 @@
 (** Runtime-authoritative validated cascade catalog.
 
     The active runtime [cascade.json] is the only authoritative catalog.
-    This module validates the active file, probes every configured
-    candidate through the same OAS execution surface as production turns,
-    and keeps serving the last-known-good snapshot when a hot reload is
-    rejected.
+    This module validates the active file statically and keeps serving the
+    last-known-good snapshot when a hot reload is rejected. Provider liveness
+    is advisory runtime state and does not invalidate an otherwise-correct
+    catalog.
 
     @stability Internal *)
 
 type candidate_probe_status =
   | Probe_ok
+  | Probe_skipped of string
   | Probe_error of string
 
 type candidate_probe = {
@@ -42,10 +43,11 @@ val inspect_active :
   (state, rejection) result
 
 val validate_path :
-  sw:Eio.Switch.t ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config_path:string ->
+  unit ->
   (snapshot, rejection) result
 (** Returns the validated subset of profiles when the catalog is partly
     usable but some presets are rejected at runtime. Inspect

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -467,20 +467,24 @@ let analyze ~base_path_input ~default_base_path () =
 let live_catalog_summary = function
   | Stdlib.Ok (Cascade_catalog_runtime.Validated snapshot) ->
       ( false,
+        false,
         "Live cascade catalog validation passed.",
         Cascade_catalog_runtime.state_to_yojson
           (Cascade_catalog_runtime.Validated snapshot) )
   | Stdlib.Ok
       (Cascade_catalog_runtime.Validated_with_rejections _ as state) ->
       ( false,
+        true,
         "Live cascade catalog validation kept the usable profile subset and rejected some presets.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Ok (Cascade_catalog_runtime.Serving_last_known_good _ as state) ->
       ( true,
+        false,
         "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Error rejection ->
       ( true,
+        false,
         "Live cascade catalog validation failed; no validated snapshot is available.",
         `Assoc
           [
@@ -496,12 +500,13 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   let report = analyze ~base_path_input ~default_base_path () in
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
-  let live_failed, live_warning, catalog_validation =
+  let live_failed, live_partial, live_warning, catalog_validation =
     match
       Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
       |> live_catalog_summary
     with
-    | failed, warning, validation -> (failed, warning, validation)
+    | failed, partial, warning, validation ->
+        (failed, partial, warning, validation)
   in
   let warnings =
     if live_warning = "" then report.warnings
@@ -518,12 +523,14 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
       report.next_actions
   in
   let status =
-    match report.status, live_failed, live_warning <> "" with
-    | Error, _, _ -> Error
-    | _, true, _ -> Error
-    | Warn, false, _ -> Warn
-    | Ok, false, true -> Warn
-    | Ok, false, false -> Ok
+    match report.status, report.init_state, live_failed, live_partial, live_warning <> "" with
+    | Error, (Invalid_env | Missing_init), _, _, _ -> Error
+    | _, _, true, _, _ -> Error
+    | Error, _, false, true, _ -> Warn
+    | Error, _, false, false, _ -> Error
+    | Warn, _, false, _, _ -> Warn
+    | Ok, _, false, _, true -> Warn
+    | Ok, _, false, _, false -> Ok
   in
   {
     report with

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -95,6 +95,20 @@ let bg_revalidate_backoff_factor = 2.0
 
 exception Compute_timeout of string * bool
 
+let is_internal_race_cancel exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ ->
+      let msg = Printexc.to_string exn in
+      String.equal msg "Cancelled: Eio__core__Fiber.Not_first"
+      || String.ends_with ~suffix:"Eio__core__Fiber.Not_first" msg
+  | _ -> false
+
+let should_restore_stale_after_failure exn =
+  match exn with
+  | Compute_timeout _ -> true
+  | Eio.Cancel.Cancelled _ -> true
+  | _ -> false
+
 let timeout_json ~key ~timeout_sec ~timeout_kind =
   `Assoc
     [
@@ -171,7 +185,11 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
           action := Some (`Wait token);
           map
         end
-      | Some (Ready _) | None ->
+      | Some (Ready entry) ->
+        let token = next_token () in
+        action := Some (`Compute token);
+        SMap.add key (Computing { token; started_at = now (); stale = Some entry.value }) map
+      | None ->
         let token = next_token () in
         action := Some (`Compute token);
         SMap.add key (Computing { token; started_at = now (); stale = None }) map
@@ -198,6 +216,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
         | exception exn ->
           (match exn with
            | Compute_timeout _ -> ()
+           | _ when is_internal_race_cancel exn -> ()
            | _ -> Log.Dashboard.warn "cache bg-revalidate failed (%s): %s" key (Printexc.to_string exn));
           atomic_update table (fun map ->
             match SMap.find_opt key map with
@@ -207,23 +226,31 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
               SMap.add key (Ready { value = stale_value; expires_at = ts; stale_until = ts +. backoff_grace }) map
             | _ -> map
           )
+      and restore_stale_ready () =
+        atomic_update table (fun map ->
+          match SMap.find_opt key map with
+          | Some (Computing { token = c; _ }) when c = token ->
+              let ts = now () in
+              let backoff_grace = stale_grace *. bg_revalidate_backoff_factor in
+              SMap.add key
+                (Ready { value = stale_value; expires_at = ts; stale_until = ts +. backoff_grace })
+                map
+          | _ -> map
+        )
       in
       (match Eio_context.get_switch_opt () with
        | Some sw ->
-           (try Eio.Fiber.fork ~sw (fun () ->
-              try do_bg_compute ()
-              with
-              | Eio.Cancel.Cancelled _ as e ->
-                atomic_update table (fun map ->
-                  match SMap.find_opt key map with
-                  | Some (Computing { token = c; _ }) when c = token ->
-                    let ts = now () in
-                    let backoff_grace = stale_grace *. bg_revalidate_backoff_factor in
-                    SMap.add key (Ready { value = stale_value; expires_at = ts; stale_until = ts +. backoff_grace }) map
-                  | _ -> map
-                );
-                raise e)
-            with Eio.Cancel.Cancelled _ -> ())
+           (try
+              Eio.Fiber.fork ~sw (fun () ->
+                try do_bg_compute ()
+                with
+                | Eio.Cancel.Cancelled _ as e ->
+                    restore_stale_ready ();
+                    raise e)
+            with
+            | Invalid_argument _ ->
+                restore_stale_ready ()
+            | Eio.Cancel.Cancelled _ -> ())
        | None ->
            Log.Dashboard.warn "cache: no switch for background revalidation, computing inline";
            do_bg_compute ());
@@ -263,13 +290,27 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
            );
            value
        | Some (Error exn) ->
-           Log.Dashboard.error "cache revalidation failed: %s" (Printexc.to_string exn);
+           let fallback_val = ref None in
+           if not (is_internal_race_cancel exn) then
+             Log.Dashboard.error "cache revalidation failed: %s" (Printexc.to_string exn);
            atomic_update table (fun map ->
              match SMap.find_opt key map with
-             | Some (Computing { token = c; _ }) when c = token -> SMap.remove key map
+             | Some (Computing { token = c; stale = Some stale_value; _ }) when c = token ->
+                 fallback_val := Some stale_value;
+                 let backoff_grace = stale_grace *. bg_revalidate_backoff_factor in
+                 SMap.add key
+                   (Ready { value = stale_value; expires_at = ts; stale_until = ts +. backoff_grace })
+                   map
+             | Some (Computing { token = c; stale = None; _ }) when c = token ->
+                 SMap.remove key map
              | _ -> map
            );
-           raise exn
+           if should_restore_stale_after_failure exn then
+             match !fallback_val with
+             | Some value -> value
+             | None -> raise exn
+           else
+             raise exn
        | None ->
            let fallback_val = ref None in
            atomic_update table (fun map ->

--- a/lib/dune
+++ b/lib/dune
@@ -393,6 +393,7 @@
    keeper_config
    keeper_toml_loader
    keeper_runtime_config
+   keeper_runtime_resolved
    keeper_cdal_contract
    proof_artifact_reader
    violation_record

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -386,24 +386,6 @@ let sdk_error_of_keeper_internal_error err =
     (keeper_internal_error_prefix
      ^ Yojson.Safe.to_string (keeper_internal_error_to_json err))
 
-let oas_env_truthy value =
-  match String.lowercase_ascii (String.trim value) with
-  | "1" | "true" | "yes" | "on" -> true
-  | _ -> false
-
-let gemini_mcp_disabled_from_env () =
-  match Sys.getenv_opt "OAS_GEMINI_NO_MCP" with
-  | Some value -> oas_env_truthy value
-  | None -> false
-
-let approval_mode_from_env () =
-  match Sys.getenv_opt "OAS_GEMINI_APPROVAL_MODE" with
-  | Some value ->
-    let trimmed = String.trim value in
-    if trimmed = "" then None else Some (trimmed, false)
-  | None ->
-    if gemini_mcp_disabled_from_env () then Some ("plan", true) else None
-
 let tool_required_affordances =
   [ "board_post_or_comment"
   ; "message_sweep"
@@ -500,7 +482,7 @@ let run_turn
       ?(turn_affordances = [])
       ?provider_filter
       ~(generation : int)
-      ?(max_turns : int = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call)
+      ?(max_turns : int = Keeper_runtime_resolved.reactive_max_turns_per_call ())
       (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
       ?(max_idle_turns : int = 3)
       ?(history_user_source = "direct_user")
@@ -593,10 +575,9 @@ let run_turn
   in
   (* 3. Build base system prompt from meta *)
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
-  (* Apply per-keeper OAS transport env vars ([[keeper.oas_env]] table)
-     before any OAS call in this turn.  OAS 0.159+ transports read
-     these at build_args time; an empty [oas_env] list is a no-op. *)
-  Keeper_types_profile.apply_oas_env ~keeper_name:meta.name profile_defaults;
+  let keeper_oas_context =
+    Keeper_types_profile.keeper_oas_context_of_defaults profile_defaults
+  in
   let config_root =
     let inputs = Config_dir_resolver.inputs_from_env () in
     let resolution =
@@ -606,12 +587,9 @@ let run_turn
     resolution.Config_dir_resolver.config_root.path
   in
   let cascade_config_path = Cascade_runtime.cascade_config_path () in
-  let gemini_mcp_disabled = gemini_mcp_disabled_from_env () in
-  let approval_mode_effective, approval_mode_derived =
-    match approval_mode_from_env () with
-    | Some (mode, derived) -> (Some mode, derived)
-    | None -> (None, false)
-  in
+  let gemini_mcp_disabled = keeper_oas_context.gemini_mcp_disabled in
+  let approval_mode_effective = keeper_oas_context.gemini_approval_mode in
+  let approval_mode_derived = keeper_oas_context.gemini_approval_mode_derived in
   let persona_extended =
     Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
       profile_defaults
@@ -2027,7 +2005,7 @@ let run_turn
   let admission_wait_timeout_sec =
     if Llm_provider.Request_priority.resolve priority
        = Llm_provider.Request_priority.Proactive
-    then Some Env_config_keeper.KeeperKeepalive.admission_wait_timeout_sec
+    then Some (Keeper_runtime_resolved.admission_wait_timeout_sec ())
     else None
   in
   ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
@@ -2044,7 +2022,22 @@ let run_turn
       match oas_timeout_s with
       | Some value -> value
       | None ->
-          Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context
+          Keeper_runtime_resolved.oas_timeout_for_context ~max_context
+    in
+    let cli_transport_overrides =
+      Some
+        ({
+          cwd = None;
+          claude_mcp_config = keeper_oas_context.claude_mcp_config;
+          claude_allowed_tools = None;
+          claude_permission_mode = None;
+          claude_max_turns = Some max_turns;
+          gemini_yolo =
+            (match approval_mode_effective with
+             | Some mode ->
+               Some (String.equal (String.lowercase_ascii mode) "yolo")
+             | None -> None);
+        } : Oas_worker.cli_transport_overrides)
     in
     (match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
@@ -2088,6 +2081,7 @@ let run_turn
            ?on_resume
            ~agent_ref
            ?contract
+           ?cli_transport_overrides
            ~allowed_paths:oas_allowed_paths
            ~cache_system_prompt:true
            ~yield_on_tool

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -560,7 +560,7 @@ let started_at ~base_path name =
   | None -> None
 
 let spawn_slots_available () =
-  let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
+  let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
   max_keepers <= 0
   || Atomic.get running_count_atomic < max_keepers
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -339,7 +339,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     let max_scan =
       max 0 Env_config.KeeperBootstrap.max_scan
     in
-    let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
+    let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
     let remaining_slots =
       ref
         (if max_keepers > 0 then

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -1,0 +1,235 @@
+type source =
+  | Env
+  | Toml
+  | Default
+  | Derived
+
+type 'a field = {
+  value : 'a;
+  source : source;
+}
+
+type t = {
+  bootstrap_max_active_keepers : int field;
+  reactive_max_turns_per_call : int field;
+  autonomous_max_turns_per_call : int field;
+  reactive_max_idle_turns : int field;
+  autonomous_max_idle_turns : int field;
+  turn_timeout_sec : float field;
+  admission_wait_timeout_sec : float field;
+  oas_timeout_override_sec : float option field;
+  oas_timeout_per_1k : float field;
+  oas_timeout_per_turn : float field;
+}
+
+let source_of_env_name name =
+  match Config_boot_overrides.source name with
+  | "env" -> Env
+  | "boot_override" -> Toml
+  | _ -> Default
+
+let source_to_string = function
+  | Env -> "env"
+  | Toml -> "toml"
+  | Default -> "default"
+  | Derived -> "derived"
+
+let get_int = Env_config_core.get_int
+let get_float = Env_config_core.get_float
+
+let bootstrap_max_active_keepers_live () =
+  get_int ~default:10000 "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
+
+let reactive_max_turns_per_call_live () =
+  max 1 (min 50 (get_int ~default:15 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
+
+let autonomous_max_turns_per_call_live () =
+  let global_cap = reactive_max_turns_per_call_live () in
+  let default = min global_cap 2 in
+  max 1
+    (min global_cap
+       (min 50
+          (get_int ~default
+             "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
+
+let reactive_max_idle_turns_live () =
+  max 2 (min 50 (get_int ~default:15 "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE"))
+
+let autonomous_max_idle_turns_live () =
+  max 2 (min 50 (get_int ~default:10 "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS"))
+
+let turn_timeout_sec_live () =
+  Float.max 60.0
+    (Float.min 3600.0
+       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+
+let admission_wait_timeout_sec_live () =
+  Float.max 5.0
+    (Float.min 1200.0
+       (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
+
+let oas_timeout_override_sec_live ~turn_timeout_sec =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
+  | Some raw ->
+      Some
+        (Float.max 30.0
+           (Float.min turn_timeout_sec
+              (Option.value ~default:300.0
+                 (Float.of_string_opt (String.trim raw)))))
+  | None -> None
+
+let freeze_from_current () =
+  let source_field name value = { value; source = source_of_env_name name } in
+  let turn_timeout_sec_value = turn_timeout_sec_live () in
+  let bootstrap_max_active_keepers =
+    source_field
+      "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
+      (bootstrap_max_active_keepers_live ())
+  in
+  let reactive_max_turns_per_call =
+    source_field
+      "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"
+      (reactive_max_turns_per_call_live ())
+  in
+  let autonomous_max_turns_per_call =
+    let source =
+      match source_of_env_name "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS" with
+      | Default -> Derived
+      | other -> other
+    in
+    {
+      value = autonomous_max_turns_per_call_live ();
+      source;
+    }
+  in
+  let reactive_max_idle_turns =
+    source_field
+      "MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE"
+      (reactive_max_idle_turns_live ())
+  in
+  let autonomous_max_idle_turns =
+    source_field
+      "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS"
+      (autonomous_max_idle_turns_live ())
+  in
+  let turn_timeout_sec =
+    source_field
+      "MASC_KEEPER_TURN_TIMEOUT_SEC"
+      turn_timeout_sec_value
+  in
+  let admission_wait_timeout_sec =
+    source_field
+      "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
+      (admission_wait_timeout_sec_live ())
+  in
+  let oas_timeout_override_sec =
+    {
+      value = oas_timeout_override_sec_live ~turn_timeout_sec:turn_timeout_sec_value;
+      source = source_of_env_name "MASC_KEEPER_OAS_TIMEOUT_SEC";
+    }
+  in
+  let oas_timeout_per_1k =
+    source_field
+      "MASC_KEEPER_OAS_TIMEOUT_PER_1K"
+      (Env_config_core.get_float ~default:1.5 "MASC_KEEPER_OAS_TIMEOUT_PER_1K")
+  in
+  let oas_timeout_per_turn =
+    source_field
+      "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
+      (Env_config_core.get_float ~default:30.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN")
+  in
+  {
+    bootstrap_max_active_keepers;
+    reactive_max_turns_per_call;
+    autonomous_max_turns_per_call;
+    reactive_max_idle_turns;
+    autonomous_max_idle_turns;
+    turn_timeout_sec;
+    admission_wait_timeout_sec;
+    oas_timeout_override_sec;
+    oas_timeout_per_1k;
+    oas_timeout_per_turn;
+  }
+
+let frozen : t option Atomic.t = Atomic.make None
+
+let init () =
+  match Atomic.get frozen with
+  | Some _ -> ()
+  | None -> Atomic.set frozen (Some (freeze_from_current ()))
+
+let reset_for_tests () =
+  Atomic.set frozen None
+
+let current () =
+  match Atomic.get frozen with
+  | Some snapshot -> snapshot
+  | None -> freeze_from_current ()
+
+let field_to_yojson value_to_yojson (field : 'a field) =
+  `Assoc
+    [
+      ("value", value_to_yojson field.value);
+      ("source", `String (source_to_string field.source));
+    ]
+
+let option_float_to_yojson = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let to_yojson (runtime : t) =
+  `Assoc
+    [
+      ("bootstrap_max_active_keepers", field_to_yojson (fun value -> `Int value) runtime.bootstrap_max_active_keepers);
+      ("reactive_max_turns_per_call", field_to_yojson (fun value -> `Int value) runtime.reactive_max_turns_per_call);
+      ("autonomous_max_turns_per_call", field_to_yojson (fun value -> `Int value) runtime.autonomous_max_turns_per_call);
+      ("reactive_max_idle_turns", field_to_yojson (fun value -> `Int value) runtime.reactive_max_idle_turns);
+      ("autonomous_max_idle_turns", field_to_yojson (fun value -> `Int value) runtime.autonomous_max_idle_turns);
+      ("turn_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.turn_timeout_sec);
+      ("admission_wait_timeout_sec", field_to_yojson (fun value -> `Float value) runtime.admission_wait_timeout_sec);
+      ("oas_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.oas_timeout_override_sec);
+      ("oas_timeout_per_1k", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_1k);
+      ("oas_timeout_per_turn", field_to_yojson (fun value -> `Float value) runtime.oas_timeout_per_turn);
+    ]
+
+let bootstrap_max_active_keepers () =
+  (current ()).bootstrap_max_active_keepers.value
+
+let reactive_max_turns_per_call () =
+  (current ()).reactive_max_turns_per_call.value
+
+let autonomous_max_turns_per_call () =
+  (current ()).autonomous_max_turns_per_call.value
+
+let reactive_max_idle_turns () =
+  (current ()).reactive_max_idle_turns.value
+
+let autonomous_max_idle_turns () =
+  (current ()).autonomous_max_idle_turns.value
+
+let turn_timeout_sec () =
+  (current ()).turn_timeout_sec.value
+
+let admission_wait_timeout_sec () =
+  (current ()).admission_wait_timeout_sec.value
+
+let oas_timeout_for_context_with_turn_budget ~(max_context : int)
+    ~(max_turns : int) : float =
+  let runtime = current () in
+  match runtime.oas_timeout_override_sec.value with
+  | Some value -> value
+  | None ->
+      let base = 120.0 in
+      let context_time =
+        Float.of_int max_context /. 1000.0 *. runtime.oas_timeout_per_1k.value
+      in
+      let effective_turns =
+        Float.of_int (min max_turns 40)
+      in
+      let turn_time = effective_turns *. runtime.oas_timeout_per_turn.value in
+      Float.max 30.0
+        (Float.min runtime.turn_timeout_sec.value (base +. context_time +. turn_time))
+
+let oas_timeout_for_context ~(max_context : int) : float =
+  oas_timeout_for_context_with_turn_budget ~max_context
+    ~max_turns:(reactive_max_turns_per_call ())

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -1,0 +1,55 @@
+(** Keeper_runtime_resolved — freeze keeper runtime knobs after bootstrap.
+
+    Values resolve with the existing precedence order:
+    environment > keeper_runtime.toml boot override > compiled default.
+
+    Before [init] is called, readers see a live snapshot of the current env/boot
+    override state. After [init], reads are frozen to the bootstrap snapshot so
+    late env drift cannot change keeper execution behaviour. *)
+
+type source =
+  | Env
+  | Toml
+  | Default
+  | Derived
+
+type 'a field = {
+  value : 'a;
+  source : source;
+}
+
+type t = {
+  bootstrap_max_active_keepers : int field;
+  reactive_max_turns_per_call : int field;
+  autonomous_max_turns_per_call : int field;
+  reactive_max_idle_turns : int field;
+  autonomous_max_idle_turns : int field;
+  turn_timeout_sec : float field;
+  admission_wait_timeout_sec : float field;
+  oas_timeout_override_sec : float option field;
+  oas_timeout_per_1k : float field;
+  oas_timeout_per_turn : float field;
+}
+
+val init : unit -> unit
+val reset_for_tests : unit -> unit
+val current : unit -> t
+
+val source_to_string : source -> string
+val to_yojson : t -> Yojson.Safe.t
+
+val bootstrap_max_active_keepers : unit -> int
+val reactive_max_turns_per_call : unit -> int
+val autonomous_max_turns_per_call : unit -> int
+val reactive_max_idle_turns : unit -> int
+val autonomous_max_idle_turns : unit -> int
+val turn_timeout_sec : unit -> float
+val admission_wait_timeout_sec : unit -> float
+val oas_timeout_for_context_with_turn_budget :
+  max_context:int ->
+  max_turns:int ->
+  float
+
+val oas_timeout_for_context :
+  max_context:int ->
+  float

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -171,7 +171,7 @@ let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =
     Fs_compat.parse_jsonl_lines ~source:"keeper_metrics_latest" lines
   in
   match
-    parsed
+    List.rev parsed
     |> List.find_opt (fun json ->
            match Yojson.Safe.Util.member "cascade" json with
            | `Assoc _ -> true
@@ -179,7 +179,7 @@ let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =
   with
   | Some json -> Some json
   | None -> (
-      match parsed with
+      match List.rev parsed with
       | json :: _ -> Some json
       | [] -> None)
 
@@ -406,12 +406,13 @@ let latest_cascade_for_current_config ~current_cascade_name ~configured_labels
         | Some observed_name -> String.equal observed_name current_cascade_name
         | None -> true
       in
-      let configured_labels_match =
-        match json_string_list_member cascade "configured_labels" with
-        | [] -> true
-        | observed_labels -> observed_labels = configured_labels
-      in
-      if cascade_name_matches && configured_labels_match then Some cascade
+      let _configured_labels = configured_labels in
+      (* Keeper meta currently surfaces resolved provider candidates, while
+         turn metrics keep the raw cascade labels that produced those
+         candidates. Matching the two verbatim drops valid recent
+         observations. Treat cascade_name as the stable identity and use
+         metrics labels only for display when a matching observation exists. *)
+      if cascade_name_matches then Some cascade
       else None
 
 let model_observability_json ~current_cascade_name ~configured_labels ~active_model
@@ -426,7 +427,14 @@ let model_observability_json ~current_cascade_name ~configured_labels ~active_mo
   let cascade_name =
     Option.value ~default:"" (nonempty_trimmed current_cascade_name)
   in
-  let configured_labels_surface = configured_labels in
+  let configured_labels_surface =
+    match latest_cascade with
+    | Some cascade -> (
+        match json_string_list_member cascade "configured_labels" with
+        | [] -> configured_labels
+        | observed_labels -> observed_labels)
+    | None -> configured_labels
+  in
   let resolved_candidates =
     match latest_cascade with
     | Some cascade ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -107,7 +107,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           p.name err;
         (false, err)
     | Ok () ->
-    let max_active_keepers = Env_config.KeeperBootstrap.max_active_keepers in
+    let max_active_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
     let active_keepers = Keeper_registry.count_running () in
     if max_active_keepers > 0 && active_keepers >= max_active_keepers then begin
       Log.Keeper.warn "create_keeper failed: max active keepers reached (%d/%d) for name=%s"

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -920,24 +920,64 @@ let effective_oas_env pairs =
   else
     pairs
 
-(** Apply [defaults.oas_env] to the process environment via [Unix.putenv].
-    Logs each applied key at info level for operator auditability.
-    Safe to call repeatedly — putenv is idempotent for identical values.
+type keeper_oas_context = {
+  env_pairs : (string * string) list;
+  gemini_mcp_disabled : bool;
+  gemini_approval_mode : string option;
+  gemini_approval_mode_derived : bool;
+  claude_mcp_config : string option;
+}
 
-    Scope note: [Unix.putenv] is process-global, so concurrent turns
-    from different keepers in the same process would race.  In the
-    current masc-mcp deployment each keeper lives in its own process,
-    which keeps this wiring simple; revisit if multiplexing is added. *)
-let apply_oas_env ~keeper_name (defaults : keeper_profile_defaults) : unit =
-  match effective_oas_env defaults.oas_env with
-  | [] -> ()
-  | pairs ->
-    List.iter
-      (fun (k, v) ->
-        Unix.putenv k v;
-        Log.Keeper.info
-          "keeper %s applied OAS env %s=%s" keeper_name k v)
-      pairs
+let empty_keeper_oas_context =
+  {
+    env_pairs = [];
+    gemini_mcp_disabled = false;
+    gemini_approval_mode = None;
+    gemini_approval_mode_derived = false;
+    claude_mcp_config = None;
+  }
+
+let keeper_oas_context_of_defaults (defaults : keeper_profile_defaults) :
+    keeper_oas_context =
+  let env_pairs = effective_oas_env defaults.oas_env in
+  let gemini_mcp_disabled =
+    match List.assoc_opt "OAS_GEMINI_NO_MCP" env_pairs with
+    | Some value -> oas_env_truthy value
+    | None -> false
+  in
+  let gemini_approval_mode_explicit =
+    List.assoc_opt "OAS_GEMINI_APPROVAL_MODE" defaults.oas_env
+    |> Option.map String.trim
+    |> fun value -> Option.bind value (fun trimmed -> if trimmed = "" then None else Some trimmed)
+  in
+  let gemini_approval_mode =
+    List.assoc_opt "OAS_GEMINI_APPROVAL_MODE" env_pairs
+    |> Option.map String.trim
+    |> fun value -> Option.bind value (fun trimmed -> if trimmed = "" then None else Some trimmed)
+  in
+  let gemini_approval_mode_derived =
+    gemini_mcp_disabled
+    && Option.is_none gemini_approval_mode_explicit
+    && Option.is_some gemini_approval_mode
+  in
+  let claude_mcp_config =
+    match List.assoc_opt "OAS_CLAUDE_MCP_CONFIG" env_pairs with
+    | Some raw when String.trim raw <> "" -> Some raw
+    | _ ->
+      if
+        match List.assoc_opt "OAS_CLAUDE_STRICT_MCP" env_pairs with
+        | Some value -> oas_env_truthy value
+        | None -> false
+      then Some {|{"mcpServers":{}}|}
+      else None
+  in
+  {
+    env_pairs;
+    gemini_mcp_disabled;
+    gemini_approval_mode;
+    gemini_approval_mode_derived;
+    claude_mcp_config;
+  }
 
 let resolved_persona_name ~keeper_name
     (defaults : keeper_profile_defaults) : string =
@@ -977,15 +1017,15 @@ let clamp_max_turns_override : int option -> int option = function
 let effective_max_turns_per_call (profile : keeper_profile_defaults) : int =
   match clamp_max_turns_override profile.max_turns_per_call with
   | Some n -> n
-  | None -> Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+  | None -> Keeper_runtime_resolved.reactive_max_turns_per_call ()
 
 let effective_max_turns_per_call_scheduled_autonomous
     (profile : keeper_profile_defaults) : int =
-  let global_cap = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call in
+  let global_cap = Keeper_runtime_resolved.reactive_max_turns_per_call () in
   match clamp_max_turns_override profile.max_turns_per_call_scheduled_autonomous with
   | Some n -> min n global_cap
   | None ->
-    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+    Keeper_runtime_resolved.autonomous_max_turns_per_call ()
 
 type keeper_default_source_snapshot = {
   source_kind : string option;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -347,7 +347,7 @@ let bounded_oas_timeout_for_turn_budget_with_turn_budget ~(max_context : int)
 let bounded_oas_timeout_for_turn_budget ~(max_context : int)
     ~(remaining_turn_budget_s : float) : float option =
   bounded_oas_timeout_for_turn_budget_with_turn_budget ~max_context
-    ~max_turns:Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+    ~max_turns:(Keeper_runtime_resolved.reactive_max_turns_per_call ())
     ~remaining_turn_budget_s
 
 (** Detect context overflow errors via structured OAS error types.
@@ -1963,7 +1963,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         Keeper_exec_context.timed (fun () ->
           let clock = Eio_context.get_clock () in
           let timeout_sec =
-            Env_config_keeper.KeeperKeepalive.turn_timeout_sec
+            Keeper_runtime_resolved.turn_timeout_sec ()
           in
           start_background_turn_event_bus_drain ~clock;
           let turn_deadline = Eio.Time.now clock +. timeout_sec in
@@ -1978,11 +1978,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             let max_idle_turns, max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
-                  ( Env_config_keeper.KeeperKeepalive.max_idle_turns_reactive,
+                  ( Keeper_runtime_resolved.reactive_max_idle_turns (),
                     Keeper_types_profile.effective_max_turns_per_call
                       keeper_profile )
               | Keeper_world_observation.Scheduled_autonomous ->
-                  ( Env_config_keeper.KeeperKeepalive.max_idle_turns_autonomous,
+                  ( Keeper_runtime_resolved.autonomous_max_idle_turns (),
                     Keeper_types_profile
                     .effective_max_turns_per_call_scheduled_autonomous
                       keeper_profile )

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -53,6 +53,15 @@ type stop_reason =
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
 
+type cli_transport_overrides = Oas_worker_exec.cli_transport_overrides = {
+  cwd : string option;
+  claude_mcp_config : string option;
+  claude_allowed_tools : string list option;
+  claude_permission_mode : string option;
+  claude_max_turns : int option;
+  gemini_yolo : bool option;
+}
+
 type run_result = {
   response : Oas.Types.api_response;
   checkpoint : Oas.Checkpoint.t option;
@@ -110,6 +119,7 @@ val run_named :
   ?proof_ref:Oas.Cdal_proof.t option ref ->
   ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
+  ?cli_transport_overrides:cli_transport_overrides ->
   ?allowed_paths:string list ->
   ?checkpoint_sidecar:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -15,6 +15,15 @@ type stop_reason =
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
 
+type cli_transport_overrides = {
+  cwd : string option;
+  claude_mcp_config : string option;
+  claude_allowed_tools : string list option;
+  claude_permission_mode : string option;
+  claude_max_turns : int option;
+  gemini_yolo : bool option;
+}
+
 type config = {
   name : string;
   provider_cfg : Llm_provider.Provider_config.t;
@@ -57,6 +66,7 @@ type config = {
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
   summarizer : (Oas.Types.message list -> string) option;
+  cli_transport_overrides : cli_transport_overrides option;
       (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
           Emergency-phase compaction. Defaults to OAS's extractive
           default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]
@@ -104,6 +114,7 @@ let default_config
     exit_condition = None;
     exit_condition_result = None;
     summarizer = None;
+    cli_transport_overrides = None;
   }
 
 type run_result = {
@@ -192,8 +203,8 @@ let provider_caps_of_config (provider_cfg : Llm_provider.Provider_config.t) =
     match provider_cfg.kind with
     | Llm_provider.Provider_config.Claude_code
     | Gemini_cli
-    | Kimi_cli
-    | Codex_cli -> base_caps
+    | Codex_cli
+    | Kimi_cli -> base_caps
     | _ ->
         (match Llm_provider.Capabilities.for_model_id provider_cfg.model_id with
          | Some caps -> caps
@@ -313,6 +324,8 @@ let make_per_call_switch_transport
 let non_http_transport_of_provider
     ~(sw : Eio.Switch.t)
     ~(provider_cfg : Llm_provider.Provider_config.t)
+    ?cli_transport_overrides
+    ()
   : (Llm_provider.Llm_transport.t option, Oas.Error.sdk_error) result =
   let _ = sw in
   let proc_mgr_result () =
@@ -325,10 +338,29 @@ let non_http_transport_of_provider
       (match proc_mgr_result () with
        | Error _ as e -> e
        | Ok mgr ->
+           let overrides =
+             Option.value
+               ~default:
+                 {
+                   cwd = None;
+                   claude_mcp_config = None;
+                   claude_allowed_tools = None;
+                   claude_permission_mode = None;
+                   claude_max_turns = None;
+                   gemini_yolo = None;
+                 }
+               cli_transport_overrides
+           in
            let config =
              {
                Llm_provider.Transport_claude_code.default_config with
                model = cli_model_override provider_cfg.model_id;
+               cwd = overrides.cwd;
+               mcp_config = overrides.claude_mcp_config;
+               allowed_tools =
+                 Option.value ~default:[] overrides.claude_allowed_tools;
+               permission_mode = overrides.claude_permission_mode;
+               max_turns = overrides.claude_max_turns;
              }
            in
            Ok
@@ -340,10 +372,25 @@ let non_http_transport_of_provider
       (match proc_mgr_result () with
        | Error _ as e -> e
        | Ok mgr ->
+           let overrides =
+             Option.value
+               ~default:
+                 {
+                   cwd = None;
+                   claude_mcp_config = None;
+                   claude_allowed_tools = None;
+                   claude_permission_mode = None;
+                   claude_max_turns = None;
+                   gemini_yolo = None;
+                 }
+               cli_transport_overrides
+           in
            let config =
              {
                Llm_provider.Transport_gemini_cli.default_config with
                model = cli_model_override provider_cfg.model_id;
+               cwd = overrides.cwd;
+               yolo = Option.value ~default:true overrides.gemini_yolo;
              }
            in
            Ok
@@ -370,13 +417,19 @@ let non_http_transport_of_provider
       (match proc_mgr_result () with
        | Error _ as e -> e
        | Ok mgr ->
+           let cwd =
+             Option.bind cli_transport_overrides (fun overrides -> overrides.cwd)
+           in
            Ok
              (Some
                 (make_per_call_switch_transport (fun ~sw ->
                      Llm_provider.Transport_codex_cli.create ~sw ~mgr
                        ~config:
-                         Llm_provider.Transport_codex_cli.default_config))))
-  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm ->
+                         {
+                           Llm_provider.Transport_codex_cli.default_config with
+                           cwd;
+                         }))))
+  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi ->
       Ok None
 
 (* ================================================================ *)
@@ -567,7 +620,11 @@ let build
     | None -> builder
   in
   let builder =
-    match non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg with
+    match
+      non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+        ?cli_transport_overrides:config.cli_transport_overrides
+        ()
+    with
     | Ok (Some transport) -> Ok (Oas.Builder.with_transport transport builder)
     | Ok None -> Ok builder
     | Error _ as e -> e
@@ -714,7 +771,11 @@ let resume_from_checkpoint
     summarizer = config.summarizer;
     priority = config.priority;
   } in
-  match non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg with
+  match
+    non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+      ?cli_transport_overrides:config.cli_transport_overrides
+      ()
+  with
   | Error _ as e -> e
   | Ok transport ->
       let options = { options with transport } in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -460,6 +460,7 @@ let run_named
     ?proof_ref
     ?contract
     ?transport
+    ?cli_transport_overrides
     ?(allowed_paths = [])
     ?checkpoint_sidecar
     ?(cache_system_prompt = false)
@@ -592,6 +593,7 @@ let run_named
                  raw_trace;
                  yield_on_tool;
                  runtime_mcp_policy;
+                 cli_transport_overrides;
              })
     in
     let local_agent_ref : Oas.Agent.t option ref = ref None in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1109,8 +1109,10 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
     else auth_env_keys_of_provider_kind cfg.kind
   | Llm_provider.Provider_config.Gemini -> [ gemini_api_key_env ]
   | Llm_provider.Provider_config.Anthropic
+  | Llm_provider.Provider_config.Kimi
   | Llm_provider.Provider_config.Ollama
   | Llm_provider.Provider_config.Gemini_cli
+  | Llm_provider.Provider_config.Kimi_cli
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.Claude_code
   | Llm_provider.Provider_config.Codex_cli ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -437,6 +437,7 @@ let runtime_resolution_json (config : Coord.config) =
           resolved_base_commit );
       ("source_mismatch", `Bool source_mismatch);
       ("diagnostics", diagnostics);
+      ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson));
       ("build", Build_identity.to_yojson build);
     ]
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -211,6 +211,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
        Log.Server.info "keeper_runtime.toml: applied %d override(s)" n
    | Error msg ->
        Log.Server.warn "keeper_runtime.toml load failed: %s (continuing with env defaults)" msg);
+  Keeper_runtime_resolved.init ();
   (* RFC-0001 Gate A: initialize instrumentation stores *)
   Heuristic_metrics.init ~base_path;
   Agent_stress.init ~base_path;

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -134,6 +134,8 @@ let start_counting_mock ~sw ~net ~port ~response =
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   (Printf.sprintf "http://127.0.0.1:%d" port, request_count)
 
+let dummy_base_url = "http://127.0.0.1:1"
+
 let json_member name json = Yojson.Safe.Util.member name json
 
 let json_string_field name json =
@@ -161,18 +163,12 @@ let require_ok = function
   | Ok value -> value
   | Error detail -> failf "expected Ok, got Error: %s" detail
 
-let test_valid_catalog_dedupes_shared_live_probes () =
+let test_valid_catalog_skips_live_probes_at_bootstrap () =
   with_temp_dir "cascade-catalog-runtime" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let base_url, request_count =
-    start_counting_mock ~sw ~net ~port
-      ~response:(openai_text_response "pong")
-  in
-  let shared_model = Printf.sprintf "custom:mock@%s/v1" base_url in
+  let shared_model = Printf.sprintf "custom:mock@%s/v1" dummy_base_url in
   ignore
     (write_cascade_json config_dir
        (Printf.sprintf
@@ -182,7 +178,7 @@ let test_valid_catalog_dedupes_shared_live_probes () =
 }|}
           shared_model shared_model));
   let snapshot =
-    match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+    match Cascade_catalog_runtime.inspect_active () with
     | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
     | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
         fail "expected fully validated snapshot without rejected profiles"
@@ -195,17 +191,14 @@ let test_valid_catalog_dedupes_shared_live_probes () =
   in
   let snapshot_json = Cascade_catalog_runtime.snapshot_to_yojson snapshot in
   check int "profile_count" 2 (json_int_field "profile_count" snapshot_json);
-  check int "shared candidate probed once" 1 (Atomic.get request_count);
   let blank_name =
     require_ok
-      (Cascade_catalog_runtime.resolve_declared_name
-         ~sw ~net ~clock ~raw_name:"" ())
+      (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ())
   in
   check string "blank name defaults to keeper_unified"
     Keeper_config.default_cascade_name blank_name;
   match
-    Cascade_catalog_runtime.resolve_declared_name
-      ~sw ~net ~clock ~raw_name:"missing_profile" ()
+    Cascade_catalog_runtime.resolve_declared_name ~raw_name:"missing_profile" ()
   with
   | Ok resolved ->
       failf "expected missing profile to be rejected, got %s" resolved
@@ -220,13 +213,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let base_url, request_count =
-    start_counting_mock ~sw ~net ~port
-      ~response:(openai_text_response "pong")
-  in
-  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
   let config_path =
     write_cascade_json config_dir
       (Printf.sprintf
@@ -235,7 +222,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
 }|}
          valid_model)
   in
-  (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+  (match Cascade_catalog_runtime.inspect_active () with
    | Ok (Cascade_catalog_runtime.Validated _) -> ()
    | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
        fail "expected the initial snapshot to validate cleanly"
@@ -245,13 +232,12 @@ let test_invalid_hot_reload_preserves_last_known_good () =
        failf "initial validation failed: %s"
          (Yojson.Safe.to_string
             (Cascade_catalog_runtime.rejection_to_yojson rejection)));
-  check int "initial live probe count" 1 (Atomic.get request_count);
   ignore
     (write_cascade_json config_dir
        {|{
   "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"]
 }|});
-  match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+  match Cascade_catalog_runtime.inspect_active () with
   | Ok
       (Cascade_catalog_runtime.Serving_last_known_good
          { snapshot; rejected_update }) ->
@@ -260,11 +246,9 @@ let test_invalid_hot_reload_preserves_last_known_good () =
         config_path (json_string_field "source_path" served_json);
       let labels =
         require_ok
-          (Cascade_catalog_runtime.models_of_cascade_name
-             ~sw ~net ~clock "keeper_unified")
+          (Cascade_catalog_runtime.models_of_cascade_name "keeper_unified")
       in
       check (list string) "served snapshot keeps prior model" [ valid_model ] labels;
-      check int "invalid hot reload does not probe again" 1 (Atomic.get request_count);
       let rejection_json =
         Cascade_catalog_runtime.rejection_to_yojson rejected_update
         |> Yojson.Safe.to_string
@@ -285,13 +269,7 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let base_url, _request_count =
-    start_counting_mock ~sw ~net ~port
-      ~response:(openai_text_response "pong")
-  in
-  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
   ignore
     (write_cascade_json config_dir
        (Printf.sprintf
@@ -299,7 +277,7 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
   "keeper_unified_models": ["%s"]
 }|}
           valid_model));
-  ignore (Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ());
+  ignore (Cascade_catalog_runtime.inspect_active ());
   check (list string) "legacy wrapper still resolves known profile"
     [ valid_model ]
     (Cascade_runtime.models_of_cascade_name Keeper_config.default_cascade_name);
@@ -351,24 +329,18 @@ let test_partial_catalog_keeps_validated_subset_available () =
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let base_url, _request_count =
-    start_counting_mock ~sw ~net ~port
-      ~response:(openai_text_response "pong")
-  in
-  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" dummy_base_url in
   ignore
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
   "keeper_unified_models": ["%s"],
   "tool_rerank_models": ["%s"],
-  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
+  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
 }|}
           valid_model valid_model));
   let rejection_json =
-    match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+    match Cascade_catalog_runtime.inspect_active () with
     | Ok
         (Cascade_catalog_runtime.Validated_with_rejections
            { rejected_update; _ }) ->
@@ -383,9 +355,9 @@ let test_partial_catalog_keeps_validated_subset_available () =
           (Yojson.Safe.to_string
              (Cascade_catalog_runtime.rejection_to_yojson rejection))
   in
-  check bool "rejected runtime probe is surfaced" true
+  check bool "rejected invalid candidate is surfaced" true
     (contains_substring rejection_json
-       "custom:flaky@http://127.0.0.1:9/v1");
+       "__nonexistent_provider_sentinel__:fake");
   check (list string) "dashboard only advertises validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
     (Masc_mcp.Server_routes_http_routes_dashboard.available_cascade_profiles ());
@@ -417,7 +389,7 @@ let test_partial_catalog_rejects_invalid_default_profile () =
       (write_cascade_json config_dir
          (Printf.sprintf
             {|{
-  "keeper_unified_models": ["custom:flaky@http://127.0.0.1:9/v1"],
+  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"],
   "tool_rerank_models": ["%s"]
 }|}
             valid_model));
@@ -436,9 +408,9 @@ let test_partial_catalog_rejects_invalid_default_profile () =
                    "required default profile \"keeper_unified\" failed validation"
              | _ -> false)
            errors);
-      check bool "rejected default profile probe is surfaced" true
+      check bool "rejected default profile invalid candidate is surfaced" true
         (contains_substring (Yojson.Safe.to_string rejection_json)
-           "custom:flaky@http://127.0.0.1:9/v1")
+           "__nonexistent_provider_sentinel__:fake")
   | Ok (Cascade_catalog_runtime.Validated _) ->
       fail "expected invalid default profile to hard-fail validation"
   | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
@@ -498,7 +470,7 @@ let test_config_doctor_live_warns_on_partial_catalog_validation () =
        (Printf.sprintf
           {|{
   "keeper_unified_models": ["%s"],
-  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
+  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
 }|}
           valid_model));
   with_config_dir config_dir @@ fun () ->
@@ -524,7 +496,7 @@ let test_config_doctor_live_warns_on_partial_catalog_validation () =
         (json_string_field "status" json);
       check bool "rejected profile is surfaced in live doctor json" true
         (contains_substring (Yojson.Safe.to_string json)
-           "custom:flaky@http://127.0.0.1:9/v1")
+           "__nonexistent_provider_sentinel__:fake")
 
 let () =
   run "cascade_catalog_runtime"
@@ -532,9 +504,9 @@ let () =
       ( "runtime",
         [
           test_case
-            "valid catalog dedupes shared live probes"
+            "valid catalog skips live probes at bootstrap"
             `Quick
-            test_valid_catalog_dedupes_shared_live_probes;
+            test_valid_catalog_skips_live_probes_at_bootstrap;
           test_case
             "invalid hot reload preserves last-known-good"
             `Quick

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -256,7 +256,40 @@ let test_stale_preserved_on_timeout ~clock ~sw () =
   in
   Alcotest.(check bool) "no timeout error cached" false is_timeout_error
 
-(* -- 10. Timeout with no stale data returns error JSON (not cached) -------- *)
+(* -- 10. Expired stale falls back to last-good on timeout ------------------- *)
+
+let test_expired_stale_restored_on_timeout ~clock () =
+  Dashboard_cache.invalidate_all ();
+  let original = `String "expired_but_last_good" in
+  let seeded =
+    Dashboard_cache.get_or_compute "expired_stale_timeout" ~ttl:0.05 (fun () ->
+      original)
+  in
+  check_json "seed expired-stale value" original seeded;
+  Eio.Time.sleep clock 0.25;
+  let result =
+    Dashboard_cache.get_or_compute_with_timeout "expired_stale_timeout" ~ttl:0.05
+      ~clock ~timeout_sec:0.05 (fun () ->
+        Eio.Time.sleep clock 1.0;
+        `String "never_reached")
+  in
+  check_json "expired stale restored on timeout" original result;
+  let after =
+    Dashboard_cache.get_or_compute "expired_stale_timeout" ~ttl:0.05 (fun () ->
+      `String "fresh_after_restore")
+  in
+  let is_timeout_error =
+    match after with
+    | `Assoc pairs ->
+      (match List.assoc_opt "error" pairs with
+       | Some (`String "computation_timeout") -> true
+       | _ -> false)
+    | _ -> false
+  in
+  Alcotest.(check bool) "expired stale restore avoids timeout poison" false
+    is_timeout_error
+
+(* -- 11. Timeout with no stale data returns error JSON (not cached) -------- *)
 
 (** When there is no stale data (first compute for a key), timeout should
     return error JSON to the caller but NOT cache it — subsequent calls
@@ -286,7 +319,7 @@ let test_timeout_no_stale_returns_error ~clock () =
   in
   check_json "recompute after timeout" (`String "recovered") v2
 
-(* -- 11. Waiter timeout returns fast error without poisoning cache --------- *)
+(* -- 12. Waiter timeout returns fast error without poisoning cache --------- *)
 
 (** When another fiber already owns the compute slot, waiters should honor the
     caller's timeout budget instead of waiting for the global 130s eviction.
@@ -394,6 +427,8 @@ let () =
             (fun () ->
                Eio.Switch.run @@ fun sw ->
                test_stale_preserved_on_timeout ~clock ~sw ());
+          test_case "expired stale restored on timeout" `Quick
+            (test_expired_stale_restored_on_timeout ~clock);
           test_case "no-stale timeout returns error, not cached" `Quick
             (test_timeout_no_stale_returns_error ~clock);
           test_case "waiter timeout returns error, not cached" `Quick

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -48,8 +48,11 @@ let parse_or_fail content =
 
 let with_clean_boot_overrides f =
   Config_boot_overrides.reset_for_tests ();
+  Keeper_runtime_resolved.reset_for_tests ();
   Fun.protect
-    ~finally:(fun () -> Config_boot_overrides.reset_for_tests ())
+    ~finally:(fun () ->
+      Config_boot_overrides.reset_for_tests ();
+      Keeper_runtime_resolved.reset_for_tests ())
     f
 
 (* --- Tests using resolve_overrides (pure, no env side effects) --- *)
@@ -256,6 +259,45 @@ let test_float_value_round_trip () =
     (Some "120.5")
     (List.assoc_opt "MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC" overrides)
 
+let test_resolved_runtime_freezes_toml_values_after_init () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path
+    "[turn]\n\
+     timeout_sec = 1500\n\
+     [reactive]\n\
+     max_turns_per_call = 12\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  Config_boot_overrides.set "MASC_KEEPER_TURN_TIMEOUT_SEC" "900";
+  Config_boot_overrides.set "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" "4";
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "turn timeout frozen from toml"
+    1500.0 runtime.turn_timeout_sec.value;
+  check string "turn timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.turn_timeout_sec.source);
+  check int "reactive max turns frozen from toml"
+    12 runtime.reactive_max_turns_per_call.value
+
+let test_resolved_runtime_prefers_env_over_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\ntimeout_sec = 1500\n";
+  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "777") @@ fun () ->
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "env timeout wins"
+    777.0 runtime.turn_timeout_sec.value;
+  check string "env source"
+    "env"
+    (Keeper_runtime_resolved.source_to_string runtime.turn_timeout_sec.source)
+
 let () =
   run "keeper_runtime_toml"
     [ ( "resolve_overrides"
@@ -272,5 +314,7 @@ let () =
         ; test_case "load_and_apply records disabled turn cost override" `Quick test_load_and_apply_records_disabled_turn_cost_override
         ; test_case "explicit MASC_CONFIG_DIR wins over base path" `Quick test_explicit_config_dir_wins_over_base_path
         ; test_case "float value round trip" `Quick test_float_value_round_trip
+        ; test_case "resolved runtime freezes toml values after init" `Quick test_resolved_runtime_freezes_toml_values_after_init
+        ; test_case "resolved runtime prefers env over toml" `Quick test_resolved_runtime_prefers_env_over_toml
         ] )
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -902,37 +902,33 @@ OAS_CODEX_CONFIG = "mcp_servers={}"
       check string "codex_config value"
         "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env)
 
-let test_apply_oas_env_demotes_gemini_no_mcp_to_plan () =
-  with_env_restore
-    [ "OAS_GEMINI_NO_MCP"; "OAS_GEMINI_APPROVAL_MODE" ]
-    (fun () ->
-      let defaults =
-        { KTP.empty_keeper_profile_defaults with
-          oas_env = [ "OAS_GEMINI_NO_MCP", "1" ];
-        }
-      in
-      KTP.apply_oas_env ~keeper_name:"test-keeper" defaults;
-      check string "no_mcp applied" "1"
-        (Option.value ~default:"" (Sys.getenv_opt "OAS_GEMINI_NO_MCP"));
-      check string "approval mode derived" "plan"
-        (Option.value ~default:"" (Sys.getenv_opt "OAS_GEMINI_APPROVAL_MODE")))
+let test_keeper_oas_context_demotes_gemini_no_mcp_to_plan () =
+  let defaults =
+    { KTP.empty_keeper_profile_defaults with
+      oas_env = [ "OAS_GEMINI_NO_MCP", "1" ];
+    }
+  in
+  let ctx = KTP.keeper_oas_context_of_defaults defaults in
+  check bool "no_mcp derived" true ctx.gemini_mcp_disabled;
+  check (option string) "approval mode derived" (Some "plan")
+    ctx.gemini_approval_mode;
+  check bool "approval marked derived" true ctx.gemini_approval_mode_derived
 
-let test_apply_oas_env_preserves_explicit_gemini_approval_mode () =
-  with_env_restore
-    [ "OAS_GEMINI_NO_MCP"; "OAS_GEMINI_APPROVAL_MODE" ]
-    (fun () ->
-      let defaults =
-        { KTP.empty_keeper_profile_defaults with
-          oas_env =
-            [
-              "OAS_GEMINI_NO_MCP", "1";
-              "OAS_GEMINI_APPROVAL_MODE", "yolo";
-            ];
-        }
-      in
-      KTP.apply_oas_env ~keeper_name:"test-keeper" defaults;
-      check string "explicit mode preserved" "yolo"
-        (Option.value ~default:"" (Sys.getenv_opt "OAS_GEMINI_APPROVAL_MODE")))
+let test_keeper_oas_context_preserves_explicit_gemini_approval_mode () =
+  let defaults =
+    { KTP.empty_keeper_profile_defaults with
+      oas_env =
+        [
+          "OAS_GEMINI_NO_MCP", "1";
+          "OAS_GEMINI_APPROVAL_MODE", "yolo";
+        ];
+    }
+  in
+  let ctx = KTP.keeper_oas_context_of_defaults defaults in
+  check (option string) "explicit mode preserved" (Some "yolo")
+    ctx.gemini_approval_mode;
+  check bool "explicit mode not marked derived" false
+    ctx.gemini_approval_mode_derived
 
 let test_oas_env_drops_non_oas_prefix () =
   (* Guards against ambient env injection via keeper TOML: keys that
@@ -1114,9 +1110,9 @@ let () =
           test_case "parses allowed OAS_* keys" `Quick
             test_oas_env_parses_allowed_keys;
           test_case "demotes Gemini no-MCP runs to plan approval mode" `Quick
-            test_apply_oas_env_demotes_gemini_no_mcp_to_plan;
+            test_keeper_oas_context_demotes_gemini_no_mcp_to_plan;
           test_case "preserves explicit Gemini approval mode" `Quick
-            test_apply_oas_env_preserves_explicit_gemini_approval_mode;
+            test_keeper_oas_context_preserves_explicit_gemini_approval_mode;
           test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
             test_oas_env_drops_non_oas_prefix;
           test_case "empty when table absent" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -332,6 +332,26 @@ let test_keeper_status_exposes_model_observability () =
         (`Assoc
           [
             ("ts", `String (Types.now_iso ()));
+            ("model_used", `String "stale:old-path");
+            ( "cascade",
+              `Assoc
+                [
+                  ("cascade_name", `String "stale-cascade");
+                  ( "configured_labels",
+                    `List [ `String "stale:old-path"; `String "stale:fallback" ] );
+                  ( "candidate_models",
+                    `List [ `String "stale:old-path"; `String "stale:fallback" ] );
+                  ("selected_model", `String "stale:old-path");
+                  ("selected_index", `Int 0);
+                  ("fallback_hops", `Int 0);
+                  ("fallback_applied", `Bool false);
+                ] );
+          ]);
+      Dated_jsonl.append
+        (Keeper_types.keeper_metrics_store config keeper_name)
+        (`Assoc
+          [
+            ("ts", `String (Types.now_iso ()));
             ("model_used", `String "llama:qwen3.5-3b-a3b-ud-q8-xl");
             ( "cascade",
               `Assoc
@@ -507,20 +527,23 @@ let test_keeper_status_ignores_stale_cascade_observation () =
       let open Yojson.Safe.Util in
       let observability = status_json |> member "model_observability" in
       let status_dump = Yojson.Safe.pretty_to_string status_json in
+      let sorted_strings = List.sort String.compare in
       Alcotest.(check (option string))
         ("current cascade name wins over stale metrics\n" ^ status_dump)
         (Some meta.cascade_name)
         (observability |> member "cascade_name" |> to_string_option);
       Alcotest.(check bool) "stale observation ignored" false
         (observability |> member "recent_turn_observation" |> to_bool);
-      Alcotest.(check (list string)) "configured labels come from current meta"
-        current_labels
+      Alcotest.(check (list string))
+        "configured labels come from current meta"
+        (sorted_strings current_labels)
         (observability |> member "configured_labels" |> to_list
-       |> List.map to_string);
-      Alcotest.(check (list string)) "resolved candidates fall back to current config"
-        current_labels
+       |> List.map to_string |> sorted_strings);
+      Alcotest.(check (list string))
+        "resolved candidates fall back to current config"
+        (sorted_strings current_labels)
         (observability |> member "resolved_candidates" |> to_list
-       |> List.map to_string);
+       |> List.map to_string |> sorted_strings);
       Alcotest.(check bool) "stale selected model not surfaced" true
         (observability |> member "selected_model" |> to_string_option
        <> Some stale_selected_model);


### PR DESCRIPTION
## What changed
- removed keeper turn dependence on process-global OAS env mutation and introduced frozen keeper runtime resolution state
- split cascade bootstrap validity from live provider probing so static-valid catalogs stay usable while provider health degrades separately
- hardened dashboard and keeper status surfaces to preserve stale cache, expose runtime health summaries, and use safer recent-cascade observability matching
- added advisory provider-health handling and filled new provider-kind exhaustiveness cases needed for current runtime enums

## Why
The runtime mixed config validity with provider liveness, re-read mutable env at execution time, and let request-path status/dashboard code depend on unstable live observations. That combination produced the degraded boot, timeout drift, and dashboard instability seen in server logs.

## Impact
- startup no longer invalidates the whole cascade catalog because provider probes time out
- keeper runtime limits are frozen at bootstrap with consistent downstream reads
- dashboard/status endpoints keep serving better diagnostics under partial failure
- recent cascade observations are surfaced correctly without accepting stale observations from unrelated configs

## Root cause
Three structural problems were interacting:
1. provider liveness was treated as config validity
2. keeper-specific execution settings were leaking through ambient process env
3. operator/dashboard reads depended on live state instead of resilient cached/snapshotted state

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-runtime-hardening test/test_operator_control.exe test/test_dashboard_cache.exe test/test_cascade_catalog_runtime.exe test/test_keeper_toml.exe`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_dashboard_cache.exe`
- `./_build/default/test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_runtime_toml.exe`
