### PR TITLE
[codex] reject partial catalogs with invalid default profile

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -578,6 +578,12 @@ let validate_path_result ~sw ~net ~clock ~config_path =
               built_profiles
           in
           let profile_snapshots = List.rev profile_snapshots in
+          let default_profile_validated =
+            List.exists
+              (fun (profile : profile_snapshot) ->
+                String.equal profile.name Keeper_config.default_cascade_name)
+              profile_snapshots
+          in
           let rejected_profiles =
             statically_rejected_profiles @ List.rev probe_rejected_profiles
           in
@@ -595,15 +601,23 @@ let validate_path_result ~sw ~net ~clock ~config_path =
             let rejection =
               rejection_of_path ~config_path ~attempted_mtime ~checked_at
                 ~errors:
-                  [
-                    Printf.sprintf
-                      "catalog validation rejected %d/%d profile(s)"
-                      (List.length rejected_profiles)
-                      (List.length profiles);
-                  ]
+                  ((if default_profile_validated then
+                      []
+                    else
+                      [
+                        Printf.sprintf
+                          "required default profile %S failed validation"
+                          Keeper_config.default_cascade_name;
+                      ])
+                  @ [
+                      Printf.sprintf
+                        "catalog validation rejected %d/%d profile(s)"
+                        (List.length rejected_profiles)
+                        (List.length profiles);
+                    ])
                 ~profiles:rejected_profiles
             in
-            if profile_snapshots = [] then
+            if profile_snapshots = [] || not default_profile_validated then
               Error rejection
             else
               Ok { snapshot; rejected_update = Some rejection }

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -44,10 +44,19 @@ type rejection = {
 
 type state =
   | Validated of snapshot
+  | Validated_with_rejections of {
+      snapshot : snapshot;
+      rejected_update : rejection;
+    }
   | Serving_last_known_good of {
       snapshot : snapshot;
       rejected_update : rejection;
     }
+
+type validation_result = {
+  snapshot : snapshot;
+  rejected_update : rejection option;
+}
 
 type candidate_runtime = {
   model_string : string;
@@ -209,6 +218,14 @@ let state_to_yojson = function
           ("serving_last_known_good", `Bool false);
           ("snapshot", snapshot_to_yojson snapshot);
           ("rejected_update", `Null);
+        ]
+  | Validated_with_rejections { snapshot; rejected_update } ->
+      `Assoc
+        [
+          ("status", `String "validated");
+          ("serving_last_known_good", `Bool false);
+          ("snapshot", snapshot_to_yojson snapshot);
+          ("rejected_update", rejection_to_yojson rejected_update);
         ]
   | Serving_last_known_good { snapshot; rejected_update } ->
       `Assoc
@@ -434,7 +451,7 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               candidates;
             }
 
-let validate_path ~sw ~net ~clock ~config_path =
+let validate_path_result ~sw ~net ~clock ~config_path =
   let checked_at = Unix.gettimeofday () in
   let attempted_mtime =
     try Some (Unix.stat config_path).Unix.st_mtime
@@ -478,7 +495,7 @@ let validate_path ~sw ~net ~clock ~config_path =
                 Keeper_config.default_cascade_name;
             ]
         in
-        let built_profiles, rejected_profiles =
+        let built_profiles, statically_rejected_profiles =
           List.fold_left
             (fun (ok_acc, err_acc) name ->
               match validate_profile_static ~config_path name with
@@ -488,11 +505,11 @@ let validate_path ~sw ~net ~clock ~config_path =
             profiles
         in
         let built_profiles = List.rev built_profiles in
-        let rejected_profiles = List.rev rejected_profiles in
-        if top_errors <> [] || rejected_profiles <> [] then
+        let statically_rejected_profiles = List.rev statically_rejected_profiles in
+        if top_errors <> [] || built_profiles = [] then
           Error
             (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-               ~errors:top_errors ~profiles:rejected_profiles)
+               ~errors:top_errors ~profiles:statically_rejected_profiles)
         else
           let unique_candidates = Hashtbl.create 16 in
           List.iter
@@ -515,7 +532,7 @@ let validate_path ~sw ~net ~clock ~config_path =
           List.iter
             (fun (key, probe) -> Hashtbl.replace probe_table key probe)
             probe_results;
-          let profile_snapshots, rejected_profiles =
+          let profile_snapshots, probe_rejected_profiles =
             List.fold_left
               (fun (ok_acc, err_acc) (profile : profile_build) ->
                 let probes =
@@ -561,26 +578,40 @@ let validate_path ~sw ~net ~clock ~config_path =
               built_profiles
           in
           let profile_snapshots = List.rev profile_snapshots in
-          let rejected_profiles = List.rev rejected_profiles in
-          if rejected_profiles <> [] then
-            Error
-              (rejection_of_path ~config_path ~attempted_mtime ~checked_at
-                 ~errors:
-                   [
-                     Printf.sprintf
-                       "catalog validation rejected %d/%d profile(s)"
-                       (List.length rejected_profiles)
-                       (List.length built_profiles);
-                   ]
-                 ~profiles:rejected_profiles)
+          let rejected_profiles =
+            statically_rejected_profiles @ List.rev probe_rejected_profiles
+          in
+          let snapshot =
+            {
+              source_path = config_path;
+              mtime = Option.value attempted_mtime ~default:0.0;
+              validated_at = checked_at;
+              profiles = profile_snapshots;
+            }
+          in
+          if rejected_profiles = [] then
+            Ok { snapshot; rejected_update = None }
           else
-            Ok
-              {
-                source_path = config_path;
-                mtime = Option.value attempted_mtime ~default:0.0;
-                validated_at = checked_at;
-                profiles = profile_snapshots;
-              }
+            let rejection =
+              rejection_of_path ~config_path ~attempted_mtime ~checked_at
+                ~errors:
+                  [
+                    Printf.sprintf
+                      "catalog validation rejected %d/%d profile(s)"
+                      (List.length rejected_profiles)
+                      (List.length profiles);
+                  ]
+                ~profiles:rejected_profiles
+            in
+            if profile_snapshots = [] then
+              Error rejection
+            else
+              Ok { snapshot; rejected_update = Some rejection }
+
+let validate_path ~sw ~net ~clock ~config_path =
+  match validate_path_result ~sw ~net ~clock ~config_path with
+  | Ok result -> Ok result.snapshot
+  | Error _ as e -> e
 
 let same_snapshot_key (snapshot : snapshot) ~path ~mtime =
   String.equal snapshot.source_path path && Float.equal snapshot.mtime mtime
@@ -624,6 +655,13 @@ let inspect_active ?sw ?net ?clock () =
       let cached_result =
         with_cache_lock (fun () ->
             match !cache.active_snapshot, !cache.rejected_update, current_mtime with
+            | Some snapshot, Some rejection, Some mtime
+              when same_snapshot_key snapshot ~path:config_path ~mtime
+                   && same_rejection_key rejection ~path:config_path ~mtime ->
+                Some
+                  (Ok
+                     (Validated_with_rejections
+                        { snapshot; rejected_update = rejection }))
             | Some snapshot, _, Some mtime
               when same_snapshot_key snapshot ~path:config_path ~mtime ->
                 Some (Ok (Validated snapshot))
@@ -662,8 +700,8 @@ let inspect_active ?sw ?net ?clock () =
                         { snapshot; rejected_update = rejection })
                | None -> Error rejection)
           | Ok (sw, net, clock) -> (
-              match validate_path ~sw ~net ~clock ~config_path with
-              | Ok snapshot ->
+              match validate_path_result ~sw ~net ~clock ~config_path with
+              | Ok { snapshot; rejected_update = None } ->
                   with_cache_lock (fun () ->
                       cache :=
                         {
@@ -671,6 +709,16 @@ let inspect_active ?sw ?net ?clock () =
                           rejected_update = None;
                         });
                   Ok (Validated snapshot)
+              | Ok { snapshot; rejected_update = Some rejection } ->
+                  with_cache_lock (fun () ->
+                      cache :=
+                        {
+                          active_snapshot = Some snapshot;
+                          rejected_update = Some rejection;
+                        });
+                  Ok
+                    (Validated_with_rejections
+                       { snapshot; rejected_update = rejection })
               | Error rejection ->
                   (match with_cache_lock (fun () -> !cache.active_snapshot) with
                    | Some snapshot ->
@@ -695,6 +743,7 @@ let inspect_active ?sw ?net ?clock () =
 let require_snapshot ?sw ?net ?clock () =
   match inspect_active ?sw ?net ?clock () with
   | Ok (Validated snapshot) -> Ok snapshot
+  | Ok (Validated_with_rejections { snapshot; _ }) -> Ok snapshot
   | Ok (Serving_last_known_good { snapshot; _ }) -> Ok snapshot
   | Error rejection ->
       let detail =

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -25,6 +25,10 @@ type rejection
 
 type state =
   | Validated of snapshot
+  | Validated_with_rejections of {
+      snapshot : snapshot;
+      rejected_update : rejection;
+    }
   | Serving_last_known_good of {
       snapshot : snapshot;
       rejected_update : rejection;
@@ -43,6 +47,9 @@ val validate_path :
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config_path:string ->
   (snapshot, rejection) result
+(** Returns the validated subset of profiles when the catalog is partly
+    usable but some presets are rejected at runtime. Inspect
+    {!inspect_active} when the caller needs the rejected-profile detail. *)
 
 val resolve_declared_name :
   ?sw:Eio.Switch.t ->

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -470,6 +470,11 @@ let live_catalog_summary = function
         "Live cascade catalog validation passed.",
         Cascade_catalog_runtime.state_to_yojson
           (Cascade_catalog_runtime.Validated snapshot) )
+  | Stdlib.Ok
+      (Cascade_catalog_runtime.Validated_with_rejections _ as state) ->
+      ( false,
+        "Live cascade catalog validation kept the usable profile subset and rejected some presets.",
+        Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Ok (Cascade_catalog_runtime.Serving_last_known_good _ as state) ->
       ( true,
         "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
@@ -513,11 +518,12 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
       report.next_actions
   in
   let status =
-    match report.status, live_failed with
-    | Error, _ -> Error
-    | _, true -> Error
-    | Ok, false -> Ok
-    | Warn, false -> Warn
+    match report.status, live_failed, live_warning <> "" with
+    | Error, _, _ -> Error
+    | _, true, _ -> Error
+    | Warn, false, _ -> Warn
+    | Ok, false, true -> Warn
+    | Ok, false, false -> Ok
   in
   {
     report with

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -159,6 +159,10 @@ let validation_summary_json ?config_path () =
         ("invalid_profiles", `List []);
       ]
   | Ok
+      (Cascade_catalog_runtime.Validated_with_rejections
+         { rejected_update; _ }) ->
+      of_rejection ~status:"validated" rejected_update
+  | Ok
       (Cascade_catalog_runtime.Serving_last_known_good
          { rejected_update; _ }) ->
       of_rejection ~status:"serving_last_known_good" rejected_update

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -734,6 +734,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                  (Cascade_catalog_runtime.snapshot_to_yojson snapshot));
             None
         | Ok
+            (Cascade_catalog_runtime.Validated_with_rejections
+               { snapshot; rejected_update }) ->
+            Log.Server.warn
+              "Validated active cascade catalog with rejected profiles: snapshot=%s rejected_update=%s"
+              (Yojson.Safe.to_string
+                 (Cascade_catalog_runtime.snapshot_to_yojson snapshot))
+              (Yojson.Safe.to_string
+                 (Cascade_catalog_runtime.rejection_to_yojson rejected_update));
+            None
+        | Ok
             (Cascade_catalog_runtime.Serving_last_known_good
                { rejected_update; _ }) ->
             Some

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -361,6 +361,52 @@ let test_partial_catalog_keeps_validated_subset_available () =
   check bool "dashboard config_json keeps rejected profile metadata" true
     (contains_substring (Yojson.Safe.to_string config_json) "broken_profile")
 
+let test_partial_catalog_rejects_invalid_default_profile () =
+  with_temp_dir "dashboard-cascade-default-gate" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
+  let port = find_free_port () in
+  let base_url, _request_count =
+    start_counting_mock ~sw ~net ~port
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  match
+    ignore
+      (write_cascade_json config_dir
+         (Printf.sprintf
+            {|{
+  "keeper_unified_models": ["custom:flaky@http://127.0.0.1:9/v1"],
+  "tool_rerank_models": ["%s"]
+}|}
+            valid_model));
+    Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
+  with
+  | Error rejection ->
+      let rejection_json =
+        Cascade_catalog_runtime.rejection_to_yojson rejection
+      in
+      let errors = json_list_field "errors" rejection_json in
+      check bool "default-profile gate is surfaced" true
+        (List.exists
+           (function
+             | `String value ->
+                 contains_substring value
+                   "required default profile \"keeper_unified\" failed validation"
+             | _ -> false)
+           errors);
+      check bool "rejected default profile probe is surfaced" true
+        (contains_substring (Yojson.Safe.to_string rejection_json)
+           "custom:flaky@http://127.0.0.1:9/v1")
+  | Ok (Cascade_catalog_runtime.Validated _) ->
+      fail "expected invalid default profile to hard-fail validation"
+  | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+      fail "expected invalid default profile to be rejected, not partially validated"
+  | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+      fail "expected direct validation against the current file"
+
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -462,6 +508,10 @@ let () =
             "partial catalog keeps validated subset available"
             `Quick
             test_partial_catalog_keeps_validated_subset_available;
+          test_case
+            "partial catalog rejects invalid default profile"
+            `Quick
+            test_partial_catalog_rejects_invalid_default_profile;
           test_case
             "config doctor live reports catalog validation"
             `Quick

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -184,6 +184,8 @@ let test_valid_catalog_dedupes_shared_live_probes () =
   let snapshot =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
     | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
+    | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+        fail "expected fully validated snapshot without rejected profiles"
     | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
         fail "expected a freshly validated snapshot"
     | Error rejection ->
@@ -235,6 +237,8 @@ let test_invalid_hot_reload_preserves_last_known_good () =
   in
   (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
    | Ok (Cascade_catalog_runtime.Validated _) -> ()
+   | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+       fail "expected the initial snapshot to validate cleanly"
    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
        fail "expected the initial snapshot to validate cleanly"
    | Error rejection ->
@@ -269,6 +273,8 @@ let test_invalid_hot_reload_preserves_last_known_good () =
         (contains_substring rejection_json "__nonexistent_provider_sentinel__")
   | Ok (Cascade_catalog_runtime.Validated _) ->
       fail "expected invalid hot reload to be rejected"
+  | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+      fail "expected invalid hot reload to use last-known-good"
   | Error rejection ->
       failf "expected last-known-good fallback, got hard error: %s"
         (Yojson.Safe.to_string
@@ -301,7 +307,7 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
     []
     (Cascade_runtime.models_of_cascade_name "missing_profile")
 
-let test_dashboard_available_profiles_use_validated_snapshot_only () =
+let test_partial_catalog_keeps_validated_subset_available () =
   with_temp_dir "dashboard-cascade-profiles" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
   init_config_root config_dir;
@@ -319,20 +325,28 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
           {|{
   "keeper_unified_models": ["%s"],
   "tool_rerank_models": ["%s"],
-  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
 }|}
           valid_model valid_model));
-  let _ =
+  let rejection_json =
     match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
-        fail "expected direct validation, not last-known-good"
+    | Ok
+        (Cascade_catalog_runtime.Validated_with_rejections
+           { rejected_update; _ }) ->
+        Cascade_catalog_runtime.rejection_to_yojson rejected_update
+        |> Yojson.Safe.to_string
     | Ok (Cascade_catalog_runtime.Validated _) ->
-        fail "expected invalid raw file to be rejected before snapshot priming"
-    | Error _ -> ()
+        fail "expected mixed catalog to keep only the validated subset"
+    | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+        fail "expected direct validation against the current file"
+    | Error rejection ->
+        failf "expected partial validation, got hard error: %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
   in
-  Cascade_catalog_runtime.install_snapshot_for_tests
-    ~source_path:(Filename.concat config_dir "cascade.json")
-    ~profile_names:[ Keeper_config.default_cascade_name; "tool_rerank" ];
+  check bool "rejected runtime probe is surfaced" true
+    (contains_substring rejection_json
+       "custom:flaky@http://127.0.0.1:9/v1");
   check (list string) "dashboard only advertises validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
     (Masc_mcp.Server_routes_http_routes_dashboard.available_cascade_profiles ());
@@ -343,7 +357,9 @@ let test_dashboard_available_profiles_use_validated_snapshot_only () =
   in
   check (list string) "dashboard config_json only renders validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
-    profile_names
+    profile_names;
+  check bool "dashboard config_json keeps rejected profile metadata" true
+    (contains_substring (Yojson.Safe.to_string config_json) "broken_profile")
 
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
@@ -380,6 +396,51 @@ let test_config_doctor_live_reports_catalog_validation () =
         (contains_substring (Yojson.Safe.to_string json)
            "__nonexistent_provider_sentinel__")
 
+let test_config_doctor_live_warns_on_partial_catalog_validation () =
+  with_temp_dir "cascade-doctor-live-partial" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_dir = Filename.concat base_path ".masc/config" in
+  init_config_root config_dir;
+  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
+  let port = find_free_port () in
+  let base_url, _request_count =
+    start_counting_mock ~sw ~net ~port
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "keeper_unified_models": ["%s"],
+  "broken_profile_models": ["custom:flaky@http://127.0.0.1:9/v1"]
+}|}
+          valid_model));
+  with_config_dir config_dir @@ fun () ->
+  let report =
+    Config_doctor.analyze_live
+      ~sw ~net ~clock ~fs ~proc_mgr
+      ~base_path_input:base_path
+      ~default_base_path:base_path
+      ()
+  in
+  check string "live doctor partial status" "warn"
+    (Config_doctor.status_to_string report.status);
+  check bool "live partial warning present" true
+    (List.exists
+       (fun warning ->
+          contains_substring warning
+            "kept the usable profile subset and rejected some presets")
+       report.warnings);
+  match report.catalog_validation with
+  | None -> fail "expected catalog_validation output from analyze_live"
+  | Some json ->
+      check string "partial catalog validation status" "validated"
+        (json_string_field "status" json);
+      check bool "rejected profile is surfaced in live doctor json" true
+        (contains_substring (Yojson.Safe.to_string json)
+           "custom:flaky@http://127.0.0.1:9/v1")
+
 let () =
   run "cascade_catalog_runtime"
     [
@@ -398,12 +459,16 @@ let () =
             `Quick
             test_legacy_runtime_wrapper_does_not_fallback_to_defaults;
           test_case
-            "dashboard available profiles use validated snapshot only"
+            "partial catalog keeps validated subset available"
             `Quick
-            test_dashboard_available_profiles_use_validated_snapshot_only;
+            test_partial_catalog_keeps_validated_subset_available;
           test_case
             "config doctor live reports catalog validation"
             `Quick
             test_config_doctor_live_reports_catalog_validation;
+          test_case
+            "config doctor live warns on partial catalog validation"
+            `Quick
+            test_config_doctor_live_warns_on_partial_catalog_validation;
         ] );
     ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -39,6 +39,21 @@ let read_all ic =
    with End_of_file -> ());
   Buffer.contents buf
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then
+      true
+    else if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -411,6 +426,18 @@ let write_partially_invalid_cascade ~base_path ~valid_model =
        {|{
   "keeper_unified_models": ["%s"],
   "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+}|}
+       valid_model)
+
+let write_partially_invalid_default_cascade ~base_path ~valid_model =
+  let config_root = Filename.concat base_path ".masc/config" in
+  mkdir_p config_root;
+  write_file
+    (Filename.concat config_root "cascade.json")
+    (Printf.sprintf
+       {|{
+  "keeper_unified_models": ["custom:flaky@http://127.0.0.1:9/v1"],
+  "tool_rerank_models": ["%s"]
 }|}
        valid_model)
 
@@ -1583,6 +1610,102 @@ let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
             Yojson.Safe.Util.(
               config_json |> member "invalid_profiles" |> to_list |> List.length)))
 
+let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
+  with_temp_dir "startup-invalid-default-partial-cascade" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let mock_port = find_free_port_from (port + 1) in
+      let mock_pid =
+        start_mock_openai_server ~port:mock_port
+          ~response:(openai_text_response "ok")
+      in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_partially_invalid_default_cascade ~base_path:dir
+        ~valid_model:(Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" mock_port);
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () ->
+          stop_process pid;
+          stop_process mock_pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "degraded") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio invalid default partial catalog did not reach startup.phase=degraded within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir
+              ~name:"health-invalid-default-partial" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup = Yojson.Safe.Util.member "startup" health_json in
+          Alcotest.(check string) "startup phase degraded" "degraded"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check bool) "startup remains ready" true
+            Yojson.Safe.Util.(startup |> member "state_ready" |> to_bool);
+          let startup_error =
+            Yojson.Safe.Util.(startup |> member "last_error" |> to_string)
+          in
+          Alcotest.(check bool) "last error mentions catalog validation" true
+            (contains_substring startup_error "startup catalog validation failed:");
+          Alcotest.(check bool) "last error mentions default profile gate" true
+            (contains_substring startup_error
+               "required default profile \"keeper_unified\" failed validation");
+          let config_headers, config_body =
+            curl_request_capture ~output_dir:dir
+              ~name:"cascade-config-invalid-default-partial" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/api/v1/cascade/config" port)
+              ()
+          in
+          Alcotest.(check (option int)) "cascade config http 200" (Some 200)
+            (http_status_from_headers config_headers);
+          let config_json = parse_json_response_file config_body in
+          Alcotest.(check string) "partial default validation is invalid"
+            "invalid"
+            Yojson.Safe.Util.(
+              config_json |> member "validation_status" |> to_string);
+          Alcotest.(check int) "one invalid profile is surfaced" 1
+            Yojson.Safe.Util.(
+              config_json |> member "invalid_profiles" |> to_list |> List.length)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1709,6 +1832,10 @@ let () =
             "main_eio partial catalog stays ready and surfaces rejections"
             `Slow
             test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections;
+          Alcotest.test_case
+            "main_eio invalid default partial catalog stays degraded"
+            `Slow
+            test_main_eio_invalid_default_partial_catalog_stays_degraded;
           Alcotest.test_case
             "main_eio invalid cascade stays degraded but serves dashboard"
             `Slow

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -96,8 +96,7 @@ goal = "example"
 room_scope = "current"
 proactive_enabled = false
 |}
-let find_free_port () =
-  let start = 9200 + (Unix.getpid () mod 1000) in
+let find_free_port_from start =
   let rec loop attempts port =
     if attempts <= 0 then
       Alcotest.skip ()
@@ -117,6 +116,43 @@ let find_free_port () =
                 (Unix.error_message err) fn arg)
   in
   loop 2048 start
+
+let find_free_port () =
+  find_free_port_from (9200 + (Unix.getpid () mod 1000))
+
+let openai_text_response ?(id = "chatcmpl-1") text =
+  Printf.sprintf
+    {|{"id":"%s","object":"chat.completion","model":"mock","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}|}
+    id text
+
+let start_mock_openai_server ~port ~response =
+  match Unix.fork () with
+  | 0 ->
+      let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, port));
+      Unix.listen socket 16;
+      let payload =
+        Printf.sprintf
+          "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+          (String.length response) response
+      in
+      let buffer = Bytes.create 4096 in
+      let rec loop () =
+        let client, _ = Unix.accept socket in
+        Fun.protect
+          ~finally:(fun () -> Unix.close client)
+          (fun () ->
+            ignore
+              (try Unix.read client buffer 0 (Bytes.length buffer)
+               with Unix.Unix_error _ -> 0);
+            ignore (Unix.write_substring client payload 0 (String.length payload)));
+        loop ()
+      in
+      loop ()
+  | pid ->
+      Unix.sleepf 0.1;
+      pid
 
 let merge_env_overrides overrides =
   let override_keys = List.map fst overrides in
@@ -329,8 +365,10 @@ let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
     match curl_health_json ~port with
     | Some json -> (
         let phase =
-          Yojson.Safe.Util.(
-            json |> member "startup" |> member "phase" |> to_string_option)
+          match Yojson.Safe.Util.member "startup" json with
+          | `Assoc _ as startup ->
+              Yojson.Safe.Util.(startup |> member "phase" |> to_string_option)
+          | _ -> None
         in
         match phase with
         | Some phase when String.equal phase expected_phase -> true
@@ -363,6 +401,18 @@ let write_invalid_local_only_cascade base_path =
     {|{
   "local_only_models": ["ollama:qwen3.6:35b-a3b-mlx-bf16"]
 }|}
+
+let write_partially_invalid_cascade ~base_path ~valid_model =
+  let config_root = Filename.concat base_path ".masc/config" in
+  mkdir_p config_root;
+  write_file
+    (Filename.concat config_root "cascade.json")
+    (Printf.sprintf
+       {|{
+  "keeper_unified_models": ["%s"],
+  "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
+}|}
+       valid_model)
 
 let stop_process pid =
   (try Unix.kill pid Sys.sigterm with _ -> ());
@@ -1444,6 +1494,95 @@ let test_main_eio_invalid_cascade_stays_degraded_but_serves_dashboard () =
             Yojson.Safe.Util.(
               config_json |> member "config_path" |> to_string)))
 
+let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
+  with_temp_dir "startup-partial-cascade" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let mock_port = find_free_port_from (port + 1) in
+      let mock_pid =
+        start_mock_openai_server ~port:mock_port
+          ~response:(openai_text_response "ok")
+      in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_partially_invalid_cascade ~base_path:dir
+        ~valid_model:(Printf.sprintf "custom:stable@http://127.0.0.1:%d/v1" mock_port);
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () ->
+          stop_process pid;
+          stop_process mock_pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "ready") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio partial catalog did not reach startup.phase=ready within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let health_headers, health_body =
+            curl_request_capture ~output_dir:dir ~name:"health-partial" ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/health" port) ()
+          in
+          ignore health_headers;
+          let health_json = parse_json_response_file health_body in
+          let startup = Yojson.Safe.Util.member "startup" health_json in
+          Alcotest.(check string) "startup phase stays ready" "ready"
+            Yojson.Safe.Util.(startup |> member "phase" |> to_string);
+          Alcotest.(check bool) "startup remains ready" true
+            Yojson.Safe.Util.(startup |> member "state_ready" |> to_bool);
+          Alcotest.(check bool) "last error remains unset" true
+            Yojson.Safe.Util.(startup |> member "last_error" |> to_string_option = None);
+          let config_headers, config_body =
+            curl_request_capture ~output_dir:dir ~name:"cascade-config-partial"
+              ~method_:"GET"
+              ~url:(Printf.sprintf "http://127.0.0.1:%d/api/v1/cascade/config" port)
+              ()
+          in
+          Alcotest.(check (option int)) "cascade config http 200" (Some 200)
+            (http_status_from_headers config_headers);
+          let config_json = parse_json_response_file config_body in
+          Alcotest.(check string) "partial validation stays validated"
+            "validated"
+            Yojson.Safe.Util.(
+              config_json |> member "validation_status" |> to_string);
+          Alcotest.(check int) "one invalid profile is surfaced" 1
+            Yojson.Safe.Util.(
+              config_json |> member "invalid_profiles" |> to_list |> List.length)))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1566,6 +1705,10 @@ let () =
           Alcotest.test_case
             "main_eio fresh bootstrap and MCP handshake"
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
+          Alcotest.test_case
+            "main_eio partial catalog stays ready and surfaces rejections"
+            `Slow
+            test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections;
           Alcotest.test_case
             "main_eio invalid cascade stays degraded but serves dashboard"
             `Slow


### PR DESCRIPTION
## Summary

- reject partially validated catalogs when the default profile `keeper_unified` fails validation
- keep partial validation behavior for non-default profiles
- add unit and startup regression tests for invalid-default partial catalogs

## Why

- startup accepted any non-empty validated subset, even when the required default cascade profile had already been rejected
- that let the server report ready while later default-cascade resolution could still fail at runtime

## Validation

- `ocamlc -stop-after parsing -c lib/cascade/cascade_catalog_runtime.ml`
- `ocamlc -stop-after parsing -c test/test_cascade_catalog_runtime.ml`
- `ocamlc -stop-after parsing -c test/test_server_runtime_bootstrap.ml`
- `dune exec --root . ./test/test_cascade_catalog_runtime.exe` (blocked by pre-existing branch compile errors in `lib/provider_adapter.ml`, `lib/cascade/cascade_config.ml`, and `lib/oas_worker_exec.ml` due to missing `Kimi|Kimi_cli` matches)
