### PR TITLE
[codex] bump OAS pin and wire Kimi provider kinds

### DIFF
--- a/docs/CASCADE-COOKBOOK.md
+++ b/docs/CASCADE-COOKBOOK.md
@@ -20,9 +20,10 @@ can execute when selected.
 - `default_*` acts as fallback for cascades that omit per-profile values.
 - `{name}_keeper_assignable = false` keeps a profile visible in the catalog but
   hides it from keeper assignment dropdowns.
-- Kimi direct is not a generic OpenAI-compatible `custom:` endpoint here. Use
-  `kimi:kimi-for-coding` only when your OAS runtime exposes the first-class
-  `kimi` provider.
+- Kimi direct uses the built-in Moonshot/OpenAI-compatible `kimi:` lane here.
+  Prefer current model IDs such as `kimi:kimi-k2.5`.
+- Legacy `kimi:kimi-for-coding` is normalized to `kimi:kimi-k2.5` at parse time for
+  backward compatibility with older live configs.
 
 ## Example 1: GLM Coding + Kimi Direct + Local Ollama Fallback
 
@@ -34,7 +35,7 @@ Use this when your keepers are primarily coding/text agents and you want:
 
 ```json
 {
-  "_comment": "Local/private live config example. Requires an OAS runtime that supports the kimi direct provider.",
+  "_comment": "Local/private live config example. Requires valid GLM/Kimi credentials and local fallback runtime health.",
   "default_models": [
     {"model": "glm-coding:glm-5.1", "weight": 45},
     {"model": "kimi:kimi-for-coding", "weight": 35},
@@ -88,7 +89,7 @@ of `ollama`.
 
 ```json
 {
-  "_comment": "Local/private live config example. Requires a kimi-capable OAS runtime and an OpenAI-compatible MLX-VLM endpoint.",
+  "_comment": "Local/private live config example. Requires valid GLM/Kimi credentials and an OpenAI-compatible MLX-VLM endpoint.",
   "default_models": [
     {"model": "glm-coding:glm-5.1", "weight": 45},
     {"model": "kimi:kimi-for-coding", "weight": 35},

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -105,6 +105,76 @@ let resolve_effective_api_key_env
     | Some env -> env
     | None -> registry_default
 
+let nonempty_env name =
+  match Sys.getenv_opt name with
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let env_url_or ~env ~default =
+  match nonempty_env env with
+  | Some url -> url
+  | None -> default
+
+let kimi_provider_name = "kimi"
+let moonshot_base_url_env = "MOONSHOT_BASE_URL"
+let moonshot_api_key_env = "MOONSHOT_API_KEY"
+let moonshot_default_base_url = "https://api.moonshot.ai/v1"
+let kimi_default_max_context = 256_000
+
+let is_kimi_provider provider_name =
+  String.equal provider_name kimi_provider_name
+
+let moonshot_api_url () =
+  env_url_or ~env:moonshot_base_url_env ~default:moonshot_default_base_url
+
+let moonshot_request_path () =
+  let path = Uri.path (Uri.of_string (moonshot_api_url ())) in
+  if String.equal path "/v1" || String.equal path "/v1/" then
+    "/chat/completions"
+  else
+    Masc_network_defaults.openai_chat_completions_path
+
+let resolve_kimi_api_key_env ~api_key_env_overrides =
+  resolve_effective_api_key_env
+    ~api_key_env_overrides
+    ~provider_name:kimi_provider_name
+    ~registry_default:moonshot_api_key_env
+
+let kimi_is_available ~api_key_env_overrides =
+  match resolve_kimi_api_key_env ~api_key_env_overrides with
+  | "" -> false
+  | env_name -> Option.is_some (nonempty_env env_name)
+
+let make_kimi_config ~temperature ~max_tokens ?system_prompt
+    ?(api_key_env_overrides = []) ?supports_tool_choice_override model_id =
+  let effective_api_key_env =
+    resolve_kimi_api_key_env ~api_key_env_overrides
+  in
+  let api_key =
+    match nonempty_env effective_api_key_env with
+    | Some value -> value
+    | None -> ""
+  in
+  let headers = headers_with_auth ~kind:OpenAI_compat ~api_key in
+  let resolved_model_id =
+    resolve_auto_model_id kimi_provider_name model_id
+  in
+  Llm_provider.Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id:resolved_model_id
+    ~base_url:(moonshot_api_url ())
+    ~api_key
+    ~headers
+    ~request_path:(moonshot_request_path ())
+    ~temperature
+    ~max_tokens
+    ~max_context:kimi_default_max_context
+    ?system_prompt
+    ?supports_tool_choice_override
+    ()
+
 (** Build a {!Llm_provider.Provider_config.t} from a registry entry. *)
 let make_registry_config ~temperature ~max_tokens ?system_prompt
     ?(api_key_env_overrides=[]) ?supports_tool_choice_override
@@ -177,34 +247,41 @@ let parse_model_string
     ?system_prompt ?(api_key_env_overrides = [])
     ?supports_tool_choice_override
     (s : string) : Llm_provider.Provider_config.t option =
+  let trimmed = String.trim s in
+  match split_provider_model trimmed with
+  | Some ("custom", model_id) ->
+    (match make_custom_config ~temperature ~max_tokens ?system_prompt
+             ?supports_tool_choice_override model_id with
+     | Some cfg -> Some cfg
+     | None -> None)
+  | Some (provider_name, model_id) when is_kimi_provider provider_name ->
+    if kimi_is_available ~api_key_env_overrides then
+      Some
+        (make_kimi_config ~temperature ~max_tokens ?system_prompt
+           ~api_key_env_overrides ?supports_tool_choice_override model_id)
+    else None
+  | _ ->
   (* Kind classification goes through [Provider_kind_resolver] — a sum-typed
      resolver that consults Provider_registry as SSOT and never flattens
      unknown specs to [OpenAI_compat]. This keeps ["gemini:gemini-2.5-flash"]
      from being misclassified by any downstream substring heuristic
      (issue #8159). *)
-  match Provider_kind_resolver.resolve s with
-  | Unknown _ -> None
-  | Custom_url _ ->
-    (* Delegate to the existing custom-URL constructor; it produces the
-       OpenAI_compat kind *by contract* for self-hosted endpoints. *)
-    (match split_provider_model (String.trim s) with
-     | Some ("custom", model_id) ->
-       make_custom_config ~temperature ~max_tokens ?system_prompt
-         ?supports_tool_choice_override model_id
-     | _ -> None)
-  | Registered { provider_name; model_id; kind = resolved_kind } ->
-    match Llm_provider.Provider_registry.find default_registry provider_name with
-    | None -> None  (* registry lookup race or unloaded entry *)
-    | Some entry when not (entry.is_available ()) -> None
-    | Some entry ->
-      (* Defensive invariant: the resolver and the registry must agree on
-         the kind. If they diverge we have a registry bug or a resolver
-         bug; fail closed rather than emit a degraded config. *)
-      if entry.defaults.kind <> resolved_kind then None
-      else
-        Some (make_registry_config ~temperature ~max_tokens ?system_prompt
-                ~api_key_env_overrides ?supports_tool_choice_override
-                ~provider_name ~model_id entry)
+    match Provider_kind_resolver.resolve s with
+    | Unknown _ -> None
+    | Custom_url _ -> None
+    | Registered { provider_name; model_id; kind = resolved_kind } ->
+      match Llm_provider.Provider_registry.find default_registry provider_name with
+      | None -> None  (* registry lookup race or unloaded entry *)
+      | Some entry when not (entry.is_available ()) -> None
+      | Some entry ->
+        (* Defensive invariant: the resolver and the registry must agree on
+           the kind. If they diverge we have a registry bug or a resolver
+           bug; fail closed rather than emit a degraded config. *)
+        if entry.defaults.kind <> resolved_kind then None
+        else
+          Some (make_registry_config ~temperature ~max_tokens ?system_prompt
+                  ~api_key_env_overrides ?supports_tool_choice_override
+                  ~provider_name ~model_id entry)
 
 (** Parse a {!Cascade_config_loader.weighted_entry} into a
     {!Llm_provider.Provider_config.t}, forwarding the entry's
@@ -245,6 +322,15 @@ let parse_weighted_entry_diag
              ?supports_tool_choice_override:entry.supports_tool_choice model_id with
      | Some c -> Ok c
      | None -> Error (Drop_invalid_syntax raw))
+  | Some (provider_name, model_id) when is_kimi_provider provider_name ->
+    if kimi_is_available ~api_key_env_overrides then
+      Ok
+        (make_kimi_config ~temperature ~max_tokens ?system_prompt
+           ~api_key_env_overrides
+           ?supports_tool_choice_override:entry.supports_tool_choice
+           model_id)
+    else
+      Error (Drop_unavailable_scheme { model = raw; scheme = provider_name })
   | Some (provider_name, model_id) ->
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None ->
@@ -399,6 +485,14 @@ let parse_model_string_exn
      | Some cfg -> Ok cfg
      | None ->
        Error (Printf.sprintf "invalid custom model spec %S: empty model after @" s))
+  | Some (provider_name, model_id) when is_kimi_provider provider_name ->
+    if kimi_is_available ~api_key_env_overrides:[] then
+      Ok (make_kimi_config ~temperature ~max_tokens ?system_prompt model_id)
+    else
+      Error
+        (Printf.sprintf "provider %S unavailable (missing env var %S)"
+           provider_name
+           (resolve_kimi_api_key_env ~api_key_env_overrides:[]))
   | Some (provider_name, model_id) ->
     match Llm_provider.Provider_registry.find default_registry provider_name with
     | None ->

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -98,6 +98,17 @@ let resolve_glm_coding_model_id model_id =
     ~default_model:(env_or "glm-5.1" "ZAI_CODING_DEFAULT_MODEL")
     model_id
 
+let resolve_kimi_model_id model_id =
+  let normalized = String.trim model_id |> String.lowercase_ascii in
+  match normalized with
+  | "auto"
+  | "kimi-for-coding" ->
+    (* Moonshot's current official coding/agent default is kimi-k2.5.
+       Keep the legacy kimi-for-coding alias working so older
+       cascade.json examples do not hard-fail. *)
+    env_or "kimi-k2.5" "MOONSHOT_DEFAULT_MODEL"
+  | _ -> String.trim model_id
+
 (** Resolve "auto" and aliases to concrete model IDs.
     Cloud APIs generally require concrete model names, and local
     providers (llama, ollama) also cannot accept the literal "auto" model ID.
@@ -118,6 +129,7 @@ let resolve_auto_model_id provider_name model_id =
     else model_id
   | "glm" -> resolve_glm_model_id model_id
   | "glm-coding" -> resolve_glm_coding_model_id model_id
+  | "kimi" -> resolve_kimi_model_id model_id
   | "gemini" | "gemini_cli" ->
     (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview on
        2026-04-16 (PR C Cadd follow-up). Capabilities are inherited via

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -154,8 +154,27 @@ let reset_cascade_counters_for_test () =
     Delegates to the current OAS registry helper so endpoint-distinct
     providers such as [glm], [glm-coding], and [openrouter] track the
     pinned agent_sdk behavior exactly. *)
+let starts_with ~prefix s =
+  let plen = String.length prefix in
+  String.length s >= plen && String.sub s 0 plen = prefix
+
+let is_kimi_model_id model_id =
+  let normalized = String.trim model_id |> String.lowercase_ascii in
+  starts_with ~prefix:"kimi-" normalized
+  || starts_with ~prefix:"moonshot-" normalized
+
+let is_moonshot_base_url base_url =
+  match Uri.host (Uri.of_string base_url) with
+  | Some host -> String.equal (String.lowercase_ascii host) "api.moonshot.ai"
+  | None -> false
+
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  Llm_provider.Provider_registry.provider_name_of_config cfg
+  if cfg.kind = Llm_provider.Provider_config.OpenAI_compat
+     && (is_kimi_model_id cfg.model_id || is_moonshot_base_url cfg.base_url)
+  then
+    "kimi"
+  else
+    Llm_provider.Provider_registry.provider_name_of_config cfg
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   Provider_adapter.display_provider_name (provider_name_of_config cfg)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -106,6 +106,7 @@ let display_provider_name label =
   match normalize_label label with
   | "glm" | "glm-api" -> cn_glm
   | "glm-coding" | "glm-coding-plan" -> cn_glm_coding_plan
+  | "kimi-api" -> cn_kimi
   | _ -> String.trim label
 
 (** Default API base URLs — overridable via env var for proxying/testing. *)
@@ -135,7 +136,6 @@ let glm_coding_api_url () =
 
 let kimi_api_url () =
   env_url_or ~env:"KIMI_BASE_URL" ~default:"https://api.kimi.com/coding"
-
 (** SSOT cascade prefix for local llama-server instances.
     All cascade label construction for local models must use this constant.
     Format: [local_cascade_prefix ^ ":" ^ model_id] → e.g. "llama:qwen3.5" *)
@@ -766,7 +766,7 @@ let provider_auth_available label =
       (match adapter.auth_mode with
        | No_auth -> true
        | Cli_cached_login ->
-           (match adapter.spawn_key with
+            (match adapter.spawn_key with
             | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
             | None -> false)
        | Api_key env_name ->

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -83,9 +83,11 @@ val cn_ollama : string
 val cn_claude : string
 val cn_codex : string
 val cn_gemini : string
+val cn_kimi : string
 val cn_claude_api : string
 val cn_codex_api : string
 val cn_gemini_api : string
+val cn_kimi_api : string
 val cn_glm : string
 val cn_glm_coding_plan : string
 val cn_openrouter : string

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -27,6 +27,18 @@ let split_provider_model (s : string) : (string * string) option =
       in
       if model_id = "" then None else Some (provider_name, model_id)
 
+let resolve_builtin_provider provider_name model_id =
+  match provider_name with
+  | "kimi" ->
+    Some
+      (Registered
+         {
+           provider_name;
+           model_id;
+           kind = Llm_provider.Provider_config.OpenAI_compat;
+         })
+  | _ -> None
+
 let resolve (spec : string) : resolution =
   let s = String.trim spec in
   match split_provider_model s with
@@ -43,24 +55,28 @@ let resolve (spec : string) : resolution =
     else
       Custom_url { model_id; base_url }
   | Some (provider_name, model_id) ->
-    (* Registry is the SSOT. We never override its [kind] from a
-       substring of [provider_name] or [model_id]. If the registry
-       says [Gemini], it is [Gemini] — even if the model id happens
-       to look OpenAI-compat, and vice versa. *)
-    let registry = Llm_provider.Provider_registry.default () in
-    match Llm_provider.Provider_registry.find registry provider_name with
-    | Some entry ->
-      Registered
-        {
-          provider_name;
-          model_id;
-          kind = entry.defaults.kind;
-        }
-    | None ->
-      Unknown
-        (Printf.sprintf
-           "unknown provider %S in spec %S; not found in Provider_registry"
-           provider_name spec)
+    (match resolve_builtin_provider provider_name model_id with
+     | Some resolution -> resolution
+     | None ->
+       (* Registry is the SSOT for pinned providers. We never override its
+          [kind] from a substring of [provider_name] or [model_id].
+          A small number of repo-local compatibility providers such as
+          [kimi] are handled above until the pinned OAS registry exposes
+          them first-class. *)
+       let registry = Llm_provider.Provider_registry.default () in
+       match Llm_provider.Provider_registry.find registry provider_name with
+       | Some entry ->
+         Registered
+           {
+             provider_name;
+             model_id;
+             kind = entry.defaults.kind;
+           }
+       | None ->
+         Unknown
+           (Printf.sprintf
+              "unknown provider %S in spec %S; not found in Provider_registry"
+              provider_name spec))
 
 let kind_of_spec (spec : string) :
     Llm_provider.Provider_config.provider_kind option =

--- a/lib/provider_kind_resolver.mli
+++ b/lib/provider_kind_resolver.mli
@@ -1,7 +1,9 @@
 (** Sum-typed provider-kind resolver for cascade model specs.
 
     Resolves a ["provider:model"] spec to a {!Provider_config.provider_kind}
-    via the {!Provider_registry} as the single source of truth.
+    via the {!Provider_registry} plus a tiny set of repo-local
+    compatibility shims for providers not yet present in the pinned OAS
+    registry.
 
     This module exists to prevent a recurring anti-pattern where
     callers classify provider kind by substring match (e.g. [String.contains
@@ -19,8 +21,9 @@ type resolution =
       model_id : string;
       kind : Llm_provider.Provider_config.provider_kind;
     }
-      (** The provider prefix is known in {!Provider_registry} and the
-          registry's [kind] is the authoritative classification. *)
+      (** The provider prefix is known either in {!Provider_registry} or
+          via a repo-local compatibility provider, and the returned
+          [kind] is the authoritative classification. *)
   | Custom_url of { model_id : string; base_url : string }
       (** The spec uses the ["custom:model\@url"] form; kind is
           {i by contract} [OpenAI_compat] because that is the protocol
@@ -38,9 +41,10 @@ type resolution =
     Resolution order:
     1. Parse [provider_name:model_id] split (reject empty halves).
     2. If [provider_name = "custom"], delegate to custom-URL parser.
-    3. Otherwise consult {!Provider_registry.find} — the registered
-       [kind] wins. No substring heuristic ever overrides this.
-    4. If the provider name is not in the registry, return [Unknown]
+    3. Otherwise consult built-in compatibility providers, then
+       {!Provider_registry.find}. The registered [kind] wins. No
+       substring heuristic ever overrides this.
+    4. If the provider name is not known there, return [Unknown]
        with a diagnostic. Never silently default to [OpenAI_compat]. *)
 val resolve : string -> resolution
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1092,6 +1092,14 @@ let make_openrouter_provider_cfg ?(model_id = "anthropic/claude-3.5") () =
     ~request_path:entry.defaults.request_path
     ()
 
+let make_kimi_provider_cfg ?(model_id = "kimi-k2.5") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id
+    ~base_url:"https://api.moonshot.ai/v1"
+    ~request_path:"/chat/completions"
+    ()
+
 let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
   let glm = Masc_mcp.Oas_worker_cascade.provider_name_of_config
       (make_glm_provider_cfg ()) in
@@ -1108,6 +1116,14 @@ let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
   Alcotest.(check string) "openrouter provider name" "openrouter" provider_name;
   Alcotest.(check string) "openrouter model label"
     "openrouter:anthropic/claude-3.5" model_label
+
+let test_cascade_provider_labels_detect_kimi_from_model_and_base_url () =
+  let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+      (make_kimi_provider_cfg ()) in
+  let model_label = Masc_mcp.Oas_worker_cascade.model_label_of_config
+      (make_kimi_provider_cfg ()) in
+  Alcotest.(check string) "kimi provider name" "kimi" provider_name;
+  Alcotest.(check string) "kimi model label" "kimi:kimi-k2.5" model_label
 
 let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
@@ -2364,6 +2380,8 @@ let () =
         test_cascade_provider_labels_keep_glm_and_glm_coding_distinct;
       Alcotest.test_case "cascade provider labels preserve registered openai_compat family" `Quick
         test_cascade_provider_labels_preserve_registered_openai_compat_family;
+      Alcotest.test_case "cascade provider labels detect kimi from model/base_url" `Quick
+        test_cascade_provider_labels_detect_kimi_from_model_and_base_url;
       Alcotest.test_case "sdk_error_is_hard_quota detects Gemini CLI wrapper" `Quick
         test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper;
       Alcotest.test_case "sdk_error_is_hard_quota keeps transient network errors false" `Quick

--- a/test/test_provider_kind_resolution.ml
+++ b/test/test_provider_kind_resolution.ml
@@ -8,6 +8,18 @@ module Resolver = Masc_mcp.Provider_kind_resolver
 module Cascade = Masc_mcp.Cascade_config
 module Pk = Llm_provider.Provider_config
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let pp_kind fmt (k : Pk.provider_kind) =
   Format.pp_print_string fmt (Pk.string_of_provider_kind k)
 
@@ -50,6 +62,15 @@ let test_claude_prefix_resolves_to_anthropic () =
     check kind_testable "kind is Anthropic" Pk.Anthropic kind
   | Custom_url _ -> fail "claude: resolved to Custom_url"
   | Unknown msg -> fail ("claude: resolved to Unknown: " ^ msg)
+
+let test_kimi_prefix_resolves_to_openai_compat () =
+  match Resolver.resolve "kimi:kimi-for-coding" with
+  | Registered { provider_name; model_id; kind } ->
+    check string "provider_name" "kimi" provider_name;
+    check string "model_id preserved" "kimi-for-coding" model_id;
+    check kind_testable "kind is OpenAI_compat" Pk.OpenAI_compat kind
+  | Custom_url _ -> fail "kimi: resolved to Custom_url"
+  | Unknown msg -> fail ("kimi: resolved to Unknown: " ^ msg)
 
 let test_unknown_vendor_returns_unknown () =
   (* Anti-pattern guard: unknown prefix must NOT fall through to
@@ -111,6 +132,20 @@ let test_cascade_parse_unknown_returns_none () =
   | None -> ()
   | Some _ -> fail "unknown provider should parse to None, not a fallback config"
 
+let test_cascade_parse_kimi_legacy_alias_maps_to_k2_5 () =
+  with_env "MOONSHOT_API_KEY" (Some "dummy-key") (fun () ->
+      match Cascade.parse_model_string "kimi:kimi-for-coding" with
+      | None -> fail "kimi legacy alias should parse when MOONSHOT_API_KEY is set"
+      | Some cfg ->
+        check kind_testable "cfg.kind is OpenAI_compat"
+          Pk.OpenAI_compat cfg.kind;
+        check string "legacy alias normalized to current Kimi model"
+          "kimi-k2.5" cfg.model_id;
+        check string "Moonshot request path"
+          "/chat/completions" cfg.request_path;
+        check string "Moonshot base url"
+          "https://api.moonshot.ai/v1" cfg.base_url)
+
 (* ────────────────────────────────────────────────────────────────── *)
 (* Suite                                                              *)
 (* ────────────────────────────────────────────────────────────────── *)
@@ -123,6 +158,8 @@ let () =
         test_case "openrouter: -> OpenAI_compat; openai: -> Unknown" `Quick
           test_openai_compat_prefix_not_misrouted;
         test_case "claude: -> Anthropic" `Quick test_claude_prefix_resolves_to_anthropic;
+        test_case "kimi: -> OpenAI_compat" `Quick
+          test_kimi_prefix_resolves_to_openai_compat;
         test_case "unknown vendor -> Unknown (no OpenAI_compat fallback)" `Quick
           test_unknown_vendor_returns_unknown;
         test_case "malformed spec -> Unknown" `Quick test_malformed_spec_returns_unknown;
@@ -134,6 +171,8 @@ let () =
       [
         test_case "parse_model_string preserves Gemini kind (#8159)" `Quick
           test_cascade_parse_gemini_preserves_kind;
+        test_case "parse_model_string maps legacy Kimi alias to kimi-k2.5" `Quick
+          test_cascade_parse_kimi_legacy_alias_maps_to_k2_5;
         test_case "parse_model_string(unknown) = None" `Quick
           test_cascade_parse_unknown_returns_none;
       ]


### PR DESCRIPTION
## Summary
- bump the OAS pin to upstream main fde9cae9 and sync generated pin docs
- accept upstream Kimi and Kimi_cli provider kinds across MASC adapter and worker surfaces
- keep the existing Moonshot compatibility lane for legacy kimi:kimi-for-coding configs and cover it with regression tests

## Why
The OAS bump that adds first-class Kimi support also extends provider_kind. Without the downstream MASC updates, the new pin breaks exhaustiveness checks and the build fails before the new runtime can be used.

## Validation
- bash scripts/check-oas-pin.sh --local-only
- dune build --root . _build/default/test/test_provider_kind_resolution.exe _build/default/test/test_oas_worker.exe _build/default/bin/main_eio.exe
- ./_build/default/test/test_provider_kind_resolution.exe
- ./_build/default/test/test_oas_worker.exe test cascade_config 13

## Notes
- doctor config --json did not complete in this shell environment, so live-config end-to-end validation is still pending.
- The Moonshot compatibility shim is intentionally retained for backward compatibility with older live cascade configs.