### PR TITLE
fix(provider): exhaustive match in docker_auth_env_keys_of_provider_config

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1108,7 +1108,13 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
     if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then []
     else auth_env_keys_of_provider_kind cfg.kind
   | Llm_provider.Provider_config.Gemini -> [ gemini_api_key_env ]
-  | _ -> auth_env_keys_of_provider_kind cfg.kind
+  | Llm_provider.Provider_config.Anthropic
+  | Llm_provider.Provider_config.Ollama
+  | Llm_provider.Provider_config.Gemini_cli
+  | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.Claude_code
+  | Llm_provider.Provider_config.Codex_cli ->
+      auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =
   direct_adapters


### PR DESCRIPTION
## Summary
- Replace `_ ->` wildcard with all 6 remaining `provider_kind` constructors in `docker_auth_env_keys_of_provider_config`
- Ensures compiler error when new provider kind is added instead of silently delegating to `auth_env_keys_of_provider_kind`

## Why
Docker sandbox auth key resolution should never silently fall through. New providers must explicitly decide whether they need special handling (like OpenAI_compat's loopback check or Gemini's fixed env key).

## Test plan
- [x] `dune build` — our file compiles clean (pre-existing OAS pin error on main unrelated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)