### PR TITLE
prompt(keeper): dual ALLOWED/DENIED labels and same-turn clone+worktree

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -61,9 +61,11 @@ Workspace:
 - Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{sandbox_repos}/{repo}/` automatically.
 - Worktrees: live inside clones at `repos/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
 
-Clone-then-worktree rule (two turns, never one):
-1. If `repos/` is empty, clone first: `keeper_shell op=git_clone url=...`
-2. NEXT turn only: `masc_worktree_create task_id=<id>` (targets first clone alphabetically, or pass `repo_name=<dir>` to pick a specific one)
+Clone-then-worktree (one turn is fine when the task is clear):
+1. If `repos/` is empty AND the task names a repo under ALLOWED (and not DENIED — see <world>): call `keeper_shell op=git_clone url=...` first.
+2. In the SAME turn, call `masc_worktree_create task_id=<id>` (targets first clone alphabetically, or pass `repo_name=<dir>` to pick a specific one). `masc_worktree_create` scans `repos/` at call time, so the clone you just issued is visible.
+3. If the clone tool result is `ok: false`, STOP — do not proceed to worktree_create. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
+4. Do NOT split this into two separate turns just to "wait and see" — turns are budgeted, and the clone result is already in the same turn's tool_result before the next call.
 
 PR workflow (Coding/Delivery/Full preset required):
 1. `masc_worktree_create task_id=<id>` — opens isolated branch

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -41,10 +41,24 @@ Including a host storage prefix causes path doubling errors. The tool maps your 
 
 ## Project
 
-- Clone targets are restricted by `config/tool_policy.toml` `[git_clone]`.
-- Allowed orgs (runtime): {{allowed_orgs}}
-- Denied repos (runtime): {{denied_repos}}
-- Never invent an org/repo outside the allowed list. The task you claim tells you which repo to work in; if unclear, ask on the board before cloning.
+Clone targets are controlled by `config/tool_policy.toml` `[git_clone]`.
+Two lists combine as **ALLOWED minus DENIED** — read both carefully.
+
+GIT CLONE POLICY:
+- ALLOWED — you MAY clone any repository under these orgs: {{allowed_orgs}}
+- DENIED  — you MUST NOT clone these specific repositories: {{denied_repos}}
+
+Worked examples (assuming a single allowed org `jeong-sik` and a single denied repo `jeong-sik/me`):
+- `git clone https://github.com/jeong-sik/masc-mcp`   → ALLOWED (org in list, repo not denied)
+- `git clone https://github.com/jeong-sik/daw-mcp`    → ALLOWED (same reason)
+- `git clone https://github.com/jeong-sik/me`         → DENIED (repo explicitly denied)
+- `git clone https://github.com/anthropics/sdk`       → DENIED (org not in ALLOWED)
+
+Reading the policy:
+- `allowed_orgs` names the orgs you are *entitled to* clone from, not orgs you must ask permission for. If the task you claim names a repo under ALLOWED (and not in DENIED), clone it directly.
+- Only ask the board when the task does not name a repo and you cannot infer one from context. Do NOT post a "may I clone?" board question when the task already names a repo that passes the ALLOWED/DENIED check.
+
+Never invent an org or repo that is not in ALLOWED.
 
 ## Environment
 


### PR DESCRIPTION
## Summary

keeper 들이 실제로 `git clone` 을 하지 못하는 원인 중 **비결정론(LLM prompt 해석) 축**을 수정합니다.

## Evidence (실측 근거)

운영 중 3 keeper (masc-improver, sojin, sangsu) 의 `.masc/keepers/*.decisions.jsonl` 을 읽으면 다음 3 가지 오독 패턴이 반복 기록됨:

| 오독 | 증거 |
|------|------|
| **N1** `allowed_orgs=["jeong-sik"]` → "jeong-sik 만 금지" 라는 EXCLUSION 해석 | sojin decisions: *"git_clone blocked(allowed org: jeong-sik만)"* — 자기 엔티틀먼트에 대해 스스로 차단 |
| **N2** "if unclear ask on the board before cloning" 이 dominant signal 로 작용, 명확한 ALLOWED 매치에서도 board 대기 | keeper 들이 task 에 repo 가 명시돼도 board-ask 단계에서 멈춤 |
| **N3** "Clone-then-worktree (two turns, never one)" 이 1 턴 완결 가능한 작업을 2 턴으로 찢어 예산 소진 | repos/ 비었을 때만 clone 트리거가 발동하므로 첫 턴에 멈추면 영구 멈춤 |

## Fixes

### `keeper.world.md` — `## Project` 섹션 재작성
- Dual-labeled **GIT CLONE POLICY** 블록 (ALLOWED / DENIED 명시).
- 4 개 worked example — ALLOWED 2 개 + DENIED 2 개 모두 보여서 '리스트의 의미' 를 양방향으로 학습시킴.
- \"`allowed_orgs` 는 '내가 clone 해도 되는 org' 이지 '허락을 구해야 하는 org' 가 아니다\" 명시.
- \"task 가 ALLOWED 레포를 명시하면 board 에 먼저 묻지 말고 clone 하라\" 명시.

### `keeper.capabilities.md` — clone-then-worktree 규칙 전환
- \"two turns, never one\" → \"**one turn is fine when the task is clear**\"
- clone 의 tool_result 가 같은 턴의 다음 tool call 이전에 이미 보이므로 2턴 분할은 무의미.
- 단, `clone ok: false` 이면 STOP (worktree_create 진행 금지) — safety 유지.
- \"turn 을 '대기하고 관망' 하려고 쪼개지 말라\" 명시.

## Scope

| 변경 | 파일 |
|------|------|
| Project 섹션 (ALLOWED/DENIED + 예제) | `config/prompts/keeper.world.md` |
| clone-then-worktree 규칙 | `config/prompts/keeper.capabilities.md` |

`template_variables` frontmatter 변경 없음 (기존 `[allowed_orgs, denied_repos]` 유지). 기존 test assertion substring (`sandbox_repos`, `keeper_bash cmd='git status'`, 등) 모두 유지.

## Related

- 선행: #9280 (sandbox profile 2-mode) — 결정론 축 정리
- 후속: Memory guard PR (`policy_hash` + stale plane) — 메모리 축 정리

이 세 PR 이 합쳐 keeper 의 `git clone` 부재 원인을 결정론/비결정론/메모리 3 축 전부에서 처리합니다.

## Test plan

- [x] Local `@lib/keeper/check` green
- [x] `test_keeper_unified.ml :: test_world_prompt_distinguishes_sandbox_and_worktree` substring 유지 확인
- [x] `test_keeper_unified.ml :: test_capabilities_prompt_distinguishes_sandbox_and_worktree` substring 유지 확인
- [ ] CI full `dune runtest`
- [ ] 운영 환경 재배포 후 3 keeper 의 다음 24h decisions.jsonl 에 \"git_clone blocked(allowed org...)\" 오독이 없는지 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)