### PR TITLE
fix(types): exhaustive GADT matches in typed_state start/complete

### DIFF
--- a/lib/types/typed_state.ml
+++ b/lib/types/typed_state.ml
@@ -36,7 +36,7 @@ let start (type p) (status : p task_status_t) : active task_status_t =
   | PClaimed { assignee; _ } ->
     let started_at = Types_core.now_iso () in
     PInProgress { assignee; started_at }
-  | _ ->
+  | PTodo | PInProgress _ | PDone _ | PCancelled _ ->
     let started_at = Types_core.now_iso () in
     PInProgress { assignee = "unknown"; started_at }
 
@@ -44,7 +44,7 @@ let complete (type p) (status : p task_status_t) ~notes : terminal task_status_t
   let assignee = match status with
     | PClaimed { assignee; _ } -> assignee
     | PInProgress { assignee; _ } -> assignee
-    | _ -> "unknown"
+    | PTodo | PDone _ | PCancelled _ -> "unknown"
   in
   let completed_at = Types_core.now_iso () in
   PDone { assignee; completed_at; notes }


### PR DESCRIPTION
## Summary
- Replace two `_ ->` wildcards in GADT phantom-typed `task_status_t` with explicit constructors
- `start`: `| PTodo | PInProgress _ | PDone _ | PCancelled _ ->` fallback branch
- `complete`: `| PTodo | PDone _ | PCancelled _ ->` assignee extraction branch

## Why
GADT `_ ->` silently matches any future phantom-typed constructors (e.g. `PAwaitingVerification`),
bypassing the compile-time safety that phantom types provide. Listing constructors explicitly
ensures the compiler will error if new variants are added.

## Test plan
- [x] `dune build` passes (exit 0)
- [ ] Zero behavior change — same runtime paths, just exhaustive

🤖 Generated with [Claude Code](https://claude.com/claude-code)