### PR TITLE
[codex] Add bonsai keepers directory parity

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -132,6 +132,10 @@ let () =
   Dashboard_bonsai_lib.Logs_fetch.start_polling ();
   Dashboard_bonsai_lib.Keepers_fetch.run ();
   Dashboard_bonsai_lib.Keepers_fetch.start_polling ();
+  Dashboard_bonsai_lib.Directory_execution_fetch.run ();
+  Dashboard_bonsai_lib.Directory_execution_fetch.start_polling ();
+  Dashboard_bonsai_lib.Directory_mission_fetch.run ();
+  Dashboard_bonsai_lib.Directory_mission_fetch.start_polling ();
   Dashboard_bonsai_lib.Archive_runs_fetch.run ();
   Dashboard_bonsai_lib.Archive_runs_fetch.start_polling ();
   Dashboard_bonsai_lib.Overview_fetch.run ();

--- a/dashboard_bonsai/src/directory_execution_fetch.ml
+++ b/dashboard_bonsai/src/directory_execution_fetch.ml
@@ -1,0 +1,28 @@
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/dashboard/execution"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Directory_execution_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Directory_execution_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:5000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/directory_execution_types.ml
+++ b/dashboard_bonsai/src/directory_execution_types.ml
@@ -1,0 +1,135 @@
+open! Core
+
+type diagnostic =
+  { health_state : string option
+  ; continuity_state : string option
+  ; last_error : string option
+  ; summary : string option
+  ; keepalive_running : bool option
+  }
+
+type keeper =
+  { name : string
+  ; agent_name : string option
+  ; status : string
+  ; phase : string option
+  ; pipeline_stage : string option
+  ; paused : bool option
+  ; model : string option
+  ; active_model : string option
+  ; active_model_label : string option
+  ; last_model_used : string option
+  ; last_model_used_label : string option
+  ; context_ratio : float option
+  ; context_tokens : int option
+  ; context_max : int option
+  ; generation : int option
+  ; turn_count : int option
+  ; last_turn_ago_s : float option
+  ; last_autonomous_action_at : string option
+  ; last_heartbeat : string option
+  ; keepalive_running : bool option
+  ; runtime_blocker_class : string option
+  ; runtime_blocker_summary : string option
+  ; runtime_blocker_continue_gate : bool option
+  ; last_blocker : string option
+  ; diagnostic : diagnostic option
+  }
+
+type response =
+  { generated_at : string
+  ; keepers : keeper list
+  }
+
+let fixture : response = { generated_at = ""; keepers = [] }
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let string_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s ->
+    let trimmed = String.strip s in
+    if String.is_empty trimmed then None else Some trimmed
+  | _ -> None
+;;
+
+let int_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> Some i
+  | `Intlit s -> Option.try_with (fun () -> Int.of_string s)
+  | _ -> None
+;;
+
+let float_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> Some f
+  | `Int i -> Some (Float.of_int i)
+  | `Intlit s -> Option.try_with (fun () -> Float.of_string s)
+  | _ -> None
+;;
+
+let bool_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> Some b
+  | _ -> None
+;;
+
+let list_field f json key =
+  match Yojson.Safe.Util.member key json with
+  | `List xs -> List.map xs ~f
+  | _ -> []
+;;
+
+let diagnostic_of_yojson json =
+  match json with
+  | `Null -> None
+  | _ ->
+    Some
+      { health_state = string_opt_field json "health_state"
+      ; continuity_state = string_opt_field json "continuity_state"
+      ; last_error = string_opt_field json "last_error"
+      ; summary = string_opt_field json "summary"
+      ; keepalive_running = bool_opt_field json "keepalive_running"
+      }
+;;
+
+let keeper_of_yojson json =
+  { name = string_field json "name"
+  ; agent_name = string_opt_field json "agent_name"
+  ; status = string_field json "status"
+  ; phase = string_opt_field json "phase"
+  ; pipeline_stage = string_opt_field json "pipeline_stage"
+  ; paused = bool_opt_field json "paused"
+  ; model = string_opt_field json "model"
+  ; active_model = string_opt_field json "active_model"
+  ; active_model_label = string_opt_field json "active_model_label"
+  ; last_model_used = string_opt_field json "last_model_used"
+  ; last_model_used_label = string_opt_field json "last_model_used_label"
+  ; context_ratio = float_opt_field json "context_ratio"
+  ; context_tokens = int_opt_field json "context_tokens"
+  ; context_max = int_opt_field json "context_max"
+  ; generation = int_opt_field json "generation"
+  ; turn_count = int_opt_field json "turn_count"
+  ; last_turn_ago_s = float_opt_field json "last_turn_ago_s"
+  ; last_autonomous_action_at = string_opt_field json "last_autonomous_action_at"
+  ; last_heartbeat = string_opt_field json "last_heartbeat"
+  ; keepalive_running = bool_opt_field json "keepalive_running"
+  ; runtime_blocker_class = string_opt_field json "runtime_blocker_class"
+  ; runtime_blocker_summary = string_opt_field json "runtime_blocker_summary"
+  ; runtime_blocker_continue_gate =
+      bool_opt_field json "runtime_blocker_continue_gate"
+  ; last_blocker = string_opt_field json "last_blocker"
+  ; diagnostic =
+      diagnostic_of_yojson (Yojson.Safe.Util.member "diagnostic" json)
+  }
+;;
+
+let response_of_yojson json =
+  { generated_at = string_field json "generated_at"
+  ; keepers = list_field keeper_of_yojson json "keepers"
+  }
+;;

--- a/dashboard_bonsai/src/directory_execution_var.ml
+++ b/dashboard_bonsai/src/directory_execution_var.ml
@@ -1,0 +1,3 @@
+let var : Directory_execution_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Directory_execution_types.fixture
+;;

--- a/dashboard_bonsai/src/directory_mission_fetch.ml
+++ b/dashboard_bonsai/src/directory_mission_fetch.ml
@@ -1,0 +1,28 @@
+open! Core
+open Brr_io
+
+let endpoint = "/api/v1/dashboard/mission"
+
+let parse_and_store (text : Jstr.t) : unit =
+  match Yojson.Safe.from_string (Jstr.to_string text) with
+  | json ->
+    let response = Directory_mission_types.response_of_yojson json in
+    Bonsai.Expert.Var.set Directory_mission_var.var response
+  | exception _ -> ()
+;;
+
+let run () : unit =
+  let open Fut.Result_syntax in
+  let work =
+    let* response = Fetch.url (Jstr.v endpoint) in
+    Fetch.Body.text (Fetch.Response.as_body response)
+  in
+  Fut.await work (function
+    | Ok text -> parse_and_store text
+    | Error _ -> ())
+;;
+
+let start_polling () : unit =
+  let _id : Brr.G.timer_id = Brr.G.set_interval ~ms:5000 run in
+  ()
+;;

--- a/dashboard_bonsai/src/directory_mission_types.ml
+++ b/dashboard_bonsai/src/directory_mission_types.ml
@@ -1,0 +1,140 @@
+open! Core
+
+type agent_brief =
+  { agent_name : string
+  ; display_name : string option
+  ; is_live : bool option
+  ; status : string option
+  ; current_work : string option
+  ; last_activity_at : string option
+  ; last_activity_age_sec : float option
+  ; signal_truth : string option
+  ; evidence_source : string option
+  ; recent_input_preview : string option
+  ; recent_output_preview : string option
+  ; recent_tool_names : string list
+  ; latest_tool_names : string list
+  ; latest_tool_call_count : int option
+  ; tool_audit_source : string option
+  ; tool_audit_at : string option
+  }
+
+type keeper_brief =
+  { name : string
+  ; agent_name : string option
+  ; status : string option
+  ; generation : int option
+  ; context_ratio : float option
+  ; last_turn_ago_s : float option
+  ; current_work : string option
+  ; last_autonomous_action_at : string option
+  ; latest_tool_names : string list
+  ; latest_tool_call_count : int option
+  ; tool_audit_source : string option
+  ; tool_audit_at : string option
+  }
+
+type response =
+  { generated_at : string
+  ; agent_briefs : agent_brief list
+  ; keeper_briefs : keeper_brief list
+  }
+
+let fixture : response =
+  { generated_at = ""; agent_briefs = []; keeper_briefs = [] }
+;;
+
+let string_field ?(default = "") json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
+;;
+
+let string_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `String s ->
+    let trimmed = String.strip s in
+    if String.is_empty trimmed then None else Some trimmed
+  | _ -> None
+;;
+
+let int_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> Some i
+  | `Intlit s -> Option.try_with (fun () -> Int.of_string s)
+  | _ -> None
+;;
+
+let float_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> Some f
+  | `Int i -> Some (Float.of_int i)
+  | `Intlit s -> Option.try_with (fun () -> Float.of_string s)
+  | _ -> None
+;;
+
+let bool_opt_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> Some b
+  | _ -> None
+;;
+
+let string_list_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `List xs ->
+    List.filter_map xs ~f:(function
+      | `String s ->
+        let trimmed = String.strip s in
+        if String.is_empty trimmed then None else Some trimmed
+      | _ -> None)
+  | _ -> []
+;;
+
+let list_field f json key =
+  match Yojson.Safe.Util.member key json with
+  | `List xs -> List.map xs ~f
+  | _ -> []
+;;
+
+let agent_brief_of_yojson json =
+  { agent_name = string_field json "agent_name"
+  ; display_name = string_opt_field json "display_name"
+  ; is_live = bool_opt_field json "is_live"
+  ; status = string_opt_field json "status"
+  ; current_work = string_opt_field json "current_work"
+  ; last_activity_at = string_opt_field json "last_activity_at"
+  ; last_activity_age_sec = float_opt_field json "last_activity_age_sec"
+  ; signal_truth = string_opt_field json "signal_truth"
+  ; evidence_source = string_opt_field json "evidence_source"
+  ; recent_input_preview = string_opt_field json "recent_input_preview"
+  ; recent_output_preview = string_opt_field json "recent_output_preview"
+  ; recent_tool_names = string_list_field json "recent_tool_names"
+  ; latest_tool_names = string_list_field json "latest_tool_names"
+  ; latest_tool_call_count = int_opt_field json "latest_tool_call_count"
+  ; tool_audit_source = string_opt_field json "tool_audit_source"
+  ; tool_audit_at = string_opt_field json "tool_audit_at"
+  }
+;;
+
+let keeper_brief_of_yojson json =
+  { name = string_field json "name"
+  ; agent_name = string_opt_field json "agent_name"
+  ; status = string_opt_field json "status"
+  ; generation = int_opt_field json "generation"
+  ; context_ratio = float_opt_field json "context_ratio"
+  ; last_turn_ago_s = float_opt_field json "last_turn_ago_s"
+  ; current_work = string_opt_field json "current_work"
+  ; last_autonomous_action_at = string_opt_field json "last_autonomous_action_at"
+  ; latest_tool_names = string_list_field json "latest_tool_names"
+  ; latest_tool_call_count = int_opt_field json "latest_tool_call_count"
+  ; tool_audit_source = string_opt_field json "tool_audit_source"
+  ; tool_audit_at = string_opt_field json "tool_audit_at"
+  }
+;;
+
+let response_of_yojson json =
+  { generated_at = string_field json "generated_at"
+  ; agent_briefs = list_field agent_brief_of_yojson json "agent_briefs"
+  ; keeper_briefs = list_field keeper_brief_of_yojson json "keeper_briefs"
+  }
+;;

--- a/dashboard_bonsai/src/directory_mission_var.ml
+++ b/dashboard_bonsai/src/directory_mission_var.ml
@@ -1,0 +1,3 @@
+let var : Directory_mission_types.response Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create Directory_mission_types.fixture
+;;

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -1,0 +1,1367 @@
+open! Core
+open! Bonsai_web
+open Virtual_dom.Vdom
+
+let selected_name_var : string option Bonsai.Expert.Var.t =
+  Bonsai.Expert.Var.create None
+;;
+
+type source =
+  [ `Runtime
+  | `Mission
+  | `Runtime_and_mission
+  ]
+
+type band =
+  [ `Active
+  | `Attention
+  | `Paused
+  | `Offline
+  ]
+
+type model_meta =
+  { label : string
+  ; display_value : string
+  ; raw_value : string option
+  }
+
+type note =
+  { label : string
+  ; text : string
+  }
+
+type row =
+  { name : string
+  ; agent_name : string option
+  ; source : source
+  ; band : band
+  ; status_label : string
+  ; status_color : Pill.color
+  ; phase_label : string option
+  ; stage_label : string option
+  ; model : model_meta option
+  ; context_pct : int option
+  ; context_detail : string option
+  ; recent_label : string
+  ; recent_value : string
+  ; note : note option
+  ; current_work : string option
+  ; sparse_reasons : string list
+  ; runtime : Directory_execution_types.keeper option
+  ; mission : Directory_mission_types.keeper_brief option
+  ; agent : Directory_mission_types.agent_brief option
+  }
+
+type counts =
+  { total : int
+  ; active : int
+  ; attention : int
+  ; paused : int
+  ; offline : int
+  }
+
+type coverage =
+  { shared : int
+  ; runtime_only : int
+  ; mission_only : int
+  ; raw_models : int
+  ; sparse_rows : int
+  }
+
+module Style =
+[%css
+stylesheet
+  {|
+  .directory {
+    border: 1px solid var(--border-main);
+    background: rgba(14, 10, 8, 0.48);
+    box-shadow: inset 0 0 0 1px rgba(232, 216, 184, 0.03);
+  }
+
+  .head {
+    display: grid;
+    grid-template-columns: 52px minmax(0, 1.1fr) minmax(0, 1.6fr) 176px 96px;
+    gap: 14px;
+    align-items: center;
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba(120, 100, 80, 0.16);
+    background: linear-gradient(180deg, #1c140e, #160f0a);
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .row {
+    position: relative;
+    display: grid;
+    grid-template-columns: 52px minmax(0, 1.1fr) minmax(0, 1.6fr) 176px 96px;
+    gap: 14px;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(120, 100, 80, 0.12);
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+
+  .row:last-child { border-bottom: 0; }
+
+  .row:hover {
+    background: rgba(160, 140, 110, 0.04);
+  }
+
+  .row_selected {
+    background: linear-gradient(90deg, rgba(212, 169, 64, 0.08), transparent 72%);
+  }
+
+  .row_selected::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--accent-brass);
+    box-shadow: 0 0 12px var(--accent-brass);
+  }
+
+  .sigil {
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--accent-brass-dim);
+    background:
+      radial-gradient(circle at 35% 30%, rgba(232, 216, 184, 0.16), transparent 58%),
+      var(--bg-panel-alt, #1b140f);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 16px;
+    letter-spacing: 0.1em;
+    color: var(--text-bright);
+    text-transform: uppercase;
+  }
+
+  .identity,
+  .summary {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .name {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 13px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-bright);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .subline {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    line-height: 1.35;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .summary_k {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .summary_v {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 12px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chip_stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .chip_row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .metric {
+    text-align: right;
+    min-width: 0;
+  }
+
+  .metric_v {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .metric_v_warn { color: var(--accent-brass); }
+  .metric_v_bad { color: var(--accent-blood); }
+
+  .metric_sub {
+    margin-top: 3px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 10px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .vial_fill_warn {
+    background: linear-gradient(90deg, #8a6a20, #d4a940);
+    box-shadow: 0 0 6px rgba(212, 169, 64, 0.35);
+  }
+
+  .vial_fill_bad {
+    background: linear-gradient(90deg, #5a0f0f, #a01818);
+    box-shadow: 0 0 6px rgba(160, 24, 24, 0.35);
+  }
+
+  .meta_strip {
+    margin: 0 0 12px;
+  }
+
+  .note_box {
+    border: 1px solid var(--border-main);
+    background: rgba(14, 10, 8, 0.4);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .note_k {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .note_v {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--text-primary);
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .list_row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .list_k {
+    min-width: 92px;
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .list_v {
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--text-bright);
+    font-variant-numeric: tabular-nums;
+    word-break: break-word;
+  }
+
+  .preview_box {
+    border: 1px solid rgba(120, 100, 80, 0.18);
+    background: rgba(8, 5, 4, 0.42);
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .preview_label {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 9px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+
+  .preview_text {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+  }
+
+  .quiet {
+    padding: 24px 18px;
+    border: 1px dashed var(--border-main);
+    font-family: var(--font-body, 'EB Garamond', serif);
+    font-size: 15px;
+    font-style: italic;
+    color: var(--text-dim);
+    text-align: center;
+  }
+
+  @media (max-width: 1180px) {
+    .head,
+    .row {
+      grid-template-columns: 44px minmax(0, 1fr) minmax(0, 1.1fr) 144px 82px;
+      gap: 10px;
+    }
+  }
+|}]
+
+let normalize_lookup_key value = String.lowercase (String.strip value)
+
+let present value =
+  let trimmed = String.strip value in
+  if String.is_empty trimmed then None else Some trimmed
+;;
+
+let add_first tbl key data =
+  let normalized = normalize_lookup_key key in
+  if not (Hashtbl.mem tbl normalized) then Hashtbl.set tbl ~key:normalized ~data
+;;
+
+let register_lookup tbl candidates data =
+  List.iter candidates ~f:(function
+    | None -> ()
+    | Some candidate ->
+      (match present candidate with
+       | None -> ()
+       | Some key -> add_first tbl key data))
+;;
+
+let short_hhmmss value =
+  if String.length value >= 19 && Char.equal value.[10] 'T'
+  then Printf.sprintf "%s UTC" (String.sub value ~pos:11 ~len:8)
+  else value
+;;
+
+let compact_model_label value =
+  match present value with
+  | None -> None
+  | Some model ->
+    (match String.lsplit2 model ~on:':' with
+     | Some (provider, suffix) ->
+       let suffix = String.strip suffix in
+       if String.is_empty suffix
+       then Some model
+       else if String.Caseless.equal suffix "auto"
+       then
+         let provider =
+           let provider = String.strip provider in
+           let drop suffix_len = String.drop_suffix provider suffix_len in
+           if String.is_suffix ~suffix:"_cli" provider
+           then drop 4
+           else if String.is_suffix ~suffix:"-cli" provider
+           then drop 4
+           else if String.is_suffix ~suffix:"_code" provider
+           then drop 5
+           else if String.is_suffix ~suffix:"-code" provider
+           then drop 5
+           else provider
+         in
+         present provider
+       else Some suffix
+     | None -> Some model)
+;;
+
+let format_compact_int value =
+  let f = Float.of_int value in
+  if value >= 1_000_000
+  then Printf.sprintf "%.1fM" (f /. 1_000_000.0)
+  else if value >= 1000
+  then Printf.sprintf "%.1fK" (f /. 1000.0)
+  else Int.to_string value
+;;
+
+let format_age seconds =
+  let seconds = Int.max 0 (Int.of_float (Float.round seconds)) in
+  if seconds < 90
+  then Printf.sprintf "%ds" seconds
+  else if seconds < 5400
+  then Printf.sprintf "%dm" (seconds / 60)
+  else if seconds < 172800
+  then Printf.sprintf "%dh" (seconds / 3600)
+  else Printf.sprintf "%dd" (seconds / 86400)
+;;
+
+let normalized_eq value target =
+  String.equal (normalize_lookup_key value) (normalize_lookup_key target)
+;;
+
+let is_one_of value values =
+  List.exists values ~f:(fun candidate -> normalized_eq value candidate)
+;;
+
+let phase_label_of_token token =
+  match normalize_lookup_key token with
+  | "running" | "active" -> Some "가동중"
+  | "busy" -> Some "작업중"
+  | "idle" | "listening" -> Some "대기"
+  | "paused" -> Some "일시정지"
+  | "offline" -> Some "오프라인"
+  | "inactive" -> Some "비활성"
+  | "stopped" -> Some "정지"
+  | "unbooted" -> Some "미기동"
+  | "dead" -> Some "종료"
+  | "failing" -> Some "오류중"
+  | "overflowed" -> Some "컨텍스트 초과"
+  | "compacting" -> Some "압축중"
+  | "handoff" | "handingoff" | "handing_off" -> Some "승계중"
+  | "draining" -> Some "종료중"
+  | "crashed" -> Some "중단"
+  | "restarting" -> Some "재시작중"
+  | _ -> present token
+;;
+
+let stage_label_of_token token =
+  match normalize_lookup_key token with
+  | "thinking" -> Some "사고"
+  | "tool_use" -> Some "도구"
+  | "compacting" -> Some "압축"
+  | "handoff" -> Some "승계"
+  | "scheduled_autonomous" -> Some "자율"
+  | "failing" -> Some "오류"
+  | "draining" -> Some "종료"
+  | "paused" -> Some "일시정지"
+  | "crashed" -> Some "중단"
+  | "restarting" -> Some "재시작"
+  | "idle" -> Some "활동 없음"
+  | "offline" -> Some "오프라인"
+  | _ -> present token
+;;
+
+let context_meta
+      (runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+  =
+  let ratio =
+    Option.first_some
+      (Option.bind runtime ~f:(fun row -> row.context_ratio))
+      (Option.bind mission ~f:(fun row -> row.context_ratio))
+  in
+  let pct =
+    Option.map ratio ~f:(fun value ->
+      Int.max 0 (Int.min 100 (Int.of_float (Float.round (value *. 100.0)))))
+  in
+  let detail =
+    match runtime with
+    | Some row ->
+      (match row.context_tokens, row.context_max with
+       | Some tokens, Some max ->
+         Some
+           (Printf.sprintf
+              "%s / %s"
+              (format_compact_int tokens)
+              (format_compact_int max))
+       | Some tokens, None -> Some (format_compact_int tokens)
+       | _ -> None)
+    | None -> None
+  in
+  pct, detail
+;;
+
+let model_meta (runtime : Directory_execution_types.keeper option) =
+  let of_field ~label ~raw =
+    match present raw with
+    | None -> None
+    | Some raw_value ->
+      Some
+        { label
+        ; display_value =
+            Option.value (compact_model_label raw_value) ~default:raw_value
+        ; raw_value = Some raw_value
+        }
+  in
+  match runtime with
+  | None -> None
+  | Some row ->
+    Option.first_some
+      (Option.map
+         (present (Option.value row.last_model_used_label ~default:""))
+         ~f:(fun label ->
+           { label = "최근 모델"; display_value = label; raw_value = None }))
+      (Option.first_some
+         (of_field
+            ~label:"최근 모델"
+            ~raw:(Option.value row.last_model_used ~default:""))
+         (Option.first_some
+            (Option.map
+               (present (Option.value row.active_model_label ~default:""))
+               ~f:(fun label ->
+                 { label = "현재 모델"; display_value = label; raw_value = None }))
+            (Option.first_some
+               (of_field
+                  ~label:"현재 모델"
+                  ~raw:(Option.value row.active_model ~default:""))
+               (of_field
+                  ~label:"모델"
+                  ~raw:(Option.value row.model ~default:"")))))
+;;
+
+let note_meta
+      (runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+      (agent : Directory_mission_types.agent_brief option)
+  =
+  let first_some_note entries =
+    List.find_map entries ~f:(fun (label, value) ->
+      Option.map (present (Option.value value ~default:"")) ~f:(fun text ->
+        { label; text }))
+  in
+  first_some_note
+    [ "최근 차단"
+    , Option.bind runtime ~f:(fun row -> row.runtime_blocker_summary)
+    ; "최근 차단"
+    , Option.bind runtime ~f:(fun row -> row.last_blocker)
+    ; "최근 오류"
+    , Option.bind runtime ~f:(fun row ->
+        Option.bind row.diagnostic ~f:(fun diagnostic -> diagnostic.last_error))
+    ; "현재 작업"
+    , Option.bind mission ~f:(fun row -> row.current_work)
+    ; "최근 출력"
+    , Option.bind agent ~f:(fun row -> row.recent_output_preview)
+    ]
+;;
+
+let recent_meta
+      (runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+      (agent : Directory_mission_types.agent_brief option)
+  =
+  match Option.bind runtime ~f:(fun row -> row.last_turn_ago_s) with
+  | Some seconds -> "최근 턴", format_age seconds
+  | None ->
+    (match Option.bind agent ~f:(fun row -> row.last_activity_age_sec) with
+     | Some seconds -> "최근 활동", format_age seconds
+     | None ->
+       (match Option.bind mission ~f:(fun row -> row.last_turn_ago_s) with
+        | Some seconds -> "최근 턴", format_age seconds
+        | None ->
+          (match Option.bind mission ~f:(fun row -> row.tool_audit_at) with
+           | Some timestamp -> "최근 audit", short_hhmmss timestamp
+           | None ->
+             (match Option.bind runtime ~f:(fun row -> row.last_heartbeat) with
+              | Some timestamp -> "최근 heartbeat", short_hhmmss timestamp
+              | None -> "최근성", "기록 없음"))))
+;;
+
+let current_work
+      (_runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+      (agent : Directory_mission_types.agent_brief option)
+  =
+  Option.first_some
+    (Option.bind mission ~f:(fun row -> row.current_work))
+    (Option.bind agent ~f:(fun row -> row.current_work))
+;;
+
+let runtime_has_attention (runtime : Directory_execution_types.keeper) =
+  let phase_attention =
+    Option.exists runtime.phase ~f:(fun value ->
+      is_one_of
+        value
+        [ "failing"
+        ; "overflowed"
+        ; "compacting"
+        ; "handoff"
+        ; "handingoff"
+        ; "handing_off"
+        ; "draining"
+        ; "crashed"
+        ; "restarting"
+        ])
+  in
+  let stage_attention =
+    Option.exists runtime.pipeline_stage ~f:(fun value ->
+      is_one_of
+        value
+        [ "failing"
+        ; "compacting"
+        ; "handoff"
+        ; "draining"
+        ; "crashed"
+        ; "restarting"
+        ])
+  in
+  let degraded =
+    Option.exists runtime.diagnostic ~f:(fun diagnostic ->
+      Option.exists diagnostic.health_state ~f:(fun value ->
+        is_one_of value [ "degraded"; "warning"; "critical" ])
+      || Option.exists diagnostic.continuity_state ~f:(fun value ->
+        is_one_of value [ "recovering"; "warning"; "critical" ]))
+  in
+  let has_blocker =
+    List.exists
+      [ runtime.runtime_blocker_summary
+      ; runtime.last_blocker
+      ; Option.bind runtime.diagnostic ~f:(fun diagnostic -> diagnostic.last_error)
+      ]
+      ~f:Option.is_some
+  in
+  let high_ctx =
+    Option.value_map runtime.context_ratio ~default:false ~f:(fun ratio ->
+      Float.(ratio >= 0.95))
+  in
+  phase_attention || stage_attention || degraded || has_blocker || high_ctx
+;;
+
+let runtime_is_offline
+      (runtime : Directory_execution_types.keeper)
+      (_mission : Directory_mission_types.keeper_brief option)
+      (_agent : Directory_mission_types.agent_brief option)
+  =
+  List.exists
+    [ Some runtime.status
+    ; runtime.phase
+    ; Option.bind runtime.diagnostic ~f:(fun diagnostic -> diagnostic.health_state)
+    ; Option.bind runtime.diagnostic ~f:(fun diagnostic -> diagnostic.continuity_state)
+    ]
+    ~f:(function
+      | None -> false
+      | Some value ->
+        is_one_of value [ "offline"; "inactive"; "stopped"; "dead"; "not_running" ])
+;;
+
+let band_of_row
+      (runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+      (agent : Directory_mission_types.agent_brief option)
+  =
+  let is_paused =
+    Option.value_map runtime ~default:false ~f:(fun row ->
+      Option.value row.paused ~default:false
+      || is_one_of row.status [ "paused" ]
+      || Option.exists row.phase ~f:(fun value -> is_one_of value [ "paused" ]))
+    || Option.exists mission ~f:(fun row ->
+      Option.exists row.status ~f:(fun value -> is_one_of value [ "paused" ]))
+  in
+  if is_paused
+  then `Paused
+  else (
+    match runtime with
+    | Some row ->
+      if runtime_is_offline row mission agent
+      then `Offline
+      else if runtime_has_attention row
+      then `Attention
+      else `Active
+    | None ->
+      if Option.exists mission ~f:(fun row ->
+        Option.exists row.status ~f:(fun value ->
+          is_one_of value [ "offline"; "inactive"; "stopped" ]))
+         || Option.exists agent ~f:(fun row ->
+           Option.exists row.status ~f:(fun value ->
+             is_one_of value [ "offline"; "inactive"; "stopped" ]))
+      then `Offline
+      else if Option.exists agent ~f:(fun row ->
+        Option.exists row.signal_truth ~f:(fun value ->
+          is_one_of value [ "stale"; "archived" ]))
+      then `Attention
+      else `Active)
+;;
+
+let status_meta
+      (runtime : Directory_execution_types.keeper option)
+      (mission : Directory_mission_types.keeper_brief option)
+      (band : band)
+  =
+  let phase_label =
+    Option.first_some
+      (Option.bind runtime ~f:(fun row -> Option.bind row.phase ~f:phase_label_of_token))
+      (Option.bind runtime ~f:(fun row -> phase_label_of_token row.status))
+  in
+  let has_error_note =
+    Option.value_map runtime ~default:false ~f:(fun row ->
+      List.exists
+        [ row.runtime_blocker_summary
+        ; row.last_blocker
+        ; Option.bind row.diagnostic ~f:(fun diagnostic -> diagnostic.last_error)
+        ]
+        ~f:Option.is_some)
+  in
+  let status_label, status_color =
+    match band with
+    | `Paused -> "일시정지", `Paused
+    | `Offline ->
+      let generation =
+        Option.first_some
+          (Option.bind runtime ~f:(fun row -> row.generation))
+          (Option.bind mission ~f:(fun row -> row.generation))
+      in
+      let turn_count = Option.bind runtime ~f:(fun row -> row.turn_count) in
+      let had_activity =
+        Option.is_some (Option.bind runtime ~f:(fun row -> row.last_turn_ago_s))
+        || Option.is_some (Option.bind mission ~f:(fun row -> row.last_turn_ago_s))
+        || Option.exists generation ~f:(fun value -> value > 0)
+        || Option.exists turn_count ~f:(fun value -> value > 0)
+      in
+      let label =
+        if not had_activity
+        then "미기동"
+        else if Option.exists runtime ~f:(fun row ->
+          Option.exists row.keepalive_running ~f:not)
+        then "오프라인"
+        else "정지"
+      in
+      label, `Neutral
+    | `Attention ->
+      let label =
+        if has_error_note
+        then "활동 오류"
+        else Option.value phase_label ~default:"주의 필요"
+      in
+      let color = if has_error_note then `Bad else `Warn in
+      label, color
+    | `Active ->
+      (match Option.bind runtime ~f:(fun row -> Option.bind row.pipeline_stage ~f:stage_label_of_token) with
+       | Some stage when not (String.equal stage "활동 없음") -> stage, `Ok
+       | _ -> "가동중", `Ok)
+  in
+  phase_label, status_label, status_color
+;;
+
+let source_of_row runtime mission =
+  match runtime, mission with
+  | Some _, Some _ -> `Runtime_and_mission
+  | Some _, None -> `Runtime
+  | None, Some _ -> `Mission
+  | None, None -> `Runtime
+;;
+
+let source_label = function
+  | `Runtime_and_mission -> "runtime + mission"
+  | `Runtime -> "runtime only"
+  | `Mission -> "mission only"
+;;
+
+let source_short = function
+  | `Runtime_and_mission -> "rt+ms"
+  | `Runtime -> "rt"
+  | `Mission -> "ms"
+;;
+
+let row_sigil name =
+  if String.is_empty name
+  then "·"
+  else Char.to_string (Char.uppercase name.[0])
+;;
+
+let build_rows
+      ~(keepers : Keepers_types.response)
+      (execution : Directory_execution_types.response)
+      (mission : Directory_mission_types.response)
+  : row list
+  =
+  let runtime_tbl = Hashtbl.create (module String) in
+  let mission_tbl = Hashtbl.create (module String) in
+  let agent_tbl = Hashtbl.create (module String) in
+  List.iter execution.keepers ~f:(fun row ->
+    register_lookup runtime_tbl [ Some row.name; row.agent_name ] row);
+  List.iter mission.keeper_briefs ~f:(fun row ->
+    register_lookup mission_tbl [ Some row.name; row.agent_name ] row);
+  List.iter mission.agent_briefs ~f:(fun row ->
+    register_lookup agent_tbl [ Some row.agent_name; row.display_name ] row);
+  let all_names =
+    List.concat
+      [ List.map keepers.keepers ~f:(fun row -> row.name)
+      ; List.map execution.keepers ~f:(fun row -> row.name)
+      ; List.map mission.keeper_briefs ~f:(fun row -> row.name)
+      ]
+  in
+  let seen = Hash_set.create (module String) in
+  List.filter_map all_names ~f:(fun raw_name ->
+    match present raw_name with
+    | None -> None
+    | Some lookup_name ->
+      let normalized = normalize_lookup_key lookup_name in
+      if Hash_set.mem seen normalized
+      then None
+      else (
+        Hash_set.add seen normalized;
+        let runtime = Hashtbl.find runtime_tbl normalized in
+        let mission_keeper = Hashtbl.find mission_tbl normalized in
+        match runtime, mission_keeper with
+        | None, None -> None
+        | _ ->
+          let name =
+            match runtime, mission_keeper with
+            | Some row, _ -> row.name
+            | None, Some row -> row.name
+            | None, None -> lookup_name
+          in
+          let agent_name =
+            Option.first_some
+              (Option.bind runtime ~f:(fun row -> row.agent_name))
+              (Option.bind mission_keeper ~f:(fun row -> row.agent_name))
+          in
+          let agent =
+            List.find_map
+              [ agent_name; Some name ]
+              ~f:(fun key ->
+                Option.bind key ~f:(fun value ->
+                  Hashtbl.find agent_tbl (normalize_lookup_key value)))
+          in
+          let source = source_of_row runtime mission_keeper in
+          let band = band_of_row runtime mission_keeper agent in
+          let phase_label, status_label, status_color =
+            status_meta runtime mission_keeper band
+          in
+          let stage_label =
+            Option.bind runtime ~f:(fun row ->
+              Option.bind row.pipeline_stage ~f:stage_label_of_token)
+          in
+          let context_pct, context_detail = context_meta runtime mission_keeper in
+          let recent_label, recent_value = recent_meta runtime mission_keeper agent in
+          let model = model_meta runtime in
+          let note = note_meta runtime mission_keeper agent in
+          let current_work = current_work runtime mission_keeper agent in
+          let sparse_reasons =
+            List.filter_opt
+              [ (match runtime with
+                 | None -> Some "runtime 없음"
+                 | Some _ -> None)
+              ; (match mission_keeper with
+                 | None -> Some "mission brief 없음"
+                 | Some _ -> None)
+              ; (match agent with
+                 | None -> Some "agent brief 없음"
+                 | Some _ -> None)
+              ; (match model with
+                 | Some { raw_value = Some _; _ } -> Some "display label 미해결(raw)"
+                 | _ -> None)
+              ]
+          in
+          Some
+            { name
+            ; agent_name
+            ; source
+            ; band
+            ; status_label
+            ; status_color
+            ; phase_label
+            ; stage_label
+            ; model
+            ; context_pct
+            ; context_detail
+            ; recent_label
+            ; recent_value
+            ; note
+            ; current_work
+            ; sparse_reasons
+            ; runtime
+            ; mission = mission_keeper
+            ; agent
+            }))
+;;
+
+let counts rows =
+  List.fold rows ~init:{ total = 0; active = 0; attention = 0; paused = 0; offline = 0 }
+    ~f:(fun acc row ->
+      match row.band with
+      | `Active ->
+        { acc with total = acc.total + 1; active = acc.active + 1 }
+      | `Attention ->
+        { acc with total = acc.total + 1; attention = acc.attention + 1 }
+      | `Paused ->
+        { acc with total = acc.total + 1; paused = acc.paused + 1 }
+      | `Offline ->
+        { acc with total = acc.total + 1; offline = acc.offline + 1 })
+;;
+
+let coverage rows =
+  List.fold rows
+    ~init:{ shared = 0; runtime_only = 0; mission_only = 0; raw_models = 0; sparse_rows = 0 }
+    ~f:(fun acc row ->
+      let shared, runtime_only, mission_only =
+        match row.source with
+        | `Runtime_and_mission -> acc.shared + 1, acc.runtime_only, acc.mission_only
+        | `Runtime -> acc.shared, acc.runtime_only + 1, acc.mission_only
+        | `Mission -> acc.shared, acc.runtime_only, acc.mission_only + 1
+      in
+      let raw_models =
+        match row.model with
+        | Some { raw_value = Some _; _ } -> acc.raw_models + 1
+        | _ -> acc.raw_models
+      in
+      let sparse_rows =
+        if List.is_empty row.sparse_reasons
+        then acc.sparse_rows
+        else acc.sparse_rows + 1
+      in
+      { shared; runtime_only; mission_only; raw_models; sparse_rows })
+;;
+
+let default_selected_name rows =
+  List.find_map rows ~f:(fun row ->
+    match row.band with
+    | `Active | `Attention -> Some row.name
+    | `Paused | `Offline -> None)
+  |> Option.first_some (List.hd rows |> Option.map ~f:(fun row -> row.name))
+;;
+
+let selected_row rows selected_name =
+  let chosen_name =
+    match selected_name with
+    | Some name when List.exists rows ~f:(fun row -> String.equal row.name name) ->
+      Some name
+    | _ -> default_selected_name rows
+  in
+  Option.bind chosen_name ~f:(fun name ->
+    List.find rows ~f:(fun row -> String.equal row.name name))
+;;
+
+let row_click_effect name =
+  Attr.on_click (fun _ ->
+    Effect.of_sync_fun
+      (fun () -> Bonsai.Expert.Var.set selected_name_var (Some name))
+      ())
+;;
+
+let context_class pct =
+  match pct with
+  | Some value when value >= 95 -> Style.metric_v_bad
+  | Some value when value >= 80 -> Style.metric_v_warn
+  | _ -> Style.metric_v
+;;
+
+let view_summary_strip
+      ~(rows : row list)
+      ~(execution : Directory_execution_types.response)
+      ~(mission : Directory_mission_types.response)
+  =
+  let execution_generated_at =
+    let open Directory_execution_types in
+    execution.generated_at
+  in
+  let mission_generated_at =
+    let open Directory_mission_types in
+    mission.generated_at
+  in
+  let summary = coverage rows in
+  Meta.strip
+    [ Meta.cell
+        ~color:
+          (if String.is_empty execution_generated_at then `Default else `Ok)
+        ~k:"runtime snapshot"
+        ~v:
+          (if String.is_empty execution_generated_at
+           then "pending"
+           else short_hhmmss execution_generated_at)
+        ()
+    ; Meta.cell
+        ~color:
+          (if String.is_empty mission_generated_at then `Default else `Ok)
+        ~k:"mission snapshot"
+        ~v:
+          (if String.is_empty mission_generated_at
+           then "pending"
+           else short_hhmmss mission_generated_at)
+        ()
+    ; Meta.cell
+        ~color:(if summary.shared > 0 then `Brass else `Default)
+        ~k:"coverage"
+        ~v:
+          (Printf.sprintf
+             "%d shared · %d rt · %d ms"
+             summary.shared
+             summary.runtime_only
+             summary.mission_only)
+        ()
+    ; Meta.cell
+        ~color:(if summary.raw_models > 0 then `Brass else `Default)
+        ~k:"raw model"
+        ~v:(Printf.sprintf "%d unresolved" summary.raw_models)
+        ()
+    ; Meta.cell
+        ~color:(if summary.sparse_rows > 0 then `Blood else `Default)
+        ~k:"sparse rows"
+        ~v:(Printf.sprintf "%d rows" summary.sparse_rows)
+        ()
+    ]
+;;
+
+let view
+      ~(rows : row list)
+      ~(selected_name : string option)
+  : Node.t
+  =
+  match rows with
+  | [] ->
+    Node.div
+      ~attrs:[ Style.quiet ]
+      [ Node.text
+          "runtime/mission snapshot이 아직 조용합니다. keepers summary만 먼저 올라왔을 가능성이 있습니다."
+      ]
+  | _ ->
+    let selected = selected_row rows selected_name in
+    Node.div
+      ~attrs:[ Style.directory ]
+      ([ Node.div
+           ~attrs:[ Style.head ]
+           [ Node.div [ Node.text "Sigil" ]
+           ; Node.div [ Node.text "Keeper" ]
+           ; Node.div [ Node.text "Brief" ]
+           ; Node.div [ Node.text "State" ]
+           ; Node.div ~attrs:[ Style.metric ] [ Node.text "Recent" ]
+           ]
+       ]
+       @ List.map rows ~f:(fun row ->
+         let is_selected =
+           Option.exists selected ~f:(fun current ->
+             String.equal current.name row.name)
+         in
+         let subtitle_bits =
+           List.filter_opt
+             [ row.agent_name
+             ; Option.map row.model ~f:(fun model ->
+                 let suffix =
+                   match model.raw_value with
+                   | Some _ -> " raw"
+                   | None -> ""
+                 in
+                 Printf.sprintf
+                   "%s %s%s"
+                   model.label
+                   model.display_value
+                   suffix)
+             ; Some (source_short row.source)
+             ]
+         in
+         let summary_k, summary_v =
+           match row.note with
+           | Some note -> note.label, note.text
+           | None ->
+             "현재 작업"
+             , Option.value
+                 row.current_work
+                 ~default:"mission/runtime note가 아직 없습니다."
+         in
+         let row_attrs =
+           [ Style.row
+           ; row_click_effect row.name
+           ]
+           @ if is_selected then [ Style.row_selected ] else []
+         in
+         Node.div
+           ~attrs:row_attrs
+           [ Node.div ~attrs:[ Style.sigil ] [ Node.text (row_sigil row.name) ]
+           ; Node.div
+               ~attrs:[ Style.identity ]
+               [ Node.div ~attrs:[ Style.name ] [ Node.text row.name ]
+               ; Node.div
+                   ~attrs:[ Style.subline ]
+                   [ Node.text (String.concat ~sep:" · " subtitle_bits) ]
+               ]
+           ; Node.div
+               ~attrs:[ Style.summary ]
+               [ Node.div ~attrs:[ Style.summary_k ] [ Node.text summary_k ]
+               ; Node.div ~attrs:[ Style.summary_v ] [ Node.text summary_v ]
+               ]
+           ; Node.div
+               ~attrs:[ Style.chip_stack ]
+               [ Node.div
+                   ~attrs:[ Style.chip_row ]
+                   [ Pill.view ~size:`Sm ~color:row.status_color
+                       ~label:row.status_label ()
+                   ; Pill.view
+                       ~size:`Sm
+                       ~color:
+                         (match row.source with
+                          | `Runtime_and_mission -> `Brass
+                          | `Runtime | `Mission -> `Neutral)
+                       ~label:(source_short row.source)
+                       ()
+                   ; (match row.model with
+                      | Some { raw_value = Some _; _ } ->
+                        Pill.view ~size:`Sm ~color:`Warn ~label:"raw" ()
+                      | _ -> Node.span [])
+                   ]
+               ; Node.div
+                   ~attrs:[ Style.subline ]
+                   [ Node.text
+                       (Option.value
+                          (Option.first_some row.phase_label row.stage_label)
+                          ~default:"상세 phase 없음")
+                   ]
+               ]
+           ; Node.div
+               ~attrs:[ Style.metric ]
+               [ Node.div
+                   ~attrs:[ context_class row.context_pct ]
+                   [ Node.text
+                       (match row.context_pct with
+                        | Some pct -> Printf.sprintf "%d%%" pct
+                        | None -> "—")
+                   ]
+               ; Node.div
+                   ~attrs:[ Style.metric_sub ]
+                   [ Node.text
+                       (Option.value
+                          (Option.first_some row.context_detail (Some row.recent_value))
+                          ~default:"—")
+                   ]
+               ; Node.div
+                   ~attrs:[ Style.metric_sub ]
+                   [ Node.text (row.recent_label ^ " · " ^ row.recent_value) ]
+               ]
+           ]))
+;;
+
+let stat_cell ~label ~value =
+  Node.div
+    [ Node.div ~attrs:[ Shell_view.Style.stat_l ] [ Node.text label ]
+    ; Node.div ~attrs:[ Shell_view.Style.stat_v ] [ Node.text value ]
+    ]
+;;
+
+let focus_card row =
+  let vial_pct = Option.value row.context_pct ~default:0 in
+  let vial_style =
+    Attr.style
+      (Css_gen.create ~field:"width" ~value:(Printf.sprintf "%d%%" vial_pct))
+  in
+  let vial_fill_attrs =
+    [ vial_style ]
+    @ if Option.exists row.context_pct ~f:(fun pct -> pct >= 95)
+      then [ Style.vial_fill_bad ]
+      else if Option.exists row.context_pct ~f:(fun pct -> pct >= 80)
+      then [ Style.vial_fill_warn ]
+      else []
+  in
+  let role_bits =
+    List.filter_opt
+      [ row.agent_name
+      ; Some (source_label row.source)
+      ]
+  in
+  let model_value =
+    match row.model with
+    | Some model ->
+      (match model.raw_value with
+       | Some _ -> model.display_value ^ " (raw)"
+       | None -> model.display_value)
+    | None -> "—"
+  in
+  Node.div
+    [ Shell_view.aside_title ~right:(row.status_label ^ " · " ^ source_short row.source) "Focus"
+    ; Node.div
+        ~attrs:[ Shell_view.Style.focus ]
+        [ Node.div
+            ~attrs:[ Shell_view.Style.focus_inner ]
+            [ Node.div
+                ~attrs:[ Shell_view.Style.focus_row ]
+                [ Node.div ~attrs:[ Shell_view.Style.portrait ]
+                    [ Node.text (row_sigil row.name) ]
+                ; Node.div
+                    [ Node.div ~attrs:[ Shell_view.Style.focus_name ] [ Node.text row.name ]
+                    ; Node.div
+                        ~attrs:[ Shell_view.Style.focus_role ]
+                        [ Node.text (String.concat ~sep:" · " role_bits) ]
+                    ]
+                ]
+            ; Node.div
+                [ Node.div
+                    ~attrs:[ Shell_view.Style.vial_lbl ]
+                    [ Node.span [ Node.text "Context" ]
+                    ; Node.span
+                        [ Node.b
+                            [ Node.text
+                                (match row.context_pct with
+                                 | Some pct -> Printf.sprintf "%d%%" pct
+                                 | None -> "—") ]
+                        ; Node.text
+                            (match row.context_detail with
+                             | Some detail -> " . " ^ detail
+                             | None -> " . runtime sparse")
+                        ]
+                    ]
+                ; Node.div
+                    ~attrs:[ Shell_view.Style.vial ]
+                    [ Node.span ~attrs:vial_fill_attrs [] ]
+                ]
+            ; Node.div
+                ~attrs:[ Shell_view.Style.stats ]
+                [ stat_cell ~label:"상태" ~value:row.status_label
+                ; stat_cell ~label:"최근성" ~value:row.recent_value
+                ; stat_cell
+                    ~label:"Phase"
+                    ~value:(Option.value row.phase_label ~default:"—")
+                ; stat_cell
+                    ~label:"Stage"
+                    ~value:(Option.value row.stage_label ~default:"—")
+                ; stat_cell ~label:"모델" ~value:model_value
+                ; stat_cell ~label:"Source" ~value:(source_label row.source)
+                ]
+            ]
+        ]
+    ]
+;;
+
+let note_section row =
+  let notes =
+    List.filter_opt
+      [ Option.map row.note ~f:(fun note -> note.label, note.text)
+      ; Option.map row.current_work ~f:(fun text -> "현재 작업", text)
+      ]
+  in
+  Node.div
+    [ Shell_view.aside_title "Note"
+    ; (match notes with
+       | [] ->
+         Node.div
+           ~attrs:[ Style.quiet ]
+           [ Node.text "note/current_work evidence가 아직 없습니다." ]
+       | entries ->
+         Node.div
+           ~attrs:[ Style.list ]
+           (List.map entries ~f:(fun (label, text) ->
+              Node.div
+                ~attrs:[ Style.note_box ]
+                [ Node.div ~attrs:[ Style.note_k ] [ Node.text label ]
+                ; Node.div ~attrs:[ Style.note_v ] [ Node.text text ]
+                ])))
+    ]
+;;
+
+let data_section row execution mission =
+  let execution_generated_at =
+    let open Directory_execution_types in
+    execution.generated_at
+  in
+  let mission_generated_at =
+    let open Directory_mission_types in
+    mission.generated_at
+  in
+  let rows =
+    [ "runtime snapshot"
+    , (if String.is_empty execution_generated_at
+       then "pending"
+       else short_hhmmss execution_generated_at)
+    ; "mission snapshot"
+    , (if String.is_empty mission_generated_at
+       then "pending"
+       else short_hhmmss mission_generated_at)
+    ; "signal"
+    , (match row.agent with
+       | Some agent ->
+         let truth =
+           Option.value agent.signal_truth ~default:"unknown"
+         in
+         let source =
+           Option.value agent.evidence_source ~default:"none"
+         in
+         truth ^ " via " ^ source
+       | None -> "agent brief 없음")
+    ]
+    @
+    match row.model with
+    | Some { raw_value = Some raw; _ } -> [ "raw model", raw ]
+    | _ -> []
+  in
+  let sparse_rows =
+    match row.sparse_reasons with
+    | [] -> []
+    | reasons -> [ "sparse", String.concat ~sep:" · " reasons ]
+  in
+  Node.div
+    [ Shell_view.aside_title "Data"
+    ; Node.div
+        ~attrs:[ Style.list ]
+        (List.map (rows @ sparse_rows) ~f:(fun (label, value) ->
+           Node.div
+             ~attrs:[ Style.list_row ]
+             [ Node.div ~attrs:[ Style.list_k ] [ Node.text label ]
+             ; Node.div ~attrs:[ Style.list_v ] [ Node.text value ]
+             ]))
+    ]
+;;
+
+let preview_section row =
+  let previews =
+    match row.agent with
+    | None -> []
+    | Some agent ->
+      List.filter_opt
+        [ Option.map agent.recent_input_preview ~f:(fun text -> "최근 입력", text)
+        ; Option.map agent.recent_output_preview ~f:(fun text -> "최근 출력", text)
+        ]
+  in
+  if List.is_empty previews
+  then
+    Node.div
+      [ Shell_view.aside_title "Preview"
+      ; Node.div
+          ~attrs:[ Style.quiet ]
+          [ Node.text "agent brief preview가 아직 없습니다." ]
+      ]
+  else
+    Node.div
+      [ Shell_view.aside_title "Preview"
+      ; Node.div
+          ~attrs:[ Style.list ]
+          (List.map previews ~f:(fun (label, text) ->
+             Node.div
+               ~attrs:[ Style.preview_box ]
+               [ Node.div ~attrs:[ Style.preview_label ] [ Node.text label ]
+               ; Node.div ~attrs:[ Style.preview_text ] [ Node.text text ]
+               ]))
+      ]
+;;
+
+let aside
+      ~(rows : row list)
+      ~(selected_name : string option)
+      ~(execution : Directory_execution_types.response)
+      ~(mission : Directory_mission_types.response)
+  : Node.t
+  =
+  match selected_row rows selected_name with
+  | None ->
+    Node.div
+      ~attrs:[ Shell_view.Style.aside ]
+      [ Shell_view.aside_title ~right:"fleet quiet" "Focus"
+      ; Node.div
+          ~attrs:[ Style.quiet ]
+          [ Node.text "선택 가능한 directory row가 아직 없습니다." ]
+      ]
+  | Some row ->
+    Node.div
+      ~attrs:[ Shell_view.Style.aside ]
+      [ focus_card row
+      ; note_section row
+      ; data_section row execution mission
+      ; preview_section row
+      ]
+;;

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -83,112 +83,135 @@ stylesheet
   }
 |}]
 
-let view_hero (keepers : Keepers_types.response) =
-  let live_n, warn_n, dead_n =
-    List.fold keepers.keepers ~init:(0, 0, 0)
-      ~f:(fun (l, w, d) (k : Keepers_types.keeper) ->
-        match k.status with
-        | Live -> l + 1, w, d
-        | Warn -> l, w + 1, d
-        | Dead -> l, w, d + 1)
-  in
+let view_hero (rows : Keepers_directory.row list) =
+  let counts = Keepers_directory.counts rows in
   let tail =
-    if live_n + warn_n + dead_n = 0
-    then "— offline"
-    else Printf.sprintf "· %d live · %d warn · %d dead" live_n warn_n dead_n
+    if counts.total = 0
+    then "· directory pending"
+    else
+      Printf.sprintf
+        "· %d active · %d attention · %d paused · %d offline"
+        counts.active
+        counts.attention
+        counts.paused
+        counts.offline
   in
   Hero.view
-    ~eyebrow:"runtime · keepers"
+    ~eyebrow:"runtime + mission · keepers"
     ~title:"fleet"
     ~tail:(tail, `Brass)
     ~sub:
-      "3s 폴링으로 본 fleet 전체. 아래 섹션은 roster(현재) · \
-       swim(60s 활동) · pressure(60m ctx)로 시간축이 짧아진다."
+      "keepers summary에 execution + mission snapshot을 덧입혀 directory를 먼저 보여준다. 아래 섹션은 roster(축약) · swim(60s 활동) · pressure(60m ctx) 순으로 이어진다."
     ()
 ;;
 
-let view_hud_strip (keepers : Keepers_types.response) =
-  let live_n, warn_n, dead_n =
-    List.fold keepers.keepers ~init:(0, 0, 0)
-      ~f:(fun (l, w, d) (k : Keepers_types.keeper) ->
-        match k.status with
-        | Live -> l + 1, w, d
-        | Warn -> l, w + 1, d
-        | Dead -> l, w, d + 1)
+let view_hud_strip
+      ~(rows : Keepers_directory.row list)
+      ~(execution : Directory_execution_types.response)
+      ~(mission : Directory_mission_types.response)
+  =
+  let execution_generated_at =
+    let open Directory_execution_types in
+    execution.generated_at
   in
-  let total = live_n + warn_n + dead_n in
-  let synced =
-    match keepers.generated_at with
-    | "" -> "—"
-    | ts ->
-      if String.length ts >= 19 && Char.equal ts.[10] 'T'
-      then Printf.sprintf "%s UTC" (String.sub ts ~pos:11 ~len:8)
-      else ts
+  let mission_generated_at =
+    let open Directory_mission_types in
+    mission.generated_at
   in
-  let dead_cls : Hud.v_class =
-    if dead_n > 0 then `Bad else `Neutral
-  in
-  let warn_cls : Hud.v_class =
-    if warn_n > 0 then `Warn else `Neutral
-  in
-  let live_cls : Hud.v_class =
-    if live_n > 0 then `Ok else `Neutral
-  in
+  let counts = Keepers_directory.counts rows in
+  let coverage = Keepers_directory.coverage rows in
   Hud.strip
-    [ Hud.cell ~k:"Fleet" ~v:(Printf.sprintf "%02d" total) ()
-    ; Hud.cell ~v_class:live_cls ~k:"Live"
-        ~v:(Printf.sprintf "%02d" live_n) ()
-    ; Hud.cell ~v_class:warn_cls ~k:"Warn"
-        ~v:(Printf.sprintf "%02d" warn_n) ()
-    ; Hud.cell ~v_class:dead_cls ~k:"Dead"
-        ~v:(Printf.sprintf "%02d" dead_n) ()
+    [ Hud.cell ~k:"Fleet" ~v:(Printf.sprintf "%02d" counts.total) ()
+    ; Hud.cell ~v_class:(if counts.active > 0 then `Ok else `Neutral)
+        ~k:"Active"
+        ~v:(Printf.sprintf "%02d" counts.active) ()
     ; Hud.cell
-        ~k:"Cycle"
-        ~v:(if keepers.cycle <= 0
-            then "—"
-            else Printf.sprintf "%d" keepers.cycle)
+        ~v_class:(if counts.attention > 0 then `Warn else `Neutral)
+        ~k:"Attention"
+        ~v:(Printf.sprintf "%02d" counts.attention) ()
+    ; Hud.cell
+        ~v_class:(if counts.paused > 0 then `Warn else `Neutral)
+        ~k:"Paused"
+        ~v:(Printf.sprintf "%02d" counts.paused) ()
+    ; Hud.cell
+        ~v_class:(if counts.offline > 0 then `Bad else `Neutral)
+        ~k:"Offline"
+        ~v:(Printf.sprintf "%02d" counts.offline) ()
+    ; Hud.cell
+        ~k:"Shared"
+        ~v:
+          (if coverage.shared = 0 && String.is_empty execution_generated_at
+              && String.is_empty mission_generated_at
+           then "—"
+           else Printf.sprintf "%02d" coverage.shared)
         ()
-    ; Hud.cell ~k:"Synced" ~v:synced ()
     ]
 ;;
 
-let render ~(shell : Overview_types.response) (keepers : Keepers_types.response) : Node.t =
+let render
+      ~(shell : Overview_types.response)
+      ~(keepers : Keepers_types.response)
+      ~(execution : Directory_execution_types.response)
+      ~(mission : Directory_mission_types.response)
+      ~(selected_name : string option)
+  : Node.t
+  =
+  let rows = Keepers_directory.build_rows ~keepers execution mission in
   let has_fleet = not (List.is_empty keepers.keepers) in
+  let page_sections =
+    [ Sec.view ~title:"directory" ~sub:"runtime + mission"
+        ~right:(Printf.sprintf "%d merged" (List.length rows))
+        ()
+    ; Node.div
+        ~attrs:[ Keepers_directory.Style.meta_strip ]
+        [ Keepers_directory.view_summary_strip ~rows ~execution ~mission ]
+    ; Keepers_directory.view ~rows ~selected_name
+    ]
+    @ if has_fleet
+      then
+        [ Sec.view ~title:"roster" ~sub:"condensed"
+            ~right:
+              (Printf.sprintf
+                 "fleet %d"
+                 (List.length keepers.keepers))
+            ()
+        ; Roster.view ~keepers ()
+        ; Sec.view ~title:"swim" ~sub:"60s"
+            ~right:"lane · activity" ()
+        ; Swim.view ~keepers ()
+        ; Sec.view ~title:"pressure" ~sub:"60m"
+            ~right:"ctx %" ()
+        ; Ctx_chart.view ~keepers ()
+        ]
+      else
+        [ Node.div
+            ~attrs:[ Style.quiet ]
+            [ Node.text
+                "keepers summary endpoint is quiet — directory snapshot만 먼저 올라와 있습니다."
+            ]
+        ]
+  in
   Shell_view.view
     ~shell
+    ~aside:(Keepers_directory.aside ~rows ~selected_name ~execution ~mission)
     ~active:Keepers
-    [ view_hero keepers
-    ; view_hud_strip keepers
-    ; (if has_fleet
-       then
-         Node.div
-           ~attrs:[]
-           [ Sec.view ~title:"roster" ~sub:"현재"
-               ~right:
-                 (Printf.sprintf
-                    "fleet %d"
-                    (List.length keepers.keepers))
-               ()
-           ; Roster.view ~keepers ()
-           ; Sec.view ~title:"swim" ~sub:"60s"
-               ~right:"lane · activity" ()
-           ; Swim.view ~keepers ()
-           ; Sec.view ~title:"pressure" ~sub:"60m"
-               ~right:"ctx %" ()
-           ; Ctx_chart.view ~keepers ()
-           ]
-       else
-         Node.div
-           ~attrs:[ Style.quiet ]
-           [ Node.text
-               "fleet endpoint is quiet — no keepers reported yet."
-           ])
+    [ view_hero rows
+    ; view_hud_strip ~rows ~execution ~mission
+    ; Node.div ~attrs:[] page_sections
     ]
 ;;
 
 let component (_graph @ local) =
-  Bonsai.map2
-    (Bonsai.Expert.Var.value Keepers_var.var)
-    (Bonsai.Expert.Var.value Overview_var.var)
-    ~f:(fun keepers shell -> render ~shell keepers)
+  Bonsai.map
+    (Bonsai.both
+       (Bonsai.both
+          (Bonsai.both
+             (Bonsai.Expert.Var.value Keepers_var.var)
+             (Bonsai.Expert.Var.value Overview_var.var))
+          (Bonsai.both
+             (Bonsai.Expert.Var.value Directory_execution_var.var)
+             (Bonsai.Expert.Var.value Directory_mission_var.var)))
+       (Bonsai.Expert.Var.value Keepers_directory.selected_name_var))
+    ~f:(fun (((keepers, shell), (execution, mission)), selected_name) ->
+      render ~shell ~keepers ~execution ~mission ~selected_name)
 ;;


### PR DESCRIPTION
## Summary
- add execution and mission decoders plus polling for bonsai keepers data
- add merged keepers directory rows with source, freshness, raw-model, and sparse-state metadata
- add keepers focus aside while preserving the existing roster, swim, and pressure sections

## Validation
- dune build --root dashboard_bonsai bin/main.bc.js --stop-on-first-error
- make bonsai-dashboard

## Notes
- live browser smoke against a server from this worktree was not run