### PR TITLE
fix(dashboard): exhaustive keeper_status match in dead_keepers_view

### DIFF
--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -137,7 +137,7 @@ let render ~(shell : Overview_types.response) (keepers : Keepers_types.response)
     List.filter keepers.keepers ~f:(fun (k : Keepers_types.keeper) ->
       match k.status with
       | Dead -> true
-      | _ -> false)
+      | Live | Warn -> false)
   in
   let dead_n = List.length dead in
   let synced =


### PR DESCRIPTION
## Summary
- Replace `_ -> false` with `| Live | Warn -> false` for `keeper_status` variant

## Why
`keeper_status` has 3 constructors (Live, Warn, Dead). Adding a new status
(e.g. `Unknown`) would silently be classified as "not dead" without compiler warning.

## Test plan
- [x] 1-line change, zero behavior difference
- [ ] CI confirms type correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)