### PR TITLE
fix(dashboard): exhaustive status matches in archive_runs_view

### DIFF
--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -309,19 +309,19 @@ let view_meta_strip (r : Archive_runs_types.response) =
     List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
       match l.status with
       | Running -> true
-      | _ -> false)
+      | Stopped | Paused | Failed | Completed | Unknown -> false)
   in
   let completed =
     List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
       match l.status with
       | Completed -> true
-      | _ -> false)
+      | Running | Stopped | Paused | Failed | Unknown -> false)
   in
   let failed =
     List.count r.loops ~f:(fun (l : Archive_runs_types.loop) ->
       match l.status with
       | Failed -> true
-      | _ -> false)
+      | Running | Stopped | Paused | Completed | Unknown -> false)
   in
   Meta.strip
     [ Meta.cell ~k:"total" ~v:(Printf.sprintf "%d" r.total) ()


### PR DESCRIPTION
## Summary
- Replace 3 `_ -> false` wildcards on `Archive_runs_types.status` with explicit branches
- `status` has 6 constructors: Running|Stopped|Paused|Failed|Completed|Unknown

## Why
New status variants would silently be excluded from all three counters
(running/completed/failed) without any compiler signal.

## Test plan
- [x] 3-line change, zero behavior difference
- [ ] CI confirms type correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)