### PR TITLE
fix(dashboard): exhaustive lane_status match in swim view_lane

### DIFF
--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -189,7 +189,7 @@ let view_lane ~name ~stat ~(status : lane_status) ~frames =
   let nm_attrs =
     match status with
     | `Dead -> [ Style.nm; Style.nm_dead ]
-    | _ -> [ Style.nm ]
+    | `Live | `Warn -> [ Style.nm ]
   in
   Node.div
     ~attrs:[ Style.lane ]


### PR DESCRIPTION
## Summary
- Replace `_ ->` with `| \`Live | \`Warn ->` for lane_status polymorphic variant

## Why
`lane_status` has 3 constructors (`\`Live | \`Warn | \`Dead`). Adding a new
lane status would silently get the default style without compiler warning.

## Test plan
- [x] 1-line change, zero behavior difference
- [ ] CI confirms type correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)