### PR TITLE
[codex] treat provider health as advisory at bootstrap

### DIFF
--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -464,28 +464,33 @@ let analyze ~base_path_input ~default_base_path () =
   current_inputs ~base_path_input ~default_base_path ()
   |> analyze_with
 
+type live_catalog_outcome =
+  | Live_catalog_valid
+  | Live_catalog_partial
+  | Live_catalog_serving_last_known_good
+  | Live_catalog_invalid
+
 let live_catalog_summary = function
   | Stdlib.Ok (Cascade_catalog_runtime.Validated snapshot) ->
-      ( false,
-        false,
-        "Live cascade catalog validation passed.",
+      ( Live_catalog_valid,
+        None,
         Cascade_catalog_runtime.state_to_yojson
           (Cascade_catalog_runtime.Validated snapshot) )
   | Stdlib.Ok
       (Cascade_catalog_runtime.Validated_with_rejections _ as state) ->
-      ( false,
-        true,
-        "Live cascade catalog validation kept the usable profile subset and rejected some presets.",
+      ( Live_catalog_partial,
+        Some
+          "Live cascade catalog validation kept the usable profile subset and rejected some presets.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Ok (Cascade_catalog_runtime.Serving_last_known_good _ as state) ->
-      ( true,
-        false,
-        "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
+      ( Live_catalog_serving_last_known_good,
+        Some
+          "Live cascade catalog validation rejected the current file; runtime is serving last-known-good.",
         Cascade_catalog_runtime.state_to_yojson state )
   | Stdlib.Error rejection ->
-      ( true,
-        false,
-        "Live cascade catalog validation failed; no validated snapshot is available.",
+      ( Live_catalog_invalid,
+        Some
+          "Live cascade catalog validation failed; no validated snapshot is available.",
         `Assoc
           [
             ("status", `String "invalid");
@@ -500,20 +505,24 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   let report = analyze ~base_path_input ~default_base_path () in
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
-  let live_failed, live_partial, live_warning, catalog_validation =
+  let live_outcome, live_warning, catalog_validation =
     match
       Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
       |> live_catalog_summary
     with
-    | failed, partial, warning, validation ->
-        (failed, partial, warning, validation)
+    | outcome, warning, validation -> (outcome, warning, validation)
   in
   let warnings =
-    if live_warning = "" then report.warnings
-    else report.warnings @ [ live_warning ]
+    match live_warning with
+    | None -> report.warnings
+    | Some warning -> report.warnings @ [ warning ]
   in
   let next_actions =
-    if live_failed then
+    if
+      match live_outcome with
+      | Live_catalog_serving_last_known_good | Live_catalog_invalid -> true
+      | Live_catalog_valid | Live_catalog_partial -> false
+    then
       report.next_actions
       @
       [
@@ -523,14 +532,14 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
       report.next_actions
   in
   let status =
-    match report.status, report.init_state, live_failed, live_partial, live_warning <> "" with
-    | Error, (Invalid_env | Missing_init), _, _, _ -> Error
-    | _, _, true, _, _ -> Error
-    | Error, _, false, true, _ -> Warn
-    | Error, _, false, false, _ -> Error
-    | Warn, _, false, _, _ -> Warn
-    | Ok, _, false, _, true -> Warn
-    | Ok, _, false, _, false -> Ok
+    match report.init_state, report.status, live_outcome with
+    | (Invalid_env | Missing_init), _, _ -> Error
+    | _, _, (Live_catalog_serving_last_known_good | Live_catalog_invalid) ->
+        Error
+    | _, _, Live_catalog_partial -> Warn
+    | _, Warn, Live_catalog_valid -> Warn
+    | _, Ok, Live_catalog_valid -> Ok
+    | _, Error, Live_catalog_valid -> Error
   in
   {
     report with

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -191,6 +191,8 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
   in
   let snapshot_json = Cascade_catalog_runtime.snapshot_to_yojson snapshot in
   check int "profile_count" 2 (json_int_field "profile_count" snapshot_json);
+  check bool "bootstrap probe status is skipped" true
+    (contains_substring (Yojson.Safe.to_string snapshot_json) "\"status\":\"skipped\"");
   let blank_name =
     require_ok
       (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ())


### PR DESCRIPTION
## Summary
- stop treating provider live probe failures as bootstrap catalog invalidation
- keep bootstrap validation static while surfacing skipped probe metadata and rejected profiles
- align Config Doctor severity with runtime behavior so usable partial catalogs report warn, not error

## Root Cause
Bootstrap validation was mixing config correctness with runtime provider liveness. Timeouts and auth failures could mark an otherwise valid catalog invalid and degrade startup/dashboard unnecessarily.

## Impact
- valid catalogs no longer fail bootstrap because a provider is temporarily unavailable
- invalid default profiles still hard-fail validation
- non-runtime-required broken presets are downgraded to warnings in Config Doctor

## Validation
- dune build --root . test/test_cascade_catalog_runtime.exe test/test_config_doctor.exe
- ./_build/default/test/test_cascade_catalog_runtime.exe
- ./_build/default/test/test_config_doctor.exe
