### PR TITLE
refactor(oas_worker_named): delegate cli_sentinel_of_kind to OAS SSOT

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -841,19 +841,19 @@ let run_named
   let candidate_base_urls =
     List.map (fun (c : Llm_provider.Provider_config.t) -> c.base_url) candidate_cfgs
   in
-  (* CLI providers (Claude_code / Gemini_cli / Kimi_cli / Codex_cli) have an
-     empty [base_url].  Map them to a stable per-kind sentinel so the
-     strategy's capacity probe and the client-capacity registry share
-     the same lookup key.  Any new CLI kind added to OAS will fall
-     through this match and get an empty key (capacity treated as
-     "unknown → optimistically available"), preserving Phase A
-     fail-open semantics until the entry is added explicitly. *)
-  let cli_sentinel_of_kind = function
-    | Llm_provider.Provider_config.Claude_code -> Some "cli:claude_code"
-    | Gemini_cli -> Some "cli:gemini_cli"
-    | Kimi_cli -> Some "cli:kimi_cli"
-    | Codex_cli -> Some "cli:codex_cli"
-    | _ -> None
+  (* CLI providers have an empty [base_url]. Map them to a stable
+     per-kind sentinel so the strategy's capacity probe and the
+     client-capacity registry share the same lookup key. Delegates
+     to the OAS SSOT {!Provider_kind.is_subprocess_cli}: any new CLI
+     kind added to OAS (e.g. future Codex variants) is picked up
+     automatically without touching this site. Sentinel format:
+     ["cli:" ^ canonical-lowercase-name], matching
+     {!Provider_kind.to_string}. *)
+  let cli_sentinel_of_kind kind =
+    if Llm_provider.Provider_config.is_subprocess_cli kind then
+      Some ("cli:" ^ Llm_provider.Provider_config.string_of_provider_kind kind)
+    else
+      None
   in
   let capacity_key_of (c : Llm_provider.Provider_config.t) =
     if c.base_url <> "" then c.base_url

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -16,6 +16,7 @@ module HK = Masc_mcp.Keeper_hooks_oas
 module KG = Masc_mcp.Keeper_guards
 module OMR = Masc_mcp.Oas_model_resolve
 module AQ = Masc_mcp.Keeper_approval_queue
+module Keeper_types = Masc_mcp.Keeper_types
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")


### PR DESCRIPTION
## Summary

Replace the 5-arm hand-maintained match in `oas_worker_named.cli_sentinel_of_kind` with a delegation to OAS 0.169.0's typed predicate + canonical name.

```diff
-  let cli_sentinel_of_kind = function
-    | Llm_provider.Provider_config.Claude_code -> Some "cli:claude_code"
-    | Gemini_cli -> Some "cli:gemini_cli"
-    | Kimi_cli -> Some "cli:kimi_cli"
-    | Codex_cli -> Some "cli:codex_cli"
-    | _ -> None
-  in
+  let cli_sentinel_of_kind kind =
+    if Llm_provider.Provider_config.is_subprocess_cli kind then
+      Some ("cli:" ^ Llm_provider.Provider_config.string_of_provider_kind kind)
+    else
+      None
+  in
```

## Why

OAS 0.169.0 introduced `Provider_kind.is_subprocess_cli : t -> bool` (#1128) and already exposed `Provider_kind.to_string` as the canonical lowercase name emitter. Combining the two expresses the intent — "kinds whose transport is a subprocess CLI map to a sentinel" — without duplicating the enumeration.

Direct benefits:

1. **No drift**: a new CLI variant added to OAS (e.g. a future codex_next) is picked up automatically. Previously each addition required a manual arm here.
2. **Single convention for the name**: `cli:claude_code`, `cli:gemini_cli`, … share the wire format with every other `provider_kind` string in the codebase.
3. **Removes a `| _ -> None` wildcard** (non-anti-pattern here — typed input, not a wire-string parse — but still hides new variants from the compiler's attention).

## Semantic preservation

| Kind         | Sentinel before  | Sentinel after       | Change |
|--------------|------------------|----------------------|--------|
| Claude_code  | `"cli:claude_code"` | `"cli:claude_code"` | same   |
| Gemini_cli   | `"cli:gemini_cli"`  | `"cli:gemini_cli"`  | same   |
| Kimi_cli     | `"cli:kimi_cli"`    | `"cli:kimi_cli"`    | same   |
| Codex_cli    | `"cli:codex_cli"`   | `"cli:codex_cli"`   | same   |
| Other kinds  | `None` (wildcard)  | `None` (predicate)  | same   |

`Provider_kind.to_string` emits exactly the lowercase constructor name.

## Drive-by fix

`test/test_keeper_unified.ml:18` gains `module Keeper_types = Masc_mcp.Keeper_types` so the file compiles on post-#9292 main (independent of #9290 which carries the same alias; git merges cleanly — identical line addition).

## Test plan

- [x] `dune build --root .` clean
- [x] `dune exec --root . test/test_oas_worker.exe` — 75/75 (direct caller of the changed code)
- [x] `dune build --root . @test/runtest` green modulo pre-existing docker/eio infra flakes (`Keeper_shell_docker_route`, `Coord`, `Keeper_docker_read`) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
