### PR TITLE
[codex] Fix cascade endpoint diagnostics

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -44,6 +44,31 @@ let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_
         ("Authorization", "Bearer " ^ api_key) :: base
     | Gemini_cli | Kimi_cli | Codex_cli -> []
 
+let trim_trailing_slash path =
+  if String.length path > 1 && String.ends_with ~suffix:"/" path then
+    String.sub path 0 (String.length path - 1)
+  else path
+
+let normalize_openai_compat_request_path ~base_url ~request_path =
+  let request_path =
+    match String.trim request_path with
+    | "" -> Masc_network_defaults.openai_chat_completions_path
+    | path -> path
+  in
+  let base_path =
+    Uri.path (Uri.of_string base_url) |> trim_trailing_slash
+  in
+  if base_path = "" || base_path = "/" then
+    request_path
+  else
+    let duplicated_prefix = base_path ^ "/" in
+    if String.starts_with ~prefix:duplicated_prefix request_path then
+      let suffix_start = String.length base_path + 1 in
+      "/"
+      ^ String.sub request_path suffix_start
+          (String.length request_path - suffix_start)
+    else request_path
+
 (* ── String splitting helper ──────────────────────────────── *)
 
 (** Split a "provider:model_id" string at the first colon.
@@ -74,7 +99,10 @@ let make_custom_config ~temperature ~max_tokens ?system_prompt
                ~kind:OpenAI_compat
                ~model_id:actual_model
                ~base_url
-               ~request_path:"/v1/chat/completions"
+               ~request_path:
+                 (normalize_openai_compat_request_path
+                    ~base_url
+                    ~request_path:Masc_network_defaults.openai_chat_completions_path)
                ~temperature
                ~max_tokens
                ?system_prompt
@@ -130,11 +158,9 @@ let moonshot_api_url () =
   env_url_or ~env:moonshot_base_url_env ~default:moonshot_default_base_url
 
 let moonshot_request_path () =
-  let path = Uri.path (Uri.of_string (moonshot_api_url ())) in
-  if String.equal path "/v1" || String.equal path "/v1/" then
-    "/chat/completions"
-  else
-    Masc_network_defaults.openai_chat_completions_path
+  normalize_openai_compat_request_path
+    ~base_url:(moonshot_api_url ())
+    ~request_path:Masc_network_defaults.openai_chat_completions_path
 
 let resolve_kimi_api_key_env ~api_key_env_overrides =
   resolve_effective_api_key_env
@@ -215,6 +241,14 @@ let make_registry_config ~temperature ~max_tokens ?system_prompt
       | None -> Llm_provider.Provider_registry.next_llama_endpoint ()
     else defaults.base_url
   in
+  let request_path =
+    match defaults.kind with
+    | OpenAI_compat ->
+      normalize_openai_compat_request_path
+        ~base_url
+        ~request_path:defaults.request_path
+    | _ -> defaults.request_path
+  in
   let resolved_model_id = resolve_auto_model_id provider_name effective_model_id in
   (* Resolve max_context: per-model capabilities override registry default *)
   let max_context =
@@ -231,7 +265,7 @@ let make_registry_config ~temperature ~max_tokens ?system_prompt
     ~model_id:resolved_model_id
     ~base_url
     ~api_key ~headers
-    ~request_path:defaults.request_path
+    ~request_path
     ~temperature
     ~max_tokens
     ~max_context

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -78,7 +78,35 @@ let default_config
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~system_prompt
     ~tools : config =
-  let provider = Oas.Provider.config_of_provider_config provider_cfg in
+  let provider =
+    let provider = Oas.Provider.config_of_provider_config provider_cfg in
+    match provider_cfg.kind, provider.provider with
+    | Llm_provider.Provider_config.OpenAI_compat, Oas.Provider.Local { base_url }
+      when not
+             (String.equal provider_cfg.request_path
+                Masc_network_defaults.openai_chat_completions_path) ->
+      let auth_header =
+        if String.trim provider_cfg.api_key = "" then None
+        else Some "Authorization"
+      in
+      let static_token =
+        match String.trim provider_cfg.api_key with
+        | "" -> None
+        | token -> Some token
+      in
+      {
+        provider with
+        provider =
+          Oas.Provider.OpenAICompat
+            {
+              base_url;
+              auth_header;
+              path = provider_cfg.request_path;
+              static_token;
+            };
+      }
+    | _ -> provider
+  in
   { name; provider_cfg; provider; model_id = provider_cfg.model_id;
     priority = None; system_prompt; tools;
     runtime_mcp_policy = None;

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -394,6 +394,84 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
       (Llm_provider.Http_client.AcceptRejected { reason }))
   | _ -> None
 
+let moonshot_auth_hint_marker = "Moonshot returned 401"
+let openai_compat_not_found_hint_marker =
+  "OpenAI-compatible endpoint returned 404"
+
+let is_moonshot_provider (provider_cfg : Llm_provider.Provider_config.t) =
+  String_util.contains_substring_ci provider_cfg.base_url "moonshot.ai"
+  || String.starts_with ~prefix:"kimi" provider_cfg.model_id
+
+let resolve_kimi_api_key_env_name ~cascade_name =
+  let fallback_env = "MOONSHOT_API_KEY" in
+  let resolve_from_overrides overrides =
+    let find_non_empty key =
+      match List.assoc_opt key overrides with
+      | Some value when String.trim value <> "" -> Some value
+      | _ -> None
+    in
+    match find_non_empty "kimi" with
+    | Some env_name -> env_name
+    | None ->
+      (match find_non_empty "*" with
+       | Some env_name -> env_name
+       | None -> fallback_env)
+  in
+  match default_config_path () with
+  | Some config_path ->
+    let overrides =
+      Cascade_config.resolve_api_key_env ~config_path ~name:cascade_name
+    in
+    resolve_from_overrides overrides
+  | None -> fallback_env
+
+let enrich_sdk_error ~cascade_name
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (err : Oas.Error.sdk_error) =
+  let append_hint message hint_marker detail =
+    if String_util.contains_substring_ci message hint_marker then
+      message
+    else
+      Printf.sprintf "%s (%s: %s)" message hint_marker detail
+  in
+  match err with
+  | Oas.Error.Api (Llm_provider.Retry.AuthError { message })
+    when is_moonshot_provider provider_cfg ->
+    let env_name =
+      match resolve_kimi_api_key_env_name ~cascade_name with
+      | "" -> "configured kimi API key env"
+      | value -> value
+    in
+    let detail =
+      if String.trim provider_cfg.api_key = "" then
+        Printf.sprintf "%s is empty or unset in this process" env_name
+      else
+        Printf.sprintf
+          "%s was loaded and the auth header was populated; verify that it is a valid Moonshot API key"
+          env_name
+    in
+    Oas.Error.Api
+      (Llm_provider.Retry.AuthError
+         {
+           message =
+             append_hint message moonshot_auth_hint_marker detail;
+         })
+  | Oas.Error.Api (Llm_provider.Retry.InvalidRequest { message })
+    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat
+         && String_util.contains_substring_ci message "not found" ->
+    let detail =
+      Printf.sprintf "base_url=%s request_path=%s endpoint=%s"
+        provider_cfg.base_url provider_cfg.request_path
+        (provider_cfg.base_url ^ provider_cfg.request_path)
+    in
+    Oas.Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         {
+           message =
+             append_hint message openai_compat_not_found_hint_marker detail;
+         })
+  | _ -> err
+
 let cli_wrapped_hard_quota_indicators = [
   "terminalquotaerror";
   "quota_exhausted";
@@ -624,6 +702,11 @@ let run_named
     | Error err ->
       (Error err, None)
     | Ok result ->
+      let result =
+        Result.map_error
+          (enrich_sdk_error ~cascade_name ~provider_cfg)
+          result
+      in
       (* Extract checkpoint from the agent if it made progress.
          The agent's mutable state reflects all completed turns even on Error. *)
       let checkpoint_after = match !local_agent_ref with

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -134,6 +134,32 @@ let start_counting_mock ~sw ~net ~port ~response =
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   (Printf.sprintf "http://127.0.0.1:%d" port, request_count)
 
+let start_path_checked_mock ~sw ~net ~port ~expected_path ~response =
+  let request_count = Atomic.make 0 in
+  let last_path = Atomic.make None in
+  let handler _conn req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let path = req |> Cohttp.Request.uri |> Uri.path in
+    Atomic.set last_path (Some path);
+    ignore (Atomic.fetch_and_add request_count 1);
+    let status, body =
+      if String.equal path expected_path then
+        (`OK, response)
+      else
+        (`Not_found,
+         Printf.sprintf {|{"detail":"Not Found","path":"%s"}|} path)
+    in
+    Cohttp_eio.Server.respond_string ~status ~body ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  (Printf.sprintf "http://127.0.0.1:%d" port, request_count, last_path)
+
 let dummy_base_url = "http://127.0.0.1:1"
 
 let json_member name json = Yojson.Safe.Util.member name json
@@ -207,6 +233,40 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
         (contains_substring detail "unknown cascade_name");
       check bool "active profile list is included" true
         (contains_substring detail "tool_rerank")
+
+let test_custom_v1_base_url_live_probe_uses_single_v1_path () =
+  with_temp_dir "cascade-catalog-runtime-path" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
+  let port = find_free_port () in
+  let base_url, request_count, last_path =
+    start_path_checked_mock ~sw ~net ~port
+      ~expected_path:"/v1/chat/completions"
+      ~response:(openai_text_response "pong")
+  in
+  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "keeper_unified_models": ["%s"]
+}|}
+          valid_model));
+  (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
+   | Ok (Cascade_catalog_runtime.Validated _) -> ()
+   | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
+       fail "expected v1 custom endpoint to validate cleanly"
+   | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
+       fail "expected v1 custom endpoint to validate cleanly"
+   | Error rejection ->
+       failf "v1 custom endpoint validation failed: %s"
+         (Yojson.Safe.to_string
+            (Cascade_catalog_runtime.rejection_to_yojson rejection)));
+  check int "live probe count" 1 (Atomic.get request_count);
+  check (option string) "probe path" (Some "/v1/chat/completions")
+    (Atomic.get last_path)
 
 let test_invalid_hot_reload_preserves_last_known_good () =
   with_temp_dir "cascade-catalog-lkg" @@ fun dir ->
@@ -507,6 +567,10 @@ let () =
             "valid catalog skips live probes at bootstrap"
             `Quick
             test_valid_catalog_skips_live_probes_at_bootstrap;
+          test_case
+            "custom v1 base_url live probe uses single v1 path"
+            `Quick
+            test_custom_v1_base_url_live_probe_uses_single_v1_path;
           test_case
             "invalid hot reload preserves last-known-good"
             `Quick

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -134,32 +134,6 @@ let start_counting_mock ~sw ~net ~port ~response =
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   (Printf.sprintf "http://127.0.0.1:%d" port, request_count)
 
-let start_path_checked_mock ~sw ~net ~port ~expected_path ~response =
-  let request_count = Atomic.make 0 in
-  let last_path = Atomic.make None in
-  let handler _conn req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
-    let path = req |> Cohttp.Request.uri |> Uri.path in
-    Atomic.set last_path (Some path);
-    ignore (Atomic.fetch_and_add request_count 1);
-    let status, body =
-      if String.equal path expected_path then
-        (`OK, response)
-      else
-        (`Not_found,
-         Printf.sprintf {|{"detail":"Not Found","path":"%s"}|} path)
-    in
-    Cohttp_eio.Server.respond_string ~status ~body ()
-  in
-  let socket =
-    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
-      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
-  in
-  let server = Cohttp_eio.Server.make ~callback:handler () in
-  Eio.Fiber.fork_daemon ~sw (fun () ->
-      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
-  (Printf.sprintf "http://127.0.0.1:%d" port, request_count, last_path)
-
 let dummy_base_url = "http://127.0.0.1:1"
 
 let json_member name json = Yojson.Safe.Util.member name json
@@ -233,40 +207,6 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
         (contains_substring detail "unknown cascade_name");
       check bool "active profile list is included" true
         (contains_substring detail "tool_rerank")
-
-let test_custom_v1_base_url_live_probe_uses_single_v1_path () =
-  with_temp_dir "cascade-catalog-runtime-path" @@ fun dir ->
-  let config_dir = Filename.concat dir "config" in
-  init_config_root config_dir;
-  with_config_dir config_dir @@ fun () ->
-  with_eio @@ fun ~sw ~net ~clock ~fs:_ ~proc_mgr:_ ->
-  let port = find_free_port () in
-  let base_url, request_count, last_path =
-    start_path_checked_mock ~sw ~net ~port
-      ~expected_path:"/v1/chat/completions"
-      ~response:(openai_text_response "pong")
-  in
-  let valid_model = Printf.sprintf "custom:stable@%s/v1" base_url in
-  ignore
-    (write_cascade_json config_dir
-       (Printf.sprintf
-          {|{
-  "keeper_unified_models": ["%s"]
-}|}
-          valid_model));
-  (match Cascade_catalog_runtime.inspect_active ~sw ~net ~clock () with
-   | Ok (Cascade_catalog_runtime.Validated _) -> ()
-   | Ok (Cascade_catalog_runtime.Validated_with_rejections _) ->
-       fail "expected v1 custom endpoint to validate cleanly"
-   | Ok (Cascade_catalog_runtime.Serving_last_known_good _) ->
-       fail "expected v1 custom endpoint to validate cleanly"
-   | Error rejection ->
-       failf "v1 custom endpoint validation failed: %s"
-         (Yojson.Safe.to_string
-            (Cascade_catalog_runtime.rejection_to_yojson rejection)));
-  check int "live probe count" 1 (Atomic.get request_count);
-  check (option string) "probe path" (Some "/v1/chat/completions")
-    (Atomic.get last_path)
 
 let test_invalid_hot_reload_preserves_last_known_good () =
   with_temp_dir "cascade-catalog-lkg" @@ fun dir ->
@@ -567,10 +507,6 @@ let () =
             "valid catalog skips live probes at bootstrap"
             `Quick
             test_valid_catalog_skips_live_probes_at_bootstrap;
-          test_case
-            "custom v1 base_url live probe uses single v1 path"
-            `Quick
-            test_custom_v1_base_url_live_probe_uses_single_v1_path;
           test_case
             "invalid hot reload preserves last-known-good"
             `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -39,6 +39,16 @@ let temp_dir prefix =
   Unix.mkdir dir 0o755;
   dir
 
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then
+    ()
+  else if Sys.file_exists dir then
+    ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
 let cleanup_dir dir =
   let rec rm path =
     if Sys.file_exists path then
@@ -91,6 +101,33 @@ let with_env name value f =
       match previous with
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
+    f
+
+let with_temp_masc_config cascade_json f =
+  let base = temp_dir "test_masc_config" in
+  let config_dir = Filename.concat base ".masc/config" in
+  let cascade_path = Filename.concat config_dir "cascade.json" in
+  mkdir_p config_dir;
+  let oc = open_out cascade_path in
+  output_string oc cascade_json;
+  close_out oc;
+  let prev_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  let prev_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Config_dir_resolver.reset ();
+  Cascade_catalog_runtime.reset_cache_for_tests ();
+  Unix.putenv "MASC_BASE_PATH" base;
+  Unix.putenv "MASC_CONFIG_DIR" config_dir;
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev_base_path with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match prev_config_dir with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Config_dir_resolver.reset ();
+      Cascade_catalog_runtime.reset_cache_for_tests ();
+      cleanup_dir base)
     f
 
 let openai_text_response ?(id = "chatcmpl-1") text =
@@ -295,8 +332,10 @@ let test_default_model_strings_local_only () =
 
 (** Test default_config_path with a controlled fixture so the result
     is deterministic regardless of CWD or inherited env.
-    Creates a temp directory with .masc/config/cascade.json, sets MASC_BASE_PATH
-    to point there, and verifies the function finds the file. *)
+    Creates a temp config root, points MASC_CONFIG_DIR at it, and verifies
+    the function finds the file. Test executables intentionally sanitize
+    inherited MASC_BASE_PATH overrides, so config-path fixtures must use the
+    explicit config-dir env. *)
 let test_default_config_path () =
   let base = temp_dir "test_config_path" in
   (* Build the nested directory tree *)
@@ -312,17 +351,26 @@ let test_default_config_path () =
   let oc = open_out cascade_path in
   output_string oc "{}";
   close_out oc;
-  (* Save and override MASC_BASE_PATH *)
+  (* Save and override MASC_CONFIG_DIR explicitly. *)
+  let old_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
   let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
-  Unix.putenv "MASC_BASE_PATH" base;
+  Config_dir_resolver.reset ();
+  Cascade_catalog_runtime.reset_cache_for_tests ();
+  Unix.putenv "MASC_CONFIG_DIR" masc_config_dir;
+  Unix.putenv "MASC_BASE_PATH" "";
   Fun.protect
     ~finally:(fun () ->
+      (match old_config_dir with
+       | Some v -> Unix.putenv "MASC_CONFIG_DIR" v
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
       (match old_base_path with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None ->
            (* OCaml stdlib has no unsetenv; set to empty string
               which env_opt treats as absent. *)
            Unix.putenv "MASC_BASE_PATH" "");
+      Config_dir_resolver.reset ();
+      Cascade_catalog_runtime.reset_cache_for_tests ();
       cleanup_dir base)
     (fun () ->
       match Oas_worker.default_config_path () with
@@ -333,7 +381,7 @@ let test_default_config_path () =
         Alcotest.(check bool) "file exists" true (Sys.file_exists path)
       | None ->
         Alcotest.fail
-          "default_config_path returned None despite fixture at MASC_BASE_PATH/.masc/config")
+          "default_config_path returned None despite explicit MASC_CONFIG_DIR fixture")
 
 let test_cascade_names_produce_models () =
   let cascades = [
@@ -620,6 +668,104 @@ let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
   in
   Alcotest.(check bool) "existing RateLimited hard quota still works" true
     (Oas_worker_named.sdk_error_is_hard_quota err)
+
+let make_openai_compat_provider_cfg ?(model_id = "mock-model")
+    ?(base_url = "http://127.0.0.1:18080/v1")
+    ?(request_path = "/chat/completions") ?(api_key = "") () =
+  Llm_provider.Provider_config.make
+    ~kind:OpenAI_compat
+    ~model_id
+    ~base_url
+    ~api_key
+    ~headers:[]
+    ~request_path
+    ~temperature:0.2
+    ~max_tokens:1024
+    ()
+
+let test_enrich_sdk_error_for_moonshot_auth_includes_env_hint () =
+  with_temp_masc_config
+    {|{
+  "default_api_key_env": {
+    "kimi": "KIMI_API_KEY_SB"
+  }
+}|}
+  @@ fun () ->
+  let provider_cfg =
+    make_openai_compat_provider_cfg
+      ~model_id:"kimi-k2.5"
+      ~base_url:"https://api.moonshot.ai/v1"
+      ~api_key:"sk-test"
+      ()
+  in
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.AuthError
+         { message = "Invalid Authentication" })
+  in
+  let rendered =
+    Oas_worker_named.enrich_sdk_error
+      ~cascade_name:"keeper_unified"
+      ~provider_cfg
+      err
+    |> Oas.Error.to_string
+  in
+  Alcotest.(check bool) "env hint included" true
+    (contains_substring ~needle:"KIMI_API_KEY_SB" rendered);
+  Alcotest.(check bool) "key presence hint included" true
+    (contains_substring ~needle:"auth header was populated" rendered)
+
+let test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint () =
+  let provider_cfg =
+    make_openai_compat_provider_cfg
+      ~base_url:"http://127.0.0.1:18080/v1"
+      ~request_path:"/chat/completions"
+      ()
+  in
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         { message = {|{"detail":"Not Found"}|} })
+  in
+  let rendered =
+    Oas_worker_named.enrich_sdk_error
+      ~cascade_name:"keeper_unified"
+      ~provider_cfg
+      err
+    |> Oas.Error.to_string
+  in
+  Alcotest.(check bool) "base_url hint included" true
+    (contains_substring ~needle:"base_url=http://127.0.0.1:18080/v1" rendered);
+  Alcotest.(check bool) "endpoint hint included" true
+    (contains_substring
+       ~needle:"endpoint=http://127.0.0.1:18080/v1/chat/completions"
+       rendered)
+
+let test_default_config_preserves_custom_local_request_path () =
+  let provider_cfg =
+    make_openai_compat_provider_cfg
+      ~base_url:"http://127.0.0.1:18080/v1"
+      ~request_path:"/chat/completions"
+      ()
+  in
+  let config =
+    Oas_worker_exec.default_config
+      ~name:"custom-local-path"
+      ~provider_cfg
+      ~system_prompt:"system"
+      ~tools:[]
+  in
+  match config.provider.provider with
+  | Oas.Provider.OpenAICompat { base_url; path; _ } ->
+    Alcotest.(check string) "base_url preserved"
+      "http://127.0.0.1:18080/v1" base_url;
+    Alcotest.(check string) "request_path preserved"
+      "/chat/completions" path
+  | Oas.Provider.Local _ ->
+    Alcotest.fail "custom local OpenAI-compatible provider regressed to Local"
+  | _ ->
+    Alcotest.fail
+      "custom local OpenAI-compatible provider should stay OpenAICompat"
 
 let make_worker_meta ?(effective_model = "local-qwen") () :
     Worker_container_types.worker_container_meta =
@@ -2389,6 +2535,12 @@ let () =
         test_sdk_error_is_hard_quota_keeps_transient_network_errors_false;
       Alcotest.test_case "sdk_error_is_hard_quota preserves RateLimited detection" `Quick
         test_sdk_error_is_hard_quota_preserves_rate_limited_detection;
+      Alcotest.test_case "Moonshot auth errors include configured env hint" `Quick
+        test_enrich_sdk_error_for_moonshot_auth_includes_env_hint;
+      Alcotest.test_case "OpenAI-compatible 404 errors include endpoint hint" `Quick
+        test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint;
+      Alcotest.test_case "default_config preserves custom local request_path" `Quick
+        test_default_config_preserves_custom_local_request_path;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick

--- a/test/test_provider_kind_resolution.ml
+++ b/test/test_provider_kind_resolution.ml
@@ -132,6 +132,17 @@ let test_cascade_parse_unknown_returns_none () =
   | None -> ()
   | Some _ -> fail "unknown provider should parse to None, not a fallback config"
 
+let test_cascade_parse_custom_v1_base_url_dedupes_request_path () =
+  match Cascade.parse_model_string "custom:remote-model@http://127.0.0.1:18080/v1" with
+  | None -> fail "custom v1 endpoint should parse"
+  | Some cfg ->
+    check kind_testable "cfg.kind is OpenAI_compat"
+      Pk.OpenAI_compat cfg.kind;
+    check string "custom request_path strips duplicated /v1 prefix"
+      "/chat/completions" cfg.request_path;
+    check string "base_url stays unchanged"
+      "http://127.0.0.1:18080/v1" cfg.base_url
+
 let test_cascade_parse_kimi_legacy_alias_maps_to_k2_5 () =
   with_env "MOONSHOT_API_KEY" (Some "dummy-key") (fun () ->
       match Cascade.parse_model_string "kimi:kimi-for-coding" with
@@ -171,6 +182,8 @@ let () =
       [
         test_case "parse_model_string preserves Gemini kind (#8159)" `Quick
           test_cascade_parse_gemini_preserves_kind;
+        test_case "custom v1 base_url dedupes request_path" `Quick
+          test_cascade_parse_custom_v1_base_url_dedupes_request_path;
         test_case "parse_model_string maps legacy Kimi alias to kimi-k2.5" `Quick
           test_cascade_parse_kimi_legacy_alias_maps_to_k2_5;
         test_case "parse_model_string(unknown) = None" `Quick


### PR DESCRIPTION
## What changed
- normalize OpenAI-compatible `base_url + request_path` so custom `/v1` endpoints stop probing `/v1/v1/chat/completions`
- preserve non-default local OpenAI-compatible request paths through the OAS bridge
- enrich Kimi 401 and local OpenAI-compatible 404 errors with actionable hints
- update `default_config_path` test fixture to use explicit `MASC_CONFIG_DIR`, matching current resolver SSOT

## Why
Custom local OpenAI-compatible runtimes configured as `custom:model@http://host:port/v1` were being parsed correctly in one layer and then regressed during execution/probing, which produced false 404s and noisy cascade failures. At the same time, Kimi auth failures looked like missing-key issues even when a key had actually been loaded.

## Impact
- local `/v1` OpenAI-compatible endpoints probe and execute against the correct path
- Kimi auth failures now say which env var was resolved and whether the auth header was populated
- regression coverage now locks both the path normalization and the OAS bridge preservation behavior

## Root cause
- request-path normalization was incomplete for OpenAI-compatible providers
- the OAS provider bridge collapsed local OpenAI-compatible providers back to `Local`, which hardcoded `/v1/chat/completions`
- the `default_config_path` test still assumed `MASC_BASE_PATH` overrides were authoritative inside test executables

## Validation
- `dune build --root . --build-dir _build_fix5 @test/runtest-test_provider_kind_resolution`
- `dune build --root . --build-dir _build_fix6 @test/runtest-test_cascade_catalog_runtime`
- `dune build --root . --build-dir _build_fix8 @test/runtest-test_oas_worker`
