### PR TITLE
chore(build): promote warning 8 (partial-match) to error

### DIFF
--- a/dune
+++ b/dune
@@ -1,2 +1,8 @@
 (dirs (:standard \ .worktrees _build_codex_trpg archive dashboard_bonsai))
+
+(env
+ (dev
+  (flags (:standard -warn-error +8)))
+ (release
+  (flags (:standard -warn-error +8))))
  


### PR DESCRIPTION
## Summary
- Add `-warn-error +8` to root `dune` `(env ...)` stanza for both dev and release profiles
- Warning 8 (partial-match) now causes build failure instead of silent warning
- All variant-type `_ ->` wildcards were replaced with explicit constructors in prior PRs (#9285, #9290, #9291, #9293, #9294, #9295)

## Why
Exhaustive pattern matching is the OCaml type system's strongest guarantee. Without `-warn-error +8`, adding a new variant constructor silently falls through `_ ->` wildcards — the compiler won't complain. With this flag, any future non-exhaustive match is caught at compile time.

## Test plan
- [x] `dune build @install` — clean (no warning 8 errors)
- [x] `dune runtest` — 119 tests pass
- [x] CI will validate full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)