### PR TITLE
fix(dashboard): clarify non-assignable cascade profiles

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1790,6 +1790,7 @@ export interface CascadeCandidate {
 export interface CascadeProfile {
   name: string
   source: 'named' | 'default_fallback' | 'hardcoded_defaults'
+  keeper_assignable: boolean
   candidates: CascadeCandidate[]
 }
 

--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -16,6 +16,8 @@ import {
   traceKindLabel,
   groupKeepersByCanonicalCascade,
   keepersWithUnknownCanonical,
+  profileSummaryText,
+  profileKeeperAssignmentNote,
 } from './cascade-config-panel'
 import type {
   CascadeCandidate,
@@ -388,7 +390,7 @@ describe('groupKeepersByCanonicalCascade', () => {
 
 describe('keepersWithUnknownCanonical', () => {
   function makeProfile(name: string): CascadeProfile {
-    return { name, source: 'named', candidates: [] }
+    return { name, source: 'named', keeper_assignable: true, candidates: [] }
   }
   function makeKeeperProfile(overrides: Partial<CascadeKeeperProfile> = {}): CascadeKeeperProfile {
     return {
@@ -416,5 +418,79 @@ describe('keepersWithUnknownCanonical', () => {
     ]
     const orphans = keepersWithUnknownCanonical(profiles, keepers)
     expect(orphans.map(o => o.keeper)).toEqual(['bob'])
+  })
+})
+
+describe('profileSummaryText', () => {
+  function makeProfile(overrides: Partial<CascadeProfile> = {}): CascadeProfile {
+    return {
+      name: 'keeper_unified',
+      source: 'named',
+      keeper_assignable: true,
+      candidates: [],
+      ...overrides,
+    }
+  }
+
+  function makeKeeperRow(overrides: Partial<CascadeKeeperProfile> = {}): CascadeKeeperProfile {
+    return {
+      keeper: 'alice',
+      cascade_name: 'keeper_unified',
+      canonical: 'keeper_unified',
+      ...overrides,
+    }
+  }
+
+  it('shows keeper count for assignable profiles', () => {
+    const profile = makeProfile({ candidates: [makeCandidate()] })
+    const keepers = groupKeepersByCanonicalCascade([makeKeeperRow()]).get('keeper_unified') ?? []
+    expect(profileSummaryText(profile, keepers)).toBe('1 candidate · 1 keeper')
+  })
+
+  it('omits zero-keeper count for manual/system-only profiles', () => {
+    const profile = makeProfile({
+      name: 'kimi_glm_local_mlx_vlm',
+      keeper_assignable: false,
+      candidates: [makeCandidate(), makeCandidate(), makeCandidate()],
+    })
+    expect(profileSummaryText(profile, [])).toBe('3 candidates')
+  })
+})
+
+describe('profileKeeperAssignmentNote', () => {
+  function makeProfile(overrides: Partial<CascadeProfile> = {}): CascadeProfile {
+    return {
+      name: 'keeper_unified',
+      source: 'named',
+      keeper_assignable: true,
+      candidates: [],
+      ...overrides,
+    }
+  }
+
+  const assignedKeepers = groupKeepersByCanonicalCascade([
+    {
+      keeper: 'alice',
+      cascade_name: 'keeper_unified',
+      canonical: 'keeper_unified',
+    },
+  ]).get('keeper_unified') ?? []
+
+  it('explains manual/system-only profiles without keepers', () => {
+    const profile = makeProfile({ keeper_assignable: false })
+    expect(profileKeeperAssignmentNote(profile, [])).toBe(
+      'manual/system-only profile; not assigned to keepers by design',
+    )
+  })
+
+  it('keeps no-keepers warning for assignable profiles', () => {
+    expect(profileKeeperAssignmentNote(makeProfile(), [])).toBe('no keepers assigned')
+  })
+
+  it('surfaces drift when manual/system-only profile still has keepers', () => {
+    const profile = makeProfile({ keeper_assignable: false })
+    expect(profileKeeperAssignmentNote(profile, assignedKeepers)).toBe(
+      'manual/system-only profile; current keepers still reference it',
+    )
   })
 })

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -101,6 +101,32 @@ export function sourceTone(source: CascadeProfile['source']): string {
   }
 }
 
+export function profileSummaryText(
+  profile: CascadeProfile,
+  keepers: readonly KeeperCascadeRow[],
+): string {
+  const parts = [
+    `${profile.candidates.length} candidate${profile.candidates.length === 1 ? '' : 's'}`,
+  ]
+  if (profile.keeper_assignable || keepers.length > 0) {
+    parts.push(`${keepers.length} keeper${keepers.length === 1 ? '' : 's'}`)
+  }
+  return parts.join(' · ')
+}
+
+export function profileKeeperAssignmentNote(
+  profile: CascadeProfile,
+  keepers: readonly KeeperCascadeRow[],
+): string | null {
+  if (!profile.keeper_assignable) {
+    return keepers.length === 0
+      ? 'manual/system-only profile; not assigned to keepers by design'
+      : 'manual/system-only profile; current keepers still reference it'
+  }
+  if (keepers.length === 0) return 'no keepers assigned'
+  return null
+}
+
 function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
   switch (status) {
     case 'validated': return 'ok'
@@ -225,6 +251,7 @@ function ProfileCard({
   keepers,
 }: { profile: CascadeProfile; keepers: readonly KeeperCascadeRow[] }) {
   const driftCount = keepers.reduce((n, k) => n + (k.drift ? 1 : 0), 0)
+  const assignmentNote = profileKeeperAssignmentNote(profile, keepers)
   return html`
     <article class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
@@ -232,21 +259,26 @@ function ProfileCard({
         <${StatusChip} tone=${sourceTone(profile.source)}>
           ${sourceLabel(profile.source)}
         <//>
+        ${!profile.keeper_assignable
+          ? html`<${StatusChip} tone="neutral" uppercase=${false}>manual/system-only<//>`
+          : null}
         <span class="text-xs text-[var(--text-muted)]">
-          ${profile.candidates.length} candidate${profile.candidates.length === 1 ? '' : 's'}
-          · ${keepers.length} keeper${keepers.length === 1 ? '' : 's'}
+          ${profileSummaryText(profile, keepers)}
         </span>
         ${driftCount > 0
           ? html`<${StatusChip} tone="warn">${driftCount} drift<//>`
           : null}
       </header>
-      ${keepers.length === 0
-        ? html`<div class="text-xs text-[var(--text-muted)] mb-2">no keepers assigned</div>`
-        : html`
+      ${assignmentNote
+        ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${assignmentNote}</div>`
+        : null}
+      ${keepers.length > 0
+        ? html`
           <div class="flex flex-wrap gap-1 mb-2">
             ${keepers.map(k => html`<${KeeperChip} row=${k} />`)}
           </div>
-        `}
+        `
+        : null}
       ${profile.candidates.length === 0
         ? html`<div class="text-xs text-[var(--text-muted)]">no candidates resolved</div>`
         : html`

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -73,28 +73,41 @@ let invalid_profiles_of_rejection_json rejection_json =
 let live_profiles ?config_path () =
   Keeper_cascade_profile.catalog_names ?config_path ()
 
-let profile_json_of_trace name (trace : CC.selection_trace) =
+let keeper_assignable_name_set ?config_path () =
+  Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+  |> List.fold_left
+       (fun acc name -> StringSet.add name acc)
+       StringSet.empty
+
+let profile_json_of_trace ~keeper_assignable name (trace : CC.selection_trace) =
   `Assoc [
     ("name", `String name);
     ("source", `String (source_to_string trace.source));
+    ("keeper_assignable", `Bool keeper_assignable);
     ("candidates", `List (List.map candidate_to_json trace.candidates));
   ]
 
-let profile_json_runtime name =
+let profile_json_runtime ~keeper_assignable_names name =
   match Cascade_catalog_runtime.resolve_selection_trace ~name () with
-  | Ok trace -> Some (profile_json_of_trace name trace)
+  | Ok trace ->
+      Some
+        (profile_json_of_trace
+           ~keeper_assignable:(StringSet.mem name keeper_assignable_names)
+           name trace)
   | Error detail ->
       Log.Keeper.warn
         "dashboard cascade config: skipping profile %s: %s"
         name detail;
       None
 
-let profile_json_raw ~config_path name =
+let profile_json_raw ~config_path ~keeper_assignable_names name =
   let defaults = Cascade_runtime.default_model_strings ~cascade_name:name in
   let (_models, trace) =
     CC.resolve_model_strings_with_trace ?config_path ~name ~defaults ()
   in
-  profile_json_of_trace name trace
+  profile_json_of_trace
+    ~keeper_assignable:(StringSet.mem name keeper_assignable_names)
+    name trace
 
 (* Two-column contract consumed by the dashboard's "Keeper → Cascade
    Mapping" table:
@@ -171,6 +184,7 @@ let validation_summary_json ?config_path () =
 
 let config_json () =
   let config_path = Cascade_runtime.cascade_config_path () in
+  let keeper_assignable_names = keeper_assignable_name_set ?config_path () in
   let keeper_entries =
     (* Issue #8619: was [with _ -> []] which silently swallowed
        Eio.Cancel.Cancelled. Re-raise cancellation; only fall back
@@ -183,7 +197,10 @@ let config_json () =
   in
   let profiles =
     match Cascade_catalog_runtime.known_profile_names () with
-    | Ok names -> List.filter_map profile_json_runtime names
+    | Ok names ->
+        List.filter_map
+          (profile_json_runtime ~keeper_assignable_names)
+          names
     | Error detail ->
         Log.Keeper.warn
           "dashboard cascade config: validated catalog unavailable: %s"
@@ -209,7 +226,9 @@ let config_json () =
             keeper_entries
           |> List.rev
         in
-        List.map (profile_json_raw ~config_path) names
+        List.map
+          (profile_json_raw ~config_path ~keeper_assignable_names)
+          names
   in
   let fields =
     [

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -23,6 +23,7 @@
         "config_path": "/path/to/cascade.json" | null,
         "profiles": [
           { "name": "keeper_unified",
+            "keeper_assignable": true,
             "candidates": [ { "model": "glm-coding:glm-5.1",
                               "config_weight": 50,
                               "effective_weight": 50,
@@ -37,8 +38,11 @@
     ]}
 
     Only validated profiles from the active runtime snapshot are surfaced in
-    [profiles]. Keepers whose raw [cascade_name] drifts from the validated
-    catalog still appear in [keeper_profiles] so the UI can show the mismatch.
+    [profiles]. Each profile also carries [keeper_assignable] metadata from the
+    live [cascade.json] catalog so the UI can distinguish keeper-routing
+    profiles from manual/system-only trial profiles. Keepers whose raw
+    [cascade_name] drifts from the validated catalog still appear in
+    [keeper_profiles] so the UI can show the mismatch.
 
     @since 0.6.0 *)
 val config_json : unit -> Yojson.Safe.t

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -78,6 +78,17 @@ let profile_names json =
         profiles
   | _ -> []
 
+let profile_by_name json target =
+  match member "profiles" json with
+  | `List profiles ->
+      List.find_opt
+        (fun profile ->
+           match member "name" profile with
+           | `String name -> String.equal name target
+           | _ -> false)
+        profiles
+  | _ -> None
+
 let with_dashboard_snapshot f =
   Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ();
   Masc_mcp.Cascade_catalog_runtime.install_snapshot_for_tests
@@ -146,6 +157,9 @@ let test_config_profile_shape () =
      | `String s when List.mem s ["named"; "default_fallback"; "hardcoded_defaults"] -> ()
      | `String s -> fail (Printf.sprintf "unexpected source: %s" s)
      | _ -> fail "profile.source should be string");
+    (match member "keeper_assignable" p with
+     | `Bool _ -> ()
+     | _ -> fail "profile.keeper_assignable should be bool");
     (match member "candidates" p with
      | `List _ -> () | _ -> fail "profile.candidates should be list")
 
@@ -194,6 +208,17 @@ let test_config_uses_live_catalog () =
         (List.mem "governance_judge" names);
       check bool "includes profiles declared by non-model schema keys" true
         (List.mem "tool_rerank" names);
+      let assert_keeper_assignable name expected =
+        match profile_by_name j name with
+        | Some profile ->
+            check bool (name ^ " keeper_assignable")
+              expected
+              Yojson.Safe.Util.(profile |> member "keeper_assignable" |> to_bool)
+        | None -> fail (Printf.sprintf "missing profile %s" name)
+      in
+      assert_keeper_assignable "custom_live" true;
+      assert_keeper_assignable "governance_judge" false;
+      assert_keeper_assignable "tool_rerank" false;
       check (option string) "config_path reflects active root"
         (Some cascade_path)
         Yojson.Safe.Util.(j |> member "config_path" |> to_string_option))


### PR DESCRIPTION
## Summary
- surface keeper-assignable metadata in dashboard cascade config JSON
- render manual/system-only cascade profiles without the misleading 'no keepers assigned' state
- add OCaml and dashboard unit coverage for the new assignment metadata and copy

## Verification
- dune build --root . _build/default/test/test_dashboard_cascade.exe
- _build/default/test/test_dashboard_cascade.exe
- dune build --root .
- pnpm exec tsc --noEmit
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/cascade-config-panel.test.ts