### PR TITLE
feat(keeper): wake-time payload telemetry (Phase 0 for tiered hydration)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -641,6 +641,24 @@ module DashboardHealth = struct
   let runtime_warning_ctx_ratio = get_float ~default:0.95 "MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO"
 end
 
+(** {1 Wake-time Payload Telemetry}
+
+    Phase 0 observability for the tiered-hydration redesign (Option C).
+    When enabled, every keeper wake captures an approximation of the LLM
+    request payload size just before [Oas_worker.run_named] is invoked.
+    The record is appended to
+    [$MASC_BASE_PATH/data/keeper-wake-payload/YYYY-MM-DD.jsonl] via
+    [Dashboard_harness_health.record_wake_payload].
+
+    Cost when disabled: a single env var lookup (bool). The entire
+    measurement path is gated behind [payload_telemetry_enabled]. *)
+module KeeperTelemetry = struct
+  (** Master switch for wake-payload measurement. Default off so the hot
+      path is untouched until a baseline sweep is explicitly requested. *)
+  let payload_telemetry_enabled () =
+    get_bool ~default:false "MASC_PAYLOAD_TELEMETRY"
+end
+
 (** {1 Cascade Runtime Overrides}
 
     Runtime-only narrowing of the MASC cascade provider set. The underlying

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -32,6 +32,30 @@ type pre_compact_event = {
   trigger : string;
 }
 
+(** Wake-time payload observation.
+
+    Captured once per keeper turn, just before [Oas_worker.run_named] fires.
+    Phase 0 baseline for the tiered-hydration redesign (Option C).
+    [approx_body_bytes] is a MASC-side estimate (sum of content text,
+    tool definition JSON, system prompt). It is NOT the exact HTTP body
+    wire size — provider layers apply further encoding. *)
+type wake_payload_event = {
+  timestamp : float;
+  keeper_name : string;
+  trace_id : string;
+  turn_index : int;
+  model_id : string;
+  context_window : int;
+  approx_body_bytes : int;
+  system_prompt_bytes : int;
+  tool_defs_bytes : int;
+  messages_bytes : int;
+  message_count : int;
+  role_counts : (string * int) list;
+  tool_count : int;
+  has_compact_happened : bool;
+}
+
 type handoff_event = {
   timestamp : float;
   keeper_name : string;
@@ -55,6 +79,10 @@ let runtime_warning_ctx_ratio = Env_config_keeper.DashboardHealth.runtime_warnin
 
 let pre_compact_store_ref : Dated_jsonl.t option ref = ref None
 
+(** Store for wake-time payload observations. Populated lazily on first
+    [record_wake_payload] call when [MASC_PAYLOAD_TELEMETRY] is enabled. *)
+let wake_payload_store_ref : Dated_jsonl.t option ref = ref None
+
 let status_to_string = function
   | Healthy -> "healthy"
   | Warning -> "warning"
@@ -68,6 +96,9 @@ let trim_recent (type a) max_items (values : a list) : a list =
 let pre_compact_store_base_dir () =
   Filename.concat (Env_config.base_path ()) "data/harness-pre-compact"
 
+let wake_payload_store_base_dir () =
+  Filename.concat (Env_config.base_path ()) "data/keeper-wake-payload"
+
 let get_or_create_store store_ref base_dir_fn =
   match !store_ref with
   | Some store -> store
@@ -79,11 +110,18 @@ let get_or_create_store store_ref base_dir_fn =
 let get_pre_compact_store () =
   get_or_create_store pre_compact_store_ref pre_compact_store_base_dir
 
+let get_wake_payload_store () =
+  get_or_create_store wake_payload_store_ref wake_payload_store_base_dir
+
 let reset_runtime_stores_for_testing () =
-  pre_compact_store_ref := None
+  pre_compact_store_ref := None;
+  wake_payload_store_ref := None
 
 let set_pre_compact_store_for_testing ~base_dir =
   pre_compact_store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let set_wake_payload_store_for_testing ~base_dir =
+  wake_payload_store_ref := Some (Dated_jsonl.create ~base_dir ())
 
 let string_field json key =
   Safe_ops.json_string ~default:"" key json
@@ -189,6 +227,82 @@ let pre_compact_event_of_json json =
         trigger = string_field json "trigger";
       }
 
+let role_counts_to_json (counts : (string * int) list) : Yojson.Safe.t =
+  `Assoc (List.map (fun (role, n) -> (role, `Int n)) counts)
+
+let role_counts_of_json json : (string * int) list =
+  Safe_ops.json_assoc "role_counts" json
+  |> List.filter_map (fun (role, value) ->
+         match value with
+         | `Int n -> Some (role, n)
+         | `Intlit s -> (try Some (role, int_of_string s) with _ -> None)
+         | _ -> None)
+
+let wake_payload_record_json (event : wake_payload_event) =
+  `Assoc
+    [
+      ("record_type", `String "wake_payload");
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("trace_id", `String event.trace_id);
+      ("turn_index", `Int event.turn_index);
+      ("model_id", `String event.model_id);
+      ("context_window", `Int event.context_window);
+      ("approx_body_bytes", `Int event.approx_body_bytes);
+      ("system_prompt_bytes", `Int event.system_prompt_bytes);
+      ("tool_defs_bytes", `Int event.tool_defs_bytes);
+      ("messages_bytes", `Int event.messages_bytes);
+      ("message_count", `Int event.message_count);
+      ("role_counts", role_counts_to_json event.role_counts);
+      ("tool_count", `Int event.tool_count);
+      ("has_compact_happened", `Bool event.has_compact_happened);
+    ]
+
+let wake_payload_event_json (event : wake_payload_event) =
+  `Assoc
+    [
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("trace_id", `String event.trace_id);
+      ("turn_index", `Int event.turn_index);
+      ("model_id", `String event.model_id);
+      ("context_window", `Int event.context_window);
+      ("approx_body_bytes", `Int event.approx_body_bytes);
+      ("system_prompt_bytes", `Int event.system_prompt_bytes);
+      ("tool_defs_bytes", `Int event.tool_defs_bytes);
+      ("messages_bytes", `Int event.messages_bytes);
+      ("message_count", `Int event.message_count);
+      ("role_counts", role_counts_to_json event.role_counts);
+      ("tool_count", `Int event.tool_count);
+      ("has_compact_happened", `Bool event.has_compact_happened);
+    ]
+
+let wake_payload_event_of_json json =
+  let record_type = string_field json "record_type" in
+  if record_type <> "" && not (String.equal record_type "wake_payload") then None
+  else
+    Some
+      {
+        timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json;
+        keeper_name = string_field json "keeper_name";
+        trace_id = string_field json "trace_id";
+        turn_index = Safe_ops.json_int ~default:0 "turn_index" json;
+        model_id = string_field json "model_id";
+        context_window =
+          Safe_ops.json_int
+            ~default:Cascade_runtime.fallback_context_window
+            "context_window" json;
+        approx_body_bytes = Safe_ops.json_int ~default:0 "approx_body_bytes" json;
+        system_prompt_bytes = Safe_ops.json_int ~default:0 "system_prompt_bytes" json;
+        tool_defs_bytes = Safe_ops.json_int ~default:0 "tool_defs_bytes" json;
+        messages_bytes = Safe_ops.json_int ~default:0 "messages_bytes" json;
+        message_count = Safe_ops.json_int ~default:0 "message_count" json;
+        role_counts = role_counts_of_json json;
+        tool_count = Safe_ops.json_int ~default:0 "tool_count" json;
+        has_compact_happened =
+          Safe_ops.json_bool ~default:false "has_compact_happened" json;
+      }
+
 let read_recent_verdicts ?since ?until ?(limit = max_recent_verdicts) ()
     : harness_verdict_item list =
   let records = read_store_records (Eval_calibration.get_store ()) ?since ?until () in
@@ -235,6 +349,16 @@ let read_pre_compact_events ?since ?until () =
   in
   List.sort
     (fun (left : pre_compact_event) (right : pre_compact_event) ->
+      Float.compare right.timestamp left.timestamp)
+    events
+
+let read_wake_payload_events ?since ?until () =
+  let records = read_store_records (get_wake_payload_store ()) ?since ?until () in
+  let events : wake_payload_event list =
+    records |> List.filter_map wake_payload_event_of_json
+  in
+  List.sort
+    (fun (left : wake_payload_event) (right : wake_payload_event) ->
       Float.compare right.timestamp left.timestamp)
     events
 
@@ -441,6 +565,41 @@ let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
   record_pre_compact_at ~timestamp:(Time_compat.now ()) ~keeper_name
     ~context_ratio ~message_count ~token_count ~strategies ~context_window
     ~is_local_model ~trigger
+
+let record_wake_payload_at ~timestamp ~keeper_name ~trace_id ~turn_index
+    ~model_id ~context_window ~approx_body_bytes ~system_prompt_bytes
+    ~tool_defs_bytes ~messages_bytes ~message_count ~role_counts ~tool_count
+    ~has_compact_happened =
+  let event =
+    {
+      timestamp;
+      keeper_name;
+      trace_id;
+      turn_index;
+      model_id;
+      context_window;
+      approx_body_bytes;
+      system_prompt_bytes;
+      tool_defs_bytes;
+      messages_bytes;
+      message_count;
+      role_counts;
+      tool_count;
+      has_compact_happened;
+    }
+  in
+  Dated_jsonl.append (get_wake_payload_store ())
+    (wake_payload_record_json event);
+  event
+
+let record_wake_payload ~keeper_name ~trace_id ~turn_index ~model_id
+    ~context_window ~approx_body_bytes ~system_prompt_bytes ~tool_defs_bytes
+    ~messages_bytes ~message_count ~role_counts ~tool_count
+    ~has_compact_happened =
+  record_wake_payload_at ~timestamp:(Time_compat.now ()) ~keeper_name
+    ~trace_id ~turn_index ~model_id ~context_window ~approx_body_bytes
+    ~system_prompt_bytes ~tool_defs_bytes ~messages_bytes ~message_count
+    ~role_counts ~tool_count ~has_compact_happened
 
 let recent_verdicts_json ?since ?until () =
   `List (List.map verdict_item_json (read_recent_verdicts ?since ?until ()))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2039,6 +2039,93 @@ let run_turn
              | None -> None);
         } : Oas_worker.cli_transport_overrides)
     in
+    (* Phase 0: wake-time payload telemetry (Option C baseline).
+       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
+       Exceptions from the telemetry path never abort the LLM call. *)
+    let () =
+      if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
+        try
+          let bytes_of_content_block : Agent_sdk.Types.content_block -> int = function
+            | Agent_sdk.Types.Text s -> String.length s
+            | Agent_sdk.Types.Thinking { content; _ } -> String.length content
+            | Agent_sdk.Types.RedactedThinking s -> String.length s
+            | Agent_sdk.Types.ToolUse { id; name; input } ->
+              String.length id + String.length name
+              + String.length (Yojson.Safe.to_string input)
+            | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
+              String.length tool_use_id + String.length content
+            | Agent_sdk.Types.Image { data; _ }
+            | Agent_sdk.Types.Document { data; _ }
+            | Agent_sdk.Types.Audio { data; _ } -> String.length data
+          in
+          let bytes_of_message (m : Agent_sdk.Types.message) =
+            List.fold_left
+              (fun acc b -> acc + bytes_of_content_block b)
+              0 m.content
+          in
+          let role_key : Agent_sdk.Types.role -> string = function
+            | Agent_sdk.Types.System -> "system"
+            | Agent_sdk.Types.User -> "user"
+            | Agent_sdk.Types.Assistant -> "assistant"
+            | Agent_sdk.Types.Tool -> "tool"
+          in
+          let tool_defs_bytes =
+            List.fold_left
+              (fun acc t ->
+                acc
+                + String.length
+                    (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json t)))
+              0 tools
+          in
+          let messages_bytes =
+            List.fold_left
+              (fun acc m -> acc + bytes_of_message m)
+              0 history_messages
+            + String.length user_message
+          in
+          let system_prompt_bytes = String.length turn_system_prompt in
+          let approx_body_bytes =
+            system_prompt_bytes + tool_defs_bytes + messages_bytes
+          in
+          let role_counts =
+            let tbl = Hashtbl.create 5 in
+            List.iter
+              (fun (m : Agent_sdk.Types.message) ->
+                let key = role_key m.role in
+                let cur = try Hashtbl.find tbl key with Not_found -> 0 in
+                Hashtbl.replace tbl key (cur + 1))
+              history_messages;
+            Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
+          in
+          let model_id =
+            match meta.models with
+            | m :: _ -> m
+            | [] -> "auto"
+          in
+          let _event : Dashboard_harness_health.wake_payload_event =
+            Dashboard_harness_health.record_wake_payload
+              ~keeper_name:meta.name
+              ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+              ~turn_index:start_turn_count
+              ~model_id
+              ~context_window:max_context
+              ~approx_body_bytes
+              ~system_prompt_bytes
+              ~tool_defs_bytes
+              ~messages_bytes
+              ~message_count:(List.length history_messages)
+              ~role_counts
+              ~tool_count:(List.length tools)
+              ~has_compact_happened:false
+          in
+          ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Harness.warn
+            "[wake_payload] telemetry failed keeper=%s: %s"
+            meta.name (Printexc.to_string exn)
+    in
     (match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -374,6 +374,146 @@ let test_outcomes_rollup_counts_gate_rejected_from_completed_turns () =
   check int "turn_failed bucket keeps non-gate failures" 1
     Yojson.Safe.Util.(outcomes |> member "failures" |> member "turn_failed" |> to_int)
 
+(* ------------------------------------------------------------------ *)
+(* Wake-time payload telemetry (Phase 0 for Option C redesign).       *)
+(* ------------------------------------------------------------------ *)
+
+let with_wake_payload_store f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = tmpdir "harness_wake_payload" in
+  Harness.set_wake_payload_store_for_testing ~base_dir;
+  Fun.protect
+    ~finally:(fun () -> Harness.reset_runtime_stores_for_testing ())
+    (fun () -> f ())
+
+let sample_role_counts =
+  [ ("system", 1); ("user", 6); ("assistant", 18); ("tool", 17) ]
+
+let test_wake_payload_round_trip () =
+  with_wake_payload_store @@ fun () ->
+  let before =
+    Harness.record_wake_payload
+      ~keeper_name:"engineering-01"
+      ~trace_id:"trc_abc"
+      ~turn_index:3
+      ~model_id:"claude-opus-4-7"
+      ~context_window:200_000
+      ~approx_body_bytes:184_231
+      ~system_prompt_bytes:12_400
+      ~tool_defs_bytes:48_200
+      ~messages_bytes:123_631
+      ~message_count:42
+      ~role_counts:sample_role_counts
+      ~tool_count:23
+      ~has_compact_happened:false
+  in
+  let events = Harness.read_wake_payload_events () in
+  check int "exactly one event persisted" 1 (List.length events);
+  let after = List.hd events in
+  check string "keeper_name round-trip" before.keeper_name after.keeper_name;
+  check string "trace_id round-trip" before.trace_id after.trace_id;
+  check int "turn_index round-trip" before.turn_index after.turn_index;
+  check string "model_id round-trip" before.model_id after.model_id;
+  check int "context_window round-trip"
+    before.context_window after.context_window;
+  check int "approx_body_bytes round-trip"
+    before.approx_body_bytes after.approx_body_bytes;
+  check int "system_prompt_bytes round-trip"
+    before.system_prompt_bytes after.system_prompt_bytes;
+  check int "tool_defs_bytes round-trip"
+    before.tool_defs_bytes after.tool_defs_bytes;
+  check int "messages_bytes round-trip"
+    before.messages_bytes after.messages_bytes;
+  check int "message_count round-trip"
+    before.message_count after.message_count;
+  check int "tool_count round-trip" before.tool_count after.tool_count;
+  check bool "has_compact_happened round-trip"
+    before.has_compact_happened after.has_compact_happened;
+  let sorted =
+    List.sort (fun (a, _) (b, _) -> compare a b)
+  in
+  check
+    (list (pair string int))
+    "role_counts round-trip"
+    (sorted sample_role_counts)
+    (sorted after.role_counts)
+
+let test_wake_payload_role_count_invariant () =
+  with_wake_payload_store @@ fun () ->
+  let role_counts = [ ("user", 3); ("assistant", 5); ("tool", 2) ] in
+  let message_count =
+    List.fold_left (fun acc (_, n) -> acc + n) 0 role_counts
+  in
+  let event =
+    Harness.record_wake_payload
+      ~keeper_name:"k"
+      ~trace_id:"t"
+      ~turn_index:0
+      ~model_id:"m"
+      ~context_window:100_000
+      ~approx_body_bytes:1_024
+      ~system_prompt_bytes:256
+      ~tool_defs_bytes:128
+      ~messages_bytes:640
+      ~message_count
+      ~role_counts
+      ~tool_count:0
+      ~has_compact_happened:false
+  in
+  let total_from_counts =
+    List.fold_left (fun acc (_, n) -> acc + n) 0 event.role_counts
+  in
+  check int "role_counts sum equals message_count"
+    event.message_count total_from_counts
+
+let test_wake_payload_empty_history () =
+  with_wake_payload_store @@ fun () ->
+  let event =
+    Harness.record_wake_payload
+      ~keeper_name:"k"
+      ~trace_id:"t"
+      ~turn_index:0
+      ~model_id:"m"
+      ~context_window:100_000
+      ~approx_body_bytes:1_024
+      ~system_prompt_bytes:1_024
+      ~tool_defs_bytes:0
+      ~messages_bytes:0
+      ~message_count:0
+      ~role_counts:[]
+      ~tool_count:0
+      ~has_compact_happened:false
+  in
+  check int "empty history message_count is zero" 0 event.message_count;
+  check (list (pair string int)) "empty history role_counts is empty"
+    [] event.role_counts;
+  let events = Harness.read_wake_payload_events () in
+  check int "empty-history event still persists" 1 (List.length events)
+
+let test_wake_payload_filters_foreign_records () =
+  with_wake_payload_store @@ fun () ->
+  (* Directly append a pre_compact-style record into the wake_payload
+     store to prove [wake_payload_event_of_json] rejects it. *)
+  Dated_jsonl.append
+    (Harness.get_wake_payload_store ())
+    (`Assoc
+      [
+        ("record_type", `String "pre_compact");
+        ("timestamp", `Float 1745000000.0);
+        ("keeper_name", `String "intruder");
+      ]);
+  ignore
+    (Harness.record_wake_payload
+       ~keeper_name:"k" ~trace_id:"t" ~turn_index:0 ~model_id:"m"
+       ~context_window:100_000 ~approx_body_bytes:0 ~system_prompt_bytes:0
+       ~tool_defs_bytes:0 ~messages_bytes:0 ~message_count:0 ~role_counts:[]
+       ~tool_count:0 ~has_compact_happened:false);
+  let events = Harness.read_wake_payload_events () in
+  check int "foreign record_type filtered out" 1 (List.length events);
+  check string "only wake_payload survives" "k"
+    (List.hd events).keeper_name
+
 let () =
   run "Dashboard_harness_health"
     [
@@ -395,5 +535,16 @@ let () =
             test_agent_scoped_verdicts_filter_before_limit;
           test_case "outcomes rollup counts gate_rejected from completed turns"
             `Quick test_outcomes_rollup_counts_gate_rejected_from_completed_turns;
+        ] );
+      ( "wake payload telemetry",
+        [
+          test_case "round-trip preserves every field" `Quick
+            test_wake_payload_round_trip;
+          test_case "role_counts sum equals message_count" `Quick
+            test_wake_payload_role_count_invariant;
+          test_case "empty history persists with zero counts" `Quick
+            test_wake_payload_empty_history;
+          test_case "non-wake_payload records ignored" `Quick
+            test_wake_payload_filters_foreign_records;
         ] );
     ]


### PR DESCRIPTION
## 목적

**Phase 0 observability** — Option C(tiered hydration 재설계) 착수 전 실측 baseline 확보. 계획 문서: `~/me/planning/claude-plans/c-precious-meerkat.md`.

현재 keeper는 wake 시 체크포인트의 `messages` 배열 전체를 OAS `Agent.run`에 무축약 전달한다. compaction은 post-turn에만 실행되므로 첫 LLM 호출은 항상 full history. 이 payload의 실제 크기 분포(p50/p95/max)가 불명확하여, 구조 재설계 전에 측정기부터 달아 ≥1주 데이터를 쌓는 것이 목표.

## 무엇을 했나

- `MASC_PAYLOAD_TELEMETRY=1`(기본 off)일 때 `Oas_worker.run_named` 직전에 wake payload를 한 번 레코드.
- 측정 필드: `approx_body_bytes`(system prompt + tool defs + full history + user message 합), per-section byte breakdown, `message_count`, `role_counts`, `tool_count`, `turn_index`, `context_window`, `has_compact_happened`.
- 저장 경로: `\$MASC_BASE_PATH/data/keeper-wake-payload/YYYY-MM-DD.jsonl` (`Dated_jsonl` 재사용, pre_compact_store 패턴 복제).
- 예외 안전: `Eio.Cancel.Cancelled`는 re-raise, 그 외 예외는 warn 후 계속 — telemetry 실패가 LLM 호출을 절대 막지 않음.
- Dashboard schema 확장 without new module: 기존 `dashboard_harness_health.ml`에 `wake_payload_event` 타입 + store + json codecs + `record_wake_payload` / `read_wake_payload_events` 추가.

## 측정 비용

- Flag off: 단일 env var 조회(bool) — dead code path.
- Flag on per turn: content text `String.length` 합산 + role별 Hashtbl 카운트 + tool schema 1회 `Yojson.Safe.to_string`. 16 keeper × ~50 msg × O(1), 무시 가능.

## 테스트

- 신규 4개 alcotest: round-trip 보존, `role_counts` 합 = `message_count` 불변식, empty history 엣지, foreign `record_type` 필터.
- 회귀: `test_dashboard`(16) + `test_keeper_unified`(191) + `test_dashboard_harness_health`(12 총 8 기존 + 4 신규) = 219개 모두 green.
- 빌드: `dune build --root=.` EXIT 0, `@check` EXIT 0.

## Rollback

`MASC_PAYLOAD_TELEMETRY` unset. 스키마 파일은 선택 생성이므로 남아도 downstream 영향 없음.

## 다음 단계 (플랜 참조)

- PR0.2 (선택): `scripts/wake_payload_stats.py` — stdlib만으로 p50/p95/max 집계.
- 파일럿 1~2 keeper에서 24~72h 측정 → 데이터 분포를 RFC에 첨부.
- Phase 1(PR1~PR6) 착수 판단: p95 > 200KB인 keeper ≥3개 확인되면.

## Test plan

- [x] `dune build --root=.` green
- [x] `dune build --root=. @check` green
- [x] 219 tests green (dashboard, keeper_unified, dashboard_harness_health)
- [ ] CI checks 모니터링
- [ ] Draft 유지; 리뷰 후 Ready 전환