### PR TITLE
fix(cascade-catalog): look up provider caps by OAS registry name, not masc adapter name

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -776,8 +776,19 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
           let provider_capabilities_of_config
               (cfg : Llm_provider.Provider_config.t) =
             let registry = Llm_provider.Provider_registry.default () in
+            (* Use the OAS registry's own naming convention, not masc's
+               adapter vocabulary (cn_claude_api / cn_kimi_api /
+               cn_codex_api, …). The registry is keyed on "claude",
+               "kimi", "claude_code", "gemini_cli", …, so calling
+               [Provider_adapter.string_of_provider_kind] — which returns
+               the masc canonical_name — missed every direct-API entry
+               and fell through to [default_capabilities]. Worse, for
+               CLI kinds the masc vocabulary collides with direct-API
+               names: masc maps [Claude_code] to "claude", but "claude"
+               is the registry's Anthropic entry, so the lookup silently
+               returned direct-API capabilities for CLI runs. *)
             let provider_name =
-              Provider_adapter.string_of_provider_kind cfg.kind
+              Llm_provider.Provider_registry.provider_name_of_config cfg
             in
             let caps =
               match Llm_provider.Provider_registry.find registry provider_name with


### PR DESCRIPTION
## Summary

Silent capability-lookup bug in `cascade_catalog_runtime.ml`. The `require_tool_choice_support` filter asked `Provider_registry` for each candidate's capabilities using the **masc adapter canonical_name** (`cn_claude_api` → `"claude-api"`, `cn_kimi_api` → `"kimi-api"`, `cn_codex_api` → `"codex-api"`, …). The OAS registry is keyed on a **different vocabulary** (`"claude"`, `"kimi"`, `"llama"`, `"ollama"`, `"claude_code"`, `"gemini_cli"`, …), so the lookup never matched for direct-API kinds and the filter silently consulted `Capabilities.default_capabilities` instead of the real entry.

For CLI kinds it got worse: masc's `Claude_code → "claude"`, `Gemini_cli → "gemini"`, `Kimi_cli → "kimi"` collide with direct-API keys in the registry, so the lookup *succeeded but returned Anthropic/Gemini/Kimi **API** capabilities for CLI runtimes* — which is the wrong capability matrix for deciding `tool_choice` support.

## Fix

One-line swap: `Provider_adapter.string_of_provider_kind cfg.kind` → `Llm_provider.Provider_registry.provider_name_of_config cfg`. OAS already exports that helper as the SSOT for registry-key naming. Two other call sites in the same file (`candidate_key_of_cfg` L261, `provider_kind_string` L310) already use the OAS canonical form; this change aligns the third.

Added a block comment documenting why the masc vocabulary is the wrong lens here — this is a recurring confusion the `Provider_adapter` doc string already warns about (different semantic concerns, same shape).

## Test plan

- [x] `dune build --root .` clean
- [x] `test/test_cascade_catalog_runtime.ml` 8/8 green
- [ ] Full `@test/runtest` on CI (runs via `Build and Test`)
- [ ] Regression test that directly constructs a `Provider_config` with `kind = Claude_code` and asserts the returned capabilities match the `"claude_code"` registry entry rather than the `"claude"` entry — intentionally deferred; the current regression surface is behavioural (tool_choice filter decisions), and adding a targeted test is a natural follow-up.

## Impact

- Ollama: no change (masc and registry names happen to agree — `"ollama"`).
- All other kinds: lookup now returns the real capability entry. Any cascade profile that declares `require_tool_choice_support=true` will filter providers against their *actual* capabilities rather than `default_capabilities` or a collided sibling entry.

No API or wire-format change. `provider_adapter.ml` itself is unchanged; it still owns the masc-side vocabulary for adapter-selection, docker-auth, and cascade-prefix concerns (where that vocabulary is correct).
