### PR TITLE
fix(keeper): count pending user turn in wake-payload telemetry; extract to testable module

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -36,9 +36,21 @@ type pre_compact_event = {
 
     Captured once per keeper turn, just before [Oas_worker.run_named] fires.
     Phase 0 baseline for the tiered-hydration redesign (Option C).
+
     [approx_body_bytes] is a MASC-side estimate (sum of content text,
-    tool definition JSON, system prompt). It is NOT the exact HTTP body
-    wire size — provider layers apply further encoding. *)
+    tool definition JSON, system prompt, plus the pending user turn).
+    It is NOT the exact HTTP body wire size — provider layers add JSON
+    structural overhead (role keys, content block wrappers, array
+    brackets, escaping). Expect the real body to be ~1.3–1.5× this
+    estimate depending on tool-call density. Use [approx_body_bytes]
+    for trend detection, not for absolute thresholds.
+
+    [message_count] and [role_counts] include the synthesized user turn
+    that OAS will append from [~goal], matching the wire-level message
+    list the LLM will receive.
+
+    [has_compact_happened] is reserved for future wake-time pre-reduction
+    (Option C PR4). Currently always false — compaction runs post-turn. *)
 type wake_payload_event = {
   timestamp : float;
   keeper_name : string;

--- a/lib/dune
+++ b/lib/dune
@@ -477,6 +477,7 @@
    keeper_tool_alias
    keeper_tool_disclosure
    keeper_turn_telemetry
+   keeper_wake_telemetry
    keeper_approval_queue
    keeper_agent_run
    keeper_world_observation

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2041,61 +2041,17 @@ let run_turn
     in
     (* Phase 0: wake-time payload telemetry (Option C baseline).
        Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Exceptions from the telemetry path never abort the LLM call. *)
+       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
+       exceptions from the telemetry path never abort the LLM call. *)
     let () =
       if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
         try
-          let bytes_of_content_block : Agent_sdk.Types.content_block -> int = function
-            | Agent_sdk.Types.Text s -> String.length s
-            | Agent_sdk.Types.Thinking { content; _ } -> String.length content
-            | Agent_sdk.Types.RedactedThinking s -> String.length s
-            | Agent_sdk.Types.ToolUse { id; name; input } ->
-              String.length id + String.length name
-              + String.length (Yojson.Safe.to_string input)
-            | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
-              String.length tool_use_id + String.length content
-            | Agent_sdk.Types.Image { data; _ }
-            | Agent_sdk.Types.Document { data; _ }
-            | Agent_sdk.Types.Audio { data; _ } -> String.length data
-          in
-          let bytes_of_message (m : Agent_sdk.Types.message) =
-            List.fold_left
-              (fun acc b -> acc + bytes_of_content_block b)
-              0 m.content
-          in
-          let role_key : Agent_sdk.Types.role -> string = function
-            | Agent_sdk.Types.System -> "system"
-            | Agent_sdk.Types.User -> "user"
-            | Agent_sdk.Types.Assistant -> "assistant"
-            | Agent_sdk.Types.Tool -> "tool"
-          in
-          let tool_defs_bytes =
-            List.fold_left
-              (fun acc t ->
-                acc
-                + String.length
-                    (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json t)))
-              0 tools
-          in
-          let messages_bytes =
-            List.fold_left
-              (fun acc m -> acc + bytes_of_message m)
-              0 history_messages
-            + String.length user_message
-          in
-          let system_prompt_bytes = String.length turn_system_prompt in
-          let approx_body_bytes =
-            system_prompt_bytes + tool_defs_bytes + messages_bytes
-          in
-          let role_counts =
-            let tbl = Hashtbl.create 5 in
-            List.iter
-              (fun (m : Agent_sdk.Types.message) ->
-                let key = role_key m.role in
-                let cur = try Hashtbl.find tbl key with Not_found -> 0 in
-                Hashtbl.replace tbl key (cur + 1))
-              history_messages;
-            Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
+          let sizes =
+            Keeper_wake_telemetry.compute_sizes
+              ~system_prompt:turn_system_prompt
+              ~tools
+              ~history_messages
+              ~user_message
           in
           let model_id =
             match meta.models with
@@ -2109,13 +2065,13 @@ let run_turn
               ~turn_index:start_turn_count
               ~model_id
               ~context_window:max_context
-              ~approx_body_bytes
-              ~system_prompt_bytes
-              ~tool_defs_bytes
-              ~messages_bytes
-              ~message_count:(List.length history_messages)
-              ~role_counts
-              ~tool_count:(List.length tools)
+              ~approx_body_bytes:sizes.approx_body_bytes
+              ~system_prompt_bytes:sizes.system_prompt_bytes
+              ~tool_defs_bytes:sizes.tool_defs_bytes
+              ~messages_bytes:sizes.messages_bytes
+              ~message_count:sizes.message_count
+              ~role_counts:sizes.role_counts
+              ~tool_count:sizes.tool_count
               ~has_compact_happened:false
           in
           ()

--- a/lib/keeper/keeper_wake_telemetry.ml
+++ b/lib/keeper/keeper_wake_telemetry.ml
@@ -1,0 +1,105 @@
+(** Pure byte-size and role-count estimation for keeper wake-time
+    payload telemetry.
+
+    Extracted from [Keeper_agent_run] so the arithmetic is unit-testable
+    without standing up a live keeper. The functions here operate purely
+    on [Agent_sdk] values and return plain records/ints; they never
+    touch stores, logs, or side effects. Callers (currently
+    [Keeper_agent_run]) feed the result to
+    [Dashboard_harness_health.record_wake_payload] when
+    [MASC_PAYLOAD_TELEMETRY] is on.
+
+    Invariant: [result.message_count =
+      List.fold_left (fun a (_, n) -> a + n) 0 result.role_counts].
+    Both include the pending user turn that OAS will synthesize from
+    [~goal], so downstream p95 analysis matches the wire-level view
+    the LLM actually receives. *)
+
+type sizes = {
+  system_prompt_bytes : int;
+  tool_defs_bytes : int;
+  messages_bytes : int;
+  approx_body_bytes : int;
+  message_count : int;
+  role_counts : (string * int) list;
+  tool_count : int;
+}
+
+let role_key : Agent_sdk.Types.role -> string = function
+  | Agent_sdk.Types.System -> "system"
+  | Agent_sdk.Types.User -> "user"
+  | Agent_sdk.Types.Assistant -> "assistant"
+  | Agent_sdk.Types.Tool -> "tool"
+
+let bytes_of_content_block : Agent_sdk.Types.content_block -> int = function
+  | Agent_sdk.Types.Text s -> String.length s
+  | Agent_sdk.Types.Thinking { content; _ } -> String.length content
+  | Agent_sdk.Types.RedactedThinking s -> String.length s
+  | Agent_sdk.Types.ToolUse { id; name; input } ->
+    String.length id + String.length name
+    + String.length (Yojson.Safe.to_string input)
+  | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
+    String.length tool_use_id + String.length content
+  | Agent_sdk.Types.Image { data; _ }
+  | Agent_sdk.Types.Document { data; _ }
+  | Agent_sdk.Types.Audio { data; _ } -> String.length data
+
+let bytes_of_message (m : Agent_sdk.Types.message) : int =
+  List.fold_left
+    (fun acc b -> acc + bytes_of_content_block b)
+    0 m.content
+
+let estimate_tool_defs_bytes (tools : Agent_sdk.Tool.t list) : int =
+  List.fold_left
+    (fun acc t ->
+      acc
+      + String.length (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json t)))
+    0 tools
+
+(** Count role occurrences across [history_messages], then add [+1] to
+    the "user" slot for the pending turn OAS will synthesize from
+    [~goal]. Returned as a stable-sorted assoc list for deterministic
+    JSON output. *)
+let role_counts_with_pending_user
+    (history_messages : Agent_sdk.Types.message list) :
+    (string * int) list =
+  let tbl = Hashtbl.create 5 in
+  List.iter
+    (fun (m : Agent_sdk.Types.message) ->
+      let key = role_key m.role in
+      let cur = try Hashtbl.find tbl key with Not_found -> 0 in
+      Hashtbl.replace tbl key (cur + 1))
+    history_messages;
+  let cur = try Hashtbl.find tbl "user" with Not_found -> 0 in
+  Hashtbl.replace tbl "user" (cur + 1);
+  Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+let compute_sizes
+    ~(system_prompt : string)
+    ~(tools : Agent_sdk.Tool.t list)
+    ~(history_messages : Agent_sdk.Types.message list)
+    ~(user_message : string) : sizes =
+  let system_prompt_bytes = String.length system_prompt in
+  let tool_defs_bytes = estimate_tool_defs_bytes tools in
+  let history_bytes =
+    List.fold_left
+      (fun acc m -> acc + bytes_of_message m)
+      0 history_messages
+  in
+  let user_message_bytes = String.length user_message in
+  let messages_bytes = history_bytes + user_message_bytes in
+  let approx_body_bytes =
+    system_prompt_bytes + tool_defs_bytes + messages_bytes
+  in
+  let role_counts = role_counts_with_pending_user history_messages in
+  let message_count = List.length history_messages + 1 in
+  {
+    system_prompt_bytes;
+    tool_defs_bytes;
+    messages_bytes;
+    approx_body_bytes;
+    message_count;
+    role_counts;
+    tool_count = List.length tools;
+  }

--- a/lib/keeper/keeper_wake_telemetry.mli
+++ b/lib/keeper/keeper_wake_telemetry.mli
@@ -1,0 +1,38 @@
+(** Pure byte-size and role-count estimation for keeper wake-time
+    payload telemetry. Unit-testable building block for
+    [Keeper_agent_run] telemetry hook. *)
+
+type sizes = {
+  system_prompt_bytes : int;
+  tool_defs_bytes : int;
+  messages_bytes : int;
+  approx_body_bytes : int;
+  message_count : int;
+  role_counts : (string * int) list;
+  tool_count : int;
+}
+
+val role_key : Agent_sdk.Types.role -> string
+
+val bytes_of_content_block : Agent_sdk.Types.content_block -> int
+
+val bytes_of_message : Agent_sdk.Types.message -> int
+
+val estimate_tool_defs_bytes : Agent_sdk.Tool.t list -> int
+
+val role_counts_with_pending_user :
+  Agent_sdk.Types.message list -> (string * int) list
+
+(** Compute payload-size estimates and role distribution for a keeper
+    turn about to invoke [Oas_worker.run_named]. The result assumes OAS
+    will synthesize a new User message from [~user_message] and append
+    it after [~history_messages]; therefore [message_count] and
+    [role_counts] include that pending user turn.
+
+    Invariant: [message_count = sum_of_role_counts result.role_counts]. *)
+val compute_sizes :
+  system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  history_messages:Agent_sdk.Types.message list ->
+  user_message:string ->
+  sizes

--- a/test/dune
+++ b/test/dune
@@ -48,6 +48,7 @@
         test_keeper_cascade_profile
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_telemetry
+        test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
         test_keeper_exec_status
@@ -165,6 +166,7 @@
           test_keeper_cascade_profile
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_telemetry
+          test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability
           test_keeper_exec_status

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -1,0 +1,195 @@
+open Alcotest
+
+module WT = Masc_mcp.Keeper_wake_telemetry
+module Types = Agent_sdk.Types
+
+let text_msg role s : Types.message =
+  { role; content = [ Types.Text s ]; name = None; tool_call_id = None }
+
+let tool_use_msg id name input : Types.message =
+  {
+    role = Types.Assistant;
+    content = [ Types.ToolUse { id; name; input } ];
+    name = None;
+    tool_call_id = None;
+  }
+
+let tool_result_msg ~tool_use_id ~content : Types.message =
+  {
+    role = Types.Tool;
+    content =
+      [ Types.ToolResult { tool_use_id; content; is_error = false; json = None } ];
+    name = None;
+    tool_call_id = Some tool_use_id;
+  }
+
+let sum_counts counts =
+  List.fold_left (fun acc (_, n) -> acc + n) 0 counts
+
+let test_text_only_message () =
+  let m = text_msg Types.User "hello" in
+  check int "text length only" 5 (WT.bytes_of_message m)
+
+let test_tool_use_bytes () =
+  let m = tool_use_msg "abc" "grep" (`Assoc [ ("q", `String "foo") ]) in
+  let expected =
+    String.length "abc"
+    + String.length "grep"
+    + String.length (Yojson.Safe.to_string (`Assoc [ ("q", `String "foo") ]))
+  in
+  check int "tool_use bytes" expected (WT.bytes_of_message m)
+
+let test_tool_result_bytes () =
+  let m = tool_result_msg ~tool_use_id:"abc" ~content:"hello world" in
+  check int "tool_result bytes"
+    (String.length "abc" + String.length "hello world")
+    (WT.bytes_of_message m)
+
+let test_thinking_and_redacted () =
+  let m : Types.message =
+    {
+      role = Types.Assistant;
+      content =
+        [
+          Types.Thinking { thinking_type = "extended"; content = "ponder" };
+          Types.RedactedThinking "redacted-blob";
+        ];
+      name = None;
+      tool_call_id = None;
+    }
+  in
+  check int "thinking uses content; redacted uses literal length"
+    (String.length "ponder" + String.length "redacted-blob")
+    (WT.bytes_of_message m)
+
+let test_role_key_mapping () =
+  check string "system -> system" "system" (WT.role_key Types.System);
+  check string "user -> user" "user" (WT.role_key Types.User);
+  check string "assistant -> assistant" "assistant"
+    (WT.role_key Types.Assistant);
+  check string "tool -> tool" "tool" (WT.role_key Types.Tool)
+
+let test_role_counts_adds_pending_user_on_empty_history () =
+  let counts = WT.role_counts_with_pending_user [] in
+  check (list (pair string int))
+    "empty history yields only the pending user turn"
+    [ ("user", 1) ] counts
+
+let test_role_counts_sum_matches_message_count () =
+  let history =
+    [
+      text_msg Types.System "sys";
+      text_msg Types.User "first question";
+      text_msg Types.Assistant "first answer";
+      text_msg Types.User "second question";
+      text_msg Types.Assistant "second answer";
+    ]
+  in
+  let sizes =
+    WT.compute_sizes ~system_prompt:"" ~tools:[] ~history_messages:history
+      ~user_message:"third"
+  in
+  check int "message_count equals sum of role_counts" sizes.message_count
+    (sum_counts sizes.role_counts);
+  check int "message_count = history + 1 pending" 6 sizes.message_count;
+  let user_count =
+    try List.assoc "user" sizes.role_counts with Not_found -> 0
+  in
+  check int "user count reflects 2 history + 1 pending" 3 user_count
+
+let test_compute_sizes_bytes_breakdown () =
+  let history =
+    [
+      text_msg Types.User "A";    (* 1 byte *)
+      text_msg Types.Assistant "BB";  (* 2 bytes *)
+    ]
+  in
+  let tools = [] in
+  let sizes =
+    WT.compute_sizes ~system_prompt:"sys" ~tools ~history_messages:history
+      ~user_message:"CCCC" (* 4 bytes *)
+  in
+  check int "system_prompt_bytes" 3 sizes.system_prompt_bytes;
+  check int "tool_defs_bytes (empty)" 0 sizes.tool_defs_bytes;
+  check int "messages_bytes (1 + 2 + 4)" 7 sizes.messages_bytes;
+  check int "approx_body_bytes = sp + tools + msgs" (3 + 0 + 7)
+    sizes.approx_body_bytes;
+  check int "tool_count" 0 sizes.tool_count
+
+let test_compute_sizes_invariant_across_shapes () =
+  (* Random-ish mixtures: every call must satisfy the invariant. *)
+  let samples : Types.message list list =
+    [
+      [];
+      [ text_msg Types.User "x" ];
+      [ text_msg Types.System "s"; text_msg Types.User "u" ];
+      List.init 20 (fun i ->
+        if i mod 2 = 0 then text_msg Types.User (string_of_int i)
+        else text_msg Types.Assistant (string_of_int i));
+      [
+        text_msg Types.Assistant "think";
+        tool_use_msg "id1" "search" (`Assoc [ ("q", `String "x") ]);
+        tool_result_msg ~tool_use_id:"id1" ~content:"result payload";
+        text_msg Types.Assistant "final";
+      ];
+    ]
+  in
+  List.iter
+    (fun history ->
+      let sizes =
+        WT.compute_sizes ~system_prompt:"p" ~tools:[] ~history_messages:history
+          ~user_message:"u"
+      in
+      check int
+        (Printf.sprintf
+           "invariant holds for history of length %d"
+           (List.length history))
+        sizes.message_count
+        (sum_counts sizes.role_counts))
+    samples
+
+let test_role_counts_are_stably_sorted () =
+  let history =
+    [
+      text_msg Types.Assistant "a";
+      text_msg Types.Tool "t";
+      text_msg Types.System "s";
+    ]
+  in
+  let counts = WT.role_counts_with_pending_user history in
+  let keys = List.map fst counts in
+  let sorted_keys = List.sort String.compare keys in
+  check (list string) "role_counts keys are sorted for stable JSON output"
+    sorted_keys keys
+
+let () =
+  run "Keeper_wake_telemetry"
+    [
+      ( "bytes_of_message",
+        [
+          test_case "text-only content" `Quick test_text_only_message;
+          test_case "tool_use serialization bytes" `Quick test_tool_use_bytes;
+          test_case "tool_result id + content bytes" `Quick
+            test_tool_result_bytes;
+          test_case "thinking + redacted thinking" `Quick
+            test_thinking_and_redacted;
+        ] );
+      ( "role_key",
+        [ test_case "all roles map to stable strings" `Quick test_role_key_mapping ] );
+      ( "role_counts_with_pending_user",
+        [
+          test_case "empty history still counts the pending user turn" `Quick
+            test_role_counts_adds_pending_user_on_empty_history;
+          test_case "assoc list is stably sorted by key" `Quick
+            test_role_counts_are_stably_sorted;
+        ] );
+      ( "compute_sizes",
+        [
+          test_case "byte breakdown matches inputs" `Quick
+            test_compute_sizes_bytes_breakdown;
+          test_case "role_counts sum matches message_count" `Quick
+            test_role_counts_sum_matches_message_count;
+          test_case "invariant holds across mixed content shapes" `Quick
+            test_compute_sizes_invariant_across_shapes;
+        ] );
+    ]


### PR DESCRIPTION
## 긴급 수정

#9303이 Draft 상태에서 label-and-review 자동화에 의해 Ready 전환되고 auto-merge되면서, 자체 재검토 과정에서 발견한 **measurement 불변식 버그 fix commit이 main에 반영되지 못한 채 놓침**.

현재 main의 wake-payload telemetry 코드는 \`messages_bytes\`에는 \`user_message\` 바이트를 포함하지만 \`message_count\`와 \`role_counts\`는 \`history_messages\`만 셈. 결과적으로 **모든 wake 기록이 1 user 메시지만큼 과소 집계**됨. \`MASC_PAYLOAD_TELEMETRY=1\` 활성화 시 p95 분석이 틀어짐.

## 수정 내용

1. **Wire view 정합성**: OAS는 \`~goal\`에서 새 User 메시지를 합성해 \`~initial_messages\` 뒤에 append. 따라서 \`message_count = len(history) + 1\`, \`role_counts["user"] += 1\`.
2. **Compute 로직을 \`Keeper_wake_telemetry\` 모듈로 추출**: pure 함수 기반, Eio context 불필요. PR4(tiered hydration)에서도 재사용 가능.
3. **\`wake_payload_event\` 타입 문서 보강**: 근사치 배율(~1.3~1.5× 실제 body), 불변식(\`message_count = sum role_counts\`), \`has_compact_happened\` 용도(PR4에 예약).

## 테스트 (신규 10개 + 회귀)

- \`test_keeper_wake_telemetry\` 10개: byte_of_message(4 variant), role_key 매핑, role_counts 빈/채워진 history, 안정 정렬, compute_sizes breakdown, 불변식 자체, 5개 mixed shape invariant.
- 회귀 green: \`test_dashboard_harness_health\`(12), \`test_keeper_unified\`(191).
- \`dune build --root=.\`, \`@check\` EXIT 0.

## ⚠️ 머지 방지 요청

이 PR은 **\`do-not-merge\` 라벨을 유지**해주세요. 사용자가 직접 리뷰 후 수동 머지. #9303에서 label-and-review 자동화가 Draft를 Ready로 전환한 사고가 있었음.

## Test plan

- [x] Cherry-picked \`0b511183c\` from feat/wake-payload-telemetry onto clean origin/main.
- [x] \`dune build --root=. @check\` EXIT 0.
- [x] 10 wake_telemetry + 12 harness_health + 191 keeper_unified = 213 tests green.
- [ ] CI green (Build and Test, Dashboard, Health, Lint, TLA+).
- [ ] \`do-not-merge\` 라벨 부착 요청.
- [ ] 사용자 수동 리뷰 후 Ready 전환 + 머지.