### PR TITLE
[codex] drop unsupported ChatGPT Codex models from auto rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,12 @@
 - **CLI auto-model rotation for cascade specs.** `gemini_cli:auto` now
   expands into a quota-aware concrete Gemini CLI candidate list
   (Flash/Lite first, Pro last), and `codex_cli:auto` expands through a
-  light-to-heavy Codex order from `gpt-5.1-codex-mini` up to `gpt-5.4`,
-  including `gpt-5.4-mini` and `gpt-5.3-codex-spark`.
+  light-to-heavy supported Codex order from `gpt-5.2` up to `gpt-5.4`,
+  including `gpt-5.4-mini` and `gpt-5.3-codex-spark`. The ChatGPT-backed
+  Codex rotation now excludes `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, and
+  `gpt-5.2-codex` after direct runtime probes returned 400
+  unsupported-model errors; operators can still re-add them explicitly
+  through `MASC_CODEX_CLI_AUTO_MODELS`.
   `claude_code:auto` remains single-entry by default but can be expanded via
   `MASC_CLAUDE_CODE_AUTO_MODELS`. This lets existing cascade
   failover/round-robin/cooldown machinery rotate CLI models without

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -155,7 +155,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
 | `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
 | `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"gemini-3-flash-preview,gemini-3.1-flash-lite-preview,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-3.1-pro-preview,gemini-2.5-pro"` | `gemini_cli:auto`를 여러 concrete model 후보로 확장하는 순서. 설정 시 `GEMINI_DEFAULT_MODEL`보다 우선 |
-| `MASC_CODEX_CLI_AUTO_MODELS` | csv string | `"gpt-5.1-codex-mini,gpt-5.1-codex-max,gpt-5.2,gpt-5.2-codex,gpt-5.3-codex-spark,gpt-5.3-codex,gpt-5.4-mini,gpt-5.4"` | `codex_cli:auto` 확장 순서. 기본은 5.1→5.4 세대 오름차순이며 mini/spark 후보를 먼저 포함 |
+| `MASC_CODEX_CLI_AUTO_MODELS` | csv string | `"gpt-5.2,gpt-5.3-codex-spark,gpt-5.3-codex,gpt-5.4-mini,gpt-5.4"` | `codex_cli:auto` 확장 순서. 기본은 ChatGPT-backed Codex에서 실제 호출 성공이 확인된 후보만 포함하며, 필요하면 env override로 후보를 직접 재지정 |
 | `MASC_CLAUDE_CODE_AUTO_MODELS` | csv string | `"auto"` | `claude_code:auto` 확장 순서. 기본은 Claude Code의 사용자 기본 모델에 위임 |
 | `ANTHROPIC_DEFAULT_MODEL` | string | `"claude-sonnet-4-6-20250514"` | `claude` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:70) |
 | `OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | `openai` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:73) |
@@ -413,7 +413,7 @@ ollama HTTP 및 CLI provider(Claude_code / Gemini_cli / Codex_cli)는 endpoint s
 
 CLI sentinel key는 내부적으로 `cli:claude_code` / `cli:gemini_cli` / `cli:codex_cli` 형태로 registry에 등록된다. 대시보드 `/api/v1/cascade/client_capacity`에서 현재 이용률 확인 가능.
 
-`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 cascade 파싱 시 concrete 후보 목록으로 확장된다. Gemini CLI는 기본적으로 Flash/Lite 우선, Pro 후순위의 quota-aware 순서를 사용한다. Codex CLI는 `gpt-5.1-codex-mini`에서 시작해 `gpt-5.4`로 올라가는 세대 오름차순을 기본으로 사용하며, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.1-codex-mini` 같은 mini/spark 후보를 로테이션에 포함한다. Claude Code는 비용과 조직별 model policy 차이가 커서 기본값을 `auto` 1개로 유지하며, 운영자가 `MASC_CLAUDE_CODE_AUTO_MODELS`를 설정할 때만 여러 후보로 로테이션한다.
+`gemini_cli:auto`, `codex_cli:auto`, `claude_code:auto`는 cascade 파싱 시 concrete 후보 목록으로 확장된다. Gemini CLI는 기본적으로 Flash/Lite 우선, Pro 후순위의 quota-aware 순서를 사용한다. Codex CLI는 기본적으로 `gpt-5.2`에서 시작해 `gpt-5.4`로 올라가는 지원 후보만 사용하며, `gpt-5.3-codex-spark`와 `gpt-5.4-mini` 같은 fast 후보도 로테이션에 포함한다. 2026-04-21 기준 ChatGPT-backed Codex CLI 실호출에서는 `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2-codex`가 모두 400 unsupported를 반환해 기본 목록에서 제외한다. Claude Code는 비용과 조직별 model policy 차이가 커서 기본값을 `auto` 1개로 유지하며, 운영자가 `MASC_CLAUDE_CODE_AUTO_MODELS`를 설정할 때만 여러 후보로 로테이션한다.
 
 Codex 후보 목록은 2026-04-20 로컬 Codex CLI model picker 기준이고, 기본 순서는 5.1→5.4로 재정렬되어 있다. hosted model menu가 바뀌면 `MASC_CODEX_CLI_AUTO_MODELS`로 즉시 override하고, 코드 기본값은 별도 PR로 갱신한다.
 

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -70,12 +70,17 @@ let gemini_cli_auto_models () =
 
 (* Mirrors the Codex CLI models observed locally on 2026-04-20, reordered
    light-to-heavy by generation (5.1 -> 5.4). Keep this operator-tunable
-   because hosted model menus drift. *)
+   because hosted model menus drift.
+
+   2026-04-21: probe the ChatGPT-backed Codex CLI (v0.122.0) before setting
+   defaults. gpt-5.1-codex-mini, gpt-5.1-codex-max, and gpt-5.2-codex all
+   returned runtime 400 unsupported-model errors, while gpt-5.2,
+   gpt-5.3-codex-spark, gpt-5.3-codex, gpt-5.4-mini, and gpt-5.4 executed
+   successfully. Keep the default rotation to the supported set; operators can
+   still opt into a different list explicitly through
+   MASC_CODEX_CLI_AUTO_MODELS when their environment supports it. *)
 let codex_cli_default_auto_models = [
-  "gpt-5.1-codex-mini";
-  "gpt-5.1-codex-max";
   "gpt-5.2";
-  "gpt-5.2-codex";
   "gpt-5.3-codex-spark";
   "gpt-5.3-codex";
   "gpt-5.4-mini";

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -101,12 +101,9 @@ let test_gemini_cli_auto_models_env_override () =
 
 let test_codex_and_claude_cli_auto_models_env_override () =
   with_clean_env (fun () ->
-    check (list string) "codex default follows 5.1-to-5.4 order"
+    check (list string) "codex default keeps ChatGPT-supported models only"
       [
-        "gpt-5.1-codex-mini";
-        "gpt-5.1-codex-max";
         "gpt-5.2";
-        "gpt-5.2-codex";
         "gpt-5.3-codex-spark";
         "gpt-5.3-codex";
         "gpt-5.4-mini";
@@ -140,10 +137,7 @@ let test_expand_auto_models_includes_cli_auto_specs () =
         "gemini_cli:gemini-2.5-flash-lite";
         "gemini_cli:gemini-3.1-pro-preview";
         "gemini_cli:gemini-2.5-pro";
-        "codex_cli:gpt-5.1-codex-mini";
-        "codex_cli:gpt-5.1-codex-max";
         "codex_cli:gpt-5.2";
-        "codex_cli:gpt-5.2-codex";
         "codex_cli:gpt-5.3-codex-spark";
         "codex_cli:gpt-5.3-codex";
         "codex_cli:gpt-5.4-mini";
@@ -219,13 +213,13 @@ let test_order_weighted_entries_rotation_scope_rotates_generically () =
              e.model)
     in
     check string "weighted first call keeps default head"
-      "codex_cli:gpt-5.1-codex-mini"
+      "codex_cli:gpt-5.2"
       (List.hd first);
     check string "weighted second call advances head"
-      "codex_cli:gpt-5.1-codex-max"
+      "codex_cli:gpt-5.3-codex-spark"
       (List.hd second);
     check string "weighted rotation is scoped"
-      "codex_cli:gpt-5.1-codex-mini"
+      "codex_cli:gpt-5.2"
       (List.hd other_scope))
 
 let () =


### PR DESCRIPTION
## Summary
- drop unsupported ChatGPT-backed Codex models from the default `codex_cli:auto` rotation
- keep only models that succeeded in direct `codex exec` probes for this runtime
- update regression tests and config docs to match the supported default list

## Why
ChatGPT-backed Codex was repeatedly returning 400 unsupported-model errors for `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, and `gpt-5.2-codex` during cascade fallback. Leaving those models at the head of the default rotation makes governance and other `codex_cli:auto` users burn turns on guaranteed failures before reaching supported models.

## Impact
- `codex_cli:auto` now starts at `gpt-5.2` and rotates only through models that executed successfully in direct probes
- operators can still override the list explicitly with `MASC_CODEX_CLI_AUTO_MODELS` if their environment supports a different set
- config docs and changelog now describe the runtime-verified default set instead of the broader catalog list

## Validation
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.1-codex-mini -C /Users/dancer/me "Reply with OK only."` -> 400 unsupported
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.1-codex-max -C /Users/dancer/me "Reply with OK only."` -> 400 unsupported
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.2-codex -C /Users/dancer/me "Reply with OK only."` -> 400 unsupported
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.2 -C /Users/dancer/me "Reply with OK only."` -> OK
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.3-codex-spark -C /Users/dancer/me "Reply with OK only."` -> OK
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.3-codex -C /Users/dancer/me "Reply with OK only."` -> OK
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.4-mini -C /Users/dancer/me "Reply with OK only."` -> OK
- `codex exec --ephemeral --skip-git-repo-check -m gpt-5.4 -C /Users/dancer/me "Reply with OK only."` -> OK
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-codex-mini-chatgpt test/test_cascade_model_resolve.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-codex-mini-chatgpt test/test_cascade_model_resolve.exe`
