### PR TITLE
feat(otel): add .mli for Otel_spans — hide mutable state

### DIFF
--- a/lib/otel/otel_spans.mli
+++ b/lib/otel/otel_spans.mli
@@ -1,0 +1,40 @@
+(** OTel Spans — OpenTelemetry span lifecycle for masc-mcp.
+
+    When [MASC_OTEL_ENABLED=true], creates real OTel spans exported via OTLP.
+    When disabled (default), all operations are zero-cost no-ops.
+
+    @since 2.103.0 *)
+
+(** Initialize OTel globals (service name, context propagation).
+    Idempotent; safe to call repeatedly. *)
+val init : unit -> unit
+
+(** [is_exporter_active ()] reports whether an OTLP exporter backend is registered. *)
+val is_exporter_active : unit -> bool
+
+(** Setup OTLP exporter with a custom setup thunk.
+    No-op when [enabled=false]. Sets [is_exporter_active] accordingly. *)
+val setup_exporter_with :
+  ?enabled:bool -> endpoint:string -> setup:(unit -> unit) -> unit -> unit
+
+(** Setup OTLP exporter using the cohttp-eio HTTP/protobuf backend.
+    Forks a 500ms tick fiber under [sw] for periodic batch flush.
+    No-op when [MASC_OTEL_ENABLED] is not set. *)
+val setup_exporter : sw:Eio.Switch.t -> Eio_unix.Stdenv.base -> unit
+
+(** Flush pending spans and remove the OTLP backend.
+    Safe to call when disabled (no-op). Resets [is_exporter_active] to [false]. *)
+val shutdown : ?enabled:bool -> unit -> unit
+
+(** [with_span ~name ~attrs f] wraps [f] in an OTel span.
+    When disabled, calls [f] with a no-op trace-id extractor.
+    [f] receives a thunk that returns [Some trace_id_hex] inside a span,
+    [None] otherwise. *)
+val with_span :
+  name:string ->
+  ?attrs:Opentelemetry.key_value list ->
+  ((unit -> string option) -> 'a) ->
+  'a
+
+(** [current_trace_id ()] returns the active OTel trace ID as hex, or [None]. *)
+val current_trace_id : unit -> string option


### PR DESCRIPTION
## Summary
- Add `lib/otel/otel_spans.mli` — explicit interface that hides internal mutable refs (`initialized`, `exporter_active`, `last_logged_*`) from external consumers
- Public API: `init`, `setup_exporter`, `setup_exporter_with`, `shutdown`, `with_span`, `current_trace_id`, `is_exporter_active`
- Build passes, 119 tests pass

## Context
Part of the OCaml quality initiative — .mli coverage axis. 129 lib modules currently lack .mli files, exposing all internal state including mutable refs. This PR demonstrates the pattern for a small, clean module.

## Next targets (by reference count)
| Module | Refs | Exposed refs |
|--------|------|-------------|
| Prometheus | 33 | `fd_warned_once` |
| Board | 21 | various |
| Config_dir_resolver | 21 | `_cached_resolution`, `last_logged_*` |
| A2a_tools | 9 | `subscriptions_file`, `uuid_rng_mutex` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)