### PR TITLE
chore(release): stamp v0.12.3 release truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## [0.12.3] - 2026-04-21
+
+### Changed
+- Keeper Phase C blocker classification now uses structured
+  `masc_internal_error` variants for admission queue timeout, turn timeout,
+  and ambiguous post-commit cases instead of relying on formatted-string
+  matching across the worker and supervisor surfaces.
+- `Otel_spans` now ships an explicit `.mli` interface that hides mutable
+  internal refs and publishes the supported tracing API surface
+  (`init`, exporter setup, `shutdown`, span helpers, and trace state accessors).
+
 ## [0.12.2] - 2026-04-21
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc-mcp Roadmap
 
 > Current package version: v0.12.3
-> Latest release: v0.12.2 (2026-04-21)
+> Latest release: v0.12.3 (2026-04-21)
 > Updated: 2026-04-21
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -10,7 +10,7 @@ code_refs:
 # Product Operating Plan
 
 > Current package version: v0.12.3
-> Latest release: v0.12.2 (2026-04-21)
+> Latest release: v0.12.3 (2026-04-21)
 > Updated: 2026-04-21
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 


### PR DESCRIPTION
## Summary
- add the 0.12.3 changelog release heading for changes already on main
- update roadmap and operating plan latest release markers to v0.12.3
- keep release-truth checks aligned so v0.12.3 can be tagged cleanly

## Testing
- bash scripts/check-version-truth.sh --tag v0.12.3
- bash scripts/check-doc-truth.sh
- bash scripts/check-release-train-guard.sh --base origin/main --head HEAD