### PR TITLE
[codex] Fail open keeper cascades after quota exhaustion

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -253,6 +253,9 @@ let is_auto_recoverable_cascade_exhausted_error (err : Oas.Error.sdk_error) : bo
       false
   | Some (Oas_worker_named.No_tool_capable_provider _)
   | Some (Oas_worker_named.Accept_rejected _)
+  | Some (Oas_worker_named.Admission_queue_timeout _)
+  | Some (Oas_worker_named.Turn_timeout _)
+  | Some (Oas_worker_named.Ambiguous_post_commit _)
   | None ->
       false
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -180,6 +180,14 @@ let fail_open_local_only_when_unavailable
          if List.exists probe ollama_urls then normalized_effective
          else normalized_base)
 
+type turn_cascade_plan = {
+  cascade_name : string;
+  max_context_resolution : Keeper_exec_context.max_context_resolution;
+  max_context : int;
+  temperature : float;
+  max_tokens : int;
+}
+
 (** {1 Retry & Side-Effect Safety}
 
     @boundary-contract
@@ -231,9 +239,54 @@ let is_required_tool_contract_violation (err : Oas.Error.sdk_error) : bool =
       contract = Agent_sdk.Completion_contract_id.Require_tool_use
   | _ -> false
 
+let is_auto_recoverable_cascade_exhausted_error (err : Oas.Error.sdk_error) : bool =
+  match Oas_worker_named.classify_masc_internal_error err with
+  | Some
+      (Oas_worker_named.Cascade_exhausted
+         { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
+      true
+  | Some
+      (Oas_worker_named.Cascade_exhausted
+         { reason = Keeper_types.Other_detail detail; _ }) ->
+      Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail
+  | Some (Oas_worker_named.Cascade_exhausted _) ->
+      false
+  | Some (Oas_worker_named.No_tool_capable_provider _)
+  | Some (Oas_worker_named.Accept_rejected _)
+  | None ->
+      false
+
+let is_auto_recoverable_cascade_fail_open_error
+    (err : Oas.Error.sdk_error) : bool =
+  Oas_worker_named.sdk_error_is_hard_quota err
+  || is_auto_recoverable_cascade_exhausted_error err
+
+let fail_open_cascade_after_auto_recoverable_error
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    (err : Oas.Error.sdk_error) : string option =
+  if not (is_auto_recoverable_cascade_fail_open_error err)
+  then None
+  else
+    let normalized_base =
+      Keeper_cascade_profile.normalize_declared_name base_cascade
+    in
+    let normalized_effective =
+      Keeper_cascade_profile.normalize_declared_name effective_cascade
+    in
+    if not (String.equal normalized_effective normalized_base)
+    then Some normalized_base
+    else if
+      String.equal normalized_effective Keeper_config.local_only_cascade_name
+      || String.equal normalized_effective Keeper_config.default_cascade_name
+    then None
+    else Some Keeper_config.default_cascade_name
+
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
+  || Oas_worker_named.sdk_error_is_hard_quota err
+  || is_auto_recoverable_cascade_exhausted_error err
 
 let ambiguous_side_effect_error_prefix =
   "turn outcome ambiguous after committed mutating tool call(s)"
@@ -1702,7 +1755,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       Ok meta
   | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade) *)
-      let effective_cascade_name =
+      let routed_cascade_name =
         let phase = match phase_opt with
           | Some p -> p
           | None ->
@@ -1731,22 +1784,52 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             meta.name (String.concat ", " routed_labels) resolved_cascade;
         resolved_cascade
       in
-      (* 1. Check API keys *)
-      let meta_for_cascade = { meta with cascade_name = effective_cascade_name } in
-      let model_labels = Keeper_coordination.effective_model_labels_for_turn meta_for_cascade in
-      match ensure_api_keys_for_labels model_labels with
-      | Error e -> Error (Oas.Error.Internal e)
-      | Ok () -> (
-      match ensure_local_discovery_ready model_labels with
-      | Error e -> Error (Oas.Error.Internal e)
-      | Ok () ->
-      let max_context_resolution =
-        Keeper_exec_context.resolve_max_context_resolution
-          ~requested_override:meta.max_context_override model_labels
+      let prepare_turn_cascade_plan ~(cascade_name : string)
+          : (turn_cascade_plan, Oas.Error.sdk_error) result =
+        let meta_for_cascade = { meta with cascade_name } in
+        let model_labels =
+          Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
+        in
+        match ensure_api_keys_for_labels model_labels with
+        | Error e -> Error (Oas.Error.Internal e)
+        | Ok () -> (
+            match ensure_local_discovery_ready model_labels with
+            | Error e -> Error (Oas.Error.Internal e)
+            | Ok () ->
+                let max_context_resolution =
+                  Keeper_exec_context.resolve_max_context_resolution
+                    ~requested_override:meta.max_context_override model_labels
+                in
+                let max_context =
+                  resolved_max_context_for_turn ~meta model_labels
+                in
+                let temperature =
+                  Cascade_inference.resolve_temperature
+                    ~cascade_name
+                    ~fallback:Keeper_config.keeper_unified_temperature
+                in
+                let raw_max_tokens =
+                  Cascade_inference.resolve_max_tokens
+                    ~cascade_name
+                    ~fallback:Keeper_config.keeper_unified_max_tokens
+                in
+                let max_tokens =
+                  (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
+                  Cascade_inference.clamp_max_tokens_to_ceiling
+                    ~provider_ceiling:(Some max_context) raw_max_tokens
+                in
+                Ok
+                  {
+                    cascade_name;
+                    max_context_resolution;
+                    max_context;
+                    temperature;
+                    max_tokens;
+                  })
       in
-      let max_context =
-        resolved_max_context_for_turn ~meta model_labels
-      in
+      match prepare_turn_cascade_plan ~cascade_name:routed_cascade_name with
+      | Error err -> Error err
+      | Ok initial_cascade_plan ->
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
       Eio.Fiber.yield ();
@@ -1768,22 +1851,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~generation:meta.runtime.generation
       in
-      (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
-      let temperature =
-        Cascade_inference.resolve_temperature
-          ~cascade_name:effective_cascade_name
-          ~fallback:Keeper_config.keeper_unified_temperature
-      in
-      let max_tokens =
-        let raw = Cascade_inference.resolve_max_tokens
-          ~cascade_name:effective_cascade_name
-          ~fallback:Keeper_config.keeper_unified_max_tokens
-        in
-        (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
-        Cascade_inference.clamp_max_tokens_to_ceiling
-          ~provider_ceiling:(Some max_context) raw
-      in
-      (* max_turns: defer to OAS default (Types.default_agent_config.max_turns).
+      (* 3. max_turns: defer to OAS default (Types.default_agent_config.max_turns).
          MASC does not hardcode agent runtime budgets. *)
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)
@@ -1980,8 +2048,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let keeper_profile =
             Keeper_types_profile.load_keeper_profile_defaults meta.name
           in
-          let do_run ~run_meta ~max_context ~run_generation ~is_retry
-              ~oas_timeout_s =
+          let active_cascade_plan = ref initial_cascade_plan in
+          let do_run ~(plan : turn_cascade_plan) ~run_meta ~run_generation
+              ~is_retry ~oas_timeout_s =
+            let max_context = plan.max_context in
             let max_idle_turns, max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
@@ -1997,7 +2067,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
               ~agent_name:run_meta.agent_name
-              ~cascade_name:effective_cascade_name
+              ~cascade_name:plan.cascade_name
               ~trace_id:(Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
               ~generation:run_generation
               ~max_context
@@ -2011,7 +2081,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               (fun () ->
                 Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                   ~max_context ~build_turn_prompt
-                  ~user_message ~cascade_name:effective_cascade_name
+                  ~user_message ~cascade_name:plan.cascade_name
                   ~turn_affordances:
                     (observed_affordances_of_observation ~meta:run_meta observation)
                   ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
@@ -2020,7 +2090,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~max_idle_turns
                   ~history_user_source:"world_state_prompt"
                   ~history_assistant_source:"internal_assistant"
-                  ~temperature ~max_tokens
+                  ~temperature:plan.temperature
+                  ~max_tokens:plan.max_tokens
                   ~oas_timeout_s
                   ?max_cost_usd
                   ~trajectory_acc
@@ -2029,9 +2100,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ?event_bus:(Keeper_event_bus.get ())
                   ())
           in
-          let rec retry_loop ~run_meta ~max_context ~run_generation
-              ~attempt ~is_retry
-              ~overflow_retry_used =
+          let rec retry_loop ~(plan : turn_cascade_plan) ~run_meta
+              ~run_generation ~attempt ~is_retry ~overflow_retry_used
+              ~cascade_fail_open_used =
+            active_cascade_plan := plan;
             let mark_terminal_error err =
               if is_cascade_exhausted_error err then
                 Keeper_registry.set_turn_cascade_state
@@ -2056,7 +2128,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               match
                 bounded_oas_timeout_for_turn_budget_with_turn_budget
                   ~max_turns
-                  ~max_context
+                  ~max_context:plan.max_context
                   ~remaining_turn_budget_s:(remaining_turn_budget_s ())
               with
               | None ->
@@ -2073,7 +2145,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_registry.set_turn_cascade_state
                     ~base_path:config.base_path meta.name
                     Keeper_registry.Cascade_trying;
-                  do_run ~run_meta ~max_context ~run_generation ~is_retry
+                  do_run ~plan ~run_meta ~run_generation ~is_retry
                     ~oas_timeout_s
             in
             match attempt_result with
@@ -2089,7 +2161,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 Keeper_registry.set_turn_cascade_state
                   ~base_path:config.base_path meta.name
                   Keeper_registry.Cascade_done;
-                Ok result
+                Ok (plan, result)
             | Error err ->
                 let _ = drain_turn_event_bus () in
                 let committed_tools = committed_mutating_tools_snapshot () in
@@ -2118,7 +2190,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     (String.concat ", " committed_tools)
                     err_preview;
                   mark_terminal_error err;
-                  Error err
+                  Error (plan, err)
                 end else if committed_tools <> [] then begin
                   let reclassified, failure_reason =
                     match
@@ -2154,105 +2226,153 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       (String.concat ", " committed_tools)
                       err_preview;
                   mark_terminal_error reclassified;
-                  Error reclassified
+                  Error (plan, reclassified)
                 end else if is_transient_network_error err
                               && attempt <= max_transient_retries then begin
                   let delay = transient_backoff_sec attempt in
                   Log.Keeper.warn
                     "%s: transient network error cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
-                    meta.name effective_cascade_name max_context_resolution.effective_budget
-                    max_context
-                    max_context_resolution.primary_budget
-                    (match max_context_resolution.requested_override with
+                    meta.name plan.cascade_name
+                    plan.max_context_resolution.effective_budget
+                    plan.max_context
+                    plan.max_context_resolution.primary_budget
+                    (match plan.max_context_resolution.requested_override with
                      | Some requested -> string_of_int requested
                      | None -> "none")
                     attempt max_transient_retries delay
                     (short_preview (Oas.Error.to_string err));
                   Eio.Time.sleep clock delay;
-                  retry_loop ~run_meta ~max_context ~run_generation
-                    ~attempt:(attempt + 1)
-                    ~is_retry:true ~overflow_retry_used
+                  retry_loop ~plan ~run_meta ~run_generation
+                    ~attempt:(attempt + 1) ~is_retry:true
+                    ~overflow_retry_used ~cascade_fail_open_used
+                end else if not cascade_fail_open_used then begin
+                  match
+                    fail_open_cascade_after_auto_recoverable_error
+                      ~base_cascade:meta.cascade_name
+                      ~effective_cascade:plan.cascade_name
+                      err
+                  with
+                  | Some fallback_cascade ->
+                      (match prepare_turn_cascade_plan
+                               ~cascade_name:fallback_cascade
+                       with
+                       | Ok fallback_plan ->
+                           Log.Keeper.warn
+                             "%s: cascade=%s fail-open to cascade=%s after auto-recoverable exhaustion: %s"
+                             meta.name plan.cascade_name
+                             fallback_plan.cascade_name
+                             (short_preview (Oas.Error.to_string err));
+                           Eio.Fiber.yield ();
+                           retry_loop ~plan:fallback_plan ~run_meta
+                             ~run_generation ~attempt:1 ~is_retry:true
+                             ~overflow_retry_used
+                             ~cascade_fail_open_used:true
+                       | Error fallback_err ->
+                           Log.Keeper.warn
+                             "%s: cascade fail-open unavailable %s -> %s: %s"
+                             meta.name plan.cascade_name fallback_cascade
+                             (short_preview
+                                (Oas.Error.to_string fallback_err));
+                           mark_terminal_error err;
+                           Error (plan, err))
+                  | None ->
+                      if is_context_overflow err then
+                        handle_context_overflow_error ~plan ~run_meta
+                          ~overflow_retry_used ~cascade_fail_open_used err
+                      else begin
+                        mark_terminal_error err;
+                        Error (plan, err)
+                      end
                 end else if is_context_overflow err then begin
-                  let current_turn_event_bus = drain_turn_event_bus () in
-                  dispatch_keeper_phase_event
-                    ~config
-                    ~keeper_name:meta.name
-                    (context_overflow_event_of_error
-                       ~fallback_tokens:max_context
-                       ~turn_event_bus:current_turn_event_bus
-                       err);
-                  if not overflow_retry_used then
-                    match
-                      recover_context_overflow_retry
-                        ~meta:run_meta
-                        ~base_dir
-                        ~max_cascade_context:max_context
-                        ~error:err
-                    with
-                    | Some retry_plan ->
-                        Keeper_registry.set_turn_phase
-                          ~base_path:config.base_path meta.name
-                          Keeper_registry.Turn_compacting;
-                        current_turn_overflow_blocker :=
-                          Some (Oas.Error.to_string err);
-                        dispatch_keeper_phase_event
-                          ~config
-                          ~keeper_name:meta.name
-                          Keeper_state_machine.Compaction_started;
-                        dispatch_keeper_phase_event
-                          ~config
-                          ~keeper_name:meta.name
-                          (Keeper_state_machine.Compaction_completed
-                             {
-                               before_tokens =
-                                 retry_plan.compaction.before_tokens;
-                               after_tokens =
-                                 retry_plan.compaction.after_tokens;
-                             });
-                        Keeper_registry.prepare_turn_retry_after_compaction
-                          ~base_path:config.base_path meta.name;
-                        let retry_meta =
-                          if retry_plan.retry_generation = run_meta.runtime.generation
-                          then run_meta
-                          else
-                            map_runtime
-                              (fun rt ->
-                                {
-                                  rt with
-                                  generation = retry_plan.retry_generation;
-                                })
-                              run_meta
-                        in
-                        Eio.Fiber.yield ();
-                        retry_loop
-                          ~run_meta:retry_meta
-                          ~max_context:retry_plan.retry_max_context
-                          ~run_generation:retry_plan.retry_generation
-                          ~attempt:1
-                          ~is_retry:true
-                          ~overflow_retry_used:true
-                    | None ->
-                        mark_paused_after_overflow
-                          ~run_meta
-                          ~reason:"auto_compact_recovery_unavailable";
-                        Keeper_registry.set_turn_phase
-                          ~base_path:config.base_path meta.name
-                          Keeper_registry.Turn_finalizing;
-                        Error err
-                  else begin
-                    mark_paused_after_overflow
-                      ~run_meta
-                      ~reason:"overflow_persisted_after_auto_compact_retry";
-                    Keeper_registry.set_turn_phase
-                      ~base_path:config.base_path meta.name
-                      Keeper_registry.Turn_finalizing;
-                    Error err
-                  end
+                  handle_context_overflow_error ~plan ~run_meta
+                    ~overflow_retry_used ~cascade_fail_open_used err
                 end
                 else begin
                   mark_terminal_error err;
-                  Error err
+                  Error (plan, err)
                 end
+          and handle_context_overflow_error ~(plan : turn_cascade_plan)
+              ~run_meta ~overflow_retry_used ~cascade_fail_open_used err =
+            let current_turn_event_bus = drain_turn_event_bus () in
+            dispatch_keeper_phase_event
+              ~config
+              ~keeper_name:meta.name
+              (context_overflow_event_of_error
+                 ~fallback_tokens:plan.max_context
+                 ~turn_event_bus:current_turn_event_bus
+                 err);
+            if not overflow_retry_used then
+              match
+                recover_context_overflow_retry
+                  ~meta:run_meta
+                  ~base_dir
+                  ~max_cascade_context:plan.max_context
+                  ~error:err
+              with
+              | Some retry_plan ->
+                  Keeper_registry.set_turn_phase
+                    ~base_path:config.base_path meta.name
+                    Keeper_registry.Turn_compacting;
+                  current_turn_overflow_blocker :=
+                    Some (Oas.Error.to_string err);
+                  dispatch_keeper_phase_event
+                    ~config
+                    ~keeper_name:meta.name
+                    Keeper_state_machine.Compaction_started;
+                  dispatch_keeper_phase_event
+                    ~config
+                    ~keeper_name:meta.name
+                    (Keeper_state_machine.Compaction_completed
+                       {
+                         before_tokens = retry_plan.compaction.before_tokens;
+                         after_tokens = retry_plan.compaction.after_tokens;
+                       });
+                  Keeper_registry.prepare_turn_retry_after_compaction
+                    ~base_path:config.base_path meta.name;
+                  let retry_meta =
+                    if retry_plan.retry_generation = run_meta.runtime.generation
+                    then run_meta
+                    else
+                      map_runtime
+                        (fun rt ->
+                          {
+                            rt with
+                            generation = retry_plan.retry_generation;
+                          })
+                        run_meta
+                  in
+                  let overflow_retry_plan =
+                    {
+                      plan with
+                      max_context = retry_plan.retry_max_context;
+                    }
+                  in
+                  Eio.Fiber.yield ();
+                  retry_loop
+                    ~plan:overflow_retry_plan
+                    ~run_meta:retry_meta
+                    ~run_generation:retry_plan.retry_generation
+                    ~attempt:1
+                    ~is_retry:true
+                    ~overflow_retry_used:true
+                    ~cascade_fail_open_used
+              | None ->
+                  mark_paused_after_overflow
+                    ~run_meta
+                    ~reason:"auto_compact_recovery_unavailable";
+                  Keeper_registry.set_turn_phase
+                    ~base_path:config.base_path meta.name
+                    Keeper_registry.Turn_finalizing;
+                  Error (plan, err)
+            else begin
+              mark_paused_after_overflow
+                ~run_meta
+                ~reason:"overflow_persisted_after_auto_compact_retry";
+              Keeper_registry.set_turn_phase
+                ~base_path:config.base_path meta.name
+                Keeper_registry.Turn_finalizing;
+              Error (plan, err)
+            end
           in
           (* Wall-clock timeout guards against indefinite TCP-level hangs
              from upstream LLM providers. Without this, a single stalled
@@ -2260,9 +2380,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (try
             Eio.Time.with_timeout_exn clock timeout_sec
               (fun () ->
-                retry_loop ~run_meta:meta ~max_context
-                  ~run_generation:generation ~attempt:1
-                  ~is_retry:false ~overflow_retry_used:false)
+                retry_loop ~plan:initial_cascade_plan ~run_meta:meta
+                  ~run_generation:generation ~attempt:1 ~is_retry:false
+                  ~overflow_retry_used:false ~cascade_fail_open_used:false)
           with Eio.Time.Timeout ->
             let msg =
               Printf.sprintf
@@ -2291,7 +2411,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
-              Error (Oas.Error.Api (Timeout { message = msg }))
+              Error
+                (!active_cascade_plan, Oas.Error.Api (Timeout { message = msg }))
             end else if committed_tools <> [] then begin
               let timeout_err =
                 Oas.Error.Api (Timeout { message = msg })
@@ -2325,15 +2446,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
-              Error reclassified
+              Error (!active_cascade_plan, reclassified)
             end else begin
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
               Error
-                (Oas_worker_named.sdk_error_of_masc_internal_error
-                   (Oas_worker_named.Turn_timeout
-                      { elapsed_sec = timeout_sec }))
+                ( !active_cascade_plan,
+                  Oas_worker_named.sdk_error_of_masc_internal_error
+                    (Oas_worker_named.Turn_timeout
+                       { elapsed_sec = timeout_sec }) )
             end)))
       in
       let turn_event_bus = drain_turn_event_bus () in
@@ -2344,7 +2466,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              correlation_id
        | None -> ());
       match run_result with
-      | Error err ->
+      | Error (failed_plan, err) ->
           finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
             (Trajectory.Failed (Oas.Error.to_string err));
           let e_str = Oas.Error.to_string err in
@@ -2356,10 +2478,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
-            meta.name effective_cascade_name max_context_resolution.effective_budget
-            max_context
-            max_context_resolution.primary_budget
-            (match max_context_resolution.requested_override with
+            meta.name failed_plan.cascade_name
+            failed_plan.max_context_resolution.effective_budget
+            failed_plan.max_context
+            failed_plan.max_context_resolution.primary_budget
+            (match failed_plan.max_context_resolution.requested_override with
              | Some requested -> string_of_int requested
              | None -> "none")
             latency_ms
@@ -2511,7 +2634,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             raise Keeper_registry.Keeper_fiber_crash
           end;
           Error err
-      | Ok result ->
+      | Ok (succeeded_plan, result) ->
           finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
             Trajectory.Completed;
           let explicit_accountability_claim =
@@ -2546,7 +2669,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_state_machine.Handoff_started)
               ~meta
               ~model:result.model_used
-              ~primary_model_max_tokens:max_context
+              ~primary_model_max_tokens:succeeded_plan.max_context
               ~current_turn_overflow_blocker:!current_turn_overflow_blocker
               ~checkpoint:result.checkpoint
           in
@@ -2754,6 +2877,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            | Oas_worker.Completed ->
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
-          Ok updated_meta)
+          Ok updated_meta
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -218,6 +218,16 @@ val fail_open_local_only_when_unavailable :
   string list ->
   string
 
+(** Opportunistically fail open to a broader cascade after a hard-quota or
+    fully-filtered exhaustion event. Returns [Some cascade] for a one-shot
+    same-turn retry target, or [None] when the current cascade should remain
+    authoritative. *)
+val fail_open_cascade_after_auto_recoverable_error :
+  base_cascade:string ->
+  effective_cascade:string ->
+  Oas.Error.sdk_error ->
+  string option
+
 val run_keeper_cycle :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -562,6 +562,9 @@ let cli_wrapped_hard_quota_indicators = [
   "quota_exhausted";
   "exhausted your capacity on this model";
   "quota will reset after";
+  "\"api_error_status\":429";
+  "you've hit your limit";
+  "resets apr ";
 ]
 
 let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
@@ -1113,20 +1116,41 @@ let run_named
       Cascade_strategy.order_candidates strategy
         ~adapter ~ctx:signal_ctx ~cycle:n candidate_cfgs
     in
+    let all_candidates_in_cooldown =
+      strategy.kind = Cascade_strategy.Circuit_breaker_cycling
+      && candidate_cfgs <> []
+      && List.for_all
+           (fun candidate ->
+             Cascade_health_tracker.is_in_cooldown signal_ctx.health
+               ~provider_key:(adapter.health_key candidate))
+           candidate_cfgs
+    in
     let last_cycle = n + 1 >= strategy.cycle.max_cycles in
     match ordered with
     | [] when last_cycle ->
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
       cascade_exhausted_after_filter ~cycle:n
     | [] ->
-      let backoff = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1) in
+      let backoff =
+        if all_candidates_in_cooldown
+        then 0
+        else Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1)
+      in
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:backoff
         ~kind:Filtered_empty;
-      Log.Misc.info
-        "cascade %s: cycle %d (%s) filtered all candidates, retrying"
-        cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
-      do_backoff (n + 1);
-      cycle_loop (n + 1)
+      if all_candidates_in_cooldown
+      then begin
+        Log.Misc.info
+          "cascade %s: cycle %d (%s) filtered all candidates because every provider is in cooldown; skipping empty-cycle retries"
+          cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
+        cascade_exhausted_after_filter ~cycle:n
+      end else begin
+        Log.Misc.info
+          "cascade %s: cycle %d (%s) filtered all candidates, retrying"
+          cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
+        do_backoff (n + 1);
+        cycle_loop (n + 1)
+      end
     | _ ->
       record_trace ~cycle:n ~candidates_out:(List.length ordered)
         ~backoff_ms:0 ~kind:Ordered;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1940,6 +1940,54 @@ let test_fail_open_local_only_preserves_healthy_local_only () =
   in
   check string "healthy ollama keeps local_only" "local_only" cascade
 
+let wrapped_claude_limit_error () =
+  Agent_sdk.Error.Api
+    (NetworkError
+       {
+         message =
+           "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+       })
+
+let test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default () =
+  let fallback =
+    UT.fail_open_cascade_after_auto_recoverable_error
+      ~base_cascade:"tool_use_strict"
+      ~effective_cascade:"tool_use_strict"
+      (wrapped_claude_limit_error ())
+  in
+  check (option string) "strict cascade broadens to default"
+    (Some KC.default_cascade_name) fallback
+
+let test_fail_open_cascade_after_auto_recoverable_error_returns_base_after_phase_override () =
+  let fallback =
+    UT.fail_open_cascade_after_auto_recoverable_error
+      ~base_cascade:"tool_use_strict"
+      ~effective_cascade:KC.local_recovery_cascade_name
+      (wrapped_claude_limit_error ())
+  in
+  check (option string) "phase override returns to keeper base"
+    (Some "tool_use_strict") fallback
+
+let test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only () =
+  let fallback =
+    UT.fail_open_cascade_after_auto_recoverable_error
+      ~base_cascade:KC.local_only_cascade_name
+      ~effective_cascade:KC.local_only_cascade_name
+      (wrapped_claude_limit_error ())
+  in
+  check (option string) "explicit local_only stays authoritative" None
+    fallback
+
+let test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade () =
+  let fallback =
+    UT.fail_open_cascade_after_auto_recoverable_error
+      ~base_cascade:KC.default_cascade_name
+      ~effective_cascade:KC.default_cascade_name
+      (wrapped_claude_limit_error ())
+  in
+  check (option string) "default cascade has no broader fallback" None
+    fallback
+
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
 let test_context_overflow_limit_parses_common_oas_errors () =
@@ -2446,6 +2494,18 @@ let test_auto_recoverable_turn_error_includes_server_parse_rejection () =
   check bool "server parse rejection is auto-recoverable" true
     (UT.is_auto_recoverable_turn_error err)
 
+let test_auto_recoverable_turn_error_includes_wrapped_hard_quota () =
+  let err =
+    Agent_sdk.Error.Api
+      (NetworkError
+         {
+           message =
+             "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+         })
+  in
+  check bool "wrapped hard quota is auto-recoverable" true
+    (UT.is_auto_recoverable_turn_error err)
+
 let test_required_tool_contract_violation_detected () =
   let err =
     Agent_sdk.Error.Agent
@@ -2506,6 +2566,32 @@ let test_auto_recoverable_turn_error_excludes_persistent_errors () =
       (AuthError { message = "Unauthorized" })
   in
   check bool "auth error is persistent" false
+    (UT.is_auto_recoverable_turn_error err)
+
+let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota () =
+  let err =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+         {
+           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           reason =
+             Keeper_types.Other_detail
+               "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+         })
+  in
+  check bool "wrapped cascade hard quota is auto-recoverable" true
+    (UT.is_auto_recoverable_turn_error err)
+
+let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion () =
+  let err =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+         {
+           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+           reason = Keeper_types.Candidates_filtered_after_cycles;
+         })
+  in
+  check bool "filtered candidates cascade exhaustion is auto-recoverable" true
     (UT.is_auto_recoverable_turn_error err)
 
 let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
@@ -3784,6 +3870,8 @@ let () =
             test_auto_recoverable_turn_error_includes_transient_network;
           test_case "auto-recoverable includes server parse rejection" `Quick
             test_auto_recoverable_turn_error_includes_server_parse_rejection;
+          test_case "auto-recoverable includes wrapped hard quota" `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_hard_quota;
           test_case "required tool contract violation detected from structured error" `Quick
             test_required_tool_contract_violation_detected;
           test_case "legacy internal contract violation is ignored" `Quick
@@ -3796,6 +3884,10 @@ let () =
             test_auto_recoverable_turn_error_excludes_required_tool_contract_violation;
           test_case "auto-recoverable excludes persistent errors" `Quick
             test_auto_recoverable_turn_error_excludes_persistent_errors;
+          test_case "auto-recoverable includes wrapped cascade hard quota" `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota;
+          test_case "auto-recoverable includes filtered candidates cascade exhaustion" `Quick
+            test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion;
           test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
             test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
           test_case "bounded OAS timeout caps to remaining turn budget" `Quick
@@ -3851,6 +3943,14 @@ let () =
             test_fail_open_local_only_preserves_explicit_local_only_base;
           test_case "healthy local_only stays selected" `Quick
             test_fail_open_local_only_preserves_healthy_local_only;
+          test_case "strict quota fail-open broadens to default cascade" `Quick
+            test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default;
+          test_case "phase override fail-open returns to base cascade" `Quick
+            test_fail_open_cascade_after_auto_recoverable_error_returns_base_after_phase_override;
+          test_case "explicit local_only keeps fail-open disabled" `Quick
+            test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only;
+          test_case "default cascade has no broader fail-open target" `Quick
+            test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade;
         ] );
       ( "tool_classification",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -669,6 +669,18 @@ let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
   Alcotest.(check bool) "existing RateLimited hard quota still works" true
     (Oas_worker_named.sdk_error_is_hard_quota err)
 
+let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.NetworkError
+         {
+           message =
+             "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+         })
+  in
+  Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
 let make_openai_compat_provider_cfg ?(model_id = "mock-model")
     ?(base_url = "http://127.0.0.1:18080/v1")
     ?(request_path = "/chat/completions") ?(api_key = "") () =
@@ -2531,6 +2543,8 @@ let () =
         test_cascade_provider_labels_detect_kimi_from_model_and_base_url;
       Alcotest.test_case "sdk_error_is_hard_quota detects Gemini CLI wrapper" `Quick
         test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper;
+      Alcotest.test_case "sdk_error_is_hard_quota detects Claude CLI limit wrapper" `Quick
+        test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper;
       Alcotest.test_case "sdk_error_is_hard_quota keeps transient network errors false" `Quick
         test_sdk_error_is_hard_quota_keeps_transient_network_errors_false;
       Alcotest.test_case "sdk_error_is_hard_quota preserves RateLimited detection" `Quick


### PR DESCRIPTION
## Summary
- classify Claude CLI wrapped 429 limit responses as hard quota
- fail open keeper turns from strict or phase-routed cascades to a broader fallback cascade when exhaustion is auto-recoverable
- stop empty circuit-breaker retry cycles when every candidate is already in cooldown

## Why
Claude CLI quota exhaustion was getting wrapped as a network/internal error, then surfaced as `cascade_exhausted`. That left keepers auto-recoverable but still stuck on the same cascade, so they did not naturally move to another provider or model in the same turn.

## Impact
- wrapped Claude limit responses now trigger hard-quota handling and cooldown instead of repeated same-provider retries
- keeper turns can broaden from `tool_use_strict` or `resilient_breaker` to `keeper_unified`, or return from a phase override to the keeper's configured base cascade, in the same turn
- `Candidates_filtered_after_cycles` stays auto-recoverable and no longer drives the keeper into `failing`
- empty retry-cycle log spam is reduced when all providers are cooling down

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-claude-limit-cascade`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-claude-limit-cascade ./test/test_oas_worker.exe`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 8-11`
