### PR TITLE
refactor(keeper): consolidate string fallback — Phase D (blocker_class_of_string)

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -145,6 +145,41 @@ let runtime_keepalive_started_at (config : Coord_utils.config)
    cascade_exhaustion_summary, blocker_class_continue_gate
    are defined in Keeper_types (keeper_types.ml). *)
 
+let blocker_class_of_string (reason : string) : blocker_class option =
+  let trimmed = String.trim reason in
+  if trimmed = "" then None
+  else if
+    String_util.contains_substring_ci trimmed
+      "turn outcome ambiguous after committed mutating tool call(s)"
+  then
+    Some
+      (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
+       then Ambiguous_post_commit_timeout
+       else Ambiguous_post_commit_failure)
+  else if String_util.contains_substring_ci trimmed "cascade_exhausted" then
+    let reason =
+      if String_util.contains_substring_ci trimmed "connection refused" then
+        Connection_refused
+      else if
+        String_util.contains_substring_ci trimmed "no providers available"
+      then
+        No_providers_available
+      else if String_util.contains_substring_ci trimmed "all providers failed"
+      then
+        All_providers_failed
+      else
+        Other_detail trimmed
+    in
+    Some (Cascade_exhausted reason)
+  else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
+  then
+    Some Admission_queue_wait_timeout
+  else if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
+  then
+    Some Turn_timeout
+  else
+    None
+
 let blocker_class_of_sdk_error (err : Oas.Error.sdk_error) : blocker_class option =
   match Oas_worker_named.classify_masc_internal_error err with
   | Some (Oas_worker_named.Cascade_exhausted { reason; _ }) ->
@@ -162,24 +197,8 @@ let blocker_class_of_sdk_error (err : Oas.Error.sdk_error) : blocker_class optio
         (if is_timeout then Ambiguous_post_commit_timeout
          else Ambiguous_post_commit_failure)
   | None -> (
-      (* Legacy fallback for pre-Phase-C persisted errors *)
       match err with
-      | Oas.Error.Internal msg ->
-          let trimmed = String.trim msg in
-          if String_util.contains_substring_ci trimmed
-               "turn outcome ambiguous after committed mutating tool call(s)"
-          then
-            Some
-              (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
-               then Ambiguous_post_commit_timeout
-               else Ambiguous_post_commit_failure)
-          else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
-          then
-            Some Admission_queue_wait_timeout
-          else if String_util.contains_substring_ci trimmed "turn wall-clock timeout" then
-            Some Turn_timeout
-          else
-            None
+      | Oas.Error.Internal msg -> blocker_class_of_string msg
       | _ -> None)
 
 (* ── Runtime blocker surface ───────────────────────────────── *)
@@ -220,63 +239,6 @@ let runtime_blocker_surface_of_failure_reason
         }
   | _ -> None
 
-let runtime_blocker_surface_of_reason (reason : string) =
-  let trimmed = String.trim reason in
-  if trimmed = "" then
-    None
-  else if
-    String_util.contains_substring_ci trimmed
-      "turn outcome ambiguous after committed mutating tool call(s)"
-  then
-    Some
-      {
-        blocker_class =
-          (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
-           then "ambiguous_post_commit_timeout"
-           else "ambiguous_post_commit_failure");
-        summary = trimmed;
-        continue_gate = true;
-      }
-  else if String_util.contains_substring_ci trimmed "cascade_exhausted"
-  then
-    Some
-      {
-        blocker_class = "cascade_exhausted";
-        summary =
-          (if String_util.contains_substring_ci trimmed "connection refused" then
-             "Cascade exhausted after provider failures; local runtime connection refused."
-           else if
-             String_util.contains_substring_ci trimmed
-               "no providers available"
-           then
-             "Cascade exhausted; no providers were available."
-           else if
-             String_util.contains_substring_ci trimmed "all providers failed"
-           then
-             "Cascade exhausted after all configured providers failed."
-           else
-             "Cascade exhausted after provider failures.");
-        continue_gate = false;
-      }
-  else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
-  then
-    Some
-      {
-        blocker_class = "admission_queue_wait_timeout";
-        summary = trimmed;
-        continue_gate = false;
-      }
-  else if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
-  then
-    Some
-      {
-        blocker_class = "turn_timeout";
-        summary = trimmed;
-        continue_gate = false;
-      }
-  else
-    None
-
 let proactive_runtime_reason_is_current (meta : keeper_meta) =
   let proactive_ts = meta.runtime.proactive_rt.last_ts in
   let last_turn_ts = meta.runtime.usage.last_turn_ts in
@@ -303,12 +265,19 @@ let runtime_blocker_fields_json (config : Coord_utils.config)
     match derived with
     | Some blocker -> Some blocker
     | None -> (
-        match runtime_blocker_surface_of_reason meta.runtime.last_blocker with
-        | Some blocker -> Some blocker
+        match blocker_class_of_string meta.runtime.last_blocker with
+        | Some cls ->
+            Some
+              (runtime_blocker_surface_of_typed_class
+                 ~summary:meta.runtime.last_blocker cls)
         | None
           when proactive_runtime_reason_is_current meta ->
-            runtime_blocker_surface_of_reason
-              meta.runtime.proactive_rt.last_reason
+            (match blocker_class_of_string meta.runtime.proactive_rt.last_reason with
+             | Some cls ->
+                 Some
+                   (runtime_blocker_surface_of_typed_class
+                      ~summary:meta.runtime.proactive_rt.last_reason cls)
+             | None -> None)
         | None -> None)
   in
   match derived with

--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -19,6 +19,9 @@ type runtime_blocker_surface = {
   continue_gate : bool;
 }
 
+val blocker_class_of_string :
+  string -> blocker_class option
+
 val blocker_class_of_sdk_error :
   Oas.Error.sdk_error -> blocker_class option
 
@@ -27,9 +30,6 @@ val runtime_blocker_surface_of_typed_class :
 
 val runtime_blocker_surface_of_failure_reason :
   Keeper_registry.failure_reason -> runtime_blocker_surface option
-
-val runtime_blocker_surface_of_reason :
-  string -> runtime_blocker_surface option
 
 val string_list_to_json : string list -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -44,18 +44,17 @@ let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
     in
     updated_ts > 0.0 && now -. updated_ts >= paused_ttl_sec
 
-let ambiguous_partial_commit_prefix =
-  "turn outcome ambiguous after committed mutating tool call(s)"
-
 let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   meta.paused
   && (match meta.runtime.last_blocker_class with
       | Some Ambiguous_post_commit_timeout | Some Ambiguous_post_commit_failure ->
           true
       | None ->
-          String_util.contains_substring_ci
-            (String.trim meta.runtime.last_blocker)
-            ambiguous_partial_commit_prefix
+          (match Keeper_status_bridge.blocker_class_of_string
+                  meta.runtime.last_blocker with
+           | Some Ambiguous_post_commit_timeout
+           | Some Ambiguous_post_commit_failure -> true
+           | _ -> false)
       | _ -> false)
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
@@ -321,9 +320,15 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
         "ambiguous_partial_commit(post_commit_timeout)"
     | Some Ambiguous_post_commit_failure ->
         "ambiguous_partial_commit(post_commit_failure)"
-    | None when String_util.contains_substring_ci blocker "turn wall-clock timeout" ->
-        "ambiguous_partial_commit(post_commit_timeout)"
-    | _ -> "ambiguous_partial_commit(post_commit_failure)"
+    | None ->
+        (match Keeper_status_bridge.blocker_class_of_string blocker with
+         | Some Ambiguous_post_commit_timeout ->
+             "ambiguous_partial_commit(post_commit_timeout)"
+         | Some Ambiguous_post_commit_failure ->
+             "ambiguous_partial_commit(post_commit_failure)"
+         | Some _ -> "ambiguous_partial_commit(post_commit_failure)"
+         | None -> "ambiguous_partial_commit(post_commit_failure)")
+    | Some _ -> "ambiguous_partial_commit(post_commit_failure)"
   in
   let input =
     `Assoc


### PR DESCRIPTION
## Summary

- Extract `blocker_class_of_string` as the **single** legacy string classification function (9 `contains_substring_ci` calls in one place)
- Delete `runtime_blocker_surface_of_reason` (~55 lines, 9 `contains_substring_ci`) — its callers now go through `blocker_class_of_string → runtime_blocker_surface_of_typed_class`
- Simplify `blocker_class_of_sdk_error` legacy `None` branch (5 → 0 `contains_substring_ci` via delegation)
- Simplify `keeper_supervisor.ml` 2 fallback sites + remove `ambiguous_partial_commit_prefix` constant
- **Blocker path**: 14 → 9 `contains_substring_ci` (all consolidated). Total lib/: ~40 → ~33.

## Phase context

Phase A→B→C→D series implementing "Parse, Don't Validate" for keeper blocker classification:
- **Phase C** (#9310): Added 3 `masc_internal_error` variants with JSON codec, updated producers, removed zombie matchers
- **Phase D** (this PR): Consolidates all remaining string fallback into one function

## Files changed

| File | Change |
|------|--------|
| `lib/keeper/keeper_status_bridge.ml` | Add `blocker_class_of_string`, delete `runtime_blocker_surface_of_reason`, rewrite level 3 fallback |
| `lib/keeper/keeper_status_bridge.mli` | Update interface (remove old val, add new val) |
| `lib/keeper/keeper_supervisor.ml` | Delegate 2 fallback sites, remove constant |

## Test plan

- [x] `dune build --root .` — compiles with warning 8 (exhaustive match)
- [x] `dune runtest --root .` — 119 tests pass
- [ ] Keeper runtime: dashboard JSON blocker_class/summary unchanged for pre-Phase-C data

🤖 Generated with [Claude Code](https://claude.com/claude-code)