### PR TITLE
[codex] Add turn-scoped keeper sandbox runtime

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -426,6 +426,7 @@
    keeper_alerting_path
    keeper_sandbox_containment
    keeper_sandbox_runtime
+   keeper_turn_sandbox_runtime
    keeper_docker_read
    keeper_timing
    keeper_tool_registry
@@ -685,6 +686,7 @@
   keeper_alerting_path
   keeper_sandbox_containment
   keeper_sandbox_runtime
+  keeper_turn_sandbox_runtime
   keeper_docker_read
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -741,8 +741,8 @@ let run_turn
               (fun (e : Keeper_tool_affinity.affinity_entry) ->
                  Printf.sprintf "%s(%.1f)" e.tool_name e.score)
               entries)));
-  let keeper_tools =
-    Keeper_tools_oas.make_tools
+  let keeper_tool_bundle =
+    Keeper_tools_oas.make_tool_bundle
       ~config
       ~meta
       ~ctx_snapshot
@@ -752,7 +752,7 @@ let run_turn
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
-  let tools = extend_turns_tool :: keeper_tools in
+  let tools = extend_turns_tool :: keeper_tool_bundle.tools in
   let tool_usage_before =
     Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
   in
@@ -890,7 +890,7 @@ let run_turn
     }
   in
   let tool_entries =
-    List.map (tool_index_entry_of_tool ~korean_kw_tbl) keeper_tools
+    List.map (tool_index_entry_of_tool ~korean_kw_tbl) keeper_tool_bundle.tools
   in
   (* Full-universe search index for keeper_tool_search.
      Separate from the preset-scoped Tool_selector used for progressive disclosure:
@@ -909,7 +909,7 @@ let run_turn
     let preset_tools =
       List.filter
         (fun (t : Agent_sdk.Tool.t) -> Hashtbl.mem preset_set t.schema.name)
-        keeper_tools
+        keeper_tool_bundle.tools
     in
     let progressive_tool_index_config =
       { Agent_sdk.Tool_index.default_config with
@@ -926,17 +926,17 @@ let run_turn
      Two maps: description (string) and full schema (tool_schema).
      Covers both keeper_* and masc_* tools from the OAS Tool.t list. *)
   let oas_description_map =
-    let tbl = Hashtbl.create (List.length keeper_tools) in
+    let tbl = Hashtbl.create (List.length keeper_tool_bundle.tools) in
     List.iter
       (fun (t : Agent_sdk.Tool.t) ->
          Hashtbl.replace tbl t.schema.name t.schema.description)
-      keeper_tools;
+      keeper_tool_bundle.tools;
     tbl
   in
   (* Map tool name → OAS input_schema JSON for keeper_tool_search enrichment.
      Covers keeper_* tools that don't appear in masc_schemas_ref. *)
   let oas_input_schema_map =
-    let tbl = Hashtbl.create (List.length keeper_tools) in
+    let tbl = Hashtbl.create (List.length keeper_tool_bundle.tools) in
     List.iter
       (fun (t : Agent_sdk.Tool.t) ->
          let param_type_str (pt : Agent_sdk.Types.param_type) =
@@ -971,7 +971,7 @@ let run_turn
              ]
          in
          Hashtbl.replace tbl t.schema.name schema)
-      keeper_tools;
+      keeper_tool_bundle.tools;
     tbl
   in
   (* Wire keeper_tool_search: update session-local ref with the real BM25 impl.
@@ -1114,7 +1114,7 @@ let run_turn
     Log.Keeper.debug
       "keeper:%s tool visibility: total=%d search_indexed=%d"
       meta.name
-      (List.length keeper_tools)
+      (List.length keeper_tool_bundle.tools)
       (List.length tool_entries);
   (* Layer 0: Core tools — always visible to the LLM regardless of preset.
      Kept to 5 survival-critical tools (#4961).  Status and other coordination tools
@@ -1127,7 +1127,10 @@ let run_turn
      this includes all candidate tools minus denied.  BM25 retrieval
      and Tool_op.Add operate within this scope. *)
   let all_tool_names =
-    "extend_turns" :: List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) keeper_tools
+    "extend_turns"
+    :: List.map
+         (fun (t : Agent_sdk.Tool.t) -> t.schema.name)
+         keeper_tool_bundle.tools
   in
   (* Precompute membership table for AllowList validation below.
      all_tool_names is constant for the session; building universe_set
@@ -2085,46 +2088,49 @@ let run_turn
             meta.name (Printexc.to_string exn)
     in
     (match
-       Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
-         Oas_worker.run_named
-           ~cascade_name
-           ~model_strings:meta.models
-           ?provider_filter
-           ~require_tool_choice_support
-           ~goal:user_message
-           ~priority
-           ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-           ~system_prompt:turn_system_prompt
-           ~tools
-           ~compact_ratio:meta.compaction.ratio_gate
-           ~initial_messages:history_messages
-           ~hooks
-           ~context_reducer:reducer
-           ~summarizer:Keeper_summarizer.keeper_summarizer
-           ~memory
-             (* Keepers use turn-level retry for transient errors but benefit
-               from OAS per-call retry for validation errors (malformed tool
-               args). retry_on_validation_error=true lets OAS re-prompt the
-               LLM with structured feedback instead of wasting a full turn.
-               retry_on_recoverable_tool_error remains false — tool-level
-               errors are handled by MASC's consecutive failure guardrail. *)
-           ~tool_retry_policy:{
-             Oas.Tool_retry_policy.max_retries = 2;
-             retry_on_validation_error = true;
-             retry_on_recoverable_tool_error = false;
-             feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
-           }
-           ~max_turns
-           ~max_idle_turns
-           ~temperature
-           ~max_tokens
-           ?max_cost_usd
-           ?wait_timeout_sec:admission_wait_timeout_sec
-           ?guardrails
-           ?on_event
-           ?on_yield
-           ?on_resume
-           ~agent_ref
+       Fun.protect
+         ~finally:keeper_tool_bundle.cleanup
+         (fun () ->
+           Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
+             Oas_worker.run_named
+               ~cascade_name
+               ~model_strings:meta.models
+               ?provider_filter
+               ~require_tool_choice_support
+               ~goal:user_message
+               ~priority
+               ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+               ~system_prompt:turn_system_prompt
+               ~tools
+               ~compact_ratio:meta.compaction.ratio_gate
+               ~initial_messages:history_messages
+               ~hooks
+               ~context_reducer:reducer
+               ~summarizer:Keeper_summarizer.keeper_summarizer
+               ~memory
+                 (* Keepers use turn-level retry for transient errors but benefit
+                   from OAS per-call retry for validation errors (malformed tool
+                   args). retry_on_validation_error=true lets OAS re-prompt the
+                   LLM with structured feedback instead of wasting a full turn.
+                   retry_on_recoverable_tool_error remains false — tool-level
+                   errors are handled by MASC's consecutive failure guardrail. *)
+               ~tool_retry_policy:{
+                 Oas.Tool_retry_policy.max_retries = 2;
+                 retry_on_validation_error = true;
+                 retry_on_recoverable_tool_error = false;
+                 feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
+               }
+               ~max_turns
+               ~max_idle_turns
+               ~temperature
+               ~max_tokens
+               ?max_cost_usd
+               ?wait_timeout_sec:admission_wait_timeout_sec
+               ?guardrails
+               ?on_event
+               ?on_yield
+               ?on_resume
+               ~agent_ref
            ?contract
            ?cli_transport_overrides
            ~allowed_paths:oas_allowed_paths
@@ -2143,6 +2149,7 @@ let run_turn
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())
+         )
      with
      | Error e -> Error e
      | Ok result ->
@@ -2281,9 +2288,10 @@ let run_turn
              meta.name
              (String.concat ", " unexpected_tool_names);
          let actual_keeper_tool_names =
-           observed_tool_names
-           |> Keeper_tool_alias.canonicalize_observed
-           |> List.filter (fun tool_name -> List.mem tool_name all_tool_names)
+           Keeper_tool_disclosure.final_keeper_tool_names
+             ~reported_tool_names
+             ~observed_tool_names
+             ~allowed_tool_names:all_tool_names
          in
          let usage = Keeper_exec_context.usage_of_response result.response in
          let ctx_composition =

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -95,70 +95,78 @@ let container_name_of meta =
     (Unix.getpid ())
     (int_of_float (Unix.gettimeofday () *. 1000.0))
 
-let run_command_in_container_with_status ?(ok_exit_codes = [ 0 ])
+let run_command_in_container_with_status ?turn_sandbox_runtime
+    ?(ok_exit_codes = [ 0 ])
     ~config ~(meta : keeper_meta)
     ~(command_argv : string list) ~(max_bytes : int)
     ~(timeout_sec : float) () : (Unix.process_status * string, string) result =
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
-  if String.trim image = "" then
+  if Option.is_none turn_sandbox_runtime && String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else if command_argv = [] then
     Error "run_command_in_container_with_status: command_argv is empty"
   else
-    match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
-    | Error err -> Error err
-    | Ok seccomp_args ->
-      let host_root = host_playground_root ~config ~meta in
-      let croot = container_root ~meta in
-      let container_name = container_name_of meta in
-      let uid = Unix.getuid () in
-      let gid = Unix.getgid () in
-      let argv =
-        build_docker_argv ~image ~container_name ~host_root ~croot
-          ~uid ~gid ~seccomp_args ~command_argv
-      in
-      let st, out =
-        Process_eio.run_argv_with_status
-          ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-      in
-      let head_program =
-        match command_argv with prog :: _ -> prog | [] -> "?"
-      in
-      (match st with
-       | Unix.WEXITED code
-         when List.exists (fun ok_code -> ok_code = code) ok_exit_codes ->
-         let body =
-           if String.length out > max_bytes then String.sub out 0 max_bytes
-           else out
-         in
-         Ok (st, body)
-       | Unix.WEXITED code ->
-         Error
-           (Printf.sprintf
-              "docker_%s_failed: exit=%d output=%s"
-              head_program code
-              (Worker_dev_tools.truncate_for_log out))
-       | Unix.WSIGNALED n ->
-         Error
-           (Printf.sprintf "docker_%s_signaled: signal=%d" head_program n)
-       | Unix.WSTOPPED n ->
-         Error
-           (Printf.sprintf "docker_%s_stopped: signal=%d" head_program n))
+    match turn_sandbox_runtime with
+    | Some runtime ->
+      let cwd = host_playground_root ~config ~meta in
+      Keeper_turn_sandbox_runtime.run_command_with_status
+        ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
+    | None ->
+      match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
+      | Error err -> Error err
+      | Ok seccomp_args ->
+        let host_root = host_playground_root ~config ~meta in
+        let croot = container_root ~meta in
+        let container_name = container_name_of meta in
+        let uid = Unix.getuid () in
+        let gid = Unix.getgid () in
+        let argv =
+          build_docker_argv ~image ~container_name ~host_root ~croot
+            ~uid ~gid ~seccomp_args ~command_argv
+        in
+        let st, out =
+          Process_eio.run_argv_with_status
+            ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+        in
+        let head_program =
+          match command_argv with prog :: _ -> prog | [] -> "?"
+        in
+        (match st with
+         | Unix.WEXITED code
+           when List.exists (fun ok_code -> ok_code = code) ok_exit_codes ->
+           let body =
+             if String.length out > max_bytes then String.sub out 0 max_bytes
+             else out
+           in
+           Ok (st, body)
+         | Unix.WEXITED code ->
+           Error
+             (Printf.sprintf
+                "docker_%s_failed: exit=%d output=%s"
+                head_program code
+                (Worker_dev_tools.truncate_for_log out))
+         | Unix.WSIGNALED n ->
+           Error
+             (Printf.sprintf "docker_%s_signaled: signal=%d" head_program n)
+         | Unix.WSTOPPED n ->
+           Error
+             (Printf.sprintf "docker_%s_stopped: signal=%d" head_program n))
 
-let run_command_in_container ?(ok_exit_codes = [ 0 ]) ~config ~meta
+let run_command_in_container ?turn_sandbox_runtime ?(ok_exit_codes = [ 0 ]) ~config ~meta
     ~command_argv ~max_bytes ~timeout_sec () =
   match
-    run_command_in_container_with_status ~ok_exit_codes ~config ~meta
+    run_command_in_container_with_status ?turn_sandbox_runtime
+      ~ok_exit_codes ~config ~meta
       ~command_argv ~max_bytes ~timeout_sec ()
   with
   | Error _ as err -> err
   | Ok (_st, out) -> Ok out
 
-let read_file_in_container ~config ~(meta : keeper_meta) ~host_path
+let read_file_in_container ?turn_sandbox_runtime ~config ~(meta : keeper_meta) ~host_path
     ~(max_bytes : int) ~(timeout_sec : float) () : (string, string) result =
   match container_path_of_host ~config ~meta ~host_path with
   | Error _ as e -> e
   | Ok container_path ->
-    run_command_in_container ~config ~meta
+    run_command_in_container ?turn_sandbox_runtime ~config ~meta
       ~command_argv:[ "cat"; container_path ]
       ~max_bytes ~timeout_sec ()

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -35,6 +35,7 @@ val container_path_of_host :
     Errors include image misconfiguration, docker exit non-zero, or
     the input not being inside the playground. *)
 val read_file_in_container :
+  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   host_path:string ->
@@ -62,6 +63,7 @@ val read_file_in_container :
     the program name (e.g. [docker_rg_failed], [docker_cat_failed])
     for caller log forensics. *)
 val run_command_in_container_with_status :
+  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?ok_exit_codes:int list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
@@ -76,6 +78,7 @@ val run_command_in_container_with_status :
     [run_command_in_container_with_status] that drops the returned
     process status and keeps only the captured stdout bytes. *)
 val run_command_in_container :
+  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?ok_exit_codes:int list ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -51,6 +51,7 @@ let is_missing_read_path_error (e : string) =
   || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
 
 let handle_keeper_fs_read
+      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -89,7 +90,7 @@ let handle_keeper_fs_read
     if Keeper_docker_read.should_route_read ~meta then
       let timeout_sec = 30.0 in
       match
-        Keeper_docker_read.read_file_in_container ~config ~meta
+        Keeper_docker_read.read_file_in_container ?turn_sandbox_runtime ~config ~meta
           ~host_path:target ~max_bytes ~timeout_sec ()
       with
       | Error msg ->
@@ -174,6 +175,7 @@ let apply_patch ~old_string ~new_string ~replace_all text =
       Ok (Buffer.contents buf, occurrences)
 
 let handle_keeper_fs_edit
+      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -220,7 +222,17 @@ let handle_keeper_fs_edit
               | Error msg ->
                 error_json ~fields:[ "path", `String target ] msg
               | Ok (updated, occurrences) ->
-                Fs_compat.save_file target updated;
+                (match turn_sandbox_runtime with
+                 | Some runtime ->
+                   (match
+                      Keeper_turn_sandbox_runtime.overwrite_file runtime
+                        ~host_path:target ~content:updated
+                        ~timeout_sec:30.0 ()
+                    with
+                    | Ok () -> ()
+                    | Error msg -> raise (Sys_error msg))
+                 | None ->
+                   Fs_compat.save_file target updated);
                 Log.Keeper.info
                   "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
                    replace_all=%b occurrences=%d bytes=%d"
@@ -251,12 +263,31 @@ let handle_keeper_fs_edit
   | Error e -> error_json e
   | Ok target ->
     (try
-       let parent = Filename.dirname target in
-       Fs_compat.mkdir_p parent;
-       (match mode with
-        | Append -> Fs_compat.append_file target content
-        | Overwrite -> Fs_compat.save_file target content
-        | Patch -> ()  (* unreachable: caught above *));
+       (match turn_sandbox_runtime with
+        | Some runtime ->
+          (match mode with
+           | Append ->
+             (match
+                Keeper_turn_sandbox_runtime.append_file runtime
+                  ~host_path:target ~content ~timeout_sec:30.0 ()
+              with
+              | Ok () -> ()
+              | Error msg -> raise (Sys_error msg))
+           | Overwrite ->
+             (match
+                Keeper_turn_sandbox_runtime.overwrite_file runtime
+                  ~host_path:target ~content ~timeout_sec:30.0 ()
+              with
+              | Ok () -> ()
+              | Error msg -> raise (Sys_error msg))
+           | Patch -> ())
+        | None ->
+          let parent = Filename.dirname target in
+          Fs_compat.mkdir_p parent;
+          (match mode with
+           | Append -> Fs_compat.append_file target content
+           | Overwrite -> Fs_compat.save_file target content
+           | Patch -> ()  (* unreachable: caught above *)));
        Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
          meta.name target mode_label
          (String.length content);

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -11,12 +11,14 @@ val all_fs_write_modes : fs_write_mode list
 val valid_fs_write_mode_strings : string list
 
 val handle_keeper_fs_read :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
   string
 
 val handle_keeper_fs_edit :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -176,11 +176,23 @@ let process_status_is_timeout = function
   | Unix.WEXITED 124 -> true  (* Process_eio returns 124 on Eio.Time.Timeout *)
   | _ -> false
 
+let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
+  let rec loop attempts_left =
+    let result = Process_eio.run_argv_with_status ?cwd ~timeout_sec argv in
+    match result with
+    | Unix.WEXITED 127, out
+      when attempts_left > 0
+           && String_util.contains_substring_ci out "interrupted system call" ->
+        loop (attempts_left - 1)
+    | _ -> result
+  in
+  loop 3
+
 let shell_command_available name =
   let probe =
     Printf.sprintf "command -v %s >/dev/null 2>&1" (Filename.quote name)
   in
-  match Process_eio.run_argv_with_status ~timeout_sec:2.0 [ "/bin/sh"; "-c"; probe ] with
+  match run_argv_with_status_retry_eintr ~timeout_sec:2.0 [ "/bin/sh"; "-c"; probe ] with
   | Unix.WEXITED 0, _ -> true
   | _ -> false
 (** Write playground repo state cache after successful clone/pull.
@@ -613,6 +625,7 @@ let run_docker_with_git_bash
          ])
 
 let run_docker_hardened_bash
+    ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(cwd : string)
@@ -630,7 +643,35 @@ let run_docker_hardened_bash
     sandbox_error_json
       "sandbox_profile=docker blocks nested container runtimes and host socket references"
   else
-    match ensure_keeper_sandbox_runtime ~timeout_sec with
+    match turn_sandbox_runtime, network_mode with
+    | Some runtime, Network_none ->
+      (match
+         Keeper_turn_sandbox_runtime.run_bash_with_status runtime
+           ~cwd ~cmd ~timeout_sec ()
+       with
+       | Error message -> sandbox_error_json message
+       | Ok (st, out) ->
+         if st <> Unix.WEXITED 0 then
+           Keeper_registry.record_error ~base_path:config.base_path meta.name
+             (Printf.sprintf "sandbox docker exec failed (%s): %s"
+                image
+                (Worker_dev_tools.truncate_for_log out))
+         else
+           Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+         Yojson.Safe.to_string
+           (`Assoc
+              [
+                ("ok", `Bool (st = Unix.WEXITED 0));
+                ("cwd", `String cwd);
+                ("sandbox_profile", `String "docker");
+                ("git_creds_enabled", `Bool false);
+                ("network_mode", `String (network_mode_to_string network_mode));
+                ("effective_sandbox_image", `String image);
+                ("status", Keeper_alerting_path.process_status_to_json st);
+                ("output", `String out);
+              ]))
+    | _ ->
+      match ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error err -> sandbox_error_json err
     | Ok seccomp_args ->
     let host_root =
@@ -705,6 +746,7 @@ let run_docker_hardened_bash
          ])
 
 let handle_keeper_bash
+      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -844,6 +886,7 @@ let handle_keeper_bash
         "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s network=%s"
         meta.name cwd cmd_for_log (network_mode_to_string sandbox_network_mode);
       run_docker_hardened_bash
+        ~turn_sandbox_runtime
         ~config ~meta ~cwd ~timeout_sec ~cmd
         ~network_mode:sandbox_network_mode)
     else
@@ -1394,6 +1437,7 @@ let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta) =
                           ()))
 
 let handle_keeper_shell
+      ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -1445,7 +1489,7 @@ let handle_keeper_shell
   in
   let render_process_result ?cwd ~cmd argv =
     let st, out =
-      Process_eio.run_argv_with_status ?cwd ~timeout_sec:io_timeout_sec argv
+      run_argv_with_status_retry_eintr ?cwd ~timeout_sec:io_timeout_sec argv
     in
     Yojson.Safe.to_string
       (Exec_core.process_result_json
@@ -1466,6 +1510,25 @@ let handle_keeper_shell
          ~output:out
          ())
   in
+  let render_completed_process_result ?cwd ~cmd ?(extra = []) st out =
+    Yojson.Safe.to_string
+      (Exec_core.process_result_json
+         ~artifact_policy:Exec_core.Inline_only
+         ~base_path:root
+         ~keeper_name:meta.name
+         ~cmd
+         ~extra:([
+             "op", `String op;
+             "cmd", `String cmd;
+             ( "cwd",
+               match cwd with
+               | Some dir -> `String dir
+               | None -> `Null );
+           ] @ extra)
+         ~status:st
+         ~output:out
+         ())
+  in
   let docker_read_error ~target msg =
     error_json ~fields:[ "op", `String op; "path", `String target ] msg
   in
@@ -1478,24 +1541,46 @@ let handle_keeper_shell
     | Ok cpath -> (
         match
           Keeper_docker_read.run_command_in_container_with_status
+            ?turn_sandbox_runtime
             ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
             ~max_bytes ~timeout_sec ()
         with
         | Error msg -> Error (docker_read_error ~target msg)
         | Ok payload -> Ok payload)
   in
+  let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
+      ~max_bytes ~timeout_sec ?(extra = []) () =
+    match turn_sandbox_runtime with
+    | Some runtime ->
+      (match
+         Keeper_turn_sandbox_runtime.run_command_with_status
+           ~ok_exit_codes runtime ~cwd ~command_argv ~max_bytes ~timeout_sec ()
+       with
+       | Error msg ->
+         error_json
+           ~fields:([ "op", `String op; "cwd", `String cwd ] @ extra) msg
+       | Ok (st, out) ->
+         render_completed_process_result ~cwd ~cmd ~extra st out)
+    | None ->
+      render_process_result ~cwd ~cmd command_argv
+  in
   match op with
   | "pwd" ->
     (match cwd_target () with
      | Error e -> path_error e
-     | Ok cwd -> render_process_result ~cwd ~cmd:"pwd" [ "/bin/pwd" ])
+     | Ok cwd ->
+       run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ "/bin/pwd" ]
+         ~max_bytes:4096 ~timeout_sec:io_timeout_sec ())
   | "git_status" ->
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       render_process_result ~cwd
-         ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
-         [ "git"; "-C"; cwd; "--no-optional-locks"; "status"; "--short"; "--branch" ])
+       run_in_turn_runtime ~cwd
+         ~cmd:"git --no-optional-locks status --short --branch"
+         ~command_argv:
+           [ "git"; "--no-optional-locks"; "status"; "--short"; "--branch" ]
+         ~max_bytes:1_000_000
+         ~timeout_sec:read_timeout_sec ())
   | "ls" ->
     (match read_target () with
      | Error e -> path_error e
@@ -1534,9 +1619,11 @@ let handle_keeper_shell
                      ; "via", `String "docker"
                      ; "entries", lines_to_json ~limit out
                      ])))
-       else
-         let st, out =
-           Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec [ "/bin/ls"; "-la"; target ]
+        else
+          let st, out =
+           run_argv_with_status_retry_eintr
+             ~timeout_sec:io_timeout_sec
+             [ "/bin/ls"; "-la"; target ]
          in
          Yojson.Safe.to_string
            (`Assoc
@@ -1580,7 +1667,9 @@ let handle_keeper_shell
                   ]))
        else
          let st, out =
-           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec [ "/bin/cat"; target ]
+           run_argv_with_status_retry_eintr
+             ~timeout_sec:read_timeout_sec
+             [ "/bin/cat"; target ]
          in
          let body =
            if String.length out > max_bytes then String.sub out 0 max_bytes else out
@@ -1655,7 +1744,7 @@ let handle_keeper_shell
                    ]))
         else
           let st, out =
-            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
+            run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec argv
           in
           (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
              Treat exit 1 as success with empty results — "no match" is a valid answer. *)
@@ -1682,18 +1771,62 @@ let handle_keeper_shell
            Printf.sprintf "-%d" count ]
        in
        let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
-       let st, out =
-         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
-       in
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "ok", `Bool (st = Unix.WEXITED 0)
-             ; "op", `String op
-             ; "cwd", `String cwd
-             ; "count", `Int count
-             ; "status", Keeper_alerting_path.process_status_to_json st
-             ; "entries", lines_to_json ~limit:50 out
-             ]))
+       (match turn_sandbox_runtime with
+        | Some runtime ->
+          let argv =
+            let base_argv =
+              [ "git"; "--no-optional-locks"; "log";
+                Printf.sprintf "--format=%s" format;
+                Printf.sprintf "-%d" count ]
+            in
+            if file_path = "" then base_argv
+            else
+              let runtime_path =
+                if Filename.is_relative file_path then file_path
+                else
+                  match
+                    Keeper_turn_sandbox_runtime.container_path_of_host runtime
+                      ~host_path:file_path
+                  with
+                  | Ok mapped -> mapped
+                  | Error _ -> file_path
+              in
+              base_argv @ [ "--"; runtime_path ]
+          in
+          (match
+             Keeper_turn_sandbox_runtime.run_command_with_status runtime
+               ~cwd ~command_argv:argv
+               ~ok_exit_codes:[ 0 ]
+               ~max_bytes:1_000_000
+               ~timeout_sec:read_timeout_sec ()
+           with
+           | Error msg ->
+             error_json
+               ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+           | Ok (st, out) ->
+             Yojson.Safe.to_string
+               (`Assoc
+                   [ "ok", `Bool true
+                   ; "op", `String op
+                   ; "cwd", `String cwd
+                   ; "count", `Int count
+                   ; "via", `String "docker"
+                   ; "status", Keeper_alerting_path.process_status_to_json st
+                   ; "entries", lines_to_json ~limit:50 out
+                   ]))
+        | None ->
+          let st, out =
+            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
+          in
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool (st = Unix.WEXITED 0)
+                ; "op", `String op
+                ; "cwd", `String cwd
+                ; "count", `Int count
+                ; "status", Keeper_alerting_path.process_status_to_json st
+                ; "entries", lines_to_json ~limit:50 out
+                ])))
   | "find" ->
     let name_pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
     if name_pattern = ""
@@ -1729,7 +1862,7 @@ let handle_keeper_shell
                    ]))
         else
           let st, out =
-            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+            run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec
               [ "find"; target; "-maxdepth"; "5"; "-name"; name_pattern;
                 "-not"; "-path"; "*/.git/*";
                 "-not"; "-path"; "*/_build/*";
@@ -1772,7 +1905,7 @@ let handle_keeper_shell
                   ]))
        else
          let st, out =
-           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+           run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec
              [ "/usr/bin/head"; "-n"; string_of_int n; target ]
          in
          Yojson.Safe.to_string
@@ -1812,7 +1945,7 @@ let handle_keeper_shell
                   ]))
        else
          let st, out =
-           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+           run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec
              [ "/usr/bin/tail"; "-n"; string_of_int n; target ]
          in
          Yojson.Safe.to_string
@@ -1886,7 +2019,7 @@ let handle_keeper_shell
                    ]))
        else
          let st, out =
-           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
+           run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec
              [ "find"; target; "-maxdepth"; "3"; "-print";
                "-not"; "-path"; "*/.git/*";
                "-not"; "-path"; "*/_build/*" ]
@@ -1903,9 +2036,9 @@ let handle_keeper_shell
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       render_process_result ~cwd
-         ~cmd:"git diff --stat"
-         [ "git"; "-C"; cwd; "--no-optional-locks"; "diff"; "--stat" ])
+       run_in_turn_runtime ~cwd ~cmd:"git diff --stat"
+         ~command_argv:[ "git"; "--no-optional-locks"; "diff"; "--stat" ]
+         ~max_bytes:1_000_000 ~timeout_sec:read_timeout_sec ())
   | "git_worktree" ->
     let action =
       Safe_ops.json_string ~default:"list" "action" args
@@ -1916,8 +2049,9 @@ let handle_keeper_shell
       (match cwd_target () with
        | Error e -> path_error e
        | Ok cwd ->
-         render_process_result ~cwd ~cmd:"git worktree list"
-           [ "git"; "-C"; cwd; "worktree"; "list" ])
+         run_in_turn_runtime ~cwd ~cmd:"git worktree list"
+           ~command_argv:[ "git"; "worktree"; "list" ]
+           ~max_bytes:1_000_000 ~timeout_sec:read_timeout_sec ())
     | "add" ->
       let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
       let base = Safe_ops.json_string ~default:"origin/main" "base" args |> String.trim in
@@ -1928,10 +2062,25 @@ let handle_keeper_shell
         match cwd_target () with
         | Error e -> path_error e
         | Ok cwd ->
-          let _st, wt_out =
-            Process_eio.run_argv_with_status ~timeout_sec:5.0
-              [ "git"; "-C"; cwd; "worktree"; "list"; "--porcelain" ]
+          let wt_out_result =
+            match turn_sandbox_runtime with
+            | Some runtime ->
+              Keeper_turn_sandbox_runtime.run_command runtime
+                ~cwd
+                ~command_argv:[ "git"; "worktree"; "list"; "--porcelain" ]
+                ~max_bytes:1_000_000
+                ~timeout_sec:5.0 ()
+            | None ->
+              let _st, wt_out =
+                run_argv_with_status_retry_eintr ~timeout_sec:5.0
+                  [ "git"; "-C"; cwd; "worktree"; "list"; "--porcelain" ]
+              in
+              Ok wt_out
           in
+          match wt_out_result with
+          | Error msg ->
+            error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+          | Ok wt_out ->
           if String_util.contains_substring_ci wt_out branch then
             let existing_path =
               String.split_on_char '\n' wt_out
@@ -1954,9 +2103,11 @@ let handle_keeper_shell
             let wt_path = Printf.sprintf ".worktrees/%s"
               (String.map (fun c -> if c = '/' then '-' else c) branch)
             in
-            render_process_result ~cwd
+            run_in_turn_runtime ~cwd
               ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
-              [ "git"; "-C"; cwd; "worktree"; "add"; wt_path; "-b"; branch; base ]
+              ~command_argv:[ "git"; "worktree"; "add"; wt_path; "-b"; branch; base ]
+              ~max_bytes:1_000_000
+              ~timeout_sec:io_timeout_sec ()
       )
     | other ->
       error_json ~fields:[ "op", `String op ]
@@ -2015,8 +2166,17 @@ let handle_keeper_shell
             | Error e -> path_error e
             | Ok () ->
               let st, out =
-                Process_eio.run_argv_with_status ~cwd ~timeout_sec
-                  [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
+                match turn_sandbox_runtime with
+                | Some runtime ->
+                  (match
+                     Keeper_turn_sandbox_runtime.run_bash_with_status runtime
+                       ~cwd ~cmd:cmd_str ~timeout_sec ()
+                   with
+                   | Ok payload -> payload
+                   | Error msg -> (Unix.WEXITED 127, msg))
+                | None ->
+                  run_argv_with_status_retry_eintr ~cwd ~timeout_sec
+                    [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
               in
               if process_status_is_timeout st then
                 Yojson.Safe.to_string
@@ -2213,21 +2373,21 @@ let handle_keeper_shell
                  ; "reversibility", `String rev_tag
                  ] @ extras))
         in
-        let run_gh_command ~command ~cwd ~(ctx : gh_repo_context option) =
+        let run_gh_command ~display_command ~parsed_command ~cwd
+            ~(ctx : gh_repo_context option) =
           if reversibility = Worker_dev_tools.R1_Reversible then
             Log.Keeper.info
               "gh_audit: keeper=%s reversibility=R1 cwd=%s cmd=%s"
-              meta.name cwd command;
-          let full_cmd =
-            Keeper_gh_env.with_env config
-              (Printf.sprintf "%s 2>&1" command)
+              meta.name cwd display_command;
+          let env = Keeper_gh_env.process_env config in
+          let gh_argv =
+            "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
           in
           let st, out =
-            Process_eio.run_argv_with_status ~cwd ~timeout_sec
-              [ "bash"; "-lc"; full_cmd ]
+            Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv
           in
           if process_status_is_timeout st then
-            gh_base ~command ~ok:false ~cwd
+            gh_base ~command:display_command ~ok:false ~cwd
               [ "error", `String "gh_command_timed_out"
               ; "timeout_sec", `Float timeout_sec
               ; "status", Keeper_alerting_path.process_status_to_json st
@@ -2267,7 +2427,7 @@ let handle_keeper_shell
                      origin remote and recreate the task worktree if needed." ]
               else base_fields
             in
-            gh_base ~command ~ok ~cwd hinted_fields
+            gh_base ~command:display_command ~ok ~cwd hinted_fields
         in
         (match reversibility with
          | Worker_dev_tools.R2_Irreversible ->
@@ -2315,7 +2475,8 @@ let handle_keeper_shell
                       ~repo_slug:ctx.repo_slug parsed_cmd
                   in
                   run_gh_command
-                    ~command:(gh_cmd_display cmd_to_run)
+                    ~display_command:(gh_cmd_display cmd_to_run)
+                    ~parsed_command:cmd_to_run
                     ~cwd:ctx.worktree_cwd
                     ~ctx:(Some ctx))
            end))

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -36,6 +36,7 @@ val cmd_targets_git_or_gh : string -> bool
     the duration of that one command. Exposed for unit testing. *)
 
 val handle_keeper_bash :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
@@ -58,6 +59,7 @@ val handle_keeper_bash_kill :
     (SIGTERM → grace → SIGKILL). Idempotent. *)
 
 val handle_keeper_shell :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -112,6 +112,7 @@ let execute_keeper_tool_call_with_outcome
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(ctx_work : working_context)
+      ?turn_sandbox_runtime
       ?search_fn
       ~(name : string)
       ~(input : Yojson.Safe.t)
@@ -239,13 +240,13 @@ let execute_keeper_tool_call_with_outcome
         (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
     | "keeper_fs_read" ->
       make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_read ~config ~meta ~args)
+        (Keeper_exec_fs.handle_keeper_fs_read ~turn_sandbox_runtime ~config ~meta ~args)
     | "keeper_fs_edit" ->
       make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta ~args)
+        (Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime ~config ~meta ~args)
     | "keeper_bash" ->
       make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_bash ~config ~meta ~args)
+        (Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime ~config ~meta ~args)
     | "keeper_bash_output" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_bash_output ~config ~meta ~args)
@@ -254,7 +255,7 @@ let execute_keeper_tool_call_with_outcome
         (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
     | "keeper_shell" ->
       make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_shell ~config ~meta ~args)
+        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime ~config ~meta ~args)
     | "keeper_voice_speak"
     | "keeper_voice_listen"
     | "keeper_voice_agent"
@@ -351,6 +352,7 @@ let execute_keeper_tool_call
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(ctx_work : working_context)
+      ?turn_sandbox_runtime
       ?search_fn
       ~(name : string)
       ~(input : Yojson.Safe.t)
@@ -359,6 +361,6 @@ let execute_keeper_tool_call
   =
   let result =
     execute_keeper_tool_call_with_outcome
-      ~config ~meta ~ctx_work ?search_fn ~name ~input ()
+      ~config ~meta ~ctx_work ?turn_sandbox_runtime ?search_fn ~name ~input ()
   in
   result.raw_output

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -156,6 +156,7 @@ val execute_keeper_tool_call_with_outcome :
   config:Coord.config ->
   meta:keeper_meta ->
   ctx_work:working_context ->
+  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
   input:Yojson.Safe.t ->
@@ -166,6 +167,7 @@ val execute_keeper_tool_call :
   config:Coord.config ->
   meta:keeper_meta ->
   ctx_work:working_context ->
+  ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
   input:Yojson.Safe.t ->

--- a/lib/keeper/keeper_gh_env.ml
+++ b/lib/keeper/keeper_gh_env.ml
@@ -23,3 +23,16 @@ let with_env (config : Coord.config) (gh_cmd : string) : string =
   | None -> gh_cmd
   | Some dir ->
     Printf.sprintf "GH_CONFIG_DIR=%s %s" (Filename.quote dir) gh_cmd
+
+let process_env (config : Coord.config) : string array option =
+  match config_dir config with
+  | None -> None
+  | Some dir ->
+    let gh_config = "GH_CONFIG_DIR=" ^ dir in
+    let base =
+      Unix.environment ()
+      |> Array.to_list
+      |> List.filter (fun entry ->
+        not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
+    in
+    Some (Array.of_list (gh_config :: base))

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -41,6 +41,19 @@ let merge_reported_and_observed_tool_names
         reported_tool_names
 ;;
 
+let final_keeper_tool_names
+      ~(reported_tool_names : string list)
+      ~(observed_tool_names : string list)
+      ~(allowed_tool_names : string list)
+  : string list
+  =
+  merge_reported_and_observed_tool_names
+    ~reported_tool_names
+    ~observed_tool_names
+  |> Keeper_tool_alias.canonicalize_observed
+  |> List.filter (fun tool_name -> List.mem tool_name allowed_tool_names)
+;;
+
 let unexpected_tool_names
       ~(allowed_tool_names : string list)
       ~(tool_names : string list)

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -20,6 +20,12 @@ type tool_call_entry = Keeper_types.tool_call_entry = {
   last_used_at : float;
 }
 
+type tool_bundle =
+  {
+    tools : Agent_sdk.Tool.t list;
+    cleanup : unit -> unit;
+  }
+
 (** Tool usage now lives in Keeper_registry (per-entry tool_usage Hashtbl).
     These public functions preserve the existing API surface. *)
 
@@ -151,6 +157,7 @@ let make_keeper_tool_handler
     ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta)
     ~(ctx_snapshot : Keeper_types.working_context)
+    ?turn_sandbox_runtime
     ?search_fn
     ?on_tool_called
     ?(translate_input = fun j -> j)
@@ -182,6 +189,7 @@ let make_keeper_tool_handler
           Inference_utils.timed (fun () ->
             Keeper_exec_tools.execute_keeper_tool_call_with_outcome
               ~config ~meta ~ctx_work:ctx_snapshot
+              ?turn_sandbox_runtime
               ?search_fn
               ~name ~input ())
         in
@@ -366,14 +374,20 @@ let make_keeper_tool_handler
           ~original_bytes:(String.length normalized_exn) ();
         (false, Tool_output_validation.cap normalized_exn)
 
-let make_tools
+let make_tool_bundle
     ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta)
     ~(ctx_snapshot : Keeper_types.working_context)
     ?search_fn
     ?on_tool_called
     ()
-  : Agent_sdk.Tool.t list =
+  : tool_bundle =
+  let turn_sandbox_runtime =
+    match meta.sandbox_profile with
+    | Keeper_types.Docker ->
+      Some (Keeper_turn_sandbox_runtime.create ~config ~meta)
+    | Keeper_types.Local -> None
+  in
   (* Build Tool.t for the full universe so BM25 and Tool_op can
      discover tools beyond the active preset.  Progressive disclosure
      (AllowList filter in before_turn_hook) controls LLM visibility;
@@ -393,6 +407,7 @@ let make_tools
           ~description:td.description
           ~input_schema:td.input_schema
           (make_keeper_tool_handler ~name:td.name ~config ~meta ~ctx_snapshot
+             ?turn_sandbox_runtime
              ?search_fn ?on_tool_called ~failure_counts ()))
       else None
     ) tool_defs
@@ -422,10 +437,28 @@ let make_tools
             ~description:internal_def.description
             ~input_schema
             (make_keeper_tool_handler ~name:internal ~config ~meta ~ctx_snapshot
+               ?turn_sandbox_runtime
                ?search_fn ?on_tool_called
                ~translate_input:(fun j ->
                  Keeper_tool_alias.translate_input ~public j)
                ~failure_counts ()))
     ) (Keeper_tool_alias.oas_dual_register_aliases ())
   in
-  internal_tools @ alias_tools
+  {
+    tools = internal_tools @ alias_tools;
+    cleanup =
+      (fun () ->
+        match turn_sandbox_runtime with
+        | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
+        | None -> ());
+  }
+
+let make_tools
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(ctx_snapshot : Keeper_types.working_context)
+    ?search_fn
+    ?on_tool_called
+    ()
+  : Agent_sdk.Tool.t list =
+  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ()).tools

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -1,0 +1,266 @@
+open Keeper_types
+
+type state =
+  | Not_started
+  | Running of { container_name : string }
+
+type t =
+  {
+    config : Coord.config;
+    meta : keeper_meta;
+    host_root : string;
+    container_root : string;
+    uid : int;
+    gid : int;
+    mutable state : state;
+  }
+
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let normalize_path path =
+  Keeper_alerting_path.normalize_path_for_check path
+  |> strip_trailing_slashes
+
+let create ~(config : Coord.config) ~(meta : keeper_meta) =
+  {
+    config;
+    meta;
+    host_root = Keeper_sandbox.host_root_abs ~config meta.name |> normalize_path;
+    container_root = Keeper_sandbox.container_root meta.name |> strip_trailing_slashes;
+    uid = Unix.getuid ();
+    gid = Unix.getgid ();
+    state = Not_started;
+  }
+
+let container_name_of (t : t) =
+  Printf.sprintf "masc-keeper-turn-%s-%d-%d"
+    (Coord_utils.safe_filename t.meta.name)
+    (Unix.getpid ())
+    (int_of_float (Unix.gettimeofday () *. 1000.0))
+
+let container_path_of_host (t : t) ~host_path =
+  let host_norm = normalize_path host_path in
+  if host_norm = t.host_root then Ok t.container_root
+  else if String.starts_with ~prefix:(t.host_root ^ "/") host_norm then
+    let suffix =
+      String.sub host_norm
+        (String.length t.host_root + 1)
+        (String.length host_norm - String.length t.host_root - 1)
+    in
+    Ok (Filename.concat t.container_root suffix)
+  else
+    Error
+      (Printf.sprintf
+         "container_path_of_host: %s is not inside playground %s"
+         host_norm t.host_root)
+
+let container_cwd_of_host (t : t) ~host_cwd =
+  match container_path_of_host t ~host_path:host_cwd with
+  | Ok container_cwd -> container_cwd
+  | Error _ -> t.container_root
+
+let format_docker_exec_error ~head_program ~st ~out =
+  match st with
+  | Unix.WEXITED code ->
+      Printf.sprintf "docker_%s_failed: exit=%d output=%s"
+        head_program code
+        (Worker_dev_tools.truncate_for_log out)
+  | Unix.WSIGNALED n ->
+      Printf.sprintf "docker_%s_signaled: signal=%d" head_program n
+  | Unix.WSTOPPED n ->
+      Printf.sprintf "docker_%s_stopped: signal=%d" head_program n
+
+let container_missing_error out =
+  String_util.contains_substring_ci out "no such container"
+  || String_util.contains_substring_ci out "is not running"
+
+let start_container (t : t) ~(timeout_sec : float) =
+  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  if String.trim image = "" then
+    Error "keeper sandbox docker image is not configured"
+  else
+    match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
+    | Error _ as err -> err
+    | Ok seccomp_args ->
+        let container_name = container_name_of t in
+        let argv =
+          [
+            "docker";
+            "run";
+            "-d";
+            "--rm";
+            "--name";
+            container_name;
+            "--user";
+            Printf.sprintf "%d:%d" t.uid t.gid;
+            "--read-only";
+            "--tmpfs";
+            Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
+              (Env_config_keeper.KeeperSandbox.tmpfs_size ());
+            "--cap-drop=ALL";
+            "--security-opt";
+            "no-new-privileges";
+          ]
+          @ seccomp_args
+          @ [
+              "--pids-limit";
+              string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
+              "--memory";
+              Env_config_keeper.KeeperSandbox.memory ();
+              "-v";
+              t.host_root ^ ":" ^ t.container_root ^ ":rw";
+              "--workdir";
+              t.container_root;
+              "--network";
+              "none";
+              image;
+              "sh";
+              "-lc";
+              "trap : TERM INT; while :; do sleep 3600; done";
+            ]
+        in
+        let st, out =
+          Process_eio.run_argv_with_status
+            ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+        in
+        match st with
+        | Unix.WEXITED 0 ->
+            t.state <- Running { container_name };
+            Ok container_name
+        | _ ->
+            Error
+              (Printf.sprintf "docker_container_start_failed: %s"
+                 (Worker_dev_tools.truncate_for_log out))
+
+let ensure_started (t : t) ~(timeout_sec : float) =
+  match t.state with
+  | Running { container_name } -> Ok container_name
+  | Not_started -> start_container t ~timeout_sec
+
+let run_exec_with_status_once
+    ?(stdin_content : string option)
+    (t : t)
+    ~(timeout_sec : float)
+    ~(cwd : string)
+    ~(command_argv : string list) =
+  match ensure_started t ~timeout_sec with
+  | Error _ as err -> err
+  | Ok container_name ->
+      let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
+      let argv =
+        [
+          "docker";
+          "exec";
+          "--user";
+          Printf.sprintf "%d:%d" t.uid t.gid;
+          "-w";
+          container_cwd;
+        ]
+        @ (match stdin_content with Some _ -> [ "-i" ] | None -> [])
+        @ (container_name :: command_argv)
+      in
+      let st, out =
+        match stdin_content with
+        | Some content ->
+            Process_eio.run_argv_with_stdin_and_status
+              ~cwd:(Sys.getcwd ()) ~timeout_sec ~stdin_content:content argv
+        | None ->
+            Process_eio.run_argv_with_status
+              ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+      in
+      Ok (st, out)
+
+let run_exec_with_status
+    ?stdin_content
+    (t : t)
+    ~(timeout_sec : float)
+    ~(cwd : string)
+    ~(command_argv : string list) =
+  match run_exec_with_status_once ?stdin_content t ~timeout_sec ~cwd ~command_argv with
+  | Error _ as err -> err
+  | Ok ((Unix.WEXITED 126 | Unix.WEXITED 127), out)
+    when container_missing_error out ->
+      t.state <- Not_started;
+      (match run_exec_with_status_once ?stdin_content t ~timeout_sec ~cwd ~command_argv with
+       | Ok _ as ok -> ok
+       | Error _ as err -> err)
+  | Ok other -> Ok other
+
+let run_command_with_status ?(ok_exit_codes = [ 0 ]) (t : t)
+    ~(cwd : string) ~(command_argv : string list)
+    ~(max_bytes : int) ~(timeout_sec : float) () =
+  match command_argv with
+  | [] -> Error "run_command_with_status: command_argv is empty"
+  | head_program :: _ ->
+      (match run_exec_with_status t ~timeout_sec ~cwd ~command_argv with
+       | Error _ as err -> err
+       | Ok (st, out) ->
+           (match st with
+            | Unix.WEXITED code
+              when List.exists (fun ok_code -> ok_code = code) ok_exit_codes ->
+                let body =
+                  if String.length out > max_bytes then String.sub out 0 max_bytes
+                  else out
+                in
+                Ok (st, body)
+            | _ -> Error (format_docker_exec_error ~head_program ~st ~out)))
+
+let run_command ?(ok_exit_codes = [ 0 ]) t ~cwd ~command_argv
+    ~max_bytes ~timeout_sec () =
+  match
+    run_command_with_status ~ok_exit_codes t ~cwd ~command_argv
+      ~max_bytes ~timeout_sec ()
+  with
+  | Ok (_st, out) -> Ok out
+  | Error _ as err -> err
+
+let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string)
+    ~(timeout_sec : float) () =
+  run_exec_with_status t ~timeout_sec ~cwd
+    ~command_argv:[ "bash"; "-lc"; cmd ^ " 2>&1" ]
+
+let write_file_common (t : t) ~(host_path : string) ~(content : string)
+    ~(timeout_sec : float) ~(append : bool) () =
+  match container_path_of_host t ~host_path with
+  | Error _ as err -> err
+  | Ok container_path ->
+      let parent = Filename.dirname container_path in
+      let redirect = if append then ">>" else ">" in
+      let shell_cmd =
+        Printf.sprintf "mkdir -p -- %s && cat %s %s"
+          (Filename.quote parent)
+          redirect
+          (Filename.quote container_path)
+      in
+      match
+        run_exec_with_status ~stdin_content:content t ~timeout_sec
+          ~cwd:t.host_root
+          ~command_argv:[ "sh"; "-lc"; shell_cmd ]
+      with
+      | Error _ as err -> err
+      | Ok (Unix.WEXITED 0, _out) -> Ok ()
+      | Ok (st, out) ->
+          Error (format_docker_exec_error ~head_program:"write_file" ~st ~out)
+
+let overwrite_file t ~host_path ~content ~timeout_sec () =
+  write_file_common t ~host_path ~content ~timeout_sec ~append:false ()
+
+let append_file t ~host_path ~content ~timeout_sec () =
+  write_file_common t ~host_path ~content ~timeout_sec ~append:true ()
+
+let cleanup (t : t) =
+  match t.state with
+  | Not_started -> ()
+  | Running { container_name } ->
+      t.state <- Not_started;
+      let argv = [ "docker"; "rm"; "-f"; container_name ] in
+      let _st, _out =
+        Process_eio.run_argv_with_status
+          ~cwd:(Sys.getcwd ()) ~timeout_sec:5.0 argv
+      in
+      ()

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -1,0 +1,65 @@
+(** Turn-scoped keeper Docker sandbox runtime.
+
+    Lazily starts one hardened container for a keeper turn and reuses it across
+    compatible tool calls. The runtime keeps the keeper playground mounted
+    read-write while the root filesystem stays read-only. *)
+
+type t
+
+val create :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  t
+
+val cleanup : t -> unit
+(** Best-effort teardown. Safe to call multiple times. *)
+
+val container_path_of_host :
+  t -> host_path:string -> (string, string) result
+
+val container_cwd_of_host :
+  t -> host_cwd:string -> string
+
+val run_command_with_status :
+  ?ok_exit_codes:int list ->
+  t ->
+  cwd:string ->
+  command_argv:string list ->
+  max_bytes:int ->
+  timeout_sec:float ->
+  unit ->
+  (Unix.process_status * string, string) result
+
+val run_command :
+  ?ok_exit_codes:int list ->
+  t ->
+  cwd:string ->
+  command_argv:string list ->
+  max_bytes:int ->
+  timeout_sec:float ->
+  unit ->
+  (string, string) result
+
+val run_bash_with_status :
+  t ->
+  cwd:string ->
+  cmd:string ->
+  timeout_sec:float ->
+  unit ->
+  (Unix.process_status * string, string) result
+
+val overwrite_file :
+  t ->
+  host_path:string ->
+  content:string ->
+  timeout_sec:float ->
+  unit ->
+  (unit, string) result
+
+val append_file :
+  t ->
+  host_path:string ->
+  content:string ->
+  timeout_sec:float ->
+  unit ->
+  (unit, string) result

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -319,6 +319,7 @@ let test_docker_blocks_nested_docker_command () =
   let meta = make_docker_meta "docker-nested" in
   let raw =
     Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_runtime:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ])
   in
@@ -338,6 +339,7 @@ let test_docker_blocks_docker_socket_reference () =
   let meta = make_docker_meta "docker-sock" in
   let raw =
     Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_runtime:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ])
   in
@@ -360,6 +362,7 @@ let test_docker_missing_seccomp_profile_fails_closed () =
     (fun () ->
       let raw =
         Keeper_exec_shell.handle_keeper_bash
+          ~turn_sandbox_runtime:None
           ~config ~meta
           ~args:(`Assoc [ ("cmd", `String "pwd") ])
       in
@@ -433,6 +436,7 @@ let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
   in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_runtime:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "ls");
@@ -455,6 +459,7 @@ let test_readonly_chaining_hint_lists_subops () =
   let meta = make_readonly_meta "chain-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_runtime:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");
@@ -483,6 +488,7 @@ let test_readonly_redirect_hint_points_at_fs_edit () =
   let meta = make_readonly_meta "redirect-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_runtime:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -8,6 +8,7 @@
 
 module Coord = Masc_mcp.Coord
 module Keeper_docker_read = Masc_mcp.Keeper_docker_read
+module Keeper_turn_sandbox_runtime = Masc_mcp.Keeper_turn_sandbox_runtime
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
@@ -45,6 +46,19 @@ let write_file path content =
   let oc = open_out_bin path in
   Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
   output_string oc content
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
 
 let make_meta ~name ~sandbox =
   let json =
@@ -317,6 +331,33 @@ done\n\
 printf '%s\\n' \"$*\"\n\
 exit 0\n"
 
+let fake_docker_turn_runtime_script =
+  "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+case \"$1\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  run)\n\
+    printf 'runtime-container\\n'\n\
+    exit 0\n\
+    ;;\n\
+  exec)\n\
+    printf 'exec ok\\n'\n\
+    exit 0\n\
+    ;;\n\
+  rm)\n\
+    printf 'removed\\n'\n\
+    exit 0\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
 let test_run_command_nonzero_exit_errors_by_default () =
   with_fake_docker fake_docker_exit_1_script @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -387,6 +428,60 @@ let test_run_command_preserves_bare_command_argv () =
       Alcotest.(check string) "preserves bare head argv"
         "head -n 1 /home/keeper/playground/minjae/mind/demo.txt\n" out
 
+let test_turn_runtime_reuses_single_container () =
+  with_fake_docker fake_docker_turn_runtime_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  let log_path = Filename.concat base "docker.log" in
+  let host_root =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  ensure_dir host_root;
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in
+  Fun.protect ~finally:(fun () ->
+    Keeper_turn_sandbox_runtime.cleanup runtime;
+    cleanup_dir base) @@ fun () ->
+  let run_once () =
+    match
+      Keeper_docker_read.run_command_in_container_with_status
+        ~turn_sandbox_runtime:runtime
+        ~config ~meta
+        ~command_argv:[ "cat"; "/home/keeper/playground/minjae/mind/demo.txt" ]
+        ~max_bytes:4096 ~timeout_sec:5.0 ()
+    with
+    | Error msg -> Alcotest.failf "expected turn runtime command success, got %s" msg
+    | Ok (st, out) ->
+        Alcotest.(check (pair string int)) "runtime exec exits cleanly"
+          ("exit", 0)
+          (match st with
+           | Unix.WEXITED code -> ("exit", code)
+           | Unix.WSIGNALED code -> ("signaled", code)
+           | Unix.WSTOPPED code -> ("stopped", code));
+        Alcotest.(check string) "runtime exec output preserved" "exec ok\n" out
+  in
+  run_once ();
+  run_once ();
+  Keeper_turn_sandbox_runtime.cleanup runtime;
+  let lines =
+    read_file log_path
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  let count prefix =
+    List.fold_left
+      (fun acc line ->
+        if String.starts_with ~prefix line then acc + 1 else acc)
+      0 lines
+  in
+  Alcotest.(check int) "docker run happens once" 1 (count "run -d ");
+  Alcotest.(check int) "docker exec happens twice" 2 (count "exec ");
+  Alcotest.(check int) "docker rm happens once" 1 (count "rm -f ")
+
 let () =
   Alcotest.run "Keeper_docker_read"
     [
@@ -431,5 +526,7 @@ let () =
             test_run_command_allows_configured_nonzero_exit;
           Alcotest.test_case "preserves bare command argv" `Quick
             test_run_command_preserves_bare_command_argv;
+          Alcotest.test_case "turn runtime reuses single container" `Quick
+            test_turn_runtime_reuses_single_container;
         ] );
     ]

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -93,7 +93,7 @@ let test_patch_unique_match () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\nlet y = 2\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -115,7 +115,7 @@ let test_patch_no_match_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -145,7 +145,7 @@ let test_patch_multiple_matches_without_replace_all_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -165,7 +165,7 @@ let test_patch_replace_all () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -187,7 +187,7 @@ let test_patch_empty_old_string_errors () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -205,7 +205,7 @@ let test_patch_missing_file_errors () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "ghost.ml" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -222,7 +222,7 @@ let test_patch_delete_via_empty_new_string () =
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -241,7 +241,7 @@ let test_overwrite_unchanged_by_patch_addition () =
   setup @@ fun ~config ~meta ~playground ->
   let path = Filename.concat playground "new.txt" in
   let raw =
-    Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta
+    Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -211,7 +211,7 @@ let test_legacy_keeper_unaffected () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "legacy bypasses symmetric containment" false
@@ -223,7 +223,7 @@ let test_hardened_flag_off_passthrough () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "flag off → containment passthrough" false
@@ -236,7 +236,7 @@ let test_hardened_flag_on_blocks_ls_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc [ ("op", `String "ls"); ("path", `String outside_dir) ])
   in
@@ -249,7 +249,7 @@ let test_hardened_flag_on_blocks_cat_outside () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "cat outside playground blocked" true
@@ -266,7 +266,7 @@ let test_hardened_flag_on_blocks_rg_outside () =
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -285,7 +285,7 @@ let test_hardened_flag_on_blocks_find_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -304,7 +304,7 @@ let test_hardened_flag_on_allows_inside_playground () =
   let demo = Filename.concat playground "demo.txt" in
   ignore (Fs_compat.save_file_atomic demo "hello inside playground");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String demo) ])
   in
   (* Goal: containment did not block. Whether `cat` succeeds depends on
@@ -319,7 +319,7 @@ let test_docker_git_creds_contained () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "docker git-creds also contained" true
@@ -358,7 +358,7 @@ let test_gh_binds_repo_from_active_task_worktree () =
   with_env "GH_PWD_FILE" gh_pwd_file @@ fun () ->
   with_env "PATH" (bin_dir ^ ":" ^ existing_path ()) @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -370,8 +370,9 @@ let test_gh_binds_repo_from_active_task_worktree () =
   let recorded_pwd = read_file gh_pwd_file in
   Alcotest.(check bool) "repo flag injected"
     true
-    (String_util.contains_substring recorded_args
-       "pr list --state open --repo jeong-sik/masc-mcp");
+    (String_util.contains_substring recorded_args "pr list --state open"
+     && String_util.contains_substring recorded_args
+          "--repo jeong-sik/masc-mcp");
   Alcotest.(check string) "gh runs from task worktree cwd"
     (normalize_realpath worktree_cwd)
     (normalize_realpath recorded_pwd);
@@ -399,7 +400,7 @@ let test_gh_missing_worktree_returns_typed_error () =
   in
   let meta = { meta with current_task_id = Some current_task_id } in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "gh"); ("cmd", `String "pr list") ])
   in
   Alcotest.(check (option string)) "typed gh error"

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -181,7 +181,7 @@ let assert_docker_route_fires ~config ~meta ~playground =
   List.iter
     (fun (op, args) ->
       let raw =
-        Keeper_exec_shell.handle_keeper_shell ~config ~meta ~args
+        Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta ~args
       in
       Alcotest.(check bool)
         (Printf.sprintf "%s surfaces docker image config error (docker route fired)" op)
@@ -209,7 +209,7 @@ let test_cat_legacy_keeper_skips_docker () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "matrix");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
   in
   Alcotest.(check bool)
@@ -227,7 +227,7 @@ let test_cat_flag_off_skips_docker () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "matrix");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
   in
   Alcotest.(check bool)
@@ -270,7 +270,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
       ~args:
         (`Assoc
             [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2836,6 +2836,17 @@ let test_merge_reported_and_observed_tool_names_preserves_synthetic_tools () =
     [ "keeper_voice_agent"; "keeper_voice_agent"; "keeper_board_post" ]
     merged
 
+let test_final_keeper_tool_names_falls_back_to_reported_tool_use () =
+  let final_tools =
+    KTD.final_keeper_tool_names
+      ~reported_tool_names:[ "keeper_task_claim"; "Bash"; "Skill" ]
+      ~observed_tool_names:[]
+      ~allowed_tool_names:[ "keeper_task_claim"; "keeper_bash" ]
+  in
+  check (list string) "reported keeper tool plus alias preserved"
+    [ "keeper_task_claim"; "keeper_bash" ]
+    final_tools
+
 (* prioritized_disclosed_tool_names tests removed: function replaced
    by OAS Tool_selector.select in #5429 boundary cleanup. *)
 
@@ -3659,6 +3670,9 @@ let () =
             test_tool_usage_delta_ignores_removed_tools;
           test_case "merge observed and synthetic tool names" `Quick
             test_merge_reported_and_observed_tool_names_preserves_synthetic_tools;
+          test_case "final keeper tool names fall back to reported tools"
+            `Quick
+            test_final_keeper_tool_names_falls_back_to_reported_tool_use;
           test_case "tool query strips continuity noise" `Quick
             test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "tool query keeps counted headers" `Quick


### PR DESCRIPTION
## What changed
- add a turn-scoped keeper Docker sandbox runtime and reuse one hardened container across Docker-routed keeper tool calls within the same turn
- route Docker-backed read/edit/shell paths through the shared runtime instead of starting scattered one-off container executions
- move Docker `gh` execution onto structured argv execution with explicit environment injection
- fix final keeper tool accounting so reported tool use is preserved even when the observed usage delta is empty
- add regression coverage for shared-container reuse, containment, Docker routing, and the tool-accounting fallback

## Why
Keeper sandbox behavior was split across multiple execution paths, which made the Docker boundary inconsistent across Bash, read-only shell ops, and file access. In parallel, keeper cycle accounting could end a turn with `tools_used=[]` and emit `No tools used this generation` even when the model response carried a valid tool-use signal but no observed usage delta was captured.

## Impact
- Docker-hardened keepers now get a single per-turn runtime boundary across the keeper surfaces that are supposed to share it
- read/edit/grep/shell behavior inside a turn is consistent because the same container instance sees the same filesystem state
- keeper continuity/state snapshots no longer drop reported tool use just because the usage observer missed that turn

## Root cause
- sandbox routing was implemented in multiple leaf helpers instead of behind one reusable turn runtime
- final keeper tool-name resolution relied on observed usage only, while completion-contract validation already accepted the merged reported/observed tool set

## Validation
- `dune clean --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-turn-runtime-sandbox && dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-turn-runtime-sandbox`
- `./_build/default/test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_fs_edit_patch.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_shell_containment.exe`
- `./_build/default/test/test_keeper_unified.exe`
