### PR TITLE
[codex] Fix keeper auth, task injection, and docker sandbox routing

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -107,18 +107,38 @@ let save_auth_config config (auth_cfg : auth_config) =
 let credential_file config agent_name =
   Filename.concat (agents_dir config) (agent_name ^ ".json")
 
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
 (* Inline copy of Nickname.is_generated_nickname / extract_agent_type.
    Auth lives below masc_coord in the module graph and cannot depend on
    it. The nickname pattern — three or more hyphen-separated segments,
    first segment is the agent type — is small enough to duplicate here
-   without drift risk. Covered by the nickname fallback tests. *)
+   without drift risk. Keeper aliases use a different canonical shape
+   (keeper-<name>-agent) and must resolve to the middle segment so
+   keeper-scoped credentials can be stored under the stable keeper name
+   rather than the transport alias. Covered by the nickname fallback
+   tests. *)
 let is_generated_nickname_shape name =
   List.length (String.split_on_char '-' name) >= 3
 
 let extract_agent_type_prefix name =
   match String.split_on_char '-' name with
+  | "keeper" :: rest -> (
+      match List.rev rest with
+      | "agent" :: middle_rev ->
+          List.rev middle_rev
+          |> String.concat "-"
+          |> trim_nonempty
+      | _ -> Some "keeper")
   | prefix :: _ when prefix <> "" -> Some prefix
   | _ -> None
+
+let credential_agent_name agent_name =
+  match extract_agent_type_prefix agent_name with
+  | Some prefix when prefix <> agent_name -> prefix
+  | _ -> agent_name
 
 let load_credential_from_path config agent_name path : agent_credential option =
   if file_exists path then
@@ -203,40 +223,50 @@ let resolve_agent_from_token config ~token : (string, masc_error) result =
   | Ok cred -> Ok cred.agent_name
   | Error e -> Error e
 
+let expires_at_for_auth_config auth_cfg =
+  if auth_cfg.token_expiry_hours > 0 then
+    let expiry = Time_compat.now () +. (float_of_int auth_cfg.token_expiry_hours *. 3600.0) in
+    let tm = Unix.gmtime expiry in
+    Some
+      (Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+         (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+         tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
+  else
+    None
+
+let save_raw_token_credential config ~agent_name ~role ~raw_token :
+    (agent_credential, masc_error) result =
+  let auth_cfg = load_auth_config config in
+  let cred =
+    {
+      agent_name;
+      token = sha256_hash raw_token;
+      role;
+      created_at = now_iso ();
+      expires_at = expires_at_for_auth_config auth_cfg;
+    }
+  in
+  try
+    save_credential config cred;
+    Ok cred
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+    let msg =
+      Printf.sprintf "Failed to save agent credential: %s"
+        (Printexc.to_string exn)
+    in
+    Log.Auth.error "%s" msg;
+    Error (IoError msg)
+
 (* ============================================ *)
 (* Token operations                             *)
 (* ============================================ *)
 
 (** Create a new token for an agent *)
 let create_token config ~agent_name ~role : (string * agent_credential, masc_error) result =
-  let auth_cfg = load_auth_config config in
   let raw_token = generate_token () in
-  let token_hash = sha256_hash raw_token in
-  let now = now_iso () in
-  let expires_at =
-    if auth_cfg.token_expiry_hours > 0 then
-      let expiry = Time_compat.now () +. (float_of_int auth_cfg.token_expiry_hours *. 3600.0) in
-      let tm = Unix.gmtime expiry in
-      Some (Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-        (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-        tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec)
-    else
-      None
-  in
-  let cred = {
-    agent_name;
-    token = token_hash;
-    role;
-    created_at = now;
-    expires_at;
-  } in
-  (try
-     save_credential config cred;
-     Ok (raw_token, cred)  (* Return raw token to user, store hash *)
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     let msg = Printf.sprintf "Failed to save agent credential: %s" (Printexc.to_string exn) in
-     Log.Auth.error "%s" msg;
-     Error (IoError msg))
+  match save_raw_token_credential config ~agent_name ~role ~raw_token with
+  | Ok cred -> Ok (raw_token, cred)
+  | Error e -> Error e
 
 let missing_credential_error config ~agent_name ~token : masc_error =
   match find_credential_by_token config ~token with
@@ -266,6 +296,23 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
               Error (TokenExpired agent_name)
             else
               Ok cred
+
+let ensure_keeper_credential config ~agent_name :
+    (string * agent_credential, masc_error) result =
+  let target_agent_name = credential_agent_name agent_name in
+  let env_token =
+    match Sys.getenv_opt "MASC_MCP_TOKEN" with
+    | Some raw -> trim_nonempty raw
+    | None -> None
+  in
+  match env_token with
+  | Some raw_token -> (
+      match verify_token config ~agent_name ~token:raw_token with
+      | Ok cred -> Ok (raw_token, cred)
+      | Error _ ->
+          create_token config ~agent_name:target_agent_name ~role:Admin)
+  | None ->
+      create_token config ~agent_name:target_agent_name ~role:Admin
 
 (** Refresh a token (generate new one, update credential) *)
 let refresh_token config ~agent_name ~old_token : (string * agent_credential, masc_error) result =

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -606,29 +606,19 @@ module KeeperSandbox = struct
     in
     get_string ~default "MASC_KEEPER_SANDBOX_GH_TOKEN"
 
-  (** RFC-0006 Phase B-1: when true, hardened keepers' read-side tools
-      (keeper_fs_read; later keeper_shell op=rg/ls/cat/find/...) are
-      restricted to the keeper's playground bundle on the host even
-      though the path resolver alone would have allowed broader access.
+  (** Legacy RFC-0006 Phase B-1 flag.
 
-      Closes the asymmetry where keeper_bash gates execution to docker
-      but keeper_fs_read still walks the host. Default off so existing
-      hardened keepers (analyst/janitor/poe/minjae) keep working until
-      operators flip the flag. *)
+      Read-side containment now follows [sandbox_profile=docker]
+      unconditionally. This getter remains only for backward-compatible
+      config surfaces and should not gate runtime sandbox policy. *)
   let symmetric_read_containment () =
     get_bool ~default:false "MASC_KEEPER_SYMMETRIC_SANDBOX"
 
-  (** RFC-0006 Phase B-2: when true (and symmetric_read_containment is
-      also on), hardened keeper read-side ops route through
-      [docker run --rm <image> cat <container_path>] so the
-      container's mount restrictions become the primary boundary.
+  (** Legacy RFC-0006 Phase B-2 flag.
 
-      The host-side containment check (B-1) remains as defense in
-      depth — if the docker route is misconfigured, the host check
-      still blocks. Default off because docker spawn per read is
-      slower (~hundreds of ms) and only worth it for deployments
-      that can absorb the latency in exchange for mount-level
-      isolation. *)
+      Docker read routing now follows [sandbox_profile=docker]
+      unconditionally. This getter remains only for backward-compatible
+      config surfaces and should not gate runtime sandbox policy. *)
   let docker_read_routing () =
     get_bool ~default:false "MASC_KEEPER_DOCKER_READ"
 end

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -332,9 +332,10 @@ let find_duplicate_task (backlog : backlog) (title : string) : string option =
 (** Add task — file-locked to prevent task ID collision under concurrency.
     Rejects tasks with duplicate titles (exact match after normalization)
     to prevent the same work from being created multiple times. *)
-let add_task ?contract ?required_preset config ~title ~priority ~description =
+let add_task ?contract ?required_preset ?created_by config ~title ~priority ~description =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
+  let actor = Option.value ~default:"system" created_by in
   try
     with_file_lock config backlog_path (fun () ->
       let backlog = read_backlog_or_raise config in
@@ -355,6 +356,7 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
         priority;
         files = [];
         created_at = now_iso ();
+        created_by;
         worktree = None;
         required_role = Types_core.Unassigned;
         required_preset;
@@ -371,13 +373,19 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
         version = backlog.version + 1;
       } in
       write_backlog config new_backlog;
-      emit_task_activity config ~agent_name:"system" ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
+      let created_by_json =
+        match created_by with
+        | Some value -> `String value
+        | None -> `Null
+      in
+      emit_task_activity config ~agent_name:actor ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
         ~payload:
           (`Assoc
             [
               ("task_id", `String task_id);
               ("title", `String title);
               ("priority", `Int priority);
+              ("created_by", created_by_json);
               ( "strict_contract",
                 `Bool
                   (match contract with
@@ -386,7 +394,7 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
             ]);
 
       (Atomic.get Coord_hooks.on_task_mutation_fn) ();
-      ignore (broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title));
+      ignore (broadcast config ~from_agent:actor ~content:(Printf.sprintf "📋 New quest: %s" title));
       Printf.sprintf "✅ Added %s: %s" task_id title))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -395,10 +403,11 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
 
 (** Add task with a required role constraint — file-locked.
     Same dedup guard as [add_task]. *)
-let add_task_with_role ?contract config ~title ~priority ~description
+let add_task_with_role ?contract ?created_by config ~title ~priority ~description
     ~required_role =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
+  let actor = Option.value ~default:"system" created_by in
   try
     with_file_lock config backlog_path (fun () ->
       let backlog = read_backlog_or_raise config in
@@ -418,6 +427,7 @@ let add_task_with_role ?contract config ~title ~priority ~description
         priority;
         files = [];
         created_at = now_iso ();
+        created_by;
         worktree = None;
         required_role;
         required_preset = None;
@@ -434,13 +444,19 @@ let add_task_with_role ?contract config ~title ~priority ~description
         version = backlog.version + 1;
       } in
       write_backlog config new_backlog;
-      emit_task_activity config ~agent_name:"system" ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
+      let created_by_json =
+        match created_by with
+        | Some value -> `String value
+        | None -> `Null
+      in
+      emit_task_activity config ~agent_name:actor ~task_id ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
         ~payload:
           (`Assoc
             [
               ("task_id", `String task_id);
               ("title", `String title);
               ("priority", `Int priority);
+              ("created_by", created_by_json);
               ( "required_role",
                 `String (Types_core.role_to_string required_role) );
               ( "strict_contract",
@@ -451,7 +467,7 @@ let add_task_with_role ?contract config ~title ~priority ~description
             ]);
 
       let role_str = Types_core.role_to_string required_role in
-      ignore (broadcast config ~from_agent:"system"
+      ignore (broadcast config ~from_agent:actor
         ~content:(Printf.sprintf "📋 New quest: %s (requires: %s)" title role_str));
       Printf.sprintf "✅ Added %s: %s (required_role: %s)" task_id title role_str))
   with
@@ -460,9 +476,10 @@ let add_task_with_role ?contract config ~title ~priority ~description
       Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
 
 (** Add multiple tasks in a batch *)
-let batch_add_tasks_internal config tasks =
+let batch_add_tasks_internal ?created_by config tasks =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
+  let actor = Option.value ~default:"system" created_by in
   with_file_lock config backlog_path (fun () ->
     try
       let backlog = read_backlog_or_raise config in
@@ -479,6 +496,7 @@ let batch_add_tasks_internal config tasks =
           priority;
           files = [];
           created_at = now_iso ();
+          created_by;
           worktree = None;
           required_role = Types_core.Unassigned;
           required_preset = None;
@@ -497,7 +515,12 @@ let batch_add_tasks_internal config tasks =
       write_backlog config new_backlog;
       List.iter
         (fun (task : Types.task) ->
-          emit_task_activity config ~agent_name:"system" ~task_id:task.id
+          let created_by_json =
+            match task.created_by with
+            | Some value -> `String value
+            | None -> `Null
+          in
+          emit_task_activity config ~agent_name:actor ~task_id:task.id
             ~kind:(Event_kind.Task.to_string Event_kind.Task.Created)
             ~payload:
               (`Assoc
@@ -505,6 +528,7 @@ let batch_add_tasks_internal config tasks =
                   ("task_id", `String task.id);
                   ("title", `String task.title);
                   ("priority", `Int task.priority);
+                  ("created_by", created_by_json);
                   ( "strict_contract",
                     `Bool
                       (match task.contract with
@@ -515,7 +539,7 @@ let batch_add_tasks_internal config tasks =
       let summary = String.concat ", " (List.map (fun (t : Types.task) -> t.id) added_tasks) in
       (Atomic.get Coord_hooks.on_task_mutation_fn) ();
       let msg = Printf.sprintf "📋 New batch of %d quests added: %s" (List.length added_tasks) summary in
-      ignore (broadcast config ~from_agent:"system" ~content:msg);
+      ignore (broadcast config ~from_agent:actor ~content:msg);
       Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -523,14 +547,14 @@ let batch_add_tasks_internal config tasks =
       Printf.sprintf "❌ Error adding batch tasks: %s" (Printexc.to_string e)
   )
 
-let batch_add_tasks config tasks =
-  batch_add_tasks_internal config
+let batch_add_tasks ?created_by config tasks =
+  batch_add_tasks_internal ?created_by config
     (List.map (fun (title, priority, description) ->
          (title, priority, description, None))
        tasks)
 
-let batch_add_tasks_with_contracts config tasks =
-  batch_add_tasks_internal config tasks
+let batch_add_tasks_with_contracts ?created_by config tasks =
+  batch_add_tasks_internal ?created_by config tasks
 
 (** Claim task with file locking (TOCTOU prevention) *)
 let claim_task config ~agent_name ~task_id =

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -69,17 +69,21 @@ val observe_task_transition :
 val add_task :
   ?contract:Types.task_contract ->
   ?required_preset:string ->
+  ?created_by:string ->
   config -> title:string -> priority:int -> description:string -> string
 
 val add_task_with_role :
   ?contract:Types.task_contract ->
+  ?created_by:string ->
   config -> title:string -> priority:int -> description:string ->
   required_role:Types_core.role -> string
 
 val batch_add_tasks :
+  ?created_by:string ->
   config -> (string * int * string) list -> string
 
 val batch_add_tasks_with_contracts :
+  ?created_by:string ->
   config -> (string * int * string * Types.task_contract option) list -> string
 
 (** {1 Task claiming} *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2006,6 +2006,21 @@ let run_turn
       Some (fun () -> Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" meta.name)
     else None
   in
+  let with_scoped_env bindings f =
+    let previous =
+      List.map (fun (key, _) -> (key, Sys.getenv_opt key)) bindings
+    in
+    List.iter (fun (key, value) -> Unix.putenv key value) bindings;
+    Fun.protect
+      ~finally:(fun () ->
+        List.iter
+          (fun (key, value) ->
+             match value with
+             | Some prior -> Unix.putenv key prior
+             | None -> Unix.putenv key "")
+          previous)
+      f
+  in
   let priority = Option.value priority ~default:Llm_provider.Request_priority.Proactive in
   let admission_wait_timeout_sec =
     if Llm_provider.Request_priority.resolve priority
@@ -2029,130 +2044,149 @@ let run_turn
       | None ->
           Keeper_runtime_resolved.oas_timeout_for_context ~max_context
     in
-    let cli_transport_overrides =
-      Some
-        ({
-          cwd = None;
-          claude_mcp_config = keeper_oas_context.claude_mcp_config;
-          claude_allowed_tools = None;
-          claude_permission_mode = None;
-          claude_max_turns = Some max_turns;
-          gemini_yolo =
-            (match approval_mode_effective with
-             | Some mode ->
-               Some (String.equal (String.lowercase_ascii mode) "yolo")
-             | None -> None);
-        } : Oas_worker.cli_transport_overrides)
-    in
-    (* Phase 0: wake-time payload telemetry (Option C baseline).
-       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-       exceptions from the telemetry path never abort the LLM call. *)
-    let () =
-      if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
-        try
-          let sizes =
-            Keeper_wake_telemetry.compute_sizes
-              ~system_prompt:turn_system_prompt
-              ~tools
-              ~history_messages
-              ~user_message
-          in
-          let model_id =
-            match meta.models with
-            | m :: _ -> m
-            | [] -> "auto"
-          in
-          let _event : Dashboard_harness_health.wake_payload_event =
-            Dashboard_harness_health.record_wake_payload
-              ~keeper_name:meta.name
-              ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-              ~turn_index:start_turn_count
-              ~model_id
-              ~context_window:max_context
-              ~approx_body_bytes:sizes.approx_body_bytes
-              ~system_prompt_bytes:sizes.system_prompt_bytes
-              ~tool_defs_bytes:sizes.tool_defs_bytes
-              ~messages_bytes:sizes.messages_bytes
-              ~message_count:sizes.message_count
-              ~role_counts:sizes.role_counts
-              ~tool_count:sizes.tool_count
-              ~has_compact_happened:false
-          in
-          ()
+    let env_bindings_result =
+      if Auth.is_auth_enabled config.base_path then
+        match
+          Auth.ensure_keeper_credential config.base_path
+            ~agent_name:meta.agent_name
         with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Harness.warn
-            "[wake_payload] telemetry failed keeper=%s: %s"
-            meta.name (Printexc.to_string exn)
+        | Ok (token, _cred) -> Ok [ ("MASC_MCP_TOKEN", token) ]
+        | Error err ->
+            Error
+              (Printf.sprintf
+                 "keeper credential bootstrap failed for %s: %s"
+                 meta.agent_name
+                 (Types.masc_error_to_string err))
+      else
+        Ok []
     in
-    (match
-       Fun.protect
-         ~finally:keeper_tool_bundle.cleanup
-         (fun () ->
-           Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
-             Oas_worker.run_named
-               ~cascade_name
-               ~model_strings:meta.models
-               ?provider_filter
-               ~require_tool_choice_support
-               ~goal:user_message
-               ~priority
-               ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-               ~system_prompt:turn_system_prompt
-               ~tools
-               ~compact_ratio:meta.compaction.ratio_gate
-               ~initial_messages:history_messages
-               ~hooks
-               ~context_reducer:reducer
-               ~summarizer:Keeper_summarizer.keeper_summarizer
-               ~memory
-                 (* Keepers use turn-level retry for transient errors but benefit
-                   from OAS per-call retry for validation errors (malformed tool
-                   args). retry_on_validation_error=true lets OAS re-prompt the
-                   LLM with structured feedback instead of wasting a full turn.
-                   retry_on_recoverable_tool_error remains false — tool-level
-                   errors are handled by MASC's consecutive failure guardrail. *)
-               ~tool_retry_policy:{
-                 Oas.Tool_retry_policy.max_retries = 2;
-                 retry_on_validation_error = true;
-                 retry_on_recoverable_tool_error = false;
-                 feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
-               }
-               ~max_turns
-               ~max_idle_turns
-               ~temperature
-               ~max_tokens
-               ?max_cost_usd
-               ?wait_timeout_sec:admission_wait_timeout_sec
-               ?guardrails
-               ?on_event
-               ?on_yield
-               ?on_resume
-               ~agent_ref
-           ?contract
-           ?cli_transport_overrides
-           ~allowed_paths:oas_allowed_paths
-           ~cache_system_prompt:true
-           ~yield_on_tool
-           ~checkpoint_dir:session_dir
-           ~context_injector
-           ~context:shared_context
-           ?slot_id:(Keeper_config.keeper_slot_id meta.name)
-           ~approval:(Governance_pipeline.to_oas_approval_callback
-                        ~governance_level:(Env_config_core.governance_level ())
-                        ~keeper_name:meta.name)
-           ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-           (* exit_condition removed with mutation_boundary — OAS runs to
-              natural completion (max_turns or model end_turn). *)
-           ?oas_checkpoint:raw_oas_checkpoint
-           ?event_bus
-           ())
-         )
-     with
-     | Error e -> Error e
-     | Ok result ->
+    match env_bindings_result with
+    | Error msg -> Error (Oas.Error.Internal msg)
+    | Ok env_bindings ->
+      let cli_transport_overrides =
+        Some
+          ({
+            cwd = None;
+            claude_mcp_config = keeper_oas_context.claude_mcp_config;
+            claude_allowed_tools = None;
+            claude_permission_mode = None;
+            claude_max_turns = Some max_turns;
+            gemini_yolo =
+              (match approval_mode_effective with
+               | Some mode ->
+                 Some (String.equal (String.lowercase_ascii mode) "yolo")
+               | None -> None);
+          } : Oas_worker.cli_transport_overrides)
+      in
+      (* Phase 0: wake-time payload telemetry (Option C baseline).
+         Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
+         Compute logic lives in [Keeper_wake_telemetry] for unit tests;
+         exceptions from the telemetry path never abort the LLM call. *)
+      let () =
+        if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
+          try
+            let sizes =
+              Keeper_wake_telemetry.compute_sizes
+                ~system_prompt:turn_system_prompt
+                ~tools
+                ~history_messages
+                ~user_message
+            in
+            let model_id =
+              match meta.models with
+              | m :: _ -> m
+              | [] -> "auto"
+            in
+            let _event : Dashboard_harness_health.wake_payload_event =
+              Dashboard_harness_health.record_wake_payload
+                ~keeper_name:meta.name
+                ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                ~turn_index:start_turn_count
+                ~model_id
+                ~context_window:max_context
+                ~approx_body_bytes:sizes.approx_body_bytes
+                ~system_prompt_bytes:sizes.system_prompt_bytes
+                ~tool_defs_bytes:sizes.tool_defs_bytes
+                ~messages_bytes:sizes.messages_bytes
+                ~message_count:sizes.message_count
+                ~role_counts:sizes.role_counts
+                ~tool_count:sizes.tool_count
+                ~has_compact_happened:false
+            in
+            ()
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Harness.warn
+              "[wake_payload] telemetry failed keeper=%s: %s"
+              meta.name (Printexc.to_string exn)
+      in
+      (match
+         Fun.protect
+           ~finally:keeper_tool_bundle.cleanup
+           (fun () ->
+             with_scoped_env env_bindings (fun () ->
+               Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
+                 Oas_worker.run_named
+                   ~cascade_name
+                   ~model_strings:meta.models
+                   ?provider_filter
+                   ~require_tool_choice_support
+                   ~goal:user_message
+                   ~priority
+                   ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                   ~system_prompt:turn_system_prompt
+                   ~tools
+                   ~compact_ratio:meta.compaction.ratio_gate
+                   ~initial_messages:history_messages
+                   ~hooks
+                   ~context_reducer:reducer
+                   ~summarizer:Keeper_summarizer.keeper_summarizer
+                   ~memory
+                     (* Keepers use turn-level retry for transient errors but benefit
+                        from OAS per-call retry for validation errors (malformed tool
+                        args). retry_on_validation_error=true lets OAS re-prompt the
+                        LLM with structured feedback instead of wasting a full turn.
+                        retry_on_recoverable_tool_error remains false — tool-level
+                        errors are handled by MASC's consecutive failure guardrail. *)
+                   ~tool_retry_policy:{
+                     Oas.Tool_retry_policy.max_retries = 2;
+                     retry_on_validation_error = true;
+                     retry_on_recoverable_tool_error = false;
+                     feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
+                   }
+                   ~max_turns
+                   ~max_idle_turns
+                   ~temperature
+                   ~max_tokens
+                   ?max_cost_usd
+                   ?wait_timeout_sec:admission_wait_timeout_sec
+                   ?guardrails
+                   ?on_event
+                   ?on_yield
+                   ?on_resume
+                   ~agent_ref
+                   ?contract
+                   ?cli_transport_overrides
+                   ~allowed_paths:oas_allowed_paths
+                   ~cache_system_prompt:true
+                   ~yield_on_tool
+                   ~checkpoint_dir:session_dir
+                   ~context_injector
+                   ~context:shared_context
+                   ?slot_id:(Keeper_config.keeper_slot_id meta.name)
+                   ~approval:(Governance_pipeline.to_oas_approval_callback
+                                ~governance_level:(Env_config_core.governance_level ())
+                                ~keeper_name:meta.name)
+                   ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
+                   (* exit_condition removed with mutation_boundary — OAS runs to
+                      natural completion (max_turns or model end_turn). *)
+                   ?oas_checkpoint:raw_oas_checkpoint
+                   ?event_bus
+                   ())))
+      with
+      | Error e -> Error e
+      | Ok result ->
        let post_turn_t0 = Time_compat.now () in
        (* Checkpoint save is deferred until after [STATE] synthesis so the
            persisted checkpoint includes the synthesized continuity block.

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -15,8 +15,6 @@ let is_hardened = function
 
 let should_route_read ~(meta : keeper_meta) : bool =
   is_hardened meta.sandbox_profile
-  && Env_config_keeper.KeeperSandbox.symmetric_read_containment ()
-  && Env_config_keeper.KeeperSandbox.docker_read_routing ()
 
 let strip_trailing_slashes path =
   let rec loop i =

--- a/lib/keeper/keeper_docker_read.mli
+++ b/lib/keeper/keeper_docker_read.mli
@@ -1,19 +1,18 @@
 (** Keeper docker-routed read execution.
 
-    RFC-0006 Phase B-2: when [MASC_KEEPER_SYMMETRIC_SANDBOX] and
-    [MASC_KEEPER_DOCKER_READ] are both true and the keeper has a
-    hardened sandbox profile, read-side operations route through
-    [docker run --rm <image> cat <container_path>] so the container's
-    mount restrictions are the load-bearing boundary instead of a
-    host-side string check.
+    RFC-0006 Phase B-2: hardened keepers route read-side operations
+    through [docker run --rm <image> cat <container_path>] so the
+    container's mount restrictions are the load-bearing boundary
+    instead of a host-side string check.
 
     The host-side containment check from Phase B-1 remains as
     defense in depth and is still applied before this module is
     consulted. *)
 
 (** [should_route_read ~meta] is [true] iff this keeper's reads
-    should go through docker. Encapsulates the (sandbox_profile,
-    env flag) triplet so callers do not have to repeat it. *)
+    should go through docker. Encapsulates the
+    [sandbox_profile=docker] policy so callers do not have to repeat
+    it. *)
 val should_route_read : meta:Keeper_types.keeper_meta -> bool
 
 (** [container_path_of_host ~config ~meta ~host_path] maps a

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -72,21 +72,18 @@ let handle_keeper_fs_read
     missing_file_error_json ~config ~target ~fallback_dir ~error:e
   | Error e -> error_json e
   | Ok target ->
-    (* RFC-0006 Phase B-1: symmetric sandbox guard. For hardened keepers
-       (sandbox_profile=docker) with MASC_KEEPER_SYMMETRIC_SANDBOX=true,
-       the resolver-level allowed_paths check is augmented by a strict
-       playground-bundle containment so the host FS cannot leak through
-       keeper_fs_read while keeper_bash is container-isolated. No-op
-       for local keepers and when the env flag is off. *)
+    (* RFC-0006 Phase B-1: Docker keepers are always contained to their
+       playground bundle on the host before any read-side I/O proceeds.
+       The resolver-level allowed_paths check is augmented by this
+       strict containment so host FS cannot leak through keeper_fs_read
+       while keeper_bash is container-isolated. *)
     (match Keeper_sandbox_containment.check_read_target ~config ~meta ~target with
      | Error e -> error_json ~fields:[ "path", `String target ] e
      | Ok () ->
-    (* RFC-0006 Phase B-2: when MASC_KEEPER_DOCKER_READ is on (and
-       symmetric_sandbox is also on, and the keeper is hardened),
-       route the actual byte read through [docker run --rm <image>
-       cat <container_path>] so the container's mount restrictions
-       are the load-bearing isolation. The host containment check
-       above remains as defense-in-depth. *)
+    (* RFC-0006 Phase B-2: Docker keepers route the actual byte read
+       through [docker run --rm <image> cat <container_path>] so the
+       container's mount restrictions are the load-bearing isolation.
+       The host containment check above remains as defense-in-depth. *)
     if Keeper_docker_read.should_route_read ~meta then
       let timeout_sec = 30.0 in
       match

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -523,105 +523,151 @@ let optional_ro_mount ~host ~container =
   else if not (Sys.file_exists host) then []
   else [ "-v"; host ^ ":" ^ container ^ ":ro" ]
 
+type docker_shell_result =
+  {
+    status : Unix.process_status;
+    output : string;
+    image : string;
+    network_label : string;
+  }
+
+let run_docker_shell_command_with_status
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(cwd : string)
+    ~(timeout_sec : float)
+    ~(cmd : string)
+    ~(git_creds_enabled : bool)
+    ~(network_mode : network_mode)
+  =
+  let image = Env_config_keeper.KeeperSandbox.docker_image () in
+  let sandbox_error message =
+    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
+    Error message
+  in
+  if String.trim image = "" then
+    sandbox_error "keeper sandbox docker image is not configured"
+  else if command_uses_nested_container_runtime cmd then
+    sandbox_error
+      (if git_creds_enabled then
+         "sandbox_profile=docker+git_creds blocks nested container runtimes and host socket references"
+       else
+         "sandbox_profile=docker blocks nested container runtimes and host socket references")
+  else
+    match ensure_keeper_sandbox_runtime ~timeout_sec with
+    | Error err -> sandbox_error err
+    | Ok seccomp_args ->
+      let host_root =
+        keeper_playground_root ~config ~meta
+        |> Keeper_alerting_path.normalize_path_for_check
+        |> Keeper_alerting_path.strip_trailing_slashes
+      in
+      let container_name = keeper_sandbox_container_name meta in
+      let container_root = keeper_private_container_root meta in
+      let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
+      let uid = Unix.getuid () in
+      let gid = Unix.getgid () in
+      let network_args, network_label =
+        if git_creds_enabled then
+          ([ "--network"; "bridge" ], "bridge")
+        else
+          match network_mode with
+          | Network_none -> ([ "--network"; "none" ], "none")
+          | Network_inherit -> ([], network_mode_to_string network_mode)
+      in
+      let gh_creds =
+        match Keeper_gh_env.config_dir config with
+        | Some dir -> dir
+        | None -> Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
+      in
+      let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
+      let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
+      let gh_token = Env_config_keeper.KeeperSandbox.gh_token () in
+      let cred_mounts =
+        if not git_creds_enabled then
+          []
+        else
+          optional_ro_mount ~host:gh_creds ~container:"/root/.config/gh"
+          @ optional_ro_mount ~host:gitconfig ~container:"/root/.gitconfig"
+          @ optional_ro_mount ~host:ssh_dir ~container:"/root/.ssh"
+      in
+      let token_env =
+        if (not git_creds_enabled) || gh_token = "" then
+          []
+        else
+          [ "-e"; "GH_TOKEN=" ^ gh_token ]
+      in
+      let argv =
+        [
+          "docker";
+          "run";
+          "--rm";
+          "--name";
+          container_name;
+          "-i";
+          "--user";
+          Printf.sprintf "%d:%d" uid gid;
+          "--read-only";
+          "--tmpfs";
+          (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
+             (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
+          "--cap-drop=ALL";
+          "--security-opt";
+          "no-new-privileges";
+        ]
+        @ seccomp_args
+        @ [
+          "--pids-limit";
+          string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
+          "--memory";
+          Env_config_keeper.KeeperSandbox.memory ();
+          "-v";
+          host_root ^ ":" ^ container_root ^ ":rw";
+          "--workdir";
+          container_cwd;
+        ]
+        @ network_args
+        @ cred_mounts
+        @ token_env
+        @ [ image; "bash"; "-lc"; cmd ^ " 2>&1" ]
+      in
+      let status, output =
+        Process_eio.run_argv_with_status
+          ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+      in
+      if status <> Unix.WEXITED 0 then
+        Keeper_registry.record_error ~base_path:config.base_path meta.name
+          (Printf.sprintf "sandbox docker exec failed (%s): %s"
+             image
+             (Worker_dev_tools.truncate_for_log output))
+      else
+        Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+      Ok { status; output; image; network_label }
+
 let run_docker_with_git_bash
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(cwd : string)
     ~(timeout_sec : float)
     ~(cmd : string) =
-  let image = Env_config_keeper.KeeperSandbox.docker_image () in
-  let sandbox_error_json message =
-    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
-    error_json message
-  in
-  if String.trim image = "" then
-    sandbox_error_json "keeper sandbox docker image is not configured"
-  else if command_uses_nested_container_runtime cmd then
-    sandbox_error_json
-      "sandbox_profile=docker+git_creds blocks nested container runtimes and host socket references"
-  else
-    match ensure_keeper_sandbox_runtime ~timeout_sec with
-    | Error err -> sandbox_error_json err
-    | Ok seccomp_args ->
-    let host_root =
-      keeper_playground_root ~config ~meta
-      |> Keeper_alerting_path.normalize_path_for_check
-      |> Keeper_alerting_path.strip_trailing_slashes
-    in
-    let container_name = keeper_sandbox_container_name meta in
-    let container_root = keeper_private_container_root meta in
-    let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
-    let uid = Unix.getuid () in
-    let gid = Unix.getgid () in
-    let gh_creds = Env_config_keeper.KeeperSandbox.gh_creds_host_path () in
-    let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
-    let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
-    let gh_token = Env_config_keeper.KeeperSandbox.gh_token () in
-    let cred_mounts =
-      optional_ro_mount ~host:gh_creds ~container:"/root/.config/gh"
-      @ optional_ro_mount ~host:gitconfig ~container:"/root/.gitconfig"
-      @ optional_ro_mount ~host:ssh_dir ~container:"/root/.ssh"
-    in
-    let token_env =
-      if gh_token = "" then [] else [ "-e"; "GH_TOKEN=" ^ gh_token ]
-    in
-    let argv =
-      [
-        "docker";
-        "run";
-        "--rm";
-        "--name";
-        container_name;
-        "-i";
-        "--user";
-        Printf.sprintf "%d:%d" uid gid;
-        "--read-only";
-        "--tmpfs";
-        (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-           (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
-        "--cap-drop=ALL";
-        "--security-opt";
-        "no-new-privileges";
-      ]
-      @ seccomp_args
-      @ [
-        "--pids-limit";
-        string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
-        "--memory";
-        Env_config_keeper.KeeperSandbox.memory ();
-        "-v";
-        host_root ^ ":" ^ container_root ^ ":rw";
-        "--workdir";
-        container_cwd;
-        "--network";
-        "bridge";
-      ]
-      @ cred_mounts
-      @ token_env
-      @ [ image; "bash"; "-lc"; cmd ^ " 2>&1" ]
-    in
-    let st, out =
-      Process_eio.run_argv_with_status
-        ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-    in
-    if st <> Unix.WEXITED 0 then
-      Keeper_registry.record_error ~base_path:config.base_path meta.name
-        (Printf.sprintf "sandbox docker exec failed (%s): %s"
-           image
-           (Worker_dev_tools.truncate_for_log out))
-    else
-      Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+  match
+    run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
+      ~cmd ~git_creds_enabled:true ~network_mode:Network_inherit
+  with
+  | Error message -> error_json message
+  | Ok result ->
     Yojson.Safe.to_string
       (`Assoc
          [
-           ("ok", `Bool (st = Unix.WEXITED 0));
+           ("ok", `Bool (result.status = Unix.WEXITED 0));
            ("cwd", `String cwd);
            ("sandbox_profile", `String "docker");
            ("git_creds_enabled", `Bool true);
-           ("network_mode", `String "bridge");
-           ("effective_sandbox_image", `String image);
-           ("status", Keeper_alerting_path.process_status_to_json st);
-           ("output", `String out);
+           ("network_mode", `String result.network_label);
+           ("effective_sandbox_image", `String result.image);
+           ( "status",
+             Keeper_alerting_path.process_status_to_json result.status );
+           ("output", `String result.output);
          ])
 
 let run_docker_hardened_bash
@@ -671,78 +717,24 @@ let run_docker_hardened_bash
                 ("output", `String out);
               ]))
     | _ ->
-      match ensure_keeper_sandbox_runtime ~timeout_sec with
-    | Error err -> sandbox_error_json err
-    | Ok seccomp_args ->
-    let host_root =
-      keeper_playground_root ~config ~meta
-      |> Keeper_alerting_path.normalize_path_for_check
-      |> Keeper_alerting_path.strip_trailing_slashes
-    in
-    let container_name = keeper_sandbox_container_name meta in
-    let container_root = keeper_private_container_root meta in
-    let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
-    let uid = Unix.getuid () in
-    let gid = Unix.getgid () in
-    let network_args =
-      match network_mode with
-      | Network_none -> [ "--network"; "none" ]
-      | Network_inherit -> []
-    in
-    let argv =
-      [
-        "docker";
-        "run";
-        "--rm";
-        "--name";
-        container_name;
-        "-i";
-        "--user";
-        Printf.sprintf "%d:%d" uid gid;
-        "--read-only";
-        "--tmpfs";
-        (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-           (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
-        "--cap-drop=ALL";
-        "--security-opt";
-        "no-new-privileges";
-      ]
-      @ seccomp_args
-      @ [
-        "--pids-limit";
-        string_of_int (Env_config_keeper.KeeperSandbox.pids_limit ());
-        "--memory";
-        Env_config_keeper.KeeperSandbox.memory ();
-        "-v";
-        host_root ^ ":" ^ container_root ^ ":rw";
-        "--workdir";
-        container_cwd;
-      ]
-      @ network_args
-      @ [ image; "bash"; "-lc"; cmd ^ " 2>&1" ]
-    in
-    let st, out =
-      Process_eio.run_argv_with_status
-        ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-    in
-    if st <> Unix.WEXITED 0 then
-      Keeper_registry.record_error ~base_path:config.base_path meta.name
-        (Printf.sprintf "sandbox docker exec failed (%s): %s"
-           image
-           (Worker_dev_tools.truncate_for_log out))
-    else
-      Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+      match
+        run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
+          ~cmd ~git_creds_enabled:false ~network_mode
+      with
+      | Error message -> error_json message
+      | Ok result ->
     Yojson.Safe.to_string
       (`Assoc
          [
-           ("ok", `Bool (st = Unix.WEXITED 0));
+           ("ok", `Bool (result.status = Unix.WEXITED 0));
            ("cwd", `String cwd);
            ("sandbox_profile", `String "docker");
            ("git_creds_enabled", `Bool false);
-           ("network_mode", `String (network_mode_to_string network_mode));
-           ("effective_sandbox_image", `String image);
-           ("status", Keeper_alerting_path.process_status_to_json st);
-           ("output", `String out);
+           ("network_mode", `String result.network_label);
+           ("effective_sandbox_image", `String result.image);
+           ( "status",
+             Keeper_alerting_path.process_status_to_json result.status );
+           ("output", `String result.output);
          ])
 
 let handle_keeper_bash
@@ -1320,7 +1312,7 @@ type gh_repo_context =
     task_id : string;
     git_root : string;
     worktree_cwd : string;
-    repo_slug : string;
+    repo_slug : string option;
   }
 
 type gh_repo_context_error =
@@ -1365,17 +1357,25 @@ let gh_repo_context_error_json ~op ~cmd_display err =
          ; "hint", `String err.hint
          ] @ extra_fields))
 
-let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta) =
+let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(cwd : string) =
+  let sandbox_git_root =
+    Filename.concat
+      (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  let sandbox_worktree_cwd =
+    if safe_is_dir cwd then cwd else sandbox_git_root
+  in
   match meta.current_task_id with
   | None ->
-      Error
-        (gh_repo_context_error
-           ~code:"gh_repo_context_missing_current_task"
-           ~detail:
-             "keeper_shell op=gh needs an active current_task_id bound to a task worktree."
-           ~hint:
-             "Call keeper_task_claim with {} first so gh can derive repo context from the active task worktree."
-           ())
+      Ok
+        {
+          task_id = "(sandbox)";
+          git_root = sandbox_git_root;
+          worktree_cwd = sandbox_worktree_cwd;
+          repo_slug = None;
+        }
   | Some task_id ->
       let task_id = Keeper_id.Task_id.to_string task_id in
       match
@@ -1424,7 +1424,13 @@ let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta) =
                else
                  match Keeper_gh_shared.repo_slug_of_git_root ~git_root with
                  | Some repo_slug ->
-                     Ok { task_id; git_root; worktree_cwd; repo_slug }
+                     Ok
+                       {
+                         task_id;
+                         git_root;
+                         worktree_cwd;
+                         repo_slug = Some repo_slug;
+                       }
                  | None ->
                      Error
                        (gh_repo_context_error ~task_id ~git_root
@@ -1460,9 +1466,8 @@ let handle_keeper_shell
   in
   let root = Keeper_alerting_path.project_root_of_config config in
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-  (* RFC-0006 Phase B-1.5: pin host-FS read guard for hardened keeper
-     shell read ops. No-op for legacy keepers and when
-     MASC_KEEPER_SYMMETRIC_SANDBOX is off. *)
+  (* RFC-0006 Phase B-1.5: pin host-FS read guard for Docker keeper
+     shell read ops. Local keepers remain on the host path. *)
   let containment_check target =
     Keeper_sandbox_containment.check_read_target ~config ~meta ~target
   in
@@ -1564,32 +1569,71 @@ let handle_keeper_shell
     | None ->
       render_process_result ~cwd ~cmd command_argv
   in
+  let render_docker_process_result ~cwd ~cmd ~docker_cmd ~timeout_sec =
+    match
+      run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
+        ~cmd:docker_cmd ~git_creds_enabled:false ~network_mode:Network_none
+    with
+    | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+    | Ok result ->
+      Yojson.Safe.to_string
+        (Exec_core.process_result_json
+           ~artifact_policy:Exec_core.Inline_only
+           ~base_path:root
+           ~keeper_name:meta.name
+           ~cmd
+           ~extra:
+             [
+               "op", `String op;
+               "cmd", `String cmd;
+               "cwd", `String cwd;
+               "via", `String "docker";
+             ]
+           ~status:result.status
+           ~output:result.output
+           ())
+  in
+  let docker_git_log_path host_path =
+    if String.trim host_path = "" then Ok ""
+    else if Filename.is_relative host_path then Ok host_path
+    else
+      Keeper_docker_read.container_path_of_host ~config ~meta ~host_path
+  in
   match op with
   | "pwd" ->
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ "/bin/pwd" ]
-         ~max_bytes:4096 ~timeout_sec:io_timeout_sec ())
+       if Keeper_docker_read.should_route_read ~meta then
+         render_docker_process_result ~cwd ~cmd:"pwd" ~docker_cmd:"pwd"
+           ~timeout_sec:io_timeout_sec
+       else
+         run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ "/bin/pwd" ]
+           ~max_bytes:4096 ~timeout_sec:io_timeout_sec ())
   | "git_status" ->
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       run_in_turn_runtime ~cwd
-         ~cmd:"git --no-optional-locks status --short --branch"
-         ~command_argv:
-           [ "git"; "--no-optional-locks"; "status"; "--short"; "--branch" ]
-         ~max_bytes:1_000_000
-         ~timeout_sec:read_timeout_sec ())
+       if Keeper_docker_read.should_route_read ~meta then
+         render_docker_process_result ~cwd
+           ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
+           ~docker_cmd:"git --no-optional-locks status --short --branch"
+           ~timeout_sec:read_timeout_sec
+       else
+         run_in_turn_runtime ~cwd
+           ~cmd:"git --no-optional-locks status --short --branch"
+           ~command_argv:
+             [ "git"; "--no-optional-locks"; "status"; "--short"; "--branch" ]
+           ~max_bytes:1_000_000
+           ~timeout_sec:read_timeout_sec ())
   | "ls" ->
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
        let limit = shell_readonly_limit args in
-       (* RFC-0006 Phase B-3b: when symmetric_sandbox+docker_read are
-          on for a hardened keeper, route ls through the same docker
-          prelude as keeper_fs_read so the container's mount is the
-          load-bearing isolation. The host-side containment guard
+       (* RFC-0006 Phase B-3b: Docker keepers route ls through the same
+          docker prelude as keeper_fs_read so the container's mount is
+          the load-bearing isolation. The host-side containment guard
           above remains as defense in depth. *)
        if Keeper_docker_read.should_route_read ~meta then
          (match
@@ -1696,27 +1740,6 @@ let handle_keeper_shell
         let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
         (* Optional glob filter (e.g. "*.ml", "lib/**/*.ml") *)
         let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
-        let rg_available = shell_command_available "rg" in
-        let grep_available = shell_command_available "grep" in
-        let argv =
-          if rg_available then
-            let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
-            let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
-            let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
-            Ok (base_argv @ type_argv @ glob_argv @ [ pattern; target ])
-          else if not grep_available then
-            Error "rg executable not found, and grep fallback is unavailable"
-          else if file_type <> "" || glob <> "" then
-            Error
-              "rg executable not found; grep fallback only supports pattern and path"
-          else
-            (* Keep readonly rg usable in lean CI images that do not ship ripgrep. *)
-            Ok
-              [ "grep"; "-R"; "-n"; "-I"; "-m"; string_of_int limit; "--"; pattern; target ]
-        in
-        match argv with
-        | Error e -> path_error e
-        | Ok argv ->
         if Keeper_docker_read.should_route_read ~meta then
           let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
           let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
@@ -1743,21 +1766,42 @@ let handle_keeper_shell
                    ; "matches", lines_to_json ~limit out
                    ]))
         else
-          let st, out =
-            run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec argv
+          let rg_available = shell_command_available "rg" in
+          let grep_available = shell_command_available "grep" in
+          let argv =
+            if rg_available then
+              let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
+              let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
+              let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
+              Ok (base_argv @ type_argv @ glob_argv @ [ pattern; target ])
+            else if not grep_available then
+              Error "rg executable not found, and grep fallback is unavailable"
+            else if file_type <> "" || glob <> "" then
+              Error
+                "rg executable not found; grep fallback only supports pattern and path"
+            else
+              (* Keep readonly rg usable in lean CI images that do not ship ripgrep. *)
+              Ok
+                [ "grep"; "-R"; "-n"; "-I"; "-m"; string_of_int limit; "--"; pattern; target ]
           in
-          (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
-             Treat exit 1 as success with empty results — "no match" is a valid answer. *)
-          let is_ok = st = Unix.WEXITED 0 || st = Unix.WEXITED 1 in
-          Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool is_ok
-                ; "op", `String op
-                ; "path", `String target
-                ; "pattern", `String pattern
-                ; "status", Keeper_alerting_path.process_status_to_json st
-                ; "matches", lines_to_json ~limit out
-                ]))
+          match argv with
+          | Error e -> path_error e
+          | Ok argv ->
+            let st, out =
+              run_argv_with_status_retry_eintr ~timeout_sec:read_timeout_sec argv
+            in
+            (* rg exit codes: 0=matches found, 1=no matches (not an error), 2+=real error.
+               Treat exit 1 as success with empty results — "no match" is a valid answer. *)
+            let is_ok = st = Unix.WEXITED 0 || st = Unix.WEXITED 1 in
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool is_ok
+                  ; "op", `String op
+                  ; "path", `String target
+                  ; "pattern", `String pattern
+                  ; "status", Keeper_alerting_path.process_status_to_json st
+                  ; "matches", lines_to_json ~limit out
+                  ]))
   | "git_log" ->
     (match cwd_target () with
      | Error e -> path_error e
@@ -1765,68 +1809,90 @@ let handle_keeper_shell
        let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
        let format = Safe_ops.json_string ~default:"%h %s" "format" args in
        let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-       let base_argv =
-         [ "git"; "-C"; cwd; "--no-optional-locks"; "log";
-           Printf.sprintf "--format=%s" format;
-           Printf.sprintf "-%d" count ]
-       in
-       let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
-       (match turn_sandbox_runtime with
-        | Some runtime ->
-          let argv =
-            let base_argv =
-              [ "git"; "--no-optional-locks"; "log";
-                Printf.sprintf "--format=%s" format;
-                Printf.sprintf "-%d" count ]
-            in
-            if file_path = "" then base_argv
-            else
-              let runtime_path =
-                if Filename.is_relative file_path then file_path
-                else
-                  match
-                    Keeper_turn_sandbox_runtime.container_path_of_host runtime
-                      ~host_path:file_path
-                  with
-                  | Ok mapped -> mapped
-                  | Error _ -> file_path
+       if Keeper_docker_read.should_route_read ~meta then
+         (match docker_git_log_path file_path with
+          | Error err ->
+            error_json
+              ~fields:[ "op", `String op; "cwd", `String cwd; "path", `String file_path ]
+              err
+          | Ok docker_file_path ->
+            let docker_cmd =
+              let base =
+                Printf.sprintf "git --no-optional-locks log --format=%s -%d"
+                  (Filename.quote format) count
               in
-              base_argv @ [ "--"; runtime_path ]
-          in
-          (match
-             Keeper_turn_sandbox_runtime.run_command_with_status runtime
-               ~cwd ~command_argv:argv
-               ~ok_exit_codes:[ 0 ]
-               ~max_bytes:1_000_000
-               ~timeout_sec:read_timeout_sec ()
-           with
-           | Error msg ->
-             error_json
-               ~fields:[ "op", `String op; "cwd", `String cwd ] msg
-           | Ok (st, out) ->
-             Yojson.Safe.to_string
-               (`Assoc
-                   [ "ok", `Bool true
-                   ; "op", `String op
-                   ; "cwd", `String cwd
-                   ; "count", `Int count
-                   ; "via", `String "docker"
-                   ; "status", Keeper_alerting_path.process_status_to_json st
-                   ; "entries", lines_to_json ~limit:50 out
-                   ]))
-        | None ->
-          let st, out =
-            Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
-          in
-          Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool (st = Unix.WEXITED 0)
-                ; "op", `String op
-                ; "cwd", `String cwd
-                ; "count", `Int count
-                ; "status", Keeper_alerting_path.process_status_to_json st
-                ; "entries", lines_to_json ~limit:50 out
-                ])))
+              if docker_file_path = "" then
+                base
+              else
+                Printf.sprintf "%s -- %s" base (Filename.quote docker_file_path)
+            in
+            render_docker_process_result ~cwd
+              ~cmd:"git -C <cwd> --no-optional-locks log --format=<fmt> -<n>"
+              ~docker_cmd ~timeout_sec:read_timeout_sec)
+       else
+         let base_argv =
+           [ "git"; "-C"; cwd; "--no-optional-locks"; "log";
+             Printf.sprintf "--format=%s" format;
+             Printf.sprintf "-%d" count ]
+         in
+         let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
+         (match turn_sandbox_runtime with
+          | Some runtime ->
+            let argv =
+              let base_argv =
+                [ "git"; "--no-optional-locks"; "log";
+                  Printf.sprintf "--format=%s" format;
+                  Printf.sprintf "-%d" count ]
+              in
+              if file_path = "" then
+                base_argv
+              else
+                let runtime_path =
+                  if Filename.is_relative file_path then file_path
+                  else
+                    match
+                      Keeper_turn_sandbox_runtime.container_path_of_host runtime
+                        ~host_path:file_path
+                    with
+                    | Ok mapped -> mapped
+                    | Error _ -> file_path
+                in
+                base_argv @ [ "--"; runtime_path ]
+            in
+            (match
+               Keeper_turn_sandbox_runtime.run_command_with_status runtime
+                 ~cwd ~command_argv:argv
+                 ~ok_exit_codes:[ 0 ]
+                 ~max_bytes:1_000_000
+                 ~timeout_sec:read_timeout_sec ()
+             with
+             | Error msg ->
+               error_json
+                 ~fields:[ "op", `String op; "cwd", `String cwd ] msg
+             | Ok (st, out) ->
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool true
+                     ; "op", `String op
+                     ; "cwd", `String cwd
+                     ; "count", `Int count
+                     ; "via", `String "docker"
+                     ; "status", Keeper_alerting_path.process_status_to_json st
+                     ; "entries", lines_to_json ~limit:50 out
+                     ]))
+          | None ->
+            let st, out =
+              Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
+            in
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool (st = Unix.WEXITED 0)
+                  ; "op", `String op
+                  ; "cwd", `String cwd
+                  ; "count", `Int count
+                  ; "status", Keeper_alerting_path.process_status_to_json st
+                  ; "entries", lines_to_json ~limit:50 out
+                  ])))
   | "find" ->
     let name_pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
     if name_pattern = ""
@@ -2379,55 +2445,77 @@ let handle_keeper_shell
             Log.Keeper.info
               "gh_audit: keeper=%s reversibility=R1 cwd=%s cmd=%s"
               meta.name cwd display_command;
-          let env = Keeper_gh_env.process_env config in
-          let gh_argv =
-            "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
-          in
-          let st, out =
-            Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv
-          in
-          if process_status_is_timeout st then
-            gh_base ~command:display_command ~ok:false ~cwd
-              [ "error", `String "gh_command_timed_out"
-              ; "timeout_sec", `Float timeout_sec
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out
-              ; "hint", `String
-                  "gh network call exceeded timeout_sec. Retry \
-                   with a larger value — gh round-trip plus auth \
-                   handshake is usually 3-10s, so prefer \
-                   timeout_sec=30 or timeout_sec=60 rather than \
-                   the 15s floor. You may also narrow the query \
-                   (--state, --limit, --json)."
+          let gh_context_fields =
+            match ctx with
+            | Some ctx ->
+              let repo_fields =
+                match ctx.repo_slug with
+                | Some repo_slug -> [ "repo", `String repo_slug ]
+                | None -> []
+              in
+              [ "task_id", `String ctx.task_id
+              ; "git_root", `String ctx.git_root
               ]
-          else
-            let ok = st = Unix.WEXITED 0 in
-            let base_fields =
-              (match ctx with
-               | Some ctx ->
-                 [ "task_id", `String ctx.task_id
-                 ; "repo", `String ctx.repo_slug
-                 ; "git_root", `String ctx.git_root
-                 ]
-               | None -> [])
-              @
-              [ "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out ]
-            in
-            let hinted_fields =
-              if (not ok)
-                 && String_util.contains_substring_ci out
-                      "Could not resolve to a Repository"
-              then
-                base_fields @
-                [ "error", `String "gh_repo_resolve_failed"
+              @ repo_fields
+            | None -> []
+          in
+          let gh_process =
+            if meta.sandbox_profile = Docker then
+              match
+                run_docker_shell_command_with_status ~config ~meta ~cwd
+                  ~timeout_sec ~cmd:display_command
+                  ~git_creds_enabled:true ~network_mode:Network_inherit
+              with
+              | Ok result -> Ok (result.status, result.output)
+              | Error msg -> Error msg
+            else
+              let env = Keeper_gh_env.process_env config in
+              let gh_argv =
+                "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
+              in
+              Ok (Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv)
+          in
+          match gh_process with
+          | Error msg ->
+            gh_base ~command:display_command ~ok:false ~cwd
+              (gh_context_fields @ [ "error", `String msg ])
+          | Ok (st, out) ->
+            if process_status_is_timeout st then
+              gh_base ~command:display_command ~ok:false ~cwd
+                (gh_context_fields @
+                [ "error", `String "gh_command_timed_out"
+                ; "timeout_sec", `Float timeout_sec
+                ; "status", Keeper_alerting_path.process_status_to_json st
+                ; "output", `String out
                 ; "hint", `String
-                    "gh is bound to the active task worktree repo. \
-                     Ensure the linked sandbox clone still has a valid \
-                     origin remote and recreate the task worktree if needed." ]
-              else base_fields
-            in
-            gh_base ~command:display_command ~ok ~cwd hinted_fields
+                    "gh network call exceeded timeout_sec. Retry \
+                     with a larger value — gh round-trip plus auth \
+                     handshake is usually 3-10s, so prefer \
+                     timeout_sec=30 or timeout_sec=60 rather than \
+                     the 15s floor. You may also narrow the query \
+                     (--state, --limit, --json)."
+                ])
+            else
+              let ok = st = Unix.WEXITED 0 in
+              let base_fields =
+                gh_context_fields @
+                [ "status", Keeper_alerting_path.process_status_to_json st
+                ; "output", `String out ]
+              in
+              let hinted_fields =
+                if (not ok)
+                   && String_util.contains_substring_ci out
+                        "Could not resolve to a Repository"
+                then
+                  base_fields @
+                  [ "error", `String "gh_repo_resolve_failed"
+                  ; "hint", `String
+                      "gh is bound to the active task worktree repo. \
+                       Ensure the linked sandbox clone still has a valid \
+                       origin remote and recreate the task worktree if needed." ]
+                else base_fields
+              in
+              gh_base ~command:display_command ~ok ~cwd hinted_fields
         in
         (match reversibility with
          | Worker_dev_tools.R2_Irreversible ->
@@ -2464,21 +2552,27 @@ let handle_keeper_shell
                           status/cache/gist. auth/secret/ssh-key are blocked."
                      ])
              | Ok () ->
-               (match resolve_gh_repo_context ~config ~meta with
-                | Error err ->
-                  gh_repo_context_error_json
-                    ~op
-                    ~cmd_display:(gh_cmd_display parsed_cmd) err
-                | Ok ctx ->
-                  let cmd_to_run =
-                    Keeper_gh_shared.gh_simple_command_with_repo_flag
-                      ~repo_slug:ctx.repo_slug parsed_cmd
-                  in
-                  run_gh_command
-                    ~display_command:(gh_cmd_display cmd_to_run)
-                    ~parsed_command:cmd_to_run
-                    ~cwd:ctx.worktree_cwd
-                    ~ctx:(Some ctx))
+               (match resolve_keeper_shell_write_cwd ~config ~meta ~args with
+                | Error e -> error_json e
+                  | Ok gh_cwd ->
+                  (match resolve_gh_repo_context ~config ~meta ~cwd:gh_cwd with
+                   | Error err ->
+                     gh_repo_context_error_json
+                       ~op
+                       ~cmd_display:(gh_cmd_display parsed_cmd) err
+                   | Ok ctx ->
+                     let cmd_to_run =
+                       match ctx.repo_slug with
+                       | Some repo_slug ->
+                           Keeper_gh_shared.gh_simple_command_with_repo_flag
+                             ~repo_slug parsed_cmd
+                       | None -> parsed_cmd
+                     in
+                     run_gh_command
+                       ~display_command:(gh_cmd_display cmd_to_run)
+                       ~parsed_command:cmd_to_run
+                       ~cwd:ctx.worktree_cwd
+                       ~ctx:(Some ctx)))
            end))
   | _ ->
     Yojson.Safe.to_string

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -24,9 +24,8 @@ let is_hardened_profile = function
   | Keeper_types.Local -> false
 
 let check_read_target ~config ~meta ~target =
-  if not (is_hardened_profile meta.Keeper_types.sandbox_profile)
-     || not (Env_config_keeper.KeeperSandbox.symmetric_read_containment ())
-  then Ok ()
+  if not (is_hardened_profile meta.Keeper_types.sandbox_profile) then
+    Ok ()
   else
     let playground = playground_root_abs ~config ~meta in
     let target_norm = normalize target in
@@ -35,8 +34,7 @@ let check_read_target ~config ~meta ~target =
       Error
         (Printf.sprintf
            "symmetric_sandbox_blocked: target %s is outside keeper playground \
-            %s. Keepers with sandbox_profile=docker and \
-            MASC_KEEPER_SYMMETRIC_SANDBOX=true may only read inside their \
-            playground. Clone the source into your playground via keeper_shell \
-            op=git_clone, or operate inside %s/repos/."
+            %s. Keepers with sandbox_profile=docker may only read inside \
+            their playground. Clone the source into your playground via \
+            keeper_shell op=git_clone, or operate inside %s/repos/."
            target_norm playground playground)

--- a/lib/keeper/keeper_sandbox_containment.mli
+++ b/lib/keeper/keeper_sandbox_containment.mli
@@ -9,10 +9,9 @@
 
     This module enforces "whichever profile decides one tool, decides
     every tool" on the host side without spinning up a per-call
-    container. When the symmetric-sandbox env flag is set
-    ([MASC_KEEPER_SYMMETRIC_SANDBOX=true]) AND the keeper's profile is
-    [Docker], read targets must lie within the keeper's playground
-    bundle ([.masc/playground/<keeper>/]).
+    container. When the keeper's profile is [Docker], read targets
+    must lie within the keeper's playground bundle
+    ([.masc/playground/<keeper>/]).
 
     Phase B-2 will route the same tools through [docker exec] so the
     container's mount restrictions become the actual primary boundary;
@@ -24,11 +23,9 @@
 
     Returns [Error msg] only when ALL of the following hold:
     - [meta.sandbox_profile = Docker]
-    - [Env_config_keeper.KeeperSandbox.symmetric_read_containment ()] is true
     - [target] does NOT resolve under the keeper's playground bundle root
 
-    A no-op (always [Ok ()]) for legacy keepers and for hardened
-    keepers when the env flag is off. *)
+    A no-op (always [Ok ()]) for local keepers. *)
 val check_read_target :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -51,18 +51,18 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   let sandbox_profile =
     resolve_sandbox_profile
       ~preferred:p.sandbox_profile_opt
-      ~fallback:None
+      ~fallback:p.profile_defaults.sandbox_profile
   in
   let network_mode =
     resolve_network_mode
       ~sandbox_profile
       ~preferred:p.network_mode_opt
-      ~fallback:None
+      ~fallback:p.profile_defaults.network_mode
   in
   let shared_memory_scope =
     resolve_shared_memory_scope
       ~preferred:p.shared_memory_scope_opt
-      ~fallback:None
+      ~fallback:p.profile_defaults.shared_memory_scope
   in
   let voice_enabled =
     Option.value ~default:(default_voice_enabled_for p.name) p.voice_enabled_opt

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -468,6 +468,53 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
   let (_init_msg : string) = Coord.init state.room_config ~agent_name:None in
   Mcp_server.set_sse_callback state Sse.broadcast
 
+let sync_admin_token_env (state : Mcp_server.server_state) =
+  let base_path = state.Mcp_server.room_config.base_path in
+  let admin_agent_name =
+    match Auth.read_initial_admin base_path with
+    | Some name when String.trim name <> "" -> String.trim name
+    | _ -> "admin"
+  in
+  match Env_config_core.admin_token_opt () with
+  | Some raw_token ->
+      let already_synced =
+        match Auth.verify_token base_path ~agent_name:admin_agent_name ~token:raw_token with
+        | Ok cred -> cred.role = Types.Admin
+        | Error _ -> false
+      in
+      (match
+         Auth.save_raw_token_credential base_path
+           ~agent_name:admin_agent_name ~role:Types.Admin ~raw_token
+       with
+       | Ok _ ->
+           if already_synced then
+             Log.Server.info
+               "startup admin token verified for %s via %s"
+               admin_agent_name Env_config_core.admin_token_env_key
+           else
+             Log.Server.warn
+               "startup admin token drift repaired for %s via %s"
+               admin_agent_name Env_config_core.admin_token_env_key
+       | Error err ->
+           Log.Server.error
+             "startup admin token sync failed for %s: %s"
+             admin_agent_name
+             (Types.masc_error_to_string err))
+  | None ->
+      (match
+         Auth.create_token base_path ~agent_name:admin_agent_name ~role:Types.Admin
+       with
+       | Ok (raw_token, _cred) ->
+           Unix.putenv Env_config_core.admin_token_env_key raw_token;
+           Log.Server.warn
+             "startup minted %s for %s because env was unset"
+             Env_config_core.admin_token_env_key admin_agent_name
+       | Error err ->
+           Log.Server.error
+             "startup admin token mint failed for %s: %s"
+             admin_agent_name
+             (Types.masc_error_to_string err))
+
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
@@ -766,6 +813,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let t1 = Eio.Time.now clock in
       Log.Server.info "State created (PG pool) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
+      sync_admin_token_env state;
       let path_diagnostics =
         runtime_path_diagnostics ~input_base_path:base_path state
       in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -380,8 +380,9 @@ let handle_add_task ctx args =
     | Error error -> (false, error)
     | Ok contract ->
         ( true,
-          Coord.add_task ?contract ?required_preset ctx.config ~title:trimmed_title ~priority
-            ~description )
+          Coord.add_task ?contract ?required_preset
+            ~created_by:ctx.agent_name ctx.config ~title:trimmed_title
+            ~priority ~description )
 
 let handle_batch_add_tasks ctx args =
   let tasks_json = match args |> member "tasks" with
@@ -423,7 +424,8 @@ let handle_batch_add_tasks ctx args =
     let tasks =
       List.filter_map (function Ok t -> Some t | Error _ -> None) validated
     in
-    (true, Coord.batch_add_tasks_with_contracts ctx.config tasks)
+    (true, Coord.batch_add_tasks_with_contracts
+      ~created_by:ctx.agent_name ctx.config tasks)
 
 (** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
 let preset_from_capabilities caps =
@@ -1020,7 +1022,7 @@ let dispatch ctx ~name ~args : tool_result option =
 (* ================================================================ *)
 
 let _tool_spec_read_only = [ "masc_task_history"; "masc_tasks" ]
-let _tool_spec_requires_join = [ "masc_add_task"; "masc_claim_next"; "masc_transition" ]
+let _tool_spec_requires_join = [ "masc_claim_next"; "masc_transition" ]
 
 let tool_required_permission = function
   | "masc_tasks" | "masc_task_history" ->

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -691,6 +691,7 @@ type task = {
   priority: int; [@default 3]
   files: string list; [@default []]
   created_at: string;
+  created_by: string option; [@default None]
   worktree: worktree_info option; [@default None]  (* linked worktree info *)
   required_role: role; [@default Unassigned]  (** Role required to claim this task *)
   required_preset: string option; [@default None]  (** Tool preset required to claim this task *)
@@ -712,10 +713,14 @@ let task_to_yojson t =
     ("files", `List (List.map (fun s -> `String s) t.files));
     ("created_at", `String t.created_at);
   ] in
+  let with_created_by = match t.created_by with
+    | None -> base
+    | Some created_by -> base @ [("created_by", `String created_by)]
+  in
   (* Add worktree field if present *)
   let with_worktree = match t.worktree with
-    | None -> base
-    | Some wt -> base @ [("worktree", worktree_info_to_yojson wt)]
+    | None -> with_created_by
+    | Some wt -> with_created_by @ [("worktree", worktree_info_to_yojson wt)]
   in
   (* Add required_role if not Unassigned *)
   let with_role = match t.required_role with
@@ -769,6 +774,7 @@ let task_of_yojson json =
     let priority = json |> member "priority" |> to_int_option |> Option.value ~default:3 in
     let files = json |> member "files" |> to_list |> List.map to_string in
     let created_at = json |> member "created_at" |> to_string in
+    let created_by = json |> member "created_by" |> to_string_option in
     (* Parse optional worktree field *)
     let worktree = match json |> member "worktree" with
       | `Null -> None
@@ -819,6 +825,7 @@ let task_of_yojson json =
             priority;
             files;
             created_at;
+            created_by;
             worktree;
             required_role;
             required_preset;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -284,6 +284,84 @@ let test_load_credential_exact_wins_over_fallback () =
                | Admin -> "Admin"))
   | None -> fail "exact match should resolve"
 
+let test_extract_agent_type_prefix_keeper_aliases () =
+  check (option string) "keeper simple alias" (Some "sangsu")
+    (Auth.extract_agent_type_prefix "keeper-sangsu-agent");
+  check (option string) "keeper hyphenated alias" (Some "masc-improver")
+    (Auth.extract_agent_type_prefix "keeper-masc-improver-agent");
+  check (option string) "generated nickname" (Some "adversary")
+    (Auth.extract_agent_type_prefix "adversary-fair-tapir");
+  check (option string) "plain name stays plain" (Some "sangsu")
+    (Auth.extract_agent_type_prefix "sangsu");
+  check (option string) "two segment keeper fallback unchanged" (Some "keeper")
+    (Auth.extract_agent_type_prefix "keeper-sangsu")
+
+let test_verify_token_keeper_alias_fallback () =
+  let dir = setup_test_room () in
+  let result =
+    match Auth.create_token dir ~agent_name:"sangsu" ~role:Types.Admin with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir ~agent_name:"keeper-sangsu-agent" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok cred -> check string "fallback credential owner" "sangsu" cred.agent_name
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "keeper alias should verify via fallback credential: %s"
+           (Types.masc_error_to_string e))
+
+let test_save_raw_token_credential_uses_provided_token () =
+  let dir = setup_test_room () in
+  let raw_token = "fixed-admin-token" in
+  let save_result =
+    Auth.save_raw_token_credential dir ~agent_name:"bootstrap-admin"
+      ~role:Types.Admin ~raw_token
+  in
+  let verify_result =
+    match save_result with
+    | Ok _ ->
+        Auth.verify_token dir ~agent_name:"bootstrap-admin" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match verify_result with
+  | Ok cred ->
+      check string "saved credential owner" "bootstrap-admin" cred.agent_name;
+      check bool "saved credential role is admin" true (cred.role = Types.Admin)
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "provided raw token should verify after save_raw_token_credential: %s"
+           (Types.masc_error_to_string e))
+
+let test_ensure_keeper_credential_uses_keeper_middle_name () =
+  let dir = setup_test_room () in
+  let ensure_result =
+    with_env "MASC_MCP_TOKEN" "" (fun () ->
+      Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+  in
+  let verify_result =
+    match ensure_result with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir ~agent_name:"keeper-masc-improver-agent"
+          ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match ensure_result, verify_result with
+  | Ok (_raw_token, cred), Ok alias_cred ->
+      check string "stored under keeper middle" "masc-improver" cred.agent_name;
+      check string "alias resolves same credential" "masc-improver"
+        alias_cred.agent_name
+  | Error e, _ | _, Error e ->
+      fail
+        (Printf.sprintf
+           "ensure_keeper_credential should mint a keeper-scoped token: %s"
+           (Types.masc_error_to_string e))
+
 (* ============================================ *)
 (* Permission tests                             *)
 (* ============================================ *)
@@ -545,6 +623,14 @@ let () =
         test_load_credential_nickname_fallback;
       test_case "load_credential exact match wins over fallback" `Quick
         test_load_credential_exact_wins_over_fallback;
+      test_case "extract_agent_type_prefix keeper aliases" `Quick
+        test_extract_agent_type_prefix_keeper_aliases;
+      test_case "verify_token keeper alias fallback" `Quick
+        test_verify_token_keeper_alias_fallback;
+      test_case "save_raw_token_credential uses provided token" `Quick
+        test_save_raw_token_credential_uses_provided_token;
+      test_case "ensure_keeper_credential uses keeper middle name" `Quick
+        test_ensure_keeper_credential_uses_keeper_middle_name;
     ];
     "permissions", [
       test_case "reader permissions" `Quick test_reader_permissions;

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -1,7 +1,7 @@
 (** Tests for Keeper_docker_read.
 
-    RFC-0006 Phase B-2: docker-routed reads for hardened keepers.
-    These tests cover the pure path-mapping and flag-gating logic;
+    RFC-0006 Phase B-2: docker-routed reads for Docker keepers.
+    These tests cover the pure path-mapping and routing logic;
     the actual [docker run] call is exercised only in environments
     where docker is available, gated through env-set integration
     tests. *)
@@ -76,50 +76,23 @@ let make_meta ~name ~sandbox =
   | Ok m -> m
   | Error e -> Alcotest.fail e
 
-(* ── should_route_read flag matrix ───────────────────────────────── *)
+(* ── should_route_read profile policy ────────────────────────────── *)
 
 let test_legacy_keeper_never_routes () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Local in
   Alcotest.(check bool) "legacy keeper never routes through docker"
     false
     (Keeper_docker_read.should_route_read ~meta)
 
-let test_hardened_with_only_symmetric_does_not_route () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "false" @@ fun () ->
+let test_docker_keeper_routes () =
   let meta =
     make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker
   in
-  Alcotest.(check bool) "B-1 alone does not enable B-2 routing"
-    false
-    (Keeper_docker_read.should_route_read ~meta)
-
-let test_hardened_with_only_docker_read_does_not_route () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "false" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
-  let meta =
-    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker
-  in
-  Alcotest.(check bool)
-    "DOCKER_READ alone (without SYMMETRIC_SANDBOX) does not route"
-    false
-    (Keeper_docker_read.should_route_read ~meta)
-
-let test_hardened_with_both_flags_routes () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
-  let meta =
-    make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker
-  in
-  Alcotest.(check bool) "hardened + both flags → docker route"
+  Alcotest.(check bool) "docker keeper routes through docker"
     true
     (Keeper_docker_read.should_route_read ~meta)
 
 let test_docker_git_creds_routes () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   let meta =
     make_meta ~name:"poe" ~sandbox:Keeper_types.Docker
   in
@@ -203,8 +176,6 @@ let test_container_path_outside_playground_errors () =
    (exercised without invoking docker) ──────────────────────────── *)
 
 let test_read_outside_playground_returns_mapping_error () =
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   match
@@ -225,8 +196,6 @@ let test_read_outside_playground_returns_mapping_error () =
          loop 0)
 
 let test_read_empty_image_config_errors () =
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
@@ -489,12 +458,8 @@ let () =
         [
           Alcotest.test_case "legacy never routes" `Quick
             test_legacy_keeper_never_routes;
-          Alcotest.test_case "B-1 alone does not enable B-2" `Quick
-            test_hardened_with_only_symmetric_does_not_route;
-          Alcotest.test_case "DOCKER_READ alone does not route" `Quick
-            test_hardened_with_only_docker_read_does_not_route;
-          Alcotest.test_case "hardened + both flags routes" `Quick
-            test_hardened_with_both_flags_routes;
+          Alcotest.test_case "docker keeper routes" `Quick
+            test_docker_keeper_routes;
           Alcotest.test_case "docker git-creds also routes" `Quick
             test_docker_git_creds_routes;
         ] );

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -76,7 +76,55 @@ let run_argv argv =
          (String.concat " " argv)
          command)
 
-let make_meta ?current_task_id () =
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let with_fake_gh script f =
+  let dir = temp_dir () in
+  let gh_path = Filename.concat dir "gh" in
+  let oc = open_out_bin gh_path in
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      cleanup_dir dir)
+    (fun () ->
+      output_string oc script;
+      close_out oc;
+      Unix.chmod gh_path 0o755;
+      let path =
+        match Sys.getenv_opt "PATH" with
+        | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+        | _ -> dir
+      in
+      with_env "PATH" path f)
+
+let with_fake_docker script f =
+  let dir = temp_dir () in
+  let docker_path = Filename.concat dir "docker" in
+  let oc = open_out_bin docker_path in
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      cleanup_dir dir)
+    (fun () ->
+      output_string oc script;
+      close_out oc;
+      Unix.chmod docker_path 0o755;
+      let path =
+        match Sys.getenv_opt "PATH" with
+        | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+        | _ -> dir
+      in
+      with_env "PATH" path f)
+
+let make_meta ?current_task_id ?(sandbox_profile = Keeper_types.Local) () =
   let base_fields =
     [
       ("name", `String "sojin");
@@ -84,6 +132,8 @@ let make_meta ?current_task_id () =
       ("trace_id", `String "trace-sojin");
       ("goal", `String "gh context test");
       ("allowed_paths", `List [ `String "*" ]);
+      ( "sandbox_profile",
+        `String (Keeper_types.sandbox_profile_to_string sandbox_profile) );
     ]
   in
   let fields =
@@ -447,6 +497,60 @@ let test_resolve_task_repo_context_rejects_non_github_origin () =
   | Ok _ -> Alcotest.fail "expected non-github origin error"
   | Error _ -> Alcotest.fail "unexpected repo context error"
 
+let fake_docker_gh_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" != \"run\" ]; then\n\
+  printf 'unexpected docker invocation\\n' >&2\n\
+  exit 2\n\
+fi\n\
+workdir=''\n\
+shift\n\
+while [ \"$#\" -gt 0 ]; do\n\
+  if [ \"$1\" = \"--workdir\" ]; then\n\
+    workdir=\"$2\"\n\
+    shift 2\n\
+    continue\n\
+  fi\n\
+  if [ \"$1\" = \"alpine:test\" ]; then\n\
+    shift\n\
+    break\n\
+  fi\n\
+  shift\n\
+done\n\
+printf 'docker-gh-ok workdir=%s cmd=%s\\n' \"$workdir\" \"$*\"\n"
+
+let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
+  with_repo_context_test_env @@ fun ~base:_ ~config ~repo_dir ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let meta = make_meta ~sandbox_profile:Keeper_types.Docker () in
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "gh");
+            ("cwd", `String repo_dir);
+            ("cmd", `String "pr list --repo example/project");
+          ])
+  in
+  let json = Yojson.Safe.from_string raw in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "gh fails through docker route without image" false
+    (json |> member "ok" |> to_bool);
+  Alcotest.(check string) "sandbox task marker" "(sandbox)"
+    (json |> member "task_id" |> to_string);
+  Alcotest.(check string) "cwd preserved" repo_dir
+    (json |> member "cwd" |> to_string);
+  Alcotest.(check bool) "repo omitted when sandbox fallback has none" true
+    (json |> member "repo" = `Null);
+  Alcotest.(check string) "docker image error surfaced"
+    "keeper sandbox docker image is not configured"
+    (json |> member "error" |> to_string)
+
 (* Tool-call observability flows through the OAS Event_bus.
    This test verifies a subscriber can receive the equivalent
    signal that MASC-side observers previously emitted. *)
@@ -769,5 +873,8 @@ let () =
             test_resolve_task_repo_context_reports_missing_worktree;
           Alcotest.test_case "non-github origin is structured error" `Quick
             test_resolve_task_repo_context_rejects_non_github_origin;
+          Alcotest.test_case
+            "keeper_shell gh without current task uses sandbox context"
+            `Quick test_keeper_shell_gh_without_current_task_uses_sandbox_context;
         ] );
     ]

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -6,6 +6,8 @@
 open Alcotest
 open Masc_mcp
 
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -217,6 +219,65 @@ shared_memory_scope = "room"
         (Keeper_types.network_mode_to_string updated.network_mode);
       check string "shared_memory_scope" "room"
         (Keeper_types.shared_memory_scope_to_string updated.shared_memory_scope)
+
+let test_keeper_up_create_uses_profile_default_sandbox_policy () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "keeper-up-sandbox-defaults-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+{|[keeper]
+goal = "test"
+sandbox_profile = "docker"
+network_mode = "inherit"
+shared_memory_scope = "room"
+|};
+  let config = Coord.default_config room_dir in
+  ignore (Coord.init config ~agent_name:(Some "operator"));
+  let keeper_ctx : _ Tool_keeper.context =
+    {
+      config;
+      agent_name = "operator";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = Some (Eio.Stdenv.process_mgr env);
+      net = None;
+    }
+  in
+  Fun.protect
+    ~finally:(fun () -> Keeper_keepalive.stop_keepalive keeper_name)
+    (fun () ->
+      let () =
+        match
+          Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up"
+            ~args:
+              (`Assoc
+                [
+                  ("name", `String keeper_name);
+                  ("proactive_enabled", `Bool false);
+                  ("autoboot_enabled", `Bool false);
+                ])
+        with
+        | Some (true, _) -> ()
+        | Some (false, err) -> fail ("keeper_up failed: " ^ err)
+        | None -> fail "missing keeper_up dispatch"
+      in
+      match Keeper_types.read_meta config keeper_name with
+      | Ok (Some meta) ->
+          check string "sandbox_profile from defaults" "docker"
+            (Keeper_types.sandbox_profile_to_string meta.sandbox_profile);
+          check string "network_mode from defaults" "inherit"
+            (Keeper_types.network_mode_to_string meta.network_mode);
+          check string "shared_memory_scope from defaults" "room"
+            (Keeper_types.shared_memory_scope_to_string meta.shared_memory_scope)
+      | Ok None -> fail "keeper meta missing after keeper_up"
+      | Error e -> fail ("read_meta failed: " ^ e))
 
 (** Test: TOML tool policy and allowed_paths overwrite stale runtime JSON values. *)
 let test_tool_policy_resync () =
@@ -878,6 +939,10 @@ let () =
             "TOML sandbox policy fields overwrite stale runtime JSON"
             `Quick
             test_sandbox_policy_resync;
+          test_case
+            "keeper_up create path uses TOML sandbox policy defaults"
+            `Quick
+            test_keeper_up_create_uses_profile_default_sandbox_policy;
           test_case
             "TOML tool policy fields overwrite stale runtime JSON"
             `Quick

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -1,8 +1,7 @@
 (** Tests for Keeper_sandbox_containment.
 
     RFC-0006 Phase B-1: pin the host-FS read guard for hardened keepers.
-    The containment is no-op for legacy keepers and for hardened keepers
-    when MASC_KEEPER_SYMMETRIC_SANDBOX is off. *)
+    The containment is no-op for local keepers. *)
 
 open Masc_mcp
 
@@ -66,33 +65,18 @@ let make_meta ~name ~sandbox =
 (* ── Tests ───────────────────────────────────────────────────────── *)
 
 let test_legacy_keeper_always_allowed () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"alice" ~sandbox:Keeper_types.Local in
   let outside = "/etc/passwd" in
   Alcotest.(check bool)
-    "Local keeper bypasses containment even with flag on"
+    "Local keeper bypasses containment"
     true
     (Result.is_ok
        (Keeper_sandbox_containment.check_read_target
           ~config ~meta ~target:outside))
 
-let test_hardened_keeper_with_flag_off_is_passthrough () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "false" @@ fun () ->
-  with_tmp_base @@ fun base ->
-  let config = Coord.default_config base in
-  let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
-  let outside = "/etc/passwd" in
-  Alcotest.(check bool)
-    "Docker with flag off allows host paths (legacy behavior)"
-    true
-    (Result.is_ok
-       (Keeper_sandbox_containment.check_read_target
-          ~config ~meta ~target:outside))
-
-let test_hardened_with_flag_on_blocks_outside () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_blocks_outside () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
@@ -110,8 +94,7 @@ let test_hardened_with_flag_on_blocks_outside () =
          String.length msg >= len
          && String.sub msg 0 len = needle)
 
-let test_hardened_with_flag_on_allows_inside_playground () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_allows_inside_playground () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
@@ -127,7 +110,6 @@ let test_hardened_with_flag_on_allows_inside_playground () =
           ~config ~meta ~target:inside))
 
 let test_docker_git_creds_contained () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"poe" ~sandbox:Keeper_types.Docker in
@@ -139,7 +121,6 @@ let test_docker_git_creds_contained () =
           ~config ~meta ~target:outside))
 
 let test_path_just_outside_playground_blocked () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
@@ -167,12 +148,10 @@ let () =
         [
           Alcotest.test_case "legacy keeper always allowed" `Quick
             test_legacy_keeper_always_allowed;
-          Alcotest.test_case "hardened with flag off is passthrough" `Quick
-            test_hardened_keeper_with_flag_off_is_passthrough;
-          Alcotest.test_case "hardened with flag on blocks /etc/passwd" `Quick
-            test_hardened_with_flag_on_blocks_outside;
-          Alcotest.test_case "hardened with flag on allows inside playground"
-            `Quick test_hardened_with_flag_on_allows_inside_playground;
+          Alcotest.test_case "docker keeper blocks /etc/passwd" `Quick
+            test_docker_keeper_blocks_outside;
+          Alcotest.test_case "docker keeper allows inside playground"
+            `Quick test_docker_keeper_allows_inside_playground;
           Alcotest.test_case "docker git-creds also contained" `Quick
             test_docker_git_creds_contained;
           Alcotest.test_case "lookalike sibling path blocked" `Quick

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -2,8 +2,9 @@
 
     RFC-0006 Phase B-1.5: extend the host-FS read guard from B-1
     (handle_keeper_fs_read) to keeper_shell read ops (ls/cat/rg/find/
-    head/tail/wc/tree/git_status/git_log/git_diff). Same env flag
-    [MASC_KEEPER_SYMMETRIC_SANDBOX], same containment module. *)
+    head/tail/wc/tree/git_status/git_log/git_diff). Docker keepers are
+    always contained to their playground via the same containment
+    module. *)
 
 module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
@@ -206,7 +207,6 @@ let blocked_by_symmetric_sandbox raw =
       String.length err >= len && String.sub err 0 len = needle
 
 let test_legacy_keeper_unaffected () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   setup ~keeper_name:"alice" ~sandbox:Keeper_types.Local
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
@@ -217,20 +217,7 @@ let test_legacy_keeper_unaffected () =
   Alcotest.(check bool) "legacy bypasses symmetric containment" false
     (blocked_by_symmetric_sandbox raw)
 
-let test_hardened_flag_off_passthrough () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "false" @@ fun () ->
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
-  @@ fun ~base ~config ~meta ~playground:_ ->
-  let outside = outside_in_root ~base "secret.txt" in
-  let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
-      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
-  in
-  Alcotest.(check bool) "flag off → containment passthrough" false
-    (blocked_by_symmetric_sandbox raw)
-
-let test_hardened_flag_on_blocks_ls_outside () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_blocks_ls_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
@@ -243,8 +230,7 @@ let test_hardened_flag_on_blocks_ls_outside () =
   Alcotest.(check bool) "ls outside playground blocked" true
     (blocked_by_symmetric_sandbox raw)
 
-let test_hardened_flag_on_blocks_cat_outside () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_blocks_cat_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
@@ -255,8 +241,7 @@ let test_hardened_flag_on_blocks_cat_outside () =
   Alcotest.(check bool) "cat outside playground blocked" true
     (blocked_by_symmetric_sandbox raw)
 
-let test_hardened_flag_on_blocks_rg_outside () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_blocks_rg_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
@@ -278,8 +263,7 @@ let test_hardened_flag_on_blocks_rg_outside () =
   Alcotest.(check bool) "rg outside playground blocked" true
     (blocked_by_symmetric_sandbox raw)
 
-let test_hardened_flag_on_blocks_find_outside () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_blocks_find_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside_dir = Filename.concat base "outside_playground" in
@@ -297,8 +281,7 @@ let test_hardened_flag_on_blocks_find_outside () =
   Alcotest.(check bool) "find outside playground blocked" true
     (blocked_by_symmetric_sandbox raw)
 
-let test_hardened_flag_on_allows_inside_playground () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
+let test_docker_keeper_allows_inside_playground () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let demo = Filename.concat playground "demo.txt" in
@@ -314,7 +297,6 @@ let test_hardened_flag_on_allows_inside_playground () =
     (blocked_by_symmetric_sandbox raw)
 
 let test_docker_git_creds_contained () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
   setup ~keeper_name:"poe" ~sandbox:Keeper_types.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
@@ -370,9 +352,8 @@ let test_gh_binds_repo_from_active_task_worktree () =
   let recorded_pwd = read_file gh_pwd_file in
   Alcotest.(check bool) "repo flag injected"
     true
-    (String_util.contains_substring recorded_args "pr list --state open"
-     && String_util.contains_substring recorded_args
-          "--repo jeong-sik/masc-mcp");
+    (String_util.contains_substring recorded_args
+       "--repo jeong-sik/masc-mcp pr list --state open");
   Alcotest.(check string) "gh runs from task worktree cwd"
     (normalize_realpath worktree_cwd)
     (normalize_realpath recorded_pwd);
@@ -417,18 +398,16 @@ let () =
         [
           Alcotest.test_case "legacy keeper unaffected" `Quick
             test_legacy_keeper_unaffected;
-          Alcotest.test_case "hardened flag off passthrough" `Quick
-            test_hardened_flag_off_passthrough;
-          Alcotest.test_case "hardened flag on blocks ls outside" `Quick
-            test_hardened_flag_on_blocks_ls_outside;
-          Alcotest.test_case "hardened flag on blocks cat outside" `Quick
-            test_hardened_flag_on_blocks_cat_outside;
-          Alcotest.test_case "hardened flag on blocks rg outside" `Quick
-            test_hardened_flag_on_blocks_rg_outside;
-          Alcotest.test_case "hardened flag on blocks find outside" `Quick
-            test_hardened_flag_on_blocks_find_outside;
-          Alcotest.test_case "hardened flag on allows inside playground"
-            `Quick test_hardened_flag_on_allows_inside_playground;
+          Alcotest.test_case "docker keeper blocks ls outside" `Quick
+            test_docker_keeper_blocks_ls_outside;
+          Alcotest.test_case "docker keeper blocks cat outside" `Quick
+            test_docker_keeper_blocks_cat_outside;
+          Alcotest.test_case "docker keeper blocks rg outside" `Quick
+            test_docker_keeper_blocks_rg_outside;
+          Alcotest.test_case "docker keeper blocks find outside" `Quick
+            test_docker_keeper_blocks_find_outside;
+          Alcotest.test_case "docker keeper allows inside playground"
+            `Quick test_docker_keeper_allows_inside_playground;
           Alcotest.test_case "docker git-creds also contained" `Quick
             test_docker_git_creds_contained;
           Alcotest.test_case "gh binds repo from active task worktree" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1,9 +1,8 @@
 (** Tests for keeper_shell docker routing (RFC-0006 Phase B-3b+).
 
-    Verifies that the [should_route_read] branch fires for path-based
-    readonly keeper_shell ops when symmetric_sandbox + docker_read are
-    both on for a hardened keeper. The docker process itself is not
-    invoked because the test environment sets
+    Verifies that Docker keepers route structured shell ops through
+    docker. The docker process itself is not invoked because the test
+    environment sets
     [MASC_KEEPER_SANDBOX_DOCKER_IMAGE=""], so the response must
     surface the structured "docker image is not configured" error from
     [Keeper_docker_read] — proof that control reached the docker
@@ -176,6 +175,16 @@ let assert_docker_route_fires ~config ~meta ~playground =
           ] );
       ("wc", `Assoc [ ("op", `String "wc"); ("path", `String host_path) ]);
       ("tree", `Assoc [ ("op", `String "tree"); ("path", `String playground) ]);
+      ("pwd", `Assoc [ ("op", `String "pwd"); ("cwd", `String playground) ]);
+      ( "git_status",
+        `Assoc [ ("op", `String "git_status"); ("cwd", `String playground) ] );
+      ( "git_log",
+        `Assoc
+          [
+            ("op", `String "git_log");
+            ("cwd", `String playground);
+            ("count", `Int 1);
+          ] );
     ]
   in
   List.iter
@@ -192,16 +201,12 @@ let assert_docker_route_fires ~config ~meta ~playground =
 (* ── Tests ───────────────────────────────────────────────────────── *)
 
 let test_readonly_ops_route_through_docker () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   assert_docker_route_fires ~config ~meta ~playground
 
 let test_cat_legacy_keeper_skips_docker () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup ~sandbox:Keeper_types.Local
   @@ fun ~config ~meta ~playground ->
@@ -214,24 +219,6 @@ let test_cat_legacy_keeper_skips_docker () =
   in
   Alcotest.(check bool)
     "legacy keeper does not surface docker image error"
-    false
-    (response_mentions raw "error" "docker image")
-
-let test_cat_flag_off_skips_docker () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "false" @@ fun () ->
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  setup ~sandbox:Keeper_types.Docker
-  @@ fun ~config ~meta ~playground ->
-  let host_path = Filename.concat playground "mind/x" in
-  ensure_dir (Filename.dirname host_path);
-  ignore (Fs_compat.save_file_atomic host_path "matrix");
-  let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
-      ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
-  in
-  Alcotest.(check bool)
-    "DOCKER_READ off → no docker route, no image error"
     false
     (response_mentions raw "error" "docker image")
 
@@ -260,8 +247,6 @@ printf '%s\\n' \"$*\"\n\
 exit 0\n"
 
 let test_rg_no_match_remains_successful_in_docker_route () =
-  with_env "MASC_KEEPER_SYMMETRIC_SANDBOX" "true" @@ fun () ->
-  with_env "MASC_KEEPER_DOCKER_READ" "true" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_rg_no_match_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
@@ -292,15 +277,13 @@ let () =
       ( "docker_route_fires",
         [
           Alcotest.test_case
-            "path-based readonly ops route through docker for hardened+flags"
+            "docker keeper shell ops route through docker"
             `Quick test_readonly_ops_route_through_docker;
         ] );
       ( "docker_route_skipped",
         [
           Alcotest.test_case "legacy keeper skips docker route" `Quick
             test_cat_legacy_keeper_skips_docker;
-          Alcotest.test_case "DOCKER_READ flag off skips docker route"
-            `Quick test_cat_flag_off_skips_docker;
         ] );
       ( "docker_route_contract",
         [

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -156,6 +156,7 @@ let test_task_required_preset_roundtrip () =
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
     worktree = None;
+    created_by = None;
     required_role = Types_core.Unassigned;
     required_preset = Some "delivery";
     stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
@@ -172,6 +173,7 @@ let test_task_required_preset_none_compat () =
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
     worktree = None;
+    created_by = None;
     required_role = Types_core.Unassigned;
     required_preset = None;
     stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1677,6 +1677,49 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
     (Masc_mcp.Planning_eio.get_current_task state.room_config);
   cleanup_dir base_path
 
+let test_execute_tool_add_task_with_admin_token_without_join () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_add_task"
+      ~arguments:
+        (`Assoc
+          [
+            ("title", `String "admin add without join");
+            ("priority", `Int 2);
+            ("description", `String "");
+          ])
+  in
+  Alcotest.(check bool) "add_task succeeds" true ok;
+  Alcotest.(check bool) "response mentions added task" true
+    (contains_substring msg "Added task-001");
+  let task =
+    match Masc_mcp.Coord.get_tasks_raw state.room_config with
+    | [ task ] -> task
+    | tasks ->
+        Alcotest.failf "expected exactly one task, found %d" (List.length tasks)
+  in
+  Alcotest.(check (option string)) "created_by set from token owner"
+    (Some "stable-admin") task.created_by;
+  Alcotest.(check string) "task remains todo" "todo"
+    (Types.task_status_to_string task.task_status);
+  cleanup_dir base_path
+
 let test_execute_tool_mcp_session_ignores_term_persistence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2670,6 +2713,8 @@ let eio_tests = [
     test_execute_tool_claim_next_requires_auth_before_mutation;
   "transition auth preflight blocks mutation", `Quick,
     test_execute_tool_transition_requires_auth_before_mutation;
+  "add_task admin token works without join", `Quick,
+    test_execute_tool_add_task_with_admin_token_without_join;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
   (* Legacy governance convo room test removed *)
 ]

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -1160,6 +1160,7 @@ let test_append_archive_tasks () =
       files = [];
       created_at = "2026-01-01T00:00:00Z";
       worktree = None;
+      created_by = None;
       required_role = Types_core.Unassigned; required_preset = None; stage = None;
       contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
     } in

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -67,6 +67,7 @@ let test_task_with_stage () =
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
+    created_by = None;
     stage = Some Task_stage.Implement;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
@@ -83,6 +84,7 @@ let test_task_without_stage () =
     task_status = Todo; priority = 3; files = [];
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
+    created_by = None;
     stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -123,6 +123,7 @@ let make_task ~id ~status : Types.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
+  created_by = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
   contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }
@@ -160,6 +161,7 @@ let make_task_with_priority ~id ~priority : Types.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
+  created_by = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
   contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1234,6 +1234,7 @@ let () =
             files = []; created_at = "2026-04-19T00:00:00Z";
             task_status = ts; priority = 5;
             worktree = None;
+            created_by = None;
             required_role = Types_core.Unassigned;
             required_preset = None;
             stage = None; contract = None; handoff_context = None;

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -560,6 +560,7 @@ let test_backlog_to_yojson_with_tasks () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
+    created_by = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
@@ -1258,6 +1259,7 @@ let test_task_to_yojson () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
+    created_by = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
@@ -1285,6 +1287,7 @@ let test_task_to_yojson_with_worktree () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     worktree = Some wt;
+    created_by = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -442,6 +442,7 @@ let test_task_roundtrip () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-01T00:00:00Z";
     worktree = None;
+    created_by = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
@@ -464,6 +465,7 @@ let test_task_with_worktree () =
       git_root = "/project";
       repo_name = "project";
     };
+    created_by = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
     contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
@@ -481,11 +483,13 @@ let test_backlog_roundtrip () =
       { id = "t1"; title = "Task 1"; description = "Desc 1";
         task_status = Todo; priority = 1; files = [];
         created_at = "2024-01-01T00:00:00Z"; worktree = None;
+        created_by = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
         contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z"; worktree = None;
+        created_by = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
         contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
     ];


### PR DESCRIPTION
## What changed
- fix keeper alias credential resolution and bootstrap per-keeper MCP tokens
- allow admin `masc_add_task` without `masc_join` and sync admin token at server bootstrap
- make `sandbox_profile` the SSOT for Docker read/shell routing, including `pwd`, `git_status`, `git_log`, and `gh`
- relax sandbox `gh` repo-context requirements so isolated keepers can use `--repo` without a claimed task
- preserve `keeper_up` runtime default precedence for `sandbox_profile`, `network_mode`, and `shared_memory_scope`

## Why
- keeper MCP calls were failing on alias credential lookup and stale admin token drift
- admin task injection had drifted from the no-join policy recorded in memory
- Docker keepers were still running parts of read/git/gh execution on the host, which broke the sandbox boundary model
- sandbox `gh` use incorrectly depended on task-bound repo context in personal keeper space

## Validation
- `dune build --root .`
- `./_build/default/test/test_auth.exe`
- `./_build/default/test/test_mcp_server_eio.exe test eio 49`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe test policy 2`
- `./_build/default/test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_sandbox_containment.exe`
- `./_build/default/test/test_keeper_shell_containment.exe`
- `./_build/default/test/test_keeper_github_read_only.exe`