### PR TITLE
Fix keeper turn runtime followups

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -176,7 +176,37 @@ let process_status_is_timeout = function
   | Unix.WEXITED 124 -> true  (* Process_eio returns 124 on Eio.Time.Timeout *)
   | _ -> false
 
+let replace_all_substrings ~needle ~replacement text =
+  let needle_len = String.length needle in
+  if needle_len = 0 || not (String_util.contains_substring text needle) then text
+  else
+    let text_len = String.length text in
+    let buf = Buffer.create text_len in
+    let rec loop i =
+      if i >= text_len then ()
+      else if i + needle_len <= text_len
+              && String.sub text i needle_len = needle then (
+        Buffer.add_string buf replacement;
+        loop (i + needle_len))
+      else (
+        Buffer.add_char buf text.[i];
+        loop (i + 1))
+    in
+    loop 0;
+    Buffer.contents buf
+
+let rewrite_turn_runtime_paths_to_host
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      text
+  =
+  replace_all_substrings
+    ~needle:(Keeper_sandbox.container_root meta.name)
+    ~replacement:(Keeper_sandbox.host_root_abs ~config meta.name)
+    text
+
 let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
+  let max_eintr_retries = 8 in
   let rec loop attempts_left =
     let result = Process_eio.run_argv_with_status ?cwd ~timeout_sec argv in
     match result with
@@ -186,7 +216,7 @@ let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
         loop (attempts_left - 1)
     | _ -> result
   in
-  loop 3
+  loop max_eintr_retries
 
 let shell_command_available name =
   let probe =
@@ -1537,6 +1567,9 @@ let handle_keeper_shell
   let docker_read_error ~target msg =
     error_json ~fields:[ "op", `String op; "path", `String target ] msg
   in
+  let hostify_turn_runtime_output out =
+    rewrite_turn_runtime_paths_to_host ~config ~meta out
+  in
   let run_readonly_in_docker ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
       ~max_bytes ~timeout_sec () =
     match
@@ -1554,7 +1587,7 @@ let handle_keeper_shell
         | Ok payload -> Ok payload)
   in
   let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
-      ~max_bytes ~timeout_sec ?(extra = []) () =
+      ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =
     match turn_sandbox_runtime with
     | Some runtime ->
       (match
@@ -1565,7 +1598,7 @@ let handle_keeper_shell
          error_json
            ~fields:([ "op", `String op; "cwd", `String cwd ] @ extra) msg
        | Ok (st, out) ->
-         render_completed_process_result ~cwd ~cmd ~extra st out)
+         render_completed_process_result ~cwd ~cmd ~extra st (map_output out))
     | None ->
       render_process_result ~cwd ~cmd command_argv
   in
@@ -1609,6 +1642,7 @@ let handle_keeper_shell
            ~timeout_sec:io_timeout_sec
        else
          run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ "/bin/pwd" ]
+           ~map_output:hostify_turn_runtime_output
            ~max_bytes:4096 ~timeout_sec:io_timeout_sec ())
   | "git_status" ->
     (match cwd_target () with
@@ -1645,7 +1679,8 @@ let handle_keeper_shell
               ~fields:[ "op", `String op; "path", `String target ] e
           | Ok cpath ->
             (match
-               Keeper_docker_read.run_command_in_container ~config ~meta
+               Keeper_docker_read.run_command_in_container
+                 ?turn_sandbox_runtime ~config ~meta
                  ~command_argv:[ "ls"; "-la"; cpath ]
                  ~max_bytes:1_000_000
                  ~timeout_sec:io_timeout_sec
@@ -1688,7 +1723,8 @@ let handle_keeper_shell
           keeper_fs_read's [via: "docker"] response field. *)
        if Keeper_docker_read.should_route_read ~meta then
          (match
-            Keeper_docker_read.read_file_in_container ~config ~meta
+            Keeper_docker_read.read_file_in_container
+              ?turn_sandbox_runtime ~config ~meta
               ~host_path:target ~max_bytes
               ~timeout_sec:read_timeout_sec
               ()
@@ -2116,6 +2152,7 @@ let handle_keeper_shell
        | Error e -> path_error e
        | Ok cwd ->
          run_in_turn_runtime ~cwd ~cmd:"git worktree list"
+           ~map_output:hostify_turn_runtime_output
            ~command_argv:[ "git"; "worktree"; "list" ]
            ~max_bytes:1_000_000 ~timeout_sec:read_timeout_sec ())
     | "add" ->

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -28,6 +28,16 @@ val gh_min_timeout_sec : float
     tests can lock the floor against drift back to sub-network-latency
     values. See #8688. *)
 
+val rewrite_turn_runtime_paths_to_host :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+(** Rewrites occurrences of the keeper sandbox container root back to the
+    corresponding host playground root in path-bearing output. Used by
+    turn-scoped sandbox responses that must preserve host-path contracts
+    for follow-up tool calls. *)
+
 val cmd_targets_git_or_gh : string -> bool
 (** Docker git-credentials per-command dispatch predicate. True when
     the trimmed command's first whitespace-separated word is exactly

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -79,6 +79,38 @@ let container_missing_error out =
   String_util.contains_substring_ci out "no such container"
   || String_util.contains_substring_ci out "is not running"
 
+let run_argv_with_status_retry_eintr ~timeout_sec argv =
+  let max_eintr_retries = 8 in
+  let rec loop attempts_left =
+    let st, out =
+      Process_eio.run_argv_with_status
+        ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+    in
+    match st with
+    | Unix.WEXITED 127
+      when attempts_left > 0
+           && String_util.contains_substring_ci out "interrupted system call" ->
+        loop (attempts_left - 1)
+    | _ -> st, out
+  in
+  loop max_eintr_retries
+
+let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv =
+  let max_eintr_retries = 8 in
+  let rec loop attempts_left =
+    let st, out =
+      Process_eio.run_argv_with_stdin_and_status
+        ~cwd:(Sys.getcwd ()) ~timeout_sec ~stdin_content argv
+    in
+    match st with
+    | Unix.WEXITED 127
+      when attempts_left > 0
+           && String_util.contains_substring_ci out "interrupted system call" ->
+        loop (attempts_left - 1)
+    | _ -> st, out
+  in
+  loop max_eintr_retries
+
 let start_container (t : t) ~(timeout_sec : float) =
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
   if String.trim image = "" then
@@ -124,10 +156,7 @@ let start_container (t : t) ~(timeout_sec : float) =
               "trap : TERM INT; while :; do sleep 3600; done";
             ]
         in
-        let st, out =
-          Process_eio.run_argv_with_status
-            ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-        in
+        let st, out = run_argv_with_status_retry_eintr ~timeout_sec argv in
         match st with
         | Unix.WEXITED 0 ->
             t.state <- Running { container_name };
@@ -167,11 +196,9 @@ let run_exec_with_status_once
       let st, out =
         match stdin_content with
         | Some content ->
-            Process_eio.run_argv_with_stdin_and_status
-              ~cwd:(Sys.getcwd ()) ~timeout_sec ~stdin_content:content argv
-        | None ->
-            Process_eio.run_argv_with_status
-              ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+            run_argv_with_stdin_and_status_retry_eintr
+              ~timeout_sec ~stdin_content:content argv
+        | None -> run_argv_with_status_retry_eintr ~timeout_sec argv
       in
       Ok (st, out)
 
@@ -259,8 +286,5 @@ let cleanup (t : t) =
   | Running { container_name } ->
       t.state <- Not_started;
       let argv = [ "docker"; "rm"; "-f"; container_name ] in
-      let _st, _out =
-        Process_eio.run_argv_with_status
-          ~cwd:(Sys.getcwd ()) ~timeout_sec:5.0 argv
-      in
+      let _st, _out = run_argv_with_status_retry_eintr ~timeout_sec:5.0 argv in
       ()

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -10,6 +10,7 @@ module Coord = Masc_mcp.Coord
 module Config_boot_overrides = Config_boot_overrides
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
@@ -521,6 +522,34 @@ let test_git_write_classification () =
   Alcotest.(check bool) "push is not destructive"
     false (is_destructive "git push origin my-branch")
 
+let test_rewrite_turn_runtime_paths_to_host () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_docker_meta "minjae" in
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let host_root = Keeper_sandbox.host_root_abs ~config meta.name in
+  let input =
+    Printf.sprintf "worktree %s/repos/masc-mcp\npwd=%s/repos/masc-mcp\n"
+      container_root container_root
+  in
+  let rewritten =
+    Keeper_exec_shell.rewrite_turn_runtime_paths_to_host ~config ~meta input
+  in
+  Alcotest.(check string) "container paths rewritten to host root"
+    (Printf.sprintf "worktree %s/repos/masc-mcp\npwd=%s/repos/masc-mcp\n"
+       host_root host_root)
+    rewritten
+
+let test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_docker_meta "minjae" in
+  let input = "worktree /tmp/other\n" in
+  Alcotest.(check string) "unrelated paths untouched" input
+    (Keeper_exec_shell.rewrite_turn_runtime_paths_to_host ~config ~meta input)
+
 let () =
   Alcotest.run "Keeper bash safety" [
     ("allowlist", [
@@ -568,5 +597,11 @@ let () =
     ("git_worktree_op", [
       Alcotest.test_case "action normalization" `Quick test_git_worktree_action_normalization;
       Alcotest.test_case "branch required for add" `Quick test_git_worktree_branch_required;
+    ]);
+    ("turn_runtime_paths", [
+      Alcotest.test_case "container paths rewrite to host paths" `Quick
+        test_rewrite_turn_runtime_paths_to_host;
+      Alcotest.test_case "unrelated paths remain unchanged" `Quick
+        test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path;
     ]);
   ]


### PR DESCRIPTION
## Summary
- remap turn-runtime path-bearing outputs back to host playground paths for follow-up tool calls
- pass turn-scoped sandbox runtimes through docker-routed _build
archive
assets
audits
benchmark
benchmarks
bin
c_flags.sexp
CHANGELOG.md
ci
config
CONTRIBUTING.md
dashboard
dashboard_bonsai
data
Dockerfile
Dockerfile.worker
Dockerfile.worker-runtime
docs
dune
dune-project
dune-workspace
examples
fixtures
infrastructure
lib
LICENSE
llms-full.txt
llms.txt
Makefile
masc_mcp.opam
memory
proto
railway.toml
README.md
reports
reputation_system_plan.md
ROADMAP.md
scripts
sidecars
specs
start-masc-mcp.sh
test
viewer/ shell ops
- harden docker/process EINTR retries and add focused regression coverage

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-turn-runtime-followups --build-dir /tmp/fix-keeper-turn-runtime-followups-dune-v2 ./test/test_keeper_shell_containment.exe ./test/test_keeper_shell_docker_route.exe ./test/test_keeper_docker_read.exe ./test/test_keeper_bash_safety.exe
- /tmp/fix-keeper-turn-runtime-followups-dune-v2/default/test/test_keeper_shell_containment.exe
- /tmp/fix-keeper-turn-runtime-followups-dune-v2/default/test/test_keeper_shell_docker_route.exe
- /tmp/fix-keeper-turn-runtime-followups-dune-v2/default/test/test_keeper_docker_read.exe
- /tmp/fix-keeper-turn-runtime-followups-dune-v2/default/test/test_keeper_bash_safety.exe