### PR TITLE
[codex] Fix keeper claim-stall failure state

### DIFF
--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -158,4 +158,7 @@ let extract_accountability_claim (result : Keeper_agent_run.run_result) =
   | _ -> None
 
 let apply_to_result = Keeper_social_model_registry.apply_to_result
-let derive_failure_state = Keeper_social_model_registry.derive_failure_state
+let derive_failure_state ~meta ~observation ~previous_state
+    ~is_auto_recoverable ~reason =
+  Keeper_social_model_registry.derive_failure_state ~meta ~observation
+    ~previous_state ~is_auto_recoverable ~reason

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -80,6 +80,7 @@ val derive_failure_state :
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:social_state option ->
+  is_auto_recoverable:bool ->
   reason:string ->
   social_state * transition_reason
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2499,7 +2499,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             (short_preview e_str);
           let social_state, social_transition_reason =
             Social.derive_failure_state ~meta ~observation
-              ~previous_state:previous_social_state ~reason:e_str
+              ~previous_state:previous_social_state ~is_auto_recoverable
+              ~reason:e_str
           in
           let failure_meta_base =
             match !paused_meta_override with

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -419,15 +419,24 @@ let apply_to_result ~(meta : keeper_meta)
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
+    ~(is_auto_recoverable : bool)
     ~(reason : string) =
+  let previous_state = Option.map state_of_social_state previous_state in
+  let blocker =
+    match String.trim reason with
+    | "" -> None
+    | value -> Some (short_preview value)
+  in
   let state =
-    make_state ~meta ~observation
-      ?previous_state:(Option.map state_of_social_state previous_state)
-      ?blocker:
-        (match String.trim reason with
-        | "" -> None
-        | value -> Some (short_preview value))
-      ()
+    if is_auto_recoverable && observation.unclaimed_task_count > 0 then
+      make_state ~meta ~observation ?previous_state
+        ~active_desire:"recover_tool_route"
+        ~current_intention:"retry_claim_after_recovery"
+        ?blocker
+        ~need:"provider_recovery_or_operator_guidance"
+        ()
+    else
+      make_state ~meta ~observation ?previous_state ?blocker ()
   in
   let output =
     { speech_act = Types.Defer; delivery_surface = Types.Silent }

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -40,6 +40,7 @@ val derive_failure_state :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
+  is_auto_recoverable:bool ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -202,9 +202,11 @@ let apply_to_result ~(meta : keeper_meta)
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
+    ~(is_auto_recoverable : bool)
     ~(reason : string) =
   let base_state, transition_reason =
-    Bdi.derive_failure_state ~meta ~observation ~previous_state ~reason
+    Bdi.derive_failure_state ~meta ~observation ~previous_state
+      ~is_auto_recoverable ~reason
   in
   let previous_snapshot =
     Option.bind previous_state Fsm.snapshot_of_social_state

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
@@ -13,6 +13,7 @@ val derive_failure_state :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
+  is_auto_recoverable:bool ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -22,11 +22,12 @@ let apply_to_result ~(meta : keeper_meta)
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
+    ~(is_auto_recoverable : bool)
     ~(reason : string) =
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.derive_failure_state ~meta
-        ~observation ~previous_state ~reason
+        ~observation ~previous_state ~is_auto_recoverable ~reason
   | Types.Magentic_ledger_v1 ->
       Keeper_social_model_magentic_ledger_v1.derive_failure_state ~meta
-        ~observation ~previous_state ~reason
+        ~observation ~previous_state ~is_auto_recoverable ~reason

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -13,6 +13,7 @@ val derive_failure_state :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
+  is_auto_recoverable:bool ->
   reason:string ->
   Keeper_social_model_types.social_state
   * Keeper_social_model_types.transition_reason

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3362,6 +3362,73 @@ let test_social_model_previous_state_of_meta_falls_back_for_unknown_model () =
       check string "delivery surface inferred under fallback" "board_post"
         (KSM.delivery_surface_to_string state.delivery_surface)
 
+let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
+  let observation = { base_observation with unclaimed_task_count = 12 } in
+  let previous_state =
+    Some
+      KSM.
+        {
+          social_model = "bdi_speech_v1";
+          belief_summary = "unclaimed_tasks=12; idle=406s";
+          active_desire = Some "claim_next_task";
+          current_intention = Some "keeper_task_claim {}";
+          blocker = None;
+          need = Some "available task";
+          speech_act = Inform;
+          delivery_surface = Visible_reply;
+        }
+  in
+  let state, transition_reason =
+    KSM.derive_failure_state ~meta:minimal_meta ~observation ~previous_state
+      ~is_auto_recoverable:true
+      ~reason:
+        "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"tool_use_strict\"}"
+  in
+  check string "transition reason" "failure:run_error"
+    (KSM.transition_reason_to_string transition_reason);
+  check string "speech act stays defer" "defer"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface stays silent" "silent"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check (option string) "active desire rewrites to route recovery"
+    (Some "recover_tool_route") state.active_desire;
+  check (option string) "stale claim intention is replaced"
+    (Some "retry_claim_after_recovery") state.current_intention;
+  check (option string) "need requests recovery guidance"
+    (Some "provider_recovery_or_operator_guidance") state.need;
+  check bool "blocker keeps failure detail" true
+    (match state.blocker with
+    | Some blocker -> contains_substring blocker "cascade_exhausted"
+    | None -> false)
+
+let test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context
+    () =
+  let previous_state =
+    Some
+      KSM.
+        {
+          social_model = "bdi_speech_v1";
+          belief_summary = "mentions=1";
+          active_desire = Some "seek_help";
+          current_intention = Some "recover_tool_route";
+          blocker = Some "tool route unavailable";
+          need = Some "operator guidance";
+          speech_act = Request_help;
+          delivery_surface = Board_post;
+        }
+  in
+  let state, _ =
+    KSM.derive_failure_state ~meta:minimal_meta ~observation:base_observation
+      ~previous_state ~is_auto_recoverable:false
+      ~reason:"local config error"
+  in
+  check (option string) "active desire still carries on ordinary failure"
+    (Some "seek_help") state.active_desire;
+  check (option string) "current intention still carries on ordinary failure"
+    (Some "recover_tool_route") state.current_intention;
+  check (option string) "need still carries on ordinary failure"
+    (Some "operator guidance") state.need
+
 let test_social_model_magentic_ledger_stalled_state_carries_until_delta () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let previous_state =
@@ -3797,6 +3864,10 @@ let () =
             test_social_model_magentic_ledger_previous_state_of_meta_restores_model;
           test_case "social model previous state falls back for unknown model" `Quick
             test_social_model_previous_state_of_meta_falls_back_for_unknown_model;
+          test_case "bdi failure rewrites stale claim retry loop" `Quick
+            test_social_model_bdi_failure_state_rewrites_claim_retry_loop;
+          test_case "bdi failure keeps ordinary carry state" `Quick
+            test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context;
           test_case "magentic ledger stalled state carries until delta" `Quick
             test_social_model_magentic_ledger_stalled_state_carries_until_delta;
           test_case "render_inline deny" `Quick


### PR DESCRIPTION
## What changed
- pass auto-recoverable failure context into keeper social failure derivation
- rewrite BDI failure state when claimable work exists so stale `keeper_task_claim {}` intent becomes a recovery-oriented retry intent
- add unified regression coverage for claim-available auto-recoverable failures and ordinary failure carry behavior

## Why
Keepers were getting stuck in a repeated claim narration loop when provider or cascade failures happened before any tool call executed. The old BDI failure path carried the previous claim intention forward unchanged, which made repeated failed turns look like inert claim attempts instead of recovery.

## Impact
Keepers with claimable tasks and auto-recoverable turn failures now record a recovery-oriented social state rather than persisting the stale claim intent. This makes the internal state and decision logs better reflect that execution failed before the claim happened.

## Root cause
`derive_failure_state` in the BDI social model reused prior intent by default and had no special handling for claim-available auto-recoverable failures.

## Validation
- `dune build --root .`
- `./_build/default/test/test_keeper_unified.exe`
