### PR TITLE
[codex] expose cascade TOML authoring path in config resolution

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -81,6 +81,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'warn',
           warnings: ['Resolved config child is missing: keepers'],
           config_root: { path: '/tmp/runtime/config', exists: true, source: 'env' },
+          cascade_authoring: { path: '/tmp/runtime/config/cascade.toml', exists: true, source: 'env' },
           cascade: { path: '/tmp/runtime/config/cascade.json', exists: true, source: 'env' },
           prompts: { path: '/tmp/runtime/config/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/runtime/config/keepers', exists: false, source: 'env' },
@@ -122,10 +123,12 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('/tmp/runtime/config')
     expect(container.textContent).toContain('env override')
     expect(container.textContent).toContain('Resolved config child is missing: keepers')
+    expect(container.textContent).toContain('cascade.toml')
     expect(container.textContent).toContain('cascade.json')
     expect(container.textContent).toContain('root-relative')
     expect(container.textContent).toContain('under config root')
     expect(container.textContent).not.toContain('/tmp/runtime/config/cascade.json')
+    expect(container.textContent).not.toContain('/tmp/runtime/config/cascade.toml')
     expect(container.textContent).toContain('/tmp/custom-personas')
     expect(container.textContent).toContain('invalid env')
     expect(container.textContent).toContain('/tmp/workspace/.masc')
@@ -144,6 +147,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root-config', exists: true, source: 'env' },
+          cascade_authoring: { path: '/tmp/root-config/cascade.toml', exists: false, source: 'env' },
           cascade: { path: '/tmp/root-config/cascade.json', exists: true, source: 'env' },
           prompts: { path: '/tmp/root-config/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root-config/keepers', exists: true, source: 'cwd' },
@@ -155,6 +159,7 @@ describe('ConfigResolutionPanel', () => {
 
     const cards = Array.from(container.querySelectorAll('[title]'))
     expect(cards.map(card => card.getAttribute('title'))).toContain('/tmp/root-config/cascade.json')
+    expect(cards.map(card => card.getAttribute('title'))).toContain('/tmp/root-config/cascade.toml')
     expect(cards.map(card => card.getAttribute('title'))).toContain('/tmp/root-config')
     expect(container.textContent?.match(/env override/g)?.length ?? 0).toBe(1)
     expect(container.textContent).toContain('cwd fallback')
@@ -167,6 +172,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root', exists: true, source: 'env' },
+          cascade_authoring: { path: '/tmp/root/cascade.toml', exists: false, source: 'env' },
           cascade: { path: '/tmp/root/cascade.json', exists: true, source: 'env' },
           prompts: { path: '/tmp/root/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root/keepers', exists: true, source: 'env' },
@@ -187,6 +193,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/root', exists: true, source: 'env' },
+          cascade_authoring: { path: '/tmp/root/cascade.toml', exists: false, source: 'env' },
           cascade: { path: '/tmp/root', exists: true, source: 'env' },
           prompts: { path: '/tmp/root/prompts', exists: true, source: 'env' },
           keepers: { path: '/tmp/root/keepers', exists: true, source: 'env' },
@@ -207,6 +214,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/', exists: true, source: 'cwd' },
+          cascade_authoring: { path: '/etc/cascade.toml', exists: false, source: 'cwd' },
           cascade: { path: '/etc/cascade.json', exists: true, source: 'cwd' },
           prompts: { path: '/var/prompts', exists: true, source: 'cwd' },
           keepers: { path: '/opt/keepers', exists: true, source: 'cwd' },
@@ -227,6 +235,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/home/test/.masc/config', exists: true, source: 'home_masc' },
+          cascade_authoring: { path: '/home/test/.masc/config/cascade.toml', exists: false, source: 'home_masc' },
           cascade: { path: '/home/test/.masc/config/cascade.json', exists: true, source: 'home_masc' },
           prompts: { path: '/home/test/.masc/config/prompts', exists: true, source: 'home_masc' },
           keepers: { path: '/home/test/.masc/config/keepers', exists: true, source: 'home_masc' },
@@ -247,6 +256,7 @@ describe('ConfigResolutionPanel', () => {
           status: 'ready',
           warnings: [],
           config_root: { path: '/tmp/project/.masc/config', exists: true, source: 'local_masc' },
+          cascade_authoring: { path: '/tmp/project/.masc/config/cascade.toml', exists: false, source: 'local_masc' },
           cascade: { path: '/tmp/project/.masc/config/cascade.json', exists: true, source: 'local_masc' },
           prompts: { path: '/tmp/project/.masc/config/prompts', exists: true, source: 'local_masc' },
           keepers: { path: '/tmp/project/.masc/config/keepers', exists: true, source: 'local_masc' },

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -439,7 +439,7 @@ export function ConfigResolutionPanel({
   return html`
     <${Card} title="설정 경로" class="section mb-4">
       <div class="mb-4 text-xs leading-relaxed text-[var(--text-muted)]">
-        서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. 체크인된 repo config는 fallback/default source일 뿐이며, 현재 실행이 바라보는 경로와는 다를 수 있습니다.
+        서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. cascade는 human-authored cascade.toml과 runtime cascade.json을 분리해 보여주며, 현재 실행이 바라보는 경로와 체크인된 seed config는 다를 수 있습니다.
       </div>
 
       ${resolution
@@ -464,7 +464,13 @@ export function ConfigResolutionPanel({
                   isRoot=${true}
                 />
                 <${ConfigRow}
-                  label="cascade"
+                  label="cascade authoring"
+                  item=${resolution.cascade_authoring}
+                  rootPath=${rootPath}
+                  rootSource=${rootSource}
+                />
+                <${ConfigRow}
+                  label="cascade runtime"
                   item=${resolution.cascade}
                   rootPath=${rootPath}
                   rootSource=${rootSource}

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -413,15 +413,17 @@ export function normalizeDashboardConfigResolution(
   if (!isRecord(raw)) return null
   const status = asString(raw.status)
   const configRoot = normalizeDashboardConfigResolutionItem(raw.config_root)
+  const cascadeAuthoring = normalizeDashboardConfigResolutionItem(raw.cascade_authoring)
   const cascade = normalizeDashboardConfigResolutionItem(raw.cascade)
   const prompts = normalizeDashboardConfigResolutionItem(raw.prompts)
   const keepers = normalizeDashboardConfigResolutionItem(raw.keepers)
   const personas = normalizeDashboardConfigResolutionItem(raw.personas)
-  if (!status || !configRoot || !cascade || !prompts || !keepers || !personas) return null
+  if (!status || !configRoot || !cascadeAuthoring || !cascade || !prompts || !keepers || !personas) return null
   return {
     status: status as DashboardConfigResolution['status'],
     warnings: asStringArray(raw.warnings),
     config_root: configRoot,
+    cascade_authoring: cascadeAuthoring,
     cascade,
     prompts,
     keepers,

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -61,6 +61,7 @@ export interface DashboardConfigResolution {
   status: 'ready' | 'warn' | 'invalid_env' | 'missing'
   warnings: string[]
   config_root: DashboardConfigResolutionItem
+  cascade_authoring: DashboardConfigResolutionItem
   cascade: DashboardConfigResolutionItem
   prompts: DashboardConfigResolutionItem
   keepers: DashboardConfigResolutionItem

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -33,6 +33,7 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
+  cascade_authoring : path_item;
   cascade : path_item;
   prompts : path_item;
   keepers : path_item;
@@ -138,6 +139,7 @@ let to_json (resolution : resolution) =
       ( "warnings",
         `List (List.map (fun warning -> `String warning) resolution.warnings) );
       ("config_root", item_to_json resolution.config_root);
+      ("cascade_authoring", item_to_json resolution.cascade_authoring);
       ("cascade", item_to_json resolution.cascade);
       ("prompts", item_to_json resolution.prompts);
       ("keepers", item_to_json resolution.keepers);
@@ -281,6 +283,11 @@ let child_item (root : path_item) name =
   in
   { path; exists; source = root.source }
 
+let file_item (root : path_item) name =
+  let path = Filename.concat root.path name in
+  let exists = existing_file path in
+  { path; exists; source = root.source }
+
 let personas_item (inputs : inputs) root =
   match trim_opt inputs.env_personas_dir with
   | Some raw ->
@@ -306,12 +313,13 @@ let inputs_from_env () =
 
 let resolve_with inputs =
   let config_root, root_warnings = config_root_resolution inputs in
+  let cascade_authoring = file_item config_root cascade_toml_filename in
   let cascade = child_item config_root cascade_json_filename in
   let prompts = child_item config_root "prompts" in
   let keepers = child_item config_root "keepers" in
   let personas, persona_warnings = personas_item inputs config_root in
   let missing_child_warnings =
-    [ (cascade_json_filename, cascade.exists); ("prompts", prompts.exists); ("keepers", keepers.exists); ("personas", personas.exists) ]
+    [ ("cascade.json/cascade.toml", cascade.exists); ("prompts", prompts.exists); ("keepers", keepers.exists); ("personas", personas.exists) ]
     |> List.filter_map (fun (label, exists) ->
            if exists then None
            else
@@ -326,7 +334,16 @@ let resolve_with inputs =
     | Env | Local_masc | Home_masc | Exe_relative | Cwd ->
         if warnings = [] then Ready else Warn
   in
-  { status; warnings; config_root; cascade; prompts; keepers; personas }
+  {
+    status;
+    warnings;
+    config_root;
+    cascade_authoring;
+    cascade;
+    prompts;
+    keepers;
+    personas;
+  }
 
 let _cached_resolution : resolution option ref = ref None
 

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -129,6 +129,7 @@ let test_env_override_valid () =
     (Lib.Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "env"
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "cascade authoring missing" false resolution.cascade_authoring.exists;
   check bool "cascade exists" true resolution.cascade.exists;
   check bool "prompts exists" true resolution.prompts.exists
 
@@ -143,6 +144,10 @@ let test_env_override_valid_with_toml_only_root () =
     (Lib.Config_dir_resolver.status_to_string resolution.status);
   check string "root source" "env"
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "cascade authoring exists" true resolution.cascade_authoring.exists;
+  check string "cascade authoring path targets toml"
+    (Filename.concat config "cascade.toml")
+    resolution.cascade_authoring.path;
   check bool "cascade exists via toml source" true resolution.cascade.exists;
   check string "cascade runtime path still targets json"
     (Filename.concat config "cascade.json")

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -147,6 +147,13 @@ let test_dashboard_shell_http_json_includes_paths () =
          match config_resolution |> member "config_root" |> member "path" with
          | `String value -> String.length value > 0
          | _ -> false));
+  check bool "shell cascade authoring path surfaced when available" true
+    (match config_resolution with
+     | `Null -> true
+     | _ -> (
+         match config_resolution |> member "cascade_authoring" |> member "path" with
+         | `String value -> String.length value > 0
+         | _ -> false));
   check bool "shell runtime resolution is object or null" true
     (match runtime_resolution with
      | `Assoc _ | `Null -> true

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -50,6 +50,10 @@ let test_dashboard_tools_projection () =
         (match config_resolution |> member "warnings" with
          | `List _ -> true
          | _ -> false);
+      check bool "cascade authoring path surfaced" true
+        (match config_resolution |> member "cascade_authoring" |> member "path" with
+         | `String value -> String.length value > 0
+         | _ -> false);
       check bool "runtime data_root path surfaced" true
         (match runtime_resolution |> member "data_root" |> member "path" with
          | `String value -> String.length value > 0

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1074,6 +1074,13 @@ let test_startup_state_json_includes_runtime_resolution () =
               ("exists", `Bool true);
               ("source", `String "local_masc");
             ] );
+        ( "cascade_authoring",
+          `Assoc
+            [
+              ("path", `String "/tmp/runtime-root/.masc/config/cascade.toml");
+              ("exists", `Bool false);
+              ("source", `String "local_masc");
+            ] );
       ]
   in
   Server_startup_state.note_runtime_resolution ~path_diagnostics
@@ -1088,6 +1095,11 @@ let test_startup_state_json_includes_runtime_resolution () =
     "/tmp/runtime-root/.masc/config"
     (json |> member "config_resolution" |> member "config_root" |> member "path"
    |> to_string)
+  ;
+  Alcotest.(check bool) "startup cascade authoring path surfaced" true
+    (match json |> member "config_resolution" |> member "cascade_authoring" |> member "path" with
+     | `String value -> String.length value > 0
+     | _ -> false)
 
 let test_create_server_state_records_runtime_resolution () =
   with_temp_dir "startup-create-state" (fun dir ->
@@ -1112,6 +1124,10 @@ let test_create_server_state_records_runtime_resolution () =
       Alcotest.(check string) "create_server_state records config root"
         (Filename.concat dir ".masc/config")
         (json |> member "config_resolution" |> member "config_root" |> member "path"
+       |> to_string);
+      Alcotest.(check string) "create_server_state records cascade authoring path"
+        (Filename.concat dir ".masc/config/cascade.toml")
+        (json |> member "config_resolution" |> member "cascade_authoring" |> member "path"
        |> to_string);
       Alcotest.(check string) "create_server_state records effective masc root"
         (Unix.realpath (Filename.concat dir ".masc"))


### PR DESCRIPTION
## What changed
- add `cascade_authoring` to config-resolution JSON so the runtime can expose the human-authored `cascade.toml` path separately from materialized `cascade.json`
- update the dashboard config-resolution types, normalizers, and panel to render `cascade authoring` and `cascade runtime` as separate rows
- extend OCaml and dashboard regression tests that assert the `config_resolution` payload shape

## Why
`#9313` makes `cascade.toml` the authoring surface, but the config-resolution/debug UI still only showed the runtime JSON path. That left the operator view ambiguous about which file is editable SSOT versus which file is the materialized runtime artifact.

## Impact
- operators can now see both the editable TOML source and the runtime JSON path in one place
- config-resolution payloads stay explicit about authoring vs runtime cascade files
- dashboard tests and server-side projection tests guard the new shape end to end

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run src/components/tools/config-resolution-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-cascade-toml-next-dev bin/main_eio.exe test/test_config_dir_resolver.exe test/test_dashboard_tools.exe test/test_dashboard_http_core.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_config_dir_resolver.exe`
- `./_build/default/test/test_dashboard_tools.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`
- `git diff --check`
