### PR TITLE
[codex] Add provider labels to keeper tool telemetry

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -468,13 +468,25 @@ let make_hooks
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
+        let model =
+          let m = (!meta_ref).runtime.usage.last_model_used in
+          if m = "" then (!meta_ref).cascade_name else m
+        in
+        let provider = provider_of_model model in
+        Prometheus.inc_counter
+          "masc_tool_call_total"
+          ~labels:
+            [ ("provider", provider)
+            ; ("tool", tool_name)
+            ; ("outcome", outcome)
+            ]
+          ();
         (try
            Keeper_tool_call_log.log_call
              ~keeper_name:(!meta_ref).name
              ~tool_name ~input ~output_text
              ~success:(outcome = "ok") ~duration_ms
-             ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
-                     if m = "" then (!meta_ref).cascade_name else m)
+             ~model ~provider
              ?lane ?tool_choice ?thinking_enabled ?thinking_budget
              ?trace_id ?session_id ?turn
              ~result_bytes ?truncated_to ()

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1194,6 +1194,7 @@ let append_decision_record
                 | None -> []
               in
               `Assoc ([
+                ("provider", `String (Keeper_hooks_oas.provider_of_model surface_model_used));
                 ("model_used", `String surface_model_used);
                 ("turn_count", `Int r.turn_count);
                 ("stop_reason", `String stop_reason_str);
@@ -1239,7 +1240,13 @@ let append_decision_record
                   else "other"
                 | _ -> "unknown"
               in
+              let error_provider =
+                match cascade_models with
+                | model :: _ -> Keeper_hooks_oas.provider_of_model model
+                | [] -> Keeper_hooks_oas.provider_of_model meta.cascade_name
+              in
               `Assoc [
+                ("provider", `String error_provider);
                 ("cascade_name", `String meta.cascade_name);
                 ("candidate_models", `List (List.map (fun s -> `String s) cascade_models));
                 ("error_category", `String error_category);

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -145,7 +145,7 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
-    ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
+    ?(model : string = "") ?provider ?lane ?tool_choice ?thinking_enabled
     ?thinking_budget ?trace_id ?session_id ?turn ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
@@ -182,6 +182,12 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       let turn = match turn with Some _ -> turn | None -> ctx_turn in
       let model_field =
         if model = "" then [] else [("model", `String model)]
+      in
+      let provider_field =
+        match provider with
+        | Some value when String.trim value <> "" ->
+          [("provider", `String value)]
+        | _ -> []
       in
       let result_bytes_field = match result_bytes with
         | Some n -> [("result_bytes", `Int n)]
@@ -232,7 +238,7 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            ; ("success", `Bool success)
            ; ("duration_ms", `Float duration_ms)
            ]
-           @ model_field @ lane_field @ tool_choice_field
+           @ model_field @ provider_field @ lane_field @ tool_choice_field
            @ thinking_enabled_field @ thinking_budget_field
            @ trace_id_field @ session_id_field @ turn_field
            @ result_bytes_field @ truncated_to_field)

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -61,6 +61,7 @@ val log_call :
   success:bool ->
   duration_ms:float ->
   ?model:string ->
+  ?provider:string ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
@@ -74,7 +75,8 @@ val log_call :
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
     Output is truncated to 4000 bytes. [model] records which LLM generated
-    the tool call. Turn-policy fields ([lane], [tool_choice],
+    the tool call. [provider] records the canonical provider label when
+    the caller knows it. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool
     selection context. [result_bytes] is the original output size before
     any truncation. [truncated_to] is present when Tool_output_validation

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -15,6 +15,7 @@ module IntMap = Map.Make (Int)
 
 type recent_entry = {
   re_ts_unix : float;
+  re_provider : string option;
   re_input_tokens : int;
   re_output_tokens : int;
   re_latency_ms : float;
@@ -43,6 +44,7 @@ type model_bucketed = {
 
 type model_stats = {
   model_id : string;
+  provider : string option;
   entry_count : int;
   avg_tok_per_sec : float;
   p50_tok_per_sec : float;
@@ -107,6 +109,7 @@ let percentile (sorted : float array) (p : float) : float =
 
 type raw_entry = {
   model : string;
+  provider : string option;
   ts_unix : float;
   tok_per_sec : float;
   prompt_tok_per_sec : float option;
@@ -128,6 +131,16 @@ type raw_entry = {
   tools_used : string list;
   is_error : bool;
 }
+
+let provider_opt_of_model (model : string) : string option =
+  let provider = Keeper_hooks_oas.provider_of_model model in
+  if String.equal provider "unknown" then None else Some provider
+
+let provider_opt_of_fields ~(model : string) (fields : (string * Yojson.Safe.t) list)
+    : string option =
+  match List.assoc_opt "provider" fields with
+  | Some (`String s) when String.trim s <> "" -> Some s
+  | _ -> provider_opt_of_model model
 
 let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
   let ts = Safe_ops.json_float_opt "ts_unix" json |> Option.value ~default:0.0 in
@@ -168,7 +181,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                  Keeper_cascade_profile.canonicalize s ^ " (cascade)"
                | _ -> "__error__"
            in
+           let provider = provider_opt_of_fields ~model tfields in
            Some { model; ts_unix = ts; tok_per_sec = 0.0;
+                  provider;
                   prompt_tok_per_sec = None;
                   hw_decode_tok_per_sec = None;
                   peak_memory_gb = None;
@@ -187,9 +202,10 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
               | Some (`String s) -> s
               | _ ->
                 match List.assoc_opt "model_used" tfields with
-                | Some (`String s) -> s
-                | _ -> "unknown")
+                   | Some (`String s) -> s
+                   | _ -> "unknown")
            in
+           let provider = provider_opt_of_fields ~model tfields in
            let tok_per_sec =
              match List.assoc_opt "tokens_per_second" tfields with
              | Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0
@@ -262,6 +278,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | _ -> None
            in
            Some { model; ts_unix = ts; tok_per_sec;
+                  provider;
                   prompt_tok_per_sec;
                   hw_decode_tok_per_sec;
                   peak_memory_gb;
@@ -368,8 +385,14 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
         let on_count = List.length (List.filter (fun x -> x) xs) in
         Some (float_of_int on_count /. float_of_int total)
     in
+    let provider =
+      match List.find_map (fun e -> e.provider) entries with
+      | Some _ as p -> p
+      | None -> provider_opt_of_model model_id
+    in
     let stats = {
       model_id;
+      provider;
       entry_count = n;
       avg_tok_per_sec = avg tok_vals;
       p50_tok_per_sec = percentile tok_vals 50.0;
@@ -417,6 +440,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
         |> (fun l -> if List.length l > 5 then List.filteri (fun i _ -> i < 5) l else l)
         |> List.map (fun e -> {
           re_ts_unix = e.ts_unix;
+          re_provider = e.provider;
           re_input_tokens = e.input_tokens;
           re_output_tokens = e.output_tokens;
           re_latency_ms = e.latency_ms;
@@ -559,8 +583,10 @@ let bucket_metric_to_json (b : bucket_metric) : Yojson.Safe.t =
 
 let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
   let opt_float = function Some f -> `Float f | None -> `Null in
+  let opt_string = function Some s -> `String s | None -> `Null in
   `Assoc
     [ ("model_id", `String s.model_id)
+    ; ("provider", opt_string s.provider)
     ; ("entry_count", `Int s.entry_count)
     ; ("avg_tok_per_sec", `Float s.avg_tok_per_sec)
     ; ("p50_tok_per_sec", `Float s.p50_tok_per_sec)
@@ -592,6 +618,7 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
     ; ("recent_entries", `List (List.map (fun (r : recent_entry) ->
         `Assoc [
           ("ts_unix", `Float r.re_ts_unix);
+          ("provider", opt_string r.re_provider);
           ("input_tokens", `Int r.re_input_tokens);
           ("output_tokens", `Int r.re_output_tokens);
           ("latency_ms", `Float r.re_latency_ms);

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -8,6 +8,7 @@
 
 type recent_entry = {
   re_ts_unix : float;
+  re_provider : string option;
   re_input_tokens : int;
   re_output_tokens : int;
   re_latency_ms : float;
@@ -41,6 +42,7 @@ type model_bucketed = {
 
 type model_stats = {
   model_id : string;
+  provider : string option;
   entry_count : int;
   avg_tok_per_sec : float;
   p50_tok_per_sec : float;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -273,6 +273,8 @@ let init () =
     "Total provider prefix cache creation tokens (Anthropic)" Counter;
   add "masc_provider_prefix_cache_read_tokens_total"
     "Total provider prefix cache read tokens (Anthropic)" Counter;
+  add "masc_tool_call_total"
+    "Total keeper tool calls labeled by provider, tool, and outcome" Counter;
   register_histogram ~name:"masc_tool_call_duration_seconds"
     ~help:"Tool call latency in seconds" ();
   (* Inference admission queue metrics *)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -115,12 +115,16 @@ let test_model_field_stored () =
       ~keeper_name:"k" ~tool_name:"masc_status"
       ~input:(`Assoc []) ~output_text:"ok"
       ~success:true ~duration_ms:2.0
-      ~model:"glm-4-9b" ();
+      ~model:"glm-4-9b" ~provider:"glm-coding" ();
     let entries = Keeper_tool_call_log.read_recent () in
     Alcotest.(check int) "one entry" 1 (List.length entries);
-    let entry_str = Yojson.Safe.to_string (List.hd entries) in
+    let entry = List.hd entries in
+    let entry_str = Yojson.Safe.to_string entry in
     Alcotest.(check bool) "model field present" true
-      (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str))
+      (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str);
+    Alcotest.(check (option string)) "provider field present"
+      (Some "glm-coding")
+      (Safe_ops.json_string_opt "provider" entry))
 
 let test_turn_context_fields_stored () =
   with_tmp_log (fun () ->

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -47,7 +47,7 @@ let now_unix () = Unix.gettimeofday ()
 
 let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ?(latency_ms=500) ?prompt_per_second ?peak_memory_gb
-    ?(cost_usd=0.01) ?(tools_used=[]) () =
+    ?provider ?(cost_usd=0.01) ?(tools_used=[]) () =
   let extra_telemetry_fields =
     (match prompt_per_second with
      | Some v -> [("prompt_per_second", `Float v)]
@@ -55,6 +55,10 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     @
     (match peak_memory_gb with
      | Some v -> [("peak_memory_gb", `Float v)]
+     | None -> [])
+    @
+    (match provider with
+     | Some v -> [("provider", `String v)]
      | None -> [])
   in
   `Assoc [
@@ -74,12 +78,16 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ] @ extra_telemetry_fields));
   ]
 
-let error_entry ~cascade_name ~ts () =
+let error_entry ~cascade_name ~ts ?provider () =
   `Assoc [
     ("ts_unix", `Float ts);
     ("tool_call_count", `Int 0);
     ("tools_used", `List []);
     ("telemetry", `Assoc [
+      ("provider",
+        match provider with
+        | Some v -> `String v
+        | None -> `Null);
       ("cascade_name", `String cascade_name);
       ("candidate_models", `List [`String "model-a"; `String "model-b"]);
       ("error_category", `String "timeout");
@@ -116,6 +124,7 @@ let test_single_model_success () =
     check int "models" 1 (List.length agg.models);
     let s = List.hd agg.models in
     check string "model_id" "claude-sonnet" s.model_id;
+    check (option string) "provider" (Some "claude") s.provider;
     check int "entry_count" 2 s.entry_count;
     check int "success_count" 2 s.success_count;
     check int "error_count" 0 s.error_count;
@@ -144,6 +153,7 @@ let test_error_turns_counted () =
       s.model_id = "model-a") agg.models in
     check bool "error model found" true (Option.is_some error_model);
     let em = Option.get error_model in
+    check (option string) "error provider unresolved" None em.provider;
     check int "error_count" 1 em.error_count;
     check int "success_count" 0 em.success_count)
 
@@ -232,6 +242,8 @@ let test_json_roundtrip () =
     let models = json |> member "models" |> to_list in
     check bool "has models" true (List.length models > 0);
     let m = List.hd models in
+    check bool "provider unresolved -> null" true
+      (match m |> member "provider" with `Null -> true | _ -> false);
     check int "success_count" 1 (m |> member "success_count" |> to_int);
     check bool "total_cost_usd = 0.05" true
       (Float.abs (m |> member "total_cost_usd" |> to_float) -. 0.05 < 0.001);
@@ -265,6 +277,8 @@ let test_prompt_tps_and_peak_memory_aggregates () =
     check (float 0.001) "max peak mem" 20.25
       (Option.value ~default:0.0 s.max_peak_memory_gb);
     let first_recent = List.hd s.recent_entries in
+    check (option string) "recent provider derived"
+      None first_recent.re_provider;
     check (float 0.001) "recent prompt tok/s" 1500.0
       (Option.value ~default:0.0 first_recent.re_prompt_tok_per_sec);
     check (float 0.001) "recent peak memory" 20.25
@@ -277,6 +291,8 @@ let test_prompt_tps_and_peak_memory_aggregates () =
     check (float 0.001) "max peak mem json" 20.25
       (m |> member "max_peak_memory_gb" |> to_float);
     let recent = m |> member "recent_entries" |> to_list |> List.hd in
+    check bool "recent provider null" true
+      (match recent |> member "provider" with `Null -> true | _ -> false);
     check (float 0.001) "recent prompt json" 1500.0
       (recent |> member "prompt_tok_per_sec" |> to_float);
     check (float 0.001) "recent peak mem json" 20.25

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -220,7 +220,9 @@ let test_keeper_metrics_registered () =
   check bool "has operator compact counter" true
     (has "masc_keeper_operator_compact_total");
   check bool "has operator clear counter" true
-    (has "masc_keeper_operator_clear_total")
+    (has "masc_keeper_operator_clear_total");
+  check bool "has tool call counter" true
+    (has "masc_tool_call_total")
 
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in


### PR DESCRIPTION
## Summary
- add provider labels to keeper tool-call observability via 
- persist provider classification in keeper tool-call logs and decision telemetry
- expose provider fields through  JSON output

## Verification
- 
- Testing `keeper_tool_call_log'.
This run has ID `1RZB1JZS'.

  [OK]          read_recent             0   n=0 returns [].
  [OK]          read_recent             1   n<0 returns [].
  [OK]          read_recent             2   keeper filter.
  [OK]          redaction               0   denied tool not logged.
  [OK]          redaction               1   sensitive input fields redacted.
  [OK]          redaction               2   model field stored.
  [OK]          redaction               3   turn context fields stored.
  [OK]          redaction               4   turn context fields absent withou...
  [OK]          redaction               5   dashboard aggregate groups runtim...
  [OK]          redaction               6   dashboard hourly trend buckets nu...
  [OK]          redaction               7   dashboard aggregate window hours.
  [OK]          utf8_sanitize           0   invalid UTF-8 bytes scrubbed befo...
  [OK]          utf8_sanitize           1   valid UTF-8 preserved verbatim.
  [OK]          blob_normalize          0   blob sentinel persists as structu...
  [OK]          blob_normalize          1   inline string output stays a JSON...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/axis4-tool-call-telemetry/_build/_tests/keeper_tool_call_log'.
Test Successful in 0.108s. 15 tests run.
- Testing `Model_inference_metrics'.
This run has ID `PX4FFDJB'.

  [OK]          basics                     0   empty dir.
  [OK]          basics                     1   single model success.
  [OK]          basics                     2   error turns counted.
  [OK]          basics                     3   multi model sorted.
  [OK]          basics                     4   window filter.
  [OK]          enrichment                 0   top tools per model.
  [OK]          enrichment                 1   recent entries capped.
  [OK]          enrichment                 2   prompt tps and peak memory agg...
  [OK]          enrichment                 3   json roundtrip.
  [OK]          thinking_fraction          0   mixed reported yields fraction.
  [OK]          thinking_fraction          1   all missing yields None.
  [OK]          thinking_fraction          2   json serialization.
  [OK]          buckets                    0   empty dir → no buckets.
  [OK]          buckets                    1   single bucket window.
  [OK]          buckets                    2   sparse entries → distinct buck...
  [OK]          buckets                    3   cache_hit_ratio zero denom.
  [OK]          buckets                    4   compute_with_buckets integration.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/axis4-tool-call-telemetry/_build/_tests/Model_inference_metrics'.
Test Successful in 0.016s. 17 tests run.
- Testing `Prometheus Coverage'.
This run has ID `C2HCB0JI'.

  [OK]          type_to_string              0   counter.
  [OK]          type_to_string              1   gauge.
  [OK]          type_to_string              2   histogram.
  [OK]          labels_to_string            0   empty.
  [OK]          labels_to_string            1   single.
  [OK]          labels_to_string            2   multiple.
  [OK]          labels_to_string            3   escaped.
  [OK]          register_counter            0   basic.
  [OK]          register_counter            1   with labels.
  [OK]          register_counter            2   idempotent.
  [OK]          register_gauge              0   basic.
  [OK]          register_gauge              1   with labels.
  [OK]          inc_counter                 0   default.
  [OK]          inc_counter                 1   with delta.
  [OK]          inc_counter                 2   with labels.
  [OK]          inc_counter                 3   auto register.
  [OK]          set_gauge                   0   basic.
  [OK]          set_gauge                   1   with labels.
  [OK]          set_gauge                   2   auto register.
  [OK]          set_gauge                   3   overwrite.
  [OK]          inc_gauge                   0   default.
  [OK]          inc_gauge                   1   with delta.
  [OK]          inc_gauge                   2   with labels.
  [OK]          dec_gauge                   0   default.
  [OK]          dec_gauge                   1   with delta.
  [OK]          to_prometheus_text          0   not empty.
  [OK]          to_prometheus_text          1   has HELP.
  [OK]          to_prometheus_text          2   has TYPE.
  [OK]          to_prometheus_text          3   has uptime.
  [OK]          to_prometheus_text          4   has sse metrics.
  [OK]          to_prometheus_text          5   keeper metrics registered.
  [OK]          to_prometheus_text          6   histogram exported as summary...
  [OK]          convenience                 0   record_request.
  [OK]          convenience                 1   record_task_completed.
  [OK]          convenience                 2   record_task_failed.
  [OK]          convenience                 3   record_error default.
  [OK]          convenience                 4   record_error with type.
  [OK]          convenience                 5   set_active_agents.
  [OK]          convenience                 6   set_pending_tasks.
  [OK]          update_uptime               0   update.
  [OK]          init                        0   init.
  [OK]          label                       0   type.
  [OK]          edge_cases                  0   empty name.
  [OK]          edge_cases                  1   underscore name.
  [OK]          edge_cases                  2   unicode label.
  [OK]          edge_cases                  3   negative gauge.
  [OK]          edge_cases                  4   zero gauge.
  [OK]          edge_cases                  5   large value.
  [OK]          edge_cases                  6   small value.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/axis4-tool-call-telemetry/_build/_tests/Prometheus Coverage'.
Test Successful in 0.004s. 49 tests run.
- Testing `keeper_hooks_oas/provider_of_model'.
This run has ID `36QHKRVU'.

  [OK]          provider_classification          0   prefixed schemes.
  [OK]          provider_classification          1   bare model ids.
  [OK]          provider_classification          2   unknown routes to unknown.

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/axis4-tool-call-telemetry/_build/_tests/keeper_hooks_oas-provider_of_model'.
Test Successful in 0.000s. 3 tests run.

## Scope
- baseline Axis 4 observability slice only
- leaves labeled tool duration histogram and per-tool decision-log detail for follow-up PRs