### PR TITLE
[codex] Add keeper tool-quality benchmark and canary model recommendations

### DIFF
--- a/benchmark/tool_call_quality_cases.json
+++ b/benchmark/tool_call_quality_cases.json
@@ -1,0 +1,107 @@
+{
+  "version": "tool_call_quality_v1",
+  "stability_mode": "repeatable",
+  "cases": [
+    {
+      "id": "read_search_prompt_fingerprint",
+      "prompt": "Search for `prompt_fingerprint`, then read the keeper tool-call log implementation file and report exactly two concrete file touch points where prompt fingerprints are recorded. Do not use bash for this case.",
+      "category": "tool_required",
+      "keeper_profiles": ["bench-analyst", "bench-executor"],
+      "required_tools": ["keeper_tool_search", "keeper_fs_read"],
+      "forbidden_tools": ["keeper_bash"],
+      "max_tool_calls": 3,
+      "success_checks": [
+        { "path": "$.status", "equals": "completed" },
+        { "path": "$.evidence_found", "min_int": 2 }
+      ],
+      "arg_checks": [
+        {
+          "tool_name": "keeper_tool_search",
+          "path": "$.query",
+          "contains": "prompt_fingerprint"
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "path": "$.path",
+          "contains": "keeper_tool_call_log"
+        }
+      ],
+      "recovery_policy": {
+        "required": false,
+        "success_after_failure": false
+      }
+    },
+    {
+      "id": "text_only_triage",
+      "prompt": "Do not call any tools. Decide whether the sentence `No lookup is needed here.` requires tools, and respond in text only.",
+      "category": "tool_forbidden",
+      "keeper_profiles": ["bench-analyst"],
+      "required_tools": [],
+      "forbidden_tools": [],
+      "max_tool_calls": 0,
+      "success_checks": [
+        { "path": "$.status", "equals": "completed" },
+        { "path": "$.mode", "equals": "text_only" }
+      ],
+      "arg_checks": [],
+      "recovery_policy": {
+        "required": false,
+        "success_after_failure": false
+      }
+    },
+    {
+      "id": "recovery_after_failed_read",
+      "prompt": "First attempt to read `lib/missing_file.ml`. After that fails, search for `keeper_agent_run prompt_fingerprint`, then read `lib/keeper/keeper_agent_run.ml` and state whether recovery succeeded. Do not use bash for this case.",
+      "category": "recovery_required",
+      "keeper_profiles": ["bench-verifier"],
+      "required_tools": ["keeper_fs_read", "keeper_tool_search"],
+      "forbidden_tools": [],
+      "max_tool_calls": 4,
+      "success_checks": [
+        { "path": "$.status", "equals": "completed" },
+        { "path": "$.recovered", "equals": true }
+      ],
+      "arg_checks": [
+        {
+          "tool_name": "keeper_tool_search",
+          "path": "$.query",
+          "contains": "keeper_agent_run"
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "path": "$.path",
+          "contains": "keeper_agent_run.ml"
+        }
+      ],
+      "recovery_policy": {
+        "required": true,
+        "success_after_failure": true,
+        "max_failures_before_success": 2
+      }
+    },
+    {
+      "id": "multi_step_board_update",
+      "prompt": "Search for `tool_call_quality_benchmark_cli`, run a short validation command with bash, and then call `masc_board_post` with a body that contains the word `verified`.",
+      "category": "multi_step",
+      "keeper_profiles": ["bench-executor", "bench-verifier"],
+      "required_tools": ["keeper_tool_search", "keeper_bash", "masc_board_post"],
+      "forbidden_tools": [],
+      "max_tool_calls": 4,
+      "success_checks": [
+        { "path": "$.status", "equals": "completed" },
+        { "path": "$.board_updated", "equals": true }
+      ],
+      "arg_checks": [
+        {
+          "tool_name": "masc_board_post",
+          "path": "$.body",
+          "contains": "verified"
+        }
+      ],
+      "recovery_policy": {
+        "required": false,
+        "success_after_failure": false
+      }
+    }
+  ]
+}

--- a/config/keepers/bench-analyst.toml
+++ b/config/keepers/bench-analyst.toml
@@ -1,0 +1,22 @@
+[keeper]
+persona_name = "analyst"
+execution_scope = "workspace"
+cascade_name = "keeper_unified"
+tool_preset = "coding"
+proactive_enabled = false
+room_signal_prompt_enabled = false
+telemetry_feedback_enabled = false
+max_turns_per_call = 6
+instructions = """
+너는 tool-quality benchmark 전용 analyst keeper다.
+같은 입력에서 같은 근거와 같은 도구 선택이 반복되도록 행동한다.
+허용된 도구가 필요할 때만 호출하고, 한 번 확인한 사실을 다시 같은 방식으로 반복 조회하지 않는다.
+과제가 text-only로 해결 가능하면 도구를 호출하지 않는다.
+답은 짧고 구조적으로 유지하고, 최종 판단은 evidence 기반으로만 내린다.
+"""
+
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"
+OAS_GEMINI_APPROVAL_MODE = "plan"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/config/keepers/bench-executor.toml
+++ b/config/keepers/bench-executor.toml
@@ -1,0 +1,22 @@
+[keeper]
+persona_name = "executor"
+execution_scope = "workspace"
+cascade_name = "keeper_unified"
+tool_preset = "coding"
+proactive_enabled = false
+room_signal_prompt_enabled = false
+telemetry_feedback_enabled = false
+max_turns_per_call = 6
+instructions = """
+너는 tool-quality benchmark 전용 executor keeper다.
+같은 입력에서는 가능한 한 같은 순서와 같은 최소 도구 집합으로 과제를 끝낸다.
+필요한 도구만 호출하고, max_tool_calls 안에서 끝내는 것을 우선한다.
+실패하면 무작정 반복하지 말고 한 번 다른 경로로 회복한 뒤 바로 마무리한다.
+최종 출력은 완료 여부와 핵심 evidence만 남긴다.
+"""
+
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"
+OAS_GEMINI_APPROVAL_MODE = "plan"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/config/keepers/bench-verifier.toml
+++ b/config/keepers/bench-verifier.toml
@@ -1,0 +1,22 @@
+[keeper]
+persona_name = "verifier"
+execution_scope = "workspace"
+cascade_name = "keeper_unified"
+tool_preset = "coding"
+proactive_enabled = false
+room_signal_prompt_enabled = false
+telemetry_feedback_enabled = false
+max_turns_per_call = 6
+instructions = """
+너는 tool-quality benchmark 전용 verifier keeper다.
+같은 입력에서 같은 검증 절차를 반복 가능하게 수행한다.
+검증이 필요하면 측정 가능한 evidence를 우선하고, 실패 후 회복이 필요하면 다른 도구나 다른 인자로 한 번만 전환한다.
+notes나 추측으로 통과시키지 않는다.
+출력은 pass/fail와 미충족 조건을 명확히 남긴다.
+"""
+
+[keeper.oas_env]
+OAS_CLAUDE_STRICT_MCP = "1"
+OAS_GEMINI_NO_MCP = "1"
+OAS_GEMINI_APPROVAL_MODE = "plan"
+OAS_CODEX_CONFIG = "mcp_servers={}"

--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -33,6 +33,7 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
+  cascade_authoring : path_item;
   cascade : path_item;
   prompts : path_item;
   keepers : path_item;

--- a/lib/dune
+++ b/lib/dune
@@ -158,6 +158,13 @@
    web_dashboard
    credits_dashboard
    repo_synthesis_benchmark
+   keeper_benchmark_canary
+   tool_call_quality_benchmark_types
+   tool_call_quality_benchmark_loader
+   tool_call_quality_benchmark_scoring
+   tool_call_quality_benchmark_summary
+   tool_call_quality_benchmark_render
+   tool_call_quality_benchmark
    room_protocol
 
    inference_utils
@@ -687,7 +694,6 @@
   keeper_alerting_path
   keeper_sandbox_containment
   keeper_sandbox_runtime
-  keeper_turn_sandbox_runtime
   keeper_docker_read
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -741,8 +741,8 @@ let run_turn
               (fun (e : Keeper_tool_affinity.affinity_entry) ->
                  Printf.sprintf "%s(%.1f)" e.tool_name e.score)
               entries)));
-  let keeper_tool_bundle =
-    Keeper_tools_oas.make_tool_bundle
+  let keeper_tools =
+    Keeper_tools_oas.make_tools
       ~config
       ~meta
       ~ctx_snapshot
@@ -752,7 +752,7 @@ let run_turn
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
-  let tools = extend_turns_tool :: keeper_tool_bundle.tools in
+  let tools = extend_turns_tool :: keeper_tools in
   let tool_usage_before =
     Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
   in
@@ -890,7 +890,7 @@ let run_turn
     }
   in
   let tool_entries =
-    List.map (tool_index_entry_of_tool ~korean_kw_tbl) keeper_tool_bundle.tools
+    List.map (tool_index_entry_of_tool ~korean_kw_tbl) keeper_tools
   in
   (* Full-universe search index for keeper_tool_search.
      Separate from the preset-scoped Tool_selector used for progressive disclosure:
@@ -909,7 +909,7 @@ let run_turn
     let preset_tools =
       List.filter
         (fun (t : Agent_sdk.Tool.t) -> Hashtbl.mem preset_set t.schema.name)
-        keeper_tool_bundle.tools
+        keeper_tools
     in
     let progressive_tool_index_config =
       { Agent_sdk.Tool_index.default_config with
@@ -926,17 +926,17 @@ let run_turn
      Two maps: description (string) and full schema (tool_schema).
      Covers both keeper_* and masc_* tools from the OAS Tool.t list. *)
   let oas_description_map =
-    let tbl = Hashtbl.create (List.length keeper_tool_bundle.tools) in
+    let tbl = Hashtbl.create (List.length keeper_tools) in
     List.iter
       (fun (t : Agent_sdk.Tool.t) ->
          Hashtbl.replace tbl t.schema.name t.schema.description)
-      keeper_tool_bundle.tools;
+      keeper_tools;
     tbl
   in
   (* Map tool name → OAS input_schema JSON for keeper_tool_search enrichment.
      Covers keeper_* tools that don't appear in masc_schemas_ref. *)
   let oas_input_schema_map =
-    let tbl = Hashtbl.create (List.length keeper_tool_bundle.tools) in
+    let tbl = Hashtbl.create (List.length keeper_tools) in
     List.iter
       (fun (t : Agent_sdk.Tool.t) ->
          let param_type_str (pt : Agent_sdk.Types.param_type) =
@@ -971,7 +971,7 @@ let run_turn
              ]
          in
          Hashtbl.replace tbl t.schema.name schema)
-      keeper_tool_bundle.tools;
+      keeper_tools;
     tbl
   in
   (* Wire keeper_tool_search: update session-local ref with the real BM25 impl.
@@ -1114,7 +1114,7 @@ let run_turn
     Log.Keeper.debug
       "keeper:%s tool visibility: total=%d search_indexed=%d"
       meta.name
-      (List.length keeper_tool_bundle.tools)
+      (List.length keeper_tools)
       (List.length tool_entries);
   (* Layer 0: Core tools — always visible to the LLM regardless of preset.
      Kept to 5 survival-critical tools (#4961).  Status and other coordination tools
@@ -1127,10 +1127,7 @@ let run_turn
      this includes all candidate tools minus denied.  BM25 retrieval
      and Tool_op.Add operate within this scope. *)
   let all_tool_names =
-    "extend_turns"
-    :: List.map
-         (fun (t : Agent_sdk.Tool.t) -> t.schema.name)
-         keeper_tool_bundle.tools
+    "extend_turns" :: List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) keeper_tools
   in
   (* Precompute membership table for AllowList validation below.
      all_tool_names is constant for the session; building universe_set
@@ -1878,6 +1875,7 @@ let run_turn
                   tool_choice)
                 ~thinking_enabled:thinking_enabled_effective
                 ?thinking_budget:current_params.thinking_budget
+                ~prompt_fingerprint:prompt_metrics.fingerprint
                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                 ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                 ~turn
@@ -2006,21 +2004,6 @@ let run_turn
       Some (fun () -> Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" meta.name)
     else None
   in
-  let with_scoped_env bindings f =
-    let previous =
-      List.map (fun (key, _) -> (key, Sys.getenv_opt key)) bindings
-    in
-    List.iter (fun (key, value) -> Unix.putenv key value) bindings;
-    Fun.protect
-      ~finally:(fun () ->
-        List.iter
-          (fun (key, value) ->
-             match value with
-             | Some prior -> Unix.putenv key prior
-             | None -> Unix.putenv key "")
-          previous)
-      f
-  in
   let priority = Option.value priority ~default:Llm_provider.Request_priority.Proactive in
   let admission_wait_timeout_sec =
     if Llm_provider.Request_priority.resolve priority
@@ -2044,149 +2027,126 @@ let run_turn
       | None ->
           Keeper_runtime_resolved.oas_timeout_for_context ~max_context
     in
-    let env_bindings_result =
-      if Auth.is_auth_enabled config.base_path then
-        match
-          Auth.ensure_keeper_credential config.base_path
-            ~agent_name:meta.agent_name
-        with
-        | Ok (token, _cred) -> Ok [ ("MASC_MCP_TOKEN", token) ]
-        | Error err ->
-            Error
-              (Printf.sprintf
-                 "keeper credential bootstrap failed for %s: %s"
-                 meta.agent_name
-                 (Types.masc_error_to_string err))
-      else
-        Ok []
+    let cli_transport_overrides =
+      Some
+        ({
+          cwd = None;
+          claude_mcp_config = keeper_oas_context.claude_mcp_config;
+          claude_allowed_tools = None;
+          claude_permission_mode = None;
+          claude_max_turns = Some max_turns;
+          gemini_yolo =
+            (match approval_mode_effective with
+             | Some mode ->
+               Some (String.equal (String.lowercase_ascii mode) "yolo")
+             | None -> None);
+        } : Oas_worker.cli_transport_overrides)
     in
-    match env_bindings_result with
-    | Error msg -> Error (Oas.Error.Internal msg)
-    | Ok env_bindings ->
-      let cli_transport_overrides =
-        Some
-          ({
-            cwd = None;
-            claude_mcp_config = keeper_oas_context.claude_mcp_config;
-            claude_allowed_tools = None;
-            claude_permission_mode = None;
-            claude_max_turns = Some max_turns;
-            gemini_yolo =
-              (match approval_mode_effective with
-               | Some mode ->
-                 Some (String.equal (String.lowercase_ascii mode) "yolo")
-               | None -> None);
-          } : Oas_worker.cli_transport_overrides)
-      in
-      (* Phase 0: wake-time payload telemetry (Option C baseline).
-         Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-         Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-         exceptions from the telemetry path never abort the LLM call. *)
-      let () =
-        if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
-          try
-            let sizes =
-              Keeper_wake_telemetry.compute_sizes
-                ~system_prompt:turn_system_prompt
-                ~tools
-                ~history_messages
-                ~user_message
-            in
-            let model_id =
-              match meta.models with
-              | m :: _ -> m
-              | [] -> "auto"
-            in
-            let _event : Dashboard_harness_health.wake_payload_event =
-              Dashboard_harness_health.record_wake_payload
-                ~keeper_name:meta.name
-                ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                ~turn_index:start_turn_count
-                ~model_id
-                ~context_window:max_context
-                ~approx_body_bytes:sizes.approx_body_bytes
-                ~system_prompt_bytes:sizes.system_prompt_bytes
-                ~tool_defs_bytes:sizes.tool_defs_bytes
-                ~messages_bytes:sizes.messages_bytes
-                ~message_count:sizes.message_count
-                ~role_counts:sizes.role_counts
-                ~tool_count:sizes.tool_count
-                ~has_compact_happened:false
-            in
-            ()
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            Log.Harness.warn
-              "[wake_payload] telemetry failed keeper=%s: %s"
-              meta.name (Printexc.to_string exn)
-      in
-      (match
-         Fun.protect
-           ~finally:keeper_tool_bundle.cleanup
-           (fun () ->
-             with_scoped_env env_bindings (fun () ->
-               Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
-                 Oas_worker.run_named
-                   ~cascade_name
-                   ~model_strings:meta.models
-                   ?provider_filter
-                   ~require_tool_choice_support
-                   ~goal:user_message
-                   ~priority
-                   ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                   ~system_prompt:turn_system_prompt
-                   ~tools
-                   ~compact_ratio:meta.compaction.ratio_gate
-                   ~initial_messages:history_messages
-                   ~hooks
-                   ~context_reducer:reducer
-                   ~summarizer:Keeper_summarizer.keeper_summarizer
-                   ~memory
-                     (* Keepers use turn-level retry for transient errors but benefit
-                        from OAS per-call retry for validation errors (malformed tool
-                        args). retry_on_validation_error=true lets OAS re-prompt the
-                        LLM with structured feedback instead of wasting a full turn.
-                        retry_on_recoverable_tool_error remains false — tool-level
-                        errors are handled by MASC's consecutive failure guardrail. *)
-                   ~tool_retry_policy:{
-                     Oas.Tool_retry_policy.max_retries = 2;
-                     retry_on_validation_error = true;
-                     retry_on_recoverable_tool_error = false;
-                     feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
-                   }
-                   ~max_turns
-                   ~max_idle_turns
-                   ~temperature
-                   ~max_tokens
-                   ?max_cost_usd
-                   ?wait_timeout_sec:admission_wait_timeout_sec
-                   ?guardrails
-                   ?on_event
-                   ?on_yield
-                   ?on_resume
-                   ~agent_ref
-                   ?contract
-                   ?cli_transport_overrides
-                   ~allowed_paths:oas_allowed_paths
-                   ~cache_system_prompt:true
-                   ~yield_on_tool
-                   ~checkpoint_dir:session_dir
-                   ~context_injector
-                   ~context:shared_context
-                   ?slot_id:(Keeper_config.keeper_slot_id meta.name)
-                   ~approval:(Governance_pipeline.to_oas_approval_callback
-                                ~governance_level:(Env_config_core.governance_level ())
-                                ~keeper_name:meta.name)
-                   ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-                   (* exit_condition removed with mutation_boundary — OAS runs to
-                      natural completion (max_turns or model end_turn). *)
-                   ?oas_checkpoint:raw_oas_checkpoint
-                   ?event_bus
-                   ())))
-      with
-      | Error e -> Error e
-      | Ok result ->
+    (* Phase 0: wake-time payload telemetry (Option C baseline).
+       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
+       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
+       exceptions from the telemetry path never abort the LLM call. *)
+    let () =
+      if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
+        try
+          let sizes =
+            Keeper_wake_telemetry.compute_sizes
+              ~system_prompt:turn_system_prompt
+              ~tools
+              ~history_messages
+              ~user_message
+          in
+          let model_id =
+            match meta.models with
+            | m :: _ -> m
+            | [] -> "auto"
+          in
+          let _event : Dashboard_harness_health.wake_payload_event =
+            Dashboard_harness_health.record_wake_payload
+              ~keeper_name:meta.name
+              ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+              ~turn_index:start_turn_count
+              ~model_id
+              ~context_window:max_context
+              ~approx_body_bytes:sizes.approx_body_bytes
+              ~system_prompt_bytes:sizes.system_prompt_bytes
+              ~tool_defs_bytes:sizes.tool_defs_bytes
+              ~messages_bytes:sizes.messages_bytes
+              ~message_count:sizes.message_count
+              ~role_counts:sizes.role_counts
+              ~tool_count:sizes.tool_count
+              ~has_compact_happened:false
+          in
+          ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Harness.warn
+            "[wake_payload] telemetry failed keeper=%s: %s"
+            meta.name (Printexc.to_string exn)
+    in
+    (match
+       Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
+         Oas_worker.run_named
+           ~cascade_name
+           ~model_strings:meta.models
+           ?provider_filter
+           ~require_tool_choice_support
+           ~goal:user_message
+           ~priority
+           ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+           ~system_prompt:turn_system_prompt
+           ~tools
+           ~compact_ratio:meta.compaction.ratio_gate
+           ~initial_messages:history_messages
+           ~hooks
+           ~context_reducer:reducer
+           ~summarizer:Keeper_summarizer.keeper_summarizer
+           ~memory
+             (* Keepers use turn-level retry for transient errors but benefit
+               from OAS per-call retry for validation errors (malformed tool
+               args). retry_on_validation_error=true lets OAS re-prompt the
+               LLM with structured feedback instead of wasting a full turn.
+               retry_on_recoverable_tool_error remains false — tool-level
+               errors are handled by MASC's consecutive failure guardrail. *)
+           ~tool_retry_policy:{
+             Oas.Tool_retry_policy.max_retries = 2;
+             retry_on_validation_error = true;
+             retry_on_recoverable_tool_error = false;
+             feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
+           }
+           ~max_turns
+           ~max_idle_turns
+           ~temperature
+           ~max_tokens
+           ?max_cost_usd
+           ?wait_timeout_sec:admission_wait_timeout_sec
+           ?guardrails
+           ?on_event
+           ?on_yield
+           ?on_resume
+           ~agent_ref
+           ?contract
+           ?cli_transport_overrides
+           ~allowed_paths:oas_allowed_paths
+           ~cache_system_prompt:true
+           ~yield_on_tool
+           ~checkpoint_dir:session_dir
+           ~context_injector
+           ~context:shared_context
+           ?slot_id:(Keeper_config.keeper_slot_id meta.name)
+           ~approval:(Governance_pipeline.to_oas_approval_callback
+                        ~governance_level:(Env_config_core.governance_level ())
+                        ~keeper_name:meta.name)
+           ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
+           (* exit_condition removed with mutation_boundary — OAS runs to
+              natural completion (max_turns or model end_turn). *)
+           ?oas_checkpoint:raw_oas_checkpoint
+           ?event_bus
+           ())
+     with
+     | Error e -> Error e
+     | Ok result ->
        let post_turn_t0 = Time_compat.now () in
        (* Checkpoint save is deferred until after [STATE] synthesis so the
            persisted checkpoint includes the synthesized continuity block.
@@ -2322,10 +2282,9 @@ let run_turn
              meta.name
              (String.concat ", " unexpected_tool_names);
          let actual_keeper_tool_names =
-           Keeper_tool_disclosure.final_keeper_tool_names
-             ~reported_tool_names
-             ~observed_tool_names
-             ~allowed_tool_names:all_tool_names
+           observed_tool_names
+           |> Keeper_tool_alias.canonicalize_observed
+           |> List.filter (fun tool_name -> List.mem tool_name all_tool_names)
          in
          let usage = Keeper_exec_context.usage_of_response result.response in
          let ctx_composition =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -462,32 +462,22 @@ let make_hooks
             , tool_choice
             , thinking_enabled
             , thinking_budget
+            , prompt_fingerprint
             , trace_id
             , session_id
             , turn ) =
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
-        let model =
-          let m = (!meta_ref).runtime.usage.last_model_used in
-          if m = "" then (!meta_ref).cascade_name else m
-        in
-        let provider = provider_of_model model in
-        Prometheus.inc_counter
-          "masc_tool_call_total"
-          ~labels:
-            [ ("provider", provider)
-            ; ("tool", tool_name)
-            ; ("outcome", outcome)
-            ]
-          ();
         (try
            Keeper_tool_call_log.log_call
              ~keeper_name:(!meta_ref).name
              ~tool_name ~input ~output_text
              ~success:(outcome = "ok") ~duration_ms
-             ~model ~provider
+             ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
+                     if m = "" then (!meta_ref).cascade_name else m)
              ?lane ?tool_choice ?thinking_enabled ?thinking_budget
+             ?prompt_fingerprint
              ?trace_id ?session_id ?turn
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -3,4 +3,9 @@ open Keeper_types
 let configured_model_labels_of_meta (m : keeper_meta) : string list =
   match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") m.models) with
   | _ :: _ as explicit -> explicit
-  | [] -> Cascade_runtime.models_of_cascade_name m.cascade_name
+  | [] ->
+      let configured = Cascade_runtime.models_of_cascade_name m.cascade_name in
+      match Keeper_benchmark_canary.recommended_model_label_for_keeper ~keeper_name:m.name with
+      | Some model_label when String.trim model_label <> "" ->
+          dedupe_keep_order (model_label :: configured)
+      | _ -> configured

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -180,14 +180,6 @@ let fail_open_local_only_when_unavailable
          if List.exists probe ollama_urls then normalized_effective
          else normalized_base)
 
-type turn_cascade_plan = {
-  cascade_name : string;
-  max_context_resolution : Keeper_exec_context.max_context_resolution;
-  max_context : int;
-  temperature : float;
-  max_tokens : int;
-}
-
 (** {1 Retry & Side-Effect Safety}
 
     @boundary-contract
@@ -288,7 +280,6 @@ let fail_open_cascade_after_auto_recoverable_error
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
-  || Oas_worker_named.sdk_error_is_hard_quota err
   || is_auto_recoverable_cascade_exhausted_error err
 
 let ambiguous_side_effect_error_prefix =
@@ -1111,7 +1102,7 @@ let append_decision_record
                  call log uses; captures the adaptive classifier's decision
                  (true=Cognitive, false=Mechanical) so the dashboard can surface
                  thinking fraction per model. *)
-              let (_, _, turn_thinking_enabled, _, _, _, _) =
+              let (_, _, turn_thinking_enabled, _, _, _, _, _) =
                 Keeper_tool_call_log.get_turn_context ~keeper_name:meta.name ()
               in
               let thinking_enabled_field =
@@ -1194,7 +1185,6 @@ let append_decision_record
                 | None -> []
               in
               `Assoc ([
-                ("provider", `String (Keeper_hooks_oas.provider_of_model surface_model_used));
                 ("model_used", `String surface_model_used);
                 ("turn_count", `Int r.turn_count);
                 ("stop_reason", `String stop_reason_str);
@@ -1240,13 +1230,7 @@ let append_decision_record
                   else "other"
                 | _ -> "unknown"
               in
-              let error_provider =
-                match cascade_models with
-                | model :: _ -> Keeper_hooks_oas.provider_of_model model
-                | [] -> Keeper_hooks_oas.provider_of_model meta.cascade_name
-              in
               `Assoc [
-                ("provider", `String error_provider);
                 ("cascade_name", `String meta.cascade_name);
                 ("candidate_models", `List (List.map (fun s -> `String s) cascade_models));
                 ("error_category", `String error_category);
@@ -1765,7 +1749,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       Ok meta
   | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade) *)
-      let routed_cascade_name =
+      let effective_cascade_name =
         let phase = match phase_opt with
           | Some p -> p
           | None ->
@@ -1794,52 +1778,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             meta.name (String.concat ", " routed_labels) resolved_cascade;
         resolved_cascade
       in
-      let prepare_turn_cascade_plan ~(cascade_name : string)
-          : (turn_cascade_plan, Oas.Error.sdk_error) result =
-        let meta_for_cascade = { meta with cascade_name } in
-        let model_labels =
-          Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
-        in
-        match ensure_api_keys_for_labels model_labels with
-        | Error e -> Error (Oas.Error.Internal e)
-        | Ok () -> (
-            match ensure_local_discovery_ready model_labels with
-            | Error e -> Error (Oas.Error.Internal e)
-            | Ok () ->
-                let max_context_resolution =
-                  Keeper_exec_context.resolve_max_context_resolution
-                    ~requested_override:meta.max_context_override model_labels
-                in
-                let max_context =
-                  resolved_max_context_for_turn ~meta model_labels
-                in
-                let temperature =
-                  Cascade_inference.resolve_temperature
-                    ~cascade_name
-                    ~fallback:Keeper_config.keeper_unified_temperature
-                in
-                let raw_max_tokens =
-                  Cascade_inference.resolve_max_tokens
-                    ~cascade_name
-                    ~fallback:Keeper_config.keeper_unified_max_tokens
-                in
-                let max_tokens =
-                  (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
-                  Cascade_inference.clamp_max_tokens_to_ceiling
-                    ~provider_ceiling:(Some max_context) raw_max_tokens
-                in
-                Ok
-                  {
-                    cascade_name;
-                    max_context_resolution;
-                    max_context;
-                    temperature;
-                    max_tokens;
-                  })
+      (* 1. Check API keys *)
+      let meta_for_cascade = { meta with cascade_name = effective_cascade_name } in
+      let model_labels = Keeper_coordination.effective_model_labels_for_turn meta_for_cascade in
+      match ensure_api_keys_for_labels model_labels with
+      | Error e -> Error (Oas.Error.Internal e)
+      | Ok () -> (
+      match ensure_local_discovery_ready model_labels with
+      | Error e -> Error (Oas.Error.Internal e)
+      | Ok () ->
+      let max_context_resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:meta.max_context_override model_labels
       in
-      match prepare_turn_cascade_plan ~cascade_name:routed_cascade_name with
-      | Error err -> Error err
-      | Ok initial_cascade_plan ->
+      let max_context =
+        resolved_max_context_for_turn ~meta model_labels
+      in
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
       Eio.Fiber.yield ();
@@ -1861,7 +1815,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~generation:meta.runtime.generation
       in
-      (* 3. max_turns: defer to OAS default (Types.default_agent_config.max_turns).
+      (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
+      let temperature =
+        Cascade_inference.resolve_temperature
+          ~cascade_name:effective_cascade_name
+          ~fallback:Keeper_config.keeper_unified_temperature
+      in
+      let max_tokens =
+        let raw = Cascade_inference.resolve_max_tokens
+          ~cascade_name:effective_cascade_name
+          ~fallback:Keeper_config.keeper_unified_max_tokens
+        in
+        (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
+        Cascade_inference.clamp_max_tokens_to_ceiling
+          ~provider_ceiling:(Some max_context) raw
+      in
+      (* max_turns: defer to OAS default (Types.default_agent_config.max_turns).
          MASC does not hardcode agent runtime budgets. *)
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)
@@ -2058,10 +2027,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let keeper_profile =
             Keeper_types_profile.load_keeper_profile_defaults meta.name
           in
-          let active_cascade_plan = ref initial_cascade_plan in
-          let do_run ~(plan : turn_cascade_plan) ~run_meta ~run_generation
-              ~is_retry ~oas_timeout_s =
-            let max_context = plan.max_context in
+          let do_run ~run_meta ~max_context ~run_generation ~is_retry
+              ~oas_timeout_s =
             let max_idle_turns, max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
@@ -2077,7 +2044,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
               ~agent_name:run_meta.agent_name
-              ~cascade_name:plan.cascade_name
+              ~cascade_name:effective_cascade_name
               ~trace_id:(Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
               ~generation:run_generation
               ~max_context
@@ -2091,7 +2058,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               (fun () ->
                 Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                   ~max_context ~build_turn_prompt
-                  ~user_message ~cascade_name:plan.cascade_name
+                  ~user_message ~cascade_name:effective_cascade_name
                   ~turn_affordances:
                     (observed_affordances_of_observation ~meta:run_meta observation)
                   ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
@@ -2100,8 +2067,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~max_idle_turns
                   ~history_user_source:"world_state_prompt"
                   ~history_assistant_source:"internal_assistant"
-                  ~temperature:plan.temperature
-                  ~max_tokens:plan.max_tokens
+                  ~temperature ~max_tokens
                   ~oas_timeout_s
                   ?max_cost_usd
                   ~trajectory_acc
@@ -2110,10 +2076,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ?event_bus:(Keeper_event_bus.get ())
                   ())
           in
-          let rec retry_loop ~(plan : turn_cascade_plan) ~run_meta
-              ~run_generation ~attempt ~is_retry ~overflow_retry_used
-              ~cascade_fail_open_used =
-            active_cascade_plan := plan;
+          let rec retry_loop ~run_meta ~max_context ~run_generation
+              ~attempt ~is_retry
+              ~overflow_retry_used =
             let mark_terminal_error err =
               if is_cascade_exhausted_error err then
                 Keeper_registry.set_turn_cascade_state
@@ -2138,7 +2103,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               match
                 bounded_oas_timeout_for_turn_budget_with_turn_budget
                   ~max_turns
-                  ~max_context:plan.max_context
+                  ~max_context
                   ~remaining_turn_budget_s:(remaining_turn_budget_s ())
               with
               | None ->
@@ -2155,7 +2120,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_registry.set_turn_cascade_state
                     ~base_path:config.base_path meta.name
                     Keeper_registry.Cascade_trying;
-                  do_run ~plan ~run_meta ~run_generation ~is_retry
+                  do_run ~run_meta ~max_context ~run_generation ~is_retry
                     ~oas_timeout_s
             in
             match attempt_result with
@@ -2171,7 +2136,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 Keeper_registry.set_turn_cascade_state
                   ~base_path:config.base_path meta.name
                   Keeper_registry.Cascade_done;
-                Ok (plan, result)
+                Ok result
             | Error err ->
                 let _ = drain_turn_event_bus () in
                 let committed_tools = committed_mutating_tools_snapshot () in
@@ -2200,7 +2165,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     (String.concat ", " committed_tools)
                     err_preview;
                   mark_terminal_error err;
-                  Error (plan, err)
+                  Error err
                 end else if committed_tools <> [] then begin
                   let reclassified, failure_reason =
                     match
@@ -2236,153 +2201,105 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       (String.concat ", " committed_tools)
                       err_preview;
                   mark_terminal_error reclassified;
-                  Error (plan, reclassified)
+                  Error reclassified
                 end else if is_transient_network_error err
                               && attempt <= max_transient_retries then begin
                   let delay = transient_backoff_sec attempt in
                   Log.Keeper.warn
                     "%s: transient network error cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
-                    meta.name plan.cascade_name
-                    plan.max_context_resolution.effective_budget
-                    plan.max_context
-                    plan.max_context_resolution.primary_budget
-                    (match plan.max_context_resolution.requested_override with
+                    meta.name effective_cascade_name max_context_resolution.effective_budget
+                    max_context
+                    max_context_resolution.primary_budget
+                    (match max_context_resolution.requested_override with
                      | Some requested -> string_of_int requested
                      | None -> "none")
                     attempt max_transient_retries delay
                     (short_preview (Oas.Error.to_string err));
                   Eio.Time.sleep clock delay;
-                  retry_loop ~plan ~run_meta ~run_generation
-                    ~attempt:(attempt + 1) ~is_retry:true
-                    ~overflow_retry_used ~cascade_fail_open_used
-                end else if not cascade_fail_open_used then begin
-                  match
-                    fail_open_cascade_after_auto_recoverable_error
-                      ~base_cascade:meta.cascade_name
-                      ~effective_cascade:plan.cascade_name
-                      err
-                  with
-                  | Some fallback_cascade ->
-                      (match prepare_turn_cascade_plan
-                               ~cascade_name:fallback_cascade
-                       with
-                       | Ok fallback_plan ->
-                           Log.Keeper.warn
-                             "%s: cascade=%s fail-open to cascade=%s after auto-recoverable exhaustion: %s"
-                             meta.name plan.cascade_name
-                             fallback_plan.cascade_name
-                             (short_preview (Oas.Error.to_string err));
-                           Eio.Fiber.yield ();
-                           retry_loop ~plan:fallback_plan ~run_meta
-                             ~run_generation ~attempt:1 ~is_retry:true
-                             ~overflow_retry_used
-                             ~cascade_fail_open_used:true
-                       | Error fallback_err ->
-                           Log.Keeper.warn
-                             "%s: cascade fail-open unavailable %s -> %s: %s"
-                             meta.name plan.cascade_name fallback_cascade
-                             (short_preview
-                                (Oas.Error.to_string fallback_err));
-                           mark_terminal_error err;
-                           Error (plan, err))
-                  | None ->
-                      if is_context_overflow err then
-                        handle_context_overflow_error ~plan ~run_meta
-                          ~overflow_retry_used ~cascade_fail_open_used err
-                      else begin
-                        mark_terminal_error err;
-                        Error (plan, err)
-                      end
+                  retry_loop ~run_meta ~max_context ~run_generation
+                    ~attempt:(attempt + 1)
+                    ~is_retry:true ~overflow_retry_used
                 end else if is_context_overflow err then begin
-                  handle_context_overflow_error ~plan ~run_meta
-                    ~overflow_retry_used ~cascade_fail_open_used err
+                  let current_turn_event_bus = drain_turn_event_bus () in
+                  dispatch_keeper_phase_event
+                    ~config
+                    ~keeper_name:meta.name
+                    (context_overflow_event_of_error
+                       ~fallback_tokens:max_context
+                       ~turn_event_bus:current_turn_event_bus
+                       err);
+                  if not overflow_retry_used then
+                    match
+                      recover_context_overflow_retry
+                        ~meta:run_meta
+                        ~base_dir
+                        ~max_cascade_context:max_context
+                        ~error:err
+                    with
+                    | Some retry_plan ->
+                        Keeper_registry.set_turn_phase
+                          ~base_path:config.base_path meta.name
+                          Keeper_registry.Turn_compacting;
+                        current_turn_overflow_blocker :=
+                          Some (Oas.Error.to_string err);
+                        dispatch_keeper_phase_event
+                          ~config
+                          ~keeper_name:meta.name
+                          Keeper_state_machine.Compaction_started;
+                        dispatch_keeper_phase_event
+                          ~config
+                          ~keeper_name:meta.name
+                          (Keeper_state_machine.Compaction_completed
+                             {
+                               before_tokens =
+                                 retry_plan.compaction.before_tokens;
+                               after_tokens =
+                                 retry_plan.compaction.after_tokens;
+                             });
+                        Keeper_registry.prepare_turn_retry_after_compaction
+                          ~base_path:config.base_path meta.name;
+                        let retry_meta =
+                          if retry_plan.retry_generation = run_meta.runtime.generation
+                          then run_meta
+                          else
+                            map_runtime
+                              (fun rt ->
+                                {
+                                  rt with
+                                  generation = retry_plan.retry_generation;
+                                })
+                              run_meta
+                        in
+                        Eio.Fiber.yield ();
+                        retry_loop
+                          ~run_meta:retry_meta
+                          ~max_context:retry_plan.retry_max_context
+                          ~run_generation:retry_plan.retry_generation
+                          ~attempt:1
+                          ~is_retry:true
+                          ~overflow_retry_used:true
+                    | None ->
+                        mark_paused_after_overflow
+                          ~run_meta
+                          ~reason:"auto_compact_recovery_unavailable";
+                        Keeper_registry.set_turn_phase
+                          ~base_path:config.base_path meta.name
+                          Keeper_registry.Turn_finalizing;
+                        Error err
+                  else begin
+                    mark_paused_after_overflow
+                      ~run_meta
+                      ~reason:"overflow_persisted_after_auto_compact_retry";
+                    Keeper_registry.set_turn_phase
+                      ~base_path:config.base_path meta.name
+                      Keeper_registry.Turn_finalizing;
+                    Error err
+                  end
                 end
                 else begin
                   mark_terminal_error err;
-                  Error (plan, err)
+                  Error err
                 end
-          and handle_context_overflow_error ~(plan : turn_cascade_plan)
-              ~run_meta ~overflow_retry_used ~cascade_fail_open_used err =
-            let current_turn_event_bus = drain_turn_event_bus () in
-            dispatch_keeper_phase_event
-              ~config
-              ~keeper_name:meta.name
-              (context_overflow_event_of_error
-                 ~fallback_tokens:plan.max_context
-                 ~turn_event_bus:current_turn_event_bus
-                 err);
-            if not overflow_retry_used then
-              match
-                recover_context_overflow_retry
-                  ~meta:run_meta
-                  ~base_dir
-                  ~max_cascade_context:plan.max_context
-                  ~error:err
-              with
-              | Some retry_plan ->
-                  Keeper_registry.set_turn_phase
-                    ~base_path:config.base_path meta.name
-                    Keeper_registry.Turn_compacting;
-                  current_turn_overflow_blocker :=
-                    Some (Oas.Error.to_string err);
-                  dispatch_keeper_phase_event
-                    ~config
-                    ~keeper_name:meta.name
-                    Keeper_state_machine.Compaction_started;
-                  dispatch_keeper_phase_event
-                    ~config
-                    ~keeper_name:meta.name
-                    (Keeper_state_machine.Compaction_completed
-                       {
-                         before_tokens = retry_plan.compaction.before_tokens;
-                         after_tokens = retry_plan.compaction.after_tokens;
-                       });
-                  Keeper_registry.prepare_turn_retry_after_compaction
-                    ~base_path:config.base_path meta.name;
-                  let retry_meta =
-                    if retry_plan.retry_generation = run_meta.runtime.generation
-                    then run_meta
-                    else
-                      map_runtime
-                        (fun rt ->
-                          {
-                            rt with
-                            generation = retry_plan.retry_generation;
-                          })
-                        run_meta
-                  in
-                  let overflow_retry_plan =
-                    {
-                      plan with
-                      max_context = retry_plan.retry_max_context;
-                    }
-                  in
-                  Eio.Fiber.yield ();
-                  retry_loop
-                    ~plan:overflow_retry_plan
-                    ~run_meta:retry_meta
-                    ~run_generation:retry_plan.retry_generation
-                    ~attempt:1
-                    ~is_retry:true
-                    ~overflow_retry_used:true
-                    ~cascade_fail_open_used
-              | None ->
-                  mark_paused_after_overflow
-                    ~run_meta
-                    ~reason:"auto_compact_recovery_unavailable";
-                  Keeper_registry.set_turn_phase
-                    ~base_path:config.base_path meta.name
-                    Keeper_registry.Turn_finalizing;
-                  Error (plan, err)
-            else begin
-              mark_paused_after_overflow
-                ~run_meta
-                ~reason:"overflow_persisted_after_auto_compact_retry";
-              Keeper_registry.set_turn_phase
-                ~base_path:config.base_path meta.name
-                Keeper_registry.Turn_finalizing;
-              Error (plan, err)
-            end
           in
           (* Wall-clock timeout guards against indefinite TCP-level hangs
              from upstream LLM providers. Without this, a single stalled
@@ -2390,9 +2307,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (try
             Eio.Time.with_timeout_exn clock timeout_sec
               (fun () ->
-                retry_loop ~plan:initial_cascade_plan ~run_meta:meta
-                  ~run_generation:generation ~attempt:1 ~is_retry:false
-                  ~overflow_retry_used:false ~cascade_fail_open_used:false)
+                retry_loop ~run_meta:meta ~max_context
+                  ~run_generation:generation ~attempt:1
+                  ~is_retry:false ~overflow_retry_used:false)
           with Eio.Time.Timeout ->
             let msg =
               Printf.sprintf
@@ -2421,8 +2338,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
-              Error
-                (!active_cascade_plan, Oas.Error.Api (Timeout { message = msg }))
+              Error (Oas.Error.Api (Timeout { message = msg }))
             end else if committed_tools <> [] then begin
               let timeout_err =
                 Oas.Error.Api (Timeout { message = msg })
@@ -2456,16 +2372,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
-              Error (!active_cascade_plan, reclassified)
+              Error reclassified
             end else begin
               Keeper_registry.set_turn_phase
                 ~base_path:config.base_path meta.name
                 Keeper_registry.Turn_finalizing;
               Error
-                ( !active_cascade_plan,
-                  Oas_worker_named.sdk_error_of_masc_internal_error
-                    (Oas_worker_named.Turn_timeout
-                       { elapsed_sec = timeout_sec }) )
+                (Oas_worker_named.sdk_error_of_masc_internal_error
+                   (Oas_worker_named.Turn_timeout
+                      { elapsed_sec = timeout_sec }))
             end)))
       in
       let turn_event_bus = drain_turn_event_bus () in
@@ -2476,7 +2391,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              correlation_id
        | None -> ());
       match run_result with
-      | Error (failed_plan, err) ->
+      | Error err ->
           finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
             (Trajectory.Failed (Oas.Error.to_string err));
           let e_str = Oas.Error.to_string err in
@@ -2488,11 +2403,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d turn_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
-            meta.name failed_plan.cascade_name
-            failed_plan.max_context_resolution.effective_budget
-            failed_plan.max_context
-            failed_plan.max_context_resolution.primary_budget
-            (match failed_plan.max_context_resolution.requested_override with
+            meta.name effective_cascade_name max_context_resolution.effective_budget
+            max_context
+            max_context_resolution.primary_budget
+            (match max_context_resolution.requested_override with
              | Some requested -> string_of_int requested
              | None -> "none")
             latency_ms
@@ -2506,8 +2420,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             (short_preview e_str);
           let social_state, social_transition_reason =
             Social.derive_failure_state ~meta ~observation
-              ~previous_state:previous_social_state ~is_auto_recoverable
-              ~reason:e_str
+              ~previous_state:previous_social_state
+              ~is_auto_recoverable ~reason:e_str
           in
           let failure_meta_base =
             match !paused_meta_override with
@@ -2645,7 +2559,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             raise Keeper_registry.Keeper_fiber_crash
           end;
           Error err
-      | Ok (succeeded_plan, result) ->
+      | Ok result ->
           finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
             Trajectory.Completed;
           let explicit_accountability_claim =
@@ -2680,7 +2594,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_state_machine.Handoff_started)
               ~meta
               ~model:result.model_used
-              ~primary_model_max_tokens:succeeded_plan.max_context
+              ~primary_model_max_tokens:max_context
               ~current_turn_overflow_blocker:!current_turn_overflow_blocker
               ~checkpoint:result.checkpoint
           in
@@ -2888,6 +2802,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            | Oas_worker.Completed ->
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
-          Ok updated_meta
+          Ok updated_meta)
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/keeper_benchmark_canary.ml
+++ b/lib/keeper_benchmark_canary.ml
@@ -1,0 +1,256 @@
+open Keeper_types
+
+type recommendation = {
+  keeper_profile : string;
+  model_label : string;
+  composite_score : float;
+  task_pass_rate : float;
+  stability_score : float option;
+  cases_total : int;
+  cases_passed : int;
+}
+
+type manifest = {
+  version : int;
+  generated_at : string;
+  source_summary_path : string option;
+  recommendations : recommendation list;
+}
+
+type cache_entry = {
+  path : string;
+  mtime : float;
+  manifest : manifest option;
+}
+
+let cache : cache_entry option ref = ref None
+
+let trim = String.trim
+
+let normalize_string_list items =
+  items
+  |> List.map trim
+  |> List.filter (fun item -> item <> "")
+  |> dedupe_keep_order
+
+let default_manifest_path () =
+  Filename.concat
+    (Filename.concat (Filename.concat (Env_config.base_path ()) ".masc") "bench")
+    "keeper_model_recommendations.json"
+
+let enabled () =
+  Keeper_config.bool_of_env_default "MASC_KEEPER_BENCH_CANARY_ENABLED"
+    ~default:false
+
+let manifest_path () =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_BENCH_CANARY_PATH" with
+  | Some path when trim path <> "" -> trim path
+  | _ -> default_manifest_path ()
+
+let row_to_recommendation
+    (row : Tool_call_quality_benchmark.summary_row) : recommendation option =
+  match row.provider, row.model, row.keeper_profile with
+  | Some provider, Some model, Some keeper_profile
+    when row.cases_total > 0
+         && row.cases_passed = row.cases_total
+         && row.unsupported_runs = 0
+         && row.runtime_unreachable_runs = 0 ->
+      Some
+        {
+          keeper_profile;
+          model_label = provider ^ ":" ^ model;
+          composite_score = row.composite_score;
+          task_pass_rate = row.task_pass_rate;
+          stability_score = row.stability_score;
+          cases_total = row.cases_total;
+          cases_passed = row.cases_passed;
+        }
+  | _ -> None
+
+let compare_float_option_desc a b =
+  match a, b with
+  | Some left, Some right -> Float.compare right left
+  | Some _, None -> -1
+  | None, Some _ -> 1
+  | None, None -> 0
+
+let compare_recommendation left right =
+  match Float.compare right.composite_score left.composite_score with
+  | 0 -> (
+      match Float.compare right.task_pass_rate left.task_pass_rate with
+      | 0 -> (
+          match compare_float_option_desc left.stability_score right.stability_score with
+          | 0 -> (
+              match Int.compare right.cases_total left.cases_total with
+              | 0 -> (
+                  match Int.compare right.cases_passed left.cases_passed with
+                  | 0 -> String.compare left.model_label right.model_label
+                  | cmp -> cmp)
+              | cmp -> cmp)
+          | cmp -> cmp)
+      | cmp -> cmp)
+  | cmp -> cmp
+
+let generated_at_utc () =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+    tm.Unix.tm_hour
+    tm.Unix.tm_min
+    tm.Unix.tm_sec
+
+let build_manifest ?source_summary_path
+    (summary : Tool_call_quality_benchmark.benchmark_summary) : manifest =
+  let grouped = Hashtbl.create 8 in
+  summary.grouped_by_provider_model_keeper
+  |> List.filter_map row_to_recommendation
+  |> List.iter (fun recommendation ->
+         let current =
+           Hashtbl.find_opt grouped recommendation.keeper_profile
+         in
+         match current with
+         | Some best when compare_recommendation recommendation best >= 0 -> ()
+         | _ ->
+             Hashtbl.replace grouped recommendation.keeper_profile recommendation);
+  let recommendations =
+    Hashtbl.to_seq_values grouped
+    |> List.of_seq
+    |> List.sort (fun left right ->
+           match String.compare left.keeper_profile right.keeper_profile with
+           | 0 -> compare_recommendation left right
+           | cmp -> cmp)
+  in
+  {
+    version = 1;
+    generated_at = generated_at_utc ();
+    source_summary_path;
+    recommendations;
+  }
+
+let recommendation_to_yojson (recommendation : recommendation) =
+  `Assoc
+    [
+      ("keeper_profile", `String recommendation.keeper_profile);
+      ("model_label", `String recommendation.model_label);
+      ("composite_score", `Float recommendation.composite_score);
+      ("task_pass_rate", `Float recommendation.task_pass_rate);
+      ( "stability_score",
+        Option.fold ~none:`Null ~some:(fun value -> `Float value)
+          recommendation.stability_score );
+      ("cases_total", `Int recommendation.cases_total);
+      ("cases_passed", `Int recommendation.cases_passed);
+    ]
+
+let manifest_to_yojson (manifest : manifest) =
+  `Assoc
+    [
+      ("version", `Int manifest.version);
+      ("generated_at", `String manifest.generated_at);
+      ( "source_summary_path",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          manifest.source_summary_path );
+      ( "recommendations",
+        `List (List.map recommendation_to_yojson manifest.recommendations) );
+    ]
+
+let parse_recommendation json =
+  let keeper_profile = Safe_ops.json_string ~default:"" "keeper_profile" json |> trim in
+  let model_label = Safe_ops.json_string ~default:"" "model_label" json |> trim in
+  if keeper_profile = "" || model_label = "" then None
+  else
+    Some
+      {
+        keeper_profile;
+        model_label;
+        composite_score = Safe_ops.json_float ~default:0.0 "composite_score" json;
+        task_pass_rate = Safe_ops.json_float ~default:0.0 "task_pass_rate" json;
+        stability_score = Safe_ops.json_float_opt "stability_score" json;
+        cases_total = Safe_ops.json_int ~default:0 "cases_total" json;
+        cases_passed = Safe_ops.json_int ~default:0 "cases_passed" json;
+      }
+
+let parse_manifest json =
+  match json with
+  | `Assoc _ ->
+      Some
+        {
+          version = Safe_ops.json_int ~default:1 "version" json;
+          generated_at = Safe_ops.json_string ~default:"" "generated_at" json;
+          source_summary_path = Safe_ops.json_string_opt "source_summary_path" json;
+          recommendations =
+            (match Yojson.Safe.Util.member "recommendations" json with
+             | `List items -> items
+             | _ -> [])
+            |> List.filter_map parse_recommendation;
+        }
+  | _ -> None
+
+let stat_mtime path =
+  try Some ((Unix.stat path).Unix.st_mtime) with Unix.Unix_error _ -> None
+
+let load_manifest_from_file path =
+  match Safe_ops.read_json_file_safe path with
+  | Error err ->
+      Log.Keeper.warn
+        "keeper benchmark canary: failed to read %s: %s" path err;
+      None
+  | Ok json -> (
+      match parse_manifest json with
+      | Some manifest -> Some manifest
+      | None ->
+          Log.Keeper.warn
+            "keeper benchmark canary: invalid manifest shape at %s" path;
+          None)
+
+let load_manifest_uncached path =
+  let manifest = load_manifest_from_file path in
+  let mtime = Option.value ~default:(-.1.0) (stat_mtime path) in
+  cache := Some { path; mtime; manifest };
+  manifest
+
+let load_manifest () =
+  let path = manifest_path () in
+  match stat_mtime path, !cache with
+  | None, Some cached when String.equal cached.path path && cached.mtime < 0.0 ->
+      cached.manifest
+  | None, _ ->
+      cache := Some { path; mtime = -.1.0; manifest = None };
+      None
+  | Some mtime, Some cached
+    when String.equal cached.path path && Float.equal cached.mtime mtime ->
+      cached.manifest
+  | Some _, _ ->
+      load_manifest_uncached path
+
+let candidate_keeper_profiles keeper_name =
+  let keeper_name = trim keeper_name in
+  if keeper_name = "" then []
+  else if String.length keeper_name > 6
+          && String.equal (String.sub keeper_name 0 6) "bench-"
+  then
+    let bare =
+      String.sub keeper_name 6 (String.length keeper_name - 6)
+    in
+    normalize_string_list [ keeper_name; bare ]
+  else
+    normalize_string_list [ keeper_name; "bench-" ^ keeper_name ]
+
+let recommended_model_label_for_keeper ~keeper_name =
+  if not (enabled ()) then None
+  else
+    match load_manifest () with
+    | None -> None
+    | Some manifest ->
+        let candidates = candidate_keeper_profiles keeper_name in
+        candidates
+        |> List.find_map (fun keeper_profile ->
+               manifest.recommendations
+               |> List.find_map (fun recommendation ->
+                      if String.equal recommendation.keeper_profile keeper_profile
+                      then Some recommendation.model_label
+                      else None))
+
+let reset_for_testing () =
+  cache := None

--- a/lib/keeper_benchmark_canary.mli
+++ b/lib/keeper_benchmark_canary.mli
@@ -1,0 +1,33 @@
+type recommendation = {
+  keeper_profile : string;
+  model_label : string;
+  composite_score : float;
+  task_pass_rate : float;
+  stability_score : float option;
+  cases_total : int;
+  cases_passed : int;
+}
+
+type manifest = {
+  version : int;
+  generated_at : string;
+  source_summary_path : string option;
+  recommendations : recommendation list;
+}
+
+val default_manifest_path : unit -> string
+val enabled : unit -> bool
+
+val build_manifest :
+     ?source_summary_path:string
+  -> Tool_call_quality_benchmark.benchmark_summary
+  -> manifest
+
+val recommendation_to_yojson : recommendation -> Yojson.Safe.t
+val manifest_to_yojson : manifest -> Yojson.Safe.t
+
+val load_manifest_from_file : string -> manifest option
+val load_manifest : unit -> manifest option
+val recommended_model_label_for_keeper : keeper_name:string -> string option
+
+val reset_for_testing : unit -> unit

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -27,6 +27,7 @@ type turn_context = {
   tool_choice: string option;
   thinking_enabled: bool option;
   thinking_budget: int option;
+  prompt_fingerprint: string option;
   trace_id: string option;
   session_id: string option;
   turn: int option;
@@ -37,6 +38,7 @@ let empty_turn_context = {
   tool_choice = None;
   thinking_enabled = None;
   thinking_budget = None;
+  prompt_fingerprint = None;
   trace_id = None;
   session_id = None;
   turn = None;
@@ -53,13 +55,14 @@ let consume_truncation_info ~keeper_name () =
   | None -> (0, None)
 
 let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?trace_id ?session_id ?turn () =
+    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn () =
   Hashtbl.replace pending_turn_context keeper_name
     {
       lane;
       tool_choice;
       thinking_enabled;
       thinking_budget;
+      prompt_fingerprint;
       trace_id;
       session_id;
       turn;
@@ -75,6 +78,7 @@ let get_turn_context ~keeper_name () =
   , ctx.tool_choice
   , ctx.thinking_enabled
   , ctx.thinking_budget
+  , ctx.prompt_fingerprint
   , ctx.trace_id
   , ctx.session_id
   , ctx.turn )
@@ -145,8 +149,8 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
-    ?(model : string = "") ?provider ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?trace_id ?session_id ?turn ?result_bytes ?truncated_to () =
+    ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
+    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
@@ -156,6 +160,7 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           , ctx_tool_choice
           , ctx_thinking_enabled
           , ctx_thinking_budget
+          , ctx_prompt_fingerprint
           , ctx_trace_id
           , ctx_session_id
           , ctx_turn ) =
@@ -175,6 +180,11 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         | Some _ -> thinking_budget
         | None -> ctx_thinking_budget
       in
+      let prompt_fingerprint =
+        match prompt_fingerprint with
+        | Some _ -> prompt_fingerprint
+        | None -> ctx_prompt_fingerprint
+      in
       let trace_id = match trace_id with Some _ -> trace_id | None -> ctx_trace_id in
       let session_id =
         match session_id with Some _ -> session_id | None -> ctx_session_id
@@ -182,12 +192,6 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       let turn = match turn with Some _ -> turn | None -> ctx_turn in
       let model_field =
         if model = "" then [] else [("model", `String model)]
-      in
-      let provider_field =
-        match provider with
-        | Some value when String.trim value <> "" ->
-          [("provider", `String value)]
-        | _ -> []
       in
       let result_bytes_field = match result_bytes with
         | Some n -> [("result_bytes", `Int n)]
@@ -211,6 +215,10 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       in
       let thinking_budget_field = match thinking_budget with
         | Some value -> [("thinking_budget", `Int value)]
+        | None -> []
+      in
+      let prompt_fingerprint_field = match prompt_fingerprint with
+        | Some value -> [("prompt_fingerprint", `String value)]
         | None -> []
       in
       let trace_id_field = match trace_id with
@@ -238,8 +246,9 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            ; ("success", `Bool success)
            ; ("duration_ms", `Float duration_ms)
            ]
-           @ model_field @ provider_field @ lane_field @ tool_choice_field
+           @ model_field @ lane_field @ tool_choice_field
            @ thinking_enabled_field @ thinking_budget_field
+           @ prompt_fingerprint_field
            @ trace_id_field @ session_id_field @ turn_field
            @ result_bytes_field @ truncated_to_field)
       in

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -32,6 +32,7 @@ val set_turn_context :
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
   ?thinking_budget:int ->
+  ?prompt_fingerprint:string ->
   ?trace_id:string ->
   ?session_id:string ->
   ?turn:int ->
@@ -44,9 +45,9 @@ val get_turn_context :
   keeper_name:string ->
   unit ->
   string option * string option * bool option * int option
-  * string option * string option * int option
+  * string option * string option * string option * int option
 (** Returns [(lane, tool_choice, thinking_enabled, thinking_budget, trace_id,
-    session_id, turn)] for the keeper, or [None] values when no turn context
+    prompt_fingerprint, session_id, turn)] for the keeper, or [None] values when no turn context
     has been recorded. *)
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
@@ -61,11 +62,11 @@ val log_call :
   success:bool ->
   duration_ms:float ->
   ?model:string ->
-  ?provider:string ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
   ?thinking_budget:int ->
+  ?prompt_fingerprint:string ->
   ?trace_id:string ->
   ?session_id:string ->
   ?turn:int ->
@@ -75,8 +76,7 @@ val log_call :
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
     Output is truncated to 4000 bytes. [model] records which LLM generated
-    the tool call. [provider] records the canonical provider label when
-    the caller knows it. Turn-policy fields ([lane], [tool_choice],
+    the tool call. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool
     selection context. [result_bytes] is the original output size before
     any truncation. [truncated_to] is present when Tool_output_validation

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -358,6 +358,7 @@ let codex_cli_prompt_preflight ~(config : Oas_worker_exec.config) ~(goal : strin
       Oas.Agent_turn.prepare_messages
         ~messages:(config.initial_messages @ [ Oas.Types.user_msg goal ])
         ~context_reducer:config.context_reducer
+        ~tiered_memory:None
         ~turn_params:Oas.Hooks.default_turn_params
     in
     let req_config =
@@ -562,10 +563,6 @@ let cli_wrapped_hard_quota_indicators = [
   "quota_exhausted";
   "exhausted your capacity on this model";
   "quota will reset after";
-  "\"api_error_status\":429";
-  "you've hit your limit";
-  "youve hit your limit";
-  "resets apr ";
 ]
 
 let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
@@ -1089,27 +1086,6 @@ let run_named
            continues without throttling. *)
         ()
   in
-  let cooldown_blocks_next_cycle ~cycle =
-    let backoff_ms = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(cycle + 1) in
-    let deadline = Unix.gettimeofday () +. (float_of_int backoff_ms /. 1000.) in
-    let infos =
-      List.filter_map
-        (fun (cfg : Llm_provider.Provider_config.t) ->
-          Cascade_health_tracker.provider_info signal_ctx.health
-            ~provider_key:(adapter.health_key cfg))
-        candidate_cfgs
-    in
-    infos <> []
-    && List.length infos = List.length candidate_cfgs
-    && List.for_all
-         (fun (info : Cascade_health_tracker.provider_info) ->
-           info.in_cooldown
-           &&
-           match info.cooldown_expires_at with
-           | Some expires_at -> expires_at > deadline
-           | None -> false)
-         infos
-  in
   let cascade_exhausted_after_filter ~cycle =
     let observation =
       Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
@@ -1138,47 +1114,20 @@ let run_named
       Cascade_strategy.order_candidates strategy
         ~adapter ~ctx:signal_ctx ~cycle:n candidate_cfgs
     in
-    let all_candidates_in_cooldown =
-      strategy.kind = Cascade_strategy.Circuit_breaker_cycling
-      && candidate_cfgs <> []
-      && List.for_all
-           (fun candidate ->
-             Cascade_health_tracker.is_in_cooldown signal_ctx.health
-               ~provider_key:(adapter.health_key candidate))
-           candidate_cfgs
-    in
     let last_cycle = n + 1 >= strategy.cycle.max_cycles in
     match ordered with
     | [] when last_cycle ->
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
       cascade_exhausted_after_filter ~cycle:n
-    | [] when cooldown_blocks_next_cycle ~cycle:n ->
-      record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
-      Log.Misc.info
-        "cascade %s: cycle %d (%s) filtered all candidates and cooldown exceeds next backoff, exhausting early"
-        cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
-      cascade_exhausted_after_filter ~cycle:n
     | [] ->
-      let backoff =
-        if all_candidates_in_cooldown
-        then 0
-        else Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1)
-      in
+      let backoff = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1) in
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:backoff
         ~kind:Filtered_empty;
-      if all_candidates_in_cooldown
-      then begin
-        Log.Misc.info
-          "cascade %s: cycle %d (%s) filtered all candidates because every provider is in cooldown; skipping empty-cycle retries"
-          cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
-        cascade_exhausted_after_filter ~cycle:n
-      end else begin
-        Log.Misc.info
-          "cascade %s: cycle %d (%s) filtered all candidates, retrying"
-          cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
-        do_backoff (n + 1);
-        cycle_loop (n + 1)
-      end
+      Log.Misc.info
+        "cascade %s: cycle %d (%s) filtered all candidates, retrying"
+        cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
+      do_backoff (n + 1);
+      cycle_loop (n + 1)
     | _ ->
       record_trace ~cycle:n ~candidates_out:(List.length ordered)
         ~backoff_ms:0 ~kind:Ordered;

--- a/lib/tool_call_quality_benchmark.ml
+++ b/lib/tool_call_quality_benchmark.ml
@@ -1,0 +1,15 @@
+include Tool_call_quality_benchmark_types
+
+let default_case_set_path = Tool_call_quality_benchmark_loader.default_case_set_path
+let default_evidence_path = Tool_call_quality_benchmark_loader.default_evidence_path
+let load_cases_from_file = Tool_call_quality_benchmark_loader.load_cases_from_file
+let load_runs_from_file = Tool_call_quality_benchmark_loader.load_runs_from_file
+let score_run = Tool_call_quality_benchmark_scoring.score_run
+let summarize = Tool_call_quality_benchmark_summary.summarize
+let json_check_to_yojson = Tool_call_quality_benchmark_render.json_check_to_yojson
+let case_score_to_yojson = Tool_call_quality_benchmark_render.case_score_to_yojson
+let summary_row_to_yojson = Tool_call_quality_benchmark_render.summary_row_to_yojson
+let benchmark_summary_to_yojson =
+  Tool_call_quality_benchmark_render.benchmark_summary_to_yojson
+
+let summary_rows_to_csv = Tool_call_quality_benchmark_render.summary_rows_to_csv

--- a/lib/tool_call_quality_benchmark.mli
+++ b/lib/tool_call_quality_benchmark.mli
@@ -1,0 +1,24 @@
+include module type of Tool_call_quality_benchmark_types
+
+val default_case_set_path : repo_root:string -> string
+val default_evidence_path : repo_root:string -> string
+
+val load_cases_from_file : string -> benchmark_case list
+val load_runs_from_file : string -> evidence_run list
+
+val score_run :
+  cases:benchmark_case list -> evidence_run -> case_score option
+
+val summarize :
+     cases:benchmark_case list
+  -> runs:evidence_run list
+  -> ?model_filters:string list
+  -> ?keeper_filters:string list
+  -> unit
+  -> benchmark_summary
+
+val json_check_to_yojson : json_check -> Yojson.Safe.t
+val case_score_to_yojson : case_score -> Yojson.Safe.t
+val summary_row_to_yojson : summary_row -> Yojson.Safe.t
+val benchmark_summary_to_yojson : benchmark_summary -> Yojson.Safe.t
+val summary_rows_to_csv : view:summary_view -> benchmark_summary -> string

--- a/lib/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark_loader.ml
@@ -1,0 +1,186 @@
+open Tool_call_quality_benchmark_types
+
+let default_case_set_path ~repo_root =
+  Filename.concat repo_root "benchmark/tool_call_quality_cases.json"
+
+let default_evidence_path ~repo_root =
+  Filename.concat repo_root "test/fixtures/tool_call_quality_benchmark/evidence_runs.json"
+
+let dedupe_keep_order items =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let normalize_string_list items =
+  items
+  |> List.map String.trim
+  |> List.filter (fun item -> item <> "")
+  |> dedupe_keep_order
+
+let raise_invalidf fmt = Printf.ksprintf invalid_arg fmt
+
+let run_status_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "" | "ok" -> Run_ok
+  | "unsupported" -> Run_unsupported
+  | "runtime_unreachable" -> Run_runtime_unreachable
+  | other -> Run_other other
+
+let case_category_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "tool_required" -> Tool_required
+  | "tool_forbidden" -> Tool_forbidden
+  | "recovery_required" -> Recovery_required
+  | "multi_step" -> Multi_step
+  | other -> raise_invalidf "unknown tool-call-quality category: %s" other
+
+let read_json_file path =
+  match Safe_ops.read_json_file_safe path with
+  | Ok json -> json
+  | Error err -> raise_invalidf "failed to read %s: %s" path err
+
+let member_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let required_string_field json key =
+  match Yojson.Safe.Util.member key json |> Yojson.Safe.Util.to_string_option with
+  | Some value when String.trim value <> "" -> value
+  | _ -> raise_invalidf "missing required string field %s" key
+
+let list_field json key =
+  match member_opt key json with
+  | Some (`List items) -> items
+  | Some `Null | None -> []
+  | Some _ -> raise_invalidf "field %s must be a list" key
+
+let string_list_field json key =
+  list_field json key
+  |> List.filter_map Yojson.Safe.Util.to_string_option
+  |> normalize_string_list
+
+let parse_json_check json =
+  let open Yojson.Safe.Util in
+  {
+    path = required_string_field json "path";
+    equals = (match member_opt "equals" json with Some value -> Some value | None -> None);
+    contains = json |> member "contains" |> to_string_option;
+    min_int = json |> member "min_int" |> to_int_option;
+    present = json |> member "present" |> to_bool_option;
+  }
+
+let parse_arg_check json =
+  let open Yojson.Safe.Util in
+  {
+    tool_name = required_string_field json "tool_name";
+    path = required_string_field json "path";
+    equals = (match member_opt "equals" json with Some value -> Some value | None -> None);
+    contains = json |> member "contains" |> to_string_option;
+    min_int = json |> member "min_int" |> to_int_option;
+    present = json |> member "present" |> to_bool_option;
+  }
+
+let parse_recovery_policy json =
+  let open Yojson.Safe.Util in
+  {
+    required = json |> member "required" |> to_bool_option |> Option.value ~default:false;
+    success_after_failure =
+      json |> member "success_after_failure" |> to_bool_option
+      |> Option.value ~default:false;
+    max_failures_before_success =
+      json |> member "max_failures_before_success" |> to_int_option;
+  }
+
+let benchmark_case_of_yojson json =
+  let open Yojson.Safe.Util in
+  let id = required_string_field json "id" in
+  let keeper_profiles = string_list_field json "keeper_profiles" in
+  let success_checks = list_field json "success_checks" |> List.map parse_json_check in
+  if keeper_profiles = [] then
+    raise_invalidf "benchmark case %s must declare keeper_profiles" id;
+  if success_checks = [] then
+    raise_invalidf "benchmark case %s must declare success_checks" id;
+  let max_tool_calls =
+    json |> member "max_tool_calls" |> to_int_option |> Option.value ~default:0
+  in
+  if max_tool_calls < 0 then
+    raise_invalidf "benchmark case %s has negative max_tool_calls" id;
+  {
+    id;
+    prompt = required_string_field json "prompt";
+    category =
+      json |> member "category" |> to_string_option
+      |> Option.value ~default:"tool_required"
+      |> case_category_of_string;
+    keeper_profiles;
+    required_tools = string_list_field json "required_tools";
+    forbidden_tools = string_list_field json "forbidden_tools";
+    max_tool_calls;
+    success_checks;
+    arg_checks = list_field json "arg_checks" |> List.map parse_arg_check;
+    recovery_policy =
+      match member_opt "recovery_policy" json with
+      | Some (`Assoc _ as value) -> Some (parse_recovery_policy value)
+      | _ -> None;
+  }
+
+let tool_call_of_yojson json =
+  let open Yojson.Safe.Util in
+  {
+    tool_name =
+      (match json |> member "tool_name" |> to_string_option with
+       | Some value -> value
+       | None -> json |> member "tool" |> to_string_option |> Option.value ~default:"");
+    success = json |> member "success" |> to_bool_option |> Option.value ~default:false;
+    input = (match member_opt "input" json with Some value -> value | None -> `Assoc []);
+    output = member_opt "output" json;
+    duration_ms = json |> member "duration_ms" |> to_float_option;
+  }
+
+let evidence_run_of_yojson json =
+  let open Yojson.Safe.Util in
+  {
+    case_id = required_string_field json "case_id";
+    provider = required_string_field json "provider";
+    model = required_string_field json "model";
+    keeper_profile = required_string_field json "keeper_profile";
+    run_id = json |> member "run_id" |> to_string_option;
+    repeat_index = json |> member "repeat_index" |> to_int_option;
+    prompt_fingerprint = json |> member "prompt_fingerprint" |> to_string_option;
+    task_success = json |> member "task_success" |> to_bool_option;
+    final_output = json |> member "final_output" |> to_string_option;
+    final_result = member_opt "final_result" json;
+    latency_ms = json |> member "latency_ms" |> to_int_option;
+    input_tokens = json |> member "input_tokens" |> to_int_option;
+    output_tokens = json |> member "output_tokens" |> to_int_option;
+    cost_usd = json |> member "cost_usd" |> to_float_option;
+    status =
+      json |> member "status" |> to_string_option |> Option.value ~default:"ok"
+      |> run_status_of_string;
+    tool_calls = list_field json "tool_calls" |> List.map tool_call_of_yojson;
+  }
+
+let load_cases_from_file path =
+  let json = read_json_file path in
+  let cases =
+    match json with
+    | `List items -> items
+    | `Assoc _ -> list_field json "cases"
+    | _ -> raise_invalidf "invalid benchmark case set at %s" path
+  in
+  cases |> List.map benchmark_case_of_yojson
+
+let load_runs_from_file path =
+  let json = read_json_file path in
+  let runs =
+    match json with
+    | `List items -> items
+    | `Assoc _ -> list_field json "runs"
+    | _ -> raise_invalidf "invalid benchmark evidence set at %s" path
+  in
+  runs |> List.map evidence_run_of_yojson

--- a/lib/tool_call_quality_benchmark_render.ml
+++ b/lib/tool_call_quality_benchmark_render.ml
@@ -1,0 +1,170 @@
+open Tool_call_quality_benchmark_types
+
+let case_score_to_yojson (score : case_score) =
+  `Assoc
+    [
+      ("case_id", `String score.case_id);
+      ("provider", `String score.provider);
+      ("model", `String score.model);
+      ("keeper_profile", `String score.keeper_profile);
+      ("passed", `Bool score.passed);
+      ("task_pass", `Float score.task_pass);
+      ("tool_selection", `Float score.tool_selection);
+      ("arg_validity", `Float score.arg_validity);
+      ("recovery", `Float score.recovery);
+      ("efficiency", `Float score.efficiency);
+      ("unnecessary_tool_rate", `Float score.unnecessary_tool_rate);
+      ("composite_score", `Float score.composite_score);
+      ("tool_call_count", `Int score.tool_call_count);
+      ("latency_ms", Option.fold ~none:`Null ~some:(fun value -> `Int value) score.latency_ms);
+      ("input_tokens", Option.fold ~none:`Null ~some:(fun value -> `Int value) score.input_tokens);
+      ("output_tokens", Option.fold ~none:`Null ~some:(fun value -> `Int value) score.output_tokens);
+      ("cost_usd", Option.fold ~none:`Null ~some:(fun value -> `Float value) score.cost_usd);
+      ("prompt_fingerprint",
+       Option.fold ~none:`Null ~some:(fun value -> `String value) score.prompt_fingerprint);
+      ("tool_sequence", `List (List.map (fun value -> `String value) score.tool_sequence));
+    ]
+
+let json_check_to_yojson (check : json_check) =
+  `Assoc
+    [
+      ("path", `String check.path);
+      ("equals", Option.value ~default:`Null check.equals);
+      ("contains", Option.fold ~none:`Null ~some:(fun value -> `String value) check.contains);
+      ("min_int", Option.fold ~none:`Null ~some:(fun value -> `Int value) check.min_int);
+      ("present", Option.fold ~none:`Null ~some:(fun value -> `Bool value) check.present);
+    ]
+
+let summary_row_to_yojson (row : summary_row) =
+  `Assoc
+    [
+      ("provider", Option.fold ~none:`Null ~some:(fun value -> `String value) row.provider);
+      ("model", Option.fold ~none:`Null ~some:(fun value -> `String value) row.model);
+      ("keeper_profile",
+       Option.fold ~none:`Null ~some:(fun value -> `String value) row.keeper_profile);
+      ("cases_total", `Int row.cases_total);
+      ("cases_passed", `Int row.cases_passed);
+      ("task_pass_rate", `Float row.task_pass_rate);
+      ("correct_tool_rate", `Float row.correct_tool_rate);
+      ("arg_valid_rate", `Float row.arg_valid_rate);
+      ("recovery_rate", `Float row.recovery_rate);
+      ("unnecessary_tool_rate", `Float row.unnecessary_tool_rate);
+      ("avg_tool_calls", `Float row.avg_tool_calls);
+      ("p95_latency_ms", `Float row.p95_latency_ms);
+      ("avg_input_tokens", `Float row.avg_input_tokens);
+      ("avg_output_tokens", `Float row.avg_output_tokens);
+      ("avg_cost_usd", `Float row.avg_cost_usd);
+      ("composite_score", `Float row.composite_score);
+      ("unsupported_runs", `Int row.unsupported_runs);
+      ("runtime_unreachable_runs", `Int row.runtime_unreachable_runs);
+      ("stability_score", Option.fold ~none:`Null ~some:(fun value -> `Float value) row.stability_score);
+      ( "tool_sequence_consistency_rate",
+        Option.fold ~none:`Null ~some:(fun value -> `Float value)
+          row.tool_sequence_consistency_rate );
+      ( "prompt_fingerprint_consistency_rate",
+        Option.fold ~none:`Null ~some:(fun value -> `Float value)
+          row.prompt_fingerprint_consistency_rate );
+      ( "pass_consistency_rate",
+        Option.fold ~none:`Null ~some:(fun value -> `Float value)
+          row.pass_consistency_rate );
+      ("repeated_case_groups", `Int row.repeated_case_groups);
+    ]
+
+let benchmark_summary_to_yojson (summary : benchmark_summary) =
+  `Assoc
+    [
+      ("cases_total", `Int summary.cases_total);
+      ("runs_total", `Int summary.runs_total);
+      ("scored_runs", `Int summary.scored_runs);
+      ("unsupported_runs", `Int summary.unsupported_runs);
+      ("runtime_unreachable_runs", `Int summary.runtime_unreachable_runs);
+      ("unknown_case_runs", `Int summary.unknown_case_runs);
+      ( "grouped_by_provider_model_keeper",
+        `List (List.map summary_row_to_yojson summary.grouped_by_provider_model_keeper) );
+      ( "grouped_by_provider_model",
+        `List (List.map summary_row_to_yojson summary.grouped_by_provider_model) );
+      ( "grouped_by_keeper_profile",
+        `List (List.map summary_row_to_yojson summary.grouped_by_keeper_profile) );
+    ]
+
+let csv_escape value =
+  let needs_quote =
+    String.contains value ','
+    || String.contains value '"'
+    || String.contains value '\n'
+  in
+  if not needs_quote then value
+  else "\"" ^ String.concat "\"\"" (String.split_on_char '"' value) ^ "\""
+
+let value_or_empty = function Some value -> value | None -> ""
+
+let string_of_float_option = function
+  | Some value -> Printf.sprintf "%.4f" value
+  | None -> ""
+
+let rows_for_view view summary =
+  match view with
+  | By_provider_model_keeper -> summary.grouped_by_provider_model_keeper
+  | By_provider_model -> summary.grouped_by_provider_model
+  | By_keeper_profile -> summary.grouped_by_keeper_profile
+
+let summary_rows_to_csv ~view summary =
+  let headers =
+    [
+      "provider";
+      "model";
+      "keeper_profile";
+      "cases_total";
+      "cases_passed";
+      "task_pass_rate";
+      "correct_tool_rate";
+      "arg_valid_rate";
+      "recovery_rate";
+      "unnecessary_tool_rate";
+      "avg_tool_calls";
+      "p95_latency_ms";
+      "avg_input_tokens";
+      "avg_output_tokens";
+      "avg_cost_usd";
+      "composite_score";
+      "unsupported_runs";
+      "runtime_unreachable_runs";
+      "stability_score";
+      "tool_sequence_consistency_rate";
+      "prompt_fingerprint_consistency_rate";
+      "pass_consistency_rate";
+      "repeated_case_groups";
+    ]
+  in
+  let row_to_values (row : summary_row) =
+    [
+      value_or_empty row.provider;
+      value_or_empty row.model;
+      value_or_empty row.keeper_profile;
+      string_of_int row.cases_total;
+      string_of_int row.cases_passed;
+      Printf.sprintf "%.4f" row.task_pass_rate;
+      Printf.sprintf "%.4f" row.correct_tool_rate;
+      Printf.sprintf "%.4f" row.arg_valid_rate;
+      Printf.sprintf "%.4f" row.recovery_rate;
+      Printf.sprintf "%.4f" row.unnecessary_tool_rate;
+      Printf.sprintf "%.4f" row.avg_tool_calls;
+      Printf.sprintf "%.1f" row.p95_latency_ms;
+      Printf.sprintf "%.1f" row.avg_input_tokens;
+      Printf.sprintf "%.1f" row.avg_output_tokens;
+      Printf.sprintf "%.6f" row.avg_cost_usd;
+      Printf.sprintf "%.2f" row.composite_score;
+      string_of_int row.unsupported_runs;
+      string_of_int row.runtime_unreachable_runs;
+      string_of_float_option row.stability_score;
+      string_of_float_option row.tool_sequence_consistency_rate;
+      string_of_float_option row.prompt_fingerprint_consistency_rate;
+      string_of_float_option row.pass_consistency_rate;
+      string_of_int row.repeated_case_groups;
+    ]
+  in
+  let lines =
+    headers :: List.map row_to_values (rows_for_view view summary)
+    |> List.map (fun values -> values |> List.map csv_escape |> String.concat ",")
+  in
+  String.concat "\n" lines ^ "\n"

--- a/lib/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark_scoring.ml
@@ -1,0 +1,246 @@
+open Tool_call_quality_benchmark_types
+
+let avg_float values =
+  match values with
+  | [] -> 0.0
+  | _ ->
+      List.fold_left ( +. ) 0.0 values /. float_of_int (List.length values)
+
+let split_path path =
+  let path = String.trim path in
+  if path = "$" then []
+  else
+    let path =
+      if String.starts_with ~prefix:"$." path then
+        String.sub path 2 (String.length path - 2)
+      else if String.starts_with ~prefix:"$" path then
+        String.sub path 1 (String.length path - 1)
+      else
+        path
+    in
+    if path = "" then [] else String.split_on_char '.' path
+
+let rec json_at_path json segments =
+  match segments, json with
+  | [], _ -> Some json
+  | segment :: rest, `Assoc fields -> (
+      match List.assoc_opt segment fields with
+      | Some value -> json_at_path value rest
+      | None -> None)
+  | segment :: rest, `List items -> (
+      match int_of_string_opt segment with
+      | Some idx when idx >= 0 && idx < List.length items ->
+          json_at_path (List.nth items idx) rest
+      | _ -> None)
+  | _ -> None
+
+let string_of_json value =
+  match value with
+  | `String s -> s
+  | _ -> Yojson.Safe.to_string value
+
+let evaluate_json_check ~(target : Yojson.Safe.t option) (check : json_check) =
+  let actual =
+    match target with
+    | Some json -> json_at_path json (split_path check.path)
+    | None -> None
+  in
+  let present_ok =
+    match check.present with
+    | None -> true
+    | Some true -> (match actual with Some `Null | None -> false | Some _ -> true)
+    | Some false -> (match actual with Some value when value <> `Null -> false | _ -> true)
+  in
+  let equals_ok =
+    match check.equals with
+    | None -> true
+    | Some expected -> actual = Some expected
+  in
+  let contains_ok =
+    match check.contains with
+    | None -> true
+    | Some needle -> (
+        match actual with
+        | Some value -> String_util.contains_substring (string_of_json value) needle
+        | None -> false)
+  in
+  let min_int_ok =
+    match check.min_int with
+    | None -> true
+    | Some min_value -> (
+        match actual with
+        | Some (`Int value) -> value >= min_value
+        | Some (`Float value) -> value >= float_of_int min_value
+        | _ -> false)
+  in
+  present_ok && equals_ok && contains_ok && min_int_ok
+
+let tool_used tool_name (run : evidence_run) =
+  List.exists (fun call -> String.equal call.tool_name tool_name) run.tool_calls
+
+let arg_check_passes (run : evidence_run) (check : arg_check) =
+  let predicate call =
+    String.equal call.tool_name check.tool_name
+    && evaluate_json_check ~target:(Some call.input)
+         { path = check.path
+         ; equals = check.equals
+         ; contains = check.contains
+         ; min_int = check.min_int
+         ; present = check.present
+         }
+  in
+  List.exists predicate run.tool_calls
+
+let tool_sequence (run : evidence_run) =
+  run.tool_calls |> List.map (fun call -> call.tool_name)
+
+let required_tool_score (benchmark_case : benchmark_case) (run : evidence_run) =
+  match benchmark_case.category with
+  | Tool_forbidden ->
+      if run.tool_calls = [] then 1.0 else 0.0
+  | _ ->
+      (match benchmark_case.required_tools with
+       | [] -> 1.0
+       | required_tools ->
+           required_tools
+           |> List.map (fun tool_name ->
+                  if tool_used tool_name run then 1.0 else 0.0)
+           |> avg_float)
+
+let forbidden_tool_used (benchmark_case : benchmark_case) (run : evidence_run) =
+  match benchmark_case.category with
+  | Tool_forbidden -> run.tool_calls <> []
+  | _ ->
+      List.exists (fun tool_name -> tool_used tool_name run) benchmark_case.forbidden_tools
+
+let task_pass_score (benchmark_case : benchmark_case) (run : evidence_run) =
+  let reported = Option.value ~default:false run.task_success in
+  let checks =
+    benchmark_case.success_checks
+    |> List.for_all (evaluate_json_check ~target:run.final_result)
+  in
+  if reported && checks then 1.0 else 0.0
+
+let arg_validity_score (benchmark_case : benchmark_case) (run : evidence_run) =
+  match benchmark_case.arg_checks with
+  | [] -> 1.0
+  | checks ->
+      checks
+      |> List.map (fun check -> if arg_check_passes run check then 1.0 else 0.0)
+      |> avg_float
+
+let recovery_score (benchmark_case : benchmark_case) (run : evidence_run) task_pass =
+  match benchmark_case.recovery_policy with
+  | None -> 1.0
+  | Some policy when not policy.required -> 1.0
+  | Some policy ->
+      let calls = run.tool_calls in
+      let rec find_success_after failures_seen failures_before_success = function
+        | [] -> None
+        | call :: rest ->
+            if call.success then
+              if failures_seen then Some failures_before_success
+              else find_success_after failures_seen failures_before_success rest
+            else
+              find_success_after true (failures_before_success + 1) rest
+      in
+      let success_after_failure =
+        if policy.success_after_failure then find_success_after false 0 calls else Some 0
+      in
+      let failure_limit_ok =
+        match success_after_failure, policy.max_failures_before_success with
+        | Some _, None -> true
+        | Some failures, Some max_failures -> failures <= max_failures
+        | None, _ -> false
+      in
+      if task_pass = 1.0 && failure_limit_ok && success_after_failure <> None then 1.0
+      else 0.0
+
+let unnecessary_tool_rate (benchmark_case : benchmark_case) (run : evidence_run) =
+  let call_count = List.length run.tool_calls in
+  if call_count = 0 then 0.0
+  else
+    match benchmark_case.category with
+    | Tool_forbidden -> 1.0
+    | _ ->
+        let forbidden_count =
+          run.tool_calls
+          |> List.filter (fun call -> List.mem call.tool_name benchmark_case.forbidden_tools)
+          |> List.length
+        in
+        let over_limit = max 0 (call_count - benchmark_case.max_tool_calls) in
+        min 1.0
+          (float_of_int (forbidden_count + over_limit) /. float_of_int call_count)
+
+let efficiency_score (benchmark_case : benchmark_case) (run : evidence_run) =
+  let call_count = List.length run.tool_calls in
+  match benchmark_case.category with
+  | Tool_forbidden ->
+      if call_count = 0 then 1.0 else 0.0
+  | _ ->
+      if benchmark_case.max_tool_calls <= 0 then
+        if call_count = 0 then 1.0 else 0.0
+      else
+        let over_limit = max 0 (call_count - benchmark_case.max_tool_calls) in
+        max 0.0
+          (1.0 -. (float_of_int over_limit /. float_of_int benchmark_case.max_tool_calls))
+
+let score_run ~cases (run : evidence_run) =
+  if run.status <> Run_ok then None
+  else
+    let cases_by_id =
+      cases
+      |> List.to_seq
+      |> Seq.map (fun case -> (case.id, case))
+      |> Hashtbl.of_seq
+    in
+    match Hashtbl.find_opt cases_by_id run.case_id with
+    | None -> None
+    | Some benchmark_case ->
+        if not (List.mem run.keeper_profile benchmark_case.keeper_profiles) then None
+        else
+          let task_pass = task_pass_score benchmark_case run in
+          let required_score = required_tool_score benchmark_case run in
+          let tool_selection =
+            if forbidden_tool_used benchmark_case run then 0.0 else required_score
+          in
+          let arg_validity = arg_validity_score benchmark_case run in
+          let recovery = recovery_score benchmark_case run task_pass in
+          let efficiency = efficiency_score benchmark_case run in
+          let unnecessary_tool_rate = unnecessary_tool_rate benchmark_case run in
+          let composite_score =
+            (40.0 *. task_pass)
+            +. (25.0 *. tool_selection)
+            +. (15.0 *. arg_validity)
+            +. (10.0 *. recovery)
+            +. (10.0 *. efficiency)
+          in
+          let passed =
+            task_pass = 1.0
+            && tool_selection = 1.0
+            && arg_validity = 1.0
+            && recovery = 1.0
+            && efficiency = 1.0
+          in
+          Some
+            {
+              case_id = run.case_id;
+              provider = run.provider;
+              model = run.model;
+              keeper_profile = run.keeper_profile;
+              passed;
+              task_pass;
+              tool_selection;
+              arg_validity;
+              recovery;
+              efficiency;
+              unnecessary_tool_rate;
+              composite_score;
+              tool_call_count = List.length run.tool_calls;
+              latency_ms = run.latency_ms;
+              input_tokens = run.input_tokens;
+              output_tokens = run.output_tokens;
+              cost_usd = run.cost_usd;
+              prompt_fingerprint = run.prompt_fingerprint;
+              tool_sequence = tool_sequence run;
+            }

--- a/lib/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark_summary.ml
@@ -1,0 +1,328 @@
+open Tool_call_quality_benchmark_types
+
+let avg_float values =
+  match values with
+  | [] -> 0.0
+  | _ ->
+      List.fold_left ( +. ) 0.0 values /. float_of_int (List.length values)
+
+let avg_int_option values =
+  values
+  |> List.filter_map (fun value -> value)
+  |> List.map float_of_int
+  |> avg_float
+
+let avg_float_option values =
+  values
+  |> List.filter_map (fun value -> value)
+  |> avg_float
+
+let percentile95_int_option values =
+  let values = List.filter_map (fun value -> value) values |> List.sort Int.compare in
+  match values with
+  | [] -> 0.0
+  | _ ->
+      let n = List.length values in
+      let idx =
+        int_of_float (Float.ceil (0.95 *. float_of_int n)) - 1
+        |> max 0 |> min (n - 1)
+      in
+      float_of_int (List.nth values idx)
+
+let dedupe_keep_order items =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let normalize_string_list items =
+  items
+  |> List.map String.trim
+  |> List.filter (fun item -> item <> "")
+  |> dedupe_keep_order
+
+let model_label (run : evidence_run) = run.provider ^ ":" ^ run.model
+
+let normalize_filter_set values =
+  let table = Hashtbl.create 8 in
+  values
+  |> normalize_string_list
+  |> List.iter (fun value -> Hashtbl.replace table value ());
+  table
+
+let keep_run ?model_filters ?keeper_filters (run : evidence_run) =
+  let model_ok =
+    match model_filters with
+    | None | Some [] -> true
+    | Some filters -> Hashtbl.mem (normalize_filter_set filters) (model_label run)
+  in
+  let keeper_ok =
+    match keeper_filters with
+    | None | Some [] -> true
+    | Some filters -> Hashtbl.mem (normalize_filter_set filters) run.keeper_profile
+  in
+  model_ok && keeper_ok
+
+let group_scores_by_case grouped_scores =
+  let grouped = Hashtbl.create 8 in
+  List.iter
+    (fun score ->
+      let current = Hashtbl.find_opt grouped score.case_id |> Option.value ~default:[] in
+      Hashtbl.replace grouped score.case_id (score :: current))
+    grouped_scores;
+  grouped
+
+let modal_ratio values =
+  match values with
+  | [] -> None
+  | _ ->
+      let counts = Hashtbl.create (List.length values) in
+      List.iter
+        (fun value ->
+          let next =
+            match Hashtbl.find_opt counts value with
+            | Some count -> count + 1
+            | None -> 1
+          in
+          Hashtbl.replace counts value next)
+        values;
+      let best =
+        Hashtbl.fold (fun _ count acc -> max acc count) counts 0
+      in
+      Some (float_of_int best /. float_of_int (List.length values))
+
+let tool_sequence (run : evidence_run) =
+  run.tool_calls |> List.map (fun call -> call.tool_name)
+
+let summary_key_of_run view (run : evidence_run) =
+  match view with
+  | By_provider_model_keeper -> (Some run.provider, Some run.model, Some run.keeper_profile)
+  | By_provider_model -> (Some run.provider, Some run.model, None)
+  | By_keeper_profile -> (None, None, Some run.keeper_profile)
+
+let summary_key_of_score view (score : case_score) =
+  match view with
+  | By_provider_model_keeper ->
+      (Some score.provider, Some score.model, Some score.keeper_profile)
+  | By_provider_model -> (Some score.provider, Some score.model, None)
+  | By_keeper_profile -> (None, None, Some score.keeper_profile)
+
+let repeated_metrics_for_view view runs =
+  let grouped = Hashtbl.create 16 in
+  List.iter
+    (fun run ->
+      if run.status = Run_ok then
+        let (provider, model, keeper_profile) = summary_key_of_run view run in
+        let key = (provider, model, keeper_profile, run.case_id) in
+        let current = Hashtbl.find_opt grouped key |> Option.value ~default:[] in
+        Hashtbl.replace grouped key (run :: current))
+    runs;
+  Hashtbl.fold
+    (fun (provider, model, keeper_profile, _case_id)
+         (grouped_runs : evidence_run list) acc ->
+      if List.length grouped_runs < 2 then acc
+      else
+        let tool_sequence_ratio =
+          grouped_runs
+          |> List.map tool_sequence
+          |> List.map (String.concat ">")
+          |> modal_ratio
+        in
+        let prompt_ratio =
+          grouped_runs
+          |> List.filter_map (fun (run : evidence_run) -> run.prompt_fingerprint)
+          |> modal_ratio
+        in
+        let pass_ratio =
+          grouped_runs
+          |> List.map (fun (run : evidence_run) ->
+                 Option.value ~default:false run.task_success |> string_of_bool)
+          |> modal_ratio
+        in
+        let stability =
+          [ tool_sequence_ratio; prompt_ratio; pass_ratio ]
+          |> List.filter_map (fun value -> value)
+          |> avg_float
+        in
+        ((provider, model, keeper_profile), (stability, tool_sequence_ratio, prompt_ratio, pass_ratio))
+        :: acc)
+    grouped []
+
+let collapse_repeated_metrics metrics =
+  let grouped = Hashtbl.create 8 in
+  List.iter
+    (fun (key, values) ->
+      let current = Hashtbl.find_opt grouped key |> Option.value ~default:[] in
+      Hashtbl.replace grouped key (values :: current))
+    metrics;
+  Hashtbl.fold
+    (fun key values acc ->
+      let stability_values, tool_values, prompt_values, pass_values =
+        List.fold_left
+          (fun (st_acc, tl_acc, pr_acc, pa_acc) (st, tl, pr, pa) ->
+            ( st :: st_acc
+            , (match tl with Some value -> value :: tl_acc | None -> tl_acc)
+            , (match pr with Some value -> value :: pr_acc | None -> pr_acc)
+            , (match pa with Some value -> value :: pa_acc | None -> pa_acc) ))
+          ([], [], [], []) values
+      in
+      ( key
+      , ( avg_float stability_values
+        , (match tool_values with [] -> None | _ -> Some (avg_float tool_values))
+        , (match prompt_values with [] -> None | _ -> Some (avg_float prompt_values))
+        , (match pass_values with [] -> None | _ -> Some (avg_float pass_values))
+        , List.length values ) )
+      :: acc)
+    grouped []
+
+let build_summary_rows view runs scores =
+  let repeated_metrics =
+    repeated_metrics_for_view view runs |> collapse_repeated_metrics
+    |> List.to_seq |> Hashtbl.of_seq
+  in
+  let scores_by_key = Hashtbl.create 16 in
+  List.iter
+    (fun score ->
+      let key = summary_key_of_score view score in
+      let current = Hashtbl.find_opt scores_by_key key |> Option.value ~default:[] in
+      Hashtbl.replace scores_by_key key (score :: current))
+    scores;
+  Hashtbl.fold
+    (fun (provider, model, keeper_profile as key)
+         (grouped_scores : case_score list) acc ->
+      let grouped_runs =
+        runs
+        |> List.filter (fun run ->
+               let run_key = summary_key_of_run view run in
+               run_key = key)
+      in
+      let grouped_scores_by_case = group_scores_by_case grouped_scores in
+      let unsupported_runs =
+        grouped_runs
+        |> List.filter (fun run -> run.status = Run_unsupported)
+        |> List.length
+      in
+      let runtime_unreachable_runs =
+        grouped_runs
+        |> List.filter (fun run -> run.status = Run_runtime_unreachable)
+        |> List.length
+      in
+      let stability_score, tool_sequence_consistency_rate,
+          prompt_fingerprint_consistency_rate, pass_consistency_rate,
+          repeated_case_groups =
+        match Hashtbl.find_opt repeated_metrics key with
+        | Some (stability, tool_rate, prompt_rate, pass_rate, group_count) ->
+            (Some stability, tool_rate, prompt_rate, pass_rate, group_count)
+        | None -> (None, None, None, None, 0)
+      in
+      let cases_total = Hashtbl.length grouped_scores_by_case in
+      let cases_passed =
+        Hashtbl.fold
+          (fun _ scores_for_case count ->
+            if List.for_all (fun score -> score.passed) scores_for_case then count + 1
+            else count)
+          grouped_scores_by_case 0
+      in
+      let row =
+        {
+          provider;
+          model;
+          keeper_profile;
+          cases_total;
+          cases_passed;
+          task_pass_rate =
+            grouped_scores |> List.map (fun (score : case_score) -> score.task_pass)
+            |> avg_float;
+          correct_tool_rate =
+            grouped_scores
+            |> List.map (fun (score : case_score) -> score.tool_selection)
+            |> avg_float;
+          arg_valid_rate =
+            grouped_scores
+            |> List.map (fun (score : case_score) -> score.arg_validity)
+            |> avg_float;
+          recovery_rate =
+            grouped_scores
+            |> List.map (fun (score : case_score) -> score.recovery)
+            |> avg_float;
+          unnecessary_tool_rate =
+            grouped_scores
+            |> List.map (fun (score : case_score) -> score.unnecessary_tool_rate)
+            |> avg_float;
+          avg_tool_calls =
+            grouped_scores
+            |> List.map (fun (score : case_score) -> float_of_int score.tool_call_count)
+            |> avg_float;
+          p95_latency_ms =
+            grouped_scores |> List.map (fun (score : case_score) -> score.latency_ms)
+            |> percentile95_int_option;
+          avg_input_tokens =
+            grouped_scores |> List.map (fun (score : case_score) -> score.input_tokens)
+            |> avg_int_option;
+          avg_output_tokens =
+            grouped_scores |> List.map (fun (score : case_score) -> score.output_tokens)
+            |> avg_int_option;
+          avg_cost_usd =
+            grouped_scores |> List.map (fun (score : case_score) -> score.cost_usd)
+            |> avg_float_option;
+          composite_score =
+            grouped_scores |> List.map (fun (score : case_score) -> score.composite_score)
+            |> avg_float;
+          unsupported_runs;
+          runtime_unreachable_runs;
+          stability_score;
+          tool_sequence_consistency_rate;
+          prompt_fingerprint_consistency_rate;
+          pass_consistency_rate;
+          repeated_case_groups;
+        }
+      in
+      row :: acc)
+    scores_by_key []
+  |> List.sort (fun a b ->
+         match Float.compare b.composite_score a.composite_score with
+         | 0 -> Int.compare b.cases_total a.cases_total
+         | cmp -> cmp)
+
+let summarize ~cases ~runs ?model_filters ?keeper_filters () =
+  let filtered_runs =
+    runs
+    |> List.filter (fun run -> keep_run ?model_filters ?keeper_filters run)
+  in
+  let score_results =
+    filtered_runs
+    |> List.filter_map (Tool_call_quality_benchmark_scoring.score_run ~cases)
+  in
+  let unsupported_runs =
+    filtered_runs |> List.filter (fun run -> run.status = Run_unsupported) |> List.length
+  in
+  let runtime_unreachable_runs =
+    filtered_runs
+    |> List.filter (fun run -> run.status = Run_runtime_unreachable)
+    |> List.length
+  in
+  let unknown_case_runs =
+    filtered_runs
+    |> List.filter (fun run ->
+           run.status = Run_ok
+           && not (List.exists (fun case -> String.equal case.id run.case_id) cases))
+    |> List.length
+  in
+  {
+    cases_total = List.length cases;
+    runs_total = List.length filtered_runs;
+    scored_runs = List.length score_results;
+    unsupported_runs;
+    runtime_unreachable_runs;
+    unknown_case_runs;
+    grouped_by_provider_model_keeper =
+      build_summary_rows By_provider_model_keeper filtered_runs score_results;
+    grouped_by_provider_model =
+      build_summary_rows By_provider_model filtered_runs score_results;
+    grouped_by_keeper_profile =
+      build_summary_rows By_keeper_profile filtered_runs score_results;
+  }

--- a/lib/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark_types.ml
@@ -1,0 +1,139 @@
+type case_category =
+  | Tool_required
+  | Tool_forbidden
+  | Recovery_required
+  | Multi_step
+
+type json_check = {
+  path : string;
+  equals : Yojson.Safe.t option;
+  contains : string option;
+  min_int : int option;
+  present : bool option;
+}
+
+type arg_check = {
+  tool_name : string;
+  path : string;
+  equals : Yojson.Safe.t option;
+  contains : string option;
+  min_int : int option;
+  present : bool option;
+}
+
+type recovery_policy = {
+  required : bool;
+  success_after_failure : bool;
+  max_failures_before_success : int option;
+}
+
+type benchmark_case = {
+  id : string;
+  prompt : string;
+  category : case_category;
+  keeper_profiles : string list;
+  required_tools : string list;
+  forbidden_tools : string list;
+  max_tool_calls : int;
+  success_checks : json_check list;
+  arg_checks : arg_check list;
+  recovery_policy : recovery_policy option;
+}
+
+type tool_call = {
+  tool_name : string;
+  success : bool;
+  input : Yojson.Safe.t;
+  output : Yojson.Safe.t option;
+  duration_ms : float option;
+}
+
+type run_status =
+  | Run_ok
+  | Run_unsupported
+  | Run_runtime_unreachable
+  | Run_other of string
+
+type evidence_run = {
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  run_id : string option;
+  repeat_index : int option;
+  prompt_fingerprint : string option;
+  task_success : bool option;
+  final_output : string option;
+  final_result : Yojson.Safe.t option;
+  latency_ms : int option;
+  input_tokens : int option;
+  output_tokens : int option;
+  cost_usd : float option;
+  status : run_status;
+  tool_calls : tool_call list;
+}
+
+type case_score = {
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  passed : bool;
+  task_pass : float;
+  tool_selection : float;
+  arg_validity : float;
+  recovery : float;
+  efficiency : float;
+  unnecessary_tool_rate : float;
+  composite_score : float;
+  tool_call_count : int;
+  latency_ms : int option;
+  input_tokens : int option;
+  output_tokens : int option;
+  cost_usd : float option;
+  prompt_fingerprint : string option;
+  tool_sequence : string list;
+}
+
+type summary_view =
+  | By_provider_model_keeper
+  | By_provider_model
+  | By_keeper_profile
+
+type summary_row = {
+  provider : string option;
+  model : string option;
+  keeper_profile : string option;
+  cases_total : int;
+  cases_passed : int;
+  task_pass_rate : float;
+  correct_tool_rate : float;
+  arg_valid_rate : float;
+  recovery_rate : float;
+  unnecessary_tool_rate : float;
+  avg_tool_calls : float;
+  p95_latency_ms : float;
+  avg_input_tokens : float;
+  avg_output_tokens : float;
+  avg_cost_usd : float;
+  composite_score : float;
+  unsupported_runs : int;
+  runtime_unreachable_runs : int;
+  stability_score : float option;
+  tool_sequence_consistency_rate : float option;
+  prompt_fingerprint_consistency_rate : float option;
+  pass_consistency_rate : float option;
+  repeated_case_groups : int;
+}
+
+type benchmark_summary = {
+  cases_total : int;
+  runs_total : int;
+  scored_runs : int;
+  unsupported_runs : int;
+  runtime_unreachable_runs : int;
+  unknown_case_runs : int;
+  grouped_by_provider_model_keeper : summary_row list;
+  grouped_by_provider_model : summary_row list;
+  grouped_by_keeper_profile : summary_row list;
+}

--- a/lib/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark_types.mli
@@ -1,0 +1,139 @@
+type case_category =
+  | Tool_required
+  | Tool_forbidden
+  | Recovery_required
+  | Multi_step
+
+type json_check = {
+  path : string;
+  equals : Yojson.Safe.t option;
+  contains : string option;
+  min_int : int option;
+  present : bool option;
+}
+
+type arg_check = {
+  tool_name : string;
+  path : string;
+  equals : Yojson.Safe.t option;
+  contains : string option;
+  min_int : int option;
+  present : bool option;
+}
+
+type recovery_policy = {
+  required : bool;
+  success_after_failure : bool;
+  max_failures_before_success : int option;
+}
+
+type benchmark_case = {
+  id : string;
+  prompt : string;
+  category : case_category;
+  keeper_profiles : string list;
+  required_tools : string list;
+  forbidden_tools : string list;
+  max_tool_calls : int;
+  success_checks : json_check list;
+  arg_checks : arg_check list;
+  recovery_policy : recovery_policy option;
+}
+
+type tool_call = {
+  tool_name : string;
+  success : bool;
+  input : Yojson.Safe.t;
+  output : Yojson.Safe.t option;
+  duration_ms : float option;
+}
+
+type run_status =
+  | Run_ok
+  | Run_unsupported
+  | Run_runtime_unreachable
+  | Run_other of string
+
+type evidence_run = {
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  run_id : string option;
+  repeat_index : int option;
+  prompt_fingerprint : string option;
+  task_success : bool option;
+  final_output : string option;
+  final_result : Yojson.Safe.t option;
+  latency_ms : int option;
+  input_tokens : int option;
+  output_tokens : int option;
+  cost_usd : float option;
+  status : run_status;
+  tool_calls : tool_call list;
+}
+
+type case_score = {
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  passed : bool;
+  task_pass : float;
+  tool_selection : float;
+  arg_validity : float;
+  recovery : float;
+  efficiency : float;
+  unnecessary_tool_rate : float;
+  composite_score : float;
+  tool_call_count : int;
+  latency_ms : int option;
+  input_tokens : int option;
+  output_tokens : int option;
+  cost_usd : float option;
+  prompt_fingerprint : string option;
+  tool_sequence : string list;
+}
+
+type summary_view =
+  | By_provider_model_keeper
+  | By_provider_model
+  | By_keeper_profile
+
+type summary_row = {
+  provider : string option;
+  model : string option;
+  keeper_profile : string option;
+  cases_total : int;
+  cases_passed : int;
+  task_pass_rate : float;
+  correct_tool_rate : float;
+  arg_valid_rate : float;
+  recovery_rate : float;
+  unnecessary_tool_rate : float;
+  avg_tool_calls : float;
+  p95_latency_ms : float;
+  avg_input_tokens : float;
+  avg_output_tokens : float;
+  avg_cost_usd : float;
+  composite_score : float;
+  unsupported_runs : int;
+  runtime_unreachable_runs : int;
+  stability_score : float option;
+  tool_sequence_consistency_rate : float option;
+  prompt_fingerprint_consistency_rate : float option;
+  pass_consistency_rate : float option;
+  repeated_case_groups : int;
+}
+
+type benchmark_summary = {
+  cases_total : int;
+  runs_total : int;
+  scored_runs : int;
+  unsupported_runs : int;
+  runtime_unreachable_runs : int;
+  unknown_case_runs : int;
+  grouped_by_provider_model_keeper : summary_row list;
+  grouped_by_provider_model : summary_row list;
+  grouped_by_keeper_profile : summary_row list;
+}

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -1,0 +1,1097 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${TOOL_CALL_QUALITY_OUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/tool-call-quality.XXXXXX")}"
+CASES_PATH="${TOOL_CALL_QUALITY_CASES_PATH:-${ROOT_DIR}/benchmark/tool_call_quality_cases.json}"
+EVIDENCE_PATH="${TOOL_CALL_QUALITY_EVIDENCE_PATH:-${ROOT_DIR}/test/fixtures/tool_call_quality_benchmark/evidence_runs.json}"
+FORMAT="${TOOL_CALL_QUALITY_FORMAT:-json}"
+VIEW="${TOOL_CALL_QUALITY_VIEW:-provider-model-keeper}"
+CLI_EXE="${ROOT_DIR}/_build/default/test/tool_call_quality_benchmark_cli.exe"
+
+MODELS="${TOOL_CALL_QUALITY_MODELS:-}"
+KEEPERS="${TOOL_CALL_QUALITY_KEEPERS:-bench-analyst,bench-executor,bench-verifier}"
+CASE_IDS="${TOOL_CALL_QUALITY_CASE_IDS:-}"
+LIVE_MODE="${TOOL_CALL_QUALITY_LIVE:-0}"
+REPEATS="${TOOL_CALL_QUALITY_REPEATS:-3}"
+TIMEOUT_SEC="${TOOL_CALL_QUALITY_TIMEOUT_SEC:-90}"
+WORKSPACE_ROOT="${TOOL_CALL_QUALITY_WORKSPACE_ROOT:-${ROOT_DIR}}"
+PORT="${TOOL_CALL_QUALITY_PORT:-}"
+POLL_INTERVAL_SEC="${TOOL_CALL_QUALITY_POLL_INTERVAL_SEC:-1}"
+
+SERVER_PID=""
+LIVE_RUN_DIR=""
+TARGET_DIR=""
+CONFIG_DIR=""
+PERSONAS_DIR=""
+RAW_DIR=""
+SERVER_LOG=""
+LAST_TOOL_RAW=""
+LAST_TOOL_ERROR=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/harness_tool_call_quality.sh [--cases PATH] [--evidence PATH] [--format json|csv]
+                                       [--view provider-model-keeper|provider-model|keeper]
+                                       [--artifact-dir DIR] [--models CSV] [--keepers CSV]
+                                       [--case-ids CSV]
+  scripts/harness_tool_call_quality.sh --live --models provider:model[,provider:model]
+                                       [--keepers CSV] [--case-ids CSV]
+                                       [--repeats N] [--timeout-sec N]
+                                       [--artifact-dir DIR] [--format json|csv]
+                                       [--view provider-model-keeper|provider-model|keeper]
+
+Modes:
+  default  Aggregate an existing evidence JSON file through the benchmark CLI.
+  --live   Start an isolated local MASC server, execute benchmark runs, emit raw
+           evidence JSON, then summarize it with the benchmark CLI.
+EOF
+}
+
+# shellcheck source=scripts/harness/lib/test_framework.sh
+source "${ROOT_DIR}/scripts/harness/lib/test_framework.sh"
+# shellcheck source=scripts/harness/lib/server_bootstrap.sh
+source "${ROOT_DIR}/scripts/harness/lib/server_bootstrap.sh"
+
+cleanup() {
+  harness_stop_server "${SERVER_PID}" 10
+}
+trap cleanup EXIT
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+trim() {
+  local value="${1:-}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+slugify() {
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "$value" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+  printf '%s' "${value:-run}"
+}
+
+csv_to_json() {
+  jq -cn --arg csv "${1:-}" '
+    $csv
+    | split(",")
+    | map(gsub("^\\s+|\\s+$"; ""))
+    | map(select(length > 0))
+  '
+}
+
+sha256_text() {
+  python3 - "${1:-}" <<'PY'
+import hashlib
+import sys
+
+value = sys.argv[1] if len(sys.argv) > 1 else ""
+print(hashlib.sha256(value.encode("utf-8")).hexdigest())
+PY
+}
+
+iso_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+ensure_cli_built() {
+  (
+    cd "${ROOT_DIR}"
+    if [[ "${TOOL_CALL_QUALITY_SKIP_BUILD:-0}" != "1" || ! -x "${CLI_EXE}" ]]; then
+      dune build --root . ./test/tool_call_quality_benchmark_cli.exe >/dev/null
+    fi
+  )
+}
+
+call_mcp_tool() {
+  local req_id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  local timeout_sec="${4:-$TIMEOUT_SEC}"
+  local saved_timeout="${CURL_TIMEOUT_SEC:-25}"
+
+  CURL_TIMEOUT_SEC="$timeout_sec"
+  LAST_TOOL_RAW="$(call_tool "$req_id" "$tool_name" "$args_json")"
+  CURL_TIMEOUT_SEC="$saved_timeout"
+
+  if printf '%s' "$LAST_TOOL_RAW" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
+    LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '._harness_error.message // "transport error"')"
+    return 1
+  fi
+
+  LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '
+    if .error?.message then .error.message
+    elif (.result?.isError // false) == true then
+      ([.result.content[]? | select(.type == "text") | .text] | join(" "))
+    else empty end
+  ' 2>/dev/null | awk 'NF { print; exit }')"
+
+  if [[ -n "${LAST_TOOL_ERROR}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+tool_result_json() {
+  printf '%s' "${LAST_TOOL_RAW}" | extract_result
+}
+
+tool_result_payload_json() {
+  printf '%s' "${LAST_TOOL_RAW}" | jq -c '
+    if ._harness_error? then
+      empty
+    else
+      try (.result.content[0].text | fromjson) catch empty
+    end
+  '
+}
+
+tool_result_text() {
+  printf '%s' "${LAST_TOOL_RAW}" | extract_text
+}
+
+tool_error_text() {
+  if [[ -n "${LAST_TOOL_ERROR}" ]]; then
+    printf '%s' "${LAST_TOOL_ERROR}"
+  else
+    printf '%s' "${LAST_TOOL_RAW}" | extract_error
+  fi
+}
+
+select_case_rows() {
+  local keepers_json case_ids_json
+  keepers_json="$(csv_to_json "${KEEPERS}")"
+  case_ids_json="$(csv_to_json "${CASE_IDS}")"
+  jq -c \
+    --argjson keepers "${keepers_json}" \
+    --argjson case_ids "${case_ids_json}" \
+    '
+      .cases[]
+      | . as $case
+      | select(($case_ids | length) == 0 or ($case_ids | index($case.id)))
+      | select(
+          ($keepers | length) == 0
+          or ([.keeper_profiles[] | select($keepers | index(.))] | length > 0)
+        )
+    ' "${CASES_PATH}"
+}
+
+keeper_profiles_for_case() {
+  local case_json="$1"
+  local keepers_json
+  keepers_json="$(csv_to_json "${KEEPERS}")"
+  printf '%s' "${case_json}" \
+    | jq -r --argjson keepers "${keepers_json}" '
+        .keeper_profiles[]
+        | select(($keepers | length) == 0 or ($keepers | index(.)))
+      '
+}
+
+prompt_contract_for_case() {
+  case "$1" in
+    read_search_prompt_fingerprint)
+      cat <<'EOF'
+Final reply contract:
+- Reply in Korean.
+- Output exactly two numbered lines.
+- Each line must contain one concrete file path and one short reason.
+EOF
+      ;;
+    text_only_triage)
+      cat <<'EOF'
+Final reply contract:
+- Reply in Korean.
+- Do not call any tools.
+- Output one short sentence starting with "text_only:".
+EOF
+      ;;
+    recovery_after_failed_read)
+      cat <<'EOF'
+Final reply contract:
+- Reply in Korean.
+- Output one short sentence starting with "recovered:".
+EOF
+      ;;
+    multi_step_board_update)
+      cat <<'EOF'
+Final reply contract:
+- Reply in Korean.
+- Output one short sentence starting with "verified:".
+EOF
+      ;;
+    *)
+      cat <<'EOF'
+Final reply contract:
+- Reply in Korean.
+- Keep the final answer short and evidence-based.
+EOF
+      ;;
+  esac
+}
+
+build_case_message() {
+  local case_json="$1"
+  local case_id prompt max_tool_calls contract
+  case_id="$(printf '%s' "${case_json}" | jq -r '.id')"
+  prompt="$(printf '%s' "${case_json}" | jq -r '.prompt')"
+  max_tool_calls="$(printf '%s' "${case_json}" | jq -r '.max_tool_calls')"
+  contract="$(prompt_contract_for_case "${case_id}")"
+  cat <<EOF
+Tool-quality benchmark case: ${case_id}
+Allowed workspace root: ${WORKSPACE_ROOT}
+Use repo-relative or absolute paths under the allowed workspace root.
+For shell commands, run inside this repo root when needed: ${WORKSPACE_ROOT}
+Keep tool usage repeatable and minimal.
+Target max_tool_calls: ${max_tool_calls}
+
+${contract}
+
+Task:
+${prompt}
+EOF
+}
+
+write_benchmark_persona_profile() {
+  local persona_name="$1"
+  local keeper_profile="$2"
+  local model_label="$3"
+  local persona_dir profile_path
+  local display_name role trait goal short_goal mid_goal long_goal will needs desires instructions
+
+  case "${keeper_profile}" in
+    bench-analyst)
+      display_name="Benchmark Analyst"
+      role="Repeatable tool-quality analyst"
+      trait="Deterministic evidence-first analyst"
+      goal="같은 입력에서 같은 도구 선택과 같은 근거 구조가 반복되도록 tool-quality benchmark 과제를 수행한다."
+      short_goal="지정된 과제를 필요한 최소 도구로 해결하고 동일한 evidence 경로를 재현한다."
+      mid_goal="benchmark 전반에서 불필요한 도구 호출을 줄이고 근거 기반 응답만 남긴다."
+      long_goal="provider:model 간 tool 선택 품질 차이를 낮은 분산으로 비교 가능한 형태로 남긴다."
+      will="필요한 도구만 호출하고, 한 번 확인한 사실을 같은 방식으로 반복 조회하지 않는다."
+      needs="명시된 benchmark 과제, 허용된 도구 표면, 접근 가능한 workspace root"
+      desires="같은 입력에서 거의 같은 tool sequence와 근거 구조가 반복되게 만든다."
+      instructions="너는 tool-quality benchmark 전용 analyst keeper다. 같은 입력에서 같은 근거와 같은 도구 선택이 반복되도록 행동한다. 허용된 도구가 필요할 때만 호출하고, text-only로 해결 가능하면 도구를 호출하지 않는다. 답은 짧고 구조적으로 유지하고, 최종 판단은 evidence 기반으로만 내린다."
+      ;;
+    bench-executor)
+      display_name="Benchmark Executor"
+      role="Repeatable tool-quality executor"
+      trait="Deterministic completion-focused executor"
+      goal="같은 입력에서 가능한 한 같은 순서와 같은 최소 도구 집합으로 benchmark 과제를 끝낸다."
+      short_goal="max_tool_calls 안에서 필요한 도구만 사용해 과제를 완료한다."
+      mid_goal="tool sequence와 완료 경로를 반복 가능하게 유지한다."
+      long_goal="completion 중심 keeper 프로필의 tool quality를 낮은 분산으로 비교 가능하게 만든다."
+      will="불필요한 탐색을 줄이고, 실패하면 한 번 다른 경로로 회복한 뒤 바로 마무리한다."
+      needs="명시된 benchmark 과제, 접근 가능한 workspace root, 허용된 tool surface"
+      desires="동일 과제에서 거의 같은 도구 순서와 완료 결과를 남긴다."
+      instructions="너는 tool-quality benchmark 전용 executor keeper다. 같은 입력에서는 가능한 한 같은 순서와 같은 최소 도구 집합으로 과제를 끝낸다. 필요한 도구만 호출하고, max_tool_calls 안에서 끝내는 것을 우선한다. 실패하면 무작정 반복하지 말고 한 번 다른 경로로 회복한 뒤 바로 마무리한다. 최종 출력은 완료 여부와 핵심 evidence만 남긴다."
+      ;;
+    bench-verifier)
+      display_name="Benchmark Verifier"
+      role="Repeatable tool-quality verifier"
+      trait="Deterministic recovery-focused verifier"
+      goal="같은 입력에서 같은 검증 절차를 반복 가능하게 수행하고, 필요한 경우 한 번만 회복한다."
+      short_goal="검증 과제를 측정 가능한 evidence로 판정하고, 회복이 필요하면 한 번만 전환한다."
+      mid_goal="failure 이후 recovery 경로의 품질을 반복 가능한 방식으로 남긴다."
+      long_goal="verification 중심 keeper 프로필의 tool quality와 recovery 품질을 비교 가능하게 만든다."
+      will="추측으로 통과시키지 않고, 실패 후 회복도 측정 가능한 단계로만 수행한다."
+      needs="검증 과제, 접근 가능한 workspace root, 허용된 tool surface"
+      desires="동일 검증 과제에서 거의 같은 recovery 절차와 판정 결과를 남긴다."
+      instructions="너는 tool-quality benchmark 전용 verifier keeper다. 같은 입력에서 같은 검증 절차를 반복 가능하게 수행한다. 검증이 필요하면 측정 가능한 evidence를 우선하고, 실패 후 회복이 필요하면 다른 도구나 다른 인자로 한 번만 전환한다. 추측으로 통과시키지 않는다. 출력은 pass/fail와 미충족 조건을 명확히 남긴다."
+      ;;
+    *)
+      echo "unknown benchmark keeper profile: ${keeper_profile}" >&2
+      return 1
+      ;;
+  esac
+
+  persona_dir="${PERSONAS_DIR}/${persona_name}"
+  profile_path="${persona_dir}/profile.json"
+  mkdir -p "${persona_dir}"
+  jq -n \
+    --arg name "${display_name}" \
+    --arg role "${role}" \
+    --arg trait "${trait}" \
+    --arg goal "${goal}" \
+    --arg short_goal "${short_goal}" \
+    --arg mid_goal "${mid_goal}" \
+    --arg long_goal "${long_goal}" \
+    --arg will "${will}" \
+    --arg needs "${needs}" \
+    --arg desires "${desires}" \
+    --arg instructions "${instructions}" \
+    --arg mention "${keeper_profile}" \
+    --arg model "${model_label}" \
+    '{
+      name: $name,
+      role: $role,
+      trait: $trait,
+      keeper: {
+        goal: $goal,
+        short_goal: $short_goal,
+        mid_goal: $mid_goal,
+        long_goal: $long_goal,
+        will: $will,
+        needs: $needs,
+        desires: $desires,
+        instructions: $instructions,
+        mention_targets: [$mention],
+        tool_preset: "coding",
+        tool_also_allow: ["masc_board_post"],
+        proactive_enabled: false,
+        telemetry_feedback_enabled: false,
+        max_turns_per_call: 6,
+        cascade_name: "keeper_unified",
+        models: [$model]
+      }
+    }' > "${profile_path}"
+}
+
+prepare_live_environment() {
+  local run_suffix
+  require_cmd jq
+  require_cmd curl
+  run_suffix="$(date +%Y%m%d_%H%M%S)-$$"
+  LIVE_RUN_DIR="${OUT_DIR}/live-${run_suffix}"
+  RAW_DIR="${LIVE_RUN_DIR}/raw"
+  TARGET_DIR="${LIVE_RUN_DIR}/target"
+  CONFIG_DIR="${LIVE_RUN_DIR}/config"
+  PERSONAS_DIR="${LIVE_RUN_DIR}/personas"
+  SERVER_LOG="${LIVE_RUN_DIR}/server.log"
+
+  mkdir -p "${RAW_DIR}" "${TARGET_DIR}" "${CONFIG_DIR}" "${PERSONAS_DIR}"
+  cp -R "${ROOT_DIR}/config/." "${CONFIG_DIR}"
+
+  if [[ -z "${PORT}" ]]; then
+    PORT="$(harness_pick_free_port)"
+  fi
+}
+
+start_live_server() {
+  local launch_log="${LIVE_RUN_DIR}/launch.log"
+  local bootstrap_log="${LIVE_RUN_DIR}/bootstrap.log"
+  (
+    export MASC_CONFIG_DIR="${CONFIG_DIR}"
+    export MASC_PERSONAS_DIR="${PERSONAS_DIR}"
+    export MASC_LOG_FILE="${SERVER_LOG}"
+    export MASC_STORAGE_TYPE="filesystem"
+    export MASC_AUTONOMY_ENABLED="0"
+    export MASC_ORCHESTRATOR_ENABLED="0"
+    export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
+    export MASC_ALLOW_LEGACY_ACCEPT="1"
+    export GRAPHQL_API_KEY=""
+    export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+    export OAS_CLAUDE_STRICT_MCP="1"
+    export OAS_GEMINI_NO_MCP="1"
+    export OAS_GEMINI_APPROVAL_MODE="plan"
+    export OAS_CODEX_CONFIG="mcp_servers={}"
+    exec "${ROOT_DIR}/scripts/run-local.sh" \
+      --target-dir "${TARGET_DIR}" \
+      --port "${PORT}" \
+      --bootstrap-only
+  ) >"${bootstrap_log}" 2>&1
+  (
+    export MASC_CONFIG_DIR="${CONFIG_DIR}"
+    export MASC_PERSONAS_DIR="${PERSONAS_DIR}"
+    export MASC_LOG_FILE="${SERVER_LOG}"
+    export MASC_STORAGE_TYPE="filesystem"
+    export MASC_AUTONOMY_ENABLED="0"
+    export MASC_ORCHESTRATOR_ENABLED="0"
+    export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
+    export MASC_ALLOW_LEGACY_ACCEPT="1"
+    export GRAPHQL_API_KEY=""
+    export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+    export OAS_CLAUDE_STRICT_MCP="1"
+    export OAS_GEMINI_NO_MCP="1"
+    export OAS_GEMINI_APPROVAL_MODE="plan"
+    export OAS_CODEX_CONFIG="mcp_servers={}"
+    exec "${ROOT_DIR}/scripts/run-local.sh" --target-dir "${TARGET_DIR}" --port "${PORT}"
+  ) >"${launch_log}" 2>&1 &
+  SERVER_PID="$!"
+
+  if ! harness_wait_for_health "${PORT}" 45; then
+    harness_print_log_tail "${bootstrap_log}" 120
+    harness_print_log_tail "${launch_log}" 120
+    harness_print_log_tail "${SERVER_LOG}" 120
+    echo "live harness failed: server did not become healthy on port ${PORT}" >&2
+    exit 1
+  fi
+
+  MCP_URL="http://127.0.0.1:${PORT}/mcp"
+  export MCP_URL
+  if ! initialize_mcp_session; then
+    harness_print_log_tail "${SERVER_LOG}" 120
+    echo "live harness failed: MCP initialize did not return a session id" >&2
+    exit 1
+  fi
+}
+
+read_tool_log_entries() {
+  local keeper_name="$1"
+  local log_dir="${TARGET_DIR}/.masc/tool_calls"
+  if [[ ! -d "${log_dir}" ]]; then
+    printf '[]'
+    return 0
+  fi
+  find "${log_dir}" -type f -name '*.jsonl' | LC_ALL=C sort \
+    | while IFS= read -r path; do
+        cat "${path}"
+      done \
+    | jq -cs --arg keeper "${keeper_name}" '
+        map(select(.keeper == $keeper))
+      '
+}
+
+tool_calls_for_evidence() {
+  local tool_log_json="$1"
+  printf '%s' "${tool_log_json}" | jq -c '
+    [ .[]
+      | {
+          tool_name: .tool,
+          success: (.success // false),
+          input: (.input // {}),
+          output: (.output // null),
+          duration_ms: (.duration_ms // null)
+        }
+    ]
+  '
+}
+
+latest_metrics_for_keeper() {
+  local keeper_name="$1"
+  local metrics_dir="${TARGET_DIR}/.masc/keepers/${keeper_name}/metrics"
+  if [[ ! -d "${metrics_dir}" ]]; then
+    printf 'null'
+    return 0
+  fi
+  find "${metrics_dir}" -type f -name '*.jsonl' | LC_ALL=C sort \
+    | while IFS= read -r path; do
+        cat "${path}"
+      done \
+    | jq -cs 'map(select(type == "object")) | last // null'
+}
+
+prompt_fingerprint_for_run() {
+  local tool_log_json="$1"
+  local metrics_json="$2"
+  local fp
+  fp="$(printf '%s' "${tool_log_json}" | jq -r '
+      map(.prompt_fingerprint // empty)
+      | map(select(length > 0))
+      | .[0] // empty
+    ')"
+  if [[ -n "${fp}" ]]; then
+    printf '%s' "${fp}"
+    return 0
+  fi
+  printf '%s' "${metrics_json}" | jq -r '.prompt_fingerprint // empty'
+}
+
+tool_surface_fingerprint_from_status() {
+  local status_json="$1"
+  local surface
+  surface="$(printf '%s' "${status_json}" | jq -r '
+      [.allowed_tool_names[]?]
+      | sort
+      | join(",")
+    ')"
+  if [[ -z "${surface}" ]]; then
+    printf ''
+  else
+    sha256_text "${surface}"
+  fi
+}
+
+derive_final_result() {
+  local case_id="$1"
+  local tool_calls_json="$2"
+
+  case "${case_id}" in
+    read_search_prompt_fingerprint)
+      printf '%s' "${tool_calls_json}" | jq -c '
+        def search_hit:
+          any(.[]; .tool_name == "keeper_tool_search"
+                    and ((.input.query // "") | tostring | contains("prompt_fingerprint")));
+        def read_hit:
+          any(.[]; .tool_name == "keeper_fs_read"
+                    and ((.input.path // "") | tostring | contains("keeper_tool_call_log")));
+        {
+          status: (if search_hit and read_hit then "completed" else "incomplete" end),
+          evidence_found: ((if search_hit then 1 else 0 end) + (if read_hit then 1 else 0 end))
+        }
+      '
+      ;;
+    text_only_triage)
+      printf '%s' "${tool_calls_json}" | jq -c '
+        {
+          status: (if length == 0 then "completed" else "incomplete" end),
+          mode: (if length == 0 then "text_only" else "tool_used" end)
+        }
+      '
+      ;;
+    recovery_after_failed_read)
+      printf '%s' "${tool_calls_json}" | jq -c '
+        def failure_index:
+          first(
+            to_entries[]
+            | select(.value.tool_name == "keeper_fs_read" and (.value.success | not))
+            | .key
+          );
+        def recovered_after_failure($idx):
+          any(
+            to_entries[];
+            .key > $idx
+            and .value.tool_name == "keeper_fs_read"
+            and .value.success
+            and ((.value.input.path // "") | tostring | contains("keeper_agent_run.ml"))
+          );
+        def searched:
+          any(.[]; .tool_name == "keeper_tool_search"
+                    and ((.input.query // "") | tostring | contains("keeper_agent_run")));
+        (failure_index) as $idx
+        | {
+            status: (if ($idx != null and searched and recovered_after_failure($idx))
+                     then "completed" else "incomplete" end),
+            recovered: ($idx != null and searched and recovered_after_failure($idx))
+          }
+      '
+      ;;
+    multi_step_board_update)
+      printf '%s' "${tool_calls_json}" | jq -c '
+        def search_hit:
+          any(.[]; .tool_name == "keeper_tool_search");
+        def bash_hit:
+          any(.[]; .tool_name == "keeper_bash" and .success);
+        def board_hit:
+          any(
+            .[];
+            .tool_name == "masc_board_post"
+            and .success
+            and (
+              ((.input.body // .input.content // "") | tostring | ascii_downcase)
+              | contains("verified")
+            )
+          );
+        {
+          status: (if search_hit and bash_hit and board_hit then "completed" else "incomplete" end),
+          board_updated: (search_hit and bash_hit and board_hit)
+        }
+      '
+      ;;
+    *)
+      jq -cn '{status:"unknown"}'
+      ;;
+  esac
+}
+
+task_success_from_final_result() {
+  local case_id="$1"
+  local final_result_json="$2"
+  case "${case_id}" in
+    read_search_prompt_fingerprint)
+      printf '%s' "${final_result_json}" | jq -e '.status == "completed" and (.evidence_found // 0) >= 2' >/dev/null
+      ;;
+    text_only_triage)
+      printf '%s' "${final_result_json}" | jq -e '.status == "completed" and .mode == "text_only"' >/dev/null
+      ;;
+    recovery_after_failed_read)
+      printf '%s' "${final_result_json}" | jq -e '.status == "completed" and .recovered == true' >/dev/null
+      ;;
+    multi_step_board_update)
+      printf '%s' "${final_result_json}" | jq -e '.status == "completed" and .board_updated == true' >/dev/null
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+classify_status() {
+  local text
+  text="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "${text}" in
+    *"not supported"*|*"unsupported"*|*"invalid_request_error"*|*"unknown model"*|*"model_not_found"*)
+      printf 'unsupported'
+      ;;
+    *)
+      printf 'executed_failed'
+      ;;
+  esac
+}
+
+create_keeper_status_snapshot() {
+  local keeper_name="$1"
+  local run_dir="$2"
+  local args status_json
+  args="$(jq -cn --arg name "${keeper_name}" '{name:$name, fast:true}')"
+  if call_mcp_tool 2500 "masc_keeper_status" "${args}" 30; then
+    status_json="$(tool_result_json)"
+    printf '%s' "${status_json}" > "${run_dir}/keeper-status.json"
+    printf '%s' "${status_json}"
+  else
+    printf 'null'
+  fi
+}
+
+stop_keeper_best_effort() {
+  local keeper_name="$1"
+  local args
+  args="$(jq -cn --arg name "${keeper_name}" '{name:$name}')"
+  call_mcp_tool 9000 "masc_keeper_down" "${args}" 20 >/dev/null 2>&1 || true
+}
+
+run_live_case() {
+  local provider="$1"
+  local model="$2"
+  local model_label="$3"
+  local keeper_profile="$4"
+  local repeat_index="$5"
+  local case_json="$6"
+
+  local case_id keeper_name run_slug run_dir persona_name
+  local message create_args create_json status_before_json status_after_json
+  local request_json request_id result_json msg_payload final_output tool_log_json
+  local tool_calls_json metrics_json prompt_fingerprint tool_surface_fingerprint
+  local final_result_json task_success=false run_status latency_ms
+  local input_tokens output_tokens cost_usd actual_model_used
+  local start_epoch end_epoch
+
+  case_id="$(printf '%s' "${case_json}" | jq -r '.id')"
+  run_slug="$(slugify "${provider}-${model}-${keeper_profile}-${case_id}-r${repeat_index}")"
+  keeper_name="bench-${run_slug}"
+  persona_name="${keeper_name}"
+  run_dir="${RAW_DIR}/${keeper_name}"
+  mkdir -p "${run_dir}"
+
+  write_benchmark_persona_profile "${persona_name}" "${keeper_profile}" "${model_label}"
+  message="$(build_case_message "${case_json}")"
+
+  create_args="$(jq -cn \
+    --arg persona_name "${persona_name}" \
+    --argjson allowed_paths "$(jq -cn --arg path "${WORKSPACE_ROOT}" '[ $path ]')" \
+    '{
+      persona_name: $persona_name,
+      autoboot_enabled: false,
+      proactive_enabled: false,
+      auto_handoff: false,
+      execution_scope: "workspace",
+      allowed_paths: $allowed_paths
+    }')"
+
+  if ! call_mcp_tool 2000 "masc_keeper_create_from_persona" "${create_args}" 45; then
+    local create_error
+    create_error="$(tool_error_text)"
+    jq -cn \
+      --arg case_id "${case_id}" \
+      --arg provider "${provider}" \
+      --arg model "${model}" \
+      --arg keeper_profile "${keeper_profile}" \
+      --arg run_id "${keeper_name}" \
+      --argjson repeat_index "${repeat_index}" \
+      --arg status "$(classify_status "${create_error}")" \
+      --arg final_output "${create_error}" \
+      '{
+        case_id: $case_id,
+        provider: $provider,
+        model: $model,
+        keeper_profile: $keeper_profile,
+        run_id: $run_id,
+        repeat_index: $repeat_index,
+        status: $status,
+        final_output: $final_output,
+        task_success: false,
+        tool_calls: []
+      }' > "${run_dir}/evidence.json"
+    cat "${run_dir}/evidence.json"
+    return 0
+  fi
+
+  create_json="$(tool_result_json)"
+  printf '%s' "${create_json}" > "${run_dir}/create.json"
+  status_before_json="$(create_keeper_status_snapshot "${keeper_name}" "${run_dir}")"
+  tool_surface_fingerprint="$(tool_surface_fingerprint_from_status "${status_before_json}")"
+
+  start_epoch="$(date +%s)"
+  if ! call_mcp_tool 3000 "masc_keeper_msg" \
+    "$(jq -cn --arg name "${keeper_name}" --arg message "${message}" --argjson timeout "${TIMEOUT_SEC}" '{name:$name, message:$message, timeout_sec:$timeout}')" \
+    "$((TIMEOUT_SEC + 30))"; then
+    local msg_error
+    msg_error="$(tool_error_text)"
+    stop_keeper_best_effort "${keeper_name}"
+    jq -cn \
+      --arg case_id "${case_id}" \
+      --arg provider "${provider}" \
+      --arg model "${model}" \
+      --arg keeper_profile "${keeper_profile}" \
+      --arg run_id "${keeper_name}" \
+      --argjson repeat_index "${repeat_index}" \
+      --arg status "$(classify_status "${msg_error}")" \
+      --arg final_output "${msg_error}" \
+      --arg keeper_name "${keeper_name}" \
+      --arg tool_surface_fingerprint "${tool_surface_fingerprint}" \
+      '{
+        case_id: $case_id,
+        provider: $provider,
+        model: $model,
+        keeper_profile: $keeper_profile,
+        run_id: $run_id,
+        repeat_index: $repeat_index,
+        keeper_name: $keeper_name,
+        tool_surface_fingerprint: (if $tool_surface_fingerprint == "" then null else $tool_surface_fingerprint end),
+        status: $status,
+        final_output: $final_output,
+        task_success: false,
+        tool_calls: []
+      }' > "${run_dir}/evidence.json"
+    cat "${run_dir}/evidence.json"
+    return 0
+  fi
+
+  request_json="$(tool_result_json)"
+  printf '%s' "${request_json}" > "${run_dir}/msg-submit.json"
+  request_id="$(printf '%s' "${request_json}" | jq -r '.request_id // empty')"
+  if [[ -z "${request_id}" ]]; then
+    stop_keeper_best_effort "${keeper_name}"
+    jq -cn \
+      --arg case_id "${case_id}" \
+      --arg provider "${provider}" \
+      --arg model "${model}" \
+      --arg keeper_profile "${keeper_profile}" \
+      --arg run_id "${keeper_name}" \
+      --argjson repeat_index "${repeat_index}" \
+      --arg status "runtime_unreachable" \
+      --arg final_output "keeper_msg returned no request_id" \
+      --arg keeper_name "${keeper_name}" \
+      --arg tool_surface_fingerprint "${tool_surface_fingerprint}" \
+      '{
+        case_id: $case_id,
+        provider: $provider,
+        model: $model,
+        keeper_profile: $keeper_profile,
+        run_id: $run_id,
+        repeat_index: $repeat_index,
+        keeper_name: $keeper_name,
+        tool_surface_fingerprint: (if $tool_surface_fingerprint == "" then null else $tool_surface_fingerprint end),
+        status: $status,
+        final_output: $final_output,
+        task_success: false,
+        tool_calls: []
+      }' > "${run_dir}/evidence.json"
+    cat "${run_dir}/evidence.json"
+    return 0
+  fi
+
+  local poll_deadline
+  poll_deadline=$(( start_epoch + TIMEOUT_SEC + 30 ))
+  result_json=""
+  while [[ "$(date +%s)" -lt "${poll_deadline}" ]]; do
+    if call_mcp_tool 3100 "masc_keeper_msg_result" \
+      "$(jq -cn --arg request_id "${request_id}" '{request_id:$request_id}')" 20; then
+      msg_payload="$(tool_result_payload_json)"
+      printf '%s' "${msg_payload}" > "${run_dir}/msg-result-last.json"
+      case "$(printf '%s' "${msg_payload}" | jq -r '.status // empty')" in
+        done|error)
+          result_json="${msg_payload}"
+          break
+          ;;
+      esac
+    fi
+    sleep "${POLL_INTERVAL_SEC}"
+  done
+
+  if [[ -z "${result_json}" ]]; then
+    stop_keeper_best_effort "${keeper_name}"
+    jq -cn \
+      --arg case_id "${case_id}" \
+      --arg provider "${provider}" \
+      --arg model "${model}" \
+      --arg keeper_profile "${keeper_profile}" \
+      --arg run_id "${keeper_name}" \
+      --argjson repeat_index "${repeat_index}" \
+      --arg status "runtime_unreachable" \
+      --arg final_output "keeper_msg_result polling timed out" \
+      --arg keeper_name "${keeper_name}" \
+      --arg tool_surface_fingerprint "${tool_surface_fingerprint}" \
+      '{
+        case_id: $case_id,
+        provider: $provider,
+        model: $model,
+        keeper_profile: $keeper_profile,
+        run_id: $run_id,
+        repeat_index: $repeat_index,
+        keeper_name: $keeper_name,
+        tool_surface_fingerprint: (if $tool_surface_fingerprint == "" then null else $tool_surface_fingerprint end),
+        status: $status,
+        final_output: $final_output,
+        task_success: false,
+        tool_calls: []
+      }' > "${run_dir}/evidence.json"
+    cat "${run_dir}/evidence.json"
+    return 0
+  fi
+
+  end_epoch="$(date +%s)"
+  latency_ms="$(( (end_epoch - start_epoch) * 1000 ))"
+  printf '%s' "${result_json}" > "${run_dir}/msg-result.json"
+
+  tool_log_json="$(read_tool_log_entries "${keeper_name}")"
+  printf '%s' "${tool_log_json}" > "${run_dir}/tool-log.json"
+  tool_calls_json="$(tool_calls_for_evidence "${tool_log_json}")"
+  printf '%s' "${tool_calls_json}" > "${run_dir}/tool-calls.json"
+
+  metrics_json="$(latest_metrics_for_keeper "${keeper_name}")"
+  printf '%s' "${metrics_json}" > "${run_dir}/latest-metrics.json"
+  prompt_fingerprint="$(prompt_fingerprint_for_run "${tool_log_json}" "${metrics_json}")"
+
+  status_after_json="$(create_keeper_status_snapshot "${keeper_name}" "${run_dir}")"
+  if [[ -z "${tool_surface_fingerprint}" ]]; then
+    tool_surface_fingerprint="$(tool_surface_fingerprint_from_status "${status_after_json}")"
+  fi
+
+  final_output="$(printf '%s' "${result_json}" | jq -r '
+      if (.result.reply? // empty) != "" then .result.reply
+      elif (.result | type) == "string" then .result
+      else (.result | tostring)
+      end
+    ')"
+  input_tokens="$(printf '%s' "${result_json}" | jq -r '.result.usage.input_tokens // empty')"
+  output_tokens="$(printf '%s' "${result_json}" | jq -r '.result.usage.output_tokens // empty')"
+  cost_usd="$(printf '%s' "${result_json}" | jq -r '.result.usage.cost_usd // empty')"
+  actual_model_used="$(printf '%s' "${result_json}" | jq -r '.result.model // empty')"
+
+  if [[ "$(printf '%s' "${result_json}" | jq -r '.status')" == "done" ]] \
+    && [[ "$(printf '%s' "${result_json}" | jq -r '.ok // false')" == "true" ]]; then
+    run_status="ok"
+    final_result_json="$(derive_final_result "${case_id}" "${tool_calls_json}")"
+    if task_success_from_final_result "${case_id}" "${final_result_json}"; then
+      task_success=true
+    fi
+  else
+    local failure_text
+    failure_text="$(printf '%s' "${result_json}" | jq -r '
+        if (.result | type) == "string" then .result
+        else (.result | tostring)
+        end
+      ')"
+    run_status="$(classify_status "${failure_text}")"
+    final_result_json='null'
+  fi
+
+  stop_keeper_best_effort "${keeper_name}"
+
+  jq -cn \
+    --arg case_id "${case_id}" \
+    --arg provider "${provider}" \
+    --arg model "${model}" \
+    --arg keeper_profile "${keeper_profile}" \
+    --arg run_id "${keeper_name}" \
+    --arg keeper_name "${keeper_name}" \
+    --argjson repeat_index "${repeat_index}" \
+    --arg prompt_fingerprint "${prompt_fingerprint}" \
+    --arg tool_surface_fingerprint "${tool_surface_fingerprint}" \
+    --arg status "${run_status}" \
+    --arg final_output "${final_output}" \
+    --arg actual_model_used "${actual_model_used}" \
+    --argjson task_success "$( [[ "${task_success}" == "true" ]] && printf 'true' || printf 'false' )" \
+    --argjson final_result "${final_result_json}" \
+    --argjson tool_calls "${tool_calls_json}" \
+    --argjson latency_ms "${latency_ms:-null}" \
+    --argjson input_tokens "${input_tokens:-null}" \
+    --argjson output_tokens "${output_tokens:-null}" \
+    --argjson cost_usd "${cost_usd:-null}" \
+    '{
+      case_id: $case_id,
+      provider: $provider,
+      model: $model,
+      keeper_profile: $keeper_profile,
+      run_id: $run_id,
+      repeat_index: $repeat_index,
+      keeper_name: $keeper_name,
+      prompt_fingerprint: (if $prompt_fingerprint == "" then null else $prompt_fingerprint end),
+      tool_surface_fingerprint: (if $tool_surface_fingerprint == "" then null else $tool_surface_fingerprint end),
+      task_success: $task_success,
+      final_output: $final_output,
+      final_result: $final_result,
+      latency_ms: $latency_ms,
+      input_tokens: $input_tokens,
+      output_tokens: $output_tokens,
+      cost_usd: $cost_usd,
+      status: $status,
+      actual_model_used: (if $actual_model_used == "" then null else $actual_model_used end),
+      tool_calls: $tool_calls
+    }' > "${run_dir}/evidence.json"
+  cat "${run_dir}/evidence.json"
+}
+
+run_live_harness() {
+  local model_label provider model case_json keeper_profile repeat_index
+  local evidence_jsonl raw_evidence_path args
+
+  if [[ -z "${MODELS}" ]]; then
+    echo "--live requires --models provider:model[,provider:model]" >&2
+    exit 2
+  fi
+  if ! [[ "${REPEATS}" =~ ^[0-9]+$ ]] || [[ "${REPEATS}" -le 0 ]]; then
+    echo "--repeats must be a positive integer" >&2
+    exit 2
+  fi
+  if ! [[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || [[ "${TIMEOUT_SEC}" -le 0 ]]; then
+    echo "--timeout-sec must be a positive integer" >&2
+    exit 2
+  fi
+
+  prepare_live_environment
+  start_live_server
+
+  evidence_jsonl="${LIVE_RUN_DIR}/evidence_runs.jsonl"
+  : > "${evidence_jsonl}"
+
+  while IFS= read -r model_label; do
+    model_label="$(trim "${model_label}")"
+    [[ -z "${model_label}" ]] && continue
+    if [[ "${model_label}" != *:* ]]; then
+      echo "invalid model label (expected provider:model): ${model_label}" >&2
+      exit 2
+    fi
+    provider="${model_label%%:*}"
+    model="${model_label#*:}"
+    while IFS= read -r case_json; do
+      [[ -z "${case_json}" ]] && continue
+      while IFS= read -r keeper_profile; do
+        [[ -z "${keeper_profile}" ]] && continue
+        for (( repeat_index = 1; repeat_index <= REPEATS; repeat_index++ )); do
+          run_live_case "${provider}" "${model}" "${model_label}" "${keeper_profile}" "${repeat_index}" "${case_json}" \
+            >> "${evidence_jsonl}"
+        done
+      done < <(keeper_profiles_for_case "${case_json}")
+    done < <(select_case_rows)
+  done < <(printf '%s\n' "${MODELS}" | tr ',' '\n')
+
+  raw_evidence_path="${LIVE_RUN_DIR}/evidence_runs.json"
+  jq -cs '{runs: .}' "${evidence_jsonl}" > "${raw_evidence_path}"
+  EVIDENCE_PATH="${raw_evidence_path}"
+
+  ensure_cli_built
+  (
+    cd "${ROOT_DIR}"
+    args=(
+      --cases "${CASES_PATH}"
+      --evidence "${EVIDENCE_PATH}"
+      --format "${FORMAT}"
+      --view "${VIEW}"
+      --artifact-dir "${LIVE_RUN_DIR}"
+    )
+    if [[ -n "${MODELS}" ]]; then
+      args+=(--models "${MODELS}")
+    fi
+    if [[ -n "${KEEPERS}" ]]; then
+      args+=(--keepers "${KEEPERS}")
+    fi
+    "${CLI_EXE}" "${args[@]}"
+  )
+
+  printf '\nartifact_dir=%s\n' "${LIVE_RUN_DIR}"
+  printf 'evidence_path=%s\n' "${EVIDENCE_PATH}"
+}
+
+run_evidence_summary() {
+  local args
+  ensure_cli_built
+  mkdir -p "${OUT_DIR}"
+  (
+    cd "${ROOT_DIR}"
+    args=(
+      --cases "${CASES_PATH}"
+      --evidence "${EVIDENCE_PATH}"
+      --format "${FORMAT}"
+      --view "${VIEW}"
+      --artifact-dir "${OUT_DIR}"
+    )
+    if [[ -n "${MODELS}" ]]; then
+      args+=(--models "${MODELS}")
+    fi
+    if [[ -n "${KEEPERS}" ]]; then
+      args+=(--keepers "${KEEPERS}")
+    fi
+    "${CLI_EXE}" "${args[@]}"
+  )
+  printf '\nartifact_dir=%s\n' "${OUT_DIR}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cases)
+      CASES_PATH="$2"
+      shift 2
+      ;;
+    --case-ids)
+      CASE_IDS="$2"
+      shift 2
+      ;;
+    --evidence)
+      EVIDENCE_PATH="$2"
+      shift 2
+      ;;
+    --format)
+      FORMAT="$2"
+      shift 2
+      ;;
+    --view)
+      VIEW="$2"
+      shift 2
+      ;;
+    --artifact-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --models)
+      MODELS="$2"
+      shift 2
+      ;;
+    --keepers)
+      KEEPERS="$2"
+      shift 2
+      ;;
+    --live)
+      LIVE_MODE=1
+      shift
+      ;;
+    --repeats)
+      REPEATS="$2"
+      shift 2
+      ;;
+    --timeout-sec)
+      TIMEOUT_SEC="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "${OUT_DIR}"
+
+if [[ "${LIVE_MODE}" == "1" ]]; then
+  run_live_harness
+else
+  run_evidence_summary
+fi

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,7 @@
         test_keeper_allowed_paths
         test_keeper_repo_readiness
         test_keeper_tool_surface_guard
+        test_keeper_benchmark_canary
         test_keeper_pr_review
         test_keeper_execution_scope
         test_playground_paths
@@ -121,6 +122,7 @@
         test_adversarial_eval
         test_labeling
         test_tool_deep_review
+        test_tool_call_quality_benchmark
         test_typed_state
         test_keeper_prompt_metrics
         test_cache_metrics_wiring
@@ -182,6 +184,7 @@
           test_keeper_allowed_paths
           test_keeper_repo_readiness
           test_keeper_tool_surface_guard
+          test_keeper_benchmark_canary
           test_keeper_pr_review
           test_keeper_execution_scope
           test_playground_paths
@@ -239,6 +242,7 @@
           test_adversarial_eval
           test_labeling
           test_tool_deep_review
+          test_tool_call_quality_benchmark
           test_typed_state
           test_keeper_prompt_metrics
           test_cache_metrics_wiring
@@ -662,17 +666,6 @@
  (action
   (setenv MASC_CASCADE_JSON_PATH %{workspace_root}/config/cascade.json
    (run %{test})))
- (libraries masc_test_deps))
-
-(test
- (name test_cascade_toml_materialization)
- (modules test_cascade_toml_materialization)
- (deps %{workspace_root}/config/cascade.toml
-       %{workspace_root}/config/cascade.json)
- (action
-  (setenv MASC_CASCADE_TOML_PATH %{workspace_root}/config/cascade.toml
-   (setenv MASC_CASCADE_JSON_PATH %{workspace_root}/config/cascade.json
-    (run %{test}))))
  (libraries masc_test_deps))
 
 (test
@@ -1157,6 +1150,11 @@
 (executable
  (name test_repo_synthesis_benchmark)
  (modules test_repo_synthesis_benchmark)
+ (libraries masc_test_deps))
+
+(executable
+ (name tool_call_quality_benchmark_cli)
+ (modules tool_call_quality_benchmark_cli)
  (libraries masc_test_deps))
 
 (executable

--- a/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
+++ b/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
@@ -1,0 +1,259 @@
+{
+  "runs": [
+    {
+      "case_id": "read_search_prompt_fingerprint",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "keeper_profile": "bench-analyst",
+      "run_id": "run-openai-analyst-1",
+      "repeat_index": 1,
+      "prompt_fingerprint": "fp-analyst-a",
+      "task_success": true,
+      "latency_ms": 1800,
+      "input_tokens": 820,
+      "output_tokens": 160,
+      "cost_usd": 0.021,
+      "status": "ok",
+      "final_output": "completed",
+      "final_result": {
+        "status": "completed",
+        "evidence_found": 2
+      },
+      "tool_calls": [
+        {
+          "tool_name": "keeper_tool_search",
+          "success": true,
+          "duration_ms": 24.0,
+          "input": {
+            "query": "prompt_fingerprint keeper_tool_call_log"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 31.0,
+          "input": {
+            "path": "lib/keeper_tool_call_log.ml"
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "read_search_prompt_fingerprint",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "keeper_profile": "bench-analyst",
+      "run_id": "run-openai-analyst-2",
+      "repeat_index": 2,
+      "prompt_fingerprint": "fp-analyst-a",
+      "task_success": true,
+      "latency_ms": 1760,
+      "input_tokens": 810,
+      "output_tokens": 158,
+      "cost_usd": 0.020,
+      "status": "ok",
+      "final_output": "completed",
+      "final_result": {
+        "status": "completed",
+        "evidence_found": 2
+      },
+      "tool_calls": [
+        {
+          "tool_name": "keeper_tool_search",
+          "success": true,
+          "duration_ms": 23.0,
+          "input": {
+            "query": "prompt_fingerprint keeper_tool_call_log"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 33.0,
+          "input": {
+            "path": "lib/keeper_tool_call_log.ml"
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "read_search_prompt_fingerprint",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "keeper_profile": "bench-executor",
+      "run_id": "run-openai-executor-1",
+      "repeat_index": 1,
+      "prompt_fingerprint": "fp-executor-a",
+      "task_success": true,
+      "latency_ms": 2010,
+      "input_tokens": 900,
+      "output_tokens": 220,
+      "cost_usd": 0.025,
+      "status": "ok",
+      "final_output": "completed",
+      "final_result": {
+        "status": "completed",
+        "evidence_found": 2
+      },
+      "tool_calls": [
+        {
+          "tool_name": "keeper_tool_search",
+          "success": true,
+          "duration_ms": 19.0,
+          "input": {
+            "query": "prompt_fingerprint keeper_tool_call_log"
+          }
+        },
+        {
+          "tool_name": "keeper_bash",
+          "success": true,
+          "duration_ms": 48.0,
+          "input": {
+            "cmd": "rg prompt_fingerprint lib"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 30.0,
+          "input": {
+            "path": "lib/keeper_tool_call_log.ml"
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "text_only_triage",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "keeper_profile": "bench-analyst",
+      "run_id": "run-openai-text-only-1",
+      "repeat_index": 1,
+      "prompt_fingerprint": "fp-analyst-text",
+      "task_success": true,
+      "latency_ms": 640,
+      "input_tokens": 250,
+      "output_tokens": 72,
+      "cost_usd": 0.004,
+      "status": "ok",
+      "final_output": "text only",
+      "final_result": {
+        "status": "completed",
+        "mode": "text_only"
+      },
+      "tool_calls": []
+    },
+    {
+      "case_id": "recovery_after_failed_read",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "keeper_profile": "bench-verifier",
+      "run_id": "run-openai-verifier-1",
+      "repeat_index": 1,
+      "prompt_fingerprint": "fp-verifier-a",
+      "task_success": true,
+      "latency_ms": 1890,
+      "input_tokens": 710,
+      "output_tokens": 145,
+      "cost_usd": 0.011,
+      "status": "ok",
+      "final_output": "recovered",
+      "final_result": {
+        "status": "completed",
+        "recovered": true
+      },
+      "tool_calls": [
+        {
+          "tool_name": "keeper_fs_read",
+          "success": false,
+          "duration_ms": 15.0,
+          "input": {
+            "path": "lib/missing_file.ml"
+          }
+        },
+        {
+          "tool_name": "keeper_tool_search",
+          "success": true,
+          "duration_ms": 20.0,
+          "input": {
+            "query": "keeper_agent_run prompt_fingerprint"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 34.0,
+          "input": {
+            "path": "lib/keeper/keeper_agent_run.ml"
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "recovery_after_failed_read",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "keeper_profile": "bench-verifier",
+      "run_id": "run-openai-verifier-2",
+      "repeat_index": 2,
+      "prompt_fingerprint": "fp-verifier-b",
+      "task_success": true,
+      "latency_ms": 1950,
+      "input_tokens": 735,
+      "output_tokens": 150,
+      "cost_usd": 0.012,
+      "status": "ok",
+      "final_output": "recovered",
+      "final_result": {
+        "status": "completed",
+        "recovered": true
+      },
+      "tool_calls": [
+        {
+          "tool_name": "keeper_fs_read",
+          "success": false,
+          "duration_ms": 18.0,
+          "input": {
+            "path": "lib/missing_file.ml"
+          }
+        },
+        {
+          "tool_name": "keeper_tool_search",
+          "success": true,
+          "duration_ms": 24.0,
+          "input": {
+            "query": "keeper_agent_run prompt_fingerprint"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 39.0,
+          "input": {
+            "path": "lib/keeper/keeper_agent_run.ml"
+          }
+        },
+        {
+          "tool_name": "keeper_fs_read",
+          "success": true,
+          "duration_ms": 22.0,
+          "input": {
+            "path": "lib/keeper/keeper_agent_run.ml"
+          }
+        }
+      ]
+    },
+    {
+      "case_id": "multi_step_board_update",
+      "provider": "anthropic",
+      "model": "claude-sonnet-latest",
+      "keeper_profile": "bench-executor",
+      "run_id": "run-anthropic-executor-1",
+      "repeat_index": 1,
+      "prompt_fingerprint": "fp-executor-board",
+      "task_success": false,
+      "status": "unsupported",
+      "tool_calls": []
+    }
+  ]
+}

--- a/test/test_keeper_benchmark_canary.ml
+++ b/test/test_keeper_benchmark_canary.ml
@@ -1,0 +1,198 @@
+open Alcotest
+
+module KBC = Masc_mcp.Keeper_benchmark_canary
+module KML = Masc_mcp.Keeper_model_labels
+module KT = Masc_mcp.Keeper_types
+module TQB = Masc_mcp.Tool_call_quality_benchmark
+
+let with_env name value_opt f =
+  let previous =
+    match Sys.getenv_opt name with
+    | Some value -> Some value
+    | None -> None
+  in
+  (match value_opt with
+   | Some value -> Unix.putenv name value
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "")
+    f
+
+let with_temp_file contents f =
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "keeper-benchmark-canary-%d-%f.json"
+         (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      output_string oc contents;
+      close_out oc;
+      f path)
+
+let make_meta ?(name = "analyst") ?(models = []) () =
+  let base_fields =
+    [
+      ("name", `String name);
+      ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+      ("trace_id", `String "trace-keeper-benchmark-canary");
+      ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
+      ("last_model_used", `String "");
+    ]
+  in
+  let fields =
+    match models with
+    | [] -> base_fields
+    | _ ->
+        ("models", `List (List.map (fun value -> `String value) models))
+        :: base_fields
+  in
+  match KT.meta_of_json (`Assoc fields) with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let recommendation_for keeper_profile (manifest : KBC.manifest) =
+  List.find_opt
+    (fun (recommendation : KBC.recommendation) ->
+      String.equal recommendation.keeper_profile keeper_profile)
+    manifest.recommendations
+
+let test_build_manifest_picks_only_fully_passing_rows () =
+  let row
+      ?(cases_total = 1)
+      ?(cases_passed = 1)
+      ?(unsupported_runs = 0)
+      ?(runtime_unreachable_runs = 0)
+      ?stability_score
+      ~provider ~model ~keeper_profile ~composite_score () =
+    {
+      TQB.provider = Some provider;
+      model = Some model;
+      keeper_profile = Some keeper_profile;
+      cases_total;
+      cases_passed;
+      task_pass_rate = 1.0;
+      correct_tool_rate = 1.0;
+      arg_valid_rate = 1.0;
+      recovery_rate = 1.0;
+      unnecessary_tool_rate = 0.0;
+      avg_tool_calls = 1.0;
+      p95_latency_ms = 1000.0;
+      avg_input_tokens = 100.0;
+      avg_output_tokens = 50.0;
+      avg_cost_usd = 0.0;
+      composite_score;
+      unsupported_runs;
+      runtime_unreachable_runs;
+      stability_score;
+      tool_sequence_consistency_rate = stability_score;
+      prompt_fingerprint_consistency_rate = stability_score;
+      pass_consistency_rate = Some 1.0;
+      repeated_case_groups = (match stability_score with Some _ -> 1 | None -> 0);
+    }
+  in
+  let summary =
+    {
+      TQB.cases_total = 4;
+      runs_total = 7;
+      scored_runs = 6;
+      unsupported_runs = 1;
+      runtime_unreachable_runs = 0;
+      unknown_case_runs = 0;
+      grouped_by_provider_model_keeper =
+        [
+          row ~provider:"openai" ~model:"gpt-5.4" ~keeper_profile:"bench-analyst"
+            ~composite_score:100.0 ~cases_total:2 ~cases_passed:2
+            ~stability_score:1.0 ();
+          row ~provider:"openai" ~model:"gpt-5.4-mini"
+            ~keeper_profile:"bench-verifier" ~composite_score:100.0
+            ~stability_score:0.6666666667 ();
+          row ~provider:"openai" ~model:"gpt-5.4" ~keeper_profile:"bench-executor"
+            ~composite_score:75.0 ~cases_passed:0 ();
+        ];
+      grouped_by_provider_model = [];
+      grouped_by_keeper_profile = [];
+    }
+  in
+  let manifest = KBC.build_manifest summary in
+  check int "analyst+verifier only" 2 (List.length manifest.recommendations);
+  let analyst =
+    match recommendation_for "bench-analyst" manifest with
+    | Some recommendation -> recommendation
+    | None -> fail "missing bench-analyst recommendation"
+  in
+  check string "analyst recommended model" "openai:gpt-5.4"
+    analyst.model_label;
+  let verifier =
+    match recommendation_for "bench-verifier" manifest with
+    | Some recommendation -> recommendation
+    | None -> fail "missing bench-verifier recommendation"
+  in
+  check string "verifier recommended model" "openai:gpt-5.4-mini"
+    verifier.model_label;
+  check bool "executor excluded because corpus did not fully pass" true
+    (recommendation_for "bench-executor" manifest = None)
+
+let test_runtime_canary_prepends_recommended_model_only_without_explicit_models () =
+  let manifest_json =
+    {
+      KBC.version = 1;
+      generated_at = "2026-04-21T00:00:00Z";
+      source_summary_path = None;
+      recommendations =
+        [
+          {
+            KBC.keeper_profile = "bench-analyst";
+            model_label = "test-provider:test-model";
+            composite_score = 100.0;
+            task_pass_rate = 1.0;
+            stability_score = Some 1.0;
+            cases_total = 2;
+            cases_passed = 2;
+          };
+        ];
+    }
+    |> KBC.manifest_to_yojson
+    |> Yojson.Safe.pretty_to_string
+  in
+  with_temp_file manifest_json (fun path ->
+    KBC.reset_for_testing ();
+    with_env "MASC_KEEPER_BENCH_CANARY_ENABLED" (Some "true") (fun () ->
+      with_env "MASC_KEEPER_BENCH_CANARY_PATH" (Some path) (fun () ->
+        let recommended =
+          KBC.recommended_model_label_for_keeper ~keeper_name:"analyst"
+        in
+        check (option string) "bare keeper name resolves bench recommendation"
+          (Some "test-provider:test-model") recommended;
+        let labels =
+          KML.configured_model_labels_of_meta (make_meta ~name:"analyst" ())
+        in
+        check string "recommended model is prepended"
+          "test-provider:test-model" (List.hd labels);
+        let explicit_meta =
+          { (make_meta ~name:"analyst" ()) with models = [ "explicit:model" ] }
+        in
+        let explicit_labels =
+          KML.configured_model_labels_of_meta explicit_meta
+        in
+        check (list string) "explicit models stay untouched"
+          [ "explicit:model" ] explicit_labels)))
+
+let () =
+  run "keeper_benchmark_canary"
+    [
+      ( "keeper_benchmark_canary",
+        [
+          test_case "build manifest from summary" `Quick
+            test_build_manifest_picks_only_fully_passing_rows;
+          test_case "runtime canary prepends recommendation" `Quick
+            test_runtime_canary_prepends_recommended_model_only_without_explicit_models;
+        ] );
+    ]

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -115,16 +115,12 @@ let test_model_field_stored () =
       ~keeper_name:"k" ~tool_name:"masc_status"
       ~input:(`Assoc []) ~output_text:"ok"
       ~success:true ~duration_ms:2.0
-      ~model:"glm-4-9b" ~provider:"glm-coding" ();
+      ~model:"glm-4-9b" ();
     let entries = Keeper_tool_call_log.read_recent () in
     Alcotest.(check int) "one entry" 1 (List.length entries);
-    let entry = List.hd entries in
-    let entry_str = Yojson.Safe.to_string entry in
+    let entry_str = Yojson.Safe.to_string (List.hd entries) in
     Alcotest.(check bool) "model field present" true
-      (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str);
-    Alcotest.(check (option string)) "provider field present"
-      (Some "glm-coding")
-      (Safe_ops.json_string_opt "provider" entry))
+      (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str))
 
 let test_turn_context_fields_stored () =
   with_tmp_log (fun () ->
@@ -134,6 +130,7 @@ let test_turn_context_fields_stored () =
       ~tool_choice:"required"
       ~thinking_enabled:false
       ~thinking_budget:1024
+      ~prompt_fingerprint:"prompt-fp-k"
       ~trace_id:"trace-k"
       ~session_id:"trace-k"
       ~turn:7
@@ -157,6 +154,9 @@ let test_turn_context_fields_stored () =
        | _ -> false);
     Alcotest.(check int) "thinking_budget field" 1024
       (Safe_ops.json_int ~default:0 "thinking_budget" entry);
+    Alcotest.(check (option string)) "prompt_fingerprint field"
+      (Some "prompt-fp-k")
+      (Safe_ops.json_string_opt "prompt_fingerprint" entry);
     Alcotest.(check (option string)) "trace_id field"
       (Some "trace-k")
       (Safe_ops.json_string_opt "trace_id" entry);
@@ -187,6 +187,10 @@ let test_turn_context_fields_absent_without_context () =
        | _ -> false);
     Alcotest.(check bool) "thinking_budget absent" true
       (match Yojson.Safe.Util.member "thinking_budget" entry with
+       | `Null -> true
+       | _ -> false);
+    Alcotest.(check bool) "prompt_fingerprint absent" true
+      (match Yojson.Safe.Util.member "prompt_fingerprint" entry with
        | `Null -> true
        | _ -> false);
     Alcotest.(check bool) "trace_id absent" true

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -1,0 +1,107 @@
+open Alcotest
+open Masc_mcp
+
+let fixture_cases repo_root =
+  Filename.concat repo_root "benchmark/tool_call_quality_cases.json"
+
+let fixture_runs repo_root =
+  Filename.concat repo_root
+    "test/fixtures/tool_call_quality_benchmark/evidence_runs.json"
+
+let load_fixture () =
+  let repo_root = Sys.getcwd () in
+  let cases = Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) in
+  let runs = Tool_call_quality_benchmark.load_runs_from_file (fixture_runs repo_root) in
+  (cases, runs)
+
+let find_row ~provider ~model ~keeper rows =
+  List.find
+    (fun (row : Tool_call_quality_benchmark.summary_row) ->
+      row.provider = provider
+      && row.model = model
+      && row.keeper_profile = keeper)
+    rows
+
+let test_load_cases_and_runs () =
+  let cases, runs = load_fixture () in
+  check int "case count" 4 (List.length cases);
+  check int "run count" 7 (List.length runs)
+
+let test_summary_rollups_and_stability () =
+  let cases, runs = load_fixture () in
+  let summary = Tool_call_quality_benchmark.summarize ~cases ~runs () in
+  check int "cases total" 4 summary.cases_total;
+  check int "runs total" 7 summary.runs_total;
+  check int "scored runs" 6 summary.scored_runs;
+  check int "unsupported runs" 1 summary.unsupported_runs;
+  check int "runtime unreachable runs" 0 summary.runtime_unreachable_runs;
+  let analyst_row =
+    find_row
+      ~provider:(Some "openai")
+      ~model:(Some "gpt-5.4")
+      ~keeper:(Some "bench-analyst")
+      summary.grouped_by_provider_model_keeper
+  in
+  check int "analyst unique cases" 2 analyst_row.cases_total;
+  check int "analyst passed cases" 2 analyst_row.cases_passed;
+  check (option (float 0.0001)) "analyst stability score" (Some 1.0)
+    analyst_row.stability_score;
+  check int "analyst repeated groups" 1 analyst_row.repeated_case_groups;
+  let executor_row =
+    find_row
+      ~provider:(Some "openai")
+      ~model:(Some "gpt-5.4")
+      ~keeper:(Some "bench-executor")
+      summary.grouped_by_provider_model_keeper
+  in
+  check int "executor unique cases" 1 executor_row.cases_total;
+  check int "executor passed cases" 0 executor_row.cases_passed;
+  check bool "executor tool selection degraded"
+    true (executor_row.correct_tool_rate < 1.0);
+  let verifier_row =
+    find_row
+      ~provider:(Some "openai")
+      ~model:(Some "gpt-5.4-mini")
+      ~keeper:(Some "bench-verifier")
+      summary.grouped_by_provider_model_keeper
+  in
+  check int "verifier unique cases" 1 verifier_row.cases_total;
+  check int "verifier passed cases" 1 verifier_row.cases_passed;
+  check bool "verifier stability below perfect"
+    true
+    (match verifier_row.stability_score with
+     | Some value -> value < 1.0
+     | None -> false);
+  let provider_row =
+    List.find
+      (fun (row : Tool_call_quality_benchmark.summary_row) ->
+        row.provider = Some "openai"
+        && row.model = Some "gpt-5.4"
+        && row.keeper_profile = None)
+      summary.grouped_by_provider_model
+  in
+  check int "provider rollup unique cases" 2 provider_row.cases_total;
+  check int "provider rollup passed cases" 1 provider_row.cases_passed
+
+let test_csv_render_has_headers () =
+  let cases, runs = load_fixture () in
+  let summary = Tool_call_quality_benchmark.summarize ~cases ~runs () in
+  let csv =
+    Tool_call_quality_benchmark.summary_rows_to_csv
+      ~view:Tool_call_quality_benchmark.By_provider_model_keeper summary
+  in
+  check bool "csv header includes stability column" true
+    (String_util.contains_substring csv "stability_score");
+  check bool "csv contains analyst keeper row" true
+    (String_util.contains_substring csv "bench-analyst")
+
+let () =
+  run "tool_call_quality_benchmark"
+    [
+      ("benchmark", [
+           test_case "loads fixture corpus" `Quick test_load_cases_and_runs;
+           test_case "summarizes rollups and stability" `Quick
+             test_summary_rollups_and_stability;
+           test_case "renders csv" `Quick test_csv_render_has_headers;
+         ]);
+    ]

--- a/test/tool_call_quality_benchmark_cli.ml
+++ b/test/tool_call_quality_benchmark_cli.ml
@@ -1,0 +1,115 @@
+open Masc_mcp
+
+let write_file path contents =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc contents)
+
+let summary_rows_json view (summary : Tool_call_quality_benchmark.benchmark_summary) =
+  let rows =
+    match view with
+    | Tool_call_quality_benchmark.By_provider_model_keeper ->
+        summary.grouped_by_provider_model_keeper
+    | Tool_call_quality_benchmark.By_provider_model ->
+        summary.grouped_by_provider_model
+    | Tool_call_quality_benchmark.By_keeper_profile ->
+        summary.grouped_by_keeper_profile
+  in
+  `List (List.map Tool_call_quality_benchmark.summary_row_to_yojson rows)
+
+let parse_csv_arg value =
+  value
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun item -> item <> "")
+
+let () =
+  let repo_root = Sys.getcwd () in
+  let cases_path =
+    ref (Tool_call_quality_benchmark.default_case_set_path ~repo_root)
+  in
+  let evidence_path =
+    ref (Tool_call_quality_benchmark.default_evidence_path ~repo_root)
+  in
+  let format = ref "json" in
+  let artifact_dir = ref "" in
+  let emit_canary_path = ref "" in
+  let view = ref "provider-model-keeper" in
+  let model_filters : string list ref = ref [] in
+  let keeper_filters : string list ref = ref [] in
+  let specs =
+    [
+      ("--cases", Arg.Set_string cases_path, "Path to tool-call benchmark case set JSON");
+      ("--evidence", Arg.Set_string evidence_path, "Path to evidence runs JSON");
+      ("--format", Arg.Set_string format, "Output format: json or csv");
+      ("--artifact-dir", Arg.Set_string artifact_dir, "Write summary artifacts to this directory");
+      ("--emit-canary", Arg.Set_string emit_canary_path, "Write keeper benchmark canary recommendation JSON to this path");
+      ("--view", Arg.Set_string view, "Summary view: provider-model-keeper, provider-model, keeper");
+      ("--models",
+       Arg.String (fun value -> model_filters := parse_csv_arg value),
+       "Comma-separated provider:model filters");
+      ("--keepers",
+       Arg.String (fun value -> keeper_filters := parse_csv_arg value),
+       "Comma-separated keeper profile filters");
+    ]
+  in
+  let usage = "tool_call_quality_benchmark_cli [--cases PATH] [--evidence PATH]" in
+  Arg.parse specs (fun _ -> ()) usage;
+  let cases = Tool_call_quality_benchmark.load_cases_from_file !cases_path in
+  let runs = Tool_call_quality_benchmark.load_runs_from_file !evidence_path in
+  let summary =
+    Tool_call_quality_benchmark.summarize ~cases ~runs
+      ~model_filters:!model_filters ~keeper_filters:!keeper_filters ()
+  in
+  let canary_manifest =
+    Keeper_benchmark_canary.build_manifest summary
+  in
+  let view =
+    match String.lowercase_ascii (String.trim !view) with
+    | "provider-model-keeper" -> Tool_call_quality_benchmark.By_provider_model_keeper
+    | "provider-model" -> Tool_call_quality_benchmark.By_provider_model
+    | "keeper" -> Tool_call_quality_benchmark.By_keeper_profile
+    | other -> failwith ("unknown --view: " ^ other)
+  in
+  let output =
+    match String.lowercase_ascii (String.trim !format) with
+    | "json" ->
+        `Assoc
+          [
+            ("cases_path", `String !cases_path);
+            ("evidence_path", `String !evidence_path);
+            ("summary", Tool_call_quality_benchmark.benchmark_summary_to_yojson summary);
+            ("keeper_benchmark_canary",
+             Keeper_benchmark_canary.manifest_to_yojson canary_manifest);
+            ("rows", summary_rows_json view summary);
+          ]
+        |> Yojson.Safe.pretty_to_string
+    | "csv" ->
+        Tool_call_quality_benchmark.summary_rows_to_csv ~view summary
+    | other -> failwith ("unknown --format: " ^ other)
+  in
+  if String.trim !artifact_dir <> "" then (
+    let ext =
+      match String.lowercase_ascii (String.trim !format) with
+      | "csv" -> "summary.csv"
+      | _ -> "summary.json"
+    in
+    write_file (Filename.concat !artifact_dir ext) output);
+  let canary_output_path =
+    match String.trim !emit_canary_path, String.trim !artifact_dir with
+    | path, _ when path <> "" -> Some path
+    | "", artifact_dir when artifact_dir <> "" ->
+        Some (Filename.concat artifact_dir "keeper_model_recommendations.json")
+    | _ -> None
+  in
+  (match canary_output_path with
+   | Some path ->
+       write_file path
+         (Keeper_benchmark_canary.manifest_to_yojson canary_manifest
+          |> Yojson.Safe.pretty_to_string)
+   | None -> ());
+  print_string output;
+  if String.length output = 0 || output.[String.length output - 1] <> '\n' then
+    print_newline ()


### PR DESCRIPTION
## Summary
- add a deterministic provider:model x keeper tool-quality benchmark with fixture-backed scoring and a live harness mode
- add benchmark keeper profiles and prompt fingerprint logging so repeated tool behavior can be compared more reliably
- emit a keeper model recommendation manifest from benchmark summaries and let real keepers opt into prepending the recommended model when explicit model labels are empty

## Why
- benchmark artifacts were useful for measurement, but they did not feed back into real keeper selection
- this adds a narrow opt-in canary path so strong benchmark results can influence runtime model choice without replacing explicit keeper config or cascade fallback

## Validation
- dune build --root . ./test/test_keeper_benchmark_canary.exe ./test/test_tool_call_quality_benchmark.exe ./test/tool_call_quality_benchmark_cli.exe
- ./_build/default/test/test_keeper_benchmark_canary.exe
- ./_build/default/test/test_tool_call_quality_benchmark.exe
- dune build --root . ./test/test_keeper_tool_call_log.exe ./test/test_keeper_toml_config_validation.exe
- ./_build/default/test/test_keeper_tool_call_log.exe
- ./_build/default/test/test_keeper_toml_config_validation.exe
- TOOL_CALL_QUALITY_SKIP_BUILD=1 ./scripts/harness_tool_call_quality.sh --format json --view provider-model --artifact-dir /tmp/tool-quality-canary-check

## Evidence
- fixture summary now emits /tmp/tool-quality-canary-check/keeper_model_recommendations.json with bench-analyst -> openai:gpt-5.4 and bench-verifier -> openai:gpt-5.4-mini
- runtime canary is gated by MASC_KEEPER_BENCH_CANARY_ENABLED and never overrides explicit keeper models