### PR TITLE
[codex] Fix config_dir_resolver interface drift

### DIFF
--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -33,6 +33,7 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
+  cascade_authoring : path_item;
   cascade : path_item;
   prompts : path_item;
   keepers : path_item;


### PR DESCRIPTION
## Summary
- add the missing cascade_authoring field to lib/config_dir_resolver.mli so it matches the implementation
- unblock builds that fail immediately on the config_dir_resolver interface mismatch
- record the repo-global build regression in #9333

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-9333-config-dir-resolver-cascade-authoring ./lib/config_dir_resolver.ml ./lib/config_dir_resolver.mli
- the broader dune build target that originally exposed this issue now moves past config_dir_resolver; it still has other unrelated blockers after this fix

Closes #9333