### PR TITLE
[codex] Align provider-kind SSOT in provider_adapter

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -146,10 +146,19 @@ let local_cascade_prefix = cn_llama
 let make_local_label (model_id : string) : string =
   local_cascade_prefix ^ ":" ^ model_id
 
-(** Map OAS Provider_config.provider_kind to MASC adapter canonical_name.
-    Note: OpenAI_compat maps to codex-api (cloud); llama (local) uses the
-    same provider_kind but is identified by endpoint, not by this function. *)
+(** SSOT string form of OAS [provider_kind].
+    This must stay aligned with [Provider_config.string_of_provider_kind]. *)
 let string_of_provider_kind
+    : Llm_provider.Provider_config.provider_kind -> string
+  = Llm_provider.Provider_config.string_of_provider_kind
+
+(** Map OAS [provider_kind] to the MASC adapter canonical name when adapter
+    semantics are required.
+
+    Note: [OpenAI_compat] maps to the direct cloud adapter [codex-api]; local
+    llama remains an [OpenAI_compat] kind but is identified by endpoint rather
+    than by this helper. *)
+let adapter_canonical_name_of_provider_kind
     : Llm_provider.Provider_config.provider_kind -> string
   = function
   | Anthropic -> cn_claude_api
@@ -1036,7 +1045,7 @@ let endpoint_url_of_adapter (adapter : adapter) = adapter.endpoint_url
     to parse the prefix directly from the original provider:model label. This
     helper should be used only when a best-effort cascade prefix is sufficient. *)
 let cascade_prefix_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string =
-  let cn = string_of_provider_kind kind in
+  let cn = adapter_canonical_name_of_provider_kind kind in
   match resolve_direct_adapter cn with
   | Some a -> a.cascade_prefix
   | None -> cn
@@ -1090,16 +1099,17 @@ let auth_detail_of_provider provider =
 
 let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
   match kind with
-  | Llm_provider.Provider_config.Anthropic -> [ "ANTHROPIC_API_KEY" ]
   | Llm_provider.Provider_config.Kimi -> kimi_api_key_envs
-  | Llm_provider.Provider_config.Glm -> [ "ZAI_API_KEY" ]
-  | Llm_provider.Provider_config.OpenAI_compat -> [ "OPENAI_API_KEY" ]
   | Llm_provider.Provider_config.Gemini -> [ google_cloud_project_env; google_cloud_location_env ]
-  | Llm_provider.Provider_config.Gemini_cli
-  | Llm_provider.Provider_config.Kimi_cli
-  | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | Llm_provider.Provider_config.Ollama -> []
+  | _ ->
+      let adapter_name = adapter_canonical_name_of_provider_kind kind in
+      match resolve_direct_adapter adapter_name with
+      | Some adapter -> (
+          match adapter.auth_mode with
+          | Api_key env_name -> [ env_name ]
+          | No_auth | Cli_cached_login | Vertex_adc _ ->
+              Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
+      | None -> Option.to_list (Llm_provider.Provider_config.default_api_key_env kind)
 
 let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t) : string list =
   match cfg.kind with

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -124,7 +124,7 @@ val local_cascade_prefix : string
     Single entry point; other modules must not concatenate prefix manually. *)
 val make_local_label : string -> string
 
-(** Map OAS [Provider_config.provider_kind] to MASC adapter canonical_name. *)
+(** SSOT string form of OAS [Provider_config.provider_kind]. *)
 val string_of_provider_kind :
   Llm_provider.Provider_config.provider_kind -> string
 

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -46,6 +46,56 @@ let test_kimi_direct_auth_accepts_primary_and_fallback_envs () =
             (Adapter.auth_env_keys_of_provider_kind
                Llm_provider.Provider_config.Kimi)))
 
+let test_provider_kind_string_uses_oas_ssot () =
+  check string "anthropic ssot" "anthropic"
+    (Adapter.string_of_provider_kind Llm_provider.Provider_config.Anthropic);
+  check string "openai_compat ssot" "openai_compat"
+    (Adapter.string_of_provider_kind Llm_provider.Provider_config.OpenAI_compat);
+  check string "claude_code ssot" "claude_code"
+    (Adapter.string_of_provider_kind Llm_provider.Provider_config.Claude_code)
+
+let test_cascade_prefix_of_provider_kind_keeps_adapter_mapping () =
+  check string "anthropic prefix" "claude"
+    (Adapter.cascade_prefix_of_provider_kind
+       Llm_provider.Provider_config.Anthropic);
+  check string "openai compat prefix" "openai"
+    (Adapter.cascade_prefix_of_provider_kind
+       Llm_provider.Provider_config.OpenAI_compat);
+  check string "codex cli prefix" "codex_cli"
+    (Adapter.cascade_prefix_of_provider_kind
+       Llm_provider.Provider_config.Codex_cli)
+
+let test_auth_env_keys_of_provider_kind_defaults () =
+  check (list string) "anthropic env keys" [ "ANTHROPIC_API_KEY" ]
+    (Adapter.auth_env_keys_of_provider_kind
+       Llm_provider.Provider_config.Anthropic);
+  check (list string) "openai compat env keys" [ "OPENAI_API_KEY" ]
+    (Adapter.auth_env_keys_of_provider_kind
+       Llm_provider.Provider_config.OpenAI_compat);
+  check (list string) "glm env keys" [ "ZAI_API_KEY" ]
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Glm);
+  check (list string) "ollama env keys" []
+    (Adapter.auth_env_keys_of_provider_kind
+       Llm_provider.Provider_config.Ollama);
+  check (list string) "claude code env keys" []
+    (Adapter.auth_env_keys_of_provider_kind
+       Llm_provider.Provider_config.Claude_code)
+
+let test_gemini_auth_env_key_paths () =
+  check (list string) "gemini inventory env keys"
+    [ "GOOGLE_CLOUD_PROJECT"; "GOOGLE_CLOUD_LOCATION" ]
+    (Adapter.auth_env_keys_of_provider_kind
+       Llm_provider.Provider_config.Gemini);
+  let config =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Gemini
+      ~model_id:"gemini-2.5-pro"
+      ~base_url:"https://generativelanguage.googleapis.com"
+      ()
+  in
+  check (list string) "gemini docker env keys" [ "GEMINI_API_KEY" ]
+    (Adapter.docker_auth_env_keys_of_provider_config config)
+
 let test_gemini_direct_auth_vertex_adc () =
   with_env "GOOGLE_CLOUD_PROJECT" (Some "demo-project") (fun () ->
       with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
@@ -239,6 +289,14 @@ let () =
           test_case "resolve cli canonicals" `Quick test_resolve_cli_canonical_names;
           test_case "kimi direct auth accepts fallback envs" `Quick
             test_kimi_direct_auth_accepts_primary_and_fallback_envs;
+          test_case "provider kind string uses oas ssot" `Quick
+            test_provider_kind_string_uses_oas_ssot;
+          test_case "cascade prefix keeps adapter mapping" `Quick
+            test_cascade_prefix_of_provider_kind_keeps_adapter_mapping;
+          test_case "provider kind auth env defaults" `Quick
+            test_auth_env_keys_of_provider_kind_defaults;
+          test_case "gemini auth env key paths" `Quick
+            test_gemini_auth_env_key_paths;
           test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc;
           test_case "gemini api key fallback" `Quick
             test_gemini_direct_auth_api_key_fallback;


### PR DESCRIPTION
## Summary
- align Provider_adapter.string_of_provider_kind with the OAS Provider_config.string_of_provider_kind SSOT
- keep adapter-specific cascade/auth behavior via an internal canonical-name helper so cascade_prefix_of_provider_kind and auth env hints do not drift
- add focused regression coverage for provider-kind strings, cascade prefixes, auth env defaults, and Gemini inventory vs Docker env handling
- include the current config_dir_resolver.mli / oas_worker_named.ml build unblocks needed to verify this slice on top of current main

## Testing
- dune build --root . test/test_provider_adapter.exe
- ./_build/default/test/test_provider_adapter.exe
- dune build --root . test/test_config_dir_resolver.exe test/test_oas_worker.exe
- ./_build/default/test/test_config_dir_resolver.exe
- ./_build/default/test/test_oas_worker.exe
