### PR TITLE
[codex] Add initial ToolCallContract TLA boundary spec

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -159,6 +159,8 @@ run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"
 run_tlc "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"
 run_tlc_buggy "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"
+run_tlc "$REPO_ROOT/specs/boundary" "ToolCallContract.tla"
+run_tlc_buggy "$REPO_ROOT/specs/boundary" "ToolCallContract.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then

--- a/specs/boundary/ToolCallContract-buggy.cfg
+++ b/specs/boundary/ToolCallContract-buggy.cfg
@@ -1,0 +1,10 @@
+\* Buggy model: a requested tool call is silently dropped into a text outcome.
+\* Expected: NeverDropSilently MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+INVARIANTS
+    NeverDropSilently
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/ToolCallContract.cfg
+++ b/specs/boundary/ToolCallContract.cfg
@@ -1,0 +1,10 @@
+\* Clean model: registered tool names only, gh_repo_context errors only in
+\* local sandbox, and requested tool use always resolves to tool_use or error.
+
+SPECIFICATION Spec
+
+INVARIANTS
+    Safety
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/ToolCallContract.tla
+++ b/specs/boundary/ToolCallContract.tla
@@ -1,0 +1,267 @@
+---- MODULE ToolCallContract ----
+(***************************************************************************)
+(* ToolCallContract — boundary contract for keeper/tool telemetry writes.  *)
+(*                                                                         *)
+(* Scope: one turn-level observation after tool planning/execution is      *)
+(* materialized into decision telemetry. This is intentionally narrower    *)
+(* than provider transport or full keeper lifecycle state.                 *)
+(*                                                                         *)
+(* Runtime projection covered by this contract:                            *)
+(*   - decision records keep tool_call_count and tools_used                *)
+(*   - gh_repo_context errors are allowed only outside Docker sandbox      *)
+(*   - tool-use outcomes require a tool-capable provider declaration       *)
+(*   - requested tool use must not disappear into a plain text outcome     *)
+(*                                                                         *)
+(* This spec is the minimal Axis 5 contract slice. It does not model       *)
+(* replay harness details, retries, or provider-specific argument schemas. *)
+(***************************************************************************)
+
+EXTENDS Naturals
+
+ToolRegistry == {"keeper_shell", "keeper_memory_search", "masc_add_task"}
+
+ToolUniverse == ToolRegistry \cup {"unknown_tool"}
+
+VARIABLES
+    phase,
+    sandbox_profile,
+    provider_declares_supports_tools,
+    request_seen,
+    outcome,
+    error_category,
+    tool_call_count,
+    tools_used
+
+vars ==
+    << phase,
+       sandbox_profile,
+       provider_declares_supports_tools,
+       request_seen,
+       outcome,
+       error_category,
+       tool_call_count,
+       tools_used >>
+
+PhaseSet == {"unstarted", "started", "requested", "finished"}
+SandboxSet == {"local", "docker"}
+OutcomeSet == {"none", "text", "tool_use", "error"}
+ErrorCategorySet == {"none", "gh_repo_context", "unsupported_tools", "other"}
+ActionSet == {
+    "StartToolCapableLocal",
+    "StartToolCapableDocker",
+    "StartTextOnlyLocal",
+    "StartTextOnlyDocker",
+    "ReplyTextNoTool",
+    "RequestTool",
+    "EmitToolCall",
+    "EmitUnsupportedToolsError",
+    "EmitGhRepoContextError"
+}
+InvariantSet == {
+    "NonNegativeToolCallCount",
+    "ToolsUsedAreRegistered",
+    "GhRepoContextNeverInDocker",
+    "ToolUseRequiresDeclaredSupport",
+    "ToolUseCarriesToolNames",
+    "NoCallsOutsideToolUse",
+    "NeverDropSilently"
+}
+
+TypeOK ==
+    /\ phase \in PhaseSet
+    /\ sandbox_profile \in SandboxSet
+    /\ provider_declares_supports_tools \in BOOLEAN
+    /\ request_seen \in BOOLEAN
+    /\ outcome \in OutcomeSet
+    /\ error_category \in ErrorCategorySet
+    /\ tool_call_count \in Nat
+    /\ tools_used \subseteq ToolUniverse
+
+Init ==
+    /\ phase = "unstarted"
+    /\ sandbox_profile = "local"
+    /\ provider_declares_supports_tools = FALSE
+    /\ request_seen = FALSE
+    /\ outcome = "none"
+    /\ error_category = "none"
+    /\ tool_call_count = 0
+    /\ tools_used = {}
+
+StartToolCapableLocal ==
+    /\ phase = "unstarted"
+    /\ phase' = "started"
+    /\ sandbox_profile' = "local"
+    /\ provider_declares_supports_tools' = TRUE
+    /\ request_seen' = FALSE
+    /\ outcome' = "none"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+
+StartToolCapableDocker ==
+    /\ phase = "unstarted"
+    /\ phase' = "started"
+    /\ sandbox_profile' = "docker"
+    /\ provider_declares_supports_tools' = TRUE
+    /\ request_seen' = FALSE
+    /\ outcome' = "none"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+
+StartTextOnlyLocal ==
+    /\ phase = "unstarted"
+    /\ phase' = "started"
+    /\ sandbox_profile' = "local"
+    /\ provider_declares_supports_tools' = FALSE
+    /\ request_seen' = FALSE
+    /\ outcome' = "none"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+
+StartTextOnlyDocker ==
+    /\ phase = "unstarted"
+    /\ phase' = "started"
+    /\ sandbox_profile' = "docker"
+    /\ provider_declares_supports_tools' = FALSE
+    /\ request_seen' = FALSE
+    /\ outcome' = "none"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+
+ReplyTextNoTool ==
+    /\ phase = "started"
+    /\ phase' = "finished"
+    /\ outcome' = "text"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools, request_seen>>
+
+RequestTool ==
+    /\ phase = "started"
+    /\ phase' = "requested"
+    /\ request_seen' = TRUE
+    /\ outcome' = "none"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools>>
+
+EmitToolCall ==
+    /\ phase = "requested"
+    /\ provider_declares_supports_tools
+    /\ phase' = "finished"
+    /\ request_seen' = TRUE
+    /\ outcome' = "tool_use"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 1
+    /\ tools_used' = {"keeper_shell"}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools>>
+
+EmitUnsupportedToolsError ==
+    /\ phase = "requested"
+    /\ ~provider_declares_supports_tools
+    /\ phase' = "finished"
+    /\ request_seen' = TRUE
+    /\ outcome' = "error"
+    /\ error_category' = "unsupported_tools"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools>>
+
+EmitGhRepoContextError ==
+    /\ phase = "requested"
+    /\ sandbox_profile = "local"
+    /\ phase' = "finished"
+    /\ request_seen' = TRUE
+    /\ outcome' = "error"
+    /\ error_category' = "gh_repo_context"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools>>
+
+Next ==
+    \/ StartToolCapableLocal
+    \/ StartToolCapableDocker
+    \/ StartTextOnlyLocal
+    \/ StartTextOnlyDocker
+    \/ ReplyTextNoTool
+    \/ RequestTool
+    \/ EmitToolCall
+    \/ EmitUnsupportedToolsError
+    \/ EmitGhRepoContextError
+
+Spec ==
+    Init /\ [][Next]_vars
+
+NonNegativeToolCallCount ==
+    tool_call_count >= 0
+
+ToolsUsedAreRegistered ==
+    tools_used \subseteq ToolRegistry
+
+GhRepoContextNeverInDocker ==
+    error_category = "gh_repo_context" =>
+        sandbox_profile # "docker"
+
+ToolUseRequiresDeclaredSupport ==
+    tool_call_count > 0 =>
+        provider_declares_supports_tools
+
+ToolUseCarriesToolNames ==
+    tool_call_count > 0 =>
+        /\ outcome = "tool_use"
+        /\ tools_used # {}
+
+NoCallsOutsideToolUse ==
+    outcome # "tool_use" =>
+        /\ tool_call_count = 0
+        /\ tools_used = {}
+
+NeverDropSilently ==
+    /\ phase = "finished"
+    /\ request_seen
+    =>
+        outcome \in {"tool_use", "error"}
+
+Safety ==
+    /\ TypeOK
+    /\ NonNegativeToolCallCount
+    /\ ToolsUsedAreRegistered
+    /\ GhRepoContextNeverInDocker
+    /\ ToolUseRequiresDeclaredSupport
+    /\ ToolUseCarriesToolNames
+    /\ NoCallsOutsideToolUse
+    /\ NeverDropSilently
+
+\* Bug model: the runtime requested a tool, finished the turn, but recorded a
+\* plain text outcome with zero tool evidence and no error.
+ToolCallDroppedSilently ==
+    /\ phase = "requested"
+    /\ provider_declares_supports_tools
+    /\ phase' = "finished"
+    /\ request_seen' = TRUE
+    /\ outcome' = "text"
+    /\ error_category' = "none"
+    /\ tool_call_count' = 0
+    /\ tools_used' = {}
+    /\ UNCHANGED <<sandbox_profile, provider_declares_supports_tools>>
+
+NextBuggy ==
+    \/ StartToolCapableLocal
+    \/ StartToolCapableDocker
+    \/ StartTextOnlyLocal
+    \/ StartTextOnlyDocker
+    \/ ReplyTextNoTool
+    \/ RequestTool
+    \/ ToolCallDroppedSilently
+    \/ EmitUnsupportedToolsError
+    \/ EmitGhRepoContextError
+
+SpecBuggy ==
+    Init /\ [][NextBuggy]_vars
+
+====


### PR DESCRIPTION
## Summary
- add an initial `ToolCallContract` boundary spec for turn-level tool-call telemetry
- encode the first Axis 5 invariants: non-negative tool counts, registered tool names, no `gh_repo_context` errors in Docker, tool use requiring tool-capable provider declaration, and no silent tool-call drops
- add a buggy model path (`ToolCallDroppedSilently`) plus buggy cfg so TLC must violate `NeverDropSilently`
- wire the new boundary spec into `scripts/tla-check.sh`

## Validation
- `bash -n scripts/tla-check.sh`
- `java -XX:+UseParallelGC -Xmx2g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/boundary/ToolCallContract.cfg specs/boundary/ToolCallContract.tla`
- `java -XX:+UseParallelGC -Xmx2g -cp /Users/dancer/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/boundary/ToolCallContract-buggy.cfg specs/boundary/ToolCallContract.tla`

## Notes
- Local `make -C specs check-boundary` is still broken on macOS due a pre-existing shell quoting issue; tracked separately in #9340.
