### PR TITLE
Integrate parsing and resource missing errors with Prometheus metrics

### DIFF
--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -46,6 +46,7 @@ let run_record_of_json (json : Yojson.Safe.t) : run_record option =
     let deliverable = Safe_ops.json_string ~default:"" "deliverable" json in
     Some { task_id; agent_name; plan; deliverable; created_at; updated_at }
   | _ ->
+    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
     Log.Misc.error "run_of_json: missing required fields";
     None
 
@@ -61,6 +62,7 @@ let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
   | Some timestamp, Some note ->
     Some { timestamp; note }
   | _ ->
+    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
     Log.Misc.error "log_entry_of_json: missing required fields";
     None
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -219,7 +219,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   (match Keeper_exec_tools.init_policy_config ~base_path with
    | Ok () -> ()
    | Error msg ->
-       Log.Server.error "Fatal tool policy config load failure: %s" msg;
+       Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
+      Log.Server.error "Fatal tool policy config load failure: %s" msg;
        exit 1);
   (* Validate Tool_spec <-> TOML coverage *)
   let validation = Tool_registration_check.validate () in
@@ -531,16 +532,22 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
       prompt_markdown_dir expected_prompt_dir;
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
+    begin
+    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
     Log.Misc.error "required prompt files missing: %s"
       (missing_prompt_files
       |> List.map (fun (key, path) -> Printf.sprintf "%s -> %s" key path)
       |> String.concat ", ");
+  end;
   let invalid_prompt_templates = Prompt_registry.validate_prompt_templates () in
   if invalid_prompt_templates <> [] then
+    begin
+    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
     Log.Misc.error "prompt templates use unknown variables: %s"
       (invalid_prompt_templates
       |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)
       |> String.concat ", ")
+  end
 
 let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
   (try

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -45,6 +45,7 @@ let parse_record (json : Yojson.Safe.t)
       |> List.filter_map (fun (field, is_missing) ->
         if is_missing then Some field else None)
     in
+    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
     Error
       (Printf.sprintf "missing required field(s): %s"
          (String.concat ", " missing))


### PR DESCRIPTION
Resolves #9334.

This PR introduces the `masc_error_events_total` Prometheus metric counter for various configuration and parsing errors across MASC components.

### Changes:
- **lib/server/server_runtime_bootstrap.ml**: Added tracking for missing prompt files (`type="missing_config"`), unknown prompt template variables, and fatal tool policy configuration failures.
- **lib/run_eio.ml**: Added tracking for missing JSON fields during run logging (`type="parsing"`).
- **lib/tool_metrics_persist.ml**: Added tracking for JSON schema validation errors during metric persistence (`type="parsing"`).

These metrics map generic log errors (`Log.Misc.error`) to explicit counters for improved observability and alerting.