### PR TITLE
fix: detect Claude CLI hard quota wrapper

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -458,6 +458,8 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.HttpError { code = 429; body = message }
       | Llm_provider.Retry.ServerError { status; message } ->
         Llm_provider.Http_client.HttpError { code = status; body = message }
+      | Llm_provider.Retry.NotFound { message } ->
+        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.AuthError { message } ->
         Llm_provider.Http_client.HttpError { code = 401; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
@@ -563,6 +565,7 @@ let cli_wrapped_hard_quota_indicators = [
   "quota_exhausted";
   "exhausted your capacity on this model";
   "quota will reset after";
+  "you've hit your limit";
 ]
 
 let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
@@ -581,6 +584,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.ServerError { message; _ } ->
        message_looks_like_cli_wrapped_hard_quota message
      | Llm_provider.Retry.RateLimited _
+     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.AuthError _
      | Llm_provider.Retry.InvalidRequest _
      | Llm_provider.Retry.ContextOverflow _

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -445,21 +445,26 @@ let with_codex_cli_preflight ~(scope : string) ~(config : Oas_worker_exec.config
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
     errors (budget, idle, exit) are not — they would recur on any model. *)
+let api_error_message_looks_like_not_found (message : string) =
+  String_util.contains_substring_ci message "not found"
+
 let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
     : Cascade_fsm.provider_outcome option =
   match err with
   | Oas.Error.Api api_err ->
+    let fallback_message = Llm_provider.Retry.error_message api_err in
     let http_err = match api_err with
       | Llm_provider.Retry.InvalidRequest { message } ->
-        Llm_provider.Http_client.HttpError { code = 400; body = message }
+        let code =
+          if api_error_message_looks_like_not_found message then 404 else 400
+        in
+        Llm_provider.Http_client.HttpError { code; body = message }
       | Llm_provider.Retry.ContextOverflow { message; _ } ->
         Llm_provider.Http_client.HttpError { code = 400; body = message }
       | Llm_provider.Retry.RateLimited { message; _ } ->
         Llm_provider.Http_client.HttpError { code = 429; body = message }
       | Llm_provider.Retry.ServerError { status; message } ->
         Llm_provider.Http_client.HttpError { code = status; body = message }
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.AuthError { message } ->
         Llm_provider.Http_client.HttpError { code = 401; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
@@ -467,6 +472,12 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
       | Llm_provider.Retry.NetworkError { message }
       | Llm_provider.Retry.Timeout { message } ->
         Llm_provider.Http_client.NetworkError { message }
+      | _ ->
+        let code =
+          if api_error_message_looks_like_not_found fallback_message then 404
+          else 500
+        in
+        Llm_provider.Http_client.HttpError { code; body = fallback_message }
     in
     Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
@@ -576,20 +587,18 @@ let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
 let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Api api_err ->
-    Llm_provider.Retry.is_hard_quota api_err
-    ||
-    (match api_err with
+    let wrapped_hard_quota =
+      match api_err with
      | Llm_provider.Retry.NetworkError { message }
      | Llm_provider.Retry.Overloaded { message }
+     | Llm_provider.Retry.RateLimited { message; _ }
      | Llm_provider.Retry.ServerError { message; _ } ->
        message_looks_like_cli_wrapped_hard_quota message
-     | Llm_provider.Retry.RateLimited _
-     | Llm_provider.Retry.NotFound _
-     | Llm_provider.Retry.AuthError _
-     | Llm_provider.Retry.InvalidRequest _
-     | Llm_provider.Retry.ContextOverflow _
-     | Llm_provider.Retry.Timeout _ ->
-       false)
+     | _ ->
+       message_looks_like_cli_wrapped_hard_quota
+         (Llm_provider.Retry.error_message api_err)
+    in
+    Llm_provider.Retry.is_hard_quota api_err || wrapped_hard_quota
   | _ -> false
 
 (** Run a single Agent.run() call with MASC-driven cascade model fallback.


### PR DESCRIPTION
## Summary
- recognize Claude CLI quota wrappers that say `You've hit your limit` in `sdk_error_is_hard_quota`
- restore the existing `cascade_config` hard-quota expectation for the Claude CLI fixture
- include the current main compile unblock for `Llm_provider.Retry.NotFound` in `oas_worker_named`

Refs #9348

## Verification
- dune build --root . -j 1 test/test_oas_worker.exe
- ./_build/default/test/test_oas_worker.exe test cascade_config