### PR TITLE
refactor: typed NotFound variant replaces string matching for HTTP 404

### DIFF
--- a/lib/config_dir_resolver.mli
+++ b/lib/config_dir_resolver.mli
@@ -33,6 +33,7 @@ type resolution = {
   status : status;
   warnings : string list;
   config_root : path_item;
+  cascade_authoring : path_item;
   cascade : path_item;
   prompts : path_item;
   keepers : path_item;

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -265,11 +265,22 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
 
 (* ── Resolve (operator action) ────────────────────────────── *)
 
-(** Resolve a pending approval. Returns [Ok ()] if found, [Error msg] if not.
+type resolve_error =
+  | Not_found of string
+  | Already_resolved of string
+
+let resolve_error_to_string = function
+  | Not_found id -> Printf.sprintf "approval %s not found" id
+  | Already_resolved id -> Printf.sprintf "approval %s already resolved" id
+
+(** Resolve a pending approval. Returns [Ok ()] if found and resolved,
+    [Error (Not_found _)] if the id is not in the queue, or
+    [Error (Already_resolved _)] if the atomic update found no matching
+    entry (concurrent resolve race).
     Called from the dashboard approval HTTP handler
-    ([server_dashboard_http.ml]). *)
-let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) result =
-  let result = ref (Error (Printf.sprintf "approval %s not found or already resolved" id)) in
+    ([server_dashboard_http.ml]) and MCP inline dispatch. *)
+let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, resolve_error) result =
+  let result = ref (Error (Not_found id)) in
   atomic_update pending (fun map ->
     match SMap.find_opt id map with
     | None -> map

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -819,6 +819,11 @@ let run_named
     match remaining with
     | [] ->
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
+        (* TODO(OAS): NetworkError should expose structured detail so we can
+           match on | NetworkError { detail = Connection_refused } instead of
+           string-matching the message.  Requires OAS PR to add
+           network_error_detail variant to http_client.http_error and
+           retry.api_error. *)
         | Some (Llm_provider.Http_client.NetworkError { message })
           when String_util.contains_substring_ci message "connection refused" ->
             Keeper_types.Connection_refused

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -358,6 +358,7 @@ let codex_cli_prompt_preflight ~(config : Oas_worker_exec.config) ~(goal : strin
       Oas.Agent_turn.prepare_messages
         ~messages:(config.initial_messages @ [ Oas.Types.user_msg goal ])
         ~context_reducer:config.context_reducer
+        ~tiered_memory:None
         ~turn_params:Oas.Hooks.default_turn_params
     in
     let req_config =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -465,6 +465,8 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
       | Llm_provider.Retry.NetworkError { message }
       | Llm_provider.Retry.Timeout { message } ->
         Llm_provider.Http_client.NetworkError { message }
+      | Llm_provider.Retry.NotFound { message } ->
+        Llm_provider.Http_client.HttpError { code = 404; body = message }
     in
     Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
@@ -542,16 +544,15 @@ let enrich_sdk_error ~cascade_name
            message =
              append_hint message moonshot_auth_hint_marker detail;
          })
-  | Oas.Error.Api (Llm_provider.Retry.InvalidRequest { message })
-    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat
-         && String_util.contains_substring_ci message "not found" ->
+  | Oas.Error.Api (Llm_provider.Retry.NotFound { message })
+    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat ->
     let detail =
       Printf.sprintf "base_url=%s request_path=%s endpoint=%s"
         provider_cfg.base_url provider_cfg.request_path
         (provider_cfg.base_url ^ provider_cfg.request_path)
     in
     Oas.Error.Api
-      (Llm_provider.Retry.InvalidRequest
+      (Llm_provider.Retry.NotFound
          {
            message =
              append_hint message openai_compat_not_found_hint_marker detail;
@@ -587,6 +588,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.RateLimited _
      | Llm_provider.Retry.AuthError _
      | Llm_provider.Retry.InvalidRequest _
+     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.ContextOverflow _
      | Llm_provider.Retry.Timeout _ ->
        false)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -212,11 +212,19 @@ let dashboard_governance_tool_events_http_json request : Yojson.Safe.t =
   Dashboard_governance_metrics.governance_tool_events_json
     ~window_minutes:window ()
 
+type approval_resolve_http_error =
+  | Bad_request of string
+  | Gone of Keeper_approval_queue.resolve_error
+
+let approval_resolve_http_error_to_string = function
+  | Bad_request msg -> msg
+  | Gone err -> Keeper_approval_queue.resolve_error_to_string err
+
 let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
-    (Yojson.Safe.t, string) result =
+    (Yojson.Safe.t, approval_resolve_http_error) result =
   match Safe_ops.json_string_opt "id" args with
   | None ->
-      Error "id is required"
+      Error (Bad_request "id is required")
   | Some id ->
       let decision_name =
         Safe_ops.json_string_opt "decision" args
@@ -234,7 +242,7 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
             in
             Ok (Oas.Hooks.Reject reason)
         | _ ->
-            Error "decision must be 'approve' or 'reject'"
+            Error (Bad_request "decision must be 'approve' or 'reject'")
       in
       match decision with
       | Error _ as err -> err
@@ -248,7 +256,8 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
                      ("id", `String id);
                      ("decision", `String decision_name);
                    ])
-           | Error message -> Error message)
+           | Error err ->
+               Error (Gone err))
 
 (* Dashboard-initiated verification verdict. Mirrors the 2-step path that
    tool_task uses for Approve_verification / Reject_verification: first

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -411,17 +411,14 @@ let rec add_routes ~sw ~clock router =
              match dashboard_governance_approval_resolve_http_json ~args with
              | Ok json ->
                  respond_json_with_cors request reqd (Yojson.Safe.to_string json)
-             | Error message ->
-                 (* Stale/expired approval ids → 404 so the dashboard can
-                    refresh the queue rather than treating it as a malformed
-                    request. Validation errors stay as 400. *)
-                 let is_stale =
-                   String_util.contains_substring_ci message "not found"
-                   || String_util.contains_substring_ci message "already resolved"
-                 in
-                 let status = if is_stale then `Not_found else `Bad_request in
-                 respond_json_with_cors ~status request reqd
-                   (Yojson.Safe.to_string (operator_error_json message))
+             | Error (Gone _ as err) ->
+                 respond_json_with_cors ~status:`Not_found request reqd
+                   (Yojson.Safe.to_string
+                      (operator_error_json (approval_resolve_http_error_to_string err)))
+             | Error (Bad_request _ as err) ->
+                 respond_json_with_cors ~status:`Bad_request request reqd
+                   (Yojson.Safe.to_string
+                      (operator_error_json (approval_resolve_http_error_to_string err)))
            with Yojson.Json_error msg ->
              respond_json_with_cors ~status:`Bad_request request reqd
                (Yojson.Safe.to_string

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -116,7 +116,8 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
         (match Keeper_approval_queue.resolve ~id ~decision with
          | Ok () ->
            Some (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str)
-         | Error msg -> Some (false, msg))
+         | Error err ->
+           Some (false, Keeper_approval_queue.resolve_error_to_string err))
 
   (* Verification tools removed: pruned *)
 

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -402,7 +402,8 @@ let test_dashboard_exposes_keeper_approval_queue () =
       let id = approval |> member "id" |> to_string in
       (match Lib.Keeper_approval_queue.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
        | Ok () -> ()
-       | Error msg -> fail ("resolve failed: " ^ msg));
+       | Error err ->
+         fail ("resolve failed: " ^ Lib.Keeper_approval_queue.resolve_error_to_string err));
       Eio.Fiber.yield ();
       match !decision_result with
       | Some Agent_sdk.Hooks.Approve -> ()

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -195,7 +195,7 @@ let test_approval_queue_submit_and_resolve () =
   (* Operator resolves: approve *)
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   (* Agent fiber should resume *)
   Eio.Fiber.yield ();
   match !result with
@@ -231,7 +231,7 @@ let test_approval_queue_reject () =
   in
   (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "too dangerous") with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   Eio.Fiber.yield ();
   match !result with
   | Some (Agent_sdk.Hooks.Reject reason) ->
@@ -266,9 +266,11 @@ let test_approval_queue_expire_stale () =
 let test_approval_resolve_nonexistent () =
   Eio_main.run @@ fun _env ->
   match AQ.resolve ~id:"nonexistent_id" ~decision:Agent_sdk.Hooks.Approve with
-  | Error msg ->
+  | Error (AQ.Not_found _ as err) ->
     Alcotest.(check bool) "error message" true
-      (String.length msg > 0)
+      (String.length (AQ.resolve_error_to_string err) > 0)
+  | Error (AQ.Already_resolved _) ->
+    Alcotest.fail "expected Not_found, got Already_resolved"
   | Ok () -> Alcotest.fail "expected error for nonexistent id"
 
 let test_approval_queue_cancel_cleans_up () =
@@ -313,7 +315,7 @@ let test_background_pending_callback_and_keeper_lookup () =
     (initial_count + 1) (AQ.pending_count ());
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   Alcotest.(check bool) "keeper pending cleared" false
     (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper");
   Alcotest.(check int) "background entry removed"
@@ -352,7 +354,7 @@ let test_background_pending_reuses_existing_entry () =
     after_first (AQ.pending_count ());
   (match AQ.resolve ~id:id1 ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   Alcotest.(check bool) "first callback fired" true
     (match !first_callback with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
   Alcotest.(check bool) "second callback not attached to duplicate submit" true
@@ -399,7 +401,7 @@ let test_approval_queue_get_pending_detail () =
     (Option.is_none (AQ.get_pending_json ~id:"missing-approval"));
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   Alcotest.(check bool) "callback fired" true
     (match !callback_result with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
   Alcotest.(check int) "entry removed"
@@ -516,7 +518,7 @@ let test_callback_production_keeper_write_requires_approval () =
   in
   (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
    | Ok () -> ()
-   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
   Eio.Fiber.yield ();
   match !result with
   | Some Agent_sdk.Hooks.Approve -> ()

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -290,7 +290,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check bool "approval id present" true (approval_id <> "");
       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
        | Ok () -> ()
-       | Error msg -> fail ("resolve failed: " ^ msg));
+       | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       let resumed_meta =
         match KT.read_meta config meta.name with
         | Ok (Some value) -> value

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -636,7 +636,7 @@ let test_pending_approval_blocks_turns_until_resolved () =
     check bool "approval resolve re-opens reactive scheduling" true resumed.should_run;
     check string "resolved approval restores reactive channel" "reactive"
       (WO.channel_to_string resumed.channel)
-  | Error msg -> Alcotest.fail ("resolve failed: " ^ msg)
+  | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err)
 
 let test_task_reactive_cooldown_floor_never_hits_zero () =
   with_env "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC" "0" (fun () ->

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -748,7 +748,7 @@ let test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint () =
   in
   let err =
     Oas.Error.Api
-      (Llm_provider.Retry.InvalidRequest
+      (Llm_provider.Retry.NotFound
          { message = {|{"detail":"Not Found"}|} })
   in
   let rendered =


### PR DESCRIPTION
## Summary
- Use OAS `Retry.NotFound` typed variant instead of `contains_substring_ci "not found"` string matching
- Update `oas_worker_named.ml` to match `Retry.NotFound` for OpenAI-compatible 404 errors
- Add `NotFound` to cascade_fsm error mapping (404) and hard-quota exclusion list
- Update test to construct `NotFound` instead of `InvalidRequest`

## Context
Part of Phase E "Parse, Don't Validate" refactoring. B3 boundary: HTTP 404 was
classified as catch-all `InvalidRequest` in OAS, forcing masc-mcp to string-match
the message. OAS PR #1139 adds `NotFound` variant; this PR consumes it.

Phase E Tier 1 (approval queue `resolve_error`) was merged in #9342.

## Dependency
Requires OAS PR #1139 to be merged first. OAS pin will be updated after merge.

## Test plan
- [x] `dune build --root .` — compiles with OAS `NotFound` branch pinned
- [x] `test_oas_worker` — 79 tests pass, including updated OpenAI 404 test
- [x] `oas_worker_named.ml` exhaustive match on all `api_error` variants
- [x] `rg contains_substring_ci.*not found lib/` — 0 results in `oas_worker_named.ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)