### PR TITLE
[codex] Handle Retry.NotFound in oas worker

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -460,6 +460,8 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.HttpError { code = status; body = message }
       | Llm_provider.Retry.AuthError { message } ->
         Llm_provider.Http_client.HttpError { code = 401; body = message }
+      | Llm_provider.Retry.NotFound { message } ->
+        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
         Llm_provider.Http_client.HttpError { code = 529; body = message }
       | Llm_provider.Retry.NetworkError { message }
@@ -582,6 +584,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
        message_looks_like_cli_wrapped_hard_quota message
      | Llm_provider.Retry.RateLimited _
      | Llm_provider.Retry.AuthError _
+     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.InvalidRequest _
      | Llm_provider.Retry.ContextOverflow _
      | Llm_provider.Retry.Timeout _ ->


### PR DESCRIPTION
## What changed
- handle `Llm_provider.Retry.NotFound` in `sdk_error_to_cascade_outcome` as HTTP 404
- treat `Retry.NotFound` as non-hard-quota in `sdk_error_is_hard_quota`

## Why
The upstream retry error surface now includes `NotFound`, but `lib/oas_worker_named.ml` still matched the older variant set. With warning 8 promoted, `dune build` failed on a non-exhaustive match.

## Impact
The OAS worker now compiles cleanly against the current retry surface and preserves the expected semantics for not-found errors.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-worker-retry-notfound`
