### PR TITLE
fix(replay): gate parser by provider format

### DIFF
--- a/lib/tool_call_replay_harness.ml
+++ b/lib/tool_call_replay_harness.ml
@@ -18,6 +18,9 @@ let ( let* ) = Result.bind
 let errorf fmt =
   Printf.ksprintf (fun msg -> Error msg) fmt
 
+type response_format =
+  | Openai_chat_completions
+
 let assoc label = function
   | `Assoc fields -> Ok fields
   | _ -> errorf "%s: expected object" label
@@ -96,6 +99,29 @@ let load_snapshots_from_jsonl path =
       in
       parse 0 [] rows
 
+let response_format_of_provider provider =
+  let canonical =
+    match Provider_adapter.resolve_direct_canonical_name provider with
+    | Some name -> name
+    | None -> String.lowercase_ascii (String.trim provider)
+  in
+  (* The seed harness only knows the OpenAI-compatible chat-completions
+     tool-call envelope; unsupported providers must add an explicit extractor
+     instead of silently reusing this parser. *)
+  match canonical with
+  | "codex-api"
+  | "glm-api"
+  | "glm-coding-plan"
+  | "kimi-api"
+  | "openrouter"
+  | "ollama"
+  | "llama" ->
+      Ok Openai_chat_completions
+  | _ ->
+      errorf
+        "snapshot provider '%s' (canonical '%s') is not supported by replay harness yet"
+        provider canonical
+
 let extract_openai_tool_calls response =
   let* fields = assoc "response" response in
   let* choices = list_field fields "choices" in
@@ -146,7 +172,10 @@ let validate_snapshot (snapshot : snapshot) =
       if not (tool_declared expected.name) then
         push "expected tool '%s' is not declared in snapshot.tools" expected.name)
     snapshot.expected_tool_calls;
-  (match extract_openai_tool_calls snapshot.response with
+  (match response_format_of_provider snapshot.provider with
+   | Error msg -> push "%s" msg
+   | Ok Openai_chat_completions ->
+       (match extract_openai_tool_calls snapshot.response with
    | Error msg -> push "%s" msg
    | Ok actual_tool_calls ->
        List.iter
@@ -170,7 +199,7 @@ let validate_snapshot (snapshot : snapshot) =
                push
                  "arguments mismatch for tool '%s'"
                  expected.name)
-           snapshot.expected_tool_calls actual_tool_calls);
+           snapshot.expected_tool_calls actual_tool_calls));
   match List.rev !errors with
   | [] -> Ok ()
   | errs -> Error errs

--- a/test/test_tool_call_replay_harness.ml
+++ b/test/test_tool_call_replay_harness.ml
@@ -86,6 +86,17 @@ let test_validate_rejects_argument_mismatch () =
       check bool "argument mismatch surfaced" true
         (contains_substring joined "arguments mismatch for tool 'masc_add_task'")
 
+let test_validate_rejects_unsupported_provider () =
+  let snapshot = load_fixture () in
+  let bad_snapshot = { snapshot with provider = "anthropic" } in
+  match Tool_call_replay_harness.validate_snapshot bad_snapshot with
+  | Ok () -> Alcotest.fail "expected unsupported provider validation to fail"
+  | Error errors ->
+      let joined = String.concat " | " errors in
+      check bool "unsupported provider surfaced" true
+        (contains_substring joined
+           "snapshot provider 'anthropic' (canonical 'claude-api') is not supported")
+
 let test_load_rejects_malformed_jsonl () =
   let dir = Filename.temp_file "tool-call-replay" ".dir" in
   Sys.remove dir;
@@ -119,6 +130,8 @@ let () =
             test_validate_rejects_undeclared_tool;
           Alcotest.test_case "reject argument mismatch" `Quick
             test_validate_rejects_argument_mismatch;
+          Alcotest.test_case "reject unsupported provider" `Quick
+            test_validate_rejects_unsupported_provider;
           Alcotest.test_case "reject malformed jsonl" `Quick
             test_load_rejects_malformed_jsonl;
         ] );


### PR DESCRIPTION
## Summary
- gate replay-harness parser selection by provider format instead of always using the OpenAI parser
- reject unsupported providers explicitly so provider metadata is not silently ignored
- add a regression test for unsupported provider snapshots

## Product impact
- Promise affected: `repo coordination`
- User-visible change: replay-harness evidence now fails fast on unsupported provider formats instead of mis-parsing them as OpenAI chat-completions

## Evidence
- self-review finding: `validate_snapshot` previously ignored `snapshot.provider` and always called `extract_openai_tool_calls`
- verified on top of `#9349` blocker fix branch:
  - `dune build --root . test/test_tool_call_replay_harness.exe`
  - `./_build/default/test/test_tool_call_replay_harness.exe`
- current `main` local build is blocked by the known `lib/oas_worker_named.ml` `Llm_provider.Retry.NotFound _` partial-match issue, already tracked in open PR `#9349`

## Review evidence
- self-review only; no additional model review yet