### PR TITLE
Bump masc_mcp version to 0.12.4

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.12.3)
+(version 0.12.4)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
Bump version for upcoming telemetry integration fixes.

(The root cause of #9335 was resolved upstream in `oas` PR).

### Changes:
- Bumped `dune-project` version to 0.12.4.