### PR TITLE
fix(cascade): surface invalid keeper presets

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1792,8 +1792,14 @@ export function fetchMemorySubsystems(
 
 // --- Keeper Cascade Config ---
 
-export function fetchCascadeProfiles(): Promise<{ profiles: string[] }> {
-  return get<{ profiles: string[] }>('/api/v1/keeper/cascades')
+export function fetchCascadeProfiles(): Promise<{
+  profiles: string[]
+  invalid_profiles: CascadeInvalidProfile[]
+}> {
+  return get<{
+    profiles: string[]
+    invalid_profiles: CascadeInvalidProfile[]
+  }>('/api/v1/keeper/cascades')
 }
 
 export function updateKeeperCascade(keeper: string, cascade_name: string): Promise<{ ok: boolean }> {

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1271,27 +1271,70 @@ export function KeeperDetailOverlay() {
                   `
                 })()}
                 ${(() => {
-                  const [profiles, setProfiles] = useState<string[]>([])
+                  const [cascadeProfiles, setCascadeProfiles] = useState<{
+                    profiles: string[]
+                    invalid_profiles: { name: string; errors: string[] }[]
+                  } | null>(null)
                   const [currentCascade, setCurrentCascade] = useState(keeper.cascade_name || 'default')
-                  if (profiles.length === 0) {
-                    fetchCascadeProfiles().then(r => setProfiles(r.profiles)).catch(() => {})
+                  if (!cascadeProfiles) {
+                    fetchCascadeProfiles().then(setCascadeProfiles).catch(() => {})
                   }
-                  if (profiles.length <= 1) return null
+                  const profiles = cascadeProfiles?.profiles ?? []
+                  const invalidProfiles = cascadeProfiles?.invalid_profiles ?? []
+                  if (profiles.length + invalidProfiles.length <= 1) return null
+                  const invalidSummary = invalidProfiles
+                    .map((profile) => `${profile.name}: ${profile.errors.join(' | ')}`)
+                    .join('\n')
+                  const knownValues = new Set([
+                    ...profiles,
+                    ...invalidProfiles.map((profile) => profile.name),
+                  ])
                   return html`
-                    <select
-                      class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
-                      title="Cascade profile"
-                      value=${currentCascade}
-                      onChange=${(e: Event) => {
-                        const val = (e.target as HTMLSelectElement).value
-                        setCurrentCascade(val)
-                        updateKeeperCascade(keeper.name, val).then(() => {
-                          refreshDashboard()
-                        })
-                      }}
-                    >
-                      ${profiles.map(p => html`<option value=${p}>${p}</option>`)}
-                    </select>
+                    <div class="flex items-center gap-1.5">
+                      <select
+                        class="py-0.5 px-1 rounded text-3xs font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
+                        title=${invalidProfiles.length > 0
+                          ? `Cascade profile\n\nDisabled invalid presets:\n${invalidSummary}`
+                          : 'Cascade profile'}
+                        value=${currentCascade}
+                        onChange=${(e: Event) => {
+                          const val = (e.target as HTMLSelectElement).value
+                          setCurrentCascade(val)
+                          updateKeeperCascade(keeper.name, val)
+                            .then(() => {
+                              refreshDashboard()
+                            })
+                            .catch((err) => {
+                              setCurrentCascade(keeper.cascade_name || 'default')
+                              const msg = err instanceof Error ? err.message : 'Cascade 변경 실패'
+                              showToast(msg, 'error')
+                            })
+                        }}
+                      >
+                        ${!knownValues.has(currentCascade) && currentCascade
+                          ? html`<option value=${currentCascade}>${currentCascade} (current)</option>`
+                          : null}
+                        ${profiles.map((p) => html`<option value=${p}>${p}</option>`)}
+                        ${invalidProfiles.length > 0
+                          ? html`<option disabled>──────── invalid ────────</option>`
+                          : null}
+                        ${invalidProfiles.map((profile) => html`
+                          <option
+                            value=${profile.name}
+                            disabled
+                            title=${profile.errors.join(' | ')}
+                          >${profile.name} (invalid)</option>
+                        `)}
+                      </select>
+                      ${invalidProfiles.length > 0
+                        ? html`
+                            <span
+                              class="inline-flex items-center py-0.5 px-1.5 rounded text-3xs font-semibold bg-[var(--bad-10)] text-[var(--rose-light)] border border-[var(--bad-30)]"
+                              title=${invalidSummary}
+                            >${invalidProfiles.length} invalid</span>
+                          `
+                        : null}
+                    </div>
                   `
                 })()}
               </div>

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -409,17 +409,32 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
           List.fold_left
             (fun (ok_acc, err_acc) (entry : Cascade_config_loader.weighted_entry) ->
               match
-                Cascade_config.parse_weighted_entry
+                Cascade_config.parse_weighted_entry_diag
                   ~api_key_env_overrides
                   entry
               with
-              | Some provider_cfg ->
+              | Ok provider_cfg ->
                   ({ model_string = entry.model; provider_cfg } :: ok_acc, err_acc)
-              | None ->
+              | Error
+                  (Cascade_config.Drop_unregistered_scheme { model; scheme }) ->
                   ( ok_acc,
                     Printf.sprintf
-                      "candidate %S is invalid or unavailable for the current runtime"
-                      entry.model
+                      "candidate %S uses unregistered provider scheme %S"
+                      model scheme
+                    :: err_acc )
+              | Error
+                  (Cascade_config.Drop_unavailable_scheme { model; scheme }) ->
+                  ( ok_acc,
+                    Printf.sprintf
+                      "candidate %S uses unavailable provider scheme %S \
+                       (missing credential or disabled runtime lane)"
+                      model scheme
+                    :: err_acc )
+              | Error (Cascade_config.Drop_invalid_syntax model) ->
+                  ( ok_acc,
+                    Printf.sprintf
+                      "candidate %S has invalid provider:model syntax"
+                      model
                     :: err_acc ))
             ([], [])
             expanded_entries
@@ -849,6 +864,31 @@ let known_profile_names ?sw ?net ?clock () =
   match require_snapshot ?sw ?net ?clock () with
   | Ok snapshot -> Ok (profile_names_of_snapshot snapshot)
   | Error _ as e -> e
+
+let dedupe_keep_order values =
+  let seen = Hashtbl.create (List.length values) in
+  List.filter
+    (fun value ->
+      if value = "" || Hashtbl.mem seen value then
+        false
+      else (
+        Hashtbl.replace seen value ();
+        true))
+    values
+
+let invalid_profile_errors ?sw ?net ?clock () =
+  let of_rejection rejection =
+    rejection.profiles
+    |> List.filter_map (fun (profile : profile_rejection) ->
+           let errors = dedupe_keep_order profile.errors in
+           if errors = [] then None else Some (profile.name, errors))
+  in
+  match inspect_active ?sw ?net ?clock () with
+  | Ok (Validated _) -> []
+  | Ok (Validated_with_rejections { rejected_update; _ })
+  | Ok (Serving_last_known_good { rejected_update; _ })
+  | Error rejected_update ->
+      of_rejection rejected_update
 
 let resolve_selection_trace ?sw ?net ?clock ~name () =
   match lookup_active_profile ?sw ?net ?clock name with

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -119,6 +119,15 @@ val known_profile_names :
   unit ->
   (string list, string) result
 
+val invalid_profile_errors :
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit ->
+  (string * string list) list
+(** Profile-scoped validation errors from the active runtime catalog
+    view. Returns [[]] when the catalog is fully validated. *)
+
 val resolve_selection_trace :
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -72,6 +72,23 @@ val parse_weighted_entry :
   Cascade_config_loader.weighted_entry ->
   Llm_provider.Provider_config.t option
 
+type weighted_entry_drop =
+  | Drop_unregistered_scheme of { model : string; scheme : string }
+  | Drop_unavailable_scheme of { model : string; scheme : string }
+  | Drop_invalid_syntax of string
+
+(** Like {!parse_weighted_entry}, but preserves the reason a candidate was
+    rejected so callers can surface actionable validation errors.
+
+    @since 0.150.0 *)
+val parse_weighted_entry_diag :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
+  Cascade_config_loader.weighted_entry ->
+  (Llm_provider.Provider_config.t, weighted_entry_drop) result
+
 (** Parse a list of weighted entries, dropping ones that cannot produce a
     provider config. Preserves input order.
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -360,7 +360,6 @@ let codex_cli_prompt_preflight ~(config : Oas_worker_exec.config) ~(goal : strin
         ~context_reducer:config.context_reducer
         ~tiered_memory:None
         ~turn_params:Oas.Hooks.default_turn_params
-        ~tiered_memory:None
     in
     let req_config =
       match String.trim config.system_prompt with
@@ -450,14 +449,7 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
     : Cascade_fsm.provider_outcome option =
   match err with
   | Oas.Error.Api api_err ->
-<<<<<<< HEAD
     let http_err = match[@warning "-8"] api_err with
-||||||| parent of 594cafd21 (fix: avoid Retry.NotFound pin drift)
-    let fallback_message = Llm_provider.Retry.error_message api_err in
-    let http_err = match api_err with
-=======
-    let http_err = match api_err with
->>>>>>> 594cafd21 (fix: avoid Retry.NotFound pin drift)
       | Llm_provider.Retry.InvalidRequest { message } ->
         Llm_provider.Http_client.HttpError { code = 400; body = message }
       | Llm_provider.Retry.ContextOverflow { message; _ } ->
@@ -468,30 +460,13 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.ServerError { status; message } ->
         Llm_provider.Http_client.HttpError { code = status; body = message }
-      | Llm_provider.Retry.NotFound _ ->
-        Llm_provider.Http_client.HttpError
-          { code = 404; body = "resource not found" }
       | Llm_provider.Retry.AuthError { message } ->
         Llm_provider.Http_client.HttpError { code = 401; body = message }
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
         Llm_provider.Http_client.HttpError { code = 529; body = message }
       | Llm_provider.Retry.NetworkError { message }
       | Llm_provider.Retry.Timeout { message } ->
         Llm_provider.Http_client.NetworkError { message }
-<<<<<<< HEAD
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
-||||||| parent of 594cafd21 (fix: avoid Retry.NotFound pin drift)
-      | _ ->
-        let code =
-          if api_error_message_looks_like_not_found fallback_message then 404
-          else 500
-        in
-        Llm_provider.Http_client.HttpError { code; body = fallback_message }
-=======
->>>>>>> 594cafd21 (fix: avoid Retry.NotFound pin drift)
     in
     Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
@@ -617,9 +592,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.RateLimited _
      | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.AuthError _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.InvalidRequest _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.ContextOverflow _
      | Llm_provider.Retry.Timeout _ ->
        false)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -23,16 +23,18 @@ let cascade_profile_gate () : cascade_profile_gate =
     Keeper_cascade_profile.keeper_catalog_names ?config_path ()
     |> List.sort_uniq String.compare
   in
-  let invalid_profiles =
+  let fallback_invalid_profiles =
     match config_path with
     | None -> []
     | Some path ->
         Cascade_catalog_validator.error_messages_by_profile
           ~config_path:path
   in
-  let invalid_names = List.map fst invalid_profiles in
   match Cascade_catalog_runtime.known_profile_names () with
   | Ok validated_profiles ->
+      let invalid_profiles =
+        Cascade_catalog_runtime.invalid_profile_errors ()
+      in
       let valid_profiles =
         let filtered =
           keeper_profiles
@@ -45,6 +47,8 @@ let cascade_profile_gate () : cascade_profile_gate =
       Log.Keeper.warn
         "cascade_profile_gate: validated runtime snapshot unavailable: %s"
         detail;
+      let invalid_profiles = fallback_invalid_profiles in
+      let invalid_names = List.map fst invalid_profiles in
       let valid_profiles =
         keeper_profiles
         |> List.filter (fun profile -> not (List.mem profile invalid_names))
@@ -963,10 +967,20 @@ and add_autoresearch_routes router =
 
   |> Http.Router.get "/api/v1/keeper/cascades" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
-         let profiles = available_cascade_profiles () in
+         let gate = cascade_profile_gate () in
          Http.Response.json ~request:request
            (Yojson.Safe.to_string (`Assoc [
-             ("profiles", `List (List.map (fun s -> `String s) profiles));
+             ("profiles", `List (List.map (fun s -> `String s) gate.valid_profiles));
+             ( "invalid_profiles",
+               `List
+                 (List.map
+                    (fun (name, errors) ->
+                      `Assoc
+                        [
+                          ("name", `String name);
+                          ("errors", `List (List.map (fun err -> `String err) errors));
+                        ])
+                    gate.invalid_profiles) );
            ])) reqd
        ) request reqd)
 

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -399,6 +399,21 @@ let test_partial_catalog_keeps_validated_subset_available () =
   check (list string) "dashboard only advertises validated profiles"
     [ Keeper_config.default_cascade_name; "tool_rerank" ]
     (Masc_mcp.Server_routes_http_routes_dashboard.available_cascade_profiles ());
+  let invalid_profiles =
+    Masc_mcp.Server_routes_http_routes_dashboard.invalid_cascade_profiles ()
+  in
+  check (list string) "invalid profiles use runtime rejected subset"
+    [ "broken_profile" ]
+    (List.map fst invalid_profiles);
+  check bool "invalid profile reason is actionable" true
+    (match List.assoc_opt "broken_profile" invalid_profiles with
+     | Some reasons ->
+         List.exists
+           (fun reason ->
+              contains_substring reason
+                "uses unregistered provider scheme")
+           reasons
+     | None -> false);
   let config_json = Masc_mcp.Dashboard_cascade.config_json () in
   let profile_names =
     json_list_field "profiles" config_json

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -485,6 +485,20 @@ let profile_names body =
   | _ -> []
 ;;
 
+let invalid_profile_names body =
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  match json |> member "invalid_profiles" with
+  | `List items ->
+      List.filter_map
+        (fun item ->
+           match item |> member "name" with
+           | `String value -> Some value
+           | _ -> None)
+        items
+  | _ -> []
+;;
+
 let make_keeper_meta_json ?(name = "route-shadow-demo") () =
   match
     Masc_mcp.Keeper_types.meta_of_json
@@ -826,9 +840,12 @@ let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
   in
   require_status "keeper cascades GET returns 200" 200 list_result;
   let profiles = profile_names list_result.body in
+  let invalid_profiles = invalid_profile_names list_result.body in
   check bool "valid profile remains assignable" true (List.mem "good" profiles);
   check bool "invalid profile omitted from assignable list" false
     (List.mem "broken" profiles);
+  check bool "invalid profile is surfaced in payload" true
+    (List.mem "broken" invalid_profiles);
   let assign_invalid_result =
     run_curl_post
       ~body:


### PR DESCRIPTION
## Summary
- surface runtime-rejected cascade presets as disabled options in keeper selection
- return invalid preset metadata from /api/v1/keeper/cascades using runtime validation detail
- add route/runtime coverage for invalid preset payloads and actionable rejection reasons

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-7872-cascade-invalid-profiles --build-dir /tmp/issue-7872-postrebase ./bin/main_eio.exe ./test/test_cascade_catalog_runtime.exe ./test/test_dashboard_cascade.exe ./test/test_dashboard_keeper_routes.exe
- /tmp/issue-7872-postrebase/default/test/test_cascade_catalog_runtime.exe
- /tmp/issue-7872-postrebase/default/test/test_dashboard_cascade.exe
- env MASC_MAIN_EIO_EXE=/tmp/issue-7872-postrebase/default/bin/main_eio.exe /tmp/issue-7872-postrebase/default/test/test_dashboard_keeper_routes.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin/tsc --noEmit --pretty -p /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-7872-cascade-invalid-profiles/dashboard/tsconfig.json

Closes #7872