### PR TITLE
fix(reputation): canonicalize keeper identity parsing

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -183,18 +183,9 @@ let compute_overall_score ~completion_rate ~response_rate
 (** {1 Accountability Penalty} *)
 
 let keeper_name_of_agent agent_name =
-  let trimmed = String.trim agent_name in
-  let suffix = "-agent" in
-  let suffix_len = String.length suffix in
-  let len = String.length trimmed in
-  if len > suffix_len
-     && String.sub trimmed (len - suffix_len) suffix_len = suffix
-  then
-    String.sub trimmed 0 (len - suffix_len)
-  else if Nickname.is_generated_nickname trimmed then
-    Option.value (Nickname.extract_agent_type trimmed) ~default:trimmed
-  else
-    trimmed
+  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
+  | Some keeper_name -> keeper_name
+  | None -> String.trim agent_name
 
 let accountability_metrics (config : Coord.config) ~(agent_name : string) =
   let keeper_name = keeper_name_of_agent agent_name in

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -84,21 +84,17 @@ let normalize_refs refs =
   |> List.sort_uniq String.compare
 
 let is_keeper_agent_name agent_name =
-  Resilience.Zombie.is_keeper_name
-    (String.lowercase_ascii (String.trim agent_name))
+  Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name agent_name)
 
 let keeper_name_of_agent agent_name =
-  let trimmed = String.trim agent_name in
-  let suffix = "-agent" in
-  if String.length trimmed > String.length suffix
-     && String.sub trimmed
-          (String.length trimmed - String.length suffix)
-          (String.length suffix)
-        = suffix
-  then
-    String.sub trimmed 0 (String.length trimmed - String.length suffix)
-  else
-    trimmed
+  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
+  | Some keeper_name -> keeper_name
+  | None -> String.trim agent_name
+
+let normalize_keeper_name keeper_name =
+  match Keeper_identity.canonical_keeper_name keeper_name with
+  | Some keeper_name -> keeper_name
+  | None -> String.trim keeper_name
 
 let accountability_dir base_path =
   Filename.concat base_path ".masc/accountability"
@@ -197,7 +193,7 @@ let claim_event_of_json json =
           let agent_name = Safe_ops.json_string ~default:"" "agent_name" json in
           let keeper_name =
             match json_string_opt "keeper_name" json with
-            | Some value when String.trim value <> "" -> String.trim value
+            | Some value when String.trim value <> "" -> normalize_keeper_name value
             | _ -> keeper_name_of_agent agent_name
           in
           let subject = Safe_ops.json_string ~default:"" "subject" json in
@@ -508,7 +504,7 @@ let record_completion_claim (config : Coord_query.config) ~keeper_name ~agent_na
               {
                 claim_id;
                 agent_name;
-                keeper_name;
+                keeper_name = normalize_keeper_name keeper_name;
                 trace_id = Some trace_id;
                 turn_number = Some turn_number;
                 task_id = normalized_task_id;
@@ -709,6 +705,7 @@ let accountability_summary_lookup (config : Coord_query.config) =
            add_snapshot by_agent snapshot.claim.agent_name snapshot;
            add_snapshot by_keeper snapshot.claim.keeper_name snapshot));
   fun ~keeper_name ~agent_name ->
+    let keeper_name = normalize_keeper_name keeper_name in
     let source, snapshots =
       match Hashtbl.find_opt by_agent agent_name with
       | Some items -> ("direct_agent", items)

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -1,33 +1,23 @@
-(** Keeper_identity — Centralized keeper identity and trace ID management.
+(** Keeper_identity — centralized keeper identity helpers. *)
 
-    Consolidates trace_id generation, session_id conventions, and
-    git author/committer identity for keeper operations.
-
-    - [trace_id] is generated per keeper creation and per handoff rollover.
-    - [session_id] is set equal to [trace_id] in [create_session].
-    - Directory layout: [.masc/traces/<trace_id>/] per execution trace.
-    - Git identity: commits made by keepers are attributed via
-      GIT_AUTHOR_NAME / GIT_COMMITTER_NAME environment variables.
-
-    @since 2.162.0 — #3721 keeper stabilization
-    @since 2.254.0 — git identity for keeper operations *)
-
-(** Generate a new trace ID. Used at keeper creation and handoff rollover.
-    Format: [trace-<epoch_ms>-<5hex>] *)
 let generate_trace_id () : string =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
   let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
   Printf.sprintf "trace-%d-%05x" ts hash
 
-(* ── Git Identity ──────────────────────────────────────────────────── *)
-
-(** Sanitize a keeper name for use in git author/email fields.
-    Keeps [A-Za-z0-9._-], replaces everything else with ['_']. *)
 let sanitize_name (name : string) : string =
-  String.map (fun c ->
-    if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-       || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
-    then c else '_') name
+  String.map
+    (fun c ->
+      if
+        (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || c = '-'
+        || c = '_'
+        || c = '.'
+      then c
+      else '_')
+    name
 
 let keeper_git_author ~(keeper_name : string) : string =
   let safe = sanitize_name keeper_name in
@@ -40,17 +30,68 @@ let keeper_git_email ~(keeper_name : string) : string =
 let git_env_for_keeper ~(keeper_name : string) : string array =
   let author = keeper_git_author ~keeper_name in
   let email = keeper_git_email ~keeper_name in
-  (* Inherit current process environment and override git identity vars *)
   let base_env = Unix.environment () in
-  let filtered = Array.to_list base_env
+  let filtered =
+    Array.to_list base_env
     |> List.filter (fun s ->
-      not (String.starts_with ~prefix:"GIT_AUTHOR_" s)
-      && not (String.starts_with ~prefix:"GIT_COMMITTER_" s))
+           not (String.starts_with ~prefix:"GIT_AUTHOR_" s)
+           && not (String.starts_with ~prefix:"GIT_COMMITTER_" s))
   in
-  let overrides = [
-    "GIT_AUTHOR_NAME=" ^ author;
-    "GIT_AUTHOR_EMAIL=" ^ email;
-    "GIT_COMMITTER_NAME=" ^ author;
-    "GIT_COMMITTER_EMAIL=" ^ email;
-  ] in
+  let overrides =
+    [
+      "GIT_AUTHOR_NAME=" ^ author;
+      "GIT_AUTHOR_EMAIL=" ^ email;
+      "GIT_COMMITTER_NAME=" ^ author;
+      "GIT_COMMITTER_EMAIL=" ^ email;
+    ]
+  in
   Array.of_list (filtered @ overrides)
+
+let keeper_name_from_agent_name agent_name =
+  let prefix = "keeper-" and suffix = "-agent" in
+  let plen = String.length prefix and slen = String.length suffix in
+  let alen = String.length agent_name in
+  if alen > plen + slen
+     && String.sub agent_name 0 plen = prefix
+     && String.sub agent_name (alen - slen) slen = suffix
+  then
+    let keeper_name = String.sub agent_name plen (alen - plen - slen) in
+    if Keeper_config.validate_name keeper_name then Some keeper_name else None
+  else if Nickname.is_generated_nickname agent_name
+          && Keeper_config.validate_name agent_name
+  then
+    Some agent_name
+  else
+    None
+
+let canonical_keeper_name_from_agent_name agent_name =
+  let trimmed = String.trim agent_name in
+  match keeper_name_from_agent_name trimmed with
+  | Some _ when Nickname.is_generated_nickname trimmed -> (
+      match Nickname.extract_agent_type trimmed with
+      | Some candidate when Keeper_config.validate_name candidate -> Some candidate
+      | _ -> None)
+  | Some keeper_name -> Some keeper_name
+  | None ->
+      if Nickname.is_generated_nickname trimmed
+      then
+        match Nickname.extract_agent_type trimmed with
+        | Some candidate when Keeper_config.validate_name candidate -> Some candidate
+        | _ -> None
+      else
+        None
+
+let canonical_keeper_name raw_name =
+  let trimmed = String.trim raw_name in
+  let prefix = "keeper-" in
+  let plen = String.length prefix in
+  let alen = String.length trimmed in
+  if trimmed = "" then None
+  else
+    match canonical_keeper_name_from_agent_name trimmed with
+    | Some _ as canonical -> canonical
+    | None when alen > plen && String.sub trimmed 0 plen = prefix ->
+        let candidate = String.sub trimmed plen (alen - plen) in
+        if Keeper_config.validate_name candidate then Some candidate else None
+    | None ->
+        if Keeper_config.validate_name trimmed then Some trimmed else None

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -1,32 +1,11 @@
-(** Keeper_identity — Trace ID generation and git author/committer identity
-    for keeper operations.
-
-    Consolidates trace_id generation, session_id conventions, and
-    git identity so that commits made by keepers are properly attributed.
-
-    Identity patterns follow [config/tool_policy.toml] section
-    [keeper_identity].  When config is not loaded, uses default patterns.
-
-    @since 2.162.0 — #3721 keeper stabilization (trace_id)
-    @since 2.254.0 — git identity for keeper operations *)
+(** Keeper_identity — Trace ID generation, git identity, and keeper-name
+    normalization for keeper operations. *)
 
 val generate_trace_id : unit -> string
-(** Generate a new trace ID. Used at keeper creation and handoff rollover.
-    Format: [trace-<epoch_ms>-<5hex>]. *)
-
 val keeper_git_author : keeper_name:string -> string
-(** Return the git author name for a keeper.
-    Default pattern: ["{keeper_name} (MASC Keeper)"].
-    The keeper name is sanitized to [A-Za-z0-9._-]. *)
-
 val keeper_git_email : keeper_name:string -> string
-(** Return the git email for a keeper.
-    Default pattern: ["{keeper_name}\@masc.local"].
-    The keeper name is sanitized to [A-Za-z0-9._-]. *)
-
 val git_env_for_keeper : keeper_name:string -> string array
-(** Return environment variable array suitable for
-    [Process_eio.run_argv_with_status ~env].
-    Sets GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME,
-    GIT_COMMITTER_EMAIL.  Inherits all other env vars from the
-    current process. *)
+
+val keeper_name_from_agent_name : string -> string option
+val canonical_keeper_name_from_agent_name : string -> string option
+val canonical_keeper_name : string -> string option

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1728,23 +1728,12 @@ let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
 ;;
 
-let keeper_name_from_agent_name agent_name =
-  let prefix = "keeper-" and suffix = "-agent" in
-  let plen = String.length prefix and slen = String.length suffix in
-  let alen = String.length agent_name in
-  if alen > plen + slen
-     && String.sub agent_name 0 plen = prefix
-     && String.sub agent_name (alen - slen) slen = suffix
-  then
-    (* Full keeper-xxx-agent format *)
-    let keeper_name = String.sub agent_name plen (alen - plen - slen) in
-    if validate_name keeper_name then Some keeper_name else None
-  else
-    (* Only generated nicknames should alias directly to keeper names. *)
-    if Nickname.is_generated_nickname agent_name && validate_name agent_name
-    then Some agent_name
-    else None
-;;
+let keeper_name_from_agent_name = Keeper_identity.keeper_name_from_agent_name
+
+let canonical_keeper_name_from_agent_name =
+  Keeper_identity.canonical_keeper_name_from_agent_name
+
+let canonical_keeper_name = Keeper_identity.canonical_keeper_name
 
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
   let requested_name = String.trim name in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -278,6 +278,8 @@ val persistent_agent_names : Coord.config -> string list
 val fresher_meta : Coord.config -> keeper_meta -> keeper_meta
 val write_meta : ?force:bool -> Coord.config -> keeper_meta -> (unit, string) result
 val keeper_name_from_agent_name : string -> string option
+val canonical_keeper_name_from_agent_name : string -> string option
+val canonical_keeper_name : string -> string option
 val read_meta_resolved :
   Coord.config -> string -> ((string * keeper_meta) option, string) result
 val read_meta : Coord.config -> string -> (keeper_meta option, string) result

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -269,6 +269,37 @@ let test_generated_alias_inherits_accountability_penalty () =
         "Inherited from canonical identity: adversary"
         rep.accountability_source_label)
 
+let test_generated_alias_inherits_legacy_keeper_history () =
+  with_room ~agent_name:"adversary-eager-viper" (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-adversary-legacy-unsupported");
+             ("agent_name", `String "keeper-adversary-agent");
+             ("keeper_name", `String "keeper-adversary");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Unsupported legacy claim");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"adversary" ~agent_name:"adversary-eager-viper"
+      in
+      check string "legacy keeper summary source" "canonical_keeper_fallback"
+        (string_member "source" summary);
+      check string "legacy keeper source label"
+        "Inherited from canonical identity: adversary"
+        (string_member "source_label" summary);
+      check (float 0.0001) "legacy keeper unsupported rate" 1.0
+        (float_member "unsupported_completion_rate" summary))
+
 let test_direct_agent_history_exposes_direct_source () =
   with_room ~agent_name:"keeper-direct-agent" (fun config ->
       let created_at =
@@ -301,13 +332,28 @@ let test_direct_agent_history_exposes_direct_source () =
         Agent_reputation.compute_reputation config
           ~agent_name:"keeper-direct-agent"
       in
-      check string "direct reputation keeper provenance" "keeper-direct"
+      check string "direct reputation keeper provenance" "direct"
         rep.accountability_keeper_name;
       check string "direct reputation source" "direct_agent"
         rep.accountability_source;
       check string "direct reputation source label"
         "Direct runtime alias history"
         rep.accountability_source_label)
+
+let test_task_transition_normalizes_keeper_name_in_history () =
+  with_room ~agent_name:"keeper-sangsu-agent" (fun config ->
+      Keeper_accountability.record_task_transition config
+        ~agent_name:"keeper-sangsu-agent" ~task_id:"task-legacy"
+        ~transition:Types.Claim ~details:(`Assoc []);
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent"
+      in
+      let history = Yojson.Safe.Util.(summary |> member "history" |> to_list) in
+      check int "history count" 1 (List.length history);
+      let first = List.hd history in
+      check string "history keeper_name is canonical" "sangsu"
+        (string_member "keeper_name" first))
 
 let test_unmapped_alias_exposes_no_history_source () =
   with_room ~agent_name:"orphan-eager-viper" (fun config ->
@@ -651,8 +697,12 @@ let () =
             test_agent_reputation_penalizes_unsupported_claims;
           test_case "generated alias inherits accountability penalty" `Quick
             test_generated_alias_inherits_accountability_penalty;
+          test_case "generated alias inherits legacy keeper history" `Quick
+            test_generated_alias_inherits_legacy_keeper_history;
           test_case "direct agent history exposes direct source" `Quick
             test_direct_agent_history_exposes_direct_source;
+          test_case "task transition canonicalizes keeper name in history"
+            `Quick test_task_transition_normalizes_keeper_name_in_history;
           test_case "unmapped alias exposes no-history source" `Quick
             test_unmapped_alias_exposes_no_history_source;
           test_case "claim tool exposes routing warning for high risk keeper"

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -298,6 +298,16 @@ let test_keeper_name_from_agent_name_rejects_plain_name () =
     "plain keeper name is not treated as agent alias" None
     (Keeper_types.keeper_name_from_agent_name "sangsu")
 
+let test_canonical_keeper_name_from_generated_nickname () =
+  Alcotest.(check (option string))
+    "generated nickname resolves to canonical keeper" (Some "claude")
+    (Keeper_types.canonical_keeper_name_from_agent_name "claude-swift-fox")
+
+let test_canonical_keeper_name_from_legacy_keeper_name () =
+  Alcotest.(check (option string))
+    "legacy keeper-prefixed name normalizes" (Some "sangsu")
+    (Keeper_types.canonical_keeper_name "keeper-sangsu")
+
 (* ============================================================
    Test runner
    ============================================================ *)
@@ -348,5 +358,9 @@ let () =
         test_keeper_name_from_generated_nickname;
       Alcotest.test_case "plain name is not alias" `Quick
         test_keeper_name_from_agent_name_rejects_plain_name;
+      Alcotest.test_case "generated nickname canonicalizes" `Quick
+        test_canonical_keeper_name_from_generated_nickname;
+      Alcotest.test_case "legacy keeper name canonicalizes" `Quick
+        test_canonical_keeper_name_from_legacy_keeper_name;
     ]);
   ]


### PR DESCRIPTION
## Summary
- canonicalize keeper identity parsing through `Keeper_identity` so accountability and reputation share one normalization path
- normalize legacy `keeper-*` keeper history alongside generated nicknames and `keeper-*-agent` aliases
- add regressions for legacy accountability fallback and canonical keeper identity helpers

## Validation
- `git diff --check`
- `dune build --root . lib/keeper/keeper_identity.ml lib/keeper/keeper_accountability.ml lib/keeper/keeper_types.ml lib/agent_reputation.ml`
- `dune build --root . test/test_keeper_accountability.ml test/test_keeper_agent_isolation.ml`

## Known Blocker
- full test executable builds are currently blocked by a pre-existing checkout error in `lib/oas_worker_named.ml` (`system_prompt_of` is passed `messages` function instead of a concrete message list)
