### PR TITLE
fix(oas): restore oas_worker_named buildability

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -360,7 +360,6 @@ let codex_cli_prompt_preflight ~(config : Oas_worker_exec.config) ~(goal : strin
         ~context_reducer:config.context_reducer
         ~tiered_memory:None
         ~turn_params:Oas.Hooks.default_turn_params
-        ~tiered_memory:None
     in
     let req_config =
       match String.trim config.system_prompt with
@@ -450,14 +449,7 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
     : Cascade_fsm.provider_outcome option =
   match err with
   | Oas.Error.Api api_err ->
-<<<<<<< HEAD
     let http_err = match[@warning "-8"] api_err with
-||||||| parent of 594cafd21 (fix: avoid Retry.NotFound pin drift)
-    let fallback_message = Llm_provider.Retry.error_message api_err in
-    let http_err = match api_err with
-=======
-    let http_err = match api_err with
->>>>>>> 594cafd21 (fix: avoid Retry.NotFound pin drift)
       | Llm_provider.Retry.InvalidRequest { message } ->
         Llm_provider.Http_client.HttpError { code = 400; body = message }
       | Llm_provider.Retry.ContextOverflow { message; _ } ->
@@ -468,30 +460,13 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.ServerError { status; message } ->
         Llm_provider.Http_client.HttpError { code = status; body = message }
-      | Llm_provider.Retry.NotFound _ ->
-        Llm_provider.Http_client.HttpError
-          { code = 404; body = "resource not found" }
       | Llm_provider.Retry.AuthError { message } ->
         Llm_provider.Http_client.HttpError { code = 401; body = message }
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
         Llm_provider.Http_client.HttpError { code = 529; body = message }
       | Llm_provider.Retry.NetworkError { message }
       | Llm_provider.Retry.Timeout { message } ->
         Llm_provider.Http_client.NetworkError { message }
-<<<<<<< HEAD
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
-||||||| parent of 594cafd21 (fix: avoid Retry.NotFound pin drift)
-      | _ ->
-        let code =
-          if api_error_message_looks_like_not_found fallback_message then 404
-          else 500
-        in
-        Llm_provider.Http_client.HttpError { code; body = fallback_message }
-=======
->>>>>>> 594cafd21 (fix: avoid Retry.NotFound pin drift)
     in
     Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
@@ -617,9 +592,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.RateLimited _
      | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.AuthError _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.InvalidRequest _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.ContextOverflow _
      | Llm_provider.Retry.Timeout _ ->
        false)


### PR DESCRIPTION
## Summary
- remove accidentally merged conflict markers from `lib/oas_worker_named.ml`
- drop the duplicated `~tiered_memory:None` call argument that broke `prepare_messages`
- remove redundant `Retry.NotFound` match arms so warning-as-error builds pass again

## Validation
- `dune build --root . --build-dir _build_hotfix2 test/test_oas_worker.exe test/test_keeper_unified.exe`
- `./_build_hotfix2/default/test/test_keeper_unified.exe`
- `./_build_hotfix2/default/test/test_oas_worker.exe` (relevant cascade/not-found cases pass; 3 pre-existing sandbox filesystem failures remain under `keeper_checkpoint_boundary`)

## Context
This hotfix repairs `main` after merged PR `#9356` introduced unresolved conflict markers into `lib/oas_worker_named.ml`.