### PR TITLE
feat(mli): phase 2 coverage — sse, tool_inline_dispatch_comm, tool_compact, cache_eio, worker_oas

### DIFF
--- a/lib/cache_eio.mli
+++ b/lib/cache_eio.mli
@@ -1,0 +1,60 @@
+(** Cache_eio — file-based cache with TTL and tags.
+
+    Filesystem-backed key-value cache with expiration, tag filtering,
+    and batch eviction.
+
+    @since 0.1.0 *)
+
+(** {1 Types} *)
+
+type cache_entry = {
+  key : string;
+  value : string;
+  created_at : float;
+  expires_at : float option;
+  tags : string list;
+}
+
+(** {1 Configuration} *)
+
+val eviction_sample_threshold : float
+val batch_eviction_interval : float
+
+(** {1 Paths} *)
+
+val cache_dir : Coord_utils.config -> string
+val ensure_cache_dir : Coord_utils.config -> unit
+val sanitize_key : string -> string
+val cache_filename : string -> string
+
+(** {1 Serialization} *)
+
+val entry_to_json : cache_entry -> Yojson.Safe.t
+val entry_of_json : Yojson.Safe.t -> cache_entry option
+
+(** {1 Core Operations} *)
+
+val set :
+  Coord_utils.config ->
+  key:string ->
+  value:string ->
+  ?ttl_seconds:int ->
+  ?tags:string list ->
+  unit ->
+  (cache_entry, string) result
+val get : Coord_utils.config -> key:string -> (cache_entry option, string) result
+val delete : Coord_utils.config -> key:string -> (bool, string) result
+val list : Coord_utils.config -> ?tag:string -> unit -> cache_entry list
+val clear : Coord_utils.config -> (int, string) result
+val stats : Coord_utils.config -> (int * int * float, string) result
+val format_stats : int * int * float -> string
+
+(** {1 Eviction} *)
+
+val evict_expired : Coord_utils.config -> int
+val maybe_evict_expired : Coord_utils.config -> int
+val count_entries : Coord_utils.config -> int
+val is_expired : cache_entry -> bool
+val last_batch_eviction : float Atomic.t
+val cached_entry_count : int Atomic.t
+val reset_cached_entry_count : unit -> unit

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -1,0 +1,102 @@
+(** Sse — Server-Sent Events hub for MASC.
+
+    Manages SSE client sessions, event broadcasting, and external subscribers.
+    Uses Atomic.t for lock-free session state and Eio.Stream for event delivery.
+
+    @since 0.1.0 *)
+
+(** {1 Types} *)
+
+type session_kind =
+  | Observer
+  | Coordinator
+
+type broadcast_target =
+  | All
+  | Observers
+  | Coordinators
+
+type client = {
+  id : int;
+  kind : session_kind;
+  event_stream : string Eio.Stream.t;
+  push : string -> unit;
+  last_event_id : int Atomic.t;
+  created_at : float;
+  last_seen_at : float Atomic.t;
+}
+
+type client_registry_state = {
+  entries : client Map.Make(String).t;
+  count : int;
+}
+
+type session_snapshot = {
+  session_id : string;
+  kind : session_kind;
+  queue_depth : int;
+  last_event_id : int;
+  idle_seconds : float;
+}
+
+(** {1 Constants} *)
+
+val max_clients : int
+
+(** {1 Session Management} *)
+
+val register :
+  ?kind:session_kind -> string -> push:(string -> unit) -> last_event_id:int ->
+  int * string Eio.Stream.t * string option
+val unregister : string -> unit
+val unregister_if_current : string -> int -> unit
+val exists : string -> bool
+val touch : string -> unit
+val update_last_event_id : string -> int -> unit
+val all_session_ids : unit -> string list
+val client_count : unit -> int
+val close_all_clients : unit -> int
+val cleanup_stale : ?max_age_s:float -> unit -> string list
+
+(** {1 Clock} *)
+
+val set_clock : float Eio.Time.clock_ty Eio.Resource.t -> unit
+
+(** {1 Events} *)
+
+val format_event : ?id:int -> ?event_type:string -> string -> string
+val next_id : unit -> int
+val current_id : unit -> int
+
+(** {1 Broadcast} *)
+
+val broadcast : Yojson.Safe.t -> unit
+val broadcast_to : broadcast_target -> Yojson.Safe.t -> unit
+val send_to : string -> Yojson.Safe.t -> unit
+val pop : string -> string option
+val try_pop : string -> string option
+
+(** {1 External Subscribers} *)
+
+val subscribe_external :
+  id:string -> callback:(string -> unit) -> ?is_alive:(unit -> bool) -> unit -> unit
+val unsubscribe_external : string -> unit
+val external_subscriber_count : unit -> int
+val external_subscriber_count_with_prefix : string -> int
+val reap_dead_external_subscribers : unit -> int
+val remove_external_subscribers : string list -> string list * int
+
+(** {1 Event Buffer} *)
+
+val get_events_after : int -> string list
+val cleanup_expired_events : unit -> int
+
+(** {1 Snapshots} *)
+
+val sync_transport_snapshot : unit -> unit
+val session_kind_to_string : session_kind -> string
+
+(** {1 Test Hooks} *)
+
+val register_commit_test_hook : (unit -> unit) option Atomic.t
+val buffer_commit_test_hook : (unit -> unit) option Atomic.t

--- a/lib/tool_compact.mli
+++ b/lib/tool_compact.mli
@@ -1,0 +1,14 @@
+(** Tool_compact — placeholder tool module.
+
+    No-op schemas and dispatch. Used when compact mode disables tools.
+
+    @since 0.1.0 *)
+
+(** {1 Types} *)
+
+type tool_result = bool * string
+
+(** {1 API} *)
+
+val schemas : Types.tool_schema list
+val dispatch : name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -6,6 +6,10 @@
 
 open Tool_inline_dispatch_types
 
+type tool_result = Tool_inline_dispatch_types.tool_result
+
+type context = Tool_inline_dispatch_types.context
+
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =
   Safe_ops.json_string ~default key ctx.arguments

--- a/lib/tool_inline_dispatch_comm.mli
+++ b/lib/tool_inline_dispatch_comm.mli
@@ -1,0 +1,15 @@
+(** Tool_inline_dispatch_comm — communication tool handlers.
+
+    Handles: masc_broadcast, masc_messages, masc_who.
+
+    @since 0.1.0 *)
+
+type tool_result = Tool_inline_dispatch_types.tool_result
+
+type context = Tool_inline_dispatch_types.context
+
+(** {1 Handlers} *)
+
+val handle_broadcast : context -> tool_result option
+val handle_messages : context -> tool_result option
+val handle_who : context -> tool_result option

--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -1,0 +1,79 @@
+(** Worker_oas — OAS-backed worker execution.
+
+    Builds OAS agents, runs workers via OAS Agent.run, handles checkpoints,
+    tool tracking hooks, and execution scope gating.
+
+    @since 0.1.0 *)
+
+(** {1 Agent Construction} *)
+
+val build_agent :
+  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  meta:Worker_container_types.worker_container_meta ->
+  provider:Oas.Provider.config ->
+  system_prompt:string ->
+  tools:Oas.Tool.t list ->
+  hooks:Oas.Hooks.hooks ->
+  raw_trace:Oas.Raw_trace.t ->
+  heartbeat_callbacks:Oas.Agent.periodic_callback list ->
+  ?gate_config:Eval_gate.gate_config option ->
+  ?context_injector:Oas.Context_injector.t ->
+  ?context:Oas.Context.t ->
+  ?approval:Oas.Hooks.approval_callback ->
+  unit ->
+  (Oas.Agent.t, string) result
+
+(** {1 Tool Tracking} *)
+
+val make_tool_tracking_hooks :
+  ?gate_config:Eval_gate.gate_config ->
+  ?context:Oas.Context.t ->
+  unit ->
+  string list ref * Oas.Hooks.hooks
+
+(** {1 Gate Configuration} *)
+
+val gate_config_of_execution_scope :
+  Worker_types.execution_scope -> Eval_gate.gate_config
+
+(** {1 Worker Execution} *)
+
+val run_worker_via_oas :
+  sw:Eio.Switch.t ->
+  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  base_path:string ->
+  auth_token:string option ->
+  meta:Worker_container_types.worker_container_meta ->
+  provider:Oas.Provider.config ->
+  system_prompt:string ->
+  prompt:string ->
+  tools:Oas.Tool.t list ->
+  raw_trace:Oas.Raw_trace.t ->
+  ?gate_config:Eval_gate.gate_config option ->
+  ?contract:string ->
+  ?worker_run_id:string ->
+  unit ->
+  (Worker_container_types.run_result, string) result
+
+val resume_worker_via_oas :
+  sw:Eio.Switch.t ->
+  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  base_path:string ->
+  auth_token:string option ->
+  meta:Worker_container_types.worker_container_meta ->
+  checkpoint:Oas.Checkpoint.t ->
+  prompt:string ->
+  tools:Oas.Tool.t list ->
+  raw_trace:Oas.Raw_trace.t ->
+  ?contract:string ->
+  ?worker_run_id:string ->
+  ?approval:Oas.Hooks.approval_callback ->
+  unit ->
+  (Worker_container_types.run_result, string) result
+
+(** {1 Checkpoint Helpers} *)
+
+val resume_model_id_of_checkpoint :
+  Worker_container_types.worker_container_meta ->
+  Oas.Checkpoint.t ->
+  string


### PR DESCRIPTION
## Summary
- Add .mli for 5 modules: sse (756 lines), tool_inline_dispatch_comm (80), tool_compact (13), cache_eio (468), worker_oas (809)
- Consumer-driven surface: grep lib/ + test/ references to determine exports
- Fix optional param normalization (?ttl_seconds:int option → ?ttl_seconds:int)
- Re-export types in tool_inline_dispatch_comm.ml for .mli visibility

## Coverage Progress
- Phase 1: 38% → 58% (dashboard, relay, shutdown, spawn, verifier_oas, tools, version, cancellation, notify, tool_registry, agent_card)
- Phase 2: 58% → 60%+ (this PR)

## Test plan
- [x] `dune build @install --root .` passes for each .mli
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)