### PR TITLE
fix(agent_card): export derived helper surface

### DIFF
--- a/lib/agent_card.mli
+++ b/lib/agent_card.mli
@@ -67,6 +67,31 @@ type agent_card = {
   updated_at : string;
 }
 
+(** {1 Derived Helpers} *)
+
+val provider_to_yojson : provider -> Yojson.Safe.t
+val provider_of_yojson : Yojson.Safe.t -> (provider, string) result
+val show_provider : provider -> string
+val equal_provider : provider -> provider -> bool
+
+val skill_to_yojson : skill -> Yojson.Safe.t
+val skill_of_yojson : Yojson.Safe.t -> (skill, string) result
+val show_skill : skill -> string
+val equal_skill : skill -> skill -> bool
+
+val binding_to_yojson : binding -> Yojson.Safe.t
+val binding_of_yojson : Yojson.Safe.t -> (binding, string) result
+val show_binding : binding -> string
+val equal_binding : binding -> binding -> bool
+
+val security_scheme_to_yojson : security_scheme -> Yojson.Safe.t
+val security_scheme_of_yojson :
+  Yojson.Safe.t -> (security_scheme, string) result
+val show_security_scheme : security_scheme -> string
+val equal_security_scheme : security_scheme -> security_scheme -> bool
+
+val show_agent_card : agent_card -> string
+
 (** {1 Serialization} *)
 
 val capabilities_to_json : agent_capabilities -> Yojson.Safe.t
@@ -78,6 +103,7 @@ val from_json : Yojson.Safe.t -> (agent_card, string) result
 
 (** {1 Construction} *)
 
+val now_iso8601 : unit -> string
 val skills_from_tools : Types.tool_schema list -> skill list
 val runtime_supported_interfaces : host:string -> port:int -> binding list
 val generate_default :


### PR DESCRIPTION
## Summary
- export the derived `yojson`/`show`/`eq` helpers for `provider`, `skill`, `binding`, and `security_scheme`
- expose `show_agent_card` and `now_iso8601` so `test_agent_card_coverage` can compile against the current public surface
- keep the change surgical to `agent_card.mli`

## Validation
- `git diff --check`
- `dune build --root . ./lib/agent_card.mli ./lib/agent_card.ml`
- full `dune build ./test/test_agent_card_coverage.exe` is still blocked by unrelated main issue `#9371` (`worker_oas.mli` uses stale `Oas.Context_injector`)

Fixes #9367
