### PR TITLE
fix: route kimi_cli keeper tools through runtime MCP lane

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -259,6 +259,22 @@ let provider_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
     | Some entry -> entry.capabilities
     | None -> Llm_provider.Capabilities.default_capabilities
   in
+  let caps =
+    match cfg.kind with
+    | Llm_provider.Provider_config.Kimi_cli ->
+        (* Keep cascade prefiltering aligned with the OAS worker resolver:
+           Kimi CLI does not consume OAS req.tools inline, but it does expose
+           runtime MCP tools and tool events via [kimi mcp] / [--mcp-config*].
+           Ref checked 2026-04-21:
+           https://moonshotai.github.io/kimi-cli/en/customization/mcp.html *)
+        {
+          caps with
+          supports_tools = false;
+          supports_runtime_mcp_tools = true;
+          supports_runtime_tool_events = true;
+        }
+    | _ -> caps
+  in
   match cfg.supports_tool_choice_override with
   | Some supports_tool_choice -> { caps with supports_tool_choice }
   | None -> caps

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -101,16 +101,19 @@ let summarize_chunk (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.mess
   match lines with
   | [] -> None
   | _ ->
-    Some {
-      Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
-      content = [
-        Agent_sdk.Types.Text
-          (Printf.sprintf "[Compacted %d messages into summary]\n%s"
-             (List.length msgs) (String.concat "\n" lines))
-      ];
-      name = None;
-      tool_call_id = None;
-    }
+    Some
+      ({
+         Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+         content = [
+           Agent_sdk.Types.Text
+             (Printf.sprintf "[Compacted %d messages into summary]\n%s"
+                (List.length msgs) (String.concat "\n" lines))
+         ];
+         name = None;
+         tool_call_id = None;
+         metadata = [];
+       }
+        : Agent_sdk.Types.message)
 
 let mask_tool_result_content ~(tool_name : string option) ~(tool_use_id : string)
     ~(content : string) : string =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2044,6 +2044,9 @@ let run_turn
   | Error e -> Error (Oas.Error.Internal e)
   | Ok oas_allowed_paths ->
     let require_tool_choice_support = initial_tool_surface.tool_gate_requested in
+    let require_tool_support =
+      initial_tool_surface.tool_gate_requested && tools <> []
+    in
     let timeout_s =
       match oas_timeout_s with
       | Some value -> value
@@ -2112,9 +2115,11 @@ let run_turn
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named
            ~cascade_name
+           ~keeper_name:meta.name
            ~model_strings:meta.models
            ?provider_filter
            ~require_tool_choice_support
+           ~require_tool_support
            ~goal:user_message
            ~priority
            ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -187,12 +187,13 @@ let metric_of_block
            | None -> 0)
     | _ -> 0
   in
-  let msg =
+  let msg : Agent_sdk.Types.message =
     {
       Agent_sdk.Types.role;
       content = [block];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   {

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -302,16 +302,18 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
         [ Agent_sdk.Types.Text text ]
   in
   Inference_utils.sanitize_message_utf8
-    {
-      Agent_sdk.Types.role;
-      content;
-      name =
-        (json |> member "name" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-      tool_call_id =
-        (json |> member "tool_call_id" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-    }
+    ({
+       Agent_sdk.Types.role;
+       content;
+       name =
+         (json |> member "name" |> to_string_option
+          |> Option.map Inference_utils.sanitize_text_utf8);
+       tool_call_id =
+         (json |> member "tool_call_id" |> to_string_option
+          |> Option.map Inference_utils.sanitize_text_utf8);
+       metadata = [];
+     }
+      : Agent_sdk.Types.message)
 
 (** Extract human-readable text from a single history.jsonl line that was
     produced by [message_to_json].  Reads structured [content_blocks]
@@ -328,6 +330,7 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
           content = blocks;
           name = None;
           tool_call_id = None;
+          metadata = [];
         }
       in
       Inference_utils.sanitize_text_utf8 (text_of_message msg)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -684,9 +684,9 @@ let set_board_cursor ~base_path name ts post_id =
 
 (* -- Tool usage tracking ------------------------------------------- *)
 
-(* Safe without mutex: each keeper has exactly one fiber calling
-   record_tool_use for a given (base_path, name) pair.  See module
-   docstring for thread-safety reasoning. *)
+(* Safe without a mutex: updates go through [update_entry]'s CAS loop, so
+   keeper-turn OAS callbacks and runtime MCP server callbacks can both
+   record usage for the same keeper without clobbering each other. *)
 let record_tool_use ~base_path name ~tool_name ~success =
   update_entry ~base_path name (fun entry ->
     let e =

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -294,13 +294,21 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      a registered keeper (keeper-internal dispatch via cli_agent runtime),
      otherwise External_mcp (true external MCP client).  Sound partial:
      missing identity falls through to External_mcp.  Issue #8915. *)
-  let source : Tool_registry.call_source =
-    if String.length agent_name = 0 then External_mcp
-    else
-      match Keeper_registry.find_by_agent_name agent_name with
-      | Some _ -> Keeper_internal
-      | None -> External_mcp
+  let keeper_entry =
+    if String.length agent_name = 0 then None
+    else Keeper_registry.find_by_agent_name agent_name
   in
+  let source : Tool_registry.call_source =
+    match keeper_entry with
+    | Some _ -> Keeper_internal
+    | None -> External_mcp
+  in
+  (match keeper_entry with
+   | Some entry ->
+       Keeper_registry.record_tool_use
+         ~base_path:entry.base_path entry.name ~tool_name:name ~success;
+       Keeper_registry.flush_tool_usage ~base_path:entry.base_path entry.name
+   | None -> ());
 
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled = Env_config_core.telemetry_enabled () in

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -133,6 +133,12 @@ let cli_model_override =
 let provider_caps_of_config =
   Oas_worker_exec_transport.provider_caps_of_config
 
+let kimi_mcp_config_json_of_policy =
+  Oas_worker_exec_transport.kimi_mcp_config_json_of_policy
+
+let kimi_cli_model_for_provider =
+  Oas_worker_exec_transport.kimi_cli_model_for_provider
+
 let provider_supports_inline_tools =
   Oas_worker_exec_transport.provider_supports_inline_tools
 
@@ -144,6 +150,15 @@ let dedupe_preserve_order =
 
 let public_mcp_tool_names_of_oas_tools =
   Oas_worker_exec_transport.public_mcp_tool_names_of_oas_tools
+
+let runtime_mcp_policy_with_masc_agent_name =
+  Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
+
+let kimi_cli_runtime_mcp_jsons =
+  Oas_worker_exec_transport.kimi_cli_runtime_mcp_jsons
+
+let public_mcp_tools_of_oas_tools =
+  Oas_worker_exec_transport.public_mcp_tools_of_oas_tools
 
 let tool_names_are_public_mcp =
   Oas_worker_exec_transport.tool_names_are_public_mcp
@@ -159,6 +174,8 @@ let resolve_tool_lane_for_oas_tools =
 
 let make_per_call_switch_transport =
   Oas_worker_exec_transport.make_per_call_switch_transport
+
+module Kimi_cli_transport_local = Oas_worker_exec_transport.Kimi_cli_transport_local
 
 let non_http_transport_of_provider =
   Oas_worker_exec_transport.non_http_transport_of_provider
@@ -194,6 +211,7 @@ let build
   : (Oas.Agent.t, Oas.Error.sdk_error) result =
   match
     non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+      ?runtime_mcp_policy:config.runtime_mcp_policy
       ?cli_transport_overrides:config.cli_transport_overrides
       ()
   with
@@ -254,6 +272,7 @@ let resume_from_checkpoint
   : (Oas.Agent.t, Oas.Error.sdk_error) result =
   match
     non_http_transport_of_provider ~sw ~provider_cfg:config.provider_cfg
+      ?runtime_mcp_policy:config.runtime_mcp_policy
       ?cli_transport_overrides:config.cli_transport_overrides
       ()
   with

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -52,6 +52,73 @@ let cli_model_override model_id =
   | "" | "auto" -> None
   | _ -> Some (String.trim model_id)
 
+let json_of_string_pairs pairs =
+  `Assoc (List.map (fun (k, v) -> (k, `String v)) pairs)
+
+let json_of_kimi_mcp_server = function
+  | Llm_provider.Llm_transport.Stdio_server { command; args; env; _ } ->
+      `Assoc
+        [
+          ("command", `String command);
+          ("args", `List (List.map (fun arg -> `String arg) args));
+          ("env", json_of_string_pairs env);
+        ]
+  | Llm_provider.Llm_transport.Http_server { url; headers; _ } ->
+      `Assoc
+        [
+          ("url", `String url);
+          ("headers", json_of_string_pairs headers);
+        ]
+
+let kimi_mcp_config_json_of_policy
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) : string option =
+  let allowed_server_name name =
+    match policy.allowed_server_names with
+    | [] -> true
+    | names -> List.mem name names
+  in
+  let servers =
+    List.filter
+      (fun server ->
+        allowed_server_name
+          (Llm_provider.Llm_transport.runtime_mcp_server_name server))
+      policy.servers
+  in
+  match servers with
+  | [] -> None
+  | servers ->
+      let config_json =
+        `Assoc
+          [
+            ( "mcpServers",
+              `Assoc
+                (List.map
+                   (fun server ->
+                     ( Llm_provider.Llm_transport.runtime_mcp_server_name server,
+                       json_of_kimi_mcp_server server ))
+                   servers) );
+          ]
+      in
+      Some (Yojson.Safe.to_string config_json)
+
+let kimi_cli_model_for_provider (provider_cfg : Llm_provider.Provider_config.t) =
+  match cli_model_override provider_cfg.model_id with
+  | Some explicit -> Some explicit
+  | None -> Llm_provider.Transport_kimi_cli.default_config.model
+
+let normalize_cli_provider_caps
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (caps : Llm_provider.Capabilities.capabilities) =
+  match provider_cfg.kind with
+  | Llm_provider.Provider_config.Kimi_cli ->
+      {
+        caps with
+        supports_tools = false;
+        supports_runtime_mcp_tools = true;
+        supports_runtime_tool_events = true;
+      }
+  | _ -> caps
+
 let provider_caps_of_config (provider_cfg : Llm_provider.Provider_config.t) =
   let base_caps =
     match provider_cfg.kind with
@@ -78,6 +145,7 @@ let provider_caps_of_config (provider_cfg : Llm_provider.Provider_config.t) =
         | Some caps -> caps
         | None -> base_caps)
   in
+  let caps = normalize_cli_provider_caps ~provider_cfg caps in
   match provider_cfg.supports_tool_choice_override with
   | Some supports_tool_choice -> { caps with supports_tool_choice }
   | None -> caps
@@ -101,8 +169,57 @@ let dedupe_preserve_order (items : string list) =
         true))
     items
 
+let upsert_http_header ~key ~value headers =
+  let key_lc = String.lowercase_ascii key in
+  let retained =
+    List.filter
+      (fun (existing_key, _) ->
+        not (String.equal (String.lowercase_ascii existing_key) key_lc))
+      headers
+  in
+  (key, value) :: retained
+
+let runtime_mcp_policy_with_masc_agent_name
+    ~(agent_name : string)
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  let agent_name = String.trim agent_name in
+  if String.equal agent_name "" then policy
+  else
+    let servers =
+      List.map
+        (function
+          | Llm_provider.Llm_transport.Http_server ({ name; headers; _ } as server)
+            when String.equal name "masc" ->
+              Llm_provider.Llm_transport.Http_server
+                {
+                  server with
+                  headers =
+                    upsert_http_header
+                      ~key:"x-masc-agent-name"
+                      ~value:agent_name headers;
+                }
+          | server -> server)
+        policy.servers
+    in
+    { policy with servers }
+
+let kimi_cli_runtime_mcp_jsons
+    ~(base : string list)
+    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
+  let request_json =
+    match policy_opt with
+    | Some policy -> Option.to_list (kimi_mcp_config_json_of_policy policy)
+    | None -> []
+  in
+  dedupe_preserve_order (base @ request_json)
+
 let public_mcp_tool_names_of_oas_tools (tools : Oas.Tool.t list) =
   List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
+
+let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
+  List.filter
+    (fun (tool : Oas.Tool.t) -> Tool_catalog.is_public_mcp tool.schema.name)
+    tools
 
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
@@ -136,6 +253,70 @@ let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
     (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
     provider_cfg.model_id
 
+let trim_nonempty value =
+  match value with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+
+let first_nonempty_env names =
+  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
+
+let kimi_cli_auth_value (provider_cfg : Llm_provider.Provider_config.t) =
+  match trim_nonempty (Some provider_cfg.api_key) with
+  | Some key -> Some key
+  | None ->
+      first_nonempty_env
+        (Provider_adapter.auth_env_keys_of_provider_kind
+           Llm_provider.Provider_config.Kimi)
+
+let kimi_cli_base_url () =
+  match Sys.getenv_opt "KIMI_BASE_URL" |> trim_nonempty with
+  | Some url -> url
+  | None -> "https://api.kimi.com/coding/v1"
+
+let kimi_cli_config_json_for_provider
+    (provider_cfg : Llm_provider.Provider_config.t) : string option =
+  match kimi_cli_model_for_provider provider_cfg, kimi_cli_auth_value provider_cfg with
+  | Some model_name, Some _ ->
+      let provider_name = "masc-kimi" in
+      let config_json =
+        `Assoc
+          [
+            ("default_model", `String model_name);
+            ( "providers",
+              `Assoc
+                [
+                  ( provider_name,
+                    `Assoc
+                      [
+                        ("type", `String "kimi");
+                        ("base_url", `String (kimi_cli_base_url ()));
+                        ("api_key", `String "");
+                      ] );
+                ] );
+            ( "models",
+              `Assoc
+                [
+                  ( model_name,
+                    `Assoc
+                      [
+                        ("provider", `String provider_name);
+                        ("model", `String model_name);
+                        ("max_context_size", `Int 262144);
+                      ] );
+                ] );
+          ]
+      in
+      Some (Yojson.Safe.to_string config_json)
+  | _ -> None
+
+let kimi_cli_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
+  match kimi_cli_auth_value provider_cfg with
+  | Some key -> [ ("KIMI_API_KEY", key) ]
+  | None -> []
+
 let resolve_tool_lane_for_oas_tools
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(tools : Oas.Tool.t list)
@@ -143,8 +324,9 @@ let resolve_tool_lane_for_oas_tools
      * Llm_provider.Llm_transport.runtime_mcp_policy option,
      Oas.Error.sdk_error)
     result =
-  let tool_names = public_mcp_tool_names_of_oas_tools tools in
-  match public_mcp_runtime_policy_of_tool_names tool_names with
+  let public_tools = public_mcp_tools_of_oas_tools tools in
+  let public_tool_names = public_mcp_tool_names_of_oas_tools public_tools in
+  match public_mcp_runtime_policy_of_tool_names public_tool_names with
   | Some runtime_mcp_policy
     when provider_supports_runtime_mcp_lane provider_cfg ->
       Ok ([], Some runtime_mcp_policy)
@@ -154,7 +336,7 @@ let resolve_tool_lane_for_oas_tools
       Ok (tools, None)
   | _ ->
       let detail =
-        if tool_names_are_public_mcp tool_names then
+        if public_tool_names <> [] then
           Printf.sprintf
             "%s does not support inline tools or request-scoped runtime MCP tools"
             (provider_label provider_cfg)
@@ -163,6 +345,411 @@ let resolve_tool_lane_for_oas_tools
             (provider_label provider_cfg)
       in
       Error (invalid_runtime_config "tool_support" detail)
+
+module Kimi_cli_transport_local = struct
+  type config = {
+    kimi_path : string;
+    model : string option;
+    cwd : string option;
+    config_json : string option;
+    mcp_config_json : string list;
+    extra_env : (string * string) list;
+    cancel : unit Eio.Promise.t option;
+  }
+
+  let default_config =
+    {
+      kimi_path = "kimi";
+      model = Some "kimi-for-coding";
+      cwd = None;
+      config_json = None;
+      mcp_config_json = [];
+      extra_env = [];
+      cancel = None;
+    }
+
+  let default_prompt_argv_threshold = 512 * 1024
+
+  let prompt_argv_threshold () =
+    match Sys.getenv_opt "OAS_KIMI_PROMPT_ARGV_THRESHOLD" with
+    | Some raw -> (
+        match int_of_string_opt (String.trim raw) with
+        | Some value when value >= 0 -> value
+        | _ -> default_prompt_argv_threshold)
+    | None -> default_prompt_argv_threshold
+
+  let prompt_exceeds_argv_budget prompt =
+    String.length prompt >= prompt_argv_threshold ()
+
+  let stdin_for_prompt prompt =
+    if prompt_exceeds_argv_budget prompt then Some prompt else None
+
+  let cli_model_override ~(config : config)
+      ~(req_config : Llm_provider.Provider_config.t) =
+    match String.trim req_config.model_id |> String.lowercase_ascii with
+    | "" | "auto" -> config.model
+    | _ -> Some (String.trim req_config.model_id)
+
+  let build_args ~(config : config)
+      ~(req_config : Llm_provider.Provider_config.t)
+      ~(mcp_config_json : string list)
+      ~prompt =
+    let prompt_via_stdin = prompt_exceeds_argv_budget prompt in
+    let args =
+      ref [ config.kimi_path; "--print"; "--output-format"; "stream-json" ]
+    in
+    let add xs = args := !args @ xs in
+    (match config.config_json with
+     | Some json -> add [ "--config"; json ]
+     | None -> ());
+    if not prompt_via_stdin then add [ "-p"; prompt ];
+    (match cli_model_override ~config ~req_config with
+     | Some model -> add [ "--model"; model ]
+     | None -> ());
+    (match config.cwd with
+     | Some dir when String.trim dir <> "" -> add [ "--work-dir"; dir ]
+     | _ -> ());
+    List.iter (fun json -> add [ "--mcp-config"; json ]) mcp_config_json;
+    (match req_config.enable_thinking with
+     | Some true -> add [ "--thinking" ]
+     | Some false -> add [ "--no-thinking" ]
+     | None -> ());
+    !args
+
+  let json_of_argument_string = function
+    | None | Some "" -> `Assoc []
+    | Some raw -> (
+        try Yojson.Safe.from_string raw with Yojson.Json_error _ -> `Assoc [])
+
+  let blocks_of_message_content json =
+    match json with
+    | `String text when String.trim text = "" -> []
+    | `String text -> [ Oas.Types.Text text ]
+    | `List items ->
+        List.filter_map Llm_provider.Api_common.content_block_of_json items
+    | `Null -> []
+    | other -> [ Oas.Types.Text (Yojson.Safe.to_string other) ]
+
+  let tool_use_of_json json =
+    let open Yojson.Safe.Util in
+    try
+      let fn = json |> member "function" in
+      let id = Llm_provider.Cli_common_json.member_str "id" json in
+      let name = Llm_provider.Cli_common_json.member_str "name" fn in
+      let args =
+        fn |> member "arguments" |> to_string_option |> json_of_argument_string
+      in
+      Some (Oas.Types.ToolUse { id; name; input = args })
+    with Type_error _ -> None
+
+  let tool_result_of_json json =
+    let open Yojson.Safe.Util in
+    match json |> member "tool_call_id" |> to_string_option with
+    | Some tool_use_id ->
+        let content_json = json |> member "content" in
+        let content, parsed_json =
+          match content_json with
+          | `String text -> text, Oas.Types.try_parse_json text
+          | `Null -> "", None
+          | other -> Yojson.Safe.to_string other, Some other
+        in
+        Some
+          (Oas.Types.ToolResult
+             { tool_use_id; content; is_error = false; json = parsed_json })
+    | None -> None
+
+  let blocks_of_output_line line =
+    let open Yojson.Safe.Util in
+    try
+      let json = Yojson.Safe.from_string line in
+      match json |> member "role" |> to_string_option with
+      | Some "assistant" ->
+          let content = blocks_of_message_content (json |> member "content") in
+          let tool_uses =
+            match json |> member "tool_calls" with
+            | `List calls -> List.filter_map tool_use_of_json calls
+            | _ -> []
+          in
+          content @ tool_uses
+      | Some "tool" -> (
+          match tool_result_of_json json with
+          | Some block -> [ block ]
+          | None -> [])
+      | _ -> []
+    with Yojson.Json_error _ | Type_error _ -> []
+
+  let response_id_of_lines lines =
+    let open Yojson.Safe.Util in
+    let find_id line =
+      try
+        let json = Yojson.Safe.from_string line in
+        match json |> member "id" |> to_string_option with
+        | Some id when String.trim id <> "" -> Some id
+        | _ -> (
+            match json |> member "session_id" |> to_string_option with
+            | Some id when String.trim id <> "" -> Some id
+            | _ -> None)
+      with Yojson.Json_error _ | Type_error _ -> None
+    in
+    List.find_map find_id lines |> Option.value ~default:"kimi-print"
+
+  let response_model_of_lines ~model_id lines =
+    let open Yojson.Safe.Util in
+    let find_model line =
+      try
+        let json = Yojson.Safe.from_string line in
+        match json |> member "model" |> to_string_option with
+        | Some model when String.trim model <> "" -> Some model
+        | _ -> None
+      with Yojson.Json_error _ | Type_error _ -> None
+    in
+    List.find_map find_model lines |> Option.value ~default:model_id
+
+  let parse_jsonl_result ~model_id lines =
+    let content = List.concat_map blocks_of_output_line lines in
+    if content = [] then
+      Error
+        (Llm_provider.Http_client.NetworkError
+           { message = "no messages parsed from kimi output" })
+    else
+      Ok
+        {
+          Oas.Types.id = response_id_of_lines lines;
+          model = response_model_of_lines ~model_id lines;
+          stop_reason = Oas.Types.EndTurn;
+          content;
+          usage = None;
+          telemetry = None;
+        }
+
+  let events_of_block ~index = function
+    | Oas.Types.Text text ->
+        [
+          Oas.Types.ContentBlockStart
+            { index; content_type = "text"; tool_id = None; tool_name = None };
+          Oas.Types.ContentBlockDelta { index; delta = Oas.Types.TextDelta text };
+          Oas.Types.ContentBlockStop { index };
+        ]
+    | Oas.Types.Thinking { content; _ } ->
+        [
+          Oas.Types.ContentBlockStart
+            {
+              index;
+              content_type = "thinking";
+              tool_id = None;
+              tool_name = None;
+            };
+          Oas.Types.ContentBlockDelta
+            { index; delta = Oas.Types.ThinkingDelta content };
+          Oas.Types.ContentBlockStop { index };
+        ]
+    | Oas.Types.ToolUse { id; name; input } ->
+        [
+          Oas.Types.ContentBlockStart
+            {
+              index;
+              content_type = "tool_use";
+              tool_id = Some id;
+              tool_name = Some name;
+            };
+          Oas.Types.ContentBlockDelta
+            {
+              index;
+              delta = Oas.Types.InputJsonDelta (Yojson.Safe.to_string input);
+            };
+          Oas.Types.ContentBlockStop { index };
+        ]
+    | Oas.Types.ToolResult { tool_use_id; content; _ } ->
+        [
+          Oas.Types.ContentBlockStart
+            {
+              index;
+              content_type = "tool_result";
+              tool_id = Some tool_use_id;
+              tool_name = None;
+            };
+          Oas.Types.ContentBlockDelta
+            { index; delta = Oas.Types.TextDelta content };
+          Oas.Types.ContentBlockStop { index };
+        ]
+    | Oas.Types.RedactedThinking _
+    | Oas.Types.Image _
+    | Oas.Types.Document _
+    | Oas.Types.Audio _ -> []
+
+  let emit_blocks ~on_event ~start_index blocks =
+    List.fold_left
+      (fun index block ->
+        match events_of_block ~index block with
+        | [] -> index
+        | events ->
+            List.iter on_event events;
+            index + 1)
+      start_index blocks
+
+  let starts_with text prefix =
+    let prefix_len = String.length prefix in
+    String.length text >= prefix_len
+    && String.sub text 0 prefix_len = prefix
+
+  let exit_code_of_message message =
+    let prefix = "kimi exited with code " in
+    if not (starts_with message prefix) then None
+    else
+      match String.index_from_opt message (String.length prefix) ':' with
+      | None -> None
+      | Some colon ->
+          let raw =
+            String.sub message (String.length prefix)
+              (colon - String.length prefix)
+            |> String.trim
+          in
+          int_of_string_opt raw
+
+  let classify_cli_error = function
+    | Error (Llm_provider.Http_client.NetworkError { message }) as err -> (
+        match exit_code_of_message message with
+        | Some 1 ->
+            Error
+              (Llm_provider.Http_client.AcceptRejected
+                 {
+                   reason =
+                     "kimi_cli rejected the request (exit 1). "
+                     ^ "This is usually a permanent auth/config/model error rather "
+                     ^ "than a transient transport failure. "
+                     ^ message;
+                 })
+        | _ -> err)
+    | other -> other
+
+  let warn_external_tools_once warned tools =
+    if !warned || tools = [] then ()
+    else (
+      warned := true;
+      Eio.traceln
+        "[warn] kimi_cli print mode ignores OAS req.tools. \
+         Provider-native built-in tools and configured MCP servers remain \
+         available; external OAS tool callbacks require a future wire-mode \
+         transport.")
+
+  let create ~sw ~(mgr : _ Eio.Process.mgr) ~(config : config) =
+    let warned = ref false in
+    {
+      Llm_provider.Llm_transport.complete_sync =
+        (fun (req : Llm_provider.Llm_transport.completion_request) ->
+          warn_external_tools_once warned req.tools;
+          let messages =
+            Llm_provider.Cli_common_prompt.non_system_messages req.messages
+          in
+          let system_prompt =
+            Llm_provider.Cli_common_prompt.system_prompt_of
+              ~req_config:req.config req.messages
+          in
+          let prompt =
+            Llm_provider.Cli_common_prompt.prompt_of_messages
+              ~include_tool_blocks:true messages
+            |> fun prompt ->
+            Llm_provider.Cli_common_prompt.prompt_with_system_prompt
+              ~prompt ~system_prompt
+          in
+          let model_id =
+            Option.value ~default:"kimi-for-coding"
+              (cli_model_override ~config ~req_config:req.config)
+          in
+          let mcp_config_json =
+            kimi_cli_runtime_mcp_jsons ~base:config.mcp_config_json
+              req.runtime_mcp_policy
+          in
+          let argv =
+            build_args ~config ~req_config:req.config ~mcp_config_json ~prompt
+          in
+          let seen_lines = ref [] in
+          let on_line line =
+            if String.trim line <> "" then seen_lines := line :: !seen_lines
+          in
+          match
+            Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+              ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
+              ?stdin_content:(stdin_for_prompt prompt)
+              ~on_line ?cancel:config.cancel argv
+          with
+          | Error _ as err ->
+              { Llm_provider.Llm_transport.response = classify_cli_error err; latency_ms = 0 }
+          | Ok { latency_ms; _ } ->
+              let response =
+                parse_jsonl_result ~model_id (List.rev !seen_lines)
+              in
+              { Llm_provider.Llm_transport.response; latency_ms });
+      complete_stream =
+        (fun ~on_event (req : Llm_provider.Llm_transport.completion_request) ->
+          warn_external_tools_once warned req.tools;
+          let messages =
+            Llm_provider.Cli_common_prompt.non_system_messages req.messages
+          in
+          let system_prompt =
+            Llm_provider.Cli_common_prompt.system_prompt_of
+              ~req_config:req.config req.messages
+          in
+          let prompt =
+            Llm_provider.Cli_common_prompt.prompt_of_messages
+              ~include_tool_blocks:true messages
+            |> fun prompt ->
+            Llm_provider.Cli_common_prompt.prompt_with_system_prompt
+              ~prompt ~system_prompt
+          in
+          let model_id =
+            Option.value ~default:"kimi-for-coding"
+              (cli_model_override ~config ~req_config:req.config)
+          in
+          let mcp_config_json =
+            kimi_cli_runtime_mcp_jsons ~base:config.mcp_config_json
+              req.runtime_mcp_policy
+          in
+          let argv =
+            build_args ~config ~req_config:req.config ~mcp_config_json ~prompt
+          in
+          let seen_lines = ref [] in
+          let next_index = ref 0 in
+          let started = ref false in
+          let ensure_started () =
+            if not !started then (
+              started := true;
+              on_event
+                (Oas.Types.MessageStart
+                   { id = "kimi-print"; model = model_id; usage = None }))
+          in
+          let on_line line =
+            if String.trim line <> "" then (
+              seen_lines := line :: !seen_lines;
+              let blocks = blocks_of_output_line line in
+              if blocks <> [] then (
+                ensure_started ();
+                next_index :=
+                  emit_blocks ~on_event ~start_index:!next_index blocks))
+          in
+          match
+            classify_cli_error
+              (Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+                 ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
+                 ?stdin_content:(stdin_for_prompt prompt)
+                 ~on_line ?cancel:config.cancel argv)
+          with
+          | Error _ as err -> err
+          | Ok _ -> (
+              match parse_jsonl_result ~model_id (List.rev !seen_lines) with
+              | Error _ as err -> err
+              | Ok resp as ok ->
+                  if !started then (
+                    on_event
+                      (Oas.Types.MessageDelta
+                         { stop_reason = Some resp.stop_reason; usage = resp.usage });
+                    on_event Oas.Types.MessageStop)
+                  else
+                    Llm_provider.Cli_common_synthetic_events.replay ~on_event
+                      resp;
+                  ok));
+    }
+end
 
 (** Wrap CLI transports in a per-call sub-switch.
 
@@ -192,6 +779,7 @@ let make_per_call_switch_transport
 let non_http_transport_of_provider
     ~(sw : Eio.Switch.t)
     ~(provider_cfg : Llm_provider.Provider_config.t)
+    ?runtime_mcp_policy
     ?cli_transport_overrides
     ()
   : (Llm_provider.Llm_transport.t option, Oas.Error.sdk_error) result =
@@ -270,16 +858,29 @@ let non_http_transport_of_provider
       match proc_mgr_result () with
       | Error _ as e -> e
       | Ok mgr ->
+          let cwd =
+            Option.bind cli_transport_overrides (fun overrides -> overrides.cwd)
+          in
+          let mcp_config_json =
+            kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy
+          in
+          let model = kimi_cli_model_for_provider provider_cfg in
+          let config_json = kimi_cli_config_json_for_provider provider_cfg in
+          let extra_env = kimi_cli_extra_env provider_cfg in
           let config =
             {
-              Llm_provider.Transport_kimi_cli.default_config with
-              model = cli_model_override provider_cfg.model_id;
+              Kimi_cli_transport_local.default_config with
+              model;
+              cwd;
+              config_json;
+              mcp_config_json;
+              extra_env;
             }
           in
           Ok
             (Some
                (make_per_call_switch_transport (fun ~sw ->
-                    Llm_provider.Transport_kimi_cli.create ~sw ~mgr
+                    Kimi_cli_transport_local.create ~sw ~mgr
                       ~config))))
   | Llm_provider.Provider_config.Codex_cli -> (
       match proc_mgr_result () with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -590,8 +590,8 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.ServerError { message; _ } ->
        message_looks_like_cli_wrapped_hard_quota message
      | Llm_provider.Retry.RateLimited _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.AuthError _
+     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.InvalidRequest _
      | Llm_provider.Retry.ContextOverflow _
      | Llm_provider.Retry.Timeout _ ->
@@ -729,6 +729,15 @@ let run_named
       Oas_worker_exec.resolve_tool_lane_for_oas_tools ~provider_cfg ~tools
       |> Result.map
            (fun (effective_tools, runtime_mcp_policy) ->
+             let runtime_mcp_policy =
+               match runtime_mcp_policy, String.trim keeper_name with
+               | Some policy, keeper_name when keeper_name <> "" ->
+                   Some
+                     (Oas_worker_exec.runtime_mcp_policy_with_masc_agent_name
+                        ~agent_name:(Keeper_types.keeper_agent_name keeper_name)
+                        policy)
+               | _ -> runtime_mcp_policy
+             in
              {
                (Oas_worker_exec.default_config ~name ~provider_cfg
                   ~system_prompt ~tools:effective_tools)

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -6,16 +6,18 @@ module Http = Http_server_eio
 
 let make_http_config ~host ~port : Http.config =
   let config = { Http.default_config with port; host } in
+  let advertised_host =
+    if Server_auth.is_unspecified_host config.host then
+      Masc_network_defaults.masc_http_default_host
+    else config.host
+  in
   Unix.putenv Env_config_core.host_env_key config.host;
   Unix.putenv Env_config_core.http_port_env_key (string_of_int config.port);
+  Unix.putenv Env_config_runtime.Local_runtime.mcp_url_env_key
+    (Printf.sprintf "http://%s:%d/mcp" advertised_host config.port);
   (match Sys.getenv_opt Env_config_core.http_base_url_env_key with
   | Some existing when String.trim existing <> "" -> ()
   | _ ->
-      let advertised_host =
-        if Server_auth.is_unspecified_host config.host then
-          Masc_network_defaults.masc_http_default_host
-        else config.host
-      in
       Unix.putenv Env_config_core.http_base_url_env_key
         (Printf.sprintf "http://%s:%d" advertised_host config.port));
   config

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -298,13 +298,14 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
           let runtime_id =
             Local_runtime_pool.runtime_id_of_base_url provider_config.base_url
           in
-          let messages =
+          let messages : Oas_types.message list =
             [
               {
                 Oas_types.role = Oas_types.User;
                 content = [ Oas_types.Text prompt ];
                 name = None;
                 tool_call_id = None;
+                metadata = [];
               };
             ]
           in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -155,13 +155,14 @@ let probe_chat_completion_compatible
           ~request_path:Masc_network_defaults.openai_chat_completions_path
           ~max_tokens:1 ~temperature:Oas_worker_cascade.deterministic_temperature ()
       in
-      let messages =
+      let messages : Oas_types.message list =
         [
           {
             Oas_types.role = Oas_types.User;
             content = [ Oas_types.Text "hi" ];
             name = None;
             tool_call_id = None;
+            metadata = [];
           };
         ]
       in

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -78,6 +78,7 @@ let callable_tool_required_model_strings =
   [ "custom:remote-model@http://127.0.0.1:18080/v1"
   ; "claude_code:auto"
   ; "codex_cli:auto"
+  ; "kimi_cli:auto"
   ; "gemini_cli:auto"
   ; "ollama:local-model"
   ]
@@ -117,6 +118,20 @@ let test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers 
   check bool "drops gemini_cli without runtime MCP lane" false
     (List.mem "gemini_cli" (provider_kinds providers))
 
+let test_required_tool_gate_filter_keeps_runtime_mcp_capable_cli_providers () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      callable_tool_required_model_strings
+  in
+  check bool "tool gate keeps at least one callable provider" true
+    (providers <> []);
+  check bool "keeps kimi_cli via runtime MCP lane" true
+    (List.mem "kimi_cli" (provider_kinds providers));
+  check bool "drops gemini_cli without runtime MCP lane" false
+    (List.mem "gemini_cli" (provider_kinds providers))
+
 let () =
   run "Cascade_runtime"
     [
@@ -133,5 +148,7 @@ let () =
           test_case "required tool support keeps inline or runtime-capable providers"
             `Quick
             test_required_tool_support_filter_keeps_inline_or_runtime_capable_providers;
+          test_case "tool gate keeps runtime MCP-capable CLI providers" `Quick
+            test_required_tool_gate_filter_keeps_runtime_mcp_capable_cli_providers;
         ] );
     ]

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -201,6 +201,20 @@ let test_masc_http_base_url_uses_explicit_host_and_port () =
           (Env_config.masc_http_base_url_result ());
         check string "base url from host+port" "http://masc.example.test:7777" (Env_config.masc_http_base_url ()))))
 
+let test_server_bootstrap_http_sets_runtime_mcp_url () =
+  with_env Env_config_core.http_base_url_env_key "https://public.example" (fun () ->
+    with_env Env_config_runtime.Local_runtime.mcp_url_env_key
+      "http://127.0.0.1:8935/mcp"
+      (fun () ->
+        ignore
+          (Masc_mcp.Server_bootstrap_http.make_http_config
+             ~host:"0.0.0.0" ~port:7777);
+        check string "base url preserved when explicitly provided"
+          "https://public.example" (Env_config.masc_http_base_url ());
+        check string "runtime MCP URL updated to active bind"
+          "http://127.0.0.1:7777/mcp"
+          (Env_config_runtime.Local_runtime.mcp_url ())))
+
 let test_sb_path_result_missing_is_error () =
   with_env "MASC_BASE_PATH" "" (fun () ->
     check bool "sb path result is error" true
@@ -585,6 +599,8 @@ let () =
         test_base_path_raw_prefers_preserved_input_env;
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
+      test_case "server bootstrap sets runtime MCP URL" `Quick
+        test_server_bootstrap_http_sets_runtime_mcp_url;
       test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;
       test_case "masc_host reads primary env" `Quick test_masc_host_prefers_primary_over_deprecated;
       test_case "assets dir reads primary env" `Quick test_assets_dir_prefers_primary_over_deprecated;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -9,6 +9,8 @@ module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
+module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_registry = Masc_mcp.Keeper_registry
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
@@ -55,6 +57,24 @@ let write_text_file path content =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
+
+let make_keeper_meta ?agent_name name =
+  let agent_name =
+    Option.value agent_name
+      ~default:(Keeper_types.keeper_agent_name name)
+  in
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String agent_name);
+        ("trace_id", `String ("trace-test-" ^ name));
+        ("goal", `String "test goal");
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_keeper_meta failed: " ^ err)
 
 let extract_json_from_text text =
   try
@@ -1853,6 +1873,58 @@ let test_handle_request_tools_call_board_post_structured_content () =
     Yojson.Safe.Util.(structured |> member "author" |> to_string);
   cleanup_dir base_path
 
+let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Keeper_registry.clear ();
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+      let keeper_name = "sangsu" in
+      let keeper_agent_name = Keeper_types.keeper_agent_name keeper_name in
+      ignore
+        (Keeper_registry.register ~base_path keeper_name
+           (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+      let request =
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("jsonrpc", `String "2.0");
+              ("id", `Int 119);
+              ("method", `String "tools/call");
+              ( "params",
+                `Assoc
+                  [
+                    ("name", `String "masc_status");
+                    ( "arguments",
+                      `Assoc
+                        [ ("_agent_name", `String keeper_agent_name) ] );
+                  ] );
+            ])
+      in
+      let response = Mcp_eio.handle_request ~clock ~sw state request in
+      ignore (result_fields_exn response);
+      match List.assoc_opt "masc_status" (Keeper_registry.tool_usage_of ~base_path keeper_name) with
+      | Some entry ->
+          Alcotest.(check int) "tool count" 1 entry.count;
+          Alcotest.(check int) "tool successes" 1 entry.successes;
+          Alcotest.(check int) "tool failures" 0 entry.failures;
+          let persisted =
+            Yojson.Safe.from_file
+              (Filename.concat base_path ".masc/keepers/tool_usage/sangsu.json")
+          in
+          let open Yojson.Safe.Util in
+          Alcotest.(check string) "persisted tool name" "masc_status"
+            (persisted |> member "tools" |> index 0 |> member "tool" |> to_string)
+      | None -> Alcotest.fail "expected keeper tool usage for masc_status")
+
 let test_handle_request_tools_call_blocks_keeper_internal_tool () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2692,6 +2764,8 @@ let eio_tests = [
   (* cache get structured content test removed: cache tools retired (#3640) *)
   "handle tools/call board post structured content", `Quick,
     test_handle_request_tools_call_board_post_structured_content;
+  "handle tools/call records keeper usage for public MCP tool", `Quick,
+    test_handle_request_tools_call_records_keeper_usage_for_public_mcp;
   "handle tools/call blocks keeper internal tool", `Quick,
     test_handle_request_tools_call_blocks_keeper_internal_tool;
   "handle invalid json", `Quick, test_handle_request_invalid_json;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -992,8 +992,9 @@ let test_oas_worker_exec_build_supports_kimi_cli () =
       ~name:"oas-worker-kimi-cli"
       ~provider_cfg
       ~system_prompt:"system"
-      ~tools:[ make_noop_tool () ]
+      ~tools:[ make_named_noop_tool "masc_status" ]
   in
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   Eio.Switch.run @@ fun sw ->
   match Oas_worker_exec.build ~sw ~net:(require_test_net ()) ~config with
   | Ok agent -> Oas.Agent.close agent
@@ -1300,6 +1301,13 @@ let make_kimi_provider_cfg ?(model_id = "kimi-k2.5") () =
     ~request_path:"/chat/completions"
     ()
 
+let make_kimi_cli_provider_cfg ?(model_id = "kimi-for-coding") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Kimi_cli
+    ~model_id
+    ~base_url:""
+    ()
+
 let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
   let glm = Masc_mcp.Oas_worker_cascade.provider_name_of_config
       (make_glm_provider_cfg ()) in
@@ -1351,6 +1359,56 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy ()
       Alcotest.fail "expected codex_cli public MCP tools to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
+let test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_kimi_cli_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, Some policy) ->
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "allowed tool names preserve public MCP set"
+        [ "masc_status"; "masc_tasks" ] policy.allowed_tool_names;
+      Alcotest.(check (list string)) "allowed server names"
+        [ "masc" ] policy.allowed_server_names;
+      Alcotest.(check (list string)) "runtime server name"
+        [ "masc" ]
+        (List.map Llm_provider.Llm_transport.runtime_mcp_server_name policy.servers);
+      Alcotest.(check bool) "strict runtime policy" true policy.strict;
+      Alcotest.(check bool) "builtins disabled" true policy.disable_builtin_tools
+  | Ok (_, None) ->
+      Alcotest.fail "expected kimi_cli public MCP tools to use runtime MCP lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_kimi_cli_mixed_tools_keeps_public_runtime_subset () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  let tools =
+    [
+      make_named_noop_tool "keeper_board_get";
+      make_named_noop_tool "masc_status";
+      make_named_noop_tool "masc_tasks";
+    ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_kimi_cli_provider_cfg ())
+      ~tools
+  with
+  | Ok (effective_tools, Some policy) ->
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "public runtime subset preserved"
+        [ "masc_status"; "masc_tasks" ] policy.allowed_tool_names
+  | Ok (_, None) ->
+      Alcotest.fail
+        "expected kimi_cli mixed surface to keep the public MCP runtime subset"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
 let test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   let tools =
@@ -1381,6 +1439,185 @@ let test_resolve_tool_lane_for_codex_cli_internal_tools_rejects () =
   | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
       Alcotest.(check string) "field" "tool_support" field
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~provider_cfg:(make_kimi_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_board_get" ]
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected kimi_cli to reject keeper-internal tools without inline tool support"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
+      Alcotest.(check string) "field" "tool_support" field
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            {
+              name = "masc";
+              url = "http://127.0.0.1:8947/mcp";
+              headers = [ ("Authorization", "Bearer token") ];
+            };
+          Llm_provider.Llm_transport.Http_server
+            { name = "other"; url = "http://127.0.0.1:9999/mcp"; headers = [] };
+        ];
+      allowed_server_names = [ "masc" ];
+      allowed_tool_names = [ "masc_status" ];
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  match Oas_worker_exec.kimi_mcp_config_json_of_policy policy with
+  | None -> Alcotest.fail "expected kimi runtime MCP config JSON"
+  | Some raw_json ->
+      let open Yojson.Safe.Util in
+      let json = Yojson.Safe.from_string raw_json in
+      let mcp_servers = json |> member "mcpServers" in
+      Alcotest.(check string) "masc url" "http://127.0.0.1:8947/mcp"
+        (mcp_servers |> member "masc" |> member "url" |> to_string);
+      Alcotest.(check string) "auth header preserved" "Bearer token"
+        (mcp_servers
+         |> member "masc"
+         |> member "headers"
+         |> member "Authorization"
+         |> to_string);
+      Alcotest.(check bool) "disallowed server omitted" true
+        (match mcp_servers |> member "other" with `Null -> true | _ -> false)
+
+let test_runtime_mcp_policy_with_masc_agent_name_upserts_header () =
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            {
+              name = "masc";
+              url = "http://127.0.0.1:8947/mcp";
+              headers =
+                [
+                  ("Authorization", "Bearer token");
+                  ("x-masc-agent-name", "stale-agent");
+                ];
+            };
+          Llm_provider.Llm_transport.Http_server
+            {
+              name = "other";
+              url = "http://127.0.0.1:9999/mcp";
+              headers = [ ("Authorization", "Other token") ];
+            };
+        ];
+      allowed_server_names = [ "masc"; "other" ];
+      allowed_tool_names = [ "masc_status" ];
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  let updated =
+    Oas_worker_exec.runtime_mcp_policy_with_masc_agent_name
+      ~agent_name:"keeper-sangsu-agent" policy
+  in
+  let find_http_headers name =
+    List.find_map
+      (function
+        | Llm_provider.Llm_transport.Http_server server
+          when String.equal server.name name -> Some server.headers
+        | _ -> None)
+      updated.servers
+  in
+  match find_http_headers "masc", find_http_headers "other" with
+  | Some masc_headers, Some other_headers ->
+      Alcotest.(check (option string)) "masc header injected"
+        (Some "keeper-sangsu-agent")
+        (List.assoc_opt "x-masc-agent-name" masc_headers);
+      Alcotest.(check (option string)) "masc auth preserved"
+        (Some "Bearer token")
+        (List.assoc_opt "Authorization" masc_headers);
+      Alcotest.(check (option string)) "other server unchanged" None
+        (List.assoc_opt "x-masc-agent-name" other_headers)
+  | _ -> Alcotest.fail "expected both masc and other HTTP servers"
+
+let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            { name = "masc"; url = "http://127.0.0.1:8947/mcp"; headers = [] };
+        ];
+      allowed_server_names = [ "masc" ];
+      allowed_tool_names = [ "masc_status" ];
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  let merged =
+    Oas_worker_exec.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy)
+  in
+  Alcotest.(check int) "request policy contributes one kimi mcp config" 1
+    (List.length merged);
+  Alcotest.(check bool) "merged config keeps masc MCP url" true
+    (List.exists
+       (contains_substring ~needle:"http://127.0.0.1:8947/mcp")
+       merged)
+
+let test_kimi_cli_build_args_include_runtime_mcp_config () =
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            { name = "masc"; url = "http://127.0.0.1:8947/mcp"; headers = [] };
+        ];
+      allowed_server_names = [ "masc" ];
+      allowed_tool_names = [ "masc_status" ];
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  let mcp_config_json =
+    Oas_worker_exec.kimi_cli_runtime_mcp_jsons ~base:[] (Some policy)
+  in
+  let argv =
+    Oas_worker_exec.Kimi_cli_transport_local.build_args
+      ~config:Oas_worker_exec.Kimi_cli_transport_local.default_config
+      ~req_config:(make_kimi_cli_provider_cfg ())
+      ~mcp_config_json
+      ~prompt:"hello"
+  in
+  Alcotest.(check bool) "mcp-config flag present" true
+    (List.mem "--mcp-config" argv);
+  Alcotest.(check bool) "mcp-config payload includes masc MCP url" true
+    (List.exists
+       (contains_substring ~needle:"http://127.0.0.1:8947/mcp")
+       argv)
+
+let test_kimi_cli_model_for_provider_keeps_transport_default_on_auto () =
+  let provider_cfg = make_kimi_cli_provider_cfg () in
+  Alcotest.(check (option string)) "auto uses transport default"
+    Llm_provider.Transport_kimi_cli.default_config.model
+    (Oas_worker_exec.kimi_cli_model_for_provider provider_cfg)
+
+let test_kimi_cli_model_for_provider_keeps_explicit_model () =
+  let provider_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Kimi_cli
+      ~model_id:"kimi-k2.5"
+      ~base_url:"" ()
+  in
+  Alcotest.(check (option string)) "explicit model preserved"
+    (Some "kimi-k2.5")
+    (Oas_worker_exec.kimi_cli_model_for_provider provider_cfg)
 
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
@@ -2640,10 +2877,28 @@ let () =
         test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow;
       Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
+      Alcotest.test_case "public MCP tools on kimi_cli use runtime MCP lane" `Quick
+        test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy;
+      Alcotest.test_case "mixed tool surface on kimi_cli keeps public runtime subset" `Quick
+        test_resolve_tool_lane_for_kimi_cli_mixed_tools_keeps_public_runtime_subset;
       Alcotest.test_case "public MCP tools on openai_compat stay inline" `Quick
         test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools;
       Alcotest.test_case "keeper-internal tools on codex_cli are rejected" `Quick
         test_resolve_tool_lane_for_codex_cli_internal_tools_rejects;
+      Alcotest.test_case "keeper-internal tools on kimi_cli are rejected" `Quick
+        test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects;
+      Alcotest.test_case "kimi runtime MCP config keeps only allowed servers" `Quick
+        test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
+      Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick
+        test_runtime_mcp_policy_with_masc_agent_name_upserts_header;
+      Alcotest.test_case "kimi request runtime MCP config is merged" `Quick
+        test_kimi_cli_runtime_mcp_jsons_include_request_policy;
+      Alcotest.test_case "kimi argv includes request runtime MCP config" `Quick
+        test_kimi_cli_build_args_include_runtime_mcp_config;
+      Alcotest.test_case "kimi auto model keeps transport default" `Quick
+        test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
+      Alcotest.test_case "kimi explicit model is preserved" `Quick
+        test_kimi_cli_model_for_provider_keeps_explicit_model;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1993,6 +1993,7 @@ let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let tool_use_msg ?(id = "tool-1") ?(name = "keeper_fs_read") input
@@ -2003,6 +2004,7 @@ let tool_use_msg ?(id = "tool-1") ?(name = "keeper_fs_read") input
       [ Agent_sdk.Types.ToolUse { id; name; input } ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let test_keeper_checkpoint_store_oas_roundtrip () =
@@ -2716,6 +2718,7 @@ let make_assistant_tool_use_msg name : Agent_sdk.Types.message =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 (** Idle error with a preceding tool-use: should append "(tool: <name>)". *)
@@ -2731,10 +2734,10 @@ let test_enrich_idle_detail_with_tool () =
 (** Idle error with no tool use in messages: detail should be unchanged. *)
 let test_enrich_idle_detail_no_tool () =
   let detail = "Idle detected after 3 identical turns" in
-  let messages =
+  let messages : Agent_sdk.Types.message list =
     [ { Agent_sdk.Types.role = Agent_sdk.Types.User;
         content = [ Agent_sdk.Types.Text "hello" ];
-        name = None; tool_call_id = None } ]
+        name = None; tool_call_id = None; metadata = [] } ]
   in
   let result = Oas_worker_exec.enrich_idle_detail detail messages in
   Alcotest.(check string) "unchanged when no tool" detail result


### PR DESCRIPTION
## Summary
- route `kimi_cli` keeper tool-required turns through the runtime MCP lane instead of treating them as inline `req.tools` / `tool_choice` turns
- pass keeper identity into the runtime MCP policy and inject `x-masc-agent-name` on the `masc` MCP HTTP server so runtime tool calls are attributed back to the keeper
- persist and flush keeper runtime MCP public-tool usage so `tool_usage/<keeper>.json` is updated during the turn, not only on a later heartbeat
- add regression coverage for provider filtering, runtime MCP config generation, keeper attribution, and bootstrap MCP URL wiring

## Product impact
- internal only
- affects keeper tool gating, OAS worker runtime MCP policy, and runtime MCP telemetry/tool attribution for `kimi_cli`
- does not change direct Kimi API behavior or GLM base capability defaults

## Why
- Kimi Code CLI's official docs describe MCP server configuration and loading via `kimi mcp`, `~/.kimi/mcp.json`, `--mcp-config-file`, and `--mcp-config`, which matches a runtime MCP transport model rather than inline OAS callbacks
- Kimi Code CLI's agent docs describe a built-in agent/tool runtime, which is consistent with routing public MASC tools through runtime MCP
- Z.AI function calling docs still describe `tool_choice` as `auto`-only, so GLM/Z.AI function-calling docs are not a good basis for claiming `kimi_cli` inline tool-choice support
- before this patch, `sangsu -> kimi_cli` keeper smoke exhausted candidates with `no_tool_capable_provider`; after the patch it completes a tool-required turn and persists keeper tool usage

## Evidence
- Official docs
  - Kimi MCP docs: https://moonshotai.github.io/kimi-cli/en/customization/mcp.html
  - Kimi agents/tools docs: https://moonshotai.github.io/kimi-cli/en/customization/agents.html
  - Z.AI function calling docs: https://docs.z.ai/guides/capabilities/function-calling
  - Z.AI GLM Coding Plan / Claude Code docs: https://docs.z.ai/devpack/tool/claude
- Local verification
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-cli-runtime-mcp ./bin/main_eio.exe ./test/test_oas_worker.exe ./test/test_cascade_runtime.exe ./test/test_env_config_coverage.exe ./test/test_mcp_server_eio.exe`
  - `./_build/default/test/test_cascade_runtime.exe` -> 6/6
  - `./_build/default/test/test_env_config_coverage.exe` -> 72/72
  - `./_build/default/test/test_oas_worker.exe` -> 87/87
  - `./_build/default/test/test_mcp_server_eio.exe` -> 64/64
- Keeper smoke
  - script: `/tmp/kimi_cli_sangsu_smoke.sh`
  - artifact root: `/var/folders/bv/cjrbl01x52s6j80krdfb63400000gp/T/kimi-cli-runtime-mcp-smoke.X2oItq`
  - `sangsu.json`: `total_turns=1`, `last_model_used="kimi_cli:kimi-for-coding"`, `last_latency_ms=22231`
  - `sangsu.decisions.jsonl`: `outcome="success"`, `selected_mode="tool_use"`, `turn_lane="tool_required"`, `tool_call_count=8`
  - `tool_usage/sangsu.json`: persisted `masc_tasks=2`, `masc_status=2`, `masc_board_list=2`, `masc_board_get=2`, `masc_board_comment=2`, `masc_messages=1`
  - `telemetry/2026-04/21.jsonl` and `audit/2026-04/21.jsonl`: runtime MCP tool calls attributed to `agent_id="keeper-sangsu-agent"`
- Local evidence record
  - `/Users/dancer/me/memory/procedural-memory/2026-04-22-kimi-cli-runtime-mcp-evidence-record.md`

## Review evidence
- No cross-model review run for this PR.
- Review basis is official-doc verification plus local build/tests plus a keeper smoke repro with persisted telemetry/tool-usage artifacts.

## Linked issue
Relates #9313
