### PR TITLE
[codex] fix(worker_oas): align interface with OAS types

### DIFF
--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -8,7 +8,7 @@
 (** {1 Agent Construction} *)
 
 val build_agent :
-  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  net:([ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
   meta:Worker_container_types.worker_container_meta ->
   provider:Oas.Provider.config ->
   system_prompt:string ->
@@ -16,8 +16,8 @@ val build_agent :
   hooks:Oas.Hooks.hooks ->
   raw_trace:Oas.Raw_trace.t ->
   heartbeat_callbacks:Oas.Agent.periodic_callback list ->
-  ?gate_config:Eval_gate.gate_config option ->
-  ?context_injector:Oas.Context_injector.t ->
+  ?gate_config:Eval_gate.gate_config ->
+  ?context_injector:Oas.Hooks.context_injector ->
   ?context:Oas.Context.t ->
   ?approval:Oas.Hooks.approval_callback ->
   unit ->
@@ -40,7 +40,7 @@ val gate_config_of_execution_scope :
 
 val run_worker_via_oas :
   sw:Eio.Switch.t ->
-  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  net:([ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
   base_path:string ->
   auth_token:string option ->
   meta:Worker_container_types.worker_container_meta ->
@@ -49,7 +49,7 @@ val run_worker_via_oas :
   prompt:string ->
   tools:Oas.Tool.t list ->
   raw_trace:Oas.Raw_trace.t ->
-  ?gate_config:Eval_gate.gate_config option ->
+  ?gate_config:Eval_gate.gate_config ->
   ?contract:string ->
   ?worker_run_id:string ->
   unit ->
@@ -57,7 +57,7 @@ val run_worker_via_oas :
 
 val resume_worker_via_oas :
   sw:Eio.Switch.t ->
-  net:([> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
+  net:([ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
   base_path:string ->
   auth_token:string option ->
   meta:Worker_container_types.worker_container_meta ->


### PR DESCRIPTION
## Summary
- fix the newly added worker_oas.mli signature drift
- use Oas.Hooks.context_injector instead of the nonexistent Oas.Context_injector.t
- align net and gate_config argument types with worker_oas.ml

## Validation
- dune build --root . --build-dir _build_fix_worker_oas_3 lib/worker_oas.mli
- dune build --root . --build-dir _build_fix_worker_oas_4 lib/worker_oas.ml lib/local/worker_container_runners.ml