### PR TITLE
cascade: respect cooldown in retry ordering

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -121,10 +121,10 @@ let filter_cooldown adapter ctx cands =
 (* ── Weighted shuffle ───────────────────────────────────────────── *)
 
 (* Weighted-random permutation using effective_weight from the health
-   tracker.  Zero-weight candidates (cooldown) are filtered, with the
-   guarantee that at least one candidate survives (the full input list)
-   to avoid starvation — mirrors
-   [Cascade_config.order_weighted_entries]:435-439. *)
+   tracker. Zero-weight candidates (cooldown) are filtered. When every
+   candidate is cooled down, return [[]] so the caller can surface the
+   filtered-empty state instead of reviving a provider that was
+   intentionally put into cooldown (e.g. hard quota exhausted). *)
 let weighted_shuffle adapter ctx cands =
   (* Compute health-adjusted weight per candidate. *)
   let weighted = List.map
@@ -137,13 +137,6 @@ let weighted_shuffle adapter ctx cands =
       cands
   in
   let active = List.filter (fun (_, w) -> w > 0) weighted in
-  let effective =
-    if active = [] then
-      (* Starvation guard: fall back to the original list, each with
-         weight 1, so that at least one call attempt is made. *)
-      List.map (fun (c, _) -> (c, 1)) weighted
-    else active
-  in
   (* Sequential weighted pick without replacement. *)
   let rec pick acc remaining =
     match remaining with
@@ -167,7 +160,7 @@ let weighted_shuffle adapter ctx cands =
         in
         step 0 remaining
   in
-  pick [] effective
+  pick [] active
 
 (* ── Priority tier ──────────────────────────────────────────────── *)
 
@@ -248,7 +241,7 @@ let round_robin_order ctx cands =
 let order_candidates t ~adapter ~ctx ~cycle cands =
   match t.kind with
   | Failover ->
-    cands
+    filter_cooldown adapter ctx cands
   | Capacity_aware ->
     filter_capacity adapter ctx cands
   | Weighted_random ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -73,6 +73,17 @@ let test_failover_preserves_order () =
   check (list string) "input order preserved"
     ["a"; "b"; "c"] (names ordered)
 
+let test_failover_filters_cooldown () =
+  let h = H.create () in
+  H.record_failure h ~provider_key:"a";
+  H.record_failure h ~provider_key:"a";
+  H.record_failure h ~provider_key:"a";
+  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
+  let ctx = mk_ctx ~health:h () in
+  let ordered = S.order_candidates S.failover ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "cooldown candidate removed, remaining order preserved"
+    ["b"; "c"] (names ordered)
+
 (* ── S2 Capacity_aware ───────────────────────────────────────── *)
 
 let test_capacity_aware_filters_busy () =
@@ -124,10 +135,10 @@ let test_weighted_random_deterministic_with_rand0 () =
   check (list string) "rand=0 picks left-to-right"
     ["a"; "b"; "c"] (names ordered)
 
-let test_weighted_random_starvation_guard () =
-  (* Cool down all providers via health tracker.  effective_weight
-     becomes 0 for all; the order_weighted_entries-style guard must
-     keep at least the original list (with weight 1). *)
+let test_weighted_random_all_cooldown_yields_empty () =
+  (* Cool down all providers via health tracker. effective_weight
+     becomes 0 for all, so weighted_random must return no candidates
+     and let the caller surface a filtered-empty cascade state. *)
   let h = H.create () in
   let cool_down k =
     H.record_failure h ~provider_key:k;
@@ -139,8 +150,8 @@ let test_weighted_random_starvation_guard () =
   let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
   let strat = mk_t S.Weighted_random in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
-  check int "all-cooldown → fallback picks at least 1"
-    2 (List.length ordered)
+  check (list string) "all-cooldown → empty"
+    [] (names ordered)
 
 (* ── S4 Circuit_breaker_cycling ──────────────────────────────── *)
 
@@ -882,6 +893,7 @@ let () =
   run "cascade_strategy" [
     "failover", [
       test_case "preserves order" `Quick test_failover_preserves_order;
+      test_case "filters cooldown" `Quick test_failover_filters_cooldown;
     ];
     "capacity_aware", [
       test_case "filters busy candidates" `Quick test_capacity_aware_filters_busy;
@@ -891,8 +903,8 @@ let () =
     "weighted_random", [
       test_case "deterministic with rand=0" `Quick
         test_weighted_random_deterministic_with_rand0;
-      test_case "starvation guard kicks in" `Quick
-        test_weighted_random_starvation_guard;
+      test_case "all cooldown yields empty" `Quick
+        test_weighted_random_all_cooldown_yields_empty;
     ];
     "circuit_breaker_cycling", [
       test_case "excludes cooldown and busy" `Quick


### PR DESCRIPTION
## Summary
- make failover respect provider cooldown state instead of retrying cooled-down candidates
- stop weighted_random from reviving all-cooldown candidates after hard quota failures
- add regression coverage for failover and weighted_random cooldown behavior

## Testing
- ./_build/default/test/test_cascade_strategy.exe
- ./_build/default/test/test_cascade_model_resolve.exe