### PR TITLE
fix(oas): avoid Retry.NotFound pin drift

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -441,6 +441,11 @@ let with_codex_cli_preflight ~(scope : string) ~(config : Oas_worker_exec.config
     Error (codex_cli_preflight_error ~scope ~provider_cfg:config.provider_cfg preflight)
   | None -> run ()
 
+let retry_message_looks_like_not_found (message : string) : bool =
+  String_util.contains_substring_ci message "not found"
+  || String_util.contains_substring_ci message "status code: 404"
+  || String_util.contains_substring_ci message "404 page not found"
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -451,13 +456,14 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
   | Oas.Error.Api api_err ->
     let http_err = match[@warning "-8"] api_err with
       | Llm_provider.Retry.InvalidRequest { message } ->
-        Llm_provider.Http_client.HttpError { code = 400; body = message }
+        let code =
+          if retry_message_looks_like_not_found message then 404 else 400
+        in
+        Llm_provider.Http_client.HttpError { code; body = message }
       | Llm_provider.Retry.ContextOverflow { message; _ } ->
         Llm_provider.Http_client.HttpError { code = 400; body = message }
       | Llm_provider.Retry.RateLimited { message; _ } ->
         Llm_provider.Http_client.HttpError { code = 429; body = message }
-      | Llm_provider.Retry.NotFound { message } ->
-        Llm_provider.Http_client.HttpError { code = 404; body = message }
       | Llm_provider.Retry.ServerError { status; message } ->
         Llm_provider.Http_client.HttpError { code = status; body = message }
       | Llm_provider.Retry.AuthError { message } ->
@@ -544,15 +550,16 @@ let enrich_sdk_error ~cascade_name
            message =
              append_hint message moonshot_auth_hint_marker detail;
          })
-  | Oas.Error.Api (Llm_provider.Retry.NotFound { message })
-    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat ->
+  | Oas.Error.Api (Llm_provider.Retry.InvalidRequest { message })
+    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat
+      && retry_message_looks_like_not_found message ->
     let detail =
       Printf.sprintf "base_url=%s request_path=%s endpoint=%s"
         provider_cfg.base_url provider_cfg.request_path
         (provider_cfg.base_url ^ provider_cfg.request_path)
     in
     Oas.Error.Api
-      (Llm_provider.Retry.NotFound
+      (Llm_provider.Retry.InvalidRequest
          {
            message =
              append_hint message openai_compat_not_found_hint_marker detail;
@@ -590,7 +597,6 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.ServerError { message; _ } ->
        message_looks_like_cli_wrapped_hard_quota message
      | Llm_provider.Retry.RateLimited _
-     | Llm_provider.Retry.NotFound _
      | Llm_provider.Retry.AuthError _
      | Llm_provider.Retry.InvalidRequest _
      | Llm_provider.Retry.ContextOverflow _

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -684,31 +684,53 @@ let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
 let test_sdk_error_is_hard_quota_keeps_not_found_false () =
   let err =
     Oas.Error.Api
-      (Llm_provider.Retry.NotFound
-         { message = "model endpoint not found" })
+      (Llm_provider.Retry.InvalidRequest
+         { message = {|{"detail":"Not Found"}|} })
   in
-  Alcotest.(check bool) "NotFound stays non-hard-quota" false
+  Alcotest.(check bool) "404-like InvalidRequest stays non-hard-quota" false
     (Oas_worker_named.sdk_error_is_hard_quota err)
 
 let test_sdk_error_to_cascade_outcome_maps_not_found_to_404 () =
   let err =
     Oas.Error.Api
-      (Llm_provider.Retry.NotFound
-         { message = "provider resource missing" })
+      (Llm_provider.Retry.InvalidRequest
+         { message = {|{"detail":"Not Found"}|} })
   in
   match Oas_worker_named.sdk_error_to_cascade_outcome err with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.HttpError
-            { code = 404; body = "provider resource missing" })) -> ()
+            { code = 404; body = {|{"detail":"Not Found"}|} })) -> ()
   | outcome ->
-      Alcotest.failf "expected Some (Call_err (HttpError 404)) for NotFound, got %s"
+      Alcotest.failf
+        "expected Some (Call_err (HttpError 404)) for 404-like InvalidRequest, got %s"
          (match outcome with
           | Some (Cascade_fsm.Call_err _) -> "some-call-err"
            | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
           | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
           | Some Cascade_fsm.Slot_full -> "some-slot-full"
           | None -> "none")
+
+let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         { message = {|{"detail":"Bad Request"}|} })
+  in
+  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  | Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.HttpError
+            { code = 400; body = {|{"detail":"Bad Request"}|} })) -> ()
+  | outcome ->
+      Alcotest.failf
+        "expected Some (Call_err (HttpError 400)) for ordinary InvalidRequest, got %s"
+        (match outcome with
+         | Some (Cascade_fsm.Call_err _) -> "some-call-err"
+         | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
+         | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
+         | Some Cascade_fsm.Slot_full -> "some-slot-full"
+         | None -> "none")
 
 let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
   let err =
@@ -777,7 +799,7 @@ let test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint () =
   in
   let err =
     Oas.Error.Api
-      (Llm_provider.Retry.NotFound
+      (Llm_provider.Retry.InvalidRequest
          { message = {|{"detail":"Not Found"}|} })
   in
   let rendered =
@@ -2594,6 +2616,8 @@ let () =
         test_sdk_error_is_hard_quota_keeps_not_found_false;
       Alcotest.test_case "sdk_error_to_cascade_outcome maps NotFound to 404" `Quick
         test_sdk_error_to_cascade_outcome_maps_not_found_to_404;
+      Alcotest.test_case "sdk_error_to_cascade_outcome keeps ordinary InvalidRequest at 400" `Quick
+        test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400;
       Alcotest.test_case "Moonshot auth errors include configured env hint" `Quick
         test_enrich_sdk_error_for_moonshot_auth_includes_env_hint;
       Alcotest.test_case "OpenAI-compatible 404 errors include endpoint hint" `Quick


### PR DESCRIPTION
## Summary
- stop referencing `Llm_provider.Retry.NotFound` from `oas_worker_named`
- treat 404-like `InvalidRequest` messages as HTTP 404 for cascade/enrichment
- update `test_oas_worker` fixtures to match the pinned `agent_sdk` retry surface

## Verification
- confirmed repo pin expects `agent_sdk` SHA `7f79cfa92dd00b2ab10f4f7e5db0a2137e44a8b7`
- confirmed that pinned `lib/llm_provider/retry.mli` does not define `NotFound`
- local `dune build` in this environment is blocked by unrelated local opam pin drift (`agent_sdk` currently points to `/Users/dancer/me/workspace/yousleepwhen/oas/.worktrees/feature-structured-replay-metadata@2e86f5a`, which introduces `metadata` field drift)
- CI on this PR should be the authoritative verifier for the pinned surface
