### PR TITLE
refactor(keeper): route public mli OAS types through facade

### DIFF
--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -74,15 +74,15 @@ type run_result =
   ; cascade_observation : Oas_worker.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
-  ; usage : Agent_sdk.Types.api_usage
+  ; usage : Oas.Types.api_usage
   ; tools_used : string list
   ; tool_calls : tool_call_detail list
-  ; checkpoint : Agent_sdk.Checkpoint.t option
-  ; proof : Agent_sdk.Cdal_proof.t option
-  ; trace_ref : Agent_sdk.Raw_trace.run_ref option
-  ; run_validation : Agent_sdk.Raw_trace.run_validation option
+  ; checkpoint : Oas.Checkpoint.t option
+  ; proof : Oas.Cdal_proof.t option
+  ; trace_ref : Oas.Raw_trace.run_ref option
+  ; run_validation : Oas.Raw_trace.run_validation option
   ; stop_reason : Oas_worker.stop_reason
-  ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
+  ; inference_telemetry : Oas.Types.inference_telemetry option
   ; tool_surface : tool_surface_metrics
   }
 
@@ -106,7 +106,7 @@ val build_ctx_composition_metrics :
   -> memory_context:string
   -> temporal_context:string
   -> user_message:string
-  -> history_messages:Agent_sdk.Types.message list
+  -> history_messages:Oas.Types.message list
   -> actual_input_tokens:int
   -> ctx_composition_metrics
 
@@ -121,7 +121,7 @@ val ctx_composition_to_json : ctx_composition_metrics -> Yojson.Safe.t
 val adaptive_thinking_budget :
      enabled:bool
   -> is_retry:bool
-  -> last_tool_results:Agent_sdk.Types.tool_result list
+  -> last_tool_results:Oas.Types.tool_result list
   -> user_message:string
   -> dynamic_context:string
   -> current_budget:int option
@@ -163,7 +163,7 @@ val run_turn :
   -> max_context:int
   -> build_turn_prompt:
        (   base_system_prompt:string
-        -> messages:Agent_sdk.Types.message list
+        -> messages:Oas.Types.message list
         -> turn_prompt)
   -> user_message:string
   -> cascade_name:string
@@ -174,17 +174,17 @@ val run_turn :
   -> ?max_idle_turns:int
   -> ?history_user_source:string
   -> ?history_assistant_source:string
-  -> ?guardrails:Agent_sdk.Guardrails.t
+  -> ?guardrails:Oas.Guardrails.t
   -> ?temperature:float
   -> ?max_tokens:int
   -> ?oas_timeout_s:float
   -> ?max_cost_usd:float
   -> ?on_event:(Oas.Types.sse_event -> unit)
   -> ?trajectory_acc:Trajectory.accumulator
-  -> ?tool_overlay:Agent_sdk.Tool_op.t ref
+  -> ?tool_overlay:Oas.Tool_op.t ref
   -> ?priority:Llm_provider.Request_priority.t
   -> ?is_retry:bool
-  -> ?shared_context:Agent_sdk.Context.t
-  -> ?event_bus:Agent_sdk.Event_bus.t
+  -> ?shared_context:Oas.Context.t
+  -> ?event_bus:Oas.Event_bus.t
   -> unit
   -> (run_result, Oas.Error.sdk_error) result

--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -27,9 +27,9 @@ type keeper_skill_route = {
 
 (** Merge two API usage records by summing all fields. *)
 val merge_usage :
-  Agent_sdk.Types.api_usage ->
-  Agent_sdk.Types.api_usage ->
-  Agent_sdk.Types.api_usage
+  Oas.Types.api_usage ->
+  Oas.Types.api_usage ->
+  Oas.Types.api_usage
 
 (** {1 Alert Retry Logic} *)
 

--- a/lib/keeper/keeper_artifact_hydrator.mli
+++ b/lib/keeper/keeper_artifact_hydrator.mli
@@ -20,7 +20,7 @@ val keep_recent_from_env : unit -> int
 val hydrate_recent :
   store:Tool_blob_store.t ->
   keep_recent:int ->
-  Agent_sdk.Context_reducer.t
+  Oas.Context_reducer.t
 (** Build a [Custom] reducer that walks the message list right-to-left
     and hydrates the last [keep_recent] [Stored] markers it encounters.
 
@@ -31,7 +31,7 @@ val hydrate_recent :
     Storage exceptions are caught — a corrupted store cannot break the
     reducer pipeline. *)
 
-val reducer_from_env : unit -> Agent_sdk.Context_reducer.t option
+val reducer_from_env : unit -> Oas.Context_reducer.t option
 (** Returns a configured reducer if a blob store can be resolved from
     [MASC_BASE_PATH], else [None]. The [None] case lets callers compose
     the pipeline conditionally without a separate enable flag. *)

--- a/lib/keeper/keeper_compact_audit.mli
+++ b/lib/keeper/keeper_compact_audit.mli
@@ -1,7 +1,7 @@
 (** Compaction audit: Event_bus subscriber + paired JSONL persistence +
     rolling retention.
 
-    Subscribes to OAS {!Agent_sdk.Event_bus} for [ContextCompactStarted]
+    Subscribes to OAS {!Oas.Event_bus} for [ContextCompactStarted]
     and [ContextCompacted] payloads, synthesizes a stable [compaction_id]
     correlating start/complete pairs per keeper, and appends each event
     to [{base_path}/data/harness-compact/YYYY-MM/DD.jsonl].
@@ -133,5 +133,5 @@ val spawn_subscriber
   -> base_path:string
   -> retention_days:int
   -> ?drain_interval_s:float
-  -> Agent_sdk.Event_bus.t
+  -> Oas.Event_bus.t
   -> unit

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -49,7 +49,7 @@ type structured_result = {
   confidence: float;
 }
 
-val structured_result_schema : structured_result Agent_sdk.Structured.schema
+val structured_result_schema : structured_result Oas.Structured.schema
 
 (** {1 World observation} *)
 

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -18,48 +18,48 @@ type session_context = Keeper_types.session_context
 
 (** {1 Working Context Operations} *)
 
-val text_of_message : Agent_sdk.Types.message -> string
-val msg_tokens : Agent_sdk.Types.message -> int
-val count_tokens : string -> Agent_sdk.Types.message list -> int
+val text_of_message : Oas.Types.message -> string
+val msg_tokens : Oas.Types.message -> int
+val count_tokens : string -> Oas.Types.message list -> int
 val max_tokens_of_context : working_context -> int
 val token_count : working_context -> int
 val message_count : working_context -> int
 val context_ratio : working_context -> float
-val checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
-val oas_context_of_context : working_context -> Agent_sdk.Context.t
+val checkpoint_of_context : working_context -> Oas.Checkpoint.t
+val oas_context_of_context : working_context -> Oas.Context.t
 val with_max_tokens : working_context -> int -> working_context
 val system_prompt_of_context : working_context -> string
-val messages_of_context : working_context -> Agent_sdk.Types.message list
+val messages_of_context : working_context -> Oas.Types.message list
 val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
-val append : working_context -> Agent_sdk.Types.message -> working_context
-val append_many : working_context -> Agent_sdk.Types.message list -> working_context
+val append : working_context -> Oas.Types.message -> working_context
+val append_many : working_context -> Oas.Types.message list -> working_context
 val sync_oas_context : working_context -> working_context
-val role_to_string : Agent_sdk.Types.role -> string
-val role_of_string : string -> Agent_sdk.Types.role
+val role_to_string : Oas.Types.role -> string
+val role_of_string : string -> Oas.Types.role
 (** Backwards-compatible: unknown -> [Tool] (safest fallback) + warn log.
     See {!role_of_string_opt} for the strict version. Issue #8623. *)
 
-val role_of_string_opt : string -> Agent_sdk.Types.role option
+val role_of_string_opt : string -> Oas.Types.role option
 (** Strict variant — returns [None] for unrecognised role strings.
     Use this in checkpoint loaders / new code where silently
     misattributing a chat-history message would corrupt the
     LLM-visible conversation. *)
-val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
-val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
+val message_to_json : Oas.Types.message -> Yojson.Safe.t
+val message_of_json : Yojson.Safe.t -> Oas.Types.message
 val serialize_context : working_context -> string
 val deserialize_context : string -> max_tokens:int -> working_context
 val context_to_json : working_context -> Yojson.Safe.t
 val create_checkpoint : working_context -> generation:int -> checkpoint
 val create_session : session_id:string -> base_dir:string -> session_context
-val persist_message : ?source:string -> session_context -> Agent_sdk.Types.message -> unit
+val persist_message : ?source:string -> session_context -> Oas.Types.message -> unit
 
 (** {1 Inference Utilities} *)
 
 val timed : (unit -> 'a) -> 'a * int
-val zero_usage : Agent_sdk.Types.api_usage
-val usage_of_response : Agent_sdk.Types.api_response -> Agent_sdk.Types.api_usage
-val total_tokens : Agent_sdk.Types.api_usage -> int
+val zero_usage : Oas.Types.api_usage
+val usage_of_response : Oas.Types.api_response -> Oas.Types.api_usage
+val total_tokens : Oas.Types.api_usage -> int
 
 (** {1 Checkpoint Store Delegation} *)
 
@@ -70,12 +70,12 @@ val save_session_checkpoint : session_context -> checkpoint -> unit
 val log_keeper_exn : label:string -> exn -> unit
 
 val checkpoint_max_tokens :
-  Agent_sdk.Checkpoint.t -> fallback:int -> int
+  Oas.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint :
   ?repair_orphans:bool ->
   max_checkpoint_messages:int ->
-  Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
+  Oas.Checkpoint.t -> primary_model_max_tokens:int -> working_context
 
 val checkpoint_model_of_meta : keeper_meta -> string
 
@@ -86,7 +86,7 @@ val save_oas_checkpoint :
   model:string ->
   ctx:working_context ->
   generation:int ->
-  (Agent_sdk.Checkpoint.t, string) result
+  (Oas.Checkpoint.t, string) result
 
 (** {1 Handoff Rollover} *)
 
@@ -114,7 +114,7 @@ type compaction_event = {
 
 type post_turn_lifecycle = {
   updated_meta : keeper_meta;
-  checkpoint : Agent_sdk.Checkpoint.t option;
+  checkpoint : Oas.Checkpoint.t option;
   handoff_json : Yojson.Safe.t option;
   handoff_attempted : bool;
   handoff_failure_reason : string option;
@@ -135,7 +135,7 @@ type max_context_resolution = {
 }
 
 type overflow_retry_recovery = {
-  checkpoint : Agent_sdk.Checkpoint.t;
+  checkpoint : Oas.Checkpoint.t;
   compaction : compaction_event;
   turn_generation : int;
 }
@@ -147,7 +147,7 @@ val maybe_rollover_oas_handoff :
   model:string ->
   primary_model_max_tokens:int ->
   current_turn_overflow_blocker:string option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
+  checkpoint:Oas.Checkpoint.t option ->
   handoff_rollover
 
 (** {2 Pure gate helpers (for testing)} *)
@@ -201,7 +201,7 @@ val context_of_legacy_checkpoint :
   checkpoint -> primary_model_max_tokens:int -> working_context
 [@@deprecated "Use Keeper_context_core.context_of_legacy_checkpoint directly; this re-export will be removed in a future release."]
 
-val checkpoint_generation : Agent_sdk.Checkpoint.t -> fallback:int -> int
+val checkpoint_generation : Oas.Checkpoint.t -> fallback:int -> int
 [@@deprecated "Use Keeper_context_core.checkpoint_generation directly; this re-export will be removed in a future release."]
 
 (** {1 Compaction} *)
@@ -222,7 +222,7 @@ val apply_post_turn_lifecycle :
   model:string ->
   primary_model_max_tokens:int ->
   current_turn_overflow_blocker:string option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
+  checkpoint:Oas.Checkpoint.t option ->
   post_turn_lifecycle
 
 val dispatch_keeper_phase_event :

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -16,7 +16,7 @@ val keeper_universe_tool_names : keeper_meta -> string list
 val keeper_internal_candidate_tool_names : string list
 
 (** Universe model tool schemas.  Returns schemas for all universe tools
-    so [make_tools] can build Agent_sdk.Tool.t for the full search scope. *)
+    so [make_tools] can build {!Oas.Tool.t} for the full search scope. *)
 val keeper_universe_model_tools : keeper_meta -> Types.tool_schema list
 
 (** Preset-scoped universe: preset allowlist + core_always - denied.

--- a/lib/keeper/keeper_extend_turns.mli
+++ b/lib/keeper/keeper_extend_turns.mli
@@ -1,6 +1,6 @@
 (** Keeper_extend_turns — Self-extending turn budget tool for keeper Agent.run.
 
-    Creates an [extend_turns] {!Agent_sdk.Tool.t} that lets the keeper request
+    Creates an [extend_turns] {!Oas.Tool.t} that lets the keeper request
     more turns at runtime.  The tool enforces a per-session extension limit
     (10 extensions) and an absolute ceiling on total turns. *)
 
@@ -11,8 +11,8 @@
     @param max_turns  Initial turn budget.
     @param ceiling    Absolute upper bound on turns (default: [max max_turns 200]). *)
 val make :
-  agent_ref:Agent_sdk.Agent.t option ref ->
+  agent_ref:Oas.Agent.t option ref ->
   max_turns:int ->
   ?ceiling:int ->
   unit ->
-  Agent_sdk.Tool.t
+  Oas.Tool.t

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -1,10 +1,10 @@
 open Keeper_types
 
 (** Inject the shared Event_bus for keeper snapshot publishing. *)
-val set_bus : Agent_sdk.Event_bus.t -> unit
+val set_bus : Oas.Event_bus.t -> unit
 
 (** Retrieve the shared Event_bus, if set. *)
-val get_bus : unit -> Agent_sdk.Event_bus.t option
+val get_bus : unit -> Oas.Event_bus.t option
 
 (** Inject a gRPC client for bidirectional heartbeat streaming.
     When set and [MASC_AGENT_TRANSPORT=grpc], keepalive opens a

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -13,7 +13,7 @@ include module type of Keeper_memory_bank
 (** {1 Cost Calculation} *)
 
 val cost_usd_of_usage :
-  Agent_sdk.Types.api_usage -> model_id:string -> float
+  Oas.Types.api_usage -> model_id:string -> float
 
 (** {1 File Reading} *)
 
@@ -58,12 +58,12 @@ val jaccard_similarity : string -> string -> float
 (** {1 Message Extraction} *)
 
 val latest_message_content_by_role :
-  role:Agent_sdk.Types.role ->
-  Agent_sdk.Types.message list ->
+  role:Oas.Types.role ->
+  Oas.Types.message list ->
   string option
 
 val previous_assistant_message_content :
-  Agent_sdk.Types.message list -> string option
+  Oas.Types.message list -> string option
 
 (** {1 Goal Alignment} *)
 
@@ -81,7 +81,7 @@ val goal_alignment_score :
 (** {1 Repetition Risk} *)
 
 val repetition_risk_score :
-  messages:Agent_sdk.Types.message list ->
+  messages:Oas.Types.message list ->
   candidate_reply:string option ->
   float
 
@@ -159,13 +159,13 @@ val learned_policy_auto_rules :
 (** {1 User Message Extraction} *)
 
 val recent_user_messages :
-  Agent_sdk.Types.message list -> max_n:int -> string list
+  Oas.Types.message list -> max_n:int -> string list
 
 val load_history_user_messages :
   path:string -> max_n:int -> string list
 
 val recall_candidates_with_history :
-  checkpoint_messages:Agent_sdk.Types.message list ->
+  checkpoint_messages:Oas.Types.message list ->
   history_path:string ->
   max_checkpoint:int ->
   max_history:int ->

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -331,7 +331,7 @@ type tool_call_entry = {
 (** {1 Working Context Types (moved from Keeper_working_context)} *)
 
 type working_context = {
-  checkpoint : Agent_sdk.Checkpoint.t;
+  checkpoint : Oas.Checkpoint.t;
   max_tokens : int;
 }
 

--- a/lib/keeper/keeper_wake_telemetry.mli
+++ b/lib/keeper/keeper_wake_telemetry.mli
@@ -12,16 +12,16 @@ type sizes = {
   tool_count : int;
 }
 
-val role_key : Agent_sdk.Types.role -> string
+val role_key : Oas.Types.role -> string
 
-val bytes_of_content_block : Agent_sdk.Types.content_block -> int
+val bytes_of_content_block : Oas.Types.content_block -> int
 
-val bytes_of_message : Agent_sdk.Types.message -> int
+val bytes_of_message : Oas.Types.message -> int
 
-val estimate_tool_defs_bytes : Agent_sdk.Tool.t list -> int
+val estimate_tool_defs_bytes : Oas.Tool.t list -> int
 
 val role_counts_with_pending_user :
-  Agent_sdk.Types.message list -> (string * int) list
+  Oas.Types.message list -> (string * int) list
 
 (** Compute payload-size estimates and role distribution for a keeper
     turn about to invoke [Oas_worker.run_named]. The result assumes OAS
@@ -32,7 +32,7 @@ val role_counts_with_pending_user :
     Invariant: [message_count = sum_of_role_counts result.role_counts]. *)
 val compute_sizes :
   system_prompt:string ->
-  tools:Agent_sdk.Tool.t list ->
-  history_messages:Agent_sdk.Types.message list ->
+  tools:Oas.Tool.t list ->
+  history_messages:Oas.Types.message list ->
   user_message:string ->
   sizes


### PR DESCRIPTION
## Summary
- route keeper public `.mli` OAS-facing type references through `Oas.*` instead of exposing `Agent_sdk.*`
- cover the remaining keeper interface files that are not already part of `#9382`
- keep this slice interface-only so it stays disjoint from the larger OAS boundary refactor tracked in `#9384`

## Files
- `lib/keeper/keeper_agent_run.mli`
- `lib/keeper/keeper_alerting.mli`
- `lib/keeper/keeper_artifact_hydrator.mli`
- `lib/keeper/keeper_compact_audit.mli`
- `lib/keeper/keeper_deliberation.mli`
- `lib/keeper/keeper_exec_context.mli`
- `lib/keeper/keeper_exec_tools.mli`
- `lib/keeper/keeper_extend_turns.mli`
- `lib/keeper/keeper_keepalive.mli`
- `lib/keeper/keeper_memory_recall.mli`
- `lib/keeper/keeper_types.mli`
- `lib/keeper/keeper_wake_telemetry.mli`

## Verification
- `rg -n "Agent_sdk\." <touched keeper .mli files>` -> no matches
- `git diff --check`
- `dune build --root . -j 1 test/test_keeper_unified.exe test/test_keeper_deliberation.exe test/test_keeper_wake_telemetry.exe test/test_keeper_prompt_metrics.exe test/test_keeper_artifact_hydrator.exe test/test_keeper_compact_audit.exe` blocked by current `origin/main` compile drift tracked in `#9389`
