### PR TITLE
test(oas): remove duplicate hard quota case

### DIFF
--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -732,18 +732,6 @@ let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
          | Some Cascade_fsm.Slot_full -> "some-slot-full"
          | None -> "none")
 
-let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
-  let err =
-    Oas.Error.Api
-      (Llm_provider.Retry.NetworkError
-         {
-           message =
-             "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-         })
-  in
-  Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
-
 let make_openai_compat_provider_cfg ?(model_id = "mock-model")
     ?(base_url = "http://127.0.0.1:18080/v1")
     ?(request_path = "/chat/completions") ?(api_key = "") () =


### PR DESCRIPTION
## Summary
- remove the duplicate Claude hard-quota test case in `test_oas_worker`

## Why
While rechecking `#9357`, the original stale-branch build failure no longer reproduced on current `main` after aligning the local OAS pin with CI. The remaining concrete drift in this area was a duplicated `test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper` definition.

## Impact
This keeps the OAS worker test surface unambiguous without changing runtime behavior.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-9357-clean -j 1 test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe`
