### PR TITLE
[codex] Restore clean build after SDK drift

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -119,6 +119,19 @@ let get_or_create_store store_ref base_dir_fn =
       store_ref := Some store;
       store
 
+let append_store_json_fail_open ~store_ref ~store_name get_store json =
+  try
+    Dated_jsonl.append (get_store ()) json
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      (* Health/event persistence is observability only. If the backing JSONL
+         append fails, drop the poisoned store so the next call can recreate
+         it instead of leaking Eio_mutex.Poisoned into keeper control flow. *)
+      store_ref := None;
+      Log.Harness.warn "[%s] append failed: %s" store_name
+        (Printexc.to_string exn)
+
 let get_pre_compact_store () =
   get_or_create_store pre_compact_store_ref pre_compact_store_base_dir
 
@@ -569,7 +582,9 @@ let record_pre_compact_at ~timestamp ~keeper_name ~context_ratio ~message_count
       trigger;
     }
   in
-  Dated_jsonl.append (get_pre_compact_store ()) (pre_compact_record_json event);
+  append_store_json_fail_open ~store_ref:pre_compact_store_ref
+    ~store_name:"pre_compact" get_pre_compact_store
+    (pre_compact_record_json event);
   event
 
 let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
@@ -600,7 +615,8 @@ let record_wake_payload_at ~timestamp ~keeper_name ~trace_id ~turn_index
       has_compact_happened;
     }
   in
-  Dated_jsonl.append (get_wake_payload_store ())
+  append_store_json_fail_open ~store_ref:wake_payload_store_ref
+    ~store_name:"wake_payload" get_wake_payload_store
     (wake_payload_record_json event);
   event
 

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -28,8 +28,6 @@ type client = {
   last_seen_at : float Atomic.t;
 }
 
-module SMap : Map.S with type key = String.t
-
 type client_registry_state = {
   entries : client SMap.t;
   count : int;
@@ -98,7 +96,6 @@ val clients : client_registry_state Atomic.t
 val event_buffer : (int * string * float) list Atomic.t
 val buffer_event : int -> string -> unit
 val get_events_after : int -> string list
-val buffer_event : int -> string -> unit
 val cleanup_expired_events : unit -> int
 
 (** {1 Snapshots} *)
@@ -110,5 +107,3 @@ val session_kind_to_string : session_kind -> string
 
 val register_commit_test_hook : (unit -> unit) option Atomic.t
 val buffer_commit_test_hook : (unit -> unit) option Atomic.t
-val clients : client_registry_state Atomic.t
-val event_buffer : (int * string * float) list Atomic.t

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -7,6 +7,8 @@
 
 (** {1 Types} *)
 
+module SMap : Map.S with type key = string
+
 type session_kind =
   | Observer
   | Coordinator
@@ -92,6 +94,9 @@ val remove_external_subscribers : string list -> string list * int
 
 (** {1 Event Buffer} *)
 
+val clients : client_registry_state Atomic.t
+val event_buffer : (int * string * float) list Atomic.t
+val buffer_event : int -> string -> unit
 val get_events_after : int -> string list
 val buffer_event : int -> string -> unit
 val cleanup_expired_events : unit -> int

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1063,7 +1063,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     (source_file_contains "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");
   check bool "keeper_shell gh runtime allows sandbox fallback" true
-    (source_file_contains "lib/keeper/keeper_exec_shell.ml"
+    (source_file_contains "lib/keeper/keeper_shell_gh_context.ml"
        "task_id = \"(sandbox)\"")
 
 (* ---------- Config tests ---------- *)


### PR DESCRIPTION
## What changed

- export the white-box `Sse` surface that `test_sse_coverage` depends on
- align MASC-side `NetworkError` construction with `agent_sdk` 5.4.1's new `kind` field
- make harness health JSONL persistence fail open so overflow-retry recovery is not blocked by observability write failures

## Why

`main` had drift in two places after upstream SDK/interface changes:

- `Sse` implementation still exposed internal state that coverage tests referenced, but the `.mli` no longer exported the matching surface
- `Llm_provider.Http_client.NetworkError` now requires `kind`, but several MASC call sites and test fixtures still constructed the old shape

That compile drift also exposed a runtime bug in overflow-retry tests: pre-compact telemetry writes could raise and poison the JSONL mutex, which broke checkpoint recovery paths that should have kept running.

## Impact

- restores a clean full `dune build` on current `main`
- restores `test_sse_coverage`
- restores overflow-retry behavior in `test_oas_worker`
- keeps telemetry persistence best-effort instead of letting it break keeper recovery

## Validation

- `dune build --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/verify-main-worker-oas-20260422 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/verify-main-worker-oas-20260422/_build_issue_chain`
- `./_build_issue_chain/default/test/test_sse_coverage.exe`
- `./_build_issue_chain/default/test/test_keeper_unified.exe`
- `./_build_issue_chain/default/test/test_oas_worker.exe`
