### PR TITLE
[codex] reduce dashboard log noise

### DIFF
--- a/lib/oas_bus_instrument.ml
+++ b/lib/oas_bus_instrument.ml
@@ -53,7 +53,6 @@ let update_gauge_for purpose value =
     ~labels:[("subscriber_purpose", purpose)]
     (float_of_int value)
 
-<<<<<<< HEAD
 let subscribe ~purpose ?(filter = Oas.Event_bus.accept_all) bus =
   let sub = Oas.Event_bus.subscribe ~filter bus in
   let t =

--- a/lib/oas_bus_instrument.ml
+++ b/lib/oas_bus_instrument.ml
@@ -21,9 +21,15 @@ type tracked = {
   purpose: string;
   filter: Oas.Event_bus.filter;
   depth: int ref;
+  warned_above_threshold: bool ref;
 }
 
 type handle = tracked
+
+type transition =
+  [ `Warn of string * int
+  | `Recovered of string * int
+  ]
 
 (* Module-global registry of active tracked subscriptions. Bounded by
    the number of live MASC subscribers (today: ~4). Not a hotspot. *)
@@ -47,9 +53,18 @@ let update_gauge_for purpose value =
     ~labels:[("subscriber_purpose", purpose)]
     (float_of_int value)
 
+<<<<<<< HEAD
 let subscribe ~purpose ?(filter = Oas.Event_bus.accept_all) bus =
   let sub = Oas.Event_bus.subscribe ~filter bus in
-  let t = { sub; purpose; filter; depth = ref 0 } in
+  let t =
+    {
+      sub;
+      purpose;
+      filter;
+      depth = ref 0;
+      warned_above_threshold = ref false;
+    }
+  in
   with_registry (fun () -> registry := t :: !registry);
   update_gauge_for purpose 0;
   t
@@ -103,24 +118,40 @@ let publish bus (evt : Oas.Event_bus.event) =
         Prometheus.inc_counter counter_publish_block_seconds ~delta:elapsed ())
     (fun () -> Oas.Event_bus.publish bus evt)
 
-let snapshot_depths () =
+let compute_threshold_transitions ~warn_threshold : transition list =
   with_registry (fun () ->
-    List.map (fun t -> (t.purpose, !(t.depth))) !registry)
+    List.filter_map
+      (fun t ->
+        let depth = !(t.depth) in
+        let above_threshold = depth > warn_threshold in
+        let was_above_threshold = !(t.warned_above_threshold) in
+        if above_threshold && not was_above_threshold then begin
+          t.warned_above_threshold := true;
+          Some (`Warn (t.purpose, depth))
+        end else if (not above_threshold) && was_above_threshold then begin
+          t.warned_above_threshold := false;
+          Some (`Recovered (t.purpose, depth))
+        end else
+          None)
+      !registry)
 
 let start_sampler ~sw ~clock ?(interval_s = 5.0) ?(warn_threshold = 200) () =
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       (try
-        let depths = snapshot_depths () in
-        List.iter
-          (fun (purpose, depth) ->
-            if depth > warn_threshold then
-              Log.Misc.warn
-                "oas_bus_instrument: subscriber_purpose=%s depth=%d exceeds \
-                 warn_threshold=%d — OAS publish may be blocking on bounded \
-                 Eio.Stream (default buffer 256)"
-                purpose depth warn_threshold)
-          depths
+        compute_threshold_transitions ~warn_threshold
+        |> List.iter (function
+             | `Warn (purpose, depth) ->
+               Log.Misc.warn
+                 "oas_bus_instrument: subscriber_purpose=%s depth=%d exceeds \
+                  warn_threshold=%d — OAS publish may be blocking on bounded \
+                  Eio.Stream (default buffer 256)"
+                 purpose depth warn_threshold
+             | `Recovered (purpose, depth) ->
+               Log.Misc.info
+                 "oas_bus_instrument: subscriber_purpose=%s depth=%d recovered \
+                  below warn_threshold=%d"
+                 purpose depth warn_threshold)
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
@@ -132,11 +163,16 @@ let start_sampler ~sw ~clock ?(interval_s = 5.0) ?(warn_threshold = 200) () =
     loop ())
 
 module For_testing = struct
+  type nonrec transition = transition
+
   let current_depth ~purpose =
     with_registry (fun () ->
       match List.find_opt (fun t -> t.purpose = purpose) !registry with
       | Some t -> !(t.depth)
       | None -> -1)
+
+  let sample_threshold_transitions ~warn_threshold =
+    compute_threshold_transitions ~warn_threshold
 
   let reset () =
     with_registry (fun () -> registry := [])

--- a/lib/oas_bus_instrument.mli
+++ b/lib/oas_bus_instrument.mli
@@ -16,7 +16,8 @@
       routed through [publish] below update every registered
       subscription's counter whose filter accepts the event.
     - A periodic sampler fiber that emits a WARN when depth crosses
-      80% of the default OAS buffer (>200 / 256).
+      80% of the default OAS buffer (>200 / 256), then stays quiet
+      until the subscriber recovers below the threshold.
 
     Subscriptions created directly via [Agent_sdk.Event_bus.subscribe]
     are invisible to this module. Use [subscribe] below for any MASC
@@ -54,9 +55,10 @@ val publish : Agent_sdk.Event_bus.t -> Agent_sdk.Event_bus.event -> unit
 
 (** Spawn the periodic depth sampler fiber. Reads the per-purpose
     depth counters every [~interval_s] seconds and emits a WARN log
-    when any exceeds [~warn_threshold] (default 200, i.e. ~80% of the
-    OAS default buffer size of 256). Safe to call once per server
-    bootstrap; multiple calls spawn independent fibers (don't). *)
+    when any crosses above [~warn_threshold] (default 200, i.e. ~80%
+    of the OAS default buffer size of 256), then an INFO when that
+    subscriber recovers below the threshold. Safe to call once per
+    server bootstrap; multiple calls spawn independent fibers (don't). *)
 val start_sampler
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
@@ -67,6 +69,14 @@ val start_sampler
 
 (** Test helpers. *)
 module For_testing : sig
+  type transition =
+    [ `Warn of string * int
+    | `Recovered of string * int
+    ]
+
   val current_depth : purpose:string -> int
+  val sample_threshold_transitions
+    :  warn_threshold:int
+    -> transition list
   val reset : unit -> unit
 end

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -111,7 +111,7 @@ let status_cache_lookup repo_root ~now ~ttl =
   end
 
 let status_cache_store repo_root lines ~now ~ttl =
-  if ttl > 0.0 && lines <> [] then begin
+  if ttl > 0.0 then begin
     Stdlib.Mutex.lock status_cache_mu;
     Fun.protect
       ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)

--- a/test/test_oas_bus_instrument.ml
+++ b/test/test_oas_bus_instrument.ml
@@ -123,6 +123,35 @@ let test_publish_updates_counters () =
     check bool "publish_block_seconds did not decrease"
       true (after_block >= before_block))
 
+let test_threshold_transitions_warn_once_until_recovery () =
+  I.For_testing.reset ();
+  run_eio (fun ~sw:_ ~env:_ ->
+    let bus = mk_bus () in
+    let h = I.subscribe ~purpose:"sampler_sub" bus in
+    for _ = 1 to 3 do
+      I.publish bus (mk_custom_event "x")
+    done;
+    (match I.For_testing.sample_threshold_transitions ~warn_threshold:2 with
+     | [ `Warn ("sampler_sub", 3) ] -> ()
+     | other ->
+       fail
+         (Printf.sprintf "expected single warn transition, got %d"
+            (List.length other)));
+    check int "no duplicate warn without recovery" 0
+      (List.length
+         (I.For_testing.sample_threshold_transitions ~warn_threshold:2));
+    ignore (I.drain h);
+    (match I.For_testing.sample_threshold_transitions ~warn_threshold:2 with
+     | [ `Recovered ("sampler_sub", 0) ] -> ()
+     | other ->
+       fail
+         (Printf.sprintf "expected single recovery transition, got %d"
+            (List.length other)));
+    check int "no duplicate recovery after state clears" 0
+      (List.length
+         (I.For_testing.sample_threshold_transitions ~warn_threshold:2));
+    I.unsubscribe bus h)
+
 let () =
   run "oas_bus_instrument" [
     ("backpressure", [
@@ -136,5 +165,7 @@ let () =
         test_multiple_subs_same_purpose_coexist;
       test_case "publish updates counters" `Quick
         test_publish_updates_counters;
+      test_case "threshold transitions warn once until recovery" `Quick
+        test_threshold_transitions_warn_once_until_recovery;
     ])
   ]

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -129,7 +129,7 @@ let test_current_status_lines_uses_short_cache_and_no_optional_locks () =
         [ "--no-optional-locks"; "status"; "--porcelain" ]
         (List.hd !calls))
 
-let test_current_status_lines_does_not_cache_clean_status () =
+let test_current_status_lines_caches_clean_status () =
   Wlc.clear_status_cache_for_tests ();
   let calls = ref 0 in
   Wlc.set_git_capture_hook_for_tests (fun ~workdir:_ _args ->
@@ -144,7 +144,7 @@ let test_current_status_lines_does_not_cache_clean_status () =
         (Wlc.current_status_lines ~repo_root:"/tmp/repo");
       check (list string) "second clean status" []
         (Wlc.current_status_lines ~repo_root:"/tmp/repo");
-      check int "clean status is not cached" 2 !calls)
+      check int "clean status is cached" 1 !calls)
 
 let () =
   run "Worktree_live_context"
@@ -158,7 +158,7 @@ let () =
             test_capture_change_block_in_eio_runtime;
           test_case "status cache uses no optional locks" `Quick
             test_current_status_lines_uses_short_cache_and_no_optional_locks;
-          test_case "status cache skips clean status" `Quick
-            test_current_status_lines_does_not_cache_clean_status;
+          test_case "status cache keeps clean status" `Quick
+            test_current_status_lines_caches_clean_status;
         ] );
     ]


### PR DESCRIPTION
## What changed
- make `worktree_live_context` cache clean `git status --porcelain` results instead of re-running the probe on every read
- change `oas_bus_instrument` backpressure logging to fire on threshold crossing and recovery instead of repeating the same warn every sampler tick
- add regression tests for clean-status caching and warn-once-until-recovery behavior

## Why
The dashboard/logs analysis showed two dominant noisy patterns that were obscuring real failures:
- repeated `oas_bus_instrument` warnings for the same over-threshold subscriber depth
- repeated `git status` probe timeouts caused by not caching empty status results

Both behaviors produced high-volume warn logs without adding new information.

## Impact
- operators should see materially less warn spam in dashboard log views
- repeated clean-worktree probes should drop, which should reduce `git status` timeout noise on large repos such as `~/me`
- backpressure still remains visible: the first threshold crossing warns, and recovery is recorded explicitly

## Validation
- attempted `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/log-noise-20260422`
- attempted `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/log-noise-20260422 test/test_oas_bus_instrument.exe`
- both are currently blocked by unrelated baseline compile errors already present in this checkout (missing record fields in existing files outside this change set)
