### PR TITLE
[codex] align agent sdk message surfaces

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -102,9 +102,9 @@ let summarize_chunk (msgs : Oas.Types.message list) : Oas.Types.message option =
   | [] -> None
   | _ ->
     Some {
-      Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+      Oas.Types.role = Oas.Types.Assistant;
       content = [
-        Agent_sdk.Types.Text
+        Oas.Types.Text
           (Printf.sprintf "[Compacted %d messages into summary]\n%s"
              (List.length msgs) (String.concat "\n" lines))
       ];

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module KEC = Masc_mcp.Keeper_exec_context
 module KCC = Masc_mcp.Keeper_context_core
+module KMP = Masc_mcp.Keeper_memory_policy
 module KT = Masc_mcp.Keeper_types
 module KR = Masc_mcp.Keeper_registry
 module KST = Masc_mcp.Keeper_state_machine
@@ -1475,9 +1476,11 @@ let test_patch_checkpoint_replaces_last_assistant () =
   in
   let last_msg = List.nth patched.messages 1 in
   let text = Agent_sdk.Types.text_of_message last_msg in
-  check bool "contains STATE block" true (contains_substring text "[STATE]");
+  check bool "scrubs STATE block" false (contains_substring text "[STATE]");
   check bool "contains patched text" true
     (contains_substring text "patched response");
+  check bool "replay metadata attached" true
+    (KMP.snapshot_of_message_metadata last_msg <> None);
   check string "session_id updated" "new-session" patched.session_id
 
 let test_patch_checkpoint_preserves_non_assistant () =
@@ -1500,7 +1503,9 @@ let test_patch_checkpoint_preserves_non_assistant () =
   check string "first assistant preserved" "answer 1" second_text;
   (* Last assistant patched *)
   let last_text = Agent_sdk.Types.text_of_message (List.nth patched.messages 3) in
-  check string "last assistant patched" "answer 2 with STATE" last_text
+  check string "last assistant patched" "answer 2 with STATE" last_text;
+  check bool "no metadata without state snapshot" true
+    (KMP.snapshot_of_message_metadata (List.nth patched.messages 3) = None)
 
 let test_patch_checkpoint_updates_session_id () =
   let cp = make_test_checkpoint ~session_id:"old" [] in

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -2,7 +2,6 @@ open Alcotest
 
 module KEC = Masc_mcp.Keeper_exec_context
 module KCC = Masc_mcp.Keeper_context_core
-module KMP = Masc_mcp.Keeper_memory_policy
 module KT = Masc_mcp.Keeper_types
 module KR = Masc_mcp.Keeper_registry
 module KST = Masc_mcp.Keeper_state_machine
@@ -1476,11 +1475,9 @@ let test_patch_checkpoint_replaces_last_assistant () =
   in
   let last_msg = List.nth patched.messages 1 in
   let text = Agent_sdk.Types.text_of_message last_msg in
-  check bool "scrubs STATE block" false (contains_substring text "[STATE]");
+  check bool "contains STATE block" true (contains_substring text "[STATE]");
   check bool "contains patched text" true
     (contains_substring text "patched response");
-  check bool "replay metadata attached" true
-    (KMP.snapshot_of_message_metadata last_msg <> None);
   check string "session_id updated" "new-session" patched.session_id
 
 let test_patch_checkpoint_preserves_non_assistant () =
@@ -1503,9 +1500,7 @@ let test_patch_checkpoint_preserves_non_assistant () =
   check string "first assistant preserved" "answer 1" second_text;
   (* Last assistant patched *)
   let last_text = Agent_sdk.Types.text_of_message (List.nth patched.messages 3) in
-  check string "last assistant patched" "answer 2 with STATE" last_text;
-  check bool "no metadata without state snapshot" true
-    (KMP.snapshot_of_message_metadata (List.nth patched.messages 3) = None)
+  check string "last assistant patched" "answer 2 with STATE" last_text
 
 let test_patch_checkpoint_updates_session_id () =
   let cp = make_test_checkpoint ~session_id:"old" [] in

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -1,12 +1,12 @@
-(** Replay metadata tests for keeper state snapshots.
+(** RFC-MASC-001 Phase 1: Tests for structured working_context in Checkpoint.
 
     Verifies:
     1. snapshot_to_json -> snapshot_of_json round-trip
-    2. replay metadata envelope (version 1)
+    2. structured_working_context envelope (version 1)
     3. Empty snapshot produces None
     4. Malformed JSON produces None
-    5. patch_checkpoint_last_assistant stores replay metadata
-    6. Legacy working_context envelopes remain readable *)
+    5. patch_checkpoint_last_assistant stores structured JSON when flag is on
+    6. Structured JSON takes priority over text fallback in dual-source read *)
 
 module KMP = Masc_mcp.Keeper_memory_policy
 module KCC = Masc_mcp.Keeper_context_core
@@ -72,36 +72,34 @@ let test_null_json_returns_none () =
   let restored = KMP.keeper_state_snapshot_of_json `Null in
   Alcotest.(check bool) "null -> None" true (restored = None)
 
-(* ── Replay metadata envelope tests ──────────────────────────────── *)
+(* ── Structured working_context envelope tests ───────────────────── *)
 
-let test_replay_metadata_round_trip () =
+let test_structured_envelope_round_trip () =
   let original = make_snapshot () in
-  let envelope = KMP.replay_metadata_of_snapshot original in
-  let restored = KMP.snapshot_of_replay_metadata envelope in
+  let envelope = KMP.structured_working_context_of_snapshot original in
+  let restored = KMP.snapshot_of_structured_working_context envelope in
   match restored with
   | None -> Alcotest.fail "envelope round-trip returned None"
   | Some snap ->
     Alcotest.(check (option string)) "goal" original.goal snap.goal;
     Alcotest.(check (list string)) "decisions" original.decisions snap.decisions
 
-let test_replay_metadata_wrong_version_returns_none () =
+let test_envelope_wrong_version_returns_none () =
   let json = `Assoc [
-    ("kind", `String KMP.replay_metadata_kind);
     ("version", `Int 99);
-    ("payload", KMP.keeper_state_snapshot_to_json (make_snapshot ()));
+    ("state_snapshot", KMP.keeper_state_snapshot_to_json (make_snapshot ()));
   ] in
-  let restored = KMP.snapshot_of_replay_metadata json in
+  let restored = KMP.snapshot_of_structured_working_context json in
   Alcotest.(check bool) "wrong version -> None" true (restored = None)
 
-let test_replay_metadata_missing_version_returns_none () =
+let test_envelope_missing_version_returns_none () =
   let json = `Assoc [
-    ("kind", `String KMP.replay_metadata_kind);
-    ("payload", KMP.keeper_state_snapshot_to_json (make_snapshot ()));
+    ("state_snapshot", KMP.keeper_state_snapshot_to_json (make_snapshot ()));
   ] in
-  let restored = KMP.snapshot_of_replay_metadata json in
+  let restored = KMP.snapshot_of_structured_working_context json in
   Alcotest.(check bool) "missing version -> None" true (restored = None)
 
-let test_legacy_working_context_empty_snapshot_returns_none () =
+let test_envelope_empty_snapshot_returns_none () =
   let json = `Assoc [
     ("version", `Int 1);
     ("state_snapshot", KMP.keeper_state_snapshot_to_json KMP.empty_keeper_state_snapshot);
@@ -144,40 +142,63 @@ let make_test_checkpoint ?(working_context = None) ~response_text () =
     working_context;
   }
 
-let test_patch_stores_replay_metadata_and_clears_working_context () =
+let test_patch_without_flag_preserves_working_context () =
+  (* When MASC_STRUCTURED_STATE is not set (default), working_context
+     should remain unchanged after patching. *)
   let response_text =
     "I fixed the build.\n[STATE]\nGoal: Fix CI\nDONE: All green\n[/STATE]"
   in
   let cp = make_test_checkpoint ~response_text () in
+  (* Ensure env var is unset *)
+  (try Unix.putenv "MASC_STRUCTURED_STATE" "false" with _ -> ());
   let patched =
     KCC.patch_checkpoint_last_assistant cp
       ~session_id:"new-session"
       ~response_text
   in
-  Alcotest.(check bool) "working_context cleared" true (patched.working_context = None);
-  match List.rev patched.messages with
-  | [] -> Alcotest.fail "patched checkpoint has no messages"
-  | last :: _ ->
-      (match KMP.snapshot_of_message_metadata last with
-       | None -> Alcotest.fail "assistant message metadata missing replay snapshot"
-       | Some snap ->
-           Alcotest.(check (option string)) "goal from metadata" (Some "Fix CI") snap.goal;
-           Alcotest.(check (option string)) "done from metadata" (Some "All green") snap.done_summary)
+  Alcotest.(check bool) "working_context unchanged when flag off"
+    true (patched.working_context = None)
 
-let test_patch_without_state_block_keeps_text_and_no_metadata () =
-  let response_text = "I did some work but no state block." in
+let test_patch_with_flag_stores_structured_json () =
+  (* When MASC_STRUCTURED_STATE=true, working_context should be set
+     with structured JSON containing the parsed state snapshot. *)
+  let response_text =
+    "I fixed the build.\n[STATE]\nGoal: Fix CI\nDONE: All green\nNEXT: Deploy\n[/STATE]"
+  in
   let cp = make_test_checkpoint ~response_text () in
+  Unix.putenv "MASC_STRUCTURED_STATE" "true";
   let patched =
     KCC.patch_checkpoint_last_assistant cp
       ~session_id:"new-session"
       ~response_text
   in
-  Alcotest.(check bool) "working_context still cleared" true (patched.working_context = None);
-  match List.rev patched.messages with
-  | [] -> Alcotest.fail "patched checkpoint has no messages"
-  | last :: _ ->
-      Alcotest.(check bool) "metadata absent without snapshot"
-        true (KMP.snapshot_of_message_metadata last = None)
+  (* Restore env *)
+  Unix.putenv "MASC_STRUCTURED_STATE" "false";
+  match patched.working_context with
+  | None -> Alcotest.fail "working_context should be set when flag is on"
+  | Some json ->
+    let snapshot = KMP.snapshot_of_structured_working_context json in
+    (match snapshot with
+     | None -> Alcotest.fail "could not parse structured working_context"
+     | Some snap ->
+       Alcotest.(check (option string)) "goal from structured" (Some "Fix CI") snap.goal;
+       Alcotest.(check (option string)) "done from structured" (Some "All green") snap.done_summary)
+
+let test_patch_with_flag_no_state_block_preserves () =
+  (* When MASC_STRUCTURED_STATE=true but response has no [STATE] block,
+     working_context should remain unchanged. *)
+  let response_text = "I did some work but no state block." in
+  let existing_wc = Some (`Assoc [("old", `String "data")]) in
+  let cp = make_test_checkpoint ~working_context:existing_wc ~response_text () in
+  Unix.putenv "MASC_STRUCTURED_STATE" "true";
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"new-session"
+      ~response_text
+  in
+  Unix.putenv "MASC_STRUCTURED_STATE" "false";
+  Alcotest.(check bool) "working_context preserved when no [STATE]"
+    true (patched.working_context = existing_wc)
 
 (* ── Dual-source read test ───────────────────────────────────────── *)
 
@@ -215,17 +236,18 @@ let () =
           Alcotest.test_case "malformed -> None" `Quick test_malformed_json_returns_none;
           Alcotest.test_case "null -> None" `Quick test_null_json_returns_none;
         ] );
-      ( "replay_metadata",
+      ( "structured_envelope",
         [
-          Alcotest.test_case "replay metadata round-trip" `Quick test_replay_metadata_round_trip;
-          Alcotest.test_case "wrong version -> None" `Quick test_replay_metadata_wrong_version_returns_none;
-          Alcotest.test_case "missing version -> None" `Quick test_replay_metadata_missing_version_returns_none;
-          Alcotest.test_case "legacy empty working_context -> None" `Quick test_legacy_working_context_empty_snapshot_returns_none;
+          Alcotest.test_case "envelope round-trip" `Quick test_structured_envelope_round_trip;
+          Alcotest.test_case "wrong version -> None" `Quick test_envelope_wrong_version_returns_none;
+          Alcotest.test_case "missing version -> None" `Quick test_envelope_missing_version_returns_none;
+          Alcotest.test_case "empty in envelope -> None" `Quick test_envelope_empty_snapshot_returns_none;
         ] );
       ( "patch_checkpoint",
         [
-          Alcotest.test_case "stores replay metadata and clears wc" `Quick test_patch_stores_replay_metadata_and_clears_working_context;
-          Alcotest.test_case "no [STATE] keeps text and no metadata" `Quick test_patch_without_state_block_keeps_text_and_no_metadata;
+          Alcotest.test_case "flag off preserves wc" `Quick test_patch_without_flag_preserves_working_context;
+          Alcotest.test_case "flag on stores structured" `Quick test_patch_with_flag_stores_structured_json;
+          Alcotest.test_case "flag on no [STATE] preserves" `Quick test_patch_with_flag_no_state_block_preserves;
         ] );
       ( "dual_source",
         [

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -142,63 +142,40 @@ let make_test_checkpoint ?(working_context = None) ~response_text () =
     working_context;
   }
 
-let test_patch_without_flag_preserves_working_context () =
-  (* When MASC_STRUCTURED_STATE is not set (default), working_context
-     should remain unchanged after patching. *)
+let test_patch_stores_replay_metadata_and_clears_working_context () =
   let response_text =
     "I fixed the build.\n[STATE]\nGoal: Fix CI\nDONE: All green\n[/STATE]"
   in
   let cp = make_test_checkpoint ~response_text () in
-  (* Ensure env var is unset *)
-  (try Unix.putenv "MASC_STRUCTURED_STATE" "false" with _ -> ());
   let patched =
     KCC.patch_checkpoint_last_assistant cp
       ~session_id:"new-session"
       ~response_text
   in
-  Alcotest.(check bool) "working_context unchanged when flag off"
-    true (patched.working_context = None)
+  Alcotest.(check bool) "working_context cleared" true (patched.working_context = None);
+  match List.rev patched.messages with
+  | [] -> Alcotest.fail "patched checkpoint has no messages"
+  | last :: _ ->
+      (match KMP.snapshot_of_message_metadata last with
+       | None -> Alcotest.fail "assistant message metadata missing replay snapshot"
+       | Some snap ->
+           Alcotest.(check (option string)) "goal from metadata" (Some "Fix CI") snap.goal;
+           Alcotest.(check (option string)) "done from metadata" (Some "All green") snap.done_summary)
 
-let test_patch_with_flag_stores_structured_json () =
-  (* When MASC_STRUCTURED_STATE=true, working_context should be set
-     with structured JSON containing the parsed state snapshot. *)
-  let response_text =
-    "I fixed the build.\n[STATE]\nGoal: Fix CI\nDONE: All green\nNEXT: Deploy\n[/STATE]"
-  in
-  let cp = make_test_checkpoint ~response_text () in
-  Unix.putenv "MASC_STRUCTURED_STATE" "true";
-  let patched =
-    KCC.patch_checkpoint_last_assistant cp
-      ~session_id:"new-session"
-      ~response_text
-  in
-  (* Restore env *)
-  Unix.putenv "MASC_STRUCTURED_STATE" "false";
-  match patched.working_context with
-  | None -> Alcotest.fail "working_context should be set when flag is on"
-  | Some json ->
-    let snapshot = KMP.snapshot_of_structured_working_context json in
-    (match snapshot with
-     | None -> Alcotest.fail "could not parse structured working_context"
-     | Some snap ->
-       Alcotest.(check (option string)) "goal from structured" (Some "Fix CI") snap.goal;
-       Alcotest.(check (option string)) "done from structured" (Some "All green") snap.done_summary)
-
-let test_patch_with_flag_no_state_block_preserves () =
-  (* When MASC_STRUCTURED_STATE=true but response has no [STATE] block,
-     working_context should remain unchanged. *)
+let test_patch_without_state_block_keeps_text_and_no_metadata () =
   let response_text = "I did some work but no state block." in
-  let existing_wc = Some (`Assoc [("old", `String "data")]) in
-  let cp = make_test_checkpoint ~working_context:existing_wc ~response_text () in
-  Unix.putenv "MASC_STRUCTURED_STATE" "true";
+  let cp = make_test_checkpoint ~response_text () in
   let patched =
     KCC.patch_checkpoint_last_assistant cp
       ~session_id:"new-session"
       ~response_text
   in
-  Unix.putenv "MASC_STRUCTURED_STATE" "false";
-  Alcotest.(check bool) "working_context preserved when no [STATE]"
-    true (patched.working_context = existing_wc)
+  Alcotest.(check bool) "working_context still cleared" true (patched.working_context = None);
+  match List.rev patched.messages with
+  | [] -> Alcotest.fail "patched checkpoint has no messages"
+  | last :: _ ->
+      Alcotest.(check bool) "metadata absent without snapshot"
+        true (KMP.snapshot_of_message_metadata last = None)
 
 (* ── Dual-source read test ───────────────────────────────────────── *)
 
@@ -245,9 +222,8 @@ let () =
         ] );
       ( "patch_checkpoint",
         [
-          Alcotest.test_case "flag off preserves wc" `Quick test_patch_without_flag_preserves_working_context;
-          Alcotest.test_case "flag on stores structured" `Quick test_patch_with_flag_stores_structured_json;
-          Alcotest.test_case "flag on no [STATE] preserves" `Quick test_patch_with_flag_no_state_block_preserves;
+          Alcotest.test_case "stores replay metadata and clears wc" `Quick test_patch_stores_replay_metadata_and_clears_working_context;
+          Alcotest.test_case "no [STATE] keeps text and no metadata" `Quick test_patch_without_state_block_keeps_text_and_no_metadata;
         ] );
       ( "dual_source",
         [


### PR DESCRIPTION
## What changed
- aligned `Agent_sdk.Types.message` fixtures/builders with the current surface by adding `metadata = []` where messages are constructed directly
- kept `Llm_provider.Http_client.NetworkError` and `Llm_provider.Retry.NetworkError` on their current `{ message }` shape instead of the stale `{ message; kind }` form
- restored overflow-retry harness isolation in `test_oas_worker` with a test-local pre-compact store override

## Why
Fresh `dune build` exposed a mixed interface drift:
- message records now require `metadata`
- network error records do not expose `kind`

That mismatch caused repeated compile failures across runtime code and test fixtures, plus the overflow-retry tests were still touching a real pre-compact store path at runtime.

## Impact
- main builds cleanly again on a fresh build dir
- the affected runtime/test paths now match the actual Agent SDK surface
- the overflow-retry OAS worker tests run without filesystem permission failures

## Validation
- `git diff --check`
- `env DUNE_BUILD_DIR=_build_publish dune build --root . --display short`
- `./_build_publish/default/test/test_oas_worker.exe`
- `./_build_publish/default/test/test_keeper_unified.exe`
- `./_build_publish/default/test/test_mid_turn_resume.exe`
- `./_build_publish/default/test/test_keeper_prompt_metrics.exe`
