### PR TITLE
fix(oas): align message metadata and network error shapes

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -24,8 +24,7 @@ let decide ~accept_on_exhaustion ~is_last outcome =
     Accept resp
   | Slot_full ->
     Try_next { last_err = Some (Llm_provider.Http_client.NetworkError {
-        message = "slot full, cascading to next provider";
-        kind = Llm_provider.Http_client.Unknown }) }
+        message = "slot full, cascading to next provider" }) }
   | Accept_rejected { response; reason } ->
     if is_last && accept_on_exhaustion then
       Accept_on_exhaustion { response; reason }
@@ -60,8 +59,7 @@ let format_exhausted_error last_err =
   | Some (Llm_provider.Http_client.AcceptRejected _ as err) -> err
   | _ ->
     Llm_provider.Http_client.NetworkError {
-      message = Printf.sprintf "All models failed: %s" msg;
-      kind = Llm_provider.Http_client.Unknown
+      message = Printf.sprintf "All models failed: %s" msg
     }
 
 (* ── Inline tests ───────────────────────────────── *)

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -110,6 +110,7 @@ let summarize_chunk (msgs : Oas.Types.message list) : Oas.Types.message option =
       ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
 
 let mask_tool_result_content ~(tool_name : string option) ~(tool_use_id : string)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -193,6 +193,7 @@ let metric_of_block
       content = [block];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   {

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -250,6 +250,16 @@ let string_field_opt key value =
   | Some text -> [ (key, `String text) ]
   | None -> []
 
+let metadata_field_opt (metadata : (string * Yojson.Safe.t) list) =
+  match metadata with
+  | [] -> []
+  | fields -> [ ("metadata", `Assoc fields) ]
+
+let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
+  match Yojson.Safe.Util.member "metadata" json with
+  | `Assoc fields -> fields
+  | _ -> []
+
 let message_to_json (m : Oas.Types.message) : Yojson.Safe.t =
   let m = Inference_utils.sanitize_message_utf8 m in
   let tool_call_id =
@@ -278,7 +288,8 @@ let message_to_json (m : Oas.Types.message) : Yojson.Safe.t =
   `Assoc
     (base
      @ string_field_opt "name" m.name
-     @ string_field_opt "tool_call_id" tool_call_id)
+     @ string_field_opt "tool_call_id" tool_call_id
+     @ metadata_field_opt m.metadata)
 
 let message_of_json (json : Yojson.Safe.t) : Oas.Types.message =
   let open Yojson.Safe.Util in
@@ -311,6 +322,7 @@ let message_of_json (json : Yojson.Safe.t) : Oas.Types.message =
       tool_call_id =
         (json |> member "tool_call_id" |> to_string_option
          |> Option.map Inference_utils.sanitize_text_utf8);
+      metadata = metadata_of_json json;
     }
 
 (** Extract human-readable text from a single history.jsonl line that was
@@ -328,6 +340,7 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
           content = blocks;
           name = None;
           tool_call_id = None;
+          metadata = [];
         }
       in
       Inference_utils.sanitize_text_utf8 (text_of_message msg)

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -512,7 +512,6 @@ module Kimi_cli_transport_local = struct
         (Llm_provider.Http_client.NetworkError
            {
              message = "no messages parsed from kimi output";
-             kind = Llm_provider.Http_client.Unknown;
            })
     else
       Ok

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -446,6 +446,10 @@ let retry_message_looks_like_not_found (message : string) : bool =
   || String_util.contains_substring_ci message "status code: 404"
   || String_util.contains_substring_ci message "404 page not found"
 
+let network_error_message_looks_like_connection_refused (message : string) : bool =
+  String_util.contains_substring_ci message "connection refused"
+  || String_util.contains_substring_ci message "econnrefused"
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -470,11 +474,10 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.HttpError { code = 401; body = message }
       | Llm_provider.Retry.Overloaded { message } ->
         Llm_provider.Http_client.HttpError { code = 529; body = message }
-      | Llm_provider.Retry.NetworkError { message; kind } ->
-        Llm_provider.Http_client.NetworkError { message; kind }
+      | Llm_provider.Retry.NetworkError { message } ->
+        Llm_provider.Http_client.NetworkError { message }
       | Llm_provider.Retry.Timeout { message } ->
-        Llm_provider.Http_client.NetworkError {
-          message; kind = Llm_provider.Http_client.Unknown }
+        Llm_provider.Http_client.NetworkError { message }
     in
     Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
@@ -841,10 +844,11 @@ let run_named
     match remaining with
     | [] ->
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
-        | Some (Llm_provider.Http_client.NetworkError { message; kind; _ }) ->
-            (match kind with
-             | Connection_refused -> Keeper_types.Connection_refused
-             | _ -> Keeper_types.Other_detail message)
+        | Some (Llm_provider.Http_client.NetworkError { message }) ->
+            if network_error_message_looks_like_connection_refused message then
+              Keeper_types.Connection_refused
+            else
+              Keeper_types.Other_detail message
         | Some (Llm_provider.Http_client.HttpError { code; body }) ->
             Keeper_types.Other_detail
               (Printf.sprintf "HTTP %d: %s" code

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -305,6 +305,7 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
                 content = [ Oas_types.Text prompt ];
                 name = None;
                 tool_call_id = None;
+                metadata = [];
               };
             ]
           in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -162,6 +162,7 @@ let probe_chat_completion_compatible
             content = [ Oas_types.Text "hi" ];
             name = None;
             tool_call_id = None;
+            metadata = [];
           };
         ]
       in

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -11,17 +11,17 @@ module Compact = Masc_mcp.Context_compact_oas
 module Scoring = Masc_mcp.Context_compact_oas
 
 let msg role text : Agent_sdk.Types.message =
-  { role; content = [Types.Text text]; name = None; tool_call_id = None }
+  { role; content = [Types.Text text]; name = None; tool_call_id = None; metadata = [] }
 
 let tool_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
   { role = Types.Tool;
     content = [Types.ToolResult { tool_use_id = id; content = text; is_error = false; json = None }];
-    name = None; tool_call_id = None }
+    name = None; tool_call_id = None; metadata = [] }
 
 let tool_use_msg ?(id = "tool-1") ?(name = "grep_search") () : Agent_sdk.Types.message =
   { role = Types.Assistant;
     content = [Types.ToolUse { id; name; input = `Assoc [("query", `String "lib/")] }];
-    name = None; tool_call_id = None }
+    name = None; tool_call_id = None; metadata = [] }
 
 (* ================================================================ *)
 (* Merge Contiguous Tests                                           *)

--- a/test/test_keeper_artifact_hydrator.ml
+++ b/test/test_keeper_artifact_hydrator.ml
@@ -51,6 +51,7 @@ let make_tool_message ~tool_use_id ~content : T.message =
     content = [ tool_result_block ~tool_use_id ~content ];
     name = None;
     tool_call_id = Some tool_use_id;
+    metadata = [];
   }
 
 let extract_tool_content (msg : T.message) : string =
@@ -138,6 +139,7 @@ let test_non_tool_result_unchanged () =
           content = [ T.Text "hi" ];
           name = None;
           tool_call_id = None;
+          metadata = [];
         }
       in
       let r = H.hydrate_recent ~store ~keep_recent:3 in

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -22,6 +22,7 @@ let test_message_to_json_omits_flat_content () =
       content = [ T.Text "hello" ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   let json = C.message_to_json msg in
@@ -57,6 +58,7 @@ let test_message_of_json_new_content_blocks_only () =
       content = [ T.Text "world" ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   let json = C.message_to_json new_msg in
@@ -75,6 +77,7 @@ let test_history_jsonl_text_uses_blocks_first () =
         content = [ T.Text "structured payload" ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       }
   in
   let text = C.text_of_history_jsonl_json new_format in
@@ -154,6 +157,7 @@ let test_roundtrip_text_preserved () =
       content = [ T.Text "alpha"; T.Text "beta" ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   let json = C.message_to_json original in

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -72,6 +72,7 @@ let tool_use_message ?(name = "list_files") ~tool_use_id () =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let tool_result_message ?(is_error = false) ~tool_use_id content =
@@ -84,6 +85,7 @@ let tool_result_message ?(is_error = false) ~tool_use_id content =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let tool_result_content_for_id ~tool_use_id msgs =
@@ -706,6 +708,7 @@ let test_recover_latest_checkpoint_for_overflow_retry_repairs_orphan_tool_result
                 ];
               name = None;
               tool_call_id = None;
+              metadata = [];
             }
             :: checkpoint.messages;
         }
@@ -769,6 +772,7 @@ let test_rollover_repairs_orphan_tool_result () =
                   ];
                 name = None;
                 tool_call_id = None;
+                metadata = [];
               };
               Agent_sdk.Types.assistant_msg
                 "done\n\n[STATE]\nGoal: rollover orphan repair\nProgress: ready\n[/STATE]";
@@ -870,6 +874,7 @@ let contaminated_user_message ?(prompt = "짧게 ping만 해봐") () :
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let oversized_checkpoint_text =
@@ -886,6 +891,7 @@ let oversized_user_message ?(prompt = "긴 텍스트도 저장되면 안 돼") (
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let summarized_contaminated_text =
@@ -902,6 +908,7 @@ let summarized_contaminated_message () : Agent_sdk.Types.message =
     content = [Agent_sdk.Types.Text summarized_contaminated_text];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let test_persist_message_drops_world_state_and_separates_internal_history () =
@@ -1120,6 +1127,7 @@ let test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget () =
         ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   match KCC.sanitize_checkpoint_message msg with
@@ -1314,6 +1322,7 @@ let test_deserialize_context_repairs_orphan_tool_result () =
           ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       }
   in
   let ctx =

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -240,6 +240,7 @@ let test_ctx_composition_splits_history_and_residual () =
         content = [Agent_sdk.Types.Text "Earlier user request"];
         name = None;
         tool_call_id = None;
+        metadata = [];
       };
       {
         Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
@@ -255,6 +256,7 @@ let test_ctx_composition_splits_history_and_residual () =
           ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       };
       {
         Agent_sdk.Types.role = Agent_sdk.Types.Tool;
@@ -270,6 +272,7 @@ let test_ctx_composition_splits_history_and_residual () =
           ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       };
     ]
   in

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -111,8 +111,8 @@ let test_envelope_empty_snapshot_returns_none () =
 
 let make_test_checkpoint ?(working_context = None) ~response_text () =
   let messages = [
-    Agent_sdk.Types.{ role = User; content = [Text "hello"]; name = None; tool_call_id = None };
-    Agent_sdk.Types.{ role = Assistant; content = [Text response_text]; name = None; tool_call_id = None };
+    Agent_sdk.Types.{ role = User; content = [Text "hello"]; name = None; tool_call_id = None; metadata = [] };
+    Agent_sdk.Types.{ role = Assistant; content = [Text response_text]; name = None; tool_call_id = None; metadata = [] };
   ] in
   Agent_sdk.Checkpoint.{
     version = 4;

--- a/test/test_keeper_summarizer.ml
+++ b/test/test_keeper_summarizer.ml
@@ -8,7 +8,7 @@
 module KS = Masc_mcp.Keeper_summarizer
 
 let msg ~role ~text : Agent_sdk.Types.message =
-  { role; content = [ Agent_sdk.Types.Text text ]; name = None; tool_call_id = None }
+  { role; content = [ Agent_sdk.Types.Text text ]; name = None; tool_call_id = None; metadata = [] }
 
 let test_scrub_text_blocks_removes_state () =
   let input =
@@ -53,7 +53,7 @@ let test_non_text_blocks_untouched () =
   let m : Agent_sdk.Types.message =
     { role = Agent_sdk.Types.Assistant;
       content = [ Agent_sdk.Types.Text "[STATE]\nDONE\n[/STATE]"; tool_use ];
-      name = None; tool_call_id = None }
+      name = None; tool_call_id = None; metadata = [] }
   in
   let scrubbed = KS.scrub_text_blocks m in
   let has_tool_use =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2016,7 +2016,6 @@ let wrapped_claude_limit_error () =
        {
          message =
            "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-         kind = Llm_provider.Http_client.Unknown;
        })
 
 let test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default () =
@@ -2081,7 +2080,11 @@ let test_is_context_overflow_only_for_overflow_errors () =
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None })));
   check bool "NetworkError does not match" false
     (UT.is_context_overflow
-       (Agent_sdk.Error.Api (NetworkError { message = "Connection_reset"; kind = Llm_provider.Http_client.Unknown })));
+       (Agent_sdk.Error.Api
+          (NetworkError
+             {
+               message = "Connection_reset";
+             })));
   check bool "Internal does not match" false
     (UT.is_context_overflow
        (Agent_sdk.Error.Internal "some error"));
@@ -2335,6 +2338,7 @@ let test_sanitize_messages_utf8_cleans_history_path () =
         content = [ Text "hist\000ory\127entry" ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       }
   in
   let tool_msg =
@@ -2353,6 +2357,7 @@ let test_sanitize_messages_utf8_cleans_history_path () =
           ];
         name = None;
         tool_call_id = None;
+        metadata = [];
       }
   in
   let sanitized =
@@ -2395,7 +2400,11 @@ let test_overflow_detection_and_limit_parsing () =
     (Agent_sdk.Retry.extract_context_limit "Network error: connection reset");
   check bool "NetworkError not overflow" false
     (UT.is_context_overflow
-       (Agent_sdk.Error.Api (NetworkError { message = "timeout"; kind = Llm_provider.Http_client.Unknown })))
+       (Agent_sdk.Error.Api
+          (NetworkError
+             {
+               message = "timeout";
+             })))
 
 let test_side_effect_timeout_reclassified_as_persistent () =
   let original =
@@ -2544,7 +2553,10 @@ let test_server_rejected_parse_error_generic_cant_find () =
 let test_server_rejected_parse_error_network_error () =
   let err =
     Agent_sdk.Error.Api
-      (NetworkError { message = "connection refused"; kind = Llm_provider.Http_client.Unknown })
+      (NetworkError
+         {
+           message = "connection refused";
+         })
   in
   check bool "network error is NOT parse error" false
     (UT.is_server_rejected_parse_error err)
@@ -2572,7 +2584,6 @@ let test_auto_recoverable_turn_error_includes_wrapped_hard_quota () =
          {
            message =
              "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-           kind = Llm_provider.Http_client.Unknown;
          })
   in
   check bool "wrapped hard quota is auto-recoverable" true
@@ -3962,7 +3973,11 @@ let () =
           test_case "NetworkError detected" `Quick (fun () ->
             check bool "network error" true
               (UT.is_transient_network_error
-                 (Agent_sdk.Error.Api (NetworkError { message = "Connection_reset"; kind = Llm_provider.Http_client.Unknown }))));
+                 (Agent_sdk.Error.Api
+                    (NetworkError
+                       {
+                         message = "Connection_reset";
+                       }))));
           test_case "Timeout detected" `Quick (fun () ->
             check bool "timeout" true
               (UT.is_transient_network_error

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -4,7 +4,7 @@ module WT = Masc_mcp.Keeper_wake_telemetry
 module Types = Agent_sdk.Types
 
 let text_msg role s : Types.message =
-  { role; content = [ Types.Text s ]; name = None; tool_call_id = None }
+  { role; content = [ Types.Text s ]; name = None; tool_call_id = None; metadata = [] }
 
 let tool_use_msg id name input : Types.message =
   {
@@ -12,6 +12,7 @@ let tool_use_msg id name input : Types.message =
     content = [ Types.ToolUse { id; name; input } ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let tool_result_msg ~tool_use_id ~content : Types.message =
@@ -21,6 +22,7 @@ let tool_result_msg ~tool_use_id ~content : Types.message =
       [ Types.ToolResult { tool_use_id; content; is_error = false; json = None } ];
     name = None;
     tool_call_id = Some tool_use_id;
+    metadata = [];
   }
 
 let sum_counts counts =
@@ -56,6 +58,7 @@ let test_thinking_and_redacted () =
         ];
       name = None;
       tool_call_id = None;
+      metadata = [];
     }
   in
   check int "thinking uses content; redacted uses literal length"

--- a/test/test_mid_turn_resume.ml
+++ b/test/test_mid_turn_resume.ml
@@ -40,15 +40,15 @@ let test_checkpoint_roundtrip () =
     Oas.Types.user_msg "turn 1 user";
     { Oas.Types.role = Oas.Types.Assistant;
       content = [Oas.Types.Text "turn 1 response"];
-      name = None; tool_call_id = None };
+      name = None; tool_call_id = None; metadata = [] };
     Oas.Types.user_msg "turn 2 user";
     { Oas.Types.role = Oas.Types.Assistant;
       content = [Oas.Types.Text "turn 2 response"];
-      name = None; tool_call_id = None };
+      name = None; tool_call_id = None; metadata = [] };
     Oas.Types.user_msg "turn 3 user";
     { Oas.Types.role = Oas.Types.Assistant;
       content = [Oas.Types.Text "turn 3 response"];
-      name = None; tool_call_id = None };
+      name = None; tool_call_id = None; metadata = [] };
   ] in
   Oas.Agent.set_state agent { (Oas.Agent.state agent) with
     messages = msgs;
@@ -91,10 +91,10 @@ let test_multi_cascade_accumulation () =
     messages = [
       Oas.Types.user_msg "t1";
       { Oas.Types.role = Oas.Types.Assistant;
-        content = [Oas.Types.Text "r1"]; name = None; tool_call_id = None };
+        content = [Oas.Types.Text "r1"]; name = None; tool_call_id = None; metadata = [] };
       Oas.Types.user_msg "t2";
       { Oas.Types.role = Oas.Types.Assistant;
-        content = [Oas.Types.Text "r2"]; name = None; tool_call_id = None };
+        content = [Oas.Types.Text "r2"]; name = None; tool_call_id = None; metadata = [] };
     ];
     turn_count = 2;
   };
@@ -106,7 +106,7 @@ let test_multi_cascade_accumulation () =
     messages = (Oas.Agent.state agent_b).messages @ [
       Oas.Types.user_msg "t3";
       { Oas.Types.role = Oas.Types.Assistant;
-        content = [Oas.Types.Text "r3"]; name = None; tool_call_id = None };
+        content = [Oas.Types.Text "r3"]; name = None; tool_call_id = None; metadata = [] };
     ];
     turn_count = 3;
   };

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -21,7 +21,7 @@ let make_test_messages () : Agent_sdk.Types.message list =
     Agent_sdk.Types.assistant_msg "The answer is 4.";
     { Agent_sdk.Types.role = Agent_sdk.Types.Tool;
       content = [ Agent_sdk.Types.ToolResult { tool_use_id = "call-1"; content = "result: 4"; is_error = false; json = None } ];
-      name = None; tool_call_id = None };
+      name = None; tool_call_id = None; metadata = [] };
     Agent_sdk.Types.user_msg "Thanks, now solve x^2 = 9.";
     Agent_sdk.Types.assistant_msg "x = 3 or x = -3.";
   ]
@@ -62,7 +62,7 @@ let test_roundtrip_tool_msg () =
   let msg : Agent_sdk.Types.message =
     { role = Agent_sdk.Types.Tool;
       content = [ Agent_sdk.Types.ToolResult { tool_use_id = "tc-1"; content = "tool output here"; is_error = false; json = None } ];
-      name = None; tool_call_id = None } in
+      name = None; tool_call_id = None; metadata = [] } in
   match (fun (m : Agent_sdk.Types.message) -> match m.role with Agent_sdk.Types.System -> None | _ -> Some m) msg with
   | None -> Alcotest.fail "tool message should not be dropped"
   | Some oas ->
@@ -156,9 +156,9 @@ let test_compact_small_list_unchanged () =
 let test_restore_messages_all_roles () =
   let oas_msgs : Agent_sdk.Types.message list = [
     { Agent_sdk.Types.role = Agent_sdk.Types.User;
-      content = [Agent_sdk.Types.Text "user question"]; name = None; tool_call_id = None };
+      content = [Agent_sdk.Types.Text "user question"]; name = None; tool_call_id = None; metadata = [] };
     { Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
-      content = [Agent_sdk.Types.Text "assistant answer"]; name = None; tool_call_id = None };
+      content = [Agent_sdk.Types.Text "assistant answer"]; name = None; tool_call_id = None; metadata = [] };
   ] in
   let masc_msgs = List.map Fun.id oas_msgs in
   Alcotest.(check int) "2 messages restored" 2 (List.length masc_msgs);

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -453,9 +453,9 @@ let test_system_role_dropped () =
 let test_restore_messages () =
   let oas_msgs : Agent_sdk.Types.message list = [
     { Agent_sdk.Types.role = Agent_sdk.Types.User;
-      content = [Agent_sdk.Types.Text "hello"]; name = None; tool_call_id = None };
+      content = [Agent_sdk.Types.Text "hello"]; name = None; tool_call_id = None; metadata = [] };
     { Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
-      content = [Agent_sdk.Types.Text "world"]; name = None; tool_call_id = None };
+      content = [Agent_sdk.Types.Text "world"]; name = None; tool_call_id = None; metadata = [] };
   ] in
   let masc_msgs = List.map Fun.id oas_msgs in
   Alcotest.(check int) "2 messages" 2 (List.length masc_msgs);

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -646,7 +646,6 @@ let test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper () =
              "gemini exited with code 1: TerminalQuotaError: You have exhausted \
               your capacity on this model. Your quota will reset after 4h41m7s. \
               reason=QUOTA_EXHAUSTED";
-           kind = Llm_provider.Http_client.Unknown;
          })
   in
   Alcotest.(check bool) "Gemini CLI quota wrapper counts as hard quota" true
@@ -659,7 +658,6 @@ let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
          {
            message =
              "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-           kind = Llm_provider.Http_client.Unknown;
          })
   in
   Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
@@ -669,8 +667,8 @@ let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
   let err =
     Oas.Error.Api
       (Llm_provider.Retry.NetworkError
-         { message = "gemini exited with code 1: connection reset by peer";
-           kind = Llm_provider.Http_client.Unknown;
+         {
+           message = "gemini exited with code 1: connection reset by peer";
          })
   in
   Alcotest.(check bool) "transient network error stays transient" false
@@ -743,7 +741,6 @@ let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
          {
            message =
              "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-           kind = Llm_provider.Http_client.Unknown;
          })
   in
   Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
@@ -2020,6 +2017,7 @@ let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let tool_use_msg ?(id = "tool-1") ?(name = "keeper_fs_read") input
@@ -2030,6 +2028,7 @@ let tool_use_msg ?(id = "tool-1") ?(name = "keeper_fs_read") input
       [ Agent_sdk.Types.ToolUse { id; name; input } ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 let test_keeper_checkpoint_store_oas_roundtrip () =
@@ -2743,6 +2742,7 @@ let make_assistant_tool_use_msg name : Agent_sdk.Types.message =
       ];
     name = None;
     tool_call_id = None;
+    metadata = [];
   }
 
 (** Idle error with a preceding tool-use: should append "(tool: <name>)". *)
@@ -2761,7 +2761,7 @@ let test_enrich_idle_detail_no_tool () =
   let messages : Agent_sdk.Types.message list =
     [ { Agent_sdk.Types.role = Agent_sdk.Types.User;
         content = [ Agent_sdk.Types.Text "hello" ];
-        name = None; tool_call_id = None } ]
+        name = None; tool_call_id = None; metadata = [] } ]
   in
   let result = Oas_worker_exec.enrich_idle_detail detail messages in
   Alcotest.(check string) "unchanged when no tool" detail result

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -110,6 +110,7 @@ let test_full_flow_externalize_hydrate_serve () =
             ];
           name = None;
           tool_call_id = Some "tool_call_42";
+          metadata = [];
         }
       in
       let reducer = H.hydrate_recent ~store ~keep_recent:3 in
@@ -166,6 +167,7 @@ let test_recency_budget_holds_across_modules () =
             ];
           name = None;
           tool_call_id = Some id;
+          metadata = [];
         }
       in
       let msgs =


### PR DESCRIPTION
## Summary
- add `metadata = []` to local OAS/Agent SDK message builders and preserve metadata in keeper history JSON roundtrips
- adapt `Retry.NetworkError` and `Http_client.NetworkError` handling to the current agent_sdk shape that only carries `message`
- update affected tests so current main builds against the installed OAS/agent_sdk pin

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-main-baseline`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-main-baseline ./test/test_oas_worker.exe`
- `cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-main-baseline && ./_build/default/test/test_oas_worker.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-main-baseline ./test/test_keeper_unified.exe`
- `cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/kimi-main-baseline && ./_build/default/test/test_keeper_unified.exe test ^transient_network_error`

## Notes
- `./_build/default/test/test_keeper_unified.exe` still has one unrelated pre-existing failure in `unified_prompt.024`; tracked separately in #9400.

Relates #9387