### PR TITLE
test(keeper): follow gh sandbox fallback refactor

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1063,7 +1063,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     (source_file_contains "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");
   check bool "keeper_shell gh runtime allows sandbox fallback" true
-    (source_file_contains "lib/keeper/keeper_exec_shell.ml"
+    (source_file_contains "lib/keeper/keeper_shell_gh_context.ml"
        "task_id = \"(sandbox)\"")
 
 (* ---------- Config tests ---------- *)


### PR DESCRIPTION
## Summary
- update the keeper unified prompt regression test to follow the gh sandbox fallback refactor
- assert the sandbox fallback source on lib/keeper/keeper_shell_gh_context.ml where task_id = "(sandbox)" now lives

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-unified-prompt-gh-fallback-test test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test unified_prompt 24
- ./_build/default/test/test_keeper_unified.exe