### PR TITLE
test(keeper): follow gh sandbox fallback refactor

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1063,7 +1063,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     (source_file_contains "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");
   check bool "keeper_shell gh runtime allows sandbox fallback" true
-    (source_file_contains "lib/keeper/keeper_exec_shell.ml"
+    (source_file_contains "lib/keeper/keeper_shell_gh_context.ml"
        "task_id = \"(sandbox)\"")
 
 (* ---------- Config tests ---------- *)


### PR DESCRIPTION
## Summary
- update the `test_keeper_unified` work-discovery assertion to follow the current gh repo-context implementation
- keep the sandbox fallback expectation intact, but point it at `lib/keeper/keeper_shell_gh_context.ml`, which now owns that behavior

## Root cause
- the sandbox fallback sentinel `task_id = "(sandbox)"` moved out of `keeper_exec_shell.ml` during the gh repo-context split
- the test kept probing the old file, so it reported a false failure even though runtime behavior still existed

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-shell-gh-fallback ./test/test_keeper_unified.exe`
- `cd /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-shell-gh-fallback && ./_build/default/test/test_keeper_unified.exe`

Closes #9400