### PR TITLE
fix: restore codex cli cascade lane

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -388,12 +388,24 @@ describe('buildRuntimePayload — sandbox diffing', () => {
 
 const mocks = vi.hoisted(() => ({
   fetchKeeperConfig: vi.fn(async () => makeKeeperConfig()),
+  fetchCascadeProfiles: vi.fn(async () => ({
+    profiles: ['keeper_unified', 'resilient_breaker'],
+    invalid_profiles: [
+      {
+        name: 'broken_profile',
+        errors: ['missing models'],
+      },
+    ],
+  })),
   patchKeeperConfig: vi.fn(),
+  updateKeeperCascade: vi.fn(async () => ({ ok: true })),
 }))
 
 vi.mock('../api/dashboard', () => ({
+  fetchCascadeProfiles: mocks.fetchCascadeProfiles,
   fetchKeeperConfig: mocks.fetchKeeperConfig,
   patchKeeperConfig: mocks.patchKeeperConfig,
+  updateKeeperCascade: mocks.updateKeeperCascade,
 }))
 
 import { KeeperConfigPanel, loadKeeperConfig, resetKeeperConfig } from './keeper-config-panel'
@@ -410,7 +422,9 @@ describe('KeeperConfigPanel', () => {
     document.body.appendChild(container)
     resetKeeperConfig()
     mocks.fetchKeeperConfig.mockClear()
+    mocks.fetchCascadeProfiles.mockClear()
     mocks.patchKeeperConfig.mockClear()
+    mocks.updateKeeperCascade.mockClear()
   })
 
   afterEach(() => {
@@ -425,10 +439,12 @@ describe('KeeperConfigPanel', () => {
     await flush()
 
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchCascadeProfiles).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('resolved config root의 cascade.json')
+    expect(container.textContent).toContain('keeper TOML의 cascade_name')
     expect(container.textContent).toContain('Cascade 선택')
     expect(container.textContent).toContain('keeper_unified')
+    expect(container.textContent).toContain('broken_profile')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
     expect(container.textContent).toContain('/tmp/config/cascade.toml')
     expect(container.textContent).toContain('/tmp/config/cascade.json')
@@ -449,6 +465,41 @@ describe('KeeperConfigPanel', () => {
     const textareas = Array.from(container.querySelectorAll('textarea'))
     expect(textareas.length).toBeGreaterThan(0)
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
+  })
+
+  it('exposes cascade selection controls directly in the config panel', async () => {
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    const cascadeSelect = Array.from(container.querySelectorAll('select')).find(
+      (select) => !select.getAttribute('aria-label'),
+    ) as HTMLSelectElement | undefined
+    expect(cascadeSelect).toBeDefined()
+    expect(cascadeSelect?.value).toBe('keeper_unified')
+
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({
+        execution: {
+          models: ['llama:test-balanced'],
+          active_model: 'llama:test-balanced',
+          verify: true,
+          selected_cascade_name: 'resilient_breaker',
+          selected_cascade_canonical: 'resilient_breaker',
+        },
+      }),
+    )
+
+    cascadeSelect!.value = 'resilient_breaker'
+    cascadeSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.updateKeeperCascade).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      'resilient_breaker',
+    )
+    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(2)
   })
 
   it('patches sandbox runtime controls from the dashboard panel', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -4,7 +4,13 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
+import {
+  fetchCascadeProfiles,
+  fetchKeeperConfig,
+  patchKeeperConfig,
+  updateKeeperCascade,
+  type CascadeInvalidProfile,
+} from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
@@ -20,9 +26,17 @@ import { SetupGuideCard } from './setup-guide-card'
 const configResource = createAsyncResource<KeeperConfig>()
 const configState = configResource.state
 const configKeeperName = signal<string>('')
+type CascadeProfileCatalog = {
+  profiles: string[]
+  invalid_profiles: CascadeInvalidProfile[]
+}
+const cascadeProfilesResource = createAsyncResource<CascadeProfileCatalog>()
+const cascadeProfilesState = cascadeProfilesResource.state
 const editMode = signal(false)
 const saving = signal(false)
 const saveError = signal<string | null>(null)
+const cascadeSaving = signal(false)
+const cascadeSaveError = signal<string | null>(null)
 
 // Draft values for editable fields (only used in edit mode)
 type EditDraft = {
@@ -207,10 +221,13 @@ export async function loadKeeperConfig(
 
 export function resetKeeperConfig(): void {
   configResource.reset()
+  cascadeProfilesResource.reset()
   configKeeperName.value = ''
   editMode.value = false
   editDraft.value = null
   saveError.value = null
+  cascadeSaveError.value = null
+  cascadeSaving.value = false
   runtimeDraft.value = null
   runtimeSaving.value = false
   hookFilterQuery.value = ''
@@ -228,6 +245,13 @@ export function peekKeeperConfigLoadStatus(
   const state = configState.value
   if (configKeeperName.value !== name) return 'other'
   return state.status
+}
+
+async function loadCascadeProfiles(options?: { force?: boolean }): Promise<void> {
+  const force = options?.force === true
+  if (!force && cascadeProfilesState.value.status === 'loaded') return
+  if (force) cascadeProfilesResource.reset()
+  await cascadeProfilesResource.load(() => fetchCascadeProfiles())
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -474,10 +498,14 @@ function cascadeSelectionSummary(c: KeeperConfig): string {
 
 export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const state = configState.value
+  const cascadeState = cascadeProfilesState.value
 
   // Trigger load on first render or name change
   if (configKeeperName.value !== keeperName || state.status === 'idle') {
     void loadKeeperConfig(keeperName)
+  }
+  if (cascadeState.status === 'idle') {
+    void loadCascadeProfiles()
   }
 
   if (state.status === 'loading') {
@@ -534,6 +562,25 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     editMode.value = false
     editDraft.value = null
     saveError.value = null
+  }
+
+  async function saveCascadeSelection(nextCascadeName: string) {
+    const currentCascade = c.execution.selected_cascade_name || ''
+    if (!nextCascadeName || nextCascadeName === currentCascade) return
+    cascadeSaving.value = true
+    cascadeSaveError.value = null
+    try {
+      await updateKeeperCascade(keeperName, nextCascadeName)
+      await loadKeeperConfig(keeperName, { force: true })
+      await loadCascadeProfiles({ force: true })
+      showToast(`cascade 변경 완료: ${nextCascadeName}`, 'success')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'cascade 변경 실패'
+      cascadeSaveError.value = message
+      showToast(message, 'error')
+    } finally {
+      cascadeSaving.value = false
+    }
   }
 
   async function saveConfig() {
@@ -626,6 +673,20 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     </details>
   `
 
+  const cascadeProfiles = cascadeState.status === 'loaded' ? cascadeState.data.profiles : []
+  const invalidCascadeProfiles =
+    cascadeState.status === 'loaded' ? cascadeState.data.invalid_profiles : []
+  const cascadeOptions = [
+    ...cascadeProfiles,
+    ...invalidCascadeProfiles.map((profile) => profile.name),
+  ]
+  const currentCascade = c.execution.selected_cascade_name || ''
+  const hasCascadeSelector =
+    currentCascade !== '' || cascadeOptions.length > 0 || cascadeState.status === 'loading'
+  const invalidCascadeSummary = invalidCascadeProfiles
+    .map((profile) => `${profile.name}: ${profile.errors.join('; ')}`)
+    .join(' | ')
+
   return html`
     <div class="flex flex-col gap-1.5">
       ${toolbar}
@@ -647,8 +708,46 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${SectionHeader} title="소스" />
       <${Callout}
         title="Cascade 선택"
-        body=${cascadeSelectionSummary(c)}
+        body=${hasCascadeSelector
+          ? '이 selector는 keeper TOML의 cascade_name 을 바꿉니다. catalog authoring source와 generated runtime JSON 경로는 아래 읽기 전용 메타데이터를 보세요.'
+          : cascadeSelectionSummary(c)}
       />
+      ${hasCascadeSelector
+        ? html`
+            <label class="flex flex-col gap-1.5 py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">
+              <span class="text-xs font-medium text-text-muted">활성 cascade profile</span>
+              <select
+                class="rounded border border-card-border/60 bg-[var(--white-4)] px-3 py-2 text-xs font-semibold text-text-strong disabled:opacity-60"
+                value=${currentCascade}
+                disabled=${cascadeSaving.value || cascadeState.status === 'loading' || cascadeOptions.length === 0}
+                onChange=${(event: Event) => {
+                  const next = (event.currentTarget as HTMLSelectElement).value
+                  void saveCascadeSelection(next)
+                }}
+              >
+                ${currentCascade !== '' && !cascadeOptions.includes(currentCascade)
+                  ? html`<option value=${currentCascade}>${currentCascade}</option>`
+                  : null}
+                ${cascadeOptions.map((profileName) => html`
+                  <option value=${profileName}>${profileName}</option>
+                `)}
+              </select>
+              <span class="text-2xs text-[var(--text-dim)]">
+                ${cascadeSaving.value
+                  ? 'cascade_name 저장 중...'
+                  : cascadeState.status === 'loading'
+                    ? '사용 가능한 cascade profile 로딩 중...'
+                    : '변경 시 keeper manifest의 cascade_name 이 즉시 갱신됩니다.'}
+              </span>
+              ${cascadeSaveError.value
+                ? html`<span class="text-2xs text-[var(--bad)]">${cascadeSaveError.value}</span>`
+                : null}
+              ${invalidCascadeProfiles.length > 0
+                ? html`<span class="text-2xs text-[var(--warn)]">invalid profile ${invalidCascadeProfiles.length}개: ${invalidCascadeSummary}</span>`
+                : null}
+            </label>
+          `
+        : null}
       <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || '--'} />
       <${ConfigRow} label="선택 cascade" value=${c.execution.selected_cascade_name || '--'} />
       ${c.execution.selected_cascade_canonical

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -154,6 +154,9 @@ let public_mcp_tool_names_of_oas_tools =
 let runtime_mcp_policy_with_masc_agent_name =
   Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
 
+let runtime_mcp_policy_for_provider =
+  Oas_worker_exec_transport.runtime_mcp_policy_for_provider
+
 let kimi_cli_runtime_mcp_jsons =
   Oas_worker_exec_transport.kimi_cli_runtime_mcp_jsons
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -203,6 +203,20 @@ let runtime_mcp_policy_with_masc_agent_name
     in
     { policy with servers }
 
+let runtime_mcp_policy_for_provider
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    ~(agent_name : string)
+    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
+  match policy_opt, provider_cfg.kind with
+  | Some policy, Llm_provider.Provider_config.Codex_cli ->
+      (* Codex CLI runtime MCP currently rejects inline HTTP headers, so
+         keep the runtime policy untouched until that transport supports
+         carrying per-request headers. *)
+      Some policy
+  | Some policy, _ ->
+      Some (runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
+  | None, _ -> None
+
 let kimi_cli_runtime_mcp_jsons
     ~(base : string list)
     (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -742,11 +742,11 @@ let run_named
              let runtime_mcp_policy =
                match runtime_mcp_policy, String.trim keeper_name with
                | Some policy, keeper_name when keeper_name <> "" ->
-                   Some
-                     (Oas_worker_exec.runtime_mcp_policy_with_masc_agent_name
-                        ~agent_name:(Keeper_types.keeper_agent_name keeper_name)
-                        policy)
-               | _ -> runtime_mcp_policy
+                   Oas_worker_exec.runtime_mcp_policy_for_provider
+                     ~provider_cfg
+                     ~agent_name:(Keeper_types.keeper_agent_name keeper_name)
+                     (Some policy)
+                | _ -> runtime_mcp_policy
              in
              {
                (Oas_worker_exec.default_config ~name ~provider_cfg

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1557,6 +1557,55 @@ let test_runtime_mcp_policy_with_masc_agent_name_upserts_header () =
         (List.assoc_opt "x-masc-agent-name" other_headers)
   | _ -> Alcotest.fail "expected both masc and other HTTP servers"
 
+let test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection () =
+  let policy =
+    {
+      Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+      servers =
+        [
+          Llm_provider.Llm_transport.Http_server
+            { name = "masc"; url = "http://127.0.0.1:8947/mcp"; headers = [] };
+        ];
+      allowed_server_names = [ "masc" ];
+      allowed_tool_names = [ "masc_status" ];
+      strict = true;
+      disable_builtin_tools = true;
+    }
+  in
+  let find_masc_headers policy_opt =
+    match policy_opt with
+    | None -> Alcotest.fail "expected runtime MCP policy"
+    | Some (policy : Llm_provider.Llm_transport.runtime_mcp_policy) ->
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+  in
+  let codex_headers =
+    find_masc_headers
+      (Oas_worker_exec.runtime_mcp_policy_for_provider
+         ~provider_cfg:(make_codex_cli_provider_cfg ())
+         ~agent_name:"keeper-sangsu-agent"
+         (Some policy))
+  in
+  let openai_headers =
+    find_masc_headers
+      (Oas_worker_exec.runtime_mcp_policy_for_provider
+         ~provider_cfg:(make_openai_compat_provider_cfg ())
+         ~agent_name:"keeper-sangsu-agent"
+         (Some policy))
+  in
+  match codex_headers, openai_headers with
+  | Some codex_headers, Some openai_headers ->
+      Alcotest.(check (option string)) "codex_cli skips agent header" None
+        (List.assoc_opt "x-masc-agent-name" codex_headers);
+      Alcotest.(check (option string)) "openai_compat still injects agent header"
+        (Some "keeper-sangsu-agent")
+        (List.assoc_opt "x-masc-agent-name" openai_headers)
+  | _ -> Alcotest.fail "expected masc runtime server headers"
+
 let test_kimi_cli_runtime_mcp_jsons_include_request_policy () =
   let policy =
     {
@@ -2905,6 +2954,8 @@ let () =
         test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
       Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick
         test_runtime_mcp_policy_with_masc_agent_name_upserts_header;
+      Alcotest.test_case "provider-aware runtime MCP policy skips codex_cli agent header injection" `Quick
+        test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection;
       Alcotest.test_case "kimi request runtime MCP config is merged" `Quick
         test_kimi_cli_runtime_mcp_jsons_include_request_policy;
       Alcotest.test_case "kimi argv includes request runtime MCP config" `Quick


### PR DESCRIPTION
## Summary
- skip keeper agent header injection for codex_cli runtime MCP requests
- add a regression test for provider-aware runtime MCP policy handling
- expose keeper cascade selection directly in the config panel and cover it with dashboard tests

## Verification
- ./_build/default/test/test_oas_worker.exe
- pnpm typecheck
- pnpm exec vitest run src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check