### PR TITLE
[codex] dashboard: add fleet control room readiness

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -4,7 +4,7 @@ import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetrySummaryResponse, ToolQualityResponse } from '../api/dashboard'
 import { normalizeKeepers } from '../keeper-store-normalize'
-import type { DashboardExecutionResponse } from '../types'
+import type { DashboardExecutionResponse, DashboardNamespaceTruthResponse } from '../types'
 import { filterFleetRows } from './fleet-telemetry-panel'
 import type { FleetRow } from './fleet-telemetry-utils'
 
@@ -27,6 +27,13 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     runtime_blocker_class: null,
     runtime_blocker_summary: null,
     tool_audit_at: null,
+    goal_label: null,
+    goal_linked: false,
+    active_goal_count: 0,
+    sandbox_profile: null,
+    sandbox_last_error: null,
+    effective_sandbox_image: null,
+    decision_required: false,
     budget_source: null,
     ...overrides,
   }
@@ -152,6 +159,81 @@ const telemetrySummaryResponse: TelemetrySummaryResponse = {
   ],
 }
 
+const namespaceTruthResponse: DashboardNamespaceTruthResponse = {
+  generated_at: '2026-04-09T08:11:30Z',
+  root: {},
+  execution: {
+    summary: {
+      active_sessions: 2,
+      active_operations: 4,
+      continuity_alerts: 1,
+    },
+    top_queue: null,
+    provenance: 'test',
+  },
+  operator: {
+    health: 'ok',
+    pending_confirm_summary: {
+      actor_filter: null,
+      filter_active: false,
+      visible_count: 1,
+      total_count: 1,
+      hidden_count: 0,
+      hidden_actors: [],
+      confirm_required_actions: [],
+    },
+    attention_summary: {
+      count: 1,
+      bad_count: 0,
+      warn_count: 1,
+      provenance: 'test',
+      top_item: null,
+    },
+    recommendation_summary: null,
+    provenance: 'test',
+  },
+  readiness: {
+    status: 'warn',
+    score: 0.67,
+    decision_required_count: 1,
+    blocking_count: 2,
+    pillars: [
+      {
+        key: 'execution_safety',
+        label: 'Execution Safety',
+        status: 'ok',
+        score: 1,
+        summary: 'Sandbox and approval posture are visible.',
+        blocking_reasons: [],
+        metrics: { keeper_count: 2 },
+      },
+      {
+        key: 'autonomy_reliability',
+        label: 'Autonomy Reliability',
+        status: 'warn',
+        score: 0.5,
+        summary: 'One keeper is asking for intervention.',
+        blocking_reasons: ['1 keeper requires a continue gate decision.'],
+        metrics: { decision_required: 1 },
+      },
+    ],
+  },
+  attention_events: [
+    {
+      severity: 'warn',
+      kind: 'continue_gate',
+      summary: 'keeper-alpha is blocked on a continue decision.',
+      requires_decision: true,
+      keeper_name: 'keeper-alpha',
+      target_type: 'keeper',
+      target_id: 'keeper-alpha',
+      recommended_action: 'Open interventions and approve or pause the run.',
+      provenance: 'test',
+    },
+  ],
+  focus: null,
+}
+
 const metricSeriesPoint = {
   ts_unix: 1_744_186_600,
   context_ratio: 0.4,
@@ -182,12 +264,16 @@ async function loadPanel(mocks: {
   fetchDashboardExecution: (opts?: { signal?: AbortSignal }) => Promise<DashboardExecutionResponse>
   fetchToolQuality: (opts?: { n?: number; windowHours?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
   fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>
+  fetchDashboardNamespaceTruth?: (opts?: { signal?: AbortSignal }) => Promise<DashboardNamespaceTruthResponse>
 }) {
   vi.resetModules()
   vi.doMock('../api/dashboard', () => ({
     fetchDashboardExecution: mocks.fetchDashboardExecution,
     fetchToolQuality: mocks.fetchToolQuality,
     fetchTelemetrySummary: mocks.fetchTelemetrySummary,
+    fetchDashboardNamespaceTruth:
+      mocks.fetchDashboardNamespaceTruth
+      ?? vi.fn().mockResolvedValue(namespaceTruthResponse),
   }))
   return import('./fleet-telemetry-panel')
 }
@@ -222,6 +308,50 @@ describe('FleetTelemetryPanel', () => {
     const fetchDashboardExecution = vi.fn().mockResolvedValue(executionResponse)
     const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
     const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const fetchDashboardNamespaceTruth = vi.fn().mockResolvedValue(namespaceTruthResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+      fetchDashboardNamespaceTruth,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+    expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('Keeper 가동률')
+    expect(container.textContent).toContain('1/2 keepers surfaced recent tool activity.')
+    expect(container.textContent).toContain('keeper-alpha')
+    expect(container.textContent).toContain('keeper-beta')
+    expect(container.textContent).toContain('Keeper 턴 로그')
+    expect(container.textContent).toContain('Failure Categories')
+    expect(container.textContent).toContain('Fleet Control Room')
+  }, 60_000)
+
+  it('renders readiness cards, attention events, and keeper goal or sandbox badges', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue({
+      ...executionResponse,
+      keepers: [
+        {
+          ...executionResponse.keepers[0],
+          active_goal_ids: ['goal-1'],
+          short_goal: 'Ship safer keeper ops',
+          sandbox_profile: 'docker',
+          effective_sandbox_image: 'ghcr.io/acme/keeper:latest',
+          sandbox_last_error: 'bind EPERM at /var/folders/tmp',
+          runtime_blocker_continue_gate: true,
+        },
+      ],
+    } satisfies DashboardExecutionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
     const { FleetTelemetryPanel } = await loadPanel({
       fetchDashboardExecution,
       fetchToolQuality,
@@ -234,15 +364,15 @@ describe('FleetTelemetryPanel', () => {
     })
     await flushUi()
 
-    expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
-    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
-    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Keeper 가동률')
-    expect(container.textContent).toContain('1/2 keepers surfaced recent tool activity.')
-    expect(container.textContent).toContain('keeper-alpha')
-    expect(container.textContent).toContain('keeper-beta')
-    expect(container.textContent).toContain('Keeper 턴 로그')
-    expect(container.textContent).toContain('Failure Categories')
+    expect(container.textContent).toContain('Readiness')
+    expect(container.textContent).toContain('Approvals')
+    expect(container.textContent).toContain('Attention Queue')
+    expect(container.textContent).toContain('keeper-alpha is blocked on a continue decision.')
+    expect(container.textContent).toContain('goal linked')
+    expect(container.textContent).toContain('sandbox docker')
+    expect(container.textContent).toContain('decision')
+    expect(container.textContent).toContain('Ship safer keeper ops')
+    expect(container.textContent).toContain('bind EPERM at /var/folders/tmp')
   }, 60_000)
 
   it('warns when keepers are stuck before reaching tool execution', async () => {
@@ -722,10 +852,12 @@ describe('FleetTelemetryPanel', () => {
     const fetchDashboardExecution = vi.fn().mockResolvedValue(executionResponse)
     const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
     const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const fetchDashboardNamespaceTruth = vi.fn().mockResolvedValue(namespaceTruthResponse)
     const { FleetTelemetryPanel } = await loadPanel({
       fetchDashboardExecution,
       fetchToolQuality,
       fetchTelemetrySummary,
+      fetchDashboardNamespaceTruth,
     })
 
     await act(async () => {
@@ -737,6 +869,7 @@ describe('FleetTelemetryPanel', () => {
     expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
     expect(fetchToolQuality).toHaveBeenCalledTimes(1)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+    expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(1)
 
     await vi.advanceTimersByTimeAsync(30_000)
     await flushUi()
@@ -744,6 +877,7 @@ describe('FleetTelemetryPanel', () => {
     expect(fetchDashboardExecution).toHaveBeenCalledTimes(2)
     expect(fetchToolQuality).toHaveBeenCalledTimes(2)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+    expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(2)
     expect(container.textContent).toContain('30초 자동 갱신')
   }, 60_000)
 
@@ -757,6 +891,8 @@ describe('FleetTelemetryPanel', () => {
     let resolveToolQualityThird: ((value: ToolQualityResponse) => void) | null = null
     let resolveSummarySecond: ((value: TelemetrySummaryResponse) => void) | null = null
     let resolveSummaryThird: ((value: TelemetrySummaryResponse) => void) | null = null
+    let resolveNamespaceSecond: ((value: DashboardNamespaceTruthResponse) => void) | null = null
+    let resolveNamespaceThird: ((value: DashboardNamespaceTruthResponse) => void) | null = null
 
     const fetchDashboardExecution = vi.fn().mockImplementation(() => {
       executionCall += 1
@@ -782,10 +918,20 @@ describe('FleetTelemetryPanel', () => {
         else resolveSummaryThird = resolve
       })
     })
+    let namespaceCall = 0
+    const fetchDashboardNamespaceTruth = vi.fn().mockImplementation(() => {
+      namespaceCall += 1
+      if (namespaceCall === 1) return Promise.resolve(namespaceTruthResponse)
+      return new Promise<DashboardNamespaceTruthResponse>(resolve => {
+        if (namespaceCall === 2) resolveNamespaceSecond = resolve
+        else resolveNamespaceThird = resolve
+      })
+    })
     const { FleetTelemetryPanel } = await loadPanel({
       fetchDashboardExecution,
       fetchToolQuality,
       fetchTelemetrySummary,
+      fetchDashboardNamespaceTruth,
     })
 
     await act(async () => {
@@ -807,6 +953,7 @@ describe('FleetTelemetryPanel', () => {
     const applyExecutionThird = requireResolver(resolveExecutionThird, 'missing newest execution resolver')
     const applyToolQualityThird = requireResolver(resolveToolQualityThird, 'missing newest tool quality resolver')
     const applySummaryThird = requireResolver(resolveSummaryThird, 'missing newest summary resolver')
+    const applyNamespaceThird = requireResolver(resolveNamespaceThird, 'missing newest namespace resolver')
     applyExecutionThird({
       ...executionResponse,
       keepers: [
@@ -830,6 +977,15 @@ describe('FleetTelemetryPanel', () => {
       ...telemetrySummaryResponse,
       total_entries: 999,
     })
+    applyNamespaceThird({
+      ...namespaceTruthResponse,
+      attention_events: [],
+      readiness: {
+        ...namespaceTruthResponse.readiness!,
+        score: 0.9,
+        status: 'ok',
+      },
+    })
     await flushUi()
 
     expect(container.textContent).toContain('keeper-gamma')
@@ -838,6 +994,7 @@ describe('FleetTelemetryPanel', () => {
     const applyExecutionSecond = requireResolver(resolveExecutionSecond, 'missing stale execution resolver')
     const applyToolQualitySecond = requireResolver(resolveToolQualitySecond, 'missing stale tool quality resolver')
     const applySummarySecond = requireResolver(resolveSummarySecond, 'missing stale summary resolver')
+    const applyNamespaceSecond = requireResolver(resolveNamespaceSecond, 'missing stale namespace resolver')
     applyExecutionSecond({
       ...executionResponse,
       keepers: [
@@ -861,6 +1018,7 @@ describe('FleetTelemetryPanel', () => {
       ...telemetrySummaryResponse,
       total_entries: 123,
     })
+    applyNamespaceSecond(namespaceTruthResponse)
     await flushUi()
 
     expect(container.textContent).toContain('keeper-gamma')
@@ -890,10 +1048,12 @@ describe('FleetTelemetryPanel', () => {
       abortableToolQuality(opts)
     ))
     const fetchTelemetrySummary = createAbortableResponse(telemetrySummaryResponse)
+    const fetchDashboardNamespaceTruth = createAbortableResponse(namespaceTruthResponse)
     const { FleetTelemetryPanel } = await loadPanel({
       fetchDashboardExecution,
       fetchToolQuality,
       fetchTelemetrySummary,
+      fetchDashboardNamespaceTruth,
     })
 
     await act(async () => {
@@ -908,6 +1068,7 @@ describe('FleetTelemetryPanel', () => {
     expect(fetchDashboardExecution).toHaveBeenCalledTimes(2)
     expect(fetchToolQuality).toHaveBeenCalledTimes(2)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+    expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(2)
     expect(abortedSignals.length).toBeGreaterThan(0)
     expect(abortedSignals.every(signal => signal.aborted)).toBe(true)
     expect(container.textContent).toContain('keeper-alpha')

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -5,6 +5,7 @@ import { RotateCcw } from 'lucide-preact'
 import { LoadingState } from './common/feedback-state'
 import {
   fetchDashboardExecution,
+  fetchDashboardNamespaceTruth,
   fetchTelemetrySummary,
   fetchToolQuality,
   type TelemetrySourceSummary,
@@ -15,11 +16,13 @@ import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { useSavedSignal } from '../lib/saved-signal'
 import { normalizeKeepers } from '../keeper-store-normalize'
+import { normalizeNamespaceTruth } from '../namespace-truth-normalizers'
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import { requestConfirm } from './common/confirm-dialog'
 import { Sparkline } from './common/sparkline'
 import { pushSnapshot, getTrend, type MetricKey, type TrendDirection } from './fleet-trend-store'
+import type { DashboardAttentionEvent, DashboardReadinessPillar } from '../types'
 import {
   EMPTY_TOOL_QUALITY,
   PRESSURE_WARN_RATIO,
@@ -145,6 +148,140 @@ function WarningBanner({ warnings }: { warnings: string[] }) {
   `
 }
 
+function readinessTone(status: string | null | undefined): 'neutral' | 'ok' | 'warn' {
+  if (status === 'ok') return 'ok'
+  if (status === 'warn' || status === 'bad') return 'warn'
+  return 'neutral'
+}
+
+function readinessStatusClass(status: string | null | undefined): string {
+  if (status === 'ok') return 'text-[var(--ok)]'
+  if (status === 'warn') return 'text-[var(--warn)]'
+  if (status === 'bad') return 'text-[var(--bad-light)]'
+  return 'text-[var(--text-dim)]'
+}
+
+function attentionSeverityClass(severity: string | null | undefined): string {
+  if (severity === 'bad') return 'border-[var(--bad-20)] bg-[var(--bad-10)] text-[var(--bad-light)]'
+  if (severity === 'warn') return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn)]'
+  return 'border-[var(--card-border)] bg-[var(--white-1)] text-[var(--text-dim)]'
+}
+
+function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
+  return html`
+    <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="text-2xs font-medium text-[var(--text)]">${pillar.label}</div>
+        <div class="font-mono text-2xs ${readinessStatusClass(pillar.status)}">
+          ${pillar.score.toFixed(2)}
+        </div>
+      </div>
+      <div class="mt-1 text-3xs ${readinessStatusClass(pillar.status)}">${pillar.summary}</div>
+      ${pillar.blocking_reasons.length > 0
+        ? html`
+          <div class="mt-2 flex flex-col gap-1 text-3xs text-[var(--text-dim)]">
+            ${pillar.blocking_reasons.slice(0, 2).map(reason => html`<div>${reason}</div>`)}
+          </div>
+        `
+        : null}
+    </div>
+  `
+}
+
+function AttentionEventList({ events }: { events: DashboardAttentionEvent[] }) {
+  if (events.length === 0) {
+    return html`
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
+        No decision-needed or blocker events are active.
+      </div>
+    `
+  }
+
+  return html`
+    <div class="flex flex-col gap-2">
+      ${events.slice(0, 6).map(event => html`
+        <div class="rounded border px-3 py-2 ${attentionSeverityClass(event.severity)}">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <div class="text-2xs font-medium">
+                ${event.keeper_name ? `${event.keeper_name} · ${event.kind}` : event.kind}
+              </div>
+              <div class="mt-0.5 text-3xs leading-relaxed">${event.summary}</div>
+            </div>
+            ${event.requires_decision
+              ? html`<span class="rounded bg-[var(--white-8)] px-1.5 py-0.5 text-3xs font-semibold">DECISION</span>`
+              : null}
+          </div>
+          ${event.recommended_action
+            ? html`<div class="mt-1 text-3xs text-[var(--text-dim)]">Next: ${event.recommended_action}</div>`
+            : null}
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function ControlRoomPanel({ state }: { state: FleetTelemetryState }) {
+  const truth = state.namespace_truth
+  const readiness = truth?.readiness ?? null
+  const attentionEvents = truth?.attention_events ?? []
+  const pendingApprovals = truth?.operator?.pending_confirm_summary?.visible_count
+    ?? truth?.operator?.pending_confirm_summary?.total_count
+    ?? 0
+
+  if (!truth || !readiness) {
+    return html`
+      <div class="rounded border border-[var(--card-border)] bg-[var(--white-1)] p-3 text-2xs text-[var(--text-dim)]">
+        Control room readiness is unavailable for this refresh.
+      </div>
+    `
+  }
+
+  return html`
+    <div class="flex flex-col gap-3">
+      <div class="grid grid-cols-1 gap-3 xl:grid-cols-4">
+        <${SummaryCard}
+          title="Readiness"
+          value=${readiness.score.toFixed(2)}
+          detail=${`${readiness.blocking_count} blockers · ${readiness.decision_required_count} decisions required.`}
+          tone=${readinessTone(readiness.status)}
+        />
+        <${SummaryCard}
+          title="Approvals"
+          value=${pendingApprovals.toString()}
+          detail=${pendingApprovals > 0 ? 'Operator approval queue is non-empty.' : 'No pending approvals are visible.'}
+          tone=${pendingApprovals > 0 ? 'warn' : 'ok'}
+        />
+        <${SummaryCard}
+          title="Attention"
+          value=${attentionEvents.length.toString()}
+          detail=${attentionEvents.length > 0 ? 'Critical blockers and pause-worthy states are surfaced here.' : 'No active attention events are reported.'}
+          tone=${attentionEvents.length > 0 ? 'warn' : 'ok'}
+        />
+        <${SummaryCard}
+          title="Goal Scope"
+          value=${state.rows.length > 0 ? `${state.rows.filter(row => row.goal_linked).length}/${state.rows.length}` : '0/0'}
+          detail=${state.rows.some(row => !row.goal_linked) ? 'Some keepers are active without a visible goal link.' : 'All surfaced keepers have a goal anchor.'}
+          tone=${state.rows.length === 0 || state.rows.every(row => row.goal_linked) ? 'ok' : 'warn'}
+        />
+      </div>
+
+      <div class="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,2fr)_minmax(0,1.3fr)]">
+        <div>
+          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Readiness Pillars</div>
+          <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
+            ${readiness.pillars.map(pillar => html`<${ReadinessPillarCard} pillar=${pillar} />`)}
+          </div>
+        </div>
+        <div>
+          <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Attention Queue</div>
+          <${AttentionEventList} events=${attentionEvents} />
+        </div>
+      </div>
+    </div>
+  `
+}
+
 function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
   const watchlist = rows
     .filter(row =>
@@ -264,6 +401,39 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 <div class="max-w-60 truncate text-3xs text-[var(--text-dim)]" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
+                <div class="mt-1 flex max-w-60 flex-wrap gap-1">
+                  <span
+                    class=${row.goal_linked
+                      ? 'rounded bg-[var(--ok-10)] px-1.5 py-0.5 text-3xs text-[var(--ok)]'
+                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--warn)]'}
+                    title=${row.goal_label ?? 'No active goal is linked to this keeper.'}
+                  >
+                    ${row.goal_label
+                      ? (row.active_goal_count > 1 ? `goal ${row.active_goal_count}` : 'goal linked')
+                      : 'goal missing'}
+                  </span>
+                  <span
+                    class=${row.sandbox_profile
+                      ? 'rounded bg-[var(--white-8)] px-1.5 py-0.5 text-3xs text-[var(--text-dim)]'
+                      : 'rounded bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--warn)]'}
+                    title=${row.effective_sandbox_image ?? row.sandbox_profile ?? 'Sandbox profile unavailable.'}
+                  >
+                    ${row.sandbox_profile ? `sandbox ${row.sandbox_profile}` : 'sandbox unknown'}
+                  </span>
+                  ${row.decision_required
+                    ? html`<span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-3xs text-[var(--bad-light)]">decision</span>`
+                    : null}
+                </div>
+                ${row.goal_label
+                  ? html`<div class="max-w-60 truncate text-3xs text-[var(--text-dim)]" title=${row.goal_label}>${row.goal_label}</div>`
+                  : null}
+                ${row.sandbox_last_error
+                  ? html`
+                    <div class="max-w-60 truncate text-3xs text-[var(--bad-light)]" title=${row.sandbox_last_error}>
+                      ${row.sandbox_last_error}
+                    </div>
+                  `
+                  : null}
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
               <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</td>
@@ -384,10 +554,11 @@ export function FleetTelemetryPanel() {
     }
 
     try {
-      const [executionResult, toolQualityResult, telemetrySummaryResult] = await Promise.allSettled([
+      const [executionResult, toolQualityResult, telemetrySummaryResult, namespaceTruthResult] = await Promise.allSettled([
         fetchDashboardExecution({ signal: controller.signal }),
         fetchToolQuality({ n: 5000, windowHours: 24, signal: controller.signal }),
         fetchTelemetrySummary({ signal: controller.signal }),
+        fetchDashboardNamespaceTruth({ signal: controller.signal }),
       ])
 
       if (controller.signal.aborted || requestId !== latestRequestId.current) return
@@ -419,6 +590,14 @@ export function FleetTelemetryPanel() {
       }
       warnings.push(...buildTelemetryWarnings(telemetrySummary.sources))
 
+      const namespaceTruth =
+        namespaceTruthResult.status === 'fulfilled'
+          ? normalizeNamespaceTruth(namespaceTruthResult.value)
+          : null
+      if (namespaceTruthResult.status === 'rejected' && !isAbortError(namespaceTruthResult.reason)) {
+        warnings.push(`Control room unavailable: ${errorMessage(namespaceTruthResult.reason)}`)
+      }
+
       const rows = buildFleetRows(keepers, toolQuality)
       warnings.push(...buildRuntimeWarnings(rows))
       const updatedAt =
@@ -441,6 +620,7 @@ export function FleetTelemetryPanel() {
         tool_quality: toolQuality,
         telemetry_sources: telemetrySummary.sources,
         total_telemetry_entries: telemetrySummary.total_entries,
+        namespace_truth: namespaceTruth,
         updated_at: updatedAt,
       }
     } finally {
@@ -559,6 +739,11 @@ export function FleetTelemetryPanel() {
           detail=${`${sourcesWithData}/${value.telemetry_sources.length || 0} stores currently have data.`}
           tone=${sourcesWithData > 0 ? 'ok' : 'warn'}
         />
+      </div>
+
+      <div>
+        <div class="mb-1 text-3xs uppercase tracking-wider text-[var(--text-dim)]">Fleet Control Room</div>
+        <${ControlRoomPanel} state=${value} />
       </div>
 
       <div>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -51,6 +51,13 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     runtime_blocker_class: null,
     runtime_blocker_summary: null,
     tool_audit_at: null,
+    goal_label: null,
+    goal_linked: false,
+    active_goal_count: 0,
+    sandbox_profile: null,
+    sandbox_last_error: null,
+    effective_sandbox_image: null,
+    decision_required: false,
     budget_source: null,
     ...overrides,
   }

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -1,4 +1,5 @@
 import type { TelemetrySourceSummary, ToolQualityResponse } from '../api/dashboard'
+import type { DashboardNamespaceTruthResponse } from '../types'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
@@ -28,6 +29,13 @@ export interface FleetRow {
   runtime_blocker_class: Keeper['runtime_blocker_class'] | null
   runtime_blocker_summary: string | null
   tool_audit_at: string | null
+  goal_label: string | null
+  goal_linked: boolean
+  active_goal_count: number
+  sandbox_profile: string | null
+  sandbox_last_error: string | null
+  effective_sandbox_image: string | null
+  decision_required: boolean
   budget_source: 'override' | 'override_invalid' | 'env' | null
 }
 
@@ -39,6 +47,7 @@ export interface FleetTelemetryState {
   tool_quality: ToolQualityResponse
   telemetry_sources: TelemetrySourceSummary[]
   total_telemetry_entries: number
+  namespace_truth: DashboardNamespaceTruthResponse | null
   updated_at: string | null
 }
 
@@ -62,6 +71,7 @@ export function emptyState(): FleetTelemetryState {
     tool_quality: EMPTY_TOOL_QUALITY,
     telemetry_sources: [],
     total_telemetry_entries: 0,
+    namespace_truth: null,
     updated_at: null,
   }
 }
@@ -165,6 +175,18 @@ function keeperRecentTools(keeper: Keeper): string[] {
     ...(keeper.latest_tool_names ?? []),
     ...keeperMetricsWindowTools(keeper),
   ]).slice(0, 3)
+}
+
+function keeperGoalLabel(keeper: Keeper): string | null {
+  return firstNonEmptyString(
+    keeper.short_goal,
+    keeper.goal_horizons?.short,
+    keeper.goal,
+    keeper.mid_goal,
+    keeper.goal_horizons?.mid,
+    keeper.long_goal,
+    keeper.goal_horizons?.long,
+  )
 }
 
 function keeperToolCallCount(keeper: Keeper, toolQualityCalls?: number): number {
@@ -331,6 +353,13 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             runtime_blocker_summary:
               firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
             tool_audit_at: keeper.tool_audit_at ?? null,
+            goal_label: keeperGoalLabel(keeper),
+            goal_linked: (keeper.active_goal_ids?.length ?? 0) > 0 || keeperGoalLabel(keeper) != null,
+            active_goal_count: keeper.active_goal_ids?.length ?? 0,
+            sandbox_profile: keeper.sandbox_profile ?? null,
+            sandbox_last_error: keeper.sandbox_last_error ?? null,
+            effective_sandbox_image: keeper.effective_sandbox_image ?? null,
+            decision_required: keeper.runtime_blocker_continue_gate === true,
             budget_source:
               keeper.turn_budget?.reactive.source === 'override' ||
               keeper.turn_budget?.reactive.source === 'override_invalid' ||
@@ -361,6 +390,13 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           runtime_blocker_class: null,
           runtime_blocker_summary: null,
           tool_audit_at: null,
+          goal_label: null,
+          goal_linked: false,
+          active_goal_count: 0,
+          sandbox_profile: null,
+          sandbox_last_error: null,
+          effective_sandbox_image: null,
+          decision_required: false,
           budget_source: null,
         }))
 

--- a/dashboard/src/components/fleet-trend-store.test.ts
+++ b/dashboard/src/components/fleet-trend-store.test.ts
@@ -19,6 +19,13 @@ function makeRow(name: string, overrides: Partial<FleetRow> = {}): FleetRow {
     runtime_blocker_class: null,
     runtime_blocker_summary: null,
     tool_audit_at: null,
+    goal_label: null,
+    goal_linked: false,
+    active_goal_count: 0,
+    sandbox_profile: null,
+    sandbox_last_error: null,
+    effective_sandbox_image: null,
+    decision_required: false,
     budget_source: null,
     ...overrides,
   }

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -398,6 +398,21 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.runtime_blocker_continue_gate === 'boolean'
             ? row.runtime_blocker_continue_gate
             : null,
+        active_goal_ids: asStringArray(row.active_goal_ids) ?? [],
+        goal: asString(row.goal) ?? null,
+        short_goal: asString(row.short_goal) ?? null,
+        mid_goal: asString(row.mid_goal) ?? null,
+        long_goal: asString(row.long_goal) ?? null,
+        goal_horizons: isRecord(row.goal_horizons)
+          ? {
+              short: asString(row.goal_horizons.short) ?? null,
+              mid: asString(row.goal_horizons.mid) ?? null,
+              long: asString(row.goal_horizons.long) ?? null,
+            }
+          : null,
+        sandbox_profile: asString(row.sandbox_profile) ?? null,
+        sandbox_last_error: asString(row.sandbox_last_error) ?? null,
+        effective_sandbox_image: asString(row.effective_sandbox_image) ?? null,
         created_at: toIsoTimestamp(row.created_at) ?? asString(row.created_at),
         updated_at: toIsoTimestamp(row.updated_at) ?? asString(row.updated_at),
         last_heartbeat: asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen),

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -346,6 +346,58 @@ describe('normalizeNamespaceTruth', () => {
     expect(pcs!.hidden_actors).toEqual([])
   })
 
+  it('extracts readiness summary and attention events', () => {
+    const result = normalizeNamespaceTruth({
+      readiness: {
+        status: 'warn',
+        score: 0.61,
+        decision_required_count: 2,
+        blocking_count: 3,
+        pillars: [
+          {
+            key: 'execution_safety',
+            label: 'Execution Safety',
+            status: 'ok',
+            score: 1,
+            summary: 'Sandbox posture is visible.',
+            blocking_reasons: [],
+            metrics: { keeper_count: 4 },
+          },
+          {
+            key: 'goal_coherence',
+            label: 'Goal Coherence',
+            status: 'warn',
+            score: 0.25,
+            summary: 'One keeper is unscoped.',
+            blocking_reasons: ['1 keeper has no active goal link.'],
+            metrics: { unscoped_keepers: 1 },
+          },
+        ],
+      },
+      attention_events: [
+        {
+          severity: 'warn',
+          kind: 'continue_gate',
+          summary: 'keeper-alpha needs a decision.',
+          requires_decision: true,
+          keeper_name: 'keeper-alpha',
+          recommended_action: 'Review the pending continue gate.',
+          provenance: 'runtime',
+        },
+      ],
+    })
+
+    expect(result.readiness).not.toBeNull()
+    expect(result.readiness!.status).toBe('warn')
+    expect(result.readiness!.score).toBe(0.61)
+    expect(result.readiness!.decision_required_count).toBe(2)
+    expect(result.readiness!.pillars).toHaveLength(2)
+    expect(result.readiness!.pillars[1]!.blocking_reasons).toEqual(['1 keeper has no active goal link.'])
+    expect(result.attention_events).toHaveLength(1)
+    expect(result.attention_events![0]!.kind).toBe('continue_gate')
+    expect(result.attention_events![0]!.requires_decision).toBe(true)
+  })
+
   // ── focus ──
 
   it('returns null focus when required fields missing', () => {

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -8,9 +8,12 @@ import {
   normalizeShellMetaCognitionSummary,
 } from './store-normalizers'
 import type {
+  DashboardAttentionEvent,
   DashboardNamespaceTruthAttentionSummary,
   DashboardNamespaceTruthFocus,
   DashboardNamespaceTruthMetaCognitionDigest,
+  DashboardReadinessPillar,
+  DashboardReadinessSummary,
   DashboardNamespaceTruthRecommendationSummary,
   DashboardNamespaceTruthResponse,
   PendingConfirmSummary,
@@ -107,6 +110,69 @@ function normalizeFocus(raw: unknown): DashboardNamespaceTruthFocus | null {
   }
 }
 
+function normalizeReadinessPillar(raw: unknown): DashboardReadinessPillar | null {
+  if (!isRecord(raw)) return null
+  const key = asString(raw.key)
+  const label = asString(raw.label)
+  const status = asString(raw.status)
+  const summary = asString(raw.summary)
+  const score = asNumber(raw.score)
+  if (!key || !label || !status || !summary || score == null) return null
+  return {
+    key,
+    label,
+    status,
+    score,
+    summary,
+    blocking_reasons: asStringArray(raw.blocking_reasons),
+    metrics: isRecord(raw.metrics)
+      ? Object.fromEntries(
+          Object.entries(raw.metrics)
+            .map(([metricKey, value]) => {
+              const numeric = asNumber(value)
+              return numeric == null ? null : [metricKey, numeric]
+            })
+            .filter((entry): entry is [string, number] => entry !== null),
+        )
+      : {},
+  }
+}
+
+function normalizeReadiness(raw: unknown): DashboardReadinessSummary | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status)
+  const score = asNumber(raw.score)
+  if (!status || score == null) return null
+  return {
+    status,
+    score,
+    decision_required_count: asNumber(raw.decision_required_count) ?? 0,
+    blocking_count: asNumber(raw.blocking_count) ?? 0,
+    pillars: extractArray(raw.pillars)
+      .map(normalizeReadinessPillar)
+      .filter((pillar): pillar is DashboardReadinessPillar => pillar !== null),
+  }
+}
+
+function normalizeAttentionEvent(raw: unknown): DashboardAttentionEvent | null {
+  if (!isRecord(raw)) return null
+  const severity = asString(raw.severity)
+  const kind = asString(raw.kind)
+  const summary = asString(raw.summary)
+  if (!severity || !kind || !summary) return null
+  return {
+    severity,
+    kind,
+    summary,
+    requires_decision: asBoolean(raw.requires_decision) ?? false,
+    keeper_name: asString(raw.keeper_name) ?? null,
+    target_type: asString(raw.target_type) ?? null,
+    target_id: asString(raw.target_id) ?? null,
+    recommended_action: asString(raw.recommended_action) ?? null,
+    provenance: asString(raw.provenance) ?? null,
+  }
+}
+
 export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthResponse {
   const root = isRecord(raw) ? raw : {}
   const namespaceBlock = isRecord(root.root) ? root.root : {}
@@ -154,6 +220,10 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
       pending_confirm_summary: normalizePendingConfirmSummary(operatorBlock.pending_confirm_summary),
       provenance: asString(operatorBlock.provenance) ?? null,
     },
+    readiness: normalizeReadiness(root.readiness),
+    attention_events: extractArray(root.attention_events)
+      .map(normalizeAttentionEvent)
+      .filter((event): event is DashboardAttentionEvent => event !== null),
     focus: normalizeFocus(root.focus),
   }
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -543,6 +543,18 @@ export interface Keeper {
   runtime_blocker_summary?: string | null
   runtime_blocker_continue_gate?: boolean | null
   active_goal_ids?: string[]
+  goal?: string | null
+  short_goal?: string | null
+  mid_goal?: string | null
+  long_goal?: string | null
+  goal_horizons?: {
+    short?: string | null
+    mid?: string | null
+    long?: string | null
+  } | null
+  sandbox_profile?: 'local' | 'docker' | string | null
+  sandbox_last_error?: string | null
+  effective_sandbox_image?: string | null
   last_autonomous_action_at?: string | null
   autonomous_action_count?: number
   autonomous_turn_count?: number

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -150,6 +150,36 @@ export interface DashboardNamespaceTruthFocus {
   suggested_params?: Record<string, string>
 }
 
+export interface DashboardReadinessPillar {
+  key: string
+  label: string
+  status: 'ok' | 'warn' | 'bad' | string
+  score: number
+  summary: string
+  blocking_reasons: string[]
+  metrics?: Record<string, number>
+}
+
+export interface DashboardReadinessSummary {
+  status: 'ok' | 'warn' | 'bad' | string
+  score: number
+  decision_required_count: number
+  blocking_count: number
+  pillars: DashboardReadinessPillar[]
+}
+
+export interface DashboardAttentionEvent {
+  severity: 'info' | 'warn' | 'bad' | string
+  kind: string
+  summary: string
+  requires_decision: boolean
+  keeper_name?: string | null
+  target_type?: string | null
+  target_id?: string | null
+  recommended_action?: string | null
+  provenance?: string | null
+}
+
 export interface DashboardNamespaceTruthResponse {
   generated_at?: string
   root: {
@@ -179,6 +209,8 @@ export interface DashboardNamespaceTruthResponse {
     pending_confirm_summary?: PendingConfirmSummary | null
     provenance?: string | null
   }
+  readiness?: DashboardReadinessSummary | null
+  attention_events?: DashboardAttentionEvent[]
   focus?: DashboardNamespaceTruthFocus | null
 }
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -248,7 +248,7 @@ let running_keeper_count (config : Coord.config) : int =
        0
 
 let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.Safe.t =
-  let include_goals = false in
+  let include_goals = true in
   let history_fragment_filter_enabled =
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in
@@ -500,6 +500,18 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 Keeper_state_machine.conditions_to_json entry.conditions
             | None -> `Null
           in
+          let sandbox_last_error =
+            match registry_entry with
+            | Some entry -> entry.last_error
+            | None -> None
+          in
+          let effective_sandbox_image =
+            if m.sandbox_profile = Keeper_types.Docker
+               || (m.sandbox_profile = Keeper_types.Local
+                   && Env_config_keeper.DockerPlayground.enabled)
+            then Some (Env_config_keeper.KeeperSandbox.docker_image ())
+            else None
+          in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m
@@ -746,6 +758,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("created_at", `String m.created_at);
               ("updated_at", `String m.updated_at);
               ("trace_history_count", `Int trace_history_count);
+              ("active_goal_ids",
+                `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids));
               ("goal", if include_goals then `String m.goal else `Null);
               ("short_goal", if include_goals then `String m.short_goal else `Null);
               ("mid_goal", if include_goals then `String m.mid_goal else `Null);
@@ -760,7 +774,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 else
                   `Null );
               ( "active_goals_tree",
-                if include_goals && m.active_goal_ids <> [] then
+                if (not compact) && include_goals && m.active_goal_ids <> [] then
                   let all_goals = Goal_store.list_goals config () in
                   let linked = List.filter (fun (g : Goal_store.goal) ->
                     List.mem g.id m.active_goal_ids) all_goals in
@@ -784,6 +798,12 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("primary_model", `String primary_model);
               ("active_model", `String active_model);
               ("next_model_hint", Json_util.string_opt_to_json next_model_hint);
+              ("sandbox_profile",
+                `String (Keeper_types.sandbox_profile_to_string m.sandbox_profile));
+              ("sandbox_last_error",
+                Json_util.string_opt_to_json sandbox_last_error);
+              ("effective_sandbox_image",
+                Json_util.string_opt_to_json effective_sandbox_image);
               ("paused", `Bool m.paused);
               ("keepalive_running", `Bool keepalive_running);
               ("autoboot_enabled", `Bool m.autoboot_enabled);

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -365,6 +365,432 @@ let namespace_truth_command_summary_json command_summary_json =
       ("provenance", `String "truth");
     ]
 
+module String_set = Set.Make (String)
+
+let json_bool_field key json ~default =
+  match safe_member key json with
+  | `Bool value -> value
+  | _ -> default
+
+let keeper_live keeper =
+  json_bool_field "keepalive_running" keeper ~default:false
+
+let keeper_goal_horizon keeper key =
+  let goal_horizons = json_assoc_field "goal_horizons" keeper in
+  match json_string_field_opt key goal_horizons with
+  | Some _ as value -> value
+  | None -> json_string_field_opt (key ^ "_goal") keeper
+
+let keeper_has_goal keeper =
+  json_list_field "active_goal_ids" keeper <> []
+  || Option.is_some (json_string_field_opt "goal" keeper)
+  || Option.is_some (keeper_goal_horizon keeper "short")
+  || Option.is_some (keeper_goal_horizon keeper "mid")
+  || Option.is_some (keeper_goal_horizon keeper "long")
+
+let keeper_actor_names keeper =
+  [ json_string_field_opt "name" keeper; json_string_field_opt "agent_name" keeper ]
+  |> List.filter_map Fun.id
+
+let task_is_active task =
+  match json_string_field_opt "status" task with
+  | Some ("todo" | "claimed" | "in_progress" | "awaiting_verification") -> true
+  | _ -> false
+
+let readiness_score_of_status = function
+  | "bad" -> 40
+  | "warn" -> 72
+  | _ -> 100
+
+let summary_of_reasons ~ok_message reasons =
+  match reasons with
+  | [] -> ok_message
+  | _ -> String.concat "; " reasons
+
+let metrics_json entries =
+  `Assoc (List.map (fun (key, value) -> (key, `Int value)) entries)
+
+let readiness_pillar_json ~key ~label ~status ~ok_message ~reasons ~metrics =
+  let score = readiness_score_of_status status in
+  `Assoc
+    [
+      ("key", `String key);
+      ("label", `String label);
+      ("status", `String status);
+      ("score", `Int score);
+      ("summary", `String (summary_of_reasons ~ok_message reasons));
+      ("blocking_reasons", `List (List.map (fun reason -> `String reason) reasons));
+      ("metrics", metrics_json metrics);
+    ]
+
+let attention_event_json
+    ?keeper_name ?target_type ?target_id ?recommended_action
+    ?(requires_decision = false) ~severity ~kind ~summary ~provenance () =
+  `Assoc
+    [
+      ("severity", `String severity);
+      ("kind", `String kind);
+      ("summary", `String summary);
+      ("requires_decision", `Bool requires_decision);
+      ( "keeper_name",
+        match keeper_name with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "target_type",
+        match target_type with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "target_id",
+        match target_id with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "recommended_action",
+        match recommended_action with
+        | Some value -> `String value
+        | None -> `Null );
+      ("provenance", `String provenance);
+    ]
+
+let derive_readiness_and_attention ~execution_json ~execution_summary
+    ~operator_digest_json =
+  let keepers = json_list_field "keepers" execution_json in
+  let live_keepers = List.filter keeper_live keepers in
+  let tasks = json_list_field "tasks" execution_json |> List.filter task_is_active in
+  let pending_confirm_summary =
+    json_assoc_field "pending_confirm_summary" operator_digest_json
+  in
+  let attention_summary =
+    json_assoc_field "attention_summary" operator_digest_json
+  in
+  let pending_visible =
+    json_int_field "visible_count" pending_confirm_summary
+      ~default:(json_int_field "total_count" pending_confirm_summary ~default:0)
+  in
+  let sandbox_error_count =
+    count_where live_keepers (fun keeper ->
+      Option.is_some (json_string_field_opt "sandbox_last_error" keeper))
+  in
+  let docker_live_count =
+    count_where live_keepers (fun keeper ->
+      json_string_field_opt "sandbox_profile" keeper = Some "docker")
+  in
+  let local_live_count =
+    count_where live_keepers (fun keeper ->
+      json_string_field_opt "sandbox_profile" keeper = Some "local")
+  in
+  let unknown_sandbox_count =
+    count_where live_keepers (fun keeper ->
+      Option.is_none (json_string_field_opt "sandbox_profile" keeper))
+  in
+  let continue_gate_count =
+    count_where live_keepers (fun keeper ->
+      json_bool_field "runtime_blocker_continue_gate" keeper ~default:false)
+  in
+  let runtime_blocker_count =
+    count_where live_keepers (fun keeper ->
+      Option.is_some (json_string_field_opt "runtime_blocker_class" keeper))
+  in
+  let goalful_keeper_names =
+    List.fold_left
+      (fun acc keeper ->
+        if keeper_has_goal keeper then
+          keeper_actor_names keeper
+          |> List.fold_left (fun names name -> String_set.add name names) acc
+        else acc)
+      String_set.empty keepers
+  in
+  let goalful_keeper_count = String_set.cardinal goalful_keeper_names in
+  let goal_dark_live_count =
+    count_where live_keepers (fun keeper -> not (keeper_has_goal keeper))
+  in
+  let unassigned_active_tasks =
+    count_where tasks (fun task ->
+      Option.is_none (json_string_field_opt "assignee" task))
+  in
+  let assigned_goal_dark_tasks =
+    count_where tasks (fun task ->
+      match json_string_field_opt "assignee" task with
+      | Some assignee -> not (String_set.mem assignee goalful_keeper_names)
+      | None -> false)
+  in
+  let missing_audit_live_count =
+    count_where live_keepers (fun keeper ->
+      Option.is_none (json_string_field_opt "tool_audit_at" keeper))
+  in
+  let attention_bad_count =
+    json_int_field "bad_count" attention_summary ~default:0
+  in
+  let attention_warn_count =
+    json_int_field "warn_count" attention_summary ~default:0
+  in
+  let continuity_alerts =
+    json_int_field "continuity_alerts" execution_summary ~default:0
+  in
+  let worker_alerts =
+    json_int_field "worker_alerts" execution_summary ~default:0
+  in
+  let execution_safety_reasons =
+    List.filter_map Fun.id
+      [
+        (if pending_visible > 0 then
+           Some (Printf.sprintf "%d operator approvals are still pending" pending_visible)
+         else None);
+        (if sandbox_error_count > 0 then
+           Some (Printf.sprintf "%d live keepers report sandbox errors" sandbox_error_count)
+         else None);
+        (if local_live_count > 0 then
+           Some (Printf.sprintf "%d live keepers are still running in local sandbox" local_live_count)
+         else None);
+        (if unknown_sandbox_count > 0 then
+           Some (Printf.sprintf "%d live keepers are missing sandbox provenance" unknown_sandbox_count)
+         else None);
+      ]
+  in
+  let execution_safety_status =
+    if pending_visible > 0 then "bad"
+    else if sandbox_error_count > 0 || local_live_count > 0 || unknown_sandbox_count > 0
+    then "warn"
+    else "ok"
+  in
+  let autonomy_reliability_reasons =
+    List.filter_map Fun.id
+      [
+        (if continue_gate_count > 0 then
+           Some (Printf.sprintf "%d keepers are waiting at a continue gate" continue_gate_count)
+         else None);
+        (if runtime_blocker_count > 0 then
+           Some (Printf.sprintf "%d live keepers have runtime blockers" runtime_blocker_count)
+         else None);
+        (if continuity_alerts > 0 then
+           Some (Printf.sprintf "%d continuity alerts are active" continuity_alerts)
+         else None);
+        (if worker_alerts > 0 then
+           Some (Printf.sprintf "%d worker support alerts are active" worker_alerts)
+         else None);
+      ]
+  in
+  let autonomy_reliability_status =
+    if continue_gate_count > 0 || runtime_blocker_count > 0 then "bad"
+    else if continuity_alerts > 0 || worker_alerts > 0 then "warn"
+    else "ok"
+  in
+  let goal_coherence_reasons =
+    List.filter_map Fun.id
+      [
+        (if tasks <> [] && goalful_keeper_count = 0 then
+           Some "Active tasks exist, but no keeper exposes linked goals or goal horizons"
+         else None);
+        (if unassigned_active_tasks > 0 then
+           Some
+             (Printf.sprintf "%d active tasks are still unassigned" unassigned_active_tasks)
+         else None);
+        (if assigned_goal_dark_tasks > 0 then
+           Some
+             (Printf.sprintf "%d active tasks are assigned to keepers without visible goal context"
+                assigned_goal_dark_tasks)
+         else None);
+        (if goal_dark_live_count > 0 then
+           Some
+             (Printf.sprintf "%d live keepers are active without linked goal context"
+                goal_dark_live_count)
+         else None);
+      ]
+  in
+  let goal_coherence_status =
+    if (tasks <> [] && goalful_keeper_count = 0) || unassigned_active_tasks > 0
+    then "bad"
+    else if assigned_goal_dark_tasks > 0 || goal_dark_live_count > 0
+    then "warn"
+    else "ok"
+  in
+  let operational_clarity_reasons =
+    List.filter_map Fun.id
+      [
+        (if attention_bad_count > 0 then
+           Some (Printf.sprintf "%d high-severity operator attention items are active" attention_bad_count)
+         else None);
+        (if attention_warn_count > 0 then
+           Some (Printf.sprintf "%d warning-level operator attention items are active" attention_warn_count)
+         else None);
+        (if missing_audit_live_count > 0 then
+           Some
+             (Printf.sprintf "%d live keepers are missing tool-audit anchors in the execution snapshot"
+                missing_audit_live_count)
+         else None);
+      ]
+  in
+  let operational_clarity_status =
+    if attention_bad_count > 0 then "bad"
+    else if attention_warn_count > 0 || missing_audit_live_count > 0
+    then "warn"
+    else "ok"
+  in
+  let pillars =
+    [
+      readiness_pillar_json
+        ~key:"execution_safety"
+        ~label:"Execution Safety"
+        ~status:execution_safety_status
+        ~ok_message:"Approval and sandbox posture are visible for live keepers."
+        ~reasons:execution_safety_reasons
+        ~metrics:
+          [
+            ("live_keepers", List.length live_keepers);
+            ("docker_live", docker_live_count);
+            ("local_live", local_live_count);
+            ("pending_approvals", pending_visible);
+          ];
+      readiness_pillar_json
+        ~key:"autonomy_reliability"
+        ~label:"Autonomy Reliability"
+        ~status:autonomy_reliability_status
+        ~ok_message:"No live keepers are blocked by runtime or operator gates."
+        ~reasons:autonomy_reliability_reasons
+        ~metrics:
+          [
+            ("runtime_blockers", runtime_blocker_count);
+            ("continue_gates", continue_gate_count);
+            ("continuity_alerts", continuity_alerts);
+            ("worker_alerts", worker_alerts);
+          ];
+      readiness_pillar_json
+        ~key:"goal_coherence"
+        ~label:"Goal Coherence"
+        ~status:goal_coherence_status
+        ~ok_message:"Active work is attached to keepers with visible goal context."
+        ~reasons:goal_coherence_reasons
+        ~metrics:
+          [
+            ("active_tasks", List.length tasks);
+            ("goalful_keepers", goalful_keeper_count);
+            ("unassigned_tasks", unassigned_active_tasks);
+            ("goal_dark_keepers", goal_dark_live_count);
+          ];
+      readiness_pillar_json
+        ~key:"operational_clarity"
+        ~label:"Operational Clarity"
+        ~status:operational_clarity_status
+        ~ok_message:"The control room has recent audit anchors and no open attention backlog."
+        ~reasons:operational_clarity_reasons
+        ~metrics:
+          [
+            ("attention_bad", attention_bad_count);
+            ("attention_warn", attention_warn_count);
+            ("missing_tool_audit", missing_audit_live_count);
+          ];
+    ]
+  in
+  let overall_status =
+    if List.exists (fun pillar ->
+      json_string_field_opt "status" pillar = Some "bad") pillars
+    then "bad"
+    else if List.exists (fun pillar ->
+      json_string_field_opt "status" pillar = Some "warn") pillars
+    then "warn"
+    else "ok"
+  in
+  let overall_score =
+    match pillars with
+    | [] -> 100
+    | _ ->
+        List.fold_left
+          (fun acc pillar -> acc + json_int_field "score" pillar ~default:100)
+          0 pillars
+        / List.length pillars
+  in
+  let blocking_count =
+    pending_visible + runtime_blocker_count + unassigned_active_tasks
+    + missing_audit_live_count
+  in
+  let base_events =
+    let events = ref [] in
+    if pending_visible > 0 then
+      events :=
+        attention_event_json ~severity:"bad" ~kind:"pending_confirm"
+          ~summary:
+            (Printf.sprintf "%d operator actions still require approval" pending_visible)
+          ~recommended_action:"Review approvals in Operations"
+          ~requires_decision:true ~provenance:"derived" ()
+        :: !events;
+    (match json_record_field "top_item" attention_summary with
+     | Some item ->
+         let summary =
+           Option.value ~default:"Operator attention item requires follow-up."
+             (json_string_field_opt "summary" item)
+         in
+         let severity =
+           Option.value ~default:"warn" (json_string_field_opt "severity" item)
+         in
+         events :=
+           attention_event_json ~severity ~kind:"operator_attention" ~summary
+             ?target_type:(json_string_field_opt "target_type" item)
+             ?target_id:(json_string_field_opt "target_id" item)
+             ~recommended_action:"Inspect the top operator attention item"
+             ~provenance:"operator" ()
+           :: !events
+     | None -> ());
+    List.rev !events
+  in
+  let keeper_events =
+    live_keepers
+    |> List.filter_map (fun keeper ->
+         let keeper_name =
+           Option.value ~default:"keeper"
+             (json_string_field_opt "name" keeper)
+         in
+         if json_bool_field "runtime_blocker_continue_gate" keeper ~default:false then
+           Some
+             (attention_event_json ~severity:"bad" ~kind:"continue_gate"
+                ~summary:
+                  (Printf.sprintf "%s is waiting for operator approval to continue"
+                     keeper_name)
+                ~keeper_name ~target_type:"keeper" ~target_id:keeper_name
+                ~recommended_action:"Inspect the keeper and confirm or resume it"
+                ~requires_decision:true ~provenance:"execution" ())
+         else
+           match json_string_field_opt "runtime_blocker_class" keeper with
+           | Some blocker ->
+               let severity =
+                 match blocker with
+                 | "cascade_exhausted" | "completion_contract_violation" -> "bad"
+                 | _ -> "warn"
+               in
+               Some
+                 (attention_event_json ~severity ~kind:"runtime_blocker"
+                    ~summary:
+                      (Printf.sprintf "%s is blocked by %s" keeper_name blocker)
+                    ~keeper_name ~target_type:"keeper" ~target_id:keeper_name
+                    ~recommended_action:"Open the keeper row and inspect the blocker"
+                    ~provenance:"execution" ())
+           | None when not (keeper_has_goal keeper) ->
+               Some
+                 (attention_event_json ~severity:"warn" ~kind:"goal_unscoped"
+                    ~summary:
+                      (Printf.sprintf "%s is active without linked goal context" keeper_name)
+                    ~keeper_name ~target_type:"keeper" ~target_id:keeper_name
+                    ~recommended_action:"Add a short/mid/long goal or link active goals"
+                    ~provenance:"execution" ())
+           | None when Option.is_none (json_string_field_opt "tool_audit_at" keeper) ->
+               Some
+                 (attention_event_json ~severity:"warn" ~kind:"history_gap"
+                    ~summary:
+                      (Printf.sprintf "%s is missing a recent tool-audit anchor" keeper_name)
+                    ~keeper_name ~target_type:"keeper" ~target_id:keeper_name
+                    ~recommended_action:"Inspect recent tool use or refresh the keeper snapshot"
+                    ~provenance:"execution" ())
+           | None -> None)
+    |> take_n 8
+  in
+  ( `Assoc
+      [
+        ("status", `String overall_status);
+        ("score", `Int overall_score);
+        ("decision_required_count", `Int (pending_visible + continue_gate_count));
+        ("blocking_count", `Int blocking_count);
+        ("pillars", `List pillars);
+      ],
+    `List (take_n 10 (base_events @ keeper_events)) )
+
 let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shell_json
     ~execution_json ~command_summary_json =
   let meta_cognition_summary = json_assoc_field "meta_cognition" shell_json in
@@ -386,6 +812,10 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
   in
   let top_queue = execution_top_queue execution_json in
   let execution_summary = execution_summary_json execution_json in
+  let readiness_json, attention_events_json =
+    derive_readiness_and_attention ~execution_json ~execution_summary
+      ~operator_digest_json
+  in
   let command_summary = namespace_truth_command_summary_json command_summary_json in
   let shell_counts = json_assoc_field "counts" shell_json in
   let configured_keepers =
@@ -445,5 +875,7 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
               json_assoc_field "pending_confirm_summary" operator_digest_json );
             ("provenance", `String "derived");
           ] );
+      ("readiness", readiness_json);
+      ("attention_events", attention_events_json);
       ("focus", focus_json);
     ]

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -168,6 +168,13 @@ let test_dashboard_namespace_truth_empty_room () =
         check int "namespace counts expose total runtimes"
           0
           (json |> member "root" |> member "counts" |> member "total_runtimes" |> to_int);
+        check bool "readiness status exposed"
+          true
+          (String.length (json |> member "readiness" |> member "status" |> to_string) > 0);
+        check int "readiness exposes four pillars"
+          4
+          (json |> member "readiness" |> member "pillars" |> to_list |> List.length);
+        ignore (json |> member "attention_events" |> to_list);
         check string "focus source"
           "namespace"
           (json |> member "focus" |> member "source" |> to_string);


### PR DESCRIPTION
## Summary
- add readiness and attention SSOT to namespace truth
- expose goal and sandbox truth in compact keeper summaries
- render a fleet control room in monitoring > fleet-health with keeper goal/sandbox/decision badges

## Why
- operators need a single surface that shows whether keepers are safe, goal-linked, sandboxed, and waiting on decisions
- the data existed in multiple places but was not visible as a single operational read-model

## Validation
- _build/default/test/test_dashboard_namespace_truth.exe
- ./node_modules/.bin/vitest run src/components/fleet-telemetry-panel.test.ts src/namespace-truth-normalizers.test.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-trend-store.test.ts --no-file-parallelism --maxWorkers=1
- ./node_modules/.bin/tsc --noEmit
