### PR TITLE
[codex] align keeper cascade routing contract

### DIFF
--- a/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
+++ b/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
@@ -30,7 +30,7 @@ code_refs:
 - `docs/tla-audit/decision-fsm-gap-2026-04-13.md`
 - `docs/design/oas-masc-state-boundary.md` — MASC/OAS SSOT
 - `specs/keeper-state-machine/KeeperStateMachine.tla` — 11-state spec
-- `specs/keeper-state-machine/KeeperCoreTriad.tla` — State × Decision × Cascade (5-phase 투사)
+- `specs/keeper-state-machine/KeeperCoreTriad.tla` — State × Decision × Cascade (7-phase 투사)
 - `specs/state-product/StateProduct.tla` — Keeper × Turn × Validation 직교 합성
 - `specs/keeper-state-machine/KeeperContextLifecycle.tla` — Context + Compaction + Checkpoint
 - `specs/keeper-state-machine/KeeperCascadeLifecycle.tla`

--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -19,9 +19,12 @@ let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase
   | Failing ->
       { effective_cascade = Keeper_config.local_recovery_cascade_name;
         reason = "failing phase: cheap local recovery" }
-  | Compacting | HandingOff | Overflowed ->
+  | Compacting | HandingOff ->
       { effective_cascade = Keeper_config.local_only_cascade_name;
         reason = "buffer operation: local model sufficient" }
+  | Overflowed ->
+      { effective_cascade = base_cascade;
+        reason = "overflowed phase: turn blocked upstream pending compaction" }
   | Draining | Paused ->
       { effective_cascade = base_cascade;
         reason = "winding down: complete in-progress work" }

--- a/lib/keeper/keeper_cascade_routing.mli
+++ b/lib/keeper/keeper_cascade_routing.mli
@@ -20,10 +20,14 @@ type routing_decision = {
     (typically ["keeper_unified"]).
 
     Routing rules (TLA+ mirrored):
-    - Running      -> [base_cascade]    (healthy, full capability)
-    - Failing      -> ["local_recovery"] (cheap local model for recovery)
-    - Compacting   -> ["local_only"]     (local model sufficient)
-    - Other phases -> [base_cascade]     (default, turn may be blocked upstream) *)
+    - [Running], [Draining], [Paused] -> [base_cascade]
+    - [Failing] -> ["local_recovery"]
+    - [Compacting], [HandingOff] -> ["local_only"]
+    - [Overflowed], terminal/non-executable phases -> [base_cascade]
+
+    This helper is total: even phases that are blocked upstream still return
+    a routing decision so dashboards/tests can inspect the same contract.
+    The keeper cycle gate remains the owner of "can this phase execute a turn?" *)
 val select_cascade :
   base_cascade:string ->
   phase:Keeper_state_machine.phase ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -755,7 +755,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
     ?(semaphore_wait_ms = 0)
     ?shared_context
     () : (keeper_meta, Oas.Error.sdk_error) result =
-  (* 0. Phase gate + state-aware cascade routing *)
+  (* 0. Phase gate + state-aware cascade routing.
+     The gate owns turn executability; select_cascade remains a total helper
+     so dashboards/tests can inspect the same routing contract for blocked
+     phases like Overflowed. *)
   let registry_base_path = config.base_path in
   let previous_social_state = Social.previous_state_of_meta meta in
   match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
@@ -765,7 +768,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         meta.name (Keeper_state_machine.phase_to_string phase);
       Ok meta
   | phase_opt ->
-      (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade) *)
+      (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
+         At this point [phase] is executable; blocked phases returned above. *)
       let effective_cascade_name =
         let phase = match phase_opt with
           | Some p -> p

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -3,7 +3,7 @@
 \*
 \* Purpose
 \*   The repository already has three partial composition specs:
-\*     - KeeperCoreTriad.tla          State x Decision x Cascade (5-phase projection)
+\*     - KeeperCoreTriad.tla          State x Decision x Cascade (7-phase projection)
 \*     - StateProduct.tla             Keeper x Turn x Validation
 \*     - KeeperContextLifecycle.tla   Context + Compaction + Checkpoint + Recovery
 \*   None of them check joint invariants that span all four domain FSMs

--- a/specs/keeper-state-machine/KeeperCoreTriad-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperCoreTriad-buggy.cfg
@@ -5,10 +5,10 @@
 \* but keeper_unified sends 65536 max_tokens.
 \*
 \* Bug model:
-\*   - BugSelectCascade: ignores phase, always uses keeper_unified
+\*   - BugSelectCascade: ignores phase, always uses the configured base cascade
 \*   - BugAttemptProvider: skips capability gate clamping
 \*   - Provider 1 ceiling = 40960 (Groq-like)
-\*   - keeper_unified_max_tokens = 65536 (the pre-fix value)
+\*   - base_cascade_max_tokens = 65536 (the pre-fix value)
 \*
 \* CapabilityGateHolds invariant MUST be violated.
 
@@ -16,7 +16,8 @@ CONSTANTS
     MaxRetries = 1
     Provider1Ceiling = 40960
     Provider2Ceiling = 131072
-    KeeperUnifiedTokens = 65536
+    BaseCascade = "keeper_unified"
+    BaseCascadeTokens = 65536
     LocalRecoveryTokens = 8192
     LocalOnlyTokens = 32768
 

--- a/specs/keeper-state-machine/KeeperCoreTriad.cfg
+++ b/specs/keeper-state-machine/KeeperCoreTriad.cfg
@@ -5,8 +5,8 @@
 \*   Provider 1 = GLM-5.1 (ceiling 65536)
 \*   Provider 2 = Ollama local (ceiling 131072)
 \*
-\* Cascade profiles:
-\*   keeper_unified = 32768 (current production value)
+\* Base cascade profile:
+\*   keeper_unified = 32768 (current production value for this cfg)
 \*   local_recovery = 8192
 \*   local_only     = 32768
 
@@ -14,7 +14,8 @@ CONSTANTS
     MaxRetries = 2
     Provider1Ceiling = 65536
     Provider2Ceiling = 131072
-    KeeperUnifiedTokens = 32768
+    BaseCascade = "keeper_unified"
+    BaseCascadeTokens = 32768
     LocalRecoveryTokens = 8192
     LocalOnlyTokens = 32768
 

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -24,15 +24,15 @@
 \*
 \* OCaml mapping:
 \*   phase              <-> Keeper_state_machine.phase (12-phase OCaml type
-\*                          projected to a 6-symbol triad alphabet; see the
+\*                          projected to a 7-symbol triad alphabet; see the
 \*                          canonical mapping in the TypeOK preamble below)
 \*   effective_cascade  <-> Keeper_cascade_routing.select_cascade result
 \*   provider_ceiling   <-> Oas_model_resolve.resolve_max_cascade_context
 \*   requested_max_tokens <-> Cascade_inference.resolve_max_tokens
 \*
-\* (The canonical 12->6 phase mapping lives next to TypeOK on line ~89.
+\* (The canonical 12->7 phase mapping lives next to TypeOK on line ~89.
 \*  An earlier version of this preamble carried a separate "Phase
-\*  simplification (12 -> 6)" mapping that classified HandingOff / Paused /
+\*  simplification (12 -> 7)" mapping that classified HandingOff / Paused /
 \*  Restarting differently from the canonical one.  Removed in #8970 to
 \*  avoid the self-contradiction that TLC could not surface.)
 
@@ -42,11 +42,13 @@ CONSTANTS
     MaxRetries,          \* Max cross-provider retries (e.g. 2)
     Provider1Ceiling,    \* max_tokens ceiling for provider 1
     Provider2Ceiling,    \* max_tokens ceiling for provider 2
-    KeeperUnifiedTokens, \* max_tokens for keeper_unified profile
+    BaseCascade,         \* keeper-configured base cascade name
+    BaseCascadeTokens,   \* max_tokens for the base cascade profile
     LocalRecoveryTokens, \* max_tokens for local_recovery profile
     LocalOnlyTokens      \* max_tokens for local_only profile
 
-ASSUME MaxRetries >= 0
+ASSUME /\ MaxRetries >= 0
+       /\ BaseCascade \notin {"local_recovery", "local_only", "none"}
 
 NumProviders == 2
 Providers == 1..NumProviders
@@ -57,10 +59,11 @@ ProviderCeiling(p) ==
 
 \* ── Cascade profile definitions ─────────────────────────
 \* Maps cascade name to its requested max_tokens.
-\* Mirrors config/cascade.json profile -> max_tokens.
+\* Mirrors config/cascade.json profile -> max_tokens, with BaseCascade
+\* standing in for the keeper's configured profile (typically keeper_unified).
 
 MaxTokensFor(cascade) ==
-    CASE cascade = "keeper_unified" -> KeeperUnifiedTokens
+    CASE cascade = BaseCascade      -> BaseCascadeTokens
       [] cascade = "local_recovery" -> LocalRecoveryTokens
       [] cascade = "local_only"     -> LocalOnlyTokens
       [] OTHER                      -> 0
@@ -68,9 +71,9 @@ MaxTokensFor(cascade) ==
 \* ── Variables ────────────────────────────────────────────
 
 VARIABLES
-    phase,               \* "Running" | "Failing" | "Overflowed" | "Compacting" | "Draining" | "Terminal"
+    phase,               \* "Running" | "Failing" | "Overflowed" | "Compacting" | "HandingOff" | "Draining" | "Terminal"
     turn_status,         \* "idle" | "selecting" | "executing" | "retrying" | "done"
-    effective_cascade,   \* "keeper_unified" | "local_recovery" | "local_only" | "none"
+    effective_cascade,   \* BaseCascade | "local_recovery" | "local_only" | "none"
     provider_idx,        \* 0..NumProviders (0 = exhausted or not started)
     requested_max_tokens,\* Nat (what the selected cascade demands)
     provider_result,     \* "pending" | "ok" | "error" | "capability_exceeded"
@@ -86,7 +89,7 @@ vars == <<phase, turn_status, effective_cascade, provider_idx,
 
 \* Issue #8642/#8701 family: explicit OCaml ↔ TLA+ mapping. SSOT for
 \* OCaml side is lib/keeper/keeper_state_machine.ml (12 phases). This
-\* spec collapses the 12 phases into a 6-symbol "core triad" alphabet
+\* spec collapses the 12 phases into a 7-symbol "core triad" alphabet
 \* because the triad invariants only depend on running/failure/
 \* compaction signals, not on the full keeper lifecycle. Mapping:
 \*
@@ -94,15 +97,15 @@ vars == <<phase, turn_status, effective_cascade, provider_idx,
 \*   "Failing"     ↔ Failing
 \*   "Overflowed"  ↔ Overflowed
 \*   "Compacting"  ↔ Compacting
+\*   "HandingOff"  ↔ HandingOff
 \*   "Draining"    ↔ Draining
-\*   "Terminal"    ↔ Stopped | Dead | Crashed | Offline   (collapsed)
+\*   "Terminal"    ↔ Offline | Paused | Stopped | Crashed | Restarting | Dead
 \*
 \* Unmodeled here (covered in companion specs):
-\*   HandingOff, Paused, Restarting   (see KeeperReconcileLiveness.tla
-\*   and KeeperGenerationLineage.tla).
-Phases == {"Running", "Failing", "Overflowed", "Compacting", "Draining", "Terminal"}
+\*   none
+Phases == {"Running", "Failing", "Overflowed", "Compacting", "HandingOff", "Draining", "Terminal"}
 TurnStatuses == {"idle", "selecting", "executing", "retrying", "done"}
-Cascades == {"keeper_unified", "local_recovery", "local_only", "none"}
+Cascades == {BaseCascade, "local_recovery", "local_only", "none"}
 ProviderResults == {"pending", "ok", "error", "capability_exceeded"}
 TurnOutcomes == {"none", "success", "error", "partial_commit"}
 
@@ -159,8 +162,16 @@ BecomeCompacting ==
                    requested_max_tokens, provider_result, has_side_effect,
                    retry_count, turn_outcome>>
 
+BecomeHandingOff ==
+    /\ phase = "Running"
+    /\ turn_status \in {"idle", "done"}
+    /\ phase' = "HandingOff"
+    /\ UNCHANGED <<turn_status, effective_cascade, provider_idx,
+                   requested_max_tokens, provider_result, has_side_effect,
+                   retry_count, turn_outcome>>
+
 BecomeDraining ==
-    /\ phase \in {"Running", "Failing", "Compacting"}
+    /\ phase \in {"Running", "Failing", "Compacting", "HandingOff"}
     /\ turn_status \in {"idle", "done"}
     /\ phase' = "Draining"
     /\ UNCHANGED <<turn_status, effective_cascade, provider_idx,
@@ -209,8 +220,8 @@ SelectCascade ==
     /\ turn_status' = "selecting"
     /\ effective_cascade' =
         IF phase = "Failing"    THEN "local_recovery"
-        ELSE IF phase = "Compacting" THEN "local_only"
-        ELSE "keeper_unified"
+        ELSE IF phase \in {"Compacting", "HandingOff"} THEN "local_only"
+        ELSE BaseCascade
     /\ requested_max_tokens' = MaxTokensFor(effective_cascade')
     /\ provider_idx' = 1
     /\ provider_result' = "pending"
@@ -328,6 +339,7 @@ Next ==
     \* Phase transitions (external events; BecomeRunning via TurnComplete)
     \/ BecomeFailing
     \/ BecomeCompacting
+    \/ BecomeHandingOff
     \/ BecomeOverflowed
     \/ OverflowedBecomeCompacting
     \/ BecomeDraining
@@ -359,6 +371,11 @@ FailingUsesRecovery ==
      /\ effective_cascade /= "none") =>
         effective_cascade = "local_recovery"
 
+BufferOpsUseLocalOnly ==
+    (phase \in {"Compacting", "HandingOff"} /\ turn_status = "selecting"
+     /\ effective_cascade /= "none") =>
+        effective_cascade = "local_only"
+
 \* S3: Active provider attempt respects ceiling
 \* After clamping, requested_max_tokens <= provider ceiling
 CapabilityGateHolds ==
@@ -380,6 +397,7 @@ SafetyInvariant ==
     /\ TypeOK
     /\ NoTerminalCascade
     /\ FailingUsesRecovery
+    /\ BufferOpsUseLocalOnly
     /\ CapabilityGateHolds
     /\ SideEffectContainment
     /\ PhaseDecisionConsistency
@@ -410,11 +428,11 @@ CapabilityNeverDeadlocks ==
 
 BugSelectCascade ==
     /\ turn_status = "idle"
-    /\ phase /= "Terminal"
+    /\ phase \notin {"Terminal", "Overflowed"}
     /\ turn_status' = "selecting"
-    \* BUG: always use keeper_unified regardless of phase
-    /\ effective_cascade' = "keeper_unified"
-    /\ requested_max_tokens' = KeeperUnifiedTokens
+    \* BUG: always use the configured base cascade regardless of phase
+    /\ effective_cascade' = BaseCascade
+    /\ requested_max_tokens' = BaseCascadeTokens
     /\ provider_idx' = 1
     /\ provider_result' = "pending"
     /\ has_side_effect' = FALSE

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -1,9 +1,10 @@
 (** test_keeper_cascade_routing — State-aware cascade profile selection.
 
     Verifies TLA+ KeeperCoreTriad safety invariants in OCaml:
-    - S1: Terminal phases never select a cascade (blocked upstream)
+    - S1: Blocked/non-executable phases still map to base_cascade in the helper;
+          actual turn blocking happens upstream in keeper_unified_turn
     - S2: Failing phase selects local_recovery
-    - S3: Compacting/HandingOff selects local_only
+    - S3: Compacting/HandingOff select local_only
     - Running selects base_cascade unchanged *)
 
 open Alcotest
@@ -40,6 +41,10 @@ let test_handing_off_uses_local_only () =
   let r = select SM.HandingOff in
   check string "HandingOff -> local_only"
     Masc_mcp.Keeper_config.local_only_cascade_name r.effective_cascade
+
+let test_overflowed_uses_base () =
+  let r = select SM.Overflowed in
+  check string "Overflowed -> base" base r.effective_cascade
 
 let test_draining_uses_base () =
   let r = select SM.Draining in
@@ -100,6 +105,7 @@ let () =
       test_case "Failing uses local_recovery" `Quick test_failing_uses_local_recovery;
       test_case "Compacting uses local_only"  `Quick test_compacting_uses_local_only;
       test_case "HandingOff uses local_only"  `Quick test_handing_off_uses_local_only;
+      test_case "Overflowed uses base"    `Quick test_overflowed_uses_base;
       test_case "Draining uses base"      `Quick test_draining_uses_base;
       test_case "Paused uses base"        `Quick test_paused_uses_base;
       test_case "Offline uses base"       `Quick test_offline_uses_base;


### PR DESCRIPTION
## Summary

- align `keeper_cascade_routing` with runtime semantics so `Overflowed` resolves to the base cascade while `Compacting` and `HandingOff` remain `local_only`
- make the routing helper explicitly total and clarify that `keeper_unified_turn` owns the executable-phase gate
- sync `KeeperCoreTriad` TLA+, cfg constants, and nearby docs/tests with the same routing contract

## Why

The repo had contract drift across OCaml, tests, and TLA+: the runtime helper treated `Overflowed` as `local_only`, the main keeper cycle blocked `Overflowed` upstream, and the spec hard-coded `keeper_unified` instead of modeling a configurable base cascade.

## Impact

- dashboards/tests now inspect the same total routing contract the runtime documents
- `KeeperCoreTriad` models `HandingOff -> local_only` and uses `BaseCascade` instead of a hard-coded default profile
- the routing regression test now locks `Overflowed -> base` explicitly

## Root Cause

The routing rule table was duplicated in interface comments, implementation, tests, and TLA+ without a single maintained source, so `Overflowed` and `HandingOff` semantics drifted independently.

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-routing-contract-align _build/default/lib/masc_mcp.cmxa`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-routing-contract-align _build/default/test/test_keeper_cascade_routing.exe`
- `./_build/default/test/test_keeper_cascade_routing.exe`
- `make -C specs check-keeper`
