### PR TITLE
feat(keeper): add runtime trust snapshot

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -722,6 +722,10 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                     ("stress_recent", stress);
                   ]
               in
+              let runtime_trust =
+                Keeper_runtime_trust_snapshot.snapshot_json
+                  ~config ~meta:m
+              in
               let detail_fields =
                 if compact then []
                 else [
@@ -804,6 +808,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 Json_util.string_opt_to_json sandbox_last_error);
               ("effective_sandbox_image",
                 Json_util.string_opt_to_json effective_sandbox_image);
+              ("runtime_trust", runtime_trust);
               ("paused", `Bool m.paused);
               ("keepalive_running", `Bool keepalive_running);
               ("autoboot_enabled", `Bool m.autoboot_enabled);

--- a/lib/dune
+++ b/lib/dune
@@ -493,6 +493,8 @@
    keeper_turn_telemetry
    keeper_wake_telemetry
    keeper_approval_queue
+   keeper_runtime_contract
+   keeper_runtime_trust_snapshot
    keeper_agent_run
    keeper_world_observation
    keeper_decision_audit

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -173,7 +173,7 @@ let install ~config ~governance_level =
 (* ── OAS Approval Pipeline bridge (#5902) ─────────────────── *)
 
 let to_oas_approval_callback
-    ~governance_level ~keeper_name : Oas.Hooks.approval_callback =
+    ~governance_level ~keeper_name ?meta () : Oas.Hooks.approval_callback =
   let queue_risk_level = function
     | Low -> Keeper_approval_queue.Low
     | Medium -> Keeper_approval_queue.Medium
@@ -213,10 +213,39 @@ let to_oas_approval_callback
         (risk_level_to_string base_risk)
         (risk_level_to_string risk);
     if needs_approval then
+      let turn_id =
+        Option.map
+          (fun (meta : Keeper_types.keeper_meta) ->
+            meta.runtime.usage.total_turns + 1)
+          meta
+      in
+      let task_id =
+        Option.bind meta (fun keeper_meta ->
+          Keeper_runtime_contract.current_task_id_opt keeper_meta)
+      in
+      let goal_id =
+        Option.bind meta (fun keeper_meta ->
+          Keeper_runtime_contract.primary_goal_id_opt keeper_meta)
+      in
+      let goal_ids =
+        Option.map
+          (fun (keeper_meta : Keeper_types.keeper_meta) ->
+            keeper_meta.active_goal_ids)
+          meta
+      in
+      let runtime_contract =
+        Option.map Keeper_runtime_contract.runtime_contract_json meta
+      in
       Keeper_approval_queue.submit_and_await
         ~keeper_name
         ~tool_name
         ~input
+        ?turn_id
+        ?task_id
+        ?goal_id
+        ?goal_ids
+        ?runtime_contract
         ~risk_level:(queue_risk_level risk)
+        ()
     else
       Oas.Hooks.Approve

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -108,6 +108,8 @@ val combinatorial_risk_escalation :
 val to_oas_approval_callback :
   governance_level:string ->
   keeper_name:string ->
+  ?meta:Keeper_types.keeper_meta ->
+  unit ->
   Oas.Hooks.approval_callback
 (** Build an OAS approval callback with genuine HITL fiber suspension.
 
@@ -122,4 +124,3 @@ val to_oas_approval_callback :
     Tools below the threshold are auto-approved.
 
     @since 2.262.0 (#5902, #5907) *)
-

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1903,6 +1903,19 @@ let run_turn
                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                 ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                 ~turn
+                ~keeper_turn_id:turn
+                ?task_id:(Option.map Keeper_id.Task_id.to_string meta.current_task_id)
+                ~goal_ids:meta.active_goal_ids
+                ~execution_scope:
+                  (Keeper_execution_scope.to_string meta.execution_scope)
+                ~sandbox_profile:
+                  (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
+                ~network_mode:
+                  (Keeper_types.network_mode_to_string meta.network_mode)
+                ~shared_memory_scope:
+                  (Keeper_types.shared_memory_scope_to_string
+                     meta.shared_memory_scope)
+                ?approval_mode:approval_mode_effective
                 ();
               (* Tool disclosure telemetry: emitted after all allow-list rewrites
            (last-turn intersect, max_tools cap) so that
@@ -2166,7 +2179,9 @@ let run_turn
            ?slot_id:(Keeper_config.keeper_slot_id meta.name)
            ~approval:(Governance_pipeline.to_oas_approval_callback
                         ~governance_level:(Env_config_core.governance_level ())
-                        ~keeper_name:meta.name)
+                        ~keeper_name:meta.name
+                        ~meta
+                        ())
            ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
            (* exit_condition removed with mutation_boundary — OAS runs to
               natural completion (max_turns or model end_turn). *)

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -26,6 +26,11 @@ type pending_approval = {
   input : Yojson.Safe.t;
   risk_level : risk_level;
   requested_at : float;
+  turn_id : int option;
+  task_id : string option;
+  goal_id : string option;
+  goal_ids : string list;
+  runtime_contract : Yojson.Safe.t option;
   resolver : Oas.Hooks.approval_decision Eio.Promise.u option;
   on_resolution : (Oas.Hooks.approval_decision -> unit) option;
 }
@@ -74,19 +79,31 @@ let get_audit_store () =
        None)
 
 let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
-    ~risk_level ?(decision="") () =
+    ~risk_level ?turn_id ?task_id ?goal_id ?(goal_ids = [])
+    ?runtime_contract ?(decision="") () =
   match get_audit_store () with
   | None -> ()
   | Some store ->
-    let json = `Assoc [
-      ("ts", `Float (Unix.gettimeofday ()));
-      ("event", `String event_type);
-      ("id", `String id);
-      ("keeper", `String keeper_name);
-      ("tool", `String tool_name);
-      ("risk", `String (risk_level_to_string risk_level));
-      ("decision", `String decision);
-    ] in
+    let json =
+      `Assoc
+        ([
+           ("ts", `Float (Unix.gettimeofday ()));
+           ("event", `String event_type);
+           ("id", `String id);
+           ("keeper", `String keeper_name);
+           ("tool", `String tool_name);
+           ("risk", `String (risk_level_to_string risk_level));
+           ("decision", `String decision);
+           ("turn_id", Json_util.int_opt_to_json turn_id);
+           ("task_id", Json_util.string_opt_to_json task_id);
+           ("goal_id", Json_util.string_opt_to_json goal_id);
+           ("goal_ids", `List (List.map (fun goal -> `String goal) goal_ids));
+         ]
+         @
+         match runtime_contract with
+         | Some json -> [("runtime_contract", json)]
+         | None -> [])
+    in
     Safe_ops.protect ~default:() (fun () ->
       Dated_jsonl.append store json)
 
@@ -108,7 +125,8 @@ let input_preview_of_json (json : Yojson.Safe.t) =
   Observability_redact.redact_preview ~max_len:200 raw
 
 let create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
-    ~resolver ~on_resolution =
+    ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
+    ~resolver ~on_resolution () =
   {
     id;
     keeper_name;
@@ -116,6 +134,11 @@ let create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
     input;
     risk_level;
     requested_at = Unix.gettimeofday ();
+    turn_id;
+    task_id;
+    goal_id;
+    goal_ids;
+    runtime_contract;
     resolver;
     on_resolution;
   }
@@ -132,6 +155,14 @@ let broadcast_pending entry =
             ("risk_level", `String (risk_level_to_string entry.risk_level));
             ("requested_at", `Float entry.requested_at);
             ("input_preview", `String (input_preview_of_json entry.input));
+            ("turn_id", Json_util.int_opt_to_json entry.turn_id);
+            ("task_id", Json_util.string_opt_to_json entry.task_id);
+            ("goal_id", Json_util.string_opt_to_json entry.goal_id);
+            ("goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids));
+            ( "runtime_contract",
+              match entry.runtime_contract with
+              | Some json -> json
+              | None -> `Null );
           ]);
        ])
   with
@@ -145,7 +176,9 @@ let record_pending entry =
     (risk_level_to_string entry.risk_level);
   audit_approval_event ~event_type:"pending" ~id:entry.id
     ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
-    ~risk_level:entry.risk_level ();
+    ~risk_level:entry.risk_level ?turn_id:entry.turn_id ?task_id:entry.task_id
+    ?goal_id:entry.goal_id ~goal_ids:entry.goal_ids
+    ?runtime_contract:entry.runtime_contract ();
   broadcast_pending entry
 
 let resolve_entry (entry : pending_approval) (decision : decision) =
@@ -159,7 +192,9 @@ let resolve_entry (entry : pending_approval) (decision : decision) =
     entry.id entry.keeper_name entry.tool_name decision_str;
   audit_approval_event ~event_type:"resolved" ~id:entry.id
     ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
-    ~risk_level:entry.risk_level ~decision:decision_str ();
+    ~risk_level:entry.risk_level ?turn_id:entry.turn_id ?task_id:entry.task_id
+    ?goal_id:entry.goal_id ~goal_ids:entry.goal_ids
+    ?runtime_contract:entry.runtime_contract ~decision:decision_str ();
   (match entry.resolver with
    | Some resolver -> Eio.Promise.resolve resolver decision
    | None -> ());
@@ -227,12 +262,15 @@ let sort_entries_by_requested_at entries =
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside agent fiber). *)
 let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
+    ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
+    ()
   : Oas.Hooks.approval_decision =
   let id = generate_id () in
   let promise, resolver = Eio.Promise.create () in
   let entry =
     create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
-      ~resolver:(Some resolver) ~on_resolution:None
+      ?turn_id ?task_id ?goal_id ~goal_ids ?runtime_contract
+      ~resolver:(Some resolver) ~on_resolution:None ()
   in
   atomic_update pending (fun map -> SMap.add id entry map);
   record_pending entry;
@@ -242,7 +280,10 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
       Safe_ops.protect ~default:() (fun () ->
         atomic_update pending (fun map -> SMap.remove id map)))
 
-let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
+let submit_pending ~keeper_name ~tool_name ~input ~risk_level
+    ?turn_id ?task_id ?goal_id ?(goal_ids = []) ?runtime_contract
+    ~on_resolution
+    ()
   : string =
   let rec submit () =
     let map = Atomic.get pending in
@@ -252,7 +293,8 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
       let id = generate_id () in
       let entry =
         create_entry ~id ~keeper_name ~tool_name ~input ~risk_level
-          ~resolver:None ~on_resolution:(Some on_resolution)
+          ?turn_id ?task_id ?goal_id ~goal_ids ?runtime_contract
+          ~resolver:None ~on_resolution:(Some on_resolution) ()
       in
       let updated = SMap.add id entry map in
       if Atomic.compare_and_set pending map updated then (
@@ -306,6 +348,10 @@ let list_pending_json () : Yojson.Safe.t =
       ("risk_level", `String (risk_level_to_string entry.risk_level));
       ("requested_at", `Float entry.requested_at);
       ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+      ("turn_id", Json_util.int_opt_to_json entry.turn_id);
+      ("task_id", Json_util.string_opt_to_json entry.task_id);
+      ("goal_id", Json_util.string_opt_to_json entry.goal_id);
+      ("goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids));
     ] :: acc
   ) (Atomic.get pending) [] in
   `List (sort_entries_by_requested_at entries)
@@ -320,6 +366,14 @@ let list_pending_dashboard_json () : Yojson.Safe.t =
       ("requested_at", `Float entry.requested_at);
       ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
       ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+      ("turn_id", Json_util.int_opt_to_json entry.turn_id);
+      ("task_id", Json_util.string_opt_to_json entry.task_id);
+      ("goal_id", Json_util.string_opt_to_json entry.goal_id);
+      ("goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids));
+      ( "runtime_contract",
+        match entry.runtime_contract with
+        | Some json -> json
+        | None -> `Null );
       ("input", entry.input);
       ("input_preview", `String (input_preview_of_json entry.input));
     ] :: acc
@@ -335,6 +389,14 @@ let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =
     ("requested_at", `Float entry.requested_at);
     ("requested_at_iso", `String (Types.iso8601_of_unix_seconds entry.requested_at));
     ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+    ("turn_id", Json_util.int_opt_to_json entry.turn_id);
+    ("task_id", Json_util.string_opt_to_json entry.task_id);
+    ("goal_id", Json_util.string_opt_to_json entry.goal_id);
+    ("goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids));
+    ( "runtime_contract",
+      match entry.runtime_contract with
+      | Some json -> json
+      | None -> `Null );
     ("input", entry.input);
     ("input_preview", `String (input_preview_of_json entry.input));
   ]
@@ -346,6 +408,12 @@ let get_pending_json ~id : Yojson.Safe.t option =
 
 let pending_count () : int =
   SMap.cardinal (Atomic.get pending)
+
+let pending_count_for_keeper ~keeper_name : int =
+  SMap.fold
+    (fun _ entry count ->
+      if String.equal entry.keeper_name keeper_name then count + 1 else count)
+    (Atomic.get pending) 0
 
 let has_pending_for_keeper ~keeper_name : bool =
   SMap.fold (fun _ entry acc -> acc || String.equal entry.keeper_name keeper_name) (Atomic.get pending) false
@@ -374,7 +442,10 @@ let expire_stale ~max_wait_s =
       id entry.keeper_name entry.tool_name;
     audit_approval_event ~event_type:"expired" ~id
       ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
-      ~risk_level:entry.risk_level ~decision:("reject:" ^ reason) ();
+      ~risk_level:entry.risk_level ?turn_id:entry.turn_id
+      ?task_id:entry.task_id ?goal_id:entry.goal_id
+      ~goal_ids:entry.goal_ids ?runtime_contract:entry.runtime_contract
+      ~decision:("reject:" ^ reason) ();
     (match entry.resolver with
      | Some resolver ->
        Eio.Promise.resolve resolver (Oas.Hooks.Reject reason)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -508,7 +508,15 @@ let make_hooks
             , prompt_fingerprint
             , trace_id
             , session_id
-            , turn ) =
+            , turn
+            , keeper_turn_id
+            , task_id
+            , goal_ids
+            , execution_scope
+            , sandbox_profile
+            , network_mode
+            , shared_memory_scope
+            , approval_mode ) =
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
@@ -521,7 +529,9 @@ let make_hooks
                      if m = "" then (!meta_ref).cascade_name else m)
              ?lane ?tool_choice ?thinking_enabled ?thinking_budget
              ?prompt_fingerprint
-             ?trace_id ?session_id ?turn
+             ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids
+             ?execution_scope ?sandbox_profile ?network_mode
+             ?shared_memory_scope ?approval_mode
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (try

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -1,0 +1,29 @@
+open Keeper_types
+
+let current_task_id_opt (meta : keeper_meta) =
+  Option.map Keeper_id.Task_id.to_string meta.current_task_id
+
+let primary_goal_id_opt (meta : keeper_meta) =
+  match meta.active_goal_ids with
+  | goal_id :: _ -> Some goal_id
+  | [] -> None
+
+let backend_of_meta (meta : keeper_meta) =
+  match meta.sandbox_profile with
+  | Docker -> "docker"
+  | Local -> "local"
+
+let runtime_contract_json (meta : keeper_meta) : Yojson.Safe.t =
+  `Assoc
+    [
+      ( "execution_scope",
+        `String (Keeper_execution_scope.to_string meta.execution_scope) );
+      ("sandbox_profile", `String (sandbox_profile_to_string meta.sandbox_profile));
+      ("network_mode", `String (network_mode_to_string meta.network_mode));
+      ( "shared_memory_scope",
+        `String (shared_memory_scope_to_string meta.shared_memory_scope) );
+      ("backend", `String (backend_of_meta meta));
+      ("task_id", Json_util.string_opt_to_json (current_task_id_opt meta));
+      ("goal_id", Json_util.string_opt_to_json (primary_goal_id_opt meta));
+      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
+    ]

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -1,0 +1,4 @@
+val current_task_id_opt : Keeper_types.keeper_meta -> string option
+val primary_goal_id_opt : Keeper_types.keeper_meta -> string option
+val backend_of_meta : Keeper_types.keeper_meta -> string
+val runtime_contract_json : Keeper_types.keeper_meta -> Yojson.Safe.t

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,0 +1,107 @@
+open Keeper_types
+
+let json_int_opt_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `Int n -> Some n
+  | `Intlit raw -> (try Some (int_of_string raw) with Failure _ -> None)
+  | _ -> None
+
+let json_string_opt_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let latest_decision_json ~(config : Coord.config) ~(keeper_name : string) :
+    Yojson.Safe.t option =
+  let path = Keeper_types.keeper_decision_log_path config keeper_name in
+  if not (Fs_compat.file_exists path) then None
+  else
+    Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:20
+    |> List.rev
+    |> List.find_map (fun line ->
+           match Yojson.Safe.from_string line with
+           | exception Yojson.Json_error _ -> None
+           | (`Assoc _ as json) -> Some json
+           | _ -> None)
+
+let latest_tool_call_json ~(keeper_name : string) =
+  Keeper_tool_call_log.read_latest ~keeper_name ()
+
+let pending_approval_json ~(keeper_name : string) =
+  match Keeper_approval_queue.list_pending_dashboard_json () with
+  | `List entries ->
+      entries
+      |> List.filter (fun json ->
+             String.equal keeper_name
+               (Safe_ops.json_string ~default:"" "keeper_name" json))
+      |> List.sort (fun left right ->
+             Float.compare
+               (Safe_ops.json_float ~default:0.0 "requested_at" right)
+               (Safe_ops.json_float ~default:0.0 "requested_at" left))
+      |> fun entries -> `List entries
+  | _ -> `List []
+
+let latest_turn_id ~(registry_entry : Keeper_registry.registry_entry option)
+    (latest_decision : Yojson.Safe.t option) =
+  match Option.bind latest_decision (json_int_opt_member "turn_id") with
+  | Some _ as turn_id -> turn_id
+  | None -> (
+      match registry_entry with
+      | Some { current_turn_observation = Some turn; _ } -> Some turn.turn_id
+      | Some { last_completed_turn = Some turn; _ } -> Some turn.ct_turn_id
+      | _ -> None)
+
+let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
+  let registry_entry =
+    Keeper_registry.get ~base_path:config.base_path meta.name
+  in
+  let latest_decision = latest_decision_json ~config ~keeper_name:meta.name in
+  let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
+  let pending_approvals = pending_approval_json ~keeper_name:meta.name in
+  let pending_approval_count =
+    match pending_approvals with
+    | `List entries -> List.length entries
+    | _ -> 0
+  in
+  let runtime_blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let runtime_phase =
+    match registry_entry with
+    | Some entry -> `String (Keeper_state_machine.phase_to_string entry.phase)
+    | None -> `Null
+  in
+  let selected_model =
+    Option.bind latest_decision (fun json ->
+        let telemetry = Yojson.Safe.Util.member "telemetry" json in
+        match json_string_opt_member "selected_model" telemetry with
+        | Some _ as value -> value
+        | None -> json_string_opt_member "model_used" telemetry)
+  in
+  let runtime_contract = Keeper_runtime_contract.runtime_contract_json meta in
+  `Assoc
+    [
+      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+      ("generation", `Int meta.runtime.generation);
+      ( "turn_id",
+        match latest_turn_id ~registry_entry latest_decision with
+        | Some turn_id -> `Int turn_id
+        | None -> `Null );
+      ("phase", runtime_phase);
+      ("current_task_id", Json_util.string_opt_to_json (Keeper_runtime_contract.current_task_id_opt meta));
+      ("goal_id", Json_util.string_opt_to_json (Keeper_runtime_contract.primary_goal_id_opt meta));
+      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
+      ("active_model", `String (Keeper_exec_status.active_model_label_of_meta meta));
+      ("selected_model", Json_util.string_opt_to_json selected_model);
+      ("runtime_contract", runtime_contract);
+      ("runtime_blockers", `Assoc runtime_blocker_fields);
+      ("pending_approval_count", `Int pending_approval_count);
+      ("pending_approvals", pending_approvals);
+      ("latest_decision", Option.value ~default:`Null latest_decision);
+      ("latest_tool_call", Option.value ~default:`Null latest_tool_call);
+      ( "last_event_bus_correlation",
+        match registry_entry with
+        | Some entry ->
+            Json_util.string_opt_to_json entry.last_event_bus_correlation
+        | None -> `Null );
+    ]

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -1,0 +1,2 @@
+val snapshot_json :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -963,6 +963,10 @@ let handle_keeper_status ctx args : tool_result =
              ~configured_labels:models
              ~active_model ~runtime_blocker_fields latest_metrics
          in
+         let runtime_trust =
+           Keeper_runtime_trust_snapshot.snapshot_json
+             ~config:ctx.config ~meta:m
+         in
 
          let json = `Assoc ([
            ("name", `String name);
@@ -1151,6 +1155,7 @@ let handle_keeper_status ctx args : tool_result =
            ]);
            ("models_resolved", models_resolved);
            ("model_observability", model_observability);
+           ("runtime_trust", runtime_trust);
            ("runtime", runtime_surface_json ctx.config m);
            ("coordination", coordination_surface_json m);
            ("sources", source_provenance_json ctx.config m);

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -358,6 +358,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
             Log.Keeper.warn
               "%s: restored reconcile continue gate rejected; keeper remains paused (%s)"
               meta.name reason)
+      ()
   in
   Log.Keeper.warn
     "%s: restored reconcile continue gate from persisted paused meta"

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -291,6 +291,46 @@ let append_decision_record
     | Some r -> r.tool_calls
     | None -> []
   in
+  let ( _turn_lane
+      , _turn_tool_choice
+      , turn_thinking_enabled
+      , _turn_thinking_budget
+      , _turn_prompt_fingerprint
+      , _turn_trace_id
+      , _turn_session_id
+      , _turn_number
+      , turn_id_opt
+      , task_id_opt
+      , turn_goal_ids_opt
+      , _execution_scope
+      , _sandbox_profile
+      , _network_mode
+      , _shared_memory_scope
+      , approval_mode ) =
+    Keeper_tool_call_log.get_turn_context ~keeper_name:meta.name ()
+  in
+  let turn_id =
+    Option.value ~default:meta.runtime.usage.total_turns turn_id_opt
+  in
+  let task_id =
+    match task_id_opt with
+    | Some _ as value -> value
+    | None -> Keeper_runtime_contract.current_task_id_opt meta
+  in
+  let goal_ids =
+    match turn_goal_ids_opt with
+    | Some values -> values
+    | None -> meta.active_goal_ids
+  in
+  let goal_id =
+    match goal_ids with
+    | value :: _ -> Some value
+    | [] -> None
+  in
+  let runtime_contract = Keeper_runtime_contract.runtime_contract_json meta in
+  let pending_approval_count =
+    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+  in
   let claim_executed = List.mem "keeper_task_claim" tools_used in
   let social_fields =
     match social_state with
@@ -328,8 +368,15 @@ let append_decision_record
         ("audience", `String "internal_human_only");
         ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
         ("generation", `Int meta.runtime.generation);
+        ("turn_id", `Int turn_id);
         ("keeper_name", `String meta.name);
         ("agent_name", `String meta.agent_name);
+        ("task_id", Json_util.string_opt_to_json task_id);
+        ("goal_id", Json_util.string_opt_to_json goal_id);
+        ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
+        ("runtime_contract", runtime_contract);
+        ("pending_approval_count", `Int pending_approval_count);
+        ("approval_mode", Json_util.string_opt_to_json approval_mode);
         ("channel", `String (decision_channel_of_observation observation));
         ("outcome", `String outcome);
         ("selected_mode", `String selected_mode);
@@ -413,13 +460,6 @@ let append_decision_record
           match result with
           | Some r ->
               let surface_model_used = Keeper_agent_run.surface_model_used r in
-              (* Per-turn thinking_enabled read from the same ref that the tool
-                 call log uses; captures the adaptive classifier's decision
-                 (true=Cognitive, false=Mechanical) so the dashboard can surface
-                 thinking fraction per model. *)
-              let (_, _, turn_thinking_enabled, _, _, _, _, _) =
-                Keeper_tool_call_log.get_turn_context ~keeper_name:meta.name ()
-              in
               let thinking_enabled_field =
                 match turn_thinking_enabled with
                 | Some b -> [("thinking_enabled", `Bool b)]

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -495,6 +495,7 @@ let enqueue_partial_commit_continue_gate
              Log.Keeper.error
                "%s: partial-commit continue gate rejected but keeper pause sync failed: %s (reason=%s)"
                meta.name err reason))
+    ()
 
 (* Dedupe "mixed cascade context budget" log: the values are constant
    per (keeper_name, model_labels) because cascade config is static at

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -31,6 +31,14 @@ type turn_context = {
   trace_id: string option;
   session_id: string option;
   turn: int option;
+  keeper_turn_id: int option;
+  task_id: string option;
+  goal_ids: string list option;
+  execution_scope: string option;
+  sandbox_profile: string option;
+  network_mode: string option;
+  shared_memory_scope: string option;
+  approval_mode: string option;
 }
 
 let empty_turn_context = {
@@ -42,6 +50,14 @@ let empty_turn_context = {
   trace_id = None;
   session_id = None;
   turn = None;
+  keeper_turn_id = None;
+  task_id = None;
+  goal_ids = None;
+  execution_scope = None;
+  sandbox_profile = None;
+  network_mode = None;
+  shared_memory_scope = None;
+  approval_mode = None;
 }
 
 let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
@@ -55,7 +71,9 @@ let consume_truncation_info ~keeper_name () =
   | None -> (0, None)
 
 let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn () =
+    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn
+    ?keeper_turn_id ?task_id ?goal_ids ?execution_scope ?sandbox_profile
+    ?network_mode ?shared_memory_scope ?approval_mode () =
   Hashtbl.replace pending_turn_context keeper_name
     {
       lane;
@@ -66,6 +84,14 @@ let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
       trace_id;
       session_id;
       turn;
+      keeper_turn_id;
+      task_id;
+      goal_ids;
+      execution_scope;
+      sandbox_profile;
+      network_mode;
+      shared_memory_scope;
+      approval_mode;
     }
 
 let get_turn_context ~keeper_name () =
@@ -81,7 +107,15 @@ let get_turn_context ~keeper_name () =
   , ctx.prompt_fingerprint
   , ctx.trace_id
   , ctx.session_id
-  , ctx.turn )
+  , ctx.turn
+  , ctx.keeper_turn_id
+  , ctx.task_id
+  , ctx.goal_ids
+  , ctx.execution_scope
+  , ctx.sandbox_profile
+  , ctx.network_mode
+  , ctx.shared_memory_scope
+  , ctx.approval_mode )
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
@@ -150,7 +184,10 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
     ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn ?result_bytes ?truncated_to () =
+    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn
+    ?keeper_turn_id ?task_id ?goal_ids ?execution_scope ?sandbox_profile
+    ?network_mode ?shared_memory_scope ?approval_mode ?result_bytes
+    ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
@@ -163,7 +200,15 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           , ctx_prompt_fingerprint
           , ctx_trace_id
           , ctx_session_id
-          , ctx_turn ) =
+          , ctx_turn
+          , ctx_keeper_turn_id
+          , ctx_task_id
+          , ctx_goal_ids
+          , ctx_execution_scope
+          , ctx_sandbox_profile
+          , ctx_network_mode
+          , ctx_shared_memory_scope
+          , ctx_approval_mode ) =
         get_turn_context ~keeper_name ()
       in
       let lane = match lane with Some _ -> lane | None -> ctx_lane in
@@ -190,6 +235,40 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         match session_id with Some _ -> session_id | None -> ctx_session_id
       in
       let turn = match turn with Some _ -> turn | None -> ctx_turn in
+      let keeper_turn_id =
+        match keeper_turn_id with
+        | Some _ -> keeper_turn_id
+        | None -> ctx_keeper_turn_id
+      in
+      let task_id = match task_id with Some _ -> task_id | None -> ctx_task_id in
+      let goal_ids =
+        match goal_ids with Some _ -> goal_ids | None -> ctx_goal_ids
+      in
+      let execution_scope =
+        match execution_scope with
+        | Some _ -> execution_scope
+        | None -> ctx_execution_scope
+      in
+      let sandbox_profile =
+        match sandbox_profile with
+        | Some _ -> sandbox_profile
+        | None -> ctx_sandbox_profile
+      in
+      let network_mode =
+        match network_mode with
+        | Some _ -> network_mode
+        | None -> ctx_network_mode
+      in
+      let shared_memory_scope =
+        match shared_memory_scope with
+        | Some _ -> shared_memory_scope
+        | None -> ctx_shared_memory_scope
+      in
+      let approval_mode =
+        match approval_mode with
+        | Some _ -> approval_mode
+        | None -> ctx_approval_mode
+      in
       let model_field =
         if model = "" then [] else [("model", `String model)]
       in
@@ -233,6 +312,39 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         | Some value -> [("turn", `Int value)]
         | None -> []
       in
+      let keeper_turn_id_field = match keeper_turn_id with
+        | Some value -> [("keeper_turn_id", `Int value)]
+        | None -> []
+      in
+      let task_id_field = match task_id with
+        | Some value -> [("task_id", `String value)]
+        | None -> []
+      in
+      let goal_ids_field = match goal_ids with
+        | Some values ->
+            [("goal_ids", `List (List.map (fun value -> `String value) values))]
+        | None -> []
+      in
+      let execution_scope_field = match execution_scope with
+        | Some value -> [("execution_scope", `String value)]
+        | None -> []
+      in
+      let sandbox_profile_field = match sandbox_profile with
+        | Some value -> [("sandbox_profile", `String value)]
+        | None -> []
+      in
+      let network_mode_field = match network_mode with
+        | Some value -> [("network_mode", `String value)]
+        | None -> []
+      in
+      let shared_memory_scope_field = match shared_memory_scope with
+        | Some value -> [("shared_memory_scope", `String value)]
+        | None -> []
+      in
+      let approval_mode_field = match approval_mode with
+        | Some value -> [("approval_mode", `String value)]
+        | None -> []
+      in
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
       let output_json = blob_aware_output_json safe_output in
@@ -250,6 +362,9 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            @ thinking_enabled_field @ thinking_budget_field
            @ prompt_fingerprint_field
            @ trace_id_field @ session_id_field @ turn_field
+           @ keeper_turn_id_field @ task_id_field @ goal_ids_field
+           @ execution_scope_field @ sandbox_profile_field @ network_mode_field
+           @ shared_memory_scope_field @ approval_mode_field
            @ result_bytes_field @ truncated_to_field)
       in
       (* Sanitize UTF-8 before persisting.  Tool output may contain invalid

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -36,6 +36,14 @@ val set_turn_context :
   ?trace_id:string ->
   ?session_id:string ->
   ?turn:int ->
+  ?keeper_turn_id:int ->
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?execution_scope:string ->
+  ?sandbox_profile:string ->
+  ?network_mode:string ->
+  ?shared_memory_scope:string ->
+  ?approval_mode:string ->
   unit ->
   unit
 (** [set_turn_context ...] stores the current effective turn policy for
@@ -46,9 +54,13 @@ val get_turn_context :
   unit ->
   string option * string option * bool option * int option
   * string option * string option * string option * int option
+  * int option * string option * string list option * string option
+  * string option * string option * string option * string option
 (** Returns [(lane, tool_choice, thinking_enabled, thinking_budget, trace_id,
-    prompt_fingerprint, session_id, turn)] for the keeper, or [None] values when no turn context
-    has been recorded. *)
+    prompt_fingerprint, session_id, turn, keeper_turn_id, task_id, goal_ids,
+    execution_scope, sandbox_profile, network_mode, shared_memory_scope,
+    approval_mode)] for the keeper, or [None] values when no turn context has
+    been recorded. *)
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl
@@ -70,6 +82,14 @@ val log_call :
   ?trace_id:string ->
   ?session_id:string ->
   ?turn:int ->
+  ?keeper_turn_id:int ->
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?execution_scope:string ->
+  ?sandbox_profile:string ->
+  ?network_mode:string ->
+  ?shared_memory_scope:string ->
+  ?approval_mode:string ->
   ?result_bytes:int ->
   ?truncated_to:int ->
   unit ->

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -376,6 +376,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
             ~tool_name:"masc_code_delete"
             ~input:(`Assoc [ ("path", `String "/tmp/danger") ])
             ~risk_level:Lib.Keeper_approval_queue.Critical
+            ()
         in
         decision_result := Some decision);
       Eio.Fiber.yield ();

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -170,6 +170,7 @@ let test_approval_queue_submit_and_resolve () =
         ~tool_name:"masc_code_delete"
         ~input:(`Assoc [("path", `String "/dangerous")])
         ~risk_level:AQ.Critical
+        ()
     in
     result := Some decision
   );
@@ -217,6 +218,7 @@ let test_approval_queue_reject () =
         ~tool_name:"masc_force_reset"
         ~input:(`Assoc [])
         ~risk_level:AQ.Critical
+        ()
     in
     result := Some decision
   );
@@ -250,6 +252,7 @@ let test_approval_queue_expire_stale () =
         ~tool_name:"masc_dangerous_tool"
         ~input:(`Assoc [])
         ~risk_level:AQ.Critical
+        ()
     in
     result := Some decision
   );
@@ -287,6 +290,7 @@ let test_approval_queue_cancel_cleans_up () =
            ~tool_name:"masc_dangerous"
            ~input:(`Assoc [])
            ~risk_level:AQ.Critical
+           ()
        in
        ());
      Eio.Fiber.yield ();
@@ -308,6 +312,7 @@ let test_background_pending_callback_and_keeper_lookup () =
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> callback_result := Some decision)
+      ()
   in
   Alcotest.(check bool) "keeper has pending approval" true
     (AQ.has_pending_for_keeper ~keeper_name:"gate-keeper");
@@ -337,6 +342,7 @@ let test_background_pending_reuses_existing_entry () =
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> first_callback := Some decision)
+      ()
   in
   let after_first = AQ.pending_count () in
   let id2 =
@@ -346,6 +352,7 @@ let test_background_pending_reuses_existing_entry () =
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> second_callback := Some decision)
+      ()
   in
   Alcotest.(check string) "existing pending id reused" id1 id2;
   Alcotest.(check int) "only one entry created"
@@ -377,7 +384,13 @@ let test_approval_queue_get_pending_detail () =
       ~tool_name:"masc_code_delete"
       ~input
       ~risk_level:AQ.Critical
+      ~turn_id:7
+      ~task_id:"task-runtime-trust"
+      ~goal_id:"goal-runtime-trust"
+      ~goal_ids:[ "goal-runtime-trust"; "goal-mid" ]
+      ~runtime_contract:(`Assoc [ ("backend", `String "docker") ])
       ~on_resolution:(fun decision -> callback_result := Some decision)
+      ()
   in
   let open Yojson.Safe.Util in
   let detail =
@@ -392,6 +405,17 @@ let test_approval_queue_get_pending_detail () =
     (detail |> member "tool_name" |> to_string);
   Alcotest.(check string) "detail risk" "critical"
     (detail |> member "risk_level" |> to_string);
+  Alcotest.(check int) "detail turn id" 7
+    (detail |> member "turn_id" |> to_int);
+  Alcotest.(check string) "detail task id" "task-runtime-trust"
+    (detail |> member "task_id" |> to_string);
+  Alcotest.(check string) "detail goal id" "goal-runtime-trust"
+    (detail |> member "goal_id" |> to_string);
+  Alcotest.(check (list string)) "detail goal ids"
+    [ "goal-runtime-trust"; "goal-mid" ]
+    (detail |> member "goal_ids" |> to_list |> List.map to_string);
+  Alcotest.(check string) "detail runtime contract backend" "docker"
+    (detail |> member "runtime_contract" |> member "backend" |> to_string);
   Alcotest.(check string) "detail includes full input"
     (Yojson.Safe.to_string input)
     (detail |> member "input" |> Yojson.Safe.to_string);
@@ -423,6 +447,7 @@ let test_approval_get_dispatch_success () =
       ~input
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> callback_result := Some decision)
+      ()
   in
   Fun.protect
     ~finally:(fun () ->
@@ -477,7 +502,7 @@ let test_approval_get_rejects_reader_role () =
 let test_callback_approves_low_risk () =
   (* development level: no confirmation needed *)
   let cb = GP.to_oas_approval_callback
-    ~governance_level:"development" ~keeper_name:"test" in
+    ~governance_level:"development" ~keeper_name:"test" () in
   let decision = cb ~tool_name:"masc_status" ~input:(`Assoc []) in
   match decision with
   | Agent_sdk.Hooks.Approve -> ()
@@ -493,7 +518,7 @@ let test_callback_production_keeper_write_requires_approval () =
   Eio.Fiber.fork ~sw (fun () ->
     let cb =
       GP.to_oas_approval_callback
-        ~governance_level:"production" ~keeper_name:"test" in
+        ~governance_level:"production" ~keeper_name:"test" () in
     let decision =
       cb
         ~tool_name:"keeper_fs_edit"
@@ -528,7 +553,7 @@ let test_callback_production_keeper_write_requires_approval () =
 let test_callback_production_keeper_shell_gh_read_only_auto_approved () =
   let cb =
     GP.to_oas_approval_callback
-      ~governance_level:"production" ~keeper_name:"test" in
+      ~governance_level:"production" ~keeper_name:"test" () in
   let decision =
     cb ~tool_name:"keeper_shell"
       ~input:(`Assoc [("op", `String "gh"); ("cmd", `String "pr view 123")])

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -134,6 +134,14 @@ let test_turn_context_fields_stored () =
       ~trace_id:"trace-k"
       ~session_id:"trace-k"
       ~turn:7
+      ~keeper_turn_id:7
+      ~task_id:"task-runtime-trust"
+      ~goal_ids:["goal-short"; "goal-long"]
+      ~execution_scope:"workspace"
+      ~sandbox_profile:"docker"
+      ~network_mode:"inherit"
+      ~shared_memory_scope:"team"
+      ~approval_mode:"manual"
       ();
     Keeper_tool_call_log.log_call
       ~keeper_name:"k" ~tool_name:"masc_status"
@@ -164,7 +172,30 @@ let test_turn_context_fields_stored () =
       (Some "trace-k")
       (Safe_ops.json_string_opt "session_id" entry);
     Alcotest.(check int) "turn field" 7
-      (Safe_ops.json_int ~default:0 "turn" entry))
+      (Safe_ops.json_int ~default:0 "turn" entry);
+    Alcotest.(check int) "keeper_turn_id field" 7
+      (Safe_ops.json_int ~default:0 "keeper_turn_id" entry);
+    Alcotest.(check (option string)) "task_id field"
+      (Some "task-runtime-trust")
+      (Safe_ops.json_string_opt "task_id" entry);
+    Alcotest.(check (list string)) "goal_ids field"
+      ["goal-short"; "goal-long"]
+      Yojson.Safe.Util.(entry |> member "goal_ids" |> to_list |> List.map to_string);
+    Alcotest.(check (option string)) "execution_scope field"
+      (Some "workspace")
+      (Safe_ops.json_string_opt "execution_scope" entry);
+    Alcotest.(check (option string)) "sandbox_profile field"
+      (Some "docker")
+      (Safe_ops.json_string_opt "sandbox_profile" entry);
+    Alcotest.(check (option string)) "network_mode field"
+      (Some "inherit")
+      (Safe_ops.json_string_opt "network_mode" entry);
+    Alcotest.(check (option string)) "shared_memory_scope field"
+      (Some "team")
+      (Safe_ops.json_string_opt "shared_memory_scope" entry);
+    Alcotest.(check (option string)) "approval_mode field"
+      (Some "manual")
+      (Safe_ops.json_string_opt "approval_mode" entry))
 
 let test_turn_context_fields_absent_without_context () =
   with_tmp_log (fun () ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7,6 +7,7 @@ module EC = Masc_mcp.Keeper_error_classify
 module UM = Masc_mcp.Keeper_unified_metrics
 module KR = Masc_mcp.Keeper_registry
 module KAR = Masc_mcp.Keeper_agent_run
+module KTCL = Masc_mcp.Keeper_tool_call_log
 module KTD = Masc_mcp.Keeper_tool_disclosure
 module KEC = Masc_mcp.Keeper_exec_context
 module KSM = Masc_mcp.Keeper_social_model
@@ -631,6 +632,7 @@ let test_pending_approval_blocks_turns_until_resolved () =
       ~input:(`Assoc [ ("kind", `String "continue_gate_required") ])
       ~risk_level:AQ.Critical
       ~on_resolution:(fun _ -> ())
+      ()
   in
   let decision = WO.unified_turn_decision ~meta:minimal_meta reactive_obs in
   check bool "approval pending blocks turn" false decision.should_run;
@@ -1803,8 +1805,20 @@ let test_append_decision_record_persists_tool_calls () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
+      let current_task_id =
+        match Masc_mcp.Keeper_id.Task_id.of_string "task-runtime-trust" with
+        | Ok task_id -> task_id
+        | Error err -> fail ("task id parse failed: " ^ err)
+      in
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      let meta =
+        {
+          minimal_meta with
+          active_goal_ids = [ "goal-runtime-trust" ];
+          current_task_id = Some current_task_id;
+        }
+      in
       let tool_calls : KAR.tool_call_detail list =
         [ { tool_name = "keeper_shell"
           ; provider = "codex_cli"
@@ -1828,20 +1842,49 @@ let test_append_decision_record_persists_tool_calls () =
           ~output_tok:20
           ()
       in
-      UM.append_decision_record
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~latency_ms:42
-        ~outcome:"tool_use"
-        ~selected_mode:"tool_use"
-        ~result:(Some result)
-        ();
+      Fun.protect
+        ~finally:KTCL.reset_for_testing
+        (fun () ->
+          KTCL.set_turn_context
+            ~keeper_name:meta.name
+            ~thinking_enabled:false
+            ~keeper_turn_id:8
+            ~approval_mode:"manual"
+            ();
+          UM.append_decision_record
+            ~config
+            ~meta
+            ~observation:base_observation
+            ~latency_ms:42
+            ~outcome:"tool_use"
+            ~selected_mode:"tool_use"
+            ~result:(Some result)
+            ());
       let json =
-        read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
+        read_jsonl_line (Keeper_types.keeper_decision_log_path config meta.name)
       in
       check int "tool call count persisted" 2
         Yojson.Safe.Util.(json |> member "tool_call_count" |> to_int);
+      check int "turn id persisted" 8
+        Yojson.Safe.Util.(json |> member "turn_id" |> to_int);
+      check (option string) "task id persisted"
+        (Some "task-runtime-trust")
+        Yojson.Safe.Util.(json |> member "task_id" |> to_string_option);
+      check (option string) "goal id persisted"
+        (Some "goal-runtime-trust")
+        Yojson.Safe.Util.(json |> member "goal_id" |> to_string_option);
+      check (list string) "goal ids persisted"
+        [ "goal-runtime-trust" ]
+        Yojson.Safe.Util.(json |> member "goal_ids" |> to_list |> List.map to_string);
+      check (option string) "approval mode persisted"
+        (Some "manual")
+        Yojson.Safe.Util.(json |> member "approval_mode" |> to_string_option);
+      check (option string) "runtime contract backend persisted"
+        (Some "local")
+        Yojson.Safe.Util.(
+          json |> member "runtime_contract" |> member "backend" |> to_string_option);
+      check int "pending approval count persisted" 0
+        Yojson.Safe.Util.(json |> member "pending_approval_count" |> to_int);
       check (list string) "tools used persisted"
         ["keeper_shell"; "keeper_board_post"]
         Yojson.Safe.Util.(json |> member "tools_used" |> to_list |> List.map to_string);

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -403,6 +403,7 @@ let test_keeper_status_exposes_model_observability () =
       let status_json = parse_json_exn body in
       let open Yojson.Safe.Util in
       let observability = status_json |> member "model_observability" in
+      let runtime_trust = status_json |> member "runtime_trust" in
       let status_dump = Yojson.Safe.pretty_to_string status_json in
       Alcotest.(check (option string))
         ("cascade name surfaced\n" ^ status_dump)
@@ -437,7 +438,12 @@ let test_keeper_status_exposes_model_observability () =
        |> to_bool);
       Alcotest.(check bool) "chat compatibility intentionally null" true
         (observability |> member "runtime_contract"
-         |> member "chat_completion_compatible" = `Null))
+         |> member "chat_completion_compatible" = `Null);
+      Alcotest.(check string) "runtime trust backend local" "local"
+        (runtime_trust |> member "runtime_contract" |> member "backend"
+       |> to_string);
+      Alcotest.(check int) "runtime trust pending approvals empty" 0
+        (runtime_trust |> member "pending_approval_count" |> to_int))
 
 let test_keeper_status_ignores_stale_cascade_observation () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- add keeper runtime contract helpers and a runtime trust snapshot read model
- persist shared runtime context across keeper decision logs, tool-call logs, approval records, and governance callback paths
- expose runtime_trust in keeper status and dashboard surfaces

## Testing
- dune build --root . -j 1 test/test_keeper_tool_call_log.exe test/test_keeper_unified.exe test/test_hitl_approval.exe
- dune build --root . -j 1 test/test_operator_control.exe
- ./_build/default/test/test_keeper_tool_call_log.exe
- ./_build/default/test/test_keeper_unified.exe
- ./_build/default/test/test_hitl_approval.exe
- ./_build/default/test/test_operator_control.exe