### PR TITLE
feat(dashboard): add safe autonomy scorecard

### DIFF
--- a/dashboard/src/components/safe-autonomy.ts
+++ b/dashboard/src/components/safe-autonomy.ts
@@ -1,0 +1,401 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+import { get } from '../api/core'
+import { AsyncContainer } from './common/async-container'
+import { Card } from './common/card'
+import { StatCard } from './common/stat-card'
+import { JsonViewerCard } from './common/json-viewer'
+import { EmptyState } from './common/empty-state'
+import { formatTimeAgo } from '../lib/format-time'
+import {
+  asBoolean,
+  asNumber,
+  asRecordArray,
+  asString,
+  asStringArray,
+  isRecord,
+} from './common/normalize'
+
+type DomainStatus = 'pass' | 'warn' | 'fail'
+
+interface ScorecardSummary {
+  global_score: number
+  status: DomainStatus
+  keeper_count: number
+  active_goal_count: number
+  keepers_with_current_task: number
+  findings_total: number
+  human_action_required_count: number
+  approval_queue_depth: number
+}
+
+interface ScorecardItem {
+  id: string
+  label: string
+  status: DomainStatus
+  score: number
+  summary: string
+  weight?: number
+  evidence_refs?: unknown[]
+}
+
+interface KeeperItem {
+  name: string
+  agent_name: string
+  status: DomainStatus
+  score: number
+  sandbox_profile: string
+  sandbox_backend: string
+  network_mode: string
+  approval_pending_count: number
+  trace_history_count: number
+  recent_activity_count: number
+  total_turns: number
+  goal: string
+  active_goal_ids: string[]
+  current_task_id: string | null
+  last_blocker: string | null
+}
+
+interface FindingItem {
+  reason_code: string
+  domain_id: string
+  severity: DomainStatus
+  keeper_name: string | null
+  summary: string
+  human_action_required: boolean
+  suggested_next_action: string
+}
+
+interface TimelineItem {
+  ts_iso: string
+  kind: string
+  keeper_name: string | null
+  summary: string
+}
+
+interface SafeAutonomyData {
+  generated_at: string
+  summary: ScorecardSummary
+  domains: ScorecardItem[]
+  per_keeper: KeeperItem[]
+  findings: FindingItem[]
+  timeline: TimelineItem[]
+  artifacts: Record<string, unknown>
+}
+
+const safeAutonomy: AsyncResource<SafeAutonomyData> = createAsyncResource()
+
+function statusTone(status: DomainStatus): string {
+  switch (status) {
+    case 'pass':
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+    case 'warn':
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+    case 'fail':
+    default:
+      return 'border-[var(--bad-30)] bg-[var(--bad-12)] text-[var(--bad)]'
+  }
+}
+
+function statusLabel(status: DomainStatus): string {
+  switch (status) {
+    case 'pass':
+      return 'PASS'
+    case 'warn':
+      return 'WARN'
+    case 'fail':
+    default:
+      return 'FAIL'
+  }
+}
+
+function normalizeSummary(value: unknown): ScorecardSummary {
+  const summary = isRecord(value) ? value : {}
+  return {
+    global_score: asNumber(summary.global_score, 0),
+    status: (asString(summary.status, 'warn') as DomainStatus),
+    keeper_count: asNumber(summary.keeper_count, 0),
+    active_goal_count: asNumber(summary.active_goal_count, 0),
+    keepers_with_current_task: asNumber(summary.keepers_with_current_task, 0),
+    findings_total: asNumber(summary.findings_total, 0),
+    human_action_required_count: asNumber(summary.human_action_required_count, 0),
+    approval_queue_depth: asNumber(summary.approval_queue_depth, 0),
+  }
+}
+
+function normalizeDomain(value: unknown): ScorecardItem {
+  const item = isRecord(value) ? value : {}
+  return {
+    id: asString(item.id, 'domain'),
+    label: asString(item.label, 'Domain'),
+    status: (asString(item.status, 'warn') as DomainStatus),
+    score: asNumber(item.score, 0),
+    summary: asString(item.summary, ''),
+    weight: asNumber(item.weight),
+    evidence_refs: Array.isArray(item.evidence_refs) ? item.evidence_refs : [],
+  }
+}
+
+function normalizeKeeper(value: unknown): KeeperItem {
+  const item = isRecord(value) ? value : {}
+  return {
+    name: asString(item.name, 'keeper'),
+    agent_name: asString(item.agent_name, ''),
+    status: (asString(item.status, 'warn') as DomainStatus),
+    score: asNumber(item.score, 0),
+    sandbox_profile: asString(item.sandbox_profile, 'unknown'),
+    sandbox_backend: asString(item.sandbox_backend, 'unknown'),
+    network_mode: asString(item.network_mode, 'unknown'),
+    approval_pending_count: asNumber(item.approval_pending_count, 0),
+    trace_history_count: asNumber(item.trace_history_count, 0),
+    recent_activity_count: asNumber(item.recent_activity_count, 0),
+    total_turns: asNumber(item.total_turns, 0),
+    goal: asString(item.goal, ''),
+    active_goal_ids: asStringArray(item.active_goal_ids),
+    current_task_id: asString(item.current_task_id) ?? null,
+    last_blocker: asString(item.last_blocker) ?? null,
+  }
+}
+
+function normalizeFinding(value: unknown): FindingItem {
+  const item = isRecord(value) ? value : {}
+  return {
+    reason_code: asString(item.reason_code, 'unknown'),
+    domain_id: asString(item.domain_id, 'unknown'),
+    severity: (asString(item.severity, 'warn') as DomainStatus),
+    keeper_name: asString(item.keeper_name) ?? null,
+    summary: asString(item.summary, ''),
+    human_action_required: asBoolean(item.human_action_required, false),
+    suggested_next_action: asString(item.suggested_next_action, ''),
+  }
+}
+
+function normalizeTimelineItem(value: unknown): TimelineItem {
+  const item = isRecord(value) ? value : {}
+  return {
+    ts_iso: asString(item.ts_iso, ''),
+    kind: asString(item.kind, 'event'),
+    keeper_name: asString(item.keeper_name) ?? null,
+    summary: asString(item.summary, ''),
+  }
+}
+
+function normalizePayload(raw: unknown): SafeAutonomyData {
+  const data = isRecord(raw) ? raw : {}
+  return {
+    generated_at: asString(data.generated_at, ''),
+    summary: normalizeSummary(data.summary),
+    domains: asRecordArray(data.domains).map(normalizeDomain),
+    per_keeper: asRecordArray(data.per_keeper).map(normalizeKeeper),
+    findings: asRecordArray(data.findings).map(normalizeFinding),
+    timeline: asRecordArray(data.timeline).map(normalizeTimelineItem),
+    artifacts: isRecord(data.artifacts) ? data.artifacts : {},
+  }
+}
+
+function loadSafeAutonomy(): Promise<void> {
+  return safeAutonomy.load(async () =>
+    normalizePayload(await get<unknown>('/api/v1/dashboard/safe-autonomy')))
+}
+
+function StatusPill({ status }: { status: DomainStatus }) {
+  return html`
+    <span class=${`inline-flex items-center rounded-sm border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wide ${statusTone(status)}`}>
+      ${statusLabel(status)}
+    </span>
+  `
+}
+
+function DomainCard({ item }: { item: ScorecardItem }) {
+  return html`
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <div class="text-sm font-semibold text-[var(--text-strong)]">${item.label}</div>
+            <${StatusPill} status=${item.status} />
+          </div>
+          <div class="mt-1 text-xs text-[var(--text-muted)]">${item.summary}</div>
+        </div>
+        <div class="text-right">
+          <div class="text-lg font-semibold text-[var(--text-strong)]">${item.score.toFixed(1)}</div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--text-muted)]">
+            weight ${item.weight ?? 0}
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function KeeperCard({ item }: { item: KeeperItem }) {
+  return html`
+    <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+      <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <div class="text-sm font-semibold text-[var(--text-strong)]">${item.name}</div>
+            <${StatusPill} status=${item.status} />
+          </div>
+          <div class="mt-1 text-xs text-[var(--text-muted)]">
+            ${item.agent_name} · ${item.sandbox_profile}/${item.sandbox_backend} · ${item.network_mode}
+          </div>
+          <div class="mt-2 text-sm text-[var(--text-body)]">${item.goal || 'goal 없음'}</div>
+          <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--text-muted)]">
+            ${item.active_goal_ids.map(goalId => html`
+              <span class="rounded border border-[var(--white-10)] bg-[var(--white-6)] px-2 py-0.5">${goalId}</span>
+            `)}
+          </div>
+          ${item.last_blocker
+            ? html`
+              <div class="mt-3 rounded border border-[var(--warn-30)] bg-[var(--warn-12)] px-3 py-2 text-xs text-[var(--warn)]">
+                blocker: ${item.last_blocker}
+              </div>
+            `
+            : null}
+        </div>
+        <div class="grid grid-cols-2 gap-2 text-xs lg:min-w-[220px]">
+          <${StatCard} label="score" value=${item.score.toFixed(1)} />
+          <${StatCard} label="approvals" value=${item.approval_pending_count} />
+          <${StatCard} label="turns" value=${item.total_turns} />
+          <${StatCard} label="activity" value=${item.recent_activity_count} />
+          <${StatCard} label="history" value=${item.trace_history_count} />
+          <${StatCard} label="task" value=${item.current_task_id ?? 'none'} />
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function FindingsList({ findings }: { findings: FindingItem[] }) {
+  if (findings.length === 0) {
+    return html`<${EmptyState} message="현재 기록된 세이프 오토노미 finding이 없습니다." compact />`
+  }
+  return html`
+    <div class="space-y-2">
+      ${findings.map(item => html`
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <code class="text-3xs text-[var(--text-muted)]">${item.reason_code}</code>
+                <${StatusPill} status=${item.severity} />
+                ${item.keeper_name ? html`<span class="text-3xs text-[var(--text-muted)]">${item.keeper_name}</span>` : null}
+              </div>
+              <div class="mt-1 text-sm text-[var(--text-strong)]">${item.summary}</div>
+              <div class="mt-1 text-xs text-[var(--text-muted)]">${item.suggested_next_action}</div>
+            </div>
+            ${item.human_action_required
+              ? html`
+                <span class="rounded border border-[var(--bad-30)] bg-[var(--bad-12)] px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-[var(--bad)]">
+                  human
+                </span>
+              `
+              : null}
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function TimelineList({ timeline }: { timeline: TimelineItem[] }) {
+  if (timeline.length === 0) {
+    return html`<${EmptyState} message="최근 타임라인 이벤트가 없습니다." compact />`
+  }
+  return html`
+    <div class="space-y-2">
+      ${timeline.map(item => html`
+        <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <div class="text-xs text-[var(--text-strong)]">${item.summary}</div>
+              <div class="mt-1 text-3xs text-[var(--text-muted)]">
+                ${item.kind}${item.keeper_name ? ` · ${item.keeper_name}` : ''}
+              </div>
+            </div>
+            <div class="shrink-0 text-3xs text-[var(--text-muted)]">
+              ${item.ts_iso ? formatTimeAgo(item.ts_iso) : '정보 없음'}
+            </div>
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+export function SafeAutonomyPanel() {
+  useEffect(() => {
+    void loadSafeAutonomy()
+  }, [])
+
+  return html`
+    <div class="space-y-4">
+      <${Card} title="Safe Autonomy" class="section">
+        <${AsyncContainer}
+          state=${safeAutonomy.state}
+          loadingMessage="세이프 오토노미 scorecard를 불러오는 중..."
+          render=${(data: SafeAutonomyData) => html`
+            <div class="space-y-4">
+              <div class="rounded border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div class="max-w-3xl">
+                    <div class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">
+                      Advisory Truth Layer
+                    </div>
+                    <div class="mt-2 flex items-center gap-2">
+                      <div class="text-2xl font-semibold text-[var(--text-strong)]">
+                        ${data.summary.global_score.toFixed(1)}
+                      </div>
+                      <${StatusPill} status=${data.summary.status} />
+                    </div>
+                    <div class="mt-2 text-sm leading-paragraph text-[var(--text-body)]">
+                      Tool correctness, sandbox truth, approval gates, cascade/FSM gracefulness,
+                      audit trail completeness를 keeper별로 한 번에 보여줍니다.
+                    </div>
+                    <div class="mt-2 text-3xs text-[var(--text-muted)]">
+                      generated ${data.generated_at ? formatTimeAgo(data.generated_at) : '정보 없음'}
+                    </div>
+                  </div>
+                  <div class="grid grid-cols-2 gap-2 xl:grid-cols-4">
+                    <${StatCard} label="keepers" value=${data.summary.keeper_count} />
+                    <${StatCard} label="active goals" value=${data.summary.active_goal_count} />
+                    <${StatCard} label="findings" value=${data.summary.findings_total} />
+                    <${StatCard} label="human queue" value=${data.summary.human_action_required_count} />
+                    <${StatCard} label="with task" value=${data.summary.keepers_with_current_task} />
+                    <${StatCard} label="approval depth" value=${data.summary.approval_queue_depth} />
+                  </div>
+                </div>
+              </div>
+
+              <div class="grid grid-cols-1 gap-3 xl:grid-cols-2">
+                ${data.domains.map(item => html`<${DomainCard} key=${item.id} item=${item} />`)}
+              </div>
+
+              <${Card} title="Keeper Matrix" class="section">
+                <div class="space-y-3">
+                  ${data.per_keeper.length === 0
+                    ? html`<${EmptyState} message="표시할 keeper snapshot이 없습니다." compact />`
+                    : data.per_keeper.map(item => html`<${KeeperCard} key=${item.name} item=${item} />`)}
+                </div>
+              <//>
+
+              <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                <${Card} title="Findings" class="section">
+                  <${FindingsList} findings=${data.findings} />
+                <//>
+                <${Card} title="Timeline" class="section">
+                  <${TimelineList} timeline=${data.timeline} />
+                <//>
+              </div>
+
+              <${JsonViewerCard} title="Artifacts" data=${data.artifacts} />
+            </div>
+          `}
+        />
+      <//>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -11,9 +11,11 @@ import { FleetHealthPanel } from './fleet-health-panel'
 import { Observatory } from './observatory/observatory'
 import { AttributionPanel } from './attribution-panel'
 import { JourneyPanel } from './journey-panel'
+import { SafeAutonomyPanel } from './safe-autonomy'
 
 type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'fleet-health'
+  | 'safe-autonomy'
   | 'memory-subsystems' | 'attribution'
 
 function currentSection(): StatusSection {
@@ -23,6 +25,7 @@ function currentSection(): StatusSection {
     || section === 'journey'
     || section === 'runtime'
     || section === 'fleet-health'
+    || section === 'safe-autonomy'
     || section === 'memory-subsystems'
     || section === 'attribution'
   ) return section
@@ -43,6 +46,8 @@ export function Status() {
             ? html`<${RuntimePanel} />`
           : section === 'fleet-health'
             ? html`<${FleetHealthPanel} />`
+          : section === 'safe-autonomy'
+            ? html`<${SafeAutonomyPanel} />`
           : section === 'memory-subsystems'
             ? html`<${MemorySubsystems} />`
           : section === 'attribution'

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -78,6 +78,7 @@ describe('monitoring navigation labels', () => {
     expect(labelFor('observatory')).toBe('관찰소 (beta)')
     expect(labelFor('journey')).toBe('여정 맵')
     expect(labelFor('fleet-health')).toBe('플릿 텔레메트리')
+    expect(labelFor('safe-autonomy')).toBe('세이프 오토노미')
     // "캐스케이드" and "에이전트 디렉터리" replaced the duplicated
     // "런타임" labels (one section renamed to cascade, the other to
     // agent directory) so monitoring no longer has two sidebar items
@@ -99,6 +100,7 @@ describe('monitoring navigation labels', () => {
 
     expect(ids).toContain('journey')
     expect(ids).toContain('fleet-health')
+    expect(ids).toContain('safe-autonomy')
     expect(ids).toContain('runtime')
     expect(ids).toContain('observatory')
     // Legacy sections removed in Phase 1

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -8,6 +8,7 @@ type SurfaceSectionId =
   | 'agents'
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
+  | 'safe-autonomy'
   | 'memory-subsystems'
   | 'attribution'     // Layer 4 gate-chain observation (per-gate outcome + recent events)
   // command
@@ -159,6 +160,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '플릿 텔레메트리',
       description: '이벤트 로그, Keeper 비교, 도구 품질, 거버넌스 신호를 한 화면에서 봅니다.',
       params: { section: 'fleet-health' },
+    },
+    {
+      id: 'safe-autonomy',
+      label: '세이프 오토노미',
+      description: '도구, 샌드박스, 승인, 캐스케이드/FSM, 감사 추적을 keeper별 scorecard로 봅니다.',
+      params: { section: 'safe-autonomy' },
     },
     {
       id: 'memory-subsystems',

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -1,0 +1,1203 @@
+open Keeper_types
+
+type domain_level =
+  | Pass
+  | Warn
+  | Fail
+
+type evidence_ref = {
+  kind : string;
+  label : string;
+  value : string;
+}
+
+type finding = {
+  reason_code : string;
+  domain_id : string;
+  severity : domain_level;
+  keeper_name : string option;
+  summary : string;
+  human_action_required : bool;
+  suggested_next_action : string;
+  evidence_refs : evidence_ref list;
+}
+
+type keeper_domain = {
+  id : string;
+  label : string;
+  weight : int;
+  status : domain_level;
+  score : float;
+  summary : string;
+  evidence_refs : evidence_ref list;
+}
+
+type live_tool_stats = {
+  calls : int;
+  success_pct : float;
+}
+
+type approval_stats = {
+  count : int;
+  oldest_wait_sec : float option;
+  entries : Yojson.Safe.t list;
+}
+
+type activity_stats = {
+  count : int;
+  last_ts : float option;
+}
+
+type artifact_state = {
+  latest_path : string;
+  history_path : string;
+  fingerprint : string;
+  history_appended : bool;
+}
+
+type keeper_snapshot = {
+  meta : keeper_meta;
+  sandbox : Keeper_sandbox.t;
+  repo_readiness : Yojson.Safe.t;
+  bench_recommendation : Keeper_benchmark_canary.recommendation option;
+  live_tool_stats : live_tool_stats option;
+  approval : approval_stats;
+  activity : activity_stats;
+  tool_domain : keeper_domain;
+  sandbox_domain : keeper_domain;
+  approval_domain : keeper_domain;
+  cascade_domain : keeper_domain;
+  audit_domain : keeper_domain;
+  findings : finding list;
+}
+
+let tool_domain_id = "tool_correctness"
+let sandbox_domain_id = "sandbox_truth"
+let approval_domain_id = "approval_truth"
+let cascade_domain_id = "cascade_fsm_gracefulness"
+let audit_domain_id = "audit_trail_completeness"
+
+let domain_catalog =
+  [
+    (tool_domain_id, "Tool Correctness", 30);
+    (sandbox_domain_id, "Sandbox Truth", 20);
+    (approval_domain_id, "Approval Truth", 20);
+    (cascade_domain_id, "Cascade & FSM Gracefulness", 20);
+    (audit_domain_id, "Audit Trail Completeness", 10);
+  ]
+
+let level_to_string = function
+  | Pass -> "pass"
+  | Warn -> "warn"
+  | Fail -> "fail"
+
+let level_rank = function
+  | Pass -> 0
+  | Warn -> 1
+  | Fail -> 2
+
+let worse_level left right =
+  if level_rank left >= level_rank right then left else right
+
+let worst_level levels =
+  match levels with
+  | [] -> Warn
+  | hd :: tl -> List.fold_left worse_level hd tl
+
+let non_empty_string_opt value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let normalize_string_opt = function
+  | Some value -> non_empty_string_opt value
+  | None -> None
+
+let float_opt_to_json = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let string_opt_to_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let evidence_ref_json (entry : evidence_ref) =
+  `Assoc
+    [
+      ("kind", `String entry.kind);
+      ("label", `String entry.label);
+      ("value", `String entry.value);
+    ]
+
+let finding_json (finding : finding) =
+  `Assoc
+    [
+      ("reason_code", `String finding.reason_code);
+      ("domain_id", `String finding.domain_id);
+      ("severity", `String (level_to_string finding.severity));
+      ("keeper_name", string_opt_to_json finding.keeper_name);
+      ("summary", `String finding.summary);
+      ("human_action_required", `Bool finding.human_action_required);
+      ("suggested_next_action", `String finding.suggested_next_action);
+      ( "evidence_refs",
+        `List (List.map evidence_ref_json finding.evidence_refs) );
+    ]
+
+let keeper_domain_json (domain : keeper_domain) =
+  `Assoc
+    [
+      ("id", `String domain.id);
+      ("label", `String domain.label);
+      ("weight", `Int domain.weight);
+      ("status", `String (level_to_string domain.status));
+      ("score", `Float domain.score);
+      ("summary", `String domain.summary);
+      ("evidence_refs", `List (List.map evidence_ref_json domain.evidence_refs));
+    ]
+
+let base_evidence_ref kind label value = { kind; label; value }
+
+let approval_stats_of_pending_json pending_json : (string, approval_stats) Hashtbl.t =
+  let table = Hashtbl.create 8 in
+  let add_entry keeper_name entry =
+    let current =
+      match Hashtbl.find_opt table keeper_name with
+      | Some value -> value
+      | None -> { count = 0; oldest_wait_sec = None; entries = [] }
+    in
+    let waiting_s = Safe_ops.json_float_opt "waiting_s" entry in
+    let oldest_wait_sec =
+      match current.oldest_wait_sec, waiting_s with
+      | Some left, Some right -> Some (Float.max left right)
+      | Some _ as left, None -> left
+      | None, other -> other
+    in
+    Hashtbl.replace table keeper_name
+      {
+        count = current.count + 1;
+        oldest_wait_sec;
+        entries = entry :: current.entries;
+      }
+  in
+  (match pending_json with
+   | `List items ->
+       List.iter
+         (fun item ->
+           let keeper_name =
+             Safe_ops.json_string ~default:"" "keeper_name" item |> String.trim
+           in
+           if keeper_name <> "" then add_entry keeper_name item)
+         items
+   | _ -> ());
+  table
+
+let activity_stats_by_keeper
+    (keepers : keeper_meta list) (items : Activity_feed.activity_item list) =
+  let alias_to_keeper = Hashtbl.create (List.length keepers * 2 + 1) in
+  let stats = Hashtbl.create (List.length keepers + 1) in
+  let register_alias alias keeper_name =
+    let alias = String.trim alias in
+    if alias <> "" then Hashtbl.replace alias_to_keeper alias keeper_name
+  in
+  List.iter
+    (fun meta ->
+      register_alias meta.name meta.name;
+      register_alias meta.agent_name meta.name;
+      Hashtbl.replace stats meta.name { count = 0; last_ts = None })
+    keepers;
+  List.iter
+    (fun (item : Activity_feed.activity_item) ->
+      let actor = String.trim item.agent_name in
+      match Hashtbl.find_opt alias_to_keeper actor with
+      | None -> ()
+      | Some keeper_name ->
+          let current =
+            match Hashtbl.find_opt stats keeper_name with
+            | Some value -> value
+            | None -> { count = 0; last_ts = None }
+          in
+          let last_ts =
+            match current.last_ts with
+            | Some value -> Some (Float.max value item.created_at)
+            | None -> Some item.created_at
+          in
+          Hashtbl.replace stats keeper_name
+            { count = current.count + 1; last_ts })
+    items;
+  stats, alias_to_keeper
+
+let bench_recommendation_path () =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_BENCH_CANARY_PATH" with
+  | Some path when String.trim path <> "" -> String.trim path
+  | _ -> Keeper_benchmark_canary.default_manifest_path ()
+
+let candidate_keeper_profiles keeper_name =
+  let trimmed = String.trim keeper_name in
+  if trimmed = "" then []
+  else if String.starts_with ~prefix:"bench-" trimmed then
+    let bare =
+      String.sub trimmed 6 (String.length trimmed - 6)
+    in
+    Keeper_types.dedupe_keep_order [ trimmed; bare ]
+  else
+    Keeper_types.dedupe_keep_order [ trimmed; "bench-" ^ trimmed ]
+
+let recommendation_for_keeper
+    (manifest : Keeper_benchmark_canary.manifest option) ~keeper_name =
+  match manifest with
+  | None -> None
+  | Some manifest ->
+      let candidates = candidate_keeper_profiles keeper_name in
+      List.find_map
+        (fun keeper_profile ->
+          List.find_opt
+            (fun (recommendation : Keeper_benchmark_canary.recommendation) ->
+              String.equal recommendation.keeper_profile keeper_profile)
+            manifest.recommendations)
+        candidates
+
+let live_tool_stats_by_keeper () =
+  let table = Hashtbl.create 8 in
+  let payload = Dashboard_http_tool_quality.aggregate () in
+  let items =
+    match Yojson.Safe.Util.member "by_keeper" payload with
+    | `List rows -> rows
+    | _ -> []
+  in
+  List.iter
+    (fun row ->
+      let name = Safe_ops.json_string ~default:"" "name" row |> String.trim in
+      if name <> "" then
+        Hashtbl.replace table name
+          {
+            calls = Safe_ops.json_int ~default:0 "calls" row;
+            success_pct = Safe_ops.json_float ~default:0.0 "success_pct" row;
+          })
+    items;
+  table, payload
+
+let transport_health_status transport_json =
+  let queue_pressure =
+    transport_json
+    |> Yojson.Safe.Util.member "summary"
+    |> Safe_ops.json_string ~default:"unknown" "queue_pressure"
+  in
+  let grpc_json = Yojson.Safe.Util.member "grpc" transport_json in
+  let ws_json = Yojson.Safe.Util.member "websocket" transport_json in
+  let grpc_enabled = Safe_ops.json_bool ~default:false "enabled" grpc_json in
+  let grpc_reachable = Safe_ops.json_bool ~default:false "reachable" grpc_json in
+  let ws_enabled = Safe_ops.json_bool ~default:false "enabled" ws_json in
+  let ws_reachable = Safe_ops.json_bool ~default:false "reachable" ws_json in
+  if (grpc_enabled && not grpc_reachable) || (ws_enabled && not ws_reachable) then
+    ( Fail,
+      "configured transport is unreachable",
+      Some "transport_unhealthy" )
+  else if String.equal queue_pressure "high" then
+    (Warn, "transport queue pressure is high", Some "transport_unhealthy")
+  else if String.equal queue_pressure "watch" then
+    (Warn, "transport queue pressure is elevated", None)
+  else
+    (Pass, "transport paths are healthy", None)
+
+let domain_definition id =
+  match List.find_opt (fun (candidate, _, _) -> String.equal candidate id) domain_catalog with
+  | Some (_, label, weight) -> (label, weight)
+  | None -> (id, 0)
+
+let make_domain ~id ~status ~score ~summary ~evidence_refs =
+  let label, weight = domain_definition id in
+  { id; label; weight; status; score; summary; evidence_refs }
+
+let make_finding
+    ~reason_code
+    ~domain_id
+    ~severity
+    ?keeper_name
+    ~summary
+    ~human_action_required
+    ~suggested_next_action
+    ~evidence_refs
+    () =
+  {
+    reason_code;
+    domain_id;
+    severity;
+    keeper_name;
+    summary;
+    human_action_required;
+    suggested_next_action;
+    evidence_refs;
+  }
+
+let classify_tool_correctness
+    ~(manifest_path : string)
+    ~(recommendation : Keeper_benchmark_canary.recommendation option)
+    ~(live_stats : live_tool_stats option)
+    ~(keeper_name : string) =
+  let evidence_refs =
+    [
+      base_evidence_ref "file" "bench_manifest" manifest_path;
+      base_evidence_ref "route" "tool_quality" "/api/v1/dashboard/tool-quality";
+    ]
+  in
+  match recommendation, live_stats with
+  | Some recommendation, Some stats when stats.calls >= 3 && stats.success_pct < 80.0 ->
+      let summary =
+        Printf.sprintf
+          "benchmark recommends %s but live tool success is %.1f%% across %d calls"
+          recommendation.model_label stats.success_pct stats.calls
+      in
+      ( make_domain ~id:tool_domain_id ~status:Fail ~score:stats.success_pct
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"tool_misuse"
+            ~domain_id:tool_domain_id
+            ~severity:Fail
+            ~keeper_name
+            ~summary
+            ~human_action_required:false
+            ~suggested_next_action:
+              "Inspect recent tool-call evidence and adjust keeper prompt/model selection."
+            ~evidence_refs
+            ();
+        ] )
+  | Some recommendation, _ ->
+      let stability = Option.value recommendation.stability_score ~default:1.0 in
+      let status =
+        if stability >= 0.9 then Pass else Warn
+      in
+      let summary =
+        Printf.sprintf
+          "benchmark recommends %s (score %.1f, stability %.2f)"
+          recommendation.model_label recommendation.composite_score stability
+      in
+      ( make_domain ~id:tool_domain_id ~status
+          ~score:recommendation.composite_score
+          ~summary ~evidence_refs,
+        [] )
+  | None, Some stats when stats.calls >= 3 && stats.success_pct < 80.0 ->
+      let summary =
+        Printf.sprintf
+          "live tool success is %.1f%% across %d calls with no benchmark proof"
+          stats.success_pct stats.calls
+      in
+      ( make_domain ~id:tool_domain_id ~status:Fail ~score:stats.success_pct
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"tool_misuse"
+            ~domain_id:tool_domain_id
+            ~severity:Fail
+            ~keeper_name
+            ~summary
+            ~human_action_required:false
+            ~suggested_next_action:
+              "Run the tool-call benchmark corpus for this keeper profile before trusting it for code work."
+            ~evidence_refs
+            ();
+        ] )
+  | None, Some stats ->
+      let summary =
+        Printf.sprintf
+          "live tool telemetry shows %.1f%% success across %d calls, but no deterministic benchmark proof"
+          stats.success_pct stats.calls
+      in
+      ( make_domain ~id:tool_domain_id ~status:Warn ~score:stats.success_pct
+          ~summary ~evidence_refs,
+        [] )
+  | None, None ->
+      ( make_domain ~id:tool_domain_id ~status:Warn ~score:50.0
+          ~summary:"no benchmark manifest or live tool telemetry for this keeper"
+          ~evidence_refs,
+        [] )
+
+let classify_sandbox_truth ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(sandbox : Keeper_sandbox.t) ~(repo_readiness : Yojson.Safe.t) =
+  let host_root_exists = Fs_compat.file_exists sandbox.host_root_abs in
+  let repo_state = Safe_ops.json_string ~default:"unknown" "state" repo_readiness in
+  let repo_clone_path =
+    Safe_ops.json_string ~default:"" "clone_path" repo_readiness
+  in
+  let evidence_refs =
+    [
+      base_evidence_ref "path" "sandbox_root" sandbox.host_root_abs;
+      base_evidence_ref "path" "repo_clone" repo_clone_path;
+    ]
+  in
+  if not host_root_exists then
+    let summary =
+      Printf.sprintf "sandbox root %s is missing" sandbox.host_root_abs
+    in
+    ( make_domain ~id:sandbox_domain_id ~status:Fail ~score:0.0
+        ~summary ~evidence_refs,
+      [
+        make_finding
+          ~reason_code:"sandbox_boundary_gap"
+          ~domain_id:sandbox_domain_id
+          ~severity:Fail
+          ~keeper_name:meta.name
+          ~summary
+          ~human_action_required:false
+          ~suggested_next_action:
+            "Recreate the keeper sandbox bundle before allowing code or shell tools."
+          ~evidence_refs
+          ();
+      ] )
+  else
+    match repo_state with
+    | "ready" ->
+        ( make_domain ~id:sandbox_domain_id ~status:Pass ~score:100.0
+            ~summary:
+              (Printf.sprintf "sandbox %s is present and repo clone is ready"
+                 sandbox.sandbox_profile)
+            ~evidence_refs,
+          [] )
+    | "missing_clone" ->
+        ( make_domain ~id:sandbox_domain_id ~status:Warn ~score:60.0
+            ~summary:
+              "sandbox exists but no repo clone is ready under the keeper playground"
+            ~evidence_refs,
+          [
+            make_finding
+              ~reason_code:"repo_not_ready"
+              ~domain_id:sandbox_domain_id
+              ~severity:Warn
+              ~keeper_name:meta.name
+              ~summary:"keeper sandbox repo clone has not been prepared yet"
+              ~human_action_required:false
+              ~suggested_next_action:
+                "Clone the target repo into the keeper playground before autonomous code work."
+              ~evidence_refs
+              ();
+          ] )
+    | _ ->
+        let summary =
+          Printf.sprintf "sandbox repo readiness is %s" repo_state
+        in
+        ( make_domain ~id:sandbox_domain_id ~status:Fail ~score:25.0
+            ~summary ~evidence_refs,
+          [
+            make_finding
+              ~reason_code:"repo_not_ready"
+              ~domain_id:sandbox_domain_id
+              ~severity:Fail
+              ~keeper_name:meta.name
+              ~summary
+              ~human_action_required:false
+              ~suggested_next_action:
+                "Repair the keeper sandbox clone state before allowing Git or file mutations."
+              ~evidence_refs
+              ();
+          ] )
+
+let classify_approval_truth ~(keeper_name : string) ~(approval : approval_stats) =
+  let evidence_refs =
+    [
+      base_evidence_ref "route" "governance" "/api/v1/dashboard/governance";
+      base_evidence_ref "tool" "approval_pending" "masc_approval_pending";
+    ]
+  in
+  match approval.count, approval.oldest_wait_sec with
+  | 0, _ ->
+      ( make_domain ~id:approval_domain_id ~status:Pass ~score:100.0
+          ~summary:"no pending approvals for this keeper"
+          ~evidence_refs,
+        [] )
+  | count, Some wait_s when wait_s >= 900.0 ->
+      let summary =
+        Printf.sprintf
+          "%d approval(s) pending; oldest has waited %.0fs"
+          count wait_s
+      in
+      ( make_domain ~id:approval_domain_id ~status:Fail ~score:25.0
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"approval_gap"
+            ~domain_id:approval_domain_id
+            ~severity:Fail
+            ~keeper_name
+            ~summary
+            ~human_action_required:true
+            ~suggested_next_action:
+              "Review or resolve the pending approvals before continuing autonomous execution."
+            ~evidence_refs
+            ();
+        ] )
+  | count, wait_s_opt ->
+      let summary =
+        match wait_s_opt with
+        | Some wait_s ->
+            Printf.sprintf
+              "%d approval(s) pending; oldest has waited %.0fs"
+              count wait_s
+        | None -> Printf.sprintf "%d approval(s) pending" count
+      in
+      ( make_domain ~id:approval_domain_id ~status:Warn ~score:60.0
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"approval_pending_pause"
+            ~domain_id:approval_domain_id
+            ~severity:Warn
+            ~keeper_name
+            ~summary
+            ~human_action_required:true
+            ~suggested_next_action:
+              "Keep the keeper paused at the human gate until the approval is resolved."
+            ~evidence_refs
+            ();
+        ] )
+
+let classify_cascade_fsm ~(config : Coord.config) ~(meta : keeper_meta) =
+  let blocker_fields =
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+  in
+  let blocker_json = `Assoc blocker_fields in
+  let blocker_class =
+    Safe_ops.json_string_opt "runtime_blocker_class" blocker_json
+    |> normalize_string_opt
+  in
+  let blocker_summary =
+    Safe_ops.json_string_opt "runtime_blocker_summary" blocker_json
+    |> normalize_string_opt
+  in
+  let continue_gate =
+    Safe_ops.json_bool ~default:false "runtime_blocker_continue_gate" blocker_json
+  in
+  let evidence_refs =
+    [ base_evidence_ref "route" "transport_health" "/api/v1/dashboard/transport-health" ]
+  in
+  match blocker_class, blocker_summary with
+  | None, None ->
+      ( make_domain ~id:cascade_domain_id ~status:Pass ~score:100.0
+          ~summary:"no current runtime blocker is recorded"
+          ~evidence_refs,
+        [] )
+  | Some "no_tool_capable_provider", Some summary ->
+      ( make_domain ~id:cascade_domain_id ~status:Warn ~score:60.0
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"unsupported_model_skip"
+            ~domain_id:cascade_domain_id
+            ~severity:Warn
+            ~keeper_name:meta.name
+            ~summary
+            ~human_action_required:false
+            ~suggested_next_action:
+              "Skip this model path or refresh the keeper's model/cascade mapping."
+            ~evidence_refs
+            ();
+        ] )
+  | Some _cls, Some summary ->
+      let next_action =
+        if continue_gate then
+          "Keep the blocker visible and watch the next turn before escalating."
+        else
+          "Pause or inspect the keeper before more autonomous turns are admitted."
+      in
+      ( make_domain ~id:cascade_domain_id ~status:Warn ~score:55.0
+          ~summary ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"cascade_thrash"
+            ~domain_id:cascade_domain_id
+            ~severity:Warn
+            ~keeper_name:meta.name
+            ~summary
+            ~human_action_required:(not continue_gate)
+            ~suggested_next_action:next_action
+            ~evidence_refs
+            ();
+        ] )
+  | None, Some summary ->
+      ( make_domain ~id:cascade_domain_id ~status:Fail ~score:20.0
+          ~summary:"keeper has a raw blocker string without normalized blocker_class"
+          ~evidence_refs,
+        [
+          make_finding
+            ~reason_code:"cascade_thrash"
+            ~domain_id:cascade_domain_id
+            ~severity:Fail
+            ~keeper_name:meta.name
+            ~summary
+            ~human_action_required:true
+            ~suggested_next_action:
+              "Normalize the blocker path or pause this keeper until the failure is classified."
+            ~evidence_refs
+            ();
+        ] )
+  | Some _, None ->
+      ( make_domain ~id:cascade_domain_id ~status:Warn ~score:50.0
+          ~summary:"keeper has a typed blocker class without a summary"
+          ~evidence_refs,
+        [] )
+
+let classify_audit_trail ~(config : Coord.config) ~(meta : keeper_meta)
+    ~(activity : activity_stats) =
+  let trace_history_count = List.length meta.runtime.trace_history in
+  let total_turns = meta.runtime.usage.total_turns in
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let evidence_refs =
+    [
+      base_evidence_ref "path" "trace_history"
+        (Keeper_types.keeper_history_path config trace_id);
+      base_evidence_ref "route" "workspace_evidence" "#workspace?section=evidence";
+    ]
+  in
+  if total_turns > 0 && trace_history_count = 0 && activity.count = 0 then
+    ( make_domain ~id:audit_domain_id ~status:Fail ~score:20.0
+        ~summary:"keeper has turns recorded but no visible trace history or activity trail"
+        ~evidence_refs,
+      [
+        make_finding
+          ~reason_code:"history_gap"
+          ~domain_id:audit_domain_id
+          ~severity:Fail
+          ~keeper_name:meta.name
+          ~summary:
+            "turns exist without trace_history, handoff lineage, or recent activity evidence"
+          ~human_action_required:false
+          ~suggested_next_action:
+            "Inspect trace persistence and activity projection before trusting this keeper's audit trail."
+          ~evidence_refs
+          ();
+      ] )
+  else if total_turns = 0 && trace_history_count = 0 && activity.count = 0 then
+    ( make_domain ~id:audit_domain_id ~status:Warn ~score:50.0
+        ~summary:"keeper has little or no runtime history yet"
+        ~evidence_refs,
+      [] )
+  else
+    ( make_domain ~id:audit_domain_id ~status:Pass ~score:100.0
+        ~summary:
+          (Printf.sprintf
+             "audit trail visible (turns=%d, handoffs=%d, recent_activity=%d)"
+             total_turns trace_history_count activity.count)
+        ~evidence_refs,
+      [] )
+
+let current_task_id_json meta =
+  match meta.current_task_id with
+  | Some task_id -> `String (Keeper_id.Task_id.to_string task_id)
+  | None -> `Null
+
+let keeper_score domains =
+  let total_weight =
+    List.fold_left (fun acc (domain : keeper_domain) -> acc + domain.weight) 0 domains
+  in
+  if total_weight = 0 then 0.0
+  else
+    List.fold_left
+      (fun acc (domain : keeper_domain) ->
+        acc +. (domain.score *. float_of_int domain.weight))
+      0.0 domains
+    /. float_of_int total_weight
+
+let keeper_status_of_domains domains =
+  let statuses = List.map (fun (domain : keeper_domain) -> domain.status) domains in
+  worst_level statuses
+
+let build_keeper_snapshot
+    ~(config : Coord.config)
+    ~(manifest_path : string)
+    ~(bench_manifest : Keeper_benchmark_canary.manifest option)
+    ~(live_tool_by_keeper : (string, live_tool_stats) Hashtbl.t)
+    ~(approval_by_keeper : (string, approval_stats) Hashtbl.t)
+    ~(activity_by_keeper : (string, activity_stats) Hashtbl.t)
+    (meta : keeper_meta) =
+  let sandbox = Keeper_sandbox.of_meta ~config ~meta in
+  let repo_readiness = Keeper_repo_readiness.inspect ~config ~keeper_name:meta.name () in
+  let recommendation =
+    recommendation_for_keeper bench_manifest ~keeper_name:meta.name
+  in
+  let live_tool_stats = Hashtbl.find_opt live_tool_by_keeper meta.name in
+  let approval =
+    match Hashtbl.find_opt approval_by_keeper meta.name with
+    | Some value -> value
+    | None -> { count = 0; oldest_wait_sec = None; entries = [] }
+  in
+  let activity =
+    match Hashtbl.find_opt activity_by_keeper meta.name with
+    | Some value -> value
+    | None -> { count = 0; last_ts = None }
+  in
+  let tool_domain, tool_findings =
+    classify_tool_correctness ~manifest_path ~recommendation ~live_stats:live_tool_stats
+      ~keeper_name:meta.name
+  in
+  let sandbox_domain, sandbox_findings =
+    classify_sandbox_truth ~config ~meta ~sandbox ~repo_readiness
+  in
+  let approval_domain, approval_findings =
+    classify_approval_truth ~keeper_name:meta.name ~approval
+  in
+  let cascade_domain, cascade_findings =
+    classify_cascade_fsm ~config ~meta
+  in
+  let audit_domain, audit_findings =
+    classify_audit_trail ~config ~meta ~activity
+  in
+  {
+    meta;
+    sandbox;
+    repo_readiness;
+    bench_recommendation = recommendation;
+    live_tool_stats;
+    approval;
+    activity;
+    tool_domain;
+    sandbox_domain;
+    approval_domain;
+    cascade_domain;
+    audit_domain;
+    findings =
+      tool_findings @ sandbox_findings @ approval_findings
+      @ cascade_findings @ audit_findings;
+  }
+
+let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
+  let meta = snapshot.meta in
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let sandbox = snapshot.sandbox in
+  let domains =
+    [
+      snapshot.tool_domain;
+      snapshot.sandbox_domain;
+      snapshot.approval_domain;
+      snapshot.cascade_domain;
+      snapshot.audit_domain;
+    ]
+  in
+  let score = keeper_score domains in
+  let status = keeper_status_of_domains domains in
+  `Assoc
+    [
+      ("name", `String meta.name);
+      ("agent_name", `String meta.agent_name);
+      ("status", `String (level_to_string status));
+      ("score", `Float score);
+      ("paused", `Bool meta.paused);
+      ("sandbox_profile", `String sandbox.sandbox_profile);
+      ("sandbox_backend", `String (Keeper_sandbox.backend_to_string sandbox.backend));
+      ("network_mode", `String sandbox.network_mode);
+      ("sandbox_root", `String sandbox.host_root_abs);
+      ("container_root", string_opt_to_json sandbox.container_root);
+      ("goal", `String meta.goal);
+      ("goal_horizons",
+       `Assoc
+         [
+           ("short", `String meta.short_goal);
+           ("mid", `String meta.mid_goal);
+           ("long", `String meta.long_goal);
+         ]);
+      ("active_goal_ids", `List (List.map (fun value -> `String value) meta.active_goal_ids));
+      ("current_task_id", current_task_id_json meta);
+      ("trace_id", `String trace_id);
+      ("trace_history_count", `Int (List.length meta.runtime.trace_history));
+      ("handoff_count_total", `Int (List.length meta.runtime.trace_history));
+      ("total_turns", `Int meta.runtime.usage.total_turns);
+      ("approval_pending_count", `Int snapshot.approval.count);
+      ("recent_activity_count", `Int snapshot.activity.count);
+      ("last_activity_ts", float_opt_to_json snapshot.activity.last_ts);
+      ("last_blocker", string_opt_to_json (non_empty_string_opt meta.runtime.last_blocker));
+      ( "last_blocker_class",
+        string_opt_to_json
+          (Option.map Keeper_types.blocker_class_to_string
+             meta.runtime.last_blocker_class) );
+      ( "benchmark_recommendation",
+        match snapshot.bench_recommendation with
+        | None -> `Null
+        | Some recommendation ->
+            `Assoc
+              [
+                ("keeper_profile", `String recommendation.keeper_profile);
+                ("model_label", `String recommendation.model_label);
+                ("composite_score", `Float recommendation.composite_score);
+                ("task_pass_rate", `Float recommendation.task_pass_rate);
+                ("stability_score", float_opt_to_json recommendation.stability_score);
+                ("cases_total", `Int recommendation.cases_total);
+                ("cases_passed", `Int recommendation.cases_passed);
+              ] );
+      ( "live_tool_stats",
+        match snapshot.live_tool_stats with
+        | None -> `Null
+        | Some stats ->
+            `Assoc
+              [
+                ("calls", `Int stats.calls);
+                ("success_pct", `Float stats.success_pct);
+              ] );
+      ("repo_readiness", snapshot.repo_readiness);
+      ("domains", `List (List.map keeper_domain_json domains));
+      ("findings", `List (List.map finding_json snapshot.findings));
+      ( "evidence_refs",
+        `List
+          [
+            evidence_ref_json
+              (base_evidence_ref "path" "keeper_meta"
+                 (Keeper_types.keeper_meta_path config meta.name));
+            evidence_ref_json
+              (base_evidence_ref "path" "history"
+                 (Keeper_types.keeper_history_path config trace_id));
+          ] );
+    ]
+
+let timeline_entries_json
+    ~(alias_to_keeper : (string, string) Hashtbl.t)
+    ~(activity_items : Activity_feed.activity_item list)
+    ~(approval_by_keeper : (string, approval_stats) Hashtbl.t)
+    ~(keepers : keeper_snapshot list) =
+  let entries = ref [] in
+  let push json = entries := json :: !entries in
+  List.iter
+    (fun (item : Activity_feed.activity_item) ->
+      let keeper_name = Hashtbl.find_opt alias_to_keeper (String.trim item.agent_name) in
+      push
+        (`Assoc
+          [
+            ("ts", `Float item.created_at);
+            ("ts_iso", `String (Types.iso8601_of_unix_seconds item.created_at));
+            ("kind", `String item.kind);
+            ("keeper_name", string_opt_to_json keeper_name);
+            ("actor", `String item.agent_name);
+            ("summary", `String item.summary);
+          ]))
+    activity_items;
+  Hashtbl.iter
+    (fun keeper_name approval ->
+      List.iter
+        (fun entry ->
+          let requested_at = Safe_ops.json_float ~default:0.0 "requested_at" entry in
+          push
+            (`Assoc
+              [
+                ("ts", `Float requested_at);
+                ("ts_iso", `String (Types.iso8601_of_unix_seconds requested_at));
+                ("kind", `String "approval_pending");
+                ("keeper_name", `String keeper_name);
+                ("actor", `String keeper_name);
+                ("summary",
+                 `String
+                   (Printf.sprintf
+                      "approval pending for %s (%s)"
+                      (Safe_ops.json_string ~default:"tool" "tool_name" entry)
+                      (Safe_ops.json_string ~default:"risk" "risk_level" entry)));
+              ]))
+        approval.entries)
+    approval_by_keeper;
+  List.iter
+    (fun snapshot ->
+      let blocker =
+        non_empty_string_opt snapshot.meta.runtime.last_blocker
+      in
+      match blocker with
+      | None -> ()
+      | Some summary ->
+          let ts = snapshot.meta.runtime.usage.last_turn_ts in
+          if ts > 0.0 then
+            push
+              (`Assoc
+                [
+                  ("ts", `Float ts);
+                  ("ts_iso", `String (Types.iso8601_of_unix_seconds ts));
+                  ("kind", `String "runtime_blocker");
+                  ("keeper_name", `String snapshot.meta.name);
+                  ("actor", `String snapshot.meta.name);
+                  ("summary", `String summary);
+                ]))
+    keepers;
+  !entries
+  |> List.sort (fun left right ->
+         let left_ts = Safe_ops.json_float ~default:0.0 "ts" left in
+         let right_ts = Safe_ops.json_float ~default:0.0 "ts" right in
+         Float.compare right_ts left_ts)
+  |> List.filteri (fun idx _ -> idx < 25)
+
+let domain_summary_json ~id ~(keepers : keeper_snapshot list)
+    ?extra_status ?extra_evidence_refs ?extra_note () =
+  let label, weight = domain_definition id in
+  let keeper_domains =
+    keepers
+    |> List.map (fun snapshot ->
+           match id with
+           | _ when String.equal id tool_domain_id -> snapshot.tool_domain
+           | _ when String.equal id sandbox_domain_id -> snapshot.sandbox_domain
+           | _ when String.equal id approval_domain_id -> snapshot.approval_domain
+           | _ when String.equal id cascade_domain_id -> snapshot.cascade_domain
+           | _ -> snapshot.audit_domain)
+  in
+  let statuses = List.map (fun (domain : keeper_domain) -> domain.status) keeper_domains in
+  let statuses =
+    match extra_status with
+    | Some level -> level :: statuses
+    | None -> statuses
+  in
+  let status = worst_level statuses in
+  let score =
+    match keeper_domains with
+    | [] -> 0.0
+    | rows ->
+        List.fold_left (fun acc (domain : keeper_domain) -> acc +. domain.score) 0.0 rows
+        /. float_of_int (List.length rows)
+  in
+  let evidence_refs =
+    (List.concat_map (fun (domain : keeper_domain) -> domain.evidence_refs) keeper_domains)
+    @ Option.value ~default:[] extra_evidence_refs
+  in
+  let pass_count =
+    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Pass) keeper_domains)
+  in
+  let warn_count =
+    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Warn) keeper_domains)
+  in
+  let fail_count =
+    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Fail) keeper_domains)
+  in
+  `Assoc
+    [
+      ("id", `String id);
+      ("label", `String label);
+      ("weight", `Int weight);
+      ("status", `String (level_to_string status));
+      ("score", `Float score);
+      ("pass_count", `Int pass_count);
+      ("warn_count", `Int warn_count);
+      ("fail_count", `Int fail_count);
+      ( "summary",
+        `String
+          (match extra_note with
+           | Some note -> note
+           | None -> Printf.sprintf "%d keepers evaluated" (List.length keeper_domains)) );
+      ("evidence_refs", `List (List.map evidence_ref_json evidence_refs));
+    ]
+
+let normalize_for_hash (json : Yojson.Safe.t) =
+  let rec aux = function
+    | `Assoc fields ->
+        `Assoc
+          (fields
+          |> List.filter_map (fun (key, value) ->
+                 if List.mem key [ "generated_at"; "generated_at_unix" ] then None
+                 else Some (key, aux value)))
+    | `List values -> `List (List.map aux values)
+    | other -> other
+  in
+  aux json
+
+let payload_hash json =
+  json
+  |> normalize_for_hash
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+
+let audit_dir config =
+  Filename.concat (Coord.masc_root_dir config) "audits/safe_autonomy"
+
+let artifact_paths config =
+  let dir = audit_dir config in
+  let latest_path = Filename.concat dir "latest.json" in
+  let history_path = Filename.concat dir "history.jsonl" in
+  dir, latest_path, history_path
+
+let write_artifacts ~(config : Coord.config) payload =
+  let dir, latest_path, history_path = artifact_paths config in
+  Fs_compat.mkdir_p dir;
+  let fingerprint = payload_hash payload in
+  let previous_hash =
+    match Safe_ops.read_json_file_safe latest_path with
+    | Ok json -> Some (payload_hash json)
+    | Error _ -> None
+  in
+  let history_appended = previous_hash <> Some fingerprint in
+  (match Fs_compat.save_file_atomic latest_path (Yojson.Safe.pretty_to_string payload) with
+   | Ok () -> ()
+   | Error message ->
+       Log.Dashboard.warn "safe autonomy latest artifact write failed: %s" message);
+  if history_appended then Fs_compat.append_jsonl history_path payload;
+  { latest_path; history_path; fingerprint; history_appended }
+
+let global_status_of_score ~has_fail score =
+  if has_fail || score < 60.0 then Fail
+  else if score < 85.0 then Warn
+  else Pass
+
+let json ~(config : Coord.config) () =
+  let keepers =
+    Keeper_types.keeper_names config
+    |> List.filter_map (fun name ->
+           match Keeper_types.read_meta config name with
+           | Ok (Some meta) -> Some meta
+           | _ -> None)
+  in
+  let activity_items = Activity_feed.recent_activity config ~limit:200 () in
+  let activity_by_keeper, alias_to_keeper =
+    activity_stats_by_keeper keepers activity_items
+  in
+  let approval_queue_json = Keeper_approval_queue.list_pending_dashboard_json () in
+  let approval_by_keeper = approval_stats_of_pending_json approval_queue_json in
+  let approval_summary = Dashboard_governance_metrics.approval_queue_summary () in
+  let live_tool_by_keeper, live_tool_payload = live_tool_stats_by_keeper () in
+  let manifest_path = bench_recommendation_path () in
+  let bench_manifest = Keeper_benchmark_canary.load_manifest () in
+  let transport_json = Transport_metrics.transport_health_json ~config in
+  let transport_level, transport_summary, transport_reason =
+    transport_health_status transport_json
+  in
+  let keeper_snapshots =
+    keepers
+    |> List.map
+         (build_keeper_snapshot ~config ~manifest_path
+            ~bench_manifest ~live_tool_by_keeper ~approval_by_keeper
+            ~activity_by_keeper)
+  in
+  let transport_finding =
+    match transport_reason with
+    | None -> []
+    | Some reason_code ->
+        [
+          make_finding
+            ~reason_code
+            ~domain_id:cascade_domain_id
+            ~severity:transport_level
+            ~summary:transport_summary
+            ~human_action_required:false
+            ~suggested_next_action:
+              "Inspect transport-health and runtime listener state before escalating keeper failures."
+            ~evidence_refs:
+              [ base_evidence_ref "route" "transport_health" "/api/v1/dashboard/transport-health" ]
+            ();
+        ]
+  in
+  let findings =
+    transport_finding
+    @ List.concat_map (fun snapshot -> snapshot.findings) keeper_snapshots
+  in
+  let domains =
+    [
+      domain_summary_json ~id:tool_domain_id ~keepers:keeper_snapshots ();
+      domain_summary_json ~id:sandbox_domain_id ~keepers:keeper_snapshots ();
+      domain_summary_json ~id:approval_domain_id ~keepers:keeper_snapshots ();
+      domain_summary_json ~id:cascade_domain_id ~keepers:keeper_snapshots
+        ~extra_status:transport_level
+        ~extra_evidence_refs:
+          [ base_evidence_ref "route" "transport_health" "/api/v1/dashboard/transport-health" ]
+        ~extra_note:
+          (Printf.sprintf "keeper blocker surfacing + transport health (%s)"
+             transport_summary)
+        ();
+      domain_summary_json ~id:audit_domain_id ~keepers:keeper_snapshots ();
+    ]
+  in
+  let per_keeper =
+    List.map (keeper_snapshot_json ~config) keeper_snapshots
+  in
+  let total_active_goals =
+    List.fold_left
+      (fun acc snapshot -> acc + List.length snapshot.meta.active_goal_ids)
+      0 keeper_snapshots
+  in
+  let keepers_with_tasks =
+    List.length
+      (List.filter
+         (fun snapshot -> snapshot.meta.current_task_id <> None)
+         keeper_snapshots)
+  in
+  let findings_total = List.length findings in
+  let human_action_required_count =
+    List.length
+      (List.filter (fun finding -> finding.human_action_required) findings)
+  in
+  let keeper_scores =
+    keeper_snapshots
+    |> List.map (fun snapshot ->
+           keeper_score
+             [
+               snapshot.tool_domain;
+               snapshot.sandbox_domain;
+               snapshot.approval_domain;
+               snapshot.cascade_domain;
+               snapshot.audit_domain;
+             ])
+  in
+  let global_score =
+    if keeper_scores = [] then 0.0
+    else
+      List.fold_left ( +. ) 0.0 keeper_scores
+      /. float_of_int (List.length keeper_scores)
+  in
+  let has_fail =
+    List.exists
+      (fun finding -> finding.severity = Fail)
+      findings
+  in
+  let global_status = global_status_of_score ~has_fail global_score in
+  let timeline =
+    timeline_entries_json ~alias_to_keeper ~activity_items ~approval_by_keeper
+      ~keepers:keeper_snapshots
+  in
+  let payload =
+    `Assoc
+      [
+        ("generated_at", `String (Types.now_iso ()));
+        ("generated_at_unix", `Float (Unix.gettimeofday ()));
+        ( "summary",
+          `Assoc
+            [
+              ("global_score", `Float global_score);
+              ("status", `String (level_to_string global_status));
+              ("keeper_count", `Int (List.length keeper_snapshots));
+              ("active_goal_count", `Int total_active_goals);
+              ("keepers_with_current_task", `Int keepers_with_tasks);
+              ("findings_total", `Int findings_total);
+              ("human_action_required_count", `Int human_action_required_count);
+              ("approval_queue_depth", `Int approval_summary.depth);
+            ] );
+        ("domains", `List domains);
+        ("per_keeper", `List per_keeper);
+        ("findings", `List (List.map finding_json findings));
+        ("timeline", `List timeline);
+        ( "transport",
+          `Assoc
+            [
+              ("status", `String (level_to_string transport_level));
+              ("summary", `String transport_summary);
+              ("detail", transport_json);
+            ] );
+        ( "evidence_refs",
+          `List
+            [
+              evidence_ref_json
+                (base_evidence_ref "file" "bench_manifest" manifest_path);
+              evidence_ref_json
+                (base_evidence_ref "route" "tool_quality" "/api/v1/dashboard/tool-quality");
+              evidence_ref_json
+                (base_evidence_ref "route" "governance" "/api/v1/dashboard/governance");
+              evidence_ref_json
+                (base_evidence_ref "route" "transport_health" "/api/v1/dashboard/transport-health");
+              evidence_ref_json
+                (base_evidence_ref "route" "surface_readiness" "/api/v1/dashboard/surface-readiness");
+              evidence_ref_json
+                (base_evidence_ref "route" "metrics" "/metrics");
+            ] );
+        ("tool_quality_live", live_tool_payload);
+      ]
+  in
+  let artifacts = write_artifacts ~config payload in
+  match payload with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+        @ [
+            ( "artifacts",
+              `Assoc
+                [
+                  ("latest_path", `String artifacts.latest_path);
+                  ("history_path", `String artifacts.history_path);
+                  ("fingerprint", `String artifacts.fingerprint);
+                  ("history_appended", `Bool artifacts.history_appended);
+                ] );
+          ])
+  | other -> other

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -144,6 +144,25 @@ let all_entries =
         };
     };
     {
+      id = "monitoring.safe_autonomy";
+      label = "세이프 오토노미";
+      exposure_status = "lab";
+      hidden_from_nav = false;
+      meets_main_gate = false;
+      rationale =
+        "Tool correctness, sandbox truth, approval gates, cascade gracefulness, audit trail completeness를 하나의 운영 scorecard로 묶은 advisory surface입니다.";
+      route_hash = Some "#monitoring?section=safe-autonomy";
+      refs =
+        {
+          fixture_harness = Some "dune exec ./test/test_dashboard_safe_autonomy.exe";
+          live_spotcheck = Some "/api/v1/dashboard/safe-autonomy";
+          logs_ref = Some "/api/v1/dashboard/logs";
+          metrics_ref = Some "/metrics";
+          proof_ref = Some "/api/v1/dashboard/proof";
+          tool_name = Some "masc_surface_audit";
+        };
+    };
+    {
       id = "monitoring.activity";
       label = "활동 그래프";
       exposure_status = "legacy";

--- a/lib/dune
+++ b/lib/dune
@@ -68,6 +68,7 @@
    dashboard_governance_judge
    dashboard_governance_metrics
    dashboard_operator_judge
+   dashboard_safe_autonomy
    dashboard_surface_readiness
    dashboard_execution
    dashboard_execution_helpers

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -555,6 +555,13 @@ let rec add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/safe-autonomy" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let config = state.Mcp_server.room_config in
+         let json = Dashboard_safe_autonomy.json ~config () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/transport-health" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_transport_health_http_json ~state in

--- a/test/dune
+++ b/test/dune
@@ -330,6 +330,7 @@
         test_tui_decode
         test_dashboard_governance
         test_dashboard_labels
+        test_dashboard_safe_autonomy
         test_dashboard_surface_readiness
         test_activity_graph
         test_masc_log
@@ -494,6 +495,7 @@
         test_tui_decode
         test_dashboard_governance
         test_dashboard_labels
+        test_dashboard_safe_autonomy
         test_dashboard_surface_readiness
         test_activity_graph
         test_masc_log

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -1,0 +1,199 @@
+open Alcotest
+open Masc_mcp
+
+module Coord = Masc_mcp.Coord
+module KT = Masc_mcp.Keeper_types
+
+let test_counter = ref 0
+
+let tmpdir prefix =
+  incr test_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%d"
+         prefix (Unix.getpid ()) !test_counter
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let with_env name value_opt f =
+  let previous = Sys.getenv_opt name in
+  (match value_opt with
+   | Some value -> Unix.putenv name value
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "")
+    f
+
+let with_safe_autonomy_store f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = tmpdir "safe_autonomy" in
+  let config = Coord.default_config base_dir in
+  ignore (Coord.init config ~agent_name:None);
+  f config
+
+let write_file path contents =
+  match Fs_compat.save_file_atomic path contents with
+  | Ok () -> ()
+  | Error err -> fail ("save_file_atomic failed: " ^ err)
+
+let make_meta ?(name = "bench-analyst") ?(trace_id = "trace-safe-autonomy") () =
+  match
+    KT.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String "bench-analyst-agent");
+          ("trace_id", `String trace_id);
+          ("cascade_name", `String Keeper_config.default_cascade_name);
+          ("last_model_used", `String "openai:gpt-5.4");
+          ("goal", `String "Keep autonomy safe and observable");
+          ("short_goal", `String "Handle code work with approval and sandbox guardrails");
+          ("mid_goal", `String "Keep the keeper queue healthy");
+          ("long_goal", `String "Reach product-grade safe autonomy");
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let task_id value =
+  match Keeper_id.Task_id.of_string value with
+  | Ok id -> id
+  | Error err -> fail ("Task_id.of_string failed: " ^ err)
+
+let persist_keeper config =
+  let meta =
+    {
+      (make_meta ()) with
+      active_goal_ids = [ "goal-short"; "goal-mid" ];
+      current_task_id = Some (task_id "task-safe-autonomy");
+      runtime =
+        {
+          (make_meta ()).runtime with
+          usage =
+            {
+              (make_meta ()).runtime.usage with
+              total_turns = 3;
+              last_turn_ts = Unix.gettimeofday ();
+              last_model_used = "openai:gpt-5.4";
+            };
+          trace_history = [ "trace-safe-autonomy-prev" ];
+        };
+    }
+  in
+  match KT.write_meta ~force:true config meta with
+  | Ok () ->
+      let sandbox_root = Keeper_sandbox.host_root_abs ~config meta.name in
+      Fs_compat.mkdir_p sandbox_root;
+      let repo_path =
+        Keeper_repo_readiness.clone_path ~config ~keeper_name:meta.name
+          ~repo_name:"masc-mcp"
+      in
+      Fs_compat.mkdir_p repo_path;
+      meta
+  | Error err -> fail ("write_meta failed: " ^ err)
+
+let write_manifest path =
+  write_file path
+    (Yojson.Safe.pretty_to_string
+       (`Assoc
+         [
+           ("version", `Int 1);
+           ("generated_at", `String "2026-04-22T00:00:00Z");
+           ("recommendations",
+            `List
+              [
+                `Assoc
+                  [
+                    ("keeper_profile", `String "bench-analyst");
+                    ("model_label", `String "openai:gpt-5.4");
+                    ("composite_score", `Float 100.0);
+                    ("task_pass_rate", `Float 1.0);
+                    ("stability_score", `Float 1.0);
+                    ("cases_total", `Int 3);
+                    ("cases_passed", `Int 3);
+                  ];
+              ]);
+         ]))
+
+let require_assoc key json = Yojson.Safe.Util.(json |> member key)
+
+let test_json_emits_scorecard_and_artifacts () =
+  with_safe_autonomy_store @@ fun config ->
+  ignore (persist_keeper config);
+  let manifest_path = Filename.concat (tmpdir "safe_autonomy_manifest") "manifest.json" in
+  Fs_compat.mkdir_p (Filename.dirname manifest_path);
+  write_manifest manifest_path;
+  with_env "MASC_KEEPER_BENCH_CANARY_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_KEEPER_BENCH_CANARY_PATH" (Some manifest_path) (fun () ->
+      let json = Dashboard_safe_autonomy.json ~config () in
+      let summary = require_assoc "summary" json in
+      let artifacts = require_assoc "artifacts" json in
+      let per_keeper = Yojson.Safe.Util.(json |> member "per_keeper" |> to_list) in
+      let domains = Yojson.Safe.Util.(json |> member "domains" |> to_list) in
+      check int "keeper_count" 1
+        Yojson.Safe.Util.(summary |> member "keeper_count" |> to_int);
+      check bool "artifacts latest exists" true
+        (Fs_compat.file_exists
+           Yojson.Safe.Util.(artifacts |> member "latest_path" |> to_string));
+      check bool "artifacts history exists" true
+        (Fs_compat.file_exists
+           Yojson.Safe.Util.(artifacts |> member "history_path" |> to_string));
+      check int "per_keeper count" 1 (List.length per_keeper);
+      check bool "domain includes tool correctness" true
+        (List.exists
+           (fun item ->
+             Yojson.Safe.Util.(item |> member "id" |> to_string = "tool_correctness"))
+           domains)))
+
+let test_history_dedupes_identical_payloads () =
+  with_safe_autonomy_store @@ fun config ->
+  ignore (persist_keeper config);
+  let manifest_path = Filename.concat (tmpdir "safe_autonomy_manifest") "manifest.json" in
+  Fs_compat.mkdir_p (Filename.dirname manifest_path);
+  write_manifest manifest_path;
+  with_env "MASC_KEEPER_BENCH_CANARY_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_KEEPER_BENCH_CANARY_PATH" (Some manifest_path) (fun () ->
+      let first = Dashboard_safe_autonomy.json ~config () in
+      let second = Dashboard_safe_autonomy.json ~config () in
+      let latest_path =
+        Yojson.Safe.Util.(first |> member "artifacts" |> member "latest_path" |> to_string)
+      in
+      let history_path =
+        Yojson.Safe.Util.(second |> member "artifacts" |> member "history_path" |> to_string)
+      in
+      let latest_json =
+        match Safe_ops.read_json_file_safe latest_path with
+        | Ok json -> json
+        | Error err -> fail ("read_json_file_safe failed: " ^ err)
+      in
+      let history_lines =
+        match Safe_ops.read_file_safe history_path with
+        | Ok contents ->
+            contents
+            |> String.split_on_char '\n'
+            |> List.filter (fun line -> String.trim line <> "")
+        | Error err -> fail ("read_file_safe failed: " ^ err)
+      in
+      check int "history lines stay deduped" 1 (List.length history_lines);
+      check bool "latest file is valid json" true
+        (match latest_json with `Assoc _ -> true | _ -> false)))
+
+let () =
+  run "dashboard_safe_autonomy"
+    [
+      ( "dashboard_safe_autonomy",
+        [
+          test_case "json emits scorecard and artifacts" `Quick
+            test_json_emits_scorecard_and_artifacts;
+          test_case "artifact history dedupes identical payloads" `Quick
+            test_history_dedupes_identical_payloads;
+        ] );
+    ]

--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -105,6 +105,7 @@ let test_visible_surfaces_are_listed () =
       "monitoring.sessions";
       "monitoring.observatory";
       "monitoring.agents";
+      "monitoring.safe_autonomy";
       "monitoring.activity";
       "command.intervene";
       "workspace.board";
@@ -133,6 +134,19 @@ let test_config_surface_stays_lab () =
       check bool "meets_main_gate" false
         Yojson.Safe.Util.(surface |> member "meets_main_gate" |> to_bool)
 
+let test_safe_autonomy_surface_stays_lab_but_visible () =
+  let json = Dashboard_surface_readiness.json ~surface_id:"monitoring.safe_autonomy" () in
+  let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
+  match find_surface surfaces "monitoring.safe_autonomy" with
+  | None -> fail "monitoring.safe_autonomy missing"
+  | Some surface ->
+      check string "exposure_status" "lab"
+        Yojson.Safe.Util.(surface |> member "exposure_status" |> to_string);
+      check bool "hidden_from_nav" false
+        Yojson.Safe.Util.(surface |> member "hidden_from_nav" |> to_bool);
+      check bool "meets_main_gate" false
+        Yojson.Safe.Util.(surface |> member "meets_main_gate" |> to_bool)
+
 let () =
   run "Dashboard_surface_readiness"
     [
@@ -152,5 +166,7 @@ let () =
           test_case "visible surfaces are listed" `Quick
             test_visible_surfaces_are_listed;
           test_case "config stays lab" `Quick test_config_surface_stays_lab;
+          test_case "safe autonomy stays lab but visible" `Quick
+            test_safe_autonomy_surface_stays_lab_but_visible;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add a Safe Autonomy dashboard scorecard that aggregates tool correctness, sandbox truth, approval truth, cascade/FSM gracefulness, and audit trail completeness
- expose the scorecard through /api/v1/dashboard/safe-autonomy and register it in surface readiness as a lab monitoring surface
- add dashboard UI, readiness tests, and scorecard artifact generation under .masc/audits/safe_autonomy

## Verification
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/safe-autonomy-scorecard ./test/test_dashboard_safe_autonomy.exe
- ./_build/default/test/test_dashboard_surface_readiness.exe
- pnpm -C dashboard typecheck
- pnpm -C dashboard exec vitest run src/config/navigation.test.ts