### PR TITLE
[codex] fix keeper detail cleanup on route exit

### DIFF
--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -37,6 +37,7 @@ vi.mock('../router', () => ({
 }))
 
 import {
+  clearKeeperDetailSelection,
   closeKeeperDetail,
   filterCheckpointHistory,
   lineageTransitionLabel,
@@ -108,10 +109,35 @@ describe('openKeeperDetail', () => {
 
     expect(selectedKeeper.value).toBeNull()
     expect(mocks.resetKeeperConfig).toHaveBeenCalledTimes(1)
+    expect(mocks.selectKeeper).toHaveBeenLastCalledWith('')
     expect(mocks.navigate).toHaveBeenLastCalledWith('monitoring', {
       section: 'agents',
       view: 'keepers',
     })
+  })
+
+  it('only clears detail state for the matching keeper when cleanup is scoped', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      agent_name: 'sangsu-agent',
+      status: 'active',
+    }
+
+    openKeeperDetail(keeper)
+    mocks.resetKeeperConfig.mockClear()
+    mocks.selectKeeper.mockClear()
+
+    clearKeeperDetailSelection('other-keeper')
+
+    expect(selectedKeeper.value).toEqual(keeper)
+    expect(mocks.resetKeeperConfig).not.toHaveBeenCalled()
+    expect(mocks.selectKeeper).not.toHaveBeenCalled()
+
+    clearKeeperDetailSelection('sangsu-agent')
+
+    expect(selectedKeeper.value).toBeNull()
+    expect(mocks.resetKeeperConfig).toHaveBeenCalledTimes(1)
+    expect(mocks.selectKeeper).toHaveBeenCalledWith('')
   })
 })
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -78,6 +78,13 @@ import { navigate, route } from '../router'
 
 export const selectedKeeper = signal<Keeper | null>(null)
 
+function selectedKeeperMatches(keeperName: string): boolean {
+  const selected = selectedKeeper.value
+  if (!selected) return false
+  const trimmed = keeperName.trim()
+  return selected.name === trimmed || selected.agent_name === trimmed
+}
+
 function baseAgentDirectoryRouteParams(): Record<string, string> {
   if (route.value.tab === 'monitoring' && route.value.params.section === 'agents') {
     const next: Record<string, string> = { ...route.value.params, section: 'agents' }
@@ -95,9 +102,15 @@ export function openKeeperDetail(k: Keeper) {
   navigate('monitoring', { ...baseAgentDirectoryRouteParams(), keeper: k.name })
 }
 
-export function closeKeeperDetail() {
+export function clearKeeperDetailSelection(keeperName?: string) {
+  if (keeperName && !selectedKeeperMatches(keeperName)) return
   selectedKeeper.value = null
+  selectKeeper('')
   resetKeeperConfig()
+}
+
+export function closeKeeperDetail() {
+  clearKeeperDetailSelection()
   navigate('monitoring', baseAgentDirectoryRouteParams())
 }
 
@@ -1318,7 +1331,7 @@ export function KeeperDetailPage() {
     selectKeeper(keeper.name)
     void loadKeeperConfig(keeper.name)
     return () => {
-      resetKeeperConfig()
+      clearKeeperDetailSelection(keeper.name)
     }
   }, [keeper.name])
   useEffect(() => {


### PR DESCRIPTION
## What changed
- add `clearKeeperDetailSelection()` so keeper detail teardown clears `selectedKeeper`, resets config, and drops the active runtime selection
- use the scoped cleanup path from the route-driven keeper detail page effect so route exits do not leave the previous keeper marked as active
- extend `keeper-detail` tests to cover close behavior and scoped cleanup by keeper/agent alias

## Why
The keeper detail surface was moved from an overlay to a route-driven page, but leaving the page only reset local config state. `activeKeeperName` could remain set after navigation, so SSE-driven keeper hydration still treated the previous keeper as the active detail target.

## Impact
- keeper detail route exits no longer leak runtime selection state
- SSE refreshes stop targeting a keeper after the operator leaves that detail page
- regression coverage now locks the cleanup behavior to the current route-driven design

## Validation
- `./node_modules/.bin/vitest run src/components/keeper-detail.test.ts`
- `pnpm typecheck`
- `pnpm build`