### PR TITLE
[codex] surface keeper execution trust receipts

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -232,6 +232,111 @@ let tokens_per_sec_json ~tokens ~latency_ms =
   if tokens <= 0 || latency_ms <= 0 then `Null
   else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
 
+let json_string_list_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `List items ->
+    items
+    |> List.filter_map (function
+         | `String value ->
+           let trimmed = String.trim value in
+           if trimmed = "" then None else Some trimmed
+         | _ -> None)
+  | _ -> []
+
+let keeper_trust_json ?(include_receipt = false)
+    (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let sandbox_json =
+    match latest_receipt with
+    | Some receipt -> Yojson.Safe.Util.member "sandbox" receipt
+    | None ->
+      `Assoc
+        [
+          ( "configured_kind",
+            `String
+              (Keeper_types.sandbox_profile_to_string meta.sandbox_profile) );
+          ( "effective_kind",
+            `String
+              (Keeper_execution_receipt.effective_sandbox_kind_of_meta meta)
+          );
+          ( "execution_scope",
+            `String
+              (Keeper_execution_scope.to_string meta.execution_scope) );
+          ("sandbox_root", `String config.base_path);
+          ("network_mode", `String (Keeper_types.network_mode_to_string meta.network_mode));
+        ]
+  in
+  let approval_json =
+    match latest_receipt with
+    | Some receipt -> Yojson.Safe.Util.member "approval" receipt
+    | None -> `Assoc [ ("profile", `Null); ("derived", `Bool false) ]
+  in
+  let cascade_json =
+    match latest_receipt with
+    | Some receipt -> Yojson.Safe.Util.member "cascade" receipt
+    | None ->
+      `Assoc
+        [
+          ("name", `String meta.cascade_name);
+          ("selected_model", `Null);
+          ("attempt_count", `Int 0);
+          ("fallback_applied", `Bool false);
+          ("outcome", `String "not_observed");
+        ]
+  in
+  let requested_tools =
+    match latest_receipt with
+    | Some receipt -> json_string_list_member "requested_tools" receipt
+    | None -> []
+  in
+  let tools_used =
+    match latest_receipt with
+    | Some receipt -> json_string_list_member "tools_used" receipt
+    | None -> []
+  in
+  let unexpected_tools =
+    match latest_receipt with
+    | Some receipt -> json_string_list_member "unexpected_tools" receipt
+    | None -> []
+  in
+  `Assoc
+    [
+      ( "last_outcome",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "outcome" receipt
+        | None -> `String "not_run" );
+      ( "terminal_reason_code",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "terminal_reason_code" receipt
+        | None -> `String "no_receipt" );
+      ( "tool_contract_result",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "tool_contract_result" receipt
+        | None -> `String "unknown" );
+      ("requested_tool_count", `Int (List.length requested_tools));
+      ("tools_used", `List (List.map (fun value -> `String value) tools_used));
+      ( "unexpected_tools",
+        `List (List.map (fun value -> `String value) unexpected_tools) );
+      ("sandbox", sandbox_json);
+      ("approval", approval_json);
+      ("cascade", cascade_json);
+      ( "last_receipt_at",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "ended_at" receipt
+        | None -> `Null );
+      ( "last_error",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "error" receipt
+        | None -> `Null );
+      ( "last_receipt",
+        if include_receipt then
+          match latest_receipt with
+          | Some receipt -> receipt
+          | None -> `Null
+        else
+          `Null );
+    ]
+
 let keeper_names (config : Coord.config) =
   Keeper_types.keeper_names config
 
@@ -630,6 +735,9 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
 	            let compact_ratio_gate = m.compaction.ratio_gate in
 	            let compact_message_gate = m.compaction.message_gate in
 	            let compact_token_gate = m.compaction.token_gate in
+              let trust_json =
+                keeper_trust_json ~include_receipt:(not compact) config m
+              in
               let recent_tool_names =
                 match metrics_window_summary with
                 | `Assoc fields -> (
@@ -743,6 +851,10 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));
               ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id));
               ("generation", `Int m.runtime.generation);
+              ( "current_task_id",
+                Json_util.string_opt_to_json
+                  (Option.map Keeper_id.Task_id.to_string m.current_task_id) );
+              ("active_goal_ids", `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids));
               ("created_at", `String m.created_at);
               ("updated_at", `String m.updated_at);
               ("trace_history_count", `Int trace_history_count);
@@ -905,6 +1017,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("k2k_mentions", k2k_mentions);
               ("last_handoff_event", match last_handoff_event with Some j -> j | None -> `Null);
               ("last_compaction_event", match last_compaction_event with Some j -> j | None -> `Null);
+              ("trust", trust_json);
               ("context", context);
               ("context_source", context_source);
               ("runtime_warning_ctx_ratio", `Float runtime_warning_ctx_ratio);
@@ -959,6 +1072,38 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
     ("recent_alerts", `List recent_alerts);
     ("alert_count", `Int (List.length recent_alerts));
   ]
+
+let execution_trust_dashboard_json (config : Coord.config) : Yojson.Safe.t =
+  let keepers =
+    match keepers_dashboard_json ~compact:true config with
+    | `Assoc fields -> (
+        match List.assoc_opt "keepers" fields with
+        | Some (`List rows) ->
+          rows
+          |> List.map (fun row ->
+                 `Assoc
+                   [
+                     ("name", Yojson.Safe.Util.member "name" row);
+                     ("agent_name", Yojson.Safe.Util.member "agent_name" row);
+                     ("phase", Yojson.Safe.Util.member "phase" row);
+                     ( "pipeline_stage",
+                       Yojson.Safe.Util.member "pipeline_stage" row );
+                     ("status", Yojson.Safe.Util.member "status" row);
+                     ("trace_id", Yojson.Safe.Util.member "trace_id" row);
+                     ("generation", Yojson.Safe.Util.member "generation" row);
+                     ("current_task_id", Yojson.Safe.Util.member "current_task_id" row);
+                     ("active_goal_ids", Yojson.Safe.Util.member "active_goal_ids" row);
+                     ("trust", Yojson.Safe.Util.member "trust" row);
+                   ])
+        | _ -> [])
+    | _ -> []
+  in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ("keepers", `List keepers);
+      ("total", `Int (List.length keepers));
+    ]
 
 (** Build a structured config JSON for a single keeper, grouped by category.
     Returns (http_status, json). *)

--- a/lib/dune
+++ b/lib/dune
@@ -510,6 +510,7 @@
    keeper_prompt
    keeper_coordination
    keeper_execution
+   keeper_execution_receipt
    keeper_event_bus
    masc_event_bus
    keeper_keepalive

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -394,6 +394,39 @@ let sdk_error_of_keeper_internal_error err =
     (keeper_internal_error_prefix
      ^ Yojson.Safe.to_string (keeper_internal_error_to_json err))
 
+let sdk_error_kind = function
+  | Oas.Error.Api _ -> "api"
+  | Oas.Error.Agent _ -> "agent"
+  | Oas.Error.Mcp _ -> "mcp"
+  | Oas.Error.Config _ -> "config"
+  | Oas.Error.Serialization _ -> "serialization"
+  | Oas.Error.Io _ -> "io"
+  | Oas.Error.Orchestration _ -> "orchestration"
+  | Oas.Error.A2a _ -> "a2a"
+  | Oas.Error.Internal _ -> "internal"
+
+let terminal_reason_code_of_sdk_error = function
+  | Oas.Error.Agent
+      (Oas.Error.CompletionContractViolation { contract; _ }) ->
+    Printf.sprintf
+      "completion_contract_violation:%s"
+      (Oas.Completion_contract_id.to_string contract)
+  | Oas.Error.Api _ -> "api_error"
+  | Oas.Error.Agent _ -> "agent_error"
+  | Oas.Error.Mcp _ -> "mcp_error"
+  | Oas.Error.Config _ -> "config_error"
+  | Oas.Error.Serialization _ -> "serialization_error"
+  | Oas.Error.Io _ -> "io_error"
+  | Oas.Error.Orchestration _ -> "orchestration_error"
+  | Oas.Error.A2a _ -> "a2a_error"
+  | Oas.Error.Internal _ -> "internal_error"
+
+let cascade_outcome_of_observation = function
+  | Some (obs : Oas_worker.cascade_observation) when obs.fallback_applied ->
+    "passed_to_next_model"
+  | Some _ -> "completed"
+  | None -> "not_observed"
+
 let tool_required_affordances =
   [ "board_post_or_comment"
   ; "message_sweep"
@@ -513,6 +546,7 @@ let run_turn
   Masc_runtime_events.emit_turn_start ();
   Fun.protect ~finally:Masc_runtime_events.emit_turn_end
   @@ fun () ->
+  let receipt_started_at = Types.now_iso () in
   (* 0. Resolve inference parameters via Cascade_inference *)
   let temperature =
     match temperature with
@@ -1193,6 +1227,20 @@ let run_turn
         approval_mode_derived;
       }
   in
+  let requested_tool_names_ref : string list ref = ref [] in
+  let reported_tool_names_ref : string list ref = ref [] in
+  let observed_tool_names_ref : string list ref = ref [] in
+  let canonical_tool_names_ref : string list ref = ref [] in
+  let unexpected_tool_names_ref : string list ref = ref [] in
+  let actual_keeper_tool_names_ref : string list ref = ref [] in
+  let receipt_turn_count_ref : int option ref = ref None in
+  let receipt_model_used_ref : string option ref = ref None in
+  let receipt_stop_reason_ref : string option ref = ref None in
+  let receipt_cascade_observation_ref : Oas_worker.cascade_observation option ref =
+    ref None
+  in
+  let receipt_response_text_present_ref = ref false in
+  let receipt_tool_contract_result_ref = ref "unknown" in
   let tool_calls_ref : tool_call_detail list ref = ref [] in
   let validate_allow_list ~turn raw =
     let raw = Tool_portal.filter_visible_tool_names portal_ctx raw in
@@ -1866,6 +1914,7 @@ let run_turn
               if turn_completion_contract = Keeper_tool_disclosure.Require_tool_use
               then required_tool_use_seen_ref := true;
               let lane = computed_surface.lane in
+              requested_tool_names_ref := all_allowed;
               tool_surface_ref :=
                 {
                   turn_lane = lane;
@@ -2111,7 +2160,8 @@ let run_turn
             "[wake_payload] telemetry failed keeper=%s: %s"
             meta.name (Printexc.to_string exn)
     in
-    (match
+    let turn_result =
+      match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named
            ~cascade_name
@@ -2186,6 +2236,11 @@ let run_turn
           flush_incremental call since AfterTurn already fired. *)
        let text = Oas.Types.text_of_content result.response.content in
        let model = result.response.model in
+       receipt_turn_count_ref := Some result.turns;
+       receipt_model_used_ref := Some model;
+       receipt_stop_reason_ref :=
+         Some (Keeper_execution_receipt.stop_reason_to_string result.stop_reason);
+       receipt_cascade_observation_ref := result.cascade_observation;
        (* Extract and persist thinking blocks to trajectory JSONL.
            NOTE: turn = acc.turn stays at 0 in the keeper path because
            Trajectory.increment_turn is never called here — the keeper
@@ -2253,12 +2308,14 @@ let run_turn
              | _ -> None)
            result.response.content
        in
+       reported_tool_names_ref := reported_tool_names;
        let tool_usage_after =
          Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
        in
        let observed_tool_names =
          Keeper_tool_disclosure.tool_usage_delta ~before:tool_usage_before ~after:tool_usage_after
        in
+       observed_tool_names_ref := observed_tool_names;
        let tool_names =
          Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
@@ -2275,11 +2332,13 @@ let run_turn
        let canonical_tool_names =
          Keeper_tool_alias.canonicalize_observed tool_names
        in
+       canonical_tool_names_ref := canonical_tool_names;
        let unexpected_tool_names =
          Keeper_tool_disclosure.unexpected_tool_names
            ~allowed_tool_names:all_tool_names
            ~tool_names:canonical_tool_names
        in
+       unexpected_tool_names_ref := unexpected_tool_names;
        (* Partial tolerance (#8471): when a turn mixes valid tool calls
           with unexpected ones (LLM hallucinating Claude Code built-ins
           like Bash/Read/Skill outside the keeper surface), do not nuke
@@ -2301,6 +2360,7 @@ let run_turn
              "keeper turn reported unexpected tool names outside keeper surface: %s"
              (String.concat ", " unexpected_tool_names)
          in
+         receipt_tool_contract_result_ref := "violated";
          Log.Keeper.error "keeper:%s %s" meta.name reason;
          Error (Oas.Error.Internal reason)
        else (
@@ -2314,6 +2374,7 @@ let run_turn
            |> Keeper_tool_alias.canonicalize_observed
            |> List.filter (fun tool_name -> List.mem tool_name all_tool_names)
          in
+         actual_keeper_tool_names_ref := actual_keeper_tool_names;
          let usage = Keeper_exec_context.usage_of_response result.response in
          let ctx_composition =
            build_ctx_composition_metrics
@@ -2339,8 +2400,11 @@ let run_turn
                ~contract:effective_completion_contract
                ~tool_present:!keeper_surface_tool_used_ref
            with
-           | Ok () -> Ok text
+           | Ok () ->
+             receipt_tool_contract_result_ref := "satisfied";
+             Ok text
            | Error reason ->
+             receipt_tool_contract_result_ref := "violated";
              let contract_str =
                match effective_completion_contract with
                | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
@@ -2401,6 +2465,7 @@ let run_turn
              | None ->
                  Keeper_text_processing.user_visible_reply_text raw_response_text
            in
+           receipt_response_text_present_ref := true;
            let assistant_msg =
              Agent_sdk.Types.make_message
                ~role:Agent_sdk.Types.Assistant
@@ -2702,5 +2767,100 @@ let run_turn
              with
              | Error e -> Error (Oas.Error.Internal e)
              | Ok response_text -> finalize_response_text response_text))
-    )
+    in
+    let receipt_ended_at = Types.now_iso () in
+    let error_kind, error_message =
+      match turn_result with
+      | Ok _ -> None, None
+      | Error err -> Some (sdk_error_kind err), Some (Oas.Error.to_string err)
+    in
+    let tool_contract_result =
+      match turn_result with
+      | Error (Oas.Error.Agent (Oas.Error.CompletionContractViolation _)) ->
+        "violated"
+      | _ ->
+        !receipt_tool_contract_result_ref
+    in
+    let terminal_reason_code =
+      match turn_result with
+      | Ok _ ->
+        Option.value
+          ~default:"completed"
+          !receipt_stop_reason_ref
+      | Error err ->
+        terminal_reason_code_of_sdk_error err
+    in
+    let cascade_observation = !receipt_cascade_observation_ref in
+    let receipt =
+      {
+        Keeper_execution_receipt.keeper_name = meta.name;
+        agent_name = meta.agent_name;
+        trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id;
+        generation;
+        turn_count = !receipt_turn_count_ref;
+        current_task_id =
+          Option.map Keeper_id.Task_id.to_string meta.current_task_id;
+        goal_ids = meta.active_goal_ids;
+        outcome =
+          (match turn_result with
+           | Ok _ -> "ok"
+           | Error _ -> "error");
+        terminal_reason_code;
+        response_text_present = !receipt_response_text_present_ref;
+        model_used = !receipt_model_used_ref;
+        requested_tools = !requested_tool_names_ref;
+        reported_tools = !reported_tool_names_ref;
+        observed_tools = !observed_tool_names_ref;
+        canonical_tools = !canonical_tool_names_ref;
+        unexpected_tools = !unexpected_tool_names_ref;
+        tools_used = !actual_keeper_tool_names_ref;
+        tool_contract_result;
+        tool_surface =
+          {
+            turn_lane = (!tool_surface_ref).turn_lane;
+            visible_tool_count = (!tool_surface_ref).visible_tool_count;
+            tool_gate_enabled = (!tool_surface_ref).tool_gate_enabled;
+            tool_surface_fallback_used =
+              (!tool_surface_ref).tool_surface_fallback_used;
+          };
+        sandbox_configured_kind =
+          Keeper_types.sandbox_profile_to_string meta.sandbox_profile;
+        sandbox_effective_kind =
+          Keeper_execution_receipt.effective_sandbox_kind_of_meta meta;
+        execution_scope =
+          Keeper_execution_scope.to_string meta.execution_scope;
+        sandbox_root = Some config.base_path;
+        network_mode = Keeper_types.network_mode_to_string meta.network_mode;
+        approval_profile = (!tool_surface_ref).approval_mode_effective;
+        approval_profile_derived = (!tool_surface_ref).approval_mode_derived;
+        cascade_name;
+        cascade_selected_model =
+          Option.bind cascade_observation (fun obs -> obs.selected_model);
+        cascade_attempt_count =
+          (match cascade_observation with
+           | Some obs -> List.length obs.attempts
+           | None -> 0);
+        cascade_fallback_applied =
+          (match cascade_observation with
+           | Some obs -> obs.fallback_applied
+           | None -> false);
+        cascade_outcome =
+          cascade_outcome_of_observation cascade_observation;
+        stop_reason = !receipt_stop_reason_ref;
+        error_kind;
+        error_message;
+        started_at = receipt_started_at;
+        ended_at = receipt_ended_at;
+      }
+    in
+    (try
+       Keeper_execution_receipt.append config receipt
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn
+         "keeper:%s execution_receipt append failed: %s"
+         meta.name
+         (Printexc.to_string exn));
+    turn_result
 ;;

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -1,0 +1,189 @@
+type tool_surface =
+  { turn_lane : string
+  ; visible_tool_count : int
+  ; tool_gate_enabled : bool
+  ; tool_surface_fallback_used : bool
+  }
+
+type t =
+  { keeper_name : string
+  ; agent_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn_count : int option
+  ; current_task_id : string option
+  ; goal_ids : string list
+  ; outcome : string
+  ; terminal_reason_code : string
+  ; response_text_present : bool
+  ; model_used : string option
+  ; requested_tools : string list
+  ; reported_tools : string list
+  ; observed_tools : string list
+  ; canonical_tools : string list
+  ; unexpected_tools : string list
+  ; tools_used : string list
+  ; tool_contract_result : string
+  ; tool_surface : tool_surface
+  ; sandbox_configured_kind : string
+  ; sandbox_effective_kind : string
+  ; execution_scope : string
+  ; sandbox_root : string option
+  ; network_mode : string
+  ; approval_profile : string option
+  ; approval_profile_derived : bool
+  ; cascade_name : string
+  ; cascade_selected_model : string option
+  ; cascade_attempt_count : int
+  ; cascade_fallback_applied : bool
+  ; cascade_outcome : string
+  ; stop_reason : string option
+  ; error_kind : string option
+  ; error_message : string option
+  ; started_at : string
+  ; ended_at : string
+  }
+
+let stop_reason_to_string = function
+  | Oas_worker.Completed -> "completed"
+  | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
+    Printf.sprintf "turn_budget_exhausted:%d/%d" turns_used limit
+  | Oas_worker.MutationBoundaryReached { turns_used; tool_name } ->
+    (match tool_name with
+     | Some tool ->
+       Printf.sprintf "mutation_boundary:%s:%d" tool turns_used
+     | None ->
+       Printf.sprintf "mutation_boundary:%d" turns_used)
+
+let effective_sandbox_kind_of_meta (meta : Keeper_types.keeper_meta) =
+  match meta.sandbox_profile with
+  | Keeper_types.Docker -> "docker"
+  | Keeper_types.Local ->
+    (match meta.execution_scope with
+     | Keeper_execution_scope.Local -> "local_playground"
+     | Keeper_execution_scope.Workspace -> "worktree"
+     | Keeper_execution_scope.Observe_only -> "observe_only")
+
+let list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let to_json (receipt : t) =
+  let error_json =
+    match receipt.error_kind, receipt.error_message with
+    | None, None -> `Null
+    | error_kind, error_message ->
+      `Assoc
+        [
+          ( "kind",
+            match error_kind with
+            | Some value -> `String value
+            | None -> `Null );
+          ( "message",
+            match error_message with
+            | Some value -> `String value
+            | None -> `Null );
+        ]
+  in
+  `Assoc
+    [
+      ("schema", `String "keeper.execution_receipt.v1");
+      ("recorded_at", `String receipt.ended_at);
+      ("keeper_name", `String receipt.keeper_name);
+      ("agent_name", `String receipt.agent_name);
+      ("trace_id", `String receipt.trace_id);
+      ("generation", `Int receipt.generation);
+      ( "turn_count",
+        match receipt.turn_count with
+        | Some value -> `Int value
+        | None -> `Null );
+      ( "current_task_id",
+        match receipt.current_task_id with
+        | Some value -> `String value
+        | None -> `Null );
+      ("goal_ids", list_json receipt.goal_ids);
+      ("outcome", `String receipt.outcome);
+      ("terminal_reason_code", `String receipt.terminal_reason_code);
+      ("response_text_present", `Bool receipt.response_text_present);
+      ( "model_used",
+        match receipt.model_used with
+        | Some value -> `String value
+        | None -> `Null );
+      ("requested_tools", list_json receipt.requested_tools);
+      ("reported_tools", list_json receipt.reported_tools);
+      ("observed_tools", list_json receipt.observed_tools);
+      ("canonical_tools", list_json receipt.canonical_tools);
+      ("unexpected_tools", list_json receipt.unexpected_tools);
+      ("tools_used", list_json receipt.tools_used);
+      ("tool_contract_result", `String receipt.tool_contract_result);
+      ( "tool_surface",
+        `Assoc
+          [
+            ("turn_lane", `String receipt.tool_surface.turn_lane);
+            ("visible_tool_count", `Int receipt.tool_surface.visible_tool_count);
+            ("tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled);
+            ( "tool_surface_fallback_used",
+              `Bool receipt.tool_surface.tool_surface_fallback_used );
+          ] );
+      ( "sandbox",
+        `Assoc
+          [
+            ("configured_kind", `String receipt.sandbox_configured_kind);
+            ("effective_kind", `String receipt.sandbox_effective_kind);
+            ("execution_scope", `String receipt.execution_scope);
+            ( "sandbox_root",
+              match receipt.sandbox_root with
+              | Some value -> `String value
+              | None -> `Null );
+            ("network_mode", `String receipt.network_mode);
+          ] );
+      ( "approval",
+        `Assoc
+          [
+            ( "profile",
+              match receipt.approval_profile with
+              | Some value -> `String value
+              | None -> `Null );
+            ("derived", `Bool receipt.approval_profile_derived);
+          ] );
+      ( "cascade",
+        `Assoc
+          [
+            ("name", `String receipt.cascade_name);
+            ( "selected_model",
+              match receipt.cascade_selected_model with
+              | Some value -> `String value
+              | None -> `Null );
+            ("attempt_count", `Int receipt.cascade_attempt_count);
+            ("fallback_applied", `Bool receipt.cascade_fallback_applied);
+            ("outcome", `String receipt.cascade_outcome);
+          ] );
+      ( "stop_reason",
+        match receipt.stop_reason with
+        | Some value -> `String value
+        | None -> `Null );
+      ("error", error_json);
+      ("started_at", `String receipt.started_at);
+      ("ended_at", `String receipt.ended_at);
+    ]
+
+let append (config : Coord.config) (receipt : t) =
+  let store =
+    Keeper_types_support.keeper_execution_receipt_store config
+      receipt.keeper_name
+  in
+  Dated_jsonl.append store (to_json receipt)
+
+let latest_json (config : Coord.config) keeper_name =
+  let store =
+    Keeper_types_support.keeper_execution_receipt_store config keeper_name
+  in
+  match Dated_jsonl.read_recent store 1 with
+  | [ json ] -> Some json
+  | _ -> None
+
+let latest_json_by_keeper (config : Coord.config) keeper_names =
+  keeper_names
+  |> List.filter_map (fun keeper_name ->
+         match latest_json config keeper_name with
+         | Some json -> Some (keeper_name, json)
+         | None -> None)

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -1,0 +1,53 @@
+type tool_surface =
+  { turn_lane : string
+  ; visible_tool_count : int
+  ; tool_gate_enabled : bool
+  ; tool_surface_fallback_used : bool
+  }
+
+type t =
+  { keeper_name : string
+  ; agent_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn_count : int option
+  ; current_task_id : string option
+  ; goal_ids : string list
+  ; outcome : string
+  ; terminal_reason_code : string
+  ; response_text_present : bool
+  ; model_used : string option
+  ; requested_tools : string list
+  ; reported_tools : string list
+  ; observed_tools : string list
+  ; canonical_tools : string list
+  ; unexpected_tools : string list
+  ; tools_used : string list
+  ; tool_contract_result : string
+  ; tool_surface : tool_surface
+  ; sandbox_configured_kind : string
+  ; sandbox_effective_kind : string
+  ; execution_scope : string
+  ; sandbox_root : string option
+  ; network_mode : string
+  ; approval_profile : string option
+  ; approval_profile_derived : bool
+  ; cascade_name : string
+  ; cascade_selected_model : string option
+  ; cascade_attempt_count : int
+  ; cascade_fallback_applied : bool
+  ; cascade_outcome : string
+  ; stop_reason : string option
+  ; error_kind : string option
+  ; error_message : string option
+  ; started_at : string
+  ; ended_at : string
+  }
+
+val stop_reason_to_string : Oas_worker.stop_reason -> string
+val effective_sandbox_kind_of_meta : Keeper_types.keeper_meta -> string
+val to_json : t -> Yojson.Safe.t
+val append : Coord.config -> t -> unit
+val latest_json : Coord.config -> string -> Yojson.Safe.t option
+val latest_json_by_keeper :
+  Coord.config -> string list -> (string * Yojson.Safe.t) list

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -48,6 +48,25 @@ let keeper_metrics_store config name : Dated_jsonl.t =
   in
   Eio_guard.with_mutex metrics_store_mu lookup
 
+let execution_receipt_store_cache : (string, Dated_jsonl.t) Hashtbl.t =
+  Hashtbl.create 8
+
+let execution_receipt_store_mu = Eio.Mutex.create ()
+
+let keeper_execution_receipt_store config name : Dated_jsonl.t =
+  let dir =
+    Filename.concat (keeper_dir_ config) (name ^ "/execution-receipts")
+  in
+  let lookup () =
+    match Hashtbl.find_opt execution_receipt_store_cache dir with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      Hashtbl.replace execution_receipt_store_cache dir store;
+      store
+  in
+  Eio_guard.with_mutex execution_receipt_store_mu lookup
+
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -432,6 +432,31 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
         ~clock ~timeout_sec:120.0 (compute ?actor ?fixture ~light)
 
+let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
+  let compute () =
+    let started_at = Unix.gettimeofday () in
+    run_dashboard_compute ~mode:Offloaded_readonly ?net:state.Mcp_server.net
+      ?mono_clock:state.Mcp_server.mono_clock ~sw ~clock
+      ~config:state.Mcp_server.room_config
+      (fun ~config ~sw:_ ->
+        Dashboard_http_keeper.execution_trust_dashboard_json config
+        |> with_projection_diagnostics ~surface:"execution_trust" ~started_at
+             ~extra:[])
+  in
+  match state.Mcp_server.clock with
+  | Some clock ->
+    Dashboard_cache.get_or_compute_with_timeout
+      "execution-trust:default"
+      ~ttl:15.0
+      ~clock
+      ~timeout_sec:30.0
+      compute
+  | None ->
+    Dashboard_cache.get_or_compute
+      "execution-trust:default"
+      ~ttl:15.0
+      compute
+
 let transport_health_cache_diagnostics () =
   match cached_surface_json _transport_health_cache with
   | `Assoc fields -> (

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -561,6 +561,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/execution-trust" ->
+          let state = get_server_state () in
+          let json =
+            dashboard_execution_trust_http_json ~state ~sw ~clock
+              httpun_request
+          in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/dashboard/board" ->
           let json = dashboard_memory_http_json httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -343,6 +343,14 @@ let rec add_routes ~sw ~clock router =
          let json = dashboard_execution_http_json ~state ~sw ~clock request in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/execution-trust" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json =
+           dashboard_execution_trust_http_json ~state ~sw ~clock request
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = dashboard_memory_http_json req in

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -417,6 +417,78 @@ let create_keeper env sw config name =
   | Some (false, err) -> fail err
   | None -> fail "missing masc_keeper_up dispatch"
 
+let append_execution_receipt config ~keeper_name =
+  let meta =
+    match Lib.Keeper_types.read_meta config keeper_name with
+    | Ok (Some meta) -> meta
+    | Ok None -> fail ("keeper meta missing for receipt: " ^ keeper_name)
+    | Error err -> fail ("read_meta failed for receipt: " ^ err)
+  in
+  let started_at = Types.now_iso () in
+  let ended_at = Types.now_iso () in
+  let receipt : Lib.Keeper_execution_receipt.t =
+    {
+      keeper_name;
+      agent_name = meta.agent_name;
+      trace_id = Lib.Keeper_id.Trace_id.to_string meta.runtime.trace_id;
+      generation = meta.runtime.generation;
+      turn_count = Some 3;
+      current_task_id = None;
+      goal_ids = meta.active_goal_ids;
+      outcome = "ok";
+      terminal_reason_code = "completed";
+      response_text_present = true;
+      model_used = Some "custom:mock";
+      requested_tools = [ "keeper_task_claim"; "keeper_fs_read" ];
+      reported_tools = [ "Read" ];
+      observed_tools = [ "keeper_fs_read" ];
+      canonical_tools = [ "keeper_fs_read" ];
+      unexpected_tools = [ "WebSearch" ];
+      tools_used = [ "keeper_fs_read" ];
+      tool_contract_result = "satisfied";
+      tool_surface =
+        {
+          turn_lane = "tool";
+          visible_tool_count = 2;
+          tool_gate_enabled = true;
+          tool_surface_fallback_used = false;
+        };
+      sandbox_configured_kind =
+        Lib.Keeper_types.sandbox_profile_to_string meta.sandbox_profile;
+      sandbox_effective_kind =
+        Lib.Keeper_execution_receipt.effective_sandbox_kind_of_meta meta;
+      execution_scope =
+        Lib.Keeper_execution_scope.to_string meta.execution_scope;
+      sandbox_root = Some config.base_path;
+      network_mode = Lib.Keeper_types.network_mode_to_string meta.network_mode;
+      approval_profile = Some "trusted_local";
+      approval_profile_derived = false;
+      cascade_name = meta.cascade_name;
+      cascade_selected_model = Some "custom:mock";
+      cascade_attempt_count = 2;
+      cascade_fallback_applied = true;
+      cascade_outcome = "passed_to_next_model";
+      stop_reason = Some "completed";
+      error_kind = None;
+      error_message = None;
+      started_at;
+      ended_at;
+    }
+  in
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let base_dir =
+    Filename.concat
+      (Lib.Keeper_types.keeper_dir config)
+      (keeper_name ^ "/execution-receipts")
+  in
+  let month_dir = Filename.concat base_dir month in
+  Fs_compat.mkdir_p month_dir;
+  Fs_compat.append_jsonl
+    (Filename.concat month_dir day)
+    (Lib.Keeper_execution_receipt.to_json receipt)
+
 let test_dashboard_shell_splits_active_and_configured_keepers () =
   let dir = test_dir () in
   Fun.protect
@@ -541,6 +613,60 @@ let test_dashboard_execution_surfaces_keeper_diagnostic () =
               (row |> member "diagnostic" |> member "health_state" <> `Null);
             check bool "diagnostic next action surfaced" true
               (row |> member "diagnostic" |> member "next_action_path" <> `Null))))
+
+let test_execution_trust_surfaces_latest_receipt () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord_utils.default_config dir in
+      ignore (Lib.Coord.init config ~agent_name:None);
+      Eio.Switch.run (fun sw ->
+        Fun.protect
+          ~finally:(fun () ->
+            Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu")
+          (fun () ->
+            create_keeper env sw config "sangsu";
+            append_execution_receipt config ~keeper_name:"sangsu";
+            let compact_json =
+              Lib.Dashboard_http_keeper.keepers_dashboard_json
+                ~compact:true config
+            in
+            let trust_json =
+              Lib.Dashboard_http_keeper.execution_trust_dashboard_json config
+            in
+            let open Yojson.Safe.Util in
+            let compact_row =
+              compact_json |> member "keepers" |> to_list
+              |> List.find (fun keeper ->
+                     keeper |> member "name" |> to_string = "sangsu")
+            in
+            let trust_row =
+              trust_json |> member "keepers" |> to_list
+              |> List.find (fun keeper ->
+                     keeper |> member "name" |> to_string = "sangsu")
+            in
+            check string "compact keeper row exposes trust outcome" "ok"
+              (compact_row |> member "trust" |> member "last_outcome"
+             |> to_string);
+            check string "compact keeper row exposes trust contract result"
+              "satisfied"
+              (compact_row |> member "trust" |> member "tool_contract_result"
+             |> to_string);
+            check string "execution trust row preserves sandbox kind"
+              "worktree"
+              (trust_row |> member "trust" |> member "sandbox"
+             |> member "effective_kind" |> to_string);
+            check string "execution trust row preserves cascade outcome"
+              "passed_to_next_model"
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "outcome" |> to_string);
+            check (list string) "execution trust row preserves unexpected tools"
+              [ "WebSearch" ]
+              (trust_row |> member "trust" |> member "unexpected_tools"
+             |> to_list |> List.map to_string))))
 
 let test_patch_keeper_dependent_caches_tolerates_null_agent () =
   let execution_json =
@@ -667,6 +793,8 @@ let () =
             test_dashboard_execution_fresh_join_not_marked_stale;
           Alcotest.test_case "execution surfaces keeper diagnostic" `Quick
             test_dashboard_execution_surfaces_keeper_diagnostic;
+          Alcotest.test_case "execution trust surfaces latest receipt" `Quick
+            test_execution_trust_surfaces_latest_receipt;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick
             test_patch_keeper_dependent_caches_tolerates_null_agent;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -538,6 +538,80 @@ let seed_auth_and_keeper ~base_path ~keeper_name =
   config, admin_token
 ;;
 
+let append_execution_receipt config ~keeper_name =
+  let meta =
+    match Masc_mcp.Keeper_types.read_meta config keeper_name with
+    | Ok (Some meta) -> meta
+    | Ok None -> fail ("keeper meta missing for receipt: " ^ keeper_name)
+    | Error err -> fail ("read_meta failed for receipt: " ^ err)
+  in
+  let started_at = Types.now_iso () in
+  let ended_at = Types.now_iso () in
+  let receipt : Masc_mcp.Keeper_execution_receipt.t =
+    {
+      keeper_name;
+      agent_name = meta.agent_name;
+      trace_id = Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id;
+      generation = meta.runtime.generation;
+      turn_count = Some 2;
+      current_task_id = None;
+      goal_ids = meta.active_goal_ids;
+      outcome = "ok";
+      terminal_reason_code = "completed";
+      response_text_present = true;
+      model_used = Some "custom:mock";
+      requested_tools = [ "keeper_task_claim"; "keeper_fs_read" ];
+      reported_tools = [ "Read" ];
+      observed_tools = [ "keeper_fs_read" ];
+      canonical_tools = [ "keeper_fs_read" ];
+      unexpected_tools = [ "WebSearch" ];
+      tools_used = [ "keeper_fs_read" ];
+      tool_contract_result = "satisfied";
+      tool_surface =
+        {
+          turn_lane = "tool";
+          visible_tool_count = 2;
+          tool_gate_enabled = true;
+          tool_surface_fallback_used = false;
+        };
+      sandbox_configured_kind =
+        Masc_mcp.Keeper_types.sandbox_profile_to_string meta.sandbox_profile;
+      sandbox_effective_kind =
+        Masc_mcp.Keeper_execution_receipt.effective_sandbox_kind_of_meta meta;
+      execution_scope =
+        Masc_mcp.Keeper_execution_scope.to_string meta.execution_scope;
+      sandbox_root = Some config.base_path;
+      network_mode =
+        Masc_mcp.Keeper_types.network_mode_to_string meta.network_mode;
+      approval_profile = Some "trusted_local";
+      approval_profile_derived = false;
+      cascade_name = meta.cascade_name;
+      cascade_selected_model = Some "custom:mock";
+      cascade_attempt_count = 2;
+      cascade_fallback_applied = true;
+      cascade_outcome = "passed_to_next_model";
+      stop_reason = Some "completed";
+      error_kind = None;
+      error_message = None;
+      started_at;
+      ended_at;
+    }
+  in
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let base_dir =
+    Filename.concat
+      (Masc_mcp.Keeper_types.keeper_dir config)
+      (keeper_name ^ "/execution-receipts")
+  in
+  let month_dir = Filename.concat base_dir month in
+  Fs_compat.mkdir_p month_dir;
+  Fs_compat.append_jsonl
+    (Filename.concat month_dir day)
+    (Masc_mcp.Keeper_execution_receipt.to_json receipt)
+;;
+
 let with_seeded_server ?(env_overrides = []) f =
   let run_with_env_overrides env_overrides =
     let exe = find_main_eio_exe () in
@@ -862,6 +936,29 @@ let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
     (contains_substr "invalid in active cascade.json" assign_invalid_result.body)
 ;;
 
+let test_execution_trust_route_surfaces_latest_receipt () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
+  append_execution_receipt config ~keeper_name;
+  let result =
+    run_curl_get ~port ~path:"/api/v1/dashboard/execution-trust" ()
+  in
+  require_status "execution trust GET returns 200" 200 result;
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string result.body in
+  let row =
+    json |> member "keepers" |> to_list
+    |> List.find (fun keeper -> keeper |> member "name" |> to_string = keeper_name)
+  in
+  check string "route surfaces trust outcome" "ok"
+    (row |> member "trust" |> member "last_outcome" |> to_string);
+  check string "route surfaces trust sandbox kind" "worktree"
+    (row |> member "trust" |> member "sandbox" |> member "effective_kind"
+     |> to_string);
+  check string "route surfaces trust contract result" "satisfied"
+    (row |> member "trust" |> member "tool_contract_result" |> to_string)
+;;
+
 let test_merge_keeper_trace_lines_includes_internal_history () =
   let base_path = Filename.temp_file "dashboard-keeper-trajectory-" "" in
   (try Sys.remove base_path with
@@ -956,6 +1053,10 @@ let () =
             "keeper cascade routes filter invalid catalog entries"
             `Slow
             test_keeper_cascade_routes_filter_invalid_catalog_entries
+        ; test_case
+            "execution trust route surfaces latest receipt"
+            `Slow
+            test_execution_trust_route_surfaces_latest_receipt
         ; test_case
             "merge keeper trace lines includes internal history"
             `Quick


### PR DESCRIPTION
## Summary

- persist keeper execution receipts with sandbox, approval, cascade, and tool contract observations
- surface receipt-backed trust data on compact keeper rows and the /api/v1/dashboard/execution-trust endpoint
- add dashboard and route coverage for latest receipt trust projections

## Why

Keeper execution trust data existed only transiently during a run, so dashboard consumers could not inspect the latest trust outcome after the fact.

## Impact

- dashboard users can inspect last outcome, sandbox mode, cascade outcome, and unexpected tools per keeper
- execution trust data is available both in-process and over HTTP

## Validation

- dune build --root . @check
- dune build --root . ./bin/main_eio.exe
- dune exec --root . ./test/test_dashboard_execution.exe
- MASC_MAIN_EIO_EXE=_build/default/bin/main_eio.exe dune exec --root . ./test/test_dashboard_keeper_routes.exe
