### PR TITLE
[codex] align cascade model provenance with runtime resolution

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -10,6 +10,7 @@
 (* ── Re-exports from extracted modules ─────────────── *)
 
 (* Model resolution *)
+let resolve_auto_model = Cascade_model_resolve.resolve_auto_model
 let resolve_glm_model_id = Cascade_model_resolve.resolve_glm_model_id
 let resolve_auto_model_id = Cascade_model_resolve.resolve_auto_model_id
 let parse_custom_model = Cascade_model_resolve.parse_custom_model
@@ -120,32 +121,32 @@ let make_registry_config ~temperature ~max_tokens ?system_prompt
     else Sys.getenv_opt effective_api_key_env |> Option.value ~default:""
   in
   let headers = headers_with_auth ~kind:defaults.kind ~api_key in
-  (* For local providers, resolve "auto" before endpoint selection so that
-     routing uses the concrete model name discovered from the server.
-     Filter by provider's own endpoint to prevent cross-provider
-     contamination (e.g. ollama:auto must not pick up llama-server models). *)
-  let is_local_auto =
-    (provider_name = "llama" || provider_name = "ollama")
-    && model_id = "auto"
+  (* Keep runtime model selection on the same resolution path as the
+     provenance helpers in [Cascade_model_resolve]. Local providers still
+     inject provider-specific discovery so routing stays isolated by
+     endpoint (e.g. ollama:auto must not pick up llama-server models). *)
+  let discover =
+    match provider_name with
+    | "ollama" ->
+        Some
+          (fun () ->
+            Llm_provider.Discovery.first_discovered_model_id_for_url
+              defaults.base_url)
+    | "llama" -> Some Llm_provider.Discovery.first_discovered_model_id
+    | _ -> None
   in
-  let effective_model_id =
-    if is_local_auto then
-      (if provider_name = "ollama" then
-         Llm_provider.Discovery.first_discovered_model_id_for_url defaults.base_url
-       else
-         Llm_provider.Discovery.first_discovered_model_id ())
-      |> Option.value ~default:model_id
-    else model_id
+  let model_resolution =
+    resolve_auto_model ?discover provider_name model_id
   in
+  let resolved_model_id = model_resolution.resolved_model_id in
   let base_url =
     if provider_name = "llama" then
       (* Route to the endpoint that has this model; round-robin fallback *)
-      match Llm_provider.Discovery.endpoint_for_model effective_model_id with
+      match Llm_provider.Discovery.endpoint_for_model resolved_model_id with
       | Some url -> url
       | None -> Llm_provider.Provider_registry.next_llama_endpoint ()
     else defaults.base_url
   in
-  let resolved_model_id = resolve_auto_model_id provider_name effective_model_id in
   (* Resolve max_context: per-model capabilities override registry default *)
   let max_context =
     let caps =

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -25,7 +25,8 @@
 val resolve_glm_model_id : string -> string
 
 (** Resolve "auto" and aliases to concrete model IDs for any provider.
-    Cloud providers resolve aliases; local providers pass through.
+    Cloud providers resolve aliases; local providers resolve ["auto"]
+    via discovery first and otherwise pass through explicit model IDs.
     @since 0.89.1 *)
 val resolve_auto_model_id : string -> string -> string
 

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -21,10 +21,83 @@
 
     All text/vision models support function calling.
     glm-5.1 supports reasoning (reasoning_content field). *)
-let env_or default var =
-  match Sys.getenv_opt var with
-  | Some v when String.trim v <> "" -> String.trim v
-  | _ -> default
+type model_resolution_provenance =
+  | Explicit_input
+  | Alias of string
+  | Env_default of string
+  | Hardcoded_default
+  | Discovery
+  | Unresolved_auto
+
+type model_resolution = {
+  requested_model_id : string;
+  resolved_model_id : string;
+  provenance : model_resolution_provenance;
+}
+
+type provider_default_spec = {
+  env_var : string;
+  hardcoded_default : string option;
+}
+
+let env_value_opt ?(getenv = Sys.getenv_opt) var =
+  match getenv var with
+  | Some v ->
+      let trimmed = String.trim v in
+      if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+
+let provider_default_spec = function
+  | "glm" ->
+      Some { env_var = "ZAI_DEFAULT_MODEL"; hardcoded_default = Some "glm-5.1" }
+  | "glm-coding" ->
+      Some
+        { env_var = "ZAI_CODING_DEFAULT_MODEL"; hardcoded_default = Some "glm-4.7" }
+  | "llama" | "ollama" ->
+      Some { env_var = "OLLAMA_DEFAULT_MODEL"; hardcoded_default = None }
+  | "gemini" ->
+      Some
+        {
+          env_var = "GEMINI_DEFAULT_MODEL";
+          hardcoded_default = Some "gemini-3-flash-preview";
+        }
+  | "claude" ->
+      Some
+        {
+          env_var = "ANTHROPIC_DEFAULT_MODEL";
+          hardcoded_default = Some "claude-sonnet-4-6-20250514";
+        }
+  | "openai" ->
+      Some { env_var = "OPENAI_DEFAULT_MODEL"; hardcoded_default = Some "gpt-4.1" }
+  | "openrouter" ->
+      Some { env_var = "OPENROUTER_DEFAULT_MODEL"; hardcoded_default = None }
+  | _ -> None
+
+let explicit_resolution requested_model_id resolved_model_id =
+  { requested_model_id; resolved_model_id; provenance = Explicit_input }
+
+let default_resolution ?getenv provider_name ~requested_model_id =
+  match provider_default_spec provider_name with
+  | Some { env_var; hardcoded_default } -> (
+      match env_value_opt ?getenv env_var with
+      | Some resolved_model_id ->
+          { requested_model_id; resolved_model_id; provenance = Env_default env_var }
+      | None -> (
+          match hardcoded_default with
+          | Some resolved_model_id ->
+              { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
+          | None ->
+              {
+                requested_model_id;
+                resolved_model_id = requested_model_id;
+                provenance = Unresolved_auto;
+              }))
+  | None ->
+      {
+        requested_model_id;
+        resolved_model_id = requested_model_id;
+        provenance = Unresolved_auto;
+      }
 
 (** Default GLM auto-cascade order: quality-first, then speed.
     glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
@@ -33,15 +106,41 @@ let env_or default var =
 let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
 let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
 
+let resolve_glm_model ?getenv model_id =
+  let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in
+  let resolved_model_id =
+    Llm_provider.Zai_catalog.resolve_glm_alias
+      ~default_model:default_model.resolved_model_id
+      model_id
+  in
+  if String.equal model_id "auto" then
+    { default_model with resolved_model_id }
+  else if String.equal resolved_model_id model_id then
+    explicit_resolution model_id resolved_model_id
+  else
+    { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+
+let resolve_glm_coding_model ?getenv model_id =
+  let default_model =
+    default_resolution ?getenv "glm-coding" ~requested_model_id:model_id
+  in
+  let resolved_model_id =
+    Llm_provider.Zai_catalog.resolve_glm_coding_alias
+      ~default_model:default_model.resolved_model_id
+      model_id
+  in
+  if String.equal model_id "auto" then
+    { default_model with resolved_model_id }
+  else if String.equal resolved_model_id model_id then
+    explicit_resolution model_id resolved_model_id
+  else
+    { requested_model_id = model_id; resolved_model_id; provenance = Alias model_id }
+
 let resolve_glm_model_id model_id =
-  Llm_provider.Zai_catalog.resolve_glm_alias
-    ~default_model:(env_or "glm-5.1" "ZAI_DEFAULT_MODEL")
-    model_id
+  (resolve_glm_model model_id).resolved_model_id
 
 let resolve_glm_coding_model_id model_id =
-  Llm_provider.Zai_catalog.resolve_glm_coding_alias
-    ~default_model:(env_or "glm-4.7" "ZAI_CODING_DEFAULT_MODEL")
-    model_id
+  (resolve_glm_coding_model model_id).resolved_model_id
 
 (** Resolve "auto" and aliases to concrete model IDs.
     Cloud APIs generally require concrete model names, and local
@@ -51,18 +150,22 @@ let resolve_glm_coding_model_id model_id =
     which returns models from the last endpoint probe.  Callers should
     resolve the model_id before invoking [Llm_provider.Discovery.endpoint_for_model]
     to avoid routing mismatches. *)
-let resolve_auto_model_id provider_name model_id =
+let resolve_auto_model
+    ?getenv
+    ?(discover = Llm_provider.Discovery.first_discovered_model_id)
+    provider_name model_id =
   match provider_name with
   | "llama" | "ollama" ->
     (* Local providers: "auto" resolved earlier via Discovery in
        cascade_config.ml.  If still "auto" here, try discovery then env var. *)
-    if model_id = "auto" then
-      match Llm_provider.Discovery.first_discovered_model_id () with
-      | Some id -> id
-      | None -> env_or model_id "OLLAMA_DEFAULT_MODEL"
-    else model_id
-  | "glm" -> resolve_glm_model_id model_id
-  | "glm-coding" -> resolve_glm_coding_model_id model_id
+    if String.equal model_id "auto" then
+      match discover () with
+      | Some resolved_model_id ->
+          { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
+      | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id
+    else explicit_resolution model_id model_id
+  | "glm" -> resolve_glm_model ?getenv model_id
+  | "glm-coding" -> resolve_glm_coding_model ?getenv model_id
   | "gemini" ->
     (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview on
        2026-04-16 (PR C Cadd follow-up). Capabilities are inherited via
@@ -70,18 +173,28 @@ let resolve_auto_model_id provider_name model_id =
        oas/lib/llm_provider/capabilities.ml:269 (1M context, tools,
        parallel tool calls). Override with GEMINI_DEFAULT_MODEL if you
        still need the 2.5 line. *)
-    if model_id = "auto" then env_or "gemini-3-flash-preview" "GEMINI_DEFAULT_MODEL"
-    else model_id
+    if String.equal model_id "auto" then
+      default_resolution ?getenv provider_name ~requested_model_id:model_id
+    else explicit_resolution model_id model_id
   | "claude" ->
-    if model_id = "auto" then env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"
-    else model_id
+    if String.equal model_id "auto" then
+      default_resolution ?getenv provider_name ~requested_model_id:model_id
+    else explicit_resolution model_id model_id
   | "openai" ->
-    if model_id = "auto" then env_or "gpt-4.1" "OPENAI_DEFAULT_MODEL"
-    else model_id
+    if String.equal model_id "auto" then
+      default_resolution ?getenv provider_name ~requested_model_id:model_id
+    else explicit_resolution model_id model_id
   | "openrouter" ->
-    if model_id = "auto" then env_or model_id "OPENROUTER_DEFAULT_MODEL"
-    else model_id
-  | _ -> model_id
+    if String.equal model_id "auto" then
+      default_resolution ?getenv provider_name ~requested_model_id:model_id
+    else explicit_resolution model_id model_id
+  | _ ->
+    if String.equal model_id "auto" then
+      { requested_model_id = model_id; resolved_model_id = model_id; provenance = Unresolved_auto }
+    else explicit_resolution model_id model_id
+
+let resolve_auto_model_id provider_name model_id =
+  (resolve_auto_model provider_name model_id).resolved_model_id
 
 let parse_custom_model model_id =
   match String.index_opt model_id '@' with
@@ -91,7 +204,7 @@ let parse_custom_model model_id =
     (model, url)
   | None ->
     let url =
-      match Sys.getenv_opt "CUSTOM_LLM_BASE_URL" with
+      match env_value_opt "CUSTOM_LLM_BASE_URL" with
       | Some u -> u
       | None -> Llm_provider.Discovery.default_endpoint
     in

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -14,8 +14,27 @@
 val glm_auto_models : unit -> string list
 val glm_coding_auto_models : unit -> string list
 
+type model_resolution_provenance =
+  | Explicit_input
+  | Alias of string
+  | Env_default of string
+  | Hardcoded_default
+  | Discovery
+  | Unresolved_auto
+
+type model_resolution = {
+  requested_model_id : string;
+  resolved_model_id : string;
+  provenance : model_resolution_provenance;
+}
+
+val resolve_glm_model :
+  ?getenv:(string -> string option) -> string -> model_resolution
+val resolve_glm_coding_model :
+  ?getenv:(string -> string option) -> string -> model_resolution
+
 (** Resolve a GLM model alias to the concrete API model ID.
-    - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5"]
+    - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5.1"]
     - ["flash"] -> ["glm-4.7-flashx"]
     - ["turbo"] -> ["glm-5-turbo"]
     - ["vision"] -> ["glm-4.6v"]
@@ -26,6 +45,12 @@ val resolve_glm_coding_model_id : string -> string
 (** Resolve "auto" and aliases to concrete model IDs for any provider.
     Cloud providers resolve aliases; local providers (llama, ollama) resolve
     "auto" via {!Llm_provider.Discovery.first_discovered_model_id}. *)
+val resolve_auto_model :
+  ?getenv:(string -> string option) ->
+  ?discover:(unit -> string option) ->
+  string ->
+  string ->
+  model_resolution
 val resolve_auto_model_id : string -> string -> string
 
 (** Parse a "model@url" custom model spec.

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -10,6 +10,21 @@ open Alcotest
 (* ── Section 1: Provider_adapter contracts ── *)
 
 module Adapter = Masc_mcp.Provider_adapter
+module Model_resolve = Masc_mcp.Cascade_model_resolve
+
+let string_of_resolution_provenance = function
+  | Model_resolve.Explicit_input -> "explicit_input"
+  | Model_resolve.Alias alias -> "alias:" ^ alias
+  | Model_resolve.Env_default var -> "env_default:" ^ var
+  | Model_resolve.Hardcoded_default -> "hardcoded_default"
+  | Model_resolve.Discovery -> "discovery"
+  | Model_resolve.Unresolved_auto -> "unresolved_auto"
+
+let resolution_provenance =
+  testable
+    (fun fmt provenance ->
+      Format.pp_print_string fmt (string_of_resolution_provenance provenance))
+    ( = )
 
 let test_alias_roundtrip () =
   let cases =
@@ -155,6 +170,56 @@ let test_labels_require_local_discovery () =
     (Masc_mcp.Oas_model_resolve.labels_require_local_discovery
        [ "default"; "glm:auto" ])
 
+let test_cascade_model_resolve_alias_provenance () =
+  let resolved =
+    Model_resolve.resolve_glm_model ~getenv:(fun _ -> None) "flash"
+  in
+  check string "glm flash alias" "glm-4.7-flashx" resolved.resolved_model_id;
+  check resolution_provenance "alias provenance"
+    (Model_resolve.Alias "flash") resolved.provenance
+
+let test_cascade_model_resolve_hardcoded_default_provenance () =
+  let resolved =
+    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openai" "auto"
+  in
+  check string "openai hardcoded default" "gpt-4.1" resolved.resolved_model_id;
+  check resolution_provenance "hardcoded provenance"
+    Model_resolve.Hardcoded_default resolved.provenance
+
+let test_cascade_model_resolve_env_default_provenance () =
+  let getenv = function
+    | "GEMINI_DEFAULT_MODEL" -> Some "gemini-2.5-flash"
+    | _ -> None
+  in
+  let resolved =
+    Model_resolve.resolve_auto_model ~getenv "gemini" "auto"
+  in
+  check string "gemini env default" "gemini-2.5-flash"
+    resolved.resolved_model_id;
+  check resolution_provenance "env provenance"
+    (Model_resolve.Env_default "GEMINI_DEFAULT_MODEL")
+    resolved.provenance
+
+let test_cascade_model_resolve_discovery_provenance () =
+  let resolved =
+    Model_resolve.resolve_auto_model
+      ~getenv:(fun _ -> None)
+      ~discover:(fun () -> Some "qwen3:8b")
+      "ollama" "auto"
+  in
+  check string "ollama discovery" "qwen3:8b" resolved.resolved_model_id;
+  check resolution_provenance "discovery provenance"
+    Model_resolve.Discovery resolved.provenance
+
+let test_cascade_model_resolve_unresolved_auto_provenance () =
+  let resolved =
+    Model_resolve.resolve_auto_model ~getenv:(fun _ -> None) "openrouter" "auto"
+  in
+  check string "openrouter unresolved auto stays auto" "auto"
+    resolved.resolved_model_id;
+  check resolution_provenance "unresolved provenance"
+    Model_resolve.Unresolved_auto resolved.provenance
+
 (* ── Section 3: Dashboard schema contracts ── *)
 
 let test_heartbeat_snapshot_has_required_fields () =
@@ -253,6 +318,16 @@ let () =
             test_effective_discovered_ctx;
           test_case "local discovery label detection" `Quick
             test_labels_require_local_discovery;
+          test_case "cascade alias provenance" `Quick
+            test_cascade_model_resolve_alias_provenance;
+          test_case "cascade hardcoded default provenance" `Quick
+            test_cascade_model_resolve_hardcoded_default_provenance;
+          test_case "cascade env default provenance" `Quick
+            test_cascade_model_resolve_env_default_provenance;
+          test_case "cascade discovery provenance" `Quick
+            test_cascade_model_resolve_discovery_provenance;
+          test_case "cascade unresolved auto provenance" `Quick
+            test_cascade_model_resolve_unresolved_auto_provenance;
           test_case "resolve max cascade context" `Quick
             test_resolve_max_cascade_context;
         ] );


### PR DESCRIPTION
## What changed
- add typed `model_resolution` / `model_resolution_provenance` helpers in `cascade_model_resolve`
- cover alias, env default, hardcoded default, discovery, and unresolved-auto cases in `test_observability_provider_contracts`
- route `Cascade_config.make_registry_config` through `resolve_auto_model` so runtime config construction uses the same model-resolution SSOT

## Why
`cascade_model_resolve` gained provenance-aware resolution logic, but `cascade_config` still had its own local `auto` resolution path. That left runtime behavior and observability/contracts on separate code paths.

## Impact
- local and cloud model resolution now share one SSOT
- future surfaces can consume provenance without re-deriving resolution decisions
- local provider discovery remains provider-specific (`ollama` stays URL-scoped, `llama` stays endpoint-scoped)

## Validation
- `git diff --check`
- attempted: `dune build --root ~/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-219-cascade-model-provenance --build-dir _build_task219 @test/runtest-test_observability_provider_contracts`
- blocker: `agent_sdk.swarm` library missing from local dune environment (`test/deps/dune`, `lib/dune`)
