### PR TITLE
feat(dashboard): render keeper_runtime resolved values with source tracking

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -35,11 +35,6 @@ import type {
   DashboardGoalsTreeResponse,
   DashboardNamespaceTruthResponse,
   DashboardShellResponse,
-  DashboardConfigResolution,
-  DashboardConfigResolutionItem,
-  DashboardRuntimeDiagnostic,
-  DashboardRuntimeResolution,
-  ServerBuildIdentity,
   BoardSortMode,
   GovernanceCaseBundle,
   GovernanceDecisionItem,
@@ -47,6 +42,8 @@ import type {
   KeeperApprovalQueueItem,
   GovernanceTimelineEvent,
   PendingConfirmation,
+  DashboardConfigResolution,
+  DashboardRuntimeResolution,
 } from '../types'
 
 // --- Dashboard projections ---
@@ -772,7 +769,12 @@ export type {
   DashboardRuntimeDiagnostic,
   DashboardRuntimeResolution,
   ServerBuildIdentity as DashboardBuildIdentity,
-}
+} from '../types'
+export type {
+  KeeperRuntimeResolved,
+  KeeperRuntimeField,
+  KeeperRuntimeSource,
+} from '../types'
 
 interface DashboardRuntimeProbeLoadedModel {
   name?: string | null

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -7,6 +7,8 @@ import type {
   DashboardRuntimeDiagnostic,
   DashboardRuntimeProbeResponse,
   DashboardRuntimeResolution,
+  KeeperRuntimeResolved,
+  KeeperRuntimeField,
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
 import { Card } from '../common/card'
@@ -279,6 +281,76 @@ function probeSignalLabel(signal: string | null | undefined): string {
     default:
       return 'probe pending'
   }
+}
+
+const KEEPER_RUNTIME_ROWS: Array<{
+  key: keyof KeeperRuntimeResolved
+  label: string
+  fmt: 'int' | 'float' | 'duration'
+}> = [
+  { key: 'bootstrap_max_active_keepers', label: 'max active keepers', fmt: 'int' },
+  { key: 'reactive_max_turns_per_call', label: 'reactive max turns/call', fmt: 'int' },
+  { key: 'autonomous_max_turns_per_call', label: 'autonomous max turns/call', fmt: 'int' },
+  { key: 'reactive_max_idle_turns', label: 'reactive max idle turns', fmt: 'int' },
+  { key: 'autonomous_max_idle_turns', label: 'autonomous max idle turns', fmt: 'int' },
+  { key: 'turn_timeout_sec', label: 'turn timeout', fmt: 'duration' },
+  { key: 'admission_wait_timeout_sec', label: 'admission wait timeout', fmt: 'duration' },
+  { key: 'oas_timeout_override_sec', label: 'OAS timeout override', fmt: 'duration' },
+  { key: 'oas_timeout_per_1k', label: 'OAS timeout per 1k ctx', fmt: 'float' },
+  { key: 'oas_timeout_per_turn', label: 'OAS timeout per turn', fmt: 'duration' },
+]
+
+function sourceTone(source: string): string {
+  switch (source) {
+    case 'env': return 'border-[var(--accent-primary)]/30 bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]'
+    case 'toml': return 'border-[var(--emerald-28)] bg-[var(--emerald-10)] text-[#bbf7d0]'
+    case 'derived': return 'border-[var(--yellow-bright-28)] bg-[var(--yellow-bright-10)] text-[var(--yellow-100)]'
+    default: return 'border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-muted)]'
+  }
+}
+
+function fmtKeeperValue(value: number | null, fmt: 'int' | 'float' | 'duration'): string {
+  if (value === null || value === undefined) return '--'
+  switch (fmt) {
+    case 'int': return String(Math.round(value))
+    case 'float': return value.toFixed(1)
+    case 'duration': return value >= 60 ? `${fmtNumber(value / 60, 1)}m` : `${fmtNumber(value, 0)}s`
+  }
+}
+
+function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null }) {
+  if (!runtime) return null
+  const tomlCount = KEEPER_RUNTIME_ROWS.filter(r => runtime[r.key]?.source === 'toml').length
+  const envCount = KEEPER_RUNTIME_ROWS.filter(r => runtime[r.key]?.source === 'env').length
+
+  return html`
+    <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
+      <div class="mb-3 flex flex-wrap items-center gap-2">
+        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">keeper runtime</div>
+        ${tomlCount > 0 ? html`
+          <${StatusChip} tone=${sourceTone('toml')}>${tomlCount} TOML<//>
+        ` : null}
+        ${envCount > 0 ? html`
+          <${StatusChip} tone=${sourceTone('env')}>${envCount} env<//>
+        ` : null}
+      </div>
+      <div class="grid gap-2 md:grid-cols-2">
+        ${KEEPER_RUNTIME_ROWS.map(row => {
+          const field: KeeperRuntimeField<number | null> | undefined = runtime[row.key]
+          if (!field) return null
+          return html`
+            <div class="flex items-center justify-between gap-3 rounded border border-[var(--card-border)] bg-[var(--white-6)] px-3 py-2">
+              <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">${row.label}</div>
+              <div class="flex items-center gap-2">
+                <span class="font-mono text-xs text-[var(--text-body)]">${fmtKeeperValue(field.value, row.fmt)}</span>
+                <span class="text-3xs px-1.5 py-0.5 rounded ${sourceTone(field.source)}">${field.source}</span>
+              </div>
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
 }
 
 function RuntimeProbePanel() {
@@ -564,6 +636,8 @@ export function ConfigResolutionPanel({
                       : visibleDiagnostics.map(item => html`<${DiagnosticRow} item=${item} />`)}
                 </div>
               </div>
+
+              <${KeeperRuntimePanel} runtime=${runtimeResolution.keeper_runtime} />
 
               <${RuntimeProbePanel} />
             </div>

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -9,6 +9,9 @@ import type {
   DashboardConfigResolutionItem,
   DashboardRuntimeDiagnostic,
   DashboardRuntimeResolution,
+  KeeperRuntimeResolved,
+  KeeperRuntimeField,
+  KeeperRuntimeSource,
   DashboardShellMetaCognitionBelief,
   DashboardShellMetaCognitionDesire,
   DashboardShellMetaCognitionSummary,
@@ -447,6 +450,71 @@ export function normalizeDashboardRuntimeDiagnostic(
   }
 }
 
+const _MISSING = Symbol('missing')
+
+function normalizeKeeperRuntimeField<T>(
+  raw: unknown,
+  valueNormalize: (v: unknown) => T | typeof _MISSING,
+): KeeperRuntimeField<T> | null {
+  if (!isRecord(raw)) return null
+  const value = valueNormalize(raw.value)
+  if (value === _MISSING) return null
+  const source = asString(raw.source)
+  if (!source) return null
+  const validSources: KeeperRuntimeSource[] = ['env', 'toml', 'default', 'derived']
+  return {
+    value: value as T,
+    source: validSources.includes(source as KeeperRuntimeSource)
+      ? (source as KeeperRuntimeSource) : 'default',
+  }
+}
+
+function normalizeKeeperRuntimeResolved(raw: unknown): KeeperRuntimeResolved | null {
+  if (!isRecord(raw)) return null
+  const toNumber = (v: unknown): number | typeof _MISSING => {
+    const n = asNumber(v)
+    return n !== null && n !== undefined ? n : _MISSING
+  }
+  const intField = (key: string) => normalizeKeeperRuntimeField(
+    (raw as Record<string, unknown>)[key], v => {
+      const n = toNumber(v)
+      return n === _MISSING ? _MISSING : Math.round(n as number)
+    },
+  )
+  const floatField = (key: string) => normalizeKeeperRuntimeField(
+    (raw as Record<string, unknown>)[key], toNumber,
+  )
+  const optFloatField = (key: string) => normalizeKeeperRuntimeField<number | null>(
+    (raw as Record<string, unknown>)[key],
+    v => v === null || v === undefined ? null : toNumber(v) === _MISSING ? _MISSING : (toNumber(v) as number),
+  )
+  const bootstrap = intField('bootstrap_max_active_keepers')
+  const reactiveMaxTurns = intField('reactive_max_turns_per_call')
+  const autonomousMaxTurns = intField('autonomous_max_turns_per_call')
+  const reactiveMaxIdle = intField('reactive_max_idle_turns')
+  const autonomousMaxIdle = intField('autonomous_max_idle_turns')
+  const turnTimeout = floatField('turn_timeout_sec')
+  const admissionWait = floatField('admission_wait_timeout_sec')
+  const oasTimeoutOverride = optFloatField('oas_timeout_override_sec')
+  const oasTimeoutPer1k = floatField('oas_timeout_per_1k')
+  const oasTimeoutPerTurn = floatField('oas_timeout_per_turn')
+  if (!bootstrap || !reactiveMaxTurns || !autonomousMaxTurns || !reactiveMaxIdle
+    || !autonomousMaxIdle || !turnTimeout || !admissionWait || !oasTimeoutPer1k
+    || !oasTimeoutPerTurn) return null
+  return {
+    bootstrap_max_active_keepers: bootstrap,
+    reactive_max_turns_per_call: reactiveMaxTurns,
+    autonomous_max_turns_per_call: autonomousMaxTurns,
+    reactive_max_idle_turns: reactiveMaxIdle,
+    autonomous_max_idle_turns: autonomousMaxIdle,
+    turn_timeout_sec: turnTimeout,
+    admission_wait_timeout_sec: admissionWait,
+    oas_timeout_override_sec: oasTimeoutOverride as KeeperRuntimeField<number | null>,
+    oas_timeout_per_1k: oasTimeoutPer1k,
+    oas_timeout_per_turn: oasTimeoutPerTurn,
+  }
+}
+
 export function normalizeDashboardRuntimeResolution(
   raw: unknown,
 ): DashboardRuntimeResolution | null {
@@ -476,6 +544,7 @@ export function normalizeDashboardRuntimeResolution(
       .map(normalizeDashboardRuntimeDiagnostic)
       .filter((item): item is DashboardRuntimeDiagnostic => item !== null),
     build,
+    keeper_runtime: normalizeKeeperRuntimeResolved(raw.keeper_runtime),
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -75,6 +75,26 @@ export interface DashboardRuntimeDiagnostic {
   message: string
 }
 
+export type KeeperRuntimeSource = 'env' | 'toml' | 'default' | 'derived'
+
+export interface KeeperRuntimeField<T> {
+  value: T
+  source: KeeperRuntimeSource
+}
+
+export interface KeeperRuntimeResolved {
+  bootstrap_max_active_keepers: KeeperRuntimeField<number>
+  reactive_max_turns_per_call: KeeperRuntimeField<number>
+  autonomous_max_turns_per_call: KeeperRuntimeField<number>
+  reactive_max_idle_turns: KeeperRuntimeField<number>
+  autonomous_max_idle_turns: KeeperRuntimeField<number>
+  turn_timeout_sec: KeeperRuntimeField<number>
+  admission_wait_timeout_sec: KeeperRuntimeField<number>
+  oas_timeout_override_sec: KeeperRuntimeField<number | null>
+  oas_timeout_per_1k: KeeperRuntimeField<number>
+  oas_timeout_per_turn: KeeperRuntimeField<number>
+}
+
 export interface DashboardRuntimeResolution {
   status: 'ready' | 'warn' | string
   warnings: string[]
@@ -88,6 +108,7 @@ export interface DashboardRuntimeResolution {
   source_mismatch: boolean
   diagnostics: DashboardRuntimeDiagnostic[]
   build: ServerBuildIdentity
+  keeper_runtime: KeeperRuntimeResolved | null
 }
 
 export interface DashboardShellResponse {


### PR DESCRIPTION
## Summary
- Server already sends `keeper_runtime` (10 fields with env/toml/default source) in `/api/v1/dashboard/shell` under `runtime_resolution`, but frontend never declared types, normalized payload, or rendered a panel
- TOML config changes to `keeper_runtime.toml` were invisible to dashboard operators
- Adds full type→normalizer→component pipeline for keeper runtime resolved values

## Changes
- **`dashboard/src/types/dashboard-execution.ts`**: `KeeperRuntimeField<T>`, `KeeperRuntimeSource`, `KeeperRuntimeResolved` types + `keeper_runtime` field on `DashboardRuntimeResolution`
- **`dashboard/src/store-normalizers.ts`**: `normalizeKeeperRuntimeResolved` with `_MISSING` sentinel pattern for nullable fields
- **`dashboard/src/components/tools/config-resolution-panel.ts`**: `KeeperRuntimePanel` component — 10-row grid with source badges and duration formatting
- **`dashboard/src/api/dashboard.ts`**: Re-export new types, restore local imports for in-file usage

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [ ] Manual: start dashboard, navigate to 설정 경로 section, verify 10 keeper runtime rows appear with correct source badges
- [ ] Manual: change a value in `keeper_runtime.toml`, restart server, verify source shows `toml` and value reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)