### PR TITLE
test(oas): fill missing NetworkError kinds

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2060,6 +2060,7 @@ let wrapped_claude_limit_error () =
        {
          message =
            "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+         kind = Unknown;
        })
 
 let test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default () =
@@ -2124,7 +2125,8 @@ let test_is_context_overflow_only_for_overflow_errors () =
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None })));
   check bool "NetworkError does not match" false
     (EC.is_context_overflow
-       (Agent_sdk.Error.Api (NetworkError { message = "Connection_reset" })));
+       (Agent_sdk.Error.Api
+          (NetworkError { message = "Connection_reset"; kind = Unknown })));
   check bool "Internal does not match" false
     (EC.is_context_overflow
        (Agent_sdk.Error.Internal "some error"));
@@ -2440,7 +2442,7 @@ let test_overflow_detection_and_limit_parsing () =
     (Agent_sdk.Retry.extract_context_limit "Network error: connection reset");
   check bool "NetworkError not overflow" false
     (EC.is_context_overflow
-       (Agent_sdk.Error.Api (NetworkError { message = "timeout" })))
+       (Agent_sdk.Error.Api (NetworkError { message = "timeout"; kind = Unknown })))
 
 let test_side_effect_timeout_reclassified_as_persistent () =
   let original =
@@ -2589,7 +2591,7 @@ let test_server_rejected_parse_error_generic_cant_find () =
 let test_server_rejected_parse_error_network_error () =
   let err =
     Agent_sdk.Error.Api
-      (NetworkError { message = "connection refused" })
+      (NetworkError { message = "connection refused"; kind = Unknown })
   in
   check bool "network error is NOT parse error" false
     (EC.is_server_rejected_parse_error err)
@@ -2617,6 +2619,7 @@ let test_auto_recoverable_turn_error_includes_wrapped_hard_quota () =
          {
            message =
              "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+           kind = Unknown;
          })
   in
   check bool "wrapped hard quota is auto-recoverable" true
@@ -4006,7 +4009,8 @@ let () =
           test_case "NetworkError detected" `Quick (fun () ->
             check bool "network error" true
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (NetworkError { message = "Connection_reset" }))));
+                 (Agent_sdk.Error.Api
+                    (NetworkError { message = "Connection_reset"; kind = Unknown }))));
           test_case "Timeout detected" `Quick (fun () ->
             check bool "timeout" true
               (EC.is_transient_network_error

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -646,6 +646,7 @@ let test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper () =
              "gemini exited with code 1: TerminalQuotaError: You have exhausted \
               your capacity on this model. Your quota will reset after 4h41m7s. \
               reason=QUOTA_EXHAUSTED";
+           kind = Unknown;
          })
   in
   Alcotest.(check bool) "Gemini CLI quota wrapper counts as hard quota" true
@@ -658,6 +659,7 @@ let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
          {
            message =
              "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+           kind = Unknown;
          })
   in
   Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
@@ -669,6 +671,7 @@ let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
       (Llm_provider.Retry.NetworkError
          {
            message = "gemini exited with code 1: connection reset by peer";
+           kind = Unknown;
          })
   in
   Alcotest.(check bool) "transient network error stays transient" false


### PR DESCRIPTION
## Summary

- Backfill `kind = Unknown` on stale `NetworkError` test fixtures in `test/test_oas_worker.ml` and `test/test_keeper_unified.ml`.
- Current `main` no longer reproduces the original `prepare_messages` drift from #9357; the same repro target now failed on the newer mandatory `NetworkError.kind` field instead.

## Product impact

- Promise affected: `none/internal`
- User-visible change: none; restores clean test-target build coverage on current `main`.

## Evidence

- `dune build --root . -j 1 test/test_oas_worker.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_oas_worker.exe`

## Review evidence

- Not run; scoped test-fixture-only change with local build/test verification above.

## Linked issue

- Closes #9357
- Relates #
