### PR TITLE
fix(tla-check): add missing KeeperCoreTriad to tla-check.sh

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -156,6 +156,8 @@ run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompactionLifecycle
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompositeLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCompositeLifecycle.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"
+run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperCoreTriad.tla"
+run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCoreTriad.tla"
 run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperCircuitBreaker.tla"
 run_tlc "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"
 run_tlc_buggy "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"


### PR DESCRIPTION
## Problem
PR #9410 changed `KeeperCoreTriad.tla` (6→7 symbol alphabet, `BaseCascade` parametrization) but `scripts/tla-check.sh` did not include it in the manual spec list.

## Verification
- Clean cfg: 176 states, 77 distinct, PASS
- Buggy cfg: 15 states, invariant VIOLATED as expected

## Fix
Add `run_tlc` and `run_tlc_buggy` calls for `KeeperCoreTriad.tla` in `scripts/tla-check.sh`.

Fixes gap between Makefile (glob-based, already covers this) and the standalone script used in local dev.