### PR TITLE
[codex] Add keeper Docker sandbox preflight and smoke checks

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      coreutils \
+      findutils \
+      git \
+      gh \
+      jq \
+      make \
+      nodejs \
+      npm \
+      opam \
+      ocaml-dune \
+      python3 \
+      ripgrep \
+      tree \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -704,7 +704,14 @@ let label_for_rc = function
 
 let doctor_all_json_exit base_path =
   let config_report =
-    Config_doctor.analyze
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    Config_doctor.analyze_live
+      ~sw
+      ~net:(Eio.Stdenv.net env)
+      ~clock:(Eio.Stdenv.clock env)
+      ~fs:(Eio.Stdenv.fs env)
+      ~proc_mgr:(Eio.Stdenv.process_mgr env)
       ~base_path_input:base_path
       ~default_base_path:(default_base_path ())
       ()

--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -85,6 +85,8 @@ Core fields:
 - `repo_config_seed_path`: checked-in seed config, when discoverable
 - `keeper_runtime_toml_present`: whether active runtime tuning exists at
   `<active_config_root>/keeper_runtime.toml`
+- `sandbox_preflight`: Docker keeper sandbox readiness (`docker` daemon,
+  local image presence, required commands, hardening checks)
 
 Important interpretation:
 
@@ -93,6 +95,9 @@ Important interpretation:
 - `shadowed` means both roots exist, but the explicit env root wins.
 - `missing_init` means the supported active root is not ready even if other
   fallback locations exist elsewhere on disk.
+- `sandbox_preflight` is independent of config init state. Even when no live
+  config root exists yet, `doctor` still reports whether the default Docker
+  keeper sandbox image can actually run.
 
 ## Secondary Proof Surfaces
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -300,8 +300,9 @@ spawn 시 인자로 직접 설정하는 필드.
 의미:
 
 - keeper shell write는 자기 sandbox 안에서만 허용된다. 현재 local/docker backend의 디스크 구현은 `.masc/playground/<keeper>/`이지만 keeper-facing 경로는 `.` / `mind` / `repos`이다.
-- `sandbox_profile=docker`는 keeper_bash를 ephemeral Docker sandbox로 실행한다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private sandbox mount, network=`none`이다.
-- git/gh 명령 dispatch: `sandbox_profile=docker` 에서 `keeper_bash` 의 cmd 가 `git` 또는 `gh` 로 시작하면 자동으로 network=bridge + `~/.config/gh` / `~/.gitconfig` read-only mount + `GH_TOKEN` env forward 가 켜진다. 한 명령에만 적용되며, git/gh 외 모든 명령은 여전히 network=none 의 hardened 컨테이너에서 실행된다. 응답 JSON에는 `git_creds_enabled: true` 필드가 함께 들어온다. 비활성화하려면 `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false`. `~/.ssh` mount 는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
+- `sandbox_profile=docker`는 keeper identity 전체에 적용된다. `keeper_bash`뿐 아니라 `keeper_fs_read`, `keeper_fs_edit`, `keeper_shell`의 read/write/git/gh 흐름도 Docker로 라우팅된다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private sandbox mount, network=`none`이다.
+- git/gh 명령 dispatch: `sandbox_profile=docker` 에서 network가 필요한 `git`/`gh` 계열 명령(`keeper_bash`, `keeper_shell op=gh`, `keeper_shell op=git_clone`)은 한 명령 단위로 network=bridge + `~/.config/gh` / `~/.gitconfig` read-only mount + `GH_TOKEN` env forward 경로를 사용한다. 그 외 명령은 계속 network=none 의 hardened container 또는 turn-scoped `docker exec` runtime 으로 실행된다. Docker 라우트 응답에는 `via: "docker"`가 들어오고, git credential dispatch가 켜진 경우 `git_creds_enabled: true`도 함께 들어온다. 비활성화하려면 `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false`. `~/.ssh` mount 는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
+- 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
 - `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
 - team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
 

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -57,7 +57,7 @@ let format_exhausted_error last_err =
     | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
     | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
       Printf.sprintf "%s provider requires a CLI transport" kind
-    | Some (Llm_provider.Http_client.NetworkError { message }) -> message
+    | Some (Llm_provider.Http_client.NetworkError { message; _ }) -> message
     | None -> "No providers available"
   in
   let network_error_kind =

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -536,9 +536,15 @@ module KeeperSandbox = struct
       Must contain bash and the CLI tools the keeper needs. *)
   let docker_image () =
     get_string
-      ~default:
-        "ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff"
+      ~default:"masc-keeper-sandbox:local"
       "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+
+  (** Global keeper sandbox preflight switch. Enabled by default so
+      keeper_up and doctor fail fast when the Docker image/runtime is
+      unusable. Tests can disable this globally and re-enable it in
+      dedicated preflight cases. *)
+  let preflight_enabled () =
+    get_bool ~default:true "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED"
 
   (** pids limit for hardened keeper containers. *)
   let pids_limit () =

--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -38,6 +38,7 @@ type t = {
   warnings : string list;
   next_actions : string list;
   catalog_validation : Yojson.Safe.t option;
+  sandbox_preflight : Yojson.Safe.t option;
 }
 
 type catalog_issue_severity = Cascade_catalog_validator.severity =
@@ -458,6 +459,7 @@ let analyze_with (inputs : inputs) =
     warnings;
     next_actions;
     catalog_validation = None;
+    sandbox_preflight = None;
   }
 
 let analyze ~base_path_input ~default_base_path () =
@@ -505,6 +507,22 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
   let report = analyze ~base_path_input ~default_base_path () in
   Process_eio.init ~cwd_default:Eio.Path.(fs / report.base_path) ~proc_mgr
     ~clock;
+  let sandbox_preflight_report =
+    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+  in
+  let sandbox_preflight =
+    sandbox_preflight_report
+    |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
+  in
+  let sandbox_warning, sandbox_actions, sandbox_preflight_ok =
+    match sandbox_preflight_report with
+    | Some preflight when not preflight.ok ->
+        ( Some (Keeper_sandbox_runtime.docker_preflight_failure_message preflight),
+          preflight.next_actions,
+          false )
+    | Some _ -> (None, [], true)
+    | None -> (None, [], true)
+  in
   let live_outcome, live_warning, catalog_validation =
     match
       Cascade_catalog_runtime.inspect_active ~sw ~net ~clock ()
@@ -513,33 +531,41 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
     | outcome, warning, validation -> (outcome, warning, validation)
   in
   let warnings =
-    match live_warning with
-    | None -> report.warnings
-    | Some warning -> report.warnings @ [ warning ]
+    [ report.warnings;
+      (match live_warning with
+       | None -> []
+       | Some warning -> [ warning ]);
+      (match sandbox_warning with
+       | None -> []
+       | Some warning -> [ warning ]) ]
+    |> List.concat
   in
   let next_actions =
-    if
-      match live_outcome with
-      | Live_catalog_serving_last_known_good | Live_catalog_invalid -> true
-      | Live_catalog_valid | Live_catalog_partial -> false
-    then
-      report.next_actions
-      @
-      [
-        "Fix the active cascade catalog candidates/strategy and rerun `masc-mcp doctor config`.";
-      ]
-    else
-      report.next_actions
+    let catalog_actions =
+      if
+        match live_outcome with
+        | Live_catalog_serving_last_known_good | Live_catalog_invalid -> true
+        | Live_catalog_valid | Live_catalog_partial -> false
+      then
+        [
+          "Fix the active cascade catalog candidates/strategy and rerun `masc-mcp doctor config`.";
+        ]
+      else
+        []
+    in
+    report.next_actions @ catalog_actions @ sandbox_actions
+    |> dedupe_keep_order
   in
   let status =
-    match report.init_state, report.status, live_outcome with
-    | (Invalid_env | Missing_init), _, _ -> Error
-    | _, _, (Live_catalog_serving_last_known_good | Live_catalog_invalid) ->
+    match report.init_state, report.status, live_outcome, sandbox_preflight_ok with
+    | (Invalid_env | Missing_init), _, _, _ -> Error
+    | _, _, (Live_catalog_serving_last_known_good | Live_catalog_invalid), _ ->
         Error
-    | _, _, Live_catalog_partial -> Warn
-    | _, Warn, Live_catalog_valid -> Warn
-    | _, Ok, Live_catalog_valid -> Ok
-    | _, Error, Live_catalog_valid -> Error
+    | _, _, Live_catalog_partial, _ -> Warn
+    | _, Error, Live_catalog_valid, _ -> Error
+    | _, Warn, Live_catalog_valid, _ -> Warn
+    | _, Ok, Live_catalog_valid, false -> Warn
+    | _, Ok, Live_catalog_valid, true -> Ok
   in
   {
     report with
@@ -547,6 +573,7 @@ let analyze_live ~sw ~net ~clock ~fs ~proc_mgr ~base_path_input
     warnings;
     next_actions;
     catalog_validation = Some catalog_validation;
+    sandbox_preflight;
   }
 
 let to_yojson (report : t) =
@@ -570,6 +597,10 @@ let to_yojson (report : t) =
       ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
       ( "catalog_validation",
         match report.catalog_validation with
+        | Some value -> value
+        | None -> `Null );
+      ( "sandbox_preflight",
+        match report.sandbox_preflight with
         | Some value -> value
         | None -> `Null );
     ]
@@ -617,6 +648,12 @@ let render_text (report : t) =
        add_line "";
        add_line "catalog_validation:";
        add_line (Yojson.Safe.pretty_to_string validation)
+   | None -> ());
+  (match report.sandbox_preflight with
+   | Some preflight ->
+       add_line "";
+       add_line "sandbox_preflight:";
+       add_line (Yojson.Safe.pretty_to_string preflight)
    | None -> ());
   if report.warnings <> [] then begin
     add_line "";

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -357,6 +357,10 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
   let history_fragment_filter_enabled =
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in
+  let sandbox_preflight_json =
+    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+    |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
+  in
   let series_points = 120 in
   let names = keeper_names config in
   let now_ts = Time_compat.now () in
@@ -616,6 +620,11 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                    && Env_config_keeper.DockerPlayground.enabled)
             then Some (Env_config_keeper.KeeperSandbox.docker_image ())
             else None
+          in
+          let sandbox_preflight =
+            match effective_sandbox_image, sandbox_preflight_json with
+            | Some _, Some preflight -> Some preflight
+            | _ -> None
           in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
@@ -918,6 +927,8 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 `String (Keeper_types.sandbox_profile_to_string m.sandbox_profile));
               ("sandbox_last_error",
                 Json_util.string_opt_to_json sandbox_last_error);
+              ("sandbox_preflight",
+                Json_util.option_to_yojson Fun.id sandbox_preflight);
               ("effective_sandbox_image",
                 Json_util.string_opt_to_json effective_sandbox_image);
               ("runtime_trust", runtime_trust);
@@ -1341,6 +1352,15 @@ let keeper_config_json (config : Coord.config) (name : string)
         then Some (Env_config_keeper.KeeperSandbox.docker_image ())
         else None
       in
+      let sandbox_preflight_json =
+        Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+        |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
+      in
+      let sandbox_preflight =
+        match effective_sandbox_image, sandbox_preflight_json with
+        | Some _, Some preflight -> Some preflight
+        | _ -> None
+      in
       let private_workspace_root =
         Filename.concat
           (Keeper_alerting_path.project_root_of_config config)
@@ -1376,6 +1396,8 @@ let keeper_config_json (config : Coord.config) (name : string)
             `Bool (Env_config_keeper.KeeperSandbox.require_rootless ()));
           ("require_userns",
             `Bool (Env_config_keeper.KeeperSandbox.require_userns ()));
+          ("preflight",
+            Json_util.option_to_yojson Fun.id sandbox_preflight);
         ]
       in
       (`OK,
@@ -1387,6 +1409,8 @@ let keeper_config_json (config : Coord.config) (name : string)
          ("shared_memory_scope",
            `String (Keeper_types.shared_memory_scope_to_string m.shared_memory_scope));
          ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
+         ("sandbox_preflight",
+           Json_util.option_to_yojson Fun.id sandbox_preflight);
          ("effective_sandbox_image",
            Json_util.string_opt_to_json effective_sandbox_image);
          ("private_workspace_root", `String private_workspace_root);

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -177,6 +177,11 @@ let handle_keeper_fs_edit
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
+  let via_field =
+    match turn_sandbox_runtime with
+    | Some _ -> [ ("via", `String "docker") ]
+    | None -> []
+  in
   let path = Safe_ops.json_string ~default:"" "path" args in
   let content = Safe_ops.json_string ~default:"" "content" args in
   let mode_raw =
@@ -237,13 +242,14 @@ let handle_keeper_fs_edit
                   (String.length updated);
                 Yojson.Safe.to_string
                   (`Assoc
-                      [ "ok", `Bool true
-                      ; "path", `String target
-                      ; "mode", `String "patch"
-                      ; "replace_all", `Bool replace_all
-                      ; "occurrences", `Int occurrences
-                      ; "bytes_written", `Int (String.length updated)
-                      ])
+                      ([ "ok", `Bool true
+                       ; "path", `String target
+                       ; "mode", `String "patch"
+                       ; "replace_all", `Bool replace_all
+                       ; "occurrences", `Int occurrences
+                       ; "bytes_written", `Int (String.length updated)
+                       ]
+                      @ via_field))
           with
           | Invalid_argument e ->
             error_json ~fields:[ "path", `String target ] e
@@ -290,11 +296,12 @@ let handle_keeper_fs_edit
          (String.length content);
        Yojson.Safe.to_string
          (`Assoc
-             [ "ok", `Bool true
-             ; "path", `String target
-             ; "mode", `String mode_label
-             ; "bytes_written", `Int (String.length content)
-             ])
+             ([ "ok", `Bool true
+              ; "path", `String target
+              ; "mode", `String mode_label
+              ; "bytes_written", `Int (String.length content)
+              ]
+             @ via_field))
      with
      | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1040,19 +1040,28 @@ let handle_keeper_shell
   in
   let run_readonly_in_docker ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
       ~max_bytes ~timeout_sec () =
-    match
-      Keeper_docker_read.container_path_of_host ~config ~meta ~host_path:target
-    with
-    | Error e -> Error (docker_read_error ~target e)
-    | Ok cpath -> (
-        match
-          Keeper_docker_read.run_command_in_container_with_status
-            ?turn_sandbox_runtime
-            ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
-            ~max_bytes ~timeout_sec ()
-        with
-        | Error msg -> Error (docker_read_error ~target msg)
-        | Ok payload -> Ok payload)
+    let max_eintr_retries = 8 in
+    let rec loop attempts_left =
+      match
+        Keeper_docker_read.container_path_of_host ~config ~meta ~host_path:target
+      with
+      | Error e -> Error (docker_read_error ~target e)
+      | Ok cpath -> (
+          match
+            Keeper_docker_read.run_command_in_container_with_status
+              ?turn_sandbox_runtime
+              ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
+              ~max_bytes ~timeout_sec ()
+          with
+          | Error msg
+            when attempts_left > 0
+                 && String_util.contains_substring_ci msg
+                      "interrupted system call" ->
+              loop (attempts_left - 1)
+          | Error msg -> Error (docker_read_error ~target msg)
+          | Ok payload -> Ok payload)
+    in
+    loop max_eintr_retries
   in
   let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
       ~max_bytes ~timeout_sec ?(map_output = fun out -> out) ?(extra = []) () =

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1809,6 +1809,7 @@ let handle_keeper_shell
            (Keeper_alerting_path.playground_path_of_keeper meta.name) in
          let repos_dir = Filename.concat root
            (Keeper_alerting_path.playground_repos_path meta.name) in
+         Fs_compat.mkdir_p repos_dir;
          (* Derive repo name from URL: strip trailing slash, .git, then basename.
             Guard against empty/traversal names (e.g. url ending with "/" or ".."). *)
          let repo_name =
@@ -1836,8 +1837,19 @@ let handle_keeper_shell
          if Fs_compat.file_exists clone_path then
            (* Already cloned — pull latest instead *)
            let st, out =
-             Process_eio.run_argv_with_status ~timeout_sec:60.0
-               [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
+             if meta.sandbox_profile = Docker then
+               match
+                 run_docker_shell_command_with_status ~config ~meta ~cwd:repos_dir
+                   ~timeout_sec:60.0
+                   ~cmd:(Printf.sprintf "git -C %s pull --ff-only"
+                           (Filename.quote repo_name))
+                   ~git_creds_enabled:true ~network_mode:Network_inherit
+               with
+               | Ok result -> (result.status, result.output)
+               | Error msg -> (Unix.WEXITED 127, msg)
+             else
+               Process_eio.run_argv_with_status ~timeout_sec:60.0
+                 [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
            in
            if st = Unix.WEXITED 0 then
              update_playground_repo_cache
@@ -1845,13 +1857,18 @@ let handle_keeper_shell
                ~action:"pull" ~shallow:false;
            Yojson.Safe.to_string
              (`Assoc
-                 [ "ok", `Bool (st = Unix.WEXITED 0)
-                 ; "op", `String op
-                 ; "action", `String "pull"
-                 ; "path", `String clone_path
-                 ; "status", Keeper_alerting_path.process_status_to_json st
-                 ; "output", `String out
-                 ])
+                 ([ "ok", `Bool (st = Unix.WEXITED 0)
+                  ; "op", `String op
+                  ; "action", `String "pull"
+                  ; "path", `String clone_path
+                  ; "status", Keeper_alerting_path.process_status_to_json st
+                  ; "output", `String out
+                  ]
+                 @
+                 (if meta.sandbox_profile = Docker then
+                    [ "via", `String "docker" ]
+                  else
+                    [])))
          else
            let depth = Keeper_tool_policy.clone_depth () |> max 0 in
            let depth_args =
@@ -1859,9 +1876,24 @@ let handle_keeper_shell
            in
            let shallow = depth > 0 in
            let st, out =
-             Process_eio.run_argv_with_status
-               ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
-               ("git" :: "clone" :: depth_args @ [ url; clone_path ])
+             if meta.sandbox_profile = Docker then
+               let clone_cmd =
+                 String.concat " "
+                   (List.map Filename.quote
+                      ("git" :: "clone" :: depth_args @ [ url; repo_name ]))
+               in
+               match
+                 run_docker_shell_command_with_status ~config ~meta ~cwd:repos_dir
+                   ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
+                   ~cmd:clone_cmd
+                   ~git_creds_enabled:true ~network_mode:Network_inherit
+               with
+               | Ok result -> (result.status, result.output)
+               | Error msg -> (Unix.WEXITED 127, msg)
+             else
+               Process_eio.run_argv_with_status
+                 ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
+                 ("git" :: "clone" :: depth_args @ [ url; clone_path ])
            in
            if st = Unix.WEXITED 0 then
              update_playground_repo_cache
@@ -1869,13 +1901,18 @@ let handle_keeper_shell
                ~action:"clone" ~shallow;
            Yojson.Safe.to_string
              (`Assoc
-                 [ "ok", `Bool (st = Unix.WEXITED 0)
-                 ; "op", `String op
-                 ; "action", `String "clone"
-                 ; "path", `String clone_path
-                 ; "status", Keeper_alerting_path.process_status_to_json st
-                 ; "output", `String out
-                 ]))
+                 ([ "ok", `Bool (st = Unix.WEXITED 0)
+                  ; "op", `String op
+                  ; "action", `String "clone"
+                  ; "path", `String clone_path
+                  ; "status", Keeper_alerting_path.process_status_to_json st
+                  ; "output", `String out
+                  ]
+                 @
+                 (if meta.sandbox_profile = Docker then
+                    [ "via", `String "docker" ]
+                  else
+                    []))))
   | "gh" ->
     let raw_cmd_str = Safe_ops.json_string ~default:"" "cmd" args in
     (* gh runs against remote network. Prior floors (1s, then 5s) kept
@@ -1935,6 +1972,12 @@ let handle_keeper_shell
             (Keeper_gh_shared.render_simple_gh_command cmd)
         in
         let gh_base ~ok ~cwd ~command extras =
+          let route_fields =
+            if meta.sandbox_profile = Docker then
+              [ "via", `String "docker" ]
+            else
+              []
+          in
           Yojson.Safe.to_string
             (`Assoc
                 ([ "ok", `Bool ok
@@ -1942,7 +1985,7 @@ let handle_keeper_shell
                  ; "cwd", `String cwd
                  ; "command", `String command
                  ; "reversibility", `String rev_tag
-                 ] @ extras))
+                 ] @ route_fields @ extras))
         in
         let run_gh_command ~display_command ~parsed_command ~cwd
             ~(ctx : gh_repo_context option) =

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -35,6 +35,177 @@ let docker_info_security_options ~timeout_sec =
              "failed to parse docker info SecurityOptions JSON: %s"
              err)
 
+type required_command_check =
+  {
+    command : string;
+    available : bool;
+  }
+
+type docker_preflight =
+  {
+    ok : bool;
+    image : string;
+    docker_runtime_ok : bool;
+    docker_runtime_error : string option;
+    hardening_ok : bool;
+    hardening_error : string option;
+    image_present : bool;
+    image_error : string option;
+    required_commands : required_command_check list;
+    missing_commands : string list;
+    next_actions : string list;
+  }
+
+let docker_preflight_timeout ~timeout_sec =
+  min 20.0 (max 5.0 timeout_sec)
+
+let required_commands =
+  [
+    "sh";
+    "bash";
+    "cat";
+    "find";
+    "head";
+    "tail";
+    "wc";
+    "git";
+    "gh";
+    "rg";
+    "tree";
+    "jq";
+    "python3";
+    "node";
+    "npm";
+    "make";
+    "opam";
+    "dune";
+  ]
+
+let option_field name = function
+  | Some value -> (name, `String value)
+  | None -> (name, `Null)
+
+let dedupe_keep_order values =
+  let seen = Hashtbl.create (List.length values) in
+  List.filter
+    (fun value ->
+      if value = "" || Hashtbl.mem seen value then
+        false
+      else (
+        Hashtbl.replace seen value ();
+        true))
+    values
+
+let docker_image_present ~image ~timeout_sec =
+  if String.trim image = "" then
+    Error "keeper sandbox docker image is not configured"
+  else
+    let st, out =
+      Process_eio.run_argv_with_status
+        ~cwd:(Sys.getcwd ())
+        ~timeout_sec
+        [ "docker"; "image"; "inspect"; image ]
+    in
+    if st = Unix.WEXITED 0 then
+      Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "keeper sandbox image %s is not available locally: %s"
+           image
+           (Worker_dev_tools.truncate_for_log out))
+
+let docker_image_required_commands ~image ~timeout_sec =
+  let script =
+    let quoted =
+      List.map Filename.quote required_commands |> String.concat " "
+    in
+    Printf.sprintf
+      "missing=''; for cmd in %s; do if ! command -v \"$cmd\" >/dev/null 2>&1; then missing=\"$missing$cmd\\n\"; fi; done; printf '%%s' \"$missing\""
+      quoted
+  in
+  let st, out =
+    Process_eio.run_argv_with_status
+      ~cwd:(Sys.getcwd ())
+      ~timeout_sec
+      [ "docker"; "run"; "--rm"; "--network"; "none"; "--entrypoint"; "sh";
+        image; "-lc"; script ]
+  in
+  if st = Unix.WEXITED 0 then
+    let missing =
+      out
+      |> String.split_on_char '\n'
+      |> List.map String.trim
+      |> List.filter (fun item -> item <> "")
+    in
+    Ok missing
+  else
+    Error
+      (Printf.sprintf
+         "failed to inspect keeper sandbox image commands: %s"
+         (Worker_dev_tools.truncate_for_log out))
+
+let docker_preflight_to_yojson (preflight : docker_preflight) =
+  `Assoc
+    [
+      ("backend", `String "docker");
+      ("status", `String (if preflight.ok then "ok" else "error"));
+      ("ok", `Bool preflight.ok);
+      ("image", `String preflight.image);
+      ("docker_runtime_ok", `Bool preflight.docker_runtime_ok);
+      (option_field "docker_runtime_error" preflight.docker_runtime_error);
+      ("hardening_ok", `Bool preflight.hardening_ok);
+      (option_field "hardening_error" preflight.hardening_error);
+      ("image_present", `Bool preflight.image_present);
+      (option_field "image_error" preflight.image_error);
+      ( "required_commands",
+        `List
+          (List.map
+             (fun item ->
+               `Assoc
+                 [
+                   ("command", `String item.command);
+                   ("available", `Bool item.available);
+                 ])
+             preflight.required_commands) );
+      ("missing_commands",
+        `List (List.map (fun command -> `String command) preflight.missing_commands));
+      ("next_actions",
+        `List (List.map (fun action -> `String action) preflight.next_actions));
+    ]
+
+let docker_preflight_failure_message (preflight : docker_preflight) =
+  let reasons =
+    [
+      (match preflight.docker_runtime_error with
+       | Some message -> Some message
+       | None -> None);
+      (match preflight.hardening_error with
+       | Some message -> Some message
+       | None -> None);
+      (match preflight.image_error with
+       | Some message -> Some message
+       | None -> None);
+      (if preflight.missing_commands = [] then
+         None
+       else
+         Some
+           (Printf.sprintf
+              "keeper sandbox image is missing required commands: %s"
+              (String.concat ", " preflight.missing_commands)));
+    ]
+    |> List.filter_map (fun item -> item)
+    |> dedupe_keep_order
+  in
+  let next_actions =
+    match preflight.next_actions with
+    | [] -> ""
+    | actions -> " Next: " ^ String.concat " " actions
+  in
+  Printf.sprintf "Docker sandbox preflight failed: %s.%s"
+    (String.concat "; " reasons)
+    next_actions
+
 let ensure_keeper_sandbox_runtime ~timeout_sec =
   let seccomp_profile =
     String.trim (Env_config_keeper.KeeperSandbox.seccomp_profile ())
@@ -58,12 +229,16 @@ let ensure_keeper_sandbox_runtime ~timeout_sec =
       if not require_rootless && not require_userns then
         Ok seccomp_args
       else
-        match docker_info_security_options ~timeout_sec:(min 20.0 (max 5.0 timeout_sec)) with
+        match
+          docker_info_security_options
+            ~timeout_sec:(min 20.0 (max 5.0 timeout_sec))
+        with
         | Error _ as err -> err
         | Ok security_options ->
             let has needle =
               List.exists
-                (fun option_text -> String_util.contains_substring option_text needle)
+                (fun option_text ->
+                  String_util.contains_substring option_text needle)
                 security_options
             in
             if require_rootless && not (has "rootless") then
@@ -74,3 +249,96 @@ let ensure_keeper_sandbox_runtime ~timeout_sec =
                 "sandbox runtime requires Docker userns support (set MASC_KEEPER_SANDBOX_REQUIRE_USERNS=false to disable this check)"
             else
               Ok seccomp_args
+
+let docker_preflight ~timeout_sec () =
+  if not (Env_config_keeper.KeeperSandbox.preflight_enabled ()) then
+    None
+  else
+    let timeout_sec = docker_preflight_timeout ~timeout_sec in
+    let image = Env_config_keeper.KeeperSandbox.docker_image () in
+    let docker_runtime_ok, docker_runtime_error =
+      match docker_info_security_options ~timeout_sec with
+      | Ok _ -> (true, None)
+      | Error message -> (false, Some message)
+    in
+    let hardening_ok, hardening_error =
+      match ensure_keeper_sandbox_runtime ~timeout_sec with
+      | Ok _ -> (true, None)
+      | Error message -> (false, Some message)
+    in
+    let image_present, image_error =
+      match docker_image_present ~image ~timeout_sec with
+      | Ok () -> (true, None)
+      | Error message -> (false, Some message)
+    in
+    let missing_commands, command_error =
+      if not image_present then
+        ([], None)
+      else
+        match docker_image_required_commands ~image ~timeout_sec with
+        | Ok missing -> (missing, None)
+        | Error message -> ([], Some message)
+    in
+    let required_commands =
+      List.map
+        (fun command ->
+          { command; available = not (List.mem command missing_commands) })
+        required_commands
+    in
+    let next_actions =
+      [
+        (if not docker_runtime_ok then
+           Some
+             "Ensure Docker is installed and the daemon is reachable from this shell."
+         else
+           None);
+        (if not image_present || missing_commands <> [] then
+           Some
+             "Run scripts/build-keeper-sandbox-image.sh to build the default keeper sandbox image."
+         else
+           None);
+        (if not hardening_ok then
+           Some
+             "Fix the keeper sandbox hardening configuration (seccomp/rootless/userns) and rerun doctor."
+         else
+           None);
+      ]
+      |> List.filter_map (fun action -> action)
+      |> dedupe_keep_order
+    in
+    let image_error =
+      match image_error, command_error with
+      | Some message, None -> Some message
+      | None, Some message -> Some message
+      | Some message, Some _ -> Some message
+      | None, None -> None
+    in
+    Some
+      {
+        ok =
+          docker_runtime_ok
+          && hardening_ok
+          && image_present
+          && command_error = None
+          && missing_commands = [];
+        image;
+        docker_runtime_ok;
+        docker_runtime_error;
+        hardening_ok;
+        hardening_error;
+        image_present;
+        image_error;
+        required_commands;
+        missing_commands;
+        next_actions;
+      }
+
+let ensure_keeper_startup_preflight ~timeout_sec ~sandbox_profile =
+  match sandbox_profile with
+  | Keeper_types.Local -> Ok ()
+  | Keeper_types.Docker ->
+      (match docker_preflight ~timeout_sec () with
+       | None -> Ok ()
+       | Some preflight ->
+           if preflight.ok then Ok ()
+           else Error (docker_preflight_failure_message preflight))

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -9,6 +9,45 @@
     Pure leaf module — no upward dependencies on other [Keeper_*]
     modules. *)
 
+type required_command_check =
+  {
+    command : string;
+    available : bool;
+  }
+
+type docker_preflight =
+  {
+    ok : bool;
+    image : string;
+    docker_runtime_ok : bool;
+    docker_runtime_error : string option;
+    hardening_ok : bool;
+    hardening_error : string option;
+    image_present : bool;
+    image_error : string option;
+    required_commands : required_command_check list;
+    missing_commands : string list;
+    next_actions : string list;
+  }
+
+val docker_preflight :
+  timeout_sec:float -> unit -> docker_preflight option
+(** Global keeper sandbox preflight used by [doctor], keeper startup,
+    and diagnostics. Returns [None] when
+    [MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false]. *)
+
+val docker_preflight_to_yojson :
+  docker_preflight -> Yojson.Safe.t
+
+val docker_preflight_failure_message :
+  docker_preflight -> string
+
+val ensure_keeper_startup_preflight :
+  timeout_sec:float ->
+  sandbox_profile:Keeper_types.sandbox_profile ->
+  (unit, string) result
+(** Fail-fast keeper-up preflight for [sandbox_profile=docker]. *)
+
 val ensure_keeper_sandbox_runtime :
   timeout_sec:float -> (string list, string) result
 (** Returns the [--security-opt seccomp=...] argv fragment when the

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -235,8 +235,9 @@ let run_docker_with_git_bash
   | Ok result ->
     Yojson.Safe.to_string
       (`Assoc
-         [
+        [
            ("ok", `Bool (result.status = Unix.WEXITED 0));
+           ("via", `String "docker");
            ("cwd", `String cwd);
            ("sandbox_profile", `String "docker");
            ("git_creds_enabled", `Bool true);
@@ -285,6 +286,7 @@ let run_docker_hardened_bash
            (`Assoc
               [
                 ("ok", `Bool (st = Unix.WEXITED 0));
+                ("via", `String "docker");
                 ("cwd", `String cwd);
                 ("sandbox_profile", `String "docker");
                 ("git_creds_enabled", `Bool false);
@@ -304,6 +306,7 @@ let run_docker_hardened_bash
       (`Assoc
          [
            ("ok", `Bool (result.status = Unix.WEXITED 0));
+           ("via", `String "docker");
            ("cwd", `String cwd);
            ("sandbox_profile", `String "docker");
            ("git_creds_enabled", `Bool false);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -952,6 +952,15 @@ let handle_keeper_status ctx args : tool_result =
            then Some (Env_config_keeper.KeeperSandbox.docker_image ())
            else None
          in
+         let sandbox_preflight =
+           match
+             effective_sandbox_image,
+             Keeper_sandbox_runtime.docker_preflight ~timeout_sec:10.0 ()
+             |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
+           with
+           | Some _, Some preflight -> Some preflight
+           | _ -> None
+         in
          let runtime_blocker_fields =
           runtime_blocker_fields_json ctx.config m
          in
@@ -1012,6 +1021,8 @@ let handle_keeper_status ctx args : tool_result =
              `String (shared_memory_scope_to_string m.shared_memory_scope));
            ("sandbox_last_error",
              Json_util.string_opt_to_json sandbox_last_error);
+           ("sandbox_preflight",
+             Json_util.option_to_yojson Fun.id sandbox_preflight);
            ("effective_sandbox_image",
              Json_util.string_opt_to_json effective_sandbox_image);
            ("tool_policy_mode",
@@ -1217,6 +1228,8 @@ let handle_keeper_status ctx args : tool_result =
                `String (shared_memory_scope_to_string m.shared_memory_scope));
              ("sandbox_last_error",
                Json_util.string_opt_to_json sandbox_last_error);
+             ("sandbox_preflight",
+               Json_util.option_to_yojson Fun.id sandbox_preflight);
              ("effective_sandbox_image",
                Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", string_list_to_json m.allowed_paths);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -107,146 +107,184 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           p.name err;
         (false, err)
     | Ok () ->
-    let max_active_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
-    let active_keepers = Keeper_registry.count_running () in
-    if max_active_keepers > 0 && active_keepers >= max_active_keepers then begin
-      Log.Keeper.warn "create_keeper failed: max active keepers reached (%d/%d) for name=%s"
-        active_keepers max_active_keepers p.name;
-      (false,
-        Printf.sprintf
-          "keeper max active reached (%d/%d). Stop/remove a keeper or set MASC_KEEPER_MAX_ACTIVE_KEEPERS."
-          active_keepers max_active_keepers)
-    end
-    else
-    let proactive_enabled =
-      Option.value
-        ~default:
-          (Option.value ~default:default_proactive_enabled p.profile_defaults.proactive_enabled)
-        p.proactive_enabled_opt
-    in
-    let proactive_idle_sec =
-      Option.value
-        ~default:
-          (Option.value ~default:default_proactive_idle_sec p.profile_defaults.proactive_idle_sec)
-        p.proactive_idle_sec_opt
-      |> normalize_proactive_idle_sec
-    in
-    let proactive_cooldown_sec =
-      Option.value
-        ~default:
-          (Option.value ~default:default_proactive_cooldown_sec p.profile_defaults.proactive_cooldown_sec)
-        p.proactive_cooldown_sec_opt
-      |> normalize_proactive_cooldown_sec
-    in
-    let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
-    let handoff_threshold =
-      match p.handoff_threshold_opt with
-      | Some threshold -> threshold
-      | None -> Runtime_params.get Governance_registry.keeper_handoff_threshold
-    in
-    let handoff_cooldown_sec =
-      match p.handoff_cooldown_sec_opt with
-      | Some cooldown_sec -> cooldown_sec
-      | None -> Runtime_params.get Governance_registry.keeper_handoff_cooldown_sec
-    in
-    let tool_access =
-      match p.tool_access_opt with
-      | Some access -> access
-      | None ->
-          let tool_preset =
-            Option.value ~default:Research
-              (first_some p.tool_preset_opt (preset_of_defaults p.profile_defaults))
-          in
-          let tool_also_allow =
-            resolve_tool_name_list
-              ~preferred:p.tool_also_allow_opt
-              ~fallback:p.profile_defaults.tool_also_allow
-          in
-          Preset { preset = tool_preset; also_allow = tool_also_allow }
-    in
-    let tool_denylist =
-      resolve_tool_name_list
-        ~preferred:p.tool_denylist_opt
-        ~fallback:p.profile_defaults.tool_denylist
-    in
-    let social_model =
-      p.profile_defaults.social_model
-      |> Option.value ~default:default_social_model
-      |> Keeper_social_model.normalize_social_model
-    in
-    
-    let will =
-      Option.value
-        ~default:(Option.value ~default:default_keeper_will p.profile_defaults.will)
-        p.will_opt
-    in
-    let needs =
-      Option.value
-        ~default:(Option.value ~default:default_keeper_needs p.profile_defaults.needs)
-        p.needs_opt
-    in
-    let desires =
-      Option.value
-        ~default:(Option.value ~default:default_keeper_desires p.profile_defaults.desires)
-        p.desires_opt
-    in
-    let (short_goal, mid_goal, long_goal) =
-      resolve_goal_horizons
-        ~goal
-        ~short_goal_opt:(first_some p.short_goal_opt p.profile_defaults.short_goal)
-        ~mid_goal_opt:(first_some p.mid_goal_opt p.profile_defaults.mid_goal)
-        ~long_goal_opt:(first_some p.long_goal_opt p.profile_defaults.long_goal)
-    in
-    let instructions = Option.value ~default:"" p.instructions_opt in
-    let (env_ratio_gate, env_message_gate, env_token_gate) =
-      keeper_compaction_policy_from_env ()
-    in
-    let continuity_compaction_cooldown_sec =
-      Option.value
-        ~default:(keeper_continuity_compaction_cooldown_sec ())
-        p.continuity_compaction_cooldown_sec_opt
-      |> normalize_continuity_compaction_cooldown_sec
-    in
-    let (compaction_profile, compaction_ratio_gate, compaction_message_gate, compaction_token_gate) =
-      resolve_compaction_policy
-        ~profile_opt:p.compaction_profile_opt
-        ~ratio_opt:p.compaction_ratio_gate_opt
-        ~message_opt:p.compaction_message_gate_opt
-        ~token_opt:p.compaction_token_gate_opt
-        ~fallback_profile:default_compaction_profile
-        ~fallback_ratio:env_ratio_gate
-        ~fallback_message:env_message_gate
-        ~fallback_token:env_token_gate
-    in
-    let cascade_models =
-      Cascade_runtime.models_of_cascade_name Keeper_config.default_cascade_name
-    in
-    ignore (Cascade_runtime.refresh_local_discovery_if_possible cascade_models);
-    let primary_max_context =
-      match p.max_context_override_opt with
-      | Some v -> v
-      | None ->
-          let resolved =
-            Cascade_runtime.resolve_max_cascade_context cascade_models
-          in
-          Cascade_runtime.clamp_context_for_pure_local_labels
-            ~labels:cascade_models ~max_context:resolved
-    in
-    Progress.Tracker.step tracker ~message:"Initializing session directory" ();
-    let trace_id = generate_trace_id () in
-    match Keeper_id.Trace_id.of_string trace_id with
-    | Error err ->
-      Log.Keeper.error
-        "create_keeper failed: generated invalid trace_id for name=%s: %s"
-        p.name err;
-      Progress.stop_tracking task_id;
-      (false, "internal keeper trace_id generation failed")
-    | Ok trace_id_t ->
-      let base_dir = session_base_dir ctx.config in
-      (* Ensure full session dir tree, not just base_dir (issue #3019) *)
-      ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
-      ignore (Keeper_alerting_path.ensure_playground_bundle ~config:ctx.config ~name:p.name);
-      let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
+        match
+          Keeper_sandbox_runtime.ensure_keeper_startup_preflight
+            ~timeout_sec:15.0 ~sandbox_profile
+        with
+        | Error err ->
+            Log.Keeper.warn "create_keeper failed sandbox preflight for %s: %s"
+              p.name err;
+            (false, err)
+        | Ok () ->
+            let max_active_keepers =
+              Keeper_runtime_resolved.bootstrap_max_active_keepers ()
+            in
+            let active_keepers = Keeper_registry.count_running () in
+            if max_active_keepers > 0 && active_keepers >= max_active_keepers then begin
+              Log.Keeper.warn
+                "create_keeper failed: max active keepers reached (%d/%d) for name=%s"
+                active_keepers max_active_keepers p.name;
+              (false,
+                Printf.sprintf
+                  "keeper max active reached (%d/%d). Stop/remove a keeper or set MASC_KEEPER_MAX_ACTIVE_KEEPERS."
+                  active_keepers max_active_keepers)
+            end
+            else
+              let proactive_enabled =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_proactive_enabled
+                       p.profile_defaults.proactive_enabled)
+                  p.proactive_enabled_opt
+              in
+              let proactive_idle_sec =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_proactive_idle_sec
+                       p.profile_defaults.proactive_idle_sec)
+                  p.proactive_idle_sec_opt
+                |> normalize_proactive_idle_sec
+              in
+              let proactive_cooldown_sec =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_proactive_cooldown_sec
+                       p.profile_defaults.proactive_cooldown_sec)
+                  p.proactive_cooldown_sec_opt
+                |> normalize_proactive_cooldown_sec
+              in
+              let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
+              let handoff_threshold =
+                match p.handoff_threshold_opt with
+                | Some threshold -> threshold
+                | None ->
+                    Runtime_params.get Governance_registry.keeper_handoff_threshold
+              in
+              let handoff_cooldown_sec =
+                match p.handoff_cooldown_sec_opt with
+                | Some cooldown_sec -> cooldown_sec
+                | None ->
+                    Runtime_params.get Governance_registry.keeper_handoff_cooldown_sec
+              in
+              let tool_access =
+                match p.tool_access_opt with
+                | Some access -> access
+                | None ->
+                    let tool_preset =
+                      Option.value ~default:Research
+                        (first_some p.tool_preset_opt
+                           (preset_of_defaults p.profile_defaults))
+                    in
+                    let tool_also_allow =
+                      resolve_tool_name_list
+                        ~preferred:p.tool_also_allow_opt
+                        ~fallback:p.profile_defaults.tool_also_allow
+                    in
+                    Preset { preset = tool_preset; also_allow = tool_also_allow }
+              in
+              let tool_denylist =
+                resolve_tool_name_list
+                  ~preferred:p.tool_denylist_opt
+                  ~fallback:p.profile_defaults.tool_denylist
+              in
+              let social_model =
+                p.profile_defaults.social_model
+                |> Option.value ~default:default_social_model
+                |> Keeper_social_model.normalize_social_model
+              in
+              let will =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_keeper_will
+                       p.profile_defaults.will)
+                  p.will_opt
+              in
+              let needs =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_keeper_needs
+                       p.profile_defaults.needs)
+                  p.needs_opt
+              in
+              let desires =
+                Option.value
+                  ~default:
+                    (Option.value ~default:default_keeper_desires
+                       p.profile_defaults.desires)
+                  p.desires_opt
+              in
+              let (short_goal, mid_goal, long_goal) =
+                resolve_goal_horizons
+                  ~goal
+                  ~short_goal_opt:
+                    (first_some p.short_goal_opt p.profile_defaults.short_goal)
+                  ~mid_goal_opt:(first_some p.mid_goal_opt p.profile_defaults.mid_goal)
+                  ~long_goal_opt:
+                    (first_some p.long_goal_opt p.profile_defaults.long_goal)
+              in
+              let instructions = Option.value ~default:"" p.instructions_opt in
+              let (env_ratio_gate, env_message_gate, env_token_gate) =
+                keeper_compaction_policy_from_env ()
+              in
+              let continuity_compaction_cooldown_sec =
+                Option.value
+                  ~default:(keeper_continuity_compaction_cooldown_sec ())
+                  p.continuity_compaction_cooldown_sec_opt
+                |> normalize_continuity_compaction_cooldown_sec
+              in
+              let
+                ( compaction_profile,
+                  compaction_ratio_gate,
+                  compaction_message_gate,
+                  compaction_token_gate )
+                =
+                resolve_compaction_policy
+                  ~profile_opt:p.compaction_profile_opt
+                  ~ratio_opt:p.compaction_ratio_gate_opt
+                  ~message_opt:p.compaction_message_gate_opt
+                  ~token_opt:p.compaction_token_gate_opt
+                  ~fallback_profile:default_compaction_profile
+                  ~fallback_ratio:env_ratio_gate
+                  ~fallback_message:env_message_gate
+                  ~fallback_token:env_token_gate
+              in
+              let cascade_models =
+                Cascade_runtime.models_of_cascade_name
+                  Keeper_config.default_cascade_name
+              in
+              ignore
+                (Cascade_runtime.refresh_local_discovery_if_possible
+                   cascade_models);
+              let primary_max_context =
+                match p.max_context_override_opt with
+                | Some v -> v
+                | None ->
+                    let resolved =
+                      Cascade_runtime.resolve_max_cascade_context cascade_models
+                    in
+                    Cascade_runtime.clamp_context_for_pure_local_labels
+                      ~labels:cascade_models ~max_context:resolved
+              in
+              Progress.Tracker.step tracker ~message:"Initializing session directory" ();
+              let trace_id = generate_trace_id () in
+              match Keeper_id.Trace_id.of_string trace_id with
+              | Error err ->
+                  Log.Keeper.error
+                    "create_keeper failed: generated invalid trace_id for name=%s: %s"
+                    p.name err;
+                  Progress.stop_tracking task_id;
+                  (false, "internal keeper trace_id generation failed")
+              | Ok trace_id_t ->
+                  let base_dir = session_base_dir ctx.config in
+                  (* Ensure full session dir tree, not just base_dir (issue #3019) *)
+                  ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
+                  ignore
+                    (Keeper_alerting_path.ensure_playground_bundle ~config:ctx.config
+                       ~name:p.name);
+                  let session =
+                    Keeper_exec_context.create_session ~session_id:trace_id
+                      ~base_dir
+                  in
         let persona_extended =
           Keeper_types_profile.resolved_persona_name ~keeper_name:p.name
             p.profile_defaults

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -239,9 +239,18 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
         p.name err;
       (false, err)
   | Ok () ->
+      (match
+         Keeper_sandbox_runtime.ensure_keeper_startup_preflight
+           ~timeout_sec:15.0 ~sandbox_profile
+       with
+       | Error err ->
+           Log.Keeper.warn "update_keeper failed sandbox preflight for %s: %s"
+             p.name err;
+           (false, err)
+       | Ok () ->
       (match write_meta ctx.config updated with
        | Error e -> (false, e)
        | Ok () ->
          stop_keepalive ~base_path:ctx.config.base_path updated.name;
          start_keepalive ctx updated;
-         (true, Yojson.Safe.to_string (meta_to_json updated)))
+         (true, Yojson.Safe.to_string (meta_to_json updated))))

--- a/scripts/build-keeper-sandbox-image.sh
+++ b/scripts/build-keeper-sandbox-image.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image_tag="${1:-${MASC_KEEPER_SANDBOX_DOCKER_IMAGE:-masc-keeper-sandbox:local}}"
+
+cd "$repo_root"
+docker build -f Dockerfile.keeper-sandbox -t "$image_tag" .

--- a/scripts/keeper-sandbox-smoke.sh
+++ b/scripts/keeper-sandbox-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image_tag="${MASC_KEEPER_SANDBOX_DOCKER_IMAGE:-masc-keeper-sandbox:local}"
+
+"$repo_root/scripts/build-keeper-sandbox-image.sh" "$image_tag"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+playground="$tmpdir/playground"
+mkdir -p "$playground"
+printf 'alpha\nbeta\ngamma\n' > "$playground/demo.txt"
+
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --network none \
+  -v "$playground:/workspace:rw" \
+  --workdir /workspace \
+  "$image_tag" \
+  bash -lc '
+    set -euo pipefail
+    for cmd in sh bash git gh rg tree jq python3 node npm make opam dune; do
+      command -v "$cmd" >/dev/null
+    done
+    test "$(cat demo.txt)" = $'"'"'alpha\nbeta\ngamma'"'"'
+    rg beta demo.txt >/dev/null
+    printf "delta\n" >> append.txt
+    test "$(cat append.txt)" = "delta"
+  '
+
+container_name="keeper-sandbox-smoke-$$"
+docker run -d --rm \
+  --name "$container_name" \
+  --read-only \
+  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --network none \
+  -v "$playground:/workspace:rw" \
+  --workdir /workspace \
+  "$image_tag" \
+  sh -lc 'trap : TERM INT; while :; do sleep 3600; done' >/dev/null
+
+trap 'docker rm -f "$container_name" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EXIT
+
+docker exec "$container_name" bash -lc 'cat demo.txt >/tmp/readback && test -s /tmp/readback'
+docker exec "$container_name" bash -lc 'printf "zeta\n" > exec-write.txt'
+docker exec "$container_name" bash -lc 'rg gamma demo.txt >/dev/null'
+docker rm -f "$container_name" >/dev/null
+
+test "$(cat "$playground/exec-write.txt")" = "zeta"
+printf 'keeper sandbox smoke passed for %s\n' "$image_tag"

--- a/test/dune
+++ b/test/dune
@@ -12,7 +12,8 @@
    (MASC_BASE_PATH "")
    ; Avoid non-deterministic external network calls during unit tests.
    (GRAPHQL_API_KEY "")
-   (ZAI_API_KEY ""))))
+   (ZAI_API_KEY "")
+   (MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED false))))
 
 ; ============================================================
 ; All standard tests share the masc_test_deps wrapper library

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -1,6 +1,16 @@
 open Alcotest
 open Masc_mcp
 
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -29,6 +39,34 @@ let rec mkdir_p path =
 let write_file path content =
   mkdir_p (Filename.dirname path);
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let with_fake_docker script f =
+  with_temp_dir "config-doctor-docker" @@ fun dir ->
+  let docker_path = Filename.concat dir "docker" in
+  Out_channel.with_open_bin docker_path (fun oc -> output_string oc script);
+  Unix.chmod docker_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  with_env "PATH" path f
+
+let with_eio f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.clear_fs ();
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  f
+    ~sw
+    ~net:(Eio.Stdenv.net env)
+    ~clock:(Eio.Stdenv.clock env)
+    ~fs:(Eio.Stdenv.fs env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
 
 let canonical_path path =
   try Unix.realpath path with
@@ -193,10 +231,14 @@ let test_non_runtime_required_cascade_catalog_warns () =
   "default_models": [
     "claude_code:claude-haiku-4-5-20251001"
   ],
-  "manual_trial_models": [
-    "__nonexistent_provider_sentinel__:fake-model"
+  "default_strategy": "priority_tier",
+  "default_tiers": [
+    ["claude_code:claude-haiku-4-5-20251001"],
+    ["gemini_cli:not-configured-here"]
   ],
-  "manual_trial_keeper_assignable": false
+  "manual_trial_models": [
+    "claude_code:claude-haiku-4-5-20251001"
+  ]
 }|}
     config_root;
   let report =
@@ -208,10 +250,70 @@ let test_non_runtime_required_cascade_catalog_warns () =
     (list_contains_substring
        ~needle:"Cascade catalog check scanned 2 preset(s): 0 error, 1 warn."
        report.warnings);
-  check bool "non-runtime-required detail surfaced" true
+  check bool "priority_tier degradation detail surfaced" true
     (list_contains_substring
-       ~needle:"non-runtime-required profile; runtime can serve a validated subset"
+       ~needle:"uses priority_tier, but 1/2 tier(s) collapse after model-id normalization"
        report.warnings)
+
+let fake_docker_missing_image_script =
+  "#!/bin/sh\n\
+case \"$1\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  image)\n\
+    printf 'Error: No such image: %s\\n' \"$3\" >&2\n\
+    exit 1\n\
+    ;;\n\
+  run)\n\
+    printf 'run should not execute when image inspect fails\\n' >&2\n\
+    exit 2\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let test_analyze_live_surfaces_sandbox_preflight_failure () =
+  with_temp_dir "config-doctor-sandbox-preflight" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_config_root config_root;
+  with_fake_docker fake_docker_missing_image_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
+  let report =
+    Config_doctor.analyze_live
+      ~sw ~net ~clock ~fs ~proc_mgr
+      ~base_path_input:base_path
+      ~default_base_path:base_path
+      ()
+  in
+  check string "status downgrades to warn" "warn" (status report.status);
+  check bool "warning mentions docker sandbox preflight" true
+    (list_contains_substring
+       ~needle:"Docker sandbox preflight failed"
+       report.warnings);
+  check bool "next action mentions build script" true
+    (list_contains_substring
+       ~needle:"scripts/build-keeper-sandbox-image.sh"
+       report.next_actions);
+  match report.sandbox_preflight with
+  | None -> fail "expected sandbox_preflight output from analyze_live"
+  | Some json ->
+      check string "sandbox preflight status" "error"
+        (Yojson.Safe.Util.member "status" json |> Yojson.Safe.Util.to_string);
+      check string "sandbox preflight image" "missing:test"
+        (Yojson.Safe.Util.member "image" json |> Yojson.Safe.Util.to_string);
+      check bool "doctor json includes sandbox_preflight" true
+        (match Yojson.Safe.Util.member "sandbox_preflight"
+                 (Config_doctor.to_yojson report) with
+         | `Null -> false
+         | _ -> true)
 
 let () =
   run "config_doctor"
@@ -224,10 +326,12 @@ let () =
            test_case "initialized local base config" `Quick
              test_initialized_local_base_config;
            test_case "shadowed explicit config dir" `Quick
-             test_shadowed_explicit_config_dir;
+           test_shadowed_explicit_config_dir;
            test_case "broken cascade catalog surfaces errors" `Quick
              test_broken_cascade_catalog_surfaces_errors;
            test_case "non-runtime-required cascade catalog warns" `Quick
              test_non_runtime_required_cascade_catalog_warns;
+           test_case "analyze_live surfaces sandbox preflight failure"
+             `Quick test_analyze_live_surfaces_sandbox_preflight_failure;
          ]);
     ]

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -12,6 +12,7 @@ module Keeper_turn_sandbox_runtime = Masc_mcp.Keeper_turn_sandbox_runtime
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
@@ -51,6 +52,17 @@ let read_file path =
   let ic = open_in_bin path in
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if nlen = 0 then true
+    else if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  loop 0
 
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
@@ -327,6 +339,87 @@ esac\n\
 printf 'unexpected docker invocation\\n' >&2\n\
 exit 2\n"
 
+let fake_docker_preflight_ok_script =
+  "#!/bin/sh\n\
+case \"$1\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  image)\n\
+    if [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+      printf '[]\\n'\n\
+      exit 0\n\
+    fi\n\
+    printf 'missing image\\n' >&2\n\
+    exit 1\n\
+    ;;\n\
+  run)\n\
+    printf ''\n\
+    exit 0\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let fake_docker_preflight_missing_image_script =
+  "#!/bin/sh\n\
+case \"$1\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  image)\n\
+    printf 'Error: No such image: %s\\n' \"$3\" >&2\n\
+    exit 1\n\
+    ;;\n\
+  run)\n\
+    printf 'run should not execute when image inspect fails\\n' >&2\n\
+    exit 2\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let test_docker_preflight_reports_ready_image () =
+  with_fake_docker fake_docker_preflight_ok_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  match Keeper_sandbox_runtime.docker_preflight ~timeout_sec:5.0 () with
+  | None -> Alcotest.fail "expected docker preflight report"
+  | Some preflight ->
+      Alcotest.(check bool) "preflight ok" true preflight.ok;
+      Alcotest.(check bool) "image present" true preflight.image_present;
+      Alcotest.(check (list string)) "no missing commands" []
+        preflight.missing_commands
+
+let test_docker_preflight_surfaces_missing_image_actions () =
+  with_fake_docker fake_docker_preflight_missing_image_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED" "true" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  match Keeper_sandbox_runtime.docker_preflight ~timeout_sec:5.0 () with
+  | None -> Alcotest.fail "expected docker preflight report"
+  | Some preflight ->
+      Alcotest.(check bool) "preflight fails" false preflight.ok;
+      Alcotest.(check bool) "image missing" false preflight.image_present;
+      Alcotest.(check bool) "next actions mention build script" true
+        (List.exists
+           (fun action ->
+             String.contains action 'b'
+             && contains_substring action
+                  "scripts/build-keeper-sandbox-image.sh")
+           preflight.next_actions);
+      Alcotest.(check bool) "failure message mentions build script" true
+        (contains_substring
+           (Keeper_sandbox_runtime.docker_preflight_failure_message preflight)
+           "scripts/build-keeper-sandbox-image.sh")
+
 let test_run_command_nonzero_exit_errors_by_default () =
   with_fake_docker fake_docker_exit_1_script @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -493,5 +586,12 @@ let () =
             test_run_command_preserves_bare_command_argv;
           Alcotest.test_case "turn runtime reuses single container" `Quick
             test_turn_runtime_reuses_single_container;
+        ] );
+      ( "docker_preflight",
+        [
+          Alcotest.test_case "ready image reports ok" `Quick
+            test_docker_preflight_reports_ready_image;
+          Alcotest.test_case "missing image surfaces remediation" `Quick
+            test_docker_preflight_surfaces_missing_image_actions;
         ] );
     ]

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -39,7 +39,7 @@ let rec ensure_dir path =
     if p <> path then ensure_dir p;
     Unix.mkdir path 0o755)
 
-let make_meta name =
+let make_meta ?(sandbox = Keeper_types.Local) name =
   let json =
     `Assoc
       [
@@ -48,6 +48,8 @@ let make_meta name =
         ("trace_id", `String ("trace-" ^ name));
         ("goal", `String "patch test");
         ("allowed_paths", `List [ `String "*" ]);
+        ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) );
       ]
   in
   match Keeper_types.meta_of_json json with
@@ -57,16 +59,20 @@ let make_meta name =
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
   f ()
 
-let setup f =
+let setup ?(sandbox = Keeper_types.Local) f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base ".masc");
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
   let config = Coord.default_config base in
-  let meta = make_meta "tester" in
+  let meta = make_meta ~sandbox "tester" in
   let playground =
     Filename.concat base
       (Keeper_alerting_path.playground_path_of_keeper meta.name)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -13,6 +13,7 @@ module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
+module Tool_code_write = Masc_mcp.Tool_code_write
 module Fs_compat = Fs_compat
 module Json = Yojson.Safe.Util
 
@@ -109,6 +110,14 @@ let with_fake_docker script f =
   in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
   with_env "PATH" path f
+
+let with_tool_policy_config f =
+  let config_dir =
+    Filename.concat (Masc_test_deps.find_project_root ()) "config"
+  in
+  Tool_code_write.reset_policy_config_cache ();
+  with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
+  Fun.protect ~finally:Tool_code_write.reset_policy_config_cache f
 
 let parse_field raw field =
   Yojson.Safe.from_string raw |> Json.member field
@@ -271,6 +280,30 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   Alcotest.(check int) "rg no-match returns empty matches" 0
     (parse_field raw "matches" |> Json.to_list |> List.length)
 
+let test_git_clone_routes_through_docker () =
+  with_tool_policy_config @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "git_clone");
+            ("url", `String "https://github.com/jeong-sik/masc-mcp.git");
+          ])
+  in
+  Alcotest.(check (option bool)) "git_clone fails through docker route" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option string)) "via=docker" (Some "docker")
+    (parse_string_field raw "via");
+  Alcotest.(check bool) "output includes docker image error" true
+    (response_mentions raw "output" "docker image");
+  Alcotest.(check bool) "clone stays inside keeper repos" true
+    (response_mentions raw "path"
+       (Filename.concat playground "repos/masc-mcp"))
+
 let () =
   Alcotest.run "Keeper_shell_docker_route"
     [
@@ -289,5 +322,7 @@ let () =
         [
           Alcotest.test_case "rg no-match remains successful" `Quick
             test_rg_no_match_remains_successful_in_docker_route;
+          Alcotest.test_case "git_clone routes through docker" `Quick
+            test_git_clone_routes_through_docker;
         ] );
     ]


### PR DESCRIPTION
## What changed
- add keeper Docker sandbox preflight checks for daemon reachability, hardening requirements, local image presence, and required commands
- fail keeper startup early when Docker sandbox preflight is not satisfied, and surface the same preflight data through config doctor and status/detail paths
- route Docker `git_clone`/`git_pull` and fs edit responses through the Docker backend consistently, including `via=docker` markers in shell/fs responses
- add a local keeper sandbox image build script, Dockerfile, and smoke script to verify image build plus mounted playground read/write behavior
- extend unit coverage for Docker preflight, doctor output, Docker shell routing, fs edit patching, and unified worker plumbing

## Why
Docker-backed keeper flows could proceed without proving that the required sandbox image and runtime constraints were actually ready. That left failures to happen late and made diagnosis noisy. There was also no repo-local smoke path to verify the Docker image and mounted playground behavior end to end.

## Impact
- keeper Docker startup now fails fast with actionable remediation when the sandbox image or runtime is not ready
- config doctor can report Docker sandbox preflight status and next actions directly
- Docker shell/fs operations expose their route more clearly for downstream callers and tests
- maintainers can rebuild and smoke test the sandbox image locally with checked-in scripts

## Validation
- `./_build/default/test/test_config_doctor.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_docker_read.exe`
- `scripts/keeper-sandbox-smoke.sh`
