### PR TITLE
[codex] align verification storage with .masc

### DIFF
--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -30,7 +30,7 @@ let decide ~accept_on_exhaustion ~is_last outcome =
             (Llm_provider.Http_client.NetworkError
                {
                  message = "slot full, cascading to next provider";
-                 kind = Unknown;
+                 kind = Llm_provider.Http_client.Local_resource_exhaustion;
                });
       }
   | Accept_rejected { response; reason } ->

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -16,53 +16,25 @@ let task_is_claim_pool_candidate (task : Types.task) =
 type verification_claim_state =
   [ `Pending | `Assigned | `Passed | `Rejected ]
 
-let verification_claim_state_of_json json =
-  let open Yojson.Safe.Util in
-  match json |> member "status" |> member "status" with
-  | `String "pending" -> Some `Pending
-  | `String "assigned" -> Some `Assigned
-  | `String "completed" -> (
-      match json |> member "status" |> member "verdict" with
-      | `String "pass" -> Some `Passed
-      | `String "fail" | `String "partial" -> Some `Rejected
-      | _ -> None)
-  | _ -> None
+let verification_claim_state_of_status
+    (status : Coord_verification_store.request_status) =
+  match status with
+  | `Pending -> `Pending
+  | `Assigned _ -> `Assigned
+  | `Completed `Pass -> `Passed
+  | `Completed (`Fail _ | `Partial _) ->
+      `Rejected
 
 let latest_verification_status_by_task config =
   let latest = Hashtbl.create 16 in
-  let dir = Filename.concat config.base_path "verifications" in
-  if Sys.file_exists dir then (
-    match Safe_ops.list_dir_safe dir with
-    | Error _ -> ()
-    | Ok files ->
-        List.iter
-          (fun file ->
-            if Filename.check_suffix file ".json" then
-              let path = Filename.concat dir file in
-              try
-                let json = Safe_ops.read_json_eio path in
-                let open Yojson.Safe.Util in
-                match
-                  json |> member "task_id",
-                  json |> member "created_at",
-                  verification_claim_state_of_json json
-                with
-                | `String task_id, (`Float _ | `Int _ as created_at_json), Some state ->
-                    let created_at =
-                      match created_at_json with
-                      | `Float value -> value
-                      | `Int value -> Float.of_int value
-                      | _ -> 0.0
-                    in
-                    (match Hashtbl.find_opt latest task_id with
-                     | Some (latest_created_at, _)
-                       when latest_created_at >= created_at -> ()
-                     | Some _ | None ->
-                         Hashtbl.replace latest task_id (created_at, state))
-                | _ -> ()
-              with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
-          files
-  );
+  Coord_verification_store.list_request_headers config.base_path
+  |> List.iter (fun (req : Coord_verification_store.request_header) ->
+         let state = verification_claim_state_of_status req.status in
+         match Hashtbl.find_opt latest req.task_id with
+         | Some (latest_created_at, _) when latest_created_at >= req.created_at ->
+             ()
+         | Some _ | None ->
+             Hashtbl.replace latest req.task_id (req.created_at, state));
   latest
 
 let verification_blocks_claim latest_status_by_task (task : Types.task) =

--- a/lib/coord/coord_verification_store.ml
+++ b/lib/coord/coord_verification_store.ml
@@ -1,0 +1,184 @@
+type verdict =
+  [ `Pass
+  | `Fail of string
+  | `Partial of float * string ]
+
+type request_status =
+  [ `Pending
+  | `Assigned of string
+  | `Completed of verdict ]
+
+type request_header = {
+  id : string;
+  task_id : string;
+  worker : string;
+  verifier : string option;
+  created_at : float;
+  status : request_status;
+}
+
+let project_root_of_base_path base_path =
+  if Filename.basename base_path = Common.masc_dirname then
+    Filename.dirname base_path
+  else
+    base_path
+
+let active_verifications_dir base_path =
+  let base_path = project_root_of_base_path base_path in
+  Filename.concat (Coord_utils.masc_dir_from_base_path ~base_path) "verifications"
+
+let legacy_verifications_dir base_path =
+  Filename.concat (project_root_of_base_path base_path) "verifications"
+
+let warned_legacy_dirs : (string, unit) Hashtbl.t = Hashtbl.create 8
+let warned_legacy_dirs_mutex = Stdlib.Mutex.create ()
+
+let dir_exists path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let warn_if_legacy_verifications_dir_present ~base_path ~active_dir =
+  let legacy_dir = legacy_verifications_dir base_path in
+  if dir_exists legacy_dir then (
+    Stdlib.Mutex.lock warned_legacy_dirs_mutex;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock warned_legacy_dirs_mutex)
+      (fun () ->
+        if not (Hashtbl.mem warned_legacy_dirs legacy_dir) then (
+          Hashtbl.add warned_legacy_dirs legacy_dir ();
+          Log.Task.warn
+            "Ignoring legacy verification directory %s; active store is %s"
+            legacy_dir active_dir)))
+
+let verifications_dir base_path =
+  let dir = active_verifications_dir base_path in
+  warn_if_legacy_verifications_dir_present ~base_path ~active_dir:dir;
+  dir
+
+let request_path base_path req_id =
+  Filename.concat (verifications_dir base_path) (req_id ^ ".json")
+
+let verdict_of_yojson = function
+  | `Assoc fields ->
+      (match List.assoc_opt "verdict" fields with
+       | Some (`String "pass") -> Ok `Pass
+       | Some (`String "fail") ->
+           let reason =
+             match List.assoc_opt "reason" fields with
+             | Some (`String s) -> s
+             | _ -> "no reason given"
+           in
+           Ok (`Fail reason)
+       | Some (`String "partial") ->
+           let score =
+             match List.assoc_opt "score" fields with
+             | Some (`Float f) -> f
+             | Some (`Int n) -> Float.of_int n
+             | _ -> 0.0
+           in
+           let reason =
+             match List.assoc_opt "reason" fields with
+             | Some (`String s) -> s
+             | _ -> "no reason given"
+           in
+           Ok (`Partial (score, reason))
+       | _ -> Error "unknown or missing verdict")
+  | _ -> Error "verdict must be a JSON object"
+
+let request_status_of_yojson = function
+  | `Assoc fields ->
+      (match List.assoc_opt "status" fields with
+       | Some (`String "pending") -> Ok `Pending
+       | Some (`String "assigned") ->
+           (match List.assoc_opt "verifier" fields with
+            | Some (`String agent) -> Ok (`Assigned agent)
+            | _ -> Error "assigned requires 'verifier' field")
+       | Some (`String "completed") ->
+           (match verdict_of_yojson (`Assoc fields) with
+            | Ok verdict -> Ok (`Completed verdict)
+            | Error err -> Error err)
+       | _ -> Error "unknown request status")
+  | _ -> Error "request status must be a JSON object"
+
+let request_header_of_yojson = function
+  | `Assoc fields ->
+      let get_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let get_float key =
+        match List.assoc_opt key fields with
+        | Some (`Float f) -> Some f
+        | Some (`Int n) -> Some (Float.of_int n)
+        | _ -> None
+      in
+      (match get_string "id", get_string "task_id", get_string "worker" with
+       | Some id, Some task_id, Some worker ->
+           let verifier =
+             match List.assoc_opt "verifier" fields with
+             | Some (`String s) -> Some s
+             | _ -> None
+           in
+           let created_at =
+             match get_float "created_at" with
+             | Some f -> f
+             | None -> Time_compat.now ()
+           in
+           let status =
+             match List.assoc_opt "status" fields with
+             | Some json -> (
+                 match request_status_of_yojson json with
+                 | Ok s -> s
+                 | Error _ -> `Pending)
+             | None -> `Pending
+           in
+           Ok { id; task_id; worker; verifier; created_at; status }
+       | _ -> Error "verification request requires 'id', 'task_id', 'worker' fields")
+  | _ -> Error "verification request must be a JSON object"
+
+let load_request_header base_path req_id =
+  let path = request_path base_path req_id in
+  if Sys.file_exists path then
+    try
+      let json = Safe_ops.read_json_eio path in
+      request_header_of_yojson json
+    with Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Error
+             (Printf.sprintf "Failed to load verification %s: %s" req_id
+                (Printexc.to_string exn))
+  else
+    Error (Printf.sprintf "Verification %s not found" req_id)
+
+let list_request_headers base_path =
+  let surface = "verification" in
+  let report_drop ~reason ~path ~detail =
+    Safe_ops.report_persistence_read_drop
+      ~on_drop:ignore
+      ~surface
+      ~reason
+      ~path
+      ~detail
+  in
+  let dir = verifications_dir base_path in
+  if not (Sys.file_exists dir) then
+    []
+  else
+    match Safe_ops.list_dir_safe dir with
+    | Error detail ->
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error
+          ~path:dir ~detail;
+        []
+    | Ok files ->
+        files
+        |> List.filter (fun f -> Filename.check_suffix f ".json")
+        |> List.filter_map (fun f ->
+               let id = Filename.chop_suffix f ".json" in
+               Safe_ops.result_to_option_logged
+                 ~on_drop:(fun () -> ())
+                 ~surface
+                 ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                 ~path:(Filename.concat dir f)
+                 (load_request_header base_path id))

--- a/lib/coord/coord_verification_store.mli
+++ b/lib/coord/coord_verification_store.mli
@@ -1,0 +1,22 @@
+type verdict =
+  [ `Pass
+  | `Fail of string
+  | `Partial of float * string ]
+
+type request_status =
+  [ `Pending
+  | `Assigned of string
+  | `Completed of verdict ]
+
+type request_header = {
+  id : string;
+  task_id : string;
+  worker : string;
+  verifier : string option;
+  created_at : float;
+  status : request_status;
+}
+
+val verifications_dir : string -> string
+val request_path : string -> string -> string
+val list_request_headers : string -> request_header list

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -26,6 +26,7 @@
   coord_task
   coord_task_lifecycle
   coord_task_schedule
+  coord_verification_store
   event_kind
   coord_git
   coord_worktree

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -1,6 +1,6 @@
 (** Dashboard projection for verification requests.
 
-    Reads [<base_path>/verifications/*.json] via {!Verification.list_requests}
+    Reads [<base_path>/.masc/verifications/*.json] via {!Verification.list_requests}
     and emits the Mission detail table row structure. No mutation, no
     network. *)
 

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -3,7 +3,7 @@
     {!Verification_protocol} request.
 
     Consumes {!Verification.list_requests}, which reads
-    [<base_path>/verifications/*.json]. Pure read-only: no mutation, no
+    [<base_path>/.masc/verifications/*.json]. Pure read-only: no mutation, no
     network.
 
     Status mapping:

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -603,7 +603,7 @@ module Kimi_cli_transport_local = struct
           int_of_string_opt raw
 
   let classify_cli_error = function
-    | Error (Llm_provider.Http_client.NetworkError { message }) as err -> (
+    | Error (Llm_provider.Http_client.NetworkError { message; _ }) as err -> (
         match exit_code_of_message message with
         | Some 1 ->
             Error

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -623,7 +623,7 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
     Llm_provider.Retry.is_hard_quota api_err
     ||
     (match[@warning "-8"] api_err with
-     | Llm_provider.Retry.NetworkError { message }
+     | Llm_provider.Retry.NetworkError { message; _ }
      | Llm_provider.Retry.Overloaded { message }
      | Llm_provider.Retry.ServerError { message; _ } ->
        message_looks_like_cli_wrapped_hard_quota message

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -120,7 +120,7 @@ let raw_completion ~model_id ~prompt ~max_tokens ~timeout_sec () =
     ~max_tokens ~timeout_sec ()
 
 let error_message_of_http_error = function
-  | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.NetworkError { message; _ } -> message
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -119,7 +119,7 @@ let first_endpoint_url endpoints =
   | [] -> None
 
 let error_message_of_http_error = function
-  | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.NetworkError { message; _ } -> message
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.CliTransportRequired { kind } ->
       Printf.sprintf "%s provider requires a CLI transport" kind

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -265,14 +265,13 @@ let validate_cross_agent ~worker ~verifier =
 
 (** File-based storage *)
 
-let verifications_dir base_path =
-  Filename.concat base_path "verifications"
+let verifications_dir = Coord_verification_store.verifications_dir
 
 let ensure_dir path =
   Fs_compat.mkdir_p path
 
 let request_path base_path req_id =
-  Filename.concat (verifications_dir base_path) (req_id ^ ".json")
+  Coord_verification_store.request_path base_path req_id
 
 let save_request base_path req =
   let dir = verifications_dir base_path in

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -12,8 +12,23 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 module V = Masc_mcp.Verification
 module D = Masc_mcp.Dashboard_verification
+module CU = Coord_utils
 
 (* ── Fixture helpers ────────────────────────────────── *)
+
+let active_verifications_dir base_path =
+  Filename.concat (CU.masc_dir_from_base_path ~base_path) "verifications"
+
+let legacy_verifications_dir base_path =
+  Filename.concat base_path "verifications"
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
 
 (** Create an isolated MASC base_path for the duration of [f].
     Restores [MASC_BASE_PATH] afterwards so subsequent tests in the same
@@ -28,14 +43,7 @@ let with_temp_base_path f =
     (match prior with
      | Some v -> Unix.putenv "MASC_BASE_PATH" v
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    let vdir = Filename.concat dir "verifications" in
-    (try
-       Array.iter (fun file ->
-         try Sys.remove (Filename.concat vdir file) with _ -> ()
-       ) (Sys.readdir vdir);
-       Sys.rmdir vdir
-     with _ -> ());
-    (try Sys.rmdir dir with _ -> ())
+    rm_rf dir
   in
   Fun.protect ~finally:cleanup (fun () -> f dir)
 
@@ -185,6 +193,30 @@ let test_task_id_filter () =
      | `List _ -> Alcotest.fail "expected empty list"
      | _ -> Alcotest.fail "requests not list"))
 
+let test_requests_json_ignores_legacy_root_entries () =
+  with_temp_base_path (fun base_path ->
+    let _ =
+      create_pending_request ~base_path ~task_id:"task-live" ~worker:"alpha"
+        ~criteria:[V.Custom "live criterion"] ~evidence:["ref-live"]
+    in
+    let legacy_dir = legacy_verifications_dir base_path in
+    Fs_compat.mkdir_p legacy_dir;
+    Fs_compat.save_file (Filename.concat legacy_dir "vrf-foreign.json")
+      {|{"id":"vrf-foreign","task_id":"task-legacy","evaluator":"oracle","overall_verdict":"approve"}|};
+    Alcotest.(check bool) "active store exists" true
+      (Sys.file_exists (active_verifications_dir base_path));
+    let j = D.requests_json () in
+    (match member "total" j with
+     | `Int 1 -> ()
+     | `Int n -> Alcotest.fail (Printf.sprintf "expected 1 live row, got %d" n)
+     | _ -> Alcotest.fail "total not int");
+    match member "requests" j with
+    | `List [row] -> (
+        match member "task_id" row with
+        | `String "task-live" -> ()
+        | _ -> Alcotest.fail "legacy root row leaked into dashboard")
+    | _ -> Alcotest.fail "expected one dashboard row")
+
 let test_requests_json_surfaces_conflict_triage_fields () =
   with_temp_base_path (fun base_path ->
     let output =
@@ -310,6 +342,8 @@ let () =
     "requests_json", [
       Alcotest.test_case "shape" `Quick test_requests_json_shape;
       Alcotest.test_case "task_id filter" `Quick test_task_id_filter;
+      Alcotest.test_case "ignores legacy root entries" `Quick
+        test_requests_json_ignores_legacy_root_entries;
       Alcotest.test_case "conflict triage fields" `Quick
         test_requests_json_surfaces_conflict_triage_fields;
     ];

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -5,6 +5,7 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 module V = Masc_mcp.Verification
 module P = Masc_mcp.Prometheus
+module CU = Coord_utils
 
 let persistence_surface = "verification"
 
@@ -15,20 +16,24 @@ let persistence_counter reason =
 (* Initialize mirage-crypto-rng once (needed by Verification.generate_id). *)
 let () = Mirage_crypto_rng_unix.use_default ()
 
+let active_verifications_dir base_path =
+  Filename.concat (CU.masc_dir_from_base_path ~base_path) "verifications"
+
+let legacy_verifications_dir base_path =
+  Filename.concat base_path "verifications"
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
 (** Use a temporary directory for each test *)
 let with_temp_dir f =
   let dir = Filename.temp_dir "masc_verify_test" "" in
-  Fun.protect ~finally:(fun () ->
-    (* Clean up *)
-    let vdir = Filename.concat dir "verifications" in
-    (try
-       Array.iter (fun file ->
-         Sys.remove (Filename.concat vdir file)
-       ) (Sys.readdir vdir);
-       Sys.rmdir vdir
-     with _ -> ());
-    (try Sys.rmdir dir with _ -> ())
-  ) (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
 (* --- Criterion tests --- *)
 
@@ -144,6 +149,10 @@ let test_create_and_load () =
         ~worker:"claude" () with
     | Error e -> Alcotest.fail e
     | Ok req ->
+        Alcotest.(check bool) "persisted under .masc/verifications" true
+          (Sys.file_exists
+             (Filename.concat (active_verifications_dir base_path)
+                (req.id ^ ".json")));
         match V.load_request base_path req.id with
         | Error e -> Alcotest.fail e
         | Ok loaded ->
@@ -175,7 +184,7 @@ let test_list_requests_skips_bad_entries_with_metric () =
   with_temp_dir (fun base_path ->
     let _ = V.create_request ~base_path ~task_id:"t1"
         ~output:`Null ~criteria:[] ~worker:"a" () in
-    let dir = Filename.concat base_path "verifications" in
+    let dir = active_verifications_dir base_path in
     Fs_compat.save_file (Filename.concat dir "broken.json") "{not-json";
     let before =
       persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -185,6 +194,24 @@ let test_list_requests_skips_bad_entries_with_metric () =
     Alcotest.(check (float 0.1)) "broken file increments metric" 1.0
       (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
        -. before))
+
+let test_list_requests_ignores_legacy_root_entries () =
+  with_temp_dir (fun base_path ->
+    let _ = V.create_request ~base_path ~task_id:"t1"
+        ~output:`Null ~criteria:[] ~worker:"a" () in
+    let legacy_dir = legacy_verifications_dir base_path in
+    Fs_compat.mkdir_p legacy_dir;
+    Fs_compat.save_file (Filename.concat legacy_dir "broken.json") "{not-json";
+    Fs_compat.save_file (Filename.concat legacy_dir "vrf-foreign.json")
+      {|{"id":"vrf-foreign","task_id":"t-foreign","evaluator":"oracle","overall_verdict":"approve"}|};
+    let before =
+      persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+    in
+    let reqs = V.list_requests base_path in
+    Alcotest.(check int) "legacy root ignored" 1 (List.length reqs);
+    Alcotest.(check (float 0.1)) "legacy root does not increment metric"
+      before
+      (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error))
 
 let test_assign_verifier () =
   with_temp_dir (fun base_path ->
@@ -398,6 +425,8 @@ let () =
         test_list_requests_missing_dir_stays_quiet;
       Alcotest.test_case "list requests skips bad entries with metric" `Quick
         test_list_requests_skips_bad_entries_with_metric;
+      Alcotest.test_case "list requests ignores legacy root entries" `Quick
+        test_list_requests_ignores_legacy_root_entries;
       Alcotest.test_case "assign verifier" `Quick test_assign_verifier;
       Alcotest.test_case "cross-agent assign fail" `Quick test_assign_verifier_cross_agent_fail;
       Alcotest.test_case "submit verdict" `Quick test_submit_verdict;

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -42,6 +42,11 @@ let with_temp_config ~fsm_enabled f =
 
 (* Add a task with strict contract requiring verification *)
 let add_strict_task config =
+  let existing_ids =
+    Coord.read_backlog config
+    |> fun backlog -> List.map (fun (t : Types.task) -> t.id) backlog.tasks
+  in
+  let title = Printf.sprintf "strict task %d" (List.length existing_ids + 1) in
   let contract : Types.task_contract = {
     strict = true;
     completion_contract = ["tests pass"];
@@ -50,12 +55,16 @@ let add_strict_task config =
     verify_gate_evidence = ["output.json"];
     links = { operation_id = None; session_id = None; autoresearch_loop_id = None };
   } in
-  let _msg = Coord.add_task ~contract config ~title:"strict task"
+  let _msg = Coord.add_task ~contract config ~title
     ~priority:3 ~description:"needs verification" in
   let backlog = Coord.read_backlog config in
-  match List.nth_opt backlog.tasks 0 with
-  | None -> Alcotest.fail "no task added"
+  match
+    List.find_opt
+      (fun (t : Types.task) -> not (List.mem t.id existing_ids))
+      backlog.tasks
+  with
   | Some t -> t.id
+  | None -> Alcotest.fail "new task not found after add_task"
 
 let claim_and_start config agent_name task_id =
   let _ = Coord.transition_task_r config ~agent_name ~task_id
@@ -63,6 +72,12 @@ let claim_and_start config agent_name task_id =
   let _ = Coord.transition_task_r config ~agent_name ~task_id
     ~action:Types.Start () in
   ()
+
+let create_pending_request config ~task_id ~worker ~request_id =
+  match Verification.create_request ~base_path:config.Coord.base_path
+          ~task_id ~output:`Null ~criteria:[] ~worker ~request_id () with
+  | Ok req -> req
+  | Error e -> Alcotest.fail ("create_request failed: " ^ e)
 
 let get_task config task_id =
   let backlog = Coord.read_backlog config in
@@ -251,6 +266,9 @@ let test_claim_next_skips_pending_verification_tasks () =
              ~task_id:task_1 ~action:Types.Submit_for_verification () with
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e));
+    ignore
+      (create_pending_request config ~task_id:task_1 ~worker:"worker"
+         ~request_id:"vrf-pending-claim-next");
     Coord.claim_next_r config ~agent_name:"worker" ()
     |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:(Some task_1);
     Coord.claim_next_r config ~agent_name:"other" ()
@@ -265,13 +283,44 @@ let test_claim_next_skips_rejected_verification_tasks () =
              ~task_id:task_1 ~action:Types.Submit_for_verification () with
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e));
+    let req =
+      create_pending_request config ~task_id:task_1 ~worker:"worker"
+        ~request_id:"vrf-rejected-claim-next"
+    in
     (match Coord.transition_task_r config ~agent_name:"verifier"
              ~task_id:task_1 ~action:Types.Reject_verification
              ~reason:"CI checks failed at plan commit and PR head" () with
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("reject failed: " ^ Types.show_masc_error e));
+    (match Verification.submit_verdict ~base_path:config.Coord.base_path
+             ~req_id:req.id ~verifier:"verifier"
+             ~verdict:(Verification.Fail "CI checks failed at plan commit and PR head") with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail ("submit_verdict failed: " ^ e));
     Coord.claim_next_r config ~agent_name:"worker" ()
     |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:(Some task_1);
+    Coord.claim_next_r config ~agent_name:"other" ()
+    |> expect_claim_next_no_eligible)
+
+let test_claim_next_blocks_pending_requests_stored_only_under_masc_root () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    let req =
+      match Verification.create_request ~base_path:config.Coord.base_path
+              ~task_id ~output:`Null ~criteria:[] ~worker:"worker"
+              ~request_id:"vrf-masc-root-only" () with
+      | Ok req -> req
+      | Error e -> Alcotest.fail ("create_request failed: " ^ e)
+    in
+    let active_path =
+      Filename.concat (Filename.concat (Coord_utils.masc_dir config) "verifications")
+        (req.id ^ ".json")
+    in
+    Alcotest.(check bool) "request stored under .masc" true
+      (Sys.file_exists active_path);
+    Alcotest.(check bool) "legacy root verifications absent" false
+      (Sys.file_exists
+         (Filename.concat config.Coord.base_path "verifications"));
     Coord.claim_next_r config ~agent_name:"other" ()
     |> expect_claim_next_no_eligible)
 
@@ -393,6 +442,8 @@ let () =
         test_claim_next_skips_pending_verification_tasks;
       Alcotest.test_case "claim_next skips rejected verification tasks" `Quick
         test_claim_next_skips_rejected_verification_tasks;
+      Alcotest.test_case ".masc pending verification blocks claim_next" `Quick
+        test_claim_next_blocks_pending_requests_stored_only_under_masc_root;
       Alcotest.test_case "self-approval blocked" `Quick
         test_self_approval_blocked;
       Alcotest.test_case "self-rejection blocked" `Quick


### PR DESCRIPTION
## What changed
- moved live verification request storage to `<base_path>/.masc/verifications` via a dedicated `Coord_verification_store`
- updated verification loading and task reclaim gating to read typed request headers from the new store instead of scanning the legacy root directory
- refreshed dashboard and verification tests to assert the new path, ignore legacy-root junk, and cover pending/rejected reclaim blocking
- added small follow-up fixes for the upstream `NetworkError.kind` shape change so the affected test/build targets compile again

## Why
Verification state had drifted from the `.masc` path convention, and claim gating still depended on the old root-level scan. That made the storage path ambiguous and left reclaim logic coupled to the legacy layout.

## Impact
- live verification data now has a single storage root under `.masc`
- legacy `<base_path>/verifications` entries are ignored and emit a once-per-process warning instead of affecting live behavior
- `claim_next` now blocks reclaim based on the latest typed verification status in the active store

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/verification-path-ssot @test/runtest-test_verification @test/runtest-test_dashboard_verification @test/runtest-test_verification_fsm @test/runtest-test_keeper_unified @test/runtest-test_oas_worker`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/verification-path-ssot`
- `git diff --check`
