### PR TITLE
refactor(cascade): consolidate 16 profile variants to 3+1 SSOT model

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,48 +1,36 @@
 {
   "_comment": "Known keeper-facing cascade profiles remain typed in lib/keeper/keeper_cascade_profile.ml. Live catalog discovery is schema-driven via lib/cascade/cascade_config_loader.ml: any recognized {name}_* cascade key participates in the catalog, and optional {name}_keeper_assignable=false marks system-only profiles that stay visible/editable but must not be assignable to keepers. Personal/playground-only cascades belong in $MASC_BASE_PATH/.masc/playground/<persona>/.../cascade.json, not in this repo config.",
   "default_models": [
-    { "model": "glm-coding:glm-5.1", "weight": 50 },
-    { "model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30 },
-    { "model": "ollama:gemma4:26b", "weight": 20 }
+    { "model": "claude_code:auto", "weight": 40 },
+    { "model": "codex_cli:auto", "weight": 30 },
+    { "model": "gemini_cli:auto", "weight": 30 }
   ],
   "default_temperature": 0.3,
   "default_max_tokens": 4096,
-  "default_api_key_env": {
-    "glm-coding": "ZAI_API_KEY_SB",
-    "glm": "ZAI_API_KEY_SB"
-  },
-  "keeper_unified_models": [
-    { "model": "glm-coding:glm-5.1", "weight": 50 },
-    { "model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30 },
-    { "model": "ollama:gemma4:26b", "weight": 20 }
+  "big_three_models": [
+    { "model": "claude_code:auto", "weight": 40 },
+    { "model": "codex_cli:auto", "weight": 30 },
+    { "model": "gemini_cli:auto", "weight": 30 }
   ],
-  "keeper_unified_temperature": 0.2,
-  "keeper_unified_max_tokens": 16384,
-  "local_only_models": [ "ollama:qwen3.5:35b-a3b-nvfp4" ],
+  "big_three_temperature": 0.2,
+  "big_three_max_tokens": 16384,
+  "underdog_models": [
+    { "model": "kimi:auto", "weight": 50 },
+    { "model": "glm-coding:auto", "weight": 50 }
+  ],
+  "underdog_temperature": 0.2,
+  "underdog_max_tokens": 16384,
+  "local_models": [ "ollama:auto" ],
+  "local_temperature": 0.2,
+  "local_max_tokens": 32768,
+  "local_only_models": [ "ollama:auto" ],
   "local_only_temperature": 0.2,
   "local_only_max_tokens": 32768,
-  "_comment_local_mlx_vlm_qwen36": "Local OpenAI-compatible mlx-vlm endpoint for Huihui Qwen3.6 35B. Keep repo profile limited to the canonical localhost endpoint and let OAS parser surface mlx-vlm telemetry fields.",
-  "local_mlx_vlm_qwen36_models": [
-    "custom:mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq@http://127.0.0.1:18080/v1"
-  ],
-  "local_mlx_vlm_qwen36_temperature": 0.2,
-  "local_mlx_vlm_qwen36_max_tokens": 16384,
-  "local_recovery_models": [ "ollama:qwen3.5:35b-a3b-nvfp4" ],
+  "local_recovery_models": [ "ollama:auto" ],
   "local_recovery_temperature": 0.1,
   "local_recovery_max_tokens": 8192,
-  "_comment_tool_rerank": "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here. Short responses for rerank scoring.",
+  "_comment_tool_rerank": "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
-  "tool_rerank_keeper_assignable": false,
-  "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls. Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle. Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04. Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama).",
-  "sangsu_models": [
-    {
-      "model": "ollama:qwen3.5:35b-a3b-nvfp4",
-      "weight": 90,
-      "supports_tool_choice": true
-    },
-    { "model": "glm-coding:glm-5.1", "weight": 10 }
-  ],
-  "sangsu_temperature": 0.1,
-  "sangsu_max_tokens": 16384
+  "tool_rerank_keeper_assignable": false
 }

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -2,59 +2,53 @@ comment = "Known keeper-facing cascade profiles remain typed in lib/keeper/keepe
 
 [default]
 models = [
-  { model = "glm-coding:glm-5.1", weight = 50 },
-  { model = "ollama:qwen3.5:35b-a3b-nvfp4", weight = 30 },
-  { model = "ollama:gemma4:26b", weight = 20 },
+  { model = "claude_code:auto", weight = 40 },
+  { model = "codex_cli:auto", weight = 30 },
+  { model = "gemini_cli:auto", weight = 30 },
 ]
 temperature = 0.3
 max_tokens = 4096
 
-[default.api_key_env]
-"glm-coding" = "ZAI_API_KEY_SB"
-glm = "ZAI_API_KEY_SB"
-
-[keeper_unified]
+[big_three]
 models = [
-  { model = "glm-coding:glm-5.1", weight = 50 },
-  { model = "ollama:qwen3.5:35b-a3b-nvfp4", weight = 30 },
-  { model = "ollama:gemma4:26b", weight = 20 },
+  { model = "claude_code:auto", weight = 40 },
+  { model = "codex_cli:auto", weight = 30 },
+  { model = "gemini_cli:auto", weight = 30 },
 ]
 temperature = 0.2
 max_tokens = 16384
 
-[local_only]
+[underdog]
 models = [
-  "ollama:qwen3.5:35b-a3b-nvfp4",
+  { model = "kimi:auto", weight = 50 },
+  { model = "glm-coding:auto", weight = 50 },
+]
+temperature = 0.2
+max_tokens = 16384
+
+[local]
+models = [
+  "ollama:auto",
 ]
 temperature = 0.2
 max_tokens = 32768
 
-[local_mlx_vlm_qwen36]
-comment = "Local OpenAI-compatible mlx-vlm endpoint for Huihui Qwen3.6 35B. Keep repo profile limited to the canonical localhost endpoint and let OAS parser surface mlx-vlm telemetry fields."
+[local_only]
 models = [
-  "custom:mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq@http://127.0.0.1:18080/v1",
+  "ollama:auto",
 ]
 temperature = 0.2
-max_tokens = 16384
+max_tokens = 32768
 
 [local_recovery]
 models = [
-  "ollama:qwen3.5:35b-a3b-nvfp4",
+  "ollama:auto",
 ]
 temperature = 0.1
 max_tokens = 8192
 
 [tool_rerank]
-comment = "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here. Short responses for rerank scoring."
+comment = "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here."
 temperature = 0.0
 max_tokens = 200
 keeper_assignable = false
-
-[sangsu]
-comment = "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls. Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle. Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04. Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama)."
-models = [
-  { model = "ollama:qwen3.5:35b-a3b-nvfp4", weight = 90, supports_tool_choice = true },
-  { model = "glm-coding:glm-5.1", weight = 10 },
-]
-temperature = 0.1
-max_tokens = 16384

--- a/config/keepers/analyst.toml
+++ b/config/keepers/analyst.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "analyst"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
 

--- a/config/keepers/bench-analyst.toml
+++ b/config/keepers/bench-analyst.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "analyst"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 tool_preset = "coding"
 proactive_enabled = false
 room_signal_prompt_enabled = false

--- a/config/keepers/bench-executor.toml
+++ b/config/keepers/bench-executor.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "executor"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 tool_preset = "coding"
 proactive_enabled = false
 room_signal_prompt_enabled = false

--- a/config/keepers/bench-verifier.toml
+++ b/config/keepers/bench-verifier.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "verifier"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 tool_preset = "coding"
 proactive_enabled = false
 room_signal_prompt_enabled = false

--- a/config/keepers/executor.toml
+++ b/config/keepers/executor.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "executor"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
 

--- a/config/keepers/scholar.toml
+++ b/config/keepers/scholar.toml
@@ -1,7 +1,8 @@
 [keeper]
 persona_name = "scholar"
 execution_scope = "workspace"
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
+autoboot_enabled = true
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
 

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -2,6 +2,7 @@
 persona_name = "verifier"
 execution_scope = "workspace"
 cascade_name = "cross_verifier"
+autoboot_enabled = true
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24
 

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -1,83 +1,63 @@
 (** See {!Keeper_cascade_profile} interface for rationale. *)
 
-(** SSOT variant. Adding a new cascade profile is a compile-time event:
-    add a variant here, then exhaustive [match] sites flag every consumer
-    that needs to handle it. Personal/playground-only cascades must NOT
-    be added here — they live in
+(** SSOT variant for the 3+1 cascade model.
+
+    Three keeper-assignable profiles ({!Big_three}, {!Underdog}, {!Local}) and
+    one system-only profile ({!Tool_rerank}).  Phase-routing names
+    ("local_only", "local_recovery") are NOT variants — they pass through
+    [canonicalize_with_catalog] as catalog names, so keeper phase-routing
+    code that references them by string continues to work without changes.
+
+    Adding a new profile is a compile-time event: add a variant here, then
+    exhaustive [match] sites flag every consumer that needs to handle it.
+    Personal/playground-only cascades must NOT be added here — they live in
     [$MASC_BASE_PATH/.masc/playground/.../cascade.json] only. *)
 type t =
-  | Default
-  | Keeper_unified
-  | Sangsu
-  | Local_only
-  | Local_mlx_vlm_qwen36
-  | Local_recovery
+  | Big_three
+  | Underdog
+  | Local
   | Tool_rerank
-  | Nick0cave
-  | Capacity_queue_trio
-  | Vendor_mix_balanced
-  | Cost_tier_ladder
-  | Oauth_cli_rotate
-  | Quality_sticky_glm51
-  | Tool_use_strict
-  | Resilient_breaker
 
 let to_string = function
-  | Default -> "default"
-  | Keeper_unified -> "keeper_unified"
-  | Sangsu -> "sangsu"
-  | Local_only -> "local_only"
-  | Local_mlx_vlm_qwen36 -> "local_mlx_vlm_qwen36"
-  | Local_recovery -> "local_recovery"
+  | Big_three -> "big_three"
+  | Underdog -> "underdog"
+  | Local -> "local"
   | Tool_rerank -> "tool_rerank"
-  | Nick0cave -> "nick0cave"
-  | Capacity_queue_trio -> "capacity_queue_trio"
-  | Vendor_mix_balanced -> "vendor_mix_balanced"
-  | Cost_tier_ladder -> "cost_tier_ladder"
-  | Oauth_cli_rotate -> "oauth_cli_rotate"
-  | Quality_sticky_glm51 -> "quality_sticky_glm51"
-  | Tool_use_strict -> "tool_use_strict"
-  | Resilient_breaker -> "resilient_breaker"
 
-let all =
-  [ Default; Keeper_unified; Sangsu; Local_only; Local_mlx_vlm_qwen36;
-    Local_recovery; Tool_rerank;
-    Nick0cave; Capacity_queue_trio; Vendor_mix_balanced; Cost_tier_ladder;
-    Oauth_cli_rotate; Quality_sticky_glm51; Tool_use_strict; Resilient_breaker ]
+let all = [ Big_three; Underdog; Local; Tool_rerank ]
 
 (** All known cascade profile names, derived from the variant. Consumers
     that still operate on strings can use this list; new code should
     take {!t} directly. *)
 let known_cascades = List.map to_string all
 
-let default = Keeper_unified
+let default = Big_three
 let default_name = to_string default
 
 let of_string_opt (raw : string) : t option =
   match String.trim raw |> String.lowercase_ascii with
   | "" -> Some default
-  | "default" -> Some Default
+  | "big_three" -> Some Big_three
+  | "underdog" -> Some Underdog
+  | "local" -> Some Local
+  | "tool_rerank" -> Some Tool_rerank
+  (* Legacy aliases → Big_three *)
+  | "default"
   | "keeper_unified"
   | "oas-keeper_unified"
   | "coding_first"
-  | "oas-coding_first" -> Some Keeper_unified
-  (* Historical drift: never defined as separate profiles, always fell
-     through to default. Collapsed here so bucket/metric code does not
-     see a ghost value. *)
-  | "keeper_turn" | "keeper_reply" -> Some default
-  | "sangsu" -> Some Sangsu
-  | "local_only" -> Some Local_only
-  | "local_mlx_vlm_qwen36" -> Some Local_mlx_vlm_qwen36
-  | "local_recovery" -> Some Local_recovery
-  | "tool_rerank" -> Some Tool_rerank
-  | "nick0cave" -> Some Nick0cave
-  | "capacity_queue_trio" -> Some Capacity_queue_trio
-  | "vendor_mix_balanced" -> Some Vendor_mix_balanced
-  | "cost_tier_ladder" -> Some Cost_tier_ladder
-  | "oauth_cli_rotate" -> Some Oauth_cli_rotate
-  | "quality_sticky_glm51" -> Some Quality_sticky_glm51
-  | "tool_use_strict" -> Some Tool_use_strict
-  | "resilient_breaker" -> Some Resilient_breaker
+  | "oas-coding_first"
+  | "keeper_turn" | "keeper_reply"
+  | "sangsu" | "local_mlx_vlm_qwen36"
+  | "nick0cave" | "capacity_queue_trio" | "vendor_mix_balanced"
+  | "cost_tier_ladder" | "oauth_cli_rotate" | "quality_sticky_glm51"
+  | "tool_use_strict" | "resilient_breaker"
+    -> Some Big_three
+  (* Phase-routing names: NOT variants.  Returning None lets
+     [canonicalize_with_catalog] preserve them as catalog names so
+     keeper phase-routing code (local_only, local_recovery) continues
+     to resolve cascade.json keys correctly. *)
+  | "local_only" | "local_recovery" -> None
   | _ -> None
 
 let canonical (raw : string) : t =

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -3,128 +3,88 @@
     Keepers historically used stringly-typed cascade names in TOML, runtime
     metadata, telemetry labels, and cascade.json lookups. This module is the
     SSOT for the active keeper cascade profile and the legacy aliases that must
-    continue to resolve to it. *)
+    continue to resolve to it.
 
-(** SSOT for valid cascade profiles in repo [config/cascade.json].
-
-    Adding a new profile is a compile-time event: add a variant here
-    and every exhaustive [match] across the codebase flags the consumer
-    sites that need to handle it. Personal/playground-only cascades
-    must NOT be added here — they live in
-    [$MASC_BASE_PATH/.masc/playground/.../cascade.json].
+    Three keeper-assignable profiles and one system-only profile (Tool_rerank).
+    Phase-routing names ("local_only", "local_recovery") are NOT variants —
+    they pass through [canonicalize_with_catalog] as catalog names.
 
     @since 0.9.5 *)
+
+(** SSOT variant for the 3+1 cascade model.
+
+    Three keeper-assignable profiles ({!Big_three}, {!Underdog}, {!Local}) and
+    one system-only profile ({!Tool_rerank}).
+
+    Adding a new profile is a compile-time event: add a variant here, then
+    exhaustive [match] sites flag every consumer that needs to handle it.
+    Personal/playground-only cascades must NOT be added here — they live in
+    [$MASC_BASE_PATH/.masc/playground/.../cascade.json] only. *)
 type t =
-  | Default
-  | Keeper_unified
-  | Sangsu
-  | Local_only
-  | Local_mlx_vlm_qwen36
-  | Local_recovery
+  | Big_three
+  | Underdog
+  | Local
   | Tool_rerank
-  (* v1 active catalog (2026-04-17): keepers route through these via
-     [config/cascade.json] presets. Adding a profile here unlocks lookup
-     for [<name>_models]/[<name>_temperature]/[<name>_max_tokens] keys.
-     Without the variant, [canonicalize] silently collapses the name to
-     [Keeper_unified] and the runtime never reads the user's preset. *)
-  | Nick0cave
-  | Capacity_queue_trio
-  | Vendor_mix_balanced
-  | Cost_tier_ladder
-  | Oauth_cli_rotate
-  | Quality_sticky_glm51
-  | Tool_use_strict
-  | Resilient_breaker
 
 val all : t list
 (** [all] is exhaustive: every variant constructor of {!t} appears
-    exactly once. Consumers that need to enumerate profiles should
-    derive from this rather than maintaining a parallel list. *)
+    exactly once. *)
 
 val to_string : t -> string
-(** Canonical lowercase-snake-case name, matching the
-    [<name>_models]/[<name>_temperature]/[<name>_max_tokens] convention
-    in [config/cascade.json]. *)
+(** Canonical lowercase-snake-case name. *)
 
 val of_string_opt : string -> t option
 (** Parse a raw cascade name into the variant. Handles legacy aliases
-    ([oas-keeper_unified], [coding_first], [keeper_turn], [keeper_reply])
-    by collapsing them to their canonical variant. Returns [None] for
-    unknown names — use {!canonical} when you want a forced fallback. *)
+    by collapsing them to [Big_three]. Returns [None] for unknown names
+    and phase-routing names ("local_only", "local_recovery"). *)
 
 val canonical : string -> t
 (** [canonical raw] = [of_string_opt raw |> Option.value ~default]. *)
 
 val default : t
 val default_name : string
-(** [default_name = to_string default = "keeper_unified"]. *)
+(** [default_name = to_string default = "big_three"]. *)
 
 val known_cascades : string list
 (** [known_cascades = List.map to_string all]. Provided for consumers
-    that still operate on strings (cascade.json key prefixes, metric
-    label allow-list); new code should take {!t} directly. *)
+    that still operate on strings; new code should take {!t} directly. *)
 
 val catalog_names : ?config_path:string -> unit -> string list
 (** Live profile catalog discovered from the active [cascade.json].
-    Discovery is delegated to {!Cascade_config_loader.load_catalog}, so
-    profiles are surfaced from recognized cascade schema keys
-    (for example [{name}_models], [{name}_temperature],
-    [{name}_strategy], ...). When the file cannot be read, returns [[]]
-    rather than synthesizing a hardcoded catalog. *)
+    When the file cannot be read, returns [[]]. *)
 
 val keeper_catalog_names : ?config_path:string -> unit -> string list
 (** Assignable live profile names from {!catalog_names}, filtered by
-    explicit [{name}_keeper_assignable = false] metadata in
-    [cascade.json]. Read failures return [[]]. *)
+    [keeper_assignable] metadata. *)
 
 val system_catalog_names : ?config_path:string -> unit -> string list
-(** Live system-only profile names present in [cascade.json], selected
-    by explicit [{name}_keeper_assignable = false] metadata. Read
-    failures return [[]]. *)
+(** Live system-only profile names present in [cascade.json]. *)
 
 val is_system_only_cascade : string -> bool
 (** Exact-name membership check against the active config's
     {!system_catalog_names}. *)
 
 val canonicalize_with_catalog : catalog:string list -> string -> string
-(** Like {!canonicalize}, but resolves dynamic profiles against an explicit
-    live catalog instead of the active config path. Intended for tests and
-    server-side validation flows that already loaded the catalog. *)
+(** Resolves dynamic profiles against an explicit live catalog. *)
 
 val resolve_live_with_catalog : catalog:string list -> string -> string
 (** Resolves a keeper-declared cascade against an explicit live catalog.
 
-    Semantics:
-    - blank/whitespace -> {!default_name}
-    - known legacy alias -> canonical known name, but only if present in [catalog]
-    - exact dynamic/live profile name -> preserved when present in [catalog]
-    - any name absent from [catalog] -> {!default_name}
-
-    Unlike {!canonicalize_with_catalog}, this treats compile-time built-in
-    names that are no longer active in the runtime catalog as drift and
-    falls back to {!default_name}. Use this at runtime read surfaces that
-    need to mirror the active catalog rather than the variant inventory. *)
+    Compile-time built-in names absent from the runtime catalog are treated
+    as drift and fall back to {!default_name}. *)
 
 val resolve_live : ?config_path:string -> string -> string
 (** Like {!resolve_live_with_catalog}, but reads the active catalog from the
     resolved cascade config path. *)
 
 val canonicalize : string -> string
-(** [canonicalize raw = to_string (canonical raw)]. Existing
-    string-based call sites continue to work; legacy aliases collapse to
-    their canonical built-in name, live catalog names pass through, and
-    unknown values fall back to {!default_name}. *)
+(** [canonicalize raw = to_string (canonical raw)]. Legacy aliases collapse
+    to their canonical name, live catalog names pass through, unknown values
+    fall back to {!default_name}. *)
 
 val normalize_declared_name : string -> string
-(** Normalizes only the keeper-side implicit default and legacy aliases.
-
-    Semantics:
-    - blank/whitespace -> {!default_name}
-    - known legacy alias -> canonical known name
-    - unknown nonblank name -> preserved (trimmed)
-
-    This lets runtime-authoritative catalogs accept dynamic profile names
-    without using the compile-time variant inventory as the source of truth. *)
+(** Normalizes keeper-side implicit default and legacy aliases.
+    Unknown nonblank names are preserved (trimmed). *)
 
 (** {1 cascade.json key helpers} *)
 

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -206,7 +206,7 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
-  "keeper_unified_models": ["%s"],
+  "big_three_models": ["%s"],
   "tool_rerank_models": ["%s"]
 }|}
           shared_model shared_model));
@@ -230,7 +230,7 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
     require_ok
       (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ())
   in
-  check string "blank name defaults to keeper_unified"
+  check string "blank name defaults to big_three"
     Keeper_config.default_cascade_name blank_name;
   match
     Cascade_catalog_runtime.resolve_declared_name ~raw_name:"missing_profile" ()
@@ -253,7 +253,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
     write_cascade_json config_dir
       (Printf.sprintf
          {|{
-  "keeper_unified_models": ["%s"]
+  "big_three_models": ["%s"]
 }|}
          valid_model)
   in
@@ -270,7 +270,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
   ignore
     (write_cascade_json config_dir
        {|{
-  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"]
+  "big_three_models": ["__nonexistent_provider_sentinel__:fake"]
 }|});
   match Cascade_catalog_runtime.inspect_active () with
   | Ok
@@ -281,7 +281,7 @@ let test_invalid_hot_reload_preserves_last_known_good () =
         config_path (json_string_field "source_path" served_json);
       let labels =
         require_ok
-          (Cascade_catalog_runtime.models_of_cascade_name "keeper_unified")
+          (Cascade_catalog_runtime.models_of_cascade_name "big_three")
       in
       check (list string) "served snapshot keeps prior model" [ valid_model ] labels;
       let rejection_json =
@@ -309,7 +309,7 @@ let test_legacy_runtime_wrapper_does_not_fallback_to_defaults () =
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
-  "keeper_unified_models": ["%s"]
+  "big_three_models": ["%s"]
 }|}
           valid_model));
   ignore (Cascade_catalog_runtime.inspect_active ());
@@ -339,7 +339,7 @@ let test_legacy_runtime_wrapper_preserves_configured_label_order () =
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
-  "keeper_unified_models": [
+  "big_three_models": [
     {"model": "%s", "weight": 2},
     {"model": "%s", "weight": 2},
     {"model": "%s", "weight": 2}
@@ -369,7 +369,7 @@ let test_partial_catalog_keeps_validated_subset_available () =
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
-  "keeper_unified_models": ["%s"],
+  "big_three_models": ["%s"],
   "tool_rerank_models": ["%s"],
   "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
 }|}
@@ -439,7 +439,7 @@ let test_partial_catalog_rejects_invalid_default_profile () =
       (write_cascade_json config_dir
          (Printf.sprintf
             {|{
-  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"],
+  "big_three_models": ["__nonexistent_provider_sentinel__:fake"],
   "tool_rerank_models": ["%s"]
 }|}
             valid_model));
@@ -455,7 +455,7 @@ let test_partial_catalog_rejects_invalid_default_profile () =
            (function
              | `String value ->
                  contains_substring value
-                   "required default profile \"keeper_unified\" failed validation"
+                   "required default profile \"big_three\" failed validation"
              | _ -> false)
            errors);
       check bool "rejected default profile invalid candidate is surfaced" true
@@ -476,7 +476,7 @@ let test_resolve_named_providers_tool_choice_filters_runtime_only_providers () =
   ignore
     (write_cascade_json config_dir
        {|{
-  "keeper_unified_models": [
+  "big_three_models": [
     "custom:remote-model@http://127.0.0.1:18080/v1",
     "codex_cli:auto",
     "gemini_cli:auto",
@@ -505,7 +505,7 @@ let test_resolve_named_providers_tool_support_keeps_runtime_mcp_providers () =
   ignore
     (write_cascade_json config_dir
        {|{
-  "keeper_unified_models": [
+  "big_three_models": [
     "custom:remote-model@http://127.0.0.1:18080/v1",
     "claude_code:auto",
     "codex_cli:auto",
@@ -537,7 +537,7 @@ let test_resolve_named_providers_runtime_mcp_headers_drop_unsupported_providers 
   ignore
     (write_cascade_json config_dir
        {|{
-  "keeper_unified_models": [
+  "big_three_models": [
     "custom:remote-model@http://127.0.0.1:18080/v1",
     "claude_code:auto",
     "codex_cli:auto",
@@ -569,7 +569,7 @@ let test_config_doctor_live_reports_catalog_validation () =
   ignore
     (write_cascade_json config_dir
        {|{
-  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"]
+  "big_three_models": ["__nonexistent_provider_sentinel__:fake"]
 }|});
   with_config_dir config_dir @@ fun () ->
   with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
@@ -612,7 +612,7 @@ let test_config_doctor_live_warns_on_partial_catalog_validation () =
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
-  "keeper_unified_models": ["%s"],
+  "big_three_models": ["%s"],
   "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
 }|}
           valid_model));

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -158,12 +158,12 @@ let test_expand_model_strings_for_execution_rotation_scope_rotates () =
     State.clear_all ();
     let first =
       C.expand_model_strings_for_execution
-        ~rotation_scope:"keeper_unified"
+        ~rotation_scope:"big_three"
         [ "gemini_cli:auto" ]
     in
     let second =
       C.expand_model_strings_for_execution
-        ~rotation_scope:"keeper_unified"
+        ~rotation_scope:"big_three"
         [ "gemini_cli:auto" ]
     in
     let other_scope =
@@ -193,14 +193,14 @@ let test_order_weighted_entries_rotation_scope_rotates_generically () =
     in
     let first =
       C.order_weighted_entries
-        ~rotation_scope:"keeper_unified"
+        ~rotation_scope:"big_three"
         [ entry "codex_cli:auto" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
              e.model)
     in
     let second =
       C.order_weighted_entries
-        ~rotation_scope:"keeper_unified"
+        ~rotation_scope:"big_three"
         [ entry "codex_cli:auto" ]
       |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
              e.model)

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -751,7 +751,7 @@ let test_history_prometheus_counter_increments () =
 
 (* ── Strategy decision trace (LT-5) ─────────────────── *)
 
-let mk_trace_event ?(ts = 0.0) ?(cascade_name = "keeper_unified")
+let mk_trace_event ?(ts = 0.0) ?(cascade_name = "big_three")
     ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
     ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered) () =
   { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
@@ -778,13 +778,13 @@ let test_trace_record_snapshot_roundtrip () =
 
 let test_trace_cascade_filter () =
   ST.clear ();
-  ST.record (mk_trace_event ~cascade_name:"keeper_unified" ~ts:1.0 ());
+  ST.record (mk_trace_event ~cascade_name:"big_three" ~ts:1.0 ());
   ST.record (mk_trace_event ~cascade_name:"nick0cave" ~ts:2.0 ());
-  ST.record (mk_trace_event ~cascade_name:"keeper_unified" ~ts:3.0 ());
-  let unified = ST.snapshot ~cascade:"keeper_unified" () in
-  check int "keeper_unified → 2 events" 2 (List.length unified);
+  ST.record (mk_trace_event ~cascade_name:"big_three" ~ts:3.0 ());
+  let unified = ST.snapshot ~cascade:"big_three" () in
+  check int "big_three → 2 events" 2 (List.length unified);
   List.iter
-    (fun e -> check string "cascade filter" "keeper_unified" e.ST.cascade_name)
+    (fun e -> check string "cascade filter" "big_three" e.ST.cascade_name)
     unified;
   let missing = ST.snapshot ~cascade:"does_not_exist" () in
   check int "missing cascade → empty" 0 (List.length missing)
@@ -862,12 +862,12 @@ let test_trace_prometheus_counter_increments () =
   let before =
     find_strategy_counter_value
       (Masc_mcp.Prometheus.to_prometheus_text ())
-      ~cascade:"keeper_unified" ~strategy:"failover" ~kind:"ordered"
+      ~cascade:"big_three" ~strategy:"failover" ~kind:"ordered"
     |> Option.value ~default:0.0
   in
-  ST.record (mk_trace_event ~cascade_name:"keeper_unified"
+  ST.record (mk_trace_event ~cascade_name:"big_three"
                ~strategy:"failover" ~kind:ST.Ordered ());
-  ST.record (mk_trace_event ~cascade_name:"keeper_unified"
+  ST.record (mk_trace_event ~cascade_name:"big_three"
                ~strategy:"failover" ~kind:ST.Ordered ());
   ST.record (mk_trace_event ~cascade_name:"nick0cave"
                ~strategy:"circuit_breaker_cycling"
@@ -875,7 +875,7 @@ let test_trace_prometheus_counter_increments () =
   let text = Masc_mcp.Prometheus.to_prometheus_text () in
   let ordered =
     find_strategy_counter_value text
-      ~cascade:"keeper_unified" ~strategy:"failover" ~kind:"ordered"
+      ~cascade:"big_three" ~strategy:"failover" ~kind:"ordered"
     |> Option.value ~default:0.0
   in
   let filtered =
@@ -884,7 +884,7 @@ let test_trace_prometheus_counter_increments () =
       ~kind:"filtered_empty"
     |> Option.value ~default:0.0
   in
-  check bool "keeper_unified/failover/ordered advanced by >= 2"
+  check bool "big_three/failover/ordered advanced by >= 2"
     true (ordered >= before +. 2.0);
   check bool "nick0cave/circuit_breaker_cycling/filtered_empty >= 1"
     true (filtered >= 1.0)

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -86,7 +86,7 @@ let repo_json_path () =
 
 let minimal_toml =
   {|
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 |}
 
@@ -105,7 +105,7 @@ let test_unknown_profile_field_is_rejected () =
   match
     Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
       {|
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 unknown_field = 1
 |}
@@ -127,7 +127,7 @@ let test_runtime_materializes_missing_json_on_load () =
   | Ok (Masc_mcp.Cascade_catalog_runtime.Validated _) ->
       check bool "json materialized on load" true (Sys.file_exists json_path);
       check bool "generated json contains profile key" true
-        (contains_substring (read_file json_path) "keeper_unified_models")
+        (contains_substring (read_file json_path) "big_three_models")
   | Ok _ -> fail "expected fully validated catalog"
   | Error rejection ->
       failf "unexpected validation failure: %s"
@@ -155,13 +155,13 @@ let test_invalid_toml_blocks_runtime_without_using_stale_json () =
   write_file
     (Filename.concat config_dir "cascade.toml")
     {|
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 unknown_field = 1
 |};
   write_file
     (Filename.concat config_dir "cascade.json")
-    {|{"keeper_unified_models":["ollama:qwen3.5:35b-a3b-nvfp4"]}|};
+    {|{"big_three_models":["ollama:qwen3.5:35b-a3b-nvfp4"]}|};
   with_config_dir config_dir @@ fun () ->
   match Masc_mcp.Cascade_catalog_runtime.inspect_active () with
   | Ok _ -> fail "invalid toml should block runtime load"

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -71,7 +71,7 @@ let make_toml_only_config_root root =
   write_file
     (Filename.concat config "cascade.toml")
     {|
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 |};
   write_file (Filename.concat config "tool_policy.toml") "# test marker\n";

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -144,7 +144,7 @@ let test_config_validated_status () =
   with_temp_config_root
     {|
       {
-        "keeper_unified_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+        "big_three_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
       }
     |}
     (fun cascade_path ->
@@ -272,7 +272,7 @@ let test_raw_config_shape () =
   with_temp_config_root
     {|
       {
-        "keeper_unified_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+        "big_three_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
       }
     |}
     (fun cascade_path ->
@@ -291,7 +291,7 @@ let test_raw_config_shape () =
       check bool "json raw is editable" true
         Yojson.Safe.Util.(j |> member "raw_json_editable" |> to_bool);
       check bool "raw_json includes current file contents" true
-        (contains_substring raw_json "keeper_unified_models"))
+        (contains_substring raw_json "big_three_models"))
 
 let test_raw_config_defaults_when_file_missing () =
   with_temp_config_root "{}\n"
@@ -334,7 +334,7 @@ models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
       check bool "generated runtime json visible" true
         (contains_substring
            Yojson.Safe.Util.(j |> member "raw_json" |> to_string)
-           "keeper_unified_models");
+           "big_three_models");
       check bool "runtime json materialized on read" true
         (Sys.file_exists json_path))
 
@@ -560,7 +560,7 @@ let test_keeper_profile_preserves_raw_unknown_cascade () =
   check string "cascade_name preserves raw TOML value"
     "playground_experiment_xyz" (lookup fs "cascade_name");
   check string "canonical collapses unknown → keeper_unified"
-    "keeper_unified" (lookup fs "canonical");
+    "big_three" (lookup fs "canonical");
   check bool "raw and canonical differ → UI shows drift"
     true (lookup fs "cascade_name" <> lookup fs "canonical")
 
@@ -572,19 +572,19 @@ let test_keeper_profile_preserves_raw_legacy_alias () =
   check string "legacy alias preserved as raw"
     "oas-keeper_unified" (lookup fs "cascade_name");
   check string "legacy alias canonicalizes to keeper_unified"
-    "keeper_unified" (lookup fs "canonical");
+    "big_three" (lookup fs "canonical");
   check bool "raw and canonical differ → UI shows drift"
     true (lookup fs "cascade_name" <> lookup fs "canonical")
 
 let test_keeper_profile_canonical_matches_when_raw_is_canonical () =
   let fs =
     Masc_mcp.Dashboard_cascade.keeper_profile_fields
-      ~keeper:"verdict" ~cascade_name:"keeper_unified"
+      ~keeper:"verdict" ~cascade_name:"big_three"
   in
   check string "cascade_name stays canonical"
-    "keeper_unified" (lookup fs "cascade_name");
+    "big_three" (lookup fs "cascade_name");
   check string "canonical matches"
-    "keeper_unified" (lookup fs "canonical");
+    "big_three" (lookup fs "canonical");
   check bool "raw == canonical → UI renders —"
     true (lookup fs "cascade_name" = lookup fs "canonical")
 
@@ -593,7 +593,7 @@ let test_keeper_profile_stale_builtin_falls_back_to_live_default () =
     {|
       {
         "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
-        "keeper_unified_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+        "big_three_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
       }
     |}
     (fun _cascade_path ->
@@ -604,7 +604,7 @@ let test_keeper_profile_stale_builtin_falls_back_to_live_default () =
       check string "stale built-in raw value preserved"
         "vendor_mix_balanced" (lookup fs "cascade_name");
       check string "stale built-in falls back to live default"
-        "keeper_unified" (lookup fs "canonical");
+        "big_three" (lookup fs "canonical");
       check bool "raw and canonical differ for inactive built-in"
         true (lookup fs "cascade_name" <> lookup fs "canonical"))
 

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -2,26 +2,9 @@ open Alcotest
 
 module Profile = Masc_mcp.Keeper_cascade_profile
 
-(* Names that must round-trip [of_string_opt] -> [to_string] without
-   collapsing to default. Pre-2026-04-17 only the first 6 worked; the
-   rest silently fell back to Keeper_unified, so cascade.json presets
-   like vendor_mix_balanced were dead config. *)
-let active_names =
-  [ "default";
-    "keeper_unified";
-    "sangsu";
-    "local_only";
-    "local_mlx_vlm_qwen36";
-    "local_recovery";
-    "tool_rerank";
-    "nick0cave";
-    "capacity_queue_trio";
-    "vendor_mix_balanced";
-    "cost_tier_ladder";
-    "oauth_cli_rotate";
-    "quality_sticky_glm51";
-    "tool_use_strict";
-    "resilient_breaker" ]
+(* Only the 4 SSOT variants round-trip through [of_string_opt] -> [to_string].
+   Legacy aliases collapse to Big_three; phase-routing names return None. *)
+let variant_names = [ "big_three"; "underdog"; "local"; "tool_rerank" ]
 
 let write_file path contents =
   let oc = open_out path in
@@ -46,43 +29,57 @@ let test_round_trip () =
     (fun name ->
       let canon = Profile.canonicalize name in
       check string ("round-trip " ^ name) name canon)
-    active_names
+    variant_names
 
-let test_known_cascades_covers_active () =
+let test_known_cascades_covers_variants () =
   List.iter
     (fun name ->
       let listed = List.mem name Profile.known_cascades in
       check bool ("known_cascades contains " ^ name) true listed)
-    active_names
+    variant_names
 
-let test_legacy_aliases_collapse_to_keeper_unified () =
+let test_legacy_aliases_collapse_to_big_three () =
   let aliases = [ "oas-keeper_unified"; "coding_first"; "oas-coding_first";
-                  "keeper_turn"; "keeper_reply"; "" ] in
+                  "keeper_turn"; "keeper_reply"; "default"; "keeper_unified";
+                  "sangsu"; "local_mlx_vlm_qwen36";
+                  "nick0cave"; "capacity_queue_trio"; "vendor_mix_balanced";
+                  "cost_tier_ladder"; "oauth_cli_rotate"; "quality_sticky_glm51";
+                  "tool_use_strict"; "resilient_breaker"; "" ] in
   List.iter
     (fun raw ->
       let canon = Profile.canonicalize raw in
-      check string ("alias " ^ raw ^ " -> keeper_unified") "keeper_unified" canon)
+      check string ("alias " ^ raw ^ " -> big_three") "big_three" canon)
     aliases
+
+let test_phase_routing_returns_none () =
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "local_only returns None"
+    None
+    (Profile.of_string_opt "local_only");
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "local_recovery returns None"
+    None
+    (Profile.of_string_opt "local_recovery")
 
 let test_unknown_falls_back_to_default () =
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
     "unknown returns None from of_string_opt"
     None
     (Profile.of_string_opt "definitely_not_a_real_cascade_xyz");
-  check string "canonicalize forces fallback to keeper_unified"
-    "keeper_unified"
+  check string "canonicalize forces fallback to big_three"
+    "big_three"
     (Profile.canonicalize "definitely_not_a_real_cascade_xyz")
 
 let test_catalog_names_follow_live_config () =
   with_temp_config
     {|
       {
-        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
-        "custom_live_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "default_models": ["ollama:auto"],
+        "custom_live_models": ["ollama:auto"],
         "tool_rerank_temperature": 0.0,
         "tool_rerank_max_tokens": 200,
         "tool_rerank_keeper_assignable": false,
-        "governance_judge_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
+        "governance_judge_models": ["ollama:auto"],
         "governance_judge_keeper_assignable": false
       }
     |}
@@ -101,18 +98,18 @@ let test_catalog_names_follow_live_config () =
         "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "custom_live");
       check string "dynamic live profile requires exact match"
-        "keeper_unified"
+        "big_three"
         (Profile.canonicalize_with_catalog ~catalog "Custom_Live");
       check string "unknown live profile still falls back"
-        "keeper_unified"
+        "big_three"
         (Profile.canonicalize_with_catalog ~catalog "missing_profile"))
 
 let test_resolve_live_with_catalog_requires_active_membership () =
   with_temp_config
     {|
       {
-        "default_models": ["ollama:qwen3.5:35b-a3b-nvfp4"],
-        "custom_live_models": ["ollama:qwen3.5:35b-a3b-nvfp4"]
+        "default_models": ["ollama:auto"],
+        "custom_live_models": ["ollama:auto"]
       }
     |}
     (fun path ->
@@ -121,13 +118,13 @@ let test_resolve_live_with_catalog_requires_active_membership () =
         "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "custom_live");
       check string "legacy alias resolves through active default"
-        "keeper_unified"
+        "big_three"
         (Profile.resolve_live_with_catalog ~catalog "oas-keeper_unified");
       check string "inactive built-in profile falls back to default"
-        "keeper_unified"
+        "big_three"
         (Profile.resolve_live_with_catalog ~catalog "vendor_mix_balanced");
       check string "unknown profile falls back to default"
-        "keeper_unified"
+        "big_three"
         (Profile.resolve_live_with_catalog ~catalog "missing_profile"))
 
 let test_catalog_read_failures_do_not_fallback_to_hardcoded_names () =
@@ -146,8 +143,9 @@ let () =
   run "keeper_cascade_profile"
     [ ( "ssot",
         [ test_case "active names round-trip" `Quick test_round_trip;
-          test_case "known_cascades covers active" `Quick test_known_cascades_covers_active;
-          test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_keeper_unified;
+          test_case "known_cascades covers active" `Quick test_known_cascades_covers_variants;
+          test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_big_three;
+          test_case "phase routing returns None" `Quick test_phase_routing_returns_none;
           test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default;
           test_case "catalog_names follow live config" `Quick test_catalog_names_follow_live_config;
           test_case "resolve_live_with_catalog requires active membership" `Quick

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -303,7 +303,7 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
   KR.clear ();
   let base = make_meta ~name:"runtime-cascade-exhausted-test" () in
   let reason =
-    "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"keeper_unified\",\"detail\":\"all providers failed: Connection refused\"}"
+    "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"big_three\",\"detail\":\"all providers failed: Connection refused\"}"
   in
   let meta =
     {

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -39,7 +39,7 @@ let overflow_blockers_are_recognized () =
 let non_overflow_blockers_are_not_matched () =
   let cases = [
     "";
-    "Internal error: cascade keeper_unified: all models failed";
+    "Internal error: cascade big_three: all models failed";
     "turn outcome ambiguous after committed message";
     "network timeout";
     "rate limited";

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -58,7 +58,7 @@ let with_config_dir f =
       write_file
         cascade_path
         {|{
-  "keeper_unified_models": ["test-only:model"]
+  "big_three_models": ["test-only:model"]
 }|};
       Unix.putenv "MASC_CONFIG_DIR" config_dir;
       Config_dir_resolver.reset ();

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -856,7 +856,7 @@ goal = "canonical"
 mention_targets = ["a", "b"]
 tool_preset = "coding"
 tool_also_allow = ["x"]
-cascade_name = "keeper_unified"
+cascade_name = "big_three"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2066,22 +2066,22 @@ let wrapped_claude_limit_error () =
 let test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default () =
   let fallback =
     EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:"tool_use_strict"
-      ~effective_cascade:"tool_use_strict"
+      ~base_cascade:"underdog"
+      ~effective_cascade:"underdog"
       (wrapped_claude_limit_error ())
   in
-  check (option string) "strict cascade broadens to default"
+  check (option string) "non-default cascade broadens to default"
     (Some KC.default_cascade_name) fallback
 
 let test_fail_open_cascade_after_auto_recoverable_error_returns_base_after_phase_override () =
   let fallback =
     EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:"tool_use_strict"
+      ~base_cascade:"underdog"
       ~effective_cascade:KC.local_recovery_cascade_name
       (wrapped_claude_limit_error ())
   in
   check (option string) "phase override returns to keeper base"
-    (Some "tool_use_strict") fallback
+    (Some "underdog") fallback
 
 let test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only () =
   let fallback =

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -69,7 +69,7 @@ let test_compute_context_ratio_uses_resolved_cli_context_budget () =
             ("name", `String "ctx-ratio-demo");
             ("agent_name", `String "keeper-ctx-ratio-demo-agent");
             ("trace_id", `String "trace-ctx-ratio-demo");
-            ("cascade_name", `String "keeper_unified");
+            ("cascade_name", `String "big_three");
           ])
     with
     | Ok meta -> meta

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -424,7 +424,7 @@ let write_partially_invalid_cascade ~base_path ~valid_model =
     (Filename.concat config_root "cascade.json")
     (Printf.sprintf
        {|{
-  "keeper_unified_models": ["%s"],
+  "big_three_models": ["%s"],
   "broken_profile_models": ["__nonexistent_provider_sentinel__:fake"]
 }|}
        valid_model)
@@ -436,7 +436,7 @@ let write_partially_invalid_default_cascade ~base_path ~valid_model =
     (Filename.concat config_root "cascade.json")
     (Printf.sprintf
        {|{
-  "keeper_unified_models": ["__nonexistent_provider_sentinel__:fake"],
+  "big_three_models": ["__nonexistent_provider_sentinel__:fake"],
   "tool_rerank_models": ["%s"]
 }|}
        valid_model)
@@ -1703,7 +1703,7 @@ let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
                "startup catalog validation failed:"
              &&
              contains_substring startup_error
-               "required default profile \"keeper_unified\" failed validation");
+               "required default profile \"big_three\" failed validation");
           let config_headers, config_body =
             curl_request_capture ~output_dir:dir ~name:"cascade-config-default-invalid"
               ~method_:"GET"


### PR DESCRIPTION
## Summary
- Reduce `keeper_cascade_profile` variants from 16 to 4: `Big_three`, `Underdog`, `Local`, `Tool_rerank`
- All legacy cascade names (`keeper_unified`, `sangsu`, `tool_use_strict`, etc.) collapse to `Big_three` via `of_string_opt`
- Phase-routing names (`local_only`, `local_recovery`) return `None` to preserve catalog pass-through
- `cascade.toml` SSOT: removed `keeper_unified`/`sangsu`/`local_mlx_vlm_qwen36`, added `big_three`/`underdog`/`local`
- Keeper TOMLs: explicit `cascade_name = "big_three"` + `autoboot_enabled = true`
- Provider strings use auto-resolving format: `claude_code:auto`, `codex_cli:auto`, `glm-coding:auto`, etc.

## Changes (25 files)
- `lib/keeper/keeper_cascade_profile.ml/mli` — variant type, alias normalization, catalog discovery
- `config/cascade.toml` — 4 SSOT profiles + phase-routing sections
- `config/cascade.json` — auto-generated from TOML materializer
- `config/keepers/*.toml` (7 files) — cascade_name + autoboot_enabled
- `test/` (16 files) — `keeper_unified` → `big_three`, `tool_use_strict` → `underdog` in fail-open fixtures

## Test plan
- [x] `dune build --root .` — clean compilation
- [x] `dune runtest --root .` — net-zero regressions (23 failures, all pre-existing)
- [x] `test_keeper_cascade_profile` — all 8 tests pass (round-trip, aliases, phase-routing, catalog)
- [x] `test_keeper_unified` phase_gate 8,9 — fixed (underdog base for fail-open broadening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)